### PR TITLE
LibWeb: Add missing GCPtr.h includes to Fetch headers

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/Body.h
+++ b/Userland/Libraries/LibWeb/Fetch/Body.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::Fetch {

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::Fetch::Fetching {

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/PendingResponse.h
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/PendingResponse.h
@@ -8,6 +8,7 @@
 
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibJS/SafeFunction.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 

--- a/Userland/Libraries/LibWeb/Fetch/Headers.h
+++ b/Userland/Libraries/LibWeb/Fetch/Headers.h
@@ -11,6 +11,7 @@
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Headers.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>

--- a/Userland/Libraries/LibWeb/Fetch/HeadersIterator.h
+++ b/Userland/Libraries/LibWeb/Fetch/HeadersIterator.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Fetch/Headers.h>
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/ConnectionTimingInfo.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/ConnectionTimingInfo.h
@@ -8,6 +8,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/HighResolutionTime/DOMHighResTimeStamp.h>
 
 namespace Web::Fetch::Infrastructure {

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchAlgorithms.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchAlgorithms.h
@@ -8,6 +8,7 @@
 
 #include <AK/Optional.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibJS/SafeFunction.h>
 #include <LibWeb/Forward.h>
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchController.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchController.h
@@ -8,6 +8,7 @@
 
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibJS/SafeFunction.h>
 #include <LibWeb/Fetch/Infrastructure/FetchTimingInfo.h>
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchParams.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchParams.h
@@ -9,6 +9,7 @@
 #include <AK/Forward.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
 #include <LibWeb/Fetch/Infrastructure/FetchController.h>
 #include <LibWeb/Fetch/Infrastructure/FetchTimingInfo.h>

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchTimingInfo.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchTimingInfo.h
@@ -10,6 +10,7 @@
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Fetch/Infrastructure/ConnectionTimingInfo.h>
 #include <LibWeb/HighResolutionTime/DOMHighResTimeStamp.h>
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
@@ -11,6 +11,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
 #include <AK/Variant.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibJS/Heap/Handle.h>
 #include <LibWeb/FileAPI/Blob.h>
 #include <LibWeb/Streams/ReadableStream.h>

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.h
@@ -15,6 +15,7 @@
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/MimeSniff/MimeType.h>
 
 namespace Web::Fetch::Infrastructure {

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
@@ -16,6 +16,7 @@
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Headers.h>
 #include <LibWeb/HTML/Origin.h>

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
@@ -14,6 +14,7 @@
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Headers.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Statuses.h>

--- a/Userland/Libraries/LibWeb/Fetch/Request.h
+++ b/Userland/Libraries/LibWeb/Fetch/Request.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Fetch/Body.h>
 #include <LibWeb/Fetch/BodyInit.h>

--- a/Userland/Libraries/LibWeb/Fetch/Response.h
+++ b/Userland/Libraries/LibWeb/Fetch/Response.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Fetch/Body.h>
 #include <LibWeb/Fetch/BodyInit.h>


### PR DESCRIPTION
These are missing in most Fetch headers, and clangd is (rightfully) very loud about it on a few of these.