### PR TITLE
Implement more ICC profile writing

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
+++ b/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
@@ -130,6 +130,16 @@ struct CLUTHeader {
 };
 static_assert(AssertSize<CLUTHeader, 20>());
 
+// Table 49 — measurementType structure
+struct MeasurementHeader {
+    BigEndian<MeasurementTagData::StandardObserver> standard_observer;
+    XYZNumber tristimulus_value_for_measurement_backing;
+    BigEndian<MeasurementTagData::MeasurementGeometry> measurement_geometry;
+    BigEndian<u16Fixed16Number> measurement_flare;
+    BigEndian<MeasurementTagData::StandardIlluminant> standard_illuminant;
+};
+static_assert(AssertSize<MeasurementHeader, 28>());
+
 // ICC v4, 10.15 multiLocalizedUnicodeType
 struct MultiLocalizedUnicodeRawRecord {
     BigEndian<u16> language_code;

--- a/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
+++ b/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
@@ -130,4 +130,13 @@ struct CLUTHeader {
 };
 static_assert(AssertSize<CLUTHeader, 20>());
 
+// ICC v4, 10.15 multiLocalizedUnicodeType
+struct MultiLocalizedUnicodeRawRecord {
+    BigEndian<u16> language_code;
+    BigEndian<u16> country_code;
+    BigEndian<u32> string_length_in_bytes;
+    BigEndian<u32> string_offset_in_bytes;
+};
+static_assert(AssertSize<MultiLocalizedUnicodeRawRecord, 12>());
+
 }

--- a/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
+++ b/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
@@ -89,6 +89,14 @@ static_assert(AssertSize<ICCHeader, 128>());
 // "The profile file signature field shall contain the value “acsp” (61637370h) as a profile file signature."
 constexpr u32 ProfileFileSignature = 0x61637370;
 
