### PR TITLE
LibDeviceTree: Start parsing structured data, and add a simple property getter API

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -136,7 +136,7 @@ struct TypeErasedParameter {
             if constexpr (sizeof(T) > sizeof(size_t))
                 VERIFY(value < NumericLimits<size_t>::max());
             if constexpr (IsSigned<T>)
-                VERIFY(value > 0);
+                VERIFY(value >= 0);
             return static_cast<size_t>(value);
         });
     }

--- a/Userland/Libraries/LibDeviceTree/CMakeLists.txt
+++ b/Userland/Libraries/LibDeviceTree/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 set(SOURCES
+  FlattenedDeviceTree.cpp
   Validation.cpp
 )
 

--- a/Userland/Libraries/LibDeviceTree/FlattenedDeviceTree.cpp
+++ b/Userland/Libraries/LibDeviceTree/FlattenedDeviceTree.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2023, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ByteBuffer.h>
+#include <AK/Error.h>
+#include <AK/IterationDecision.h>
+#include <AK/MemoryStream.h>
+#include <AK/StringView.h>
+#include <LibDeviceTree/FlattenedDeviceTree.h>
+
+namespace DeviceTree {
+
+static ErrorOr<StringView> read_string_view(ReadonlyBytes bytes, StringView error_string)
+{
+    auto len = strnlen(reinterpret_cast<char const*>(bytes.data()), bytes.size());
+    if (len == bytes.size()) {
+        return Error::from_string_view_or_print_error_and_return_errno(error_string, EINVAL);
+    }
+    return StringView { bytes.slice(0, len) };
+}
+
+ErrorOr<void> walk_device_tree(FlattenedDeviceTreeHeader const& header, ReadonlyBytes raw_device_tree, DeviceTreeCallbacks callbacks)
+{
+    ReadonlyBytes struct_bytes { raw_device_tree.data() + header.off_dt_struct, header.size_dt_struct };
+    FixedMemoryStream stream(struct_bytes);
+    char const* begin_strings_block = reinterpret_cast<char const*>(raw_device_tree.data() + header.off_dt_strings);
+
+    FlattenedDeviceTreeTokenType prev_token = EndNode;
+    StringView current_node_name;
+
+    while (!stream.is_eof()) {
+        auto current_token = TRY(stream.read_value<BigEndian<u32>>());
+
+        switch (current_token) {
+        case BeginNode: {
+            current_node_name = TRY(read_string_view(struct_bytes.slice(stream.offset()), "Non-null terminated name for FDT_BEGIN_NODE token!"sv));
+            size_t const consume_len = round_up_to_power_of_two(current_node_name.length() + 1, 4);
+            TRY(stream.discard(consume_len));
+            if (callbacks.on_node_begin) {
+                if (IterationDecision::Break == TRY(callbacks.on_node_begin(current_node_name)))
+                    return {};
+            }
+            break;
+        }
+        case EndNode:
+            if (callbacks.on_node_end) {
+                if (IterationDecision::Break == TRY(callbacks.on_node_end(current_node_name)))
+                    return {};
+            }
+            break;
+        case Property: {
+            if (prev_token == EndNode) {
+                return Error::from_string_view_or_print_error_and_return_errno("Invalid node sequence, FDT_PROP after FDT_END_NODE"sv, EINVAL);
+            }
+            auto len = TRY(stream.read_value<BigEndian<u32>>());
+            auto nameoff = TRY(stream.read_value<BigEndian<u32>>());
+            if (nameoff >= header.size_dt_strings) {
+                return Error::from_string_view_or_print_error_and_return_errno("Invalid name offset in FDT_PROP"sv, EINVAL);
+            }
+            size_t const prop_name_max_len = header.size_dt_strings - nameoff;
+            size_t const prop_name_len = strnlen(begin_strings_block + nameoff, prop_name_max_len);
+            if (prop_name_len == prop_name_max_len) {
+                return Error::from_string_view_or_print_error_and_return_errno("Non-null terminated name for FDT_PROP token!"sv, EINVAL);
+            }
+            StringView prop_name(begin_strings_block + nameoff, prop_name_len);
+            if (len >= stream.remaining()) {
+                return Error::from_string_view_or_print_error_and_return_errno("Property value length too large"sv, EINVAL);
+            }
+            ReadonlyBytes prop_value;
+            if (len != 0) {
+                prop_value = { struct_bytes.slice(stream.offset()).data(), len };
+                size_t const consume_len = round_up_to_power_of_two(static_cast<u32>(len), 4);
+                TRY(stream.discard(consume_len));
+            }
+            if (callbacks.on_property) {
+                if (IterationDecision::Break == TRY(callbacks.on_property(prop_name, prop_value)))
+                    return {};
+            }
+            break;
+        }
+        case NoOp:
+            if (callbacks.on_noop) {
+                if (IterationDecision::Break == TRY(callbacks.on_noop()))
+                    return {};
+            }
+            break;
+        case End: {
+            if (prev_token == BeginNode || prev_token == Property) {
+                return Error::from_string_view_or_print_error_and_return_errno("Invalid node sequence, FDT_END after BEGIN_NODE or PROP"sv, EINVAL);
+            }
+            if (!stream.is_eof()) {
+                return Error::from_string_view_or_print_error_and_return_errno("Expected EOF at FTD_END but more data remains"sv, EINVAL);
+            }
+
+            if (callbacks.on_end) {
+                return callbacks.on_end();
+            }
+            return {};
+        }
+        default:
+            return Error::from_string_view_or_print_error_and_return_errno("Invalid token"sv, EINVAL);
+        }
+        prev_token = static_cast<FlattenedDeviceTreeTokenType>(static_cast<u32>(current_token));
+    }
+    return Error::from_string_view_or_print_error_and_return_errno("Unexpected end of stream"sv, EINVAL);
+}
+
+} // namespace DeviceTree

