### PR TITLE
LibGUI + WidgetGallery: Improvements to default dynamic layout behaviour, and WidgetGallery layout fix

### DIFF
--- a/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
@@ -5,13 +5,13 @@
     }
 
     @GUI::GroupBox {
-        fixed_height: 129
+        preferred_height: "fit"
         layout: @GUI::VerticalBoxLayout {
             margins: [6]
         }
 
         @GUI::GroupBox {
-            max_height: 30
+            preferred_height: "fit"
             layout: @GUI::HorizontalBoxLayout {
                 margins: [8]
             }
@@ -37,9 +37,8 @@
         @GUI::Frame {
             shape: "Panel"
             shadow: "Sunken"
+            preferred_height: "fit"
             thickness: 1
-            max_width: 394
-            max_height: 79
             layout: @GUI::VerticalBoxLayout {
                 margins: [1]
             }
@@ -51,12 +50,10 @@
     }
 
     @GUI::Widget {
-        fixed_height: 88
+        preferred_height: "fit"
         layout: @GUI::VerticalBoxLayout {
             margins: [0, 8]
         }
-
-        @GUI::Layout::Spacer {}
 
         @GUI::Scrollbar {
             name: "enabled_scrollbar"
@@ -66,11 +63,7 @@
             value: 50
         }
 
-        @GUI::Layout::Spacer {}
-
         @GUI::HorizontalSeparator {}
-
-        @GUI::Layout::Spacer {}
 
         @GUI::Scrollbar {
             name: "disabled_scrollbar"
@@ -84,6 +77,9 @@
         layout: @GUI::HorizontalBoxLayout {
             margins: [6]
         }
+        preferred_height: "opportunistic_grow"
+
+        @GUI::Layout::Spacer {}
 
         @GUI::VerticalProgressbar {
             name: "vertical_progressbar_left"
@@ -99,6 +95,8 @@
             tooltip: "Fixed"
         }
 
+        @GUI::Layout::Spacer {}
+
         @GUI::VerticalSeparator {}
 
         @GUI::VerticalSlider {
@@ -110,6 +108,8 @@
         }
 
         @GUI::VerticalSeparator {}
+
+        @GUI::Layout::Spacer {}
 
         @GUI::VerticalProgressbar {
             name: "vertical_progressbar_right"
@@ -124,15 +124,19 @@
             value: 0
             tooltip: "Proportional"
         }
+
+        @GUI::Layout::Spacer {}
     }
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
             margins: [6]
         }
+        preferred_height: "fit"
 
         @GUI::Widget {
             layout: @GUI::HorizontalBoxLayout {}
+            preferred_height: "fit"
 
             @GUI::HorizontalSlider {
                 name: "horizontal_slider_left"

--- a/Userland/Libraries/LibGUI/Frame.cpp
+++ b/Userland/Libraries/LibGUI/Frame.cpp
@@ -39,6 +39,7 @@ void Frame::set_frame_thickness(int thickness)
         return;
     m_thickness = thickness;
     set_grabbable_margins(thickness);
+    layout_relevant_change_occurred();
 }
 
 void Frame::paint_event(PaintEvent& event)

--- a/Userland/Libraries/LibGUI/OpacitySlider.cpp
+++ b/Userland/Libraries/LibGUI/OpacitySlider.cpp
@@ -22,6 +22,7 @@ OpacitySlider::OpacitySlider(Gfx::Orientation orientation)
     set_min(0);
     set_max(100);
     set_value(100);
+    set_preferred_size(SpecialDimension::Fit);
 }
 
 Gfx::IntRect OpacitySlider::frame_inner_rect() const
@@ -192,17 +193,15 @@ void OpacitySlider::mousewheel_event(MouseEvent& event)
 Optional<UISize> OpacitySlider::calculated_min_size() const
 {
     if (orientation() == Gfx::Orientation::Vertical)
-        return { { 20, 40 } };
-    else
-        return { { 40, 20 } };
+        return { { 22, 40 } };
+    return { { 40, 22 } };
 }
 
 Optional<UISize> OpacitySlider::calculated_preferred_size() const
 {
     if (orientation() == Gfx::Orientation::Vertical)
         return { { SpecialDimension::Shrink, SpecialDimension::OpportunisticGrow } };
-    else
-        return { { SpecialDimension::OpportunisticGrow, SpecialDimension::Shrink } };
+    return { { SpecialDimension::OpportunisticGrow, SpecialDimension::Shrink } };
 }
 
 }

--- a/Userland/Libraries/LibGUI/Progressbar.cpp
+++ b/Userland/Libraries/LibGUI/Progressbar.cpp
@@ -27,6 +27,8 @@ Progressbar::Progressbar(Orientation orientation)
         { Format::ValueSlashMax, "ValueSlashMax" });
     REGISTER_INT_PROPERTY("min", min, set_min);
     REGISTER_INT_PROPERTY("max", max, set_max);
