### PR TITLE
AK: Fix 64-bit alignment issue in shared-superstring substrings

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -77,7 +77,7 @@ private:
     bool m_substring { false };
     bool m_is_fly_string { false };
 
-    u8 m_bytes_or_substring_data[0];
+    alignas(SubstringData) u8 m_bytes_or_substring_data[0];
 };
 
 void StringData::operator delete(void* ptr)

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -97,6 +97,17 @@ TEST_CASE(substring)
     EXPECT_EQ(long_substring, "Hello I am"sv);
 }
 
+TEST_CASE(substring_with_shared_superstring)
+{
+    auto superstring = MUST(String::from_utf8("Hello I am a long string"sv));
+
+    auto substring1 = MUST(superstring.substring_from_byte_offset_with_shared_superstring(0, 5));
+    EXPECT_EQ(substring1, "Hello"sv);
+
+    auto substring2 = MUST(superstring.substring_from_byte_offset_with_shared_superstring(0, 10));
+    EXPECT_EQ(substring2, "Hello I am"sv);
+}
+
 TEST_CASE(code_points)
 {
     auto string = MUST(String::from_utf8("🦬🪒"sv));


### PR DESCRIPTION
Thanks to Timothy Flynn for the test!

Fixes #17141