### PR TITLE
LibGfx: Use `AK::Stream` to serialize and deserialize bitmaps (and some error 'propagation')

### DIFF
--- a/Userland/Libraries/LibGUI/DragOperation.cpp
+++ b/Userland/Libraries/LibGUI/DragOperation.cpp
@@ -84,7 +84,7 @@ void DragOperation::set_bitmap(Gfx::Bitmap const* bitmap)
     if (!m_mime_data)
         m_mime_data = Core::MimeData::construct();
     if (bitmap)
-        m_mime_data->set_data("image/x-raw-bitmap", bitmap->serialize_to_byte_buffer());
+        m_mime_data->set_data("image/x-raw-bitmap", bitmap->serialize_to_byte_buffer().release_value_but_fixme_should_propagate_errors());
 }
 void DragOperation::set_data(DeprecatedString const& data_type, DeprecatedString const& data)
 {

--- a/Userland/Libraries/LibGUI/Model.cpp
+++ b/Userland/Libraries/LibGUI/Model.cpp
@@ -128,7 +128,7 @@ RefPtr<Core::MimeData> Model::mime_data(ModelSelection const& selection) const
     mime_data->set_data(drag_data_type(), data_builder.to_byte_buffer());
     mime_data->set_text(text_builder.to_deprecated_string());
     if (bitmap)
-        mime_data->set_data("image/x-raw-bitmap", bitmap->serialize_to_byte_buffer());
+        mime_data->set_data("image/x-raw-bitmap", bitmap->serialize_to_byte_buffer().release_value_but_fixme_should_propagate_errors());
 
     return mime_data;
 }

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -121,7 +121,7 @@ public:
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> scaled(float sx, float sy) const;
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> cropped(Gfx::IntRect, Optional<BitmapFormat> new_bitmap_format = {}) const;
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> to_bitmap_backed_by_anonymous_buffer() const;
-    [[nodiscard]] ByteBuffer serialize_to_byte_buffer() const;
+    [[nodiscard]] ErrorOr<ByteBuffer> serialize_to_byte_buffer() const;
 
     [[nodiscard]] ShareableBitmap to_shareable_bitmap() const;
 


### PR DESCRIPTION
Depends on #17264.