### PR TITLE
Utilities/netstat: Don't unveil /tmp/portal/lookup for numerical output

### DIFF
--- a/Userland/Utilities/netstat.cpp
+++ b/Userland/Utilities/netstat.cpp
@@ -48,7 +48,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/sys/kernel/processes", "r"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil("/etc/services", "r"));
-    TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
+    if (!flag_numeric)
+        TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
+
     TRY(Core::System::unveil(nullptr, nullptr));
 
     bool has_protocol_flag = (flag_tcp || flag_udp);


### PR DESCRIPTION
It's not needed in such case, and in the near-future when we would want to use this utility in an initramfs environment where there's no service such as LookupServer being running, it's still useful to have the option to invoke this utility with the mentioned limited output functionality.

This is useful for #16855, as I intend to add the `netstat` utility to `BuggieBox` program and since in an initramfs boot environment there might be no `LookupServer`, the only valid option to use this `netstat` utility is by forcing it to use numerical output and to not resolve anything beyond that.