### PR TITLE
LibWeb: Port more CSS things to new Strings

### DIFF
--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -21,7 +21,7 @@ public:
     ~FlyString();
 
     static ErrorOr<FlyString> from_utf8(StringView);
-    explicit FlyString(String const&);
+    FlyString(String const&);
     FlyString& operator=(String const&);
 
     FlyString(FlyString const&);

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
@@ -51,7 +51,7 @@ DeprecatedString CSSStyleRule::serialized() const
 
     // 1. Let s initially be the result of performing serialize a group of selectors on the rule’s associated selectors,
     //    followed by the string " {", i.e., a single SPACE (U+0020), followed by LEFT CURLY BRACKET (U+007B).
-    builder.append(serialize_a_group_of_selectors(selectors()));
+    builder.append(serialize_a_group_of_selectors(selectors()).release_value_but_fixme_should_propagate_errors());
     builder.append(" {"sv);
 
     // 2. Let decls be the result of performing serialize a CSS declaration block on the rule’s associated declarations, or null if there are no such declarations.
@@ -92,7 +92,7 @@ DeprecatedString CSSStyleRule::serialized() const
 DeprecatedString CSSStyleRule::selector_text() const
 {
     // The selectorText attribute, on getting, must return the result of serializing the associated group of selectors.
-    return serialize_a_group_of_selectors(selectors());
+    return serialize_a_group_of_selectors(selectors()).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 }
 
 // https://www.w3.org/TR/cssom/#dom-cssstylerule-selectortext

--- a/Userland/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Userland/Libraries/LibWeb/CSS/FontFace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,7 +8,7 @@
 
 namespace Web::CSS {
 
-FontFace::FontFace(DeprecatedFlyString font_family, Vector<Source> sources, Vector<UnicodeRange> unicode_ranges)
+FontFace::FontFace(FlyString font_family, Vector<Source> sources, Vector<UnicodeRange> unicode_ranges)
     : m_font_family(move(font_family))
     , m_sources(move(sources))
     , m_unicode_ranges(move(unicode_ranges))

--- a/Userland/Libraries/LibWeb/CSS/FontFace.h
+++ b/Userland/Libraries/LibWeb/CSS/FontFace.h
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
+#include <AK/FlyString.h>
 #include <AK/URL.h>
 #include <LibWeb/CSS/UnicodeRange.h>
 
@@ -17,19 +17,19 @@ public:
     struct Source {
         AK::URL url;
         // FIXME: Do we need to keep this around, or is it only needed to discard unwanted formats during parsing?
-        Optional<DeprecatedFlyString> format;
+        Optional<FlyString> format;
     };
 
-    FontFace(DeprecatedFlyString font_family, Vector<Source> sources, Vector<UnicodeRange> unicode_ranges);
+    FontFace(FlyString font_family, Vector<Source> sources, Vector<UnicodeRange> unicode_ranges);
     ~FontFace() = default;
 
-    DeprecatedFlyString font_family() const { return m_font_family; }
+    FlyString font_family() const { return m_font_family; }
     Vector<Source> const& sources() const { return m_sources; }
     Vector<UnicodeRange> const& unicode_ranges() const { return m_unicode_ranges; }
     // FIXME: font-style, font-weight, font-stretch, font-feature-settings
 
 private:
-    DeprecatedFlyString m_font_family;
+    FlyString m_font_family;
     Vector<Source> m_sources;
     Vector<UnicodeRange> m_unicode_ranges;
 };

