### PR TITLE
LibWeb: Implement CORS preflight

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -332,6 +332,14 @@ struct Traits<ByteBuffer> : public GenericTraits<ByteBuffer> {
     {
         return Traits<ReadonlyBytes>::hash(byte_buffer.span());
     }
+    static bool equals(ByteBuffer const& byte_buffer, Bytes const& other)
+    {
+        return byte_buffer.bytes() == other;
+    }
+    static bool equals(ByteBuffer const& byte_buffer, ReadonlyBytes const& other)
+    {
+        return byte_buffer.bytes() == other;
+    }
 };
 
 }

--- a/Ladybird/RequestManagerQt.cpp
+++ b/Ladybird/RequestManagerQt.cpp
@@ -64,6 +64,12 @@ ErrorOr<NonnullRefPtr<RequestManagerQt::Request>> RequestManagerQt::Request::cre
         reply = qnam.get(request);
     } else if (method.equals_ignoring_case("post"sv)) {
         reply = qnam.post(request, QByteArray((char const*)request_body.data(), request_body.size()));
+    } else if (method.equals_ignoring_case("put"sv)) {
+        reply = qnam.put(request, QByteArray((char const*)request_body.data(), request_body.size()));
+    } else if (method.equals_ignoring_case("delete"sv)) {
+        reply = qnam.deleteResource(request);
+    } else {
+        reply = qnam.sendCustomRequest(request, QByteArray(method.characters()), QByteArray((char const*)request_body.data(), request_body.size()));
     }
 
     return adopt_ref(*new Request(*reply));

--- a/Tests/AK/TestByteBuffer.cpp
+++ b/Tests/AK/TestByteBuffer.cpp
@@ -7,6 +7,7 @@
 #include <LibTest/TestCase.h>
 
 #include <AK/ByteBuffer.h>
+#include <AK/Vector.h>
 
 TEST_CASE(equality_operator)
 {
@@ -31,6 +32,18 @@ TEST_CASE(equality_operator)
     EXPECT_EQ(d == b, false);
     EXPECT_EQ(d == c, false);
     EXPECT_EQ(d == d, true);
+}
+
+TEST_CASE(byte_buffer_vector_contains_slow_bytes)
+{
+    Vector<ByteBuffer> vector;
+    ByteBuffer a = ByteBuffer::copy("Hello, friend", 13).release_value();
+    vector.append(a);
+
+    ReadonlyBytes b = "Hello, friend"sv.bytes();
+    Bytes c = a.bytes();
+    EXPECT_EQ(vector.contains_slow(b), true);
+    EXPECT_EQ(vector.contains_slow(c), true);
 }
 
 BENCHMARK_CASE(append)

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1583,7 +1583,12 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_load
     if (is<HTML::Window>(global_object))
         page = static_cast<HTML::Window&>(global_object).page();
 
-    auto load_request = LoadRequest::create_for_url_on_page(request->current_url(), page);
+    // NOTE: Using LoadRequest::create_for_url_on_page here will unconditionally add cookies as long as there's a page available.
+    //       However, it is up to http_network_or_cache_fetch to determine if cookies should be added to the request.
+    LoadRequest load_request;
+    load_request.set_url(request->current_url());
+    if (page)
+        load_request.set_page(*page);
     load_request.set_method(DeprecatedString::copy(request->method()));
     for (auto const& header : *request->header_list())
         load_request.set_header(DeprecatedString::copy(header.name), DeprecatedString::copy(header.value));

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
@@ -37,5 +37,6 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_fetch(JS::Realm&, In
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_redirect_fetch(JS::Realm&, Infrastructure::FetchParams const&, Infrastructure::Response const&);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_network_or_cache_fetch(JS::Realm&, Infrastructure::FetchParams const&, IsAuthenticationFetch is_authentication_fetch = IsAuthenticationFetch::No, IsNewConnectionFetch is_new_connection_fetch = IsNewConnectionFetch::No);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_loader_http_network_fetch(JS::Realm&, Infrastructure::FetchParams const&, IncludeCredentials include_credentials = IncludeCredentials::No, IsNewConnectionFetch is_new_connection_fetch = IsNewConnectionFetch::No);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> cors_preflight_fetch(JS::Realm&, Infrastructure::Request const&);
 
 }

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
@@ -685,11 +685,11 @@ ErrorOr<Optional<Vector<ByteBuffer>>> extract_header_values(Header const& header
 }
 
 // https://fetch.spec.whatwg.org/#extract-header-list-values
