### PR TITLE
Everywhere: Remove and forbid improper moves of `const&`s

### DIFF
--- a/AK/FixedArray.h
+++ b/AK/FixedArray.h
@@ -35,10 +35,10 @@ public:
 
     static ErrorOr<FixedArray<T>> create(std::initializer_list<T> initializer)
     {
-        auto array = TRY(create(initializer.size()));
+        auto array = TRY(create_uninitialized(initializer.size()));
         auto it = initializer.begin();
         for (size_t i = 0; i < array.size(); ++i) {
-            array[i] = move(*it);
+            new (&array[i]) T(move(const_cast<T&>(*it)));
             ++it;
         }
         return array;

--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -32,8 +32,10 @@ public:
     {
     }
 
+    JsonArray(Vector<JsonValue> source) { m_values = move(source); }
+
     template<IterableContainer ContainerT>
-    JsonArray(ContainerT const& source)
+    JsonArray(ContainerT source)
     {
         for (auto& value : source)
             m_values.append(move(value));

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -247,7 +247,7 @@ public:
     {
         if (m_has_value)
             return move(value());
-        return move(fallback);
+        return fallback;
     }
 
     template<typename Callback>

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -65,6 +65,17 @@ constexpr T&& move(T& arg)
     return static_cast<T&&>(arg);
 }
 
+#ifndef NO_STRICT_MOVE
+
+template<typename T>
+constexpr T&& move(T const& arg)
+{
+    // This should raise an error, because you cannot move from constant references,
+    // The normal move usually just copies the value instead
+    return static_cast<T&&>(arg);
+}
+#endif
+
 }
 
 namespace AK {

--- a/Ladybird/RequestManagerQt.cpp
+++ b/Ladybird/RequestManagerQt.cpp
@@ -88,7 +88,7 @@ void RequestManagerQt::Request::did_finish()
     auto buffer = m_reply.readAll();
     auto http_status_code = m_reply.attribute(QNetworkRequest::Attribute::HttpStatusCodeAttribute).toInt();
     HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> response_headers;
-    Vector<DeprecatedString> set_cookie_headers;
+    JsonArray set_cookie_headers;
     for (auto& it : m_reply.rawHeaderPairs()) {
         auto name = DeprecatedString(it.first.data(), it.first.length());
         auto value = DeprecatedString(it.second.data(), it.second.length());
@@ -104,7 +104,7 @@ void RequestManagerQt::Request::did_finish()
         }
     }
     if (!set_cookie_headers.is_empty()) {
-        response_headers.set("set-cookie"sv, JsonArray { set_cookie_headers }.to_deprecated_string());
+        response_headers.set("set-cookie"sv, set_cookie_headers.to_deprecated_string());
     }
     on_buffered_request_finish(success, buffer.length(), response_headers, http_status_code, ReadonlyBytes { buffer.data(), (size_t)buffer.size() });
 }

