### PR TITLE
Userland: Use allocation-failure safe functions where it's easy

### DIFF
--- a/Userland/DevTools/HackStudio/ProjectConfig.cpp
+++ b/Userland/DevTools/HackStudio/ProjectConfig.cpp
@@ -24,7 +24,7 @@ ErrorOr<NonnullOwnPtr<ProjectConfig>> ProjectConfig::try_load_project_config(Dep
     if (!json.is_object())
         return Error::from_string_literal("The topmost JSON element is not an object");
 
-    return adopt_own(*new ProjectConfig(json.as_object()));
+    return try_make<ProjectConfig>(json.as_object());
 }
 
 NonnullOwnPtr<ProjectConfig> ProjectConfig::create_empty()

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -334,13 +334,13 @@ ErrorOr<NonnullOwnPtr<Profile>> Profile::load_from_perfcore_file(StringView path
                 .executable = executable,
             };
 
-            auto sampled_process = adopt_own(*new Process {
+            auto sampled_process = TRY(adopt_nonnull_own_or_enomem(new (nothrow) Process {
                 .pid = event.pid,
                 .executable = executable,
                 .basename = LexicalPath::basename(executable),
                 .start_valid = event.serial,
                 .end_valid = {},
-            });
+            }));
 
             current_processes.set(sampled_process->pid, sampled_process);
             all_processes.append(move(sampled_process));
@@ -356,13 +356,13 @@ ErrorOr<NonnullOwnPtr<Profile>> Profile::load_from_perfcore_file(StringView path
 
             current_processes.remove(event.pid);
 
-            auto sampled_process = adopt_own(*new Process {
+            auto sampled_process = TRY(adopt_nonnull_own_or_enomem(new (nothrow) Process {
                 .pid = event.pid,
                 .executable = executable,
                 .basename = LexicalPath::basename(executable),
                 .start_valid = event.serial,
                 .end_valid = {},
-            });
+            }));
 
             current_processes.set(sampled_process->pid, sampled_process);
             all_processes.append(move(sampled_process));

--- a/Userland/Libraries/LibGLSL/Compiler.cpp
+++ b/Userland/Libraries/LibGLSL/Compiler.cpp
@@ -12,7 +12,7 @@ ErrorOr<NonnullOwnPtr<ObjectFile>> Compiler::compile(Vector<String> const&)
 {
     // FIXME: implement this function
     m_messages = {};
-    return adopt_own(*new ObjectFile());
+    return try_make<ObjectFile>();
 }
 
 }

--- a/Userland/Libraries/LibGLSL/Linker.cpp
+++ b/Userland/Libraries/LibGLSL/Linker.cpp
@@ -26,7 +26,7 @@ ErrorOr<NonnullOwnPtr<LinkedShader>> Linker::link(Vector<ObjectFile const*> cons
     };
     TRY(shader.instructions.try_append(instruction));
 
-    return adopt_own(*new LinkedShader(shader));
+    return try_make<LinkedShader>(shader);
 }
 
 }


### PR DESCRIPTION
I went through all callers of adopt_own() and replaced them with try_make<>() if possible or adopt_nonnull_own_or_enomem() else in cases where it was easy (i.e. in functions already returning ErrorOr).

No intended behavior change.