### PR TITLE
AK/StackInfo: Add support for NetBSD

### DIFF
--- a/AK/StackInfo.cpp
+++ b/AK/StackInfo.cpp
@@ -12,7 +12,7 @@
 
 #ifdef AK_OS_SERENITY
 #    include <serenity.h>
-#elif defined(AK_OS_LINUX) or defined(AK_OS_MACOS)
+#elif defined(AK_OS_LINUX) or defined(AK_OS_MACOS) or defined(AK_OS_NETBSD)
 #    include <pthread.h>
 #elif defined(AK_OS_FREEBSD) or defined(AK_OS_OPENBSD)
 #    include <pthread.h>
@@ -28,7 +28,7 @@ StackInfo::StackInfo()
         perror("get_stack_bounds");
         VERIFY_NOT_REACHED();
     }
-#elif defined(AK_OS_LINUX) or defined(AK_OS_FREEBSD)
+#elif defined(AK_OS_LINUX) or defined(AK_OS_FREEBSD) or defined(AK_OS_NETBSD)
     int rc;
     pthread_attr_t attr;
     pthread_attr_init(&attr);


### PR DESCRIPTION
Add support for StackInfo on NetBSD.
Without that,Ladybird on NetBSD crashes often on a little bit more complicated websites.
StackInfo on NetBSD works the same way as it does on FreeBSD,except that it has the _np functions directly in pthread.h and doesn't need an extra pthread_np.h include.