### PR TITLE
AK: Allow formatted strings in Error

### DIFF
--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -4,6 +4,7 @@ set(AK_SOURCES
     CircularBuffer.cpp
     DeprecatedFlyString.cpp
     DeprecatedString.cpp
+    Error.cpp
     FloatingPointStringConversions.cpp
     FlyString.cpp
     Format.cpp

--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Error.h>
+#include <AK/String.h>
+
+namespace AK {
+
+Error::Error(Error&& other)
+{
+    swap(this->m_syscall, other.m_syscall);
+    swap(this->m_code, other.m_code);
+#if defined(KERNEL)
+    swap(this->m_string_literal, other.m_string_literal);
+#else
+    if (other.m_string_literal.has<StringView>())
+        this->m_string_literal = other.m_string_literal.get<StringView>();
+    else if (other.m_string_literal.get<String const*>() != nullptr) {
+        this->m_string_literal = other.m_string_literal.get<String const*>();
+        // Make sure the other Error doesn't destruct the string!
+        other.m_string_literal.get<String const*>() = nullptr;
+    }
+#endif
+}
+
+Error::Error(Error const& other)
+    : m_code(other.m_code)
+    , m_syscall(other.m_syscall)
+{
+#if defined(KERNEL)
+    this->m_string_literal = other.m_string_literal;
+#else
+    if (other.m_string_literal.has<StringView>())
+        this->m_string_literal = other.m_string_literal.get<StringView>();
+    else if (other.m_string_literal.get<String const*>() != nullptr)
+        this->m_string_literal = new (nothrow) String { *other.m_string_literal.get<String const*>() };
+#endif
+}
+
+Error::Error(Error& other)
+    : Error(static_cast<Error const&>(other))
+{
+}
+
+Error::~Error()
+{
+#if !defined(KERNEL)
+    if (m_string_literal.has<String const*>() && m_string_literal.get<String const*>() != nullptr)
+        delete m_string_literal.get<String const*>();
+#endif
+}
+
+#if !defined(KERNEL)
+Error::Error(String const* owned_string_literal)
+    : m_string_literal(owned_string_literal)
+{
+}
+
+Error::Error(String const* owned_string_literal, int code)
+    : m_string_literal(owned_string_literal)
+    , m_code(code)
+{
+    VERIFY(m_string_literal.has<String const*>());
+}
+
+Error Error::from_string(ErrorOr<String>&& string_or_error, Optional<int> code)
+{
+    // We intentionally do not return the String creation error here, since that is probably unrelated to the actual error.
+    if (string_or_error.is_error()) {
+        if (code.has_value())
+            return { code.value() };
+        return { ""sv };
+    }
+
+    // Note that we can safely put the nullptr into the new Error, since string_literal handles that case.
+    auto const* heap_string = new (nothrow) String { string_or_error.release_value() };
+
+    if (code.has_value())
+        return { heap_string, code.value() };
+
+    return Error { heap_string };
+}
+#endif
+
+StringView Error::string_literal() const
+{
+#if defined(KERNEL)
+    return m_string_literal;
+#else
+    return m_string_literal.visit(
+        [](StringView const& view) { return view; },
+        [](String const* owned_string) { return owned_string != nullptr ? owned_string->bytes_as_string_view() : StringView {}; });
+#endif
+}
+
+}

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -690,8 +690,11 @@ struct Formatter<Error> : Formatter<FormatString> {
 #else
         if (error.is_syscall())
             return Formatter<FormatString>::format(builder, "{}: {} (errno={})"sv, error.string_literal(), strerror(error.code()), error.code());
-        if (error.is_errno())
-            return Formatter<FormatString>::format(builder, "{} (errno={})"sv, strerror(error.code()), error.code());
+        if (error.is_errno()) {
+            if (error.string_literal().is_empty())
+                return Formatter<FormatString>::format(builder, "{} (errno={})"sv, strerror(error.code()), error.code());
+            return Formatter<FormatString>::format(builder, "{} (errno={})"sv, error.string_literal(), error.code());
+        }
 
         return Formatter<FormatString>::format(builder, "{}"sv, error.string_literal());
 #endif

--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -418,6 +418,15 @@ public:
         return index_of<T>() == m_index;
     }
 
+    bool operator==(Variant const& other) const
+    {
+        return this->visit([&]<typename T>(T const& self) {
+            if (auto const* p = other.get_pointer<T>())
+                return static_cast<T const&>(self) == static_cast<T const&>(*p);
+            return false;
+        });
+    }
+
     template<typename... Fs>
     ALWAYS_INLINE decltype(auto) visit(Fs&&... functions)
     {

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -480,13 +480,14 @@ elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
 endif()
 
 set(AK_SOURCES
+    ../AK/Error.cpp
+    ../AK/Format.cpp
     ../AK/GenericLexer.cpp
     ../AK/Hex.cpp
     ../AK/StringBuilder.cpp
     ../AK/StringUtils.cpp
     ../AK/StringView.cpp
     ../AK/Time.cpp
-    ../AK/Format.cpp
     ../AK/UUID.cpp
 )
 

--- a/Userland/Libraries/LibManual/SectionNode.cpp
+++ b/Userland/Libraries/LibManual/SectionNode.cpp
@@ -19,10 +19,10 @@ ErrorOr<NonnullRefPtr<SectionNode>> SectionNode::try_create_from_number(StringVi
 {
     auto maybe_section_number = section.to_uint<u32>();
     if (!maybe_section_number.has_value())
-        return Error::from_string_literal("Section is not a number");
+        return Error::from_string(String::formatted("Bad section number {}", section));
     auto section_number = maybe_section_number.release_value();
     if (section_number > number_of_sections)
-        return Error::from_string_literal("Section number too large");
+        return Error::from_string(String::formatted("Section number {} out of bounds, there are {} sections", section_number, number_of_sections));
     return sections[section_number - 1];
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1331,25 +1331,6 @@ bool Filter::HueRotate::operator==(Filter::HueRotate const& b) const
     return this->angle == b.angle;
 }
 
-static bool variant_equals(auto const& a, auto const& b)
-{
-    return a.visit([&](auto const& held_value) {
-        using HeldType = AK::Detail::Decay<decltype(held_value)>;
-        bool other_holds_same_type = b.template has<HeldType>();
-        return other_holds_same_type && held_value == b.template get<HeldType>();
-    });
-}
-
-static bool operator==(Filter::HueRotate::AngleOrZero const& a, Filter::HueRotate::AngleOrZero const& b)
-{
-    return variant_equals(a, b);
-}
-
-static bool operator==(FilterFunction const& a, FilterFunction const& b)
-{
-    return variant_equals(a, b);
-}
-
 bool FilterValueListStyleValue::equals(StyleValue const& other) const
 {
     if (type() != other.type())
@@ -1867,15 +1848,6 @@ ErrorOr<String> LinearGradientStyleValue::to_string() const
     return builder.to_string();
 }
 
-static bool operator==(LinearGradientStyleValue::GradientDirection const& a, LinearGradientStyleValue::GradientDirection const& b)
-{
-    if (a.has<SideOrCorner>() && b.has<SideOrCorner>())
-        return a.get<SideOrCorner>() == b.get<SideOrCorner>();
-    if (a.has<Angle>() && b.has<Angle>())
-        return a.get<Angle>() == b.get<Angle>();
-    return false;
-}
-
 static bool operator==(EdgeRect const& a, EdgeRect const& b)
 {
     return a.top_edge == b.top_edge && a.right_edge == b.right_edge && a.bottom_edge == b.bottom_edge && a.left_edge == b.left_edge;
@@ -2043,8 +2015,8 @@ bool PositionValue::operator==(PositionValue const& other) const
     return (
         x_relative_to == other.x_relative_to
         && y_relative_to == other.y_relative_to
-        && variant_equals(horizontal_position, other.horizontal_position)
-        && variant_equals(vertical_position, other.vertical_position));
+        && horizontal_position == other.horizontal_position
+        && vertical_position == other.vertical_position);
 }
 
 ErrorOr<String> RadialGradientStyleValue::to_string() const
@@ -2240,7 +2212,7 @@ bool RadialGradientStyleValue::equals(StyleValue const& other) const
         return false;
     auto& other_gradient = other.as_radial_gradient();
     return (m_ending_shape == other_gradient.m_ending_shape
-        && variant_equals(m_size, other_gradient.m_size)
+        && m_size == other_gradient.m_size
         && m_position == other_gradient.m_position
         && m_color_stop_list == other_gradient.m_color_stop_list);
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1306,29 +1306,9 @@ ErrorOr<String> FilterValueListStyleValue::to_string() const
     return builder.to_string();
 }
 
-bool Filter::Blur::operator==(Filter::Blur const& b) const
-{
-    return this->radius == b.radius;
-}
-
-bool Filter::DropShadow::operator==(Filter::DropShadow const& b) const
-{
-    return this->offset_x == b.offset_x && this->offset_y == b.offset_y && this->radius == b.radius && this->color == b.color;
-}
-
 bool Filter::HueRotate::Zero::operator==(Filter::HueRotate::Zero const&) const
 {
     return true;
-}
-
-bool Filter::Color::operator==(Filter::Color const& b) const
-{
-    return this->operation == b.operation && this->amount == b.amount;
-}
-
-bool Filter::HueRotate::operator==(Filter::HueRotate const& b) const
-{
-    return this->angle == b.angle;
 }
 
 bool FilterValueListStyleValue::equals(StyleValue const& other) const
@@ -1848,11 +1828,6 @@ ErrorOr<String> LinearGradientStyleValue::to_string() const
     return builder.to_string();
 }
 
