### PR TITLE
LibSQL: fchmod on sockets is not supported by any BSD

### DIFF
--- a/Userland/Libraries/LibSQL/SQLClient.cpp
+++ b/Userland/Libraries/LibSQL/SQLClient.cpp
@@ -37,7 +37,7 @@ static ErrorOr<int> create_database_socket(DeprecatedString const& socket_path)
     TRY(Core::System::fcntl(socket_fd, F_SETFD, FD_CLOEXEC));
 #    endif
 
-#    if !defined(AK_OS_MACOS) && !defined(AK_OS_FREEBSD) && !defined(AK_OS_OPENBSD)
+#    if !defined(AK_OS_BSD_GENERIC)
     TRY(Core::System::fchmod(socket_fd, 0600));
 #    endif
 


### PR DESCRIPTION
No BSD or BSD-derived system seems to support fchmod on sockets,so it's probably better to use AK_OS_BSD_GENERIC instead of just listing most of the affected systems.
NetBSD was forgotten in the list before,and so Ladybird crashed here before even showing a window.
This change fixes the problem.