### PR TITLE
 AK: Always initialize vector capacity to inline_capacity 

### DIFF
--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -55,7 +55,6 @@ private:
 public:
     using ValueType = T;
     Vector()
-        : m_capacity(inline_capacity)
     {
     }
 
@@ -833,7 +832,7 @@ private:
     StorageType& raw_at(size_t index) { return *slot(index); }
 
     size_t m_size { 0 };
-    size_t m_capacity { 0 };
+    size_t m_capacity { inline_capacity };
 
     static constexpr size_t storage_size()
     {

--- a/Tests/AK/TestVector.cpp
+++ b/Tests/AK/TestVector.cpp
@@ -572,3 +572,48 @@ TEST_CASE(reverse_range_for_loop)
     for (auto item : v.in_reverse())
         EXPECT_EQ(item, index--);
 }
+
+static bool is_inline_element(auto& el, auto& vector)
+{
+    uintptr_t vector_ptr = (uintptr_t)&vector;
+    uintptr_t element_ptr = (uintptr_t)&el;
+    return (element_ptr >= vector_ptr && element_ptr < (vector_ptr + sizeof(vector)));
+}
+
+TEST_CASE(uses_inline_capacity_when_appended_to)
+{
+    Vector<int, 10> v;
+    v.unchecked_append(1);
+    v.unchecked_append(123);
+    v.unchecked_append(50);
+    v.unchecked_append(43);
+
+    for (auto& el : v)
+        EXPECT(is_inline_element(el, v));
+}
+
+TEST_CASE(uses_inline_capacity_when_constructed_from_initializer_list)
+{
+    Vector<int, 10> v { 10, 9, 3, 1, 3 };
+
+    for (auto& el : v)
+        EXPECT(is_inline_element(el, v));
+}
+
+TEST_CASE(uses_inline_capacity_when_constructed_from_other_vector)
+{
+    Vector other { 4, 3, 2, 1 };
+    Vector<int, 10> v(other);
+
+    for (auto& el : v)
+        EXPECT(is_inline_element(el, v));
+}
+
+TEST_CASE(uses_inline_capacity_when_constructed_from_span)
+{
+    Array array { "f00", "bar", "baz" };
+    Vector<char const*, 10> v(array.span());
+
+    for (auto& el : v)
+        EXPECT(is_inline_element(el, v));
+}


### PR DESCRIPTION
Previously constructors such as `Vector(std::initializer_list<T> list)` did not make use of the inline capacity so would always allocate, even if there was enough inline space.