### PR TITLE
WindowServer: Restore cursor animation

### DIFF
--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -933,6 +933,7 @@ void Compositor::change_cursor(Cursor const* cursor)
                     m_current_cursor_frame = 0;
                 invalidate_cursor(true);
             });
+        m_cursor_timer->start();
     }
 }
 


### PR DESCRIPTION
This regressed in 6edc0cf5ab2fce211318b5d4f83e319897b621e5.

Now the 'Wait' cursor will animate again when a window freezes (for example, after opening /res/emoji in File Manager)