### PR TITLE
LibJS+LibWeb: Convert string view PrimitiveString instances to String

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2576,7 +2576,7 @@ JS::ThrowCompletionOr<void> @prototype_class@::initialize(JS::Realm& realm)
     }
 
     generator.append(R"~~~(
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), JS::PrimitiveString::create(vm, "@name@"), JS::Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(JS::PrimitiveString::create(vm, "@name@"sv)), JS::Attribute::Configurable);
 
     MUST_OR_THROW_OOM(Object::initialize(realm));
     return {};
@@ -2890,7 +2890,7 @@ JS::ThrowCompletionOr<void> @prototype_class@::initialize(JS::Realm& realm)
     MUST_OR_THROW_OOM(Object::initialize(realm));
 
     define_native_function(realm, vm.names.next, next, 0, JS::Attribute::Writable | JS::Attribute::Enumerable | JS::Attribute::Configurable);
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), JS::PrimitiveString::create(vm, "Iterator"), JS::Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(JS::PrimitiveString::create(vm, "Iterator"sv)), JS::Attribute::Configurable);
 
     return {};
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
@@ -181,7 +181,7 @@ void Intrinsics::create_web_prototype_and_constructor<@prototype_class@>(JS::Rea
     m_constructors.set("@interface_name@"sv, constructor);
 
     prototype->define_direct_property(vm.names.constructor, constructor.ptr(), JS::Attribute::Writable | JS::Attribute::Configurable);
-    constructor->define_direct_property(vm.names.name, JS::PrimitiveString::create(vm, "@interface_name@"sv), JS::Attribute::Configurable);
+    constructor->define_direct_property(vm.names.name, JS::PrimitiveString::create(vm, "@interface_name@"sv).release_allocated_value_but_fixme_should_propagate_errors(), JS::Attribute::Configurable);
 )~~~");
 
         if (legacy_constructor.has_value()) {
@@ -191,7 +191,7 @@ void Intrinsics::create_web_prototype_and_constructor<@prototype_class@>(JS::Rea
     auto legacy_constructor = heap().allocate<@legacy_constructor_class@>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
     m_constructors.set("@legacy_interface_name@"sv, legacy_constructor);
 
-    legacy_constructor->define_direct_property(vm.names.name, JS::PrimitiveString::create(vm, "@legacy_interface_name@"sv), JS::Attribute::Configurable);)~~~");
+    legacy_constructor->define_direct_property(vm.names.name, JS::PrimitiveString::create(vm, "@legacy_interface_name@"sv).release_allocated_value_but_fixme_should_propagate_errors(), JS::Attribute::Configurable);)~~~");
         }
 
         gen.append(R"~~~(

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -1627,7 +1627,7 @@ Completion UnaryExpression::execute(Interpreter& interpreter) const
     case UnaryOp::Minus:
         return TRY(unary_minus(vm, lhs_result));
     case UnaryOp::Typeof:
-        return Value { PrimitiveString::create(vm, lhs_result.typeof()) };
+        return Value { MUST_OR_THROW_OOM(PrimitiveString::create(vm, lhs_result.typeof())) };
     case UnaryOp::Void:
         return js_undefined();
     case UnaryOp::Delete:

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -150,7 +150,7 @@ static ThrowCompletionOr<Value> not_(VM&, Value value)
 
 static ThrowCompletionOr<Value> typeof_(VM& vm, Value value)
 {
-    return Value(PrimitiveString::create(vm, value.typeof()));
+    return MUST_OR_THROW_OOM(PrimitiveString::create(vm, value.typeof()));
 }
 
 #define JS_DEFINE_COMMON_UNARY_OP(OpTitleCase, op_snake_case)                                   \
@@ -1035,7 +1035,7 @@ ThrowCompletionOr<void> TypeofVariable::execute_impl(Bytecode::Interpreter& inte
     // 2. If val is a Reference Record, then
     //    a. If IsUnresolvableReference(val) is true, return "undefined".
     if (reference.is_unresolvable()) {
-        interpreter.accumulator() = PrimitiveString::create(vm, "undefined"sv);
+        interpreter.accumulator() = MUST_OR_THROW_OOM(PrimitiveString::create(vm, "undefined"sv));
         return {};
     }
 
@@ -1044,7 +1044,7 @@ ThrowCompletionOr<void> TypeofVariable::execute_impl(Bytecode::Interpreter& inte
 
     // 4. NOTE: This step is replaced in section B.3.6.3.
     // 5. Return a String according to Table 41.
-    interpreter.accumulator() = PrimitiveString::create(vm, value.typeof());
+    interpreter.accumulator() = MUST_OR_THROW_OOM(PrimitiveString::create(vm, value.typeof()));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Console.cpp
+++ b/Userland/Libraries/LibJS/Console.cpp
@@ -186,7 +186,7 @@ ThrowCompletionOr<Value> Console::assert_()
         return js_undefined();
 
     // 2. Let message be a string without any formatting specifiers indicating generically an assertion failure (such as "Assertion failed").
-    auto message = PrimitiveString::create(vm, "Assertion failed");
+    auto message = MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Assertion failed"sv));
 
     // NOTE: Assemble `data` from the function arguments.
     MarkedVector<Value> data { vm.heap() };

--- a/Userland/Libraries/LibJS/Console.cpp
+++ b/Userland/Libraries/LibJS/Console.cpp
@@ -622,7 +622,7 @@ ThrowCompletionOr<MarkedVector<Value>> ConsoleClient::formatter(MarkedVector<Val
         else if (specifier == "%c"sv) {
             // NOTE: This has no spec yet. `%c` specifiers treat the argument as CSS styling for the log message.
             add_css_style_to_current_message(TRY(current.to_deprecated_string(vm)));
-            converted = PrimitiveString::create(vm, "");
+            converted = PrimitiveString::create(vm, String {});
         }
 
         // 7. If any of the previous steps set converted, replace specifier in target with converted.

--- a/Userland/Libraries/LibJS/Runtime/AggregateErrorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AggregateErrorPrototype.cpp
@@ -21,7 +21,7 @@ ThrowCompletionOr<void> AggregateErrorPrototype::initialize(Realm& realm)
     MUST_OR_THROW_OOM(Base::initialize(realm));
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_direct_property(vm.names.name, PrimitiveString::create(vm, "AggregateError"), attr);
-    define_direct_property(vm.names.message, PrimitiveString::create(vm, ""), attr);
+    define_direct_property(vm.names.message, PrimitiveString::create(vm, String {}), attr);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/AggregateErrorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AggregateErrorPrototype.cpp
@@ -20,7 +20,7 @@ ThrowCompletionOr<void> AggregateErrorPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
     MUST_OR_THROW_OOM(Base::initialize(realm));
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    define_direct_property(vm.names.name, PrimitiveString::create(vm, "AggregateError"), attr);
+    define_direct_property(vm.names.name, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "AggregateError"sv)), attr);
     define_direct_property(vm.names.message, PrimitiveString::create(vm, String {}), attr);
 
     return {};

--- a/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
@@ -27,7 +27,7 @@ ThrowCompletionOr<void> ArrayIteratorPrototype::initialize(Realm& realm)
     define_native_function(realm, vm.names.next, next, 0, Attribute::Configurable | Attribute::Writable);
 
     // 23.1.5.2.2 %ArrayIteratorPrototype% [ @@toStringTag ], https://tc39.es/ecma262/#sec-%arrayiteratorprototype%-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Array Iterator"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Array Iterator"sv)), Attribute::Configurable);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -993,7 +993,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::join)
     // FWIW: engine262, a "100% spec compliant" ECMA-262 impl, aborts with "too much recursion".
     // Same applies to Array.prototype.toLocaleString().
     if (s_array_join_seen_objects.contains(this_object))
-        return PrimitiveString::create(vm, "");
+        return PrimitiveString::create(vm, String {});
     s_array_join_seen_objects.set(this_object);
     ArmedScopeGuard unsee_object_guard = [&] {
         s_array_join_seen_objects.remove(this_object);
@@ -1704,7 +1704,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::to_locale_string)
     auto* this_object = TRY(vm.this_value().to_object(vm));
 
     if (s_array_join_seen_objects.contains(this_object))
-        return PrimitiveString::create(vm, "");
+        return PrimitiveString::create(vm, String {});
     s_array_join_seen_objects.set(this_object);
     ArmedScopeGuard unsee_object_guard = [&] {
         s_array_join_seen_objects.remove(this_object);

--- a/Userland/Libraries/LibJS/Runtime/AsyncGeneratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGeneratorPrototype.cpp
@@ -20,7 +20,7 @@ ThrowCompletionOr<void> AsyncGeneratorPrototype::initialize(Realm& realm)
     MUST_OR_THROW_OOM(Base::initialize(realm));
 
     // 27.6.1.5 AsyncGenerator.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-asyncgenerator-prototype-tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "AsyncGenerator"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "AsyncGenerator"sv)), Attribute::Configurable);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/AtomicsObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AtomicsObject.cpp
@@ -147,7 +147,7 @@ ThrowCompletionOr<void> AtomicsObject::initialize(Realm& realm)
     define_native_function(realm, vm.names.xor_, xor_, 3, attr);
 
     // 25.4.15 Atomics [ @@toStringTag ], https://tc39.es/ecma262/#sec-atomics-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Atomics"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Atomics"sv)), Attribute::Configurable);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -952,7 +952,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_date_string)
 
     // 3. If tv is NaN, return "Invalid Date".
     if (isnan(time))
-        return PrimitiveString::create(vm, "Invalid Date"sv);
+        return MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Invalid Date"sv));
 
     // 4. Let t be LocalTime(tv).
     // 5. Return DateString(t).
@@ -1003,7 +1003,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_locale_date_string)
 
     // 2. If x is NaN, return "Invalid Date".
     if (isnan(time))
-        return PrimitiveString::create(vm, "Invalid Date"sv);
+        return MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Invalid Date"sv));
 
     // 3. Let options be ? ToDateTimeOptions(options, "date", "date").
     options = Value(TRY(Intl::to_date_time_options(vm, options, Intl::OptionRequired::Date, Intl::OptionDefaults::Date)));
@@ -1028,7 +1028,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_locale_string)
 
     // 2. If x is NaN, return "Invalid Date".
     if (isnan(time))
-        return PrimitiveString::create(vm, "Invalid Date"sv);
+        return MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Invalid Date"sv));
 
     // 3. Let options be ? ToDateTimeOptions(options, "any", "all").
     options = Value(TRY(Intl::to_date_time_options(vm, options, Intl::OptionRequired::Any, Intl::OptionDefaults::All)));
@@ -1053,7 +1053,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_locale_time_string)
 
     // 2. If x is NaN, return "Invalid Date".
     if (isnan(time))
-        return PrimitiveString::create(vm, "Invalid Date"sv);
+        return MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Invalid Date"sv));
 
     // 3. Let options be ? ToDateTimeOptions(options, "time", "time").
     options = Value(TRY(Intl::to_date_time_options(vm, options, Intl::OptionRequired::Time, Intl::OptionDefaults::Time)));
@@ -1210,7 +1210,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_time_string)
 
     // 3. If tv is NaN, return "Invalid Date".
     if (isnan(time))
-        return PrimitiveString::create(vm, "Invalid Date"sv);
+        return MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Invalid Date"sv));
 
     // 4. Let t be LocalTime(tv).
     // 5. Return the string-concatenation of TimeString(t) and TimeZoneString(tv).
@@ -1227,7 +1227,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_utc_string)
 
     // 3. If tv is NaN, return "Invalid Date".
     if (isnan(time))
