### PR TITLE
LibVideo/PlaybackManager: Organize playback states into virtual classes and related fixes

### DIFF
--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -56,8 +56,8 @@ ErrorOr<void> VideoPlayerWidget::setup_interface()
         auto progress = value / static_cast<double>(m_seek_slider->max());
         auto duration = m_playback_manager->duration().to_milliseconds();
         Time timestamp = Time::from_milliseconds(static_cast<i64>(round(progress * static_cast<double>(duration))));
-        set_current_timestamp(timestamp);
         m_playback_manager->seek_to_timestamp(timestamp);
+        set_current_timestamp(m_playback_manager->current_playback_time());
     };
 
     m_play_icon = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/play.png"sv));
@@ -237,6 +237,8 @@ void VideoPlayerWidget::event(Core::Event& event)
     } else if (event.type() == Video::EventType::PlaybackStateChange) {
         update_play_pause_icon();
         event.accept();
+    } else if (event.type() == Video::EventType::FatalPlaybackError) {
+        close_file();
     }
 
     Widget::event(event);

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -234,7 +234,7 @@ void VideoPlayerWidget::event(Core::Event& event)
         set_current_timestamp(m_playback_manager->current_playback_time());
 
         frame_event.accept();
-    } else if (event.type() == Video::EventType::PlaybackStatusChange) {
+    } else if (event.type() == Video::EventType::PlaybackStateChange) {
         update_play_pause_icon();
         event.accept();
     }

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
@@ -46,7 +46,6 @@ private:
     void set_current_timestamp(Time);
     void set_time_label(Time);
     void on_decoding_error(Video::DecoderError const&);
-    void update_seek_mode();
 
     void cycle_sizing_modes();
 

--- a/Userland/Libraries/LibVideo/Containers/Demuxer.h
+++ b/Userland/Libraries/LibVideo/Containers/Demuxer.h
@@ -29,7 +29,9 @@ public:
     }
 
     // Returns the timestamp of the keyframe that was seeked to.
-    virtual DecoderErrorOr<Time> seek_to_most_recent_keyframe(Track track, Time timestamp) = 0;
+    // The value is `Optional` to allow the demuxer to decide not to seek so that it can keep its position
+    // in the case that the timestamp is closer to the current time than the nearest keyframe.
+    virtual DecoderErrorOr<Optional<Time>> seek_to_most_recent_keyframe(Track track, Time timestamp, Optional<Time> earliest_available_sample = OptionalNone()) = 0;
 
     virtual DecoderErrorOr<Time> duration() = 0;
 

