### PR TITLE
LibGfx: Use premultiplied alpha when scaling images

### DIFF
--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TEST_SOURCES
     TestFontHandling.cpp
     TestICCProfile.cpp
     TestImageDecoder.cpp
+    TestScalingFunctions.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibGfx/TestScalingFunctions.cpp
+++ b/Tests/LibGfx/TestScalingFunctions.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/Painter.h>
+#include <LibTest/TestCase.h>
+
+// Scaling modes which use linear interpolation should use premultiplied alpha.
+// This prevents colors from changing hue unexpectedly when there is a change in opacity.
+// This test uses an image that transitions from a completely opaque pixel in the top left to a completely transparent background.
+// We ensure that premultipled alpha is used by checking that the RGB values of the interpolated pixels do not change, just the alpha values.
+TEST_CASE(test_painter_scaling_uses_premultiplied_alpha)
+{
+    auto test_scaling_mode = [](auto scaling_mode) {
+        auto src_bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { 2, 2 }));
+        src_bitmap->fill(Color::Transparent);
+        src_bitmap->set_pixel({ 0, 0 }, Color::White);
+
+        auto scaled_bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { 5, 5 }));
+        scaled_bitmap->fill(Color::Transparent);
+
+        Gfx::Painter painter(scaled_bitmap);
+        painter.draw_scaled_bitmap(scaled_bitmap->rect(), src_bitmap, src_bitmap->rect(), 1.0f, scaling_mode);
+
+        auto top_left_pixel = scaled_bitmap->get_pixel(0, 0);
+        EXPECT_EQ(top_left_pixel, Color::White);
+
+        auto center_pixel = scaled_bitmap->get_pixel(scaled_bitmap->rect().center());
+        EXPECT(center_pixel.alpha() > 0);
+        EXPECT(center_pixel.alpha() < 255);
+        EXPECT_EQ(center_pixel.with_alpha(0), Color(Color::White).with_alpha(0));
+
+        auto bottom_right_pixel = scaled_bitmap->get_pixel(scaled_bitmap->rect().bottom_right());
+        EXPECT_EQ(bottom_right_pixel, Color::Transparent);
+    };
+
+    test_scaling_mode(Gfx::Painter::ScalingMode::BilinearBlend);
+    // FIXME: Include ScalingMode::SmoothPixels as part of this test
+    //        This mode does not currently pass this test, as it  behave according to the spec
+    //        defined here: https://drafts.csswg.org/css-images/#valdef-image-rendering-pixelated
+    // test_scaling_mode(Gfx::Painter::ScalingMode::SmoothPixels);
+}
+
+TEST_CASE(test_bitmap_scaling_uses_premultiplied_alpha)
+{
+    auto src_bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { 2, 2 }));
+    src_bitmap->fill(Color::Transparent);
+    src_bitmap->set_pixel({ 0, 0 }, Color::White);
+
+    auto scaled_bitmap = MUST(src_bitmap->scaled(2.5f, 2.5f));
+    EXPECT_EQ(scaled_bitmap->width(), 5);
+    EXPECT_EQ(scaled_bitmap->height(), 5);
+    auto top_left_pixel = scaled_bitmap->get_pixel(0, 0);
+    EXPECT_EQ(top_left_pixel, Color::White);
+
+    auto center_pixel = scaled_bitmap->get_pixel(scaled_bitmap->rect().center());
+    EXPECT(center_pixel.alpha() > 0);
+    EXPECT(center_pixel.alpha() < 255);
+    EXPECT_EQ(center_pixel.with_alpha(0), Color(Color::White).with_alpha(0));
+
+    auto bottom_right_pixel = scaled_bitmap->get_pixel(scaled_bitmap->rect().bottom_right());
+    EXPECT_EQ(bottom_right_pixel, Color::Transparent);
+}

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -403,9 +403,9 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Bitmap::scaled(float sx, float sy) const
             auto c = get_pixel(i, j + 1);
             auto d = get_pixel(i + 1, j + 1);
 
-            auto e = a.interpolate(b, u);
-            auto f = c.interpolate(d, u);
-            auto color = e.interpolate(f, v);
+            auto e = a.mixed_with(b, u);
+            auto f = c.mixed_with(d, u);
+            auto color = e.mixed_with(f, v);
             new_bitmap->set_pixel(x, y, color);
         }
     }
