### PR TITLE
LibWeb: Clarify WebIDL::Promise as an alias for JS::PromiseCapability

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
@@ -151,13 +151,13 @@ JS::NonnullGCPtr<JS::Promise> fetch_impl(JS::VM& vm, RequestInfo const& input, R
 }
 
 // https://fetch.spec.whatwg.org/#abort-fetch
-void abort_fetch(JS::VM& vm, JS::PromiseCapability const& promise_capability, JS::NonnullGCPtr<Infrastructure::Request> request, JS::GCPtr<Response> response_object, JS::Value error)
+void abort_fetch(JS::VM& vm, WebIDL::Promise const& promise, JS::NonnullGCPtr<Infrastructure::Request> request, JS::GCPtr<Response> response_object, JS::Value error)
 {
     dbgln_if(WEB_FETCH_DEBUG, "Fetch: Aborting fetch with: request @ {}, error = {}", request.ptr(), error);
 
     // 1. Reject promise with error.
     // NOTE: This is a no-op if promise has already fulfilled.
-    WebIDL::reject_promise(vm, promise_capability, error);
+    WebIDL::reject_promise(vm, promise, error);
 
     // 2. If request’s body is non-null and is readable, then cancel request’s body with error.
     if (auto* body = request->body().get_pointer<Infrastructure::Body>(); body != nullptr && body->stream()->is_readable()) {

--- a/Userland/Libraries/LibWeb/Fetch/FetchMethod.h
+++ b/Userland/Libraries/LibWeb/Fetch/FetchMethod.h
@@ -10,10 +10,11 @@
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Fetch/Request.h>
+#include <LibWeb/WebIDL/Promise.h>
 
 namespace Web::Fetch {
 
 JS::NonnullGCPtr<JS::Promise> fetch_impl(JS::VM&, RequestInfo const& input, RequestInit const& init = {});
-void abort_fetch(JS::VM&, JS::PromiseCapability const&, JS::NonnullGCPtr<Infrastructure::Request>, JS::GCPtr<Response>, JS::Value error);
+void abort_fetch(JS::VM&, WebIDL::Promise const&, JS::NonnullGCPtr<Infrastructure::Request>, JS::GCPtr<Response>, JS::Value error);
 
 }

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -41,7 +41,7 @@ WebIDL::ExceptionOr<Body> Body::clone() const
 }
 
 // https://fetch.spec.whatwg.org/#fully-reading-body-as-promise
-JS::NonnullGCPtr<JS::PromiseCapability> Body::fully_read_as_promise() const
+JS::NonnullGCPtr<WebIDL::Promise> Body::fully_read_as_promise() const
 {
     auto& vm = Bindings::main_thread_vm();
     auto& realm = *vm.current_realm();

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
@@ -15,6 +15,7 @@
 #include <LibJS/Heap/Handle.h>
 #include <LibWeb/FileAPI/Blob.h>
 #include <LibWeb/Streams/ReadableStream.h>
+#include <LibWeb/WebIDL/Promise.h>
 
 namespace Web::Fetch::Infrastructure {
 
@@ -32,7 +33,7 @@ public:
 
     [[nodiscard]] WebIDL::ExceptionOr<Body> clone() const;
 
-    [[nodiscard]] JS::NonnullGCPtr<JS::PromiseCapability> fully_read_as_promise() const;
+    [[nodiscard]] JS::NonnullGCPtr<WebIDL::Promise> fully_read_as_promise() const;
 
 private:
     // https://fetch.spec.whatwg.org/#concept-body-stream

--- a/Userland/Libraries/LibWeb/WebIDL/Promise.h
+++ b/Userland/Libraries/LibWeb/WebIDL/Promise.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2023, networkException <networkexception@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,14 +15,17 @@ namespace Web::WebIDL {
 
 using ReactionSteps = JS::SafeFunction<WebIDL::ExceptionOr<JS::Value>(JS::Value)>;
 
-JS::NonnullGCPtr<JS::PromiseCapability> create_promise(JS::Realm&);
-JS::NonnullGCPtr<JS::PromiseCapability> create_resolved_promise(JS::Realm&, JS::Value);
-JS::NonnullGCPtr<JS::PromiseCapability> create_rejected_promise(JS::Realm&, JS::Value);
-void resolve_promise(JS::VM&, JS::PromiseCapability const&, JS::Value = JS::js_undefined());
-void reject_promise(JS::VM&, JS::PromiseCapability const&, JS::Value);
-JS::NonnullGCPtr<JS::Promise> react_to_promise(JS::PromiseCapability const&, Optional<ReactionSteps> on_fulfilled_callback, Optional<ReactionSteps> on_rejected_callback);
-JS::NonnullGCPtr<JS::Promise> upon_fulfillment(JS::PromiseCapability const&, ReactionSteps);
-JS::NonnullGCPtr<JS::Promise> upon_rejection(JS::PromiseCapability const&, ReactionSteps);
-void mark_promise_as_handled(JS::PromiseCapability const&);
+// https://webidl.spec.whatwg.org/#es-promise
+using Promise = JS::PromiseCapability;
+
+JS::NonnullGCPtr<Promise> create_promise(JS::Realm&);
+JS::NonnullGCPtr<Promise> create_resolved_promise(JS::Realm&, JS::Value);
+JS::NonnullGCPtr<Promise> create_rejected_promise(JS::Realm&, JS::Value);
+void resolve_promise(JS::VM&, Promise const&, JS::Value = JS::js_undefined());
+void reject_promise(JS::VM&, Promise const&, JS::Value);
+JS::NonnullGCPtr<JS::Promise> react_to_promise(Promise const&, Optional<ReactionSteps> on_fulfilled_callback, Optional<ReactionSteps> on_rejected_callback);
+JS::NonnullGCPtr<JS::Promise> upon_fulfillment(Promise const&, ReactionSteps);
+JS::NonnullGCPtr<JS::Promise> upon_rejection(Promise const&, ReactionSteps);
+void mark_promise_as_handled(Promise const&);
 
 }


### PR DESCRIPTION
This pull request adds the `WebIDL::Promise` type explicitly defined in the WebIDL spec to be a PromiseCapability Record from ecma262.
