### PR TITLE
js: Save REPL history when exiting interpreter with `exit()`

### DIFF
--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -417,6 +417,7 @@ JS_DEFINE_NATIVE_FUNCTION(ReplObject::save_to_file)
 
 JS_DEFINE_NATIVE_FUNCTION(ReplObject::exit_interpreter)
 {
+    s_editor->save_history(s_history_path.to_deprecated_string());
     if (!vm.argument_count())
         exit(0);
     exit(TRY(vm.argument(0).to_number(vm)).as_double());


### PR DESCRIPTION
Previously, we only saved the REPL history when the interpreter was shutdown with a signal. This change ensures that we save the history when a user calls `exit()`.