### PR TITLE
LibFileSystemAccessClient: Remove the deprecated API

### DIFF
--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -12,6 +12,7 @@
 #include <AK/URL.h>
 #include <Applications/CrashReporter/CrashReporterWindowGML.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/DeprecatedFile.h>
 #include <LibCore/System.h>
 #include <LibCoredump/Backtrace.h>
 #include <LibCoredump/Reader.h>

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -10,6 +10,7 @@
 #include <AK/ScopeGuard.h>
 #include <AK/Try.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/DeprecatedFile.h>
 #include <LibCore/System.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Application.h>

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -15,6 +15,7 @@
 #include <Applications/ThemeEditor/MetricPropertyGML.h>
 #include <Applications/ThemeEditor/PathPropertyGML.h>
 #include <Applications/ThemeEditor/ThemeEditorGML.h>
+#include <LibCore/DeprecatedFile.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/BoxLayout.h>

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -9,8 +9,8 @@
  */
 
 #include "MainWidget.h"
-#include "PreviewWidget.h"
 #include <LibCore/ArgsParser.h>
+#include <LibCore/DeprecatedFile.h>
 #include <LibCore/System.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Application.h>

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/LexicalPath.h>
+#include <LibCore/DeprecatedFile.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/ConnectionToWindowServer.h>
 #include <LibGUI/MessageBox.h>
@@ -20,31 +21,6 @@ Client& Client::the()
     if (!s_the || !s_the->is_open())
         s_the = Client::try_create().release_value_but_fixme_should_propagate_errors();
     return *s_the;
-}
-
-DeprecatedResult Client::try_request_file_read_only_approved_deprecated(GUI::Window* parent_window, DeprecatedString const& path)
-{
-    auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { { Core::Promise<DeprecatedResult>::construct() }, parent_window });
-
-    auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
-    auto child_window_server_client_id = expose_window_server_client_id();
-    auto parent_window_id = parent_window->window_id();
-
-    GUI::ConnectionToWindowServer::the().add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-
-    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
-        GUI::ConnectionToWindowServer::the().remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-    });
-
-    if (path.starts_with('/')) {
-        async_request_file_read_only_approved(id, parent_window_server_client_id, parent_window_id, path);
-    } else {
-        auto full_path = LexicalPath::join(Core::DeprecatedFile::current_working_directory(), path).string();
-        async_request_file_read_only_approved(id, parent_window_server_client_id, parent_window_id, full_path);
-    }
-
-    return handle_promise<DeprecatedResult>(id);
 }
 
 Result Client::request_file_read_only_approved(GUI::Window* parent_window, DeprecatedString const& path)
@@ -69,55 +45,7 @@ Result Client::request_file_read_only_approved(GUI::Window* parent_window, Depre
         async_request_file_read_only_approved(id, parent_window_server_client_id, parent_window_id, full_path);
     }
 
-    return handle_promise<Result>(id);
-}
-
-static Core::File::OpenMode to_stream_open_mode(Core::OpenMode open_mode)
-{
-    Core::File::OpenMode result {};
-    if ((open_mode & Core::OpenMode::ReadOnly) == Core::OpenMode::ReadOnly)
-        result |= Core::File::OpenMode::Read;
-    if ((open_mode & Core::OpenMode::WriteOnly) == Core::OpenMode::WriteOnly)
-        result |= Core::File::OpenMode::Write;
-    if ((open_mode & Core::OpenMode::ReadWrite) == Core::OpenMode::ReadWrite)
-        result |= Core::File::OpenMode::ReadWrite;
-    if ((open_mode & Core::OpenMode::Append) == Core::OpenMode::Append)
-        result |= Core::File::OpenMode::Append;
-    if ((open_mode & Core::OpenMode::Truncate) == Core::OpenMode::Truncate)
-        result |= Core::File::OpenMode::Truncate;
-    if ((open_mode & Core::OpenMode::MustBeNew) == Core::OpenMode::MustBeNew)
-        result |= Core::File::OpenMode::MustBeNew;
-    if ((open_mode & Core::OpenMode::KeepOnExec) == Core::OpenMode::KeepOnExec)
-        result |= Core::File::OpenMode::KeepOnExec;
-
-    return result;
-}
-
-DeprecatedResult Client::try_request_file_deprecated(GUI::Window* parent_window, DeprecatedString const& path, Core::OpenMode deprecated_mode)
-{
-    auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { { Core::Promise<DeprecatedResult>::construct() }, parent_window });
-
-    auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
-    auto child_window_server_client_id = expose_window_server_client_id();
-    auto parent_window_id = parent_window->window_id();
-
-    GUI::ConnectionToWindowServer::the().add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-
-    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
-        GUI::ConnectionToWindowServer::the().remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-    });
-
-    auto const mode = to_stream_open_mode(deprecated_mode);
-
-    if (path.starts_with('/')) {
-        async_request_file(id, parent_window_server_client_id, parent_window_id, path, mode);
-    } else {
-        auto full_path = LexicalPath::join(Core::DeprecatedFile::current_working_directory(), path).string();
-        async_request_file(id, parent_window_server_client_id, parent_window_id, full_path, mode);
-    }
-
-    return handle_promise<DeprecatedResult>(id);
+    return handle_promise(id);
 }
 
 Result Client::request_file(GUI::Window* parent_window, DeprecatedString const& path, Core::File::OpenMode mode)