--- a/Ladybird/WebSocketLadybird.cpp
+++ b/Ladybird/WebSocketLadybird.cpp
@@ -26,7 +26,7 @@ WebSocketLadybird::WebSocketLadybird(NonnullRefPtr<WebSocket::WebSocket> underly
         if (auto strong_this = weak_this.strong_ref()) {
             if (strong_this->on_message) {
                 strong_this->on_message(Web::WebSockets::WebSocketClientSocket::Message {
-                    .data = move(message.data()),
+                    .data = message.release_data(),
                     .is_text = message.is_text(),
                 });
             }

--- a/Tests/LibGfx/TestFontHandling.cpp
+++ b/Tests/LibGfx/TestFontHandling.cpp
@@ -142,7 +142,7 @@ TEST_CASE(test_write_to_file)
 
     char path[] = "/tmp/new.font.XXXXXX";
     EXPECT(mkstemp(path) != -1);
-    EXPECT(!font->write_to_file(path).is_error());
+    EXPECT(!font->write_to_file(StringView { path, strlen(path) }).is_error());
     unlink(path);
 }
 

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -256,7 +256,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto& match = results_container.add<Assistant::ResultRow>();
             match.set_icon(result.bitmap());
             match.set_text(String::from_deprecated_string(result.title()).release_value_but_fixme_should_propagate_errors());
-            match.set_tooltip(move(result.tooltip()));
+            match.set_tooltip(result.tooltip());
             match.on_click = [&result](auto) {
                 result.activate();
                 GUI::Application::the()->quit();

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -66,7 +66,7 @@ static void do_create_archive(Vector<DeprecatedString> const& selected_file_path
 static void do_set_wallpaper(DeprecatedString const& file_path, GUI::Window* window);
 static void do_unzip_archive(Vector<DeprecatedString> const& selected_file_paths, GUI::Window* window);
 static void show_properties(DeprecatedString const& container_dir_path, DeprecatedString const& path, Vector<DeprecatedString> const& selected, GUI::Window* window);
-static bool add_launch_handler_actions_to_menu(RefPtr<GUI::Menu>& menu, DirectoryView const& directory_view, DeprecatedString const& full_path, RefPtr<GUI::Action>& default_action, NonnullRefPtrVector<LauncherHandler>& current_file_launch_handlers);
+static bool add_launch_handler_actions_to_menu(RefPtr<GUI::Menu>& menu, DirectoryView const& directory_view, DeprecatedString full_path, RefPtr<GUI::Action>& default_action, NonnullRefPtrVector<LauncherHandler>& current_file_launch_handlers);
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -310,14 +310,14 @@ void show_properties(DeprecatedString const& container_dir_path, DeprecatedStrin
     properties->show();
 }
 
-bool add_launch_handler_actions_to_menu(RefPtr<GUI::Menu>& menu, DirectoryView const& directory_view, DeprecatedString const& full_path, RefPtr<GUI::Action>& default_action, NonnullRefPtrVector<LauncherHandler>& current_file_launch_handlers)
+bool add_launch_handler_actions_to_menu(RefPtr<GUI::Menu>& menu, DirectoryView const& directory_view, DeprecatedString full_path, RefPtr<GUI::Action>& default_action, NonnullRefPtrVector<LauncherHandler>& current_file_launch_handlers)
 {
     current_file_launch_handlers = directory_view.get_launch_handlers(full_path);
 
     bool added_open_menu_items = false;
     auto default_file_handler = directory_view.get_default_launch_handler(current_file_launch_handlers);
     if (default_file_handler) {
-        auto file_open_action = default_file_handler->create_launch_action([&, full_path = move(full_path)](auto& launcher_handler) {
+        auto file_open_action = default_file_handler->create_launch_action([&, full_path](auto& launcher_handler) {
             directory_view.launch(URL::create_with_file_scheme(full_path), launcher_handler);
         });
         if (default_file_handler->details().launcher_type == Desktop::Launcher::LauncherType::Application)

--- a/Userland/Applications/FontEditor/main.cpp
+++ b/Userland/Applications/FontEditor/main.cpp
@@ -45,7 +45,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (path) {
         TRY(font_editor->open_file(path));
     } else {
-        auto mutable_font = TRY(TRY(Gfx::BitmapFont::try_load_from_file("/res/fonts/KaticaRegular10.font"))->unmasked_character_set());
+        auto mutable_font = TRY(TRY(Gfx::BitmapFont::try_load_from_file("/res/fonts/KaticaRegular10.font"sv))->unmasked_character_set());
         TRY(font_editor->initialize({}, move(mutable_font)));
     }
 

--- a/Userland/Applications/HexEditor/SearchResultsModel.h
+++ b/Userland/Applications/HexEditor/SearchResultsModel.h
@@ -25,7 +25,7 @@ public:
         Value
     };
 
-    explicit SearchResultsModel(Vector<Match> const&& matches)
+    explicit SearchResultsModel(Vector<Match>&& matches)
         : m_matches(move(matches))
     {
     }

--- a/Userland/Applications/PixelPaint/ProjectLoader.h
+++ b/Userland/Applications/PixelPaint/ProjectLoader.h
@@ -22,7 +22,7 @@ public:
 
     bool is_raw_image() const { return m_is_raw_image; }
     bool has_image() const { return !m_image.is_null(); }
-    RefPtr<Image> release_image() const { return move(m_image); }
+    RefPtr<Image> release_image() { return move(m_image); }
     JsonArray const& json_metadata() const { return m_json_metadata; }
 
 private:

--- a/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
+++ b/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
@@ -31,7 +31,7 @@ public:
         __Count
     };
 
-    explicit SearchResultsModel(Vector<Match> const&& matches)
+    explicit SearchResultsModel(Vector<Match>&& matches)
         : m_matches(move(matches))
     {
     }

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -282,7 +282,7 @@ void HackStudioWidget::open_project(DeprecatedString const& root_path)
     if (recent_projects.size() > recent_projects_history_size)
         recent_projects.shrink(recent_projects_history_size);
 
-    Config::write_string("HackStudio"sv, "Global"sv, "RecentProjects"sv, JsonArray(recent_projects).to_deprecated_string());
+    Config::write_string("HackStudio"sv, "Global"sv, "RecentProjects"sv, JsonArray(move(recent_projects)).to_deprecated_string());
     update_recent_projects_submenu();
 }
 

--- a/Userland/DevTools/HackStudio/LanguageClient.cpp
+++ b/Userland/DevTools/HackStudio/LanguageClient.cpp
@@ -127,7 +127,7 @@ void ConnectionToServer::declarations_in_document(DeprecatedString const& filena
 
 void ConnectionToServer::todo_entries_in_document(DeprecatedString const& filename, Vector<CodeComprehension::TodoEntry> const& todo_entries)
 {
-    ToDoEntries::the().set_entries(filename, move(todo_entries));
+    ToDoEntries::the().set_entries(filename, move(const_cast<Vector<CodeComprehension::TodoEntry>&>(todo_entries)));
 }
 
 void LanguageClient::search_declaration(DeprecatedString const& path, size_t line, size_t column)

--- a/Userland/DevTools/HackStudio/ToDoEntries.cpp
+++ b/Userland/DevTools/HackStudio/ToDoEntries.cpp
@@ -14,7 +14,7 @@ ToDoEntries& HackStudio::ToDoEntries::the()
     return s_instance;
 }
 
-void ToDoEntries::set_entries(DeprecatedString const& filename, Vector<CodeComprehension::TodoEntry> const&& entries)
+void ToDoEntries::set_entries(DeprecatedString const& filename, Vector<CodeComprehension::TodoEntry> entries)
 {
     m_document_to_entries.set(filename, move(entries));
     if (on_update)

--- a/Userland/DevTools/HackStudio/ToDoEntries.h
+++ b/Userland/DevTools/HackStudio/ToDoEntries.h
@@ -20,7 +20,7 @@ class ToDoEntries {
 public:
     static ToDoEntries& the();
 
-    void set_entries(DeprecatedString const& filename, Vector<CodeComprehension::TodoEntry> const&& entries);
+    void set_entries(DeprecatedString const& filename, Vector<CodeComprehension::TodoEntry> entries);
 
     Vector<CodeComprehension::TodoEntry> get_entries();
 

--- a/Userland/DevTools/HackStudio/ToDoEntriesWidget.cpp
+++ b/Userland/DevTools/HackStudio/ToDoEntriesWidget.cpp
@@ -22,7 +22,7 @@ public:
         __Count
     };
 
-    explicit ToDoEntriesModel(Vector<CodeComprehension::TodoEntry> const&& matches)
+    explicit ToDoEntriesModel(Vector<CodeComprehension::TodoEntry>&& matches)
         : m_matches(move(matches))
     {
     }
@@ -86,7 +86,7 @@ private:
 
 void ToDoEntriesWidget::refresh()
 {
-    auto const& entries = ToDoEntries::the().get_entries();
+    auto entries = ToDoEntries::the().get_entries();
     auto results_model = adopt_ref(*new ToDoEntriesModel(move(entries)));
     m_result_view->set_model(results_model);
 }

--- a/Userland/Games/ColorLines/ColorLines.cpp
+++ b/Userland/Games/ColorLines/ColorLines.cpp
@@ -56,7 +56,7 @@ ColorLines::ColorLines(StringView app_name)
     , m_board { make<MarbleBoard>() }
     , m_marble_bitmaps { build_marble_color_bitmaps() }
     , m_trace_bitmaps { build_marble_trace_bitmaps() }
-    , m_score_font { Gfx::BitmapFont::load_from_file("/res/fonts/MarietaBold24.font") }
+    , m_score_font { Gfx::BitmapFont::load_from_file("/res/fonts/MarietaBold24.font"sv) }
 {
     VERIFY(m_marble_bitmaps.size() == Marble::number_of_colors);
     set_font(Gfx::FontDatabase::default_fixed_width_font().bold_variant());

--- a/Userland/Games/FlappyBug/Game.h
+++ b/Userland/Games/FlappyBug/Game.h
@@ -128,7 +128,7 @@ public:
         int bitmap_id {};
 
     private:
-        Cloud(Vector<NonnullRefPtr<Gfx::Bitmap>> const cloud_bitmaps_value)
+        Cloud(Vector<NonnullRefPtr<Gfx::Bitmap>> cloud_bitmaps_value)
             : cloud_bitmaps(move(cloud_bitmaps_value))
         {
             reset();
@@ -138,7 +138,7 @@ public:
     public:
         static ErrorOr<Cloud> construct()
         {
-            Vector<NonnullRefPtr<Gfx::Bitmap>> const cloud_bitmaps {
+            Vector<NonnullRefPtr<Gfx::Bitmap>> cloud_bitmaps {
                 TRY(Gfx::Bitmap::load_from_file("/res/icons/flappybug/cloud_0.png"sv)),
                 TRY(Gfx::Bitmap::load_from_file("/res/icons/flappybug/cloud_1.png"sv)),
                 TRY(Gfx::Bitmap::load_from_file("/res/icons/flappybug/cloud_2.png"sv)),

--- a/Userland/Libraries/LibCore/DeprecatedFile.h
+++ b/Userland/Libraries/LibCore/DeprecatedFile.h
@@ -29,7 +29,7 @@ public:
     static ErrorOr<NonnullRefPtr<DeprecatedFile>> open(DeprecatedString filename, OpenMode, mode_t = 0644);
 
     DeprecatedString filename() const { return m_filename; }
-    void set_filename(const DeprecatedString filename) { m_filename = move(filename); }
+    void set_filename(DeprecatedString filename) { m_filename = move(filename); }
 
     bool is_directory() const;
     static bool is_directory(DeprecatedString const& filename);

--- a/Userland/Libraries/LibCoredump/Backtrace.cpp
+++ b/Userland/Libraries/LibCoredump/Backtrace.cpp
@@ -41,8 +41,8 @@ ELFObjectInfo const* Backtrace::object_info_for_region(Reader const& coredump, M
     return info_ptr;
 }
 
-Backtrace::Backtrace(Reader const& coredump, const ELF::Core::ThreadInfo& thread_info, Function<void(size_t, size_t)> on_progress)
-    : m_thread_info(move(thread_info))
+Backtrace::Backtrace(Reader const& coredump, ELF::Core::ThreadInfo const& thread_info, Function<void(size_t, size_t)> on_progress)
+    : m_thread_info(thread_info)
 {
 #if ARCH(X86_64)
     auto start_bp = m_thread_info.regs.rbp;

--- a/Userland/Libraries/LibGL/CMakeLists.txt
+++ b/Userland/Libraries/LibGL/CMakeLists.txt
@@ -20,6 +20,13 @@ set(SOURCES
     Vertex.cpp
 )
 
+# FIXME: Figure out what is going wrong here:
+#        In the construction of the command list, we somewhere try to move a
+#        const-ref which does not actually move, so us beign strict about
+#        move-semantics breaks here, and the build-log is not very helpful to
+#        look at.
+add_compile_definitions(NO_STRICT_MOVE)
+
 generate_libgl_implementation()
 
 set(GENERATED_SOURCES

--- a/Userland/Libraries/LibGUI/Calendar.cpp
+++ b/Userland/Libraries/LibGUI/Calendar.cpp
@@ -20,10 +20,10 @@ REGISTER_WIDGET(GUI, Calendar);
 
 namespace GUI {
 
-static auto const extra_large_font = Gfx::BitmapFont::load_from_file("/res/fonts/MarietaRegular36.font");
-static auto const large_font = Gfx::BitmapFont::load_from_file("/res/fonts/MarietaRegular24.font");
-static auto const medium_font = Gfx::BitmapFont::load_from_file("/res/fonts/PebbletonRegular14.font");
-static auto const small_font = Gfx::BitmapFont::load_from_file("/res/fonts/KaticaRegular10.font");
+static auto const extra_large_font = Gfx::BitmapFont::load_from_file("/res/fonts/MarietaRegular36.font"sv);
+static auto const large_font = Gfx::BitmapFont::load_from_file("/res/fonts/MarietaRegular24.font"sv);
+static auto const medium_font = Gfx::BitmapFont::load_from_file("/res/fonts/PebbletonRegular14.font"sv);
+static auto const small_font = Gfx::BitmapFont::load_from_file("/res/fonts/KaticaRegular10.font"sv);
 
 Calendar::Calendar(Core::DateTime date_time, Mode mode)
     : m_selected_date(date_time)

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -184,7 +184,7 @@ auto EmojiInputDialog::supported_emoji() -> Vector<Emoji>
         auto button = EmojiButton::construct(move(code_points));
         button->set_fixed_size(button_size, button_size);
         button->set_button_style(Gfx::ButtonStyle::Coolbar);
-        button->on_click = [this, text](auto) {
+        button->on_click = [this, text](auto) mutable {
             m_selected_emoji_text = move(text);
             done(ExecResult::OK);
         };

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -173,7 +173,7 @@ void TextDocumentLine::clear(TextDocument& document)
     document.update_views({});
 }
 
-void TextDocumentLine::set_text(TextDocument& document, Vector<u32> const text)
+void TextDocumentLine::set_text(TextDocument& document, Vector<u32> text)
 {
     m_text = move(text);
     document.update_views({});

--- a/Userland/Libraries/LibGemini/Job.cpp
+++ b/Userland/Libraries/LibGemini/Job.cpp
@@ -267,9 +267,8 @@ void Job::finish_up()
         return;
     }
 
-    auto response = GeminiResponse::create(m_status, m_meta);
-    deferred_invoke([this, response] {
-        did_finish(move(response));
+    deferred_invoke([this] {
+        did_finish(GeminiResponse::create(m_status, m_meta));
     });
 }
 

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
@@ -226,12 +226,12 @@ ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::load_from_memory(u8 const* data)
     return adopt_nonnull_ref_or_enomem(new (nothrow) BitmapFont(DeprecatedString(header.name), DeprecatedString(header.family), rows, widths, !header.is_variable_width, header.glyph_width, header.glyph_height, header.glyph_spacing, header.range_mask_size, range_mask, header.baseline, header.mean_line, header.presentation_size, header.weight, header.slope));
 }
 
-RefPtr<BitmapFont> BitmapFont::load_from_file(DeprecatedString const& path)
+RefPtr<BitmapFont> BitmapFont::load_from_file(StringView path)
 {
-    return MUST(try_load_from_file(move(path)));
+    return MUST(try_load_from_file(path));
 }
 
-ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::try_load_from_file(DeprecatedString const& path)
+ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::try_load_from_file(StringView path)
 {
     auto file = TRY(Core::MappedFile::map(path));
     auto font = TRY(load_from_memory((u8 const*)file->data()));
@@ -239,7 +239,7 @@ ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::try_load_from_file(DeprecatedStri
     return font;
 }
 
-ErrorOr<void> BitmapFont::write_to_file(DeprecatedString const& path)
+ErrorOr<void> BitmapFont::write_to_file(StringView path)
 {
     FontFileHeader header;
     memset(&header, 0, sizeof(FontFileHeader));

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -30,9 +30,9 @@ public:
     ErrorOr<NonnullRefPtr<BitmapFont>> masked_character_set() const;
     ErrorOr<NonnullRefPtr<BitmapFont>> unmasked_character_set() const;
 
-    static RefPtr<BitmapFont> load_from_file(DeprecatedString const& path);
-    static ErrorOr<NonnullRefPtr<BitmapFont>> try_load_from_file(DeprecatedString const& path);
-    ErrorOr<void> write_to_file(DeprecatedString const& path);
+    static RefPtr<BitmapFont> load_from_file(StringView path);
+    static ErrorOr<NonnullRefPtr<BitmapFont>> try_load_from_file(StringView path);
+    ErrorOr<void> write_to_file(StringView path);
 
     ~BitmapFont();
 

--- a/Userland/Libraries/LibHTTP/HttpRequest.h
+++ b/Userland/Libraries/LibHTTP/HttpRequest.h
@@ -48,7 +48,7 @@ public:
     Vector<Header> const& headers() const { return m_headers; }
 
     URL const& url() const { return m_url; }
-    void set_url(URL const& url) { m_url = url; }
+    void set_url(URL url) { m_url = move(url); }
 
     Method method() const { return m_method; }
     void set_method(Method method) { m_method = method; }

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -588,7 +588,7 @@ ThrowCompletionOr<Array*> supported_locales(VM& vm, Vector<String> const& reques
     }
 
     // 5. Return CreateArrayFromList(supportedLocales).
-    return Array::create_from<String>(realm, supported_locales, [&vm](auto& locale) { return PrimitiveString::create(vm, move(locale)); }).ptr();
+    return Array::create_from<String>(realm, supported_locales, [&vm](auto& locale) { return PrimitiveString::create(vm, locale); }).ptr();
 }
 
 // 9.2.12 CoerceOptionsToObject ( options ), https://tc39.es/ecma402/#sec-coerceoptionstoobject

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.cpp
@@ -11,7 +11,7 @@
 namespace JS::Intl {
 
 // 18.6.1 CreateSegmentIterator ( segmenter, string ), https://tc39.es/ecma402/#sec-createsegmentsobject
-NonnullGCPtr<SegmentIterator> SegmentIterator::create(Realm& realm, Segmenter& segmenter, Utf16View const& string, Segments const& segments)
+NonnullGCPtr<SegmentIterator> SegmentIterator::create(Realm& realm, Segmenter& segmenter, Utf16View string, Segments const& segments)
 {
     // 1. Let internalSlotsList be « [[IteratingSegmenter]], [[IteratedString]], [[IteratedStringNextSegmentCodeUnitIndex]] ».
     // 2. Let iterator be OrdinaryObjectCreate(%SegmentIteratorPrototype%, internalSlotsList).

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.h
@@ -16,7 +16,7 @@ class SegmentIterator final : public Object {
     JS_OBJECT(SegmentIterator, Object);
 
 public:
-    static NonnullGCPtr<SegmentIterator> create(Realm&, Segmenter&, Utf16View const&, Segments const&);
+    static NonnullGCPtr<SegmentIterator> create(Realm&, Segmenter&, Utf16View, Segments const&);
 
     virtual ~SegmentIterator() override = default;
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentsPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentsPrototype.cpp
@@ -79,7 +79,7 @@ JS_DEFINE_NATIVE_FUNCTION(SegmentsPrototype::symbol_iterator)
     auto string = segments->segments_string();
 
     // 5. Return ! CreateSegmentIterator(segmenter, string).
-    return SegmentIterator::create(realm, segmenter, string, *segments);
+    return SegmentIterator::create(realm, segmenter, move(string), *segments);
 }
 
 }

--- a/Userland/Libraries/LibMarkdown/CodeBlock.h
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.h
@@ -17,10 +17,10 @@ namespace Markdown {
 
 class CodeBlock final : public Block {
 public:
-    CodeBlock(DeprecatedString const& language, DeprecatedString const& style, DeprecatedString const& code, Heading* current_section)
+    CodeBlock(DeprecatedString language, DeprecatedString style, DeprecatedString code, Heading* current_section)
         : m_code(move(code))
-        , m_language(language)
-        , m_style(style)
+        , m_language(move(language))
+        , m_style(move(style))
         , m_current_section(current_section)
     {
     }

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -97,7 +97,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Infrastructure::FetchController>> fetch(JS:
     //    response consume body is processResponseConsumeBody, process response end-of-body is processResponseEndOfBody,
     //    task destination is taskDestination, and cross-origin isolated capability is crossOriginIsolatedCapability.
     auto fetch_params = Infrastructure::FetchParams::create(vm, request, timing_info);
-    fetch_params->set_algorithms(move(algorithms));
+    fetch_params->set_algorithms(algorithms);
     if (task_destination)
         fetch_params->set_task_destination({ *task_destination });
     fetch_params->set_cross_origin_isolated_capability(cross_origin_isolated_capability);
@@ -1644,7 +1644,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_load
 
     ResourceLoader::the().load(
         load_request,
-        [&realm, &vm, request, pending_response](auto data, auto& response_headers, auto status_code) {
+        [&realm, &vm, request, pending_response](auto data, auto response_headers, auto status_code) {
             dbgln_if(WEB_FETCH_DEBUG, "Fetch: ResourceLoader load for '{}' complete", request->url());
             if constexpr (WEB_FETCH_DEBUG)
                 log_response(status_code, response_headers, data);

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -384,7 +384,7 @@ void fetch_single_module_script(AK::URL const& url, EnvironmentSettingsObject&, 
 
     ResourceLoader::the().load(
         request,
-        [url, module_type, &module_map_settings_object, on_complete = move(on_complete), &module_map](StringView data, auto& response_headers, auto) {
+        [url, module_type, &module_map_settings_object, on_complete = move(on_complete), &module_map](StringView data, auto response_headers, auto) {
             if (data.is_null()) {
                 dbgln("Failed to load module {}", url);
                 module_map.set(url, module_type, { ModuleMap::EntryType::Failed, nullptr });

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -498,7 +498,7 @@ i32 Window::run_timer_initialization_steps(TimerHandler handler, i32 timeout, JS
     // 8. Assert: initiating script is not null, since this algorithm is always called from some script.
 
     // 9. Let task be a task that runs the following substeps:
-    JS::SafeFunction<void()> task = [this, handler = move(handler), timeout, arguments = move(arguments), repeat, id] {
+    JS::SafeFunction<void()> task = [this, handler = move(handler), timeout, arguments = move(arguments), repeat, id]() mutable {
         // 1. If id does not exist in global's map of active timers, then abort these steps.
         if (!m_timers.contains(id))
             return;

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -208,7 +208,7 @@ void Worker::run_a_worker(AK::URL& url, EnvironmentSettingsObject& outside_setti
 
     ResourceLoader::the().load(
         url,
-        [this, is_shared, is_top_level, url, &outside_port](auto data, auto&, auto) {
+        [this, is_shared, is_top_level, url, &outside_port](auto data, auto, auto) {
             // In both cases, to perform the fetch given request, perform the following steps if the is top-level flag is set:
             if (is_top_level) {
                 // 1. Set request's reserved client to inside settings.

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -250,7 +250,7 @@ bool FrameLoader::load(LoadRequest& request, Type type)
 
         ResourceLoader::the().load(
             favicon_url,
-            [this, favicon_url](auto data, auto&, auto) {
+            [this, favicon_url](auto data, auto, auto) {
                 // Always fetch the current document
                 auto* document = this->browsing_context().active_document();
                 if (document && document->has_active_favicon())
@@ -336,7 +336,7 @@ void FrameLoader::load_error_page(const AK::URL& failed_url, DeprecatedString co
 
     ResourceLoader::the().load(
         request,
-        [this, failed_url, error](auto data, auto&, auto) {
+        [this, failed_url, error](auto data, auto, auto) {
             VERIFY(!data.is_null());
             StringBuilder builder;
             SourceGenerator generator { builder };

--- a/Userland/Libraries/LibWeb/Loader/Resource.h
+++ b/Userland/Libraries/LibWeb/Loader/Resource.h
@@ -60,7 +60,7 @@ public:
 
     void for_each_client(Function<void(ResourceClient&)>);
 
-    void did_load(Badge<ResourceLoader>, ReadonlyBytes data, HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> const& headers, Optional<u32> status_code);
+    void did_load(Badge<ResourceLoader>, ReadonlyBytes data, HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> headers, Optional<u32> status_code);
     void did_fail(Badge<ResourceLoader>, DeprecatedString const& error, Optional<u32> status_code);
 
 protected:

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -93,8 +93,8 @@ public:
 
     RefPtr<Resource> load_resource(Resource::Type, LoadRequest&);
 
-    void load(LoadRequest&, Function<void(ReadonlyBytes, HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> const& response_headers, Optional<u32> status_code)> success_callback, Function<void(DeprecatedString const&, Optional<u32> status_code)> error_callback = nullptr, Optional<u32> timeout = {}, Function<void()> timeout_callback = nullptr);
-    void load(const AK::URL&, Function<void(ReadonlyBytes, HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> const& response_headers, Optional<u32> status_code)> success_callback, Function<void(DeprecatedString const&, Optional<u32> status_code)> error_callback = nullptr, Optional<u32> timeout = {}, Function<void()> timeout_callback = nullptr);
+    void load(LoadRequest&, Function<void(ReadonlyBytes, HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> response_headers, Optional<u32> status_code)> success_callback, Function<void(DeprecatedString const&, Optional<u32> status_code)> error_callback = nullptr, Optional<u32> timeout = {}, Function<void()> timeout_callback = nullptr);
+    void load(const AK::URL&, Function<void(ReadonlyBytes, HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> response_headers, Optional<u32> status_code)> success_callback, Function<void(DeprecatedString const&, Optional<u32> status_code)> error_callback = nullptr, Optional<u32> timeout = {}, Function<void()> timeout_callback = nullptr);
 
     ResourceLoaderConnector& connector() { return *m_connector; }
 

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -156,6 +156,7 @@ static ErrorOr<JsonValue, ExecuteScriptResultType> clone_an_object(JS::Realm& re
             if (length > NumericLimits<u32>::max())
                 return ExecuteScriptResultType::JavaScriptError;
             auto array = JsonArray {};
+            array.ensure_capacity(length);
             for (size_t i = 0; i < length; ++i)
                 array.append(JsonValue {});
             return array;

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -524,7 +524,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
         //        See: https://github.com/whatwg/fetch/issues/1142
         ResourceLoader::the().load(
             request,
-            [weak_this = make_weak_ptr<XMLHttpRequest>()](auto data, auto& response_headers, auto status_code) {
+            [weak_this = make_weak_ptr<XMLHttpRequest>()](auto data, auto response_headers, auto status_code) {
                 JS::GCPtr<XMLHttpRequest> strong_this = weak_this.ptr();
                 if (!strong_this)
                     return;

--- a/Userland/Libraries/LibWebSocket/Message.h
+++ b/Userland/Libraries/LibWebSocket/Message.h
@@ -26,14 +26,9 @@ public:
     {
     }
 
-    explicit Message(ByteBuffer const&& data, bool is_text)
-        : m_is_text(is_text)
-        , m_data(move(data))
-    {
-    }
-
     bool is_text() const { return m_is_text; }
     ByteBuffer const& data() const { return m_data; }
+    ByteBuffer&& release_data() { return move(m_data); }
 
 private:
     bool m_is_text { false };

--- a/Userland/Services/AudioServer/FadingProperty.h
+++ b/Userland/Services/AudioServer/FadingProperty.h
@@ -17,11 +17,11 @@ constexpr int DEFAULT_FADE_TIME = 10;
 template<typename T>
 class FadingProperty {
 public:
-    FadingProperty(T const value)
+    FadingProperty(T value)
         : FadingProperty(value, DEFAULT_FADE_TIME)
     {
     }
-    FadingProperty(T const value, int const fade_time)
+    FadingProperty(T value, int fade_time)
         : m_old_value(value)
         , m_new_value(move(value))
         , m_fade_time(fade_time)

--- a/Userland/Services/DHCPClient/DHCPv4.h
+++ b/Userland/Services/DHCPClient/DHCPv4.h
@@ -113,7 +113,7 @@ struct AK::Traits<DHCPOption> : public GenericTraits<DHCPOption> {
 
 struct ParsedDHCPv4Options {
     template<typename T>
-    Optional<T const> get(DHCPOption option_name) const
+    Optional<T> get(DHCPOption option_name) const
     requires(IsTriviallyCopyable<T>)
     {
         auto option = options.get(option_name);

--- a/Userland/Services/RequestServer/ConnectionCache.cpp
+++ b/Userland/Services/RequestServer/ConnectionCache.cpp
@@ -38,7 +38,7 @@ void request_did_finish(URL const& url, Core::Socket const* socket)
 
         auto& connection = *connection_it;
         if (connection->request_queue.is_empty()) {
-            Core::deferred_invoke([&connection, &cache_entry = *it->value, key = it->key, &cache] {
+            Core::deferred_invoke([&connection, &cache_entry = *it->value, key = it->key, &cache]() mutable {
                 connection->socket->set_notifications_enabled(false);
                 connection->has_started = false;
                 connection->current_url = {};

--- a/Userland/Services/WebContent/ImageCodecPluginSerenity.cpp
+++ b/Userland/Services/WebContent/ImageCodecPluginSerenity.cpp
@@ -30,7 +30,7 @@ Optional<Web::Platform::DecodedImage> ImageCodecPluginSerenity::decode_image(Rea
     Web::Platform::DecodedImage decoded_image;
     decoded_image.is_animated = result.is_animated;
     decoded_image.loop_count = result.loop_count;
-    for (auto const& frame : result.frames) {
+    for (auto& frame : result.frames) {
         decoded_image.frames.empend(move(frame.bitmap), frame.duration);
     }
 

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -350,7 +350,7 @@ Optional<Web::Cookie::Cookie> PageHost::page_did_request_named_cookie(URL const&
 
 DeprecatedString PageHost::page_did_request_cookie(const URL& url, Web::Cookie::Source source)
 {
-    auto response = m_client.send_sync_but_allow_failure<Messages::WebContentClient::DidRequestCookie>(move(url), static_cast<u8>(source));
+    auto response = m_client.send_sync_but_allow_failure<Messages::WebContentClient::DidRequestCookie>(url, static_cast<u8>(source));
     if (!response) {
         dbgln("WebContent client disconnected during DidRequestCookie. Exiting peacefully.");
         exit(0);

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1432,7 +1432,7 @@ Messages::WebDriverClient::GetSourceResponse WebDriverConnection::get_source()
 Messages::WebDriverClient::ExecuteScriptResponse WebDriverConnection::execute_script(JsonValue const& payload)
 {
     // 1. Let body and arguments be the result of trying to extract the script arguments from a request with argument parameters.
-    auto const& [body, arguments] = TRY(extract_the_script_arguments_from_a_request(payload));
+    auto [body, arguments] = TRY(extract_the_script_arguments_from_a_request(payload));
 
     // 2. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
@@ -1441,7 +1441,7 @@ Messages::WebDriverClient::ExecuteScriptResponse WebDriverConnection::execute_sc
     TRY(handle_any_user_prompts());
 
     // 4., 5.1-5.3.
-    auto result = Web::WebDriver::execute_script(m_page_client.page(), body, move(arguments), m_timeouts_configuration.script_timeout);
+    auto result = Web::WebDriver::execute_script(m_page_client.page(), move(body), move(arguments), m_timeouts_configuration.script_timeout);
     dbgln_if(WEBDRIVER_DEBUG, "Executing script returned: {}", result.value);
 
     switch (result.type) {
@@ -1464,7 +1464,7 @@ Messages::WebDriverClient::ExecuteScriptResponse WebDriverConnection::execute_sc
 Messages::WebDriverClient::ExecuteAsyncScriptResponse WebDriverConnection::execute_async_script(JsonValue const& payload)
 {
     // 1. Let body and arguments by the result of trying to extract the script arguments from a request with argument parameters.
-    auto const& [body, arguments] = TRY(extract_the_script_arguments_from_a_request(payload));
+    auto [body, arguments] = TRY(extract_the_script_arguments_from_a_request(payload));
 
     // 2. If the current browsing context is no longer open, return error with error code no such window.
     TRY(ensure_open_top_level_browsing_context());
@@ -1473,7 +1473,7 @@ Messages::WebDriverClient::ExecuteAsyncScriptResponse WebDriverConnection::execu
     TRY(handle_any_user_prompts());
 
     // 4., 5.1-5.11.
-    auto result = Web::WebDriver::execute_async_script(m_page_client.page(), body, move(arguments), m_timeouts_configuration.script_timeout);
+    auto result = Web::WebDriver::execute_async_script(m_page_client.page(), move(body), move(arguments), m_timeouts_configuration.script_timeout);
     dbgln_if(WEBDRIVER_DEBUG, "Executing async script returned: {}", result.value);
 
     switch (result.type) {

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -168,7 +168,7 @@ ErrorOr<bool> Client::handle_request(ReadonlyBytes raw_request)
 
     auto stream = TRY(Core::File::open(real_path.bytes_as_string_view(), Core::File::OpenMode::Read));
 
-    auto const info = ContentInfo {
+    auto info = ContentInfo {
         .type = TRY(String::from_deprecated_string(Core::guess_mime_type_based_on_filename(real_path.bytes_as_string_view()))),
         .length = TRY(Core::DeprecatedFile::size(real_path.bytes_as_string_view()))
     };

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -624,7 +624,7 @@ public:
                 if (auto strong_this = weak_this.strong_ref()) {
                     if (strong_this->on_message) {
                         strong_this->on_message(Web::WebSockets::WebSocketClientSocket::Message {
-                            .data = move(message.data()),
+                            .data = message.release_data(),
                             .is_text = message.is_text(),
                         });
                     }

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -314,7 +314,7 @@ public:
                 request.set_method(HTTP::HttpRequest::POST);
             else
                 request.set_method(HTTP::HttpRequest::Invalid);
-            request.set_url(move(url));
+            request.set_url(url);
             request.set_headers(request_headers);
             request.set_body(TRY(ByteBuffer::copy(request_body)));
 
@@ -393,7 +393,7 @@ public:
                 request.set_method(HTTP::HttpRequest::POST);
             else
                 request.set_method(HTTP::HttpRequest::Invalid);
-            request.set_url(move(url));
+            request.set_url(url);
             request.set_headers(request_headers);
             request.set_body(TRY(ByteBuffer::copy(request_body)));
 

--- a/Userland/Utilities/json.cpp
+++ b/Userland/Utilities/json.cpp
@@ -124,7 +124,7 @@ JsonValue query(JsonValue const& value, Vector<StringView>& key_parts, size_t ke
     auto key = key_parts[key_index++];
 
     if (key == "*"sv) {
-        Vector<JsonValue> matches;
+        JsonArray matches;
         if (value.is_object()) {
             value.as_object().for_each_member([&](auto&, auto& member_value) {
                 matches.append(query(member_value, key_parts, key_index));
@@ -134,7 +134,7 @@ JsonValue query(JsonValue const& value, Vector<StringView>& key_parts, size_t ke
                 matches.append(query(member, key_parts, key_index));
             });
         }
-        return JsonValue(JsonArray(matches));
+        return matches;
     }
 
     JsonValue result {};


### PR DESCRIPTION
These are actually implicit copies and the compiler is not nice enough to yell at us for doing this, so we are now forcing it to do so.

I tried to accomplish the intended behaviour, avoiding needless copies.

My spell-check plugin is broken beyond repair, so I hope there aren't too many typos....