### PR TITLE
LibWeb: Convert FormData to String and Vector storage

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -139,7 +139,7 @@ CppType idl_type_name_to_cpp_type(Type const& type, Interface const& interface)
         return { .name = "JS::Handle<JS::Object>", .sequence_storage_type = SequenceStorageType::MarkedVector };
 
     if (type.name() == "File")
-        return { .name = "JS::NonnullGCPtr<FileAPI::File>", .sequence_storage_type = SequenceStorageType::MarkedVector };
+        return { .name = "JS::Handle<FileAPI::File>", .sequence_storage_type = SequenceStorageType::MarkedVector };
 
     if (type.name() == "sequence") {
         auto& parameterized_type = verify_cast<ParameterizedType>(type);

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -101,8 +101,12 @@ CppType idl_type_name_to_cpp_type(Type const& type, Interface const& interface)
     if (is_platform_object(type))
         return { .name = DeprecatedString::formatted("JS::Handle<{}>", type.name()), .sequence_storage_type = SequenceStorageType::MarkedVector };
 
-    if (type.is_string())
+    if (type.is_string()) {
+        if (interface.extended_attributes.contains("UseNewAKString"))
+            return { .name = "String", .sequence_storage_type = SequenceStorageType::Vector };
+
         return { .name = "DeprecatedString", .sequence_storage_type = SequenceStorageType::Vector };
+    }
 
     if (type.name() == "double" && !type.is_nullable())
         return { .name = "double", .sequence_storage_type = SequenceStorageType::Vector };
@@ -251,6 +255,104 @@ static void emit_includes_for_all_imports(auto& interface, auto& generator, bool
 }
 
 template<typename ParameterType>
+static void generate_to_deprecated_string(SourceGenerator& scoped_generator, ParameterType const& parameter, bool variadic, bool optional, Optional<DeprecatedString> const& optional_default_value)
+{
+    if (variadic) {
+        scoped_generator.append(R"~~~(
+    Vector<DeprecatedString> @cpp_name@;
+    @cpp_name@.ensure_capacity(vm.argument_count() - @js_suffix@);
+
+    for (size_t i = @js_suffix@; i < vm.argument_count(); ++i) {
+        auto to_string_result = TRY(vm.argument(i).to_deprecated_string(vm));
+        @cpp_name@.append(move(to_string_result));
+    }
+)~~~");
+    } else if (!optional) {
+        if (!parameter.type->is_nullable()) {
+            scoped_generator.append(R"~~~(
+    DeprecatedString @cpp_name@;
+    if (@js_name@@js_suffix@.is_null() && @legacy_null_to_empty_string@) {
+        @cpp_name@ = DeprecatedString::empty();
+    } else {
+        @cpp_name@ = TRY(@js_name@@js_suffix@.to_deprecated_string(vm));
+    }
+)~~~");
+        } else {
+            scoped_generator.append(R"~~~(
+    DeprecatedString @cpp_name@;
+    if (!@js_name@@js_suffix@.is_nullish())
+        @cpp_name@ = TRY(@js_name@@js_suffix@.to_deprecated_string(vm));
+)~~~");
+        }
+    } else {
+        scoped_generator.append(R"~~~(
+    DeprecatedString @cpp_name@;
+    if (!@js_name@@js_suffix@.is_undefined()) {
+        if (@js_name@@js_suffix@.is_null() && @legacy_null_to_empty_string@)
+            @cpp_name@ = DeprecatedString::empty();
+        else
+            @cpp_name@ = TRY(@js_name@@js_suffix@.to_deprecated_string(vm));
+    })~~~");
+        if (optional_default_value.has_value() && (!parameter.type->is_nullable() || optional_default_value.value() != "null")) {
+            scoped_generator.append(R"~~~( else {
+        @cpp_name@ = @parameter.optional_default_value@;
+    }
+)~~~");
+        } else {
+            scoped_generator.append(R"~~~(
+)~~~");
+        }
+    }
+}
+
+template<typename ParameterType>
+static void generate_to_new_string(SourceGenerator& scoped_generator, ParameterType const& parameter, bool variadic, bool optional, Optional<DeprecatedString> const& optional_default_value)
+{
+    if (variadic) {
+        scoped_generator.append(R"~~~(
+    Vector<String> @cpp_name@;
+    @cpp_name@.ensure_capacity(vm.argument_count() - @js_suffix@);
+
+    for (size_t i = @js_suffix@; i < vm.argument_count(); ++i) {
+        auto to_string_result = TRY(vm.argument(i).to_string(vm));
+        @cpp_name@.append(move(to_string_result));
+    }
+)~~~");
+    } else if (!optional) {
+        if (!parameter.type->is_nullable()) {
+            scoped_generator.append(R"~~~(
+    String @cpp_name@;
+    if (!@legacy_null_to_empty_string@ || !@js_name@@js_suffix@.is_null()) {
+        @cpp_name@ = TRY(@js_name@@js_suffix@.to_string(vm));
+    }
+)~~~");
+        } else {
+            scoped_generator.append(R"~~~(
+    Optional<String> @cpp_name@;
+    if (!@js_name@@js_suffix@.is_nullish())
+        @cpp_name@ = TRY(@js_name@@js_suffix@.to_string(vm));
+)~~~");
+        }
+    } else {
+        scoped_generator.append(R"~~~(
+    Optional<String> @cpp_name@;
+    if (!@js_name@@js_suffix@.is_undefined()) {
+        if (!@legacy_null_to_empty_string@ || !@js_name@@js_suffix@.is_null())
+            @cpp_name@ = TRY(@js_name@@js_suffix@.to_string(vm));
+    })~~~");
+        if (optional_default_value.has_value() && (!parameter.type->is_nullable() || optional_default_value.value() != "null")) {
+            scoped_generator.append(R"~~~( else {
+        @cpp_name@ = TRY_OR_THROW_OOM(vm, String::from_utf8(@parameter.optional_default_value@));
+    }
+)~~~");
+        } else {
+            scoped_generator.append(R"~~~(
+)~~~");
+        }
+    }
+}
+
+template<typename ParameterType>
 static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter, DeprecatedString const& js_name, DeprecatedString const& js_suffix, DeprecatedString const& cpp_name, IDL::Interface const& interface, bool legacy_null_to_empty_string = false, bool optional = false, Optional<DeprecatedString> optional_default_value = {}, bool variadic = false, size_t recursion_depth = 0)
 {
     auto scoped_generator = generator.fork();
@@ -266,52 +368,11 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
 
     // FIXME: Add support for optional, variadic, nullable and default values to all types
     if (parameter.type->is_string()) {
-        if (variadic) {
-            scoped_generator.append(R"~~~(
-    Vector<DeprecatedString> @cpp_name@;
-    @cpp_name@.ensure_capacity(vm.argument_count() - @js_suffix@);
-
-    for (size_t i = @js_suffix@; i < vm.argument_count(); ++i) {
-        auto to_string_result = TRY(vm.argument(i).to_deprecated_string(vm));
-        @cpp_name@.append(move(to_string_result));
-    }
-)~~~");
-        } else if (!optional) {
-            if (!parameter.type->is_nullable()) {
-                scoped_generator.append(R"~~~(
-    DeprecatedString @cpp_name@;
-    if (@js_name@@js_suffix@.is_null() && @legacy_null_to_empty_string@) {
-        @cpp_name@ = DeprecatedString::empty();
-    } else {
-        @cpp_name@ = TRY(@js_name@@js_suffix@.to_deprecated_string(vm));
-    }
-)~~~");
-            } else {
-                scoped_generator.append(R"~~~(
-    DeprecatedString @cpp_name@;
-    if (!@js_name@@js_suffix@.is_nullish())
-        @cpp_name@ = TRY(@js_name@@js_suffix@.to_deprecated_string(vm));
-)~~~");
-            }
-        } else {
-            scoped_generator.append(R"~~~(
-    DeprecatedString @cpp_name@;
-    if (!@js_name@@js_suffix@.is_undefined()) {
-        if (@js_name@@js_suffix@.is_null() && @legacy_null_to_empty_string@)
-            @cpp_name@ = DeprecatedString::empty();
+        bool use_new_ak_string = interface.extended_attributes.contains("UseNewAKString");
+        if (!use_new_ak_string)
+            generate_to_deprecated_string(scoped_generator, parameter, variadic, optional, optional_default_value);
         else
-            @cpp_name@ = TRY(@js_name@@js_suffix@.to_deprecated_string(vm));
-    })~~~");
-            if (optional_default_value.has_value() && (!parameter.type->is_nullable() || optional_default_value.value() != "null")) {
-                scoped_generator.append(R"~~~( else {
-        @cpp_name@ = @parameter.optional_default_value@;
-    }
-)~~~");
-            } else {
-                scoped_generator.append(R"~~~(
-)~~~");
-            }
-        }
+            generate_to_new_string(scoped_generator, parameter, variadic, optional, optional_default_value);
     } else if (parameter.type->name().is_one_of("EventListener", "NodeFilter")) {
         // FIXME: Replace this with support for callback interfaces. https://webidl.spec.whatwg.org/#idl-callback-interface
 

--- a/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.h
+++ b/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.h
@@ -10,14 +10,7 @@
 
 namespace Web::HTML {
 
-using HashMapWithVectorOfFormDataEntryValue = HashMap<DeprecatedString, Vector<XHR::FormDataEntryValue>>;
-
-struct Entry {
-    String name;
-    Variant<JS::NonnullGCPtr<FileAPI::File>, String> value;
-};
-
-WebIDL::ExceptionOr<Entry> create_entry(JS::Realm& realm, String const& name, Variant<JS::NonnullGCPtr<FileAPI::Blob>, String> const& value, Optional<String> const& filename = {});
-WebIDL::ExceptionOr<Optional<HashMapWithVectorOfFormDataEntryValue>> construct_entry_list(JS::Realm&, HTMLFormElement&);
+WebIDL::ExceptionOr<XHR::FormDataEntry> create_entry(JS::Realm& realm, String const& name, Variant<JS::NonnullGCPtr<FileAPI::Blob>, String> const& value, Optional<String> const& filename = {});
+WebIDL::ExceptionOr<Optional<Vector<XHR::FormDataEntry>>> construct_entry_list(JS::Realm&, HTMLFormElement&);
 
 }

--- a/Userland/Libraries/LibWeb/XHR/FormData.h
+++ b/Userland/Libraries/LibWeb/XHR/FormData.h
@@ -15,7 +15,12 @@
 namespace Web::XHR {
 
 // https://xhr.spec.whatwg.org/#formdataentryvalue
-using FormDataEntryValue = Variant<JS::NonnullGCPtr<FileAPI::File>, DeprecatedString>;
+using FormDataEntryValue = Variant<JS::Handle<FileAPI::File>, String>;
+
+struct FormDataEntry {
+    String name;
+    FormDataEntryValue value;
+};
 
 // https://xhr.spec.whatwg.org/#interface-formdata
 class FormData : public Bindings::PlatformObject {
@@ -25,27 +30,26 @@ public:
     virtual ~FormData() override;
 
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<FormData>> construct_impl(JS::Realm&, Optional<JS::NonnullGCPtr<HTML::HTMLFormElement>> form = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<FormData>> construct_impl(JS::Realm&, HashMap<DeprecatedString, Vector<FormDataEntryValue>> entry_list);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<FormData>> construct_impl(JS::Realm&, Vector<FormDataEntry> entry_list);
 
-    WebIDL::ExceptionOr<void> append(DeprecatedString const& name, DeprecatedString const& value);
-    WebIDL::ExceptionOr<void> append(DeprecatedString const& name, JS::NonnullGCPtr<FileAPI::Blob> const& blob_value, Optional<DeprecatedString> const& filename = {});
-    void delete_(DeprecatedString const& name);
-    Variant<JS::NonnullGCPtr<FileAPI::File>, DeprecatedString, Empty> get(DeprecatedString const& name);
-    Vector<FormDataEntryValue> get_all(DeprecatedString const& name);
-    bool has(DeprecatedString const& name);
-    WebIDL::ExceptionOr<void> set(DeprecatedString const& name, DeprecatedString const& value);
-    WebIDL::ExceptionOr<void> set(DeprecatedString const& name, JS::NonnullGCPtr<FileAPI::Blob> const& blob_value, Optional<DeprecatedString> const& filename = {});
+    WebIDL::ExceptionOr<void> append(String const& name, String const& value);
+    WebIDL::ExceptionOr<void> append(String const& name, JS::NonnullGCPtr<FileAPI::Blob> const& blob_value, Optional<String> const& filename = {});
+    void delete_(String const& name);
+    Variant<JS::Handle<FileAPI::File>, String, Empty> get(String const& name);
+    WebIDL::ExceptionOr<Vector<FormDataEntryValue>> get_all(String const& name);
+    bool has(String const& name);
+    WebIDL::ExceptionOr<void> set(String const& name, String const& value);
+    WebIDL::ExceptionOr<void> set(String const& name, JS::NonnullGCPtr<FileAPI::Blob> const& blob_value, Optional<String> const& filename = {});
 
 private:
-    explicit FormData(JS::Realm&, HashMap<DeprecatedString, Vector<FormDataEntryValue>> entry_list = {});
+    explicit FormData(JS::Realm&, Vector<FormDataEntry> entry_list = {});
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
-    virtual void visit_edges(Cell::Visitor&) override;
 
     WebIDL::ExceptionOr<void> append_impl(String const& name, Variant<JS::NonnullGCPtr<FileAPI::Blob>, String> const& value, Optional<String> const& filename = {});
     WebIDL::ExceptionOr<void> set_impl(String const& name, Variant<JS::NonnullGCPtr<FileAPI::Blob>, String> const& value, Optional<String> const& filename = {});
 
-    HashMap<DeprecatedString, Vector<FormDataEntryValue>> m_entry_list;
+    Vector<FormDataEntry> m_entry_list;
 };
 
 }

--- a/Userland/Libraries/LibWeb/XHR/FormData.idl
+++ b/Userland/Libraries/LibWeb/XHR/FormData.idl
@@ -5,7 +5,7 @@
 typedef (File or USVString) FormDataEntryValue;
 
 // https://xhr.spec.whatwg.org/#interface-formdata
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface FormData {
     constructor(optional HTMLFormElement form);
 


### PR DESCRIPTION
This makes use of a new interface extended attribute called "UseNewAKString", which makes all IDL string types used by the interface use AK::String instead of AK::DeprecatedString. See the first commit for the reasons this is on the interface. Using Vector storage will make it easier to make FormData into an IDL iterable. It seems the reason it didn't use Vector originally was due to awkward DeprecatedString -> String conversions.