### PR TITLE
LibWeb: Moar fallible factory functions

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -389,7 +389,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
             return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObject, TRY_OR_THROW_OOM(vm, @js_name@@js_suffix@.to_string_without_side_effects()));
 
         auto callback_type = vm.heap().allocate_without_realm<WebIDL::CallbackType>(@js_name@@js_suffix@.as_object(), HTML::incumbent_settings_object());
-        @cpp_name@ = @cpp_type@::create(realm, *callback_type).ptr();
+        @cpp_name@ = TRY(throw_dom_exception_if_needed(vm, [&] { return @cpp_type@::create(realm, *callback_type); }));
     }
 )~~~");
         } else {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2815,7 +2815,7 @@ JS_DEFINE_NATIVE_FUNCTION(@prototype_class@::entries)
 {
     auto* impl = TRY(impl_from(vm));
 
-    return @iterator_name@::create(*impl, Object::PropertyKind::KeyAndValue).ptr();
+    return TRY(throw_dom_exception_if_needed(vm, [&] { return @iterator_name@::create(*impl, Object::PropertyKind::KeyAndValue); }));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(@prototype_class@::for_each)
@@ -2844,14 +2844,14 @@ JS_DEFINE_NATIVE_FUNCTION(@prototype_class@::keys)
 {
     auto* impl = TRY(impl_from(vm));
 
-    return @iterator_name@::create(*impl, Object::PropertyKind::Key).ptr();
+    return TRY(throw_dom_exception_if_needed(vm, [&] { return @iterator_name@::create(*impl, Object::PropertyKind::Key);  }));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(@prototype_class@::values)
 {
     auto* impl = TRY(impl_from(vm));
 
-    return @iterator_name@::create(*impl, Object::PropertyKind::Value).ptr();
+    return TRY(throw_dom_exception_if_needed(vm, [&] { return @iterator_name@::create(*impl, Object::PropertyKind::Value); }));
 }
 )~~~");
     }

--- a/Userland/Libraries/LibWeb/Bindings/AudioConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/AudioConstructor.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/AudioConstructor.h>
+#include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/HTMLAudioElementPrototype.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
@@ -44,7 +45,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> AudioConstructor::construct(
     auto& document = window.associated_document();
 
     // 2. Let audio be the result of creating an element given document, audio, and the HTML namespace.
-    auto audio = DOM::create_element(document, HTML::TagNames::audio, Namespace::HTML);
+    auto audio = TRY(Bindings::throw_dom_exception_if_needed(vm, [&]() { return DOM::create_element(document, HTML::TagNames::audio, Namespace::HTML); }));
 
     // 3. Set an attribute value for audio using "preload" and "auto".
     MUST(audio->set_attribute(HTML::AttributeNames::preload, "auto"sv));

--- a/Userland/Libraries/LibWeb/Bindings/ImageConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/ImageConstructor.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/HTMLImageElementPrototype.h>
 #include <LibWeb/Bindings/ImageConstructor.h>
 #include <LibWeb/DOM/ElementFactory.h>
@@ -44,7 +45,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> ImageConstructor::construct(
     auto& document = window.associated_document();
 
     // 2. Let img be the result of creating an element given document, img, and the HTML namespace.
-    auto image_element = DOM::create_element(document, HTML::TagNames::img, Namespace::HTML);
+    auto image_element = TRY(Bindings::throw_dom_exception_if_needed(vm, [&]() { return DOM::create_element(document, HTML::TagNames::img, Namespace::HTML); }));
 
     // 3. If width is given, then set an attribute value for img using "width" and width.
     if (vm.argument_count() > 0) {

--- a/Userland/Libraries/LibWeb/Bindings/OptionConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/OptionConstructor.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/HTMLOptionElementPrototype.h>
 #include <LibWeb/Bindings/OptionConstructor.h>
 #include <LibWeb/DOM/ElementFactory.h>
@@ -47,7 +48,8 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> OptionConstructor::construct
     auto& document = window.associated_document();
 
     // 2. Let option be the result of creating an element given document, option, and the HTML namespace.
-    JS::NonnullGCPtr<HTML::HTMLOptionElement> option_element = verify_cast<HTML::HTMLOptionElement>(*DOM::create_element(document, HTML::TagNames::option, Namespace::HTML));
+    auto element = TRY(Bindings::throw_dom_exception_if_needed(vm, [&]() { return DOM::create_element(document, HTML::TagNames::option, Namespace::HTML); }));
+    JS::NonnullGCPtr<HTML::HTMLOptionElement> option_element = verify_cast<HTML::HTMLOptionElement>(*element);
 
     // 3. If text is not the empty string, then append to option a new Text node whose data is text.
     if (vm.argument_count() > 0) {

--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
@@ -88,21 +88,21 @@ JS::NonnullGCPtr<Document> DOMImplementation::create_html_document(DeprecatedStr
     doctype->set_name("html");
     MUST(html_document->append_child(*doctype));
 
-    auto html_element = create_element(html_document, HTML::TagNames::html, Namespace::HTML);
+    auto html_element = create_element(html_document, HTML::TagNames::html, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
     MUST(html_document->append_child(html_element));
 
-    auto head_element = create_element(html_document, HTML::TagNames::head, Namespace::HTML);
+    auto head_element = create_element(html_document, HTML::TagNames::head, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
     MUST(html_element->append_child(head_element));
 
     if (!title.is_null()) {
-        auto title_element = create_element(html_document, HTML::TagNames::title, Namespace::HTML);
+        auto title_element = create_element(html_document, HTML::TagNames::title, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
         MUST(head_element->append_child(title_element));
 
         auto text_node = heap().allocate<Text>(realm(), html_document, title).release_allocated_value_but_fixme_should_propagate_errors();
         MUST(title_element->append_child(*text_node));
     }
 
-    auto body_element = create_element(html_document, HTML::TagNames::body, Namespace::HTML);
+    auto body_element = create_element(html_document, HTML::TagNames::body, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
     MUST(html_element->append_child(body_element));
 
     html_document->set_origin(document().origin());

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -211,12 +211,12 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> Document::create_and_initialize(
 
         // FIXME: Why do we assume `creation_url` is non-empty here? Is this a spec bug?
         // FIXME: Why do we assume `top_level_creation_url` is non-empty here? Is this a spec bug?
-        HTML::WindowEnvironmentSettingsObject::setup(
+        TRY(HTML::WindowEnvironmentSettingsObject::setup(
             creation_url.value(),
             move(realm_execution_context),
             navigation_params.reserved_environment,
             top_level_creation_url.value(),
-            top_level_origin);
+            top_level_origin));
     }
 
     // FIXME: 7. Let loadTimingInfo be a new document load timing info with its navigation start time set to response's timing info's start time.

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -378,7 +378,7 @@ JS::GCPtr<Selection::Selection> Document::get_selection()
     }
 
     if (!m_selection) {
-        m_selection = Selection::Selection::create(realm(), *this);
+        m_selection = Selection::Selection::create(realm(), *this).release_value_but_fixme_should_propagate_errors();
     }
     return m_selection;
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1287,7 +1287,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Document::create_event(DeprecatedSt
         || Infra::is_ascii_case_insensitive_match(interface, "events"sv)) {
         event = TRY(Event::create(realm, ""));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "focusevent"sv)) {
-        event = UIEvents::FocusEvent::create(realm, "");
+        event = TRY(UIEvents::FocusEvent::create(realm, ""));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "hashchangeevent"sv)) {
         event = TRY(Event::create(realm, "")); // FIXME: Create HashChangeEvent
     } else if (Infra::is_ascii_case_insensitive_match(interface, "htmlevents"sv)) {
@@ -1309,7 +1309,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Document::create_event(DeprecatedSt
         event = TRY(Event::create(realm, "")); // FIXME: Create TouchEvent
     } else if (Infra::is_ascii_case_insensitive_match(interface, "uievent"sv)
         || Infra::is_ascii_case_insensitive_match(interface, "uievents"sv)) {
-        event = UIEvents::UIEvent::create(realm, "");
+        event = TRY(UIEvents::UIEvent::create(realm, ""));
     }
 
     // 3. If constructor is null, then throw a "NotSupportedError" DOMException.

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1211,7 +1211,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> Document::create_element(Deprecat
         namespace_ = Namespace::HTML;
 
     // 6. Return the result of creating an element given this, localName, namespace, null, is, and with the synchronous custom elements flag set.
-    return DOM::create_element(*this, local_name, namespace_);
+    return TRY(DOM::create_element(*this, local_name, namespace_));
 }
 
 // https://dom.spec.whatwg.org/#dom-document-createelementns
@@ -1226,7 +1226,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> Document::create_element_ns(Depre
     // FIXME: 3. If options is a dictionary and options["is"] exists, then set is to it.
 
     // 4. Return the result of creating an element given document, localName, namespace, prefix, is, and with the synchronous custom elements flag set.
-    return DOM::create_element(*this, extracted_qualified_name.local_name(), extracted_qualified_name.namespace_(), extracted_qualified_name.prefix());
+    return TRY(DOM::create_element(*this, extracted_qualified_name.local_name(), extracted_qualified_name.namespace_(), extracted_qualified_name.prefix()));
 }
 
 JS::NonnullGCPtr<DocumentFragment> Document::create_document_fragment()

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1293,7 +1293,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Document::create_event(DeprecatedSt
     } else if (Infra::is_ascii_case_insensitive_match(interface, "htmlevents"sv)) {
         event = TRY(Event::create(realm, ""));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "keyboardevent"sv)) {
-        event = UIEvents::KeyboardEvent::create(realm, "");
+        event = TRY(UIEvents::KeyboardEvent::create(realm, ""));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "messageevent"sv)) {
         event = TRY(HTML::MessageEvent::create(realm, ""));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "mouseevent"sv)

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -657,12 +657,12 @@ JS::NonnullGCPtr<Geometry::DOMRect> Element::get_bounding_client_rect() const
     // FIXME: Support inline layout nodes as well.
     auto* paint_box = this->paint_box();
     if (!paint_box)
-        return Geometry::DOMRect::construct_impl(realm(), 0, 0, 0, 0);
+        return Geometry::DOMRect::construct_impl(realm(), 0, 0, 0, 0).release_value_but_fixme_should_propagate_errors();
 
     VERIFY(document().browsing_context());
     auto viewport_offset = document().browsing_context()->viewport_scroll_offset();
 
-    return Geometry::DOMRect::create(realm(), paint_box->absolute_rect().translated(-viewport_offset.x(), -viewport_offset.y()).to_type<float>());
+    return Geometry::DOMRect::create(realm(), paint_box->absolute_rect().translated(-viewport_offset.x(), -viewport_offset.y()).to_type<float>()).release_value_but_fixme_should_propagate_errors();
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-getclientrects

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -675,7 +675,7 @@ JS::NonnullGCPtr<Geometry::DOMRectList> Element::get_client_rects() const
 
     // 1. If the element on which it was invoked does not have an associated layout box return an empty DOMRectList object and stop this algorithm.
     if (!layout_node() || !layout_node()->is_box())
-        return Geometry::DOMRectList::create(realm(), move(rects));
+        return Geometry::DOMRectList::create(realm(), move(rects)).release_value_but_fixme_should_propagate_errors();
 
     // FIXME: 2. If the element has an associated SVG layout box return a DOMRectList object containing a single DOMRect object that describes
     // the bounding box of the element as defined by the SVG specification, applying the transforms that apply to the element and its ancestors.
@@ -689,7 +689,7 @@ JS::NonnullGCPtr<Geometry::DOMRectList> Element::get_client_rects() const
 
     auto bounding_rect = get_bounding_client_rect();
     rects.append(*bounding_rect);
-    return Geometry::DOMRectList::create(realm(), move(rects));
+    return Geometry::DOMRectList::create(realm(), move(rects)).release_value_but_fixme_should_propagate_errors();
 }
 
 int Element::client_top() const

--- a/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
@@ -95,7 +95,7 @@
 namespace Web::DOM {
 
 // https://dom.spec.whatwg.org/#concept-create-element
-JS::NonnullGCPtr<Element> create_element(Document& document, DeprecatedFlyString local_name, DeprecatedFlyString namespace_, DeprecatedFlyString prefix)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document, DeprecatedFlyString local_name, DeprecatedFlyString namespace_, DeprecatedFlyString prefix)
 {
     // 1. If prefix was not given, let prefix be null.
     // NOTE: This is already taken care of by `prefix` having a default value.
@@ -120,180 +120,180 @@ JS::NonnullGCPtr<Element> create_element(Document& document, DeprecatedFlyString
 
     auto qualified_name = QualifiedName { local_name, prefix, namespace_ };
     if (lowercase_tag_name == HTML::TagNames::a)
-        return realm.heap().allocate<HTML::HTMLAnchorElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLAnchorElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::area)
-        return realm.heap().allocate<HTML::HTMLAreaElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLAreaElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::audio)
-        return realm.heap().allocate<HTML::HTMLAudioElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLAudioElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::base)
-        return realm.heap().allocate<HTML::HTMLBaseElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLBaseElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::blink)
-        return realm.heap().allocate<HTML::HTMLBlinkElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLBlinkElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::body)
-        return realm.heap().allocate<HTML::HTMLBodyElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLBodyElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::br)
-        return realm.heap().allocate<HTML::HTMLBRElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLBRElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::button)
-        return realm.heap().allocate<HTML::HTMLButtonElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLButtonElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::canvas)
-        return realm.heap().allocate<HTML::HTMLCanvasElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLCanvasElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::data)
-        return realm.heap().allocate<HTML::HTMLDataElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLDataElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::datalist)
-        return realm.heap().allocate<HTML::HTMLDataListElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLDataListElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::details)
-        return realm.heap().allocate<HTML::HTMLDetailsElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLDetailsElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::dialog)
-        return realm.heap().allocate<HTML::HTMLDialogElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLDialogElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::dir)
-        return realm.heap().allocate<HTML::HTMLDirectoryElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLDirectoryElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::div)
-        return realm.heap().allocate<HTML::HTMLDivElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLDivElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::dl)
-        return realm.heap().allocate<HTML::HTMLDListElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLDListElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::embed)
-        return realm.heap().allocate<HTML::HTMLEmbedElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLEmbedElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::fieldset)
-        return realm.heap().allocate<HTML::HTMLFieldSetElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLFieldSetElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::font)
-        return realm.heap().allocate<HTML::HTMLFontElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLFontElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::form)
-        return realm.heap().allocate<HTML::HTMLFormElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLFormElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::frame)
-        return realm.heap().allocate<HTML::HTMLFrameElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLFrameElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::frameset)
-        return realm.heap().allocate<HTML::HTMLFrameSetElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLFrameSetElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::head)
-        return realm.heap().allocate<HTML::HTMLHeadElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLHeadElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name.is_one_of(HTML::TagNames::h1, HTML::TagNames::h2, HTML::TagNames::h3, HTML::TagNames::h4, HTML::TagNames::h5, HTML::TagNames::h6))
-        return realm.heap().allocate<HTML::HTMLHeadingElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLHeadingElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::hr)
-        return realm.heap().allocate<HTML::HTMLHRElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLHRElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::html)
-        return realm.heap().allocate<HTML::HTMLHtmlElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLHtmlElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::iframe)
-        return realm.heap().allocate<HTML::HTMLIFrameElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLIFrameElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::img)
-        return realm.heap().allocate<HTML::HTMLImageElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLImageElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::input)
-        return realm.heap().allocate<HTML::HTMLInputElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLInputElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::label)
-        return realm.heap().allocate<HTML::HTMLLabelElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLLabelElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::legend)
-        return realm.heap().allocate<HTML::HTMLLegendElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLLegendElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::li)
-        return realm.heap().allocate<HTML::HTMLLIElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLLIElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::link)
-        return realm.heap().allocate<HTML::HTMLLinkElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLLinkElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::map)
-        return realm.heap().allocate<HTML::HTMLMapElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLMapElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::marquee)
-        return realm.heap().allocate<HTML::HTMLMarqueeElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLMarqueeElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::menu)
-        return realm.heap().allocate<HTML::HTMLMenuElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLMenuElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::meta)
-        return realm.heap().allocate<HTML::HTMLMetaElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLMetaElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::meter)
-        return realm.heap().allocate<HTML::HTMLMeterElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLMeterElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name.is_one_of(HTML::TagNames::ins, HTML::TagNames::del))
-        return realm.heap().allocate<HTML::HTMLModElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLModElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::object)
-        return realm.heap().allocate<HTML::HTMLObjectElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLObjectElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::ol)
-        return realm.heap().allocate<HTML::HTMLOListElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLOListElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::optgroup)
-        return realm.heap().allocate<HTML::HTMLOptGroupElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLOptGroupElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::option)
-        return realm.heap().allocate<HTML::HTMLOptionElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLOptionElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::output)
-        return realm.heap().allocate<HTML::HTMLOutputElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLOutputElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::p)
-        return realm.heap().allocate<HTML::HTMLParagraphElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLParagraphElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::param)
-        return realm.heap().allocate<HTML::HTMLParamElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLParamElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::picture)
-        return realm.heap().allocate<HTML::HTMLPictureElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLPictureElement>(realm, document, move(qualified_name)));
     // NOTE: The obsolete elements "listing" and "xmp" are explicitly mapped to HTMLPreElement in the specification.
     if (lowercase_tag_name.is_one_of(HTML::TagNames::pre, HTML::TagNames::listing, HTML::TagNames::xmp))