-static bool operator==(EdgeRect const& a, EdgeRect const& b)
-{
-    return a.top_edge == b.top_edge && a.right_edge == b.right_edge && a.bottom_edge == b.bottom_edge && a.left_edge == b.left_edge;
-}
-
 bool LinearGradientStyleValue::equals(StyleValue const& other_) const
 {
     if (type() != other_.type())
@@ -2008,15 +1983,6 @@ ErrorOr<void> PositionValue::serialize(StringBuilder& builder) const
             return builder.try_append(TRY(length_percentage.to_string()));
         }));
     return {};
-}
-
-bool PositionValue::operator==(PositionValue const& other) const
-{
-    return (
-        x_relative_to == other.x_relative_to
-        && y_relative_to == other.y_relative_to
-        && horizontal_position == other.horizontal_position
-        && vertical_position == other.vertical_position);
 }
 
 ErrorOr<String> RadialGradientStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1306,29 +1306,29 @@ ErrorOr<String> FilterValueListStyleValue::to_string() const
     return builder.to_string();
 }
 
-static bool operator==(Filter::Blur const& a, Filter::Blur const& b)
+bool Filter::Blur::operator==(Filter::Blur const& b) const
 {
-    return a.radius == b.radius;
+    return this->radius == b.radius;
 }
 
