### PR TITLE
AK: Move adopt_nonnull_{own,ref}_or_enomem() to Nonnull{Own,Ref}Ptr.h

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -161,6 +161,15 @@ inline NonnullOwnPtr<T> make(Args&&... args)
 
 #endif
 
+// Use like `adopt_nonnull_own_or_enomem(new (nothrow) T(args...))`.
+template<typename T>
+inline ErrorOr<NonnullOwnPtr<T>> adopt_nonnull_own_or_enomem(T* object)
+{
+    if (!object)
+        return Error::from_errno(ENOMEM);
+    return NonnullOwnPtr<T>(NonnullOwnPtr<T>::Adopt, *object);
+}
+
 template<typename T>
 struct Traits<NonnullOwnPtr<T>> : public GenericTraits<NonnullOwnPtr<T>> {
     using PeekType = T*;
@@ -190,5 +199,6 @@ struct Formatter<NonnullOwnPtr<T>> : Formatter<T const*> {
 using AK::adopt_own;
 using AK::make;
 #    endif
+using AK::adopt_nonnull_own_or_enomem;
 using AK::NonnullOwnPtr;
 #endif

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -226,6 +226,15 @@ inline NonnullRefPtr<T> adopt_ref(T& object)
     return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, object);
 }
 
+// Use like `adopt_nonnull_own_or_enomem(new (nothrow) T(args...))`.
+template<typename T>
+inline ErrorOr<NonnullRefPtr<T>> adopt_nonnull_ref_or_enomem(T* object)
+{
+    if (!object)
+        return Error::from_errno(ENOMEM);
+    return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, *object);
+}
+
 template<Formattable T>
 struct Formatter<NonnullRefPtr<T>> : Formatter<T> {
     ErrorOr<void> format(FormatBuilder& builder, NonnullRefPtr<T> const& value)
@@ -274,6 +283,7 @@ struct Traits<NonnullRefPtr<T>> : public GenericTraits<NonnullRefPtr<T>> {
 }
 
 #if USING_AK_GLOBALLY
+using AK::adopt_nonnull_ref_or_enomem;
 using AK::adopt_ref;
 using AK::make_ref_counted;
 using AK::NonnullRefPtr;

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -192,15 +192,6 @@ inline OwnPtr<T> adopt_own_if_nonnull(T* object)
     return {};
 }
 
-template<typename T>
-inline ErrorOr<NonnullOwnPtr<T>> adopt_nonnull_own_or_enomem(T* object)
-{
-    auto result = adopt_own_if_nonnull(object);
-    if (!result)
-        return Error::from_errno(ENOMEM);
-    return result.release_nonnull();
-}
-
 template<typename T, class... Args>
 requires(IsConstructible<T, Args...>) inline ErrorOr<NonnullOwnPtr<T>> try_make(Args&&... args)
 {
@@ -226,7 +217,6 @@ struct Traits<OwnPtr<T>> : public GenericTraits<OwnPtr<T>> {
 }
 
 #if USING_AK_GLOBALLY
-using AK::adopt_nonnull_own_or_enomem;
 using AK::adopt_own_if_nonnull;
 using AK::OwnPtr;
 using AK::try_make;

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -341,19 +341,9 @@ inline ErrorOr<NonnullRefPtr<T>> try_make_ref_counted(Args&&... args)
     return adopt_nonnull_ref_or_enomem(new (nothrow) T { forward<Args>(args)... });
 }
 
-template<typename T>
-inline ErrorOr<NonnullRefPtr<T>> adopt_nonnull_ref_or_enomem(T* object)
-{
-    auto result = adopt_ref_if_nonnull(object);
-    if (!result)
-        return Error::from_errno(ENOMEM);
-    return result.release_nonnull();
-}
-
 }
 
 #if USING_AK_GLOBALLY
-using AK::adopt_nonnull_ref_or_enomem;
 using AK::adopt_ref_if_nonnull;
 using AK::RefPtr;
 using AK::static_ptr_cast;


### PR DESCRIPTION
Rewrite the implementation to not depend on OwnPtr.h.

No intended behavior change.

---

@awesomekling Maybe this is subtly wrong somehow? It builds fine, at least.