### PR TITLE
Spreadsheet: Improve navigation performance

### DIFF
--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -194,7 +194,7 @@ void SheetModel::set_data(const GUI::ModelIndex& index, const GUI::Variant& valu
 void SheetModel::update()
 {
     m_sheet->update();
-    did_update(UpdateFlag::DontInvalidateIndices);
+    did_update(UpdateFlag::DontInvalidateIndices | Model::UpdateFlag::DontResizeColumns);
 }
 
 CellsUndoCommand::CellsUndoCommand(Vector<CellChange> cell_changes)

--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -352,7 +352,9 @@ void AbstractTableView::model_did_update(unsigned flags)
 {
     AbstractView::model_did_update(flags);
     update_row_sizes();
-    update_column_sizes();
+    if (!(flags & Model::UpdateFlag::DontResizeColumns))
+        update_column_sizes();
+
     update_content_size();
     update();
 }

--- a/Userland/Libraries/LibGUI/Model.h
+++ b/Userland/Libraries/LibGUI/Model.h
@@ -51,6 +51,7 @@ public:
     enum UpdateFlag {
         DontInvalidateIndices = 0,
         InvalidateAllIndices = 1 << 0,
+        DontResizeColumns = 1 << 1,
     };
 
     enum MatchesFlag {

--- a/Userland/Libraries/LibGUI/Variant.h
+++ b/Userland/Libraries/LibGUI/Variant.h
@@ -204,6 +204,7 @@ public:
     {
         return visit(
             [](Empty) -> DeprecatedString { return "[null]"; },
+            [](DeprecatedString v) { return v; },
             [](Gfx::TextAlignment v) { return DeprecatedString::formatted("Gfx::TextAlignment::{}", Gfx::to_string(v)); },
             [](Gfx::ColorRole v) { return DeprecatedString::formatted("Gfx::ColorRole::{}", Gfx::to_string(v)); },
             [](Gfx::AlignmentRole v) { return DeprecatedString::formatted("Gfx::AlignmentRole::{}", Gfx::to_string(v)); },


### PR DESCRIPTION
This PR improves navigation performance and data input performance for large spreadsheets.

Previously, when navigating, a lot of CPU time was spent recalculating column sizes after creating new rows and columns, even when no new data had been added. This PR introduces `Model::UpdateFlag::DontResizeColumns` flag, so that we can signal that column sizes do not need to be recalculated.

This PR also adds a fast path to `GUI::Variant::to_deprecated_string()` when the underlying type is already a string. This improves data input performance on large spreadsheets.

Data input performan
ce could be improved further, if we used the `DontResizeColumns` flag after updating cell data. This stops cells from resizing when data does not fit in them. I was not sure if this behavior was desired, so I did not make the change.

Here is a profile without the fixes from this PR. Profile was generated by opening a new spreadsheet and navigating to cell A10000.

![spreadsheet_navigation_old](https://user-images.githubusercontent.com/2817754/217927010-94907774-c3b9-49d2-9cc5-a1a1642c5151.png)

With these changes applied, the highlighted entry disappears from the profile entirely.
