### PR TITLE
LibWeb: Scale font size to device pixels

### DIFF
--- a/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
@@ -381,6 +381,11 @@ DeprecatedString BitmapFont::variant() const
     return builder.to_deprecated_string();
 }
 
+RefPtr<Font> BitmapFont::with_size(float point_size) const
+{
+    return Gfx::FontDatabase::the().get(family(), point_size, weight(), width(), slope());
+}
+
 Font const& Font::bold_variant() const
 {
     if (m_bold_variant)

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -125,6 +125,8 @@ public:
     DeprecatedString qualified_name() const override;
     DeprecatedString human_readable_name() const override { return DeprecatedString::formatted("{} {} {}", family(), variant(), presentation_size()); }
 
+    virtual RefPtr<Font> with_size(float point_size) const override;
+
 private:
     BitmapFont(DeprecatedString name, DeprecatedString family, u8* rows, u8* widths, bool is_fixed_width,
         u8 glyph_width, u8 glyph_height, u8 glyph_spacing, u16 range_mask_size, u8* range_mask,

--- a/Userland/Libraries/LibGfx/Font/Font.h
+++ b/Userland/Libraries/LibGfx/Font/Font.h
@@ -197,6 +197,8 @@ public:
     virtual DeprecatedString qualified_name() const = 0;
     virtual DeprecatedString human_readable_name() const = 0;
 
+    virtual RefPtr<Font> with_size(float point_size) const = 0;
+
     Font const& bold_variant() const;
 
 private:

--- a/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
@@ -123,6 +123,11 @@ u8 ScaledFont::glyph_fixed_width() const
     return glyph_metrics(glyph_id_for_code_point(' ')).advance_width;
 }
 
+RefPtr<Font> ScaledFont::with_size(float point_size) const
+{
+    return adopt_ref(*new Gfx::ScaledFont(*m_font, point_size, point_size));
+}
+
 Gfx::FontPixelMetrics ScaledFont::pixel_metrics() const
 {
     return m_pixel_metrics;

--- a/Userland/Libraries/LibGfx/Font/ScaledFont.h
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.h
@@ -67,6 +67,8 @@ public:
     virtual DeprecatedString qualified_name() const override { return DeprecatedString::formatted("{} {} {} {}", family(), presentation_size(), weight(), slope()); }
     virtual DeprecatedString human_readable_name() const override { return DeprecatedString::formatted("{} {} {}", family(), variant(), presentation_size()); }
 
+    virtual RefPtr<Font> with_size(float point_size) const override;
+
 private:
     NonnullRefPtr<VectorFont> m_font;
     float m_x_scale { 0.0f };


### PR DESCRIPTION
This change makes font size be transformed into device pixels on painting step. I am not very familiar with LibGfx yet but I tested the change inside SerenityOS and Ladybird on sites that use TTF, WOFF and Bitmap fonts and it seems to work correct.

Screenshot taken with 2x scale:
<img width="912" alt="Screenshot 2023-02-09 at 03 07 36" src="https://user-images.githubusercontent.com/45686940/217680311-4a5f0773-4df8-4e73-a096-aa0873fdb36b.png">
