### PR TITLE
LibCore: Enable file descriptor passing on all BSDs

### DIFF
--- a/Userland/Libraries/LibCore/Socket.cpp
+++ b/Userland/Libraries/LibCore/Socket.cpp
@@ -282,7 +282,7 @@ ErrorOr<int> LocalSocket::receive_fd(int flags)
 {
 #if defined(AK_OS_SERENITY)
     return Core::System::recvfd(m_helper.fd(), flags);
-#elif defined(AK_OS_LINUX) || defined(AK_OS_MACOS) || defined(AK_OS_FREEBSD) || defined(AK_OS_OPENBSD)
+#elif defined(AK_OS_LINUX) || defined(AK_OS_BSD_GENERIC)
     union {
         struct cmsghdr cmsghdr;
         char control[CMSG_SPACE(sizeof(int))];
@@ -323,7 +323,7 @@ ErrorOr<void> LocalSocket::send_fd(int fd)
 {
 #if defined(AK_OS_SERENITY)
     return Core::System::sendfd(m_helper.fd(), fd);
-#elif defined(AK_OS_LINUX) || defined(AK_OS_MACOS) || defined(AK_OS_FREEBSD) || defined(AK_OS_OPENBSD)
+#elif defined(AK_OS_LINUX) || defined(AK_OS_BSD_GENERIC)
     char c = 'F';
     struct iovec iov {
         .iov_base = &c,


### PR DESCRIPTION
All BSDs and BSD-derived systems seem to support file descriptor passing,so it's probably better to use AK_OS_BSD_GENERIC instead of listing most of those systems.
This fixes errors of this type: `IPC::ConnectionBase (0x0000000805bf2b00) had an error (File descriptor passing not supported on this platform), disconnecting. WebContent process crashed!` on NetBSD which wasn't in the list of supported systems before.