### PR TITLE
LibGUI: Update Arrow Keys to move cursor to grapheme cluster boundaries

### DIFF
--- a/Userland/Libraries/LibGUI/EditingEngine.h
+++ b/Userland/Libraries/LibGUI/EditingEngine.h
@@ -74,7 +74,8 @@ protected:
     void move_page_down();
     void move_to_first_line();
     void move_to_last_line();
-
+    void move_to_previous_grapheme_boundary();
+    void move_to_next_grapheme_boundary();
     void move_up(double page_height_factor);
     void move_down(double page_height_factor);
 


### PR DESCRIPTION
Update the Event handler for left and right arrow keys in the editing engine so that the default behavior is to move the cursor until the next/previous grapheme cluster boundary. The previous behavior of only moving one codepoint at a time is still maintained by doing Alt + arrow key.  This allows for more "natural" feeling traversal of text that contains emoji with the arrow keys, while still maintaining the existing functionality of traveling through individual codepoints if necessary