+// ICC V4, 7.3 Tag table, Table 24 - Tag table structure
+struct TagTableEntry {
+    BigEndian<TagSignature> tag_signature;
+    BigEndian<u32> offset_to_beginning_of_tag_data_element;
+    BigEndian<u32> size_of_tag_data_element;
+};
+static_assert(AssertSize<TagTableEntry, 12>());
+
 // Common bits of ICC v4, Table 40 — lut16Type encoding and Table 44 — lut8Type encoding
 struct LUTHeader {
     u8 number_of_input_channels;

--- a/Userland/Libraries/LibGfx/ICC/BinaryWriter.cpp
+++ b/Userland/Libraries/LibGfx/ICC/BinaryWriter.cpp
@@ -139,6 +139,16 @@ static ErrorOr<ByteBuffer> encode_s15_fixed_array(S15Fixed16ArrayTagData const& 
     return bytes;
 }
 
+static ErrorOr<ByteBuffer> encode_signature(SignatureTagData const& tag_data)
+{
+    // ICC v4, 10.23 signatureType
+    auto bytes = TRY(ByteBuffer::create_uninitialized(3 * sizeof(u32)));
+    *bit_cast<BigEndian<u32>*>(bytes.data()) = (u32)SignatureTagData::Type;
+    *bit_cast<BigEndian<u32>*>(bytes.data() + 4) = 0;
+    *bit_cast<BigEndian<u32>*>(bytes.data() + 8) = tag_data.signature();
+    return bytes;
+}
+
 static ErrorOr<ByteBuffer> encode_xyz(XYZTagData const& tag_data)
 {
     // ICC v4, 10.31 XYZType
@@ -168,6 +178,8 @@ static ErrorOr<ByteBuffer> encode_tag_data(TagData const& tag_data)
         return encode_parametric_curve(static_cast<ParametricCurveTagData const&>(tag_data));
     case S15Fixed16ArrayTagData::Type:
         return encode_s15_fixed_array(static_cast<S15Fixed16ArrayTagData const&>(tag_data));
+    case SignatureTagData::Type:
+        return encode_signature(static_cast<SignatureTagData const&>(tag_data));
     case XYZTagData::Type:
         return encode_xyz(static_cast<XYZTagData const&>(tag_data));
     }

--- a/Userland/Libraries/LibGfx/ICC/BinaryWriter.cpp
+++ b/Userland/Libraries/LibGfx/ICC/BinaryWriter.cpp
@@ -11,13 +11,8 @@
 
 namespace Gfx::ICC {
 
-ErrorOr<ByteBuffer> encode(Profile const& profile)
+static ErrorOr<void> encode_header(ByteBuffer& bytes, Profile const& profile)
 {
-
-    // Leaves enough room for the profile header and the tag table count.
-    // FIXME: Serialize tag data and write tag table and tag data too.
-    auto bytes = TRY(ByteBuffer::create_zeroed(sizeof(ICCHeader) + sizeof(u32)));
-
     VERIFY(bytes.size() >= sizeof(ICCHeader));
     auto& raw_header = *bit_cast<ICCHeader*>(bytes.data());
 
@@ -61,6 +56,17 @@ ErrorOr<ByteBuffer> encode(Profile const& profile)
     auto id = Profile::compute_id(bytes);
     static_assert(sizeof(id.data) == sizeof(raw_header.profile_id));
     memcpy(raw_header.profile_id, id.data, sizeof(id.data));
+
+    return {};
+}
+
+ErrorOr<ByteBuffer> encode(Profile const& profile)
+{
+    // Leaves enough room for the profile header and the tag table count.
+    // FIXME: Serialize tag data and write tag table and tag data too.
+    auto bytes = TRY(ByteBuffer::create_zeroed(sizeof(ICCHeader) + sizeof(u32)));
+
+    TRY(encode_header(bytes, profile));
 
     return bytes;
 }

--- a/Userland/Libraries/LibGfx/ICC/BinaryWriter.cpp
+++ b/Userland/Libraries/LibGfx/ICC/BinaryWriter.cpp
@@ -34,6 +34,19 @@ static ErrorOr<ByteBuffer> encode_chromaticity(ChromaticityTagData const& tag_da
     return bytes;
 }
 
+static ErrorOr<ByteBuffer> encode_cipc(CicpTagData const& tag_data)
+{
+    // ICC v4, 10.3 cicpType
+    auto bytes = TRY(ByteBuffer::create_uninitialized(2 * sizeof(u32) + 4));
+    *bit_cast<BigEndian<u32>*>(bytes.data()) = (u32)CicpTagData::Type;
+    *bit_cast<BigEndian<u32>*>(bytes.data() + 4) = 0;
+    bytes.data()[8] = tag_data.color_primaries();
+    bytes.data()[9] = tag_data.transfer_characteristics();
+    bytes.data()[10] = tag_data.matrix_coefficients();
+    bytes.data()[11] = tag_data.video_full_range_flag();
+    return bytes;
+}
+
 static ErrorOr<ByteBuffer> encode_multi_localized_unicode(MultiLocalizedUnicodeTagData const& tag_data)
 {
     // ICC v4, 10.15 multiLocalizedUnicodeType
@@ -130,6 +143,8 @@ static ErrorOr<ByteBuffer> encode_tag_data(TagData const& tag_data)
     switch (tag_data.type()) {
     case ChromaticityTagData::Type:
         return encode_chromaticity(static_cast<ChromaticityTagData const&>(tag_data));
+    case CicpTagData::Type:
+        return encode_cipc(static_cast<CicpTagData const&>(tag_data));
     case MultiLocalizedUnicodeTagData::Type:
         return encode_multi_localized_unicode(static_cast<MultiLocalizedUnicodeTagData const&>(tag_data));
     case ParametricCurveTagData::Type:

--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -629,14 +629,6 @@ static ErrorOr<OrderedHashMap<TagSignature, NonnullRefPtr<TagData>>> read_tag_ta
         return Error::from_string_literal("ICC::Profile: Not enough data for tag count");
     auto tag_count = *bit_cast<BigEndian<u32> const*>(tag_table_bytes.data());
 
-    // ICC V4, 7.3 Tag table, Table 24 - Tag table structure
-    struct TagTableEntry {
-        BigEndian<TagSignature> tag_signature;
-        BigEndian<u32> offset_to_beginning_of_tag_data_element;
-        BigEndian<u32> size_of_tag_data_element;
-    };
-    static_assert(AssertSize<TagTableEntry, 12>());
-
     tag_table_bytes = tag_table_bytes.slice(sizeof(u32));
     if (tag_table_bytes.size() < tag_count * sizeof(TagTableEntry))
         return Error::from_string_literal("ICC::Profile: Not enough data for tag table entries");

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -247,6 +247,8 @@ public:
             callback(tag.key, tag.value);
     }
 
+    size_t tag_count() const { return m_tag_table.size(); }
+
     // Only versions 2 and 4 are in use.
     bool is_v2() const { return version().major_version() == 2; }
     bool is_v4() const { return version().major_version() == 4; }

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.cpp
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.cpp
@@ -551,16 +551,6 @@ ErrorOr<NonnullRefPtr<MeasurementTagData>> MeasurementTagData::from_bytes(Readon
     VERIFY(tag_type(bytes) == Type);
     TRY(check_reserved(bytes));
 
-    // Table 49 — measurementType structure
-    struct MeasurementHeader {
-        BigEndian<StandardObserver> standard_observer;
-        XYZNumber tristimulus_value_for_measurement_backing;
-        BigEndian<MeasurementGeometry> measurement_geometry;
-        BigEndian<u16Fixed16Number> measurement_flare;
-        BigEndian<StandardIlluminant> standard_illuminant;
-    };
-    static_assert(AssertSize<MeasurementHeader, 28>());
-
     if (bytes.size() < 2 * sizeof(u32) + sizeof(MeasurementHeader))
         return Error::from_string_literal("ICC::Profile: measurementTag has not enough data");
 

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -762,6 +762,8 @@ public:
         : TagData(offset, size, Type)
         , m_text(move(text))
     {
+        for (u8 byte : text.bytes())
+            VERIFY(byte < 128);
     }
 
     // Guaranteed to be 7-bit ASCII.

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -626,6 +626,13 @@ public:
 
     static unsigned parameter_count(FunctionType);
 
+    unsigned parameter_count() const { return parameter_count(function_type()); }
+    S15Fixed16 parameter(size_t i) const
+    {
+        VERIFY(i < parameter_count());
+        return m_parameters[i];
+    }
+
     S15Fixed16 g() const { return m_parameters[0]; }
     S15Fixed16 a() const
     {


### PR DESCRIPTION
This implements writing 10 of the currently 17 implemented tag types. It implements enough to write complete v4 matrix profiles that `icc` can read again. It doesn't quite implement enough for v2 matrix profiles (the `'desc'` type is the one missing tag type for that).

It also doesn't dedupe identical tag types yet.