### PR TITLE
Shell: Moar PO6 Parser: io_here is here

### DIFF
--- a/AK/GenericLexer.h
+++ b/AK/GenericLexer.h
@@ -22,6 +22,7 @@ public:
     constexpr size_t tell_remaining() const { return m_input.length() - m_index; }
 
     StringView remaining() const { return m_input.substring_view(m_index); }
+    StringView input() const { return m_input; }
 
     constexpr bool is_eof() const { return m_index >= m_input.length(); }
 

--- a/Userland/Shell/AST.h
+++ b/Userland/Shell/AST.h
@@ -1338,20 +1338,22 @@ private:
 
 class Heredoc final : public Node {
 public:
-    Heredoc(Position, DeprecatedString end, bool allow_interpolation, bool deindent);
+    Heredoc(Position, DeprecatedString end, bool allow_interpolation, bool deindent, Optional<int> target_fd = {});
     virtual ~Heredoc();
     virtual void visit(NodeVisitor& visitor) override { visitor.visit(this); }
 
     DeprecatedString const& end() const { return m_end; }
     bool allow_interpolation() const { return m_allows_interpolation; }
     bool deindent() const { return m_deindent; }
+    Optional<int> target_fd() const { return m_target_fd; }
+    bool evaluates_to_string() const { return !m_target_fd.has_value(); }
     RefPtr<AST::Node> const& contents() const { return m_contents; }
     void set_contents(RefPtr<AST::Node> contents)
     {
         m_contents = move(contents);
         if (m_contents->is_syntax_error())
             set_is_syntax_error(m_contents->syntax_error_node());
-        else
+        else if (is_syntax_error())
             clear_syntax_error();
     }
 
@@ -1366,6 +1368,7 @@ private:
     DeprecatedString m_end;
     bool m_allows_interpolation { false };
     bool m_deindent { false };
+    Optional<int> m_target_fd;
     RefPtr<AST::Node> m_contents;
 };
 

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -6,6 +6,7 @@
 
 #include "AST.h"
 #include "Formatter.h"
+#include "PosixParser.h"
 #include "Shell.h"
 #include <AK/DeprecatedString.h>
 #include <AK/LexicalPath.h>
@@ -32,10 +33,17 @@ int Shell::builtin_noop(int, char const**)
 
 int Shell::builtin_dump(int argc, char const** argv)
 {
-    if (argc != 2)
+    bool posix = false;
+    StringView source;
+
+    Core::ArgsParser parser;
+    parser.add_positional_argument(source, "Shell code to parse and dump", "source");
+    parser.add_option(posix, "Use the POSIX parser", "posix", 'p');
+
+    if (!parser.parse(argc, const_cast<char**>(argv), Core::ArgsParser::FailureBehavior::PrintUsage))
         return 1;
 
-    Parser { StringView { argv[1], strlen(argv[1]) } }.parse()->dump(0);
+    (posix ? Posix::Parser { source }.parse() : Parser { source }.parse())->dump(0);
     return 0;
 }
 

--- a/Userland/Shell/PosixLexer.cpp
+++ b/Userland/Shell/PosixLexer.cpp
@@ -533,6 +533,7 @@ Lexer::ReductionResult Lexer::reduce_start()
     if (m_lexer.is_eof()) {
         auto tokens = Token::maybe_from_state(m_state);
         m_state.buffer.clear();
+        m_state.expansions.clear();
         m_state.position.start_offset = m_state.position.end_offset;
         m_state.position.start_line = m_state.position.end_line;
 
@@ -615,6 +616,7 @@ Lexer::ReductionResult Lexer::reduce_start()
         m_state.on_new_line = true;
 
         m_state.buffer.clear();
+        m_state.expansions.clear();
         m_state.position.start_offset = m_state.position.end_offset;
         m_state.position.start_line = m_state.position.end_line;
 
@@ -637,6 +639,7 @@ Lexer::ReductionResult Lexer::reduce_start()
         auto tokens = Token::maybe_from_state(m_state);
         m_state.buffer.clear();
         m_state.buffer.append(consume());
+        m_state.expansions.clear();
         m_state.position.start_offset = m_state.position.end_offset;
         m_state.position.start_line = m_state.position.end_line;
 

--- a/Userland/Shell/PosixLexer.cpp
+++ b/Userland/Shell/PosixLexer.cpp
@@ -773,7 +773,7 @@ Lexer::ReductionResult Lexer::reduce_parameter_expansion()
     }
 
     auto next = m_lexer.peek();
-    if (is_ascii_alphanumeric(next)) {
+    if (is_ascii_alphanumeric(next) || next == '_') {
         m_state.buffer.append(consume());
         expansion.parameter.append(next);
         expansion.range.length = m_state.position.end_offset - expansion.range.start - m_state.position.start_offset;

--- a/Userland/Shell/PosixLexer.cpp
+++ b/Userland/Shell/PosixLexer.cpp
@@ -751,7 +751,9 @@ Lexer::ReductionResult Lexer::reduce_special_parameter_expansion()
         .parameter = StringBuilder {},
         .range = range(-1),
     };
-    m_state.expansions.last().get<ParameterExpansion>().parameter.append(ch);
+    auto& expansion = m_state.expansions.last().get<ParameterExpansion>();
+    expansion.parameter.append(ch);
+    expansion.range.length = m_state.position.end_offset - expansion.range.start - m_state.position.start_offset;
 
     return {
         .tokens = {},

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -2352,6 +2352,12 @@ void Shell::possibly_print_error() const
     case ShellError::LaunchError:
         warnln("Shell: {}", m_error_description);
         break;
+    case ShellError::PipeFailure:
+        warnln("Shell: pipe() failed for {}", m_error_description);
+        break;
+    case ShellError::WriteFailure:
+        warnln("Shell: write() failed for {}", m_error_description);
+        break;
     case ShellError::InternalControlFlowBreak:
     case ShellError::InternalControlFlowContinue:
     case ShellError::InternalControlFlowInterrupted:

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -343,6 +343,8 @@ public:
         OpenFailure,
         OutOfMemory,
         LaunchError,
+        PipeFailure,
+        WriteFailure,
     };
 
     void raise_error(ShellError kind, DeprecatedString description, Optional<AST::Position> position = {})


### PR DESCRIPTION
Heredocs + bugfixes.

my little test case `config.sub` is actually running far enough to say hi (incorrectly) now:
```
❯ Build/lagom/Userland/Shell/Shell --posix --skip-shellrc Base/home/anon/config.sub
Parameter expansion range 16- is out of bounds for 'IFS=$saved_IFS'
config.sub: missing argument
Try \`config.sub --help' for more information.
```