### PR TITLE
LibWeb: Use specified_main_size() to find free space in flex container

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex-column-height-unconstrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-height-unconstrained.txt
@@ -1,0 +1,29 @@
+InitialContainingBlock <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x324 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x308 children: not-inline
+      Box <div.my-container.column> at (9,9) content-size 782x306 flex-container(column) children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (10,10) content-size 100x100 flex-item children: inline
+          line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (10,112) content-size 100x100 flex-item children: inline
+          line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [10,112 8.8125x17.46875]
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (10,214) content-size 100x100 flex-item children: inline
+          line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [10,214 9.09375x17.46875]
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,316) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/flex-column-height-unconstrained.html
+++ b/Tests/LibWeb/Layout/input/flex-column-height-unconstrained.html
@@ -1,0 +1,25 @@
+<style>
+    body {
+        font-family: 'SerenitySans';
+    }
+
+    .my-container {
+        display: flex;
+        border: 1px solid salmon;
+    }
+
+    .column {
+        flex-direction: column;
+    }
+
+    .box {
+        width: 100px;
+        height: 100px;
+        border: 1px solid black;
+    }
+</style>
+<div class="my-container column">
+    <div class="box">1</div>
+    <div class="box">2</div>
+    <div class="box">3</div>
+</div>

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -895,7 +895,7 @@ void FlexFormattingContext::resolve_flexible_lengths()
         for (auto& flex_item : flex_line.items) {
             sum_of_hypothetical_main_sizes += (flex_item->hypothetical_main_size + flex_item->margins.main_before + flex_item->margins.main_after + flex_item->borders.main_before + flex_item->borders.main_after + flex_item->padding.main_before + flex_item->padding.main_after);
         }
-        if (sum_of_hypothetical_main_sizes < m_available_space_for_items->main.to_px_or_zero())
+        if (sum_of_hypothetical_main_sizes < specified_main_size(flex_container()))
             used_flex_factor = FlexFactor::FlexGrowFactor;
         else
             used_flex_factor = FlexFactor::FlexShrinkFactor;
@@ -937,7 +937,7 @@ void FlexFormattingContext::resolve_flexible_lengths()
                 else
                     sum_of_items_on_line += flex_item->flex_base_size + flex_item->margins.main_before + flex_item->margins.main_after + flex_item->borders.main_before + flex_item->borders.main_after + flex_item->padding.main_before + flex_item->padding.main_after;
             }
-            return m_available_space_for_items->main.to_px_or_zero() - sum_of_items_on_line;
+            return specified_main_size(flex_container()) - sum_of_items_on_line;
         };
 
         CSSPixels initial_free_space = calculate_free_space();


### PR DESCRIPTION
In case `m_available_space_for_items.main` is not defined it will be 0 in calculation of free space on main axis, even if the main size of the flex container has been determined as a non-zero on `determine_main_size_of_flex_container` step.