-        return PrimitiveString::create(vm, "Invalid Date"sv);
+        return MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Invalid Date"sv));
 
     // 4. Let weekday be the Name of the entry in Table 62 with the Number WeekDay(tv).
     auto weekday = short_day_names[week_day(time)];

--- a/Userland/Libraries/LibJS/Runtime/ErrorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ErrorPrototype.cpp
@@ -24,7 +24,7 @@ ThrowCompletionOr<void> ErrorPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
     MUST_OR_THROW_OOM(Base::initialize(realm));
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    define_direct_property(vm.names.name, PrimitiveString::create(vm, "Error"), attr);
+    define_direct_property(vm.names.name, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Error"sv)), attr);
     define_direct_property(vm.names.message, PrimitiveString::create(vm, String {}), attr);
     define_native_function(realm, vm.names.toString, to_string, 0, attr);
     // Non standard property "stack"
@@ -124,21 +124,21 @@ JS_DEFINE_NATIVE_FUNCTION(ErrorPrototype::stack_setter)
     return TRY(this_object.create_data_property_or_throw(vm.names.stack, vm.argument(0)));
 }
 
-#define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType)        \
-    PrototypeName::PrototypeName(Realm& realm)                                                  \
-        : PrototypeObject(*realm.intrinsics().error_prototype())                                \
-    {                                                                                           \
-    }                                                                                           \
-                                                                                                \
-    ThrowCompletionOr<void> PrototypeName::initialize(Realm& realm)                             \
-    {                                                                                           \
-        auto& vm = this->vm();                                                                  \
-        MUST_OR_THROW_OOM(Base::initialize(realm));                                             \
-        u8 attr = Attribute::Writable | Attribute::Configurable;                                \
-        define_direct_property(vm.names.name, PrimitiveString::create(vm, #ClassName), attr);   \
-        define_direct_property(vm.names.message, PrimitiveString::create(vm, String {}), attr); \
-                                                                                                \
-        return {};                                                                              \
+#define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType)                             \
+    PrototypeName::PrototypeName(Realm& realm)                                                                       \
+        : PrototypeObject(*realm.intrinsics().error_prototype())                                                     \
+    {                                                                                                                \
+    }                                                                                                                \
+                                                                                                                     \
+    ThrowCompletionOr<void> PrototypeName::initialize(Realm& realm)                                                  \
+    {                                                                                                                \
+        auto& vm = this->vm();                                                                                       \
+        MUST_OR_THROW_OOM(Base::initialize(realm));                                                                  \
+        u8 attr = Attribute::Writable | Attribute::Configurable;                                                     \
+        define_direct_property(vm.names.name, MUST_OR_THROW_OOM(PrimitiveString::create(vm, #ClassName##sv)), attr); \
+        define_direct_property(vm.names.message, PrimitiveString::create(vm, String {}), attr);                      \
+                                                                                                                     \
+        return {};                                                                                                   \
     }
 
 JS_ENUMERATE_NATIVE_ERRORS

--- a/Userland/Libraries/LibJS/Runtime/ErrorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ErrorPrototype.cpp
@@ -25,7 +25,7 @@ ThrowCompletionOr<void> ErrorPrototype::initialize(Realm& realm)
     MUST_OR_THROW_OOM(Base::initialize(realm));
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_direct_property(vm.names.name, PrimitiveString::create(vm, "Error"), attr);
-    define_direct_property(vm.names.message, PrimitiveString::create(vm, ""), attr);
+    define_direct_property(vm.names.message, PrimitiveString::create(vm, String {}), attr);
     define_native_function(realm, vm.names.toString, to_string, 0, attr);
     // Non standard property "stack"
     // Every other engine seems to have this in some way or another, and the spec
@@ -124,21 +124,21 @@ JS_DEFINE_NATIVE_FUNCTION(ErrorPrototype::stack_setter)
     return TRY(this_object.create_data_property_or_throw(vm.names.stack, vm.argument(0)));
 }
 
-#define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType)      \
-    PrototypeName::PrototypeName(Realm& realm)                                                \
-        : PrototypeObject(*realm.intrinsics().error_prototype())                              \
-    {                                                                                         \
-    }                                                                                         \
-                                                                                              \
-    ThrowCompletionOr<void> PrototypeName::initialize(Realm& realm)                           \
-    {                                                                                         \
-        auto& vm = this->vm();                                                                \
-        MUST_OR_THROW_OOM(Base::initialize(realm));                                           \
-        u8 attr = Attribute::Writable | Attribute::Configurable;                              \
-        define_direct_property(vm.names.name, PrimitiveString::create(vm, #ClassName), attr); \
-        define_direct_property(vm.names.message, PrimitiveString::create(vm, ""), attr);      \
-                                                                                              \
-        return {};                                                                            \
+#define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType)        \
+    PrototypeName::PrototypeName(Realm& realm)                                                  \
+        : PrototypeObject(*realm.intrinsics().error_prototype())                                \
+    {                                                                                           \
+    }                                                                                           \
+                                                                                                \
+    ThrowCompletionOr<void> PrototypeName::initialize(Realm& realm)                             \
+    {                                                                                           \
+        auto& vm = this->vm();                                                                  \
+        MUST_OR_THROW_OOM(Base::initialize(realm));                                             \
+        u8 attr = Attribute::Writable | Attribute::Configurable;                                \
+        define_direct_property(vm.names.name, PrimitiveString::create(vm, #ClassName), attr);   \
+        define_direct_property(vm.names.message, PrimitiveString::create(vm, String {}), attr); \
+                                                                                                \
+        return {};                                                                              \
     }
 
 JS_ENUMERATE_NATIVE_ERRORS

--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -36,7 +36,7 @@ ThrowCompletionOr<void> FunctionPrototype::initialize(Realm& realm)
     define_native_function(realm, vm.names.toString, to_string, 0, attr);
     define_native_function(realm, *vm.well_known_symbol_has_instance(), symbol_has_instance, 1, 0);
     define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
-    define_direct_property(vm.names.name, PrimitiveString::create(vm, ""), Attribute::Configurable);
+    define_direct_property(vm.names.name, PrimitiveString::create(vm, String {}), Attribute::Configurable);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -171,7 +171,7 @@ JS_DEFINE_NATIVE_FUNCTION(FunctionPrototype::to_string)
 
     // 4. If Type(func) is Object and IsCallable(func) is true, return an implementation-defined String source code representation of func. The representation must have the syntax of a NativeFunction.
     // NOTE: ProxyObject, BoundFunction, WrappedFunction
-    return PrimitiveString::create(vm, "function () { [native code] }");
+    return MUST_OR_THROW_OOM(PrimitiveString::create(vm, "function () { [native code] }"sv));
 }
 
 // 20.2.3.6 Function.prototype [ @@hasInstance ] ( V ), https://tc39.es/ecma262/#sec-function.prototype-@@hasinstance

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.cpp
@@ -23,7 +23,7 @@ ThrowCompletionOr<void> GeneratorFunctionPrototype::initialize(Realm& realm)
     // 27.3.3.2 GeneratorFunction.prototype.prototype, https://tc39.es/ecma262/#sec-generatorfunction.prototype.prototype
     define_direct_property(vm.names.prototype, realm.intrinsics().generator_prototype(), Attribute::Configurable);
     // 27.3.3.3 GeneratorFunction.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-generatorfunction.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "GeneratorFunction"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "GeneratorFunction"sv)), Attribute::Configurable);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/GeneratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorPrototype.cpp
@@ -24,7 +24,7 @@ ThrowCompletionOr<void> GeneratorPrototype::initialize(Realm& realm)
     define_native_function(realm, vm.names.throw_, throw_, 1, attr);
 
     // 27.5.1.5 Generator.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-generator.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Generator"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Generator"sv)), Attribute::Configurable);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
@@ -88,7 +88,7 @@ static ThrowCompletionOr<Collator*> initialize_collator(VM& vm, Collator& collat
     // 24. If relevantExtensionKeys contains "kn", then
     if (relevant_extension_keys.span().contains_slow("kn"sv) && result.kn.has_value()) {
         // a. Set collator.[[Numeric]] to SameValue(r.[[kn]], "true").
-        collator.set_numeric(same_value(PrimitiveString::create(vm, result.kn.release_value()), PrimitiveString::create(vm, "true"sv)));
+        collator.set_numeric(same_value(PrimitiveString::create(vm, result.kn.release_value()), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "true"sv))));
     }
 
     // 25. If relevantExtensionKeys contains "kf", then
@@ -105,14 +105,14 @@ static ThrowCompletionOr<Collator*> initialize_collator(VM& vm, Collator& collat
         // a. If usage is "sort", then
         if (collator.usage() == Collator::Usage::Sort) {
             // i. Let sensitivity be "variant".
-            sensitivity = PrimitiveString::create(vm, "variant"sv);
+            sensitivity = MUST_OR_THROW_OOM(PrimitiveString::create(vm, "variant"sv));
         }
         // b. Else,
         else {
             // i. Let dataLocale be r.[[dataLocale]].
             // ii. Let dataLocaleData be localeData.[[<dataLocale>]].
             // iii. Let sensitivity be dataLocaleData.[[sensitivity]].
-            sensitivity = PrimitiveString::create(vm, "base"sv);
+            sensitivity = MUST_OR_THROW_OOM(PrimitiveString::create(vm, "base"sv));
         }
     }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorPrototype.cpp
@@ -24,7 +24,7 @@ ThrowCompletionOr<void> CollatorPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 10.3.2 Intl.Collator.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-intl.collator.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Intl.Collator"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Intl.Collator"sv)), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_accessor(realm, vm.names.compare, compare_getter, {}, attr);
@@ -78,12 +78,12 @@ JS_DEFINE_NATIVE_FUNCTION(CollatorPrototype::resolved_options)
     //     d. If v is not undefined, then
     //         i. Perform ! CreateDataPropertyOrThrow(options, p, v).
     MUST(options->create_data_property_or_throw(vm.names.locale, PrimitiveString::create(vm, collator->locale())));
-    MUST(options->create_data_property_or_throw(vm.names.usage, PrimitiveString::create(vm, collator->usage_string())));
-    MUST(options->create_data_property_or_throw(vm.names.sensitivity, PrimitiveString::create(vm, collator->sensitivity_string())));
+    MUST(options->create_data_property_or_throw(vm.names.usage, MUST_OR_THROW_OOM(PrimitiveString::create(vm, collator->usage_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.sensitivity, MUST_OR_THROW_OOM(PrimitiveString::create(vm, collator->sensitivity_string()))));
     MUST(options->create_data_property_or_throw(vm.names.ignorePunctuation, Value(collator->ignore_punctuation())));
     MUST(options->create_data_property_or_throw(vm.names.collation, PrimitiveString::create(vm, collator->collation())));
     MUST(options->create_data_property_or_throw(vm.names.numeric, Value(collator->numeric())));
-    MUST(options->create_data_property_or_throw(vm.names.caseFirst, PrimitiveString::create(vm, collator->case_first_string())));
+    MUST(options->create_data_property_or_throw(vm.names.caseFirst, MUST_OR_THROW_OOM(PrimitiveString::create(vm, collator->case_first_string()))));
 
     // 5. Return options.
     return options;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -136,7 +136,7 @@ ThrowCompletionOr<Object*> to_date_time_options(VM& vm, Value options_value, Opt
         // a. For each property name prop of « "year", "month", "day" », do
         for (auto const& property : AK::Array { vm.names.year, vm.names.month, vm.names.day }) {
             // i. Perform ? CreateDataPropertyOrThrow(options, prop, "numeric").
-            TRY(options->create_data_property_or_throw(property, PrimitiveString::create(vm, "numeric"sv)));
+            TRY(options->create_data_property_or_throw(property, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "numeric"sv))));
         }
     }
 
@@ -145,7 +145,7 @@ ThrowCompletionOr<Object*> to_date_time_options(VM& vm, Value options_value, Opt
         // a. For each property name prop of « "hour", "minute", "second" », do
         for (auto const& property : AK::Array { vm.names.hour, vm.names.minute, vm.names.second }) {
             // i. Perform ? CreateDataPropertyOrThrow(options, prop, "numeric").
-            TRY(options->create_data_property_or_throw(property, PrimitiveString::create(vm, "numeric"sv)));
+            TRY(options->create_data_property_or_throw(property, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "numeric"sv))));
         }
     }
 
@@ -875,7 +875,7 @@ ThrowCompletionOr<Array*> format_date_time_to_parts(VM& vm, DateTimeFormat& date
         auto object = Object::create(realm, realm.intrinsics().object_prototype());
 
         // b. Perform ! CreateDataPropertyOrThrow(O, "type", part.[[Type]]).
-        MUST(object->create_data_property_or_throw(vm.names.type, PrimitiveString::create(vm, part.type)));
+        MUST(object->create_data_property_or_throw(vm.names.type, MUST_OR_THROW_OOM(PrimitiveString::create(vm, part.type))));
 
         // c. Perform ! CreateDataPropertyOrThrow(O, "value", part.[[Value]]).
         MUST(object->create_data_property_or_throw(vm.names.value, PrimitiveString::create(vm, move(part.value))));
@@ -1192,13 +1192,13 @@ ThrowCompletionOr<Array*> format_date_time_range_to_parts(VM& vm, DateTimeFormat
         auto object = Object::create(realm, realm.intrinsics().object_prototype());
 
         // b. Perform ! CreateDataPropertyOrThrow(O, "type", part.[[Type]]).
-        MUST(object->create_data_property_or_throw(vm.names.type, PrimitiveString::create(vm, part.type)));
+        MUST(object->create_data_property_or_throw(vm.names.type, MUST_OR_THROW_OOM(PrimitiveString::create(vm, part.type))));
 
         // c. Perform ! CreateDataPropertyOrThrow(O, "value", part.[[Value]]).
         MUST(object->create_data_property_or_throw(vm.names.value, PrimitiveString::create(vm, move(part.value))));
 
         // d. Perform ! CreateDataPropertyOrThrow(O, "source", part.[[Source]]).
-        MUST(object->create_data_property_or_throw(vm.names.source, PrimitiveString::create(vm, part.source)));
+        MUST(object->create_data_property_or_throw(vm.names.source, MUST_OR_THROW_OOM(PrimitiveString::create(vm, part.source))));
 
         // e. Perform ! CreateDataProperty(result, ! ToString(n), O).
         MUST(result->create_data_property_or_throw(n, object));

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.cpp
@@ -26,7 +26,7 @@ ThrowCompletionOr<void> DateTimeFormatPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 11.3.2 Intl.DateTimeFormat.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Intl.DateTimeFormat"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Intl.DateTimeFormat"sv)), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.format, format, nullptr, Attribute::Configurable);
 
@@ -179,7 +179,7 @@ JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::resolved_options)
     MUST(options->create_data_property_or_throw(vm.names.timeZone, PrimitiveString::create(vm, date_time_format->time_zone())));
 
     if (date_time_format->has_hour_cycle()) {
-        MUST(options->create_data_property_or_throw(vm.names.hourCycle, PrimitiveString::create(vm, date_time_format->hour_cycle_string())));
+        MUST(options->create_data_property_or_throw(vm.names.hourCycle, MUST_OR_THROW_OOM(PrimitiveString::create(vm, date_time_format->hour_cycle_string()))));
 
         switch (date_time_format->hour_cycle()) {
         case ::Locale::HourCycle::H11:
@@ -201,10 +201,10 @@ JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::resolved_options)
                 return {};
 
             if constexpr (IsIntegral<ValueType>) {
-                TRY(options->create_data_property_or_throw(property, Value(*option)));
+                MUST(options->create_data_property_or_throw(property, Value(*option)));
             } else {
                 auto name = ::Locale::calendar_pattern_style_to_string(*option);
-                TRY(options->create_data_property_or_throw(property, PrimitiveString::create(vm, name)));
+                MUST(options->create_data_property_or_throw(property, MUST_OR_THROW_OOM(PrimitiveString::create(vm, name))));
             }
 
             return {};
@@ -212,9 +212,9 @@ JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::resolved_options)
     }
 
     if (date_time_format->has_date_style())
-        MUST(options->create_data_property_or_throw(vm.names.dateStyle, PrimitiveString::create(vm, date_time_format->date_style_string())));
+        MUST(options->create_data_property_or_throw(vm.names.dateStyle, MUST_OR_THROW_OOM(PrimitiveString::create(vm, date_time_format->date_style_string()))));
     if (date_time_format->has_time_style())
-        MUST(options->create_data_property_or_throw(vm.names.timeStyle, PrimitiveString::create(vm, date_time_format->time_style_string())));
+        MUST(options->create_data_property_or_throw(vm.names.timeStyle, MUST_OR_THROW_OOM(PrimitiveString::create(vm, date_time_format->time_style_string()))));
 
     // 6. Return options.
     return options;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
@@ -166,7 +166,7 @@ ThrowCompletionOr<Value> canonical_code_for_display_names(VM& vm, DisplayNames::
             return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, code, "dateTimeField"sv);
 
         // b. Return code.
-        return PrimitiveString::create(vm, code);
+        return MUST_OR_THROW_OOM(PrimitiveString::create(vm, code));
     }
 
     // 6. Assert: type is "currency".

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
@@ -26,7 +26,7 @@ ThrowCompletionOr<void> DisplayNamesPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 12.3.2 Intl.DisplayNames.prototype[ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Intl.DisplayNames"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Intl.DisplayNames"sv)), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, vm.names.of, of, 1, attr);
@@ -111,7 +111,7 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
     }
 
     if (result.has_value())