--- a/Userland/Libraries/LibWeb/CSS/GeneralEnclosed.h
+++ b/Userland/Libraries/LibWeb/CSS/GeneralEnclosed.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 
 namespace Web::CSS {
 
@@ -71,15 +71,15 @@ inline MatchResult evaluate_or(Collection& collection, Evaluate evaluate)
 // https://www.w3.org/TR/mediaqueries-4/#typedef-general-enclosed
 class GeneralEnclosed {
 public:
-    GeneralEnclosed(DeprecatedString serialized_contents)
+    GeneralEnclosed(String serialized_contents)
         : m_serialized_contents(move(serialized_contents))
     {
     }
 
     MatchResult evaluate() const { return MatchResult::Unknown; }
-    StringView to_string() const { return m_serialized_contents.view(); }
+    String const& to_string() const { return m_serialized_contents; }
 
 private:
-    DeprecatedString m_serialized_contents;
+    String m_serialized_contents;
 };
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5299,7 +5299,7 @@ CSSRule* Parser::parse_font_face_rule(TokenStream<ComponentValue>& tokens)
 {
     auto declarations_and_at_rules = parse_a_list_of_declarations(tokens);
 
-    Optional<DeprecatedFlyString> font_family;
+    Optional<FlyString> font_family;
     Vector<FontFace::Source> src;
     Vector<UnicodeRange> unicode_range;
 
@@ -5351,7 +5351,7 @@ CSSRule* Parser::parse_font_face_rule(TokenStream<ComponentValue>& tokens)
             if (had_syntax_error || font_family_parts.is_empty())
                 continue;
 
-            font_family = DeprecatedString::join(' ', font_family_parts);
+            font_family = String::join(' ', font_family_parts).release_value_but_fixme_should_propagate_errors();
             continue;
         }
         if (declaration.name().equals_ignoring_case("src"sv)) {
@@ -5422,7 +5422,7 @@ Vector<FontFace::Source> Parser::parse_font_face_src(TokenStream<ComponentValue>
         // FIXME: Implement optional tech() function from CSS-Fonts-4.
         if (auto maybe_url = parse_url_function(first, AllowedDataUrlType::Font); maybe_url.has_value()) {
             auto url = maybe_url.release_value();
-            Optional<DeprecatedFlyString> format;
+            Optional<FlyString> format;
 
             source_tokens.skip_whitespace();
             if (!source_tokens.has_next_token()) {
@@ -5456,7 +5456,7 @@ Vector<FontFace::Source> Parser::parse_font_face_src(TokenStream<ComponentValue>
                     continue;
                 }
 
-                format = format_name;
+                format = FlyString::from_utf8(format_name).release_value_but_fixme_should_propagate_errors();
             } else {
                 dbgln_if(CSS_PARSER_DEBUG, "CSSParser: @font-face src invalid (unrecognized function token `{}`); discarding.", function.name());
                 return {};

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1426,13 +1426,13 @@ Optional<GeneralEnclosed> Parser::parse_general_enclosed(TokenStream<ComponentVa
     // `[ <function-token> <any-value>? ) ]`
     if (first_token.is_function()) {
         transaction.commit();
-        return GeneralEnclosed { first_token.to_string().release_value_but_fixme_should_propagate_errors().to_deprecated_string() };
+        return GeneralEnclosed { first_token.to_string().release_value_but_fixme_should_propagate_errors() };
     }
 
     // `( <any-value>? )`
     if (first_token.is_block() && first_token.block().is_paren()) {
         transaction.commit();
-        return GeneralEnclosed { first_token.to_string().release_value_but_fixme_should_propagate_errors().to_deprecated_string() };
+        return GeneralEnclosed { first_token.to_string().release_value_but_fixme_should_propagate_errors() };
     }
 
     return {};

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -279,7 +279,7 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_attribute_simple_se
             // they are converted to lowercase, so we do that here too. If we want to be
             // correct with XML later, we'll need to keep the original case and then do
             // a case-insensitive compare later.
-            .name = attribute_part.token().ident().to_lowercase_string(),
+            .name = FlyString::from_utf8(attribute_part.token().ident().to_lowercase_string()).release_value_but_fixme_should_propagate_errors(),
             .case_type = Selector::SimpleSelector::Attribute::CaseType::DefaultMatch,
         }
     };
@@ -339,7 +339,8 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_attribute_simple_se
         dbgln_if(CSS_PARSER_DEBUG, "Expected a string or ident for the value to match attribute against, got: '{}'", value_part.to_debug_string());
         return ParseError::SyntaxError;
     }
-    simple_selector.attribute().value = value_part.token().is(Token::Type::Ident) ? value_part.token().ident() : value_part.token().string();
+    auto value_string_view = value_part.token().is(Token::Type::Ident) ? value_part.token().ident() : value_part.token().string();
+    simple_selector.attribute().value = String::from_utf8(value_string_view).release_value_but_fixme_should_propagate_errors();
 
     attribute_tokens.skip_whitespace();
     // Handle case-sensitivity suffixes. https://www.w3.org/TR/selectors-4/#attribute-case
@@ -562,8 +563,8 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
                 return ParseError::SyntaxError;
             }
             // FIXME: Support multiple, comma-separated, language ranges.
-            Vector<DeprecatedFlyString> languages;
-            languages.append(pseudo_function.values().first().token().to_string().release_value_but_fixme_should_propagate_errors().to_deprecated_string());
+            Vector<FlyString> languages;
+            languages.append(pseudo_function.values().first().token().to_string().release_value_but_fixme_should_propagate_errors());
             return Selector::SimpleSelector {
                 .type = Selector::SimpleSelector::Type::PseudoClass,
                 .value = Selector::SimpleSelector::PseudoClass {
@@ -617,7 +618,7 @@ Parser::ParseErrorOr<Optional<Selector::SimpleSelector>> Parser::parse_simple_se
             }
             return Selector::SimpleSelector {
                 .type = Selector::SimpleSelector::Type::Class,
-                .value = Selector::SimpleSelector::Name { class_name_value.token().ident() }
+                .value = Selector::SimpleSelector::Name { FlyString::from_utf8(class_name_value.token().ident()).release_value_but_fixme_should_propagate_errors() }
             };
         }
         case '>':
@@ -641,13 +642,13 @@ Parser::ParseErrorOr<Optional<Selector::SimpleSelector>> Parser::parse_simple_se
         }
         return Selector::SimpleSelector {
             .type = Selector::SimpleSelector::Type::Id,
-            .value = Selector::SimpleSelector::Name { first_value.token().hash_value() }
+            .value = Selector::SimpleSelector::Name { FlyString::from_utf8(first_value.token().hash_value()).release_value_but_fixme_should_propagate_errors() }
         };
     }
     if (first_value.is(Token::Type::Ident)) {
         return Selector::SimpleSelector {
             .type = Selector::SimpleSelector::Type::TagName,
-            .value = Selector::SimpleSelector::Name { first_value.token().ident() }
+            .value = Selector::SimpleSelector::Name { FlyString::from_utf8(first_value.token().ident()).release_value_but_fixme_should_propagate_errors() }
         };
     }
     if (first_value.is_block() && first_value.block().is_square())

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -115,9 +115,8 @@ static CSSStyleSheet& default_stylesheet()
 {
     static JS::Handle<CSSStyleSheet> sheet;
     if (!sheet.cell()) {
-        extern char const default_stylesheet_source[];
-        DeprecatedString css = default_stylesheet_source;
-        sheet = JS::make_handle(parse_css_stylesheet(CSS::Parser::ParsingContext(), css));
+        extern StringView default_stylesheet_source;
+        sheet = JS::make_handle(parse_css_stylesheet(CSS::Parser::ParsingContext(), default_stylesheet_source));
     }
     return *sheet;
 }
