### PR TITLE
WindowServer: Fix glitches rendering stretched wallpaper on multiple screens

### DIFF
--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -320,7 +320,7 @@ void Compositor::compose()
                 painter.draw_tiled_bitmap(rect, *m_wallpaper);
             } else if (m_wallpaper_mode == WallpaperMode::Stretch) {
                 VERIFY(screen.compositor_screen_data().m_wallpaper_bitmap);
-                painter.blit(rect.location(), *screen.compositor_screen_data().m_wallpaper_bitmap, rect);
+                painter.blit(rect.location(), *screen.compositor_screen_data().m_wallpaper_bitmap, rect.translated(-screen.location()));
             } else {
                 VERIFY_NOT_REACHED();
             }

--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -40,7 +40,6 @@ struct CompositorScreenData {
     OwnPtr<Gfx::Painter> m_back_painter;
     OwnPtr<Gfx::Painter> m_front_painter;
     OwnPtr<Gfx::Painter> m_temp_painter;
-    OwnPtr<Gfx::Painter> m_wallpaper_painter;
     RefPtr<Gfx::Bitmap> m_cursor_back_bitmap;
     OwnPtr<Gfx::Painter> m_cursor_back_painter;
     Gfx::IntRect m_last_cursor_rect;
@@ -62,7 +61,6 @@ struct CompositorScreenData {
     void flip_buffers(Screen&);
     void draw_cursor(Screen&, Gfx::IntRect const&);
     bool restore_cursor_back(Screen&, Gfx::IntRect&);
-    void init_wallpaper_bitmap(Screen&);
     void clear_wallpaper_bitmap();
 
     template<typename F>

--- a/Userland/Services/WindowServer/Screen.h
+++ b/Userland/Services/WindowServer/Screen.h
@@ -164,6 +164,7 @@ public:
 
     Gfx::IntSize physical_size() const { return { physical_width(), physical_height() }; }
 
+    Gfx::IntPoint location() const { return m_virtual_rect.location(); }
     Gfx::IntSize size() const { return { m_virtual_rect.width(), m_virtual_rect.height() }; }
     Gfx::IntRect rect() const { return m_virtual_rect; }
 


### PR DESCRIPTION
Noticed some major glitches when running with `SERENITY_SCREENS=2`.

Before:

https://user-images.githubusercontent.com/10320822/219831495-c8c0d5fa-6ef9-48d3-bf21-9c0c63b15064.mp4


After:

https://user-images.githubusercontent.com/10320822/219831548-3ec791ef-9b69-4912-9ecf-02156dd5949c.mp4