+
+    set_preferred_size(SpecialDimension::Fit);
 }
 
 void Progressbar::set_value(int value)
@@ -79,6 +81,13 @@ void Progressbar::set_orientation(Orientation value)
         return;
     m_orientation = value;
     update();
+}
+
+Optional<UISize> Progressbar::calculated_preferred_size() const
+{
+    if (orientation() == Gfx::Orientation::Vertical)
+        return { { 22, SpecialDimension::OpportunisticGrow } };
+    return { { SpecialDimension::OpportunisticGrow, 22 } };
 }
 
 }

--- a/Userland/Libraries/LibGUI/Progressbar.h
+++ b/Userland/Libraries/LibGUI/Progressbar.h
@@ -45,6 +45,8 @@ protected:
     virtual void paint_event(PaintEvent&) override;
 
 private:
+    virtual Optional<UISize> calculated_preferred_size() const override;
+
     Format m_format { Percentage };
     int m_min { 0 };
     int m_max { 100 };

--- a/Userland/Libraries/LibGUI/SeparatorWidget.cpp
+++ b/Userland/Libraries/LibGUI/SeparatorWidget.cpp
@@ -17,10 +17,7 @@ namespace GUI {
 SeparatorWidget::SeparatorWidget(Gfx::Orientation orientation)
     : m_orientation(orientation)
 {
-    if (m_orientation == Gfx::Orientation::Vertical)
-        set_fixed_width(8);
-    else
-        set_fixed_height(8);
+    set_preferred_size(SpecialDimension::Fit);
 }
 
 void SeparatorWidget::paint_event(PaintEvent& event)
@@ -37,6 +34,13 @@ void SeparatorWidget::paint_event(PaintEvent& event)
         painter.draw_line({ 0, 0 }, { rect().right(), 0 }, palette().threed_shadow1());
         painter.draw_line({ 0, 1 }, { rect().right(), 1 }, palette().threed_highlight());
     }
+}
+
+Optional<UISize> SeparatorWidget::calculated_preferred_size() const
+{
+    if (m_orientation == Gfx::Orientation::Vertical)
+        return UISize { 8, SpecialDimension::OpportunisticGrow };
+    return UISize { SpecialDimension::OpportunisticGrow, 8 };
 }
 
 }

--- a/Userland/Libraries/LibGUI/SeparatorWidget.h
+++ b/Userland/Libraries/LibGUI/SeparatorWidget.h
@@ -22,6 +22,7 @@ protected:
 
 private:
     virtual void paint_event(PaintEvent&) override;
+    virtual Optional<UISize> calculated_preferred_size() const override;
 
     const Gfx::Orientation m_orientation;
 };

--- a/Userland/Libraries/LibGUI/Slider.cpp
+++ b/Userland/Libraries/LibGUI/Slider.cpp
@@ -24,6 +24,8 @@ Slider::Slider(Orientation orientation)
         { KnobSizeMode::Fixed, "Fixed" },
         { KnobSizeMode::Proportional, "Proportional" });
     REGISTER_BOOL_PROPERTY("jump_to_cursor", jump_to_cursor, set_jump_to_cursor);
+
+    set_preferred_size(SpecialDimension::Fit);
 }
 
 void Slider::paint_event(PaintEvent& event)
@@ -197,6 +199,20 @@ void Slider::set_knob_hovered(bool hovered)
         return;
     m_knob_hovered = hovered;
     update(knob_rect());
