### PR TITLE
LibWeb: A couple bug fixes for algorithm 'construct the entry list given a form'

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
@@ -150,9 +150,9 @@ WebIDL::ExceptionOr<Optional<HashMapWithVectorOfFormDataEntryValue>> construct_e
         // FIXME:    2. Create an entry with name and charset, and append it to entry list.
         // 10. Otherwise, create an entry with name and the value of the field element, and append it to entry list.
         else {
-            auto* input_element = dynamic_cast<HTML::HTMLInputElement*>(control.ptr());
-            VERIFY(input_element);
-            TRY_OR_THROW_OOM(vm, form_data_entries.try_append(input_element->value()));
+            auto* element = dynamic_cast<HTML::HTMLElement*>(control.ptr());
+            VERIFY(element);
+            TRY_OR_THROW_OOM(vm, form_data_entries.try_append(element->attribute("value"sv)));
             TRY_OR_THROW_OOM(vm, entry_list.try_set(name, form_data_entries));
         }
 

--- a/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
@@ -83,7 +83,7 @@ WebIDL::ExceptionOr<Optional<HashMapWithVectorOfFormDataEntryValue>> construct_e
         }
 
         // 2. If the field element is an input element whose type attribute is in the Image Button state, then:
-        if (auto* input_element = dynamic_cast<HTML::HTMLInputElement*>(control.ptr()); input_element->type() == "image") {
+        if (auto* input_element = dynamic_cast<HTML::HTMLInputElement*>(control.ptr()); input_element && input_element->type() == "image") {
             // FIXME: 1. If the field element has a name attribute specified and its value is not the empty string, let name be that value followed by a single U+002E FULL STOP character (.). Otherwise, let name be the empty string.
             // FIXME: 2. Let namex be the string consisting of the concatenation of name and a single U0078 LATIN SMALL LETTER X character (x).
             // FIXME: 3. Let namey be the string consisting of the concatenation of name and a single U+0079 LATIN SMALL LETTER Y character (y).


### PR DESCRIPTION
##### LibWeb: Avoid dereferencing null pointer

Null check was missing and we would crash when dereferencing the
pointer to access the type() member.

##### LibWeb: Do not assume field element is always a HTMLInputElement

Cast to a HTMLElement instead and retrieve the value attribute from here
instead.