### PR TITLE
Utilities/arp: Don't unveil /tmp/portal/lookup for numerical output

### DIFF
--- a/Userland/Utilities/arp.cpp
+++ b/Userland/Utilities/arp.cpp
@@ -28,9 +28,6 @@
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath tty inet unix"));
-    TRY(Core::System::unveil("/sys/kernel/net/arp", "r"));
-    TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
-    TRY(Core::System::unveil(nullptr, nullptr));
 
     static bool flag_set;
     static bool flag_delete;
@@ -46,6 +43,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(value_ipv4_address, "IPv4 protocol address", "address", Core::ArgsParser::Required::No);
     args_parser.add_positional_argument(value_hw_address, "Hardware address", "hwaddress", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
+
+    TRY(Core::System::unveil("/sys/kernel/net/arp", "r"));
+    if (!flag_numeric)
+        TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
+
+    TRY(Core::System::unveil(nullptr, nullptr));
 
     enum class Alignment {
         Left,


### PR DESCRIPTION
It's not needed in such case, and in the near-future when we would want to use this utility in an initramfs environment where there's no service such as LookupServer being running, it's still useful to have the option to invoke this utility with the mentioned limited output functionality.