-        return realm.heap().allocate<HTML::HTMLPreElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLPreElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::progress)
-        return realm.heap().allocate<HTML::HTMLProgressElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLProgressElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name.is_one_of(HTML::TagNames::blockquote, HTML::TagNames::q))
-        return realm.heap().allocate<HTML::HTMLQuoteElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLQuoteElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::script)
-        return realm.heap().allocate<HTML::HTMLScriptElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLScriptElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::select)
-        return realm.heap().allocate<HTML::HTMLSelectElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLSelectElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::slot)
-        return realm.heap().allocate<HTML::HTMLSlotElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLSlotElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::source)
-        return realm.heap().allocate<HTML::HTMLSourceElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLSourceElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::span)
-        return realm.heap().allocate<HTML::HTMLSpanElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLSpanElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::style)
-        return realm.heap().allocate<HTML::HTMLStyleElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLStyleElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::caption)
-        return realm.heap().allocate<HTML::HTMLTableCaptionElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTableCaptionElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name.is_one_of(Web::HTML::TagNames::td, Web::HTML::TagNames::th))
-        return realm.heap().allocate<HTML::HTMLTableCellElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTableCellElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name.is_one_of(HTML::TagNames::colgroup, HTML::TagNames::col))
-        return realm.heap().allocate<HTML::HTMLTableColElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTableColElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::table)
-        return realm.heap().allocate<HTML::HTMLTableElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTableElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::tr)
-        return realm.heap().allocate<HTML::HTMLTableRowElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTableRowElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name.is_one_of(HTML::TagNames::tbody, HTML::TagNames::thead, HTML::TagNames::tfoot))
-        return realm.heap().allocate<HTML::HTMLTableSectionElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTableSectionElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::template_)
-        return realm.heap().allocate<HTML::HTMLTemplateElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTemplateElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::textarea)
-        return realm.heap().allocate<HTML::HTMLTextAreaElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTextAreaElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::time)
-        return realm.heap().allocate<HTML::HTMLTimeElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTimeElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::title)
-        return realm.heap().allocate<HTML::HTMLTitleElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTitleElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::track)
-        return realm.heap().allocate<HTML::HTMLTrackElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTrackElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::ul)
-        return realm.heap().allocate<HTML::HTMLUListElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLUListElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::video)
-        return realm.heap().allocate<HTML::HTMLVideoElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLVideoElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name.is_one_of(
             HTML::TagNames::article, HTML::TagNames::section, HTML::TagNames::nav, HTML::TagNames::aside, HTML::TagNames::hgroup, HTML::TagNames::header, HTML::TagNames::footer, HTML::TagNames::address, HTML::TagNames::dt, HTML::TagNames::dd, HTML::TagNames::figure, HTML::TagNames::figcaption, HTML::TagNames::main, HTML::TagNames::em, HTML::TagNames::strong, HTML::TagNames::small, HTML::TagNames::s, HTML::TagNames::cite, HTML::TagNames::dfn, HTML::TagNames::abbr, HTML::TagNames::ruby, HTML::TagNames::rt, HTML::TagNames::rp, HTML::TagNames::code, HTML::TagNames::var, HTML::TagNames::samp, HTML::TagNames::kbd, HTML::TagNames::sub, HTML::TagNames::sup, HTML::TagNames::i, HTML::TagNames::b, HTML::TagNames::u, HTML::TagNames::mark, HTML::TagNames::bdi, HTML::TagNames::bdo, HTML::TagNames::wbr, HTML::TagNames::summary, HTML::TagNames::noscript,
             // Obsolete
             HTML::TagNames::acronym, HTML::TagNames::basefont, HTML::TagNames::big, HTML::TagNames::center, HTML::TagNames::nobr, HTML::TagNames::noembed, HTML::TagNames::noframes, HTML::TagNames::plaintext, HTML::TagNames::rb, HTML::TagNames::rtc, HTML::TagNames::strike, HTML::TagNames::tt))
