### PR TITLE
LibGfx+icc: Read signatureType

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -584,6 +584,8 @@ ErrorOr<NonnullRefPtr<TagData>> Profile::read_tag(ReadonlyBytes bytes, u32 offse
         return ParametricCurveTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case S15Fixed16ArrayTagData::Type:
         return S15Fixed16ArrayTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
+    case SignatureTagData::Type:
+        return SignatureTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case TextDescriptionTagData::Type:
         return TextDescriptionTagData::from_bytes(tag_bytes, offset_to_beginning_of_tag_data_element, size_of_tag_data_element);
     case TextTagData::Type:
@@ -990,7 +992,8 @@ ErrorOr<void> Profile::check_tag_types()
 
     // ICC v4, 9.2.21 colorimetricIntentImageStateTag
     // "Permitted tag types: signatureType"
-    // FIXME
+    if (!has_type(colorimetricIntentImageStateTag, { SignatureTagData::Type }, {}))
+        return Error::from_string_literal("ICC::Profile: colorimetricIntentImageStateTag has unexpected type");
 
     // ICC v4, 9.2.22 copyrightTag
     // "Permitted tag types: multiLocalizedUnicodeType"
@@ -1145,7 +1148,8 @@ ErrorOr<void> Profile::check_tag_types()
 
     // ICC v4, 9.2.39 perceptualRenderingIntentGamutTag
     // "Permitted tag types: signatureType"
-    // FIXME
+    if (!has_type(perceptualRenderingIntentGamutTag, { SignatureTagData::Type }, {}))
+        return Error::from_string_literal("ICC::Profile: perceptualRenderingIntentGamutTag has unexpected type");
 
     // ICC v4, 9.2.40 preview0Tag
     // "Permitted tag types: lut8Type or lut16Type or lutAToBType or lutBToAType"
@@ -1211,11 +1215,13 @@ ErrorOr<void> Profile::check_tag_types()
 
     // ICC v4, 9.2.48 saturationRenderingIntentGamutTag
     // "Permitted tag types: signatureType"
-    // FIXME
+    if (!has_type(saturationRenderingIntentGamutTag, { SignatureTagData::Type }, {}))
+        return Error::from_string_literal("ICC::Profile: saturationRenderingIntentGamutTag has unexpected type");
 
     // ICC v4, 9.2.49 technologyTag
     // "Permitted tag types: signatureType"
-    // FIXME
+    if (!has_type(technologyTag, { SignatureTagData::Type }, {}))
+        return Error::from_string_literal("ICC::Profile: technologyTag has unexpected type");
 
     // ICC v4, 9.2.50 viewingCondDescTag
     // "Permitted tag types: multiLocalizedUnicodeType"

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.cpp
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.cpp
@@ -460,6 +460,20 @@ ErrorOr<NonnullRefPtr<TextDescriptionTagData>> TextDescriptionTagData::from_byte
     return adopt_ref(*new TextDescriptionTagData(offset, size, TRY(String::from_utf8(ascii_description)), unicode_language_code, move(unicode_description), move(macintosh_description)));
 }
 
+ErrorOr<NonnullRefPtr<SignatureTagData>> SignatureTagData::from_bytes(ReadonlyBytes bytes, u32 offset, u32 size)
+{
+    // ICC v4, 10.23 signatureType
+    VERIFY(tag_type(bytes) == Type);
+    TRY(check_reserved(bytes));
+
+    if (bytes.size() < 3 * sizeof(u32))
+        return Error::from_string_literal("ICC::Profile: signatureType has not enough data");
+
+    u32 signature = *bit_cast<BigEndian<u32> const*>(bytes.data() + 8);
+
+    return adopt_ref(*new SignatureTagData(offset, size, signature));
+}
+
 ErrorOr<NonnullRefPtr<TextTagData>> TextTagData::from_bytes(ReadonlyBytes bytes, u32 offset, u32 size)
 {
     // ICC v4, 10.24 textType

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -388,6 +388,25 @@ private:
     Optional<String> m_macintosh_description;
 };
 
+// ICC v4, 10.23 signatureType
+class SignatureTagData : public TagData {
+public:
+    static constexpr TagTypeSignature Type { 0x73696720 }; // 'sig '
+
+    static ErrorOr<NonnullRefPtr<SignatureTagData>> from_bytes(ReadonlyBytes, u32 offset, u32 size);
+
+    SignatureTagData(u32 offset, u32 size, u32 signature)
+        : TagData(offset, size, Type)
+        , m_signature(signature)
+    {
+    }
+
+    u32 signature() const { return m_signature; }
+
+private:
+    u32 m_signature;
+};
+
 // ICC v4, 10.24 textType
 class TextTagData : public TagData {
 public:

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -209,6 +209,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 i++;
             }
             outln(" ]");
+        } else if (tag_data->type() == Gfx::ICC::SignatureTagData::Type) {
+            auto& signature = static_cast<Gfx::ICC::SignatureTagData&>(*tag_data);
+
+            // FIXME: For colorimetricIntentImageStateTag, interpret signature according to ICC v4 Table 26
+            // FIXME: For perceptualRenderingIntentGamutTag, interpret signature according to ICC v4 Table 27
+            // FIXME: For saturationRenderingIntentGamutTag, interpret signature according to ICC v4 Table 28
+            // FIXME: For technologyTag, interpret signature according to ICC v4 Table 29
+            outln("    signature: '{:c}{:c}{:c}{:c}' / 0x{:08x}",
+                signature.signature() >> 24, (signature.signature() >> 16) & 0xff, (signature.signature() >> 8) & 0xff, signature.signature() & 0xff,
+                signature.signature());
         } else if (tag_data->type() == Gfx::ICC::TextDescriptionTagData::Type) {
             auto& text_description = static_cast<Gfx::ICC::TextDescriptionTagData&>(*tag_data);
             outln("    ascii: \"{}\"", text_description.ascii_description());


### PR DESCRIPTION
This isn't used by any mandatory tags, and it's not terribly useful. But jpegs exported by Lightroom Classic write the 'tech' tag, and it seems nice to be able to dump its contents.

signatureType stores a single u32 which for different tags with this type means different things.

In each case, the value is one from a short table of valid values, suggesting this should be a per-tag enum class instead of a per-tag DistinctFourCC, per the comment at the top of DistincFourCC.h. On the other hand, 3 of the 4 tables have an explicit "It is possible that the ICC will define other signature values in the future" note, which suggests the FourCC might actually be the way to go.

For now, just punt on that and manually dump the u32 in fourcc style in icc.cpp and don't add any to_string() methods that return a readable string based on the contents of these tables.