### PR TITLE
LibWeb: Replace `RefPtr` with `ValueComparingRefPtr` in StyleValue 

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3997,7 +3997,7 @@ RefPtr<StyleValue> Parser::parse_comma_separated_value_list(Vector<ComponentValu
     if (!first || !tokens.has_next_token())
         return first;
 
-    NonnullRefPtrVector<StyleValue> values;
+    StyleValueVector values;
     values.append(first.release_nonnull());
 
     while (tokens.has_next_token()) {
@@ -4027,13 +4027,13 @@ RefPtr<StyleValue> Parser::parse_simple_comma_separated_value_list(Vector<Compon
 
 RefPtr<StyleValue> Parser::parse_background_value(Vector<ComponentValue> const& component_values)
 {
-    NonnullRefPtrVector<StyleValue> background_images;
-    NonnullRefPtrVector<StyleValue> background_positions;
-    NonnullRefPtrVector<StyleValue> background_sizes;
-    NonnullRefPtrVector<StyleValue> background_repeats;
-    NonnullRefPtrVector<StyleValue> background_attachments;
-    NonnullRefPtrVector<StyleValue> background_clips;
-    NonnullRefPtrVector<StyleValue> background_origins;
+    StyleValueVector background_images;
+    StyleValueVector background_positions;
+    StyleValueVector background_sizes;
+    StyleValueVector background_repeats;
+    StyleValueVector background_attachments;
+    StyleValueVector background_clips;
+    StyleValueVector background_origins;
     RefPtr<StyleValue> background_color;
 
     // Per-layer values
@@ -4778,8 +4778,8 @@ RefPtr<StyleValue> Parser::parse_content_value(Vector<ComponentValue> const& com
         }
     }
 
-    NonnullRefPtrVector<StyleValue> content_values;
-    NonnullRefPtrVector<StyleValue> alt_text_values;
+    StyleValueVector content_values;
+    StyleValueVector alt_text_values;
     bool in_alt_text = false;
 
     for (auto const& value : component_values) {
@@ -5239,7 +5239,7 @@ RefPtr<StyleValue> Parser::parse_font_family_value(Vector<ComponentValue> const&
     // eg, these are equivalent:
     //     font-family: my cool     font\!, serif;
     //     font-family: "my cool font!", serif;
-    NonnullRefPtrVector<StyleValue> font_families;
+    StyleValueVector font_families;
     Vector<DeprecatedString> current_name_parts;
     for (size_t i = start_index; i < component_values.size(); ++i) {
         auto const& part = component_values[i];
@@ -5642,7 +5642,7 @@ RefPtr<StyleValue> Parser::parse_text_decoration_value(Vector<ComponentValue> co
 
 RefPtr<StyleValue> Parser::parse_text_decoration_line_value(TokenStream<ComponentValue>& tokens)
 {
-    NonnullRefPtrVector<StyleValue> style_values;
+    StyleValueVector style_values;
 
     while (tokens.has_next_token()) {
         auto const& token = tokens.next_token();
@@ -5681,7 +5681,7 @@ RefPtr<StyleValue> Parser::parse_text_decoration_line_value(TokenStream<Componen
 
 RefPtr<StyleValue> Parser::parse_transform_value(Vector<ComponentValue> const& component_values)
 {
-    NonnullRefPtrVector<StyleValue> transformations;
+    StyleValueVector transformations;
     auto tokens = TokenStream { component_values };
     tokens.skip_whitespace();
 
@@ -5706,7 +5706,7 @@ RefPtr<StyleValue> Parser::parse_transform_value(Vector<ComponentValue> const& c
         auto function = maybe_function.release_value();
         auto function_metadata = transform_function_metadata(function);
 
-        NonnullRefPtrVector<StyleValue> values;
+        StyleValueVector values;
         auto argument_tokens = TokenStream { part.function().values() };
         argument_tokens.skip_whitespace();
         size_t argument_index = 0;
@@ -5851,7 +5851,7 @@ RefPtr<StyleValue> Parser::parse_transform_origin_value(Vector<ComponentValue> c
     };
 
     auto make_list = [](NonnullRefPtr<StyleValue> const& x_value, NonnullRefPtr<StyleValue> const& y_value) -> NonnullRefPtr<StyleValueList> {
-        NonnullRefPtrVector<StyleValue> values;
+        StyleValueVector values;
         values.append(x_value);
         values.append(y_value);
         return StyleValueList::create(move(values), StyleValueList::Separator::Space);
@@ -6615,7 +6615,7 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
 
     // We have multiple values, so treat them as a StyleValueList.
     if (property_maximum_value_count(property_id) > 1) {
-        NonnullRefPtrVector<StyleValue> parsed_values;
+        StyleValueVector parsed_values;
         for (auto& component_value : component_values) {
             auto parsed_value = parse_css_value(component_value);
             if (!parsed_value || !property_accepts_value(property_id, *parsed_value))

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -54,7 +54,7 @@ static RefPtr<StyleValue> style_value_for_display(CSS::Display display)
         return IdentifierStyleValue::create(CSS::ValueID::None);
 
     if (display.is_outside_and_inside()) {
-        NonnullRefPtrVector<StyleValue> values;
+        StyleValueVector values;
         switch (display.outside()) {
         case CSS::Display::Outside::Inline:
             values.append(IdentifierStyleValue::create(CSS::ValueID::Inline));
@@ -288,7 +288,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         if (box_shadow_layers.size() == 1)
             return make_box_shadow_style_value(box_shadow_layers.first());
 
-        NonnullRefPtrVector<StyleValue> box_shadow;
+        StyleValueVector box_shadow;
         box_shadow.ensure_capacity(box_shadow_layers.size());
         for (auto const& layer : box_shadow_layers)
             box_shadow.append(make_box_shadow_style_value(layer));
@@ -412,7 +412,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().list_style_type()));
     case CSS::PropertyID::Margin: {
         auto margin = layout_node.computed_values().margin();
-        auto values = NonnullRefPtrVector<StyleValue> {};
+        auto values = StyleValueVector {};
         values.append(style_value_for_length_percentage(margin.top()));
         values.append(style_value_for_length_percentage(margin.right()));
         values.append(style_value_for_length_percentage(margin.bottom()));
@@ -445,7 +445,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().overflow_y()));
     case CSS::PropertyID::Padding: {
         auto padding = layout_node.computed_values().padding();
-        auto values = NonnullRefPtrVector<StyleValue> {};
+        auto values = StyleValueVector {};
         values.append(style_value_for_length_percentage(padding.top()));
         values.append(style_value_for_length_percentage(padding.right()));
         values.append(style_value_for_length_percentage(padding.bottom()));
@@ -472,7 +472,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         auto text_decoration_lines = layout_node.computed_values().text_decoration_line();
         if (text_decoration_lines.is_empty())
             return IdentifierStyleValue::create(ValueID::None);
-        NonnullRefPtrVector<StyleValue> style_values;
+        StyleValueVector style_values;
         for (auto const& line : text_decoration_lines) {
             style_values.append(IdentifierStyleValue::create(to_value_id(line)));
         }
@@ -505,7 +505,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         //        https://w3c.github.io/csswg-drafts/css-transforms-2/#serialization-of-the-computed-value
         auto affine_matrix = paintable_box->stacking_context()->affine_transform_matrix();
 
-        NonnullRefPtrVector<StyleValue> parameters;
+        StyleValueVector parameters;
         parameters.ensure_capacity(6);
         parameters.append(NumericStyleValue::create_float(affine_matrix.a()));
         parameters.append(NumericStyleValue::create_float(affine_matrix.b()));
@@ -517,7 +517,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         NonnullRefPtr<StyleValue> matrix_function = TransformationStyleValue::create(TransformFunction::Matrix, move(parameters));
         // Elsewhere we always store the transform property's value as a StyleValueList of TransformationStyleValues,
         // so this is just for consistency.
-        NonnullRefPtrVector<StyleValue> matrix_functions;
+        StyleValueVector matrix_functions;
         matrix_functions.append(matrix_function);
         return StyleValueList::create(move(matrix_functions), StyleValueList::Separator::Space);
     }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -291,14 +291,14 @@ StyleValueList const& StyleValue::as_value_list() const
 }
 
 BackgroundStyleValue::BackgroundStyleValue(
-    NonnullRefPtr<StyleValue> color,
-    NonnullRefPtr<StyleValue> image,
-    NonnullRefPtr<StyleValue> position,
-    NonnullRefPtr<StyleValue> size,
-    NonnullRefPtr<StyleValue> repeat,
-    NonnullRefPtr<StyleValue> attachment,
-    NonnullRefPtr<StyleValue> origin,
-    NonnullRefPtr<StyleValue> clip)
+    ValueComparingNonnullRefPtr<StyleValue> color,
+    ValueComparingNonnullRefPtr<StyleValue> image,
+    ValueComparingNonnullRefPtr<StyleValue> position,
+    ValueComparingNonnullRefPtr<StyleValue> size,
+    ValueComparingNonnullRefPtr<StyleValue> repeat,
+    ValueComparingNonnullRefPtr<StyleValue> attachment,
+    ValueComparingNonnullRefPtr<StyleValue> origin,
+    ValueComparingNonnullRefPtr<StyleValue> clip)
     : StyleValueWithDefaultOperators(Type::Background)
     , m_properties {
         .color = move(color),
@@ -335,7 +335,7 @@ ErrorOr<String> BackgroundStyleValue::to_string() const
         return String::formatted("{} {} {} {} {} {} {} {}", TRY(m_properties.color->to_string()), TRY(m_properties.image->to_string()), TRY(m_properties.position->to_string()), TRY(m_properties.size->to_string()), TRY(m_properties.repeat->to_string()), TRY(m_properties.attachment->to_string()), TRY(m_properties.origin->to_string()), TRY(m_properties.clip->to_string()));
     }
 
-    auto get_layer_value_string = [](NonnullRefPtr<StyleValue> const& style_value, size_t index) {
+    auto get_layer_value_string = [](ValueComparingNonnullRefPtr<StyleValue> const& style_value, size_t index) {
         if (style_value->is_value_list())
             return style_value->as_value_list().value_at(index, true)->to_string();
         return style_value->to_string();
@@ -574,7 +574,7 @@ ErrorOr<String> CalculatedStyleValue::to_string() const
     return String::formatted("calc({})", TRY(m_expression->to_string()));
 }
 
-bool CalculatedStyleValue::operator==(StyleValue const& other) const
+bool CalculatedStyleValue::equals(StyleValue const& other) const
 {
     if (type() != other.type())
         return false;
@@ -1549,7 +1549,7 @@ ErrorOr<String> ImageStyleValue::to_string() const
     return serialize_a_url(m_url.to_deprecated_string());
 }
 
-bool ImageStyleValue::operator==(StyleValue const& other) const
+bool ImageStyleValue::equals(StyleValue const& other) const
 {
     if (type() != other.type())
         return false;
@@ -1640,7 +1640,7 @@ ErrorOr<String> LinearGradientStyleValue::to_string() const
     return builder.to_string();
 }
 
-bool LinearGradientStyleValue::operator==(StyleValue const& other_) const
+bool LinearGradientStyleValue::equals(StyleValue const& other_) const
 {
     if (type() != other_.type())
         return false;
@@ -1981,7 +1981,7 @@ void RadialGradientStyleValue::resolve_for_size(Layout::Node const& node, CSSPix
     };
 }
 
-bool RadialGradientStyleValue::operator==(StyleValue const& other) const
+bool RadialGradientStyleValue::equals(StyleValue const& other) const
 {
     if (type() != other.type())
         return false;
@@ -2033,7 +2033,7 @@ void ConicGradientStyleValue::paint(PaintContext& context, DevicePixelRect const
     Painting::paint_conic_gradient(context, dest_rect, m_resolved->data, context.rounded_device_point(m_resolved->position));
 }
 
-bool ConicGradientStyleValue::operator==(StyleValue const& other) const
+bool ConicGradientStyleValue::equals(StyleValue const& other) const
 {
     if (type() != other.type())
         return false;
@@ -2131,7 +2131,7 @@ ErrorOr<String> UnresolvedStyleValue::to_string() const
     return builder.to_string();
 }
 
-bool UnresolvedStyleValue::operator==(StyleValue const& other) const
+bool UnresolvedStyleValue::equals(StyleValue const& other) const
 {
     if (type() != other.type())
         return false;
@@ -2161,7 +2161,7 @@ ErrorOr<String> StyleValueList::to_string() const
     return String::from_deprecated_string(DeprecatedString::join(separator, m_properties.values));
 }
 
-NonnullRefPtr<ColorStyleValue> ColorStyleValue::create(Color color)
+ValueComparingNonnullRefPtr<ColorStyleValue> ColorStyleValue::create(Color color)
 {
     if (color.value() == 0) {
         static auto transparent = adopt_ref(*new ColorStyleValue(color));
@@ -2181,32 +2181,32 @@ NonnullRefPtr<ColorStyleValue> ColorStyleValue::create(Color color)
     return adopt_ref(*new ColorStyleValue(color));
 }
 
-NonnullRefPtr<GridTemplateAreaStyleValue> GridTemplateAreaStyleValue::create(Vector<Vector<String>> grid_template_area)
+ValueComparingNonnullRefPtr<GridTemplateAreaStyleValue> GridTemplateAreaStyleValue::create(Vector<Vector<String>> grid_template_area)
 {
     return adopt_ref(*new GridTemplateAreaStyleValue(grid_template_area));
 }
 
-NonnullRefPtr<GridTrackPlacementStyleValue> GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement grid_track_placement)
+ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement grid_track_placement)
 {
     return adopt_ref(*new GridTrackPlacementStyleValue(grid_track_placement));
 }
 
-NonnullRefPtr<GridTrackSizeStyleValue> GridTrackSizeStyleValue::create(CSS::GridTrackSizeList grid_track_size_list)
+ValueComparingNonnullRefPtr<GridTrackSizeStyleValue> GridTrackSizeStyleValue::create(CSS::GridTrackSizeList grid_track_size_list)
 {
     return adopt_ref(*new GridTrackSizeStyleValue(grid_track_size_list));
 }
 
-NonnullRefPtr<GridTrackSizeStyleValue> GridTrackSizeStyleValue::make_auto()
+ValueComparingNonnullRefPtr<GridTrackSizeStyleValue> GridTrackSizeStyleValue::make_auto()
 {
     return adopt_ref(*new GridTrackSizeStyleValue(CSS::GridTrackSizeList()));
 }
 
-NonnullRefPtr<RectStyleValue> RectStyleValue::create(EdgeRect rect)
+ValueComparingNonnullRefPtr<RectStyleValue> RectStyleValue::create(EdgeRect rect)
 {
     return adopt_ref(*new RectStyleValue(rect));
 }
 
-NonnullRefPtr<LengthStyleValue> LengthStyleValue::create(Length const& length)
+ValueComparingNonnullRefPtr<LengthStyleValue> LengthStyleValue::create(Length const& length)
 {
     if (length.is_auto()) {
         static auto value = adopt_ref(*new LengthStyleValue(CSS::Length::make_auto()));
@@ -2236,19 +2236,19 @@ static Optional<CSS::Length> absolutized_length(CSS::Length const& length, CSSPi
     return {};
 }
 
-NonnullRefPtr<StyleValue> StyleValue::absolutized(CSSPixelRect const&, Gfx::FontPixelMetrics const&, CSSPixels, CSSPixels) const
+ValueComparingNonnullRefPtr<StyleValue> StyleValue::absolutized(CSSPixelRect const&, Gfx::FontPixelMetrics const&, CSSPixels, CSSPixels) const
 {
     return *this;
 }
 
-NonnullRefPtr<StyleValue> LengthStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
+ValueComparingNonnullRefPtr<StyleValue> LengthStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
 {
     if (auto length = absolutized_length(m_length, viewport_rect, font_metrics, font_size, root_font_size); length.has_value())
         return LengthStyleValue::create(length.release_value());
     return *this;
 }
 
-NonnullRefPtr<StyleValue> ShadowStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
+ValueComparingNonnullRefPtr<StyleValue> ShadowStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
 {
     auto absolutized_offset_x = absolutized_length(m_properties.offset_x, viewport_rect, font_metrics, font_size, root_font_size).value_or(m_properties.offset_x);
     auto absolutized_offset_y = absolutized_length(m_properties.offset_y, viewport_rect, font_metrics, font_size, root_font_size).value_or(m_properties.offset_y);
@@ -2257,7 +2257,7 @@ NonnullRefPtr<StyleValue> ShadowStyleValue::absolutized(CSSPixelRect const& view
     return ShadowStyleValue::create(m_properties.color, absolutized_offset_x, absolutized_offset_y, absolutized_blur_radius, absolutized_spread_distance, m_properties.placement);
 }
 
-NonnullRefPtr<StyleValue> BorderRadiusStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
+ValueComparingNonnullRefPtr<StyleValue> BorderRadiusStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
 {
     if (m_properties.horizontal_radius.is_percentage() && m_properties.vertical_radius.is_percentage())
         return *this;


### PR DESCRIPTION
Like the name suggests this pointer type compares its pointees by value rather than just by the pointer. This is needed for the defaulted struct Properties equality operator.

This commit also contains a few changes to StyleValue such as replacing the operator==()s with a .equals() again. This is done to avoid the new reversed operator==()s ambiguity in C++20.