### PR TITLE
AK: Make `HashTable` steal from the rich, give to the poor, and improve `test-js` runtime by ~13%

### DIFF
--- a/AK/HashFunctions.h
+++ b/AK/HashFunctions.h
@@ -19,20 +19,6 @@ constexpr unsigned int_hash(u32 key)
     return key;
 }
 
-constexpr unsigned rehash_for_collision(u32 key)
-{
-    unsigned const magic = 0xBA5EDB01;
-    if (key == magic)
-        return 0u;
-    if (key == 0u)
-        key = magic;
-
-    key ^= key << 13;
-    key ^= key >> 17;
-    key ^= key << 5;
-    return key;
-}
-
 constexpr unsigned pair_int_hash(u32 key1, u32 key2)
 {
     return int_hash((int_hash(key1) * 209) ^ (int_hash(key2 * 413)));

--- a/AK/StringImpl.cpp
+++ b/AK/StringImpl.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/CharacterTypes.h>
 #include <AK/DeprecatedFlyString.h>
-#include <AK/HashTable.h>
 #include <AK/StringHash.h>
 #include <AK/StringImpl.h>
 #include <AK/kmalloc.h>

--- a/Tests/AK/TestHashFunctions.cpp
+++ b/Tests/AK/TestHashFunctions.cpp
@@ -15,13 +15,6 @@ TEST_CASE(int_hash)
     static_assert(int_hash(0) == 1177991625u);
 }
 
-TEST_CASE(rehash_for_collision)
-{
-    static_assert(rehash_for_collision(666) == 171644115u);
-    static_assert(rehash_for_collision(0) == 1189591134u);
-    static_assert(rehash_for_collision(0xBA5EDB01) == 0u);
-}
-
 TEST_CASE(pair_int_hash)
 {
     static_assert(pair_int_hash(42, 17) == 339337046u);

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -1007,12 +1007,13 @@ static Optional<Object::IntrinsicAccessor> find_intrinsic_accessor(Object const*
     if (intrinsics == s_intrinsics.end())
         return {};
 
-    auto accessor = intrinsics->value.find(property_key.as_string());
-    if (accessor == intrinsics->value.end())
+    auto accessor_iterator = intrinsics->value.find(property_key.as_string());
+    if (accessor_iterator == intrinsics->value.end())
         return {};
 
-    intrinsics->value.remove(accessor);
-    return move(accessor->value);
+    auto accessor = accessor_iterator->value;
+    intrinsics->value.remove(accessor_iterator);
+    return accessor;
 }
 
 Optional<ValueAndAttributes> Object::storage_get(PropertyKey const& property_key) const


### PR DESCRIPTION
Reimplement `AK::HashTable` using the Robin Hood hashing algorithm: a simple linear probe where we keep track of the distance between the bucket and its ideal position. On insertion, we allow a new bucket to "steal" the position of "rich" buckets (those near their ideal position) and move them further down.

On removal, we shift buckets back up into the freed slot, decrementing their distance while doing so.

This behavior automatically optimizes the number of required probes for any value, and removes the need for periodic rehashing (except when expanding the capacity).

Running `test-js` inside Serenity used to take 11.8±.07s on my machine (based on 5 warm runs), and with this new `HashTable` implementation it takes 10.2±.05s. This comes down to a ~13% runtime improvement.