@@ -421,7 +421,7 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Bitmap::scaled(float sx, float sy) const
 
         auto a = get_pixel(i, old_bottom_y);
         auto b = get_pixel(i + 1, old_bottom_y);
-        auto color = a.interpolate(b, u);
+        auto color = a.mixed_with(b, u);
         new_bitmap->set_pixel(x, new_bottom_y, color);
     }
 
@@ -437,7 +437,7 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Bitmap::scaled(float sx, float sy) const
         auto c = get_pixel(old_right_x, j);
         auto d = get_pixel(old_right_x, j + 1);
 
-        auto color = c.interpolate(d, v);
+        auto color = c.mixed_with(d, v);
         new_bitmap->set_pixel(new_right_x, y, color);
     }
 

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1229,10 +1229,10 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
                 auto bottom_left = get_pixel(source, scaled_x0, scaled_y1);
                 auto bottom_right = get_pixel(source, scaled_x1, scaled_y1);
 
-                auto top = top_left.interpolate(top_right, x_ratio);
-                auto bottom = bottom_left.interpolate(bottom_right, x_ratio);
+                auto top = top_left.mixed_with(top_right, x_ratio);
+                auto bottom = bottom_left.mixed_with(bottom_right, x_ratio);
 
-                src_pixel = top.interpolate(bottom, y_ratio);
+                src_pixel = top.mixed_with(bottom, y_ratio);
             } else if constexpr (scaling_mode == Painter::ScalingMode::SmoothPixels) {
                 auto scaled_x1 = clamp(desired_x >> 32, clipped_src_rect.left(), clipped_src_rect.right());
                 auto scaled_x0 = clamp(scaled_x1 - 1, clipped_src_rect.left(), clipped_src_rect.right());
@@ -1250,10 +1250,10 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
                 auto bottom_left = get_pixel(source, scaled_x0, scaled_y1);
                 auto bottom_right = get_pixel(source, scaled_x1, scaled_y1);
 
-                auto top = top_left.interpolate(top_right, scaled_x_ratio);
-                auto bottom = bottom_left.interpolate(bottom_right, scaled_x_ratio);
+                auto top = top_left.mixed_with(top_right, scaled_x_ratio);
+                auto bottom = bottom_left.mixed_with(bottom_right, scaled_x_ratio);
 
-                src_pixel = top.interpolate(bottom, scaled_y_ratio);
+                src_pixel = top.mixed_with(bottom, scaled_y_ratio);
             } else {
                 auto scaled_x = clamp(desired_x >> 32, clipped_src_rect.left(), clipped_src_rect.right());
                 auto scaled_y = clamp(desired_y >> 32, clipped_src_rect.top(), clipped_src_rect.bottom());


### PR DESCRIPTION
This commit replaces usages of `Color::interpolate()` with `Color::mixed_with()` in `Painter::draw_scaled_bitmap()`. The latter uses premultiplied alpha, which results in more visually pleasing edges when images are scaled against a transparent background.

These changes affect the SmoothPixels and BilinearBlend scaling modes.

Fixes #17153.

The pictures below show the output from [canvas-gradients.html](https://github.com/SerenityOS/serenity/blob/master/Base/res/html/misc/canvas-gradients.html) in Ladybird.

Testing was also done in PixelPaint and ImageViewer, where the effect is easier to see.

Before:
![scaling_with_transparent_background_old](https://user-images.githubusercontent.com/2817754/219511185-4c48ae13-1ad7-4f86-91c7-ff789706529a.png)

After:
![scaling_with_transparent_background_new](https://user-images.githubusercontent.com/2817754/219511207-b05f1704-0e81-47a6-98d9-edcd44b6493e.png)


NB: This PR only affects the scaling functions used in `Painter::draw_scaled_bitmap()`, it does not touch the scaling function used by `Bitmap::scaled()`.

A more complete fix to this problem may be to combine `Color::mixed_with()` and `Color::interpolate()` into a single function taking an optional flag. I didn't do this, as I wanted to limit the scope of this PR to fixing the issue mentioned above.