### PR TITLE
LibGUI: Make Layout more comfy to use :^)

### DIFF
--- a/Base/res/devel/templates/serenity-application/main.cpp
+++ b/Base/res/devel/templates/serenity-application/main.cpp
@@ -23,8 +23,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
 
-    auto layout = TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
-    layout->set_margins(16);
+    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>(16));
 
     auto button = TRY(main_widget->try_add<GUI::Button>("Click me!"));
     button->on_click = [&](auto) {

--- a/Base/res/devel/templates/serenity-application/main.cpp
+++ b/Base/res/devel/templates/serenity-application/main.cpp
@@ -23,7 +23,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
 
-    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>(16));
+    TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>(16));
 
     auto button = TRY(main_widget->try_add<GUI::Button>("Click me!"));
     button->on_click = [&](auto) {

--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -82,9 +82,7 @@ private:
 
         m_root_container = TRY(m_slider_window->set_main_widget<GUI::Frame>());
         m_root_container->set_fill_with_background_color(true);
-        m_root_container->set_layout<GUI::VerticalBoxLayout>();
-        m_root_container->layout()->set_margins({ 4 });
-        m_root_container->layout()->set_spacing(0);
+        m_root_container->set_layout<GUI::VerticalBoxLayout>(4, 0);
         m_root_container->set_frame_shape(Gfx::FrameShape::Window);
 
         m_percent_box = m_root_container->add<GUI::CheckBox>(String::from_utf8_short_string("\xE2\x84\xB9"sv));

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -182,12 +182,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto container = TRY(window->set_main_widget<GUI::Frame>());
     container->set_fill_with_background_color(true);
     container->set_frame_shape(Gfx::FrameShape::Window);
-    auto& layout = container->set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 8 });
+    container->set_layout<GUI::VerticalBoxLayout>(8);
 
     auto& text_box = container->add<GUI::TextBox>();
     auto& results_container = container->add<GUI::Widget>();
