### PR TITLE
LibGUI: A selection of small TextEditor fixes

### DIFF
--- a/Userland/Libraries/LibGUI/EditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/EditingEngine.cpp
@@ -301,15 +301,8 @@ EditingEngine::DidMoveALine EditingEngine::move_one_up(KeyEvent const& event)
             }
             return DidMoveALine::No;
         }
-        TextPosition new_cursor;
-        if (m_editor->is_wrapping_enabled()) {
-            auto position_above = m_editor->cursor_content_rect().location().translated(0, -m_editor->line_height());
-            new_cursor = m_editor->text_position_at_content_position(position_above);
-        } else {
-            size_t new_line = m_editor->cursor().line() - 1;
-            size_t new_column = min(m_editor->cursor().column(), m_editor->line(new_line).length());
-            new_cursor = { new_line, new_column };
-        }
+        auto position_above = m_editor->cursor_content_rect().location().translated(0, -m_editor->line_height());
+        TextPosition new_cursor = m_editor->text_position_at_content_position(position_above);
         m_editor->set_cursor(new_cursor);
     }
     return DidMoveALine::No;
@@ -325,15 +318,8 @@ EditingEngine::DidMoveALine EditingEngine::move_one_down(KeyEvent const& event)
             }
             return DidMoveALine::No;
         }
-        TextPosition new_cursor;
-        if (m_editor->is_wrapping_enabled()) {
-            auto position_below = m_editor->cursor_content_rect().location().translated(0, m_editor->line_height());
-            new_cursor = m_editor->text_position_at_content_position(position_below);
-        } else {
-            size_t new_line = m_editor->cursor().line() + 1;
-            size_t new_column = min(m_editor->cursor().column(), m_editor->line(new_line).length());
-            new_cursor = { new_line, new_column };
-        }
+        auto position_below = m_editor->cursor_content_rect().location().translated(0, m_editor->line_height());
+        TextPosition new_cursor = m_editor->text_position_at_content_position(position_below);
         m_editor->set_cursor(new_cursor);
     }
     return DidMoveALine::No;
@@ -343,17 +329,8 @@ void EditingEngine::move_up(double page_height_factor)
 {
     if (m_editor->cursor().line() > 0 || m_editor->is_wrapping_enabled()) {
         int pixels = (int)(m_editor->visible_content_rect().height() * page_height_factor);
-
-        TextPosition new_cursor;
-        if (m_editor->is_wrapping_enabled()) {
-            auto position_above = m_editor->cursor_content_rect().location().translated(0, -pixels);
-            new_cursor = m_editor->text_position_at_content_position(position_above);
-        } else {
-            size_t page_step = (size_t)pixels / (size_t)m_editor->line_height();
-            size_t new_line = m_editor->cursor().line() < page_step ? 0 : m_editor->cursor().line() - page_step;
-            size_t new_column = min(m_editor->cursor().column(), m_editor->line(new_line).length());
-            new_cursor = { new_line, new_column };
-        }
+        auto position_above = m_editor->cursor_content_rect().location().translated(0, -pixels);
+        TextPosition new_cursor = m_editor->text_position_at_content_position(position_above);
         m_editor->set_cursor(new_cursor);
     }
 };
