### PR TITLE
Meta: Use fixed ruby version in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           python-version: '3.x'
 
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+
       # === OS SETUP ===
 
       # An attempt to avoid the (fairly common) azure apt mirror downtime.

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -45,6 +45,10 @@ jobs:
           repository: tc39/test262-parser-tests
           path: test262-parser-tests
 
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+
       - name: "Select best APT mirror"
         run: |
           sudo gem install apt-spy2

--- a/.github/workflows/pvs-studio-static-analysis.yml
+++ b/.github/workflows/pvs-studio-static-analysis.yml
@@ -19,6 +19,10 @@ jobs:
           wget -q -O - https://files.pvs-studio.com/beta/etc/pubkey.txt | sudo apt-key add -
           sudo wget -O /etc/apt/sources.list.d/viva64.list https://files.pvs-studio.com/beta/etc/viva64.list
 
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+
       - name: "Select best APT mirror"
         run: |
           sudo gem install apt-spy2

--- a/.github/workflows/serenity-js-artifacts.yml
+++ b/.github/workflows/serenity-js-artifacts.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Checkout SerenityOS/serenity
         uses: actions/checkout@v3
 
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+
       - name: "Select best APT mirror"
         run: |
           sudo gem install apt-spy2

--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -53,6 +53,10 @@ jobs:
       # === OS SETUP ===
       # TODO: Is there someway to share these steps with the cmake.yml?
 
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+
       - name: "Select best APT mirror"
         run: |
           sudo gem install apt-spy2

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
       - name: "Select best APT mirror"
         run: |
           sudo gem install apt-spy2

--- a/Meta/Azure/Setup.yml
+++ b/Meta/Azure/Setup.yml
@@ -5,10 +5,16 @@ steps:
   - checkout: self
     persistCredentials: true
 
+  - task: UseRubyVersion@0
+    inputs:
+      versionSpec: '3.1'
+
+  # Hacky path workaround since the azure ruby paths don't seem to work.
   - ${{ if in(parameters.os, 'Linux', 'Serenity', 'Android') }}:
     - script: |
-        sudo gem install apt-spy2
-        sudo apt-spy2 fix --commit --launchpad --country=US
+        export PATH="$(ruby -r rubygems -e 'puts Gem.user_dir')/bin:$PATH"
+        gem install --user-install apt-spy2
+        sudo -E env "PATH=$PATH" apt-spy2 fix --commit --launchpad --country=US
       displayName: 'Select best APT mirror'
 
   - ${{ if eq(parameters.os, 'Serenity') }}:


### PR DESCRIPTION
It seems there's some bugs in the version shipped by default,
that means it (rarely?) and randomly segfaults after installing
packages. This now properly sets up ruby and uses a fixed version.

(This should also fix the JS test runner, probably)