-        return realm.heap().allocate<HTML::HTMLElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == SVG::TagNames::svg)
-        return realm.heap().allocate<SVG::SVGSVGElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGSVGElement>(realm, document, move(qualified_name)));
     // FIXME: Support SVG's mixedCase tag names properly.
     if (lowercase_tag_name.equals_ignoring_case(SVG::TagNames::clipPath))
-        return realm.heap().allocate<SVG::SVGClipPathElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGClipPathElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == SVG::TagNames::circle)
-        return realm.heap().allocate<SVG::SVGCircleElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGCircleElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name.equals_ignoring_case(SVG::TagNames::defs))
-        return realm.heap().allocate<SVG::SVGDefsElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGDefsElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == SVG::TagNames::ellipse)
-        return realm.heap().allocate<SVG::SVGEllipseElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGEllipseElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name.equals_ignoring_case(SVG::TagNames::foreignObject))
-        return realm.heap().allocate<SVG::SVGForeignObjectElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGForeignObjectElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == SVG::TagNames::line)
-        return realm.heap().allocate<SVG::SVGLineElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGLineElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == SVG::TagNames::path)
-        return realm.heap().allocate<SVG::SVGPathElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGPathElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == SVG::TagNames::polygon)
-        return realm.heap().allocate<SVG::SVGPolygonElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGPolygonElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == SVG::TagNames::polyline)
-        return realm.heap().allocate<SVG::SVGPolylineElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGPolylineElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == SVG::TagNames::rect)
-        return realm.heap().allocate<SVG::SVGRectElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGRectElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == SVG::TagNames::g)
-        return realm.heap().allocate<SVG::SVGGElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGGElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == SVG::TagNames::text)
-        return realm.heap().allocate<SVG::SVGTextContentElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGTextContentElement>(realm, document, move(qualified_name)));
 
     // FIXME: If name is a valid custom element name, then return HTMLElement.
 