@@ -142,29 +70,7 @@ Result Client::request_file(GUI::Window* parent_window, DeprecatedString const& 
         async_request_file(id, parent_window_server_client_id, parent_window_id, full_path, mode);
     }
 
-    return handle_promise<Result>(id);
-}
-
-DeprecatedResult Client::try_open_file_deprecated(GUI::Window* parent_window, DeprecatedString const& window_title, StringView path, Core::OpenMode deprecated_requested_access)
-{
-    auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { { Core::Promise<DeprecatedResult>::construct() }, parent_window });
-
-    auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
-    auto child_window_server_client_id = expose_window_server_client_id();
-    auto parent_window_id = parent_window->window_id();
-
-    GUI::ConnectionToWindowServer::the().add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-
-    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
-        GUI::ConnectionToWindowServer::the().remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-    });
-
-    auto const requested_access = to_stream_open_mode(deprecated_requested_access);
-
-    async_prompt_open_file(id, parent_window_server_client_id, parent_window_id, window_title, path, requested_access);
-
-    return handle_promise<DeprecatedResult>(id);
+    return handle_promise(id);
 }
 
 Result Client::open_file(GUI::Window* parent_window, DeprecatedString const& window_title, StringView path, Core::File::OpenMode requested_access)
@@ -184,29 +90,7 @@ Result Client::open_file(GUI::Window* parent_window, DeprecatedString const& win
 
     async_prompt_open_file(id, parent_window_server_client_id, parent_window_id, window_title, path, requested_access);
 
-    return handle_promise<Result>(id);
-}
-
-DeprecatedResult Client::try_save_file_deprecated(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::OpenMode deprecated_requested_access)
-{
-    auto const id = get_new_id();
-    m_promises.set(id, PromiseAndWindow { { Core::Promise<DeprecatedResult>::construct() }, parent_window });
-
-    auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
-    auto child_window_server_client_id = expose_window_server_client_id();
-    auto parent_window_id = parent_window->window_id();
-
-    GUI::ConnectionToWindowServer::the().add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-
-    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
-        GUI::ConnectionToWindowServer::the().remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-    });
-
-    auto const requested_access = to_stream_open_mode(deprecated_requested_access);
-
-    async_prompt_save_file(id, parent_window_server_client_id, parent_window_id, name.is_null() ? "Untitled" : name, ext.is_null() ? "txt" : ext, Core::StandardPaths::home_directory(), requested_access);
-
-    return handle_promise<DeprecatedResult>(id);
+    return handle_promise(id);
 }
 
 Result Client::save_file(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::File::OpenMode requested_access)
@@ -226,7 +110,7 @@ Result Client::save_file(GUI::Window* parent_window, DeprecatedString const& nam
 
     async_prompt_save_file(id, parent_window_server_client_id, parent_window_id, name.is_null() ? "Untitled" : name, ext.is_null() ? "txt" : ext, Core::StandardPaths::home_directory(), requested_access);
 
-    return handle_promise<Result>(id);
+    return handle_promise(id);
 }
 
 void Client::handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> const& ipc_file, Optional<DeprecatedString> const& chosen_file)
@@ -235,42 +119,24 @@ void Client::handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> co
     VERIFY(potential_data.has_value());
     auto& request_data = potential_data.value();
 
