### PR TITLE
LibGUI: Callback with the clamped value of Sliders on a jump to cursor

### DIFF
--- a/Userland/Libraries/LibGUI/Slider.cpp
+++ b/Userland/Libraries/LibGUI/Slider.cpp
@@ -104,7 +104,7 @@ void Slider::mousedown_event(MouseEvent& event)
             start_drag(event.position());
             // Delay the callback to make it aware that a drag has started.
             if (on_change)
-                on_change(new_value);
+                on_change(value());
             return;
         }
 


### PR DESCRIPTION
This prevents an assertion failure due to a negative timestamp when seeking a Matroska video.