### PR TITLE
HexEditor: Display control characters in the value inspector

### DIFF
--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -40,6 +40,8 @@ private:
     virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
+    ErrorOr<String> make_display_string(StringView string);
+
     RefPtr<HexEditor> m_editor;
     DeprecatedString m_path;
     DeprecatedString m_name;


### PR DESCRIPTION
Fixes #17487

This PR replaces some ASCII control characters in the ASCII, UTF-8, and UTF-16 display so they are visible/readable

Before             |  After
:-------------------------:|:-------------------------:
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/2068912/219388130-a13846ce-fd16-4911-a024-5888eb423dd2.png">  |  <img width="1136" alt="image" src="https://user-images.githubusercontent.com/2068912/221250647-b1215079-5517-41b6-9df2-e60d3b2b87b8.png">

As a general note, most ASCII control characters are rendered as `�`. While not great (semantically `�` should probably imply "invalid character"), it does have the benefit that it doesn't interfere with the rendering of subsequent characters in the value inspector. Hence this PR only narrowly targets control characters which cause problems (i.e. that ones that are rendered literally). These are the following

- `09` horizontal tab
- `0A` line feed
- `0B` vertical tab
- `0C` form feed
- `0D` carriage return

One cool thing is I did learn that there are special unicode characters dedicated to displaying these control characters (e.g. [␇](https://fonts.serenityos.net/char/2407)). However, I found them not very readable in SerenityOS, so I wasn't convinced they are a suitable display