--- a/Userland/Libraries/LibDeviceTree/FlattenedDeviceTree.h
+++ b/Userland/Libraries/LibDeviceTree/FlattenedDeviceTree.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Andrew Kaster <akaster@serenityos.org>
+ * Copyright (c) 2021-2023, Andrew Kaster <akaster@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,6 +7,10 @@
 #pragma once
 
 #include <AK/Endian.h>
+#include <AK/Error.h>
+#include <AK/Function.h>
+#include <AK/IterationDecision.h>
+#include <AK/StringView.h>
 #include <AK/Types.h>
 
 namespace DeviceTree {
@@ -36,5 +40,24 @@ struct FlattenedDeviceTreeReserveEntry {
     bool operator==(FlattenedDeviceTreeReserveEntry const& other) const { return other.address == address && other.size == size; }
 };
 static_assert(sizeof(FlattenedDeviceTreeReserveEntry) == 16, "FDT Memory Reservation entry size must match specification");
+
+// https://devicetree-specification.readthedocs.io/en/v0.3/flattened-format.html#lexical-structure
+enum FlattenedDeviceTreeTokenType : u32 {
+    BeginNode = 1,
+    EndNode = 2,
+    Property = 3,
+    NoOp = 4,
+    End = 9
+};
+
+struct DeviceTreeCallbacks {
+    Function<ErrorOr<IterationDecision>(StringView)> on_node_begin;
+    Function<ErrorOr<IterationDecision>(StringView)> on_node_end;
+    Function<ErrorOr<IterationDecision>(StringView, ReadonlyBytes)> on_property;
+    Function<ErrorOr<IterationDecision>()> on_noop;
+    Function<ErrorOr<void>()> on_end;
+};
+
+ErrorOr<void> walk_device_tree(FlattenedDeviceTreeHeader const&, ReadonlyBytes raw_device_tree, DeviceTreeCallbacks);
 
 } // namespace DeviceTree

--- a/Userland/Libraries/LibDeviceTree/FlattenedDeviceTree.h
+++ b/Userland/Libraries/LibDeviceTree/FlattenedDeviceTree.h
@@ -60,4 +60,12 @@ struct DeviceTreeCallbacks {
 
 ErrorOr<void> walk_device_tree(FlattenedDeviceTreeHeader const&, ReadonlyBytes raw_device_tree, DeviceTreeCallbacks);
 
+template<typename T>
+ErrorOr<T> slow_get_property(StringView name, FlattenedDeviceTreeHeader const&, ReadonlyBytes raw_device_tree);
+
+extern template ErrorOr<void> slow_get_property(StringView name, FlattenedDeviceTreeHeader const& header, ReadonlyBytes raw_device_tree);
+extern template ErrorOr<u32> slow_get_property(StringView name, FlattenedDeviceTreeHeader const& header, ReadonlyBytes raw_device_tree);
+extern template ErrorOr<u64> slow_get_property(StringView name, FlattenedDeviceTreeHeader const& header, ReadonlyBytes raw_device_tree);
+extern template ErrorOr<StringView> slow_get_property(StringView name, FlattenedDeviceTreeHeader const& header, ReadonlyBytes raw_device_tree);
+
 } // namespace DeviceTree

