### PR TITLE
LibJS: Fix the regexp escape mess

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -248,8 +248,31 @@ DeprecatedString RegExpObject::escape_regexp_pattern() const
     // 3. Return S.
     if (m_pattern.is_empty())
         return "(?:)";
+
     // FIXME: Check the 'u' and 'v' flags and escape accordingly
-    return m_pattern.replace("\n"sv, "\\n"sv, ReplaceMode::All).replace("\r"sv, "\\r"sv, ReplaceMode::All).replace(LINE_SEPARATOR_STRING, "\\u2028"sv, ReplaceMode::All).replace(PARAGRAPH_SEPARATOR_STRING, "\\u2029"sv, ReplaceMode::All).replace("/"sv, "\\/"sv, ReplaceMode::All);
+    StringBuilder builder;
+    auto pattern = Utf8View { m_pattern };
+    auto escaped = false;
+    for (auto code_point : pattern) {
+        if (escaped) {
+            escaped = false;
+            builder.append_code_point('\\');
+            builder.append_code_point(code_point);
+            continue;
+        }
+
+        if (code_point == '\\') {
+            escaped = true;
+            continue;
+        }
+
+        if (code_point == '\r' || code_point == LINE_SEPARATOR || code_point == PARAGRAPH_SEPARATOR || code_point == '/') {
+            builder.append_code_point('\\');
+        }
+        builder.append_code_point(code_point);
+    }
+
+    return builder.to_deprecated_string();
 }
 
 // 22.2.3.2.4 RegExpCreate ( P, F ), https://tc39.es/ecma262/#sec-regexpcreate

--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.source.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.source.js
@@ -3,6 +3,5 @@ test("basic functionality", () => {
     expect(RegExp().source).toBe("(?:)");
     expect(/test/.source).toBe("test");
     expect(/\n/.source).toBe("\\n");
-    // FIXME: RegExp parse doesn't parse \/ :(
-    // expect(/foo\/bar/.source).toBe("foo\\/bar");
+    expect(/foo\/bar/.source).toBe("foo\\/bar");
 });


### PR DESCRIPTION
Thanks ECMA262, `\/` is not confusing at all.
Also prints strings correctly in the REPL:
```
> '\r'
"\r"
```

(Depends on #17481)