-ErrorOr<Optional<Vector<ByteBuffer>>> extract_header_list_values(ReadonlyBytes name, HeaderList const& list)
+ErrorOr<Variant<Vector<ByteBuffer>, ExtractHeaderParseFailure, Empty>> extract_header_list_values(ReadonlyBytes name, HeaderList const& list)
 {
     // 1. If list does not contain name, then return null.
     if (!list.contains(name))
-        return Optional<Vector<ByteBuffer>> {};
+        return Empty {};
 
     // FIXME: 2. If the ABNF for name allows a single header and list contains more than one, then return failure.
     // NOTE: If different error handling is needed, extract the desired header first.
@@ -706,10 +706,8 @@ ErrorOr<Optional<Vector<ByteBuffer>>> extract_header_list_values(ReadonlyBytes n
         auto extract = TRY(extract_header_values(header));
 
         // 2. If extract is failure, then return failure.
-        // FIXME: Currently we treat the null return above and failure return as the same thing,
-        //        ErrorOr already signals OOM to the caller.
         if (!extract.has_value())
-            return Optional<Vector<ByteBuffer>> {};
+            return ExtractHeaderParseFailure {};
 
         // 3. Append each value in extract, in order, to values.
         values.extend(extract.release_value());

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.h
@@ -59,6 +59,9 @@ struct RangeHeaderValue {
     Optional<u64> end;
 };
 
+struct ExtractHeaderParseFailure {
+};
+
 [[nodiscard]] ErrorOr<Optional<Vector<DeprecatedString>>> get_decode_and_split_header_value(ReadonlyBytes);
 [[nodiscard]] ErrorOr<OrderedHashTable<ByteBuffer>> convert_header_names_to_a_sorted_lowercase_set(Span<ReadonlyBytes>);
 [[nodiscard]] bool is_header_name(ReadonlyBytes);
@@ -76,7 +79,7 @@ struct RangeHeaderValue {
 [[nodiscard]] bool is_forbidden_response_header_name(ReadonlyBytes);
 [[nodiscard]] bool is_request_body_header_name(ReadonlyBytes);
 [[nodiscard]] ErrorOr<Optional<Vector<ByteBuffer>>> extract_header_values(Header const&);
-[[nodiscard]] ErrorOr<Optional<Vector<ByteBuffer>>> extract_header_list_values(ReadonlyBytes, HeaderList const&);
+[[nodiscard]] ErrorOr<Variant<Vector<ByteBuffer>, ExtractHeaderParseFailure, Empty>> extract_header_list_values(ReadonlyBytes, HeaderList const&);
 [[nodiscard]] Optional<RangeHeaderValue> parse_single_range_header_value(ReadonlyBytes);
 [[nodiscard]] ErrorOr<ByteBuffer> default_user_agent_value();
 


### PR DESCRIPTION
Example with local copy of <https://changelog.serenityos.org/>:
```
Fetch: Running 'fetch' with: request @ 0x000055f56f75ec38
Fetch: Running 'main fetch' with: fetch_params @ 0x000055f56fa4ddd8
Fetch: Running 'main fetch' get_response() function
Fetch: Running 'HTTP fetch' with: fetch_params @ 0x000055f56fa4ddd8, make_cors_preflight = Yes
Fetch: Running 'CORS-preflight fetch' with request @ 0x000055f56f75ec38
Fetch: Running 'HTTP-network-or-cache fetch' with: fetch_params @ 0x000055f56fa4def8, is_authentication_fetch = No, is_new_connection_fetch = No
Fetch: Running 'non-standard HTTP-network fetch' with: fetch_params @ 0x000055f56fa4dfb8
Fetch: Invoking ResourceLoader
Fetch: Invoking ResourceLoader
> OPTIONS https://api.github.com/repos/SerenityOS/serenity/commits?per_page=100&since=2023-02-08T00:00:00Z&until=2023-02-08T23:59:59Z&page=1 HTTP/1.1
> User-Agent: Mozilla/5.0 (Linux; x86_64) LibWeb+LibJS/1.0 Ladybird/1.0
> Accept: */*
> Origin: http://192.168.0.10:8080
> Access-Control-Request-Headers: authorization
> Access-Control-Request-Method: GET
>
ResourceLoader: Starting load of: "https://api.github.com/repos/SerenityOS/serenity/commits?per_page=100&since=2023-02-08T00:00:00Z&until=2023-02-08T23:59:59Z&page=1"
ResourceLoader: Finished load of: "https://api.github.com/repos/SerenityOS/serenity/commits?per_page=100&since=2023-02-08T00:00:00Z&until=2023-02-08T23:59:59Z&page=1", Duration: 144ms
Fetch: ResourceLoader load for 'https://api.github.com/repos/SerenityOS/serenity/commits?per_page=100&since=2023-02-08T00:00:00Z&until=2023-02-08T23:59:59Z&page=1' complete
< HTTP/1.1 204
< Date: Wed, 08 Feb 2023 20:43:33 GMT
< Vary: Accept-Encoding, Accept, X-Requested-With
< Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
< Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset
< Access-Control-Allow-Origin: *
< access-control-max-age: 86400
< X-XSS-Protection: 0
< Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
< X-GitHub-Request-Id: E6F0:78A2:2695BA9:272FEA7:63E40975
< Server: GitHub.com
< access-control-allow-headers: Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, Accept-Encoding, X-GitHub-OTP, X-Requested-With, User-Agent, GraphQL-Features
< access-control-allow-methods: GET, POST, PATCH, PUT, DELETE
< X-Frame-Options: deny
< X-Content-Type-Options: nosniff
< Content-Security-Policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com objects-origin.githubusercontent.com secured-user-images.githubusercontent.com/ opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
<
Fetch: Running 'HTTP-network-or-cache fetch' pending_forward_response load callback
Fetch: Running 'HTTP network-or-cache fetch' inner_pending_response load callback
Fetch: Running 'CORS-preflight fetch' preflight_response load callback
Fetch: Running 'HTTP fetch' pending_preflight_response load callback
Fetch: Running 'HTTP-network-or-cache fetch' with: fetch_params @ 0x000055f56fa4ddd8, is_authentication_fetch = No, is_new_connection_fetch = No
Fetch: Running 'non-standard HTTP-network fetch' with: fetch_params @ 0x000055f56fa4ef78
Fetch: Invoking ResourceLoader
Fetch: Invoking ResourceLoader
> GET https://api.github.com/repos/SerenityOS/serenity/commits?per_page=100&since=2023-02-08T00:00:00Z&until=2023-02-08T23:59:59Z&page=1 HTTP/1.1
> User-Agent: Mozilla/5.0 (Linux; x86_64) LibWeb+LibJS/1.0 Ladybird/1.0
> Accept: application/vnd.github.v3+json
> Accept-Language: *
> Origin: http://192.168.0.10:8080
> Authorization: [removed]
>
ResourceLoader: Starting load of: "https://api.github.com/repos/SerenityOS/serenity/commits?per_page=100&since=2023-02-08T00:00:00Z&until=2023-02-08T23:59:59Z&page=1"
ResourceLoader: Finished load of: "https://api.github.com/repos/SerenityOS/serenity/commits?per_page=100&since=2023-02-08T00:00:00Z&until=2023-02-08T23:59:59Z&page=1", Duration: 312ms
Fetch: ResourceLoader load for 'https://api.github.com/repos/SerenityOS/serenity/commits?per_page=100&since=2023-02-08T00:00:00Z&until=2023-02-08T23:59:59Z&page=1' complete
< HTTP/1.1 200
< Last-Modified: Wed, 08 Feb 2023 19:44:03 GMT
< Date: Wed, 08 Feb 2023 20:43:33 GMT
< Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept, X-Requested-With
< X-RateLimit-Remaining: 4995
< X-RateLimit-Limit: 5000
< Server: GitHub.com
< X-RateLimit-Used: 5
< X-GitHub-Request-Id: E6F0:78A2:2695C09:272FF17:63E40975
< ETag: W/"35f3958316066bdec1dd9dc33a60a1f1135abdfd0f72241146c1d81cb9e9ea09"
< X-Frame-Options: deny
< Content-Security-Policy: default-src 'none'
< X-OAuth-Scopes: read:org
< X-RateLimit-Reset: 1675891968
< Cache-Control: private, max-age=60, s-maxage=60
< Access-Control-Allow-Origin: *
< Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
< Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
< Content-Type: application/json; charset=utf-8
< X-XSS-Protection: 0
< Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset
< Transfer-Encoding: chunked
< x-github-api-version-selected: 2022-11-28
< Content-Encoding: gzip
< X-RateLimit-Resource: core
< X-Content-Type-Options: nosniff
< X-GitHub-Media-Type: github.v3; format=json
<
< (response data removed)
Fetch: Running 'HTTP-network-or-cache fetch' pending_forward_response load callback
Fetch: Running 'HTTP network-or-cache fetch' inner_pending_response load callback
Fetch: Running 'HTTP fetch' pending_main_content_response load callback
Fetch: Running 'HTTP fetch' pending_actual_response load callback
Fetch: Running 'main fetch' cors_with_preflight_response load callback
Fetch: Running 'main fetch' pending_response load callback
Fetch: Running 'fetch response handover' with: fetch_params @ 0x000055f56fa4ddd8, response @ 0x000055f56faf5c38
```