@@ -126,9 +125,8 @@ static CSSStyleSheet& quirks_mode_stylesheet()
 {
     static JS::Handle<CSSStyleSheet> sheet;
     if (!sheet.cell()) {
-        extern char const quirks_mode_stylesheet_source[];
-        DeprecatedString css = quirks_mode_stylesheet_source;
-        sheet = JS::make_handle(parse_css_stylesheet(CSS::Parser::ParsingContext(), css));
+        extern StringView quirks_mode_stylesheet_source;
+        sheet = JS::make_handle(parse_css_stylesheet(CSS::Parser::ParsingContext(), quirks_mode_stylesheet_source));
     }
     return *sheet;
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1532,9 +1532,11 @@ void StyleComputer::load_fonts_from_sheet(CSSStyleSheet const& sheet)
         if (!is<CSSFontFaceRule>(rule))
             continue;
         auto const& font_face = static_cast<CSSFontFaceRule const&>(rule).font_face();
+        // FIXME: Use font_face.font_family() directly when we port to new Strings here.
+        auto font_family = font_face.font_family().to_string().to_deprecated_string();
         if (font_face.sources().is_empty())
             continue;
-        if (m_loaded_fonts.contains(font_face.font_family()))
+        if (m_loaded_fonts.contains(font_family))
             continue;
 
         // NOTE: This is rather ad-hoc, we just look for the first valid
@@ -1562,8 +1564,8 @@ void StyleComputer::load_fonts_from_sheet(CSSStyleSheet const& sheet)
 
         LoadRequest request;
         auto url = m_document.parse_url(candidate_url.value().to_deprecated_string());
-        auto loader = make<FontLoader>(const_cast<StyleComputer&>(*this), font_face.font_family(), move(url));
-        const_cast<StyleComputer&>(*this).m_loaded_fonts.set(font_face.font_family(), move(loader));
+        auto loader = make<FontLoader>(const_cast<StyleComputer&>(*this), font_family, move(url));
+        const_cast<StyleComputer&>(*this).m_loaded_fonts.set(font_family, move(loader));
     }
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1469,19 +1469,19 @@ void StyleComputer::build_rule_cache()
                 if (!added_to_bucket) {
                     for (auto const& simple_selector : selector.compound_selectors().last().simple_selectors) {
                         if (simple_selector.type == CSS::Selector::SimpleSelector::Type::Id) {
-                            m_rule_cache->rules_by_id.ensure(simple_selector.name()).append(move(matching_rule));
+                            m_rule_cache->rules_by_id.ensure(simple_selector.name().to_string().to_deprecated_string()).append(move(matching_rule));
                             ++num_id_rules;
                             added_to_bucket = true;
                             break;
                         }
                         if (simple_selector.type == CSS::Selector::SimpleSelector::Type::Class) {
-                            m_rule_cache->rules_by_class.ensure(simple_selector.name()).append(move(matching_rule));
+                            m_rule_cache->rules_by_class.ensure(simple_selector.name().to_string().to_deprecated_string()).append(move(matching_rule));
                             ++num_class_rules;
                             added_to_bucket = true;
                             break;
                         }
                         if (simple_selector.type == CSS::Selector::SimpleSelector::Type::TagName) {
-                            m_rule_cache->rules_by_tag_name.ensure(simple_selector.name()).append(move(matching_rule));
+                            m_rule_cache->rules_by_tag_name.ensure(simple_selector.name().to_string().to_deprecated_string()).append(move(matching_rule));
                             ++num_tag_name_rules;
                             added_to_bucket = true;
                             break;

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -31,7 +31,7 @@ struct MatchingRule {
 
 class PropertyDependencyNode : public RefCounted<PropertyDependencyNode> {
 public:
-    static NonnullRefPtr<PropertyDependencyNode> create(DeprecatedString name)
+    static NonnullRefPtr<PropertyDependencyNode> create(String name)
     {
         return adopt_ref(*new PropertyDependencyNode(move(name)));
     }
@@ -40,9 +40,9 @@ public:
     bool has_cycles();
 
 private:
-    explicit PropertyDependencyNode(DeprecatedString name);
+    explicit PropertyDependencyNode(String name);
 
-    DeprecatedString m_name;
+    String m_name;
     NonnullRefPtrVector<PropertyDependencyNode> m_children;
     bool m_marked { false };
 };
@@ -87,7 +87,7 @@ private:
     void compute_defaulted_property_value(StyleProperties&, DOM::Element const*, CSS::PropertyID, Optional<CSS::Selector::PseudoElement>) const;
 
     RefPtr<StyleValue> resolve_unresolved_style_value(DOM::Element&, PropertyID, UnresolvedStyleValue const&) const;
-    bool expand_variables(DOM::Element&, StringView property_name, HashMap<DeprecatedFlyString, NonnullRefPtr<PropertyDependencyNode>>& dependencies, Parser::TokenStream<Parser::ComponentValue>& source, Vector<Parser::ComponentValue>& dest) const;
+    bool expand_variables(DOM::Element&, StringView property_name, HashMap<FlyString, NonnullRefPtr<PropertyDependencyNode>>& dependencies, Parser::TokenStream<Parser::ComponentValue>& source, Vector<Parser::ComponentValue>& dest) const;
     bool expand_unresolved_values(DOM::Element&, StringView property_name, Parser::TokenStream<Parser::ComponentValue>& source, Vector<Parser::ComponentValue>& dest) const;
 
     template<typename Callback>
@@ -109,9 +109,9 @@ private:
     DOM::Document& m_document;
 
     struct RuleCache {
-        HashMap<DeprecatedFlyString, Vector<MatchingRule>> rules_by_id;
-        HashMap<DeprecatedFlyString, Vector<MatchingRule>> rules_by_class;
-        HashMap<DeprecatedFlyString, Vector<MatchingRule>> rules_by_tag_name;
+        HashMap<FlyString, Vector<MatchingRule>> rules_by_id;
+        HashMap<FlyString, Vector<MatchingRule>> rules_by_class;
+        HashMap<FlyString, Vector<MatchingRule>> rules_by_tag_name;
         HashMap<Selector::PseudoElement, Vector<MatchingRule>> rules_by_pseudo_element;
         Vector<MatchingRule> other_rules;
     };

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -73,7 +73,7 @@ public:
 
     Gfx::Font const& initial_font() const;
 
-    void did_load_font(DeprecatedFlyString const& family_name);
+    void did_load_font(FlyString const& family_name);
 
     void load_fonts_from_sheet(CSSStyleSheet const&);
 
@@ -118,7 +118,7 @@ private:
     OwnPtr<RuleCache> m_rule_cache;
 
     class FontLoader;
-    HashMap<DeprecatedString, NonnullOwnPtr<FontLoader>> m_loaded_fonts;
+    HashMap<String, NonnullOwnPtr<FontLoader>> m_loaded_fonts;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Supports.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Supports.cpp
@@ -93,7 +93,7 @@ ErrorOr<String> Supports::InParens::to_string() const
     return value.visit(
         [](NonnullOwnPtr<Condition> const& condition) -> ErrorOr<String> { return String::formatted("({})", TRY(condition->to_string())); },
         [](Supports::Feature const& it) -> ErrorOr<String> { return it.to_string(); },
-        [](GeneralEnclosed const& it) -> ErrorOr<String> { return String::from_utf8(it.to_string()); });
+        [](GeneralEnclosed const& it) -> ErrorOr<String> { return it.to_string(); });
 }
 
 ErrorOr<String> Supports::Condition::to_string() const

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -599,7 +599,7 @@ void dump_font_face_rule(StringBuilder& builder, CSS::CSSFontFaceRule const& rul
     builder.append("sources:\n"sv);
     for (auto const& source : font_face.sources()) {
         indent(builder, indent_levels + 2);
-        builder.appendff("url={}, format={}\n", source.url, source.format.value_or("???"));
+        builder.appendff("url={}, format={}\n", source.url, source.format.value_or(String::from_utf8_short_string("???"sv)));
     }
 
     indent(builder, indent_levels + 1);

--- a/Userland/Libraries/LibWeb/FontCache.h
+++ b/Userland/Libraries/LibWeb/FontCache.h
@@ -6,14 +6,13 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
-#include <AK/DeprecatedString.h>
+#include <AK/FlyString.h>
 #include <AK/HashMap.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Forward.h>
 
 struct FontSelector {
-    DeprecatedFlyString family;
+    FlyString family;
     float point_size { 0 };
     int weight { 0 };
     int width { 0 };

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -515,7 +515,7 @@ static void paint_text_fragment(PaintContext& context, Layout::TextNode const& t
         auto& font = fragment.layout_node().font();
         auto scaled_font = [&]() -> RefPtr<Gfx::Font> {
             auto device_font_pt_size = context.enclosing_device_pixels(font.presentation_size());
-            FontSelector font_selector = { font.family(), static_cast<float>(device_font_pt_size.value()), font.weight(), font.width(), font.slope() };
+            FontSelector font_selector = { FlyString::from_utf8(font.family()).release_value_but_fixme_should_propagate_errors(), static_cast<float>(device_font_pt_size.value()), font.weight(), font.width(), font.slope() };
             if (auto cached_font = FontCache::the().get(font_selector)) {
                 return cached_font;
             }

--- a/Userland/Libraries/LibWeb/Scripts/GenerateStyleSheetSource.sh
+++ b/Userland/Libraries/LibWeb/Scripts/GenerateStyleSheetSource.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 
+echo "#include <AK/StringView.h>"
 echo "namespace Web::CSS {"
-echo "extern const char $1[];"
-echo "const char $1[] = \"\\"
+echo "extern StringView $1;"
+echo "StringView $1 = \"\\"
 grep -v '^ *#' < "$2" | while IFS= read -r line; do
   echo "$line""\\"
 done
-echo "\";"
+echo "\"sv;"
 echo "}"


### PR DESCRIPTION
I think all that's left after this, are classes that are accessible from JS. AFAIK those will require changes to the bindings generator.