### PR TITLE
LibGfx: Correctly handle JPEG image with restart markers

### DIFF
--- a/Userland/Libraries/LibGfx/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPEGLoader.cpp
@@ -383,7 +383,7 @@ static ErrorOr<Vector<Macroblock>> decode_huffman_stream(JPEGLoadingContext& con
         for (u32 hcursor = 0; hcursor < context.mblock_meta.hcount; hcursor += context.hsample_factor) {
             u32 i = vcursor * context.mblock_meta.hpadded_count + hcursor;
             if (context.dc_reset_interval > 0) {
-                if (i % context.dc_reset_interval == 0) {
+                if (i != 0 && i % (context.dc_reset_interval * context.vsample_factor * context.hsample_factor) == 0) {
                     context.previous_dc_values[0] = 0;
                     context.previous_dc_values[1] = 0;
                     context.previous_dc_values[2] = 0;


### PR DESCRIPTION
Restart markers are supposed to be applied every restart interval. However, in these loops macroblocks are counted taking the luma sampling factor into consideration. Meaning that we need to correct this factor when testing if we should reset the DC.

Also, the decoder was discarding the first byte of every scan with a set restart interval, as `0 % n == 0` is always true.

![WHF](https://user-images.githubusercontent.com/26030965/219883771-7b6e5434-49d2-46db-b900-33cacc9329c9.png)


Fixes #16955 