### PR TITLE
AK: Move try_make{,ref_counted}() to Nonnull{Own,Ref}Ptr.h

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -170,6 +170,20 @@ inline ErrorOr<NonnullOwnPtr<T>> adopt_nonnull_own_or_enomem(T* object)
     return NonnullOwnPtr<T>(NonnullOwnPtr<T>::Adopt, *object);
 }
 
+template<typename T, class... Args>
+requires(IsConstructible<T, Args...>) inline ErrorOr<NonnullOwnPtr<T>> try_make(Args&&... args)
+{
+    return adopt_nonnull_own_or_enomem(new (nothrow) T(forward<Args>(args)...));
+}
+
+// FIXME: Remove once P0960R3 is available in Clang.
+template<typename T, class... Args>
+inline ErrorOr<NonnullOwnPtr<T>> try_make(Args&&... args)
+
+{
+    return adopt_nonnull_own_or_enomem(new (nothrow) T { forward<Args>(args)... });
+}
+
 template<typename T>
 struct Traits<NonnullOwnPtr<T>> : public GenericTraits<NonnullOwnPtr<T>> {
     using PeekType = T*;
@@ -201,4 +215,5 @@ using AK::make;
 #    endif
 using AK::adopt_nonnull_own_or_enomem;
 using AK::NonnullOwnPtr;
+using AK::try_make;
 #endif

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -235,6 +235,19 @@ inline ErrorOr<NonnullRefPtr<T>> adopt_nonnull_ref_or_enomem(T* object)
     return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, *object);
 }
 
+template<typename T, class... Args>
+requires(IsConstructible<T, Args...>) inline ErrorOr<NonnullRefPtr<T>> try_make_ref_counted(Args&&... args)
+{
+    return adopt_nonnull_ref_or_enomem(new (nothrow) T(forward<Args>(args)...));
+}
+
+// FIXME: Remove once P0960R3 is available in Clang.
+template<typename T, class... Args>
+inline ErrorOr<NonnullRefPtr<T>> try_make_ref_counted(Args&&... args)
+{
+    return adopt_nonnull_ref_or_enomem(new (nothrow) T { forward<Args>(args)... });
+}
+
 template<Formattable T>
 struct Formatter<NonnullRefPtr<T>> : Formatter<T> {
     ErrorOr<void> format(FormatBuilder& builder, NonnullRefPtr<T> const& value)
@@ -287,4 +300,5 @@ using AK::adopt_nonnull_ref_or_enomem;
 using AK::adopt_ref;
 using AK::make_ref_counted;
 using AK::NonnullRefPtr;
+using AK::try_make_ref_counted;
 #endif

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -192,20 +192,6 @@ inline OwnPtr<T> adopt_own_if_nonnull(T* object)
     return {};
 }
 
-template<typename T, class... Args>
-requires(IsConstructible<T, Args...>) inline ErrorOr<NonnullOwnPtr<T>> try_make(Args&&... args)
-{
-    return adopt_nonnull_own_or_enomem(new (nothrow) T(forward<Args>(args)...));
-}
-
-// FIXME: Remove once P0960R3 is available in Clang.
-template<typename T, class... Args>
-inline ErrorOr<NonnullOwnPtr<T>> try_make(Args&&... args)
-
-{
-    return adopt_nonnull_own_or_enomem(new (nothrow) T { forward<Args>(args)... });
-}
-
 template<typename T>
 struct Traits<OwnPtr<T>> : public GenericTraits<OwnPtr<T>> {
     using PeekType = T*;
@@ -219,5 +205,4 @@ struct Traits<OwnPtr<T>> : public GenericTraits<OwnPtr<T>> {
 #if USING_AK_GLOBALLY
 using AK::adopt_own_if_nonnull;
 using AK::OwnPtr;
-using AK::try_make;
 #endif

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -328,24 +328,10 @@ inline RefPtr<T> adopt_ref_if_nonnull(T* object)
     return {};
 }
 
-template<typename T, class... Args>
-requires(IsConstructible<T, Args...>) inline ErrorOr<NonnullRefPtr<T>> try_make_ref_counted(Args&&... args)
-{
-    return adopt_nonnull_ref_or_enomem(new (nothrow) T(forward<Args>(args)...));
-}
-
-// FIXME: Remove once P0960R3 is available in Clang.
-template<typename T, class... Args>
-inline ErrorOr<NonnullRefPtr<T>> try_make_ref_counted(Args&&... args)
-{
-    return adopt_nonnull_ref_or_enomem(new (nothrow) T { forward<Args>(args)... });
-}
-
 }
 
 #if USING_AK_GLOBALLY
 using AK::adopt_ref_if_nonnull;
 using AK::RefPtr;
 using AK::static_ptr_cast;
-using AK::try_make_ref_counted;
 #endif


### PR DESCRIPTION
Hot on the heels of the success of #17424, this moves the helper wrapper too, for the same reason. The only reason it was in the wrong file previously was probably because the _enomem function was there.