### PR TITLE
LibWeb: Move setting of FormDataPrototype to initialize()

### DIFF
--- a/Userland/Libraries/LibWeb/XHR/FormData.cpp
+++ b/Userland/Libraries/LibWeb/XHR/FormData.cpp
@@ -42,10 +42,17 @@ FormData::FormData(JS::Realm& realm, HashMap<DeprecatedString, Vector<FormDataEn
     : PlatformObject(realm)
     , m_entry_list(move(entry_list))
 {
-    set_prototype(&Bindings::ensure_web_prototype<Bindings::FormDataPrototype>(realm, "FormData"));
 }
 
 FormData::~FormData() = default;
+
+JS::ThrowCompletionOr<void> FormData::initialize(JS::Realm& realm)
+{
+    MUST_OR_THROW_OOM(Base::initialize(realm));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::FormDataPrototype>(realm, "FormData"));
+
+    return {};
+}
 
 void FormData::visit_edges(Cell::Visitor& visitor)
 {

--- a/Userland/Libraries/LibWeb/XHR/FormData.h
+++ b/Userland/Libraries/LibWeb/XHR/FormData.h
@@ -39,6 +39,7 @@ public:
 private:
     explicit FormData(JS::Realm&, HashMap<DeprecatedString, Vector<FormDataEntryValue>> entry_list = {});
 
+    virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
     WebIDL::ExceptionOr<void> append_impl(String const& name, Variant<JS::NonnullGCPtr<FileAPI::Blob>, String> const& value, Optional<String> const& filename = {});


### PR DESCRIPTION
This moves the setting of FormDataPrototype out of the constructor to initialize().

Missed this new pattern when working on PR #16356. It's already implemented for the FormDataEvent interface since that caused a regression.