### PR TITLE
AK+Piano+LibGUI: Prepare for per-track controls

### DIFF
--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -95,6 +95,15 @@ public:
         return create_raw(m_value & radix_mask);
     }
 
+    constexpr This clamp(This minimum, This maximum) const
+    {
+        if (*this < minimum)
+            return minimum;
+        if (*this > maximum)
+            return maximum;
+        return *this;
+    }
+
     constexpr This round() const
     {
         return This { static_cast<Underlying>(*this) };

--- a/Userland/Applications/Piano/CMakeLists.txt
+++ b/Userland/Applications/Piano/CMakeLists.txt
@@ -11,12 +11,12 @@ set(SOURCES
     AudioPlayerLoop.cpp
     ExportProgressWindow.cpp
     KeysWidget.cpp
-    KnobsWidget.cpp
     main.cpp
     MainWidget.cpp
     PlayerWidget.cpp
     RollWidget.cpp
     SamplerWidget.cpp
+    TrackControlsWidget.cpp
     TrackManager.cpp
     WaveWidget.cpp
     ProcessorParameterWidget/ParameterWidget.cpp

--- a/Userland/Applications/Piano/KeysWidget.cpp
+++ b/Userland/Applications/Piano/KeysWidget.cpp
@@ -23,8 +23,7 @@ int KeysWidget::mouse_note() const
 {
     if (m_mouse_down && m_mouse_note + m_keyboard->virtual_keyboard_octave_base() < note_count)
         return m_mouse_note; // Can be -1.
-    else
-        return -1;
+    return -1;
 }
 
 void KeysWidget::set_key(i8 key, DSP::Keyboard::Switch switch_note)

--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -94,8 +94,7 @@ void MainWidget::keydown_event(GUI::KeyEvent& event)
         // This is to stop held-down keys from creating multiple events.
         if (m_keys_pressed[event.key()])
             return;
-        else
-            m_keys_pressed[event.key()] = true;
+        m_keys_pressed[event.key()] = true;
 
         bool event_was_accepted = false;
         if (note_key_action(event.key(), DSP::Keyboard::Switch::On))

--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -8,10 +8,10 @@
 
 #include "MainWidget.h"
 #include "KeysWidget.h"
-#include "KnobsWidget.h"
 #include "PlayerWidget.h"
 #include "RollWidget.h"
 #include "SamplerWidget.h"
+#include "TrackControlsWidget.h"
 #include "TrackManager.h"
 #include "WaveWidget.h"
 #include <LibGUI/Action.h>
@@ -55,7 +55,7 @@ ErrorOr<void> MainWidget::initialize()
 
     m_keys_widget = TRY(m_keys_and_knobs_container->try_add<KeysWidget>(m_track_manager.keyboard()));
 
-    m_knobs_widget = TRY(m_keys_and_knobs_container->try_add<KnobsWidget>(m_track_manager, *this));
+    m_knobs_widget = TRY(m_keys_and_knobs_container->try_add<TrackControlsWidget>(m_track_manager, *this));
 
     m_roll_widget->set_keys_widget(m_keys_widget);
 

--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -17,6 +17,7 @@
 #include <LibGUI/Action.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Menu.h>
+#include <LibGUI/Slider.h>
 #include <LibGUI/TabWidget.h>
 
 ErrorOr<NonnullRefPtr<MainWidget>> MainWidget::try_create(TrackManager& manager, AudioPlayerLoop& loop)
@@ -55,6 +56,28 @@ ErrorOr<void> MainWidget::initialize()
 
     m_keys_widget = TRY(m_keys_and_knobs_container->try_add<KeysWidget>(m_track_manager.keyboard()));
 
+    m_octave_container = TRY(m_keys_and_knobs_container->try_add<GUI::Widget>());
+    m_octave_container->set_preferred_width(GUI::SpecialDimension::Fit);
+    TRY(m_octave_container->try_set_layout<GUI::VerticalBoxLayout>());
+    auto octave_label = TRY(m_octave_container->try_add<GUI::Label>("Octave"));
+    octave_label->set_preferred_width(GUI::SpecialDimension::Fit);
+    m_octave_value = TRY(m_octave_container->try_add<GUI::Label>(DeprecatedString::number(m_track_manager.keyboard()->virtual_keyboard_octave())));
+    m_octave_value->set_preferred_width(GUI::SpecialDimension::Fit);
+
+    // FIXME: Implement vertical flipping in GUI::Slider, not here.
+    m_octave_knob = TRY(m_octave_container->try_add<GUI::VerticalSlider>());
+    m_octave_knob->set_preferred_width(GUI::SpecialDimension::Fit);
+    m_octave_knob->set_tooltip("Z: octave down, X: octave up");
+    m_octave_knob->set_range(octave_min - 1, octave_max - 1);
+    m_octave_knob->set_value((octave_max - 1) - (m_track_manager.keyboard()->virtual_keyboard_octave() - 1));
+    m_octave_knob->set_step(1);
+    m_octave_knob->on_change = [this](int value) {
+        int new_octave = octave_max - value;
+        set_octave_via_slider(new_octave);
+        VERIFY(new_octave == m_track_manager.keyboard()->virtual_keyboard_octave());
+        m_octave_value->set_text(DeprecatedString::number(new_octave));
+    };
+
     m_knobs_widget = TRY(m_keys_and_knobs_container->try_add<TrackControlsWidget>(m_track_manager, *this));
 
     m_roll_widget->set_keys_widget(m_keys_widget);
@@ -72,8 +95,6 @@ ErrorOr<void> MainWidget::add_track_actions(GUI::Menu& menu)
         turn_off_pressed_keys();
         m_player_widget->next_track();
         turn_on_pressed_keys();
-
-        m_knobs_widget->update_knobs();
     })));
 
     return {};