--- a/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.cpp
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "MatroskaDemuxer.h"
+#include "AK/Debug.h"
 
 namespace Video::Matroska {
 
@@ -53,7 +54,7 @@ DecoderErrorOr<MatroskaDemuxer::TrackStatus*> MatroskaDemuxer::get_track_status(
     return &m_track_statuses.get(track).release_value();
 }
 
-DecoderErrorOr<Time> MatroskaDemuxer::seek_to_most_recent_keyframe(Track track, Time timestamp)
+DecoderErrorOr<Optional<Time>> MatroskaDemuxer::seek_to_most_recent_keyframe(Track track, Time timestamp, Optional<Time> earliest_available_sample)
 {
     // Removing the track status will cause us to start from the beginning.
     if (timestamp.is_zero()) {
@@ -62,7 +63,22 @@ DecoderErrorOr<Time> MatroskaDemuxer::seek_to_most_recent_keyframe(Track track, 
     }
 
     auto& track_status = *TRY(get_track_status(track));
-    TRY(m_reader.seek_to_random_access_point(track_status.iterator, timestamp));
+    auto seeked_iterator = TRY(m_reader.seek_to_random_access_point(track_status.iterator, timestamp));
+    VERIFY(seeked_iterator.last_timestamp().has_value());
+
+    auto last_sample = earliest_available_sample;
+    if (!last_sample.has_value()) {
+        last_sample = track_status.iterator.last_timestamp();
+    }
+    if (last_sample.has_value()) {
+        bool skip_seek = seeked_iterator.last_timestamp().value() <= last_sample.value() && last_sample.value() <= timestamp;
+        dbgln_if(MATROSKA_DEBUG, "The last available sample at {}ms is {}closer to target timestamp {}ms than the keyframe at {}ms, {}", last_sample->to_milliseconds(), skip_seek ? ""sv : "not "sv, timestamp.to_milliseconds(), seeked_iterator.last_timestamp()->to_milliseconds(), skip_seek ? "skipping seek"sv : "seeking"sv);
+        if (skip_seek) {
+            return OptionalNone();
+        }
+    }
+
+    track_status.iterator = move(seeked_iterator);
     return track_status.iterator.last_timestamp();
 }
 

--- a/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.h
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.h
@@ -27,7 +27,7 @@ public:
 
     DecoderErrorOr<Vector<Track>> get_tracks_for_type(TrackType type) override;
 
-    DecoderErrorOr<Time> seek_to_most_recent_keyframe(Track track, Time timestamp) override;
+    DecoderErrorOr<Optional<Time>> seek_to_most_recent_keyframe(Track track, Time timestamp, Optional<Time> earliest_available_sample = OptionalNone()) override;
 
     DecoderErrorOr<Time> duration() override;
 

--- a/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
@@ -806,7 +806,7 @@ DecoderErrorOr<void> Reader::seek_to_cue_for_timestamp(SampleIterator& iterator,
     return {};
 }
 
-static DecoderErrorOr<bool> find_keyframe_before_timestamp(SampleIterator& iterator, Time const& timestamp)
+static DecoderErrorOr<void> search_clusters_for_keyframe_before_timestamp(SampleIterator& iterator, Time const& timestamp)
 {
 #if MATROSKA_DEBUG
     size_t inter_frames_count;
@@ -837,10 +837,9 @@ static DecoderErrorOr<bool> find_keyframe_before_timestamp(SampleIterator& itera
         dbgln("Seeked to a keyframe with {} inter frames to skip", inter_frames_count);
 #endif
         iterator = last_keyframe.release_value();
-        return true;
     }
 
-    return false;
+    return {};
 }
 
 DecoderErrorOr<bool> Reader::has_cues_for_track(u64 track_number)
@@ -849,37 +848,23 @@ DecoderErrorOr<bool> Reader::has_cues_for_track(u64 track_number)
     return m_cues.contains(track_number);
 }
 
-DecoderErrorOr<void> Reader::seek_to_random_access_point(SampleIterator& iterator, Time timestamp)
+DecoderErrorOr<SampleIterator> Reader::seek_to_random_access_point(SampleIterator iterator, Time timestamp)
 {
-    if (iterator.m_last_timestamp == timestamp)
-        return {};
-
     if (TRY(has_cues_for_track(iterator.m_track.track_number()))) {
-        auto seeked_iterator = iterator;
-        TRY(seek_to_cue_for_timestamp(seeked_iterator, timestamp));
-        VERIFY(seeked_iterator.m_last_timestamp <= timestamp);
-
-        // We only need to seek to a keyframe if it's not faster to continue from the current position.
-        if (timestamp < iterator.m_last_timestamp || seeked_iterator.m_last_timestamp > iterator.m_last_timestamp)
-            iterator = seeked_iterator;
-        return {};
+        TRY(seek_to_cue_for_timestamp(iterator, timestamp));
+        VERIFY(iterator.last_timestamp().has_value() && iterator.last_timestamp().value() <= timestamp);
+        return iterator;
     }
 
-    // FIXME: This could cache the keyframes it finds. Is it worth doing? Probably not, most files will have Cues :^)
-    if (timestamp < iterator.last_timestamp() || iterator.last_timestamp().is_negative()) {
+    if (!iterator.last_timestamp().has_value() || timestamp < iterator.last_timestamp().value()) {
         // If the timestamp is before the iterator's current position, then we need to start from the beginning of the Segment.
         iterator = TRY(create_sample_iterator(iterator.m_track.track_number()));
-        if (!TRY(find_keyframe_before_timestamp(iterator, timestamp)))
-            return DecoderError::corrupted("No random access points found"sv);
-
-        return {};
+        TRY(search_clusters_for_keyframe_before_timestamp(iterator, timestamp));
+        return iterator;
     }
 
-    auto seeked_iterator = iterator;
-    if (TRY(find_keyframe_before_timestamp(seeked_iterator, timestamp)))
-        iterator = seeked_iterator;
-    VERIFY(iterator.last_timestamp() <= timestamp);
-    return {};
+    TRY(search_clusters_for_keyframe_before_timestamp(iterator, timestamp));
+    return iterator;
 }
 
 DecoderErrorOr<Optional<Vector<CuePoint> const&>> Reader::cue_points_for_track(u64 track_number)

--- a/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
@@ -798,12 +798,11 @@ DecoderErrorOr<void> Reader::seek_to_cue_for_timestamp(SampleIterator& iterator,
     }
 
     while (index < cue_points.size()) {
-        auto const& cue_point = cue_points[index++];
+        auto const& cue_point = cue_points[++index];
         dbgln_if(MATROSKA_DEBUG, "Checking future cue point {}ms", cue_point.timestamp().to_milliseconds());
         if (cue_point.timestamp() > timestamp)
             break;
         prev_cue_point = &cue_point;
-        index++;
     }
 
     TRY(iterator.seek_to_cue_point(*prev_cue_point));

--- a/Userland/Libraries/LibVideo/Containers/Matroska/Reader.h
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/Reader.h
@@ -38,7 +38,7 @@ public:
     DecoderErrorOr<size_t> track_count();
 
     DecoderErrorOr<SampleIterator> create_sample_iterator(u64 track_number);
-    DecoderErrorOr<void> seek_to_random_access_point(SampleIterator&, Time);
+    DecoderErrorOr<SampleIterator> seek_to_random_access_point(SampleIterator, Time);
     DecoderErrorOr<Optional<Vector<CuePoint> const&>> cue_points_for_track(u64 track_number);
     DecoderErrorOr<bool> has_cues_for_track(u64 track_number);
 
@@ -83,7 +83,7 @@ class SampleIterator {
 public:
     DecoderErrorOr<Block> next_block();
     Cluster const& current_cluster() { return *m_current_cluster; }
-    Time const& last_timestamp() { return m_last_timestamp; }
+    Optional<Time> const& last_timestamp() { return m_last_timestamp; }
 
 private:
     friend class Reader;
@@ -107,7 +107,7 @@ private:
     // Must always point to an element ID or the end of the stream.
     size_t m_position { 0 };
 
-    Time m_last_timestamp { Time::min() };
+    Optional<Time> m_last_timestamp;
 
     Optional<Cluster> m_current_cluster;
 };

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -109,9 +109,9 @@ void PlaybackManager::timer_callback()
     TRY_OR_FATAL_ERROR(m_playback_handler->on_timer_callback());
 }
 
-void PlaybackManager::seek_to_timestamp(Time target_timestamp)
+void PlaybackManager::seek_to_timestamp(Time target_timestamp, SeekMode seek_mode)
 {
-    TRY_OR_FATAL_ERROR(m_playback_handler->seek(target_timestamp, m_seek_mode));
+    TRY_OR_FATAL_ERROR(m_playback_handler->seek(target_timestamp, seek_mode));
 }
 
 Optional<Time> PlaybackManager::seek_demuxer_to_most_recent_keyframe(Time timestamp, Optional<Time> earliest_available_sample)

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -57,7 +57,7 @@ void PlaybackManager::set_playback_status(PlaybackStatus status)
             m_present_timer->stop();
         }
 
