### PR TITLE
LibJS: Add missing assignment to offset_string in ZDT conversion

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021-2023, Linus Groh <linusg@serenityos.org>
- * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2021-2023, Luke Wilde <lukew@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -174,6 +174,9 @@ ThrowCompletionOr<ZonedDateTime*> to_temporal_zoned_date_time(VM& vm, Value item
         if (offset_string_value.is_undefined()) {
             // i. Set offsetBehaviour to wall.
             offset_behavior = OffsetBehavior::Wall;
+        } else {
+            // NOTE: Not in the spec, since it directly assigns to offsetString in step i, but we can't do it there as it's a type mismatch.
+            offset_string = TRY(offset_string_value.as_string().utf8_string());
         }
 
         // l. Let result be ? InterpretTemporalDateTimeFields(calendar, fields, options).


### PR DESCRIPTION
```
Summary:
    Diff Tests:
        +19 ✅   +5 ❌    -24 💥️   

Diff Tests:
    test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-invalid-offset-string.js                      💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-offset-not-agreeing-with-timezone.js          💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/compare/order-of-operations.js                                             💥️ -> ❌
    test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-invalid-offset-string.js                         💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-offset-not-agreeing-with-timezone.js             💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-timezone-getoffsetnanosecondsfor-not-callable.js 💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/from/offset-undefined.js                                                   💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/from/offset-wrong-type.js                                                  💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/from/options-undefined.js                                                  💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/from/order-of-operations.js                                                💥️ -> ❌
    test/built-ins/Temporal/ZonedDateTime/from/zoneddatetime-sub-minute-offset.js                                    💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-invalid-offset-string.js             💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-offset-not-agreeing-with-timezone.js 💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/prototype/equals/order-of-operations.js                                    💥️ -> ❌
    test/built-ins/Temporal/ZonedDateTime/prototype/equals/sub-minute-offset.js                                      💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-invalid-offset-string.js              💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-offset-not-agreeing-with-timezone.js  💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js                                     💥️ -> ❌
    test/built-ins/Temporal/ZonedDateTime/prototype/since/sub-minute-offset.js                                       💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-invalid-offset-string.js              💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-offset-not-agreeing-with-timezone.js  💥️ -> ✅
    test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js                                     💥️ -> ❌
    test/built-ins/Temporal/ZonedDateTime/prototype/until/sub-minute-offset.js                                       💥️ -> ✅
    test/staging/Temporal/ZonedDateTime/old/property-bags.js                                                         💥️ -> ✅
```