-        return PrimitiveString::create(vm, result.release_value());
+        return MUST_OR_THROW_OOM(PrimitiveString::create(vm, result.release_value()));
     if (formatted_result.has_value())
         return PrimitiveString::create(vm, formatted_result.release_value());
 
@@ -141,13 +141,13 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::resolved_options)
     //     c. Assert: v is not undefined.
     //     d. Perform ! CreateDataPropertyOrThrow(options, p, v).
     MUST(options->create_data_property_or_throw(vm.names.locale, PrimitiveString::create(vm, display_names->locale())));
-    MUST(options->create_data_property_or_throw(vm.names.style, PrimitiveString::create(vm, display_names->style_string())));
-    MUST(options->create_data_property_or_throw(vm.names.type, PrimitiveString::create(vm, display_names->type_string())));
-    MUST(options->create_data_property_or_throw(vm.names.fallback, PrimitiveString::create(vm, display_names->fallback_string())));
+    MUST(options->create_data_property_or_throw(vm.names.style, MUST_OR_THROW_OOM(PrimitiveString::create(vm, display_names->style_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.type, MUST_OR_THROW_OOM(PrimitiveString::create(vm, display_names->type_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.fallback, MUST_OR_THROW_OOM(PrimitiveString::create(vm, display_names->fallback_string()))));
 
     // NOTE: Step 4c indicates languageDisplay must not be undefined, but it is only set when the type option is language.
     if (display_names->has_language_display())
-        MUST(options->create_data_property_or_throw(vm.names.languageDisplay, PrimitiveString::create(vm, display_names->language_display_string())));
+        MUST(options->create_data_property_or_throw(vm.names.languageDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, display_names->language_display_string()))));
 
     // 5. Return options.
     return options;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -492,14 +492,14 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_duration_format_pattern(VM
             // ii. Else,
             else {
                 // 1. Perform ! CreateDataPropertyOrThrow(nfOpts, "style", "unit").
-                MUST(number_format_options->create_data_property_or_throw(vm.names.style, PrimitiveString::create(vm, "unit"sv)));
+                MUST(number_format_options->create_data_property_or_throw(vm.names.style, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "unit"sv))));
 
                 // 2. Perform ! CreateDataPropertyOrThrow(nfOpts, "unit", numberFormatUnit).
-                MUST(number_format_options->create_data_property_or_throw(vm.names.unit, PrimitiveString::create(vm, number_format_unit)));
+                MUST(number_format_options->create_data_property_or_throw(vm.names.unit, MUST_OR_THROW_OOM(PrimitiveString::create(vm, number_format_unit))));
 
                 // 3. Perform ! CreateDataPropertyOrThrow(nfOpts, "unitDisplay", style).
                 auto unicode_style = ::Locale::style_to_string(static_cast<::Locale::Style>(style));
-                MUST(number_format_options->create_data_property_or_throw(vm.names.unitDisplay, PrimitiveString::create(vm, unicode_style)));
+                MUST(number_format_options->create_data_property_or_throw(vm.names.unitDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, unicode_style))));
 
                 // 4. Let nf be ! Construct(%NumberFormat%, « durationFormat.[[Locale]], nfOpts »).
                 auto* number_format = static_cast<NumberFormat*>(MUST(construct(vm, *realm.intrinsics().intl_number_format_constructor(), PrimitiveString::create(vm, duration_format.locale()), number_format_options)).ptr());
@@ -526,7 +526,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_duration_format_pattern(VM
     auto list_format_options = Object::create(realm, nullptr);
 
     // 5. Perform ! CreateDataPropertyOrThrow(lfOpts, "type", "unit").
-    MUST(list_format_options->create_data_property_or_throw(vm.names.type, PrimitiveString::create(vm, "unit"sv)));
+    MUST(list_format_options->create_data_property_or_throw(vm.names.type, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "unit"sv))));
 
     // 6. Let listStyle be durationFormat.[[Style]].
     auto list_style = duration_format.style();
@@ -540,7 +540,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_duration_format_pattern(VM
     auto unicode_list_style = ::Locale::style_to_string(static_cast<::Locale::Style>(list_style));
 
     // 8. Perform ! CreateDataPropertyOrThrow(lfOpts, "style", listStyle).
-    MUST(list_format_options->create_data_property_or_throw(vm.names.style, PrimitiveString::create(vm, unicode_list_style)));
+    MUST(list_format_options->create_data_property_or_throw(vm.names.style, MUST_OR_THROW_OOM(PrimitiveString::create(vm, unicode_list_style))));
 
     // 9. Let lf be ! Construct(%ListFormat%, « durationFormat.[[Locale]], lfOpts »).
     auto* list_format = static_cast<ListFormat*>(MUST(construct(vm, *realm.intrinsics().intl_list_format_constructor(), PrimitiveString::create(vm, duration_format.locale()), list_format_options)).ptr());

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.cpp
@@ -25,7 +25,7 @@ ThrowCompletionOr<void> DurationFormatPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 1.4.2 Intl.DurationFormat.prototype [ @@toStringTag ], https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Intl.DurationFormat"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Intl.DurationFormat"sv)), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, vm.names.format, format, 1, attr);
@@ -88,7 +88,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationFormatPrototype::format_to_parts)
         auto object = Object::create(realm, realm.intrinsics().object_prototype());
 
         // b. Perform ! CreateDataPropertyOrThrow(obj, "type", part.[[Type]]).
