### PR TITLE
Revert "Kernel: Migrate ‘main id registerʼ access in Aarch64 MMIO"

### DIFF
--- a/Kernel/Arch/aarch64/CPUID.h
+++ b/Kernel/Arch/aarch64/CPUID.h
@@ -272,26 +272,6 @@ AK_MAKE_ARBITRARY_SIZED_ENUM(CPUFeature, u256,
 
     __End = CPUFeature(1u) << 255u); // SENTINEL VALUE
 
-enum class ArmLimited { // 0x41
-    Cortex_A34 = 0xd02,
-    Cortex_A53 = 0xd03, // Raspberry Pi 2 v1.2 / Raspberry Pi 3
-    Cortex_A35 = 0xd04,
-    Cortex_A55 = 0xd05,
-    Cortex_A65 = 0xd06,
-    Cortex_A57 = 0xd07,
-    Cortex_A72 = 0xd08, // Raspberry Pi 4
-    Cortex_A73 = 0xd09,
-    Cortex_A75 = 0xd0a,
-    Cortex_A76 = 0xd0b,
-    Neoverse_N1 = 0xd0c,
-    Cortex_A77 = 0xd0d,
-    Cortex_A78 = 0xd41,
-    Cortex_A65AE = 0xd43,
-    Cortex_X1 = 0xd44,
-    Cortex_A78C = 0xd4b,
-    Cortex_X1C = 0xd4c,
-};
-
 CPUFeature::Type detect_cpu_features();
 StringView cpu_feature_to_name(CPUFeature::Type const&);
 StringView cpu_feature_to_description(CPUFeature::Type const&);

--- a/Kernel/Arch/aarch64/MainIdRegister.cpp
+++ b/Kernel/Arch/aarch64/MainIdRegister.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/aarch64/MainIdRegister.h>
+
+namespace Kernel {
+
+MainIdRegister::MainIdRegister()
+{
+    unsigned int mrs;
+    asm volatile("mrs %x0, MIDR_EL1"
+                 : "=r"(mrs));
+    m_value = mrs;
+}
+
+}

--- a/Kernel/Arch/aarch64/MainIdRegister.h
+++ b/Kernel/Arch/aarch64/MainIdRegister.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Kernel {
+
+class MainIdRegister {
+public:
+    MainIdRegister();
+
+    enum Implementer {
+        ArmLimited = 0x41,
+    };
+    unsigned implementer() const { return (m_value >> 24) & 0xFF; }
+    unsigned variant() const { return (m_value >> 20) & 0xF; }
+    unsigned architecture() const { return (m_value >> 16) & 0xF; }
+
+    enum PartNum {
+        RaspberryPi1 = 0xB76,
+        RaspberryPi2 = 0xC07,
+        RaspberryPi3 = 0xD03,
+        RaspberryPi4 = 0xD08,
+    };
+    unsigned part_num() const { return (m_value >> 4) & 0xFFF; }
+
+    unsigned revision() const { return m_value & 0xF; }
+
+private:
+    unsigned int m_value;
+};
+
+}

--- a/Kernel/Arch/aarch64/RPi/MMIO.cpp
+++ b/Kernel/Arch/aarch64/RPi/MMIO.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <Kernel/Arch/aarch64/CPUID.h>
+#include <Kernel/Arch/aarch64/MainIdRegister.h>
 #include <Kernel/Arch/aarch64/RPi/MMIO.h>
 
 namespace Kernel::RPi {
@@ -12,8 +12,8 @@ namespace Kernel::RPi {
 MMIO::MMIO()
     : m_base_address(0xFE00'0000)
 {
-    auto main_id_register = Aarch64::MIDR_EL1::read();
-    if (static_cast<ArmLimited>(main_id_register.PartNum) <= ArmLimited::Cortex_A53) // Raspberry Pi 3
+    MainIdRegister id;
+    if (id.part_num() <= MainIdRegister::RaspberryPi3)
         m_base_address = PhysicalAddress(0x3F00'0000);
 }
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -460,6 +460,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
         Arch/aarch64/InterruptManagement.cpp
         Arch/aarch64/Interrupts.cpp
         Arch/aarch64/kprintf.cpp
+        Arch/aarch64/MainIdRegister.cpp
         Arch/aarch64/PageDirectory.cpp
         Arch/aarch64/Panic.cpp
         Arch/aarch64/Processor.cpp


### PR DESCRIPTION
This patch needed more review than it got.

This reverts commits a6526cd and 84e8d5f41842f6c3f9f613f3570f669328fe4d06