### PR TITLE
Base: don’t try to start spice agent by default

### DIFF
--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -59,9 +59,6 @@ User=root
 WorkingDirectory=/root/
 SystemModes=generate-manpages
 
-[SpiceAgent]
-KeepAlive=false
-
 [LoginServer]
 User=root
 Arguments=--auto-login anon


### PR DESCRIPTION
Spice agent has been broken for quite some time,
so let’s not slow down normal boot by starting it on a default setup.