### PR TITLE
AK: Fix printing of negative FixedPoint values

### DIFF
--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -420,10 +420,14 @@ struct Formatter<FixedPoint<precision, Underlying>> : StandardFormatter {
         m_width = m_width.value_or(0);
         m_precision = m_precision.value_or(6);
 
+        bool is_negative = false;
+        if constexpr (IsSigned<Underlying>)
+            is_negative = value < 0;
+
         i64 integer = value.ltrunk();
         constexpr u64 one = static_cast<Underlying>(1) << precision;
         u64 fraction_raw = value.raw() & (one - 1);
-        return builder.put_fixed_point(integer, fraction_raw, one, base, upper_case, m_zero_pad, m_align, m_width.value(), m_precision.value(), m_fill, m_sign_mode, real_number_display_mode);
+        return builder.put_fixed_point(is_negative, integer, fraction_raw, one, base, upper_case, m_zero_pad, m_align, m_width.value(), m_precision.value(), m_fill, m_sign_mode, real_number_display_mode);
     }
 };
 

--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -357,6 +357,7 @@ ErrorOr<void> FormatBuilder::put_i64(
 }
 
 ErrorOr<void> FormatBuilder::put_fixed_point(
+    bool is_negative,
     i64 integer_value,
     u64 fraction_value,
     u64 fraction_one,
@@ -373,7 +374,6 @@ ErrorOr<void> FormatBuilder::put_fixed_point(
     StringBuilder string_builder;
     FormatBuilder format_builder { string_builder };
 
-    bool is_negative = integer_value < 0;
     if (is_negative)
         integer_value = -integer_value;
 

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -209,6 +209,7 @@ public:
         SignMode sign_mode = SignMode::OnlyIfNeeded);
 
     ErrorOr<void> put_fixed_point(
+        bool is_negative,
         i64 integer_value,
         u64 fraction_value,
         u64 fraction_one,

--- a/Tests/AK/TestFixedPoint.cpp
+++ b/Tests/AK/TestFixedPoint.cpp
@@ -155,4 +155,7 @@ TEST_CASE(formatter)
     EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<16>(0.003)), "0.00299"sv);
     EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<16>(0.0004)), "0.000396"sv);
     EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<16>(0.0000000005)), "0"sv);
+    EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<16>(-0.1)), "-0.099991"sv);
+    EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<16>(-0.02)), "-0.01999"sv);
+    EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<16>(-0.0000000005)), "0"sv);
 }


### PR DESCRIPTION
Fixes #17514 by comparing to 0 before truncating the fractional part.