-        MUST(object->create_data_property_or_throw(vm.names.type, PrimitiveString::create(vm, part.type)));
+        MUST(object->create_data_property_or_throw(vm.names.type, MUST_OR_THROW_OOM(PrimitiveString::create(vm, part.type))));
 
         // c. Perform ! CreateDataPropertyOrThrow(obj, "value", part.[[Value]]).
         MUST(object->create_data_property_or_throw(vm.names.value, PrimitiveString::create(vm, part.value)));
@@ -121,27 +121,27 @@ JS_DEFINE_NATIVE_FUNCTION(DurationFormatPrototype::resolved_options)
     //     c. Assert: v is not undefined.
     //     d. Perform ! CreateDataPropertyOrThrow(options, p, v).
     MUST(options->create_data_property_or_throw(vm.names.locale, PrimitiveString::create(vm, duration_format->locale())));
-    MUST(options->create_data_property_or_throw(vm.names.style, PrimitiveString::create(vm, duration_format->style_string())));
-    MUST(options->create_data_property_or_throw(vm.names.years, PrimitiveString::create(vm, duration_format->years_style_string())));
-    MUST(options->create_data_property_or_throw(vm.names.yearsDisplay, PrimitiveString::create(vm, duration_format->years_display_string())));
-    MUST(options->create_data_property_or_throw(vm.names.months, PrimitiveString::create(vm, duration_format->months_style_string())));
-    MUST(options->create_data_property_or_throw(vm.names.monthsDisplay, PrimitiveString::create(vm, duration_format->months_display_string())));
-    MUST(options->create_data_property_or_throw(vm.names.weeks, PrimitiveString::create(vm, duration_format->weeks_style_string())));
-    MUST(options->create_data_property_or_throw(vm.names.weeksDisplay, PrimitiveString::create(vm, duration_format->weeks_display_string())));
-    MUST(options->create_data_property_or_throw(vm.names.days, PrimitiveString::create(vm, duration_format->days_style_string())));
-    MUST(options->create_data_property_or_throw(vm.names.daysDisplay, PrimitiveString::create(vm, duration_format->days_display_string())));
-    MUST(options->create_data_property_or_throw(vm.names.hours, PrimitiveString::create(vm, duration_format->hours_style_string())));
-    MUST(options->create_data_property_or_throw(vm.names.hoursDisplay, PrimitiveString::create(vm, duration_format->hours_display_string())));
-    MUST(options->create_data_property_or_throw(vm.names.minutes, PrimitiveString::create(vm, duration_format->minutes_style_string())));
-    MUST(options->create_data_property_or_throw(vm.names.minutesDisplay, PrimitiveString::create(vm, duration_format->minutes_display_string())));
-    MUST(options->create_data_property_or_throw(vm.names.seconds, PrimitiveString::create(vm, duration_format->seconds_style_string())));
-    MUST(options->create_data_property_or_throw(vm.names.secondsDisplay, PrimitiveString::create(vm, duration_format->seconds_display_string())));
-    MUST(options->create_data_property_or_throw(vm.names.milliseconds, PrimitiveString::create(vm, duration_format->milliseconds_style_string())));
-    MUST(options->create_data_property_or_throw(vm.names.millisecondsDisplay, PrimitiveString::create(vm, duration_format->milliseconds_display_string())));
-    MUST(options->create_data_property_or_throw(vm.names.microseconds, PrimitiveString::create(vm, duration_format->microseconds_style_string())));
-    MUST(options->create_data_property_or_throw(vm.names.microsecondsDisplay, PrimitiveString::create(vm, duration_format->microseconds_display_string())));
-    MUST(options->create_data_property_or_throw(vm.names.nanoseconds, PrimitiveString::create(vm, duration_format->nanoseconds_style_string())));
-    MUST(options->create_data_property_or_throw(vm.names.nanosecondsDisplay, PrimitiveString::create(vm, duration_format->nanoseconds_display_string())));
+    MUST(options->create_data_property_or_throw(vm.names.style, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->style_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.years, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->years_style_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.yearsDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->years_display_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.months, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->months_style_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.monthsDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->months_display_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.weeks, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->weeks_style_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.weeksDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->weeks_display_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.days, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->days_style_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.daysDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->days_display_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.hours, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->hours_style_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.hoursDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->hours_display_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.minutes, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->minutes_style_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.minutesDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->minutes_display_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.seconds, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->seconds_style_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.secondsDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->seconds_display_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.milliseconds, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->milliseconds_style_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.millisecondsDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->milliseconds_display_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.microseconds, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->microseconds_style_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.microsecondsDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->microseconds_display_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.nanoseconds, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->nanoseconds_style_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.nanosecondsDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, duration_format->nanoseconds_display_string()))));
     MUST(options->create_data_property_or_throw(vm.names.fractionalDigits, duration_format->has_fractional_digits() ? Value(duration_format->fractional_digits()) : js_undefined()));
     MUST(options->create_data_property_or_throw(vm.names.numberingSystem, PrimitiveString::create(vm, duration_format->numbering_system())));
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
@@ -39,7 +39,7 @@ ThrowCompletionOr<void> Intl::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 8.1.1 Intl[ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl-toStringTag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Intl"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Intl"sv)), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_intrinsic_accessor(vm.names.Collator, attr, [](auto& realm) -> Value { return realm.intrinsics().intl_collator_constructor(); });
@@ -157,7 +157,9 @@ JS_DEFINE_NATIVE_FUNCTION(Intl::supported_values_of)
     }
 
     // 9. Return CreateArrayFromList( list ).
-    return Array::create_from<StringView>(realm, list, [&](auto value) { return PrimitiveString::create(vm, value); });
+    return MUST_OR_THROW_OOM(Array::try_create_from<StringView>(vm, realm, list, [&](auto value) {
+        return PrimitiveString::create(vm, value);
+    }));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
@@ -222,7 +222,7 @@ ThrowCompletionOr<Array*> format_list_to_parts(VM& vm, ListFormat const& list_fo
         auto object = Object::create(realm, realm.intrinsics().object_prototype());
 
         // b. Perform ! CreateDataPropertyOrThrow(O, "type", part.[[Type]]).
-        MUST(object->create_data_property_or_throw(vm.names.type, PrimitiveString::create(vm, part.type)));
+        MUST(object->create_data_property_or_throw(vm.names.type, MUST_OR_THROW_OOM(PrimitiveString::create(vm, part.type))));
 
         // c. Perform ! CreateDataPropertyOrThrow(O, "value", part.[[Value]]).
         MUST(object->create_data_property_or_throw(vm.names.value, PrimitiveString::create(vm, move(part.value))));

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
@@ -25,7 +25,7 @@ ThrowCompletionOr<void> ListFormatPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 13.3.2 Intl.ListFormat.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype-toStringTag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Intl.ListFormat"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Intl.ListFormat"sv)), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, vm.names.format, format, 1, attr);
@@ -86,8 +86,8 @@ JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::resolved_options)
     //     c. Assert: v is not undefined.
     //     d. Perform ! CreateDataPropertyOrThrow(options, p, v).
     MUST(options->create_data_property_or_throw(vm.names.locale, PrimitiveString::create(vm, list_format->locale())));
-    MUST(options->create_data_property_or_throw(vm.names.type, PrimitiveString::create(vm, list_format->type_string())));
-    MUST(options->create_data_property_or_throw(vm.names.style, PrimitiveString::create(vm, list_format->style_string())));
+    MUST(options->create_data_property_or_throw(vm.names.type, MUST_OR_THROW_OOM(PrimitiveString::create(vm, list_format->type_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.style, MUST_OR_THROW_OOM(PrimitiveString::create(vm, list_format->style_string()))));
 
     // 5. Return options.
     return options;

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -31,7 +31,7 @@ ThrowCompletionOr<void> LocalePrototype::initialize(Realm& realm)
     define_native_function(realm, vm.names.toString, to_string, 0, attr);
 
     // 14.3.2 Intl.Locale.prototype[ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.Locale.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Intl.Locale"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Intl.Locale"sv)), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.baseName, base_name, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.calendar, calendar, {}, Attribute::Configurable);
@@ -266,7 +266,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::text_info)
     auto direction = MUST_OR_THROW_OOM(character_direction_of_locale(vm, *locale_object));
 
     // 5. Perform ! CreateDataPropertyOrThrow(info, "direction", dir).
-    MUST(info->create_data_property_or_throw(vm.names.direction, PrimitiveString::create(vm, direction)));
+    MUST(info->create_data_property_or_throw(vm.names.direction, MUST_OR_THROW_OOM(PrimitiveString::create(vm, direction))));
 
     // 6. Return info.
     return info;

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -243,15 +243,15 @@ void NumberFormatBase::set_trailing_zero_display(StringView trailing_zero_displa
         VERIFY_NOT_REACHED();
 }
 
-Value NumberFormat::use_grouping_to_value(VM& vm) const
+ThrowCompletionOr<Value> NumberFormat::use_grouping_to_value(VM& vm) const
 {
     switch (m_use_grouping) {
     case UseGrouping::Always:
-        return PrimitiveString::create(vm, "always"sv);
+        return MUST_OR_THROW_OOM(PrimitiveString::create(vm, "always"sv));
     case UseGrouping::Auto:
-        return PrimitiveString::create(vm, "auto"sv);
+        return MUST_OR_THROW_OOM(PrimitiveString::create(vm, "auto"sv));
     case UseGrouping::Min2:
-        return PrimitiveString::create(vm, "min2"sv);
+        return MUST_OR_THROW_OOM(PrimitiveString::create(vm, "min2"sv));
     case UseGrouping::False:
         return Value(false);
     default:
@@ -948,7 +948,7 @@ ThrowCompletionOr<Array*> format_numeric_to_parts(VM& vm, NumberFormat& number_f
         auto object = Object::create(realm, realm.intrinsics().object_prototype());
 
         // b. Perform ! CreateDataPropertyOrThrow(O, "type", part.[[Type]]).
-        MUST(object->create_data_property_or_throw(vm.names.type, PrimitiveString::create(vm, part.type)));
+        MUST(object->create_data_property_or_throw(vm.names.type, MUST_OR_THROW_OOM(PrimitiveString::create(vm, part.type))));
 
         // c. Perform ! CreateDataPropertyOrThrow(O, "value", part.[[Value]]).
         MUST(object->create_data_property_or_throw(vm.names.value, PrimitiveString::create(vm, move(part.value))));
@@ -1932,13 +1932,13 @@ ThrowCompletionOr<Array*> format_numeric_range_to_parts(VM& vm, NumberFormat& nu
         auto object = Object::create(realm, realm.intrinsics().object_prototype());
 
         // b. Perform ! CreateDataPropertyOrThrow(O, "type", part.[[Type]]).
-        MUST(object->create_data_property_or_throw(vm.names.type, PrimitiveString::create(vm, part.type)));
+        MUST(object->create_data_property_or_throw(vm.names.type, MUST_OR_THROW_OOM(PrimitiveString::create(vm, part.type))));
 
         // c. Perform ! CreateDataPropertyOrThrow(O, "value", part.[[Value]]).
         MUST(object->create_data_property_or_throw(vm.names.value, PrimitiveString::create(vm, move(part.value))));
 
         // d. Perform ! CreateDataPropertyOrThrow(O, "source", part.[[Source]]).
-        MUST(object->create_data_property_or_throw(vm.names.source, PrimitiveString::create(vm, part.source)));
+        MUST(object->create_data_property_or_throw(vm.names.source, MUST_OR_THROW_OOM(PrimitiveString::create(vm, part.source))));
 
         // e. Perform ! CreateDataPropertyOrThrow(result, ! ToString(n), O).
         MUST(result->create_data_property_or_throw(n, object));

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -210,7 +210,7 @@ public:
     void set_unit_display(StringView unit_display) { m_unit_display = ::Locale::style_from_string(unit_display); }
 
     UseGrouping use_grouping() const { return m_use_grouping; }
-    Value use_grouping_to_value(VM&) const;
+    ThrowCompletionOr<Value> use_grouping_to_value(VM&) const;
     void set_use_grouping(StringOrBoolean const& use_grouping);
 
     Notation notation() const { return m_notation; }

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
@@ -26,7 +26,7 @@ ThrowCompletionOr<void> NumberFormatPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 15.3.2 Intl.NumberFormat.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-intl.numberformat.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Intl.NumberFormat"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Intl.NumberFormat"sv)), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.format, format, nullptr, Attribute::Configurable);
 
@@ -156,17 +156,17 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::resolved_options)
     //         i. Perform ! CreateDataPropertyOrThrow(options, p, v).
     MUST(options->create_data_property_or_throw(vm.names.locale, PrimitiveString::create(vm, number_format->locale())));
     MUST(options->create_data_property_or_throw(vm.names.numberingSystem, PrimitiveString::create(vm, number_format->numbering_system())));
-    MUST(options->create_data_property_or_throw(vm.names.style, PrimitiveString::create(vm, number_format->style_string())));
+    MUST(options->create_data_property_or_throw(vm.names.style, MUST_OR_THROW_OOM(PrimitiveString::create(vm, number_format->style_string()))));
     if (number_format->has_currency())
         MUST(options->create_data_property_or_throw(vm.names.currency, PrimitiveString::create(vm, number_format->currency())));
     if (number_format->has_currency_display())
-        MUST(options->create_data_property_or_throw(vm.names.currencyDisplay, PrimitiveString::create(vm, number_format->currency_display_string())));
+        MUST(options->create_data_property_or_throw(vm.names.currencyDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, number_format->currency_display_string()))));
     if (number_format->has_currency_sign())
