### PR TITLE
Kernel: Fix methods of TCP data offset and flags

### DIFF
--- a/Kernel/Net/TCP.h
+++ b/Kernel/Net/TCP.h
@@ -57,7 +57,7 @@ public:
     u32 ack_number() const { return m_ack_number; }
     void set_ack_number(u32 number) { m_ack_number = number; }
 
-    u16 flags() const { return m_flags_and_data_offset & 0x1ff; }
+    NetworkOrdered<u16> flags() const { return m_flags_and_data_offset & 0xff01; }
     void set_flags(u16 flags) { m_flags_and_data_offset = (m_flags_and_data_offset & ~0x1ff) | (flags & 0x1ff); }
 
     bool has_syn() const { return flags() & TCPFlags::SYN; }
@@ -65,8 +65,8 @@ public:
     bool has_fin() const { return flags() & TCPFlags::FIN; }
     bool has_rst() const { return flags() & TCPFlags::RST; }
 
-    u8 data_offset() const { return (m_flags_and_data_offset & 0xf000) >> 12; }
-    void set_data_offset(u16 data_offset) { m_flags_and_data_offset = (m_flags_and_data_offset & ~0xf000) | data_offset << 12; }
+    u8 data_offset() const { return (__builtin_bswap16(m_flags_and_data_offset) & 0xf000) >> 12; }
+    void set_data_offset(u16 data_offset) { m_flags_and_data_offset = (__builtin_bswap16(m_flags_and_data_offset) & ~0xf000) | (data_offset << 12); }
 
     u16 window_size() const { return m_window_size; }
     void set_window_size(u16 window_size) { m_window_size = window_size; }


### PR DESCRIPTION
There is a problem with filling flags and data offset with proper values within the current implementation, regardless of whether a setter method is used manually or if the class is simply constructed with a network stream. This patch takes care of the bitwise manipulations and data types. I realize using `__builtin_bswap16()` is not the best option, so I'll wait for your ideas. Feel free to use my isolated playground to test this:
https://github.com/ImanSeyed/SerenityTCPTest
[The first commit](https://github.com/ImanSeyed/SerenityTCPTest/commit/f3dc7a6cb486666f652619672db2d510d90dad4b) is the current implementation of SerenityOS, and [the third](https://github.com/ImanSeyed/SerenityTCPTest/commit/59e4828287533718182b622c2b0747bcb6327aa4) is my patch. Just use `nc` to send SYN or whatever you want to 192.168.20.0/24 network (no matter which IP it is).

Note 1: Using `NetworkOrdered<u16>` as a return type for `flags()` was necessary because of `has_X()` methods.
Note 2: Using bit fields makes this more complicated because of type promotions and endianess getting involved. 
Note 3: The assignment in `BigEndian<>` type ruins everything. Take a look at this:
```c++
u16 data_offset = 0x14;
NetworkOrdered<u16> m_flags_and_data_offset = data_offset; // 0x1400
m_flags_and_data_offset = m_flags_and_data_offset & m_flags_and_data_offset;  // 0x14
```
The last line shows that `m_flags_and_data_offset` gets `bswap`ed twice instead of once in the & operation. This is what's happening right now in the `TCPPacket::set_data_offset()`.