@@ -131,10 +152,10 @@ bool MainWidget::special_key_action(int key_code)
 {
     switch (key_code) {
     case Key_Z:
-        set_octave_and_ensure_note_change(DSP::Keyboard::Direction::Down);
+        change_octave_via_keys(DSP::Keyboard::Direction::Down);
         return true;
     case Key_X:
-        set_octave_and_ensure_note_change(DSP::Keyboard::Direction::Up);
+        change_octave_via_keys(DSP::Keyboard::Direction::Up);
         return true;
     case Key_Space:
         m_player_widget->toggle_paused();
@@ -164,22 +185,21 @@ void MainWidget::turn_on_pressed_keys()
     }
 }
 
-void MainWidget::set_octave_and_ensure_note_change(int octave)
+void MainWidget::set_octave_via_slider(int octave)
 {
     turn_off_pressed_keys();
     MUST(m_track_manager.keyboard()->set_virtual_keyboard_octave(octave));
     turn_on_pressed_keys();
 
-    m_knobs_widget->update_knobs();
     m_keys_widget->update();
 }
 
-void MainWidget::set_octave_and_ensure_note_change(DSP::Keyboard::Direction direction)
+void MainWidget::change_octave_via_keys(DSP::Keyboard::Direction direction)
 {
     turn_off_pressed_keys();
     m_track_manager.keyboard()->change_virtual_keyboard_octave(direction);
     turn_on_pressed_keys();
 
-    m_knobs_widget->update_knobs();
+    m_octave_knob->set_value(octave_max - m_track_manager.keyboard()->virtual_keyboard_octave());
     m_keys_widget->update();
 }

--- a/Userland/Applications/Piano/MainWidget.h
+++ b/Userland/Applications/Piano/MainWidget.h
@@ -19,7 +19,7 @@ class WaveWidget;
 class RollWidget;
 class SamplerWidget;
 class KeysWidget;
