### PR TITLE
Piano: Fix insertion and deletion of notes

### DIFF
--- a/Userland/Applications/Piano/RollWidget.h
+++ b/Userland/Applications/Piano/RollWidget.h
@@ -43,12 +43,13 @@ private:
     double m_note_width { 0.0 };
     int m_zoom_level { 1 };
 
-    Optional<Gfx::IntPoint> m_note_drag_start;
-    Optional<RollNote> m_note_drag_location;
-    int m_drag_note;
+    Optional<GUI::MouseEvent> m_mousedown_event;
 
     RefPtr<Gfx::Bitmap> m_background;
     int m_prev_zoom_level { m_zoom_level };
     int m_prev_scroll_x { horizontal_scrollbar().value() };
     int m_prev_scroll_y { vertical_scrollbar().value() };
+
+    u8 get_pitch_for_y(int y) const;
+    int get_note_for_x(int x) const;
 };

--- a/Userland/Libraries/LibDSP/Clip.cpp
+++ b/Userland/Libraries/LibDSP/Clip.cpp
@@ -14,6 +14,15 @@ Sample AudioClip::sample_at(u32 time)
     return m_samples[time];
 }
 
+Optional<RollNote> NoteClip::note_at(u32 time, u8 pitch) const
+{
+    for (auto& note : m_notes) {
+        if (time >= note.on_sample && time <= note.off_sample && pitch == note.pitch)
+            return note;
+    }
+    return {};
+}
+
 void NoteClip::set_note(RollNote note)
 {
     m_notes.remove_all_matching([&](auto const& other) {

--- a/Userland/Libraries/LibDSP/Clip.h
+++ b/Userland/Libraries/LibDSP/Clip.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Forward.h>
 #include <AK/RefCounted.h>
 #include <AK/SinglyLinkedList.h>
 #include <AK/Types.h>
@@ -50,6 +51,7 @@ public:
     {
     }
 
+    Optional<RollNote> note_at(u32 time, u8 pitch) const;
     void set_note(RollNote note);
     // May do nothing; that's fine.
     void remove_note(RollNote note);

--- a/Userland/Libraries/LibDSP/Track.cpp
+++ b/Userland/Libraries/LibDSP/Track.cpp
@@ -146,6 +146,16 @@ void AudioTrack::compute_current_clips_signal()
     TODO();
 }
 
+Optional<RollNote> NoteTrack::note_at(u32 time, u8 pitch) const
+{
+    for (auto& clip : m_clips) {
+        if (time >= clip.start() && time <= clip.end())
+            return clip.note_at(time, pitch);
+    }
+
+    return {};
+}
+
 void NoteTrack::set_note(RollNote note)
 {
     for (auto& clip : m_clips) {

--- a/Userland/Libraries/LibDSP/Track.h
+++ b/Userland/Libraries/LibDSP/Track.h
@@ -80,6 +80,7 @@ public:
     bool check_processor_chain_valid() const override;
     ReadonlySpan<NonnullRefPtr<NoteClip>> notes() const { return m_clips.span(); }
 
+    Optional<RollNote> note_at(u32 time, u8 pitch) const;
     void set_note(RollNote note);
     void remove_note(RollNote note);
 


### PR DESCRIPTION
On mouse move the pressed button is not present in the event argument which causes the corresponding code to never fire. Instead it now stores the original mouse down event and acts according to that on mouse move.

This was split off of #17350 according to the review comments.