### PR TITLE
LibJS: Use isnanf instead of isnan on NetBSD

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -212,7 +212,11 @@ public:
             VERIFY(!(SHIFTED_INT32_TAG & (static_cast<i32>(value) & 0xFFFFFFFFul)));
             m_value.encoded = SHIFTED_INT32_TAG | (static_cast<i32>(value) & 0xFFFFFFFFul);
         } else {
+#if defined(AK_OS_NETBSD)
+            if (isnanf(value)) [[unlikely]]
+#else
             if (isnan(value)) [[unlikely]]
+#endif
                 m_value.encoded = CANON_NAN_BITS;
             else
                 m_value.as_double = value;


### PR DESCRIPTION
NetBSD throws an error that isnan isn't defined.
The isnanf function should do nearly the same,and it works on NetBSD,so I added a ifdef to use that one when building on NetBSD.