-class KnobsWidget;
+class TrackControlsWidget;
 class PlayerWidget;
 
 class MainWidget final : public GUI::Widget {
@@ -57,7 +57,7 @@ private:
     RefPtr<GUI::TabWidget> m_tab_widget;
     RefPtr<GUI::Widget> m_keys_and_knobs_container;
     RefPtr<KeysWidget> m_keys_widget;
-    RefPtr<KnobsWidget> m_knobs_widget;
+    RefPtr<TrackControlsWidget> m_knobs_widget;
     RefPtr<PlayerWidget> m_player_widget;
 
     // Not the piano keys, but the computer keyboard keys!

--- a/Userland/Applications/Piano/MainWidget.h
+++ b/Userland/Applications/Piano/MainWidget.h
@@ -30,8 +30,8 @@ public:
 
     ErrorOr<void> add_track_actions(GUI::Menu&);
 
-    void set_octave_and_ensure_note_change(DSP::Keyboard::Direction);
-    void set_octave_and_ensure_note_change(int);
+    void change_octave_via_keys(DSP::Keyboard::Direction);
+    void set_octave_via_slider(int octave);
 
 private:
     explicit MainWidget(TrackManager&, AudioPlayerLoop&);
@@ -59,6 +59,11 @@ private:
     RefPtr<KeysWidget> m_keys_widget;
     RefPtr<TrackControlsWidget> m_knobs_widget;
     RefPtr<PlayerWidget> m_player_widget;
+
+    RefPtr<GUI::Widget> m_octave_container;
+    RefPtr<GUI::Slider> m_octave_knob;
+    RefPtr<GUI::Label> m_octave_value;
+    bool m_octave_change_in_progress { false };
 
     // Not the piano keys, but the computer keyboard keys!
     bool m_keys_pressed[key_code_count] { false };

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
@@ -30,12 +30,12 @@ ProcessorParameterSlider::ProcessorParameterSlider(Orientation orientation, DSP:
     if (m_value_label != nullptr)
         m_value_label->set_text(DeprecatedString::formatted("{:.2f}", static_cast<double>(m_parameter)));
 
-    on_change = [this](auto value) {
+    on_change = [this](auto raw_value) {
         if (m_currently_setting_from_ui)
             return;
         m_currently_setting_from_ui = true;
         DSP::ParameterFixedPoint real_value;
-        real_value.raw() = value;
+        real_value.raw() = raw_value;
         if (is_logarithmic())
             // FIXME: Implement exponential for fixed point
             real_value = exp2(static_cast<double>(real_value));

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
@@ -27,7 +27,8 @@ ProcessorParameterSlider::ProcessorParameterSlider(Orientation orientation, DSP:
         set_step((min_log - max_log) / slider_steps);
     }
     set_tooltip(m_parameter.name().to_deprecated_string());
-    m_value_label->set_text(DeprecatedString::formatted("{:.2f}", static_cast<double>(m_parameter)));
+    if (m_value_label != nullptr)
+        m_value_label->set_text(DeprecatedString::formatted("{:.2f}", static_cast<double>(m_parameter)));
 
     on_change = [this](auto value) {
         if (m_currently_setting_from_ui)

--- a/Userland/Applications/Piano/TrackControlsWidget.cpp
+++ b/Userland/Applications/Piano/TrackControlsWidget.cpp
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "KnobsWidget.h"
+#include "TrackControlsWidget.h"
 #include "MainWidget.h"
 #include "ProcessorParameterWidget/ParameterWidget.h"
 #include "TrackManager.h"
@@ -16,7 +16,7 @@
 #include <LibGUI/Slider.h>
 #include <LibGfx/Orientation.h>
 
-KnobsWidget::KnobsWidget(TrackManager& track_manager, MainWidget& main_widget)
+TrackControlsWidget::TrackControlsWidget(TrackManager& track_manager, MainWidget& main_widget)
     : m_track_manager(track_manager)
     , m_main_widget(main_widget)
 {
@@ -52,7 +52,7 @@ KnobsWidget::KnobsWidget(TrackManager& track_manager, MainWidget& main_widget)
         m_parameter_widgets.append(add<ProcessorParameterWidget>(parameter));
 }
 
-void KnobsWidget::update_knobs()
+void TrackControlsWidget::update_knobs()
 {
     // FIXME: This is needed because when the slider is changed normally, we
     // need to change the underlying value, but if the keyboard was used, we

--- a/Userland/Applications/Piano/TrackControlsWidget.cpp
+++ b/Userland/Applications/Piano/TrackControlsWidget.cpp
@@ -13,7 +13,6 @@
 #include <LibDSP/ProcessorParameter.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Label.h>
-#include <LibGUI/Slider.h>
 #include <LibGfx/Orientation.h>
 
 TrackControlsWidget::TrackControlsWidget(TrackManager& track_manager, MainWidget& main_widget)
@@ -21,26 +20,8 @@ TrackControlsWidget::TrackControlsWidget(TrackManager& track_manager, MainWidget
     , m_main_widget(main_widget)
 {
     set_layout<GUI::HorizontalBoxLayout>();
+    set_preferred_width(GUI::SpecialDimension::Grow);
     set_fill_with_background_color(true);
-
-    m_octave_container = add<GUI::Widget>();
-    m_octave_container->set_layout<GUI::VerticalBoxLayout>();
-    m_octave_container->add<GUI::Label>("Octave");
-    m_octave_value = m_octave_container->add<GUI::Label>(DeprecatedString::number(m_track_manager.keyboard()->virtual_keyboard_octave()));
-
-    // FIXME: Implement vertical flipping in GUI::Slider, not here.
-    m_octave_knob = m_octave_container->add<GUI::VerticalSlider>();
-    m_octave_knob->set_tooltip("Z: octave down, X: octave up");
-    m_octave_knob->set_range(octave_min - 1, octave_max - 1);
-    m_octave_knob->set_value((octave_max - 1) - (m_track_manager.keyboard()->virtual_keyboard_octave() - 1));
-    m_octave_knob->set_step(1);
-    m_octave_knob->on_change = [this](int value) {
-        int new_octave = octave_max - value;
-        if (m_change_underlying)
-            m_main_widget.set_octave_and_ensure_note_change(new_octave);
-        VERIFY(new_octave == m_track_manager.keyboard()->virtual_keyboard_octave());
-        m_octave_value->set_text(DeprecatedString::number(new_octave));
-    };
 
     for (auto& parameter : m_track_manager.current_track()->track_mastering()->parameters())
         m_parameter_widgets.append(add<ProcessorParameterWidget>(parameter));
@@ -50,16 +31,4 @@ TrackControlsWidget::TrackControlsWidget(TrackManager& track_manager, MainWidget
 
     for (auto& parameter : m_track_manager.current_track()->delay()->parameters())
         m_parameter_widgets.append(add<ProcessorParameterWidget>(parameter));
-}
-
-void TrackControlsWidget::update_knobs()
-{
-    // FIXME: This is needed because when the slider is changed normally, we
-    // need to change the underlying value, but if the keyboard was used, we
-    // need to change the slider without changing the underlying value.
-    m_change_underlying = false;
-
-    m_octave_knob->set_value(octave_max - m_track_manager.keyboard()->virtual_keyboard_octave());
-
-    m_change_underlying = true;
 }

--- a/Userland/Applications/Piano/TrackControlsWidget.h
+++ b/Userland/Applications/Piano/TrackControlsWidget.h
@@ -24,19 +24,11 @@ class TrackControlsWidget final : public GUI::Frame {
 public:
     virtual ~TrackControlsWidget() override = default;
 
-    void update_knobs();
-
 private:
     TrackControlsWidget(TrackManager&, MainWidget&);
 
     TrackManager& m_track_manager;
     MainWidget& m_main_widget;
 
-    RefPtr<GUI::Widget> m_octave_container;
-    RefPtr<GUI::Slider> m_octave_knob;
-    RefPtr<GUI::Label> m_octave_value;
-
     NonnullRefPtrVector<ProcessorParameterWidget> m_parameter_widgets;
-
-    bool m_change_underlying { true };
 };

--- a/Userland/Applications/Piano/TrackControlsWidget.h
+++ b/Userland/Applications/Piano/TrackControlsWidget.h
@@ -19,15 +19,15 @@
 class TrackManager;
 class MainWidget;
 
-class KnobsWidget final : public GUI::Frame {
-    C_OBJECT(KnobsWidget)
+class TrackControlsWidget final : public GUI::Frame {
+    C_OBJECT(TrackControlsWidget)
 public:
-    virtual ~KnobsWidget() override = default;
+    virtual ~TrackControlsWidget() override = default;
 
     void update_knobs();
 
 private:
-    KnobsWidget(TrackManager&, MainWidget&);
+    TrackControlsWidget(TrackManager&, MainWidget&);
 
     TrackManager& m_track_manager;
     MainWidget& m_main_widget;

--- a/Userland/Applications/Piano/TrackManager.cpp
+++ b/Userland/Applications/Piano/TrackManager.cpp
@@ -74,6 +74,5 @@ int TrackManager::next_track_index() const
     auto next_track_index = m_current_track + 1;
     if (next_track_index >= m_tracks.size())
         return 0;
-    else
-        return next_track_index;
+    return static_cast<int>(next_track_index);
 }

--- a/Userland/Libraries/LibDSP/ProcessorParameter.h
+++ b/Userland/Libraries/LibDSP/ProcessorParameter.h
@@ -137,8 +137,7 @@ public:
     ParameterFixedPoint default_value() const { return m_default_value; }
     void set_value(ParameterFixedPoint value)
     {
-        VERIFY(value <= m_max_value && value >= m_min_value);
-        Detail::ProcessorParameterSingleValue<ParameterFixedPoint>::set_value(value);
+        Detail::ProcessorParameterSingleValue<ParameterFixedPoint>::set_value(value.clamp(min_value(), max_value()));
     }
 
 private:

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -111,7 +111,12 @@ void Label::paint_event(PaintEvent& event)
 
 void Label::size_to_fit()
 {
-    set_fixed_width(static_cast<int>(ceilf(font().width(m_text))) + m_autosize_padding * 2);
+    set_fixed_width(text_calculated_preferred_width());
+}
+
+int Label::text_calculated_preferred_width() const
+{
+    return static_cast<int>(ceilf(font().width(m_text))) + m_autosize_padding * 2;
 }
 
 int Label::text_calculated_preferred_height() const
@@ -121,6 +126,7 @@ int Label::text_calculated_preferred_height() const
 
 Optional<UISize> Label::calculated_preferred_size() const
 {
-    return GUI::UISize(SpecialDimension::Grow, text_calculated_preferred_height());
+    return GUI::UISize(text_calculated_preferred_width(), text_calculated_preferred_height());
 }
+
 }

--- a/Userland/Libraries/LibGUI/Label.h
+++ b/Userland/Libraries/LibGUI/Label.h
@@ -40,6 +40,7 @@ public:
 
     virtual Optional<UISize> calculated_preferred_size() const override;
     int text_calculated_preferred_height() const;
+    int text_calculated_preferred_width() const;
 
     Gfx::IntRect text_rect() const;
 


### PR DESCRIPTION
This is an assortment of bug fixes, layouting improvements, and small Piano refactors in order to prepare for per-track controls in Piano.

The LibGUI fixes make dynamic layouting work better with labels and sliders, as you can see in these screenshots:

![](https://media.discordapp.net/attachments/830529037251641374/1073247084054065263/image.png)

![](https://media.discordapp.net/attachments/830529037251641374/1073235537353261116/image.png)