@@ -362,15 +339,8 @@ void EditingEngine::move_down(double page_height_factor)
 {
     if (m_editor->cursor().line() < (m_editor->line_count() - 1) || m_editor->is_wrapping_enabled()) {
         int pixels = (int)(m_editor->visible_content_rect().height() * page_height_factor);
-        TextPosition new_cursor;
-        if (m_editor->is_wrapping_enabled()) {
-            auto position_below = m_editor->cursor_content_rect().location().translated(0, pixels);
-            new_cursor = m_editor->text_position_at_content_position(position_below);
-        } else {
-            size_t new_line = min(m_editor->line_count() - 1, m_editor->cursor().line() + pixels / m_editor->line_height());
-            size_t new_column = min(m_editor->cursor().column(), m_editor->lines()[new_line].length());
-            new_cursor = { new_line, new_column };
-        }
+        auto position_below = m_editor->cursor_content_rect().location().translated(0, pixels);
+        TextPosition new_cursor = m_editor->text_position_at_content_position(position_below);
         m_editor->set_cursor(new_cursor);
     };
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -395,9 +395,9 @@ Gfx::IntRect TextEditor::gutter_rect_in_inner_coordinates() const
 Gfx::IntRect TextEditor::visible_text_rect_in_inner_coordinates() const
 {
     return {
-        m_horizontal_content_padding + (m_ruler_visible ? (ruler_rect_in_inner_coordinates().right() + 1) : 0),
+        m_horizontal_content_padding + ruler_width() + gutter_width(),
         0,
-        frame_inner_rect().width() - (m_horizontal_content_padding * 2) - width_occupied_by_vertical_scrollbar() - ruler_width(),
+        frame_inner_rect().width() - (m_horizontal_content_padding * 2) - width_occupied_by_vertical_scrollbar() - ruler_width() - gutter_width(),
         frame_inner_rect().height() - height_occupied_by_horizontal_scrollbar()
     };
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -149,18 +149,14 @@ TextPosition TextEditor::text_position_at_content_position(Gfx::IntPoint content
     size_t line_index = 0;
 
     if (position.y() >= 0) {
-        if (is_wrapping_enabled()) {
-            for (size_t i = 0; i < line_count(); ++i) {
-                auto& rect = m_line_visual_data[i].visual_rect;
-                if (position.y() >= rect.top() && position.y() <= rect.bottom()) {
-                    line_index = i;
-                    break;
-                }
-                if (position.y() > rect.bottom())
-                    line_index = line_count() - 1;
+        for (size_t i = 0; i < line_count(); ++i) {
+            auto& rect = m_line_visual_data[i].visual_rect;
+            if (position.y() >= rect.top() && position.y() <= rect.bottom()) {
+                line_index = i;
+                break;
             }
-        } else {
-            line_index = (size_t)(position.y() / line_height());
+            if (position.y() > rect.bottom())
+                line_index = line_count() - 1;
         }
         line_index = max((size_t)0, min(line_index, line_count() - 1));
     }
@@ -1357,14 +1353,7 @@ Gfx::IntRect TextEditor::line_content_rect(size_t line_index) const
         line_rect.center_vertically_within({ {}, frame_inner_rect().size() });
         return line_rect;
     }
-    if (is_wrapping_enabled())
-        return m_line_visual_data[line_index].visual_rect;
-    return {
-        content_x_for_position({ line_index, 0 }),
-        (int)line_index * line_height(),
-        text_width_for_font(line.view(), font()),
-        line_height()
-    };
+    return m_line_visual_data[line_index].visual_rect;
 }
 
 void TextEditor::set_cursor_and_focus_line(size_t line, size_t column)

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -623,13 +623,13 @@ void TextEditor::paint_event(PaintEvent& event)
                         continue;
                     }
                     size_t span_end;
-                    bool span_consumned;
+                    bool span_consumed;
                     if (span.range.end().line() > line_index || span.range.end().column() > start_of_visual_line + visual_line_text.length()) {
                         span_end = visual_line_text.length();
-                        span_consumned = false;
+                        span_consumed = false;
                     } else {
                         span_end = span.range.end().column() - start_of_visual_line;
-                        span_consumned = true;
+                        span_consumed = true;
                     }
 
                     if (span_start != next_column) {
@@ -643,7 +643,7 @@ void TextEditor::paint_event(PaintEvent& event)
                     }
                     draw_text_helper(span_start, span_end, font, span.attributes);
                     next_column = span_end;
-                    if (!span_consumned) {
+                    if (!span_consumed) {
                         // continue with same span on next line
                         break;
                     } else {

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -312,7 +312,9 @@ void TextEditor::mousemove_event(MouseEvent& event)
         return;
     }
 
-    if (m_ruler_visible && (ruler_rect_in_inner_coordinates().contains(event.position()))) {
+    if (m_ruler_visible && ruler_rect_in_inner_coordinates().contains(event.position())) {
+        set_override_cursor(Gfx::StandardCursor::None);
+    } else if (m_gutter_visible && gutter_rect_in_inner_coordinates().contains(event.position())) {
         set_override_cursor(Gfx::StandardCursor::None);
     } else {
         set_editing_cursor();


### PR DESCRIPTION
- **Fix typo in `span_consumed` variable:** In which I try to steal Nico's job.
- **Combine wrapping/non-wrapping TextEditor code paths:** Less of a fix, but removes alternative non-wrapping code paths because the wrapping path works fine, and because code-folding will prevent the shortcuts from working anyway.
- **Don't show caret cursor when hovering TextEditor's gutter:** Show the arrow cursor, same as when hovering the ruler.
- **Take gutter into account when measuring TextEditor content area:** This makes text wrap properly when the gutter is visible.