### PR TITLE
Everywhere: Change all XXX into FIXME or remove as appropriate

### DIFF
--- a/Kernel/Arch/aarch64/CPUID.cpp
+++ b/Kernel/Arch/aarch64/CPUID.cpp
@@ -196,11 +196,11 @@ CPUFeature::Type detect_cpu_features()
         features |= CPUFeature::MTE3;
     if (processor_feature_register_1.MTE >= 0b0010 && processor_feature_register_1.MTEX == 0b0001) {
         features |= CPUFeature::MTE4;
-        features |= CPUFeature::MTE_CANONICAL_TAGS;  // XXX: not really explicit in the spec
-        features |= CPUFeature::MTE_NO_ADDRESS_TAGS; // XXX: not really explicit in the spec
+        features |= CPUFeature::MTE_CANONICAL_TAGS;  // FIXME: not really explicit in the spec
+        features |= CPUFeature::MTE_NO_ADDRESS_TAGS; // FIXME: not really explicit in the spec
     }
     if (processor_feature_register_1.MTE >= 0b0011 && processor_feature_register_1.MTE_frac == 0b0000)
-        features |= CPUFeature::MTE_ASYM_FAULT; // XXX: not really explicit in the spec
+        features |= CPUFeature::MTE_ASYM_FAULT; // FIXME: not really explicit in the spec
     if (processor_feature_register_1.SME == 0b0010)
         features |= CPUFeature::SME2;
     if (processor_feature_register_1.RNDR_trap == 0b0001)
@@ -427,7 +427,7 @@ CPUFeature::Type detect_cpu_features()
         features |= CPUFeature::BRBE;
     if (debug_feature_register_0.BRBE == 0b0010)
         features |= CPUFeature::BRBEv1p1;
-    if (debug_feature_register_0.ExtTrcBuff == 0b0001 && features.has_flag(CPUFeature::TRBE)) // XXX: order-dependent!
+    if (debug_feature_register_0.ExtTrcBuff == 0b0001 && features.has_flag(CPUFeature::TRBE)) // FIXME: order-dependent!
         features |= CPUFeature::TRBE_EXT;
     if (debug_feature_register_0.HPMN0 == 0b0001)
         features |= CPUFeature::HPMN0;

--- a/Kernel/Arch/aarch64/CPUID.h
+++ b/Kernel/Arch/aarch64/CPUID.h
@@ -270,7 +270,7 @@ AK_MAKE_ARBITRARY_SIZED_ENUM(CPUFeature, u256,
     TRBE = CPUFeature(1u) << 239u,         // Trace Buffer Extension
     SME = CPUFeature(1u) << 240u,          // Scalable Matrix Extension
 
-    __End = CPUFeature(1u) << 255u); // XXX — SENTINEL VALUE — XXX
+    __End = CPUFeature(1u) << 255u); // SENTINEL VALUE
 
 enum class ArmLimited { // 0x41
     Cortex_A34 = 0xd02,

--- a/Userland/DevTools/UserspaceEmulator/SoftFPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftFPU.cpp
@@ -437,7 +437,7 @@ void SoftFPU::FCMOVNU(const X86::Instruction& insn)
 // BASIC ARITHMETIC
 void SoftFPU::FADD_RM32(const X86::Instruction& insn)
 {
-    // XXX look at ::INC_foo for how mem/reg stuff is handled, and use that here too to make sure this is only called for mem32 ops
+    // FIXME look at ::INC_foo for how mem/reg stuff is handled, and use that here too to make sure this is only called for mem32 ops
     if (insn.modrm().is_register()) {
         fpu_set(0, fpu_get(insn.modrm().register_index()) + fpu_get(0));
     } else {
@@ -449,7 +449,7 @@ void SoftFPU::FADD_RM32(const X86::Instruction& insn)
 }
 void SoftFPU::FADD_RM64(const X86::Instruction& insn)
 {
-    // XXX look at ::INC_foo for how mem/reg stuff is handled, and use that here too to make sure this is only called for mem64 ops
+    // FIXME look at ::INC_foo for how mem/reg stuff is handled, and use that here too to make sure this is only called for mem64 ops
     if (insn.modrm().is_register()) {
         fpu_set(insn.modrm().register_index(), fpu_get(insn.modrm().register_index()) + fpu_get(0));
     } else {
@@ -573,7 +573,7 @@ void SoftFPU::FISUBR_RM32(const X86::Instruction& insn)
 
 void SoftFPU::FMUL_RM32(const X86::Instruction& insn)
 {
-    // XXX look at ::INC_foo for how mem/reg stuff is handled, and use that here too to make sure this is only called for mem32 ops
+    // FIXME look at ::INC_foo for how mem/reg stuff is handled, and use that here too to make sure this is only called for mem32 ops
     if (insn.modrm().is_register()) {
         fpu_set(0, fpu_get(0) * fpu_get(insn.modrm().register_index()));
     } else {
@@ -585,7 +585,7 @@ void SoftFPU::FMUL_RM32(const X86::Instruction& insn)
 }
 void SoftFPU::FMUL_RM64(const X86::Instruction& insn)
 {
-    // XXX look at ::INC_foo for how mem/reg stuff is handled, and use that here too to make sure this is only called for mem64 ops
+    // FIXME look at ::INC_foo for how mem/reg stuff is handled, and use that here too to make sure this is only called for mem64 ops
     if (insn.modrm().is_register()) {
         fpu_set(insn.modrm().register_index(), fpu_get(insn.modrm().register_index()) * fpu_get(0));
     } else {

--- a/Userland/Libraries/LibC/elf.h
+++ b/Userland/Libraries/LibC/elf.h
@@ -685,7 +685,7 @@ struct elfcore_procinfo {
 };
 
 /*
- * XXX - these _KERNEL items aren't part of the ABI!
+ * FIXME - these _KERNEL items aren't part of the ABI!
  */
 #if defined(_KERNEL) || defined(_DYN_LOADER)
 


### PR DESCRIPTION
I was [touching up the FIXME counter](https://github.com/BenWiederhake/serenity-fixmes/issues/7) and wondering whether `XXX` needs to be included as a marker. Answer: Not really, basically all matches are false positives, and even `\bXXX\b` still has a bunch of false positives, so it's not really a good marker. However, *some* places actually do use it as a FIXME marker.

This commit makes them more easily recognizable by replacing them with "FIXME". Or removes one instance where it's clearly not intended to be a FIXME marker.

It seems like most instances came from "konrad"; could someone tag his github handle here? ^^