-        MUST(options->create_data_property_or_throw(vm.names.currencySign, PrimitiveString::create(vm, number_format->currency_sign_string())));
+        MUST(options->create_data_property_or_throw(vm.names.currencySign, MUST_OR_THROW_OOM(PrimitiveString::create(vm, number_format->currency_sign_string()))));
     if (number_format->has_unit())
         MUST(options->create_data_property_or_throw(vm.names.unit, PrimitiveString::create(vm, number_format->unit())));
     if (number_format->has_unit_display())
-        MUST(options->create_data_property_or_throw(vm.names.unitDisplay, PrimitiveString::create(vm, number_format->unit_display_string())));
+        MUST(options->create_data_property_or_throw(vm.names.unitDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, number_format->unit_display_string()))));
     MUST(options->create_data_property_or_throw(vm.names.minimumIntegerDigits, Value(number_format->min_integer_digits())));
     if (number_format->has_min_fraction_digits())
         MUST(options->create_data_property_or_throw(vm.names.minimumFractionDigits, Value(number_format->min_fraction_digits())));
@@ -176,30 +176,30 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::resolved_options)
         MUST(options->create_data_property_or_throw(vm.names.minimumSignificantDigits, Value(number_format->min_significant_digits())));
     if (number_format->has_max_significant_digits())
         MUST(options->create_data_property_or_throw(vm.names.maximumSignificantDigits, Value(number_format->max_significant_digits())));
-    MUST(options->create_data_property_or_throw(vm.names.useGrouping, number_format->use_grouping_to_value(vm)));
-    MUST(options->create_data_property_or_throw(vm.names.notation, PrimitiveString::create(vm, number_format->notation_string())));
+    MUST(options->create_data_property_or_throw(vm.names.useGrouping, MUST_OR_THROW_OOM(number_format->use_grouping_to_value(vm))));
+    MUST(options->create_data_property_or_throw(vm.names.notation, MUST_OR_THROW_OOM(PrimitiveString::create(vm, number_format->notation_string()))));
     if (number_format->has_compact_display())
-        MUST(options->create_data_property_or_throw(vm.names.compactDisplay, PrimitiveString::create(vm, number_format->compact_display_string())));
-    MUST(options->create_data_property_or_throw(vm.names.signDisplay, PrimitiveString::create(vm, number_format->sign_display_string())));
-    MUST(options->create_data_property_or_throw(vm.names.roundingMode, PrimitiveString::create(vm, number_format->rounding_mode_string())));
+        MUST(options->create_data_property_or_throw(vm.names.compactDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, number_format->compact_display_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.signDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, number_format->sign_display_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.roundingMode, MUST_OR_THROW_OOM(PrimitiveString::create(vm, number_format->rounding_mode_string()))));
     MUST(options->create_data_property_or_throw(vm.names.roundingIncrement, Value(number_format->rounding_increment())));
-    MUST(options->create_data_property_or_throw(vm.names.trailingZeroDisplay, PrimitiveString::create(vm, number_format->trailing_zero_display_string())));
+    MUST(options->create_data_property_or_throw(vm.names.trailingZeroDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, number_format->trailing_zero_display_string()))));
 
     switch (number_format->rounding_type()) {
     // 6. If nf.[[RoundingType]] is morePrecision, then
     case NumberFormatBase::RoundingType::MorePrecision:
         // a. Perform ! CreateDataPropertyOrThrow(options, "roundingPriority", "morePrecision").
-        MUST(options->create_data_property_or_throw(vm.names.roundingPriority, PrimitiveString::create(vm, "morePrecision"sv)));
+        MUST(options->create_data_property_or_throw(vm.names.roundingPriority, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "morePrecision"sv))));
         break;
     // 7. Else if nf.[[RoundingType]] is lessPrecision, then
     case NumberFormatBase::RoundingType::LessPrecision:
         // a. Perform ! CreateDataPropertyOrThrow(options, "roundingPriority", "lessPrecision").
-        MUST(options->create_data_property_or_throw(vm.names.roundingPriority, PrimitiveString::create(vm, "lessPrecision"sv)));
+        MUST(options->create_data_property_or_throw(vm.names.roundingPriority, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "lessPrecision"sv))));
         break;
     // 8. Else,
     default:
         // a. Perform ! CreateDataPropertyOrThrow(options, "roundingPriority", "auto").
-        MUST(options->create_data_property_or_throw(vm.names.roundingPriority, PrimitiveString::create(vm, "auto"sv)));
+        MUST(options->create_data_property_or_throw(vm.names.roundingPriority, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "auto"sv))));
         break;
     }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
@@ -25,7 +25,7 @@ ThrowCompletionOr<void> PluralRulesPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 16.3.2 Intl.PluralRules.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-intl.pluralrules.prototype-tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Intl.PluralRules"sv), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Intl.PluralRules"sv)), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, vm.names.select, select, 1, attr);
@@ -48,7 +48,7 @@ JS_DEFINE_NATIVE_FUNCTION(PluralRulesPrototype::select)
 
     // 4. Return ! ResolvePlural(pr, n).[[PluralCategory]].
     auto plurality = MUST_OR_THROW_OOM(resolve_plural(vm, *plural_rules, number));
-    return PrimitiveString::create(vm, ::Locale::plural_category_to_string(plurality.plural_category));
+    return MUST_OR_THROW_OOM(PrimitiveString::create(vm, ::Locale::plural_category_to_string(plurality.plural_category)));
 }
 
 // 1.3.4 Intl.PluralRules.prototype.selectRange ( start, end ), https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/proposed.html#sec-intl.pluralrules.prototype.selectrange
@@ -75,7 +75,7 @@ JS_DEFINE_NATIVE_FUNCTION(PluralRulesPrototype::select_range)
 
     // 6. Return ? ResolvePluralRange(pr, x, y).
     auto plurality = TRY(resolve_plural_range(vm, *plural_rules, x, y));
-    return PrimitiveString::create(vm, ::Locale::plural_category_to_string(plurality));
+    return MUST_OR_THROW_OOM(PrimitiveString::create(vm, ::Locale::plural_category_to_string(plurality)));
 }
 
 // 16.3.4 Intl.PluralRules.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.resolvedoptions
@@ -97,7 +97,7 @@ JS_DEFINE_NATIVE_FUNCTION(PluralRulesPrototype::resolved_options)
     //     c. If v is not undefined, then
     //         i. Perform ! CreateDataPropertyOrThrow(options, p, v).
     MUST(options->create_data_property_or_throw(vm.names.locale, PrimitiveString::create(vm, plural_rules->locale())));
-    MUST(options->create_data_property_or_throw(vm.names.type, PrimitiveString::create(vm, plural_rules->type_string())));
+    MUST(options->create_data_property_or_throw(vm.names.type, MUST_OR_THROW_OOM(PrimitiveString::create(vm, plural_rules->type_string()))));
     MUST(options->create_data_property_or_throw(vm.names.minimumIntegerDigits, Value(plural_rules->min_integer_digits())));
     if (plural_rules->has_min_fraction_digits())
         MUST(options->create_data_property_or_throw(vm.names.minimumFractionDigits, Value(plural_rules->min_fraction_digits())));
@@ -107,16 +107,16 @@ JS_DEFINE_NATIVE_FUNCTION(PluralRulesPrototype::resolved_options)
         MUST(options->create_data_property_or_throw(vm.names.minimumSignificantDigits, Value(plural_rules->min_significant_digits())));
     if (plural_rules->has_max_significant_digits())
         MUST(options->create_data_property_or_throw(vm.names.maximumSignificantDigits, Value(plural_rules->max_significant_digits())));
-    MUST(options->create_data_property_or_throw(vm.names.roundingMode, PrimitiveString::create(vm, plural_rules->rounding_mode_string())));
+    MUST(options->create_data_property_or_throw(vm.names.roundingMode, MUST_OR_THROW_OOM(PrimitiveString::create(vm, plural_rules->rounding_mode_string()))));
     MUST(options->create_data_property_or_throw(vm.names.roundingIncrement, Value(plural_rules->rounding_increment())));
-    MUST(options->create_data_property_or_throw(vm.names.trailingZeroDisplay, PrimitiveString::create(vm, plural_rules->trailing_zero_display_string())));
+    MUST(options->create_data_property_or_throw(vm.names.trailingZeroDisplay, MUST_OR_THROW_OOM(PrimitiveString::create(vm, plural_rules->trailing_zero_display_string()))));
 
     // 5. Let pluralCategories be a List of Strings containing all possible results of PluralRuleSelect for the selected locale pr.[[Locale]].
     auto available_categories = ::Locale::available_plural_categories(plural_rules->locale(), plural_rules->type());
 
-    auto plural_categories = Array::create_from<::Locale::PluralCategory>(realm, available_categories, [&](auto category) {
+    auto plural_categories = MUST_OR_THROW_OOM(Array::try_create_from<::Locale::PluralCategory>(vm, realm, available_categories, [&](auto category) {
         return PrimitiveString::create(vm, ::Locale::plural_category_to_string(category));
-    });
+    }));
 
     // 6. Perform ! CreateDataProperty(options, "pluralCategories", CreateArrayFromList(pluralCategories)).
     MUST(options->create_data_property_or_throw(vm.names.pluralCategories, plural_categories));
@@ -125,17 +125,17 @@ JS_DEFINE_NATIVE_FUNCTION(PluralRulesPrototype::resolved_options)
     // 7. If pr.[[RoundingType]] is morePrecision, then
     case NumberFormatBase::RoundingType::MorePrecision:
         // a. Perform ! CreateDataPropertyOrThrow(options, "roundingPriority", "morePrecision").