--- a/Userland/Libraries/LibDeviceTree/Validation.cpp
+++ b/Userland/Libraries/LibDeviceTree/Validation.cpp
@@ -104,7 +104,7 @@ bool validate_flattened_device_tree(FlattenedDeviceTreeHeader const& header, u8 
     u64 strings_block_size = header.off_dt_strings + header.size_dt_strings;
     if (strings_block_size > blob_size) {
         if (verbose == Verbose::Yes)
-            warnln("FDT Header reports invalid StringsBlock size: {} is too large given total size {}", structure_block_size, blob_size);
+            warnln("FDT Header reports invalid StringsBlock size: {} is too large given total size {}", strings_block_size, blob_size);
         return false;
     }
 

--- a/Userland/Libraries/LibDeviceTree/Validation.h
+++ b/Userland/Libraries/LibDeviceTree/Validation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Andrew Kaster <akaster@serenityos.org>
+ * Copyright (c) 2021-2023, Andrew Kaster <akaster@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -15,8 +15,8 @@ enum class Verbose {
     Yes
 };
 
-bool validate_flattened_device_tree(FlattenedDeviceTreeHeader const& header, u8 const* blob_start, size_t blob_size, Verbose = Verbose::No);
+bool validate_flattened_device_tree(FlattenedDeviceTreeHeader const& header, ReadonlyBytes raw_device_tree, Verbose = Verbose::No);
 
-bool dump(FlattenedDeviceTreeHeader const& header, u8 const* blob_start, size_t blob_size);
+ErrorOr<void> dump(FlattenedDeviceTreeHeader const& header, ReadonlyBytes raw_device_tree);
 
 }

--- a/Userland/Libraries/LibDeviceTree/Validation.h
+++ b/Userland/Libraries/LibDeviceTree/Validation.h
@@ -18,5 +18,6 @@ enum class Verbose {
 bool validate_flattened_device_tree(FlattenedDeviceTreeHeader const& header, ReadonlyBytes raw_device_tree, Verbose = Verbose::No);
 
 ErrorOr<void> dump(FlattenedDeviceTreeHeader const& header, ReadonlyBytes raw_device_tree);
+ErrorOr<void> dump_flattened_device_tree_structure(FlattenedDeviceTreeHeader const& header, ReadonlyBytes raw_device_tree);
 
 }

--- a/Userland/Utilities/fdtdump.cpp
+++ b/Userland/Utilities/fdtdump.cpp
@@ -8,6 +8,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/MappedFile.h>
 #include <LibCore/System.h>
+#include <LibDeviceTree/FlattenedDeviceTree.h>
 #include <LibDeviceTree/Validation.h>
 #include <LibMain/Main.h>
 
@@ -33,6 +34,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto bytes = ReadonlyBytes { file->data(), file->size() };
 
     TRY(DeviceTree::dump(*fdt_header, bytes));
+
+    auto compatible = TRY(DeviceTree::slow_get_property<StringView>("/compatible"sv, *fdt_header, bytes));
+    auto compatible_strings = compatible.split_view('\0');
+    dbgln("compatible with: {}", compatible_strings);
+
+    auto bootargs = TRY(DeviceTree::slow_get_property<StringView>("/chosen/bootargs"sv, *fdt_header, bytes));
+    dbgln("bootargs: {}", bootargs);
+
+    auto cpu_compatible = TRY(DeviceTree::slow_get_property<StringView>("/cpus/cpu@0/compatible"sv, *fdt_header, bytes));
+    dbgln("cpu0 compatible: {}", cpu_compatible);
 
     return 0;
 }

--- a/Userland/Utilities/fdtdump.cpp
+++ b/Userland/Utilities/fdtdump.cpp
@@ -29,9 +29,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    auto* fdt_header = reinterpret_cast<DeviceTree::FlattenedDeviceTreeHeader const*>(file->data());
+    auto const* fdt_header = reinterpret_cast<DeviceTree::FlattenedDeviceTreeHeader const*>(file->data());
+    auto bytes = ReadonlyBytes { file->data(), file->size() };
 
-    bool valid = DeviceTree::dump(*fdt_header, static_cast<u8 const*>(file->data()), file->size());
+    TRY(DeviceTree::dump(*fdt_header, bytes));
 
-    return valid ? 0 : 1;
+    return 0;
 }


### PR DESCRIPTION
Front-load some refactors of the existing functions to be a bit more idiomatic.

With these changes in place, we can parse a device tree blob's structured data and dump it out to file from `fdtdump`. The initial property getter API is (as the name suggests) very slow, but will be useful during early boot to query properties about the hardware before we have all the prerequisites for memory management setup (some of the things we need to know are contained in the device tree!).

The walk_device_tree API should hopefully be extensible enough for someone to implement a proper tree structure for use after early boot. :^)