### PR TITLE
AK: Make a limited form of custom errors possible

### DIFF
--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -4,6 +4,7 @@ set(AK_SOURCES
     CircularBuffer.cpp
     DeprecatedFlyString.cpp
     DeprecatedString.cpp
+    Error.cpp
     FloatingPointStringConversions.cpp
     FlyString.cpp
     Format.cpp

--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Error.h>
+#include <AK/String.h>
+
+namespace AK {
+
+template<typename R>
+R Error::format_impl() const
+{
+    static_assert(IsSame<R, ErrorOr<AK::String>>);
+
+    auto& format_data = m_data.get<FormattedString>();
+    alignas(AK::TypeErasedParameter) u8 params_bits[sizeof(AK::TypeErasedParameter) * ((64 - sizeof(StringView)) / 2)];
+    auto* params = bit_cast<AK::TypeErasedParameter*>(&params_bits[0]);
+    size_t count = 0;
+    size_t offset = 0;
+
+    u8 aligned_local_storage[1 * KiB] {};
+    size_t aligned_local_storage_offset = 0;
+    auto allocate_aligned_on_local_storage = [&]<typename T>(u8 const* p) {
+        auto start_offset = align_up_to(aligned_local_storage_offset, alignof(T));
+        VERIFY(array_size(aligned_local_storage) >= start_offset + sizeof(T));
+        __builtin_memcpy(&aligned_local_storage[start_offset], p, sizeof(T));
+        aligned_local_storage_offset = start_offset + sizeof(T);
+        return bit_cast<T const*>(&aligned_local_storage[start_offset]);
+    };
+
+    for (; format_data.buffer[offset] != 0;) {
+        auto type = static_cast<FormattedString::Type>(format_data.buffer[offset]);
+        offset += 1;
+        switch (type) {
+        case FormattedString::Type::Nothing:
+            VERIFY_NOT_REACHED();
+
+#define CASE(Name, T)                                                                              \
+    case FormattedString::Type::Name:                                                              \
+        params[count++] = AK::TypeErasedParameter {                                                \
+            allocate_aligned_on_local_storage.template operator()<T>(&format_data.buffer[offset]), \
+            AK::TypeErasedParameter::get_type<T>(),                                                \
+            AK::__format_value<T>                                                                  \
+        };                                                                                         \
+        offset += sizeof(T);                                                                       \
+        break
+
+            CASE(StringView, StringView);
+            CASE(U8, u8);
+            CASE(U16, u16);
+            CASE(U32, u32);
+            CASE(U64, u64);
+            CASE(I8, i8);
+            CASE(I16, i16);
+            CASE(I32, i32);
+            CASE(I64, i64);
+
+#undef CASE
+        }
+    }
+
+    TypeErasedFormatParams format_params;
+    format_params.set_parameters({ params, count });
+    return AK::String::vformatted(format_data.format_string, format_params);
+}
+
+template ErrorOr<String> Error::format_impl<ErrorOr<String>>() const;
+
+}

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -681,21 +681,7 @@ struct Formatter<FormatString> : Formatter<StringView> {
 
 template<>
 struct Formatter<Error> : Formatter<FormatString> {
-    ErrorOr<void> format(FormatBuilder& builder, Error const& error)
-    {
-#if defined(AK_OS_SERENITY) && defined(KERNEL)
-        if (error.is_errno())
-            return Formatter<FormatString>::format(builder, "Error(errno={})"sv, error.code());
-        return Formatter<FormatString>::format(builder, "Error({})"sv, error.string_literal());
-#else
-        if (error.is_syscall())
-            return Formatter<FormatString>::format(builder, "{}: {} (errno={})"sv, error.string_literal(), strerror(error.code()), error.code());
-        if (error.is_errno())
-            return Formatter<FormatString>::format(builder, "{} (errno={})"sv, strerror(error.code()), error.code());
-
-        return Formatter<FormatString>::format(builder, "{}"sv, error.string_literal());
-#endif
-    }
+    ErrorOr<void> format(FormatBuilder& builder, Error const& error);
 };
 
 template<typename T, typename ErrorType>


### PR DESCRIPTION
This commit increases the size of Error to 72 bytes, but allows the user
to produce errors in one of the following formats:
- A syscall (syscall name + return code) error
- An errno (errno value) error
- A 63-byte string, could be anything
- A limited form of a formatted string, where only integers and
  StringViews can be used as format arguments - I believe this covers
  _most_ errors

This could be extended to fit basically anything in the 64-byte buffer
available in the error object, including traceback information or a
custom POD object.

Initial performance testing concludes that there is no noticeable
performance impact, with results being within 0.1% of the baseline test
case.

---

Let's talk about stack space usage!
Individually, function stack sizes _mostly_ remain unchanged, either due to alignment changes, or due to not having to allocate space for an Error object on the stack; however, increases of up to ~380 bytes are observed (X axis corresponds to functions required to build `test-js`, Y axis shows the difference in bytes between master and this branch - positive meaning "increased by this change"):
![plot](https://user-images.githubusercontent.com/14001776/217903939-bfd31d06-d12d-4e80-ab85-35b2306e1127.png)

Overall, however, there's a surprising _decrease_ in dynamic stack depth at thread preemption boundaries (running `test-js`):
```
mean   min     max   stddev
20405  4888  76520  16388 # master
19388  3560  72464  16537 # curstom errors
```
No idea why, and no, I did _not_ flip the order unintentionally (or intentionally), but if that were the case, the increases would've been negligible (less than one page) anyway.

---

As a sample, the second commit showcases what this allows, if everything goes well, this PR might contain a lot of those :^)