### PR TITLE
LibCore: Fix wrong call to stat on the Core::System::lstat method

### DIFF
--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -503,7 +503,7 @@ ErrorOr<struct stat> lstat(StringView path)
     HANDLE_SYSCALL_RETURN_VALUE("lstat", rc, st);
 #else
     DeprecatedString path_string = path;
-    if (::stat(path_string.characters(), &st) < 0)
+    if (::lstat(path_string.characters(), &st) < 0)
         return Error::from_syscall("lstat"sv, -errno);
     return st;
 #endif


### PR DESCRIPTION
We should call lstat and not stat, because lstat gives information on the symbolic link itself (if the path is about a symbolic link).