-    return realm.heap().allocate<HTML::HTMLUnknownElement>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLUnknownElement>(realm, document, move(qualified_name)));
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/ElementFactory.h
+++ b/Userland/Libraries/LibWeb/DOM/ElementFactory.h
@@ -10,6 +10,6 @@
 
 namespace Web::DOM {
 
-JS::NonnullGCPtr<Element> create_element(Document&, DeprecatedFlyString local_name, DeprecatedFlyString namespace_, DeprecatedFlyString prefix = {});
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document&, DeprecatedFlyString local_name, DeprecatedFlyString namespace_, DeprecatedFlyString prefix = {});
 
 }

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -561,7 +561,7 @@ void EventTarget::activate_event_handler(DeprecatedFlyString const& name, HTML::
     // 5. Let listener be a new event listener whose type is the event handler event type corresponding to eventHandler and callback is callback.
     auto listener = realm.heap().allocate_without_realm<DOMEventListener>();
     listener->type = name;
-    listener->callback = IDLEventListener::create(realm, *callback).ptr();
+    listener->callback = IDLEventListener::create(realm, *callback).release_value_but_fixme_should_propagate_errors();
 
     // 6. Add an event listener with eventTarget and listener.
     add_an_event_listener(*listener);

--- a/Userland/Libraries/LibWeb/DOM/IDLEventListener.cpp
+++ b/Userland/Libraries/LibWeb/DOM/IDLEventListener.cpp
@@ -8,9 +8,9 @@
 
 namespace Web::DOM {
 
-JS::NonnullGCPtr<IDLEventListener> IDLEventListener::create(JS::Realm& realm, JS::NonnullGCPtr<WebIDL::CallbackType> callback)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<IDLEventListener>> IDLEventListener::create(JS::Realm& realm, JS::NonnullGCPtr<WebIDL::CallbackType> callback)
 {
-    return realm.heap().allocate<IDLEventListener>(realm, realm, move(callback)).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<IDLEventListener>(realm, realm, move(callback)));
 }
 
 IDLEventListener::IDLEventListener(JS::Realm& realm, JS::NonnullGCPtr<WebIDL::CallbackType> callback)

--- a/Userland/Libraries/LibWeb/DOM/IDLEventListener.h
+++ b/Userland/Libraries/LibWeb/DOM/IDLEventListener.h
@@ -28,7 +28,7 @@ class IDLEventListener final : public JS::Object {
     JS_OBJECT(IDLEventListener, JS::Object);
 
 public:
-    static JS::NonnullGCPtr<IDLEventListener> create(JS::Realm&, JS::NonnullGCPtr<WebIDL::CallbackType>);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<IDLEventListener>> create(JS::Realm&, JS::NonnullGCPtr<WebIDL::CallbackType>);
     IDLEventListener(JS::Realm&, JS::NonnullGCPtr<WebIDL::CallbackType>);
 
     virtual ~IDLEventListener() = default;

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -727,7 +727,7 @@ JS::NonnullGCPtr<Node> Node::clone_node(Document* document, bool clone_children)
     if (is<Element>(this)) {
         // 1. Let copy be the result of creating an element, given document, node’s local name, node’s namespace, node’s namespace prefix, and node’s is value, with the synchronous custom elements flag unset.
         auto& element = *verify_cast<Element>(this);
-        auto element_copy = DOM::create_element(*document, element.local_name(), element.namespace_() /* FIXME: node’s namespace prefix, and node’s is value, with the synchronous custom elements flag unset */);
+        auto element_copy = DOM::create_element(*document, element.local_name(), element.namespace_() /* FIXME: node’s namespace prefix, and node’s is value, with the synchronous custom elements flag unset */).release_value_but_fixme_should_propagate_errors();
 
         // 2. For each attribute in node’s attribute list:
         element.for_each_attribute([&](auto& name, auto& value) {

--- a/Userland/Libraries/LibWeb/DOM/NodeFilter.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeFilter.cpp
@@ -6,12 +6,13 @@
 
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/DOM/NodeFilter.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::DOM {
 
-JS::NonnullGCPtr<NodeFilter> NodeFilter::create(JS::Realm& realm, WebIDL::CallbackType& callback)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeFilter>> NodeFilter::create(JS::Realm& realm, WebIDL::CallbackType& callback)
 {
-    return realm.heap().allocate<NodeFilter>(realm, realm, callback).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<NodeFilter>(realm, realm, callback));
 }
 
 NodeFilter::NodeFilter(JS::Realm& realm, WebIDL::CallbackType& callback)

--- a/Userland/Libraries/LibWeb/DOM/NodeFilter.h
+++ b/Userland/Libraries/LibWeb/DOM/NodeFilter.h
@@ -15,7 +15,7 @@ class NodeFilter final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(NodeFilter, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<NodeFilter> create(JS::Realm&, WebIDL::CallbackType&);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeFilter>> create(JS::Realm&, WebIDL::CallbackType&);
 
     virtual ~NodeFilter() = default;
 

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -1139,7 +1139,7 @@ WebIDL::ExceptionOr<void> Range::delete_contents()
 JS::NonnullGCPtr<Geometry::DOMRect> Range::get_bounding_client_rect() const
 {
     dbgln("(STUBBED) Range::get_bounding_client_rect()");
-    return Geometry::DOMRect::construct_impl(realm(), 0, 0, 0, 0);
+    return Geometry::DOMRect::construct_impl(realm(), 0, 0, 0, 0).release_value_but_fixme_should_propagate_errors();
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
@@ -21,9 +21,9 @@
 
 namespace Web::DOMParsing {
 
-JS::NonnullGCPtr<XMLSerializer> XMLSerializer::construct_impl(JS::Realm& realm)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<XMLSerializer>> XMLSerializer::construct_impl(JS::Realm& realm)
 {
-    return (realm.heap().allocate<XMLSerializer>(realm, realm)).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<XMLSerializer>(realm, realm));
 }
 
 XMLSerializer::XMLSerializer(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.h
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.h
@@ -14,7 +14,7 @@ class XMLSerializer final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(XMLSerializer, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<XMLSerializer> construct_impl(JS::Realm&);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<XMLSerializer>> construct_impl(JS::Realm&);
 
     virtual ~XMLSerializer() override;
 

--- a/Userland/Libraries/LibWeb/Encoding/TextEncoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextEncoder.cpp
@@ -8,12 +8,13 @@
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Encoding/TextEncoder.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::Encoding {
 
-JS::NonnullGCPtr<TextEncoder> TextEncoder::construct_impl(JS::Realm& realm)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<TextEncoder>> TextEncoder::construct_impl(JS::Realm& realm)
 {
-    return realm.heap().allocate<TextEncoder>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<TextEncoder>(realm, realm));
 }
 
 TextEncoder::TextEncoder(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/Encoding/TextEncoder.h
+++ b/Userland/Libraries/LibWeb/Encoding/TextEncoder.h
@@ -20,7 +20,7 @@ class TextEncoder final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(TextEncoder, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<TextEncoder> construct_impl(JS::Realm&);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<TextEncoder>> construct_impl(JS::Realm&);
 
     virtual ~TextEncoder() override;
 

--- a/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
@@ -106,7 +106,7 @@ JS::NonnullGCPtr<JS::Promise> fetch_impl(JS::VM& vm, RequestInfo const& input, R
 
         // 4. Set responseObject to the result of creating a Response object, given response, "immutable", and
         //    relevantRealm.
-        auto response_object = Response::create(relevant_realm, response, Headers::Guard::Immutable);
+        auto response_object = Response::create(relevant_realm, response, Headers::Guard::Immutable).release_value_but_fixme_should_propagate_errors();
         response_object_handle = JS::make_handle(response_object);
 
         // 5. Resolve p with responseObject.

--- a/Userland/Libraries/LibWeb/Fetch/HeadersIterator.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/HeadersIterator.cpp
@@ -23,9 +23,9 @@ void Intrinsics::create_web_prototype_and_constructor<HeadersIteratorPrototype>(
 
 namespace Web::Fetch {
 
-JS::NonnullGCPtr<HeadersIterator> HeadersIterator::create(Headers const& headers, JS::Object::PropertyKind iteration_kind)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<HeadersIterator>> HeadersIterator::create(Headers const& headers, JS::Object::PropertyKind iteration_kind)
 {
-    return headers.heap().allocate<HeadersIterator>(headers.realm(), headers, iteration_kind).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(headers.heap().allocate<HeadersIterator>(headers.realm(), headers, iteration_kind));
 }
 
 HeadersIterator::HeadersIterator(Headers const& headers, JS::Object::PropertyKind iteration_kind)

--- a/Userland/Libraries/LibWeb/Fetch/HeadersIterator.h
+++ b/Userland/Libraries/LibWeb/Fetch/HeadersIterator.h
@@ -16,7 +16,7 @@ class HeadersIterator final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(HeadersIterator, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<HeadersIterator> create(Headers const&, JS::Object::PropertyKind iteration_kind);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<HeadersIterator>> create(Headers const&, JS::Object::PropertyKind iteration_kind);
 
     virtual ~HeadersIterator() override;
 

--- a/Userland/Libraries/LibWeb/Fetch/Request.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Request.cpp
@@ -81,18 +81,18 @@ Optional<Infrastructure::Body&> Request::body_impl()
 }
 
 // https://fetch.spec.whatwg.org/#request-create
-JS::NonnullGCPtr<Request> Request::create(JS::Realm& realm, JS::NonnullGCPtr<Infrastructure::Request> request, Headers::Guard guard)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::create(JS::Realm& realm, JS::NonnullGCPtr<Infrastructure::Request> request, Headers::Guard guard)
 {
     // 1. Let requestObject be a new Request object with realm.
     // 2. Set requestObject’s request to request.
-    auto request_object = realm.heap().allocate<Request>(realm, realm, request).release_allocated_value_but_fixme_should_propagate_errors();
+    auto request_object = MUST_OR_THROW_OOM(realm.heap().allocate<Request>(realm, realm, request));
 
     // 3. Set requestObject’s headers to a new Headers object with realm, whose headers list is request’s headers list and guard is guard.
-    request_object->m_headers = realm.heap().allocate<Headers>(realm, realm, request->header_list()).release_allocated_value_but_fixme_should_propagate_errors();
+    request_object->m_headers = MUST_OR_THROW_OOM(realm.heap().allocate<Headers>(realm, realm, request->header_list()));
     request_object->m_headers->set_guard(guard);
 
     // 4. Set requestObject’s signal to a new AbortSignal object with realm.
-    request_object->m_signal = realm.heap().allocate<DOM::AbortSignal>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    request_object->m_signal = MUST_OR_THROW_OOM(realm.heap().allocate<DOM::AbortSignal>(realm, realm));
 
     // 5. Return requestObject.
     return request_object;
@@ -639,7 +639,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::clone() const
     auto cloned_request = TRY(m_request->clone(vm));
 
     // 3. Let clonedRequestObject be the result of creating a Request object, given clonedRequest, this’s headers’s guard, and this’s relevant Realm.
-    auto cloned_request_object = Request::create(HTML::relevant_realm(*this), cloned_request, m_headers->guard());
+    auto cloned_request_object = TRY(Request::create(HTML::relevant_realm(*this), cloned_request, m_headers->guard()));
 
     // 4. Make clonedRequestObject’s signal follow this’s signal.
     cloned_request_object->m_signal->follow(*m_signal);

--- a/Userland/Libraries/LibWeb/Fetch/Request.h
+++ b/Userland/Libraries/LibWeb/Fetch/Request.h
@@ -65,7 +65,7 @@ class Request final
     WEB_PLATFORM_OBJECT(Request, Bindings::PlatformObject);
 
 public:
-    [[nodiscard]] static JS::NonnullGCPtr<Request> create(JS::Realm&, JS::NonnullGCPtr<Infrastructure::Request>, Headers::Guard);
+    [[nodiscard]] static WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> create(JS::Realm&, JS::NonnullGCPtr<Infrastructure::Request>, Headers::Guard);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> construct_impl(JS::Realm&, RequestInfo const& input, RequestInit const& init = {});
 
     virtual ~Request() override;

--- a/Userland/Libraries/LibWeb/Fetch/Response.h
+++ b/Userland/Libraries/LibWeb/Fetch/Response.h
@@ -32,7 +32,7 @@ class Response final
     WEB_PLATFORM_OBJECT(Response, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<Response> create(JS::Realm&, JS::NonnullGCPtr<Infrastructure::Response>, Headers::Guard);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> create(JS::Realm&, JS::NonnullGCPtr<Infrastructure::Response>, Headers::Guard);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> construct_impl(JS::Realm&, Optional<BodyInit> const& body = {}, ResponseInit const& init = {});
 
     virtual ~Response() override;

--- a/Userland/Libraries/LibWeb/Geometry/DOMPoint.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPoint.cpp
@@ -7,12 +7,13 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMPoint.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::Geometry {
 
-JS::NonnullGCPtr<DOMPoint> DOMPoint::construct_impl(JS::Realm& realm, double x, double y, double z, double w)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMPoint>> DOMPoint::construct_impl(JS::Realm& realm, double x, double y, double z, double w)
 {
-    return realm.heap().allocate<DOMPoint>(realm, realm, x, y, z, w).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMPoint>(realm, realm, x, y, z, w));
 }
 
 DOMPoint::DOMPoint(JS::Realm& realm, double x, double y, double z, double w)
@@ -24,7 +25,7 @@ DOMPoint::DOMPoint(JS::Realm& realm, double x, double y, double z, double w)
 JS::NonnullGCPtr<DOMPoint> DOMPoint::from_point(JS::VM& vm, DOMPointInit const& other)
 {
     // The fromPoint(other) static method on DOMPoint must create a DOMPoint from the dictionary other.
-    return construct_impl(*vm.current_realm(), other.x, other.y, other.z, other.w);
+    return construct_impl(*vm.current_realm(), other.x, other.y, other.z, other.w).release_value_but_fixme_should_propagate_errors();
 }
 
 DOMPoint::~DOMPoint() = default;

--- a/Userland/Libraries/LibWeb/Geometry/DOMPoint.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPoint.h
@@ -16,7 +16,7 @@ class DOMPoint final : public DOMPointReadOnly {
     WEB_PLATFORM_OBJECT(DOMPoint, DOMPointReadOnly);
 
 public:
-    static JS::NonnullGCPtr<DOMPoint> construct_impl(JS::Realm&, double x = 0, double y = 0, double z = 0, double w = 1);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMPoint>> construct_impl(JS::Realm&, double x = 0, double y = 0, double z = 0, double w = 1);
 
     static JS::NonnullGCPtr<DOMPoint> from_point(JS::VM&, DOMPointInit const&);
 

--- a/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.cpp
@@ -7,12 +7,13 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMPointReadOnly.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::Geometry {
 
-JS::NonnullGCPtr<DOMPointReadOnly> DOMPointReadOnly::construct_impl(JS::Realm& realm, double x, double y, double z, double w)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMPointReadOnly>> DOMPointReadOnly::construct_impl(JS::Realm& realm, double x, double y, double z, double w)
 {
-    return realm.heap().allocate<DOMPointReadOnly>(realm, realm, x, y, z, w).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMPointReadOnly>(realm, realm, x, y, z, w));
 }
 
 DOMPointReadOnly::DOMPointReadOnly(JS::Realm& realm, double x, double y, double z, double w)
@@ -25,7 +26,7 @@ DOMPointReadOnly::DOMPointReadOnly(JS::Realm& realm, double x, double y, double 
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dompointreadonly-frompoint
-JS::NonnullGCPtr<DOMPointReadOnly> DOMPointReadOnly::from_point(JS::VM& vm, DOMPointInit const& other)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMPointReadOnly>> DOMPointReadOnly::from_point(JS::VM& vm, DOMPointInit const& other)
 {
     // The fromPoint(other) static method on DOMPointReadOnly must create a DOMPointReadOnly from the dictionary other.
     return construct_impl(*vm.current_realm(), other.x, other.y, other.z, other.w);

--- a/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.h
@@ -25,9 +25,9 @@ class DOMPointReadOnly : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(DOMPointReadOnly, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<DOMPointReadOnly> construct_impl(JS::Realm&, double x = 0, double y = 0, double z = 0, double w = 1);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMPointReadOnly>> construct_impl(JS::Realm&, double x = 0, double y = 0, double z = 0, double w = 1);
 
-    static JS::NonnullGCPtr<DOMPointReadOnly> from_point(JS::VM&, DOMPointInit const&);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMPointReadOnly>> from_point(JS::VM&, DOMPointInit const&);
 
     virtual ~DOMPointReadOnly() override;
 

--- a/Userland/Libraries/LibWeb/Geometry/DOMRect.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRect.cpp
@@ -6,15 +6,16 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMRect.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::Geometry {
 
-JS::NonnullGCPtr<DOMRect> DOMRect::construct_impl(JS::Realm& realm, double x, double y, double width, double height)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRect>> DOMRect::construct_impl(JS::Realm& realm, double x, double y, double width, double height)
 {
-    return realm.heap().allocate<DOMRect>(realm, realm, x, y, width, height).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMRect>(realm, realm, x, y, width, height));
 }
 
-JS::NonnullGCPtr<DOMRect> DOMRect::create(JS::Realm& realm, Gfx::FloatRect const& rect)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRect>> DOMRect::create(JS::Realm& realm, Gfx::FloatRect const& rect)
 {
     return construct_impl(realm, rect.x(), rect.y(), rect.width(), rect.height());
 }

--- a/Userland/Libraries/LibWeb/Geometry/DOMRect.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRect.h
@@ -15,8 +15,8 @@ class DOMRect final : public DOMRectReadOnly {
     WEB_PLATFORM_OBJECT(DOMRect, DOMRectReadOnly);
 
 public:
-    static JS::NonnullGCPtr<DOMRect> construct_impl(JS::Realm&, double x = 0, double y = 0, double width = 0, double height = 0);
-    static JS::NonnullGCPtr<DOMRect> create(JS::Realm&, Gfx::FloatRect const&);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRect>> construct_impl(JS::Realm&, double x = 0, double y = 0, double width = 0, double height = 0);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRect>> create(JS::Realm&, Gfx::FloatRect const&);
 
     virtual ~DOMRect() override;
 

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectList.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectList.cpp
@@ -8,15 +8,16 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMRect.h>
 #include <LibWeb/Geometry/DOMRectList.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::Geometry {
 
-JS::NonnullGCPtr<DOMRectList> DOMRectList::create(JS::Realm& realm, Vector<JS::Handle<DOMRect>> rect_handles)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRectList>> DOMRectList::create(JS::Realm& realm, Vector<JS::Handle<DOMRect>> rect_handles)
 {
     Vector<JS::NonnullGCPtr<DOMRect>> rects;
     for (auto& rect : rect_handles)
         rects.append(*rect);
-    return realm.heap().allocate<DOMRectList>(realm, realm, move(rects)).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMRectList>(realm, realm, move(rects)));
 }
 
 DOMRectList::DOMRectList(JS::Realm& realm, Vector<JS::NonnullGCPtr<DOMRect>> rects)

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectList.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectList.h
@@ -17,7 +17,7 @@ class DOMRectList final : public Bindings::LegacyPlatformObject {
     WEB_PLATFORM_OBJECT(DOMRectList, Bindings::LegacyPlatformObject);
 
 public:
-    static JS::NonnullGCPtr<DOMRectList> create(JS::Realm&, Vector<JS::Handle<DOMRect>>);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRectList>> create(JS::Realm&, Vector<JS::Handle<DOMRect>>);
 
     virtual ~DOMRectList() override;
 

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.cpp
@@ -6,12 +6,13 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Geometry/DOMRectReadOnly.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::Geometry {
 
-JS::NonnullGCPtr<DOMRectReadOnly> DOMRectReadOnly::construct_impl(JS::Realm& realm, double x, double y, double width, double height)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRectReadOnly>> DOMRectReadOnly::construct_impl(JS::Realm& realm, double x, double y, double width, double height)
 {
-    return realm.heap().allocate<DOMRectReadOnly>(realm, realm, x, y, width, height).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMRectReadOnly>(realm, realm, x, y, width, height));
 }
 
 DOMRectReadOnly::DOMRectReadOnly(JS::Realm& realm, double x, double y, double width, double height)

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.h
@@ -17,7 +17,7 @@ class DOMRectReadOnly : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(DOMRectReadOnly, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<DOMRectReadOnly> construct_impl(JS::Realm&, double x = 0, double y = 0, double width = 0, double height = 0);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRectReadOnly>> construct_impl(JS::Realm&, double x = 0, double y = 0, double width = 0, double height = 0);
 
     virtual ~DOMRectReadOnly() override;
 

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -139,7 +139,8 @@ JS::NonnullGCPtr<BrowsingContext> BrowsingContext::create_a_new_browsing_context
         move(realm_execution_context),
         {},
         top_level_creation_url,
-        top_level_origin);
+        top_level_origin)
+        .release_value_but_fixme_should_propagate_errors();
 
     // 12. Let loadTimingInfo be a new document load timing info with its navigation start time set to the result of calling
     //     coarsen time with unsafeContextCreationTime and the new environment settings object's cross-origin isolated capability.

--- a/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
@@ -68,7 +68,7 @@ JS::NonnullGCPtr<DOM::Document> DOMParser::parse_from_string(DeprecatedString co
             // 1. Assert: document has no child nodes.
             document->remove_all_children(true);
             // 2. Let root be the result of creating an element given document, "parsererror", and "http://www.mozilla.org/newlayout/xml/parsererror.xml".
-            auto root = DOM::create_element(*document, "parsererror", "http://www.mozilla.org/newlayout/xml/parsererror.xml");
+            auto root = DOM::create_element(*document, "parsererror", "http://www.mozilla.org/newlayout/xml/parsererror.xml").release_value_but_fixme_should_propagate_errors();
             // FIXME: 3. Optionally, add attributes or children to root to describe the nature of the parsing error.
             // 4. Append root to document.
             MUST(document->append_child(*root));

--- a/Userland/Libraries/LibWeb/HTML/Focus.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Focus.cpp
@@ -65,9 +65,9 @@ static void run_focus_update_steps(Vector<JS::Handle<DOM::Node>> old_chain, Vect
         //    with related blur target as the related target.
         if (blur_event_target) {
             // FIXME: Implement the "fire a focus event" spec operation.
-            auto blur_event = UIEvents::FocusEvent::create(blur_event_target->realm(), HTML::EventNames::blur);
+            auto blur_event = UIEvents::FocusEvent::create(blur_event_target->realm(), HTML::EventNames::blur).release_value_but_fixme_should_propagate_errors();
             blur_event->set_related_target(related_blur_target);
-            blur_event_target->dispatch_event(*blur_event);
+            blur_event_target->dispatch_event(blur_event);
         }
     }
 
@@ -108,9 +108,9 @@ static void run_focus_update_steps(Vector<JS::Handle<DOM::Node>> old_chain, Vect
         //    with related focus target as the related target.
         if (focus_event_target) {
             // FIXME: Implement the "fire a focus event" spec operation.
-            auto focus_event = UIEvents::FocusEvent::create(focus_event_target->realm(), HTML::EventNames::focus);
+            auto focus_event = UIEvents::FocusEvent::create(focus_event_target->realm(), HTML::EventNames::focus).release_value_but_fixme_should_propagate_errors();
             focus_event->set_related_target(related_focus_target);
-            focus_event_target->dispatch_event(*focus_event);
+            focus_event_target->dispatch_event(focus_event);
         }
     }
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -88,7 +88,7 @@ JS::NonnullGCPtr<HTMLTableCaptionElement> HTMLTableElement::create_caption()
         return *maybe_caption;
     }
 
-    auto caption = DOM::create_element(document(), TagNames::caption, Namespace::HTML);
+    auto caption = DOM::create_element(document(), TagNames::caption, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
     MUST(pre_insert(caption, first_child()));
     return static_cast<HTMLTableCaptionElement&>(*caption);
 }
@@ -166,7 +166,7 @@ JS::NonnullGCPtr<HTMLTableSectionElement> HTMLTableElement::create_t_head()
     if (maybe_thead)
         return *maybe_thead;
 
-    auto thead = DOM::create_element(document(), TagNames::thead, Namespace::HTML);
+    auto thead = DOM::create_element(document(), TagNames::thead, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
 
     // We insert the new thead after any <caption> or <colgroup> elements
     DOM::Node* child_to_insert_before = nullptr;
@@ -242,7 +242,7 @@ JS::NonnullGCPtr<HTMLTableSectionElement> HTMLTableElement::create_t_foot()
     if (maybe_tfoot)
         return *maybe_tfoot;
 
-    auto tfoot = DOM::create_element(document(), TagNames::tfoot, Namespace::HTML);
+    auto tfoot = DOM::create_element(document(), TagNames::tfoot, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
     MUST(append_child(tfoot));
     return static_cast<HTMLTableSectionElement&>(*tfoot);
 }
@@ -272,7 +272,7 @@ JS::NonnullGCPtr<DOM::HTMLCollection> HTMLTableElement::t_bodies()
 // https://html.spec.whatwg.org/multipage/tables.html#dom-table-createtbody
 JS::NonnullGCPtr<HTMLTableSectionElement> HTMLTableElement::create_t_body()
 {
-    auto tbody = DOM::create_element(document(), TagNames::tbody, Namespace::HTML);
+    auto tbody = DOM::create_element(document(), TagNames::tbody, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
 
     // We insert the new tbody after the last <tbody> element
     DOM::Node* child_to_insert_before = nullptr;
@@ -335,9 +335,9 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> HTMLTableElement::ins
     if (index < -1 || index > (long)rows_length) {
         return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of rows");
     }
-    auto& tr = static_cast<HTMLTableRowElement&>(*DOM::create_element(document(), TagNames::tr, Namespace::HTML));
+    auto& tr = static_cast<HTMLTableRowElement&>(*TRY(DOM::create_element(document(), TagNames::tr, Namespace::HTML)));
     if (rows_length == 0 && !has_child_of_type<HTMLTableRowElement>()) {
-        auto tbody = DOM::create_element(document(), TagNames::tbody, Namespace::HTML);
+        auto tbody = TRY(DOM::create_element(document(), TagNames::tbody, Namespace::HTML));
         TRY(tbody->append_child(tr));
         TRY(append_child(tbody));
     } else if (rows_length == 0) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -112,7 +112,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableCellElement>> HTMLTableRowElement:
         return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of cells");
 
     // 2. Let table cell be the result of creating an element given this tr element's node document, td, and the HTML namespace.
-    auto& table_cell = static_cast<HTMLTableCellElement&>(*DOM::create_element(document(), HTML::TagNames::td, Namespace::HTML));
+    auto& table_cell = static_cast<HTMLTableCellElement&>(*TRY(DOM::create_element(document(), HTML::TagNames::td, Namespace::HTML)));
 
     // 3. If index is equal to −1 or equal to the number of items in cells collection, then append table cell to this tr element.
     if (index == -1 || index == cells_collection_size)

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
@@ -60,7 +60,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> HTMLTableSectionEleme
         return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of rows");
 
     // 2. Let table row be the result of creating an element given this element's node document, tr, and the HTML namespace.
-    auto& table_row = static_cast<HTMLTableRowElement&>(*DOM::create_element(document(), TagNames::tr, Namespace::HTML));
+    auto& table_row = static_cast<HTMLTableRowElement&>(*TRY(DOM::create_element(document(), TagNames::tr, Namespace::HTML)));
 
     // 3. If index is −1 or equal to the number of items in the rows collection, then append table row to this element.
     if (index == -1 || index == rows_collection_size)

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -536,8 +536,8 @@ void HTMLParser::handle_before_html(HTMLToken& token)
     // -> Anything else
 AnythingElse:
     // Create an html element whose node document is the Document object. Append it to the Document object. Put this element in the stack of open elements.
-    auto element = create_element(document(), HTML::TagNames::html, Namespace::HTML);
-    MUST(document().append_child(*element));
+    auto element = create_element(document(), HTML::TagNames::html, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
+    MUST(document().append_child(element));
     m_stack_of_open_elements.push(element);
 
     // Switch the insertion mode to "before head", then reprocess the token.
@@ -638,7 +638,7 @@ JS::NonnullGCPtr<DOM::Element> HTMLParser::create_element_for(HTMLToken const& t
     // 9. Let element be the result of creating an element given document, localName, given namespace, null, and is.
     // FIXME: If will execute script is true, set the synchronous custom elements flag; otherwise, leave it unset.
     // FIXME: Pass in `null` and `is`.
-    auto element = create_element(*document, local_name, namespace_);
+    auto element = create_element(*document, local_name, namespace_).release_value_but_fixme_should_propagate_errors();
 
     // 10. Append each attribute in the given token to element.
     // FIXME: This isn't the exact `append` the spec is talking about.
@@ -3499,7 +3499,7 @@ Vector<JS::Handle<DOM::Node>> HTMLParser::parse_html_fragment(DOM::Element& cont
     }
 
     // 5. Let root be a new html element with no attributes.
-    auto root = create_element(context_element.document(), HTML::TagNames::html, Namespace::HTML);
+    auto root = create_element(context_element.document(), HTML::TagNames::html, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
 
     // 6. Append the element root to the Document node created above.
     MUST(temp_document->append_child(root));

--- a/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h
@@ -15,7 +15,7 @@ class WindowEnvironmentSettingsObject final : public EnvironmentSettingsObject {
     JS_CELL(WindowEnvironmentSettingsObject, EnvironmentSettingsObject);
 
 public:
-    static void setup(AK::URL const& creation_url, NonnullOwnPtr<JS::ExecutionContext>, Optional<Environment>, AK::URL top_level_creation_url, Origin top_level_origin);
+    static WebIDL::ExceptionOr<void> setup(AK::URL const& creation_url, NonnullOwnPtr<JS::ExecutionContext>, Optional<Environment>, AK::URL top_level_creation_url, Origin top_level_origin);
 
     virtual ~WindowEnvironmentSettingsObject() override;
 

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -988,7 +988,7 @@ void Window::invoke_idle_callbacks()
         // 1. Pop the top callback from window's list of runnable idle callbacks.
         auto callback = m_runnable_idle_callbacks.take_first();
         // 2. Let deadlineArg be a new IdleDeadline whose [get deadline time algorithm] is getDeadline.
-        auto deadline_arg = RequestIdleCallback::IdleDeadline::create(realm());
+        auto deadline_arg = RequestIdleCallback::IdleDeadline::create(realm()).release_value_but_fixme_should_propagate_errors();
         // 3. Call callback with deadlineArg as its argument. If an uncaught runtime script error occurs, then report the exception.
         auto result = callback->invoke(deadline_arg);
         if (result.is_error())

--- a/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -11,13 +11,13 @@
 namespace Web::IntersectionObserver {
 
 // https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-intersectionobserver
-JS::NonnullGCPtr<IntersectionObserver> IntersectionObserver::construct_impl(JS::Realm& realm, WebIDL::CallbackType* callback, IntersectionObserverInit const& options)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<IntersectionObserver>> IntersectionObserver::construct_impl(JS::Realm& realm, WebIDL::CallbackType* callback, IntersectionObserverInit const& options)
 {
     // FIXME: Implement
     (void)callback;
     (void)options;
 
-    return realm.heap().allocate<IntersectionObserver>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<IntersectionObserver>(realm, realm));
 }
 
 IntersectionObserver::IntersectionObserver(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
+++ b/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
@@ -22,7 +22,7 @@ class IntersectionObserver : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(IntersectionObserver, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<IntersectionObserver> construct_impl(JS::Realm&, WebIDL::CallbackType* callback, IntersectionObserverInit const& options = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<IntersectionObserver>> construct_impl(JS::Realm&, WebIDL::CallbackType* callback, IntersectionObserverInit const& options = {});
 
     virtual ~IntersectionObserver() override;
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -684,17 +684,17 @@ bool EventHandler::fire_keyboard_event(DeprecatedFlyString const& event_name, HT
                 return fire_keyboard_event(event_name, *browsing_context_container.nested_browsing_context(), key, modifiers, code_point);
         }
 
-        auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), event_name, key, modifiers, code_point);
-        return !focused_element->dispatch_event(*event);
+        auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), event_name, key, modifiers, code_point).release_value_but_fixme_should_propagate_errors();
+        return !focused_element->dispatch_event(event);
     }
 
     // FIXME: De-duplicate this. This is just to prevent wasting a KeyboardEvent allocation when recursing into an (i)frame.
-    auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), event_name, key, modifiers, code_point);
+    auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), event_name, key, modifiers, code_point).release_value_but_fixme_should_propagate_errors();
 
     if (JS::GCPtr<HTML::HTMLElement> body = document->body())
-        return !body->dispatch_event(*event);
+        return !body->dispatch_event(event);
 
-    return !document->root().dispatch_event(*event);
+    return !document->root().dispatch_event(event);
 }
 
 bool EventHandler::handle_keydown(KeyCode key, unsigned modifiers, u32 code_point)

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -185,7 +185,7 @@ bool EventHandler::handle_mousewheel(CSSPixelPoint position, unsigned button, un
                 return false;
 
             auto offset = compute_mouse_event_offset(position, *layout_node);
-            if (node->dispatch_event(*UIEvents::WheelEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::wheel, offset.x(), offset.y(), position.x(), position.y(), wheel_delta_x, wheel_delta_y, buttons, button))) {
+            if (node->dispatch_event(UIEvents::WheelEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::wheel, offset.x(), offset.y(), position.x(), position.y(), wheel_delta_x, wheel_delta_y, buttons, button).release_value_but_fixme_should_propagate_errors())) {
                 if (auto* page = m_browsing_context.page()) {
                     page->client().page_did_request_scroll(wheel_delta_x * 20, wheel_delta_y * 20);
                 }

--- a/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.cpp
+++ b/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.cpp
@@ -12,9 +12,9 @@
 
 namespace Web::RequestIdleCallback {
 
-JS::NonnullGCPtr<IdleDeadline> IdleDeadline::create(JS::Realm& realm, bool did_timeout)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<IdleDeadline>> IdleDeadline::create(JS::Realm& realm, bool did_timeout)
 {
-    return realm.heap().allocate<IdleDeadline>(realm, realm, did_timeout).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<IdleDeadline>(realm, realm, did_timeout));
 }
 
 IdleDeadline::IdleDeadline(JS::Realm& realm, bool did_timeout)

--- a/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.h
+++ b/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.h
@@ -15,7 +15,7 @@ class IdleDeadline final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(IdleDeadline, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<IdleDeadline> create(JS::Realm&, bool did_timeout = false);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<IdleDeadline>> create(JS::Realm&, bool did_timeout = false);
     virtual ~IdleDeadline() override;
 
     double time_remaining() const;

--- a/Userland/Libraries/LibWeb/ResizeObserver/ResizeObserver.cpp
+++ b/Userland/Libraries/LibWeb/ResizeObserver/ResizeObserver.cpp
@@ -11,11 +11,11 @@
 namespace Web::ResizeObserver {
 
 // https://drafts.csswg.org/resize-observer/#dom-resizeobserver-resizeobserver
-JS::NonnullGCPtr<ResizeObserver> ResizeObserver::construct_impl(JS::Realm& realm, WebIDL::CallbackType* callback)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<ResizeObserver>> ResizeObserver::construct_impl(JS::Realm& realm, WebIDL::CallbackType* callback)
 {
     // FIXME: Implement
     (void)callback;
-    return realm.heap().allocate<ResizeObserver>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<ResizeObserver>(realm, realm));
 }
 
 ResizeObserver::ResizeObserver(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/ResizeObserver/ResizeObserver.h
+++ b/Userland/Libraries/LibWeb/ResizeObserver/ResizeObserver.h
@@ -19,7 +19,7 @@ class ResizeObserver : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(ResizeObserver, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<ResizeObserver> construct_impl(JS::Realm&, WebIDL::CallbackType* callback);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ResizeObserver>> construct_impl(JS::Realm&, WebIDL::CallbackType* callback);
 
     virtual ~ResizeObserver() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
@@ -36,7 +36,7 @@ float SVGGeometryElement::get_total_length()
 JS::NonnullGCPtr<Geometry::DOMPoint> SVGGeometryElement::get_point_at_length(float distance)
 {
     (void)distance;
-    return Geometry::DOMPoint::construct_impl(realm(), 0, 0, 0, 0);
+    return Geometry::DOMPoint::construct_impl(realm(), 0, 0, 0, 0).release_value_but_fixme_should_propagate_errors();
 }
 
 }

--- a/Userland/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Userland/Libraries/LibWeb/Selection/Selection.cpp
@@ -11,9 +11,9 @@
 
 namespace Web::Selection {
 
-JS::NonnullGCPtr<Selection> Selection::create(JS::NonnullGCPtr<JS::Realm> realm, JS::NonnullGCPtr<DOM::Document> document)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Selection>> Selection::create(JS::NonnullGCPtr<JS::Realm> realm, JS::NonnullGCPtr<DOM::Document> document)
 {
-    return realm->heap().allocate<Selection>(realm, realm, document).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm->heap().allocate<Selection>(realm, realm, document));
 }
 
 Selection::Selection(JS::NonnullGCPtr<JS::Realm> realm, JS::NonnullGCPtr<DOM::Document> document)

--- a/Userland/Libraries/LibWeb/Selection/Selection.h
+++ b/Userland/Libraries/LibWeb/Selection/Selection.h
@@ -15,7 +15,7 @@ class Selection final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(Selection, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<Selection> create(JS::NonnullGCPtr<JS::Realm>, JS::NonnullGCPtr<DOM::Document>);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Selection>> create(JS::NonnullGCPtr<JS::Realm>, JS::NonnullGCPtr<DOM::Document>);
 
     virtual ~Selection() override;
 

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -14,7 +14,7 @@ namespace Web::Streams {
 // https://streams.spec.whatwg.org/#rs-constructor
 WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> ReadableStream::construct_impl(JS::Realm& realm)
 {
-    return realm.heap().allocate<ReadableStream>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<ReadableStream>(realm, realm));
 }
 
 ReadableStream::ReadableStream(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/UIEvents/FocusEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/FocusEvent.cpp
@@ -9,9 +9,9 @@
 
 namespace Web::UIEvents {
 
-FocusEvent* FocusEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, FocusEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<FocusEvent>> FocusEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, FocusEventInit const& event_init)
 {
-    return realm.heap().allocate<FocusEvent>(realm, realm, event_name, event_init).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<FocusEvent>(realm, realm, event_name, event_init));
 }
 
 FocusEvent::FocusEvent(JS::Realm& realm, DeprecatedFlyString const& event_name, FocusEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/UIEvents/FocusEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/FocusEvent.h
@@ -18,7 +18,7 @@ class FocusEvent final : public UIEvent {
     WEB_PLATFORM_OBJECT(FocusEvent, UIEvent);
 
 public:
-    static FocusEvent* construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, FocusEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<FocusEvent>> construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, FocusEventInit const& event_init);
 
     virtual ~FocusEvent() override;
 

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
@@ -66,7 +66,7 @@ static unsigned long determine_key_code(KeyCode platform_key, u32 code_point)
     return platform_key;
 }
 
-KeyboardEvent* KeyboardEvent::create_from_platform_event(JS::Realm& realm, DeprecatedFlyString const& event_name, KeyCode platform_key, unsigned modifiers, u32 code_point)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyboardEvent>> KeyboardEvent::create_from_platform_event(JS::Realm& realm, DeprecatedFlyString const& event_name, KeyCode platform_key, unsigned modifiers, u32 code_point)
 {
     // FIXME: Figure out what these should actually contain.
     DeprecatedString event_key = key_code_to_string(platform_key);
@@ -104,12 +104,12 @@ bool KeyboardEvent::get_modifier_state(DeprecatedString const& key_arg)
     return false;
 }
 
-KeyboardEvent* KeyboardEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, KeyboardEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyboardEvent>> KeyboardEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, KeyboardEventInit const& event_init)
 {
-    return realm.heap().allocate<KeyboardEvent>(realm, realm, event_name, event_init).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<KeyboardEvent>(realm, realm, event_name, event_init));
 }
 
-KeyboardEvent* KeyboardEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, KeyboardEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyboardEvent>> KeyboardEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, KeyboardEventInit const& event_init)
 {
     return create(realm, event_name, event_init);
 }

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
@@ -28,9 +28,9 @@ class KeyboardEvent final : public UIEvent {
     WEB_PLATFORM_OBJECT(KeyboardEvent, UIEvent);
 
 public:
-    static KeyboardEvent* create(JS::Realm&, DeprecatedFlyString const& event_name, KeyboardEventInit const& event_init = {});
-    static KeyboardEvent* construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, KeyboardEventInit const& event_init);
-    static KeyboardEvent* create_from_platform_event(JS::Realm&, DeprecatedFlyString const& event_name, KeyCode, unsigned modifiers, u32 code_point);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyboardEvent>> create(JS::Realm&, DeprecatedFlyString const& event_name, KeyboardEventInit const& event_init = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyboardEvent>> construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, KeyboardEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyboardEvent>> create_from_platform_event(JS::Realm&, DeprecatedFlyString const& event_name, KeyCode, unsigned modifiers, u32 code_point);
 
     virtual ~KeyboardEvent() override;
 

--- a/Userland/Libraries/LibWeb/UIEvents/UIEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/UIEvent.cpp
@@ -9,14 +9,14 @@
 
 namespace Web::UIEvents {
 
-UIEvent* UIEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> UIEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name)
 {
-    return realm.heap().allocate<UIEvent>(realm, realm, event_name).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<UIEvent>(realm, realm, event_name));
 }
 
-UIEvent* UIEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, UIEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> UIEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, UIEventInit const& event_init)
 {
-    return realm.heap().allocate<UIEvent>(realm, realm, event_name, event_init).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<UIEvent>(realm, realm, event_name, event_init));
 }
 
 UIEvent::UIEvent(JS::Realm& realm, DeprecatedFlyString const& event_name)

--- a/Userland/Libraries/LibWeb/UIEvents/UIEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/UIEvent.h
@@ -21,8 +21,8 @@ class UIEvent : public DOM::Event {
     WEB_PLATFORM_OBJECT(UIEvent, DOM::Event);
 
 public:
-    static UIEvent* create(JS::Realm&, DeprecatedFlyString const& type);
-    static UIEvent* construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, UIEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> create(JS::Realm&, DeprecatedFlyString const& type);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, UIEventInit const& event_init);
 
     virtual ~UIEvent() override;
 

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/UIEvents/EventNames.h>
 #include <LibWeb/UIEvents/WheelEvent.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::UIEvents {
 
@@ -30,12 +31,12 @@ JS::ThrowCompletionOr<void> WheelEvent::initialize(JS::Realm& realm)
     return {};
 }
 
-WheelEvent* WheelEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, WheelEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, WheelEventInit const& event_init)
 {
-    return realm.heap().allocate<WheelEvent>(realm, realm, event_name, event_init).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<WheelEvent>(realm, realm, event_name, event_init));
 }
 
-WheelEvent* WheelEvent::create_from_platform_event(JS::Realm& realm, DeprecatedFlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, double delta_x, double delta_y, unsigned buttons, unsigned button)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create_from_platform_event(JS::Realm& realm, DeprecatedFlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, double delta_x, double delta_y, unsigned buttons, unsigned button)
 {
     WheelEventInit event_init {};
     event_init.offset_x = static_cast<double>(offset_x.value());

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
@@ -29,8 +29,8 @@ class WheelEvent final : public MouseEvent {
     WEB_PLATFORM_OBJECT(WheelEvent, MouseEvent);
 
 public:
-    static WheelEvent* create(JS::Realm&, DeprecatedFlyString const& event_name, WheelEventInit const& event_init = {});
-    static WheelEvent* create_from_platform_event(JS::Realm&, DeprecatedFlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, double delta_x, double delta_y, unsigned buttons, unsigned button);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> create(JS::Realm&, DeprecatedFlyString const& event_name, WheelEventInit const& event_init = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> create_from_platform_event(JS::Realm&, DeprecatedFlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, double delta_x, double delta_y, unsigned buttons, unsigned button);
 
     virtual ~WheelEvent() override;
 

--- a/Userland/Libraries/LibWeb/URL/URLSearchParamsIterator.cpp
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParamsIterator.cpp
@@ -23,9 +23,9 @@ void Intrinsics::create_web_prototype_and_constructor<URLSearchParamsIteratorPro
 
 namespace Web::URL {
 
-JS::NonnullGCPtr<URLSearchParamsIterator> URLSearchParamsIterator::create(URLSearchParams const& url_search_params, JS::Object::PropertyKind iteration_kind)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<URLSearchParamsIterator>> URLSearchParamsIterator::create(URLSearchParams const& url_search_params, JS::Object::PropertyKind iteration_kind)
 {
-    return url_search_params.heap().allocate<URLSearchParamsIterator>(url_search_params.realm(), url_search_params, iteration_kind).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(url_search_params.heap().allocate<URLSearchParamsIterator>(url_search_params.realm(), url_search_params, iteration_kind));
 }
 
 URLSearchParamsIterator::URLSearchParamsIterator(URLSearchParams const& url_search_params, JS::Object::PropertyKind iteration_kind)

--- a/Userland/Libraries/LibWeb/URL/URLSearchParamsIterator.h
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParamsIterator.h
@@ -15,7 +15,7 @@ class URLSearchParamsIterator : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(URLSearchParamsIterator, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<URLSearchParamsIterator> create(URLSearchParams const&, JS::Object::PropertyKind iteration_kind);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<URLSearchParamsIterator>> create(URLSearchParams const&, JS::Object::PropertyKind iteration_kind);
 
     virtual ~URLSearchParamsIterator() override;
 

--- a/Userland/Libraries/LibWeb/WebDriver/Screenshot.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Screenshot.cpp
@@ -57,7 +57,7 @@ Response capture_element_screenshot(Painter const& painter, Page& page, DOM::Ele
         auto viewport_rect = page.top_level_browsing_context().viewport_rect();
         rect.intersect(page.enclosing_device_rect(viewport_rect).to_type<int>());
 
-        auto canvas_element = DOM::create_element(element.document(), HTML::TagNames::canvas, Namespace::HTML);
+        auto canvas_element = DOM::create_element(element.document(), HTML::TagNames::canvas, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
         auto& canvas = verify_cast<HTML::HTMLCanvasElement>(*canvas_element);
 
         if (!canvas.create_bitmap(rect.width(), rect.height())) {

--- a/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.cpp
@@ -9,12 +9,12 @@
 
 namespace Web::WebGL {
 
-WebGLContextEvent* WebGLContextEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, WebGLContextEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> WebGLContextEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, WebGLContextEventInit const& event_init)
 {
-    return realm.heap().allocate<WebGLContextEvent>(realm, realm, event_name, event_init).release_allocated_value_but_fixme_should_propagate_errors();
+    return MUST_OR_THROW_OOM(realm.heap().allocate<WebGLContextEvent>(realm, realm, event_name, event_init));
 }
 
-WebGLContextEvent* WebGLContextEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, WebGLContextEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> WebGLContextEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, WebGLContextEventInit const& event_init)
 {
     return create(realm, event_name, event_init);
 }

--- a/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.h
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.h
@@ -19,8 +19,8 @@ class WebGLContextEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(WebGLContextEvent, DOM::Event);
 
 public:
-    static WebGLContextEvent* create(JS::Realm&, DeprecatedFlyString const& type, WebGLContextEventInit const& event_init);
-    static WebGLContextEvent* construct_impl(JS::Realm&, DeprecatedFlyString const& type, WebGLContextEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> create(JS::Realm&, DeprecatedFlyString const& type, WebGLContextEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> construct_impl(JS::Realm&, DeprecatedFlyString const& type, WebGLContextEventInit const& event_init);
 
     virtual ~WebGLContextEvent() override;
 

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
@@ -17,7 +17,7 @@ static void fire_webgl_context_event(HTML::HTMLCanvasElement& canvas_element, De
 {
     // To fire a WebGL context event named e means that an event using the WebGLContextEvent interface, with its type attribute [DOM4] initialized to e, its cancelable attribute initialized to true, and its isTrusted attribute [DOM4] initialized to true, is to be dispatched at the given object.
     // FIXME: Consider setting a status message.
-    auto event = WebGLContextEvent::create(canvas_element.realm(), type, WebGLContextEventInit {});
+    auto event = WebGLContextEvent::create(canvas_element.realm(), type, WebGLContextEventInit {}).release_value_but_fixme_should_propagate_errors();
     event->set_is_trusted(true);
     event->set_cancelable(true);
     canvas_element.dispatch_event(*event);

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -64,7 +64,7 @@ void XMLDocumentBuilder::element_start(const XML::Name& name, HashMap<XML::Name,
         }
     }
 
-    auto node = DOM::create_element(m_document, name, {});
+    auto node = DOM::create_element(m_document, name, {}).release_value_but_fixme_should_propagate_errors();
     // When an XML parser with XML scripting support enabled creates a script element,
     // it must have its parser document set and its "force async" flag must be unset.
     // FIXME: If the parser was created as part of the XML fragment parsing algorithm, then the element must be marked as "already started" also.


### PR DESCRIPTION
Also contains modifications to the IDL generator to allow error propagation from the factory methods for IDLEventListener/NodeFilter, and error propagation from iterators (prototype.{entries,keys.values}).