### PR TITLE
LibGUI: Skip over grapheme clusters on left/right arrow key presses

### DIFF
--- a/Userland/Libraries/LibGUI/EditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/EditingEngine.cpp
@@ -167,26 +167,28 @@ bool EditingEngine::on_key(KeyEvent const& event)
 void EditingEngine::move_one_left()
 {
     if (m_editor->cursor().column() > 0) {
-        int new_column = m_editor->cursor().column() - 1;
+        auto new_column = m_editor->document().get_previous_grapheme_cluster_boundary(m_editor->cursor());
         m_editor->set_cursor(m_editor->cursor().line(), new_column);
     } else if (m_editor->cursor().line() > 0) {
-        int new_line = m_editor->cursor().line() - 1;
-        int new_column = m_editor->lines()[new_line].length();
+        auto new_line = m_editor->cursor().line() - 1;
+        auto new_column = m_editor->lines()[new_line].length();
         m_editor->set_cursor(new_line, new_column);
     }
 }
 
 void EditingEngine::move_one_right()
 {
-    int new_line = m_editor->cursor().line();
-    int new_column = m_editor->cursor().column();
+    auto new_line = m_editor->cursor().line();
+    auto new_column = m_editor->cursor().column();
+
     if (m_editor->cursor().column() < m_editor->current_line().length()) {
         new_line = m_editor->cursor().line();
-        new_column = m_editor->cursor().column() + 1;
+        new_column = m_editor->document().get_next_grapheme_cluster_boundary(m_editor->cursor());
     } else if (m_editor->cursor().line() != m_editor->line_count() - 1) {
         new_line = m_editor->cursor().line() + 1;
         new_column = 0;
     }
+
     m_editor->set_cursor(new_line, new_column);
 }
 


### PR DESCRIPTION
Currently, if you use the left/right arrow keys to move over a multi- code point glyph, we will move through that glyph one code point at a time. This means you can "pause" your movement in the middle of a glyph and delete a subsection of a grapheme cluster. This now moves the cursor across the entire cluster.

Visually, we will need to separately track physical and virtual cursor positions. That is, when you move across a multi-code point glyph, the visual cursor should only move one position at a time, while a physical cursor stores the "real" position in terms of number of code points.

Before, showing you could delete part of a cluster:

[before.webm](https://user-images.githubusercontent.com/5600524/219687272-c4e6848f-e95c-4891-85d2-0cde3af3b336.webm)


After:

[after.webm](https://user-images.githubusercontent.com/5600524/219687301-33666d85-d6d5-4ab5-bed4-f91dcb5d8026.webm)
