### PR TITLE
LibPDF: Add support for Type1 accented characters

### DIFF
--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -243,6 +243,14 @@ public:
         return m_bounding_box.value();
     }
 
+    void append_path(Path const& path)
+    {
+        m_segments.ensure_capacity(m_segments.size() + path.m_segments.size());
+        for (auto const& segment : path.m_segments)
+            m_segments.unchecked_append(segment);
+        invalidate_split_lines();
+    }
+
     Path copy_transformed(AffineTransform const&) const;
 
     DeprecatedString to_deprecated_string() const;

--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -119,6 +119,11 @@ public:
         return cast_to<T>(TRY(resolve(value)));
     }
 
+    /// Whether this Document is reasdy to resolve references, which is usually
+    /// true, except just before the XRef table is parsed (and while the linearization
+    /// dict is being read).
+    bool can_resolve_refefences() { return m_parser->can_resolve_references(); }
+
 private:
     explicit Document(NonnullRefPtr<DocumentParser> const& parser);
 

--- a/Userland/Libraries/LibPDF/DocumentParser.h
+++ b/Userland/Libraries/LibPDF/DocumentParser.h
@@ -25,6 +25,8 @@ public:
     // Parses the header and initializes the xref table and trailer
     PDFErrorOr<void> initialize();
 
+    bool can_resolve_references() { return m_xref_table; };
+
     PDFErrorOr<Value> parse_object_with_index(u32 index);
 
     // Specialized version of parse_dict which aborts early if the dict being parsed

--- a/Userland/Libraries/LibPDF/Encoding.cpp
+++ b/Userland/Libraries/LibPDF/Encoding.cpp
@@ -168,4 +168,12 @@ u16 Encoding::get_char_code(DeprecatedString const& name) const
     return 0;
 }
 
+DeprecatedFlyString Encoding::get_name(u8 char_code) const
+{
+    auto name_iterator = m_descriptors.find(char_code);
+    if (name_iterator != m_descriptors.end())
+        return name_iterator->value;
+    return 0;
+}
+
 }

--- a/Userland/Libraries/LibPDF/Encoding.h
+++ b/Userland/Libraries/LibPDF/Encoding.h
@@ -641,6 +641,8 @@ public:
     HashMap<DeprecatedString, CharCodeType> const& name_mapping() const { return m_name_mapping; }
 
     u16 get_char_code(DeprecatedString const&) const;
+    DeprecatedFlyString get_name(u8 char_code) const;
+
     void set(CharCodeType char_code, DeprecatedFlyString const& glyph_name);
 
 protected:

--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -102,10 +102,10 @@ PDFErrorOr<NonnullRefPtr<CFF>> CFF::create(ReadonlyBytes const& cff_bytes, RefPt
 
     // Adjust glyphs' widths as they are deltas from nominalWidthX
     for (auto& glyph : glyphs) {
-        if (!glyph.width_specified)
-            glyph.width = float(defaultWidthX);
+        if (!glyph.has_width())
+            glyph.set_width(float(defaultWidthX));
         else
-            glyph.width += float(nominalWidthX);
+            glyph.set_width(glyph.width() + float(nominalWidthX));
     }
 
     for (size_t i = 0; i < glyphs.size(); i++) {

--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -116,6 +116,7 @@ PDFErrorOr<NonnullRefPtr<CFF>> CFF::create(ReadonlyBytes const& cff_bytes, RefPt
         auto const& name = charset[i - 1];
         TRY(cff->add_glyph(name, move(glyphs[i])));
     }
+    cff->consolidate_glyphs();
 
     // Encoding given or read
     if (encoding) {

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
@@ -140,7 +140,7 @@ PDFErrorOr<Vector<ByteBuffer>> PS1FontProgram::parse_subroutines(Reader& reader)
             } else {
                 array[index] = TRY(ByteBuffer::copy(entry.bytes()));
             }
-        } else if (word == "index") {
+        } else if (word == "index" || word == "def" || word == "ND") {
             break;
         }
     }

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
@@ -92,9 +92,8 @@ PDFErrorOr<void> PS1FontProgram::parse_encrypted_portion(ByteBuffer const& buffe
                 auto line = TRY(decrypt(reader.bytes().slice(reader.offset(), encrypted_size), m_encryption_key, m_lenIV));
                 reader.move_by(encrypted_size);
                 auto glyph_name = word.substring_view(1);
-                auto char_code = encoding()->get_char_code(glyph_name);
                 GlyphParserState state;
-                TRY(add_glyph(char_code, TRY(parse_glyph(line, subroutines, state, false))));
+                TRY(add_glyph(glyph_name, TRY(parse_glyph(line, subroutines, state, false))));
             }
         }
     }

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
@@ -98,6 +98,7 @@ PDFErrorOr<void> PS1FontProgram::parse_encrypted_portion(ByteBuffer const& buffe
         }
     }
 
+    consolidate_glyphs();
     return {};
 }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -86,7 +86,8 @@ void Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float w
         return;
     }
 