-    auto& results_layout = results_container.set_layout<GUI::VerticalBoxLayout>();
+    results_container.set_layout<GUI::VerticalBoxLayout>();
 
     auto mark_selected_item = [&]() {
         for (size_t i = 0; i < app_state.visible_result_count; ++i) {
@@ -250,7 +249,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto update_ui_timer = TRY(Core::Timer::create_single_shot(10, [&] {
         results_container.remove_all_children();
-        results_layout.set_margins(app_state.visible_result_count ? GUI::Margins { 4, 0, 0, 0 } : GUI::Margins { 0 });
+        results_container.layout()->set_margins(app_state.visible_result_count ? GUI::Margins { 4, 0, 0, 0 } : GUI::Margins { 0 });
 
         for (size_t i = 0; i < app_state.visible_result_count; ++i) {
             auto& result = app_state.results[i];

--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -103,9 +103,7 @@ BookmarksBarWidget& BookmarksBarWidget::the()
 BookmarksBarWidget::BookmarksBarWidget(DeprecatedString const& bookmarks_file, bool enabled)
 {
     s_the = this;
-    set_layout<GUI::HorizontalBoxLayout>();
-    layout()->set_spacing(0);
-    layout()->set_margins(2);
+    set_layout<GUI::HorizontalBoxLayout>(2, 0);
 
     set_fixed_height(20);
 

--- a/Userland/Applications/Browser/DownloadWidget.cpp
+++ b/Userland/Applications/Browser/DownloadWidget.cpp
@@ -64,11 +64,11 @@ DownloadWidget::DownloadWidget(const URL& url)
 
     auto& animation_container = add<GUI::Widget>();
     animation_container.set_fixed_height(32);
-    auto& animation_layout = animation_container.set_layout<GUI::HorizontalBoxLayout>();
+    animation_container.set_layout<GUI::HorizontalBoxLayout>();
 
     m_browser_image = animation_container.add<GUI::ImageWidget>();
     m_browser_image->load_from_file("/res/graphics/download-animation.gif"sv);
-    animation_layout.add_spacer();
+    animation_container.add_spacer().release_value_but_fixme_should_propagate_errors();
 
     auto& source_label = add<GUI::Label>(DeprecatedString::formatted("From: {}", url));
     source_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -93,8 +93,8 @@ DownloadWidget::DownloadWidget(const URL& url)
     };
 
     auto& button_container = add<GUI::Widget>();
-    auto& button_container_layout = button_container.set_layout<GUI::HorizontalBoxLayout>();
-    button_container_layout.add_spacer();
+    button_container.set_layout<GUI::HorizontalBoxLayout>();
+    button_container.add_spacer().release_value_but_fixme_should_propagate_errors();
     m_cancel_button = button_container.add<GUI::Button>(String::from_utf8_short_string("Cancel"sv));
     m_cancel_button->set_fixed_size(100, 22);
     m_cancel_button->on_click = [this](auto) {

--- a/Userland/Applications/Browser/DownloadWidget.cpp
+++ b/Userland/Applications/Browser/DownloadWidget.cpp
@@ -59,8 +59,7 @@ DownloadWidget::DownloadWidget(const URL& url)
     m_download->stream_into(*m_output_file_stream);
 
     set_fill_with_background_color(true);
-    auto& layout = set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins(4);
+    set_layout<GUI::VerticalBoxLayout>(4);
 
     auto& animation_container = add<GUI::Widget>();
     animation_container.set_fixed_height(32);

--- a/Userland/Applications/Browser/InspectorWidget.cpp
+++ b/Userland/Applications/Browser/InspectorWidget.cpp
@@ -77,15 +77,13 @@ InspectorWidget::InspectorWidget()
 {
     set_fill_with_background_color(true);
 
-    auto& layout = set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 4, 4, 4, 4 });
+    set_layout<GUI::VerticalBoxLayout>(4);
     auto& splitter = add<GUI::VerticalSplitter>();
 
     auto& top_tab_widget = splitter.add<GUI::TabWidget>();
 
     auto& dom_tree_container = top_tab_widget.add_tab<GUI::Widget>("DOM");
-    dom_tree_container.set_layout<GUI::VerticalBoxLayout>();
-    dom_tree_container.layout()->set_margins({ 4, 4, 4, 4 });
+    dom_tree_container.set_layout<GUI::VerticalBoxLayout>(4);
     m_dom_tree_view = dom_tree_container.add<GUI::TreeView>();
     m_dom_tree_view->on_selection_change = [this] {
         const auto& index = m_dom_tree_view->selection().first();
@@ -93,30 +91,25 @@ InspectorWidget::InspectorWidget()
     };
 
     auto& accessibility_tree_container = top_tab_widget.add_tab<GUI::Widget>("Accessibility");
-    accessibility_tree_container.set_layout<GUI::VerticalBoxLayout>();
-    accessibility_tree_container.layout()->set_margins({ 4, 4, 4, 4 });
+    accessibility_tree_container.set_layout<GUI::VerticalBoxLayout>(4);
     m_accessibility_tree_view = accessibility_tree_container.add<GUI::TreeView>();
 
     auto& bottom_tab_widget = splitter.add<GUI::TabWidget>();
 
     auto& computed_style_table_container = bottom_tab_widget.add_tab<GUI::Widget>("Computed");
-    computed_style_table_container.set_layout<GUI::VerticalBoxLayout>();
-    computed_style_table_container.layout()->set_margins({ 4, 4, 4, 4 });
+    computed_style_table_container.set_layout<GUI::VerticalBoxLayout>(4);
     m_computed_style_table_view = computed_style_table_container.add<GUI::TableView>();
 
     auto& resolved_style_table_container = bottom_tab_widget.add_tab<GUI::Widget>("Resolved");
-    resolved_style_table_container.set_layout<GUI::VerticalBoxLayout>();
-    resolved_style_table_container.layout()->set_margins({ 4, 4, 4, 4 });
+    resolved_style_table_container.set_layout<GUI::VerticalBoxLayout>(4);
     m_resolved_style_table_view = resolved_style_table_container.add<GUI::TableView>();
 
     auto& custom_properties_table_container = bottom_tab_widget.add_tab<GUI::Widget>("Variables");
-    custom_properties_table_container.set_layout<GUI::VerticalBoxLayout>();
-    custom_properties_table_container.layout()->set_margins({ 4, 4, 4, 4 });
+    custom_properties_table_container.set_layout<GUI::VerticalBoxLayout>(4);
     m_custom_properties_table_view = custom_properties_table_container.add<GUI::TableView>();
 
     auto& box_model_widget = bottom_tab_widget.add_tab<GUI::Widget>("Box Model");
-    box_model_widget.set_layout<GUI::VerticalBoxLayout>();
-    box_model_widget.layout()->set_margins({ 4, 4, 4, 4 });
+    box_model_widget.set_layout<GUI::VerticalBoxLayout>(4);
     m_element_size_view = box_model_widget.add<ElementSizePreviewWidget>();
     m_element_size_view->set_should_hide_unnecessary_scrollbars(true);
 

--- a/Userland/Applications/Calculator/RoundingDialog.cpp
+++ b/Userland/Applications/Calculator/RoundingDialog.cpp
@@ -53,7 +53,7 @@ RoundingDialog::RoundingDialog(GUI::Window* parent_window, StringView title)
     main_widget->add_child(*m_buttons_container);
 
     m_buttons_container->set_layout<GUI::HorizontalBoxLayout>();
-    m_buttons_container->layout()->add_spacer();
+    m_buttons_container->add_spacer().release_value_but_fixme_should_propagate_errors();
     m_buttons_container->add_child(*m_ok_button);
     m_buttons_container->add_child(*m_cancel_button);
 

--- a/Userland/Applications/Calendar/AddEventDialog.cpp
+++ b/Userland/Applications/Calendar/AddEventDialog.cpp
@@ -33,9 +33,8 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
     widget->set_layout<GUI::VerticalBoxLayout>();
 
     auto& top_container = widget->add<GUI::Widget>();
-    top_container.set_layout<GUI::VerticalBoxLayout>();
+    top_container.set_layout<GUI::VerticalBoxLayout>(4);
     top_container.set_fixed_height(45);
-    top_container.layout()->set_margins(4);
 
     auto& add_label = top_container.add<GUI::Label>("Add title & date:");
     add_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -46,14 +45,12 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
     event_title_textbox.set_fixed_height(20);
 
     auto& middle_container = widget->add<GUI::Widget>();
-    middle_container.set_layout<GUI::HorizontalBoxLayout>();
+    middle_container.set_layout<GUI::HorizontalBoxLayout>(4);
     middle_container.set_fixed_height(25);
-    middle_container.layout()->set_margins(4);
 
     auto& time_container = widget->add<GUI::Widget>();
-    time_container.set_layout<GUI::HorizontalBoxLayout>();
+    time_container.set_layout<GUI::HorizontalBoxLayout>(4);
     time_container.set_fixed_height(25);
-    time_container.layout()->set_margins(4);
 
     auto& starting_month_combo = middle_container.add<GUI::ComboBox>();
     starting_month_combo.set_only_allow_values_from_model(true);

--- a/Userland/Applications/Calendar/AddEventDialog.cpp
+++ b/Userland/Applications/Calendar/AddEventDialog.cpp
@@ -87,12 +87,12 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
     starting_meridiem_combo.set_model(MeridiemListModel::create());
     starting_meridiem_combo.set_selected_index(0);
 
-    widget->layout()->add_spacer();
+    widget->add_spacer().release_value_but_fixme_should_propagate_errors();
 
     auto& button_container = widget->add<GUI::Widget>();
     button_container.set_fixed_height(20);
     button_container.set_layout<GUI::HorizontalBoxLayout>();
-    button_container.layout()->add_spacer();
+    button_container.add_spacer().release_value_but_fixme_should_propagate_errors();
     auto& ok_button = button_container.add<GUI::Button>(String::from_utf8_short_string("OK"sv));
     ok_button.set_fixed_size(80, 20);
     ok_button.on_click = [this](auto) {

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -216,7 +216,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& tab_widget = *widget->find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
 
     auto backtrace_tab = TRY(tab_widget.try_add_tab<GUI::Widget>("Backtrace"));
-    (void)TRY(backtrace_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
+    TRY(backtrace_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
 
     auto backtrace_label = TRY(backtrace_tab->try_add<GUI::Label>("A backtrace for each thread alive during the crash is listed below:"));
     backtrace_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -236,7 +236,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     cpu_registers_tab_widget->set_tab_position(GUI::TabWidget::TabPosition::Bottom);
 
     auto environment_tab = TRY(tab_widget.try_add_tab<GUI::Widget>("Environment"));
-    (void)TRY(environment_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
+    TRY(environment_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
 
     auto environment_text_editor = TRY(environment_tab->try_add<GUI::TextEditor>());
     environment_text_editor->set_text(DeprecatedString::join('\n', environment));
@@ -245,7 +245,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     environment_text_editor->set_should_hide_unnecessary_scrollbars(true);
 
     auto memory_regions_tab = TRY(tab_widget.try_add_tab<GUI::Widget>("Memory Regions"));
-    (void)TRY(memory_regions_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
+    TRY(memory_regions_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
 
     auto memory_regions_text_editor = TRY(memory_regions_tab->try_add<GUI::TextEditor>());
     memory_regions_text_editor->set_text(DeprecatedString::join('\n', memory_regions));
@@ -303,7 +303,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         [&](auto results) -> ErrorOr<void> {
             for (auto& backtrace : results.thread_backtraces) {
                 auto container = TRY(backtrace_tab_widget->try_add_tab<GUI::Widget>(backtrace.title));
-                (void)TRY(container->template try_set_layout<GUI::VerticalBoxLayout>(4));
+                TRY(container->template try_set_layout<GUI::VerticalBoxLayout>(4));
                 auto backtrace_text_editor = TRY(container->template try_add<GUI::TextEditor>());
                 backtrace_text_editor->set_text(backtrace.text);
                 backtrace_text_editor->set_mode(GUI::TextEditor::Mode::ReadOnly);
@@ -314,7 +314,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
             for (auto& cpu_registers : results.thread_cpu_registers) {
                 auto container = TRY(cpu_registers_tab_widget->try_add_tab<GUI::Widget>(cpu_registers.title));
-                (void)TRY(container->template try_set_layout<GUI::VerticalBoxLayout>(4));
+                TRY(container->template try_set_layout<GUI::VerticalBoxLayout>(4));
                 auto cpu_registers_text_editor = TRY(container->template try_add<GUI::TextEditor>());
                 cpu_registers_text_editor->set_text(cpu_registers.text);
                 cpu_registers_text_editor->set_mode(GUI::TextEditor::Mode::ReadOnly);

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -216,8 +216,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& tab_widget = *widget->find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
 
     auto backtrace_tab = TRY(tab_widget.try_add_tab<GUI::Widget>("Backtrace"));
-    (void)TRY(backtrace_tab->try_set_layout<GUI::VerticalBoxLayout>());
-    backtrace_tab->layout()->set_margins(4);
+    (void)TRY(backtrace_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
 
     auto backtrace_label = TRY(backtrace_tab->try_add<GUI::Label>("A backtrace for each thread alive during the crash is listed below:"));
     backtrace_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -227,8 +226,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     backtrace_tab_widget->set_tab_position(GUI::TabWidget::TabPosition::Bottom);
 
     auto cpu_registers_tab = TRY(tab_widget.try_add_tab<GUI::Widget>("CPU Registers"));
-    cpu_registers_tab->set_layout<GUI::VerticalBoxLayout>();
-    cpu_registers_tab->layout()->set_margins(4);
+    cpu_registers_tab->set_layout<GUI::VerticalBoxLayout>(4);
 
     auto cpu_registers_label = TRY(cpu_registers_tab->try_add<GUI::Label>("The CPU register state for each thread alive during the crash is listed below:"));
     cpu_registers_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -238,8 +236,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     cpu_registers_tab_widget->set_tab_position(GUI::TabWidget::TabPosition::Bottom);
 
     auto environment_tab = TRY(tab_widget.try_add_tab<GUI::Widget>("Environment"));
-    (void)TRY(environment_tab->try_set_layout<GUI::VerticalBoxLayout>());
-    environment_tab->layout()->set_margins(4);
+    (void)TRY(environment_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
 
     auto environment_text_editor = TRY(environment_tab->try_add<GUI::TextEditor>());
     environment_text_editor->set_text(DeprecatedString::join('\n', environment));
@@ -248,8 +245,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     environment_text_editor->set_should_hide_unnecessary_scrollbars(true);
 
     auto memory_regions_tab = TRY(tab_widget.try_add_tab<GUI::Widget>("Memory Regions"));
-    (void)TRY(memory_regions_tab->try_set_layout<GUI::VerticalBoxLayout>());
-    memory_regions_tab->layout()->set_margins(4);
+    (void)TRY(memory_regions_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
 
     auto memory_regions_text_editor = TRY(memory_regions_tab->try_add<GUI::TextEditor>());
     memory_regions_text_editor->set_text(DeprecatedString::join('\n', memory_regions));
@@ -307,8 +303,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         [&](auto results) -> ErrorOr<void> {
             for (auto& backtrace : results.thread_backtraces) {
                 auto container = TRY(backtrace_tab_widget->try_add_tab<GUI::Widget>(backtrace.title));
-                (void)TRY(container->template try_set_layout<GUI::VerticalBoxLayout>());
-                container->layout()->set_margins(4);
+                (void)TRY(container->template try_set_layout<GUI::VerticalBoxLayout>(4));
                 auto backtrace_text_editor = TRY(container->template try_add<GUI::TextEditor>());
                 backtrace_text_editor->set_text(backtrace.text);
                 backtrace_text_editor->set_mode(GUI::TextEditor::Mode::ReadOnly);
@@ -319,8 +314,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
             for (auto& cpu_registers : results.thread_cpu_registers) {
                 auto container = TRY(cpu_registers_tab_widget->try_add_tab<GUI::Widget>(cpu_registers.title));
-                (void)TRY(container->template try_set_layout<GUI::VerticalBoxLayout>());
-                container->layout()->set_margins(4);
+                (void)TRY(container->template try_set_layout<GUI::VerticalBoxLayout>(4));
                 auto cpu_registers_text_editor = TRY(container->template try_add<GUI::TextEditor>());
                 cpu_registers_text_editor->set_text(cpu_registers.text);
                 cpu_registers_text_editor->set_mode(GUI::TextEditor::Mode::ReadOnly);

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -53,9 +53,7 @@ PropertiesWindow::PropertiesWindow(DeprecatedString const& path, Window* parent_
 ErrorOr<void> PropertiesWindow::create_widgets(bool disable_rename)
 {
     auto main_widget = TRY(set_main_widget<GUI::Widget>());
-    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
-    main_widget->layout()->set_spacing(6);
-    main_widget->layout()->set_margins(4);
+    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>(4, 6));
     main_widget->set_fill_with_background_color(true);
 
     auto tab_widget = TRY(main_widget->try_add<GUI::TabWidget>());
@@ -151,9 +149,8 @@ ErrorOr<void> PropertiesWindow::create_widgets(bool disable_rename)
     TRY(setup_permission_checkboxes(*others_read, *others_write, *others_execute, { S_IROTH, S_IWOTH, S_IXOTH }, m_mode));
 
     auto button_widget = TRY(main_widget->try_add<GUI::Widget>());
-    (void)TRY(button_widget->try_set_layout<GUI::HorizontalBoxLayout>());
+    (void)TRY(button_widget->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 5));
     button_widget->set_fixed_height(22);
-    button_widget->layout()->set_spacing(5);
 
     TRY(button_widget->add_spacer());
 

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -53,7 +53,7 @@ PropertiesWindow::PropertiesWindow(DeprecatedString const& path, Window* parent_
 ErrorOr<void> PropertiesWindow::create_widgets(bool disable_rename)
 {
     auto main_widget = TRY(set_main_widget<GUI::Widget>());
-    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>(4, 6));
+    TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>(4, 6));
     main_widget->set_fill_with_background_color(true);
 
     auto tab_widget = TRY(main_widget->try_add<GUI::TabWidget>());
@@ -149,7 +149,7 @@ ErrorOr<void> PropertiesWindow::create_widgets(bool disable_rename)
     TRY(setup_permission_checkboxes(*others_read, *others_write, *others_execute, { S_IROTH, S_IWOTH, S_IXOTH }, m_mode));
 
     auto button_widget = TRY(main_widget->try_add<GUI::Widget>());
-    (void)TRY(button_widget->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 5));
+    TRY(button_widget->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 5));
     button_widget->set_fixed_height(22);
 
     TRY(button_widget->add_spacer());

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -155,7 +155,7 @@ ErrorOr<void> PropertiesWindow::create_widgets(bool disable_rename)
     button_widget->set_fixed_height(22);
     button_widget->layout()->set_spacing(5);
 
-    button_widget->layout()->add_spacer();
+    TRY(button_widget->add_spacer());
 
     auto ok_button = TRY(make_button(String::from_utf8_short_string("OK"sv), button_widget));
     ok_button->on_click = [this](auto) {

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -358,7 +358,7 @@ ErrorOr<int> run_in_desktop_mode()
     window->set_has_alpha_channel(true);
 
     auto desktop_widget = TRY(window->set_main_widget<FileManager::DesktopWidget>());
-    (void)TRY(desktop_widget->try_set_layout<GUI::VerticalBoxLayout>());
+    TRY(desktop_widget->try_set_layout<GUI::VerticalBoxLayout>());
 
     auto directory_view = TRY(desktop_widget->try_add<DirectoryView>(DirectoryView::Mode::Desktop));
     directory_view->set_name("directory_view");

--- a/Userland/Applications/ImageViewer/MainWidget.cpp
+++ b/Userland/Applications/ImageViewer/MainWidget.cpp
@@ -11,8 +11,7 @@ namespace ImageViewer {
 MainWidget::MainWidget()
 {
     set_fill_with_background_color(true);
-    set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_spacing(2);
+    set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 2);
 }
 
 void MainWidget::keydown_event(GUI::KeyEvent& event)

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -95,7 +95,7 @@ void KeyboardMapperWidget::create_frame()
     add_map_radio_button("alt_map"sv, String::from_utf8_short_string("Alt"sv));
     add_map_radio_button("shift_altgr_map"sv, String::from_utf8("Shift+AltGr"sv).release_value_but_fixme_should_propagate_errors());
 
-    bottom_widget.layout()->add_spacer();
+    bottom_widget.add_spacer().release_value_but_fixme_should_propagate_errors();
 }
 
 void KeyboardMapperWidget::add_map_radio_button(const StringView map_name, String button_text)

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -39,8 +39,7 @@ bool KeyboardMapperWidget::request_close()
 void KeyboardMapperWidget::create_frame()
 {
     set_fill_with_background_color(true);
-    set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins(4);
+    set_layout<GUI::VerticalBoxLayout>(4);
 
     auto& main_widget = add<GUI::Widget>();
     main_widget.set_relative_rect(0, 0, 200, 200);

--- a/Userland/Applications/PDFViewer/SidebarWidget.cpp
+++ b/Userland/Applications/PDFViewer/SidebarWidget.cpp
@@ -18,8 +18,7 @@ SidebarWidget::SidebarWidget()
     auto& tab_bar = add<GUI::TabWidget>();
 
     auto& outline_container = tab_bar.add_tab<GUI::Widget>("Outline");
-    outline_container.set_layout<GUI::VerticalBoxLayout>();
-    outline_container.layout()->set_margins(4);
+    outline_container.set_layout<GUI::VerticalBoxLayout>(4);
 
     m_outline_tree_view = outline_container.add<GUI::TreeView>();
     m_outline_tree_view->set_activates_on_selection(true);
@@ -34,8 +33,7 @@ SidebarWidget::SidebarWidget()
     };
 
     auto& thumbnails_container = tab_bar.add_tab<GUI::Widget>("Thumbnails");
-    thumbnails_container.set_layout<GUI::VerticalBoxLayout>();
-    thumbnails_container.layout()->set_margins(4);
+    thumbnails_container.set_layout<GUI::VerticalBoxLayout>(4);
 
     // FIXME: Add thumbnail previews
 }

--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -34,9 +34,7 @@ MainWidget::MainWidget(TrackManager& track_manager, AudioPlayerLoop& loop)
 
 ErrorOr<void> MainWidget::initialize()
 {
-    (void)TRY(try_set_layout<GUI::VerticalBoxLayout>());
-    layout()->set_spacing(2);
-    layout()->set_margins(2);
+    (void)TRY(try_set_layout<GUI::VerticalBoxLayout>(2, 2));
     set_fill_with_background_color(true);
 
     m_wave_widget = TRY(try_add<WaveWidget>(m_track_manager));
@@ -51,8 +49,7 @@ ErrorOr<void> MainWidget::initialize()
     m_player_widget = TRY(try_add<PlayerWidget>(m_track_manager, m_audio_loop));
 
     m_keys_and_knobs_container = TRY(try_add<GUI::Widget>());
-    (void)TRY(m_keys_and_knobs_container->try_set_layout<GUI::HorizontalBoxLayout>());
-    m_keys_and_knobs_container->layout()->set_spacing(2);
+    (void)TRY(m_keys_and_knobs_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 2));
     m_keys_and_knobs_container->set_fixed_height(130);
     m_keys_and_knobs_container->set_fill_with_background_color(true);
 

--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -34,7 +34,7 @@ MainWidget::MainWidget(TrackManager& track_manager, AudioPlayerLoop& loop)
 
 ErrorOr<void> MainWidget::initialize()
 {
-    (void)TRY(try_set_layout<GUI::VerticalBoxLayout>(2, 2));
+    TRY(try_set_layout<GUI::VerticalBoxLayout>(2, 2));
     set_fill_with_background_color(true);
 
     m_wave_widget = TRY(try_add<WaveWidget>(m_track_manager));
@@ -49,7 +49,7 @@ ErrorOr<void> MainWidget::initialize()
     m_player_widget = TRY(try_add<PlayerWidget>(m_track_manager, m_audio_loop));
 
     m_keys_and_knobs_container = TRY(try_add<GUI::Widget>());
-    (void)TRY(m_keys_and_knobs_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 2));
+    TRY(m_keys_and_knobs_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 2));
     m_keys_and_knobs_container->set_fixed_height(130);
     m_keys_and_knobs_container->set_fill_with_background_color(true);
 

--- a/Userland/Applications/Piano/PlayerWidget.cpp
+++ b/Userland/Applications/Piano/PlayerWidget.cpp
@@ -39,7 +39,7 @@ PlayerWidget::PlayerWidget(TrackManager& manager, AudioPlayerLoop& loop)
 
 ErrorOr<void> PlayerWidget::initialize()
 {
-    (void)TRY(try_set_layout<GUI::HorizontalBoxLayout>());
+    TRY(try_set_layout<GUI::HorizontalBoxLayout>());
     set_fill_with_background_color(true);
     TRY(m_track_number_choices.try_append("1"));
 

--- a/Userland/Applications/Piano/SamplerWidget.cpp
+++ b/Userland/Applications/Piano/SamplerWidget.cpp
@@ -40,14 +40,11 @@ void WaveEditor::paint_event(GUI::PaintEvent& event)
 SamplerWidget::SamplerWidget(TrackManager& track_manager)
     : m_track_manager(track_manager)
 {
-    set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins(10);
-    layout()->set_spacing(10);
+    set_layout<GUI::VerticalBoxLayout>(10, 10);
     set_fill_with_background_color(true);
 
     m_open_button_and_recorded_sample_name_container = add<GUI::Widget>();
-    m_open_button_and_recorded_sample_name_container->set_layout<GUI::HorizontalBoxLayout>();
-    m_open_button_and_recorded_sample_name_container->layout()->set_spacing(10);
+    m_open_button_and_recorded_sample_name_container->set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 10);
     m_open_button_and_recorded_sample_name_container->set_fixed_height(24);
 
     m_open_button = m_open_button_and_recorded_sample_name_container->add<GUI::Button>();

--- a/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
@@ -30,8 +30,7 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
     main_widget->set_fill_with_background_color(true);
 
-    auto& layout = main_widget->set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins(4);
+    main_widget->set_layout<GUI::VerticalBoxLayout>(4);
 
     auto& name_label = main_widget->add<GUI::Label>("Name:");
     name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);

--- a/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
@@ -22,9 +22,7 @@ CreateNewLayerDialog::CreateNewLayerDialog(Gfx::IntSize suggested_size, GUI::Win
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
     main_widget->set_fill_with_background_color(true);
-
-    auto& layout = main_widget->set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins(4);
+    main_widget->set_layout<GUI::VerticalBoxLayout>(4);
 
     auto& name_label = main_widget->add<GUI::Label>("Name:");
     name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);

--- a/Userland/Applications/PixelPaint/FilterParams.h
+++ b/Userland/Applications/PixelPaint/FilterParams.h
@@ -52,8 +52,7 @@ private:
         main_widget->set_frame_shape(Gfx::FrameShape::Container);
         main_widget->set_frame_shadow(Gfx::FrameShadow::Raised);
         main_widget->set_fill_with_background_color(true);
-        auto& layout = main_widget->template set_layout<GUI::VerticalBoxLayout>();
-        layout.set_margins(4);
+        main_widget->template set_layout<GUI::VerticalBoxLayout>(4);
 
         size_t index = 0;
         size_t columns = N;

--- a/Userland/Applications/PixelPaint/Filters/Bloom.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Bloom.cpp
@@ -38,7 +38,7 @@ ErrorOr<RefPtr<GUI::Widget>> Bloom::get_settings_widget()
 {
     if (!m_settings_widget) {
         auto settings_widget = TRY(GUI::Widget::try_create());
-        (void)TRY(settings_widget->try_set_layout<GUI::VerticalBoxLayout>());
+        TRY(settings_widget->try_set_layout<GUI::VerticalBoxLayout>());
 
         auto name_label = TRY(settings_widget->try_add<GUI::Label>("Bloom Filter"));
         name_label->set_font_weight(Gfx::FontWeight::Bold);
@@ -47,7 +47,7 @@ ErrorOr<RefPtr<GUI::Widget>> Bloom::get_settings_widget()
 
         auto luma_lower_container = TRY(settings_widget->try_add<GUI::Widget>());
         luma_lower_container->set_fixed_height(50);
-        (void)TRY(luma_lower_container->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
+        TRY(luma_lower_container->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
 
         auto luma_lower_label = TRY(luma_lower_container->try_add<GUI::Label>("Luma lower bound:"));
         luma_lower_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -63,7 +63,7 @@ ErrorOr<RefPtr<GUI::Widget>> Bloom::get_settings_widget()
 
         auto radius_container = TRY(settings_widget->try_add<GUI::Widget>());
         radius_container->set_fixed_height(50);
-        (void)TRY(radius_container->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
+        TRY(radius_container->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
 
         auto radius_label = TRY(radius_container->try_add<GUI::Label>("Blur Radius:"));
         radius_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);

--- a/Userland/Applications/PixelPaint/Filters/Bloom.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Bloom.cpp
@@ -47,8 +47,7 @@ ErrorOr<RefPtr<GUI::Widget>> Bloom::get_settings_widget()
 
         auto luma_lower_container = TRY(settings_widget->try_add<GUI::Widget>());
         luma_lower_container->set_fixed_height(50);
-        auto luma_lower_container_layout = TRY(luma_lower_container->try_set_layout<GUI::VerticalBoxLayout>());
-        luma_lower_container_layout->set_margins({ 4, 0, 4, 0 });
+        (void)TRY(luma_lower_container->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
 
         auto luma_lower_label = TRY(luma_lower_container->try_add<GUI::Label>("Luma lower bound:"));
         luma_lower_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -64,8 +63,7 @@ ErrorOr<RefPtr<GUI::Widget>> Bloom::get_settings_widget()
 
         auto radius_container = TRY(settings_widget->try_add<GUI::Widget>());
         radius_container->set_fixed_height(50);
-        auto radius_container_layout = TRY(radius_container->try_set_layout<GUI::VerticalBoxLayout>());
-        radius_container_layout->set_margins({ 4, 0, 4, 0 });
+        (void)TRY(radius_container->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
 
         auto radius_label = TRY(radius_container->try_add<GUI::Label>("Blur Radius:"));
         radius_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);

--- a/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
+++ b/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
@@ -40,7 +40,7 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
 {
     if (!m_settings_widget) {
         auto settings_widget = TRY(GUI::Widget::try_create());
-        (void)TRY(settings_widget->try_set_layout<GUI::VerticalBoxLayout>());
+        TRY(settings_widget->try_set_layout<GUI::VerticalBoxLayout>());
 
         auto name_label = TRY(settings_widget->try_add<GUI::Label>("Fast Box Blur Filter"));
         name_label->set_font_weight(Gfx::FontWeight::Bold);
@@ -86,7 +86,7 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
 
         m_radius_container = TRY(settings_widget->try_add<GUI::Widget>());
         m_radius_container->set_fixed_height(20);
-        (void)TRY(m_radius_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
+        TRY(m_radius_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
 
         auto radius_label = TRY(m_radius_container->try_add<GUI::Label>("Radius:"));
         radius_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -103,7 +103,7 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
         m_asymmetric_radius_container = TRY(settings_widget->try_add<GUI::Widget>());
         m_asymmetric_radius_container->set_visible(false);
         m_asymmetric_radius_container->set_fixed_height(50);
-        (void)TRY(m_asymmetric_radius_container->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
+        TRY(m_asymmetric_radius_container->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
 
         auto radius_x_container = TRY(m_asymmetric_radius_container->try_add<GUI::Widget>());
         radius_x_container->set_fixed_height(20);
@@ -123,7 +123,7 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
 
         auto radius_y_container = TRY(m_asymmetric_radius_container->try_add<GUI::Widget>());
         radius_y_container->set_fixed_height(20);
-        (void)TRY(radius_y_container->try_set_layout<GUI::HorizontalBoxLayout>());
+        TRY(radius_y_container->try_set_layout<GUI::HorizontalBoxLayout>());
 
         auto radius_y_label = TRY(radius_y_container->try_add<GUI::Label>("Radius Y:"));
         radius_y_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -140,11 +140,11 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
         m_vector_container = TRY(settings_widget->try_add<GUI::Widget>());
         m_vector_container->set_visible(false);
         m_vector_container->set_fixed_height(50);
-        (void)TRY(m_vector_container->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
+        TRY(m_vector_container->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
 
         auto angle_container = TRY(m_vector_container->try_add<GUI::Widget>());
         angle_container->set_fixed_height(20);
-        (void)TRY(angle_container->try_set_layout<GUI::HorizontalBoxLayout>());
+        TRY(angle_container->try_set_layout<GUI::HorizontalBoxLayout>());
 
         auto angle_label = TRY(angle_container->try_add<GUI::Label>("Angle:"));
         angle_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -160,7 +160,7 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
 
         auto magnitude_container = TRY(m_vector_container->try_add<GUI::Widget>());
         magnitude_container->set_fixed_height(20);
-        (void)TRY(magnitude_container->try_set_layout<GUI::HorizontalBoxLayout>());
+        TRY(magnitude_container->try_set_layout<GUI::HorizontalBoxLayout>());
 
         auto magnitude_label = TRY(magnitude_container->try_add<GUI::Label>("Magnitude:"));
         magnitude_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -176,7 +176,7 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
 
         auto gaussian_container = TRY(settings_widget->try_add<GUI::Widget>());
         gaussian_container->set_fixed_height(20);
-        (void)TRY(gaussian_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
+        TRY(gaussian_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
 
         m_gaussian_checkbox = TRY(gaussian_container->try_add<GUI::CheckBox>(TRY(String::from_utf8("Approximate Gaussian Blur"sv))));
         m_gaussian_checkbox->set_checked(m_approximate_gauss);

--- a/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
+++ b/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
@@ -86,8 +86,7 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
 
         m_radius_container = TRY(settings_widget->try_add<GUI::Widget>());
         m_radius_container->set_fixed_height(20);
-        auto radius_container_layout = TRY(m_radius_container->try_set_layout<GUI::HorizontalBoxLayout>());
-        radius_container_layout->set_margins({ 4, 0, 4, 0 });
+        (void)TRY(m_radius_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
 
         auto radius_label = TRY(m_radius_container->try_add<GUI::Label>("Radius:"));
         radius_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -104,8 +103,7 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
         m_asymmetric_radius_container = TRY(settings_widget->try_add<GUI::Widget>());
         m_asymmetric_radius_container->set_visible(false);
         m_asymmetric_radius_container->set_fixed_height(50);
-        auto asymmetric_radius_container_label = TRY(m_asymmetric_radius_container->try_set_layout<GUI::VerticalBoxLayout>());
-        asymmetric_radius_container_label->set_margins({ 4, 0, 4, 0 });
+        (void)TRY(m_asymmetric_radius_container->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
 
         auto radius_x_container = TRY(m_asymmetric_radius_container->try_add<GUI::Widget>());
         radius_x_container->set_fixed_height(20);
@@ -142,8 +140,7 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
         m_vector_container = TRY(settings_widget->try_add<GUI::Widget>());
         m_vector_container->set_visible(false);
         m_vector_container->set_fixed_height(50);
-        auto vector_container_layout = TRY(m_vector_container->try_set_layout<GUI::VerticalBoxLayout>());
-        vector_container_layout->set_margins({ 4, 0, 4, 0 });
+        (void)TRY(m_vector_container->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
 
         auto angle_container = TRY(m_vector_container->try_add<GUI::Widget>());
         angle_container->set_fixed_height(20);
@@ -179,8 +176,7 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
 
         auto gaussian_container = TRY(settings_widget->try_add<GUI::Widget>());
         gaussian_container->set_fixed_height(20);
-        auto gaussian_container_layout = TRY(gaussian_container->try_set_layout<GUI::HorizontalBoxLayout>());
-        gaussian_container_layout->set_margins({ 4, 0, 4, 0 });
+        (void)TRY(gaussian_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
 
         m_gaussian_checkbox = TRY(gaussian_container->try_add<GUI::CheckBox>(TRY(String::from_utf8("Approximate Gaussian Blur"sv))));
         m_gaussian_checkbox->set_checked(m_approximate_gauss);

--- a/Userland/Applications/PixelPaint/Filters/Sepia.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Sepia.cpp
@@ -21,7 +21,7 @@ ErrorOr<RefPtr<GUI::Widget>> Sepia::get_settings_widget()
 {
     if (!m_settings_widget) {
         auto settings_widget = TRY(GUI::Widget::try_create());
-        (void)TRY(settings_widget->try_set_layout<GUI::VerticalBoxLayout>());
+        TRY(settings_widget->try_set_layout<GUI::VerticalBoxLayout>());
 
         auto name_label = TRY(settings_widget->try_add<GUI::Label>("Sepia Filter"));
         name_label->set_font_weight(Gfx::FontWeight::Bold);
@@ -30,7 +30,7 @@ ErrorOr<RefPtr<GUI::Widget>> Sepia::get_settings_widget()
 
         auto amount_container = TRY(settings_widget->try_add<GUI::Widget>());
         amount_container->set_fixed_height(20);
-        (void)TRY(amount_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
+        TRY(amount_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
 
         auto amount_label = TRY(amount_container->try_add<GUI::Label>("Amount:"));
         amount_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);

--- a/Userland/Applications/PixelPaint/Filters/Sepia.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Sepia.cpp
@@ -30,8 +30,7 @@ ErrorOr<RefPtr<GUI::Widget>> Sepia::get_settings_widget()
 
         auto amount_container = TRY(settings_widget->try_add<GUI::Widget>());
         amount_container->set_fixed_height(20);
-        auto amount_layout = TRY(amount_container->try_set_layout<GUI::HorizontalBoxLayout>());
-        amount_layout->set_margins({ 4, 0, 4, 0 });
+        (void)TRY(amount_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 4, 0 }));
 
         auto amount_label = TRY(amount_container->try_add<GUI::Label>("Amount:"));
         amount_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);

--- a/Userland/Applications/PixelPaint/LayerPropertiesWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerPropertiesWidget.cpp
@@ -24,9 +24,7 @@ LayerPropertiesWidget::LayerPropertiesWidget()
     set_layout<GUI::VerticalBoxLayout>();
 
     auto& group_box = add<GUI::GroupBox>("Layer properties"sv);
-    auto& layout = group_box.set_layout<GUI::VerticalBoxLayout>();
-
-    layout.set_margins({ 8 });
+    group_box.set_layout<GUI::VerticalBoxLayout>(8);
 
     auto& name_container = group_box.add<GUI::Widget>();
     name_container.set_fixed_height(20);

--- a/Userland/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Userland/Applications/PixelPaint/PaletteWidget.cpp
@@ -118,18 +118,15 @@ PaletteWidget::PaletteWidget()
 
     m_color_container = add<GUI::Widget>();
     m_color_container->set_relative_rect(m_secondary_color_widget->relative_rect().right() + 2, 2, 500, 33);
-    m_color_container->set_layout<GUI::VerticalBoxLayout>();
-    m_color_container->layout()->set_spacing(1);
+    m_color_container->set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 1);
 
     auto& top_color_container = m_color_container->add<GUI::Widget>();
     top_color_container.set_name("top_color_container");
-    top_color_container.set_layout<GUI::HorizontalBoxLayout>();
-    top_color_container.layout()->set_spacing(1);
+    top_color_container.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 1);
 
     auto& bottom_color_container = m_color_container->add<GUI::Widget>();
     bottom_color_container.set_name("bottom_color_container");
-    bottom_color_container.set_layout<GUI::HorizontalBoxLayout>();
-    bottom_color_container.layout()->set_spacing(1);
+    bottom_color_container.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 1);
 
     auto result = load_palette_path("/res/color-palettes/default.palette");
     if (result.is_error()) {

--- a/Userland/Applications/PixelPaint/ToolPropertiesWidget.cpp
+++ b/Userland/Applications/PixelPaint/ToolPropertiesWidget.cpp
@@ -20,8 +20,7 @@ ToolPropertiesWidget::ToolPropertiesWidget()
     set_layout<GUI::VerticalBoxLayout>();
 
     m_group_box = add<GUI::GroupBox>("Tool properties"sv);
-    auto& layout = m_group_box->set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 8 });
+    m_group_box->set_layout<GUI::VerticalBoxLayout>(8);
     m_tool_widget_stack = m_group_box->add<GUI::StackWidget>();
     m_blank_widget = m_tool_widget_stack->add<GUI::Widget>();
     m_error_label = m_tool_widget_stack->add<GUI::Label>();

--- a/Userland/Applications/PixelPaint/ToolboxWidget.cpp
+++ b/Userland/Applications/PixelPaint/ToolboxWidget.cpp
@@ -39,10 +39,7 @@ ToolboxWidget::ToolboxWidget()
     set_fill_with_background_color(true);
 
     set_fixed_width(26);
-
-    set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_spacing(0);
-    layout()->set_margins(2);
+    set_layout<GUI::VerticalBoxLayout>(2, 0);
 
     m_action_group.set_exclusive(true);
     m_action_group.set_unchecking_allowed(false);

--- a/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
@@ -214,7 +214,7 @@ ErrorOr<GUI::Widget*> GradientTool::get_properties_widget()
 
         auto button_container = TRY(properties_widget->try_add<GUI::Widget>());
         button_container->set_fixed_height(22);
-        (void)TRY(button_container->try_set_layout<GUI::HorizontalBoxLayout>());
+        TRY(button_container->try_set_layout<GUI::HorizontalBoxLayout>());
         button_container->add_spacer().release_value_but_fixme_should_propagate_errors();
 
         auto apply_button = TRY(button_container->try_add<GUI::DialogButton>(String::from_utf8_short_string("Apply"sv)));

--- a/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
@@ -214,8 +214,8 @@ ErrorOr<GUI::Widget*> GradientTool::get_properties_widget()
 
         auto button_container = TRY(properties_widget->try_add<GUI::Widget>());
         button_container->set_fixed_height(22);
-        auto button_container_layout = TRY(button_container->try_set_layout<GUI::HorizontalBoxLayout>());
-        button_container_layout->add_spacer();
+        (void)TRY(button_container->try_set_layout<GUI::HorizontalBoxLayout>());
+        button_container->add_spacer().release_value_but_fixme_should_propagate_errors();
 
         auto apply_button = TRY(button_container->try_add<GUI::DialogButton>(String::from_utf8_short_string("Apply"sv)));
         apply_button->on_click = [this](auto) {

--- a/Userland/Applications/SpaceAnalyzer/ProgressWindow.cpp
+++ b/Userland/Applications/SpaceAnalyzer/ProgressWindow.cpp
@@ -16,7 +16,7 @@ ErrorOr<NonnullRefPtr<ProgressWindow>> ProgressWindow::try_create(StringView tit
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
-    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
+    TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
 
     auto label = TRY(main_widget->try_add<GUI::Label>("Analyzing storage space..."));
     label->set_fixed_height(22);

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -46,7 +46,7 @@ CellTypeDialog::CellTypeDialog(Vector<Position> const& positions, Sheet& sheet, 
     resize(285, 360);
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->set_layout<GUI::VerticalBoxLayout>().set_margins(4);
+    main_widget->set_layout<GUI::VerticalBoxLayout>(4);
     main_widget->set_fill_with_background_color(true);
 
     auto& tab_widget = main_widget->add<GUI::TabWidget>();
@@ -54,8 +54,7 @@ CellTypeDialog::CellTypeDialog(Vector<Position> const& positions, Sheet& sheet, 
 
     auto& buttonbox = main_widget->add<GUI::Widget>();
     buttonbox.set_shrink_to_fit(true);
-    auto& button_layout = buttonbox.set_layout<GUI::HorizontalBoxLayout>();
-    button_layout.set_spacing(10);
+    buttonbox.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 10);
     buttonbox.add_spacer().release_value_but_fixme_should_propagate_errors();
     auto& ok_button = buttonbox.add<GUI::Button>(String::from_utf8_short_string("OK"sv));
     ok_button.set_fixed_width(80);
@@ -134,7 +133,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
     }
 
     auto& type_tab = tabs.add_tab<GUI::Widget>("Type");
-    type_tab.set_layout<GUI::HorizontalBoxLayout>().set_margins(4);
+    type_tab.set_layout<GUI::HorizontalBoxLayout>(4);
     {
         auto& left_side = type_tab.add<GUI::Widget>();
         left_side.set_layout<GUI::VerticalBoxLayout>();
@@ -199,14 +198,13 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
     }
 
     auto& alignment_tab = tabs.add_tab<GUI::Widget>("Alignment");
-    alignment_tab.set_layout<GUI::VerticalBoxLayout>().set_margins(4);
+    alignment_tab.set_layout<GUI::VerticalBoxLayout>(4);
     {
         // FIXME: Frame?
         // Horizontal alignment
         {
             auto& horizontal_alignment_selection_container = alignment_tab.add<GUI::Widget>();
-            horizontal_alignment_selection_container.set_layout<GUI::HorizontalBoxLayout>();
-            horizontal_alignment_selection_container.layout()->set_margins({ 4, 0, 0 });
+            horizontal_alignment_selection_container.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 0 });
             horizontal_alignment_selection_container.set_fixed_height(22);
 
             auto& horizontal_alignment_label = horizontal_alignment_selection_container.add<GUI::Label>();
@@ -237,8 +235,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
         // Vertical alignment
         {
             auto& vertical_alignment_container = alignment_tab.add<GUI::Widget>();
-            vertical_alignment_container.set_layout<GUI::HorizontalBoxLayout>();
-            vertical_alignment_container.layout()->set_margins({ 4, 0, 0 });
+            vertical_alignment_container.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 0 });
             vertical_alignment_container.set_fixed_height(22);
 
             auto& vertical_alignment_label = vertical_alignment_container.add<GUI::Label>();
@@ -268,7 +265,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
     }
 
     auto& colors_tab = tabs.add_tab<GUI::Widget>("Color");
-    colors_tab.set_layout<GUI::VerticalBoxLayout>().set_margins(4);
+    colors_tab.set_layout<GUI::VerticalBoxLayout>(4);
     {
         // Static formatting
         {
@@ -279,8 +276,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
             {
                 // FIXME: Somehow allow unsetting these.
                 auto& foreground_container = static_formatting_container.add<GUI::Widget>();
-                foreground_container.set_layout<GUI::HorizontalBoxLayout>();
-                foreground_container.layout()->set_margins({ 4, 0, 0 });
+                foreground_container.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 0 });
                 foreground_container.set_preferred_height(GUI::SpecialDimension::Fit);
 
                 auto& foreground_label = foreground_container.add<GUI::Label>();
@@ -299,8 +295,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
             {
                 // FIXME: Somehow allow unsetting these.
                 auto& background_container = static_formatting_container.add<GUI::Widget>();
-                background_container.set_layout<GUI::HorizontalBoxLayout>();
-                background_container.layout()->set_margins({ 4, 0, 0 });
+                background_container.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 0 });
                 background_container.set_preferred_height(GUI::SpecialDimension::Fit);
 
                 auto& background_label = background_container.add<GUI::Label>();
@@ -427,9 +422,7 @@ ConditionView::~ConditionView()
 
 ConditionsView::ConditionsView()
 {
-    auto& layout = set_layout<GUI::VerticalBoxLayout>();
-    layout.set_spacing(4);
-    layout.set_margins({ 6 });
+    set_layout<GUI::VerticalBoxLayout>(6, 4);
 }
 
 void ConditionsView::set_formats(Vector<ConditionalFormat>* formats)

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -56,7 +56,7 @@ CellTypeDialog::CellTypeDialog(Vector<Position> const& positions, Sheet& sheet, 
     buttonbox.set_shrink_to_fit(true);
     auto& button_layout = buttonbox.set_layout<GUI::HorizontalBoxLayout>();
     button_layout.set_spacing(10);
-    button_layout.add_spacer();
+    buttonbox.add_spacer().release_value_but_fixme_should_propagate_errors();
     auto& ok_button = buttonbox.add<GUI::Button>(String::from_utf8_short_string("OK"sv));
     ok_button.set_fixed_width(80);
     ok_button.on_click = [&](auto) { done(ExecResult::OK); };

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -305,7 +305,7 @@ SpreadsheetView::SpreadsheetView(Sheet& sheet)
     : m_sheet(sheet)
     , m_sheet_model(SheetModel::create(*m_sheet))
 {
-    set_layout<GUI::VerticalBoxLayout>().set_margins(2);
+    set_layout<GUI::VerticalBoxLayout>(2);
     m_table_view = add<InfinitelyScrollableTableView>();
     m_table_view->set_grid_style(GUI::TableView::GridStyle::Both);
     m_table_view->set_selection_behavior(GUI::AbstractView::SelectionBehavior::SelectItems);

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -31,7 +31,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, NonnullRefPtrVe
     : m_workbook(make<Workbook>(move(sheets), parent_window))
 {
     set_fill_with_background_color(true);
-    set_layout<GUI::VerticalBoxLayout>().set_margins(2);
+    set_layout<GUI::VerticalBoxLayout>(2);
 
     auto& toolbar_container = add<GUI::ToolbarContainer>();
     auto& toolbar = toolbar_container.add<GUI::Toolbar>();
@@ -39,7 +39,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, NonnullRefPtrVe
     auto& container = add<GUI::VerticalSplitter>();
 
     auto& top_bar = container.add<GUI::Frame>();
-    top_bar.set_layout<GUI::HorizontalBoxLayout>().set_spacing(1);
+    top_bar.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 1);
     top_bar.set_preferred_height(26);
     auto& current_cell_label = top_bar.add<GUI::Label>("");
     current_cell_label.set_fixed_width(50);
@@ -83,7 +83,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, NonnullRefPtrVe
     m_inline_documentation_window->set_resizable(false);
     auto inline_widget = m_inline_documentation_window->set_main_widget<GUI::Frame>().release_value_but_fixme_should_propagate_errors();
     inline_widget->set_fill_with_background_color(true);
-    inline_widget->set_layout<GUI::VerticalBoxLayout>().set_margins(4);
+    inline_widget->set_layout<GUI::VerticalBoxLayout>(4);
     inline_widget->set_frame_shape(Gfx::FrameShape::Box);
     m_inline_documentation_label = inline_widget->add<GUI::Label>();
     m_inline_documentation_label->set_fill_with_background_color(true);

--- a/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
@@ -43,9 +43,7 @@ MemoryStatsWidget::MemoryStatsWidget(GraphWidget* graph)
 
     set_fixed_height(110);
 
-    set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins({ 8, 0, 0 });
-    layout()->set_spacing(3);
+    set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 8, 0, 0 }, 3);
 
     auto build_widgets_for_label = [this](DeprecatedString const& description) -> RefPtr<GUI::Label> {
         auto& container = add<GUI::Widget>();

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -22,8 +22,7 @@ namespace SystemMonitor {
 NetworkStatisticsWidget::NetworkStatisticsWidget()
 {
     on_first_show = [this](auto&) {
-        set_layout<GUI::VerticalBoxLayout>();
-        layout()->set_margins(4);
+        set_layout<GUI::VerticalBoxLayout>(4);
         set_fill_with_background_color(true);
 
         m_network_connected_bitmap = Gfx::Bitmap::load_from_file("/res/icons/16x16/network-connected.png"sv).release_value_but_fixme_should_propagate_errors();
@@ -38,8 +37,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
         }
 
         auto& adapters_group_box = add<GUI::GroupBox>("Adapters"sv);
-        adapters_group_box.set_layout<GUI::VerticalBoxLayout>();
-        adapters_group_box.layout()->set_margins(6);
+        adapters_group_box.set_layout<GUI::VerticalBoxLayout>(6);
         adapters_group_box.set_fixed_height(120);
 
         m_adapter_table_view = adapters_group_box.add<GUI::TableView>();
@@ -94,8 +92,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
         };
 
         auto& tcp_sockets_group_box = add<GUI::GroupBox>("TCP Sockets"sv);
-        tcp_sockets_group_box.set_layout<GUI::VerticalBoxLayout>();
-        tcp_sockets_group_box.layout()->set_margins(6);
+        tcp_sockets_group_box.set_layout<GUI::VerticalBoxLayout>(6);
 
         m_tcp_socket_table_view = tcp_sockets_group_box.add<GUI::TableView>();
 
@@ -115,8 +112,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
         m_tcp_socket_table_view->set_model(MUST(GUI::SortingProxyModel::create(*m_tcp_socket_model)));
 
         auto& udp_sockets_group_box = add<GUI::GroupBox>("UDP Sockets"sv);
-        udp_sockets_group_box.set_layout<GUI::VerticalBoxLayout>();
-        udp_sockets_group_box.layout()->set_margins(6);
+        udp_sockets_group_box.set_layout<GUI::VerticalBoxLayout>(6);
 
         m_udp_socket_table_view = udp_sockets_group_box.add<GUI::TableView>();
 

--- a/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
@@ -17,8 +17,7 @@ namespace SystemMonitor {
 
 ProcessFileDescriptorMapWidget::ProcessFileDescriptorMapWidget()
 {
-    set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins(4);
+    set_layout<GUI::VerticalBoxLayout>(4);
     m_table_view = add<GUI::TableView>();
 
     Vector<GUI::JsonArrayModel::FieldSpec> pid_fds_fields;

--- a/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
@@ -51,8 +51,7 @@ public:
 
 ProcessMemoryMapWidget::ProcessMemoryMapWidget()
 {
-    set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins(4);
+    set_layout<GUI::VerticalBoxLayout>(4);
     m_table_view = add<GUI::TableView>();
     Vector<GUI::JsonArrayModel::FieldSpec> pid_vm_fields;
     pid_vm_fields.empend(

--- a/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
@@ -95,8 +95,7 @@ private:
 
 ProcessStateWidget::ProcessStateWidget()
 {
-    set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins(4);
+    set_layout<GUI::VerticalBoxLayout>(4);
     m_table_view = add<GUI::TableView>();
     m_table_view->set_model(adopt_ref(*new ProcessStateModel(ProcessModel::the(), 0)));
     m_table_view->column_header().set_visible(false);

--- a/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.cpp
@@ -18,8 +18,7 @@ namespace SystemMonitor {
 
 ProcessUnveiledPathsWidget::ProcessUnveiledPathsWidget()
 {
-    set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins(4);
+    set_layout<GUI::VerticalBoxLayout>(4);
     m_table_view = add<GUI::TableView>();
 
     Vector<GUI::JsonArrayModel::FieldSpec> pid_unveil_fields;

--- a/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
@@ -73,8 +73,7 @@ private:
 
 ThreadStackWidget::ThreadStackWidget()
 {
-    set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins(4);
+    set_layout<GUI::VerticalBoxLayout>(4);
     m_stack_table = add<GUI::TableView>();
     m_stack_table->set_model(adopt_ref(*new ThreadStackModel()));
 }

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -561,8 +561,7 @@ void build_performance_tab(GUI::Widget& graphs_container)
     Vector<SystemMonitor::GraphWidget&> cpu_graphs;
     for (auto row = 0u; row < cpu_graph_rows; ++row) {
         auto& cpu_graph_row = cpu_graph_group_box.add<GUI::Widget>();
-        cpu_graph_row.set_layout<GUI::HorizontalBoxLayout>();
-        cpu_graph_row.layout()->set_margins(6);
+        cpu_graph_row.set_layout<GUI::HorizontalBoxLayout>(6);
         cpu_graph_row.set_fixed_height(108);
         for (auto i = 0u; i < cpu_graphs_per_row; ++i) {
             auto& cpu_graph = cpu_graph_row.add<SystemMonitor::GraphWidget>();

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -175,12 +175,10 @@ static ErrorOr<NonnullRefPtr<GUI::Window>> create_find_window(VT::TerminalWidget
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
     main_widget->set_background_role(ColorRole::Button);
-    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
-    main_widget->layout()->set_margins(4);
+    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>(4));
 
     auto find = TRY(main_widget->try_add<GUI::Widget>());
-    (void)TRY(find->try_set_layout<GUI::HorizontalBoxLayout>());
-    find->layout()->set_margins(4);
+    (void)TRY(find->try_set_layout<GUI::HorizontalBoxLayout>(4));
     find->set_fixed_height(30);
 
     auto find_textbox = TRY(find->try_add<GUI::TextBox>());

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -175,10 +175,10 @@ static ErrorOr<NonnullRefPtr<GUI::Window>> create_find_window(VT::TerminalWidget
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
     main_widget->set_background_role(ColorRole::Button);
-    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>(4));
+    TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>(4));
 
     auto find = TRY(main_widget->try_add<GUI::Widget>());
-    (void)TRY(find->try_set_layout<GUI::HorizontalBoxLayout>(4));
+    TRY(find->try_set_layout<GUI::HorizontalBoxLayout>(4));
     find->set_fixed_height(30);
 
     auto find_textbox = TRY(find->try_add<GUI::TextBox>());

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -435,12 +435,12 @@ ErrorOr<void> MainWidget::add_property_tab(PropertyTab const& property_tab)
 
     auto properties_list = TRY(GUI::Widget::try_create());
     scrollable_container->set_widget(properties_list);
-    (void)TRY(properties_list->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 8 }, 12));
+    TRY(properties_list->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 8 }, 12));
 
     for (auto const& group : property_tab.property_groups) {
         NonnullRefPtr<GUI::GroupBox> group_box = TRY(properties_list->try_add<GUI::GroupBox>(group.title));
         // 1px less on the left makes the text line up with the group title.
-        (void)TRY(group_box->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 8, 8, 8, 7 }, 12));
+        TRY(group_box->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 8, 8, 8, 7 }, 12));
         group_box->set_preferred_height(GUI::SpecialDimension::Fit);
 
         for (auto const& property : group.properties) {

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -435,16 +435,12 @@ ErrorOr<void> MainWidget::add_property_tab(PropertyTab const& property_tab)
 
     auto properties_list = TRY(GUI::Widget::try_create());
     scrollable_container->set_widget(properties_list);
-    (void)TRY(properties_list->try_set_layout<GUI::VerticalBoxLayout>());
-    properties_list->layout()->set_spacing(12);
-    properties_list->layout()->set_margins({ 8 });
+    (void)TRY(properties_list->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 8 }, 12));
 
     for (auto const& group : property_tab.property_groups) {
         NonnullRefPtr<GUI::GroupBox> group_box = TRY(properties_list->try_add<GUI::GroupBox>(group.title));
-        (void)TRY(group_box->try_set_layout<GUI::VerticalBoxLayout>());
-        group_box->layout()->set_spacing(12);
         // 1px less on the left makes the text line up with the group title.
-        group_box->layout()->set_margins({ 8, 8, 8, 7 });
+        (void)TRY(group_box->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 8, 8, 8, 7 }, 12));
         group_box->set_preferred_height(GUI::SpecialDimension::Fit);
 
         for (auto const& property : group.properties) {

--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -42,7 +42,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto catdog_widget = TRY(CatDog::create());
     window->set_main_widget(catdog_widget);
-    (void)TRY(catdog_widget->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 0));
+    TRY(catdog_widget->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 0));
 
     auto context_menu = TRY(GUI::Menu::try_create());
     TRY(context_menu->try_add_action(GUI::CommonActions::make_about_action("CatDog Demo", app_icon, window)));
@@ -62,7 +62,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     advice_window->set_alpha_hit_threshold(1.0f);
 
     auto advice_widget = TRY(advice_window->set_main_widget<SpeechBubble>(catdog_widget));
-    (void)TRY(advice_widget->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 0));
+    TRY(advice_widget->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 0));
 
     auto advice_timer = TRY(Core::Timer::create_single_shot(15'000, [&] {
         window->move_to_front();

--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -42,8 +42,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto catdog_widget = TRY(CatDog::create());
     window->set_main_widget(catdog_widget);
-    (void)TRY(catdog_widget->try_set_layout<GUI::VerticalBoxLayout>());
-    catdog_widget->layout()->set_spacing(0);
+    (void)TRY(catdog_widget->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 0));
 
     auto context_menu = TRY(GUI::Menu::try_create());
     TRY(context_menu->try_add_action(GUI::CommonActions::make_about_action("CatDog Demo", app_icon, window)));
@@ -63,8 +62,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     advice_window->set_alpha_hit_threshold(1.0f);
 
     auto advice_widget = TRY(advice_window->set_main_widget<SpeechBubble>(catdog_widget));
-    (void)TRY(advice_widget->try_set_layout<GUI::VerticalBoxLayout>());
-    advice_widget->layout()->set_spacing(0);
+    (void)TRY(advice_widget->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 0));
 
     auto advice_timer = TRY(Core::Timer::create_single_shot(15'000, [&] {
         window->move_to_front();

--- a/Userland/Demos/ModelGallery/GalleryWidget.cpp
+++ b/Userland/Demos/ModelGallery/GalleryWidget.cpp
@@ -13,8 +13,7 @@ GalleryWidget::GalleryWidget()
     set_layout<GUI::VerticalBoxLayout>();
 
     auto& inner_widget = add<GUI::Widget>();
-    auto inner_layout = inner_widget.try_set_layout<GUI::VerticalBoxLayout>().release_value_but_fixme_should_propagate_errors();
-    inner_layout->set_margins({ 4 });
+    (void)inner_widget.try_set_layout<GUI::VerticalBoxLayout>(4).release_value_but_fixme_should_propagate_errors();
 
     m_tab_widget = inner_widget.try_add<GUI::TabWidget>().release_value_but_fixme_should_propagate_errors();
     m_statusbar = add<GUI::Statusbar>();

--- a/Userland/Demos/ModelGallery/GalleryWidget.cpp
+++ b/Userland/Demos/ModelGallery/GalleryWidget.cpp
@@ -13,7 +13,7 @@ GalleryWidget::GalleryWidget()
     set_layout<GUI::VerticalBoxLayout>();
 
     auto& inner_widget = add<GUI::Widget>();
-    (void)inner_widget.try_set_layout<GUI::VerticalBoxLayout>(4).release_value_but_fixme_should_propagate_errors();
+    inner_widget.try_set_layout<GUI::VerticalBoxLayout>(4).release_value_but_fixme_should_propagate_errors();
 
     m_tab_widget = inner_widget.try_add<GUI::TabWidget>().release_value_but_fixme_should_propagate_errors();
     m_statusbar = add<GUI::Statusbar>();

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -85,8 +85,7 @@ ErrorOr<NonnullRefPtr<HackStudioWidget>> HackStudioWidget::create(DeprecatedStri
 
     widget->m_editor_font = widget->read_editor_font_from_config();
     widget->set_fill_with_background_color(true);
-    widget->set_layout<GUI::VerticalBoxLayout>();
-    widget->layout()->set_spacing(2);
+    widget->set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 2);
 
     auto& toolbar_container = widget->add<GUI::ToolbarContainer>();
 
@@ -1363,15 +1362,13 @@ void HackStudioWidget::create_project_tab(GUI::Widget& parent)
     m_project_tab->set_tab_position(GUI::TabWidget::TabPosition::Bottom);
 
     auto& tree_view_container = m_project_tab->add_tab<GUI::Widget>("Files");
-    tree_view_container.set_layout<GUI::VerticalBoxLayout>();
-    tree_view_container.layout()->set_margins(2);
+    tree_view_container.set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 2);
 
     m_project_tree_view = tree_view_container.add<GUI::TreeView>();
     configure_project_tree_view();
 
     auto& class_view_container = m_project_tab->add_tab<GUI::Widget>("Classes");
-    class_view_container.set_layout<GUI::VerticalBoxLayout>();
-    class_view_container.layout()->set_margins(2);
+    class_view_container.set_layout<GUI::VerticalBoxLayout>(2);
 
     m_class_view = class_view_container.add<ClassViewWidget>();
 

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -132,7 +132,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto tab_widget = TRY(main_splitter->try_add<GUI::TabWidget>());
 
     auto tree_tab = TRY(tab_widget->try_add_tab<GUI::Widget>("Call Tree"));
-    (void)TRY(tree_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
+    TRY(tree_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
     auto bottom_splitter = TRY(tree_tab->try_add<GUI::VerticalSplitter>());
 
     auto tree_view = TRY(bottom_splitter->try_add<GUI::TreeView>());
@@ -181,7 +181,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     });
 
     auto samples_tab = TRY(tab_widget->try_add_tab<GUI::Widget>("Samples"));
-    (void)TRY(samples_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
+    TRY(samples_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
 
     auto samples_splitter = TRY(samples_tab->try_add<GUI::HorizontalSplitter>());
     auto samples_table_view = TRY(samples_splitter->try_add<GUI::TableView>());
@@ -195,7 +195,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     auto signposts_tab = TRY(tab_widget->try_add_tab<GUI::Widget>("Signposts"));
-    (void)TRY(signposts_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
+    TRY(signposts_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
 
     auto signposts_splitter = TRY(signposts_tab->try_add<GUI::HorizontalSplitter>());
     auto signposts_table_view = TRY(signposts_splitter->try_add<GUI::TableView>());
@@ -209,7 +209,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     auto flamegraph_tab = TRY(tab_widget->try_add_tab<GUI::Widget>("Flame Graph"));
-    (void)TRY(flamegraph_tab->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 4, 4, 4 }));
+    TRY(flamegraph_tab->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 4, 4, 4 }));
 
     auto flamegraph_view = TRY(flamegraph_tab->try_add<FlameGraphView>(profile->model(), ProfileModel::Column::StackFrame, ProfileModel::Column::SampleCount));
 
@@ -257,7 +257,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     flamegraph_view->on_hover_change = [&] { statusbar_update(); };
 
     auto filesystem_events_tab = TRY(tab_widget->try_add_tab<GUI::Widget>("Filesystem events"));
-    (void)TRY(filesystem_events_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
+    TRY(filesystem_events_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
 
     auto filesystem_events_tree_view = TRY(filesystem_events_tab->try_add<GUI::TreeView>());
     filesystem_events_tree_view->set_should_fill_selected_rows(true);

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -132,8 +132,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto tab_widget = TRY(main_splitter->try_add<GUI::TabWidget>());
 
     auto tree_tab = TRY(tab_widget->try_add_tab<GUI::Widget>("Call Tree"));
-    tree_tab->set_layout<GUI::VerticalBoxLayout>();
-    tree_tab->layout()->set_margins(4);
+    (void)TRY(tree_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
     auto bottom_splitter = TRY(tree_tab->try_add<GUI::VerticalSplitter>());
 
     auto tree_view = TRY(bottom_splitter->try_add<GUI::TreeView>());
@@ -182,8 +181,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     });
 
     auto samples_tab = TRY(tab_widget->try_add_tab<GUI::Widget>("Samples"));
-    samples_tab->set_layout<GUI::VerticalBoxLayout>();
-    samples_tab->layout()->set_margins(4);
+    (void)TRY(samples_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
 
     auto samples_splitter = TRY(samples_tab->try_add<GUI::HorizontalSplitter>());
     auto samples_table_view = TRY(samples_splitter->try_add<GUI::TableView>());
@@ -197,8 +195,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     auto signposts_tab = TRY(tab_widget->try_add_tab<GUI::Widget>("Signposts"));
-    signposts_tab->set_layout<GUI::VerticalBoxLayout>();
-    signposts_tab->layout()->set_margins(4);
+    (void)TRY(signposts_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
 
     auto signposts_splitter = TRY(signposts_tab->try_add<GUI::HorizontalSplitter>());
     auto signposts_table_view = TRY(signposts_splitter->try_add<GUI::TableView>());
@@ -212,8 +209,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     auto flamegraph_tab = TRY(tab_widget->try_add_tab<GUI::Widget>("Flame Graph"));
-    flamegraph_tab->set_layout<GUI::VerticalBoxLayout>();
-    flamegraph_tab->layout()->set_margins({ 4, 4, 4, 4 });
+    (void)TRY(flamegraph_tab->try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 4, 4, 4 }));
 
     auto flamegraph_view = TRY(flamegraph_tab->try_add<FlameGraphView>(profile->model(), ProfileModel::Column::StackFrame, ProfileModel::Column::SampleCount));
 
@@ -261,8 +257,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     flamegraph_view->on_hover_change = [&] { statusbar_update(); };
 
     auto filesystem_events_tab = TRY(tab_widget->try_add_tab<GUI::Widget>("Filesystem events"));
-    filesystem_events_tab->set_layout<GUI::VerticalBoxLayout>();
-    filesystem_events_tab->layout()->set_margins(4);
+    (void)TRY(filesystem_events_tab->try_set_layout<GUI::VerticalBoxLayout>(4));
 
     auto filesystem_events_tree_view = TRY(filesystem_events_tab->try_add<GUI::TreeView>());
     filesystem_events_tree_view->set_should_fill_selected_rows(true);
@@ -320,8 +315,7 @@ static bool prompt_to_stop_profiling(pid_t pid, DeprecatedString const& process_
 
     auto widget = window->set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
     widget->set_fill_with_background_color(true);
-    auto& layout = widget->set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 0, 0, 16 });
+    widget->set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 0, 0, 16 });
 
     auto& timer_label = widget->add<GUI::Label>("...");
     Core::ElapsedTimer clock;

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -227,8 +227,7 @@ MainWidget::MainWidget()
     m_action_tab_widget = find_descendant_of_type_named<GUI::TabWidget>("action_tab_widget"sv);
 
     m_query_results_widget = m_action_tab_widget->add_tab<GUI::Widget>("Results");
-    m_query_results_widget->set_layout<GUI::VerticalBoxLayout>();
-    m_query_results_widget->layout()->set_margins(6);
+    m_query_results_widget->set_layout<GUI::VerticalBoxLayout>(6);
     m_query_results_table_view = m_query_results_widget->add<GUI::TableView>();
 
     m_action_tab_widget->on_tab_close_click = [this](auto&) {

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -60,7 +60,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     main_toolbar.layout()->set_margins({ 0, 6 });
 
     auto& board_widget_container = *main_widget->find_descendant_of_type_named<GUI::Widget>("board_widget_container");
-    (void)TRY(board_widget_container.try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 0));
+    TRY(board_widget_container.try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 0));
     auto board_widget = TRY(board_widget_container.try_add<BoardWidget>(board_rows, board_columns));
     board_widget->randomize_cells();
 

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -60,8 +60,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     main_toolbar.layout()->set_margins({ 0, 6 });
 
     auto& board_widget_container = *main_widget->find_descendant_of_type_named<GUI::Widget>("board_widget_container");
-    auto board_layout = TRY(board_widget_container.try_set_layout<GUI::VerticalBoxLayout>());
-    board_layout->set_spacing(0);
+    (void)TRY(board_widget_container.try_set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 0));
     auto board_widget = TRY(board_widget_container.try_add<BoardWidget>(board_rows, board_columns));
     board_widget->randomize_cells();
 

--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -124,9 +124,7 @@ void Game::show_score_card(bool game_over)
 
     auto score_widget = score_dialog->set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
     score_widget->set_fill_with_background_color(true);
-    auto& layout = score_widget->set_layout<GUI::HorizontalBoxLayout>();
-    layout.set_margins(10);
-    layout.set_spacing(15);
+    score_widget->set_layout<GUI::HorizontalBoxLayout>(10, 15);
 
     auto& card_container = score_widget->add<GUI::Widget>();
     auto& score_card = card_container.add<ScoreCard>(m_players, game_over);

--- a/Userland/Games/Hearts/SettingsDialog.cpp
+++ b/Userland/Games/Hearts/SettingsDialog.cpp
@@ -22,12 +22,10 @@ SettingsDialog::SettingsDialog(GUI::Window* parent, DeprecatedString player_name
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
     main_widget->set_fill_with_background_color(true);
 
-    auto& layout = main_widget->set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins(4);
+    main_widget->set_layout<GUI::VerticalBoxLayout>(4);
 
     auto& name_box = main_widget->add<GUI::Widget>();
-    auto& input_layout = name_box.set_layout<GUI::HorizontalBoxLayout>();
-    input_layout.set_spacing(4);
+    name_box.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 4);
 
     auto& name_label = name_box.add<GUI::Label>("Name:");
     name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -39,8 +37,7 @@ SettingsDialog::SettingsDialog(GUI::Window* parent, DeprecatedString player_name
     };
 
     auto& button_box = main_widget->add<GUI::Widget>();
-    auto& button_layout = button_box.set_layout<GUI::HorizontalBoxLayout>();
-    button_layout.set_spacing(10);
+    button_box.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 12);
 
     button_box.add<GUI::Button>(String::from_utf8_short_string("Cancel"sv)).on_click = [this](auto) {
         done(ExecResult::Cancel);

--- a/Userland/Libraries/LibGUI/BoxLayout.cpp
+++ b/Userland/Libraries/LibGUI/BoxLayout.cpp
@@ -17,8 +17,9 @@ REGISTER_LAYOUT(GUI, VerticalBoxLayout)
 
 namespace GUI {
 
-BoxLayout::BoxLayout(Orientation orientation)
-    : m_orientation(orientation)
+BoxLayout::BoxLayout(Orientation orientation, Margins margins, int spacing)
+    : Layout(margins, spacing)
+    , m_orientation(orientation)
 {
     register_property(
         "orientation", [this] { return m_orientation == Gfx::Orientation::Vertical ? "Vertical" : "Horizontal"; }, nullptr);

--- a/Userland/Libraries/LibGUI/BoxLayout.h
+++ b/Userland/Libraries/LibGUI/BoxLayout.h
@@ -26,7 +26,7 @@ public:
     virtual UISize min_size() const override;
 
 protected:
-    explicit BoxLayout(Gfx::Orientation);
+    explicit BoxLayout(Gfx::Orientation, Margins = {}, int spacing = Layout::default_spacing);
 
 private:
     Gfx::Orientation m_orientation;
@@ -36,8 +36,8 @@ class VerticalBoxLayout final : public BoxLayout {
     C_OBJECT(VerticalBoxLayout);
 
 private:
-    explicit VerticalBoxLayout()
-        : BoxLayout(Gfx::Orientation::Vertical)
+    explicit VerticalBoxLayout(Margins margins = {}, int spacing = Layout::default_spacing)
+        : BoxLayout(Gfx::Orientation::Vertical, margins, spacing)
     {
     }
     virtual ~VerticalBoxLayout() override = default;
@@ -47,8 +47,8 @@ class HorizontalBoxLayout final : public BoxLayout {
     C_OBJECT(HorizontalBoxLayout);
 
 private:
-    explicit HorizontalBoxLayout()
-        : BoxLayout(Gfx::Orientation::Horizontal)
+    explicit HorizontalBoxLayout(Margins margins = {}, int spacing = Layout::default_spacing)
+        : BoxLayout(Gfx::Orientation::Horizontal, margins, spacing)
     {
     }
     virtual ~HorizontalBoxLayout() override = default;

--- a/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
@@ -60,8 +60,7 @@ private:
 
 Breadcrumbbar::Breadcrumbbar()
 {
-    auto& layout = set_layout<HorizontalBoxLayout>();
-    layout.set_spacing(0);
+    set_layout<HorizontalBoxLayout>(GUI::Margins {}, 0);
 }
 
 void Breadcrumbbar::clear_segments()

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -207,31 +207,25 @@ void ColorPicker::set_color_has_alpha_channel(bool has_alpha)
 void ColorPicker::build_ui()
 {
     auto root_container = set_main_widget<Widget>().release_value_but_fixme_should_propagate_errors();
-    root_container->set_layout<VerticalBoxLayout>();
-    root_container->layout()->set_margins(4);
+    root_container->set_layout<VerticalBoxLayout>(4);
     root_container->set_fill_with_background_color(true);
 
     auto& tab_widget = root_container->add<GUI::TabWidget>();
 
     auto& tab_palette = tab_widget.add_tab<Widget>("Palette");
-    tab_palette.set_layout<VerticalBoxLayout>();
-    tab_palette.layout()->set_margins(4);
-    tab_palette.layout()->set_spacing(4);
+    tab_palette.set_layout<VerticalBoxLayout>(4, 4);
 
     build_ui_palette(tab_palette);
 
     auto& tab_custom_color = tab_widget.add_tab<Widget>("Custom Color");
-    tab_custom_color.set_layout<VerticalBoxLayout>();
-    tab_custom_color.layout()->set_margins(4);
-    tab_custom_color.layout()->set_spacing(4);
+    tab_custom_color.set_layout<VerticalBoxLayout>(4, 4);
 
     build_ui_custom(tab_custom_color);
 
     auto& button_container = root_container->add<Widget>();
     button_container.set_preferred_height(GUI::SpecialDimension::Fit);
-    button_container.set_layout<HorizontalBoxLayout>();
-    button_container.layout()->set_spacing(4);
-    button_container.layout()->add_spacer();
+    button_container.set_layout<HorizontalBoxLayout>(4);
+    button_container.add_spacer().release_value_but_fixme_should_propagate_errors();
 
     auto& ok_button = button_container.add<DialogButton>();
     ok_button.set_text(String::from_utf8_short_string("OK"sv));
@@ -315,14 +309,11 @@ void ColorPicker::build_ui_custom(Widget& root_container)
 
     // Right Side
     auto& vertical_container = horizontal_container.add<Widget>();
-    vertical_container.set_layout<VerticalBoxLayout>();
-    vertical_container.layout()->set_margins({ 0, 0, 0, 8 });
+    vertical_container.set_layout<VerticalBoxLayout>(GUI::Margins { 0, 0, 0, 8 });
     vertical_container.set_min_width(120);
 
     auto& preview_container = vertical_container.add<Frame>();
-    preview_container.set_layout<VerticalBoxLayout>();
-    preview_container.layout()->set_margins(2);
-    preview_container.layout()->set_spacing(0);
+    preview_container.set_layout<VerticalBoxLayout>(2, 0);
     preview_container.set_fixed_height(100);
 
     // Current color

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -331,7 +331,7 @@ void ColorPicker::build_ui_custom(Widget& root_container)
     // Preview selected color
     m_preview_widget = preview_container.add<ColorPreview>(m_color);
 
-    vertical_container.layout()->add_spacer();
+    vertical_container.add_spacer().release_value_but_fixme_should_propagate_errors();
 
     // HTML
     auto& html_container = vertical_container.add<GUI::Widget>();

--- a/Userland/Libraries/LibGUI/CommandPalette.cpp
+++ b/Userland/Libraries/LibGUI/CommandPalette.cpp
@@ -186,8 +186,7 @@ CommandPalette::CommandPalette(GUI::Window& parent_window, ScreenPosition screen
     main_widget->set_frame_shape(Gfx::FrameShape::Window);
     main_widget->set_fill_with_background_color(true);
 
-    auto& layout = main_widget->set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins(4);
+    main_widget->set_layout<GUI::VerticalBoxLayout>(4);
 
     m_text_box = main_widget->add<GUI::TextBox>();
     m_table_view = main_widget->add<GUI::TableView>();

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -219,9 +219,7 @@ void EmojiInputDialog::update_displayed_emoji()
     for (size_t row = 0; row < rows && index < m_emojis.size(); ++row) {
         auto& horizontal_container = m_emojis_widget->add<Widget>();
         horizontal_container.set_preferred_height(SpecialDimension::Fit);
-
-        auto& horizontal_layout = horizontal_container.set_layout<HorizontalBoxLayout>();
-        horizontal_layout.set_spacing(0);
+        horizontal_container.set_layout<HorizontalBoxLayout>(GUI::Margins {}, 0);
 
         for (size_t column = 0; column < columns; ++column) {
             bool found_match = false;

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -104,7 +104,7 @@ void InputBox::build()
     button_container_inner.set_layout<HorizontalBoxLayout>();
     button_container_inner.set_preferred_height(SpecialDimension::Fit);
     button_container_inner.layout()->set_spacing(6);
-    button_container_inner.layout()->add_spacer();
+    button_container_inner.add_spacer().release_value_but_fixme_should_propagate_errors();
 
     m_ok_button = button_container_inner.add<DialogButton>();
     m_ok_button->set_text(String::from_utf8_short_string("OK"sv));

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -67,12 +67,9 @@ void InputBox::build()
     int title_width = widget->font().width(title()) + 24 /* icon, plus a little padding -- not perfect */;
     int max_width = max(text_width, title_width);
 
-    widget->set_layout<VerticalBoxLayout>();
+    widget->set_layout<VerticalBoxLayout>(6, 6);
     widget->set_fill_with_background_color(true);
     widget->set_preferred_height(SpecialDimension::Fit);
-
-    widget->layout()->set_margins(6);
-    widget->layout()->set_spacing(6);
 
     auto& label_editor_container = widget->add<Widget>();
     label_editor_container.set_layout<HorizontalBoxLayout>();
@@ -101,9 +98,8 @@ void InputBox::build()
     button_container_outer.set_layout<VerticalBoxLayout>();
 
     auto& button_container_inner = button_container_outer.add<Widget>();
-    button_container_inner.set_layout<HorizontalBoxLayout>();
+    button_container_inner.set_layout<HorizontalBoxLayout>(GUI::Margins {}, 6);
     button_container_inner.set_preferred_height(SpecialDimension::Fit);
-    button_container_inner.layout()->set_spacing(6);
     button_container_inner.add_spacer().release_value_but_fixme_should_propagate_errors();
 
     m_ok_button = button_container_inner.add<DialogButton>();

--- a/Userland/Libraries/LibGUI/Layout.cpp
+++ b/Userland/Libraries/LibGUI/Layout.cpp
@@ -14,7 +14,9 @@ REGISTER_ABSTRACT_CORE_OBJECT(GUI, Layout)
 
 namespace GUI {
 
-Layout::Layout()
+Layout::Layout(Margins initial_margins, int spacing)
+    : m_margins(initial_margins)
+    , m_spacing(spacing)
 {
     REGISTER_INT_PROPERTY("spacing", spacing, set_spacing);
     REGISTER_MARGINS_PROPERTY("margins", margins, set_margins);

--- a/Userland/Libraries/LibGUI/Layout.h
+++ b/Userland/Libraries/LibGUI/Layout.h
@@ -58,11 +58,12 @@ public:
     Margins const& margins() const { return m_margins; }
     void set_margins(Margins const&);
 
+    static constexpr int default_spacing = 3;
     int spacing() const { return m_spacing; }
     void set_spacing(int);
 
 protected:
-    Layout();
+    Layout(Margins, int spacing);
 
     struct Entry {
         enum class Type {
@@ -83,7 +84,7 @@ protected:
     Vector<Entry> m_entries;
 
     Margins m_margins;
-    int m_spacing { 3 };
+    int m_spacing { default_spacing };
 };
 
 }

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -121,15 +121,11 @@ void MessageBox::build()
     int total_text_height = number_of_lines * padded_text_height;
     int icon_width = 0;
 
-    widget->set_layout<VerticalBoxLayout>();
+    widget->set_layout<VerticalBoxLayout>(8, 6);
     widget->set_fill_with_background_color(true);
 
-    widget->layout()->set_margins(8);
-    widget->layout()->set_spacing(6);
-
     auto& message_container = widget->add<Widget>();
-    message_container.set_layout<HorizontalBoxLayout>();
-    message_container.layout()->set_spacing(8);
+    message_container.set_layout<HorizontalBoxLayout>(GUI::Margins {}, 8);
 
     if (m_type != Type::None) {
         auto& icon_image = message_container.add<ImageWidget>();
@@ -147,9 +143,8 @@ void MessageBox::build()
         label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
     auto& button_container = widget->add<Widget>();
-    button_container.set_layout<HorizontalBoxLayout>();
+    button_container.set_layout<HorizontalBoxLayout>(GUI::Margins {}, 8);
     button_container.set_fixed_height(24);
-    button_container.layout()->set_spacing(8);
 
     constexpr int button_width = 80;
     int button_count = 0;

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -165,7 +165,7 @@ void MessageBox::build()
         return button;
     };
 
-    button_container.layout()->add_spacer();
+    button_container.add_spacer().release_value_but_fixme_should_propagate_errors();
     if (should_include_ok_button())
         m_ok_button = add_button(String::from_utf8_short_string("OK"sv), ExecResult::OK);
     if (should_include_yes_button())
@@ -174,7 +174,7 @@ void MessageBox::build()
         m_no_button = add_button(String::from_utf8_short_string("No"sv), ExecResult::No);
     if (should_include_cancel_button())
         m_cancel_button = add_button(String::from_utf8_short_string("Cancel"sv), ExecResult::Cancel);
-    button_container.layout()->add_spacer();
+    button_container.add_spacer().release_value_but_fixme_should_propagate_errors();
 
     int width = (button_count * button_width) + ((button_count - 1) * button_container.layout()->spacing()) + 32;
     width = max(width, text_width + icon_width + 56);

--- a/Userland/Libraries/LibGUI/ProcessChooser.cpp
+++ b/Userland/Libraries/LibGUI/ProcessChooser.cpp
@@ -50,7 +50,7 @@ ProcessChooser::ProcessChooser(StringView window_title, String button_label, Gfx
     button_container.set_fixed_height(30);
     button_container.set_layout<GUI::HorizontalBoxLayout>();
     button_container.layout()->set_margins({ 0, 4, 0 });
-    button_container.layout()->add_spacer();
+    button_container.add_spacer().release_value_but_fixme_should_propagate_errors();
 
     auto& select_button = button_container.add<GUI::Button>(m_button_label);
     select_button.set_fixed_width(80);

--- a/Userland/Libraries/LibGUI/ProcessChooser.cpp
+++ b/Userland/Libraries/LibGUI/ProcessChooser.cpp
@@ -48,8 +48,7 @@ ProcessChooser::ProcessChooser(StringView window_title, String button_label, Gfx
 
     auto& button_container = widget->add<GUI::Widget>();
     button_container.set_fixed_height(30);
-    button_container.set_layout<GUI::HorizontalBoxLayout>();
-    button_container.layout()->set_margins({ 0, 4, 0 });
+    button_container.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 0, 4, 0 });
     button_container.add_spacer().release_value_but_fixme_should_propagate_errors();
 
     auto& select_button = button_container.add<GUI::Button>(m_button_label);

--- a/Userland/Libraries/LibGUI/SettingsWindow.cpp
+++ b/Userland/Libraries/LibGUI/SettingsWindow.cpp
@@ -34,13 +34,13 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(DeprecatedString t
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
-    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>(4, 6));
+    TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>(4, 6));
 
     window->m_tab_widget = TRY(main_widget->try_add<GUI::TabWidget>());
 
     auto button_container = TRY(main_widget->try_add<GUI::Widget>());
     button_container->set_preferred_size({ SpecialDimension::Grow, SpecialDimension::Fit });
-    (void)TRY(button_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 6));
+    TRY(button_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 6));
 
     if (show_defaults_button == ShowDefaultsButton::Yes) {
         window->m_reset_button = TRY(button_container->try_add<GUI::DialogButton>(TRY(String::from_utf8("Defaults"sv))));

--- a/Userland/Libraries/LibGUI/SettingsWindow.cpp
+++ b/Userland/Libraries/LibGUI/SettingsWindow.cpp
@@ -34,16 +34,13 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(DeprecatedString t
 
     auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
-    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
-    main_widget->layout()->set_margins(4);
-    main_widget->layout()->set_spacing(6);
+    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>(4, 6));
 
     window->m_tab_widget = TRY(main_widget->try_add<GUI::TabWidget>());
 
     auto button_container = TRY(main_widget->try_add<GUI::Widget>());
     button_container->set_preferred_size({ SpecialDimension::Grow, SpecialDimension::Fit });
-    (void)TRY(button_container->try_set_layout<GUI::HorizontalBoxLayout>());
-    button_container->layout()->set_spacing(6);
+    (void)TRY(button_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 6));
 
     if (show_defaults_button == ShowDefaultsButton::Yes) {
         window->m_reset_button = TRY(button_container->try_add<GUI::DialogButton>(TRY(String::from_utf8("Defaults"sv))));

--- a/Userland/Libraries/LibGUI/SettingsWindow.cpp
+++ b/Userland/Libraries/LibGUI/SettingsWindow.cpp
@@ -52,7 +52,7 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(DeprecatedString t
         };
     }
 
-    TRY(button_container->layout()->try_add_spacer());
+    TRY(button_container->add_spacer());
 
     window->m_ok_button = TRY(button_container->try_add<GUI::DialogButton>(String::from_utf8_short_string("OK"sv)));
     window->m_ok_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) {

--- a/Userland/Libraries/LibGUI/Statusbar.cpp
+++ b/Userland/Libraries/LibGUI/Statusbar.cpp
@@ -20,9 +20,7 @@ namespace GUI {
 Statusbar::Statusbar(int count)
 {
     set_fixed_height(18);
-    set_layout<HorizontalBoxLayout>();
-    layout()->set_margins(0);
-    layout()->set_spacing(2);
+    set_layout<HorizontalBoxLayout>(0, 2);
 
     m_corner = add<ResizeCorner>();
     set_segment_count(count);

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -176,7 +176,7 @@ ErrorOr<void> Toolbar::create_overflow_objects()
     m_overflow_action->set_status_tip("Show hidden toolbar actions");
     m_overflow_action->set_enabled(false);
 
-    TRY(layout()->try_add_spacer());
+    TRY(add_spacer());
 
     m_overflow_button = TRY(try_add_action(*m_overflow_action));
     m_overflow_button->set_visible(false);

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -34,9 +34,7 @@ Toolbar::Toolbar(Orientation orientation, int button_size)
     else
         set_fixed_width(button_size);
 
-    set_layout<BoxLayout>(orientation);
-    layout()->set_spacing(0);
-    layout()->set_margins({ 2, 2, 2, 2 });
+    set_layout<BoxLayout>(orientation, GUI::Margins { 2, 2, 2, 2 }, 0);
 }
 
 class ToolbarButton final : public Button {

--- a/Userland/Libraries/LibGUI/ToolbarContainer.cpp
+++ b/Userland/Libraries/LibGUI/ToolbarContainer.cpp
@@ -23,8 +23,7 @@ ToolbarContainer::ToolbarContainer(Gfx::Orientation orientation)
     set_frame_shape(Gfx::FrameShape::Box);
     set_frame_shadow(Gfx::FrameShadow::Sunken);
 
-    auto& layout = set_layout<VerticalBoxLayout>();
-    layout.set_spacing(2);
+    set_layout<VerticalBoxLayout>(GUI::Margins {}, 2);
     set_shrink_to_fit(true);
 }
 

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -1266,4 +1266,10 @@ bool Widget::is_visible_for_timer_purposes() const
     return is_visible() && Object::is_visible_for_timer_purposes();
 }
 
+ErrorOr<void> Widget::add_spacer()
+{
+    VERIFY(layout());
+    return layout()->try_add_spacer();
+}
+
 }

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -366,6 +366,8 @@ public:
     // In order for others to be able to call this, it needs to be public.
     virtual ErrorOr<void> load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, UnregisteredChildHandler);
 
+    ErrorOr<void> add_spacer();
+
 protected:
     Widget();
 

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -83,19 +83,18 @@ public:
     void set_layout(NonnullRefPtr<Layout>);
 
     template<class T, class... Args>
-    ErrorOr<NonnullRefPtr<T>> try_set_layout(Args&&... args)
+    ErrorOr<void> try_set_layout(Args&&... args)
     {
         auto layout = TRY(T::try_create(forward<Args>(args)...));
         set_layout(*layout);
-        return layout;
+        return {};
     }
 
     template<class T, class... Args>
-    inline T& set_layout(Args&&... args)
+    inline void set_layout(Args&&... args)
     {
         auto layout = T::construct(forward<Args>(args)...);
         set_layout(*layout);
-        return layout;
     }
 
     UISize min_size() const { return m_min_size; }

--- a/Userland/Libraries/LibGUI/Wizards/CoverWizardPage.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/CoverWizardPage.cpp
@@ -24,8 +24,7 @@ CoverWizardPage::CoverWizardPage()
     m_banner_image_widget->load_from_file("/res/graphics/wizard-banner-simple.png"sv);
 
     m_content_widget = add<Widget>();
-    m_content_widget->set_layout<VerticalBoxLayout>();
-    m_content_widget->layout()->set_margins(20);
+    m_content_widget->set_layout<VerticalBoxLayout>(20);
 
     m_header_label = m_content_widget->add<Label>();
     m_header_label->set_font(Gfx::FontDatabase::the().get("Pebbleton", 14, 700, Gfx::FontWidth::Normal, 0));

--- a/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
@@ -44,7 +44,7 @@ WizardDialog::WizardDialog(Window* parent_window)
     nav_container_widget.set_fixed_height(42);
     nav_container_widget.layout()->set_margins({ 0, 10 });
     nav_container_widget.layout()->set_spacing(0);
-    nav_container_widget.layout()->add_spacer();
+    nav_container_widget.add_spacer().release_value_but_fixme_should_propagate_errors();
 
     m_back_button = nav_container_widget.add<DialogButton>(String::from_utf8_short_string("< Back"sv));
     m_back_button->on_click = [&](auto) {

--- a/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
@@ -29,8 +29,7 @@ WizardDialog::WizardDialog(Window* parent_window)
 
     auto main_widget = set_main_widget<Widget>().release_value_but_fixme_should_propagate_errors();
     main_widget->set_fill_with_background_color(true);
-    main_widget->set_layout<VerticalBoxLayout>();
-    main_widget->layout()->set_spacing(0);
+    main_widget->set_layout<VerticalBoxLayout>(GUI::Margins {}, 0);
 
     m_page_container_widget = main_widget->add<Widget>();
     m_page_container_widget->set_fixed_size(500, 315);
@@ -40,10 +39,8 @@ WizardDialog::WizardDialog(Window* parent_window)
     separator.set_fixed_height(2);
 
     auto& nav_container_widget = main_widget->add<Widget>();
-    nav_container_widget.set_layout<HorizontalBoxLayout>();
+    nav_container_widget.set_layout<HorizontalBoxLayout>(GUI::Margins { 0, 10 }, 0);
     nav_container_widget.set_fixed_height(42);
-    nav_container_widget.layout()->set_margins({ 0, 10 });
-    nav_container_widget.layout()->set_spacing(0);
     nav_container_widget.add_spacer().release_value_but_fixme_should_propagate_errors();
 
     m_back_button = nav_container_widget.add<DialogButton>(String::from_utf8_short_string("< Back"sv));

--- a/Userland/Libraries/LibGUI/Wizards/WizardPage.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/WizardPage.cpp
@@ -17,16 +17,14 @@ namespace GUI {
 WizardPage::WizardPage(DeprecatedString const& title_text, DeprecatedString const& subtitle_text)
     : AbstractWizardPage()
 {
-    set_layout<VerticalBoxLayout>();
-    layout()->set_spacing(0);
+    set_layout<VerticalBoxLayout>(GUI::Margins {}, 0);
 
     auto& header_widget = add<Widget>();
     header_widget.set_fill_with_background_color(true);
     header_widget.set_background_role(Gfx::ColorRole::Base);
     header_widget.set_fixed_height(58);
 
-    header_widget.set_layout<VerticalBoxLayout>();
-    header_widget.layout()->set_margins({ 15, 30, 0 });
+    header_widget.set_layout<VerticalBoxLayout>(GUI::Margins { 15, 30, 0 });
     m_title_label = header_widget.add<Label>(title_text);
     m_title_label->set_font(Gfx::FontDatabase::default_font().bold_variant());
     m_title_label->set_fixed_height(m_title_label->font().glyph_height() + 2);
@@ -40,8 +38,7 @@ WizardPage::WizardPage(DeprecatedString const& title_text, DeprecatedString cons
     separator.set_fixed_height(2);
 
     m_body_widget = add<Widget>();
-    m_body_widget->set_layout<VerticalBoxLayout>();
-    m_body_widget->layout()->set_margins(20);
+    m_body_widget->set_layout<VerticalBoxLayout>(20);
 }
 
 void WizardPage::set_page_title(DeprecatedString const& text)

--- a/Userland/Libraries/LibGUI/Wizards/WizardPage.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/WizardPage.cpp
@@ -34,7 +34,7 @@ WizardPage::WizardPage(DeprecatedString const& title_text, DeprecatedString cons
     m_subtitle_label = header_widget.add<Label>(subtitle_text);
     m_subtitle_label->set_text_alignment(Gfx::TextAlignment::TopLeft);
     m_subtitle_label->set_fixed_height(m_subtitle_label->font().glyph_height());
-    header_widget.layout()->add_spacer();
+    header_widget.add_spacer().release_value_but_fixme_should_propagate_errors();
 
     auto& separator = add<SeparatorWidget>(Gfx::Orientation::Horizontal);
     separator.set_fixed_height(2);

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -70,9 +70,7 @@ NotificationWindow::NotificationWindow(i32 client_id, DeprecatedString const& te
     auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
 
     widget->set_fill_with_background_color(true);
-    widget->set_layout<GUI::HorizontalBoxLayout>();
-    widget->layout()->set_margins(8);
-    widget->layout()->set_spacing(6);
+    widget->set_layout<GUI::HorizontalBoxLayout>(8, 6);
 
     m_image = &widget->add<GUI::ImageWidget>();
     m_image->set_visible(icon.is_valid());

--- a/Userland/Services/Taskbar/ClockWidget.cpp
+++ b/Userland/Services/Taskbar/ClockWidget.cpp
@@ -43,15 +43,12 @@ ClockWidget::ClockWidget()
 
     auto root_container = m_calendar_window->set_main_widget<GUI::Frame>().release_value_but_fixme_should_propagate_errors();
     root_container->set_fill_with_background_color(true);
-    root_container->set_layout<GUI::VerticalBoxLayout>();
-    root_container->layout()->set_margins({ 2, 0 });
-    root_container->layout()->set_spacing(0);
+    root_container->set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 2, 0 }, 0);
     root_container->set_frame_shape(Gfx::FrameShape::Window);
 
     auto& navigation_container = root_container->add<GUI::Widget>();
     navigation_container.set_fixed_height(24);
-    navigation_container.set_layout<GUI::HorizontalBoxLayout>();
-    navigation_container.layout()->set_margins({ 2 });
+    navigation_container.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 2 });
 
     m_prev_date = navigation_container.add<GUI::Button>();
     m_prev_date->set_button_style(Gfx::ButtonStyle::Coolbar);
@@ -114,8 +111,7 @@ ClockWidget::ClockWidget()
     separator1.set_fixed_height(2);
 
     auto& calendar_container = root_container->add<GUI::Widget>();
-    calendar_container.set_layout<GUI::HorizontalBoxLayout>();
-    calendar_container.layout()->set_margins({ 2 });
+    calendar_container.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 2 });
 
     m_calendar = calendar_container.add<GUI::Calendar>();
     m_selected_calendar_button->set_text(m_calendar->formatted_date().release_value_but_fixme_should_propagate_errors());
@@ -133,8 +129,7 @@ ClockWidget::ClockWidget()
 
     auto& settings_container = root_container->add<GUI::Widget>();
     settings_container.set_fixed_height(24);
-    settings_container.set_layout<GUI::HorizontalBoxLayout>();
-    settings_container.layout()->set_margins({ 2 });
+    settings_container.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 2 });
     settings_container.add_spacer().release_value_but_fixme_should_propagate_errors();
 
     m_jump_to_button = settings_container.add<GUI::Button>();

--- a/Userland/Services/Taskbar/ClockWidget.cpp
+++ b/Userland/Services/Taskbar/ClockWidget.cpp
@@ -135,7 +135,7 @@ ClockWidget::ClockWidget()
     settings_container.set_fixed_height(24);
     settings_container.set_layout<GUI::HorizontalBoxLayout>();
     settings_container.layout()->set_margins({ 2 });
-    settings_container.layout()->add_spacer();
+    settings_container.add_spacer().release_value_but_fixme_should_propagate_errors();
 
     m_jump_to_button = settings_container.add<GUI::Button>();
     m_jump_to_button->set_button_style(Gfx::ButtonStyle::Coolbar);

--- a/Userland/Services/Taskbar/QuickLaunchWidget.cpp
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.cpp
@@ -105,8 +105,7 @@ ErrorOr<NonnullRefPtr<QuickLaunchWidget>> QuickLaunchWidget::create()
 QuickLaunchWidget::QuickLaunchWidget()
 {
     set_shrink_to_fit(true);
-    set_layout<GUI::HorizontalBoxLayout>();
-    layout()->set_spacing(0);
+    set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 0);
     set_frame_thickness(0);
     set_fixed_height(24);
 }

--- a/Userland/Services/Taskbar/ShutdownDialog.cpp
+++ b/Userland/Services/Taskbar/ShutdownDialog.cpp
@@ -96,7 +96,7 @@ ShutdownDialog::ShutdownDialog()
     button_container.set_fixed_height(23);
     button_container.set_layout<GUI::HorizontalBoxLayout>();
     button_container.layout()->set_spacing(5);
-    button_container.layout()->add_spacer();
+    button_container.add_spacer().release_value_but_fixme_should_propagate_errors();
     auto& ok_button = button_container.add<GUI::Button>(String::from_utf8_short_string("OK"sv));
     ok_button.set_fixed_size(80, 23);
     ok_button.on_click = [this](auto) {

--- a/Userland/Services/Taskbar/ShutdownDialog.cpp
+++ b/Userland/Services/Taskbar/ShutdownDialog.cpp
@@ -44,8 +44,7 @@ ShutdownDialog::ShutdownDialog()
 {
     auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
     widget->set_fill_with_background_color(true);
-    widget->set_layout<GUI::VerticalBoxLayout>();
-    widget->layout()->set_spacing(0);
+    widget->set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 0);
 
     auto& banner_image = widget->add<GUI::ImageWidget>();
     banner_image.load_from_file("/res/graphics/brand-banner.png"sv);
@@ -55,8 +54,7 @@ ShutdownDialog::ShutdownDialog()
 
     auto& left_container = content_container.add<GUI::Widget>();
     left_container.set_fixed_width(60);
-    left_container.set_layout<GUI::VerticalBoxLayout>();
-    left_container.layout()->set_margins({ 12, 0, 0 });
+    left_container.set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 12, 0, 0 });
 
     auto& icon_wrapper = left_container.add<GUI::Widget>();
     icon_wrapper.set_fixed_size(32, 48);
@@ -66,8 +64,7 @@ ShutdownDialog::ShutdownDialog()
     icon_image.set_bitmap(Gfx::Bitmap::load_from_file("/res/icons/32x32/shutdown.png"sv).release_value_but_fixme_should_propagate_errors());
 
     auto& right_container = content_container.add<GUI::Widget>();
-    right_container.set_layout<GUI::VerticalBoxLayout>();
-    right_container.layout()->set_margins({ 12, 12, 8, 0 });
+    right_container.set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 12, 12, 8, 0 });
 
     auto& label = right_container.add<GUI::Label>("What would you like to do?");
     label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -90,12 +87,11 @@ ShutdownDialog::ShutdownDialog()
         }
     }
 
-    right_container.layout()->add_spacer();
+    right_container.add_spacer().release_value_but_fixme_should_propagate_errors();
 
     auto& button_container = right_container.add<GUI::Widget>();
     button_container.set_fixed_height(23);
-    button_container.set_layout<GUI::HorizontalBoxLayout>();
-    button_container.layout()->set_spacing(5);
+    button_container.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 5);
     button_container.add_spacer().release_value_but_fixme_should_propagate_errors();
     auto& ok_button = button_container.add<GUI::Button>(String::from_utf8_short_string("OK"sv));
     ok_button.set_fixed_size(80, 23);

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -73,13 +73,13 @@ TaskbarWindow::TaskbarWindow()
 ErrorOr<void> TaskbarWindow::populate_taskbar()
 {
     auto main_widget = TRY(set_main_widget<TaskbarWidget>());
-    (void)TRY(main_widget->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 2, 3, 0, 3 }));
+    TRY(main_widget->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 2, 3, 0, 3 }));
 
     m_quick_launch = TRY(Taskbar::QuickLaunchWidget::create());
     TRY(main_widget->try_add_child(*m_quick_launch));
 
     m_task_button_container = TRY(main_widget->try_add<GUI::Widget>());
-    (void)TRY(m_task_button_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 3));
+    TRY(m_task_button_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 3));
 
     m_default_icon = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/window.png"sv));
 

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -73,15 +73,13 @@ TaskbarWindow::TaskbarWindow()
 ErrorOr<void> TaskbarWindow::populate_taskbar()
 {
     auto main_widget = TRY(set_main_widget<TaskbarWidget>());
-    (void)TRY(main_widget->try_set_layout<GUI::HorizontalBoxLayout>());
-    main_widget->layout()->set_margins({ 2, 3, 0, 3 });
+    (void)TRY(main_widget->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 2, 3, 0, 3 }));
 
     m_quick_launch = TRY(Taskbar::QuickLaunchWidget::create());
     TRY(main_widget->try_add_child(*m_quick_launch));
 
     m_task_button_container = TRY(main_widget->try_add<GUI::Widget>());
-    (void)TRY(m_task_button_container->try_set_layout<GUI::HorizontalBoxLayout>());
-    m_task_button_container->layout()->set_spacing(3);
+    (void)TRY(m_task_button_container->try_set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 3));
 
     m_default_icon = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/window.png"sv));
 


### PR DESCRIPTION
Before:
```c++
(void)TRY(widget.try_set_layout<BoxLayout>(orientation));
widget.layout()->set_margins({ 2, 2, 2, 2 });
widget.layout()->set_spacing(0);

// (Or, saving the value returning by try_set_layout() and then calling set_foo() on it.)

// ...

TRY(widget.layout()->try_add_spacer());
```

After:
```c++
TRY(widget.set_layout<BoxLayout>(orientation, GUI::Margins { 2, 2, 2, 2 }, 0));

// ...

TRY(widget.add_spacer());
```
