### PR TITLE
Presenter: Fix unintentional U+00A0 codepoint in text

### DIFF
--- a/Base/usr/share/man/man5/presenter.md
+++ b/Base/usr/share/man/man5/presenter.md
@@ -46,7 +46,7 @@ The slides array contains a list of slide objects, their JSON order determines t
 
 Most slide objects are graphical objects of one of the pre-defined types. All graphical objects, like GUI widgets, have a bounding box rectangle which determines their position and size. Objects choose which frames they appear on.
 
-In the file format, slide objects are JSON objects with the following basic properties:
+In the file format, slide objects are JSON objects with the following basic properties:
 
 -   `type`: (string enum) Specifies the type of the slide object and what other properties the object may have, see below.
 -   `rect`: (4-element array of integers: `[left, top, width, height]`, optional) Specifies the bounding box of the object. Is mandatory for most types.


### PR DESCRIPTION
U+00A0 is "NO-BREAK SPACE", looks exactly like U+0020 "SPACE", but behaves slightly differently. You might know it as "that annoying thing that looks like a space but is a special non-ASCII thing and breaks everything". Here it didn't cause any actual issue, but let's remove it just to be sure.

Found using `git grep -FIn $'\u00a0'` (works only in bash but not dash)

I just got bit by this type of bug in a different project, and was wondering whether Serenity has this problem, too. See also: https://dhwthompson.com/2019/my-favourite-git-commit

Note that there are some legitimate uses of U+00A0 in the codebase, specifically:

```
Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js:27:        expect(ar.format()).toBe("ليس رقم");
Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js:28:        expect(ar.format(NaN)).toBe("ليس رقم");
Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js:29:        expect(ar.format(undefined)).toBe("ليس رقم");
Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatToParts.js:23:        expect(ar.formatToParts()).toEqual([{ type: "nan", value: "ليس رقم" }]);
Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatToParts.js:24:        expect(ar.formatToParts(NaN)).toEqual([{ type: "nan", value: "ليس رقم" }]);
Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatToParts.js:25:        expect(ar.formatToParts(undefined)).toEqual([{ type: "nan", value: "ليس رقم" }]);
Userland/Libraries/LibJS/Tests/builtins/Number/Number.prototype.toLocaleString.js:22:        expect(NaN.toLocaleString("ar")).toBe("ليس رقم");
```

Given that this only occurred once, and that a linter won't be completely trivial (reading and checking the entire repo isn't totally free afterall), I'm not going to write yet another linter. We already have enough linters of questionable value.

EDIT: Initial description of U+00A0.