### PR TITLE
Start on ICC serialization code

### DIFF
--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES
     Font/WOFF/Font.cpp
     GradientPainting.cpp
     GIFLoader.cpp
+    ICC/BinaryWriter.cpp
     ICC/Profile.cpp
     ICC/Tags.cpp
     ICC/TagTypes.cpp

--- a/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
+++ b/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
@@ -64,7 +64,7 @@ struct ICCHeader {
     BigEndian<DeviceManufacturer> device_manufacturer;
     BigEndian<DeviceModel> device_model;
     BigEndian<u64> device_attributes;
-    BigEndian<u32> rendering_intent;
+    BigEndian<RenderingIntent> rendering_intent;
 
     XYZNumber pcs_illuminant;
 

--- a/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
+++ b/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2023, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Endian.h>
+#include <LibGfx/ICC/DistinctFourCC.h>
+#include <LibGfx/ICC/Profile.h>
+#include <LibGfx/ICC/TagTypes.h>
+
+namespace Gfx::ICC {
+
+// ICC V4, 4.2 dateTimeNumber
+// "All the dateTimeNumber values in a profile shall be in Coordinated Universal Time [...]."
+struct DateTimeNumber {
+    BigEndian<u16> year;
+    BigEndian<u16> month;
+    BigEndian<u16> day;
+    BigEndian<u16> hours;
+    BigEndian<u16> minutes;
+    BigEndian<u16> seconds;
+};
+
+// ICC V4, 4.6 s15Fixed16Number
+using s15Fixed16Number = i32;
+
+// ICC V4, 4.7 u16Fixed16Number
+using u16Fixed16Number = u32;
+
+// ICC V4, 4.14 XYZNumber
+struct XYZNumber {
+    BigEndian<s15Fixed16Number> x;
+    BigEndian<s15Fixed16Number> y;
+    BigEndian<s15Fixed16Number> z;
+
+    operator XYZ() const
+    {
+        return XYZ { x / (double)0x1'0000, y / (double)0x1'0000, z / (double)0x1'0000 };
+    }
+};
+
+// ICC V4, 7.2 Profile header
+struct ICCHeader {
+    BigEndian<u32> profile_size;
+    BigEndian<PreferredCMMType> preferred_cmm_type;
+
+    u8 profile_version_major;
+    u8 profile_version_minor_bugfix;
+    BigEndian<u16> profile_version_zero;
+
+    BigEndian<DeviceClass> profile_device_class;
+    BigEndian<ColorSpace> data_color_space;
+    BigEndian<ColorSpace> profile_connection_space; // "PCS" in the spec.
+
+    DateTimeNumber profile_creation_time;
+
+    BigEndian<u32> profile_file_signature;
+    BigEndian<PrimaryPlatform> primary_platform;
+
+    BigEndian<u32> profile_flags;
+    BigEndian<DeviceManufacturer> device_manufacturer;
+    BigEndian<DeviceModel> device_model;
+    BigEndian<u64> device_attributes;
+    BigEndian<u32> rendering_intent;
+
+    XYZNumber pcs_illuminant;
+
+    BigEndian<Creator> profile_creator;
+
+    u8 profile_id[16];
+    u8 reserved[28];
+};
+static_assert(AssertSize<ICCHeader, 128>());
+
+// Common bits of ICC v4, Table 40 — lut16Type encoding and Table 44 — lut8Type encoding
+struct LUTHeader {
+    u8 number_of_input_channels;
+    u8 number_of_output_channels;
+    u8 number_of_clut_grid_points;
+    u8 reserved_for_padding;
+    BigEndian<s15Fixed16Number> e_parameters[9];
+};
+static_assert(AssertSize<LUTHeader, 40>());
+
+// Common bits of ICC v4, Table 45 — lutAToBType encoding and Table 47 — lutBToAType encoding
+struct AdvancedLUTHeader {
+    u8 number_of_input_channels;
+    u8 number_of_output_channels;
+    BigEndian<u16> reserved_for_padding;
+    BigEndian<u32> offset_to_b_curves;
+    BigEndian<u32> offset_to_matrix;
+    BigEndian<u32> offset_to_m_curves;
+    BigEndian<u32> offset_to_clut;
+    BigEndian<u32> offset_to_a_curves;
+};
+static_assert(AssertSize<AdvancedLUTHeader, 24>());
+
+// ICC v4, Table 46 — lutAToBType CLUT encoding
+// ICC v4, Table 48 — lutBToAType CLUT encoding
+// (They're identical.)
+struct CLUTHeader {
+    u8 number_of_grid_points_in_dimension[16];
+    u8 precision_of_data_elements; // 1 for u8 entries, 2 for u16 entries.
+    u8 reserved_for_padding[3];
+};
+static_assert(AssertSize<CLUTHeader, 20>());
+
+}

--- a/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
+++ b/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
@@ -10,6 +10,7 @@
 #include <LibGfx/ICC/DistinctFourCC.h>
 #include <LibGfx/ICC/Profile.h>
 #include <LibGfx/ICC/TagTypes.h>
+#include <math.h>
 
 namespace Gfx::ICC {
 
@@ -35,6 +36,15 @@ struct XYZNumber {
     BigEndian<s15Fixed16Number> x;
     BigEndian<s15Fixed16Number> y;
     BigEndian<s15Fixed16Number> z;
+
+    XYZNumber() = default;
+
+    XYZNumber(XYZ const& xyz)
+        : x(round(xyz.x * 0x1'0000))
+        , y(round(xyz.y * 0x1'0000))
+        , z(round(xyz.z * 0x1'0000))
+    {
+    }
 
     operator XYZ() const
     {

--- a/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
+++ b/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
@@ -75,6 +75,10 @@ struct ICCHeader {
 };
 static_assert(AssertSize<ICCHeader, 128>());
 
+// ICC v4, 7.2.9 Profile file signature field
+// "The profile file signature field shall contain the value “acsp” (61637370h) as a profile file signature."
+constexpr u32 ProfileFileSignature = 0x61637370;
+
 // Common bits of ICC v4, Table 40 — lut16Type encoding and Table 44 — lut8Type encoding
 struct LUTHeader {
     u8 number_of_input_channels;

--- a/Userland/Libraries/LibGfx/ICC/BinaryWriter.cpp
+++ b/Userland/Libraries/LibGfx/ICC/BinaryWriter.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/ICC/BinaryFormat.h>
+#include <LibGfx/ICC/BinaryWriter.h>
+#include <LibGfx/ICC/Profile.h>
+#include <time.h>
+
+namespace Gfx::ICC {
+
+ErrorOr<ByteBuffer> encode(Profile const& profile)
+{
+
+    // Leaves enough room for the profile header and the tag table count.
+    // FIXME: Serialize tag data and write tag table and tag data too.
+    auto bytes = TRY(ByteBuffer::create_zeroed(sizeof(ICCHeader) + sizeof(u32)));
+
+    VERIFY(bytes.size() >= sizeof(ICCHeader));
+    auto& raw_header = *bit_cast<ICCHeader*>(bytes.data());
+
+    raw_header.profile_size = bytes.size();
+    raw_header.preferred_cmm_type = profile.preferred_cmm_type().value_or(PreferredCMMType { 0 });
+
+    raw_header.profile_version_major = profile.version().major_version();
+    raw_header.profile_version_minor_bugfix = profile.version().minor_and_bugfix_version();
+    raw_header.profile_version_zero = 0;
+
+    raw_header.profile_device_class = profile.device_class();
+    raw_header.data_color_space = profile.data_color_space();
+    raw_header.profile_connection_space = profile.connection_space();
+
+    time_t profile_timestamp = profile.creation_timestamp();
+    struct tm tm;
+    if (!gmtime_r(&profile_timestamp, &tm))
+        return Error::from_errno(errno);
+    raw_header.profile_creation_time.year = tm.tm_year + 1900;
+    raw_header.profile_creation_time.month = tm.tm_mon + 1;
+    raw_header.profile_creation_time.day = tm.tm_mday;
+    raw_header.profile_creation_time.hours = tm.tm_hour;
+    raw_header.profile_creation_time.minutes = tm.tm_min;
+    raw_header.profile_creation_time.seconds = tm.tm_sec;
+
+    raw_header.profile_file_signature = ProfileFileSignature;
+    raw_header.primary_platform = profile.primary_platform().value_or(PrimaryPlatform { 0 });
+
+    raw_header.profile_flags = profile.flags().bits();
+    raw_header.device_manufacturer = profile.device_manufacturer().value_or(DeviceManufacturer { 0 });
+    raw_header.device_model = profile.device_model().value_or(DeviceModel { 0 });
+    raw_header.device_attributes = profile.device_attributes().bits();
+    raw_header.rendering_intent = profile.rendering_intent();
+
+    raw_header.pcs_illuminant = profile.pcs_illuminant();
+
+    raw_header.profile_creator = profile.creator().value_or(Creator { 0 });
+
+    memset(raw_header.reserved, 0, sizeof(raw_header.reserved));
+
+    auto id = Profile::compute_id(bytes);
+    static_assert(sizeof(id.data) == sizeof(raw_header.profile_id));
+    memcpy(raw_header.profile_id, id.data, sizeof(id.data));
+
+    return bytes;
+}
+
+}

--- a/Userland/Libraries/LibGfx/ICC/BinaryWriter.h
+++ b/Userland/Libraries/LibGfx/ICC/BinaryWriter.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+
+namespace Gfx::ICC {
+
+class Profile;
+
+// Serializes a Profile object.
+// Ignores the Profile's on_disk_size() and id() and recomputes them instead.
+// Also ignores and the offsets and sizes in tag data.
+// But if the profile has its tag data in tag order and has a computed id,
+// it's a goal that  encode(Profile::try_load_from_externally_owned_memory(bytes) returns `bytes`.
+// Unconditionally computes a Profile ID (which is an MD5 hash of most of the contents, see Profile::compute_id()) and writes it to the output.
+ErrorOr<ByteBuffer> encode(Profile const&);
+
+}

--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -179,8 +179,7 @@ ErrorOr<time_t> parse_creation_date_time(ICCHeader const& header)
 ErrorOr<void> parse_file_signature(ICCHeader const& header)
 {
     // ICC v4, 7.2.9 Profile file signature field
-    // "The profile file signature field shall contain the value “acsp” (61637370h) as a profile file signature."
-    if (header.profile_file_signature != 0x61637370)
+    if (header.profile_file_signature != ProfileFileSignature)
         return Error::from_string_literal("ICC::Profile: profile file signature not 'acsp'");
     return {};
 }

--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -249,14 +249,11 @@ ErrorOr<RenderingIntent> parse_rendering_intent(ICCHeader const& header)
 {
     // ICC v4, 7.2.15 Rendering intent field
     switch (header.rendering_intent) {
-    case 0:
-        return RenderingIntent::Perceptual;
-    case 1:
-        return RenderingIntent::MediaRelativeColorimetric;
-    case 2:
-        return RenderingIntent::Saturation;
-    case 3:
-        return RenderingIntent::ICCAbsoluteColorimetric;
+    case RenderingIntent::Perceptual:
+    case RenderingIntent::MediaRelativeColorimetric:
+    case RenderingIntent::Saturation:
+    case RenderingIntent::ICCAbsoluteColorimetric:
+        return header.rendering_intent;
     }
     return Error::from_string_literal("ICC::Profile: Invalid rendering intent");
 }

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -96,11 +96,11 @@ enum class PrimaryPlatform : u32 {
 StringView primary_platform_name(PrimaryPlatform);
 
 // ICC v4, 7.2.15 Rendering intent field
-enum class RenderingIntent {
-    Perceptual,
-    MediaRelativeColorimetric,
-    Saturation,
-    ICCAbsoluteColorimetric,
+enum class RenderingIntent : u32 {
+    Perceptual = 0,
+    MediaRelativeColorimetric = 1,
+    Saturation = 2,
+    ICCAbsoluteColorimetric = 3,
 };
 StringView rendering_intent_name(RenderingIntent);
 

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -36,6 +36,8 @@ public:
     u8 minor_version() const { return m_minor_and_bugfix_version >> 4; }
     u8 bugfix_version() const { return m_minor_and_bugfix_version & 0xf; }
 
+    u8 minor_and_bugfix_version() const { return m_minor_and_bugfix_version; }
+
 private:
     u8 m_major_version = 0;
     u8 m_minor_and_bugfix_version = 0;

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.cpp
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/DeprecatedString.h>
 #include <AK/Endian.h>
+#include <LibGfx/ICC/BinaryFormat.h>
 #include <LibGfx/ICC/TagTypes.h>
 #include <LibGfx/ICC/Tags.h>
 #include <LibTextCodec/Decoder.h>
@@ -13,57 +14,6 @@
 namespace Gfx::ICC {
 
 namespace {
-
-// ICC V4, 4.6 s15Fixed16Number
-using s15Fixed16Number = i32;
-
-// ICC V4, 4.7 u16Fixed16Number
-using u16Fixed16Number = u32;
-
-// ICC V4, 4.14 XYZNumber
-struct XYZNumber {
-    BigEndian<s15Fixed16Number> x;
-    BigEndian<s15Fixed16Number> y;
-    BigEndian<s15Fixed16Number> z;
-
-    operator XYZ() const
-    {
-        return XYZ { x / (double)0x1'0000, y / (double)0x1'0000, z / (double)0x1'0000 };
-    }
-};
-
-// Common bits of ICC v4, Table 40 — lut16Type encoding and Table 44 — lut8Type encoding
-struct LUTHeader {
-    u8 number_of_input_channels;
-    u8 number_of_output_channels;
-    u8 number_of_clut_grid_points;
-    u8 reserved_for_padding;
-    BigEndian<s15Fixed16Number> e_parameters[9];
-};
-static_assert(AssertSize<LUTHeader, 40>());
-
-// Common bits of ICC v4, Table 45 — lutAToBType encoding and Table 47 — lutBToAType encoding
-struct AdvancedLUTHeader {
-    u8 number_of_input_channels;
-    u8 number_of_output_channels;
-    BigEndian<u16> reserved_for_padding;
-    BigEndian<u32> offset_to_b_curves;
-    BigEndian<u32> offset_to_matrix;
-    BigEndian<u32> offset_to_m_curves;
-    BigEndian<u32> offset_to_clut;
-    BigEndian<u32> offset_to_a_curves;
-};
-static_assert(AssertSize<AdvancedLUTHeader, 24>());
-
-// ICC v4, Table 46 — lutAToBType CLUT encoding
-// ICC v4, Table 48 — lutBToAType CLUT encoding
-// (They're identical.)
-struct CLUTHeader {
-    u8 number_of_grid_points_in_dimension[16];
-    u8 precision_of_data_elements; // 1 for u8 entries, 2 for u16 entries.
-    u8 reserved_for_padding[3];
-};
-static_assert(AssertSize<CLUTHeader, 20>());
 
 ErrorOr<void> check_reserved(ReadonlyBytes tag_bytes)
 {


### PR DESCRIPTION
This adds initial ICC serialization code, only for the header so far.

It also adds flags to `icc` to test this code.

Writing ICC profiles might be useful for:
* embedding ICC profiles in screenshots
* programmatically creating ICC profiles as part of the build (which we may or may not want to do)
* creating custom ICC profiles that do funny business (in particular, I'd like to see if I can create an oklab.icc profile that allows you to put oklab pixel data in e.g. a png and then have the color management module do the oklab -> rgb conversion)