-        m_main_loop.post_event(m_event_handler, make<PlaybackStatusChangeEvent>(status, old_status));
+        m_main_loop.post_event(m_event_handler, make<PlaybackStateChangeEvent>());
     }
 }
 

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -126,7 +126,7 @@ private:
 
     void start_timer(int milliseconds);
     void timer_callback();
-    Time seek_demuxer_to_most_recent_keyframe(Time timestamp);
+    Optional<Time> seek_demuxer_to_most_recent_keyframe(Time timestamp, Optional<Time> earliest_available_sample = OptionalNone());
 
     bool decode_and_queue_one_sample();
     void on_decode_timer();

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -98,14 +98,11 @@ public:
     void resume_playback();
     void pause_playback();
     void restart_playback();
-    void seek_to_timestamp(Time);
+    void seek_to_timestamp(Time, SeekMode = DEFAULT_SEEK_MODE);
     bool is_playing() const
     {
         return m_playback_handler->is_playing();
     }
-
-    SeekMode seek_mode() { return m_seek_mode; }
-    void set_seek_mode(SeekMode mode) { m_seek_mode = mode; }
 
     u64 number_of_skipped_frames() const { return m_skipped_frames; }
 
@@ -139,8 +136,6 @@ private:
     Core::EventLoop& m_main_loop;
 
     Time m_last_present_in_media_time = Time::zero();