-    auto const resolve_any_promise = [&promise = request_data.promise](Error&& error) {
-        if (promise.has<PromiseType<DeprecatedResult>>()) {
-            promise.get<PromiseType<DeprecatedResult>>()->resolve(move(error));
-            return;
-        }
-        promise.get<PromiseType<Result>>()->resolve(move(error));
-    };
-
     if (error != 0) {
         // We don't want to show an error message for non-existent files since some applications may want
         // to handle it as opening a new, named file.
         if (error != -1 && error != ENOENT)
             GUI::MessageBox::show_error(request_data.parent_window, DeprecatedString::formatted("Opening \"{}\" failed: {}", *chosen_file, strerror(error)));
-        resolve_any_promise(Error::from_errno(error));
+        request_data.promise->resolve(Error::from_errno(error));
         return;
     }
 
     if (Core::DeprecatedFile::is_device(ipc_file->fd())) {
         GUI::MessageBox::show_error(request_data.parent_window, DeprecatedString::formatted("Opening \"{}\" failed: Cannot open device files", *chosen_file));
-        resolve_any_promise(Error::from_string_literal("Cannot open device files"));
+        request_data.promise->resolve(Error::from_string_literal("Cannot open device files"));
         return;
     }
 
     if (Core::DeprecatedFile::is_directory(ipc_file->fd())) {
         GUI::MessageBox::show_error(request_data.parent_window, DeprecatedString::formatted("Opening \"{}\" failed: Cannot open directory", *chosen_file));
-        resolve_any_promise(Error::from_errno(EISDIR));
-        return;
-    }
-
-    if (request_data.promise.has<PromiseType<DeprecatedResult>>()) {
-        auto file = Core::DeprecatedFile::construct();
-        auto fd = ipc_file->take_fd();
-        file->open(fd, Core::OpenMode::ReadWrite, Core::DeprecatedFile::ShouldCloseFileDescriptor::Yes);
-        file->set_filename(*chosen_file);
-
-        request_data.promise.get<PromiseType<DeprecatedResult>>()->resolve(file);
+        request_data.promise->resolve(Error::from_errno(EISDIR));
         return;
     }
 
@@ -280,11 +146,11 @@ void Client::handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> co
         return File({}, move(stream), filename);
     }();
     if (file_or_error.is_error()) {
-        resolve_any_promise(file_or_error.release_error());
+        request_data.promise->resolve(file_or_error.release_error());
         return;
     }
 
-    request_data.promise.get<PromiseType<Result>>()->resolve(file_or_error.release_value());
+    request_data.promise->resolve(file_or_error.release_value());
 }
 
 void Client::die()
@@ -302,10 +168,9 @@ int Client::get_new_id()
     return new_id;
 }
 
-template<typename AnyResult>
-AnyResult Client::handle_promise(int id)
+Result Client::handle_promise(int id)
 {
-    auto result = m_promises.get(id)->promise.get<PromiseType<AnyResult>>()->await();
+    auto result = m_promises.get(id)->promise->await();
     m_promises.remove(id);
     return result;
 }

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -11,7 +11,7 @@
 #include <AK/String.h>
 #include <FileSystemAccessServer/FileSystemAccessClientEndpoint.h>
 #include <FileSystemAccessServer/FileSystemAccessServerEndpoint.h>
-#include <LibCore/DeprecatedFile.h>
+#include <LibCore/File.h>
 #include <LibCore/Promise.h>
 #include <LibCore/StandardPaths.h>
 #include <LibGUI/Window.h>
@@ -37,7 +37,6 @@ private:
     String m_filename;
 };
 
-using DeprecatedResult = ErrorOr<NonnullRefPtr<Core::DeprecatedFile>>;
 using Result = ErrorOr<File>;
 
 class Client final
@@ -46,11 +45,6 @@ class Client final
     IPC_CLIENT_CONNECTION(Client, "/tmp/session/%sid/portal/filesystemaccess"sv)
 
 public:
-    DeprecatedResult try_request_file_read_only_approved_deprecated(GUI::Window* parent_window, DeprecatedString const& path);
-    DeprecatedResult try_request_file_deprecated(GUI::Window* parent_window, DeprecatedString const& path, Core::OpenMode mode);
-    DeprecatedResult try_open_file_deprecated(GUI::Window* parent_window, DeprecatedString const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::OpenMode requested_access = Core::OpenMode::ReadOnly);
-    DeprecatedResult try_save_file_deprecated(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::OpenMode requested_access = Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
-
     Result request_file_read_only_approved(GUI::Window* parent_window, DeprecatedString const& path);
     Result request_file(GUI::Window* parent_window, DeprecatedString const& path, Core::File::OpenMode requested_access);
     Result open_file(GUI::Window* parent_window, DeprecatedString const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::File::OpenMode requested_access = Core::File::OpenMode::Read);
@@ -70,14 +64,13 @@ private:
     virtual void handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> const& fd, Optional<DeprecatedString> const& chosen_file) override;
 
     int get_new_id();
-    template<typename AnyResult>
-    AnyResult handle_promise(int);
+    Result handle_promise(int);
 
     template<typename T>
     using PromiseType = RefPtr<Core::Promise<T>>;
 
     struct PromiseAndWindow {
-        Variant<PromiseType<DeprecatedResult>, PromiseType<Result>> promise;
+        PromiseType<Result> promise;
         GUI::Window* parent_window { nullptr };
     };
 


### PR DESCRIPTION
Concerned functions are:
 - try_request_file_read_only_approved_deprecated
 - try_request_file_deprecated
 - try_open_file_deprecated
 - try_save_file_deprecated

It also allows some simplifications in the implementation of the client.

This patch depends on many PRs:
1. #17018 
2. #17021 
3. #17023 
5. #17024 
6. #17025
7. #17045 