-static bool operator==(Filter::DropShadow const& a, Filter::DropShadow const& b)
+bool Filter::DropShadow::operator==(Filter::DropShadow const& b) const
 {
-    return a.offset_x == b.offset_x && a.offset_y == b.offset_y && a.radius == b.radius && a.color == b.color;
+    return this->offset_x == b.offset_x && this->offset_y == b.offset_y && this->radius == b.radius && this->color == b.color;
 }
 
-static bool operator==(Filter::HueRotate::Zero const&, Filter::HueRotate::Zero const&)
+bool Filter::HueRotate::Zero::operator==(Filter::HueRotate::Zero const&) const
 {
     return true;
 }
 
-static bool operator==(Filter::Color const& a, Filter::Color const& b)
+bool Filter::Color::operator==(Filter::Color const& b) const
 {
-    return a.operation == b.operation && a.amount == b.amount;
+    return this->operation == b.operation && this->amount == b.amount;
 }
 
-static bool operator==(Filter::HueRotate const& a, Filter::HueRotate const& b)
+bool Filter::HueRotate::operator==(Filter::HueRotate const& b) const
 {
-    return a.angle == b.angle;
+    return this->angle == b.angle;
 }
 
 static bool variant_equals(auto const& a, auto const& b)

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -134,7 +134,7 @@ struct PositionValue {
 
     CSSPixelPoint resolved(Layout::Node const& node, CSSPixelRect const& rect) const;
     ErrorOr<void> serialize(StringBuilder&) const;
-    bool operator==(PositionValue const&) const;
+    bool operator==(PositionValue const&) const = default;
 };
 
 struct EdgeRect {
@@ -143,6 +143,7 @@ struct EdgeRect {
     Length bottom_edge;
     Length left_edge;
     Gfx::FloatRect resolved(Layout::Node const&, Gfx::FloatRect) const;
+    bool operator==(EdgeRect const& b) const = default;
 };
 
 namespace Filter {
@@ -150,7 +151,7 @@ namespace Filter {
 struct Blur {
     Optional<Length> radius {};
     float resolved_radius(Layout::Node const&) const;
-    bool operator==(Filter::Blur const& b) const;
+    bool operator==(Filter::Blur const& b) const = default;
 };
 
 struct DropShadow {
@@ -165,7 +166,7 @@ struct DropShadow {
         Color color;
     };
     Resolved resolved(Layout::Node const&) const;
-    bool operator==(Filter::DropShadow const& b) const;
+    bool operator==(Filter::DropShadow const& b) const = default;
 };
 
 struct HueRotate {
@@ -175,7 +176,7 @@ struct HueRotate {
     using AngleOrZero = Variant<Angle, Zero>;
     Optional<AngleOrZero> angle {};
     float angle_degrees() const;
-    bool operator==(Filter::HueRotate const& b) const;
+    bool operator==(Filter::HueRotate const& b) const = default;
 };
 
 struct Color {
@@ -190,7 +191,7 @@ struct Color {
     } operation;
     Optional<NumberPercentage> amount {};
     float resolved_amount() const;
-    bool operator==(Filter::Color const& b) const;
+    bool operator==(Filter::Color const& b) const = default;
 };
 
 };

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -150,6 +150,7 @@ namespace Filter {
 struct Blur {
     Optional<Length> radius {};
     float resolved_radius(Layout::Node const&) const;
+    bool operator==(Filter::Blur const& b) const;
 };
 
 struct DropShadow {
@@ -164,13 +165,17 @@ struct DropShadow {
         Color color;
     };
     Resolved resolved(Layout::Node const&) const;
+    bool operator==(Filter::DropShadow const& b) const;
 };
 
 struct HueRotate {
-    struct Zero { };
+    struct Zero {
+        bool operator==(Zero const&) const;
+    };
     using AngleOrZero = Variant<Angle, Zero>;
     Optional<AngleOrZero> angle {};
     float angle_degrees() const;
+    bool operator==(Filter::HueRotate const& b) const;
 };
 
 struct Color {
@@ -185,6 +190,7 @@ struct Color {
     } operation;
     Optional<NumberPercentage> amount {};
     float resolved_amount() const;
+    bool operator==(Filter::Color const& b) const;
 };
 
 };


### PR DESCRIPTION
**TL;DR: You can now do this:**
```cpp
return Error::from_string(String::formatted("Section number {} out of bounds, there are {} sections", section_number, number_of_sections));
```

---

Error can now hold either a StringView like before, or an owned String pointer. A raw pointer is necessary because of include cycles, but this will allow you to put formatted strings into Error without worrying about UAFs.

Of course, we don't implement this API for DeprecatedString to encourage the switch to new string :^)

Note that this feature is limited to userland. In the Kernel, it doesn't have much application and is difficult to OOM-harden.

A first implementation is provided for LibManual, which instantly improves error feedback of Help and man's command line arguments.

@linusg FOSDEM yakbait taken!