### PR TITLE
LibWeb: Use device pixels for transform rect of stacking context

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -375,7 +375,7 @@ void StackingContext::paint(PaintContext& context) const
 
     if (opacity < 1.0f || !affine_transform.is_identity_or_translation()) {
         auto transform_origin = this->transform_origin();
-        auto source_rect = paintable().absolute_paint_rect().to_type<float>().translated(-transform_origin);
+        auto source_rect = context.enclosing_device_rect(paintable().absolute_paint_rect()).to_type<int>().to_type<float>().translated(-transform_origin);
         auto transformed_destination_rect = affine_transform.map(source_rect).translated(transform_origin);
         auto destination_rect = transformed_destination_rect.to_rounded<int>();
 


### PR DESCRIPTION
This change fixes crash in following example that is caused by attempt to access non-existing bitmap scanline:
```html
<style>
  img {
    opacity: 0.7;
  }
</style><img
    src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAD/klEQVRogc2az0tVQRTHP10uLuQR8ZAQeYsQeUSrqCg1FyK0EZFoERHRMipchURb/wARV61cCK1sG20ibCdiZm0i7CdEkFmBpYG/qMXMpXnnzr3vztx7H35h4L2ZM+ec+XVmzjn3EMWgExgEzgN1oBvoACq6fRP4DnwA3gALwDPga0HyvVAFxoAl4K9nWdI8qq1UvAZMA1s5FJdlC5gCuspUvA24m1HxXWAdeK/Luq5r1u+3lhEWrXwdWEkRvAbMAFeB43qwEm267ZqmXUvhtwL0FKX8JdTM2AQ9AYaBwINvqPs+TeC9AVzMqTs3gH0L8yWgNy9zA/3AskXOvtbBCzctDHeBO/jNeDMEwDj2s3LTldlF4jO/BpwtSNk09BI/H/vAqI34kKWujlrOilH3CbgAvGsi/CxwsgnNC+B5E5oe1Pk6ZtRtAqeB1bSOIfCKxtGvk90ipFkWcyWzoEfLltYp1cTeEx22cds2GxkGsOHAr5/4mRhPIq4Rv6TuOAgrYwBoheVl12kjnBaES7hbmzIGEBC/RKckUQfx2fexOGUMAGBA8NhCPADHBMETDyFQ3gAgfmOPmY3ySTzsKaTMAYwIPotRQ6doWMP/NVjmAELiZvpoAAwJwkfAnqeQMrEHPBZ1QwHQJyqftkYfL0jdzgWop4OJly1SxgdSt+OgPCbztZnHGyrzDIByisxH5tuARnv6k4O5/yPsoHSMUA2AdqNis7X6eOGX8btShmPSUgTAH+N/JYnwAOGw8XszRO2pI7qiijrEWc7BIHCfxghElgmooAxHhB3gFipS1wxtiDMbojycbl0Roszq6wzMamgz5ojAkGfyyoI6jS/k1YC4m3gqI7MHwFxG2jTMaV5ZIN3VVYArNNrpGQfh7eSPjbbHuCZjVvS/DPkfczXgs4fyn8m+ddA6SR+5I2qUszjiwBiU8+MS7N3C3WGSz+kFs1E6ND4POrkV08oVD/7zgsdts7FKfAb7PYRMZFB+woNvU5cSlKNsEi3jF0J8mKD4X93mCptTP2kj7CIehU6MwaSgHXugdhk3ixNBxqoSwyqgkgsm8TZ+W6kGfDH4fMHN4kSwBbZSY1Uh8eVyCS2aiCyTj8UBe2hxmQwmvk58K33EbxBndHFFXcs0ddhw0WEUe3i9yKRGEgaIz3xieD0NSQmOccpJcISoA1tIgiNCUoppBb/DnYQB7EnEXCmmCKMkO+vzqCveJxAQ6r7yhjX3vOuTJhE9NE+zzqJSqCdITrOeAK5rWrnP5QoXlmaNEKL2f1LKVS79D/4nun9g34qy/NYyCk90m+hEXeVFf2owScoNWwaijz0Wcyi+QM6PPWxZSh8cRTn5fSg/OevnNt/yCv4HEYeH0zj+LxYAAAAASUVORK5CYII="
    width="100"
    height="100"
/>
```