-    auto translation = m_data.font_program->glyph_translation(char_code, width);
+    auto char_name = m_data.encoding->get_name(char_code);
+    auto translation = m_data.font_program->glyph_translation(char_name, width);
     point = point.translated(translation);
 
     auto glyph_position = Gfx::GlyphRasterPosition::get_nearest_fit_for(point);
@@ -97,7 +98,7 @@ void Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float w
     if (maybe_bitmap.has_value()) {
         bitmap = maybe_bitmap.value();
     } else {
-        bitmap = m_data.font_program->rasterize_glyph(char_code, width, glyph_position.subpixel_offset);
+        bitmap = m_data.font_program->rasterize_glyph(char_name, width, glyph_position.subpixel_offset);
         m_glyph_cache.set(index, bitmap);
     }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
@@ -52,9 +52,9 @@ enum ExtendedCommand {
     Flex1,
 };
 
-RefPtr<Gfx::Bitmap> Type1FontProgram::rasterize_glyph(u32 char_code, float width, Gfx::GlyphSubpixelOffset subpixel_offset)
+RefPtr<Gfx::Bitmap> Type1FontProgram::rasterize_glyph(DeprecatedFlyString const& char_name, float width, Gfx::GlyphSubpixelOffset subpixel_offset)
 {
-    auto path = build_char(char_code, width, subpixel_offset);
+    auto path = build_char(char_name, width, subpixel_offset);
     auto bounding_box = path.bounding_box().size();
 
     u32 w = (u32)ceilf(bounding_box.width()) + 2;
@@ -65,9 +65,9 @@ RefPtr<Gfx::Bitmap> Type1FontProgram::rasterize_glyph(u32 char_code, float width
     return rasterizer.accumulate();
 }
 
-Gfx::Path Type1FontProgram::build_char(u32 char_code, float width, Gfx::GlyphSubpixelOffset subpixel_offset)
+Gfx::Path Type1FontProgram::build_char(DeprecatedFlyString const& char_name, float width, Gfx::GlyphSubpixelOffset subpixel_offset)
 {
-    auto maybe_glyph = m_glyph_map.get(char_code);
+    auto maybe_glyph = m_glyph_map.get(char_name);
     if (!maybe_glyph.has_value())
         return {};
 
@@ -84,9 +84,9 @@ Gfx::Path Type1FontProgram::build_char(u32 char_code, float width, Gfx::GlyphSub
     return glyph.path.copy_transformed(transform);
 }
 
-Gfx::FloatPoint Type1FontProgram::glyph_translation(u32 char_code, float width) const
+Gfx::FloatPoint Type1FontProgram::glyph_translation(DeprecatedFlyString const& char_name, float width) const
 {
-    auto maybe_glyph = m_glyph_map.get(char_code);
+    auto maybe_glyph = m_glyph_map.get(char_name);
     if (!maybe_glyph.has_value())
         return {};
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
@@ -46,6 +46,10 @@ enum ExtendedCommand {
     CallOtherSubr = 16,
     Pop,
     SetCurrentPoint = 33,
+    Hflex,
+    Flex,
+    Hflex1,
+    Flex1,
 };
 
 RefPtr<Gfx::Bitmap> Type1FontProgram::rasterize_glyph(u32 char_code, float width, Gfx::GlyphSubpixelOffset subpixel_offset)
@@ -411,6 +415,14 @@ PDFErrorOr<Type1FontProgram::Glyph> Type1FontProgram::parse_glyph(ReadonlyBytes 
                     state.sp = 0;
                     break;
                 }
+
+                case Hflex:
+                case Flex:
+                case Hflex1:
+                case Flex1:
+                    // TODO: implement these
+                    state.sp = 0;
+                    break;
 
                 default:
                     return error(DeprecatedString::formatted("Unhandled command: 12 {}", data[i]));

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
@@ -397,10 +397,20 @@ PDFErrorOr<Type1FontProgram::Glyph> Type1FontProgram::parse_glyph(ReadonlyBytes 
                 case DotSection:
                 case VStem3:
                 case HStem3:
-                case Seac:
                     // FIXME: Do something with these?
                     state.sp = 0;
                     break;
+
+                case Seac: {
+                    auto achar = pop();
+                    auto bchar = pop();
+                    auto ady = pop();
+                    auto adx = pop();
+                    // auto asb = pop();
+                    state.glyph.set_accented_character(AccentedCharacter { (u8)bchar, (u8)achar, adx, ady });
+                    state.sp = 0;
+                    break;
+                }
 
                 case Div: {
                     auto num2 = pop();

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
@@ -20,8 +20,8 @@ class Encoding;
 class Type1FontProgram : public RefCounted<Type1FontProgram> {
 
 public:
-    RefPtr<Gfx::Bitmap> rasterize_glyph(u32 char_code, float width, Gfx::GlyphSubpixelOffset subpixel_offset);
-    Gfx::FloatPoint glyph_translation(u32 char_code, float width) const;
+    RefPtr<Gfx::Bitmap> rasterize_glyph(DeprecatedFlyString const& char_name, float width, Gfx::GlyphSubpixelOffset subpixel_offset);
+    Gfx::FloatPoint glyph_translation(DeprecatedFlyString const& char_name, float width) const;
     RefPtr<Encoding> encoding() const { return m_encoding; }
 
 protected:
@@ -68,18 +68,18 @@ protected:
         m_font_matrix = move(font_matrix);
     }
 
-    PDFErrorOr<void> add_glyph(u16 char_code, Glyph&& glyph)
+    PDFErrorOr<void> add_glyph(DeprecatedFlyString name, Glyph&& glyph)
     {
-        TRY(m_glyph_map.try_set(char_code, glyph));
+        TRY(m_glyph_map.try_set(move(name), move(glyph)));
         return {};
     }
 
 private:
-    HashMap<u16, Glyph> m_glyph_map;
+    HashMap<DeprecatedFlyString, Glyph> m_glyph_map;
     Gfx::AffineTransform m_font_matrix;
     RefPtr<Encoding> m_encoding;
 
-    Gfx::Path build_char(u32 char_code, float width, Gfx::GlyphSubpixelOffset subpixel_offset);
+    Gfx::Path build_char(DeprecatedFlyString const& char_name, float width, Gfx::GlyphSubpixelOffset subpixel_offset);
     Gfx::AffineTransform glyph_transform_to_device_space(Glyph const& glyph, float width) const;
 };
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
@@ -25,10 +25,22 @@ public:
     RefPtr<Encoding> encoding() const { return m_encoding; }
 
 protected:
-    struct Glyph {
-        Gfx::Path path;
-        float width { 0 };
-        bool width_specified { false };
+    class Glyph {
+
+    public:
+        bool has_width() const { return m_width.has_value(); }
+        float width() const { return m_width.value(); }
+        void set_width(float width)
+        {
+            m_width = width;
+        }
+
+        Gfx::Path& path() { return m_path; }
+        Gfx::Path const& path() const { return m_path; }
+
+    private:
+        Gfx::Path m_path;
+        Optional<float> m_width;
     };
 
     struct GlyphParserState {

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
@@ -25,6 +25,19 @@ public:
     RefPtr<Encoding> encoding() const { return m_encoding; }
 
 protected:
+    struct AccentedCharacter {
+        AccentedCharacter(u8 base_char_code, u8 accent_char_code, float adx, float ady)
+            : base_character(Encoding::standard_encoding()->get_name(base_char_code))
+            , accent_character(Encoding::standard_encoding()->get_name(accent_char_code))
+            , accent_origin(adx, ady)
+        {
+        }
+
+        DeprecatedFlyString base_character;
+        DeprecatedFlyString accent_character;
+        Gfx::FloatPoint accent_origin;
+    };
+
     class Glyph {
 
     public:
@@ -38,9 +51,17 @@ protected:
         Gfx::Path& path() { return m_path; }
         Gfx::Path const& path() const { return m_path; }
 
+        bool is_accented_character() const { return m_accented_character.has_value(); }
+        AccentedCharacter const& accented_character() const { return m_accented_character.value(); }
+        void set_accented_character(AccentedCharacter&& accented_character)
+        {
+            m_accented_character = move(accented_character);
+        }
+
     private:
         Gfx::Path m_path;
         Optional<float> m_width;
+        Optional<AccentedCharacter> m_accented_character;
     };
 
     struct GlyphParserState {
@@ -85,6 +106,8 @@ protected:
         TRY(m_glyph_map.try_set(move(name), move(glyph)));
         return {};
     }
+
+    void consolidate_glyphs();
 
 private:
     HashMap<DeprecatedFlyString, Glyph> m_glyph_map;


### PR DESCRIPTION
Type1 characters are usually defined by a series of strokes defining the outline of the glyph, which are encoded as a series of instructions within a glyph definition (a "charstring" in Type1 parlance). However, there's a special instruction, `saec`, that instead of providing a line/stroke, points to a "base" and an "accent" characters, with a relative positioning for the latter with respect to the first. The idea in this case is that the outlines for the glyphs corresponding to those characters must be composed together to draw this one.

A simple example is using `saec` to describe a glyph for `á`: it would point to the glyph for `a` and the glyph for `´`.

We currently simply ignore this instruction, so any glyphs using it render nothing. After the change, they render as expected.

To implement this I had to also introduce two important changes:
 * A new `Gfx::Path::append_path` to append a path into another.
 * The internal indexing of glyphs in Type1 Font Programs is now name-based (DeprecatedFlyString, so should be fast) instead of char_code-based. This was not only required for these changes, but in general is a good thing, as it finally decouples the Type1 Font Program from the encoding it is used with. This coupling currently prevents us from re-using loaded Font Programs, and instead we need to keep loading them every time a new font is specified in the operations stream.

There was also a small fix on the `PDF::Parser` class, which had a potentially infinite loop when parsing streams.

*Before* | *After*
--- | ---
![presentation_dantemv35_en.pdf_p1_before](https://user-images.githubusercontent.com/620848/217346208-2369eb00-1b01-437c-9e9e-c378c6a325f7.png) | ![presentation_dantemv35_en.pdf_p1_after](https://user-images.githubusercontent.com/620848/217346004-75a47020-1061-405e-b060-93fcc84a9b87.png)
