### PR TITLE
LibCore: Add support for NetBSD in anon_create

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -333,6 +333,10 @@ install(TARGETS LibC LibCrypt LibSystem NoCoverage EXPORT LagomTargets)
 add_serenity_subdirectory(AK)
 add_serenity_subdirectory(Userland/Libraries/LibCore)
 target_link_libraries(LibCore PRIVATE Threads::Threads)
+if (${CMAKE_SYSTEM_NAME} MATCHES "NetBSD")
+    # NetBSD has its shm_open and shm_unlink functions in librt so we need to link that
+    target_link_libraries(LibCore PRIVATE librt.so)
+endif()
 target_sources(LibCore PRIVATE ${AK_SOURCES})
 
 # LibMain

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -403,7 +403,7 @@ ErrorOr<int> anon_create([[maybe_unused]] size_t size, [[maybe_unused]] int opti
         TRY(close(fd));
         return Error::from_errno(saved_errno);
     }
-#elif defined(AK_OS_MACOS) || defined(AK_OS_EMSCRIPTEN) || defined(AK_OS_OPENBSD)
+#elif defined(AK_OS_MACOS) || defined(AK_OS_EMSCRIPTEN) || defined(AK_OS_OPENBSD) || defined(AK_OS_NETBSD)
     struct timespec time;
     clock_gettime(CLOCK_REALTIME, &time);
     auto name = DeprecatedString::formatted("/shm-{}{}", (unsigned long)time.tv_sec, (unsigned long)time.tv_nsec);


### PR DESCRIPTION
Add support for the anon_create function on NetBSD.
Without that,Ladybird crashes without even showing a window and with a quite misleading error message related to loading the theme.
NetBSD has its shm_open and shm_unlink functions in another library,librt,which needs to be linked by CMake.
Besides that,it works the same way as on OpenBSD or MacOS.