### PR TITLE
LibWeb: Re-implement checkbox painting using the UA stylesheet

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -64,6 +64,25 @@ button:hover, input[type=submit]:hover, input[type=button]:hover, input[type=res
     background-color: -libweb-palette-hover-highlight;
 }
 
+input[type=checkbox] {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    margin: 2px;
+    border: 1px solid -libweb-palette-threed-shadow1;
+}
+
+input[type=checkbox]:checked {
+    /*
+    This roughly resembles ClassicStylePainter's paint_check_box() while uncoupling the styling from LibGfx, similar to
+    <button> above. This is a simple checkmark that still looks ok at 2x scale.
+    Eventually we should respect the `accent-color` property here, which may require going back to an implementation via
+    CheckBoxPaintable::paint().
+    */
+    image-rendering: pixelated;
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAABHNCSVQICAgIfAhkiAAAAEhJREFUKFNjYBgs4D/MIYxEuAiuGKiWkZAGFMUgw5mQbECWBAljKAYJwmxAl0Tnw81FdhK6DcgGYtWA0xlw1TgY2GzCoZQWwgCU1woFwvnCFQAAAABJRU5ErkJggg==);
+}
+
 option {
     display: none;
 }

--- a/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <LibGUI/Event.h>
-#include <LibGfx/StylePainter.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/Layout/CheckBox.h>
@@ -32,18 +31,6 @@ Layout::CheckBox const& CheckBoxPaintable::layout_box() const
 Layout::CheckBox& CheckBoxPaintable::layout_box()
 {
     return static_cast<Layout::CheckBox&>(layout_node());
-}
-
-void CheckBoxPaintable::paint(PaintContext& context, PaintPhase phase) const
-{
-    if (!is_visible())
-        return;
-
-    PaintableBox::paint(context, phase);
-
-    auto const& checkbox = static_cast<HTML::HTMLInputElement const&>(layout_box().dom_node());
-    if (phase == PaintPhase::Foreground)
-        Gfx::StylePainter::paint_check_box(context.painter(), context.enclosing_device_rect(absolute_rect()).to_type<int>(), context.palette(), layout_box().dom_node().enabled(), checkbox.checked(), being_pressed());
 }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.h
@@ -17,8 +17,6 @@ class CheckBoxPaintable final : public LabelablePaintable {
 public:
     static JS::NonnullGCPtr<CheckBoxPaintable> create(Layout::CheckBox const&);
 
-    virtual void paint(PaintContext&, PaintPhase) const override;
-
     Layout::CheckBox const& layout_box() const;
     Layout::CheckBox& layout_box();
 


### PR DESCRIPTION
Before and after:

![image](https://user-images.githubusercontent.com/19366641/218284991-ec1757c1-09bb-4825-a668-2eb1f991bcb4.png)

![image](https://user-images.githubusercontent.com/19366641/218284945-5086a3d0-61fd-42b5-9bee-8aca37cd6745.png)