-
-    SeekMode m_seek_mode = DEFAULT_SEEK_MODE;
 
     NonnullOwnPtr<Demuxer> m_demuxer;
     Track m_selected_video_track;

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -165,7 +165,7 @@ private:
 enum EventType : unsigned {
     DecoderErrorOccurred = (('v' << 2) | ('i' << 1) | 'd') << 4,
     VideoFramePresent,
-    PlaybackStatusChange,
+    PlaybackStateChange,
 };
 
 class DecoderErrorEvent : public Core::Event {
@@ -199,20 +199,13 @@ private:
     RefPtr<Gfx::Bitmap> m_frame;
 };
 
-class PlaybackStatusChangeEvent : public Core::Event {
+class PlaybackStateChangeEvent : public Core::Event {
 public:
-    PlaybackStatusChangeEvent() = default;
-    explicit PlaybackStatusChangeEvent(PlaybackStatus status, PlaybackStatus previous_status)
-        : Core::Event(PlaybackStatusChange)
-        , m_status(status)
-        , m_previous_status(previous_status)
+    explicit PlaybackStateChangeEvent()
+        : Core::Event(PlaybackStateChange)
     {
     }
-    virtual ~PlaybackStatusChangeEvent() = default;
-
-private:
-    PlaybackStatus m_status;
-    PlaybackStatus m_previous_status;
+    virtual ~PlaybackStateChangeEvent() = default;
 };
 
 inline StringView playback_status_to_string(PlaybackStatus status)


### PR DESCRIPTION
Storing playback states in virtual classes allows the behavior to be much more clearly written. Each `PlaybackStateHandler` subclass can implement some event-handling functions to model their behavior, and has functions to change its parent PlaybackManager's state to any other state.

This will allow expanding the functionality of playback in the future, for example to allow skipping a single frame forward or backward, which will require different behavior to seeking to ensure that variable frame rates are handled correctly.

The demuxer interface is also changed to allow passing the earliest sample the manager is still able to display. This enables it to avoid re-buffering unless absolutely necessary. Previously, seeking forward into the buffered time range would cause the demuxer to think that it should seek since its iterator is past the end of the buffer and thinks that its caller has no access to anything before that timestamp.

Functionally, the player should behave pretty much the same. I tested this fairly extensively to make sure that it would be a solid solution, so hopefully it's mostly bug-free in normal circumstances. If there should be any regressions, let me know so that I can make sure this code is robust!