### PR TITLE
AK: Allow explicitly copying and provide `is_errno` for Kernel Errors

### DIFF
--- a/AK/Error.h
+++ b/AK/Error.h
@@ -79,7 +79,10 @@ public:
     {
         return m_code != 0;
     }
-    bool is_syscall() const { return m_syscall; }
+    bool is_syscall() const
+    {
+        return m_syscall;
+    }
     StringView string_literal() const
     {
         return m_string_literal;

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -76,11 +76,11 @@ public:
     }
 
     int code() const { return m_code; }
-#ifndef KERNEL
     bool is_errno() const
     {
         return m_code != 0;
     }
+#ifndef KERNEL
     bool is_syscall() const
     {
         return m_syscall;

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -38,12 +38,14 @@ public:
         return Error(syscall_name, rc);
     }
     [[nodiscard]] static Error from_string_view(StringView string_literal) { return Error(string_literal); }
+#endif
 
     [[nodiscard]] static Error copy(Error const& error)
     {
         return Error(error);
     }
 
+#ifndef KERNEL
     // NOTE: Prefer `from_string_literal` when directly typing out an error message:
     //
     //     return Error::from_string_literal("Class: Some failure");
@@ -108,10 +110,12 @@ private:
         , m_syscall(true)
     {
     }
+#endif
 
     Error(Error const&) = default;
     Error& operator=(Error const&) = default;
 
+#ifndef KERNEL
     StringView m_string_literal;
 #endif
 

--- a/AK/Stream.cpp
+++ b/AK/Stream.cpp
@@ -20,15 +20,10 @@ ErrorOr<void> Stream::read_entire_buffer(Bytes buffer)
 
         auto result = read(buffer.slice(nread));
         if (result.is_error()) {
-#ifdef KERNEL
-            if (result.error().code() == EINTR) {
-                continue;
-            }
-#else
             if (result.error().is_errno() && result.error().code() == EINTR) {
                 continue;
             }
-#endif
+
             return result.release_error();
         }
 
@@ -89,15 +84,10 @@ ErrorOr<void> Stream::write_entire_buffer(ReadonlyBytes buffer)
     while (nwritten < buffer.size()) {
         auto result = write(buffer.slice(nwritten));
         if (result.is_error()) {
-#ifdef KERNEL
-            if (result.error().code() == EINTR) {
-                continue;
-            }
-#else
             if (result.error().is_errno() && result.error().code() == EINTR) {
                 continue;
             }
-#endif
+
             return result.release_error();
         }
 


### PR DESCRIPTION
This fixes a build issue that wasn't caught before merging, and removes a few ifdefs that can be abstracted away better.