### PR TITLE
AK+Everywhere: Remove and disallow needless copies of Error and ErrorOr objects

### DIFF
--- a/AK/BufferedStream.h
+++ b/AK/BufferedStream.h
@@ -238,12 +238,12 @@ private:
             auto result = stream().read(fillable_slice);
             if (result.is_error()) {
                 if (!result.error().is_errno())
-                    return result.error();
+                    return result.release_error();
                 if (result.error().code() == EINTR)
                     continue;
                 if (result.error().code() == EAGAIN)
                     break;
-                return result.error();
+                return result.release_error();
             }
             auto const filled_slice = result.value();
             VERIFY(m_buffer.write(filled_slice) == filled_slice.size());

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -21,6 +21,9 @@ namespace AK {
 
 class Error {
 public:
+    ALWAYS_INLINE Error(Error&&) = default;
+    ALWAYS_INLINE Error& operator=(Error&&) = default;
+
     [[nodiscard]] static Error from_errno(int code) { return Error(code); }
     [[nodiscard]] static Error from_syscall(StringView syscall_name, int rc) { return Error(syscall_name, rc); }
     [[nodiscard]] static Error from_string_view(StringView string_literal) { return Error(string_literal); }
@@ -79,6 +82,9 @@ private:
     {
     }
 
+    Error(Error const&) = default;
+    Error& operator=(Error const&) = default;
+
     StringView m_string_literal;
     int m_code { 0 };
     bool m_syscall { false };
@@ -100,23 +106,10 @@ public:
     }
 
     ALWAYS_INLINE ErrorOr(ErrorOr&&) = default;
-    ALWAYS_INLINE ErrorOr(ErrorOr const&) = default;
     ALWAYS_INLINE ErrorOr& operator=(ErrorOr&&) = default;
-    ALWAYS_INLINE ErrorOr& operator=(ErrorOr const&) = default;
 
-    template<typename U>
-    ALWAYS_INLINE ErrorOr(ErrorOr<U, ErrorType> const& value)
-    requires(IsConvertible<U, T>)
-        : m_value_or_error(value.m_value_or_error.visit([](U const& v) -> Variant<T, ErrorType> { return v; }, [](ErrorType const& error) -> Variant<T, ErrorType> { return error; }))
-    {
-    }
-
-    template<typename U>
-    ALWAYS_INLINE ErrorOr(ErrorOr<U, ErrorType>& value)
-    requires(IsConvertible<U, T>)
-        : m_value_or_error(value.m_value_or_error.visit([](U& v) { return Variant<T, ErrorType>(move(v)); }, [](ErrorType& error) { return Variant<T, ErrorType>(move(error)); }))
-    {
-    }
+    ErrorOr(ErrorOr const&) = delete;
+    ErrorOr& operator=(ErrorOr const&) = delete;
 
     template<typename U>
     ALWAYS_INLINE ErrorOr(ErrorOr<U, ErrorType>&& value)

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -25,6 +25,11 @@ public:
     [[nodiscard]] static Error from_syscall(StringView syscall_name, int rc) { return Error(syscall_name, rc); }
     [[nodiscard]] static Error from_string_view(StringView string_literal) { return Error(string_literal); }
 
+    [[nodiscard]] static Error copy(Error const& error)
+    {
+        return Error(error);
+    }
+
     // NOTE: Prefer `from_string_literal` when directly typing out an error message:
     //
     //     return Error::from_string_literal("Class: Some failure");

--- a/AK/Try.h
+++ b/AK/Try.h
@@ -25,7 +25,7 @@
     ({                                                                                               \
         /* Ignore -Wshadow to allow nesting the macro. */                                            \
         AK_IGNORE_DIAGNOSTIC("-Wshadow",                                                             \
-            auto _temporary_result = (expression));                                                  \
+            auto&& _temporary_result = (expression));                                                \
         static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \
             "Do not return a reference from a fallible expression");                                 \
         if (_temporary_result.is_error()) [[unlikely]]                                               \
@@ -37,7 +37,7 @@
     ({                                                                                               \
         /* Ignore -Wshadow to allow nesting the macro. */                                            \
         AK_IGNORE_DIAGNOSTIC("-Wshadow",                                                             \
-            auto _temporary_result = (expression));                                                  \
+            auto&& _temporary_result = (expression));                                                \
         static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \
             "Do not return a reference from a fallible expression");                                 \
         VERIFY(!_temporary_result.is_error());                                                       \

--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -137,7 +137,7 @@ ErrorOr<void> Access::add_host_controller_and_scan_for_devices(NonnullOwnPtr<Hos
     m_host_controllers.get(domain_number).value()->enumerate_attached_devices([&](EnumerableDeviceIdentifier const& device_identifier) -> IterationDecision {
         auto device_identifier_or_error = DeviceIdentifier::from_enumerable_identifier(device_identifier);
         if (device_identifier_or_error.is_error()) {
-            error_or_void = device_identifier_or_error.error();
+            error_or_void = device_identifier_or_error.release_error();
             return IterationDecision::Break;
         }
         m_device_identifiers.append(device_identifier_or_error.release_value());
@@ -167,7 +167,7 @@ UNMAP_AFTER_INIT void Access::rescan_hardware()
         (*it).value->enumerate_attached_devices([this, &error_or_void](EnumerableDeviceIdentifier device_identifier) -> IterationDecision {
             auto device_identifier_or_error = DeviceIdentifier::from_enumerable_identifier(device_identifier);
             if (device_identifier_or_error.is_error()) {
-                error_or_void = device_identifier_or_error.error();
+                error_or_void = device_identifier_or_error.release_error();
                 return IterationDecision::Break;
             }
             m_device_identifiers.append(device_identifier_or_error.release_value());

--- a/Kernel/FileSystem/Plan9FS/FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FS/FileSystem.cpp
@@ -334,7 +334,7 @@ void Plan9FS::thread_main()
             MutexLocker locker(m_lock);
 
             for (auto& it : m_completions) {
-                it.value->result = result;
+                it.value->result = Error::copy(result.error());
                 it.value->completed = true;
             }
             m_completions.clear();

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -403,7 +403,7 @@ ErrorOr<size_t> IPv4Socket::recvfrom(OpenFileDescription& description, UserOrKer
             nreceived = receive_packet_buffered(description, offset_buffer, offset_buffer_length, flags, user_addr, user_addr_length, packet_timestamp, blocking);
 
         if (nreceived.is_error())
-            total_nreceived = nreceived;
+            total_nreceived = move(nreceived);
         else
             total_nreceived.value() += nreceived.value();
     } while ((flags & MSG_WAITALL) && !total_nreceived.is_error() && total_nreceived.value() < buffer_length);

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -169,11 +169,9 @@ ErrorOr<void> Socket::getsockopt(OpenFileDescription&, int level, int option, Us
     case SO_ERROR: {
         if (size < sizeof(int))
             return EINVAL;
-        int errno;
-        if (so_error().is_error())
-            errno = so_error().error().code();
-        else
-            errno = 0;
+        int errno = 0;
+        if (auto const& error = so_error(); error.has_value())
+            errno = error.value();
         TRY(copy_to_user(static_ptr_cast<int*>(value), &errno));
         size = sizeof(int);
         TRY(copy_to_user(value_size, &size));

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -124,7 +124,7 @@ protected:
 
     Role m_role { Role::None };
 
-    ErrorOr<void> so_error() const
+    Optional<ErrnoCode> const& so_error() const
     {
         VERIFY(m_mutex.is_exclusively_locked_by_current_thread());
         return m_so_error;
@@ -133,14 +133,16 @@ protected:
     Error set_so_error(ErrnoCode error_code)
     {
         MutexLocker locker(mutex());
-        auto error = Error::from_errno(error_code);
-        m_so_error = error;
-        return error;
+        m_so_error = error_code;
+
+        return Error::from_errno(error_code);
     }
+
     Error set_so_error(Error error)
     {
         MutexLocker locker(mutex());
-        m_so_error = error;
+        m_so_error = static_cast<ErrnoCode>(error.code());
+
         return error;
     }
 
@@ -178,7 +180,7 @@ private:
     Time m_send_timeout {};
     int m_timestamp { 0 };
 
-    ErrorOr<void> m_so_error;
+    Optional<ErrnoCode> m_so_error;
 
     NonnullLockRefPtrVector<Socket> m_pending;
 };

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -188,7 +188,7 @@ private:
 // This is a special variant of TRY() that also updates the socket's SO_ERROR field on error.
 #define SOCKET_TRY(expression)                                                            \
     ({                                                                                    \
-        auto result = (expression);                                                       \
+        auto&& result = (expression);                                                     \
         if (result.is_error())                                                            \
             return set_so_error(result.release_error());                                  \
         static_assert(!::AK::Detail::IsLvalueReference<decltype(result.release_value())>, \

--- a/Kernel/PerformanceEventBuffer.cpp
+++ b/Kernel/PerformanceEventBuffer.cpp
@@ -22,7 +22,7 @@ PerformanceEventBuffer::PerformanceEventBuffer(NonnullOwnPtr<KBuffer> buffer)
 {
 }
 
-NEVER_INLINE ErrorOr<void> PerformanceEventBuffer::append(int type, FlatPtr arg1, FlatPtr arg2, StringView arg3, Thread* current_thread, FlatPtr arg4, u64 arg5, ErrorOr<FlatPtr> arg6)
+NEVER_INLINE ErrorOr<void> PerformanceEventBuffer::append(int type, FlatPtr arg1, FlatPtr arg2, StringView arg3, Thread* current_thread, FlatPtr arg4, u64 arg5, ErrorOr<FlatPtr> const& arg6)
 {
     FlatPtr base_pointer = (FlatPtr)__builtin_frame_address(0);
     return append_with_ip_and_bp(current_thread->pid(), current_thread->tid(), 0, base_pointer, type, 0, arg1, arg2, arg3, arg4, arg5, arg6);
@@ -66,13 +66,13 @@ static Vector<FlatPtr, PerformanceEvent::max_stack_frame_count> raw_backtrace(Fl
 }
 
 ErrorOr<void> PerformanceEventBuffer::append_with_ip_and_bp(ProcessID pid, ThreadID tid, RegisterState const& regs,
-    int type, u32 lost_samples, FlatPtr arg1, FlatPtr arg2, StringView arg3, FlatPtr arg4, u64 arg5, ErrorOr<FlatPtr> arg6)
+    int type, u32 lost_samples, FlatPtr arg1, FlatPtr arg2, StringView arg3, FlatPtr arg4, u64 arg5, ErrorOr<FlatPtr> const& arg6)
 {
     return append_with_ip_and_bp(pid, tid, regs.ip(), regs.bp(), type, lost_samples, arg1, arg2, arg3, arg4, arg5, arg6);
 }
 
 ErrorOr<void> PerformanceEventBuffer::append_with_ip_and_bp(ProcessID pid, ThreadID tid,
-    FlatPtr ip, FlatPtr bp, int type, u32 lost_samples, FlatPtr arg1, FlatPtr arg2, StringView arg3, FlatPtr arg4, u64 arg5, ErrorOr<FlatPtr> arg6)
+    FlatPtr ip, FlatPtr bp, int type, u32 lost_samples, FlatPtr arg1, FlatPtr arg2, StringView arg3, FlatPtr arg4, u64 arg5, ErrorOr<FlatPtr> const& arg6)
 {
     if (count() >= capacity())
         return ENOBUFS;

--- a/Kernel/PerformanceEventBuffer.h
+++ b/Kernel/PerformanceEventBuffer.h
@@ -110,11 +110,11 @@ class PerformanceEventBuffer {
 public:
     static OwnPtr<PerformanceEventBuffer> try_create_with_size(size_t buffer_size);
 
-    ErrorOr<void> append(int type, FlatPtr arg1, FlatPtr arg2, StringView arg3, Thread* current_thread = Thread::current(), FlatPtr arg4 = 0, u64 arg5 = 0, ErrorOr<FlatPtr> arg6 = 0);
+    ErrorOr<void> append(int type, FlatPtr arg1, FlatPtr arg2, StringView arg3, Thread* current_thread = Thread::current(), FlatPtr arg4 = 0, u64 arg5 = 0, ErrorOr<FlatPtr> const& arg6 = 0);
     ErrorOr<void> append_with_ip_and_bp(ProcessID pid, ThreadID tid, FlatPtr eip, FlatPtr ebp,
-        int type, u32 lost_samples, FlatPtr arg1, FlatPtr arg2, StringView arg3, FlatPtr arg4 = 0, u64 arg5 = {}, ErrorOr<FlatPtr> arg6 = 0);
+        int type, u32 lost_samples, FlatPtr arg1, FlatPtr arg2, StringView arg3, FlatPtr arg4 = 0, u64 arg5 = {}, ErrorOr<FlatPtr> const& arg6 = 0);
     ErrorOr<void> append_with_ip_and_bp(ProcessID pid, ThreadID tid, RegisterState const& regs,
-        int type, u32 lost_samples, FlatPtr arg1, FlatPtr arg2, StringView arg3, FlatPtr arg4 = 0, u64 arg5 = {}, ErrorOr<FlatPtr> arg6 = 0);
+        int type, u32 lost_samples, FlatPtr arg1, FlatPtr arg2, StringView arg3, FlatPtr arg4 = 0, u64 arg5 = {}, ErrorOr<FlatPtr> const& arg6 = 0);
 
     void clear()
     {

--- a/Kernel/PerformanceManager.h
+++ b/Kernel/PerformanceManager.h
@@ -127,7 +127,7 @@ public:
         }
     }
 
-    static void add_read_event(Thread& thread, int fd, size_t size, OpenFileDescription const& file_description, u64 start_timestamp, ErrorOr<FlatPtr> result)
+    static void add_read_event(Thread& thread, int fd, size_t size, OpenFileDescription const& file_description, u64 start_timestamp, ErrorOr<FlatPtr> const& result)
     {
         if (thread.is_profiling_suppressed())
             return;

--- a/Kernel/Syscalls/read.cpp
+++ b/Kernel/Syscalls/read.cpp
@@ -74,7 +74,7 @@ ErrorOr<FlatPtr> Process::sys$readv(int fd, Userspace<const struct iovec*> iov, 
 ErrorOr<FlatPtr> Process::sys$read(int fd, Userspace<u8*> buffer, size_t size)
 {
     auto const start_timestamp = TimeManagement::the().uptime_ms();
-    auto const result = read_impl(fd, buffer, size);
+    auto result = read_impl(fd, buffer, size);
 
     if (Thread::current()->is_profiling_suppressed())
         return result;

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
@@ -233,7 +233,7 @@ struct CLDR {
 // with locales such as "en-GB-oed" that are canonically invalid locale IDs.
 #define TRY_OR_DISCARD(expression)                                                                   \
     ({                                                                                               \
-        auto _temporary_result = (expression);                                                       \
+        auto&& _temporary_result = (expression);                                                     \
         if (_temporary_result.is_error())                                                            \
             return;                                                                                  \
         static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -101,9 +101,9 @@ ErrorOr<void> MainWidget::create_actions()
         new_font_wizard->hide();
         auto maybe_font = new_font_wizard->create_font();
         if (maybe_font.is_error())
-            return show_error(maybe_font.error(), "Creating new font failed"sv);
+            return show_error(maybe_font.release_error(), "Creating new font failed"sv);
         if (auto result = initialize({}, move(maybe_font.value())); result.is_error())
-            show_error(result.error(), "Initializing new font failed"sv);
+            show_error(result.release_error(), "Initializing new font failed"sv);
     });
     m_new_action->set_status_tip("Create a new font");
 
@@ -114,14 +114,14 @@ ErrorOr<void> MainWidget::create_actions()
         if (!open_path.has_value())
             return;
         if (auto result = open_file(open_path.value()); result.is_error())
-            show_error(result.error(), "Opening"sv, LexicalPath { open_path.value() }.basename());
+            show_error(result.release_error(), "Opening"sv, LexicalPath { open_path.value() }.basename());
     });
 
     m_save_action = GUI::CommonActions::make_save_action([&](auto&) {
         if (m_path.is_empty())
             return m_save_as_action->activate();
         if (auto result = save_file(m_path); result.is_error())
-            show_error(result.error(), "Saving"sv, LexicalPath { m_path }.basename());
+            show_error(result.release_error(), "Saving"sv, LexicalPath { m_path }.basename());
     });
 
     m_save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
@@ -130,17 +130,17 @@ ErrorOr<void> MainWidget::create_actions()
         if (!save_path.has_value())
             return;
         if (auto result = save_file(save_path.value()); result.is_error())
-            show_error(result.error(), "Saving"sv, lexical_path.basename());
+            show_error(result.release_error(), "Saving"sv, lexical_path.basename());
     });
 
     m_cut_action = GUI::CommonActions::make_cut_action([&](auto&) {
         if (auto result = cut_selected_glyphs(); result.is_error())
-            show_error(result.error(), "Cutting selection failed"sv);
+            show_error(result.release_error(), "Cutting selection failed"sv);
     });
 
     m_copy_action = GUI::CommonActions::make_copy_action([&](auto&) {
         if (auto result = copy_selected_glyphs(); result.is_error())
-            show_error(result.error(), "Copying selection failed"sv);
+            show_error(result.release_error(), "Copying selection failed"sv);
     });
 
     m_paste_action = GUI::CommonActions::make_paste_action([&](auto&) {
@@ -178,7 +178,7 @@ ErrorOr<void> MainWidget::create_actions()
     m_open_preview_action = GUI::Action::create("&Preview Font", { Mod_Ctrl, Key_P }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/find.png"sv)), [&](auto&) {
         if (!m_font_preview_window) {
             if (auto maybe_window = create_preview_window(); maybe_window.is_error())
-                show_error(maybe_window.error(), "Creating preview window failed"sv);
+                show_error(maybe_window.release_error(), "Creating preview window failed"sv);
             else
                 m_font_preview_window = maybe_window.release_value();
         }
@@ -792,12 +792,12 @@ void MainWidget::push_undo()
 {
     auto maybe_state = m_undo_selection->save_state();
     if (maybe_state.is_error())
-        return show_error(maybe_state.error(), "Saving undo state failed"sv);
+        return show_error(maybe_state.release_error(), "Saving undo state failed"sv);
     auto maybe_command = try_make<SelectionUndoCommand>(*m_undo_selection, move(maybe_state.value()));
     if (maybe_command.is_error())
-        return show_error(maybe_command.error(), "Making undo command failed"sv);
+        return show_error(maybe_command.release_error(), "Making undo command failed"sv);
     if (auto maybe_push = m_undo_stack->try_push(move(maybe_command.value())); maybe_push.is_error())
-        show_error(maybe_push.error(), "Pushing undo stack failed"sv);
+        show_error(maybe_push.release_error(), "Pushing undo stack failed"sv);
 }
 
 void MainWidget::reset_selection_and_push_undo()
@@ -976,7 +976,7 @@ void MainWidget::drop_event(GUI::DropEvent& event)
             return;
 
         if (auto result = open_file(urls.first().path()); result.is_error())
-            show_error(result.error(), "Opening"sv, LexicalPath { urls.first().path() }.basename());
+            show_error(result.release_error(), "Opening"sv, LexicalPath { urls.first().path() }.basename());
     }
 }
 

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -27,9 +27,8 @@ bool KeyboardMapperWidget::request_close()
         return true;
     auto result = GUI::MessageBox::ask_about_unsaved_changes(window(), m_filename);
     if (result == GUI::MessageBox::ExecResult::Yes) {
-        ErrorOr<void> error_or = save();
-        if (error_or.is_error())
-            show_error_to_user(error_or.error());
+        if (auto error_or = save(); error_or.is_error())
+            show_error_to_user(error_or.release_error());
 
         if (!window()->is_modified())
             return true;

--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -54,16 +54,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (!path.has_value())
                 return;
 
-            ErrorOr<void> error_or = keyboard_mapper_widget->load_map_from_file(path.value());
-            if (error_or.is_error())
-                keyboard_mapper_widget->show_error_to_user(error_or.error());
+            if (auto error_or = keyboard_mapper_widget->load_map_from_file(path.value()); error_or.is_error())
+                keyboard_mapper_widget->show_error_to_user(error_or.release_error());
         });
 
     auto save_action = GUI::CommonActions::make_save_action(
         [&](auto&) {
-            ErrorOr<void> error_or = keyboard_mapper_widget->save();
-            if (error_or.is_error())
-                keyboard_mapper_widget->show_error_to_user(error_or.error());
+            if (auto error_or = keyboard_mapper_widget->save(); error_or.is_error())
+                keyboard_mapper_widget->show_error_to_user(error_or.release_error());
         });
 
     auto save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
@@ -72,9 +70,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         if (!save_path.has_value())
             return;
 
-        ErrorOr<void> error_or = keyboard_mapper_widget->save_to_file(save_path.value());
-        if (error_or.is_error())
-            keyboard_mapper_widget->show_error_to_user(error_or.error());
+        if (auto error_or = keyboard_mapper_widget->save_to_file(save_path.value()); error_or.is_error())
+            keyboard_mapper_widget->show_error_to_user(error_or.release_error());
     });
 
     auto quit_action = GUI::CommonActions::make_quit_action(

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1021,8 +1021,8 @@ ErrorOr<NonnullRefPtr<GUI::Action>> HackStudioWidget::create_debug_action()
             return;
         }
 
-        Debugger::the().set_child_setup_callback([this, ptm_res]() {
-            return m_terminal_wrapper->setup_slave_pseudoterminal(ptm_res.value());
+        Debugger::the().set_child_setup_callback([this, ptm_res = ptm_res.release_value()]() {
+            return m_terminal_wrapper->setup_slave_pseudoterminal(ptm_res);
         });
 
         m_debugger_thread = Threading::Thread::construct(Debugger::start_static);
@@ -1789,7 +1789,7 @@ ErrorOr<NonnullRefPtr<GUI::Action>> HackStudioWidget::create_open_project_config
 
             auto maybe_error = Core::System::mkdir(LexicalPath::absolute_path(m_project->root_path(), parent_directory), 0755);
             if (maybe_error.is_error() && maybe_error.error().code() != EEXIST)
-                return maybe_error.error();
+                return maybe_error.release_error();
 
             auto file = TRY(Core::Stream::File::open(absolute_config_file_path, Core::Stream::OpenMode::Write));
             TRY(file->write_entire_buffer(

--- a/Userland/Libraries/LibAudio/LoaderError.h
+++ b/Userland/Libraries/LibAudio/LoaderError.h
@@ -68,7 +68,7 @@ struct LoaderError {
 // Convenience TRY-like macro to convert an Error to a LoaderError
 #define LOADER_TRY(expression)                                                                       \
     ({                                                                                               \
-        auto _temporary_result = (expression);                                                       \
+        auto&& _temporary_result = (expression);                                                     \
         if (_temporary_result.is_error())                                                            \
             return LoaderError(_temporary_result.release_error());                                   \
         static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \

--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -47,7 +47,7 @@ ErrorOr<NonnullRefPtr<ConfigFile>> ConfigFile::open(DeprecatedString const& file
         // the same as if we had opened an empty file. This behavior is a little weird, but is required by
         // user code, which does not check the config file exists before opening.
         if (!(allow_altering == AllowWriting::No && maybe_file.error().code() == ENOENT))
-            return maybe_file.error();
+            return maybe_file.release_error();
     } else {
         buffered_file = TRY(Stream::BufferedFile::create(maybe_file.release_value()));
     }

--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -531,7 +531,7 @@ ErrorOr<void, File::CopyError> File::copy_directory(DeprecatedString const& dst_
             DeprecatedString::formatted("{}/{}", src_path, filename),
             RecursionMode::Allowed, link, AddDuplicateFileMarker::Yes, preserve_mode);
         if (result.is_error())
-            return result.error();
+            return result.release_error();
     }
 
     auto my_umask = umask(0);

--- a/Userland/Libraries/LibEDID/EDID.cpp
+++ b/Userland/Libraries/LibEDID/EDID.cpp
@@ -907,14 +907,14 @@ ErrorOr<IterationDecision> Parser::for_each_detailed_timing(Function<IterationDe
         });
         if (result.is_error()) {
             dbgln("Failed to iterate DTDs in CEA861 extension block: {}", result.error());
-            extension_error = result.error();
+            extension_error = result.release_error();
             return IterationDecision::Break;
         }
 
         return result.value();
     }));
     if (extension_error.has_value())
-        return extension_error.value();
+        return extension_error.release_value();
     return result;
 }
 
@@ -948,7 +948,7 @@ ErrorOr<IterationDecision> Parser::for_each_short_video_descriptor(Function<Iter
             return callback(block_id, is_native, vic);
         });
         if (result.is_error()) {
-            extension_error = result.error();
+            extension_error = result.release_error();
             return IterationDecision::Break;
         }
         return result.value();
@@ -985,14 +985,14 @@ ErrorOr<IterationDecision> Parser::for_each_display_descriptor(Function<Iteratio
         });
         if (result.is_error()) {
             dbgln("Failed to iterate display descriptors in CEA861 extension block: {}", result.error());
-            extension_error = result.error();
+            extension_error = result.release_error();
             return IterationDecision::Break;
         }
 
         return result.value();
     }));
     if (extension_error.has_value())
-        return extension_error.value();
+        return extension_error.release_value();
     return result;
 }
 

--- a/Userland/Libraries/LibGL/Shaders/Program.cpp
+++ b/Userland/Libraries/LibGL/Shaders/Program.cpp
@@ -65,7 +65,7 @@ ErrorOr<void> Program::link(GPU::Device& device)
     if (linked_vertex_shader_or_error.is_error()) {
         m_link_status = false;
         m_info_log = linker.messages();
-        return linked_vertex_shader_or_error.error();
+        return linked_vertex_shader_or_error.release_error();
     }
 
     m_linked_vertex_shader = linked_vertex_shader_or_error.release_value();
@@ -81,7 +81,7 @@ ErrorOr<void> Program::link(GPU::Device& device)
     if (linked_fragment_shader_or_error.is_error()) {
         m_link_status = false;
         m_info_log = linker.messages();
-        return linked_fragment_shader_or_error.error();
+        return linked_fragment_shader_or_error.release_error();
     }
 
     m_linked_fragment_shader = linked_fragment_shader_or_error.release_value();

--- a/Userland/Libraries/LibGL/Shaders/Shader.cpp
+++ b/Userland/Libraries/LibGL/Shaders/Shader.cpp
@@ -33,7 +33,7 @@ ErrorOr<void> Shader::compile()
     if (object_file_or_error.is_error()) {
         m_compile_status = false;
         m_info_log = compiler.messages();
-        return object_file_or_error.error();
+        return object_file_or_error.release_error();
     }
 
     m_object_file = object_file_or_error.release_value();

--- a/Userland/Libraries/LibGfx/QOILoader.h
+++ b/Userland/Libraries/LibGfx/QOILoader.h
@@ -35,7 +35,6 @@ struct QOILoadingContext {
     OwnPtr<AK::Stream> stream {};
     QOIHeader header {};
     RefPtr<Bitmap> bitmap;
-    Optional<Error> error;
 };
 
 class QOIImageDecoderPlugin final : public ImageDecoderPlugin {

--- a/Userland/Libraries/LibJS/Runtime/Completion.h
+++ b/Userland/Libraries/LibJS/Runtime/Completion.h
@@ -21,7 +21,7 @@ namespace JS {
     ({                                                                                               \
         /* Ignore -Wshadow to allow nesting the macro. */                                            \
         AK_IGNORE_DIAGNOSTIC("-Wshadow",                                                             \
-            auto _temporary_result = (expression));                                                  \
+            auto&& _temporary_result = (expression));                                                \
         if (_temporary_result.is_error()) {                                                          \
             VERIFY(_temporary_result.error().code() == ENOMEM);                                      \
             return vm.throw_completion<JS::InternalError>(JS::ErrorType::OutOfMemory);               \
@@ -35,7 +35,7 @@ namespace JS {
     ({                                                                                                 \
         /* Ignore -Wshadow to allow nesting the macro. */                                              \
         AK_IGNORE_DIAGNOSTIC("-Wshadow",                                                               \
-            auto _temporary_result = (expression));                                                    \
+            auto&& _temporary_result = (expression));                                                  \
         if (_temporary_result.is_error()) {                                                            \
             auto _completion = _temporary_result.release_error();                                      \
                                                                                                        \

--- a/Userland/Libraries/LibJS/Runtime/PromiseCapability.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseCapability.h
@@ -43,7 +43,7 @@ private:
 // 27.2.1.1.1 IfAbruptRejectPromise ( value, capability ), https://tc39.es/ecma262/#sec-ifabruptrejectpromise
 #define __TRY_OR_REJECT(vm, capability, expression, CALL_CHECK)                                                                          \
     ({                                                                                                                                   \
-        auto _temporary_try_or_reject_result = (expression);                                                                             \
+        auto&& _temporary_try_or_reject_result = (expression);                                                                           \
         /* 1. If value is an abrupt completion, then */                                                                                  \
         if (_temporary_try_or_reject_result.is_error()) {                                                                                \
             /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                            \
@@ -69,7 +69,7 @@ private:
 // 27.2.1.1.1 IfAbruptRejectPromise ( value, capability ), https://tc39.es/ecma262/#sec-ifabruptrejectpromise
 #define TRY_OR_REJECT_WITH_VALUE(vm, capability, expression)                                                                      \
     ({                                                                                                                            \
-        auto _temporary_try_or_reject_result = (expression);                                                                      \
+        auto&& _temporary_try_or_reject_result = (expression);                                                                    \
         /* 1. If value is an abrupt completion, then */                                                                           \
         if (_temporary_try_or_reject_result.is_error()) {                                                                         \
             /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                     \

--- a/Userland/Libraries/LibSQL/Heap.cpp
+++ b/Userland/Libraries/LibSQL/Heap.cpp
@@ -53,7 +53,7 @@ ErrorOr<void> Heap::open()
     if (file_size > 0) {
         if (auto error_maybe = read_zero_block(); error_maybe.is_error()) {
             m_file = nullptr;
-            return error_maybe.error();
+            return error_maybe.release_error();
         }
     } else {
         initialize_zero_block();

--- a/Userland/Libraries/LibVideo/DecoderError.h
+++ b/Userland/Libraries/LibVideo/DecoderError.h
@@ -79,7 +79,7 @@ private:
 
 #define DECODER_TRY(category, expression)                                                  \
     ({                                                                                     \
-        auto _result = ((expression));                                                     \
+        auto&& _result = ((expression));                                                   \
         if (_result.is_error()) [[unlikely]] {                                             \
             auto _error_string = _result.release_error().string_literal();                 \
             return DecoderError::from_source_location(                                     \

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -15,7 +15,7 @@ namespace Video {
 
 #define TRY_OR_FATAL_ERROR(expression)                                                               \
     ({                                                                                               \
-        auto _fatal_expression = (expression);                                                       \
+        auto&& _fatal_expression = (expression);                                                     \
         if (_fatal_expression.is_error()) {                                                          \
             dispatch_fatal_error(_fatal_expression.release_error());                                 \
             return;                                                                                  \
@@ -156,7 +156,7 @@ bool PlaybackManager::decode_and_queue_one_sample()
 
 #define TRY_OR_ENQUEUE_ERROR(expression)                                                                                \
     ({                                                                                                                  \
-        auto _temporary_result = ((expression));                                                                        \
+        auto&& _temporary_result = ((expression));                                                                      \
         if (_temporary_result.is_error()) {                                                                             \
             dbgln_if(PLAYBACK_MANAGER_DEBUG, "Enqueued decoder error: {}", _temporary_result.error().string_literal()); \
             m_frame_queue->enqueue(FrameQueueItem::error_marker(_temporary_result.release_error()));                    \

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -85,7 +85,7 @@ void PlaybackManager::dispatch_fatal_error(Error error)
     // FIXME: For threading, this will have to use a pre-allocated event to send to the main loop
     //        to be able to gracefully handle OOM.
     VERIFY(&m_main_loop == &Core::EventLoop::current());
-    FatalPlaybackErrorEvent event { error };
+    FatalPlaybackErrorEvent event { move(error) };
     m_event_handler.dispatch_event(event);
 }
 

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -247,11 +247,11 @@ class FatalPlaybackErrorEvent : public Core::Event {
 public:
     explicit FatalPlaybackErrorEvent(Error error)
         : Core::Event(FatalPlaybackError)
-        , m_error(error)
+        , m_error(move(error))
     {
     }
     virtual ~FatalPlaybackErrorEvent() = default;
-    Error error() { return m_error; }
+    Error const& error() { return m_error; }
 
 private:
     Error m_error;

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -44,7 +44,7 @@ namespace Web::Fetch::Fetching {
 
 #define TRY_OR_IGNORE(expression)                                                                    \
     ({                                                                                               \
-        auto _temporary_result = (expression);                                                       \
+        auto&& _temporary_result = (expression);                                                     \
         if (_temporary_result.is_error())                                                            \
             return;                                                                                  \
         static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -172,7 +172,7 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, Has
         dbgln("ResourceLoader: Finished load of: \"{}\", Duration: {}ms", url_for_logging, load_time_ms);
     };
 
-    auto const log_failure = [url_for_logging, id](auto const& request, auto const error_message) {
+    auto const log_failure = [url_for_logging, id](auto const& request, auto const& error_message) {
         auto load_time_ms = request.load_time().to_milliseconds();
         emit_signpost(DeprecatedString::formatted("Failed load: {}", url_for_logging), id);
         dbgln("ResourceLoader: Failed load of: \"{}\", \033[31;1mError: {}\033[0m, Duration: {}ms", url_for_logging, error_message, load_time_ms);

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -33,7 +33,7 @@ namespace Web::WebDriver {
 
 #define TRY_OR_JS_ERROR(expression)                                                                  \
     ({                                                                                               \
-        auto _temporary_result = (expression);                                                       \
+        auto&& _temporary_result = (expression);                                                     \
         if (_temporary_result.is_error()) [[unlikely]]                                               \
             return ExecuteScriptResultType::JavaScriptError;                                         \
         static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \

--- a/Userland/Services/FileOperation/main.cpp
+++ b/Userland/Services/FileOperation/main.cpp
@@ -243,7 +243,7 @@ ErrorOr<int> execute_work_items(Vector<WorkItem> const& items)
                 if (auto result = destination_file->write(bytes_read); result.is_error()) {
                     // FIXME: Return the formatted string directly. There is no way to do this right now without the temporary going out of scope and being destroyed.
                     report_warning(DeprecatedString::formatted("Failed to write to destination file: {}", result.error()));
-                    return result.error();
+                    return result.release_error();
                 }
                 item_done += bytes_read.size();
                 executed_work_bytes += bytes_read.size();

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -238,8 +238,8 @@ public:
 
     void request_file(Web::FileRequest request) override
     {
-        auto const file = Core::System::open(request.path(), O_RDONLY);
-        request.on_file_request_finish(file);
+        auto file = Core::System::open(request.path(), O_RDONLY);
+        request.on_file_request_finish(move(file));
     }
 
 private:

--- a/Userland/Utilities/keymap.cpp
+++ b/Userland/Utilities/keymap.cpp
@@ -65,10 +65,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         // Verify that all specified keymaps are loadable
         for (auto& keymap_name : mappings_vector) {
-            auto keymap = Keyboard::CharacterMap::load_from_file(keymap_name);
-            if (keymap.is_error()) {
+            if (auto keymap = Keyboard::CharacterMap::load_from_file(keymap_name); keymap.is_error()) {
                 warnln("Cannot load keymap {}: {}({})", keymap_name, keymap.error().string_literal(), keymap.error().code());
-                return keymap.error();
+                return keymap.release_error();
             }
         }
 

--- a/Userland/Utilities/ln.cpp
+++ b/Userland/Utilities/ln.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto stat = Core::System::lstat(path);
 
     if (stat.is_error() && stat.error().code() != ENOENT)
-        return stat.error();
+        return stat.release_error();
 
     if (!stat.is_error() && S_ISDIR(stat.value().st_mode)) {
         // The target path is a directory, so we presumably want <path>/<filename> as the effective path.

--- a/Userland/Utilities/matroska.cpp
+++ b/Userland/Utilities/matroska.cpp
@@ -12,7 +12,7 @@
 
 #define TRY_PARSE(expression)                                                                        \
     ({                                                                                               \
-        auto _temporary_result = ((expression));                                                     \
+        auto&& _temporary_result = ((expression));                                                   \
         if (_temporary_result.is_error()) [[unlikely]] {                                             \
             outln("Encountered a parsing error: {}", _temporary_result.error().string_literal());    \
             return Error::from_string_literal("Failed to parse :(");                                 \

--- a/Userland/Utilities/rm.cpp
+++ b/Userland/Utilities/rm.cpp
@@ -46,7 +46,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto result = Core::File::remove(path, recursive ? Core::File::RecursionMode::Allowed : Core::File::RecursionMode::Disallowed);
 
         if (result.is_error()) {
-            auto error = result.error();
+            auto error = result.release_error();
 
             if (force && error.is_errno() && error.code() == ENOENT)
                 continue;

--- a/Userland/Utilities/tail.cpp
+++ b/Userland/Utilities/tail.cpp
@@ -110,7 +110,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (event.type == Core::FileWatcherEvent::Type::ContentModified) {
                 auto buffer_or_error = f->read_until_eof();
                 if (buffer_or_error.is_error()) {
-                    auto error = buffer_or_error.error();
+                    auto error = buffer_or_error.release_error();
                     warnln(error.string_literal());
                     event_loop.quit(error.code());
                     return;
@@ -120,7 +120,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
                 auto potential_error = f->seek(0, SeekMode::FromEndPosition);
                 if (potential_error.is_error()) {
-                    auto error = potential_error.error();
+                    auto error = potential_error.release_error();
                     warnln(error.string_literal());
                     event_loop.quit(error.code());
                     return;

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -181,7 +181,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
                     auto result_or_error = Core::System::mkdir(absolute_path, header_mode);
                     if (result_or_error.is_error() && result_or_error.error().code() != EEXIST)
-                        return result_or_error.error();
+                        return result_or_error.release_error();
                     break;
                 }
                 default:


### PR DESCRIPTION
For example, copying something like `ErrorOr<ByteBuffer>` can hide large allocations. But in general, it doesn't make much sense to copy these objects anyways, and in all cases where we copy them now, we can happily move them instead.