### PR TITLE
Kernel+SystemServer: Don't assume needed root mount flags in the kernel

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -26,7 +26,7 @@
 namespace Kernel {
 
 static Singleton<VirtualFileSystem> s_the;
-static constexpr int root_mount_flags = MS_NODEV | MS_NOSUID | MS_RDONLY;
+static constexpr int root_mount_flags = 0;
 
 UNMAP_AFTER_INIT void VirtualFileSystem::initialize()
 {

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -386,6 +386,10 @@ static ErrorOr<void> populate_devtmpfs()
 
 static ErrorOr<void> prepare_synthetic_filesystems()
 {
+    // FIXME: Don't hardcode the fs type as the ext2 filesystem and once there's
+    // more than this filesystem implementation (which is suitable for usage on
+    // physical storage), find a way to detect it.
+    TRY(Core::System::mount(-1, "/"sv, "ext2"sv, MS_REMOUNT | MS_NODEV | MS_NOSUID | MS_RDONLY));
     // FIXME: Find a better way to all of this stuff, without hardcoding all of this!
     TRY(Core::System::mount(-1, "/proc"sv, "proc"sv, MS_NOSUID));
     TRY(Core::System::mount(-1, "/sys"sv, "sys"sv, 0));


### PR DESCRIPTION
When doing an initramfs booting (#16855), we could be dropped to a shell environment. It will fail to invoke the embedded Shell because it cannot create a config file for LibLine.
To fix this, I decided it's about time we stop assuming special flags for the root mount and let userspace figure this out on itself (i.e. re-mounting / with desired mount flags).