### PR TITLE
PixelPaint: Make layer merging actions work with different sized layers

### DIFF
--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -83,8 +83,8 @@ public:
     void change_layer_index(size_t old_index, size_t new_index);
     void remove_layer(Layer&);
     void select_layer(Layer*);
-    void flatten_all_layers();
-    void merge_visible_layers();
+    ErrorOr<void> flatten_all_layers();
+    ErrorOr<void> merge_visible_layers();
     void merge_active_layer_up(Layer& layer);
     void merge_active_layer_down(Layer& layer);
 
@@ -106,11 +106,18 @@ public:
     Color color_at(Gfx::IntPoint point) const;
 
 private:
+    enum class LayerMergeMode {
+        All,
+        VisibleOnly
+    };
+
     explicit Image(Gfx::IntSize);
 
     void did_change(Gfx::IntRect const& modified_rect = {});
     void did_change_rect(Gfx::IntRect const& modified_rect = {});
     void did_modify_layer_stack();
+
+    ErrorOr<void> merge_layers(LayerMergeMode);
 
     Gfx::IntSize m_size;
     NonnullRefPtrVector<Layer> m_layers;

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -85,8 +85,8 @@ public:
     void select_layer(Layer*);
     ErrorOr<void> flatten_all_layers();
     ErrorOr<void> merge_visible_layers();
-    void merge_active_layer_up(Layer& layer);
-    void merge_active_layer_down(Layer& layer);
+    ErrorOr<void> merge_active_layer_up(Layer& layer);
+    ErrorOr<void> merge_active_layer_down(Layer& layer);
 
     void add_client(ImageClient&);
     void remove_client(ImageClient&);
@@ -111,6 +111,11 @@ private:
         VisibleOnly
     };
 
+    enum class LayerMergeDirection {
+        Up,
+        Down
+    };
+
     explicit Image(Gfx::IntSize);
 
     void did_change(Gfx::IntRect const& modified_rect = {});
@@ -118,6 +123,7 @@ private:
     void did_modify_layer_stack();
 
     ErrorOr<void> merge_layers(LayerMergeMode);
+    ErrorOr<void> merge_active_layer(NonnullRefPtr<Layer> const&, LayerMergeDirection);
 
     Gfx::IntSize m_size;
     NonnullRefPtrVector<Layer> m_layers;

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -845,7 +845,10 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         "Fl&atten Image", { Mod_Ctrl, Key_F }, g_icon_bag.flatten_image, [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
-            editor->image().flatten_all_layers();
+            if (auto maybe_error = editor->image().flatten_all_layers(); maybe_error.is_error()) {
+                GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to flatten all layers: {}", maybe_error.release_error()));
+                return;
+            }
             editor->did_complete_action("Flatten Image"sv);
         }));
 
@@ -853,7 +856,10 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         "&Merge Visible", { Mod_Ctrl, Key_M }, g_icon_bag.merge_visible, [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
-            editor->image().merge_visible_layers();
+            if (auto maybe_error = editor->image().merge_visible_layers(); maybe_error.is_error()) {
+                GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to merge visible layers: {}", maybe_error.release_error()));
+                return;
+            }
             editor->did_complete_action("Merge Visible"sv);
         }));
 

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -870,7 +870,11 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             auto active_layer = editor->active_layer();
             if (!active_layer)
                 return;
-            editor->image().merge_active_layer_up(*active_layer);
+
+            if (auto maybe_error = editor->image().merge_active_layer_up(*active_layer); maybe_error.is_error()) {
+                GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to merge active layer up: {}", maybe_error.release_error()));
+                return;
+            }
             editor->did_complete_action("Merge Active Layer Up"sv);
         }));
 
@@ -881,7 +885,11 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             auto active_layer = editor->active_layer();
             if (!active_layer)
                 return;
-            editor->image().merge_active_layer_down(*active_layer);
+
+            if (auto maybe_error = editor->image().merge_active_layer_down(*active_layer); maybe_error.is_error()) {
+                GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to merge active layer down: {}", maybe_error.release_error()));
+                return;
+            }
             editor->did_complete_action("Merge Active Layer Down"sv);
         }));
 


### PR DESCRIPTION
This PR modifies the following actions

* Flatten Image
* Merge Visible
* Merge Active Layer Up
* Merge Active Layer Down

These actions now work correctly with non-overlapping layers and layers of different sizes. Each of these actions will now size the bounding rect of the newly merged layer to contain all layers being merged. In addition the Merge Up and Merge Down actions will not merge into a layer which is not visible.

Video:

https://user-images.githubusercontent.com/2817754/218277511-d469cfb5-6aec-4497-9b92-45ec08fde271.mp4





