### PR TITLE
Kernel: Remove unnecessary include from SysFS PowerStateSwitch code

### DIFF
--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/PowerStateSwitch.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/PowerStateSwitch.cpp
@@ -16,7 +16,6 @@
 #include <Kernel/Process.h>
 #include <Kernel/Sections.h>
 #include <Kernel/TTY/ConsoleManagement.h>
-#include <Kernel/WorkQueue.h>
 
 namespace Kernel {
 


### PR DESCRIPTION
I added that include in 2e55956784ac0c61fe877c316867074e0f432452 by a mistake, so we should get rid of it as soon as possible.

I found this after looking at #17528 to see if there are any more details and found this too.