### PR TITLE
LibCore: Implement socket credentials for NetBSD

### DIFF
--- a/Userland/Libraries/LibCore/Socket.cpp
+++ b/Userland/Libraries/LibCore/Socket.cpp
@@ -367,6 +367,9 @@ ErrorOr<pid_t> LocalSocket::peer_pid() const
 #elif defined(AK_OS_OPENBSD)
     struct sockpeercred creds = {};
     socklen_t creds_size = sizeof(creds);
+#elif defined(AK_OS_NETBSD)
+    struct sockcred creds = {};
+    socklen_t creds_size = sizeof(creds);
 #else
     struct ucred creds = {};
     socklen_t creds_size = sizeof(creds);
@@ -378,6 +381,9 @@ ErrorOr<pid_t> LocalSocket::peer_pid() const
 #elif defined(AK_OS_FREEBSD)
     TRY(System::getsockopt(m_helper.fd(), SOL_LOCAL, LOCAL_PEERCRED, &creds, &creds_size));
     return creds.cr_pid;
+#elif defined(AK_OS_NETBSD)
+    TRY(System::getsockopt(m_helper.fd(), SOL_SOCKET, SCM_CREDS, &creds, &creds_size));
+    return creds.sc_pid;
 #else
     TRY(System::getsockopt(m_helper.fd(), SOL_SOCKET, SO_PEERCRED, &creds, &creds_size));
     return creds.pid;


### PR DESCRIPTION
Add an implementation for socket credentials for NetBSD.
Without that,building Ladybird crashes very early.