### PR TITLE
Kernel/aarch64: Disable memory access alignment check

### DIFF
--- a/Kernel/Arch/aarch64/Exceptions.cpp
+++ b/Kernel/Arch/aarch64/Exceptions.cpp
@@ -74,7 +74,10 @@ static void setup_el1()
     system_control_register_el1.UMA = 1;  // Don't trap access to DAIF (debugging) flags of EFLAGS register
     system_control_register_el1.SA0 = 1;  // Enable stack access alignment check for EL0
     system_control_register_el1.SA = 1;   // Enable stack access alignment check for EL1
-    system_control_register_el1.A = 1;    // Enable memory access alignment check
+
+    // FIXME: Enable memory access alignment check when userspace will not execute unaligned memory accesses anymore.
+    //        See: https://github.com/SerenityOS/serenity/issues/17516
+    system_control_register_el1.A = 0; // Disable memory access alignment check
 
     Aarch64::SCTLR_EL1::write(system_control_register_el1);
 

--- a/Kernel/Arch/aarch64/Interrupts.cpp
+++ b/Kernel/Arch/aarch64/Interrupts.cpp
@@ -53,7 +53,7 @@ void dump_registers(RegisterState const& regs)
     dbgln("x30={:p}", regs.x[30]);
 }
 
-static PageFault page_fault_from_exception_syndrome_register(VirtualAddress fault_address, Aarch64::ESR_EL1 esr_el1)
+static ErrorOr<PageFault> page_fault_from_exception_syndrome_register(VirtualAddress fault_address, Aarch64::ESR_EL1 esr_el1)
 {
     PageFault fault { fault_address };
 
@@ -63,7 +63,8 @@ static PageFault page_fault_from_exception_syndrome_register(VirtualAddress faul
     } else if (data_fault_status_code >= 0b000100 && data_fault_status_code <= 0b000111) {
         fault.set_type(PageFault::Type::PageNotPresent);
     } else {
-        PANIC("Unknown DFSC: {}", data_fault_status_code);
+        dbgln("Unknown DFSC: {}", Aarch64::data_fault_status_code_to_string(esr_el1.ISS));
+        return Error::from_errno(EFAULT);
     }
 
     fault.set_access((esr_el1.ISS & (1 << 6)) == (1 << 6) ? PageFault::Access::Write : PageFault::Access::Read);
@@ -86,13 +87,17 @@ extern "C" void exception_common(Kernel::TrapFrame* trap_frame)
     Processor::enable_interrupts();
 
     if (Aarch64::exception_class_is_data_abort(esr_el1.EC) || Aarch64::exception_class_is_instruction_abort(esr_el1.EC)) {
-        auto page_fault = page_fault_from_exception_syndrome_register(VirtualAddress(fault_address), esr_el1);
-        page_fault.handle(*trap_frame->regs);
+        auto page_fault_or_error = page_fault_from_exception_syndrome_register(VirtualAddress(fault_address), esr_el1);
+        if (page_fault_or_error.is_error()) {
+            handle_crash(*trap_frame->regs, "Unknown page fault", SIGSEGV, false);
+        } else {
+            auto page_fault = page_fault_or_error.release_value();
+            page_fault.handle(*trap_frame->regs);
+        }
     } else if (Aarch64::exception_class_is_svc_instruction_execution(esr_el1.EC)) {
         syscall_handler(trap_frame);
     } else {
-        dump_registers(*trap_frame->regs);
-        PANIC("Unexpected exception!");
+        handle_crash(*trap_frame->regs, "Unexpected exception", SIGSEGV, false);
     }
 
     Processor::disable_interrupts();


### PR DESCRIPTION
Even though we currently build all of Userland and the Kernel with the -mstrict-align flag, the compiler will still emit unaligned memory accesses. To work around this, we disable the check for now. See #17516 for the relevant issue.