### PR TITLE
CI: Add script to post mastodon toots for commits on master

### DIFF
--- a/.github/workflows/social-media.yml
+++ b/.github/workflows/social-media.yml
@@ -1,4 +1,4 @@
-name: Twitter notifications
+name: Social media notifications
 
 on: [ push ]
 
@@ -22,3 +22,20 @@ jobs:
           CONSUMER_SECRET: ${{ secrets.CONSUMER_SECRET }}
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           ACCESS_TOKEN_SECRET: ${{ secrets.ACCESS_TOKEN_SECRET }}
+
+  notify_mastodon:
+    runs-on: ubuntu-22.04
+    if: always() && github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master'
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+      - run: npm i mastodon
+      - run: |
+          node ${{ github.workspace }}/Meta/toot-commits.js << 'EOF'
+          ${{ toJSON(github.event) }}
+          EOF
+        env:
+          ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}

--- a/Meta/toot-commits.js
+++ b/Meta/toot-commits.js
@@ -1,0 +1,34 @@
+const fs = require("fs");
+const Mastodon = require("mastodon");
+const { ACCESS_TOKEN } = process.env;
+const tootLength = 500;
+// Mastodon always considers links to be 23 chars, see https://docs.joinmastodon.org/user/posting/#links
+const mastodonLinkLength = 23;
+
+const mastodon = new Mastodon({
+    access_token: ACCESS_TOKEN,
+    timeout_ms: 60 * 1000,
+    api_url: "https://serenityos.social/api/v1/",
+});
+
+(async () => {
+    const githubEvent = JSON.parse(fs.readFileSync(0).toString());
+    const toots = [];
+    for (const commit of githubEvent["commits"]) {
+        const authorLine = `Author: ${commit["author"]["name"]}`;
+        const maxMessageLength = tootLength - authorLine.length - mastodonLinkLength - 2; // -2 for newlines
+        const commitMessage =
+            commit["message"].length > maxMessageLength
+                ? commit["message"].substring(0, maxMessageLength - 2) + "…" // Ellipsis counts as 2 characters
+                : commit["message"];
+
+        toots.push(`${commitMessage}\n${authorLine}\n${commit["url"]}`);
+    }
+    for (const toot of toots) {
+        try {
+            await mastodon.post("statuses", { status: toot, visibility: "unlisted" });
+        } catch (e) {
+            console.error("Failed to post a toot!", e.message);
+        }
+    }
+})();


### PR DESCRIPTION
This pull request adds the toot-commits script (mirroring tweet-commits), posting new commits on the master branch to
https://serenityos.social/@commits.

Note that a new secret called `MASTODON_ACCESS_TOKEN` is required