-        MUST(options->create_data_property_or_throw(vm.names.roundingPriority, PrimitiveString::create(vm, "morePrecision"sv)));
+        MUST(options->create_data_property_or_throw(vm.names.roundingPriority, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "morePrecision"sv))));
         break;
     // 8. Else if pr.[[RoundingType]] is lessPrecision, then
     case NumberFormatBase::RoundingType::LessPrecision:
         // a. Perform ! CreateDataPropertyOrThrow(options, "roundingPriority", "lessPrecision").
-        MUST(options->create_data_property_or_throw(vm.names.roundingPriority, PrimitiveString::create(vm, "lessPrecision"sv)));
+        MUST(options->create_data_property_or_throw(vm.names.roundingPriority, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "lessPrecision"sv))));
         break;
     // 9. Else,
     default:
         // a. Perform ! CreateDataPropertyOrThrow(options, "roundingPriority", "auto").
-        MUST(options->create_data_property_or_throw(vm.names.roundingPriority, PrimitiveString::create(vm, "auto"sv)));
+        MUST(options->create_data_property_or_throw(vm.names.roundingPriority, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "auto"sv))));
         break;
     }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
@@ -262,7 +262,7 @@ ThrowCompletionOr<Array*> format_relative_time_to_parts(VM& vm, RelativeTimeForm
         auto object = Object::create(realm, realm.intrinsics().object_prototype());
 
         // b. Perform ! CreateDataPropertyOrThrow(O, "type", part.[[Type]]).
-        MUST(object->create_data_property_or_throw(vm.names.type, PrimitiveString::create(vm, part.type)));
+        MUST(object->create_data_property_or_throw(vm.names.type, MUST_OR_THROW_OOM(PrimitiveString::create(vm, part.type))));
 
         // c. Perform ! CreateDataPropertyOrThrow(O, "value", part.[[Value]]).
         MUST(object->create_data_property_or_throw(vm.names.value, PrimitiveString::create(vm, move(part.value))));
@@ -270,7 +270,7 @@ ThrowCompletionOr<Array*> format_relative_time_to_parts(VM& vm, RelativeTimeForm
         // d. If part.[[Unit]] is not empty, then
         if (!part.unit.is_empty()) {
             // i. Perform ! CreateDataPropertyOrThrow(O, "unit", part.[[Unit]]).
-            MUST(object->create_data_property_or_throw(vm.names.unit, PrimitiveString::create(vm, part.unit)));
+            MUST(object->create_data_property_or_throw(vm.names.unit, MUST_OR_THROW_OOM(PrimitiveString::create(vm, part.unit))));
         }
 
         // e. Perform ! CreateDataPropertyOrThrow(result, ! ToString(n), O).

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.cpp
@@ -23,7 +23,7 @@ ThrowCompletionOr<void> RelativeTimeFormatPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 17.3.2 Intl.RelativeTimeFormat.prototype[ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype-toStringTag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Intl.RelativeTimeFormat"sv), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Intl.RelativeTimeFormat"sv)), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, vm.names.format, format, 2, attr);
@@ -86,8 +86,8 @@ JS_DEFINE_NATIVE_FUNCTION(RelativeTimeFormatPrototype::resolved_options)
     //     c. Assert: v is not undefined.
     //     d. Perform ! CreateDataPropertyOrThrow(options, p, v).
     MUST(options->create_data_property_or_throw(vm.names.locale, PrimitiveString::create(vm, relative_time_format->locale())));
-    MUST(options->create_data_property_or_throw(vm.names.style, PrimitiveString::create(vm, relative_time_format->style_string())));
-    MUST(options->create_data_property_or_throw(vm.names.numeric, PrimitiveString::create(vm, relative_time_format->numeric_string())));
+    MUST(options->create_data_property_or_throw(vm.names.style, MUST_OR_THROW_OOM(PrimitiveString::create(vm, relative_time_format->style_string()))));
+    MUST(options->create_data_property_or_throw(vm.names.numeric, MUST_OR_THROW_OOM(PrimitiveString::create(vm, relative_time_format->numeric_string()))));
     MUST(options->create_data_property_or_throw(vm.names.numberingSystem, PrimitiveString::create(vm, relative_time_format->numbering_system())));
 
     // 5. Return options.

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIteratorPrototype.cpp
@@ -25,7 +25,7 @@ ThrowCompletionOr<void> SegmentIteratorPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 18.6.2.2 %SegmentIteratorPrototype% [ @@toStringTag ], https://tc39.es/ecma402/#sec-%segmentiteratorprototype%.@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Segmenter String Iterator"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Segmenter String Iterator"sv)), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, vm.names.next, next, 0, attr);

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.cpp
@@ -24,7 +24,7 @@ ThrowCompletionOr<void> SegmenterPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 18.3.2 Intl.Segmenter.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-intl.segmenter.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Intl.Segmenter"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Intl.Segmenter"sv)), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, vm.names.resolvedOptions, resolved_options, 0, attr);
@@ -51,7 +51,7 @@ JS_DEFINE_NATIVE_FUNCTION(SegmenterPrototype::resolved_options)
     //     c. Assert: v is not undefined.
     //     d. Perform ! CreateDataPropertyOrThrow(options, p, v).
     MUST(options->create_data_property_or_throw(vm.names.locale, PrimitiveString::create(vm, segmenter->locale())));
-    MUST(options->create_data_property_or_throw(vm.names.granularity, PrimitiveString::create(vm, segmenter->segmenter_granularity_string())));
+    MUST(options->create_data_property_or_throw(vm.names.granularity, MUST_OR_THROW_OOM(PrimitiveString::create(vm, segmenter->segmenter_granularity_string()))));
 
     // 5. Return options.
     return options;

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
@@ -232,7 +232,7 @@ void Intrinsics::initialize_intrinsics(Realm& realm)
         },
         0, "", &realm);
     m_throw_type_error_function->define_direct_property(vm.names.length, Value(0), 0);
-    m_throw_type_error_function->define_direct_property(vm.names.name, PrimitiveString::create(vm, ""), 0);
+    m_throw_type_error_function->define_direct_property(vm.names.name, PrimitiveString::create(vm, String {}), 0);
     MUST(m_throw_type_error_function->internal_prevent_extensions());
 
     initialize_constructor(vm, vm.names.Error, *m_error_constructor, m_error_prototype);

--- a/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -40,7 +40,7 @@ ThrowCompletionOr<void> JSONObject::initialize(Realm& realm)
     define_native_function(realm, vm.names.parse, parse, 2, attr);
 
     // 25.5.3 JSON [ @@toStringTag ], https://tc39.es/ecma262/#sec-json-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "JSON"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "JSON"sv)), Attribute::Configurable);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
@@ -24,7 +24,7 @@ ThrowCompletionOr<void> MapIteratorPrototype::initialize(Realm& realm)
     MUST_OR_THROW_OOM(Base::initialize(realm));
 
     define_native_function(realm, vm.names.next, next, 0, Attribute::Configurable | Attribute::Writable);
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Map Iterator"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Map Iterator"sv)), Attribute::Configurable);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
@@ -27,7 +27,7 @@ ThrowCompletionOr<void> ModuleNamespaceObject::initialize(Realm& realm)
     MUST_OR_THROW_OOM(Base::initialize(realm));
 
     // 28.3.1 @@toStringTag, https://tc39.es/ecma262/#sec-@@tostringtag
-    define_direct_property(*vm().well_known_symbol_to_string_tag(), PrimitiveString::create(vm(), "Module"sv), 0);
+    define_direct_property(*vm().well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm(), "Module"sv)), 0);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
@@ -446,9 +446,9 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_string)
 
     // 6. Return the String representation of this Number value using the radix specified by radixMV. Letters a-z are used for digits with values 10 through 35. The precise algorithm is implementation-defined, however the algorithm should be a generalization of that specified in 6.1.6.1.20.
     if (number_value.is_positive_infinity())
-        return PrimitiveString::create(vm, "Infinity");
+        return MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Infinity"sv));
     if (number_value.is_negative_infinity())
-        return PrimitiveString::create(vm, "-Infinity");
+        return MUST_OR_THROW_OOM(PrimitiveString::create(vm, "-Infinity"sv));
     if (number_value.is_nan())
         return PrimitiveString::create(vm, String::from_utf8_short_string("NaN"sv));
     if (number_value.is_positive_zero() || number_value.is_negative_zero())

--- a/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
@@ -450,9 +450,9 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_string)
     if (number_value.is_negative_infinity())
         return PrimitiveString::create(vm, "-Infinity");
     if (number_value.is_nan())
-        return PrimitiveString::create(vm, "NaN");
+        return PrimitiveString::create(vm, String::from_utf8_short_string("NaN"sv));
     if (number_value.is_positive_zero() || number_value.is_negative_zero())
-        return PrimitiveString::create(vm, "0");
+        return PrimitiveString::create(vm, String::from_utf8_short_string("0"sv));
 
     double number = number_value.as_double();
     bool negative = number < 0;

--- a/Userland/Libraries/LibJS/Runtime/ObjectPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectPrototype.cpp
@@ -72,11 +72,11 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectPrototype::to_string)
 
     // 1. If the this value is undefined, return "[object Undefined]".
     if (this_value.is_undefined())
-        return PrimitiveString::create(vm, "[object Undefined]");
+        return MUST_OR_THROW_OOM(PrimitiveString::create(vm, "[object Undefined]"sv));
 
     // 2. If the this value is null, return "[object Null]".
     if (this_value.is_null())
-        return PrimitiveString::create(vm, "[object Null]");
+        return MUST_OR_THROW_OOM(PrimitiveString::create(vm, "[object Null]"sv));
 
     // 3. Let O be ! ToObject(this value).
     auto* object = MUST(this_value.to_object(vm));

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -188,6 +188,11 @@ NonnullGCPtr<PrimitiveString> PrimitiveString::create(VM& vm, String string)
     return *new_string;
 }
 
+ThrowCompletionOr<NonnullGCPtr<PrimitiveString>> PrimitiveString::create(VM& vm, StringView string)
+{
+    return create(vm, TRY_OR_THROW_OOM(vm, String::from_utf8(string)));
+}
+
 NonnullGCPtr<PrimitiveString> PrimitiveString::create(VM& vm, DeprecatedString string)
 {
     if (string.is_empty())
@@ -207,6 +212,11 @@ NonnullGCPtr<PrimitiveString> PrimitiveString::create(VM& vm, DeprecatedString s
         return *new_string;
     }
     return *it->value;
+}
+
+NonnullGCPtr<PrimitiveString> PrimitiveString::create(VM& vm, DeprecatedFlyString const& string)
+{
+    return create(vm, string.impl());
 }
 
 NonnullGCPtr<PrimitiveString> PrimitiveString::create(VM& vm, PrimitiveString& lhs, PrimitiveString& rhs)

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -26,7 +26,9 @@ public:
     [[nodiscard]] static NonnullGCPtr<PrimitiveString> create(VM&, Utf16String);
     [[nodiscard]] static NonnullGCPtr<PrimitiveString> create(VM&, String);
     [[nodiscard]] static NonnullGCPtr<PrimitiveString> create(VM&, DeprecatedString);
+    [[nodiscard]] static NonnullGCPtr<PrimitiveString> create(VM&, DeprecatedFlyString const&);
     [[nodiscard]] static NonnullGCPtr<PrimitiveString> create(VM&, PrimitiveString&, PrimitiveString&);