+}
+
+Optional<UISize> Slider::calculated_min_size() const
+{
+    if (orientation() == Gfx::Orientation::Vertical)
+        return { { knob_secondary_size(), knob_fixed_primary_size() * 2 + track_margin() * 2 } };
+    return { { knob_fixed_primary_size() * 2 + track_margin() * 2, knob_secondary_size() } };
+}
+
+Optional<UISize> Slider::calculated_preferred_size() const
+{
+    if (orientation() == Gfx::Orientation::Vertical)
+        return { { SpecialDimension::Shrink, SpecialDimension::OpportunisticGrow } };
+    return { { SpecialDimension::OpportunisticGrow, SpecialDimension::Shrink } };
 }
 
 }

--- a/Userland/Libraries/LibGUI/Slider.h
+++ b/Userland/Libraries/LibGUI/Slider.h
@@ -46,6 +46,9 @@ public:
 protected:
     explicit Slider(Orientation = Orientation::Vertical);
 
+    virtual Optional<UISize> calculated_min_size() const override;
+    virtual Optional<UISize> calculated_preferred_size() const override;
+
     virtual void paint_event(PaintEvent&) override;
     void start_drag(Gfx::IntPoint);
     virtual void mousedown_event(MouseEvent&) override;

--- a/Userland/Libraries/LibGUI/ValueSlider.cpp
+++ b/Userland/Libraries/LibGUI/ValueSlider.cpp
@@ -24,7 +24,7 @@ ValueSlider::ValueSlider(Gfx::Orientation orientation, String suffix)
     // FIXME: Implement vertical mode
     VERIFY(orientation == Orientation::Horizontal);
 
-    set_fixed_height(20);
+    set_preferred_size(SpecialDimension::Fit);
 
     m_textbox = add<GUI::TextBox>();
     m_textbox->set_relative_rect({ 0, 0, 34, 20 });
@@ -119,9 +119,14 @@ Gfx::IntRect ValueSlider::bar_rect() const
     return bar_rect;
 }
 
+int ValueSlider::knob_length() const
+{
+    return m_knob_style == KnobStyle::Wide ? 13 : 7;
+}
+
 Gfx::IntRect ValueSlider::knob_rect() const
 {
-    int knob_thickness = m_knob_style == KnobStyle::Wide ? 13 : 7;
+    int knob_thickness = knob_length();
 
     Gfx::IntRect knob_rect = bar_rect();
     knob_rect.set_width(knob_thickness);
@@ -200,6 +205,22 @@ void ValueSlider::mouseup_event(MouseEvent& event)
         return;
 
     m_dragging = false;
+}
+
+Optional<UISize> ValueSlider::calculated_min_size() const
+{
+    auto content_min_size = m_textbox->effective_min_size();
+
+    if (orientation() == Gfx::Orientation::Vertical)
+        return { { content_min_size.width(), content_min_size.height().as_int() + knob_length() } };
+    return { { content_min_size.width().as_int() + knob_length(), content_min_size.height() } };
+}
+
+Optional<UISize> ValueSlider::calculated_preferred_size() const
+{
+    if (orientation() == Gfx::Orientation::Vertical)
+        return { { SpecialDimension::Shrink, SpecialDimension::OpportunisticGrow } };
+    return { { SpecialDimension::OpportunisticGrow, SpecialDimension::Shrink } };
 }
 
 }

--- a/Userland/Libraries/LibGUI/ValueSlider.h
+++ b/Userland/Libraries/LibGUI/ValueSlider.h
@@ -43,6 +43,10 @@ private:
     int value_at(Gfx::IntPoint position) const;
     Gfx::IntRect bar_rect() const;
     Gfx::IntRect knob_rect() const;
+    int knob_length() const;
+
+    virtual Optional<UISize> calculated_min_size() const override;
+    virtual Optional<UISize> calculated_preferred_size() const override;
 
     String m_suffix {};
     Orientation m_orientation { Orientation::Horizontal };


### PR DESCRIPTION
These are a bunch of little improvements, all prompted by wanting to use the dynamic lay-outing system for the sliders tab in WidgetGallery, to fix the image overflow problem there.