### PR TITLE
LibTextCodec: Refurbish decoders

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzCyrillicDecoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzCyrillicDecoder.cpp
@@ -11,8 +11,8 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto* decoder = TextCodec::decoder_for("windows-1251"sv);
-    VERIFY(decoder);
+    auto decoder = TextCodec::decoder_for("windows-1251"sv);
+    VERIFY(decoder.has_value());
     decoder->to_utf8({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzCyrillicDecoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzCyrillicDecoder.cpp
@@ -13,6 +13,6 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     auto decoder = TextCodec::decoder_for("windows-1251"sv);
     VERIFY(decoder.has_value());
-    decoder->to_utf8({ data, size });
+    (void)decoder->to_utf8({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzHebrewDecoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzHebrewDecoder.cpp
@@ -11,8 +11,8 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto* decoder = TextCodec::decoder_for("windows-1255"sv);
-    VERIFY(decoder);
+    auto decoder = TextCodec::decoder_for("windows-1255"sv);
+    VERIFY(decoder.has_value());
     decoder->to_utf8({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzHebrewDecoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzHebrewDecoder.cpp
@@ -13,6 +13,6 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     auto decoder = TextCodec::decoder_for("windows-1255"sv);
     VERIFY(decoder.has_value());
-    decoder->to_utf8({ data, size });
+    (void)decoder->to_utf8({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzLatin1Decoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzLatin1Decoder.cpp
@@ -13,6 +13,6 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     auto decoder = TextCodec::decoder_for("windows-1252"sv);
     VERIFY(decoder.has_value());
-    decoder->to_utf8({ data, size });
+    (void)decoder->to_utf8({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzLatin1Decoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzLatin1Decoder.cpp
@@ -11,8 +11,8 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto* decoder = TextCodec::decoder_for("windows-1252"sv);
-    VERIFY(decoder);
+    auto decoder = TextCodec::decoder_for("windows-1252"sv);
+    VERIFY(decoder.has_value());
     decoder->to_utf8({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzLatin2Decoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzLatin2Decoder.cpp
@@ -13,6 +13,6 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     auto decoder = TextCodec::decoder_for("iso-8859-2"sv);
     VERIFY(decoder.has_value());
-    decoder->to_utf8({ data, size });
+    (void)decoder->to_utf8({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzLatin2Decoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzLatin2Decoder.cpp
@@ -11,8 +11,8 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto* decoder = TextCodec::decoder_for("iso-8859-2"sv);
-    VERIFY(decoder);
+    auto decoder = TextCodec::decoder_for("iso-8859-2"sv);
+    VERIFY(decoder.has_value());
     decoder->to_utf8({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzUTF16BEDecoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzUTF16BEDecoder.cpp
@@ -11,8 +11,8 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto* decoder = TextCodec::decoder_for("utf-16be"sv);
-    VERIFY(decoder);
+    auto decoder = TextCodec::decoder_for("utf-16be"sv);
+    VERIFY(decoder.has_value());
     decoder->to_utf8({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzUTF16BEDecoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzUTF16BEDecoder.cpp
@@ -13,6 +13,6 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     auto decoder = TextCodec::decoder_for("utf-16be"sv);
     VERIFY(decoder.has_value());
-    decoder->to_utf8({ data, size });
+    (void)decoder->to_utf8({ data, size });
     return 0;
 }

--- a/Tests/LibTextCodec/TestTextDecoders.cpp
+++ b/Tests/LibTextCodec/TestTextDecoders.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibTest/TestCase.h>
 #include <LibTextCodec/Decoder.h>
@@ -15,13 +16,13 @@ TEST_CASE(test_utf8_decode)
     auto test_string = "\xf0\x9f\x98\x80"sv;
 
     Vector<u32> processed_code_points;
-    decoder.process(test_string, [&](u32 code_point) {
-        processed_code_points.append(code_point);
-    });
+    MUST(decoder.process(test_string, [&](u32 code_point) {
+        return processed_code_points.try_append(code_point);
+    }));
     EXPECT(processed_code_points.size() == 1);
     EXPECT(processed_code_points[0] == 0x1F600);
 
-    EXPECT(decoder.to_utf8(test_string) == test_string);
+    EXPECT(MUST(decoder.to_utf8(test_string)) == test_string);
 }
 
 TEST_CASE(test_utf16be_decode)
@@ -31,9 +32,9 @@ TEST_CASE(test_utf16be_decode)
     auto test_string = "\x00s\x00\xe4\x00k\xd8=\xde\x00"sv;
 
     Vector<u32> processed_code_points;
-    decoder.process(test_string, [&](u32 code_point) {
-        processed_code_points.append(code_point);
-    });
+    MUST(decoder.process(test_string, [&](u32 code_point) {
+        return processed_code_points.try_append(code_point);
+    }));
     EXPECT(processed_code_points.size() == 4);
     EXPECT(processed_code_points[0] == 0x73);
     EXPECT(processed_code_points[1] == 0xE4);
@@ -48,9 +49,9 @@ TEST_CASE(test_utf16le_decode)
     auto test_string = "s\x00\xe4\x00k\x00=\xd8\x00\xde"sv;
 
     Vector<u32> processed_code_points;
-    decoder.process(test_string, [&](u32 code_point) {
-        processed_code_points.append(code_point);
-    });
+    MUST(decoder.process(test_string, [&](u32 code_point) {
+        return processed_code_points.try_append(code_point);
+    }));
     EXPECT(processed_code_points.size() == 4);
     EXPECT(processed_code_points[0] == 0x73);
     EXPECT(processed_code_points[1] == 0xE4);

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -392,7 +392,7 @@ void HexEditorWidget::update_inspector_values(size_t position)
 
     // FIXME: Parse as other values like Timestamp etc
 
-    DeprecatedString utf16_string = TextCodec::decoder_for("utf-16le"sv)->to_utf8(StringView(selected_bytes.span()));
+    DeprecatedString utf16_string = TextCodec::decoder_for("utf-16le"sv)->to_utf8(StringView(selected_bytes.span())).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
     value_inspector_model->set_parsed_value(ValueInspectorModel::ValueType::UTF16String, utf16_string);
 
     m_value_inspector->set_model(value_inspector_model);

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -322,7 +322,7 @@ DeprecatedString Name::string_for_id(NameId id) const
 
     if (platform_id == to_underlying(Platform::Windows)) {
         static auto& decoder = *TextCodec::decoder_for("utf-16be"sv);
-        return decoder.to_utf8(StringView { (char const*)m_slice.offset_pointer(storage_offset + offset), length });
+        return decoder.to_utf8(StringView { (char const*)m_slice.offset_pointer(storage_offset + offset), length }).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
     }
 
     return DeprecatedString((char const*)m_slice.offset_pointer(storage_offset + offset), length);

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.cpp
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.cpp
@@ -721,7 +721,7 @@ ErrorOr<NonnullRefPtr<MultiLocalizedUnicodeTagData>> MultiLocalizedUnicodeTagDat
             return Error::from_string_literal("ICC::Profile: multiLocalizedUnicodeType string offset out of bounds");
 
         StringView utf_16be_data { bytes.data() + record.string_offset_in_bytes, record.string_length_in_bytes };
-        records[i].text = TRY(String::from_deprecated_string(utf_16be_decoder.to_utf8(utf_16be_data)));
+        records[i].text = TRY(utf_16be_decoder.to_utf8(utf_16be_data));
     }
 
     return try_make_ref_counted<MultiLocalizedUnicodeTagData>(offset, size, move(records));
@@ -973,7 +973,7 @@ ErrorOr<NonnullRefPtr<TextDescriptionTagData>> TextDescriptionTagData::from_byte
             return Error::from_string_literal("ICC::Profile: textDescriptionType Unicode description not \\0-terminated");
 
         StringView utf_16be_data { unicode_description_data, byte_size_without_nul };
-        unicode_description = TRY(String::from_deprecated_string(TextCodec::decoder_for("utf-16be"sv)->to_utf8(utf_16be_data)));
+        unicode_description = TRY(TextCodec::decoder_for("utf-16be"sv)->to_utf8(utf_16be_data));
     }
 
     // ScriptCode
@@ -1019,7 +1019,7 @@ ErrorOr<NonnullRefPtr<TextDescriptionTagData>> TextDescriptionTagData::from_byte
             if (macintosh_description_data[macintosh_description_length - 1] != '\0')
                 return Error::from_string_literal("ICC::Profile: textDescriptionType ScriptCode not \\0-terminated");
 
-            macintosh_description = TRY(String::from_deprecated_string(TextCodec::decoder_for("x-mac-roman"sv)->to_utf8({ macintosh_description_data, (size_t)macintosh_description_length - 1 })));
+            macintosh_description = TRY(TextCodec::decoder_for("x-mac-roman"sv)->to_utf8({ macintosh_description_data, (size_t)macintosh_description_length - 1 }));
         } else {
             dbgln("TODO: ICCProfile textDescriptionType ScriptCode {}, length {}", scriptcode_code, macintosh_description_length);
         }

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -267,7 +267,7 @@ NonnullRefPtr<StringObject> Parser::parse_string()
 
     if (unencrypted_string.bytes().starts_with(Array<u8, 2> { 0xfe, 0xff })) {
         // The string is encoded in UTF16-BE
-        string_object->set_string(TextCodec::decoder_for("utf-16be"sv)->to_utf8(unencrypted_string));
+        string_object->set_string(TextCodec::decoder_for("utf-16be"sv)->to_utf8(unencrypted_string).release_value_but_fixme_should_propagate_errors().to_deprecated_string());
     } else if (unencrypted_string.bytes().starts_with(Array<u8, 3> { 239, 187, 191 })) {
         // The string is encoded in UTF-8. This is the default anyways, but if these bytes
         // are explicitly included, we have to trim them

--- a/Userland/Libraries/LibTextCodec/Decoder.cpp
+++ b/Userland/Libraries/LibTextCodec/Decoder.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -30,37 +31,37 @@ TurkishDecoder s_turkish_decoder;
 XUserDefinedDecoder s_x_user_defined_decoder;
 }
 
-Decoder* decoder_for(StringView a_encoding)
+Optional<Decoder&> decoder_for(StringView a_encoding)
 {
     auto encoding = get_standardized_encoding(a_encoding);
     if (encoding.has_value()) {
         if (encoding.value().equals_ignoring_case("windows-1252"sv))
-            return &s_latin1_decoder;
+            return s_latin1_decoder;
         if (encoding.value().equals_ignoring_case("utf-8"sv))
-            return &s_utf8_decoder;
+            return s_utf8_decoder;
         if (encoding.value().equals_ignoring_case("utf-16be"sv))
-            return &s_utf16be_decoder;
+            return s_utf16be_decoder;
         if (encoding.value().equals_ignoring_case("utf-16le"sv))
-            return &s_utf16le_decoder;
+            return s_utf16le_decoder;
         if (encoding.value().equals_ignoring_case("iso-8859-2"sv))
-            return &s_latin2_decoder;
+            return s_latin2_decoder;
         if (encoding.value().equals_ignoring_case("windows-1255"sv))
-            return &s_hebrew_decoder;
+            return s_hebrew_decoder;
         if (encoding.value().equals_ignoring_case("windows-1251"sv))
-            return &s_cyrillic_decoder;
+            return s_cyrillic_decoder;
         if (encoding.value().equals_ignoring_case("koi8-r"sv))
-            return &s_koi8r_decoder;
+            return s_koi8r_decoder;
         if (encoding.value().equals_ignoring_case("iso-8859-15"sv))
-            return &s_latin9_decoder;
+            return s_latin9_decoder;
         if (encoding.value().equals_ignoring_case("macintosh"sv))
-            return &s_mac_roman_decoder;
+            return s_mac_roman_decoder;
         if (encoding.value().equals_ignoring_case("windows-1254"sv))
-            return &s_turkish_decoder;
+            return s_turkish_decoder;
         if (encoding.value().equals_ignoring_case("x-user-defined"sv))
-            return &s_x_user_defined_decoder;
+            return s_x_user_defined_decoder;
     }
     dbgln("TextCodec: No decoder implemented for encoding '{}'", a_encoding);
-    return nullptr;
+    return {};
 }
 
 // https://encoding.spec.whatwg.org/#concept-encoding-get

--- a/Userland/Libraries/LibTextCodec/Decoder.h
+++ b/Userland/Libraries/LibTextCodec/Decoder.h
@@ -11,13 +11,14 @@
 #include <AK/Forward.h>
 #include <AK/Function.h>
 #include <AK/Optional.h>
+#include <AK/String.h>
 
 namespace TextCodec {
 
 class Decoder {
 public:
-    virtual void process(StringView, Function<void(u32)> on_code_point) = 0;
-    virtual DeprecatedString to_utf8(StringView);
+    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) = 0;
+    virtual ErrorOr<String> to_utf8(StringView);
 
 protected:
     virtual ~Decoder() = default;
@@ -25,65 +26,65 @@ protected:
 
 class UTF8Decoder final : public Decoder {
 public:
-    virtual void process(StringView, Function<void(u32)> on_code_point) override;
-    virtual DeprecatedString to_utf8(StringView) override;
+    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
+    virtual ErrorOr<String> to_utf8(StringView) override;
 };
 
 class UTF16BEDecoder final : public Decoder {
 public:
-    virtual void process(StringView, Function<void(u32)> on_code_point) override;
-    virtual DeprecatedString to_utf8(StringView) override;
+    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
+    virtual ErrorOr<String> to_utf8(StringView) override;
 };
 
 class UTF16LEDecoder final : public Decoder {
 public:
-    virtual void process(StringView, Function<void(u32)> on_code_point) override;
-    virtual DeprecatedString to_utf8(StringView) override;
+    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
+    virtual ErrorOr<String> to_utf8(StringView) override;
 };
 
 class Latin1Decoder final : public Decoder {
 public:
-    virtual void process(StringView, Function<void(u32)> on_code_point) override;
+    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
 };
 
 class Latin2Decoder final : public Decoder {
 public:
-    virtual void process(StringView, Function<void(u32)> on_code_point) override;
+    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
 };
 
 class HebrewDecoder final : public Decoder {
 public:
-    virtual void process(StringView, Function<void(u32)> on_code_point) override;
+    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
 };
 
 class CyrillicDecoder final : public Decoder {
 public:
-    virtual void process(StringView, Function<void(u32)> on_code_point) override;
+    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
 };
 
 class Koi8RDecoder final : public Decoder {
 public:
-    virtual void process(StringView, Function<void(u32)> on_code_point) override;
+    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
 };
 
 class Latin9Decoder final : public Decoder {
 public:
-    virtual void process(StringView, Function<void(u32)> on_code_point) override;
+    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
 };
 
 class MacRomanDecoder final : public Decoder {
 public:
-    virtual void process(StringView, Function<void(u32)> on_code_point) override;
+    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
 };
 
 class TurkishDecoder final : public Decoder {
 public:
-    virtual void process(StringView, Function<void(u32)> on_code_point) override;
+    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
 };
 
 class XUserDefinedDecoder final : public Decoder {
 public:
-    virtual void process(StringView, Function<void(u32)> on_code_point) override;
+    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
 };
 
 Optional<Decoder&> decoder_for(StringView encoding);
@@ -94,6 +95,6 @@ Optional<Decoder&> bom_sniff_to_decoder(StringView);
 
 // NOTE: This has an obnoxious name to discourage usage. Only use this if you absolutely must! For example, XHR in LibWeb uses this.
 // This will use the given decoder unless there is a byte order mark in the input, in which we will instead use the appropriate Unicode decoder.
-DeprecatedString convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(Decoder&, StringView);
+ErrorOr<String> convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(Decoder&, StringView);
 
 }

--- a/Userland/Libraries/LibTextCodec/Decoder.h
+++ b/Userland/Libraries/LibTextCodec/Decoder.h
@@ -89,8 +89,8 @@ public:
 Optional<Decoder&> decoder_for(StringView encoding);
 Optional<StringView> get_standardized_encoding(StringView encoding);
 
-// This returns the appropriate Unicode decoder for the sniffed BOM or nullptr if there is no appropriate decoder.
-Decoder* bom_sniff_to_decoder(StringView);
+// This returns the appropriate Unicode decoder for the sniffed BOM or nothing if there is no appropriate decoder.
+Optional<Decoder&> bom_sniff_to_decoder(StringView);
 
 // NOTE: This has an obnoxious name to discourage usage. Only use this if you absolutely must! For example, XHR in LibWeb uses this.
 // This will use the given decoder unless there is a byte order mark in the input, in which we will instead use the appropriate Unicode decoder.

--- a/Userland/Libraries/LibTextCodec/Decoder.h
+++ b/Userland/Libraries/LibTextCodec/Decoder.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,6 +10,7 @@
 
 #include <AK/Forward.h>
 #include <AK/Function.h>
+#include <AK/Optional.h>
 
 namespace TextCodec {
 
@@ -84,7 +86,7 @@ public:
     virtual void process(StringView, Function<void(u32)> on_code_point) override;
 };
 
-Decoder* decoder_for(StringView encoding);
+Optional<Decoder&> decoder_for(StringView encoding);
 Optional<StringView> get_standardized_encoding(StringView encoding);
 
 // This returns the appropriate Unicode decoder for the sniffed BOM or nullptr if there is no appropriate decoder.

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -206,37 +206,39 @@ Tokenizer::Tokenizer(StringView input, StringView encoding)
         bool last_was_carriage_return = false;
 
         // To filter code points from a stream of (unfiltered) code points input:
-        decoder->process(input, [&builder, &last_was_carriage_return](u32 code_point) {
-            // Replace any U+000D CARRIAGE RETURN (CR) code points,
-            // U+000C FORM FEED (FF) code points,
-            // or pairs of U+000D CARRIAGE RETURN (CR) followed by U+000A LINE FEED (LF)
-            // in input by a single U+000A LINE FEED (LF) code point.
-            if (code_point == '\r') {
-                if (last_was_carriage_return) {
-                    builder.append('\n');
-                } else {
-                    last_was_carriage_return = true;
-                }
-            } else {
-                if (last_was_carriage_return)
-                    builder.append('\n');
+        decoder->process(input, [&builder, &last_was_carriage_return](u32 code_point) -> ErrorOr<void> {
+                   // Replace any U+000D CARRIAGE RETURN (CR) code points,
+                   // U+000C FORM FEED (FF) code points,
+                   // or pairs of U+000D CARRIAGE RETURN (CR) followed by U+000A LINE FEED (LF)
+                   // in input by a single U+000A LINE FEED (LF) code point.
+                   if (code_point == '\r') {
+                       if (last_was_carriage_return) {
+                           TRY(builder.try_append('\n'));
+                       } else {
+                           last_was_carriage_return = true;
+                       }
+                   } else {
+                       if (last_was_carriage_return)
+                           TRY(builder.try_append('\n'));
 
-                if (code_point == '\n') {
-                    if (!last_was_carriage_return)
-                        builder.append('\n');
+                       if (code_point == '\n') {
+                           if (!last_was_carriage_return)
+                               TRY(builder.try_append('\n'));
 
-                } else if (code_point == '\f') {
-                    builder.append('\n');
-                    // Replace any U+0000 NULL or surrogate code points in input with U+FFFD REPLACEMENT CHARACTER (�).
-                } else if (code_point == 0x00 || (code_point >= 0xD800 && code_point <= 0xDFFF)) {
-                    builder.append_code_point(REPLACEMENT_CHARACTER);
-                } else {
-                    builder.append_code_point(code_point);
-                }
+                       } else if (code_point == '\f') {
+                           TRY(builder.try_append('\n'));
+                           // Replace any U+0000 NULL or surrogate code points in input with U+FFFD REPLACEMENT CHARACTER (�).
+                       } else if (code_point == 0x00 || (code_point >= 0xD800 && code_point <= 0xDFFF)) {
+                           TRY(builder.try_append_code_point(REPLACEMENT_CHARACTER));
+                       } else {
+                           TRY(builder.try_append_code_point(code_point));
+                       }
 
-                last_was_carriage_return = false;
-            }
-        });
+                       last_was_carriage_return = false;
+                   }
+                   return {};
+               })
+            .release_value_but_fixme_should_propagate_errors();
         return builder.to_string();
     };
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -199,8 +199,8 @@ Tokenizer::Tokenizer(StringView input, StringView encoding)
 {
     // https://www.w3.org/TR/css-syntax-3/#css-filter-code-points
     auto filter_code_points = [](StringView input, auto encoding) -> ErrorOr<String> {
-        auto* decoder = TextCodec::decoder_for(encoding);
-        VERIFY(decoder);
+        auto decoder = TextCodec::decoder_for(encoding);
+        VERIFY(decoder.has_value());
 
         StringBuilder builder { input.length() };
         bool last_was_carriage_return = false;

--- a/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
@@ -50,7 +50,7 @@ WebIDL::ExceptionOr<DeprecatedString> TextDecoder::decode(JS::Handle<JS::Object>
     if (data_buffer_or_error.is_error())
         return WebIDL::OperationError::create(realm(), "Failed to copy bytes from ArrayBuffer");
     auto& data_buffer = data_buffer_or_error.value();
-    return m_decoder.to_utf8({ data_buffer.data(), data_buffer.size() });
+    return TRY_OR_THROW_OOM(vm(), m_decoder.to_utf8({ data_buffer.data(), data_buffer.size() }));
 }
 
 }

--- a/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
@@ -15,7 +15,7 @@ namespace Web::Encoding {
 WebIDL::ExceptionOr<JS::NonnullGCPtr<TextDecoder>> TextDecoder::construct_impl(JS::Realm& realm, DeprecatedFlyString encoding)
 {
     auto decoder = TextCodec::decoder_for(encoding);
-    if (!decoder)
+    if (!decoder.has_value())
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, DeprecatedString::formatted("Invalid encoding {}", encoding) };
 
     return MUST_OR_THROW_OOM(realm.heap().allocate<TextDecoder>(realm, realm, *decoder, move(encoding), false, false));

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -512,7 +512,7 @@ void HTMLScriptElement::resource_did_load()
     // If the resource has an explicit encoding (i.e from a HTTP Content-Type header)
     // we have to re-encode it to UTF-8.
     if (resource()->has_encoding()) {
-        if (auto* codec = TextCodec::decoder_for(resource()->encoding().value())) {
+        if (auto codec = TextCodec::decoder_for(resource()->encoding().value()); codec.has_value()) {
             data = codec->to_utf8(data).to_byte_buffer();
         }
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -513,7 +513,7 @@ void HTMLScriptElement::resource_did_load()
     // we have to re-encode it to UTF-8.
     if (resource()->has_encoding()) {
         if (auto codec = TextCodec::decoder_for(resource()->encoding().value()); codec.has_value()) {
-            data = codec->to_utf8(data).to_byte_buffer();
+            data = codec->to_utf8(data).release_value_but_fixme_should_propagate_errors().to_deprecated_string().to_byte_buffer();
         }
     }
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -2800,7 +2800,7 @@ HTMLTokenizer::HTMLTokenizer(StringView input, DeprecatedString const& encoding)
 {
     auto decoder = TextCodec::decoder_for(encoding);
     VERIFY(decoder.has_value());
-    m_decoded_input = decoder->to_utf8(input);
+    m_decoded_input = decoder->to_utf8(input).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
     m_utf8_view = Utf8View(m_decoded_input);
     m_utf8_iterator = m_utf8_view.begin();
     m_prev_utf8_iterator = m_utf8_view.begin();

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -2798,8 +2798,8 @@ HTMLTokenizer::HTMLTokenizer()
 
 HTMLTokenizer::HTMLTokenizer(StringView input, DeprecatedString const& encoding)
 {
-    auto* decoder = TextCodec::decoder_for(encoding);
-    VERIFY(decoder);
+    auto decoder = TextCodec::decoder_for(encoding);
+    VERIFY(decoder.has_value());
     m_decoded_input = decoder->to_utf8(input);
     m_utf8_view = Utf8View(m_decoded_input);
     m_utf8_iterator = m_utf8_view.begin();

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1421,9 +1421,9 @@ JS_DEFINE_NATIVE_FUNCTION(Window::atob)
     // NOTE: Any 8-bit encoding -> utf-8 decoder will work for this
     auto text_decoder = TextCodec::decoder_for("windows-1252"sv);
     VERIFY(text_decoder.has_value());
-    auto text = text_decoder->to_utf8(decoded.release_value());
+    auto text = TRY_OR_THROW_OOM(vm, text_decoder->to_utf8(decoded.release_value()));
 
-    return JS::PrimitiveString::create(vm, DeprecatedString(text));
+    return JS::PrimitiveString::create(vm, text);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(Window::btoa)

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1420,7 +1420,7 @@ JS_DEFINE_NATIVE_FUNCTION(Window::atob)
     // The bytes object might contain bytes greater than 128, encode them in UTF8
     // NOTE: Any 8-bit encoding -> utf-8 decoder will work for this
     auto text_decoder = TextCodec::decoder_for("windows-1252"sv);
-    VERIFY(text_decoder);
+    VERIFY(text_decoder.has_value());
     auto text = text_decoder->to_utf8(decoded.release_value());
 
     return JS::PrimitiveString::create(vm, DeprecatedString(text));

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
@@ -163,7 +163,7 @@ WebIDL::ExceptionOr<DeprecatedString> WorkerGlobalScope::atob(DeprecatedString c
     // decode_base64() returns a byte string. LibJS uses UTF-8 for strings. Use Latin1Decoder to convert bytes 128-255 to UTF-8.
     auto decoder = TextCodec::decoder_for("windows-1252"sv);
     VERIFY(decoder.has_value());
-    return decoder->to_utf8(decoded_data.value());
+    return TRY_OR_THROW_OOM(vm(), decoder->to_utf8(decoded_data.value()));
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
@@ -161,8 +161,8 @@ WebIDL::ExceptionOr<DeprecatedString> WorkerGlobalScope::atob(DeprecatedString c
 
     // 3. Return decodedData.
     // decode_base64() returns a byte string. LibJS uses UTF-8 for strings. Use Latin1Decoder to convert bytes 128-255 to UTF-8.
-    auto* decoder = TextCodec::decoder_for("windows-1252"sv);
-    VERIFY(decoder);
+    auto decoder = TextCodec::decoder_for("windows-1252"sv);
+    VERIFY(decoder.has_value());
     return decoder->to_utf8(decoded_data.value());
 }
 

--- a/Userland/Libraries/LibWeb/Infra/JSON.cpp
+++ b/Userland/Libraries/LibWeb/Infra/JSON.cpp
@@ -27,7 +27,7 @@ WebIDL::ExceptionOr<JS::Value> parse_json_bytes_to_javascript_value(JS::VM& vm, 
 {
     // 1. Let string be the result of running UTF-8 decode on bytes.
     TextCodec::UTF8Decoder decoder;
-    auto string = decoder.to_utf8(bytes);
+    auto string = TRY_OR_THROW_OOM(vm, decoder.to_utf8(bytes));
 
     // 2. Return the result of parsing a JSON string to an Infra value given string.
     return parse_json_string_to_javascript_value(vm, string);

--- a/Userland/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/Resource.cpp
@@ -83,7 +83,7 @@ static DeprecatedString mime_type_from_content_type(DeprecatedString const& cont
 
 static bool is_valid_encoding(StringView encoding)
 {
-    return TextCodec::decoder_for(encoding);
+    return TextCodec::decoder_for(encoding).has_value();
 }
 
 void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> const& headers, Optional<u32> status_code)

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -219,10 +219,10 @@ DeprecatedString XMLHttpRequest::get_text_response() const
         charset = "UTF-8"sv;
 
     // 5. Return the result of running decode on xhr’s received bytes using fallback encoding charset.
-    auto* decoder = TextCodec::decoder_for(charset.value());
+    auto decoder = TextCodec::decoder_for(charset.value());
 
     // If we don't support the decoder yet, let's crash instead of attempting to return something, as the result would be incorrect and create obscure bugs.
-    VERIFY(decoder);
+    VERIFY(decoder.has_value());
 
     return TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, m_received_bytes);
 }

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -224,7 +224,7 @@ DeprecatedString XMLHttpRequest::get_text_response() const
     // If we don't support the decoder yet, let's crash instead of attempting to return something, as the result would be incorrect and create obscure bugs.
     VERIFY(decoder.has_value());
 
-    return TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, m_received_bytes);
+    return TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, m_received_bytes).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 }
 
 // https://xhr.spec.whatwg.org/#final-mime-type

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -884,7 +884,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     auto decoder = TextCodec::decoder_for("windows-1252"sv);
                     VERIFY(decoder.has_value());
 
-                    auto utf8_source = TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, source);
+                    auto utf8_source = TRY(TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, source));
                     builder.append(utf8_source);
                 }
             }

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -881,8 +881,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 if (Utf8View { file_contents }.validate()) {
                     builder.append(source);
                 } else {
-                    auto* decoder = TextCodec::decoder_for("windows-1252"sv);
-                    VERIFY(decoder);
+                    auto decoder = TextCodec::decoder_for("windows-1252"sv);
+                    VERIFY(decoder.has_value());
 
                     auto utf8_source = TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, source);
                     builder.append(utf8_source);


### PR DESCRIPTION
Bring LibTextCodec from the dark ages of `DeprecatedString` and `Decoder*` into the glistening cyberfuture of `ErrorOr<String>` and `Optional<Decoder&>`.