+    static ThrowCompletionOr<NonnullGCPtr<PrimitiveString>> create(VM&, StringView);
 
     virtual ~PrimitiveString();
 

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
@@ -106,7 +106,7 @@ ThrowCompletionOr<Value> PromiseAllSettledResolveElementFunction::resolve_elemen
     auto object = Object::create(realm, realm.intrinsics().object_prototype());
 
     // 10. Perform ! CreateDataPropertyOrThrow(obj, "status", "fulfilled").
-    MUST(object->create_data_property_or_throw(vm.names.status, PrimitiveString::create(vm, "fulfilled"sv)));
+    MUST(object->create_data_property_or_throw(vm.names.status, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "fulfilled"sv))));
 
     // 11. Perform ! CreateDataPropertyOrThrow(obj, "value", x).
     MUST(object->create_data_property_or_throw(vm.names.value, vm.argument(0)));
@@ -147,7 +147,7 @@ ThrowCompletionOr<Value> PromiseAllSettledRejectElementFunction::resolve_element
     auto object = Object::create(realm, realm.intrinsics().object_prototype());
 
     // 10. Perform ! CreateDataPropertyOrThrow(obj, "status", "rejected").
-    MUST(object->create_data_property_or_throw(vm.names.status, PrimitiveString::create(vm, "rejected"sv)));
+    MUST(object->create_data_property_or_throw(vm.names.status, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "rejected"sv))));
 
     // 11. Perform ! CreateDataPropertyOrThrow(obj, "reason", x).
     MUST(object->create_data_property_or_throw(vm.names.reason, vm.argument(0)));

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -883,7 +883,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::source)
     if (!is<RegExpObject>(regexp_object)) {
         // a. If SameValue(R, %RegExp.prototype%) is true, return "(?:)".
         if (same_value(regexp_object, realm.intrinsics().regexp_prototype()))
-            return PrimitiveString::create(vm, "(?:)");
+            return MUST_OR_THROW_OOM(PrimitiveString::create(vm, "(?:)"sv));
 
         // b. Otherwise, throw a TypeError exception.
         return vm.throw_completion<TypeError>(ErrorType::NotAnObjectOfType, "RegExp");

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.cpp
@@ -26,7 +26,7 @@ ThrowCompletionOr<void> RegExpStringIteratorPrototype::initialize(Realm& realm)
     define_native_function(realm, vm.names.next, next, 0, attr);
 
     // 22.2.7.2.2 %RegExpStringIteratorPrototype% [ @@toStringTag ], https://tc39.es/ecma262/#sec-%regexpstringiteratorprototype%-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "RegExp String Iterator"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "RegExp String Iterator"sv)), Attribute::Configurable);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
@@ -26,7 +26,7 @@ ThrowCompletionOr<void> SetIteratorPrototype::initialize(Realm& realm)
     define_native_function(realm, vm.names.next, next, 0, Attribute::Configurable | Attribute::Writable);
 
     // 24.2.5.2.2 %SetIteratorPrototype% [ @@toStringTag ], https://tc39.es/ecma262/#sec-%setiteratorprototype%-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Set Iterator"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Set Iterator"sv)), Attribute::Configurable);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -59,7 +59,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> StringConstructor::construct(FunctionObj
 
     PrimitiveString* primitive_string;
     if (!vm.argument_count())
-        primitive_string = PrimitiveString::create(vm, "");
+        primitive_string = PrimitiveString::create(vm, String {});
     else
         primitive_string = TRY(vm.argument(0).to_primitive_string(vm));
     auto* prototype = TRY(get_prototype_from_constructor(vm, new_target, &Intrinsics::string_prototype));
@@ -75,7 +75,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringConstructor::raw)
     auto literal_segments = TRY(length_of_array_like(vm, *raw));
 
     if (literal_segments == 0)
-        return PrimitiveString::create(vm, "");
+        return PrimitiveString::create(vm, String {});
 
     auto const number_of_substituions = vm.argument_count() - 1;
 

--- a/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.cpp
@@ -25,7 +25,7 @@ ThrowCompletionOr<void> StringIteratorPrototype::initialize(Realm& realm)
     define_native_function(realm, vm.names.next, next, 0, Attribute::Configurable | Attribute::Writable);
 
     // 22.1.5.1.2 %StringIteratorPrototype% [ @@toStringTag ], https://tc39.es/ecma262/#sec-%stringiteratorprototype%-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "String Iterator"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "String Iterator"sv)), Attribute::Configurable);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -494,7 +494,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::match_all)
 
     auto string = TRY(this_object.to_utf16_string(vm));
 
-    auto rx = TRY(regexp_create(vm, regexp, PrimitiveString::create(vm, "g")));
+    auto rx = TRY(regexp_create(vm, regexp, PrimitiveString::create(vm, String::from_utf8_short_string("g"sv))));
     return TRY(Value(rx).invoke(vm, *vm.well_known_symbol_match_all(), PrimitiveString::create(vm, move(string))));
 }
 

--- a/Userland/Libraries/LibJS/Runtime/SuppressedErrorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SuppressedErrorPrototype.cpp
@@ -20,7 +20,7 @@ ThrowCompletionOr<void> SuppressedErrorPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
     MUST_OR_THROW_OOM(Base::initialize(realm));
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    define_direct_property(vm.names.name, PrimitiveString::create(vm, "SuppressedError"), attr);
+    define_direct_property(vm.names.name, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "SuppressedError"sv)), attr);
     define_direct_property(vm.names.message, PrimitiveString::create(vm, String {}), attr);
 
     return {};

--- a/Userland/Libraries/LibJS/Runtime/SuppressedErrorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SuppressedErrorPrototype.cpp
@@ -21,7 +21,7 @@ ThrowCompletionOr<void> SuppressedErrorPrototype::initialize(Realm& realm)
     MUST_OR_THROW_OOM(Base::initialize(realm));
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_direct_property(vm.names.name, PrimitiveString::create(vm, "SuppressedError"), attr);
-    define_direct_property(vm.names.message, PrimitiveString::create(vm, ""), attr);
+    define_direct_property(vm.names.message, PrimitiveString::create(vm, String {}), attr);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/SymbolPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolPrototype.cpp
@@ -34,7 +34,7 @@ ThrowCompletionOr<void> SymbolPrototype::initialize(Realm& realm)
     define_native_function(realm, *vm.well_known_symbol_to_primitive(), symbol_to_primitive, 1, Attribute::Configurable);
 
     // 20.4.3.6 Symbol.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-symbol.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Symbol"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Symbol"sv)), Attribute::Configurable);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
@@ -112,11 +112,11 @@ ThrowCompletionOr<Value> get_option(VM& vm, Object const& options, PropertyKey c
 
         // b. Return default.
         return default_.visit(
-            [](GetOptionRequired) -> Value { VERIFY_NOT_REACHED(); },
-            [](Empty) { return js_undefined(); },
-            [](bool b) { return Value(b); },
-            [](double d) { return Value(d); },
-            [&vm](StringView s) { return Value(PrimitiveString::create(vm, s)); });
+            [](GetOptionRequired) -> ThrowCompletionOr<Value> { VERIFY_NOT_REACHED(); },
+            [](Empty) -> ThrowCompletionOr<Value> { return js_undefined(); },
+            [](bool b) -> ThrowCompletionOr<Value> { return Value(b); },
+            [](double d) -> ThrowCompletionOr<Value> { return Value(d); },
+            [&vm](StringView s) -> ThrowCompletionOr<Value> { return MUST_OR_THROW_OOM(PrimitiveString::create(vm, s)); });
     }
 
     // 5. If type is "boolean", then
@@ -602,7 +602,7 @@ ThrowCompletionOr<Value> to_relative_temporal_object(VM& vm, Object const& optio
         auto date_options = Object::create(realm, nullptr);
 
         // g. Perform ! CreateDataPropertyOrThrow(dateOptions, "overflow", "constrain").
-        MUST(date_options->create_data_property_or_throw(vm.names.overflow, PrimitiveString::create(vm, "constrain"sv)));
+        MUST(date_options->create_data_property_or_throw(vm.names.overflow, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "constrain"sv))));
 
         // h. Let result be ? InterpretTemporalDateTimeFields(calendar, fields, dateOptions).
         result = TRY(interpret_temporal_date_time_fields(vm, *calendar, *fields, *date_options));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -120,7 +120,10 @@ ThrowCompletionOr<Vector<String>> calendar_fields(VM& vm, Object& calendar, Vect
     }
 
     // 3. Let fieldsArray be ? Call(fields, calendar, « CreateArrayFromList(fieldNames) »).
-    auto fields_array = TRY(call(vm, *fields, &calendar, Array::create_from<StringView>(realm, field_names, [&](auto value) { return PrimitiveString::create(vm, value); })));
+    auto field_names_array = MUST_OR_THROW_OOM(Array::try_create_from<StringView>(vm, realm, field_names, [&](auto value) {
+        return PrimitiveString::create(vm, value);
+    }));
+    auto fields_array = TRY(call(vm, *fields, &calendar, field_names_array));
 
     // 4. Return ? IterableToListOfType(fieldsArray, « String »).
     auto list = TRY(iterable_to_list_of_type(vm, fields_array, { OptionType::String }));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
@@ -36,7 +36,7 @@ ThrowCompletionOr<void> CalendarPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 12.4.2 Temporal.Calendar.prototype[ @@toStringTag ], https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal.Calendar"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Temporal.Calendar"sv)), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.id, id_getter, {}, Attribute::Configurable);
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Duration.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Duration.cpp
@@ -692,7 +692,7 @@ ThrowCompletionOr<DateDurationRecord> unbalance_duration_relative(VM& vm, double
             auto until_options = Object::create(realm, nullptr);
 
             // iii. Perform ! CreateDataPropertyOrThrow(untilOptions, "largestUnit", "month").
-            MUST(until_options->create_data_property_or_throw(vm.names.largestUnit, PrimitiveString::create(vm, "month"sv)));
+            MUST(until_options->create_data_property_or_throw(vm.names.largestUnit, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "month"sv))));
 
             // iv. Let untilResult be ? CalendarDateUntil(calendar, relativeTo, newRelativeTo, untilOptions, dateUntil).
             auto* until_result = TRY(calendar_date_until(vm, *calendar, relative_to, new_relative_to, *until_options, date_until));
@@ -928,7 +928,7 @@ ThrowCompletionOr<DateDurationRecord> balance_duration_relative(VM& vm, double y
         auto until_options = Object::create(realm, nullptr);
 
         // m. Perform ! CreateDataPropertyOrThrow(untilOptions, "largestUnit", "month").
-        MUST(until_options->create_data_property_or_throw(vm.names.largestUnit, PrimitiveString::create(vm, "month"sv)));
+        MUST(until_options->create_data_property_or_throw(vm.names.largestUnit, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "month"sv))));
 
         // n. Let untilResult be ? CalendarDateUntil(calendar, relativeTo, newRelativeTo, untilOptions, dateUntil).
         auto* until_result = TRY(calendar_date_until(vm, calendar, relative_to, new_relative_to, *until_options, date_until));
@@ -954,7 +954,7 @@ ThrowCompletionOr<DateDurationRecord> balance_duration_relative(VM& vm, double y
             until_options = Object::create(realm, nullptr);
 
             // vi. Perform ! CreateDataPropertyOrThrow(untilOptions, "largestUnit", "month").
-            MUST(until_options->create_data_property_or_throw(vm.names.largestUnit, PrimitiveString::create(vm, "month"sv)));
+            MUST(until_options->create_data_property_or_throw(vm.names.largestUnit, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "month"sv))));
 
             // vii. Set untilResult to ? CalendarDateUntil(calendar, relativeTo, newRelativeTo, untilOptions, dateUntil).
             until_result = TRY(calendar_date_until(vm, calendar, relative_to, new_relative_to, *until_options, date_until));
