### PR TITLE
LibVideo/VideoPlayer: Improve behavior when starting and seeking videos, and other fixes

### DIFF
--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -129,7 +129,6 @@ void VideoPlayerWidget::resume_playback()
     if (!m_playback_manager || m_seek_slider->knob_dragging())
         return;
     m_playback_manager->resume_playback();
-    update_play_pause_icon();
 }
 
 void VideoPlayerWidget::pause_playback()
@@ -137,7 +136,6 @@ void VideoPlayerWidget::pause_playback()
     if (!m_playback_manager || m_seek_slider->knob_dragging())
         return;
     m_playback_manager->pause_playback();
-    update_play_pause_icon();
 }
 
 void VideoPlayerWidget::toggle_pause()

--- a/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
@@ -797,8 +797,8 @@ DecoderErrorOr<void> Reader::seek_to_cue_for_timestamp(SampleIterator& iterator,
         return {};
     }
 
-    while (index < cue_points.size()) {
-        auto const& cue_point = cue_points[++index];
+    while (++index < cue_points.size()) {
+        auto const& cue_point = cue_points[index];
         dbgln_if(MATROSKA_DEBUG, "Checking future cue point {}ms", cue_point.timestamp().to_milliseconds());
         if (cue_point.timestamp() > timestamp)
             break;

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -45,7 +45,7 @@ PlaybackManager::PlaybackManager(Core::Object& event_handler, NonnullOwnPtr<Demu
     , m_selected_video_track(video_track)
     , m_decoder(move(decoder))
     , m_frame_queue(make<VideoFrameQueue>())
-    , m_playback_handler(make<StoppedStateHandler>(*this))
+    , m_playback_handler(make<StartingStateHandler>(*this, false))
 {
     m_present_timer = Core::Timer::create_single_shot(0, [&] { timer_callback(); }).release_value_but_fixme_should_propagate_errors();
     m_decode_timer = Core::Timer::create_single_shot(0, [&] { on_decode_timer(); }).release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -121,6 +121,11 @@ bool PlaybackManager::dispatch_frame_queue_item(FrameQueueItem&& item)
     return false;
 }
 
+void PlaybackManager::dispatch_state_change()
+{
+    m_main_loop.post_event(m_event_handler, TRY_OR_FATAL_ERROR(try_make<PlaybackStateChangeEvent>()));
+}
+
 void PlaybackManager::timer_callback()
 {
     TRY_OR_FATAL_ERROR(m_playback_handler->on_timer_callback());
@@ -265,6 +270,7 @@ ErrorOr<void> PlaybackManager::PlaybackStateHandler::replace_handler_and_delete_
     m_has_exited = true;
     dbgln("Changing state from {} to {}", temp_handler->name(), m_manager.m_playback_handler->name());
 #endif
+    m_manager.dispatch_state_change();
     TRY(m_manager.m_playback_handler->on_enter());
     return {};
 }

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -132,6 +132,7 @@ private:
     void dispatch_new_frame(RefPtr<Gfx::Bitmap> frame);
     // Returns whether we changed playback states. If so, any PlaybackStateHandler processing must cease.
     [[nodiscard]] bool dispatch_frame_queue_item(FrameQueueItem&&);
+    void dispatch_state_change();
     void dispatch_fatal_error(Error);
 
     Core::Object& m_event_handler;

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -114,6 +114,8 @@ public:
 
 private:
     class PlaybackStateHandler;
+    // Abstract class to allow resuming play/pause after the state is completed.
+    class ResumingStateHandler;
     class StartingStateHandler;
     class PlayingStateHandler;
     class PausedStateHandler;

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -106,8 +106,6 @@ public:
 
     u64 number_of_skipped_frames() const { return m_skipped_frames; }
 
-    void on_decoder_error(DecoderError error);
-
     Time current_playback_time();
     Time duration();
 
@@ -130,6 +128,8 @@ private:
 
     void dispatch_decoder_error(DecoderError error);
     void dispatch_new_frame(RefPtr<Gfx::Bitmap> frame);
+    // Returns whether we changed playback states. If so, any PlaybackStateHandler processing must cease.
+    [[nodiscard]] bool dispatch_frame_queue_item(FrameQueueItem&&);
     void dispatch_fatal_error(Error);
 
     Core::Object& m_event_handler;

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -114,6 +114,7 @@ public:
 
 private:
     class PlaybackStateHandler;
+    class StartingStateHandler;
     class PlayingStateHandler;
     class PausedStateHandler;
     class BufferingStateHandler;

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -25,6 +25,8 @@
 namespace Video {
 
 struct FrameQueueItem {
+    static constexpr Time no_timestamp = Time::min();
+
     enum class Type {
         Frame,
         Error,
@@ -35,14 +37,14 @@ struct FrameQueueItem {
         return FrameQueueItem(move(bitmap), timestamp);
     }
 
-    static FrameQueueItem error_marker(DecoderError&& error)
+    static FrameQueueItem error_marker(DecoderError&& error, Time timestamp)
     {
-        return FrameQueueItem(move(error));
+        return FrameQueueItem(move(error), timestamp);
     }
 
-    bool is_frame() const { return m_data.has<FrameData>(); }
-    RefPtr<Gfx::Bitmap> bitmap() const { return m_data.get<FrameData>().bitmap; }
-    Time timestamp() const { return m_data.get<FrameData>().timestamp; }
+    bool is_frame() const { return m_data.has<RefPtr<Gfx::Bitmap>>(); }
+    RefPtr<Gfx::Bitmap> bitmap() const { return m_data.get<RefPtr<Gfx::Bitmap>>(); }
+    Time timestamp() const { return m_timestamp; }
 
     bool is_error() const { return m_data.has<DecoderError>(); }
     DecoderError const& error() const { return m_data.get<DecoderError>(); }
@@ -56,27 +58,26 @@ struct FrameQueueItem {
     DeprecatedString debug_string() const
     {
         if (is_error())
-            return error().string_literal();
+            return DeprecatedString::formatted("{} at {}ms", error().string_literal(), timestamp().to_milliseconds());
         return DeprecatedString::formatted("frame at {}ms", timestamp().to_milliseconds());
     }
 
 private:
-    struct FrameData {
-        RefPtr<Gfx::Bitmap> bitmap;
-        Time timestamp;
-    };
-
     FrameQueueItem(RefPtr<Gfx::Bitmap> bitmap, Time timestamp)
-        : m_data(FrameData { move(bitmap), timestamp })
+        : m_data(move(bitmap))
+        , m_timestamp(timestamp)
     {
+        VERIFY(m_timestamp != no_timestamp);
     }
 
-    FrameQueueItem(DecoderError&& error)
+    FrameQueueItem(DecoderError&& error, Time timestamp)
         : m_data(move(error))
+        , m_timestamp(timestamp)
     {
     }
 
-    Variant<Empty, FrameData, DecoderError> m_data;
+    Variant<Empty, RefPtr<Gfx::Bitmap>, DecoderError> m_data;
+    Time m_timestamp;
 };
 
 static constexpr size_t FRAME_BUFFER_COUNT = 4;


### PR DESCRIPTION
Here's a list of the notable improvements (that I remember):

- Add a `StartingStateHandler` to retrieve the first frame and display it, allowing the video to start paused and still display a frame. Currently this is not an option in the player, but it can be added now.
- Prevented an out-of-bounds when seeking to the end of the stream.
- Removed some unnecessarily duplicated code, such as that which dispatches frame queue items, and handler classes that track pausing/playing to resume those states (starting, buffering, seeking).
- Started sending state change events again, and dropped code to update icons after playing/pausing in favor of reacting to those events.
- Ensure that we don't display frames too soon. Since we're single-threaded currently, on slowly decoded videos, this may cause worse frame drops, depending on how close the Timer fires to the frame presentation timestamp, but it allows the StartingStateHandler to not cause the first two frames to fire instantly.