@@ -1109,7 +1109,7 @@ ThrowCompletionOr<DurationRecord> add_duration(VM& vm, double years1, double mon
         auto difference_options = Object::create(realm, nullptr);
 
         // i. Perform ! CreateDataPropertyOrThrow(differenceOptions, "largestUnit", dateLargestUnit).
-        MUST(difference_options->create_data_property_or_throw(vm.names.largestUnit, PrimitiveString::create(vm, date_largest_unit)));
+        MUST(difference_options->create_data_property_or_throw(vm.names.largestUnit, MUST_OR_THROW_OOM(PrimitiveString::create(vm, date_largest_unit))));
 
         // j. Let dateDifference be ? CalendarDateUntil(calendar, relativeTo, end, differenceOptions).
         auto* date_difference = TRY(calendar_date_until(vm, calendar, &relative_to, end, *difference_options));
@@ -1312,7 +1312,7 @@ ThrowCompletionOr<RoundedDuration> round_duration(VM& vm, double years, double m
         auto until_options = Object::create(realm, nullptr);
 
         // l. Perform ! CreateDataPropertyOrThrow(untilOptions, "largestUnit", "year").
-        MUST(until_options->create_data_property_or_throw(vm.names.largestUnit, PrimitiveString::create(vm, "year"sv)));
+        MUST(until_options->create_data_property_or_throw(vm.names.largestUnit, MUST_OR_THROW_OOM(PrimitiveString::create(vm, "year"sv))));
 
         // m. Let timePassed be ? CalendarDateUntil(calendar, relativeTo, wholeDaysLater, untilOptions).
         auto* time_passed = TRY(calendar_date_until(vm, *calendar, relative_to, whole_days_later, *until_options));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
@@ -27,7 +27,7 @@ ThrowCompletionOr<void> DurationPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 7.3.2 Temporal.Duration.prototype[ @@toStringTag ], https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal.Duration"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Temporal.Duration"sv)), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.years, years_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.months, months_getter, {}, Attribute::Configurable);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.cpp
@@ -31,7 +31,7 @@ ThrowCompletionOr<void> InstantPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 8.3.2 Temporal.Instant.prototype[ @@toStringTag ], https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal.Instant"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Temporal.Instant"sv)), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.epochSeconds, epoch_seconds_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.epochMilliseconds, epoch_milliseconds_getter, {}, Attribute::Configurable);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Now.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Now.cpp
@@ -33,7 +33,7 @@ ThrowCompletionOr<void> Now::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 2.1.1 Temporal.Now [ @@toStringTag ], https://tc39.es/proposal-temporal/#sec-temporal-now-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal.Now"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Temporal.Now"sv)), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, vm.names.timeZone, time_zone, 0, attr);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.cpp
@@ -32,7 +32,7 @@ ThrowCompletionOr<void> PlainDatePrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 3.3.2 Temporal.PlainDate.prototype[ @@toStringTag ], https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal.PlainDate"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Temporal.PlainDate"sv)), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.year, year_getter, {}, Attribute::Configurable);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -33,7 +33,7 @@ ThrowCompletionOr<void> PlainDateTimePrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 5.3.2 Temporal.PlainDateTime.prototype[ @@toStringTag ], https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal.PlainDateTime"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Temporal.PlainDateTime"sv)), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.year, year_getter, {}, Attribute::Configurable);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.cpp
@@ -27,7 +27,7 @@ ThrowCompletionOr<void> PlainMonthDayPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 10.3.2 Temporal.PlainMonthDay.prototype[ @@toStringTag ], https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal.PlainMonthDay"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Temporal.PlainMonthDay"sv)), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.monthCode, month_code_getter, {}, Attribute::Configurable);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.cpp
@@ -32,7 +32,7 @@ ThrowCompletionOr<void> PlainTimePrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 4.3.2 Temporal.PlainTime.prototype[ @@toStringTag ], https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal.PlainTime"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Temporal.PlainTime"sv)), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.hour, hour_getter, {}, Attribute::Configurable);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -29,7 +29,7 @@ ThrowCompletionOr<void> PlainYearMonthPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 9.3.2 Temporal.PlainYearMonth.prototype[ @@toStringTag ], https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal.PlainYearMonth"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Temporal.PlainYearMonth"sv)), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.year, year_getter, {}, Attribute::Configurable);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Temporal.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Temporal.cpp
@@ -33,7 +33,7 @@ ThrowCompletionOr<void> Temporal::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 1.1.1 Temporal [ @@toStringTag ], https://tc39.es/proposal-temporal/#sec-temporal-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Temporal"sv)), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_direct_property(vm.names.Now, MUST_OR_THROW_OOM(heap().allocate<Now>(realm, realm)), attr);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
@@ -42,7 +42,7 @@ ThrowCompletionOr<void> TimeZonePrototype::initialize(Realm& realm)
     define_native_function(realm, vm.names.toJSON, to_json, 0, attr);
 
     // 11.4.2 Temporal.TimeZone.prototype[ @@toStringTag ], https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal.TimeZone"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Temporal.TimeZone"sv)), Attribute::Configurable);
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
@@ -33,7 +33,7 @@ ThrowCompletionOr<void> ZonedDateTimePrototype::initialize(Realm& realm)
     auto& vm = this->vm();
 
     // 6.3.2 Temporal.ZonedDateTime.prototype[ @@toStringTag ], https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype-@@tostringtag
-    define_direct_property(*vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal.ZonedDateTime"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), MUST_OR_THROW_OOM(PrimitiveString::create(vm, "Temporal.ZonedDateTime"sv)), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.timeZone, time_zone_getter, {}, Attribute::Configurable);

--- a/Userland/Libraries/LibJS/SyntheticModule.cpp
+++ b/Userland/Libraries/LibJS/SyntheticModule.cpp
@@ -151,7 +151,7 @@ ThrowCompletionOr<NonnullGCPtr<Module>> parse_json_module(StringView source_text
     auto* json_parse = realm.intrinsics().json_parse_function();
 
     // 2. Let json be ? Call(jsonParse, undefined, « sourceText »).
-    auto json = TRY(call(vm, *json_parse, js_undefined(), PrimitiveString::create(realm.vm(), source_text)));
+    auto json = TRY(call(vm, *json_parse, js_undefined(), MUST_OR_THROW_OOM(PrimitiveString::create(realm.vm(), source_text))));
 
     // 3. Return CreateDefaultExportSyntheticModule(json, realm, hostDefined).
     return SyntheticModule::create_default_export_synthetic_module(json, realm, filename);

--- a/Userland/Libraries/LibWeb/Fetch/HeadersIterator.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/HeadersIterator.cpp
@@ -68,14 +68,16 @@ JS::ThrowCompletionOr<JS::Object*> HeadersIterator::next()
         return create_iterator_result_object(vm(), JS::js_undefined(), true);
 
     auto const& pair = pairs[m_index++];
+    StringView pair_name { pair.name };
+    StringView pair_value { pair.value };
 
     switch (m_iteration_kind) {
     case JS::Object::PropertyKind::Key:
-        return create_iterator_result_object(vm(), JS::PrimitiveString::create(vm(), StringView { pair.name }), false);
+        return create_iterator_result_object(vm(), MUST_OR_THROW_OOM(JS::PrimitiveString::create(vm(), pair_name)), false);
     case JS::Object::PropertyKind::Value:
-        return create_iterator_result_object(vm(), JS::PrimitiveString::create(vm(), StringView { pair.value }), false);
+        return create_iterator_result_object(vm(), MUST_OR_THROW_OOM(JS::PrimitiveString::create(vm(), pair_value)), false);
     case JS::Object::PropertyKind::KeyAndValue: {
-        auto array = JS::Array::create_from(realm(), { JS::PrimitiveString::create(vm(), StringView { pair.name }), JS::PrimitiveString::create(vm(), StringView { pair.value }) });
+        auto array = JS::Array::create_from(realm(), { MUST_OR_THROW_OOM(JS::PrimitiveString::create(vm(), pair_name)), MUST_OR_THROW_OOM(JS::PrimitiveString::create(vm(), pair_value)) });
         return create_iterator_result_object(vm(), array, false);
     }
     default:

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1769,7 +1769,7 @@ JS_DEFINE_NATIVE_FUNCTION(Window::scroll_by)
         options = JS::Object::create(realm, nullptr);
         MUST(options->set("left", vm.argument(0), ShouldThrowExceptions::No));
         MUST(options->set("top", vm.argument(1), ShouldThrowExceptions::No));
-        MUST(options->set("behavior", JS::PrimitiveString::create(vm, "auto"), ShouldThrowExceptions::No));
+        MUST(options->set("behavior", MUST_OR_THROW_OOM(JS::PrimitiveString::create(vm, "auto"sv)), ShouldThrowExceptions::No));
     }
 
     auto left_value = TRY(options->get("left"));

--- a/Userland/Libraries/LibWeb/Infra/JSON.cpp
+++ b/Userland/Libraries/LibWeb/Infra/JSON.cpp
@@ -19,7 +19,7 @@ WebIDL::ExceptionOr<JS::Value> parse_json_string_to_javascript_value(JS::VM& vm,
     auto& realm = *vm.current_realm();
 
     // 1. Return ? Call(%JSON.parse%, undefined, « string »).
-    return TRY(JS::call(vm, realm.intrinsics().json_parse_function(), JS::js_undefined(), JS::PrimitiveString::create(vm, string)));
+    return TRY(JS::call(vm, realm.intrinsics().json_parse_function(), JS::js_undefined(), MUST_OR_THROW_OOM(JS::PrimitiveString::create(vm, string))));
 }
 
 // https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryPrototype.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryPrototype.cpp
@@ -53,7 +53,7 @@ JS_DEFINE_NATIVE_FUNCTION(WebAssemblyMemoryPrototype::buffer_getter)
         return JS::js_undefined();
 
     auto array_buffer = JS::ArrayBuffer::create(realm, &memory->data());
-    array_buffer->set_detach_key(JS::PrimitiveString::create(vm, "WebAssembly.Memory"));
+    array_buffer->set_detach_key(MUST_OR_THROW_OOM(JS::PrimitiveString::create(vm, "WebAssembly.Memory"sv)));
     return array_buffer;
 }
 

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -129,7 +129,7 @@ WebIDL::ExceptionOr<JS::Value> XMLHttpRequest::response()
     if (m_response_type == Bindings::XMLHttpRequestResponseType::Empty || m_response_type == Bindings::XMLHttpRequestResponseType::Text) {
         // 1. If this’s state is not loading or done, then return the empty string.
         if (m_state != State::Loading && m_state != State::Done)
-            return JS::PrimitiveString::create(vm, "");
+            return JS::PrimitiveString::create(vm, String {});
 
         // 2. Return the result of getting a text response for this.
         return JS::PrimitiveString::create(vm, get_text_response());


### PR DESCRIPTION
First, this adds an overload of `PrimitiveString::create` for `StringView`.
This overload will throw an OOM completion if creating a `String` fails.
This is not only a bit more convenient, but it also ensures at compile
time that all `PrimitiveString::create(string_view)` invocations will be
handled as `String` and OOM-aware.

Next, this wraps all invocations to `PrimitiveString::create(string_view)`
with `MUST_OR_THROW_OOM`.