### PR TITLE
AK+Everywhere: Stop "const laundering" in smart pointers

### DIFF
--- a/AK/DeprecatedFlyString.cpp
+++ b/AK/DeprecatedFlyString.cpp
@@ -24,9 +24,9 @@ struct DeprecatedFlyStringImplTraits : public Traits<StringImpl*> {
     }
 };
 
-static Singleton<HashTable<StringImpl*, DeprecatedFlyStringImplTraits>> s_table;
+static Singleton<HashTable<StringImpl const*, DeprecatedFlyStringImplTraits>> s_table;
 
-static HashTable<StringImpl*, DeprecatedFlyStringImplTraits>& fly_impls()
+static HashTable<StringImpl const*, DeprecatedFlyStringImplTraits>& fly_impls()
 {
     return *s_table;
 }

--- a/AK/DeprecatedFlyString.h
+++ b/AK/DeprecatedFlyString.h
@@ -29,7 +29,7 @@ public:
     {
     }
 
-    static DeprecatedFlyString from_fly_impl(NonnullRefPtr<StringImpl> impl)
+    static DeprecatedFlyString from_fly_impl(NonnullRefPtr<StringImpl const> impl)
     {
         VERIFY(impl->is_fly());
         DeprecatedFlyString string;
@@ -91,7 +91,7 @@ public:
     }
 
 private:
-    RefPtr<StringImpl> m_impl;
+    RefPtr<StringImpl const> m_impl;
 };
 
 template<>

--- a/AK/DeprecatedString.h
+++ b/AK/DeprecatedString.h
@@ -18,7 +18,7 @@ namespace AK {
 
 // DeprecatedString is a convenience wrapper around StringImpl, suitable for passing
 // around as a value type. It's basically the same as passing around a
-// RefPtr<StringImpl>, with a bit of syntactic sugar.
+// RefPtr<StringImpl const>, with a bit of syntactic sugar.
 //
 // Note that StringImpl is an immutable object that cannot shrink or grow.
 // Its allocation size is snugly tailored to the specific string it contains.
@@ -48,7 +48,7 @@ public:
     }
 
     DeprecatedString(DeprecatedString const& other)
-        : m_impl(const_cast<DeprecatedString&>(other).m_impl)
+        : m_impl(other.m_impl)
     {
     }
 
@@ -73,21 +73,21 @@ public:
     }
 
     DeprecatedString(StringImpl const& impl)
-        : m_impl(const_cast<StringImpl&>(impl))
+        : m_impl(impl)
     {
     }
 
     DeprecatedString(StringImpl const* impl)
-        : m_impl(const_cast<StringImpl*>(impl))
+        : m_impl(impl)
     {
     }
 
-    DeprecatedString(RefPtr<StringImpl>&& impl)
+    DeprecatedString(RefPtr<StringImpl const>&& impl)
         : m_impl(move(impl))
     {
     }
 
-    DeprecatedString(NonnullRefPtr<StringImpl>&& impl)
+    DeprecatedString(NonnullRefPtr<StringImpl const>&& impl)
         : m_impl(move(impl))
     {
     }
@@ -234,7 +234,6 @@ public:
         return StringImpl::the_empty_stringimpl();
     }
 
-    [[nodiscard]] StringImpl* impl() { return m_impl.ptr(); }
     [[nodiscard]] StringImpl const* impl() const { return m_impl.ptr(); }
 
     DeprecatedString& operator=(DeprecatedString&& other)
@@ -323,7 +322,7 @@ public:
     }
 
 private:
-    RefPtr<StringImpl> m_impl;
+    RefPtr<StringImpl const> m_impl;
 };
 
 template<>

--- a/AK/NonnullPtrVector.h
+++ b/AK/NonnullPtrVector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -33,10 +33,10 @@ public:
 
     using Base::size;
 
-    using ConstIterator = SimpleIterator<NonnullPtrVector const, T const>;
+    using ConstIterator = SimpleIterator<NonnullPtrVector const, T>;
     using Iterator = SimpleIterator<NonnullPtrVector, T>;
     using ReverseIterator = SimpleReverseIterator<NonnullPtrVector, T>;
-    using ReverseConstIterator = SimpleReverseIterator<NonnullPtrVector const, T const>;
+    using ReverseConstIterator = SimpleReverseIterator<NonnullPtrVector const, T>;
 
     ALWAYS_INLINE constexpr ConstIterator begin() const { return ConstIterator::begin(*this); }
     ALWAYS_INLINE constexpr Iterator begin() { return Iterator::begin(*this); }
@@ -60,17 +60,12 @@ public:
         return {};
     }
 
-    ALWAYS_INLINE PtrType& ptr_at(size_t index) { return Base::at(index); }
-    ALWAYS_INLINE PtrType const& ptr_at(size_t index) const { return Base::at(index); }
+    ALWAYS_INLINE PtrType& ptr_at(size_t index) const { return const_cast<PtrType&>(Base::at(index)); }
 
-    ALWAYS_INLINE T& at(size_t index) { return *Base::at(index); }
-    ALWAYS_INLINE T const& at(size_t index) const { return *Base::at(index); }
-    ALWAYS_INLINE T& operator[](size_t index) { return at(index); }
-    ALWAYS_INLINE T const& operator[](size_t index) const { return at(index); }
-    ALWAYS_INLINE T& first() { return at(0); }
-    ALWAYS_INLINE T const& first() const { return at(0); }
-    ALWAYS_INLINE T& last() { return at(size() - 1); }
-    ALWAYS_INLINE T const& last() const { return at(size() - 1); }
+    ALWAYS_INLINE T& at(size_t index) const { return const_cast<T&>(*Base::at(index)); }
+    ALWAYS_INLINE T& operator[](size_t index) const { return at(index); }
+    ALWAYS_INLINE T& first() const { return at(0); }
+    ALWAYS_INLINE T& last() const { return at(size() - 1); }
 
 private:
     // NOTE: You can't use resize() on a NonnullFooPtrVector since making the vector

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -47,16 +47,16 @@ public:
 
     enum AdoptTag { Adopt };
 
-    ALWAYS_INLINE NonnullRefPtr(T const& object)
-        : m_ptr(const_cast<T*>(&object))
+    ALWAYS_INLINE NonnullRefPtr(T& object)
+        : m_ptr(&object)
     {
         m_ptr->ref();
     }
 
     template<typename U>
-    ALWAYS_INLINE NonnullRefPtr(U const& object)
+    ALWAYS_INLINE NonnullRefPtr(U& object)
     requires(IsConvertible<U*, T*>)
-        : m_ptr(const_cast<T*>(static_cast<T const*>(&object)))
+        : m_ptr(static_cast<T*>(&object))
     {
         m_ptr->ref();
     }
@@ -79,7 +79,7 @@ public:
     }
 
     ALWAYS_INLINE NonnullRefPtr(NonnullRefPtr const& other)
-        : m_ptr(const_cast<T*>(other.ptr()))
+        : m_ptr(other.ptr())
     {
         m_ptr->ref();
     }
@@ -87,7 +87,7 @@ public:
     template<typename U>
     ALWAYS_INLINE NonnullRefPtr(NonnullRefPtr<U> const& other)
     requires(IsConvertible<U*, T*>)
-        : m_ptr(const_cast<T*>(static_cast<T const*>(other.ptr())))
+        : m_ptr(static_cast<T*>(other.ptr()))
     {
         m_ptr->ref();
     }
@@ -145,7 +145,7 @@ public:
         return *this;
     }
 
-    NonnullRefPtr& operator=(T const& object)
+    NonnullRefPtr& operator=(T& object)
     {
         NonnullRefPtr tmp { object };
         swap(tmp);

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -35,14 +35,14 @@ public:
     };
 
     RefPtr() = default;
-    RefPtr(T const* ptr)
-        : m_ptr(const_cast<T*>(ptr))
+    RefPtr(T* ptr)
+        : m_ptr(ptr)
     {
         ref_if_not_null(m_ptr);
     }
 
-    RefPtr(T const& object)
-        : m_ptr(const_cast<T*>(&object))
+    RefPtr(T& object)
+        : m_ptr(&object)
     {
         m_ptr->ref();
     }
@@ -58,7 +58,7 @@ public:
     }
 
     ALWAYS_INLINE RefPtr(NonnullRefPtr<T> const& other)
-        : m_ptr(const_cast<T*>(other.ptr()))
+        : m_ptr(other.ptr())
     {
         m_ptr->ref();
     }
@@ -66,7 +66,7 @@ public:
     template<typename U>
     ALWAYS_INLINE RefPtr(NonnullRefPtr<U> const& other)
     requires(IsConvertible<U*, T*>)
-        : m_ptr(const_cast<T*>(static_cast<T const*>(other.ptr())))
+        : m_ptr(static_cast<T*>(other.ptr()))
     {
         m_ptr->ref();
     }
@@ -94,7 +94,7 @@ public:
     template<typename U>
     RefPtr(RefPtr<U> const& other)
     requires(IsConvertible<U*, T*>)
-        : m_ptr(const_cast<T*>(static_cast<T const*>(other.ptr())))
+        : m_ptr(static_cast<T*>(other.ptr()))
     {
         ref_if_not_null(m_ptr);
     }
@@ -181,14 +181,14 @@ public:
         return *this;
     }
 
-    ALWAYS_INLINE RefPtr& operator=(T const* ptr)
+    ALWAYS_INLINE RefPtr& operator=(T* ptr)
     {
         RefPtr tmp { ptr };
         swap(tmp);
         return *this;
     }
 
-    ALWAYS_INLINE RefPtr& operator=(T const& object)
+    ALWAYS_INLINE RefPtr& operator=(T& object)
     {
         RefPtr tmp { object };
         swap(tmp);
@@ -304,13 +304,13 @@ struct Traits<RefPtr<T>> : public GenericTraits<RefPtr<T>> {
 template<typename T, typename U>
 inline NonnullRefPtr<T> static_ptr_cast(NonnullRefPtr<U> const& ptr)
 {
-    return NonnullRefPtr<T>(static_cast<T const&>(*ptr));
+    return NonnullRefPtr<T>(static_cast<T&>(*ptr));
 }
 
 template<typename T, typename U>
 inline RefPtr<T> static_ptr_cast(RefPtr<U> const& ptr)
 {
-    return RefPtr<T>(static_cast<T const*>(ptr.ptr()));
+    return RefPtr<T>(static_cast<T*>(ptr.ptr()));
 }
 
 template<typename T, typename U>

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -63,7 +63,7 @@ public:
     }
 
     bool is_fly_string() const { return m_is_fly_string; }
-    void set_fly_string(bool is_fly_string) { m_is_fly_string = is_fly_string; }
+    void set_fly_string(bool is_fly_string) const { m_is_fly_string = is_fly_string; }
 
 private:
     explicit StringData(size_t byte_count);
@@ -75,7 +75,7 @@ private:
     mutable unsigned m_hash { 0 };
     mutable bool m_has_hash { false };
     bool m_substring { false };
-    bool m_is_fly_string { false };
+    mutable bool m_is_fly_string { false };
 
     alignas(SubstringData) u8 m_bytes_or_substring_data[0];
 };
@@ -165,7 +165,7 @@ void StringData::compute_hash() const
 
 }
 
-String::String(NonnullRefPtr<Detail::StringData> data)
+String::String(NonnullRefPtr<Detail::StringData const> data)
     : m_data(&data.leak_ref())
 {
 }
@@ -485,7 +485,7 @@ String String::fly_string_data_to_string(Badge<FlyString>, uintptr_t const& data
         return String { *reinterpret_cast<ShortString const*>(&data) };
 
     auto const* string_data = reinterpret_cast<Detail::StringData const*>(data);
-    return String { NonnullRefPtr<Detail::StringData>(*string_data) };
+    return String { NonnullRefPtr<Detail::StringData const>(*string_data) };
 }
 
 StringView String::fly_string_data_to_string_view(Badge<FlyString>, uintptr_t const& data)

--- a/AK/String.h
+++ b/AK/String.h
@@ -230,7 +230,7 @@ private:
         u8 storage[MAX_SHORT_STRING_BYTE_COUNT] = { 0 };
     };
 
-    explicit String(NonnullRefPtr<Detail::StringData>);
+    explicit String(NonnullRefPtr<Detail::StringData const>);
 
     explicit constexpr String(ShortString short_string)
         : m_short_string(short_string)
@@ -241,7 +241,7 @@ private:
 
     union {
         ShortString m_short_string;
-        Detail::StringData* m_data { nullptr };
+        Detail::StringData const* m_data { nullptr };
     };
 };
 

--- a/AK/StringImpl.cpp
+++ b/AK/StringImpl.cpp
@@ -34,7 +34,7 @@ StringImpl::~StringImpl()
         DeprecatedFlyString::did_destroy_impl({}, *this);
 }
 
-NonnullRefPtr<StringImpl> StringImpl::create_uninitialized(size_t length, char*& buffer)
+NonnullRefPtr<StringImpl const> StringImpl::create_uninitialized(size_t length, char*& buffer)
 {
     VERIFY(length);
     void* slot = kmalloc(allocation_size_for_stringimpl(length));
@@ -45,7 +45,7 @@ NonnullRefPtr<StringImpl> StringImpl::create_uninitialized(size_t length, char*&
     return new_stringimpl;
 }
 
-RefPtr<StringImpl> StringImpl::create(char const* cstring, size_t length, ShouldChomp should_chomp)
+RefPtr<StringImpl const> StringImpl::create(char const* cstring, size_t length, ShouldChomp should_chomp)
 {
     if (!cstring)
         return nullptr;
@@ -70,7 +70,7 @@ RefPtr<StringImpl> StringImpl::create(char const* cstring, size_t length, Should
     return new_stringimpl;
 }
 
-RefPtr<StringImpl> StringImpl::create(char const* cstring, ShouldChomp shouldChomp)
+RefPtr<StringImpl const> StringImpl::create(char const* cstring, ShouldChomp shouldChomp)
 {
     if (!cstring)
         return nullptr;
@@ -81,12 +81,12 @@ RefPtr<StringImpl> StringImpl::create(char const* cstring, ShouldChomp shouldCho
     return create(cstring, strlen(cstring), shouldChomp);
 }
 
-RefPtr<StringImpl> StringImpl::create(ReadonlyBytes bytes, ShouldChomp shouldChomp)
+RefPtr<StringImpl const> StringImpl::create(ReadonlyBytes bytes, ShouldChomp shouldChomp)
 {
     return StringImpl::create(reinterpret_cast<char const*>(bytes.data()), bytes.size(), shouldChomp);
 }
 
-RefPtr<StringImpl> StringImpl::create_lowercased(char const* cstring, size_t length)
+RefPtr<StringImpl const> StringImpl::create_lowercased(char const* cstring, size_t length)
 {
     if (!cstring)
         return nullptr;
@@ -99,7 +99,7 @@ RefPtr<StringImpl> StringImpl::create_lowercased(char const* cstring, size_t len
     return impl;
 }
 
-RefPtr<StringImpl> StringImpl::create_uppercased(char const* cstring, size_t length)
+RefPtr<StringImpl const> StringImpl::create_uppercased(char const* cstring, size_t length)
 {
     if (!cstring)
         return nullptr;
@@ -112,7 +112,7 @@ RefPtr<StringImpl> StringImpl::create_uppercased(char const* cstring, size_t len
     return impl;
 }
 
-NonnullRefPtr<StringImpl> StringImpl::to_lowercase() const
+NonnullRefPtr<StringImpl const> StringImpl::to_lowercase() const
 {
     for (size_t i = 0; i < m_length; ++i) {
         if (is_ascii_upper_alpha(characters()[i]))
@@ -121,7 +121,7 @@ NonnullRefPtr<StringImpl> StringImpl::to_lowercase() const
     return const_cast<StringImpl&>(*this);
 }
 
-NonnullRefPtr<StringImpl> StringImpl::to_uppercase() const
+NonnullRefPtr<StringImpl const> StringImpl::to_uppercase() const
 {
     for (size_t i = 0; i < m_length; ++i) {
         if (is_ascii_lower_alpha(characters()[i]))

--- a/AK/StringImpl.h
+++ b/AK/StringImpl.h
@@ -24,15 +24,15 @@ size_t allocation_size_for_stringimpl(size_t length);
 
 class StringImpl : public RefCounted<StringImpl> {
 public:
-    static NonnullRefPtr<StringImpl> create_uninitialized(size_t length, char*& buffer);
-    static RefPtr<StringImpl> create(char const* cstring, ShouldChomp = NoChomp);
-    static RefPtr<StringImpl> create(char const* cstring, size_t length, ShouldChomp = NoChomp);
-    static RefPtr<StringImpl> create(ReadonlyBytes, ShouldChomp = NoChomp);
-    static RefPtr<StringImpl> create_lowercased(char const* cstring, size_t length);
-    static RefPtr<StringImpl> create_uppercased(char const* cstring, size_t length);
+    static NonnullRefPtr<StringImpl const> create_uninitialized(size_t length, char*& buffer);
+    static RefPtr<StringImpl const> create(char const* cstring, ShouldChomp = NoChomp);
+    static RefPtr<StringImpl const> create(char const* cstring, size_t length, ShouldChomp = NoChomp);
+    static RefPtr<StringImpl const> create(ReadonlyBytes, ShouldChomp = NoChomp);
+    static RefPtr<StringImpl const> create_lowercased(char const* cstring, size_t length);
+    static RefPtr<StringImpl const> create_uppercased(char const* cstring, size_t length);
 
-    NonnullRefPtr<StringImpl> to_lowercase() const;
-    NonnullRefPtr<StringImpl> to_uppercase() const;
+    NonnullRefPtr<StringImpl const> to_lowercase() const;
+    NonnullRefPtr<StringImpl const> to_uppercase() const;
 
     void operator delete(void* ptr)
     {

--- a/Kernel/Bus/PCI/Device.h
+++ b/Kernel/Bus/PCI/Device.h
@@ -16,7 +16,7 @@ namespace Kernel::PCI {
 
 class Device {
 public:
-    DeviceIdentifier& device_identifier() const { return *m_pci_identifier; };
+    DeviceIdentifier const& device_identifier() const { return *m_pci_identifier; };
 
     virtual ~Device() = default;
 
@@ -38,7 +38,7 @@ protected:
     explicit Device(DeviceIdentifier const& pci_identifier);
 
 private:
-    NonnullRefPtr<DeviceIdentifier> m_pci_identifier;
+    NonnullRefPtr<DeviceIdentifier const> m_pci_identifier;
 };
 
 template<typename... Parameters>

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.h
@@ -16,14 +16,14 @@ namespace Kernel {
 class PCIDeviceSysFSDirectory final : public SysFSDirectory {
 public:
     static NonnullLockRefPtr<PCIDeviceSysFSDirectory> create(SysFSDirectory const&, PCI::DeviceIdentifier const&);
-    PCI::DeviceIdentifier& device_identifier() const { return *m_device_identifier; }
+    PCI::DeviceIdentifier const& device_identifier() const { return *m_device_identifier; }
 
     virtual StringView name() const override { return m_device_directory_name->view(); }
 
 private:
     PCIDeviceSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, SysFSDirectory const&, PCI::DeviceIdentifier const&);
 
-    NonnullRefPtr<PCI::DeviceIdentifier> m_device_identifier;
+    NonnullRefPtr<PCI::DeviceIdentifier const> m_device_identifier;
 
     NonnullOwnPtr<KString> m_device_directory_name;
 };

--- a/Kernel/Memory/PhysicalPage.cpp
+++ b/Kernel/Memory/PhysicalPage.cpp
@@ -26,7 +26,7 @@ PhysicalAddress PhysicalPage::paddr() const
     return MM.get_physical_address(*this);
 }
 
-void PhysicalPage::free_this()
+void PhysicalPage::free_this() const
 {
     auto paddr = MM.get_physical_address(*this);
     if (m_may_return_to_freelist == MayReturnToFreeList::Yes) {

--- a/Kernel/Memory/PhysicalPage.h
+++ b/Kernel/Memory/PhysicalPage.h
@@ -25,12 +25,12 @@ class PhysicalPage {
 public:
     PhysicalAddress paddr() const;
 
-    void ref()
+    void ref() const
     {
         m_ref_count.fetch_add(1, AK::memory_order_relaxed);
     }
 
-    void unref()
+    void unref() const
     {
         if (m_ref_count.fetch_sub(1, AK::memory_order_acq_rel) == 1)
             free_this();
@@ -47,9 +47,9 @@ private:
     explicit PhysicalPage(MayReturnToFreeList may_return_to_freelist);
     ~PhysicalPage() = default;
 
-    void free_this();
+    void free_this() const;
 
-    Atomic<u32> m_ref_count { 1 };
+    mutable Atomic<u32> m_ref_count { 1 };
     MayReturnToFreeList m_may_return_to_freelist { MayReturnToFreeList::Yes };
 };
 

--- a/Kernel/Storage/NVMe/NVMeQueue.h
+++ b/Kernel/Storage/NVMe/NVMeQueue.h
@@ -77,6 +77,6 @@ private:
     NonnullRefPtrVector<Memory::PhysicalPage> m_sq_dma_page;
     Span<NVMeCompletion> m_cqe_array;
     Memory::TypedMapping<DoorbellRegister volatile> m_db_regs;
-    NonnullRefPtr<Memory::PhysicalPage> m_rw_dma_page;
+    NonnullRefPtr<Memory::PhysicalPage const> m_rw_dma_page;
 };
 }

--- a/Kernel/Storage/StorageManagement.cpp
+++ b/Kernel/Storage/StorageManagement.cpp
@@ -156,7 +156,7 @@ UNMAP_AFTER_INIT void StorageManagement::dump_storage_devices_and_partitions() c
     }
 }
 
-UNMAP_AFTER_INIT ErrorOr<NonnullOwnPtr<Partition::PartitionTable>> StorageManagement::try_to_initialize_partition_table(StorageDevice const& device) const
+UNMAP_AFTER_INIT ErrorOr<NonnullOwnPtr<Partition::PartitionTable>> StorageManagement::try_to_initialize_partition_table(StorageDevice& device) const
 {
     auto mbr_table_or_error = Partition::MBRPartitionTable::try_to_initialize(device);
     if (!mbr_table_or_error.is_error())

--- a/Kernel/Storage/StorageManagement.h
+++ b/Kernel/Storage/StorageManagement.h
@@ -61,7 +61,7 @@ private:
 
     void dump_storage_devices_and_partitions() const;
 
-    ErrorOr<NonnullOwnPtr<Partition::PartitionTable>> try_to_initialize_partition_table(StorageDevice const&) const;
+    ErrorOr<NonnullOwnPtr<Partition::PartitionTable>> try_to_initialize_partition_table(StorageDevice&) const;
 
     LockRefPtr<BlockDevice> boot_block_device() const;
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021-2023, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
  * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
@@ -915,7 +915,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
         // 3. Let types be the flattened member types of the union type.
         auto types = union_type.flattened_member_types();
 
-        RefPtr<Type> dictionary_type;
+        RefPtr<Type const> dictionary_type;
         for (auto& dictionary : interface.dictionaries) {
             for (auto& type : types) {
                 if (type.name() == dictionary.key) {
@@ -1077,7 +1077,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
 
         // 10. If Type(V) is Object, then:
         //     1. If types includes a sequence type, then:
-        RefPtr<IDL::ParameterizedType> sequence_type;
+        RefPtr<IDL::ParameterizedType const> sequence_type;
         for (auto& type : types) {
             if (type.name() == "sequence") {
                 sequence_type = verify_cast<IDL::ParameterizedType>(type);
@@ -1117,7 +1117,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
         }
 
         // 4. If types includes a record type, then return the result of converting V to that record type.
-        RefPtr<IDL::ParameterizedType> record_type;
+        RefPtr<IDL::ParameterizedType const> record_type;
         for (auto& type : types) {
             if (type.name() == "record") {
                 record_type = verify_cast<IDL::ParameterizedType>(type);
@@ -1165,7 +1165,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
 )~~~");
         }
 
-        RefPtr<IDL::Type> numeric_type;
+        RefPtr<IDL::Type const> numeric_type;
         for (auto& type : types) {
             if (type.is_numeric()) {
                 numeric_type = type;
@@ -1794,7 +1794,7 @@ static EffectiveOverloadSet compute_the_effective_overload_set(auto const& overl
         int argument_count = (int)arguments.size();
 
         // 3. Let types be a type list.
-        NonnullRefPtrVector<Type> types;
+        NonnullRefPtrVector<Type const> types;
 
         // 4. Let optionalityValues be an optionality list.
         Vector<Optionality> optionality_values;
@@ -1911,7 +1911,7 @@ static DeprecatedString generate_constructor_for_idl_type(Type const& type)
     case Type::Kind::Parameterized: {
         auto const& parameterized_type = type.as_parameterized();
         StringBuilder builder;
-        builder.appendff("make_ref_counted<IDL::ParameterizedTypeType>(\"{}\", {}, NonnullRefPtrVector<IDL::Type> {{", type.name(), type.is_nullable());
+        builder.appendff("make_ref_counted<IDL::ParameterizedTypeType>(\"{}\", {}, NonnullRefPtrVector<IDL::Type const> {{", type.name(), type.is_nullable());
         append_type_list(builder, parameterized_type.parameters());
         builder.append("})"sv);
         return builder.to_deprecated_string();
@@ -1919,7 +1919,7 @@ static DeprecatedString generate_constructor_for_idl_type(Type const& type)
     case Type::Kind::Union: {
         auto const& union_type = type.as_union();
         StringBuilder builder;
-        builder.appendff("make_ref_counted<IDL::UnionType>(\"{}\", {}, NonnullRefPtrVector<IDL::Type> {{", type.name(), type.is_nullable());
+        builder.appendff("make_ref_counted<IDL::UnionType>(\"{}\", {}, NonnullRefPtrVector<IDL::Type const> {{", type.name(), type.is_nullable());
         append_type_list(builder, union_type.member_types());
         builder.append("})"sv);
         return builder.to_deprecated_string();
@@ -1978,7 +1978,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@function.name:snakecase@)
                 continue;
 
             StringBuilder types_builder;
-            types_builder.append("NonnullRefPtrVector<IDL::Type> { "sv);
+            types_builder.append("NonnullRefPtrVector<IDL::Type const> { "sv);
             StringBuilder optionality_builder;
             optionality_builder.append("Vector<IDL::Optionality> { "sv);
 

--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -87,7 +87,7 @@ static Result<void, TestError> run_program(InterpreterT& interpreter, ScriptOrMo
             });
     } else {
         auto program_node = program.visit(
-            [](auto& visitor) -> NonnullRefPtr<JS::Program> {
+            [](auto& visitor) -> NonnullRefPtr<JS::Program const> {
                 return visitor->parse_node();
             });
 

--- a/Userland/Applications/Assistant/Providers.h
+++ b/Userland/Applications/Assistant/Providers.h
@@ -52,7 +52,7 @@ private:
 
 class AppResult final : public Result {
 public:
-    AppResult(RefPtr<Gfx::Bitmap> bitmap, DeprecatedString title, DeprecatedString tooltip, NonnullRefPtr<Desktop::AppFile> af, DeprecatedString arguments, int score)
+    AppResult(RefPtr<Gfx::Bitmap const> bitmap, DeprecatedString title, DeprecatedString tooltip, NonnullRefPtr<Desktop::AppFile> af, DeprecatedString arguments, int score)
         : Result(move(title), move(tooltip), score)
         , m_app_file(move(af))
         , m_arguments(move(arguments))
@@ -67,7 +67,7 @@ public:
 private:
     NonnullRefPtr<Desktop::AppFile> m_app_file;
     DeprecatedString m_arguments;
-    RefPtr<Gfx::Bitmap> m_bitmap;
+    RefPtr<Gfx::Bitmap const> m_bitmap;
 };
 
 class CalculatorResult final : public Result {
@@ -83,7 +83,7 @@ public:
     virtual Gfx::Bitmap const* bitmap() const override { return m_bitmap; }
 
 private:
-    RefPtr<Gfx::Bitmap> m_bitmap;
+    RefPtr<Gfx::Bitmap const> m_bitmap;
 };
 
 class FileResult final : public Result {
@@ -111,7 +111,7 @@ public:
     virtual Gfx::Bitmap const* bitmap() const override { return m_bitmap; }
 
 private:
-    RefPtr<Gfx::Bitmap> m_bitmap;
+    RefPtr<Gfx::Bitmap const> m_bitmap;
 };
 
 class URLResult final : public Result {
@@ -127,7 +127,7 @@ public:
     virtual Gfx::Bitmap const* bitmap() const override { return m_bitmap; }
 
 private:
-    RefPtr<Gfx::Bitmap> m_bitmap;
+    RefPtr<Gfx::Bitmap const> m_bitmap;
 };
 
 class Provider : public RefCounted<Provider> {

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -36,7 +36,7 @@ namespace Assistant {
 
 struct AppState {
     Optional<size_t> selected_index;
-    NonnullRefPtrVector<Result> results;
+    NonnullRefPtrVector<Result const> results;
     size_t visible_result_count { 0 };
 
     Threading::Mutex lock;
@@ -84,7 +84,7 @@ public:
     {
     }
 
-    Function<void(NonnullRefPtrVector<Result>)> on_new_results;
+    Function<void(NonnullRefPtrVector<Result const>)> on_new_results;
 
     void search(DeprecatedString const& query)
     {
@@ -121,7 +121,7 @@ private:
         // NonnullRefPtrVector will provide dual_pivot_quick_sort references rather than pointers,
         // and dual_pivot_quick_sort requires being able to construct the underlying type on the
         // stack. Assistant::Result is pure virtual, thus cannot be constructed on the stack.
-        Vector<NonnullRefPtr<Result>> all_results;
+        Vector<NonnullRefPtr<Result const>> all_results;
         for (auto const& results_for_provider : new_results->value) {
             if (results_for_provider == nullptr)
                 continue;

--- a/Userland/Applications/FontEditor/UndoSelection.h
+++ b/Userland/Applications/FontEditor/UndoSelection.h
@@ -13,7 +13,7 @@
 
 class UndoSelection : public RefCounted<UndoSelection> {
 public:
-    explicit UndoSelection(int const start, int const size, u32 const active_glyph, Gfx::BitmapFont const& font, NonnullRefPtr<GUI::GlyphMapWidget> glyph_map_widget)
+    explicit UndoSelection(int const start, int const size, u32 const active_glyph, Gfx::BitmapFont& font, NonnullRefPtr<GUI::GlyphMapWidget> glyph_map_widget)
         : m_start(start)
         , m_size(size)
         , m_active_glyph(active_glyph)

--- a/Userland/Applications/Help/ManualModel.cpp
+++ b/Userland/Applications/Help/ManualModel.cpp
@@ -149,7 +149,7 @@ GUI::ModelIndex ManualModel::parent_index(const GUI::ModelIndex& index) const
         return {};
     auto children = maybe_children.release_value();
     for (size_t row = 0; row < children.size(); row++) {
-        Manual::Node* child_at_row = children[row];
+        Manual::Node const* child_at_row = children[row];
         if (child_at_row == parent)
             return create_index(row, 0, parent);
     }

--- a/Userland/Applications/ImageViewer/ViewWidget.h
+++ b/Userland/Applications/ImageViewer/ViewWidget.h
@@ -66,7 +66,7 @@ private:
     Vector<DeprecatedString> load_files_from_directory(DeprecatedString const& path) const;
 
     DeprecatedString m_path;
-    RefPtr<Gfx::Bitmap> m_bitmap;
+    RefPtr<Gfx::Bitmap const> m_bitmap;
     Optional<ImageDecoderClient::DecodedImage> m_decoded_image;
 
     size_t m_current_frame_index { 0 };

--- a/Userland/Applications/PixelPaint/Filters/Filter.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Filter.cpp
@@ -38,7 +38,7 @@ ErrorOr<RefPtr<GUI::Widget>> Filter::get_settings_widget()
     return m_settings_widget.ptr();
 }
 
-void Filter::apply() const
+void Filter::apply()
 {
     if (!m_editor)
         return;

--- a/Userland/Applications/PixelPaint/Filters/Filter.h
+++ b/Userland/Applications/PixelPaint/Filters/Filter.h
@@ -19,7 +19,7 @@ class Filter : public RefCounted<Filter> {
     friend class FilterApplicationCommand;
 
 public:
-    virtual void apply() const;
+    void apply();
     virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const = 0;
 
     virtual ErrorOr<RefPtr<GUI::Widget>> get_settings_widget();

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -187,7 +187,7 @@ private:
 
     float m_pixel_grid_threshold { 15.0f };
 
-    Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_active_cursor { Gfx::StandardCursor::None };
+    Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> m_active_cursor { Gfx::StandardCursor::None };
 
     bool m_loaded_from_image { true };
 

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.h
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.h
@@ -23,7 +23,7 @@ public:
     virtual void on_mousemove(Layer*, MouseEvent&) override;
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override
     {
         if (m_editor && m_editor->scale() != m_scale_last_created_cursor)
             refresh_editor_cursor();
@@ -59,7 +59,7 @@ private:
     bool m_was_drawing { false };
     bool m_has_clicked { false };
     Gfx::IntPoint m_last_position;
-    NonnullRefPtr<Gfx::Bitmap> m_cursor = build_cursor();
+    NonnullRefPtr<Gfx::Bitmap const> m_cursor = build_cursor();
 };
 
 }

--- a/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
@@ -24,7 +24,7 @@ namespace PixelPaint {
 
 BucketTool::BucketTool()
 {
-    m_cursor = Gfx::Bitmap::load_from_file("/res/icons/pixelpaint/bucket.png"sv).release_value_but_fixme_should_propagate_errors();
+    m_cursor = NonnullRefPtr<Gfx::Bitmap const> { Gfx::Bitmap::load_from_file("/res/icons/pixelpaint/bucket.png"sv).release_value_but_fixme_should_propagate_errors() };
 }
 
 static void flood_fill(Gfx::Bitmap& bitmap, Gfx::IntPoint start_position, Color fill_color, int threshold)

--- a/Userland/Applications/PixelPaint/Tools/BucketTool.h
+++ b/Userland/Applications/PixelPaint/Tools/BucketTool.h
@@ -18,14 +18,14 @@ public:
 
     virtual void on_mousedown(Layer*, MouseEvent&) override;
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return m_cursor; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return m_cursor; }
 
 private:
     virtual StringView tool_name() const override { return "Bucket Tool"sv; }
 
     RefPtr<GUI::Widget> m_properties_widget;
     int m_threshold { 0 };
-    Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_cursor { Gfx::StandardCursor::Crosshair };
+    Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> m_cursor { Gfx::StandardCursor::Crosshair };
 };
 
 }

--- a/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
@@ -52,7 +52,7 @@ void CloneTool::draw_line(Gfx::Bitmap& bitmap, Gfx::Color color, Gfx::IntPoint s
     BrushTool::draw_line(bitmap, color, start, end);
 }
 
-Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> CloneTool::cursor()
+Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> CloneTool::cursor()
 {
     if (m_is_selecting_location)
         return Gfx::StandardCursor::Eyedropper;

--- a/Userland/Applications/PixelPaint/Tools/CloneTool.h
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.h
@@ -16,7 +16,7 @@ public:
     virtual ~CloneTool() override = default;
 
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override;
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override;
 
     virtual bool is_overriding_alt() override { return true; }
 

--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.h
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.h
@@ -26,7 +26,7 @@ public:
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual bool on_keydown(GUI::KeyEvent&) override;
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     virtual StringView tool_name() const override { return "Ellipse Tool"sv; }

--- a/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
@@ -24,7 +24,7 @@
 
 namespace PixelPaint {
 
-Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> GradientTool::cursor()
+Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> GradientTool::cursor()
 {
     if (m_hover_over_drag_handle || m_hover_over_start_handle || m_hover_over_end_handle)
         return Gfx::StandardCursor::Hand;

--- a/Userland/Applications/PixelPaint/Tools/GradientTool.h
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.h
@@ -25,7 +25,7 @@ public:
     virtual void on_tool_activation() override;
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
 
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override;
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
 
 protected:

--- a/Userland/Applications/PixelPaint/Tools/GuideTool.h
+++ b/Userland/Applications/PixelPaint/Tools/GuideTool.h
@@ -28,7 +28,7 @@ public:
     virtual void on_tool_activation() override;
 
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     virtual StringView tool_name() const override { return "Guide Tool"sv; }

--- a/Userland/Applications/PixelPaint/Tools/LineTool.h
+++ b/Userland/Applications/PixelPaint/Tools/LineTool.h
@@ -24,7 +24,7 @@ public:
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual bool on_keydown(GUI::KeyEvent&) override;
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
     void draw_using(GUI::Painter&, Gfx::IntPoint start_position, Gfx::IntPoint end_position, Color color, int thickness);
 

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -274,7 +274,7 @@ Optional<ResizeAnchorLocation const> MoveTool::resize_anchor_location_from_curso
     return {};
 }
 
-Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> MoveTool::cursor()
+Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> MoveTool::cursor()
 {
     if (m_resize_anchor_location.has_value()) {
         switch (m_resize_anchor_location.value()) {

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.h
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.h
@@ -36,7 +36,7 @@ public:
     virtual void on_keyup(GUI::KeyEvent&) override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override;
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override;
     virtual bool is_overriding_alt() override { return true; }
     LayerSelectionMode layer_selection_mode() const { return m_layer_selection_mode; }
 

--- a/Userland/Applications/PixelPaint/Tools/PenTool.h
+++ b/Userland/Applications/PixelPaint/Tools/PenTool.h
@@ -18,7 +18,7 @@ class PenTool final : public BrushTool {
 public:
     PenTool();
     virtual ~PenTool() override = default;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
 
 protected:

--- a/Userland/Applications/PixelPaint/Tools/PickerTool.h
+++ b/Userland/Applications/PixelPaint/Tools/PickerTool.h
@@ -22,7 +22,7 @@ public:
     virtual void on_mousemove(Layer*, MouseEvent&) override;
 
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Eyedropper; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Eyedropper; }
 
 private:
     virtual StringView tool_name() const override { return "Picker Tool"sv; }

--- a/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.h
+++ b/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.h
@@ -23,7 +23,7 @@ public:
     virtual bool on_keydown(GUI::KeyEvent&) override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
     virtual Gfx::IntPoint point_position_to_preferred_cell(Gfx::FloatPoint position) const override;
 
 private:

--- a/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.h
+++ b/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.h
@@ -27,7 +27,7 @@ public:
     virtual void on_keyup(GUI::KeyEvent&) override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
     virtual Gfx::IntPoint point_position_to_preferred_cell(Gfx::FloatPoint position) const override;
 
 private:

--- a/Userland/Applications/PixelPaint/Tools/RectangleTool.h
+++ b/Userland/Applications/PixelPaint/Tools/RectangleTool.h
@@ -25,7 +25,7 @@ public:
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual bool on_keydown(GUI::KeyEvent&) override;
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     virtual StringView tool_name() const override { return "Rectangle Tool"sv; }

--- a/Userland/Applications/PixelPaint/Tools/SprayTool.h
+++ b/Userland/Applications/PixelPaint/Tools/SprayTool.h
@@ -23,7 +23,7 @@ public:
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual void on_mousemove(Layer*, MouseEvent&) override;
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     virtual StringView tool_name() const override { return "Spray Tool"sv; }

--- a/Userland/Applications/PixelPaint/Tools/TextTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/TextTool.cpp
@@ -304,7 +304,7 @@ bool TextTool::on_keydown(GUI::KeyEvent& event)
     return true;
 }
 
-Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> TextTool::cursor()
+Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> TextTool::cursor()
 {
     if (m_mouse_is_over_text)
         return Gfx::StandardCursor::Move;

--- a/Userland/Applications/PixelPaint/Tools/TextTool.h
+++ b/Userland/Applications/PixelPaint/Tools/TextTool.h
@@ -40,7 +40,7 @@ public:
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual void on_primary_color_change(Color) override;
     virtual void on_tool_deactivation() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override;
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override;
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
 
 private:

--- a/Userland/Applications/PixelPaint/Tools/TextTool.h
+++ b/Userland/Applications/PixelPaint/Tools/TextTool.h
@@ -53,7 +53,7 @@ private:
     RefPtr<Core::Timer> m_cursor_blink_timer;
     RefPtr<PixelPaint::TextToolEditor> m_text_editor;
     Gfx::IntPoint m_add_text_position { 0, 0 };
-    RefPtr<Gfx::Font> m_selected_font;
+    RefPtr<Gfx::Font const> m_selected_font;
     bool m_text_input_is_active { false };
     bool m_cursor_blink_state { false };
     bool m_mouse_is_over_text { false };

--- a/Userland/Applications/PixelPaint/Tools/Tool.h
+++ b/Userland/Applications/PixelPaint/Tools/Tool.h
@@ -68,7 +68,7 @@ public:
     virtual void on_tool_activation() { }
     virtual void on_tool_deactivation() { }
     virtual ErrorOr<GUI::Widget*> get_properties_widget() { return nullptr; }
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() { return Gfx::StandardCursor::None; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() { return Gfx::StandardCursor::None; }
     virtual Gfx::IntPoint point_position_to_preferred_cell(Gfx::FloatPoint position) const { return position.to_type<int>(); }
 
     void clear() { m_editor = nullptr; }

--- a/Userland/Applications/PixelPaint/Tools/WandSelectTool.h
+++ b/Userland/Applications/PixelPaint/Tools/WandSelectTool.h
@@ -24,7 +24,7 @@ public:
     virtual void on_mousedown(Layer*, MouseEvent& event) override;
     virtual bool on_keydown(GUI::KeyEvent&) override;
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     virtual StringView tool_name() const override { return "Wand Select Tool"sv; }

--- a/Userland/Applications/PixelPaint/Tools/ZoomTool.h
+++ b/Userland/Applications/PixelPaint/Tools/ZoomTool.h
@@ -19,7 +19,7 @@ public:
 
     virtual void on_mousedown(Layer*, MouseEvent&) override;
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
-    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Zoom; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Zoom; }
 
 private:
     virtual StringView tool_name() const override { return "Zoom Tool"sv; }

--- a/Userland/Applications/TerminalSettings/TerminalSettingsWidget.h
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsWidget.h
@@ -47,13 +47,13 @@ private:
     TerminalSettingsViewWidget();
     void write_back_settings() const;
 
-    RefPtr<Gfx::Font> m_font;
+    RefPtr<Gfx::Font const> m_font;
     float m_opacity;
     DeprecatedString m_color_scheme;
     VT::CursorShape m_cursor_shape { VT::CursorShape::Block };
     bool m_cursor_is_blinking_set { true };
 
-    RefPtr<Gfx::Font> m_original_font;
+    RefPtr<Gfx::Font const> m_original_font;
     float m_original_opacity;
     DeprecatedString m_original_color_scheme;
     VT::CursorShape m_original_cursor_shape;

--- a/Userland/Applications/ThemeEditor/PreviewWidget.cpp
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.cpp
@@ -39,7 +39,7 @@ public:
         return gallery;
     }
 
-    void set_preview_palette(Gfx::Palette const& palette)
+    void set_preview_palette(Gfx::Palette& palette)
     {
         set_palette(palette);
         Function<void(GUI::Widget&)> recurse = [&](GUI::Widget& parent_widget) {

--- a/Userland/Applications/VideoPlayer/VideoFrameWidget.h
+++ b/Userland/Applications/VideoPlayer/VideoFrameWidget.h
@@ -26,7 +26,6 @@ public:
     virtual ~VideoFrameWidget() override = default;
 
     void set_bitmap(Gfx::Bitmap const*);
-    Gfx::Bitmap* bitmap() { return m_bitmap.ptr(); }
     Gfx::Bitmap const* bitmap() const { return m_bitmap.ptr(); }
 
     void set_sizing_mode(VideoSizingMode value) { m_sizing_mode = value; }
@@ -44,7 +43,7 @@ protected:
     virtual void paint_event(GUI::PaintEvent&) override;
 
 private:
-    RefPtr<Gfx::Bitmap> m_bitmap;
+    RefPtr<Gfx::Bitmap const> m_bitmap;
     VideoSizingMode m_sizing_mode { VideoSizingMode::Fit };
     bool m_auto_resize { false };
 };

--- a/Userland/Demos/WidgetGallery/GalleryWidget.cpp
+++ b/Userland/Demos/WidgetGallery/GalleryWidget.cpp
@@ -306,7 +306,7 @@ GalleryWidget::GalleryWidget()
 
     m_cursors_tableview->on_activation = [&](const GUI::ModelIndex& index) {
         auto icon_index = index.model()->index(index.row(), MouseCursorModel::Column::Bitmap);
-        m_cursors_tableview->set_override_cursor(NonnullRefPtr<Gfx::Bitmap>(icon_index.data().as_bitmap()));
+        m_cursors_tableview->set_override_cursor(NonnullRefPtr<Gfx::Bitmap const>(icon_index.data().as_bitmap()));
     };
 
     auto icons_tab = tab_widget.try_add_tab<GUI::Widget>("Icons").release_value_but_fixme_should_propagate_errors();

--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -50,7 +50,8 @@ void EditorWrapper::set_mode_displayable()
 {
     editor().set_mode(GUI::TextEditor::Editable);
     editor().set_background_role(Gfx::ColorRole::Base);
-    editor().set_palette(GUI::Application::the()->palette());
+    auto palette = GUI::Application::the()->palette();
+    editor().set_palette(palette);
 }
 
 void EditorWrapper::set_mode_non_displayable()

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1837,7 +1837,7 @@ void HackStudioWidget::update_history_actions()
         m_locations_history_forward_action->set_enabled(true);
 }
 
-RefPtr<Gfx::Font> HackStudioWidget::read_editor_font_from_config()
+RefPtr<Gfx::Font const> HackStudioWidget::read_editor_font_from_config()
 {
     auto font_family = Config::read_string("HackStudio"sv, "EditorFont"sv, "Family"sv, "Csilla"sv);
     auto font_variant = Config::read_string("HackStudio"sv, "EditorFont"sv, "Variant"sv, "Regular"sv);
@@ -1850,7 +1850,7 @@ RefPtr<Gfx::Font> HackStudioWidget::read_editor_font_from_config()
     return font;
 }
 
-void HackStudioWidget::change_editor_font(RefPtr<Gfx::Font> font)
+void HackStudioWidget::change_editor_font(RefPtr<Gfx::Font const> font)
 {
     m_editor_font = move(font);
     for (auto& editor_wrapper : m_all_editor_wrappers) {

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -248,9 +248,9 @@ private:
     RefPtr<GUI::Action> m_toggle_semantic_highlighting_action;
     RefPtr<GUI::Action> m_open_project_configuration_action;
 
-    RefPtr<Gfx::Font> read_editor_font_from_config();
-    void change_editor_font(RefPtr<Gfx::Font>);
-    RefPtr<Gfx::Font> m_editor_font;
+    RefPtr<Gfx::Font const> read_editor_font_from_config();
+    void change_editor_font(RefPtr<Gfx::Font const>);
+    RefPtr<Gfx::Font const> m_editor_font;
     RefPtr<GUI::Action> m_editor_font_action;
 
     GUI::TextEditor::WrappingMode m_wrapping_mode { GUI::TextEditor::NoWrap };

--- a/Userland/DevTools/Profiler/TimelineHeader.h
+++ b/Userland/DevTools/Profiler/TimelineHeader.h
@@ -32,7 +32,7 @@ private:
 
     Profile& m_profile;
     Process const& m_process;
-    RefPtr<Gfx::Bitmap> m_icon;
+    RefPtr<Gfx::Bitmap const> m_icon;
     DeprecatedString m_text;
     bool m_selected;
 };

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -421,7 +421,7 @@ Chess::Square ChessWidget::mouse_to_square(GUI::MouseEvent& event) const
     }
 }
 
-RefPtr<Gfx::Bitmap> ChessWidget::get_piece_graphic(Chess::Piece const& piece) const
+RefPtr<Gfx::Bitmap const> ChessWidget::get_piece_graphic(Chess::Piece const& piece) const
 {
     return m_pieces.get(piece).value();
 }

--- a/Userland/Games/Chess/ChessWidget.h
+++ b/Userland/Games/Chess/ChessWidget.h
@@ -48,7 +48,7 @@ public:
 
     bool drag_enabled() const { return m_drag_enabled; }
     void set_drag_enabled(bool e) { m_drag_enabled = e; }
-    RefPtr<Gfx::Bitmap> get_piece_graphic(Chess::Piece const& piece) const;
+    RefPtr<Gfx::Bitmap const> get_piece_graphic(Chess::Piece const& piece) const;
 
     bool show_available_moves() const { return m_show_available_moves; }
     void set_show_available_moves(bool e) { m_show_available_moves = e; }
@@ -128,7 +128,7 @@ private:
     Color m_marking_alternate_color { Color::from_argb(0x66ffaa00) };
     Color m_marking_secondary_color { Color::from_argb(0x6655dd55) };
     Chess::Color m_side { Chess::Color::White };
-    HashMap<Chess::Piece, RefPtr<Gfx::Bitmap>> m_pieces;
+    HashMap<Chess::Piece, RefPtr<Gfx::Bitmap const>> m_pieces;
     DeprecatedString m_piece_set;
     Chess::Square m_moving_square { 50, 50 };
     Gfx::IntPoint m_drag_point;

--- a/Userland/Games/ColorLines/ColorLines.cpp
+++ b/Userland/Games/ColorLines/ColorLines.cpp
@@ -40,7 +40,7 @@ ColorLines::BitmapArray ColorLines::build_marble_color_bitmaps()
 ColorLines::BitmapArray ColorLines::build_marble_trace_bitmaps()
 {
     // Use "Paw Prints" Unicode Character (U+1F43E)
-    auto trace_bitmap = NonnullRefPtr<Gfx::Bitmap>(*Gfx::Emoji::emoji_for_code_point(0x1F43E));
+    auto trace_bitmap = NonnullRefPtr<Gfx::Bitmap const>(*Gfx::Emoji::emoji_for_code_point(0x1F43E));
     BitmapArray result;
     result.ensure_capacity(number_of_marble_trace_bitmaps);
     result.append(trace_bitmap);

--- a/Userland/Games/ColorLines/ColorLines.h
+++ b/Userland/Games/ColorLines/ColorLines.h
@@ -47,7 +47,7 @@ private:
     void restart_timer(int milliseconds);
 
     using Point = Gfx::IntPoint;
-    using BitmapArray = Vector<NonnullRefPtr<Gfx::Bitmap>>;
+    using BitmapArray = Vector<NonnullRefPtr<Gfx::Bitmap const>>;
 
     StringView const m_app_name;
     GameState m_game_state { GameState::Idle };

--- a/Userland/Games/Hearts/Player.cpp
+++ b/Userland/Games/Hearts/Player.cpp
@@ -162,7 +162,7 @@ void Player::remove_cards(NonnullRefPtrVector<Card> const& cards)
 {
     for (auto& card : cards) {
         hand.remove_first_matching([&card](auto& other_card) {
-            return other_card == card;
+            return other_card.ptr() == &card;
         });
     }
 }

--- a/Userland/Libraries/LibCards/CardGame.cpp
+++ b/Userland/Libraries/LibCards/CardGame.cpp
@@ -59,14 +59,14 @@ ErrorOr<void> CardGame::pick_up_cards_from_stack(Cards::CardStack& stack, Gfx::I
     return {};
 }
 
-RefPtr<CardStack> CardGame::find_stack_to_drop_on(CardStack::MovementRule movement_rule) const
+RefPtr<CardStack> CardGame::find_stack_to_drop_on(CardStack::MovementRule movement_rule)
 {
     auto bounds_to_check = moving_cards_bounds();
 
     RefPtr<CardStack> closest_stack;
     float closest_distance = FLT_MAX;
 
-    for (auto const& stack : stacks()) {
+    for (auto& stack : stacks()) {
         if (stack == moving_cards_source_stack())
             continue;
 

--- a/Userland/Libraries/LibCards/CardGame.h
+++ b/Userland/Libraries/LibCards/CardGame.h
@@ -43,7 +43,7 @@ public:
     Gfx::IntRect moving_cards_bounds() const;
     RefPtr<CardStack> moving_cards_source_stack() const { return m_moving_cards_source_stack; }
     ErrorOr<void> pick_up_cards_from_stack(CardStack&, Gfx::IntPoint click_location, CardStack::MovementRule);
-    RefPtr<CardStack> find_stack_to_drop_on(CardStack::MovementRule) const;
+    RefPtr<CardStack> find_stack_to_drop_on(CardStack::MovementRule);
     ErrorOr<void> drop_cards_on_stack(CardStack&, CardStack::MovementRule);
     void clear_moving_cards();
 

--- a/Userland/Libraries/LibCodeComprehension/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/Libraries/LibCodeComprehension/Cpp/CppComprehensionEngine.cpp
@@ -331,7 +331,7 @@ Vector<CppComprehensionEngine::Symbol> CppComprehensionEngine::properties_of_typ
     return properties;
 }
 
-CppComprehensionEngine::Symbol CppComprehensionEngine::Symbol::create(StringView name, Vector<StringView> const& scope, NonnullRefPtr<Cpp::Declaration> declaration, IsLocal is_local)
+CppComprehensionEngine::Symbol CppComprehensionEngine::Symbol::create(StringView name, Vector<StringView> const& scope, NonnullRefPtr<Cpp::Declaration const> declaration, IsLocal is_local)
 {
     return { { name, scope }, move(declaration), is_local == IsLocal::Yes };
 }
@@ -416,7 +416,7 @@ Optional<CodeComprehension::ProjectLocation> CppComprehensionEngine::find_declar
     return find_preprocessor_definition(document, identifier_position);
 }
 
-RefPtr<Cpp::Declaration> CppComprehensionEngine::find_declaration_of(DocumentData const& document, const GUI::TextPosition& identifier_position)
+RefPtr<Cpp::Declaration const> CppComprehensionEngine::find_declaration_of(DocumentData const& document, const GUI::TextPosition& identifier_position)
 {
     auto node = document.parser().node_at(Cpp::Position { identifier_position.line(), identifier_position.column() });
     if (!node) {
@@ -509,7 +509,7 @@ static Optional<TargetDeclaration> get_target_declaration(ASTNode const& node, D
 
     return TargetDeclaration { TargetDeclaration::Type::Variable, name };
 }
-RefPtr<Cpp::Declaration> CppComprehensionEngine::find_declaration_of(DocumentData const& document_data, ASTNode const& node) const
+RefPtr<Cpp::Declaration const> CppComprehensionEngine::find_declaration_of(DocumentData const& document_data, ASTNode const& node) const
 {
     dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "find_declaration_of: {} ({})", document_data.parser().text_of_node(node), node.class_name());
 
@@ -669,15 +669,15 @@ Vector<StringView> CppComprehensionEngine::scope_of_node(ASTNode const& node) co
     if (!parent->is_declaration())
         return parent_scope;
 
-    auto& parent_decl = static_cast<Cpp::Declaration&>(*parent);
+    auto& parent_decl = static_cast<Cpp::Declaration const&>(*parent);
 
     StringView containing_scope;
     if (parent_decl.is_namespace())
-        containing_scope = static_cast<NamespaceDeclaration&>(parent_decl).full_name();
+        containing_scope = static_cast<NamespaceDeclaration const&>(parent_decl).full_name();
     if (parent_decl.is_struct_or_class())
-        containing_scope = static_cast<StructOrClassDeclaration&>(parent_decl).full_name();
+        containing_scope = static_cast<StructOrClassDeclaration const&>(parent_decl).full_name();
     if (parent_decl.is_function())
-        containing_scope = static_cast<FunctionDeclaration&>(parent_decl).full_name();
+        containing_scope = static_cast<FunctionDeclaration const&>(parent_decl).full_name();
 
     parent_scope.append(containing_scope);
     return parent_scope;
@@ -751,9 +751,9 @@ Optional<Vector<CodeComprehension::AutocompleteResultEntry>> CppComprehensionEng
     return options;
 }
 
-RefPtr<Cpp::Declaration> CppComprehensionEngine::find_declaration_of(CppComprehensionEngine::DocumentData const& document, CppComprehensionEngine::SymbolName const& target_symbol_name) const
+RefPtr<Cpp::Declaration const> CppComprehensionEngine::find_declaration_of(CppComprehensionEngine::DocumentData const& document, CppComprehensionEngine::SymbolName const& target_symbol_name) const
 {
-    RefPtr<Cpp::Declaration> target_declaration;
+    RefPtr<Cpp::Declaration const> target_declaration;
     for_each_available_symbol(document, [&](Symbol const& symbol) {
         if (symbol.name == target_symbol_name) {
             target_declaration = symbol.declaration;
@@ -834,7 +834,7 @@ Optional<CodeComprehensionEngine::FunctionParamsHint> CppComprehensionEngine::ge
 
     dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "node type: {}", node->class_name());
 
-    FunctionCall* call_node { nullptr };
+    FunctionCall const* call_node { nullptr };
 
     if (node->is_function_call()) {
         call_node = verify_cast<FunctionCall>(node.ptr());
@@ -880,7 +880,7 @@ Optional<CodeComprehensionEngine::FunctionParamsHint> CppComprehensionEngine::ge
 
 Optional<CppComprehensionEngine::FunctionParamsHint> CppComprehensionEngine::get_function_params_hint(
     DocumentData const& document,
-    FunctionCall& call_node,
+    FunctionCall const& call_node,
     size_t argument_index)
 {
     Identifier const* callee = nullptr;

--- a/Userland/Libraries/LibCodeComprehension/Cpp/CppComprehensionEngine.h
+++ b/Userland/Libraries/LibCodeComprehension/Cpp/CppComprehensionEngine.h
@@ -47,7 +47,7 @@ private:
 
     struct Symbol {
         SymbolName name;
-        NonnullRefPtr<Cpp::Declaration> declaration;
+        NonnullRefPtr<Cpp::Declaration const> declaration;
 
         // Local symbols are symbols that should not appear in a global symbol search.
         // For example, a variable that is declared inside a function will have is_local = true.
@@ -57,7 +57,7 @@ private:
             No,
             Yes
         };
-        static Symbol create(StringView name, Vector<StringView> const& scope, NonnullRefPtr<Cpp::Declaration>, IsLocal is_local);
+        static Symbol create(StringView name, Vector<StringView> const& scope, NonnullRefPtr<Cpp::Declaration const>, IsLocal is_local);
     };
 
     friend Traits<SymbolName>;
@@ -101,9 +101,9 @@ private:
     DeprecatedString type_of_property(DocumentData const&, Identifier const&) const;
     DeprecatedString type_of_variable(Identifier const&) const;
     bool is_property(ASTNode const&) const;
-    RefPtr<Cpp::Declaration> find_declaration_of(DocumentData const&, ASTNode const&) const;
-    RefPtr<Cpp::Declaration> find_declaration_of(DocumentData const&, SymbolName const&) const;
-    RefPtr<Cpp::Declaration> find_declaration_of(DocumentData const&, const GUI::TextPosition& identifier_position);
+    RefPtr<Cpp::Declaration const> find_declaration_of(DocumentData const&, ASTNode const&) const;
+    RefPtr<Cpp::Declaration const> find_declaration_of(DocumentData const&, SymbolName const&) const;
+    RefPtr<Cpp::Declaration const> find_declaration_of(DocumentData const&, const GUI::TextPosition& identifier_position);
 
     enum class RecurseIntoScopes {
         No,
@@ -134,7 +134,7 @@ private:
     Optional<Vector<CodeComprehension::AutocompleteResultEntry>> try_autocomplete_name(DocumentData const&, ASTNode const&, Optional<Token> containing_token) const;
     Optional<Vector<CodeComprehension::AutocompleteResultEntry>> try_autocomplete_include(DocumentData const&, Token include_path_token, Cpp::Position const& cursor_position) const;
     static bool is_symbol_available(Symbol const&, Vector<StringView> const& current_scope, Vector<StringView> const& reference_scope);
-    Optional<FunctionParamsHint> get_function_params_hint(DocumentData const&, FunctionCall&, size_t argument_index);
+    Optional<FunctionParamsHint> get_function_params_hint(DocumentData const&, FunctionCall const&, size_t argument_index);
 
     template<typename Func>
     void for_each_available_symbol(DocumentData const&, Func) const;

--- a/Userland/Libraries/LibCodeComprehension/Shell/ShellComprehensionEngine.cpp
+++ b/Userland/Libraries/LibCodeComprehension/Shell/ShellComprehensionEngine.cpp
@@ -180,7 +180,7 @@ Optional<CodeComprehension::ProjectLocation> ShellComprehensionEngine::find_decl
         return {};
     }
 
-    auto name = static_ptr_cast<::Shell::AST::BarewordLiteral>(result.matching_node)->text();
+    auto name = static_ptr_cast<::Shell::AST::BarewordLiteral const>(result.matching_node)->text();
     auto& declarations = all_declarations();
     for (auto& entry : declarations) {
         for (auto& declaration : entry.value) {
@@ -209,7 +209,7 @@ void ShellComprehensionEngine::update_declared_symbols(DocumentData const& docum
 
                 DeprecatedString name;
                 if (literal->is_bareword())
-                    name = static_ptr_cast<::Shell::AST::BarewordLiteral>(literal)->text();
+                    name = static_ptr_cast<::Shell::AST::BarewordLiteral const>(literal)->text();
 
                 if (!name.is_empty()) {
                     dbgln("Found variable {}", name);

--- a/Userland/Libraries/LibCpp/AST.cpp
+++ b/Userland/Libraries/LibCpp/AST.cpp
@@ -55,9 +55,9 @@ void FunctionDeclaration::dump(FILE* output, size_t indent) const
     }
 }
 
-NonnullRefPtrVector<Declaration> FunctionDeclaration::declarations() const
+NonnullRefPtrVector<Declaration const> FunctionDeclaration::declarations() const
 {
-    NonnullRefPtrVector<Declaration> declarations;
+    NonnullRefPtrVector<Declaration const> declarations;
     for (auto& arg : m_parameters) {
         declarations.append(arg);
     }
@@ -162,9 +162,9 @@ void FunctionDefinition::dump(FILE* output, size_t indent) const
     outln(output, "}}");
 }
 
-NonnullRefPtrVector<Declaration> FunctionDefinition::declarations() const
+NonnullRefPtrVector<Declaration const> FunctionDefinition::declarations() const
 {
-    NonnullRefPtrVector<Declaration> declarations;
+    NonnullRefPtrVector<Declaration const> declarations;
     for (auto& statement : m_statements) {
         declarations.extend(statement.declarations());
     }
@@ -350,9 +350,9 @@ void StructOrClassDeclaration::dump(FILE* output, size_t indent) const
         member.dump(output, indent + 1);
     }
 }
-NonnullRefPtrVector<Declaration> StructOrClassDeclaration::declarations() const
+NonnullRefPtrVector<Declaration const> StructOrClassDeclaration::declarations() const
 {
-    NonnullRefPtrVector<Declaration> declarations;
+    NonnullRefPtrVector<Declaration const> declarations;
     for (auto& member : m_members)
         declarations.append(member);
     return declarations;
@@ -458,10 +458,10 @@ void ForStatement::dump(FILE* output, size_t indent) const
         m_body->dump(output, indent + 1);
 }
 
-NonnullRefPtrVector<Declaration> Statement::declarations() const
+NonnullRefPtrVector<Declaration const> Statement::declarations() const
 {
     if (is_declaration()) {
-        NonnullRefPtrVector<Declaration> vec;
+        NonnullRefPtrVector<Declaration const> vec;
         auto const& decl = static_cast<Declaration const&>(*this);
         vec.empend(const_cast<Declaration&>(decl));
         return vec;
@@ -469,9 +469,9 @@ NonnullRefPtrVector<Declaration> Statement::declarations() const
     return {};
 }
 
-NonnullRefPtrVector<Declaration> ForStatement::declarations() const
+NonnullRefPtrVector<Declaration const> ForStatement::declarations() const
 {
-    NonnullRefPtrVector<Declaration> declarations;
+    NonnullRefPtrVector<Declaration const> declarations;
     if (m_init)
         declarations.extend(m_init->declarations());
     if (m_body)
@@ -479,9 +479,9 @@ NonnullRefPtrVector<Declaration> ForStatement::declarations() const
     return declarations;
 }
 
-NonnullRefPtrVector<Declaration> BlockStatement::declarations() const
+NonnullRefPtrVector<Declaration const> BlockStatement::declarations() const
 {
-    NonnullRefPtrVector<Declaration> declarations;
+    NonnullRefPtrVector<Declaration const> declarations;
     for (auto& statement : m_statements) {
         declarations.extend(statement.declarations());
     }
@@ -508,9 +508,9 @@ void IfStatement::dump(FILE* output, size_t indent) const
     }
 }
 
-NonnullRefPtrVector<Declaration> IfStatement::declarations() const
+NonnullRefPtrVector<Declaration const> IfStatement::declarations() const
 {
-    NonnullRefPtrVector<Declaration> declarations;
+    NonnullRefPtrVector<Declaration const> declarations;
     if (m_predicate)
         declarations.extend(m_predicate->declarations());
     if (m_then)

--- a/Userland/Libraries/LibCpp/AST.h
+++ b/Userland/Libraries/LibCpp/AST.h
@@ -36,7 +36,7 @@ public:
     template<typename T>
     bool fast_is() const = delete;
 
-    ASTNode* parent() const { return m_parent; }
+    ASTNode const* parent() const { return m_parent; }
     Position start() const
     {
         VERIFY(m_start.has_value());
@@ -52,9 +52,9 @@ public:
         return m_filename;
     }
     void set_end(Position const& end) { m_end = end; }
-    void set_parent(ASTNode& parent) { m_parent = &parent; }
+    void set_parent(ASTNode const& parent) { m_parent = &parent; }
 
-    virtual NonnullRefPtrVector<Declaration> declarations() const { return {}; }
+    virtual NonnullRefPtrVector<Declaration const> declarations() const { return {}; }
 
     virtual bool is_identifier() const { return false; }
     virtual bool is_member_expression() const { return false; }
@@ -66,7 +66,7 @@ public:
     virtual bool is_dummy_node() const { return false; }
 
 protected:
-    ASTNode(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    ASTNode(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : m_parent(parent)
         , m_start(start)
         , m_end(end)
@@ -75,7 +75,7 @@ protected:
     }
 
 private:
-    ASTNode* m_parent { nullptr };
+    ASTNode const* m_parent { nullptr };
     Optional<Position> m_start;
     Optional<Position> m_end;
     DeprecatedFlyString m_filename;
@@ -87,17 +87,17 @@ public:
     virtual ~TranslationUnit() override = default;
     virtual StringView class_name() const override { return "TranslationUnit"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
-    virtual NonnullRefPtrVector<Declaration> declarations() const override { return m_declarations; }
+    virtual NonnullRefPtrVector<Declaration const> declarations() const override { return m_declarations; }
 
-    TranslationUnit(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    TranslationUnit(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : ASTNode(parent, start, end, filename)
     {
     }
 
-    void set_declarations(NonnullRefPtrVector<Declaration>&& declarations) { m_declarations = move(declarations); }
+    void set_declarations(NonnullRefPtrVector<Declaration const>&& declarations) { m_declarations = move(declarations); }
 
 private:
-    NonnullRefPtrVector<Declaration> m_declarations;
+    NonnullRefPtrVector<Declaration const> m_declarations;
 };
 
 class Statement : public ASTNode {
@@ -105,10 +105,10 @@ public:
     virtual ~Statement() override = default;
     virtual StringView class_name() const override { return "Statement"sv; }
 
-    virtual NonnullRefPtrVector<Declaration> declarations() const override;
+    virtual NonnullRefPtrVector<Declaration const> declarations() const override;
 
 protected:
-    Statement(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    Statement(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : ASTNode(parent, start, end, filename)
     {
     }
@@ -129,15 +129,15 @@ public:
     bool is_member() const { return parent() != nullptr && parent()->is_declaration() && verify_cast<Declaration>(parent())->is_struct_or_class(); }
     Name const* name() const { return m_name; }
     StringView full_name() const;
-    void set_name(RefPtr<Name> name) { m_name = move(name); }
+    void set_name(RefPtr<Name const> name) { m_name = move(name); }
 
 protected:
-    Declaration(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    Declaration(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Statement(parent, start, end, filename)
     {
     }
 
-    RefPtr<Name> m_name;
+    RefPtr<Name const> m_name;
     mutable Optional<DeprecatedString> m_full_name;
 };
 
@@ -146,7 +146,7 @@ class InvalidDeclaration : public Declaration {
 public:
     virtual ~InvalidDeclaration() override = default;
     virtual StringView class_name() const override { return "InvalidDeclaration"sv; }
-    InvalidDeclaration(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    InvalidDeclaration(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Declaration(parent, start, end, filename)
     {
     }
@@ -160,28 +160,28 @@ public:
     virtual bool is_function() const override { return true; }
     virtual bool is_constructor() const { return false; }
     virtual bool is_destructor() const { return false; }
-    RefPtr<FunctionDefinition> definition() { return m_definition; }
+    RefPtr<FunctionDefinition const> definition() { return m_definition; }
 
-    FunctionDeclaration(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    FunctionDeclaration(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Declaration(parent, start, end, filename)
     {
     }
 
-    virtual NonnullRefPtrVector<Declaration> declarations() const override;
+    virtual NonnullRefPtrVector<Declaration const> declarations() const override;
     Vector<StringView> const& qualifiers() const { return m_qualifiers; }
     void set_qualifiers(Vector<StringView> const& qualifiers) { m_qualifiers = qualifiers; }
     Type const* return_type() const { return m_return_type.ptr(); }
-    void set_return_type(RefPtr<Type> const& return_type) { m_return_type = return_type; }
-    NonnullRefPtrVector<Parameter> const& parameters() const { return m_parameters; }
-    void set_parameters(NonnullRefPtrVector<Parameter> const& parameters) { m_parameters = parameters; }
+    void set_return_type(RefPtr<Type const> const& return_type) { m_return_type = return_type; }
+    NonnullRefPtrVector<Parameter const> const& parameters() const { return m_parameters; }
+    void set_parameters(NonnullRefPtrVector<Parameter const> const& parameters) { m_parameters = parameters; }
     FunctionDefinition const* definition() const { return m_definition.ptr(); }
-    void set_definition(RefPtr<FunctionDefinition>&& definition) { m_definition = move(definition); }
+    void set_definition(RefPtr<FunctionDefinition const>&& definition) { m_definition = move(definition); }
 
 private:
     Vector<StringView> m_qualifiers;
-    RefPtr<Type> m_return_type;
-    NonnullRefPtrVector<Parameter> m_parameters;
-    RefPtr<FunctionDefinition> m_definition;
+    RefPtr<Type const> m_return_type;
+    NonnullRefPtrVector<Parameter const> m_parameters;
+    RefPtr<FunctionDefinition const> m_definition;
 };
 
 class VariableOrParameterDeclaration : public Declaration {
@@ -189,16 +189,16 @@ public:
     virtual ~VariableOrParameterDeclaration() override = default;
     virtual bool is_variable_or_parameter_declaration() const override { return true; }
 
-    void set_type(RefPtr<Type>&& type) { m_type = move(type); }
+    void set_type(RefPtr<Type const>&& type) { m_type = move(type); }
     Type const* type() const { return m_type.ptr(); }
 
 protected:
-    VariableOrParameterDeclaration(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    VariableOrParameterDeclaration(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Declaration(parent, start, end, filename)
     {
     }
 
-    RefPtr<Type> m_type;
+    RefPtr<Type const> m_type;
 };
 
 class Parameter : public VariableOrParameterDeclaration {
@@ -208,7 +208,7 @@ public:
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual bool is_parameter() const override { return true; }
 
-    Parameter(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename, RefPtr<Name> name)
+    Parameter(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename, RefPtr<Name const> name)
         : VariableOrParameterDeclaration(parent, start, end, filename)
     {
         m_name = name;
@@ -237,7 +237,7 @@ public:
     void set_qualifiers(Vector<StringView>&& qualifiers) { m_qualifiers = move(qualifiers); }
 
 protected:
-    Type(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    Type(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : ASTNode(parent, start, end, filename)
     {
     }
@@ -254,16 +254,16 @@ public:
     virtual DeprecatedString to_deprecated_string() const override;
     virtual bool is_named_type() const override { return true; }
 
-    NamedType(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    NamedType(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Type(parent, start, end, filename)
     {
     }
 
     Name const* name() const { return m_name.ptr(); }
-    void set_name(RefPtr<Name>&& name) { m_name = move(name); }
+    void set_name(RefPtr<Name const>&& name) { m_name = move(name); }
 
 private:
-    RefPtr<Name> m_name;
+    RefPtr<Name const> m_name;
 };
 
 class Pointer : public Type {
@@ -273,16 +273,16 @@ public:
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual DeprecatedString to_deprecated_string() const override;
 
-    Pointer(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    Pointer(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Type(parent, start, end, filename)
     {
     }
 
     Type const* pointee() const { return m_pointee.ptr(); }
-    void set_pointee(RefPtr<Type>&& pointee) { m_pointee = move(pointee); }
+    void set_pointee(RefPtr<Type const>&& pointee) { m_pointee = move(pointee); }
 
 private:
-    RefPtr<Type> m_pointee;
+    RefPtr<Type const> m_pointee;
 };
 
 class Reference : public Type {
@@ -297,14 +297,14 @@ public:
         Rvalue,
     };
 
-    Reference(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename, Kind kind)
+    Reference(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename, Kind kind)
         : Type(parent, start, end, filename)
         , m_kind(kind)
     {
     }
 
     Type const* referenced_type() const { return m_referenced_type.ptr(); }
-    void set_referenced_type(RefPtr<Type>&& pointee) { m_referenced_type = move(pointee); }
+    void set_referenced_type(RefPtr<Type const>&& pointee) { m_referenced_type = move(pointee); }
     Kind kind() const { return m_kind; }
 
 private:
@@ -319,17 +319,17 @@ public:
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual DeprecatedString to_deprecated_string() const override;
 
-    FunctionType(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    FunctionType(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Type(parent, start, end, filename)
     {
     }
 
     void set_return_type(Type& type) { m_return_type = type; }
-    void set_parameters(NonnullRefPtrVector<Parameter> parameters) { m_parameters = move(parameters); }
+    void set_parameters(NonnullRefPtrVector<Parameter const> parameters) { m_parameters = move(parameters); }
 
 private:
-    RefPtr<Type> m_return_type;
-    NonnullRefPtrVector<Parameter> m_parameters;
+    RefPtr<Type const> m_return_type;
+    NonnullRefPtrVector<Parameter const> m_parameters;
 };
 
 class FunctionDefinition : public ASTNode {
@@ -338,24 +338,24 @@ public:
     virtual StringView class_name() const override { return "FunctionDefinition"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
-    FunctionDefinition(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    FunctionDefinition(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : ASTNode(parent, start, end, filename)
     {
     }
 
-    virtual NonnullRefPtrVector<Declaration> declarations() const override;
-    NonnullRefPtrVector<Statement> const& statements() { return m_statements; }
-    void add_statement(NonnullRefPtr<Statement>&& statement) { m_statements.append(move(statement)); }
+    virtual NonnullRefPtrVector<Declaration const> declarations() const override;
+    NonnullRefPtrVector<Statement const> const& statements() { return m_statements; }
+    void add_statement(NonnullRefPtr<Statement const>&& statement) { m_statements.append(move(statement)); }
 
 private:
-    NonnullRefPtrVector<Statement> m_statements;
+    NonnullRefPtrVector<Statement const> m_statements;
 };
 
 class InvalidStatement : public Statement {
 public:
     virtual ~InvalidStatement() override = default;
     virtual StringView class_name() const override { return "InvalidStatement"sv; }
-    InvalidStatement(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    InvalidStatement(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Statement(parent, start, end, filename)
     {
     }
@@ -367,7 +367,7 @@ public:
     virtual StringView class_name() const override { return "Expression"sv; }
 
 protected:
-    Expression(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    Expression(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Statement(parent, start, end, filename)
     {
     }
@@ -377,7 +377,7 @@ class InvalidExpression : public Expression {
 public:
     virtual ~InvalidExpression() override = default;
     virtual StringView class_name() const override { return "InvalidExpression"sv; }
-    InvalidExpression(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    InvalidExpression(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Expression(parent, start, end, filename)
     {
     }
@@ -389,7 +389,7 @@ public:
     virtual StringView class_name() const override { return "VariableDeclaration"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
-    VariableDeclaration(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    VariableDeclaration(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : VariableOrParameterDeclaration(parent, start, end, filename)
     {
     }
@@ -397,10 +397,10 @@ public:
     virtual bool is_variable_declaration() const override { return true; }
 
     Expression const* initial_value() const { return m_initial_value; }
-    void set_initial_value(RefPtr<Expression>&& initial_value) { m_initial_value = move(initial_value); }
+    void set_initial_value(RefPtr<Expression const>&& initial_value) { m_initial_value = move(initial_value); }
 
 private:
-    RefPtr<Expression> m_initial_value;
+    RefPtr<Expression const> m_initial_value;
 };
 
 class Identifier : public Expression {
@@ -409,12 +409,12 @@ public:
     virtual StringView class_name() const override { return "Identifier"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
-    Identifier(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename, StringView name)
+    Identifier(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename, StringView name)
         : Expression(parent, start, end, filename)
         , m_name(name)
     {
     }
-    Identifier(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    Identifier(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Identifier(parent, start, end, filename, {})
     {
     }
@@ -436,21 +436,21 @@ public:
     virtual bool is_name() const override { return true; }
     virtual bool is_templatized() const { return false; }
 
-    Name(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    Name(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Expression(parent, start, end, filename)
     {
     }
     virtual StringView full_name() const;
 
     Identifier const* name() const { return m_name.ptr(); }
-    void set_name(RefPtr<Identifier>&& name) { m_name = move(name); }
-    NonnullRefPtrVector<Identifier> const& scope() const { return m_scope; }
-    void set_scope(NonnullRefPtrVector<Identifier> scope) { m_scope = move(scope); }
-    void add_to_scope(NonnullRefPtr<Identifier>&& part) { m_scope.append(move(part)); }
+    void set_name(RefPtr<Identifier const>&& name) { m_name = move(name); }
+    NonnullRefPtrVector<Identifier const> const& scope() const { return m_scope; }
+    void set_scope(NonnullRefPtrVector<Identifier const> scope) { m_scope = move(scope); }
+    void add_to_scope(NonnullRefPtr<Identifier const>&& part) { m_scope.append(move(part)); }
 
 private:
-    RefPtr<Identifier> m_name;
-    NonnullRefPtrVector<Identifier> m_scope;
+    RefPtr<Identifier const> m_name;
+    NonnullRefPtrVector<Identifier const> m_scope;
     mutable Optional<DeprecatedString> m_full_name;
 };
 
@@ -461,15 +461,15 @@ public:
     virtual bool is_templatized() const override { return true; }
     virtual StringView full_name() const override;
 
-    TemplatizedName(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    TemplatizedName(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Name(parent, start, end, filename)
     {
     }
 
-    void add_template_argument(NonnullRefPtr<Type>&& type) { m_template_arguments.append(move(type)); }
+    void add_template_argument(NonnullRefPtr<Type const>&& type) { m_template_arguments.append(move(type)); }
 
 private:
-    NonnullRefPtrVector<Type> m_template_arguments;
+    NonnullRefPtrVector<Type const> m_template_arguments;
     mutable Optional<DeprecatedString> m_full_name;
 };
 
@@ -479,7 +479,7 @@ public:
     virtual StringView class_name() const override { return "NumericLiteral"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
-    NumericLiteral(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename, StringView value)
+    NumericLiteral(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename, StringView value)
         : Expression(parent, start, end, filename)
         , m_value(value)
     {
@@ -495,7 +495,7 @@ public:
     virtual StringView class_name() const override { return "NullPointerLiteral"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
-    NullPointerLiteral(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    NullPointerLiteral(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Expression(parent, start, end, filename)
     {
     }
@@ -507,7 +507,7 @@ public:
     virtual StringView class_name() const override { return "BooleanLiteral"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
-    BooleanLiteral(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename, bool value)
+    BooleanLiteral(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename, bool value)
         : Expression(parent, start, end, filename)
         , m_value(value)
     {
@@ -541,7 +541,7 @@ enum class BinaryOp {
 
 class BinaryExpression : public Expression {
 public:
-    BinaryExpression(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    BinaryExpression(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Expression(parent, start, end, filename)
     {
     }
@@ -553,14 +553,14 @@ public:
     BinaryOp op() const { return m_op; }
     void set_op(BinaryOp op) { m_op = op; }
     Expression const* lhs() const { return m_lhs.ptr(); }
-    void set_lhs(RefPtr<Expression>&& e) { m_lhs = move(e); }
+    void set_lhs(RefPtr<Expression const>&& e) { m_lhs = move(e); }
     Expression const* rhs() const { return m_rhs.ptr(); }
-    void set_rhs(RefPtr<Expression>&& e) { m_rhs = move(e); }
+    void set_rhs(RefPtr<Expression const>&& e) { m_rhs = move(e); }
 
 private:
     BinaryOp m_op;
-    RefPtr<Expression> m_lhs;
-    RefPtr<Expression> m_rhs;
+    RefPtr<Expression const> m_lhs;
+    RefPtr<Expression const> m_rhs;
 };
 
 enum class AssignmentOp {
@@ -571,7 +571,7 @@ enum class AssignmentOp {
 
 class AssignmentExpression : public Expression {
 public:
-    AssignmentExpression(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    AssignmentExpression(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Expression(parent, start, end, filename)
     {
     }
@@ -583,19 +583,19 @@ public:
     AssignmentOp op() const { return m_op; }
     void set_op(AssignmentOp op) { m_op = op; }
     Expression const* lhs() const { return m_lhs; }
-    void set_lhs(RefPtr<Expression>&& e) { m_lhs = move(e); }
+    void set_lhs(RefPtr<Expression const>&& e) { m_lhs = move(e); }
     Expression const* rhs() const { return m_rhs; }
-    void set_rhs(RefPtr<Expression>&& e) { m_rhs = move(e); }
+    void set_rhs(RefPtr<Expression const>&& e) { m_rhs = move(e); }
 
 private:
     AssignmentOp m_op {};
-    RefPtr<Expression> m_lhs;
-    RefPtr<Expression> m_rhs;
+    RefPtr<Expression const> m_lhs;
+    RefPtr<Expression const> m_rhs;
 };
 
 class FunctionCall : public Expression {
 public:
-    FunctionCall(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    FunctionCall(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Expression(parent, start, end, filename)
     {
     }
@@ -606,19 +606,19 @@ public:
     virtual bool is_function_call() const override { return true; }
 
     Expression const* callee() const { return m_callee.ptr(); }
-    void set_callee(RefPtr<Expression>&& callee) { m_callee = move(callee); }
+    void set_callee(RefPtr<Expression const>&& callee) { m_callee = move(callee); }
 
-    void add_argument(NonnullRefPtr<Expression>&& arg) { m_arguments.append(move(arg)); }
-    NonnullRefPtrVector<Expression> const& arguments() const { return m_arguments; }
+    void add_argument(NonnullRefPtr<Expression const>&& arg) { m_arguments.append(move(arg)); }
+    NonnullRefPtrVector<Expression const> const& arguments() const { return m_arguments; }
 
 private:
-    RefPtr<Expression> m_callee;
-    NonnullRefPtrVector<Expression> m_arguments;
+    RefPtr<Expression const> m_callee;
+    NonnullRefPtrVector<Expression const> m_arguments;
 };
 
 class StringLiteral final : public Expression {
 public:
-    StringLiteral(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    StringLiteral(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Expression(parent, start, end, filename)
     {
     }
@@ -639,17 +639,17 @@ public:
     virtual ~ReturnStatement() override = default;
     virtual StringView class_name() const override { return "ReturnStatement"sv; }
 
-    ReturnStatement(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    ReturnStatement(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Statement(parent, start, end, filename)
     {
     }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     Expression const* value() const { return m_value.ptr(); }
-    void set_value(RefPtr<Expression>&& value) { m_value = move(value); }
+    void set_value(RefPtr<Expression const>&& value) { m_value = move(value); }
 
 private:
-    RefPtr<Expression> m_value;
+    RefPtr<Expression const> m_value;
 };
 
 class EnumDeclaration : public Declaration {
@@ -659,7 +659,7 @@ public:
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual bool is_enum() const override { return true; }
 
-    EnumDeclaration(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    EnumDeclaration(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Declaration(parent, start, end, filename)
     {
     }
@@ -670,13 +670,13 @@ public:
     };
 
     void set_type(Type type) { m_type = type; }
-    void add_entry(StringView entry, RefPtr<Expression> value = nullptr) { m_entries.append({ entry, move(value) }); }
+    void add_entry(StringView entry, RefPtr<Expression const> value = nullptr) { m_entries.append({ entry, move(value) }); }
 
 private:
     Type m_type { Type::RegularEnum };
     struct EnumerationEntry {
         StringView name;
-        RefPtr<Expression> value;
+        RefPtr<Expression const> value;
     };
     Vector<EnumerationEntry> m_entries;
 };
@@ -689,29 +689,29 @@ public:
     virtual bool is_struct_or_class() const override { return true; }
     virtual bool is_struct() const override { return m_type == Type::Struct; }
     virtual bool is_class() const override { return m_type == Type::Class; }
-    virtual NonnullRefPtrVector<Declaration> declarations() const override;
+    virtual NonnullRefPtrVector<Declaration const> declarations() const override;
 
     enum class Type {
         Struct,
         Class
     };
 
-    StructOrClassDeclaration(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename, StructOrClassDeclaration::Type type)
+    StructOrClassDeclaration(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename, StructOrClassDeclaration::Type type)
         : Declaration(parent, start, end, filename)
         , m_type(type)
     {
     }
 
-    NonnullRefPtrVector<Declaration> const& members() const { return m_members; }
-    void set_members(NonnullRefPtrVector<Declaration>&& members) { m_members = move(members); }
+    NonnullRefPtrVector<Declaration const> const& members() const { return m_members; }
+    void set_members(NonnullRefPtrVector<Declaration const>&& members) { m_members = move(members); }
 
-    NonnullRefPtrVector<Name> const& baseclasses() const { return m_baseclasses; }
-    void set_baseclasses(NonnullRefPtrVector<Name>&& baseclasses) { m_baseclasses = move(baseclasses); }
+    NonnullRefPtrVector<Name const> const& baseclasses() const { return m_baseclasses; }
+    void set_baseclasses(NonnullRefPtrVector<Name const>&& baseclasses) { m_baseclasses = move(baseclasses); }
 
 private:
     StructOrClassDeclaration::Type m_type;
-    NonnullRefPtrVector<Declaration> m_members;
-    NonnullRefPtrVector<Name> m_baseclasses;
+    NonnullRefPtrVector<Declaration const> m_members;
+    NonnullRefPtrVector<Name const> m_baseclasses;
 };
 
 enum class UnaryOp {
@@ -726,7 +726,7 @@ enum class UnaryOp {
 
 class UnaryExpression : public Expression {
 public:
-    UnaryExpression(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    UnaryExpression(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Expression(parent, start, end, filename)
     {
     }
@@ -736,16 +736,16 @@ public:
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     void set_op(UnaryOp op) { m_op = op; }
-    void set_lhs(RefPtr<Expression>&& e) { m_lhs = move(e); }
+    void set_lhs(RefPtr<Expression const>&& e) { m_lhs = move(e); }
 
 private:
     UnaryOp m_op;
-    RefPtr<Expression> m_lhs;
+    RefPtr<Expression const> m_lhs;
 };
 
 class MemberExpression : public Expression {
 public:
-    MemberExpression(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    MemberExpression(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Expression(parent, start, end, filename)
     {
     }
@@ -756,18 +756,18 @@ public:
     virtual bool is_member_expression() const override { return true; }
 
     Expression const* object() const { return m_object.ptr(); }
-    void set_object(RefPtr<Expression>&& object) { m_object = move(object); }
+    void set_object(RefPtr<Expression const>&& object) { m_object = move(object); }
     Expression const* property() const { return m_property.ptr(); }
-    void set_property(RefPtr<Expression>&& property) { m_property = move(property); }
+    void set_property(RefPtr<Expression const>&& property) { m_property = move(property); }
 
 private:
-    RefPtr<Expression> m_object;
-    RefPtr<Expression> m_property;
+    RefPtr<Expression const> m_object;
+    RefPtr<Expression const> m_property;
 };
 
 class ForStatement : public Statement {
 public:
-    ForStatement(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    ForStatement(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Statement(parent, start, end, filename)
     {
     }
@@ -776,24 +776,24 @@ public:
     virtual StringView class_name() const override { return "ForStatement"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
-    virtual NonnullRefPtrVector<Declaration> declarations() const override;
+    virtual NonnullRefPtrVector<Declaration const> declarations() const override;
 
-    void set_init(RefPtr<VariableDeclaration>&& init) { m_init = move(init); }
-    void set_test(RefPtr<Expression>&& test) { m_test = move(test); }
-    void set_update(RefPtr<Expression>&& update) { m_update = move(update); }
-    void set_body(RefPtr<Statement>&& body) { m_body = move(body); }
+    void set_init(RefPtr<VariableDeclaration const>&& init) { m_init = move(init); }
+    void set_test(RefPtr<Expression const>&& test) { m_test = move(test); }
+    void set_update(RefPtr<Expression const>&& update) { m_update = move(update); }
+    void set_body(RefPtr<Statement const>&& body) { m_body = move(body); }
     Statement const* body() const { return m_body.ptr(); }
 
 private:
-    RefPtr<VariableDeclaration> m_init;
-    RefPtr<Expression> m_test;
-    RefPtr<Expression> m_update;
-    RefPtr<Statement> m_body;
+    RefPtr<VariableDeclaration const> m_init;
+    RefPtr<Expression const> m_test;
+    RefPtr<Expression const> m_update;
+    RefPtr<Statement const> m_body;
 };
 
 class BlockStatement final : public Statement {
 public:
-    BlockStatement(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    BlockStatement(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Statement(parent, start, end, filename)
     {
     }
@@ -802,17 +802,17 @@ public:
     virtual StringView class_name() const override { return "BlockStatement"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
-    virtual NonnullRefPtrVector<Declaration> declarations() const override;
+    virtual NonnullRefPtrVector<Declaration const> declarations() const override;
 
-    void add_statement(NonnullRefPtr<Statement>&& statement) { m_statements.append(move(statement)); }
+    void add_statement(NonnullRefPtr<Statement const>&& statement) { m_statements.append(move(statement)); }
 
 private:
-    NonnullRefPtrVector<Statement> m_statements;
+    NonnullRefPtrVector<Statement const> m_statements;
 };
 
 class Comment final : public Statement {
 public:
-    Comment(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    Comment(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Statement(parent, start, end, filename)
     {
     }
@@ -823,7 +823,7 @@ public:
 
 class IfStatement : public Statement {
 public:
-    IfStatement(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    IfStatement(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Statement(parent, start, end, filename)
     {
     }
@@ -831,19 +831,19 @@ public:
     virtual ~IfStatement() override = default;
     virtual StringView class_name() const override { return "IfStatement"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
-    virtual NonnullRefPtrVector<Declaration> declarations() const override;
+    virtual NonnullRefPtrVector<Declaration const> declarations() const override;
 
-    void set_predicate(RefPtr<Expression>&& predicate) { m_predicate = move(predicate); }
-    void set_then_statement(RefPtr<Statement>&& then) { m_then = move(then); }
-    void set_else_statement(RefPtr<Statement>&& _else) { m_else = move(_else); }
+    void set_predicate(RefPtr<Expression const>&& predicate) { m_predicate = move(predicate); }
+    void set_then_statement(RefPtr<Statement const>&& then) { m_then = move(then); }
+    void set_else_statement(RefPtr<Statement const>&& _else) { m_else = move(_else); }
 
     Statement const* then_statement() const { return m_then.ptr(); }
     Statement const* else_statement() const { return m_else.ptr(); }
 
 private:
-    RefPtr<Expression> m_predicate;
-    RefPtr<Statement> m_then;
-    RefPtr<Statement> m_else;
+    RefPtr<Expression const> m_predicate;
+    RefPtr<Statement const> m_then;
+    RefPtr<Statement const> m_else;
 };
 
 class NamespaceDeclaration : public Declaration {
@@ -853,21 +853,21 @@ public:
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual bool is_namespace() const override { return true; }
 
-    NamespaceDeclaration(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    NamespaceDeclaration(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Declaration(parent, start, end, filename)
     {
     }
 
-    virtual NonnullRefPtrVector<Declaration> declarations() const override { return m_declarations; }
-    void add_declaration(NonnullRefPtr<Declaration>&& declaration) { m_declarations.append(move(declaration)); }
+    virtual NonnullRefPtrVector<Declaration const> declarations() const override { return m_declarations; }
+    void add_declaration(NonnullRefPtr<Declaration const>&& declaration) { m_declarations.append(move(declaration)); }
 
 private:
-    NonnullRefPtrVector<Declaration> m_declarations;
+    NonnullRefPtrVector<Declaration const> m_declarations;
 };
 
 class CppCastExpression : public Expression {
 public:
-    CppCastExpression(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    CppCastExpression(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Expression(parent, start, end, filename)
     {
     }
@@ -877,18 +877,18 @@ public:
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     void set_cast_type(StringView cast_type) { m_cast_type = move(cast_type); }
-    void set_type(NonnullRefPtr<Type>&& type) { m_type = move(type); }
-    void set_expression(NonnullRefPtr<Expression>&& e) { m_expression = move(e); }
+    void set_type(NonnullRefPtr<Type const>&& type) { m_type = move(type); }
+    void set_expression(NonnullRefPtr<Expression const>&& e) { m_expression = move(e); }
 
 private:
     StringView m_cast_type;
-    RefPtr<Type> m_type;
-    RefPtr<Expression> m_expression;
+    RefPtr<Type const> m_type;
+    RefPtr<Expression const> m_expression;
 };
 
 class CStyleCastExpression : public Expression {
 public:
-    CStyleCastExpression(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    CStyleCastExpression(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Expression(parent, start, end, filename)
     {
     }
@@ -897,17 +897,17 @@ public:
     virtual StringView class_name() const override { return "CStyleCastExpression"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
-    void set_type(NonnullRefPtr<Type>&& type) { m_type = move(type); }
-    void set_expression(NonnullRefPtr<Expression>&& e) { m_expression = move(e); }
+    void set_type(NonnullRefPtr<Type const>&& type) { m_type = move(type); }
+    void set_expression(NonnullRefPtr<Expression const>&& e) { m_expression = move(e); }
 
 private:
-    RefPtr<Type> m_type;
-    RefPtr<Expression> m_expression;
+    RefPtr<Type const> m_type;
+    RefPtr<Expression const> m_expression;
 };
 
 class SizeofExpression : public Expression {
 public:
-    SizeofExpression(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    SizeofExpression(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Expression(parent, start, end, filename)
     {
     }
@@ -916,15 +916,15 @@ public:
     virtual StringView class_name() const override { return "SizeofExpression"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
-    void set_type(RefPtr<Type>&& type) { m_type = move(type); }
+    void set_type(RefPtr<Type const>&& type) { m_type = move(type); }
 
 private:
-    RefPtr<Type> m_type;
+    RefPtr<Type const> m_type;
 };
 
 class BracedInitList : public Expression {
 public:
-    BracedInitList(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    BracedInitList(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Expression(parent, start, end, filename)
     {
     }
@@ -933,15 +933,15 @@ public:
     virtual StringView class_name() const override { return "BracedInitList"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
-    void add_expression(NonnullRefPtr<Expression>&& exp) { m_expressions.append(move(exp)); }
+    void add_expression(NonnullRefPtr<Expression const>&& exp) { m_expressions.append(move(exp)); }
 
 private:
-    NonnullRefPtrVector<Expression> m_expressions;
+    NonnullRefPtrVector<Expression const> m_expressions;
 };
 
 class DummyAstNode : public ASTNode {
 public:
-    DummyAstNode(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    DummyAstNode(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : ASTNode(parent, start, end, filename)
     {
     }
@@ -957,7 +957,7 @@ public:
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual bool is_constructor() const override { return true; }
 
-    Constructor(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    Constructor(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : FunctionDeclaration(parent, start, end, filename)
     {
     }
@@ -970,7 +970,7 @@ public:
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual bool is_destructor() const override { return true; }
 
-    Destructor(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    Destructor(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : FunctionDeclaration(parent, start, end, filename)
     {
     }
@@ -982,7 +982,7 @@ public:
     virtual StringView class_name() const override { return "UsingNamespaceDeclaration"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
-    UsingNamespaceDeclaration(ASTNode* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
+    UsingNamespaceDeclaration(ASTNode const* parent, Optional<Position> start, Optional<Position> end, DeprecatedString const& filename)
         : Declaration(parent, start, end, filename)
     {
     }

--- a/Userland/Libraries/LibCpp/Parser.h
+++ b/Userland/Libraries/LibCpp/Parser.h
@@ -25,7 +25,7 @@ public:
     NonnullRefPtr<TranslationUnit> parse();
     bool eof() const;
 
-    RefPtr<ASTNode> node_at(Position) const;
+    RefPtr<ASTNode const> node_at(Position) const;
     Optional<size_t> index_of_node_at(Position) const;
     Optional<Token> token_at(Position) const;
     Optional<size_t> index_of_token_at(Position) const;
@@ -83,45 +83,45 @@ private:
     bool match_destructor(StringView class_name);
     bool match_using_namespace_declaration();
 
-    Optional<NonnullRefPtrVector<Parameter>> parse_parameter_list(ASTNode& parent);
+    Optional<NonnullRefPtrVector<Parameter const>> parse_parameter_list(ASTNode const& parent);
     Optional<Token> consume_whitespace();
     void consume_preprocessor();
 
-    NonnullRefPtr<Declaration> parse_declaration(ASTNode& parent, DeclarationType);
-    NonnullRefPtr<FunctionDeclaration> parse_function_declaration(ASTNode& parent);
-    NonnullRefPtr<FunctionDefinition> parse_function_definition(ASTNode& parent);
-    NonnullRefPtr<Statement> parse_statement(ASTNode& parent);
-    NonnullRefPtr<VariableDeclaration> parse_variable_declaration(ASTNode& parent, bool expect_semicolon = true);
-    NonnullRefPtr<Expression> parse_expression(ASTNode& parent);
-    NonnullRefPtr<Expression> parse_primary_expression(ASTNode& parent);
-    NonnullRefPtr<Expression> parse_secondary_expression(ASTNode& parent, NonnullRefPtr<Expression> lhs);
-    NonnullRefPtr<StringLiteral> parse_string_literal(ASTNode& parent);
-    NonnullRefPtr<ReturnStatement> parse_return_statement(ASTNode& parent);
-    NonnullRefPtr<EnumDeclaration> parse_enum_declaration(ASTNode& parent);
-    NonnullRefPtr<StructOrClassDeclaration> parse_class_declaration(ASTNode& parent);
-    NonnullRefPtr<Expression> parse_literal(ASTNode& parent);
-    NonnullRefPtr<UnaryExpression> parse_unary_expression(ASTNode& parent);
-    NonnullRefPtr<BooleanLiteral> parse_boolean_literal(ASTNode& parent);
-    NonnullRefPtr<Type> parse_type(ASTNode& parent);
-    NonnullRefPtr<BinaryExpression> parse_binary_expression(ASTNode& parent, NonnullRefPtr<Expression> lhs, BinaryOp);
-    NonnullRefPtr<AssignmentExpression> parse_assignment_expression(ASTNode& parent, NonnullRefPtr<Expression> lhs, AssignmentOp);
-    NonnullRefPtr<ForStatement> parse_for_statement(ASTNode& parent);
-    NonnullRefPtr<BlockStatement> parse_block_statement(ASTNode& parent);
-    NonnullRefPtr<Comment> parse_comment(ASTNode& parent);
-    NonnullRefPtr<IfStatement> parse_if_statement(ASTNode& parent);
-    NonnullRefPtr<NamespaceDeclaration> parse_namespace_declaration(ASTNode& parent, bool is_nested_namespace = false);
-    NonnullRefPtrVector<Declaration> parse_declarations_in_translation_unit(ASTNode& parent);
-    RefPtr<Declaration> parse_single_declaration_in_translation_unit(ASTNode& parent);
-    NonnullRefPtrVector<Type> parse_template_arguments(ASTNode& parent);
-    NonnullRefPtr<Name> parse_name(ASTNode& parent);
-    NonnullRefPtr<CppCastExpression> parse_cpp_cast_expression(ASTNode& parent);
-    NonnullRefPtr<SizeofExpression> parse_sizeof_expression(ASTNode& parent);
-    NonnullRefPtr<BracedInitList> parse_braced_init_list(ASTNode& parent);
-    NonnullRefPtr<CStyleCastExpression> parse_c_style_cast_expression(ASTNode& parent);
-    NonnullRefPtrVector<Declaration> parse_class_members(StructOrClassDeclaration& parent);
-    NonnullRefPtr<Constructor> parse_constructor(ASTNode& parent);
-    NonnullRefPtr<Destructor> parse_destructor(ASTNode& parent);
-    NonnullRefPtr<UsingNamespaceDeclaration> parse_using_namespace_declaration(ASTNode& parent);
+    NonnullRefPtr<Declaration const> parse_declaration(ASTNode const& parent, DeclarationType);
+    NonnullRefPtr<FunctionDeclaration const> parse_function_declaration(ASTNode const& parent);
+    NonnullRefPtr<FunctionDefinition const> parse_function_definition(ASTNode const& parent);
+    NonnullRefPtr<Statement const> parse_statement(ASTNode const& parent);
+    NonnullRefPtr<VariableDeclaration const> parse_variable_declaration(ASTNode const& parent, bool expect_semicolon = true);
+    NonnullRefPtr<Expression const> parse_expression(ASTNode const& parent);
+    NonnullRefPtr<Expression const> parse_primary_expression(ASTNode const& parent);
+    NonnullRefPtr<Expression const> parse_secondary_expression(ASTNode const& parent, NonnullRefPtr<Expression const> lhs);
+    NonnullRefPtr<StringLiteral const> parse_string_literal(ASTNode const& parent);
+    NonnullRefPtr<ReturnStatement const> parse_return_statement(ASTNode const& parent);
+    NonnullRefPtr<EnumDeclaration const> parse_enum_declaration(ASTNode const& parent);
+    NonnullRefPtr<StructOrClassDeclaration const> parse_class_declaration(ASTNode const& parent);
+    NonnullRefPtr<Expression const> parse_literal(ASTNode const& parent);
+    NonnullRefPtr<UnaryExpression const> parse_unary_expression(ASTNode const& parent);
+    NonnullRefPtr<BooleanLiteral const> parse_boolean_literal(ASTNode const& parent);
+    NonnullRefPtr<Type const> parse_type(ASTNode const& parent);
+    NonnullRefPtr<BinaryExpression const> parse_binary_expression(ASTNode const& parent, NonnullRefPtr<Expression const> lhs, BinaryOp);
+    NonnullRefPtr<AssignmentExpression const> parse_assignment_expression(ASTNode const& parent, NonnullRefPtr<Expression const> lhs, AssignmentOp);
+    NonnullRefPtr<ForStatement const> parse_for_statement(ASTNode const& parent);
+    NonnullRefPtr<BlockStatement const> parse_block_statement(ASTNode const& parent);
+    NonnullRefPtr<Comment const> parse_comment(ASTNode const& parent);
+    NonnullRefPtr<IfStatement const> parse_if_statement(ASTNode const& parent);
+    NonnullRefPtr<NamespaceDeclaration const> parse_namespace_declaration(ASTNode const& parent, bool is_nested_namespace = false);
+    NonnullRefPtrVector<Declaration const> parse_declarations_in_translation_unit(ASTNode const& parent);
+    RefPtr<Declaration const> parse_single_declaration_in_translation_unit(ASTNode const& parent);
+    NonnullRefPtrVector<Type const> parse_template_arguments(ASTNode const& parent);
+    NonnullRefPtr<Name const> parse_name(ASTNode const& parent);
+    NonnullRefPtr<CppCastExpression const> parse_cpp_cast_expression(ASTNode const& parent);
+    NonnullRefPtr<SizeofExpression const> parse_sizeof_expression(ASTNode const& parent);
+    NonnullRefPtr<BracedInitList const> parse_braced_init_list(ASTNode const& parent);
+    NonnullRefPtr<CStyleCastExpression const> parse_c_style_cast_expression(ASTNode const& parent);
+    NonnullRefPtrVector<Declaration const> parse_class_members(StructOrClassDeclaration& parent);
+    NonnullRefPtr<Constructor const> parse_constructor(ASTNode const& parent);
+    NonnullRefPtr<Destructor const> parse_destructor(ASTNode const& parent);
+    NonnullRefPtr<UsingNamespaceDeclaration const> parse_using_namespace_declaration(ASTNode const& parent);
 
     bool match(Token::Type);
     Token consume(Token::Type);
@@ -145,7 +145,7 @@ private:
 
     template<class T, class... Args>
     NonnullRefPtr<T>
-    create_ast_node(ASTNode& parent, Position const& start, Optional<Position> end, Args&&... args)
+    create_ast_node(ASTNode const& parent, Position const& start, Optional<Position> end, Args&&... args)
     {
         auto node = adopt_ref(*new T(&parent, start, end, m_filename, forward<Args>(args)...));
 

--- a/Userland/Libraries/LibGL/Shaders/Program.cpp
+++ b/Userland/Libraries/LibGL/Shaders/Program.cpp
@@ -57,7 +57,7 @@ ErrorOr<void> Program::link(GPU::Device& device)
     // Link vertex shader objects
 
     Vector<GLSL::ObjectFile const*> vertex_shader_object_files;
-    for (auto vertex_shader : m_vertex_shaders)
+    for (auto const& vertex_shader : m_vertex_shaders)
         vertex_shader_object_files.append(vertex_shader->object_file());
 
     auto linked_vertex_shader_or_error = linker.link(vertex_shader_object_files);

--- a/Userland/Libraries/LibGL/Shaders/Program.h
+++ b/Userland/Libraries/LibGL/Shaders/Program.h
@@ -32,13 +32,13 @@ public:
 
 private:
     bool m_link_status { false };
-    Vector<NonnullRefPtr<Shader>> m_vertex_shaders;
-    Vector<NonnullRefPtr<Shader>> m_fragment_shaders;
+    Vector<NonnullRefPtr<Shader const>> m_vertex_shaders;
+    Vector<NonnullRefPtr<Shader const>> m_fragment_shaders;
     Optional<String> m_info_log;
     OwnPtr<GLSL::LinkedShader> m_linked_vertex_shader;
     OwnPtr<GLSL::LinkedShader> m_linked_fragment_shader;
-    RefPtr<GPU::Shader> m_gpu_vertex_shader;
-    RefPtr<GPU::Shader> m_gpu_fragment_shader;
+    RefPtr<GPU::Shader const> m_gpu_vertex_shader;
+    RefPtr<GPU::Shader const> m_gpu_fragment_shader;
 };
 
 }

--- a/Userland/Libraries/LibGUI/AboutDialog.h
+++ b/Userland/Libraries/LibGUI/AboutDialog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -31,7 +31,7 @@ private:
     AboutDialog(StringView name, StringView version, Gfx::Bitmap const* icon = nullptr, Window* parent_window = nullptr);
 
     DeprecatedString m_name;
-    RefPtr<Gfx::Bitmap> m_icon;
+    RefPtr<Gfx::Bitmap const> m_icon;
     DeprecatedString m_version_string;
 };
 }

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
@@ -67,7 +67,7 @@ void AbstractThemePreview::load_theme_bitmaps()
     load_bitmap(m_preview_palette.tooltip_shadow_path(), m_last_tooltip_shadow_path, m_tooltip_shadow);
 }
 
-void AbstractThemePreview::set_preview_palette(Gfx::Palette const& palette)
+void AbstractThemePreview::set_preview_palette(Gfx::Palette& palette)
 {
     m_preview_palette = palette;
     palette_changed();

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.h
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.h
@@ -22,8 +22,8 @@ class AbstractThemePreview : public GUI::Frame {
 public:
     virtual ~AbstractThemePreview() override = default;
 
-    Gfx::Palette const& preview_palette() const { return m_preview_palette; }
-    void set_preview_palette(Gfx::Palette const&);
+    Gfx::Palette& preview_palette() { return m_preview_palette; }
+    void set_preview_palette(Gfx::Palette&);
     ErrorOr<void> set_theme_from_file(StringView path, NonnullOwnPtr<Core::File>);
     void set_theme(Core::AnonymousBuffer const&);
 

--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -221,7 +221,7 @@ void AbstractView::notify_selection_changed(Badge<ModelSelection>)
         update();
 }
 
-NonnullRefPtr<Gfx::Font> AbstractView::font_for_index(ModelIndex const& index) const
+NonnullRefPtr<Gfx::Font const> AbstractView::font_for_index(ModelIndex const& index) const
 {
     if (!model())
         return font();

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -109,7 +109,7 @@ public:
 
     void notify_selection_changed(Badge<ModelSelection>);
 
-    NonnullRefPtr<Gfx::Font> font_for_index(ModelIndex const&) const;
+    NonnullRefPtr<Gfx::Font const> font_for_index(ModelIndex const&) const;
 
     void set_key_column_and_sort_order(int column, SortOrder);
 

--- a/Userland/Libraries/LibGUI/AbstractZoomPanWidget.h
+++ b/Userland/Libraries/LibGUI/AbstractZoomPanWidget.h
@@ -78,7 +78,7 @@ private:
     float m_max_scale { 10.0f };
     float m_scale { 1.0f };
 
-    AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_saved_cursor { Gfx::StandardCursor::None };
+    AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> m_saved_cursor { Gfx::StandardCursor::None };
 };
 
 }

--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -18,7 +18,7 @@ NonnullRefPtr<Action> Action::create(DeprecatedString text, Function<void(Action
     return adopt_ref(*new Action(move(text), move(callback), parent));
 }
 
-NonnullRefPtr<Action> Action::create(DeprecatedString text, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent)
+NonnullRefPtr<Action> Action::create(DeprecatedString text, RefPtr<Gfx::Bitmap const> icon, Function<void(Action&)> callback, Core::Object* parent)
 {
     return adopt_ref(*new Action(move(text), move(icon), move(callback), parent));
 }
@@ -33,12 +33,12 @@ NonnullRefPtr<Action> Action::create(DeprecatedString text, Shortcut const& shor
     return adopt_ref(*new Action(move(text), shortcut, alternate_shortcut, move(callback), parent));
 }
 
-NonnullRefPtr<Action> Action::create(DeprecatedString text, Shortcut const& shortcut, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent)
+NonnullRefPtr<Action> Action::create(DeprecatedString text, Shortcut const& shortcut, RefPtr<Gfx::Bitmap const> icon, Function<void(Action&)> callback, Core::Object* parent)
 {
     return adopt_ref(*new Action(move(text), shortcut, Shortcut {}, move(icon), move(callback), parent));
 }
 
-NonnullRefPtr<Action> Action::create(DeprecatedString text, Shortcut const& shortcut, Shortcut const& alternate_shortcut, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent)
+NonnullRefPtr<Action> Action::create(DeprecatedString text, Shortcut const& shortcut, Shortcut const& alternate_shortcut, RefPtr<Gfx::Bitmap const> icon, Function<void(Action&)> callback, Core::Object* parent)
 {
     return adopt_ref(*new Action(move(text), shortcut, alternate_shortcut, move(icon), move(callback), parent));
 }
@@ -48,7 +48,7 @@ NonnullRefPtr<Action> Action::create_checkable(DeprecatedString text, Function<v
     return adopt_ref(*new Action(move(text), move(callback), parent, true));
 }
 
-NonnullRefPtr<Action> Action::create_checkable(DeprecatedString text, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent)
+NonnullRefPtr<Action> Action::create_checkable(DeprecatedString text, RefPtr<Gfx::Bitmap const> icon, Function<void(Action&)> callback, Core::Object* parent)
 {
     return adopt_ref(*new Action(move(text), move(icon), move(callback), parent, true));
 }
@@ -58,7 +58,7 @@ NonnullRefPtr<Action> Action::create_checkable(DeprecatedString text, Shortcut c
     return adopt_ref(*new Action(move(text), shortcut, move(callback), parent, true));
 }
 
-NonnullRefPtr<Action> Action::create_checkable(DeprecatedString text, Shortcut const& shortcut, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent)
+NonnullRefPtr<Action> Action::create_checkable(DeprecatedString text, Shortcut const& shortcut, RefPtr<Gfx::Bitmap const> icon, Function<void(Action&)> callback, Core::Object* parent)
 {
     return adopt_ref(*new Action(move(text), shortcut, Shortcut {}, move(icon), move(callback), parent, true));
 }
@@ -86,7 +86,7 @@ Action::Action(DeprecatedString text, Function<void(Action&)> on_activation_call
 {
 }
 
-Action::Action(DeprecatedString text, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> on_activation_callback, Core::Object* parent, bool checkable)
+Action::Action(DeprecatedString text, RefPtr<Gfx::Bitmap const> icon, Function<void(Action&)> on_activation_callback, Core::Object* parent, bool checkable)
     : Action(move(text), Shortcut {}, Shortcut {}, move(icon), move(on_activation_callback), parent, checkable)
 {
 }
@@ -101,7 +101,7 @@ Action::Action(DeprecatedString text, Shortcut const& shortcut, Shortcut const& 
 {
 }
 
-Action::Action(DeprecatedString text, Shortcut const& shortcut, Shortcut const& alternate_shortcut, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> on_activation_callback, Core::Object* parent, bool checkable)
+Action::Action(DeprecatedString text, Shortcut const& shortcut, Shortcut const& alternate_shortcut, RefPtr<Gfx::Bitmap const> icon, Function<void(Action&)> on_activation_callback, Core::Object* parent, bool checkable)
     : Core::Object(parent)
     , on_activation(move(on_activation_callback))
     , m_text(move(text))

--- a/Userland/Libraries/LibGUI/Action.h
+++ b/Userland/Libraries/LibGUI/Action.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -66,15 +66,15 @@ public:
         ApplicationGlobal,
     };
     static NonnullRefPtr<Action> create(DeprecatedString text, Function<void(Action&)> callback, Core::Object* parent = nullptr);
-    static NonnullRefPtr<Action> create(DeprecatedString text, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent = nullptr);
+    static NonnullRefPtr<Action> create(DeprecatedString text, RefPtr<Gfx::Bitmap const> icon, Function<void(Action&)> callback, Core::Object* parent = nullptr);
     static NonnullRefPtr<Action> create(DeprecatedString text, Shortcut const& shortcut, Function<void(Action&)> callback, Core::Object* parent = nullptr);
     static NonnullRefPtr<Action> create(DeprecatedString text, Shortcut const& shortcut, Shortcut const& alternate_shortcut, Function<void(Action&)> callback, Core::Object* parent = nullptr);
-    static NonnullRefPtr<Action> create(DeprecatedString text, Shortcut const& shortcut, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent = nullptr);
-    static NonnullRefPtr<Action> create(DeprecatedString text, Shortcut const& shortcut, Shortcut const& alternate_shortcut, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent = nullptr);
+    static NonnullRefPtr<Action> create(DeprecatedString text, Shortcut const& shortcut, RefPtr<Gfx::Bitmap const> icon, Function<void(Action&)> callback, Core::Object* parent = nullptr);
+    static NonnullRefPtr<Action> create(DeprecatedString text, Shortcut const& shortcut, Shortcut const& alternate_shortcut, RefPtr<Gfx::Bitmap const> icon, Function<void(Action&)> callback, Core::Object* parent = nullptr);
     static NonnullRefPtr<Action> create_checkable(DeprecatedString text, Function<void(Action&)> callback, Core::Object* parent = nullptr);
-    static NonnullRefPtr<Action> create_checkable(DeprecatedString text, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent = nullptr);
+    static NonnullRefPtr<Action> create_checkable(DeprecatedString text, RefPtr<Gfx::Bitmap const> icon, Function<void(Action&)> callback, Core::Object* parent = nullptr);
     static NonnullRefPtr<Action> create_checkable(DeprecatedString text, Shortcut const& shortcut, Function<void(Action&)> callback, Core::Object* parent = nullptr);
-    static NonnullRefPtr<Action> create_checkable(DeprecatedString text, Shortcut const& shortcut, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent = nullptr);
+    static NonnullRefPtr<Action> create_checkable(DeprecatedString text, Shortcut const& shortcut, RefPtr<Gfx::Bitmap const> icon, Function<void(Action&)> callback, Core::Object* parent = nullptr);
 
     static ErrorOr<NonnullRefPtr<Action>> try_create_checkable(DeprecatedString text, Shortcut const& shortcut, Function<void(Action&)> callback, Core::Object* parent = nullptr);
 
@@ -135,8 +135,8 @@ private:
     Action(DeprecatedString, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);
     Action(DeprecatedString, Shortcut const&, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);
     Action(DeprecatedString, Shortcut const&, Shortcut const&, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);
-    Action(DeprecatedString, Shortcut const&, Shortcut const&, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);
-    Action(DeprecatedString, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);
+    Action(DeprecatedString, Shortcut const&, Shortcut const&, RefPtr<Gfx::Bitmap const> icon, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);
+    Action(DeprecatedString, RefPtr<Gfx::Bitmap const> icon, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);
 
     template<typename Callback>
     void for_each_toolbar_button(Callback);
@@ -145,7 +145,7 @@ private:
 
     DeprecatedString m_text;
     DeprecatedString m_status_tip;
-    RefPtr<Gfx::Bitmap> m_icon;
+    RefPtr<Gfx::Bitmap const> m_icon;
     Shortcut m_shortcut;
     Shortcut m_alternate_shortcut;
     bool m_enabled { true };

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -211,7 +211,7 @@ void Application::set_system_palette(Core::AnonymousBuffer& buffer)
         m_palette = m_system_palette;
 }
 
-void Application::set_palette(Palette const& palette)
+void Application::set_palette(Palette& palette)
 {
     m_palette = palette.impl();
 }

--- a/Userland/Libraries/LibGUI/Application.h
+++ b/Userland/Libraries/LibGUI/Application.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -41,7 +41,7 @@ public:
     void show_tooltip(DeprecatedString, Widget const* tooltip_source_widget);
     void show_tooltip_immediately(DeprecatedString, Widget const* tooltip_source_widget);
     void hide_tooltip();
-    Widget* tooltip_source_widget() { return m_tooltip_source_widget; };
+    Widget const* tooltip_source_widget() { return m_tooltip_source_widget; };
 
     bool quit_when_last_window_deleted() const { return m_quit_when_last_window_deleted; }
     void set_quit_when_last_window_deleted(bool b) { m_quit_when_last_window_deleted = b; }
@@ -53,7 +53,7 @@ public:
     Vector<DeprecatedString> const& args() const { return m_args; }
 
     Gfx::Palette palette() const;
-    void set_palette(Gfx::Palette const&);
+    void set_palette(Gfx::Palette&);
 
     void set_system_palette(Core::AnonymousBuffer&);
 
@@ -110,7 +110,7 @@ private:
     RefPtr<Core::Timer> m_tooltip_show_timer;
     RefPtr<Core::Timer> m_tooltip_hide_timer;
     RefPtr<TooltipWindow> m_tooltip_window;
-    RefPtr<Widget> m_tooltip_source_widget;
+    RefPtr<Widget const> m_tooltip_source_widget;
     WeakPtr<Window> m_active_window;
     bool m_quit_when_last_window_deleted { true };
     bool m_focus_debugging_enabled { false };

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -89,18 +89,15 @@ void Button::paint_event(PaintEvent& event)
             // Reusing that threshold here as it seems to work reasonably well.
             should_invert_icon = contrast_ratio < 4.5f && contrast_ratio < palette().button().contrast_ratio(solid_color->inverted());
         }
-        if (should_invert_icon)
-            m_icon->invert();
+        auto icon = should_invert_icon ? m_icon->inverted().release_value_but_fixme_should_propagate_errors() : NonnullRefPtr { *m_icon };
         if (is_enabled()) {
             if (is_hovered())
-                painter.blit_brightened(icon_location, *m_icon, m_icon->rect());
+                painter.blit_brightened(icon_location, *icon, icon->rect());
             else
-                painter.blit(icon_location, *m_icon, m_icon->rect());
+                painter.blit(icon_location, *icon, icon->rect());
         } else {
-            painter.blit_disabled(icon_location, *m_icon, m_icon->rect(), palette());
+            painter.blit_disabled(icon_location, *icon, icon->rect(), palette());
         }
-        if (should_invert_icon)
-            m_icon->invert();
     }
     auto& font = is_checked() ? this->font().bold_variant() : this->font();
     if (m_icon && !text().is_empty()) {

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -178,7 +178,7 @@ void Button::set_action(Action& action)
         set_checked(action.is_checked());
 }
 
-void Button::set_icon(RefPtr<Gfx::Bitmap> icon)
+void Button::set_icon(RefPtr<Gfx::Bitmap const> icon)
 {
     if (m_icon == icon)
         return;

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -28,10 +28,9 @@ public:
 
     virtual ~Button() override;
 
-    void set_icon(RefPtr<Gfx::Bitmap>);
+    void set_icon(RefPtr<Gfx::Bitmap const>);
     void set_icon_from_path(DeprecatedString const&);
     Gfx::Bitmap const* icon() const { return m_icon.ptr(); }
-    Gfx::Bitmap* icon() { return m_icon.ptr(); }
 
     void set_text_alignment(Gfx::TextAlignment text_alignment) { m_text_alignment = text_alignment; }
     Gfx::TextAlignment text_alignment() const { return m_text_alignment; }
@@ -78,7 +77,7 @@ protected:
 private:
     virtual void timer_event(Core::TimerEvent&) override;
 
-    RefPtr<Gfx::Bitmap> m_icon;
+    RefPtr<Gfx::Bitmap const> m_icon;
     RefPtr<GUI::Menu> m_menu;
     Gfx::ButtonStyle m_button_style { Gfx::ButtonStyle::Normal };
     Gfx::TextAlignment m_text_alignment { Gfx::TextAlignment::Center };

--- a/Userland/Libraries/LibGUI/Desktop.cpp
+++ b/Userland/Libraries/LibGUI/Desktop.cpp
@@ -59,7 +59,7 @@ RefPtr<Gfx::Bitmap> Desktop::wallpaper_bitmap() const
     return ConnectionToWindowServer::the().get_wallpaper().bitmap();
 }
 
-bool Desktop::set_wallpaper(RefPtr<Gfx::Bitmap> wallpaper_bitmap, Optional<DeprecatedString> path)
+bool Desktop::set_wallpaper(RefPtr<Gfx::Bitmap const> wallpaper_bitmap, Optional<DeprecatedString> path)
 {
     if (m_is_setting_desktop_wallpaper)
         return false;

--- a/Userland/Libraries/LibGUI/Desktop.h
+++ b/Userland/Libraries/LibGUI/Desktop.h
@@ -33,7 +33,7 @@ public:
 
     DeprecatedString wallpaper_path() const;
     RefPtr<Gfx::Bitmap> wallpaper_bitmap() const;
-    bool set_wallpaper(RefPtr<Gfx::Bitmap> wallpaper_bitmap, Optional<DeprecatedString> path);
+    bool set_wallpaper(RefPtr<Gfx::Bitmap const> wallpaper_bitmap, Optional<DeprecatedString> path);
 
     void set_system_effects(Vector<bool> effects) { m_system_effects = { effects }; };
     SystemEffects const& system_effects() const { return m_system_effects; }

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -46,7 +46,7 @@ static constexpr auto s_emoji_groups = Array {
     EmojiCateogry { Unicode::EmojiGroup::SerenityOS, 0x10CD0B },
 };
 
-static void resize_bitmap_if_needed(RefPtr<Gfx::Bitmap>& bitmap)
+static void resize_bitmap_if_needed(RefPtr<Gfx::Bitmap const>& bitmap)
 {
     constexpr int max_icon_size = 12;
 
@@ -74,7 +74,7 @@ private:
         if (m_first_paint_event) {
             m_first_paint_event = false;
 
-            RefPtr<Gfx::Bitmap> bitmap = Gfx::Emoji::emoji_for_code_points(m_emoji_code_points);
+            RefPtr<Gfx::Bitmap const> bitmap = Gfx::Emoji::emoji_for_code_points(m_emoji_code_points);
             VERIFY(bitmap);
 
             resize_bitmap_if_needed(bitmap);
@@ -113,7 +113,7 @@ EmojiInputDialog::EmojiInputDialog(Window* parent_window)
         auto name = Unicode::emoji_group_to_string(category.group);
         auto tooltip = name.replace("&"sv, "&&"sv, ReplaceMode::FirstOnly);
 
-        RefPtr<Gfx::Bitmap> bitmap = Gfx::Emoji::emoji_for_code_point(category.emoji_code_point);
+        RefPtr<Gfx::Bitmap const> bitmap = Gfx::Emoji::emoji_for_code_point(category.emoji_code_point);
         VERIFY(bitmap);
         resize_bitmap_if_needed(bitmap);
 

--- a/Userland/Libraries/LibGUI/Event.cpp
+++ b/Userland/Libraries/LibGUI/Event.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -12,7 +12,7 @@
 
 namespace GUI {
 
-DropEvent::DropEvent(Gfx::IntPoint position, DeprecatedString const& text, NonnullRefPtr<Core::MimeData> mime_data)
+DropEvent::DropEvent(Gfx::IntPoint position, DeprecatedString const& text, NonnullRefPtr<Core::MimeData const> mime_data)
     : Event(Event::Drop)
     , m_position(position)
     , m_text(text)

--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -229,7 +229,7 @@ public:
     Gfx::Bitmap const* bitmap() const { return m_bitmap; }
 
 private:
-    RefPtr<Gfx::Bitmap> m_bitmap;
+    RefPtr<Gfx::Bitmap const> m_bitmap;
 };
 
 class WMWorkspaceChangedEvent : public WMEvent {
@@ -477,7 +477,7 @@ private:
 
 class DropEvent final : public Event {
 public:
-    DropEvent(Gfx::IntPoint, DeprecatedString const& text, NonnullRefPtr<Core::MimeData> mime_data);
+    DropEvent(Gfx::IntPoint, DeprecatedString const& text, NonnullRefPtr<Core::MimeData const> mime_data);
 
     ~DropEvent() = default;
 
@@ -488,7 +488,7 @@ public:
 private:
     Gfx::IntPoint m_position;
     DeprecatedString m_text;
-    NonnullRefPtr<Core::MimeData> m_mime_data;
+    NonnullRefPtr<Core::MimeData const> m_mime_data;
 };
 
 class ThemeChangeEvent final : public Event {

--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -205,7 +205,7 @@ Icon FileIconProvider::icon_for_executable(DeprecatedString const& path)
     for (auto const& icon_section : icon_sections) {
         auto section = image.lookup_section(icon_section.section_name);
 
-        RefPtr<Gfx::Bitmap> bitmap;
+        RefPtr<Gfx::Bitmap const> bitmap;
         if (!section.has_value()) {
             bitmap = s_executable_icon.bitmap_for_size(icon_section.image_size);
         } else {

--- a/Userland/Libraries/LibGUI/FontPicker.h
+++ b/Userland/Libraries/LibGUI/FontPicker.h
@@ -19,7 +19,7 @@ class FontPicker final : public GUI::Dialog {
 public:
     virtual ~FontPicker() override = default;
 
-    RefPtr<Gfx::Font> font() const { return m_font; }
+    RefPtr<Gfx::Font const> font() const { return m_font; }
     void set_font(Gfx::Font const*);
 
 private:
@@ -29,7 +29,7 @@ private:
 
     bool const m_fixed_width_only;
 
-    RefPtr<Gfx::Font> m_font;
+    RefPtr<Gfx::Font const> m_font;
 
     RefPtr<ListView> m_family_list_view;
     RefPtr<ListView> m_variant_list_view;

--- a/Userland/Libraries/LibGUI/GML/AST.h
+++ b/Userland/Libraries/LibGUI/GML/AST.h
@@ -152,7 +152,7 @@ public:
 class Object : public ValueNode {
 public:
     Object() = default;
-    Object(DeprecatedString name, NonnullRefPtrVector<Node> properties, NonnullRefPtrVector<Node> sub_objects)
+    Object(DeprecatedString name, NonnullRefPtrVector<Node const> properties, NonnullRefPtrVector<Node const> sub_objects)
         : m_properties(move(properties))
         , m_sub_objects(move(sub_objects))
         , m_name(move(name))
@@ -164,13 +164,13 @@ public:
     StringView name() const { return m_name; }
     void set_name(DeprecatedString name) { m_name = move(name); }
 
-    ErrorOr<void> add_sub_object_child(NonnullRefPtr<Node> child)
+    ErrorOr<void> add_sub_object_child(NonnullRefPtr<Node const> child)
     {
         VERIFY(is<Object>(child.ptr()) || is<Comment>(child.ptr()));
         return m_sub_objects.try_append(move(child));
     }
 
-    ErrorOr<void> add_property_child(NonnullRefPtr<Node> child)
+    ErrorOr<void> add_property_child(NonnullRefPtr<Node const> child)
     {
         VERIFY(is<KeyValuePair>(child.ptr()) || is<Comment>(child.ptr()));
         return m_properties.try_append(move(child));
@@ -178,7 +178,7 @@ public:
 
     // Does not return key-value pair `layout: ...`!
     template<typename Callback>
-    void for_each_property(Callback callback)
+    void for_each_property(Callback callback) const
     {
         for (auto const& child : m_properties) {
             if (is<KeyValuePair>(child)) {
@@ -190,52 +190,51 @@ public:
     }
 
     template<typename Callback>
-    void for_each_child_object(Callback callback)
+    void for_each_child_object(Callback callback) const
     {
-        for (NonnullRefPtr<Node> child : m_sub_objects) {
+        for (NonnullRefPtr<Node const> child : m_sub_objects) {
             // doesn't capture layout as intended, as that's behind a kv-pair
             if (is<Object>(child.ptr())) {
-                auto object = static_ptr_cast<Object>(child);
+                auto object = static_ptr_cast<Object const>(child);
                 callback(object);
             }
         }
     }
 
     template<FallibleFunction<NonnullRefPtr<Object>> Callback>
-    ErrorOr<void> try_for_each_child_object(Callback callback)
+    ErrorOr<void> try_for_each_child_object(Callback callback) const
     {
-        for (NonnullRefPtr<Node> child : m_sub_objects) {
+        for (auto const& child : m_sub_objects) {
             // doesn't capture layout as intended, as that's behind a kv-pair
-            if (is<Object>(child.ptr())) {
-                auto object = static_ptr_cast<Object>(child);
-                TRY(callback(object));
+            if (is<Object>(child)) {
+                TRY(callback(static_cast<Object const&>(child)));
             }
         }
 
         return {};
     }
 
-    RefPtr<Object> layout_object() const
+    RefPtr<Object const> layout_object() const
     {
-        for (NonnullRefPtr<Node> child : m_properties) {
-            if (is<KeyValuePair>(child.ptr())) {
-                auto property = static_ptr_cast<KeyValuePair>(child);
-                if (property->key() == "layout") {
-                    VERIFY(is<Object>(property->value().ptr()));
-                    return static_ptr_cast<Object>(property->value());
+        for (auto const& child : m_properties) {
+            if (is<KeyValuePair>(child)) {
+                auto const& property = static_cast<KeyValuePair const&>(child);
+                if (property.key() == "layout") {
+                    VERIFY(is<Object>(property.value().ptr()));
+                    return static_cast<Object const&>(*property.value());
                 }
             }
         }
         return nullptr;
     }
 
-    RefPtr<ValueNode> get_property(StringView property_name)
+    RefPtr<ValueNode const> get_property(StringView property_name) const
     {
-        for (NonnullRefPtr<Node> child : m_properties) {
-            if (is<KeyValuePair>(child.ptr())) {
-                auto property = static_ptr_cast<KeyValuePair>(child);
-                if (property->key() == property_name)
-                    return property->value();
+        for (auto const& child : m_properties) {
+            if (is<KeyValuePair>(child)) {
+                auto const& property = static_cast<KeyValuePair const&>(child);
+                if (property.key() == property_name)
+                    return property.value();
             }
         }
         return nullptr;
@@ -275,9 +274,9 @@ public:
 
 private:
     // Properties and comments
-    NonnullRefPtrVector<Node> m_properties;
+    NonnullRefPtrVector<Node const> m_properties;
     // Sub objects and comments
-    NonnullRefPtrVector<Node> m_sub_objects;
+    NonnullRefPtrVector<Node const> m_sub_objects;
     DeprecatedString m_name {};
 };
 
@@ -285,14 +284,14 @@ class GMLFile : public Node {
 public:
     virtual ~GMLFile() override = default;
 
-    ErrorOr<void> add_child(NonnullRefPtr<Node> child)
+    ErrorOr<void> add_child(NonnullRefPtr<Node const> child)
     {
         if (!has_main_class()) {
             if (is<Comment>(child.ptr())) {
-                return m_leading_comments.try_append(*static_ptr_cast<Comment>(child));
+                return m_leading_comments.try_append(*static_ptr_cast<Comment const>(child));
             }
             if (is<Object>(child.ptr())) {
-                m_main_class = static_ptr_cast<Object>(child);
+                m_main_class = static_ptr_cast<Object const>(child);
                 return {};
             }
             return Error::from_string_literal("Unexpected data before main class");
@@ -300,18 +299,18 @@ public:
         // After the main class, only comments are allowed.
         if (!is<Comment>(child.ptr()))
             return Error::from_string_literal("Data not allowed after main class");
-        return m_trailing_comments.try_append(*static_ptr_cast<Comment>(child));
+        return m_trailing_comments.try_append(*static_ptr_cast<Comment const>(child));
     }
 
     bool has_main_class() const { return m_main_class != nullptr; }
 
-    NonnullRefPtrVector<Comment> leading_comments() const { return m_leading_comments; }
-    Object& main_class()
+    NonnullRefPtrVector<Comment const> leading_comments() const { return m_leading_comments; }
+    Object const& main_class() const
     {
         VERIFY(!m_main_class.is_null());
         return *m_main_class.ptr();
     }
-    NonnullRefPtrVector<Comment> trailing_comments() const { return m_trailing_comments; }
+    NonnullRefPtrVector<Comment const> trailing_comments() const { return m_trailing_comments; }
 
     virtual void format(StringBuilder& builder, size_t indentation, [[maybe_unused]] bool is_inline) const override
     {
@@ -329,9 +328,9 @@ public:
     }
 
 private:
-    NonnullRefPtrVector<Comment> m_leading_comments;
-    RefPtr<Object> m_main_class;
-    NonnullRefPtrVector<Comment> m_trailing_comments;
+    NonnullRefPtrVector<Comment const> m_leading_comments;
+    RefPtr<Object const> m_main_class;
+    NonnullRefPtrVector<Comment const> m_trailing_comments;
 };
 
 }

--- a/Userland/Libraries/LibGUI/GML/Parser.cpp
+++ b/Userland/Libraries/LibGUI/GML/Parser.cpp
@@ -82,7 +82,7 @@ static ErrorOr<NonnullRefPtr<Object>> parse_gml_object(Queue<Token>& tokens)
                 else if (peek() == Token::Type::JsonValue)
                     value = TRY(try_make_ref_counted<JsonValueNode>(TRY(JsonValueNode::from_string(tokens.dequeue().m_view))));
 
-                auto property = TRY(try_make_ref_counted<KeyValuePair>(property_name.m_view, value.release_nonnull()));
+                auto property = TRY(try_make_ref_counted<KeyValuePair const>(property_name.m_view, value.release_nonnull()));
                 TRY(object->add_property_child(property));
             } else if (peek() == Token::Type::Comment) {
                 pending_comments.append(TRY(Node::from_token<Comment>(tokens.dequeue())));

--- a/Userland/Libraries/LibGUI/Icon.cpp
+++ b/Userland/Libraries/LibGUI/Icon.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Julius Heijmen <julius.heijmen@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -26,7 +26,7 @@ Icon::Icon(Icon const& other)
 {
 }
 
-Icon::Icon(RefPtr<Gfx::Bitmap>&& bitmap)
+Icon::Icon(RefPtr<Gfx::Bitmap const>&& bitmap)
     : Icon()
 {
     if (bitmap) {
@@ -36,7 +36,7 @@ Icon::Icon(RefPtr<Gfx::Bitmap>&& bitmap)
     }
 }
 
-Icon::Icon(RefPtr<Gfx::Bitmap>&& bitmap1, RefPtr<Gfx::Bitmap>&& bitmap2)
+Icon::Icon(RefPtr<Gfx::Bitmap const>&& bitmap1, RefPtr<Gfx::Bitmap const>&& bitmap2)
     : Icon(move(bitmap1))
 {
     if (bitmap2) {
@@ -64,7 +64,7 @@ Gfx::Bitmap const* IconImpl::bitmap_for_size(int size) const
     return best_fit;
 }
 
-void IconImpl::set_bitmap_for_size(int size, RefPtr<Gfx::Bitmap>&& bitmap)
+void IconImpl::set_bitmap_for_size(int size, RefPtr<Gfx::Bitmap const>&& bitmap)
 {
     if (!bitmap) {
         m_bitmaps.remove(size);

--- a/Userland/Libraries/LibGUI/Icon.h
+++ b/Userland/Libraries/LibGUI/Icon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Julius Heijmen <julius.heijmen@gmail.com>
  * Copyright (c) 2022, the SerenityOS developers.
  *
@@ -21,7 +21,7 @@ public:
     ~IconImpl() = default;
 
     Gfx::Bitmap const* bitmap_for_size(int) const;
-    void set_bitmap_for_size(int, RefPtr<Gfx::Bitmap>&&);
+    void set_bitmap_for_size(int, RefPtr<Gfx::Bitmap const>&&);
 
     Vector<int> sizes() const
     {
@@ -33,14 +33,14 @@ public:
 
 private:
     IconImpl() = default;
-    HashMap<int, RefPtr<Gfx::Bitmap>> m_bitmaps;
+    HashMap<int, RefPtr<Gfx::Bitmap const>> m_bitmaps;
 };
 
 class Icon {
 public:
     Icon();
-    explicit Icon(RefPtr<Gfx::Bitmap>&&);
-    explicit Icon(RefPtr<Gfx::Bitmap>&&, RefPtr<Gfx::Bitmap>&&);
+    explicit Icon(RefPtr<Gfx::Bitmap const>&&);
+    explicit Icon(RefPtr<Gfx::Bitmap const>&&, RefPtr<Gfx::Bitmap const>&&);
     explicit Icon(IconImpl const&);
     Icon(Icon const&);
     ~Icon() = default;
@@ -56,7 +56,7 @@ public:
     }
 
     Gfx::Bitmap const* bitmap_for_size(int size) const { return m_impl->bitmap_for_size(size); }
-    void set_bitmap_for_size(int size, RefPtr<Gfx::Bitmap>&& bitmap) { m_impl->set_bitmap_for_size(size, move(bitmap)); }
+    void set_bitmap_for_size(int size, RefPtr<Gfx::Bitmap const>&& bitmap) { m_impl->set_bitmap_for_size(size, move(bitmap)); }
 
     IconImpl const& impl() const { return *m_impl; }
 

--- a/Userland/Libraries/LibGUI/ImageWidget.h
+++ b/Userland/Libraries/LibGUI/ImageWidget.h
@@ -19,7 +19,6 @@ public:
     virtual ~ImageWidget() override = default;
 
     void set_bitmap(Gfx::Bitmap const*);
-    Gfx::Bitmap* bitmap() { return m_bitmap.ptr(); }
     Gfx::Bitmap const* bitmap() const { return m_bitmap.ptr(); }
 
     void set_should_stretch(bool value) { m_should_stretch = value; }
@@ -43,7 +42,7 @@ protected:
     virtual void paint_event(PaintEvent&) override;
 
 private:
-    RefPtr<Gfx::Bitmap> m_bitmap;
+    RefPtr<Gfx::Bitmap const> m_bitmap;
     bool m_should_stretch { false };
     bool m_auto_resize { false };
 

--- a/Userland/Libraries/LibGUI/Label.h
+++ b/Userland/Libraries/LibGUI/Label.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -25,7 +25,6 @@ public:
     void set_icon(Gfx::Bitmap const*);
     void set_icon_from_path(DeprecatedString const&);
     Gfx::Bitmap const* icon() const { return m_icon.ptr(); }
-    Gfx::Bitmap* icon() { return m_icon.ptr(); }
 
     Gfx::TextAlignment text_alignment() const { return m_text_alignment; }
     void set_text_alignment(Gfx::TextAlignment text_alignment) { m_text_alignment = text_alignment; }
@@ -54,7 +53,7 @@ private:
     void size_to_fit();
 
     DeprecatedString m_text;
-    RefPtr<Gfx::Bitmap> m_icon;
+    RefPtr<Gfx::Bitmap const> m_icon;
     Gfx::TextAlignment m_text_alignment { Gfx::TextAlignment::Center };
     Gfx::TextWrapping m_text_wrapping { Gfx::TextWrapping::Wrap };
     bool m_should_stretch_icon { false };

--- a/Userland/Libraries/LibGUI/Menu.h
+++ b/Userland/Libraries/LibGUI/Menu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -74,7 +74,7 @@ private:
 
     int m_menu_id { -1 };
     DeprecatedString m_name;
-    RefPtr<Gfx::Bitmap> m_icon;
+    RefPtr<Gfx::Bitmap const> m_icon;
     NonnullOwnPtrVector<MenuItem> m_items;
     WeakPtr<Action> m_current_default_action;
     bool m_visible { false };

--- a/Userland/Libraries/LibGUI/Model.cpp
+++ b/Userland/Libraries/LibGUI/Model.cpp
@@ -100,7 +100,7 @@ WeakPtr<PersistentHandle> Model::register_persistent_index(Badge<PersistentModel
 RefPtr<Core::MimeData> Model::mime_data(ModelSelection const& selection) const
 {
     auto mime_data = Core::MimeData::construct();
-    RefPtr<Gfx::Bitmap> bitmap;
+    RefPtr<Gfx::Bitmap const> bitmap;
 
     StringBuilder text_builder;
     StringBuilder data_builder;

--- a/Userland/Libraries/LibGUI/Notification.h
+++ b/Userland/Libraries/LibGUI/Notification.h
@@ -57,7 +57,7 @@ private:
     bool m_title_dirty;
     DeprecatedString m_text;
     bool m_text_dirty;
-    RefPtr<Gfx::Bitmap> m_icon;
+    RefPtr<Gfx::Bitmap const> m_icon;
     bool m_icon_dirty;
 
     bool m_destroyed { false };

--- a/Userland/Libraries/LibGUI/ProcessChooser.h
+++ b/Userland/Libraries/LibGUI/ProcessChooser.h
@@ -31,7 +31,7 @@ private:
 
     DeprecatedString m_window_title;
     String m_button_label;
-    RefPtr<Gfx::Bitmap> m_window_icon;
+    RefPtr<Gfx::Bitmap const> m_window_icon;
     RefPtr<TableView> m_table_view;
     RefPtr<RunningProcessesModel> m_process_model;
 

--- a/Userland/Libraries/LibGUI/RunningProcessesModel.h
+++ b/Userland/Libraries/LibGUI/RunningProcessesModel.h
@@ -38,7 +38,7 @@ private:
     struct Process {
         pid_t pid;
         uid_t uid;
-        RefPtr<Gfx::Bitmap> icon;
+        RefPtr<Gfx::Bitmap const> icon;
         DeprecatedString name;
     };
     Vector<Process> m_processes;

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -102,32 +102,32 @@ void ScrollableContainerWidget::set_widget(GUI::Widget* widget)
     update_widget_position();
 }
 
-ErrorOr<void> ScrollableContainerWidget::load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, UnregisteredChildHandler unregistered_child_handler)
+ErrorOr<void> ScrollableContainerWidget::load_from_gml_ast(NonnullRefPtr<GUI::GML::Node const> ast, UnregisteredChildHandler unregistered_child_handler)
 {
     if (is<GUI::GML::GMLFile>(ast.ptr()))
-        return load_from_gml_ast(static_ptr_cast<GUI::GML::GMLFile>(ast)->main_class(), unregistered_child_handler);
+        return load_from_gml_ast(static_cast<GUI::GML::GMLFile const&>(*ast).main_class(), unregistered_child_handler);
 
     VERIFY(is<GUI::GML::Object>(ast.ptr()));
-    auto object = static_ptr_cast<GUI::GML::Object>(ast);
+    auto const& object = static_cast<GUI::GML::Object const&>(*ast);
 
-    object->for_each_property([&](auto key, auto value) {
+    object.for_each_property([&](auto key, auto value) {
         set_property(key, value);
     });
 
-    auto content_widget_value = object->get_property("content_widget"sv);
+    auto content_widget_value = object.get_property("content_widget"sv);
     if (!content_widget_value.is_null() && !is<GUI::GML::Object>(content_widget_value.ptr())) {
         return Error::from_string_literal("ScrollableContainerWidget content_widget is not an object");
     }
 
     auto has_children = false;
-    object->for_each_child_object([&](auto) { has_children = true; });
+    object.for_each_child_object([&](auto) { has_children = true; });
     if (has_children) {
         return Error::from_string_literal("Children specified for ScrollableContainerWidget, but only 1 widget as content_widget is supported");
     }
 
     if (!content_widget_value.is_null() && is<GUI::GML::Object>(content_widget_value.ptr())) {
-        auto content_widget = static_ptr_cast<GUI::GML::Object>(content_widget_value);
-        auto class_name = content_widget->name();
+        auto const& content_widget = static_cast<GUI::GML::Object const&>(*content_widget_value);
+        auto class_name = content_widget.name();
 
         RefPtr<Core::Object> child;
         if (auto* registration = Core::ObjectClassRegistration::find(class_name)) {
@@ -139,7 +139,7 @@ ErrorOr<void> ScrollableContainerWidget::load_from_gml_ast(NonnullRefPtr<GUI::GM
             return Error::from_string_literal("Unable to construct a Widget class for ScrollableContainerWidget content_widget property");
         auto widget_ptr = verify_cast<GUI::Widget>(child.ptr());
         set_widget(widget_ptr);
-        TRY(static_ptr_cast<Widget>(child)->load_from_gml_ast(content_widget.release_nonnull(), unregistered_child_handler));
+        TRY(static_cast<Widget&>(*child).load_from_gml_ast(content_widget, unregistered_child_handler));
     }
 
     return {};

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
@@ -30,7 +30,7 @@ private:
     void update_widget_size();
     void update_widget_position();
     void update_widget_min_size();
-    virtual ErrorOr<void> load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, UnregisteredChildHandler) override;
+    virtual ErrorOr<void> load_from_gml_ast(NonnullRefPtr<GUI::GML::Node const> ast, UnregisteredChildHandler) override;
 
     ScrollableContainerWidget();
 

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Peter Elliott <pelliott@serenityos.org>
  * Copyright (c) 2022, Cameron Youell <cameronyouell@gmail.com>
  * Copyright (c) 2022, the SerenityOS developers.

--- a/Userland/Libraries/LibGUI/TabWidget.h
+++ b/Userland/Libraries/LibGUI/TabWidget.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -148,7 +148,7 @@ private:
     struct TabData {
         int width(Gfx::Font const&) const;
         DeprecatedString title;
-        RefPtr<Gfx::Bitmap> icon;
+        RefPtr<Gfx::Bitmap const> icon;
         Widget* widget { nullptr };
         bool modified { false };
     };

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, networkException <networkexception@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
@@ -562,12 +562,12 @@ void TextEditor::paint_event(PaintEvent& event)
                 auto unspanned_color = palette().color(is_enabled() ? foreground_role() : Gfx::ColorRole::DisabledText);
                 if (is_displayonly() && is_focused())
                     unspanned_color = palette().color(is_enabled() ? Gfx::ColorRole::SelectionText : Gfx::ColorRole::DisabledText);
-                RefPtr<Gfx::Font> unspanned_font = this->font();
+                RefPtr<Gfx::Font const> unspanned_font = this->font();
 
                 size_t next_column = 0;
                 Gfx::IntRect span_rect = { visual_line_rect.location(), { 0, line_height() } };
 
-                auto draw_text_helper = [&](size_t start, size_t end, RefPtr<Gfx::Font>& font, Gfx::TextAttributes text_attributes) {
+                auto draw_text_helper = [&](size_t start, size_t end, RefPtr<Gfx::Font const>& font, Gfx::TextAttributes text_attributes) {
                     size_t length = end - start;
                     if (length == 0)
                         return;

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
  *
@@ -438,7 +438,7 @@ private:
 
     Gfx::IntPoint m_last_mousemove_position;
 
-    RefPtr<Gfx::Bitmap> m_icon;
+    RefPtr<Gfx::Bitmap const> m_icon;
 
     bool m_text_is_secret { false };
 

--- a/Userland/Libraries/LibGUI/Tray.cpp
+++ b/Userland/Libraries/LibGUI/Tray.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -33,7 +33,7 @@ Gfx::IntRect Tray::Item::rect(Tray const& tray) const
     };
 }
 
-size_t Tray::add_item(DeprecatedString text, RefPtr<Gfx::Bitmap> bitmap, DeprecatedString custom_data)
+size_t Tray::add_item(DeprecatedString text, RefPtr<Gfx::Bitmap const> bitmap, DeprecatedString custom_data)
 {
     auto new_index = m_items.size();
 

--- a/Userland/Libraries/LibGUI/Tray.h
+++ b/Userland/Libraries/LibGUI/Tray.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -18,7 +18,7 @@ class Tray : public GUI::Frame {
 public:
     virtual ~Tray() override = default;
 
-    size_t add_item(DeprecatedString text, RefPtr<Gfx::Bitmap>, DeprecatedString custom_data);
+    size_t add_item(DeprecatedString text, RefPtr<Gfx::Bitmap const>, DeprecatedString custom_data);
 
     void set_item_checked(size_t index, bool);
 
@@ -39,7 +39,7 @@ private:
 
     struct Item {
         DeprecatedString text;
-        RefPtr<Gfx::Bitmap> bitmap;
+        RefPtr<Gfx::Bitmap const> bitmap;
         DeprecatedString custom_data;
         size_t index { 0 };
         Gfx::IntRect rect(Tray const&) const;

--- a/Userland/Libraries/LibGUI/TreeViewModel.h
+++ b/Userland/Libraries/LibGUI/TreeViewModel.h
@@ -49,7 +49,7 @@ public:
         requires(IsBaseOf<Node, NodeType>)
         {
             auto node = adopt_ref(*new NodeType(move(text), move(icon), this, forward<Args>(args)...));
-            m_child_nodes.append(*static_cast<Node const*>(node.ptr()));
+            m_child_nodes.append(*static_cast<Node*>(node.ptr()));
             return node;
         }
 
@@ -77,7 +77,7 @@ public:
     requires(IsBaseOf<Node, NodeType>)
     {
         auto node = adopt_ref(*new NodeType(move(text), move(icon), nullptr, forward<Args>(args)...));
-        m_nodes.append(*static_cast<Node const*>(node.ptr()));
+        m_nodes.append(*static_cast<Node*>(node.ptr()));
         return node;
     }
 

--- a/Userland/Libraries/LibGUI/Variant.h
+++ b/Userland/Libraries/LibGUI/Variant.h
@@ -21,7 +21,7 @@ namespace Detail {
 struct Boolean {
     bool value;
 };
-using VariantUnderlyingType = AK::Variant<Empty, Boolean, float, i32, i64, u32, u64, DeprecatedString, Color, Gfx::IntPoint, Gfx::IntSize, Gfx::IntRect, Gfx::TextAlignment, Gfx::ColorRole, Gfx::AlignmentRole, Gfx::FlagRole, Gfx::MetricRole, Gfx::PathRole, NonnullRefPtr<Gfx::Bitmap>, NonnullRefPtr<Gfx::Font>, GUI::Icon>;
+using VariantUnderlyingType = AK::Variant<Empty, Boolean, float, i32, i64, u32, u64, DeprecatedString, Color, Gfx::IntPoint, Gfx::IntSize, Gfx::IntRect, Gfx::TextAlignment, Gfx::ColorRole, Gfx::AlignmentRole, Gfx::FlagRole, Gfx::MetricRole, Gfx::PathRole, NonnullRefPtr<Gfx::Bitmap const>, NonnullRefPtr<Gfx::Font const>, GUI::Icon>;
 }
 
 class Variant : public Detail::VariantUnderlyingType {
@@ -57,7 +57,7 @@ public:
 
     template<OneOfIgnoringCV<Gfx::Bitmap, Gfx::Font> T>
     Variant(T const& value)
-        : Variant(NonnullRefPtr<RemoveCV<T>>(value))
+        : Variant(NonnullRefPtr<RemoveCV<T> const>(value))
     {
     }
     template<OneOfIgnoringCV<Gfx::Bitmap, Gfx::Font> T>
@@ -77,13 +77,13 @@ public:
     bool is_u64() const { return has<u64>(); }
     bool is_float() const { return has<float>(); }
     bool is_string() const { return has<DeprecatedString>(); }
-    bool is_bitmap() const { return has<NonnullRefPtr<Gfx::Bitmap>>(); }
+    bool is_bitmap() const { return has<NonnullRefPtr<Gfx::Bitmap const>>(); }
     bool is_color() const { return has<Color>(); }
     bool is_icon() const { return has<GUI::Icon>(); }
     bool is_point() const { return has<Gfx::IntPoint>(); }
     bool is_size() const { return has<Gfx::IntSize>(); }
     bool is_rect() const { return has<Gfx::IntRect>(); }
-    bool is_font() const { return has<NonnullRefPtr<Gfx::Font>>(); }
+    bool is_font() const { return has<NonnullRefPtr<Gfx::Font const>>(); }
     bool is_text_alignment() const { return has<Gfx::TextAlignment>(); }
     bool is_color_role() const { return has<Gfx::ColorRole>(); }
     bool is_alignment_role() const { return has<Gfx::AlignmentRole>(); }
@@ -103,7 +103,7 @@ public:
             [](Gfx::IntPoint const& v) { return !v.is_zero(); },
             [](OneOf<Gfx::IntRect, Gfx::IntSize> auto const& v) { return !v.is_empty(); },
             [](Enum auto const&) { return true; },
-            [](OneOf<float, DeprecatedString, Color, NonnullRefPtr<Gfx::Font>, NonnullRefPtr<Gfx::Bitmap>, GUI::Icon> auto const&) { return true; });
+            [](OneOf<float, DeprecatedString, Color, NonnullRefPtr<Gfx::Font const>, NonnullRefPtr<Gfx::Bitmap const>, GUI::Icon> auto const&) { return true; });
     }
 
     i32 as_i32() const { return get<i32>(); }
@@ -126,7 +126,7 @@ public:
                     return v.to_int<T>().value_or(0);
             },
             [](Enum auto const&) -> T { return 0; },
-            [](OneOf<Gfx::IntPoint, Gfx::IntRect, Gfx::IntSize, Color, NonnullRefPtr<Gfx::Font>, NonnullRefPtr<Gfx::Bitmap>, GUI::Icon> auto const&) -> T { return 0; });
+            [](OneOf<Gfx::IntPoint, Gfx::IntRect, Gfx::IntSize, Color, NonnullRefPtr<Gfx::Font const>, NonnullRefPtr<Gfx::Bitmap const>, GUI::Icon> auto const&) -> T { return 0; });
     }
 
     i32 to_i32() const { return to_integer<i32>(); }
@@ -144,10 +144,10 @@ public:
     Gfx::IntSize as_size() const { return get<Gfx::IntSize>(); }
     Gfx::IntRect as_rect() const { return get<Gfx::IntRect>(); }
     DeprecatedString as_string() const { return get<DeprecatedString>(); }
-    Gfx::Bitmap const& as_bitmap() const { return *get<NonnullRefPtr<Gfx::Bitmap>>(); }
+    Gfx::Bitmap const& as_bitmap() const { return *get<NonnullRefPtr<Gfx::Bitmap const>>(); }
     GUI::Icon as_icon() const { return get<GUI::Icon>(); }
     Color as_color() const { return get<Color>(); }
-    Gfx::Font const& as_font() const { return *get<NonnullRefPtr<Gfx::Font>>(); }
+    Gfx::Font const& as_font() const { return *get<NonnullRefPtr<Gfx::Font const>>(); }
 
     Gfx::TextAlignment to_text_alignment(Gfx::TextAlignment default_value) const
     {
@@ -211,8 +211,8 @@ public:
             [](Gfx::FlagRole v) { return DeprecatedString::formatted("Gfx::FlagRole::{}", Gfx::to_string(v)); },
             [](Gfx::MetricRole v) { return DeprecatedString::formatted("Gfx::MetricRole::{}", Gfx::to_string(v)); },
             [](Gfx::PathRole v) { return DeprecatedString::formatted("Gfx::PathRole::{}", Gfx::to_string(v)); },
-            [](NonnullRefPtr<Gfx::Font> const& font) { return DeprecatedString::formatted("[Font: {}]", font->name()); },
-            [](NonnullRefPtr<Gfx::Bitmap> const&) -> DeprecatedString { return "[Gfx::Bitmap]"; },
+            [](NonnullRefPtr<Gfx::Font const> const& font) { return DeprecatedString::formatted("[Font: {}]", font->name()); },
+            [](NonnullRefPtr<Gfx::Bitmap const> const&) -> DeprecatedString { return "[Gfx::Bitmap]"; },
             [](GUI::Icon const&) -> DeprecatedString { return "[GUI::Icon]"; },
             [](Detail::Boolean v) { return DeprecatedString::formatted("{}", v.value); },
             [](auto const& v) { return DeprecatedString::formatted("{}", v); });

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -332,7 +332,7 @@ public:
     void do_layout();
 
     Gfx::Palette palette() const;
-    void set_palette(Gfx::Palette const&);
+    void set_palette(Gfx::Palette&);
 
     DeprecatedString title() const;
     void set_title(DeprecatedString);
@@ -349,8 +349,8 @@ public:
 
     virtual Gfx::IntRect children_clip_rect() const;
 
-    AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> const& override_cursor() const { return m_override_cursor; }
-    void set_override_cursor(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>>);
+    AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> const& override_cursor() const { return m_override_cursor; }
+    void set_override_cursor(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>>);
 
     using UnregisteredChildHandler = ErrorOr<NonnullRefPtr<Core::Object>>(DeprecatedString const&);
     ErrorOr<void> load_from_gml(StringView);
@@ -363,7 +363,7 @@ public:
     bool has_pending_drop() const;
 
     // In order for others to be able to call this, it needs to be public.
-    virtual ErrorOr<void> load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, UnregisteredChildHandler);
+    virtual ErrorOr<void> load_from_gml_ast(NonnullRefPtr<GUI::GML::Node const> ast, UnregisteredChildHandler);
 
     ErrorOr<void> add_spacer();
 
@@ -439,7 +439,7 @@ private:
     Gfx::IntRect m_relative_rect;
     Gfx::ColorRole m_background_role;
     Gfx::ColorRole m_foreground_role;
-    NonnullRefPtr<Gfx::Font> m_font;
+    NonnullRefPtr<Gfx::Font const> m_font;
     DeprecatedString m_tooltip;
 
     UISize m_min_size { SpecialDimension::Shrink };
@@ -464,7 +464,7 @@ private:
     Vector<WeakPtr<Widget>> m_focus_delegators;
     FocusPolicy m_focus_policy { FocusPolicy::NoFocus };
 
-    AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_override_cursor { Gfx::StandardCursor::None };
+    AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> m_override_cursor { Gfx::StandardCursor::None };
 };
 
 inline Widget* Widget::parent_widget()

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -183,7 +183,7 @@ public:
     void set_resize_aspect_ratio(Optional<Gfx::IntSize> const& ratio);
 
     void set_cursor(Gfx::StandardCursor);
-    void set_cursor(NonnullRefPtr<Gfx::Bitmap>);
+    void set_cursor(NonnullRefPtr<Gfx::Bitmap const>);
 
     void set_icon(Gfx::Bitmap const*);
     void apply_icon();
@@ -270,7 +270,7 @@ private:
     void flip(Vector<Gfx::IntRect, 32> const& dirty_rects);
     void force_update();
 
-    bool are_cursors_the_same(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> const&, AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> const&) const;
+    bool are_cursors_the_same(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> const&, AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> const&) const;
 
     WeakPtr<Widget> m_previously_focused_widget;
 
@@ -279,7 +279,7 @@ private:
 
     NonnullRefPtr<Menubar> m_menubar;
 
-    RefPtr<Gfx::Bitmap> m_icon;
+    RefPtr<Gfx::Bitmap const> m_icon;
     int m_window_id { 0 };
     float m_opacity_when_windowless { 1.0f };
     float m_alpha_hit_threshold { 0.0f };
@@ -296,8 +296,8 @@ private:
     Gfx::IntSize m_base_size;
     WindowType m_window_type { WindowType::Normal };
     WindowMode m_window_mode { WindowMode::Modeless };
-    AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_cursor { Gfx::StandardCursor::None };
-    AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_effective_cursor { Gfx::StandardCursor::None };
+    AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> m_cursor { Gfx::StandardCursor::None };
+    AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> m_effective_cursor { Gfx::StandardCursor::None };
     bool m_has_alpha_channel { false };
     bool m_double_buffering_enabled { true };
     bool m_resizable { true };

--- a/Userland/Libraries/LibGfx/BMPWriter.cpp
+++ b/Userland/Libraries/LibGfx/BMPWriter.cpp
@@ -42,7 +42,7 @@ private:
     u8* m_data;
 };
 
-static ByteBuffer write_pixel_data(RefPtr<Bitmap> const bitmap, int pixel_row_data_size, int bytes_per_pixel, bool include_alpha_channel)
+static ByteBuffer write_pixel_data(RefPtr<Bitmap const> bitmap, int pixel_row_data_size, int bytes_per_pixel, bool include_alpha_channel)
 {
     int image_size = pixel_row_data_size * bitmap->height();
     auto buffer_result = ByteBuffer::create_uninitialized(image_size);
@@ -78,7 +78,7 @@ static ByteBuffer compress_pixel_data(ByteBuffer const& pixel_data, BMPWriter::C
     VERIFY_NOT_REACHED();
 }
 
-ByteBuffer BMPWriter::dump(RefPtr<Bitmap> const bitmap, DibHeader dib_header)
+ByteBuffer BMPWriter::dump(RefPtr<Bitmap const> bitmap, DibHeader dib_header)
 {
 
     switch (dib_header) {

--- a/Userland/Libraries/LibGfx/BMPWriter.h
+++ b/Userland/Libraries/LibGfx/BMPWriter.h
@@ -27,7 +27,7 @@ public:
         V4 = 108,
     };
 
-    ByteBuffer dump(RefPtr<Bitmap> const, DibHeader dib_header = DibHeader::V4);
+    ByteBuffer dump(RefPtr<Bitmap const>, DibHeader dib_header = DibHeader::V4);
 
     inline void set_compression(Compression compression) { m_compression = compression; }
 

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, Timothy Slater <tslater2006@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -468,8 +468,10 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Bitmap::cropped(Gfx::IntRect crop, Optional<
 
 ErrorOr<NonnullRefPtr<Bitmap>> Bitmap::to_bitmap_backed_by_anonymous_buffer() const
 {
-    if (m_buffer.is_valid())
-        return NonnullRefPtr { *this };
+    if (m_buffer.is_valid()) {
+        // FIXME: The const_cast here is awkward.
+        return NonnullRefPtr { const_cast<Bitmap&>(*this) };
+    }
     auto buffer = TRY(Core::AnonymousBuffer::create_with_size(round_up_to_power_of_two(size_in_bytes(), PAGE_SIZE)));
     auto bitmap = TRY(Bitmap::create_with_anonymous_buffer(m_format, move(buffer), size(), scale(), palette_to_vector()));
     memcpy(bitmap->scanline(0), scanline(0), size_in_bytes());

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -343,7 +343,7 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Bitmap::scaled(int sx, int sy) const
 {
     VERIFY(sx >= 0 && sy >= 0);
     if (sx == 1 && sy == 1)
-        return NonnullRefPtr { *this };
+        return clone();
 
     auto new_bitmap = TRY(Gfx::Bitmap::create(format(), { width() * sx, height() * sy }, scale()));
 

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -476,12 +476,14 @@ ErrorOr<NonnullRefPtr<Bitmap>> Bitmap::to_bitmap_backed_by_anonymous_buffer() co
     return bitmap;
 }
 
-void Bitmap::invert()
+ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Bitmap::inverted() const
 {
+    auto inverted_bitmap = TRY(clone());
     for (auto y = 0; y < height(); y++) {
         for (auto x = 0; x < width(); x++)
-            set_pixel(x, y, get_pixel(x, y).inverted());
+            inverted_bitmap->set_pixel(x, y, get_pixel(x, y).inverted());
     }
+    return inverted_bitmap;
 }
 
 Bitmap::~Bitmap()

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -126,7 +126,7 @@ public:
 
     [[nodiscard]] ShareableBitmap to_shareable_bitmap() const;
 
-    void invert();
+    ErrorOr<NonnullRefPtr<Gfx::Bitmap>> inverted() const;
 
     ~Bitmap();
 

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, Timothy Slater <tslater2006@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause

--- a/Userland/Libraries/LibGfx/Font/Font.h
+++ b/Userland/Libraries/LibGfx/Font/Font.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -202,7 +203,7 @@ public:
     Font const& bold_variant() const;
 
 private:
-    mutable RefPtr<Gfx::Font> m_bold_variant;
+    mutable RefPtr<Gfx::Font const> m_bold_variant;
 };
 
 }

--- a/Userland/Libraries/LibGfx/Font/ScaledFont.h
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -33,7 +34,7 @@ public:
 
     // ^Gfx::Font
     virtual NonnullRefPtr<Font> clone() const override { return MUST(try_clone()); } // FIXME: clone() should not need to be implemented
-    virtual ErrorOr<NonnullRefPtr<Font>> try_clone() const override { return *this; }
+    virtual ErrorOr<NonnullRefPtr<Font>> try_clone() const override { return const_cast<ScaledFont&>(*this); }
     virtual u8 presentation_size() const override { return m_point_height; }
     virtual float pixel_size() const override { return m_point_height * 1.33333333f; }
     virtual Gfx::FontPixelMetrics pixel_metrics() const override;

--- a/Userland/Libraries/LibGfx/Font/WOFF/Font.h
+++ b/Userland/Libraries/LibGfx/Font/WOFF/Font.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -38,14 +39,14 @@ public:
     virtual bool is_fixed_width() const override { return m_input_font->is_fixed_width(); }
 
 private:
-    Font(NonnullRefPtr<Gfx::VectorFont> input_font, ByteBuffer input_font_buffer)
+    Font(NonnullRefPtr<Gfx::VectorFont const> input_font, ByteBuffer input_font_buffer)
         : m_input_font_buffer(move(input_font_buffer))
         , m_input_font(move(input_font))
     {
     }
 
     ByteBuffer m_input_font_buffer;
-    NonnullRefPtr<Gfx::VectorFont> m_input_font;
+    NonnullRefPtr<Gfx::VectorFont const> m_input_font;
 };
 
 }

--- a/Userland/Libraries/LibGfx/Palette.cpp
+++ b/Userland/Libraries/LibGfx/Palette.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
  *
@@ -22,7 +22,7 @@ PaletteImpl::PaletteImpl(Core::AnonymousBuffer buffer)
 {
 }
 
-Palette::Palette(PaletteImpl const& impl)
+Palette::Palette(PaletteImpl& impl)
     : m_impl(impl)
 {
 }

--- a/Userland/Libraries/LibGfx/Palette.h
+++ b/Userland/Libraries/LibGfx/Palette.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
  *
@@ -59,7 +59,7 @@ private:
 class Palette {
 
 public:
-    explicit Palette(PaletteImpl const&);
+    explicit Palette(PaletteImpl&);
     ~Palette() = default;
 
     Color accent() const { return color(ColorRole::Accent); }

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -291,7 +291,7 @@ void Path::segmentize_path()
             break;
         }
         case Segment::Type::QuadraticBezierCurveTo: {
-            auto control = static_cast<QuadraticBezierCurveSegment&>(segment).through();
+            auto control = static_cast<QuadraticBezierCurveSegment const&>(segment).through();
             Painter::for_each_line_segment_on_bezier_curve(control, cursor, segment.point(), [&](FloatPoint p0, FloatPoint p1) {
                 add_line(p0, p1);
             });
@@ -309,7 +309,7 @@ void Path::segmentize_path()
             break;
         }
         case Segment::Type::EllipticalArcTo: {
-            auto& arc = static_cast<EllipticalArcSegment&>(segment);
+            auto& arc = static_cast<EllipticalArcSegment const&>(segment);
             Painter::for_each_line_segment_on_elliptical_arc(cursor, arc.point(), arc.center(), arc.radii(), arc.x_axis_rotation(), arc.theta_1(), arc.theta_delta(), [&](FloatPoint p0, FloatPoint p1) {
                 add_line(p0, p1);
             });

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -218,7 +218,7 @@ public:
         float x;
     };
 
-    NonnullRefPtrVector<Segment> const& segments() const { return m_segments; }
+    NonnullRefPtrVector<Segment const> const& segments() const { return m_segments; }
     auto& split_lines() const
     {
         if (!m_split_lines.has_value()) {
@@ -268,7 +268,7 @@ private:
         m_segments.append(adopt_ref(*new T(forward<Args>(args)...)));
     }
 
-    NonnullRefPtrVector<Segment> m_segments {};
+    NonnullRefPtrVector<Segment const> m_segments {};
 
     Optional<Vector<SplitLineSegment>> m_split_lines {};
     Optional<Gfx::FloatRect> m_bounding_box;

--- a/Userland/Libraries/LibIDL/IDLParser.h
+++ b/Userland/Libraries/LibIDL/IDLParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
  * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
@@ -54,7 +54,7 @@ private:
     void parse_iterable(Interface&);
     Function parse_function(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&, IsSpecialOperation is_special_operation = IsSpecialOperation::No);
     Vector<Parameter> parse_parameters();
-    NonnullRefPtr<Type> parse_type();
+    NonnullRefPtr<Type const> parse_type();
     void parse_constant(Interface&);
 
     DeprecatedString import_base_path;

--- a/Userland/Libraries/LibIDL/Types.h
+++ b/Userland/Libraries/LibIDL/Types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
  * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
@@ -143,7 +143,7 @@ private:
 };
 
 struct Parameter {
-    NonnullRefPtr<Type> type;
+    NonnullRefPtr<Type const> type;
     DeprecatedString name;
     bool optional { false };
     Optional<DeprecatedString> optional_default_value;
@@ -152,7 +152,7 @@ struct Parameter {
 };
 
 struct Function {
-    NonnullRefPtr<Type> return_type;
+    NonnullRefPtr<Type const> return_type;
     DeprecatedString name;
     Vector<Parameter> parameters;
     HashMap<DeprecatedString, DeprecatedString> extended_attributes;
@@ -170,7 +170,7 @@ struct Constructor {
 };
 
 struct Constant {
-    NonnullRefPtr<Type> type;
+    NonnullRefPtr<Type const> type;
     DeprecatedString name;
     DeprecatedString value;
 };
@@ -178,7 +178,7 @@ struct Constant {
 struct Attribute {
     bool inherit { false };
     bool readonly { false };
-    NonnullRefPtr<Type> type;
+    NonnullRefPtr<Type const> type;
     DeprecatedString name;
     HashMap<DeprecatedString, DeprecatedString> extended_attributes;
 
@@ -189,7 +189,7 @@ struct Attribute {
 
 struct DictionaryMember {
     bool required { false };
-    NonnullRefPtr<Type> type;
+    NonnullRefPtr<Type const> type;
     DeprecatedString name;
     HashMap<DeprecatedString, DeprecatedString> extended_attributes;
     Optional<DeprecatedString> default_value;
@@ -202,7 +202,7 @@ struct Dictionary {
 
 struct Typedef {
     HashMap<DeprecatedString, DeprecatedString> extended_attributes;
-    NonnullRefPtr<Type> type;
+    NonnullRefPtr<Type const> type;
 };
 
 struct Enumeration {
@@ -213,7 +213,7 @@ struct Enumeration {
 };
 
 struct CallbackFunction {
-    NonnullRefPtr<Type> return_type;
+    NonnullRefPtr<Type const> return_type;
     Vector<Parameter> parameters;
     bool is_legacy_treat_non_object_as_null { false };
 };
@@ -222,7 +222,7 @@ class Interface;
 
 class ParameterizedType : public Type {
 public:
-    ParameterizedType(DeprecatedString name, bool nullable, NonnullRefPtrVector<Type> parameters)
+    ParameterizedType(DeprecatedString name, bool nullable, NonnullRefPtrVector<Type const> parameters)
         : Type(Kind::Parameterized, move(name), nullable)
         , m_parameters(move(parameters))
     {
@@ -232,11 +232,11 @@ public:
 
     void generate_sequence_from_iterable(SourceGenerator& generator, DeprecatedString const& cpp_name, DeprecatedString const& iterable_cpp_name, DeprecatedString const& iterator_method_cpp_name, IDL::Interface const&, size_t recursion_depth) const;
 
-    NonnullRefPtrVector<Type> const& parameters() const { return m_parameters; }
-    NonnullRefPtrVector<Type>& parameters() { return m_parameters; }
+    NonnullRefPtrVector<Type const> const& parameters() const { return m_parameters; }
+    NonnullRefPtrVector<Type const>& parameters() { return m_parameters; }
 
 private:
-    NonnullRefPtrVector<Type> m_parameters;
+    NonnullRefPtrVector<Type const> m_parameters;
 };
 
 static inline size_t get_shortest_function_length(Vector<Function&> const& overload_set)
@@ -270,8 +270,8 @@ public:
     Optional<DeprecatedString> stringifier_attribute;
     bool has_unscopable_member { false };
 
-    Optional<NonnullRefPtr<Type>> value_iterator_type;
-    Optional<Tuple<NonnullRefPtr<Type>, NonnullRefPtr<Type>>> pair_iterator_types;
+    Optional<NonnullRefPtr<Type const>> value_iterator_type;
+    Optional<Tuple<NonnullRefPtr<Type const>, NonnullRefPtr<Type const>>> pair_iterator_types;
 
     Optional<Function> named_property_getter;
     Optional<Function> named_property_setter;
@@ -318,7 +318,7 @@ public:
 
 class UnionType : public Type {
 public:
-    UnionType(DeprecatedString name, bool nullable, NonnullRefPtrVector<Type> member_types)
+    UnionType(DeprecatedString name, bool nullable, NonnullRefPtrVector<Type const> member_types)
         : Type(Kind::Union, move(name), nullable)
         , m_member_types(move(member_types))
     {
@@ -326,16 +326,16 @@ public:
 
     virtual ~UnionType() override = default;
 
-    NonnullRefPtrVector<Type> const& member_types() const { return m_member_types; }
-    NonnullRefPtrVector<Type>& member_types() { return m_member_types; }
+    NonnullRefPtrVector<Type const> const& member_types() const { return m_member_types; }
+    NonnullRefPtrVector<Type const>& member_types() { return m_member_types; }
 
     // https://webidl.spec.whatwg.org/#dfn-flattened-union-member-types
-    NonnullRefPtrVector<Type> flattened_member_types() const
+    NonnullRefPtrVector<Type const> flattened_member_types() const
     {
         // 1. Let T be the union type.
 
         // 2. Initialize S to ∅.
-        NonnullRefPtrVector<Type> types;
+        NonnullRefPtrVector<Type const> types;
 
         // 3. For each member type U of T:
         for (auto& type : m_member_types) {
@@ -390,7 +390,7 @@ public:
     }
 
 private:
-    NonnullRefPtrVector<Type> m_member_types;
+    NonnullRefPtrVector<Type const> m_member_types;
 };
 
 // https://webidl.spec.whatwg.org/#dfn-optionality-value
@@ -405,7 +405,7 @@ class EffectiveOverloadSet {
 public:
     struct Item {
         int callable_id;
-        NonnullRefPtrVector<Type> types;
+        NonnullRefPtrVector<Type const> types;
         Vector<Optionality> optionality_values;
     };
 

--- a/Userland/Libraries/LibImageDecoderClient/Client.cpp
+++ b/Userland/Libraries/LibImageDecoderClient/Client.cpp
@@ -49,9 +49,10 @@ Optional<DecodedImage> Client::decode_image(ReadonlyBytes encoded_data, Optional
     image.is_animated = response.is_animated();
     image.loop_count = response.loop_count();
     image.frames.resize(response.bitmaps().size());
+    auto bitmaps = response.take_bitmaps();
     for (size_t i = 0; i < image.frames.size(); ++i) {
         auto& frame = image.frames[i];
-        frame.bitmap = response.bitmaps()[i].bitmap();
+        frame.bitmap = bitmaps[i].bitmap();
         frame.duration = response.durations()[i];
     }
     return image;

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2020-2022, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021-2022, David Tuin <davidot@serenityos.org>
  *
@@ -97,7 +97,7 @@ private:
     // NOTE: These members are carefully ordered so that `m_start_offset` is packed with the padding after RefCounted::m_ref_count.
     //       This creates a 4-byte padding hole after `m_end_offset` which is used to pack subclasses better.
     u32 m_start_offset { 0 };
-    RefPtr<SourceCode> m_source_code;
+    RefPtr<SourceCode const> m_source_code;
     u32 m_end_offset { 0 };
 };
 
@@ -152,7 +152,7 @@ public:
 // 14.13 Labelled Statements, https://tc39.es/ecma262/#sec-labelled-statements
 class LabelledStatement : public Statement {
 public:
-    LabelledStatement(SourceRange source_range, DeprecatedFlyString label, NonnullRefPtr<Statement> labelled_item)
+    LabelledStatement(SourceRange source_range, DeprecatedFlyString label, NonnullRefPtr<Statement const> labelled_item)
         : Statement(source_range)
         , m_label(move(label))
         , m_labelled_item(move(labelled_item))
@@ -166,14 +166,13 @@ public:
 
     DeprecatedFlyString const& label() const { return m_label; }
     DeprecatedFlyString& label() { return m_label; }
-    NonnullRefPtr<Statement> const& labelled_item() const { return m_labelled_item; }
-    NonnullRefPtr<Statement>& labelled_item() { return m_labelled_item; }
+    NonnullRefPtr<Statement const> const& labelled_item() const { return m_labelled_item; }
 
 private:
     virtual bool is_labelled_statement() const final { return true; }
 
     DeprecatedFlyString m_label;
-    NonnullRefPtr<Statement> m_labelled_item;
+    NonnullRefPtr<Statement const> m_labelled_item;
 };
 
 class LabelableStatement : public Statement {
@@ -219,7 +218,7 @@ public:
 
 class ExpressionStatement final : public Statement {
 public:
-    ExpressionStatement(SourceRange source_range, NonnullRefPtr<Expression> expression)
+    ExpressionStatement(SourceRange source_range, NonnullRefPtr<Expression const> expression)
         : Statement(source_range)
         , m_expression(move(expression))
     {
@@ -234,7 +233,7 @@ public:
 private:
     virtual bool is_expression_statement() const override { return true; }
 
-    NonnullRefPtr<Expression> m_expression;
+    NonnullRefPtr<Expression const> m_expression;
 };
 
 template<typename Func, typename... Args>
@@ -275,7 +274,7 @@ public:
         m_children.append(move(child));
         return static_cast<T&>(m_children.last());
     }
-    void append(NonnullRefPtr<Statement> child)
+    void append(NonnullRefPtr<Statement const> child)
     {
         m_children.append(move(child));
     }
@@ -288,15 +287,15 @@ public:
         m_functions_hoistable_with_annexB_extension.shrink_to_fit();
     }
 
-    NonnullRefPtrVector<Statement> const& children() const { return m_children; }
+    NonnullRefPtrVector<Statement const> const& children() const { return m_children; }
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     Completion evaluate_statements(Interpreter&) const;
 
-    void add_var_scoped_declaration(NonnullRefPtr<Declaration> variables);
-    void add_lexical_declaration(NonnullRefPtr<Declaration> variables);
-    void add_hoisted_function(NonnullRefPtr<FunctionDeclaration> declaration);
+    void add_var_scoped_declaration(NonnullRefPtr<Declaration const> variables);
+    void add_lexical_declaration(NonnullRefPtr<Declaration const> variables);
+    void add_hoisted_function(NonnullRefPtr<FunctionDeclaration const> declaration);
 
     [[nodiscard]] bool has_lexical_declarations() const { return !m_lexical_declarations.is_empty(); }
     [[nodiscard]] bool has_var_declarations() const { return !m_var_declarations.is_empty(); }
@@ -325,11 +324,11 @@ protected:
 private:
     virtual bool is_scope_node() const final { return true; }
 
-    NonnullRefPtrVector<Statement> m_children;
-    NonnullRefPtrVector<Declaration> m_lexical_declarations;
-    NonnullRefPtrVector<Declaration> m_var_declarations;
+    NonnullRefPtrVector<Statement const> m_children;
+    NonnullRefPtrVector<Declaration const> m_lexical_declarations;
+    NonnullRefPtrVector<Declaration const> m_var_declarations;
 
-    NonnullRefPtrVector<FunctionDeclaration> m_functions_hoistable_with_annexB_extension;
+    NonnullRefPtrVector<FunctionDeclaration const> m_functions_hoistable_with_annexB_extension;
 };
 
 // ImportEntry Record, https://tc39.es/ecma262/#table-importentry-record-fields
@@ -375,7 +374,6 @@ public:
     bool has_bound_name(DeprecatedFlyString const& name) const;
     Vector<ImportEntry> const& entries() const { return m_entries; }
     ModuleRequest const& module_request() const { return m_module_request; }
-    ModuleRequest& module_request() { return m_module_request; }
 
 private:
     ModuleRequest m_module_request;
@@ -453,7 +451,7 @@ class ExportStatement final : public Statement {
 public:
     static DeprecatedFlyString local_name_for_default;
 
-    ExportStatement(SourceRange source_range, RefPtr<ASTNode> statement, Vector<ExportEntry> entries, bool is_default_export, ModuleRequest module_request)
+    ExportStatement(SourceRange source_range, RefPtr<ASTNode const> statement, Vector<ExportEntry> entries, bool is_default_export, ModuleRequest module_request)
         : Statement(source_range)
         , m_statement(move(statement))
         , m_entries(move(entries))
@@ -483,14 +481,14 @@ public:
         return *m_statement;
     }
 
-    ModuleRequest& module_request()
+    ModuleRequest const& module_request() const
     {
         VERIFY(!m_module_request.module_specifier.is_null());
         return m_module_request;
     }
 
 private:
-    RefPtr<ASTNode> m_statement;
+    RefPtr<ASTNode const> m_statement;
     Vector<ExportEntry> m_entries;
     bool m_is_default_export { false };
     ModuleRequest m_module_request;
@@ -516,23 +514,23 @@ public:
 
     Type type() const { return m_type; }
 
-    void append_import(NonnullRefPtr<ImportStatement> import_statement)
+    void append_import(NonnullRefPtr<ImportStatement const> import_statement)
     {
         m_imports.append(import_statement);
         append(import_statement);
     }
 
-    void append_export(NonnullRefPtr<ExportStatement> export_statement)
+    void append_export(NonnullRefPtr<ExportStatement const> export_statement)
     {
         m_exports.append(export_statement);
         append(export_statement);
     }
 
-    NonnullRefPtrVector<ImportStatement> const& imports() const { return m_imports; }
-    NonnullRefPtrVector<ExportStatement> const& exports() const { return m_exports; }
+    NonnullRefPtrVector<ImportStatement const> const& imports() const { return m_imports; }
+    NonnullRefPtrVector<ExportStatement const> const& exports() const { return m_exports; }
 
-    NonnullRefPtrVector<ImportStatement>& imports() { return m_imports; }
-    NonnullRefPtrVector<ExportStatement>& exports() { return m_exports; }
+    NonnullRefPtrVector<ImportStatement const>& imports() { return m_imports; }
+    NonnullRefPtrVector<ExportStatement const>& exports() { return m_exports; }
 
     bool has_top_level_await() const { return m_has_top_level_await; }
     void set_has_top_level_await() { m_has_top_level_await = true; }
@@ -545,8 +543,8 @@ private:
     bool m_is_strict_mode { false };
     Type m_type { Type::Script };
 
-    NonnullRefPtrVector<ImportStatement> m_imports;
-    NonnullRefPtrVector<ExportStatement> m_exports;
+    NonnullRefPtrVector<ImportStatement const> m_imports;
+    NonnullRefPtrVector<ExportStatement const> m_exports;
     bool m_has_top_level_await { false };
 };
 
@@ -618,9 +616,9 @@ struct BindingPattern : RefCounted<BindingPattern> {
     // This covers both BindingProperty and BindingElement, hence the more generic name
     struct BindingEntry {
         // If this entry represents a BindingElement, then name will be Empty
-        Variant<NonnullRefPtr<Identifier>, NonnullRefPtr<Expression>, Empty> name {};
-        Variant<NonnullRefPtr<Identifier>, NonnullRefPtr<BindingPattern>, NonnullRefPtr<MemberExpression>, Empty> alias {};
-        RefPtr<Expression> initializer {};
+        Variant<NonnullRefPtr<Identifier const>, NonnullRefPtr<Expression const>, Empty> name {};
+        Variant<NonnullRefPtr<Identifier const>, NonnullRefPtr<BindingPattern const>, NonnullRefPtr<MemberExpression const>, Empty> alias {};
+        RefPtr<Expression const> initializer {};
         bool is_rest { false };
 
         bool is_elision() const { return name.has<Empty>() && alias.has<Empty>(); }
@@ -642,8 +640,8 @@ struct BindingPattern : RefCounted<BindingPattern> {
 };
 
 struct FunctionParameter {
-    Variant<DeprecatedFlyString, NonnullRefPtr<BindingPattern>> binding;
-    RefPtr<Expression> default_value;
+    Variant<DeprecatedFlyString, NonnullRefPtr<BindingPattern const>> binding;
+    RefPtr<Expression const> default_value;
     bool is_rest { false };
 };
 
@@ -661,7 +659,7 @@ public:
     FunctionKind kind() const { return m_kind; }
 
 protected:
-    FunctionNode(DeprecatedFlyString name, DeprecatedString source_text, NonnullRefPtr<Statement> body, Vector<FunctionParameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function)
+    FunctionNode(DeprecatedFlyString name, DeprecatedString source_text, NonnullRefPtr<Statement const> body, Vector<FunctionParameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function)
         : m_name(move(name))
         , m_source_text(move(source_text))
         , m_body(move(body))
@@ -682,7 +680,7 @@ protected:
 private:
     DeprecatedFlyString m_name;
     DeprecatedString m_source_text;
-    NonnullRefPtr<Statement> m_body;
+    NonnullRefPtr<Statement const> m_body;
     Vector<FunctionParameter> const m_parameters;
     const i32 m_function_length;
     FunctionKind m_kind;
@@ -698,7 +696,7 @@ class FunctionDeclaration final
 public:
     static bool must_have_name() { return true; }
 
-    FunctionDeclaration(SourceRange source_range, DeprecatedFlyString const& name, DeprecatedString source_text, NonnullRefPtr<Statement> body, Vector<FunctionParameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, bool might_need_arguments_object, bool contains_direct_call_to_eval)
+    FunctionDeclaration(SourceRange source_range, DeprecatedFlyString const& name, DeprecatedString source_text, NonnullRefPtr<Statement const> body, Vector<FunctionParameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, bool might_need_arguments_object, bool contains_direct_call_to_eval)
         : Declaration(source_range)
         , FunctionNode(name, move(source_text), move(body), move(parameters), function_length, kind, is_strict_mode, might_need_arguments_object, contains_direct_call_to_eval, false)
     {
@@ -724,7 +722,7 @@ class FunctionExpression final
 public:
     static bool must_have_name() { return false; }
 
-    FunctionExpression(SourceRange source_range, DeprecatedFlyString const& name, DeprecatedString source_text, NonnullRefPtr<Statement> body, Vector<FunctionParameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function = false)
+    FunctionExpression(SourceRange source_range, DeprecatedFlyString const& name, DeprecatedString source_text, NonnullRefPtr<Statement const> body, Vector<FunctionParameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function = false)
         : Expression(source_range)
         , FunctionNode(name, move(source_text), move(body), move(parameters), function_length, kind, is_strict_mode, might_need_arguments_object, contains_direct_call_to_eval, is_arrow_function)
     {
@@ -755,7 +753,7 @@ public:
 
 class YieldExpression final : public Expression {
 public:
-    explicit YieldExpression(SourceRange source_range, RefPtr<Expression> argument, bool is_yield_from)
+    explicit YieldExpression(SourceRange source_range, RefPtr<Expression const> argument, bool is_yield_from)
         : Expression(source_range)
         , m_argument(move(argument))
         , m_is_yield_from(is_yield_from)
@@ -770,13 +768,13 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
-    RefPtr<Expression> m_argument;
+    RefPtr<Expression const> m_argument;
     bool m_is_yield_from { false };
 };
 
 class AwaitExpression final : public Expression {
 public:
-    explicit AwaitExpression(SourceRange source_range, NonnullRefPtr<Expression> argument)
+    explicit AwaitExpression(SourceRange source_range, NonnullRefPtr<Expression const> argument)
         : Expression(source_range)
         , m_argument(move(argument))
     {
@@ -787,12 +785,12 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
-    NonnullRefPtr<Expression> m_argument;
+    NonnullRefPtr<Expression const> m_argument;
 };
 
 class ReturnStatement final : public Statement {
 public:
-    explicit ReturnStatement(SourceRange source_range, RefPtr<Expression> argument)
+    explicit ReturnStatement(SourceRange source_range, RefPtr<Expression const> argument)
         : Statement(source_range)
         , m_argument(move(argument))
     {
@@ -805,12 +803,12 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
-    RefPtr<Expression> m_argument;
+    RefPtr<Expression const> m_argument;
 };
 
 class IfStatement final : public Statement {
 public:
-    IfStatement(SourceRange source_range, NonnullRefPtr<Expression> predicate, NonnullRefPtr<Statement> consequent, RefPtr<Statement> alternate)
+    IfStatement(SourceRange source_range, NonnullRefPtr<Expression const> predicate, NonnullRefPtr<Statement const> consequent, RefPtr<Statement const> alternate)
         : Statement(source_range)
         , m_predicate(move(predicate))
         , m_consequent(move(consequent))
@@ -827,14 +825,14 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
-    NonnullRefPtr<Expression> m_predicate;
-    NonnullRefPtr<Statement> m_consequent;
-    RefPtr<Statement> m_alternate;
+    NonnullRefPtr<Expression const> m_predicate;
+    NonnullRefPtr<Statement const> m_consequent;
+    RefPtr<Statement const> m_alternate;
 };
 
 class WhileStatement final : public IterationStatement {
 public:
-    WhileStatement(SourceRange source_range, NonnullRefPtr<Expression> test, NonnullRefPtr<Statement> body)
+    WhileStatement(SourceRange source_range, NonnullRefPtr<Expression const> test, NonnullRefPtr<Statement const> body)
         : IterationStatement(source_range)
         , m_test(move(test))
         , m_body(move(body))
@@ -851,13 +849,13 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&) const override;
 
 private:
-    NonnullRefPtr<Expression> m_test;
-    NonnullRefPtr<Statement> m_body;
+    NonnullRefPtr<Expression const> m_test;
+    NonnullRefPtr<Statement const> m_body;
 };
 
 class DoWhileStatement final : public IterationStatement {
 public:
-    DoWhileStatement(SourceRange source_range, NonnullRefPtr<Expression> test, NonnullRefPtr<Statement> body)
+    DoWhileStatement(SourceRange source_range, NonnullRefPtr<Expression const> test, NonnullRefPtr<Statement const> body)
         : IterationStatement(source_range)
         , m_test(move(test))
         , m_body(move(body))
@@ -874,13 +872,13 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&) const override;
 
 private:
-    NonnullRefPtr<Expression> m_test;
-    NonnullRefPtr<Statement> m_body;
+    NonnullRefPtr<Expression const> m_test;
+    NonnullRefPtr<Statement const> m_body;
 };
 
 class WithStatement final : public Statement {
 public:
-    WithStatement(SourceRange source_range, NonnullRefPtr<Expression> object, NonnullRefPtr<Statement> body)
+    WithStatement(SourceRange source_range, NonnullRefPtr<Expression const> object, NonnullRefPtr<Statement const> body)
         : Statement(source_range)
         , m_object(move(object))
         , m_body(move(body))
@@ -895,13 +893,13 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
-    NonnullRefPtr<Expression> m_object;
-    NonnullRefPtr<Statement> m_body;
+    NonnullRefPtr<Expression const> m_object;
+    NonnullRefPtr<Statement const> m_body;
 };
 
 class ForStatement final : public IterationStatement {
 public:
-    ForStatement(SourceRange source_range, RefPtr<ASTNode> init, RefPtr<Expression> test, RefPtr<Expression> update, NonnullRefPtr<Statement> body)
+    ForStatement(SourceRange source_range, RefPtr<ASTNode const> init, RefPtr<Expression const> test, RefPtr<Expression const> update, NonnullRefPtr<Statement const> body)
         : IterationStatement(source_range)
         , m_init(move(init))
         , m_test(move(test))
@@ -924,15 +922,15 @@ public:
 private:
     Completion for_body_evaluation(Interpreter&, Vector<DeprecatedFlyString> const&, size_t per_iteration_bindings_size) const;
 
-    RefPtr<ASTNode> m_init;
-    RefPtr<Expression> m_test;
-    RefPtr<Expression> m_update;
-    NonnullRefPtr<Statement> m_body;
+    RefPtr<ASTNode const> m_init;
+    RefPtr<Expression const> m_test;
+    RefPtr<Expression const> m_update;
+    NonnullRefPtr<Statement const> m_body;
 };
 
 class ForInStatement final : public IterationStatement {
 public:
-    ForInStatement(SourceRange source_range, Variant<NonnullRefPtr<ASTNode>, NonnullRefPtr<BindingPattern>> lhs, NonnullRefPtr<Expression> rhs, NonnullRefPtr<Statement> body)
+    ForInStatement(SourceRange source_range, Variant<NonnullRefPtr<ASTNode const>, NonnullRefPtr<BindingPattern const>> lhs, NonnullRefPtr<Expression const> rhs, NonnullRefPtr<Statement const> body)
         : IterationStatement(source_range)
         , m_lhs(move(lhs))
         , m_rhs(move(rhs))
@@ -951,14 +949,14 @@ public:
     virtual void dump(int indent) const override;
 
 private:
-    Variant<NonnullRefPtr<ASTNode>, NonnullRefPtr<BindingPattern>> m_lhs;
-    NonnullRefPtr<Expression> m_rhs;
-    NonnullRefPtr<Statement> m_body;
+    Variant<NonnullRefPtr<ASTNode const>, NonnullRefPtr<BindingPattern const>> m_lhs;
+    NonnullRefPtr<Expression const> m_rhs;
+    NonnullRefPtr<Statement const> m_body;
 };
 
 class ForOfStatement final : public IterationStatement {
 public:
-    ForOfStatement(SourceRange source_range, Variant<NonnullRefPtr<ASTNode>, NonnullRefPtr<BindingPattern>> lhs, NonnullRefPtr<Expression> rhs, NonnullRefPtr<Statement> body)
+    ForOfStatement(SourceRange source_range, Variant<NonnullRefPtr<ASTNode const>, NonnullRefPtr<BindingPattern const>> lhs, NonnullRefPtr<Expression const> rhs, NonnullRefPtr<Statement const> body)
         : IterationStatement(source_range)
         , m_lhs(move(lhs))
         , m_rhs(move(rhs))
@@ -977,14 +975,14 @@ public:
     virtual void dump(int indent) const override;
 
 private:
-    Variant<NonnullRefPtr<ASTNode>, NonnullRefPtr<BindingPattern>> m_lhs;
-    NonnullRefPtr<Expression> m_rhs;
-    NonnullRefPtr<Statement> m_body;
+    Variant<NonnullRefPtr<ASTNode const>, NonnullRefPtr<BindingPattern const>> m_lhs;
+    NonnullRefPtr<Expression const> m_rhs;
+    NonnullRefPtr<Statement const> m_body;
 };
 
 class ForAwaitOfStatement final : public IterationStatement {
 public:
-    ForAwaitOfStatement(SourceRange source_range, Variant<NonnullRefPtr<ASTNode>, NonnullRefPtr<BindingPattern>> lhs, NonnullRefPtr<Expression> rhs, NonnullRefPtr<Statement> body)
+    ForAwaitOfStatement(SourceRange source_range, Variant<NonnullRefPtr<ASTNode const>, NonnullRefPtr<BindingPattern const>> lhs, NonnullRefPtr<Expression const> rhs, NonnullRefPtr<Statement const> body)
         : IterationStatement(source_range)
         , m_lhs(move(lhs))
         , m_rhs(move(rhs))
@@ -997,9 +995,9 @@ public:
     virtual void dump(int indent) const override;
 
 private:
-    Variant<NonnullRefPtr<ASTNode>, NonnullRefPtr<BindingPattern>> m_lhs;
-    NonnullRefPtr<Expression> m_rhs;
-    NonnullRefPtr<Statement> m_body;
+    Variant<NonnullRefPtr<ASTNode const>, NonnullRefPtr<BindingPattern const>> m_lhs;
+    NonnullRefPtr<Expression const> m_rhs;
+    NonnullRefPtr<Statement const> m_body;
 };
 
 enum class BinaryOp {
@@ -1029,7 +1027,7 @@ enum class BinaryOp {
 
 class BinaryExpression final : public Expression {
 public:
-    BinaryExpression(SourceRange source_range, BinaryOp op, NonnullRefPtr<Expression> lhs, NonnullRefPtr<Expression> rhs)
+    BinaryExpression(SourceRange source_range, BinaryOp op, NonnullRefPtr<Expression const> lhs, NonnullRefPtr<Expression const> rhs)
         : Expression(source_range)
         , m_op(op)
         , m_lhs(move(lhs))
@@ -1043,8 +1041,8 @@ public:
 
 private:
     BinaryOp m_op;
-    NonnullRefPtr<Expression> m_lhs;
-    NonnullRefPtr<Expression> m_rhs;
+    NonnullRefPtr<Expression const> m_lhs;
+    NonnullRefPtr<Expression const> m_rhs;
 };
 
 enum class LogicalOp {
@@ -1055,7 +1053,7 @@ enum class LogicalOp {
 
 class LogicalExpression final : public Expression {
 public:
-    LogicalExpression(SourceRange source_range, LogicalOp op, NonnullRefPtr<Expression> lhs, NonnullRefPtr<Expression> rhs)
+    LogicalExpression(SourceRange source_range, LogicalOp op, NonnullRefPtr<Expression const> lhs, NonnullRefPtr<Expression const> rhs)
         : Expression(source_range)
         , m_op(op)
         , m_lhs(move(lhs))
@@ -1069,8 +1067,8 @@ public:
 
 private:
     LogicalOp m_op;
-    NonnullRefPtr<Expression> m_lhs;
-    NonnullRefPtr<Expression> m_rhs;
+    NonnullRefPtr<Expression const> m_lhs;
+    NonnullRefPtr<Expression const> m_rhs;
 };
 
 enum class UnaryOp {
@@ -1085,7 +1083,7 @@ enum class UnaryOp {
 
 class UnaryExpression final : public Expression {
 public:
-    UnaryExpression(SourceRange source_range, UnaryOp op, NonnullRefPtr<Expression> lhs)
+    UnaryExpression(SourceRange source_range, UnaryOp op, NonnullRefPtr<Expression const> lhs)
         : Expression(source_range)
         , m_op(op)
         , m_lhs(move(lhs))
@@ -1098,12 +1096,12 @@ public:
 
 private:
     UnaryOp m_op;
-    NonnullRefPtr<Expression> m_lhs;
+    NonnullRefPtr<Expression const> m_lhs;
 };
 
 class SequenceExpression final : public Expression {
 public:
-    SequenceExpression(SourceRange source_range, NonnullRefPtrVector<Expression> expressions)
+    SequenceExpression(SourceRange source_range, NonnullRefPtrVector<Expression const> expressions)
         : Expression(source_range)
         , m_expressions(move(expressions))
     {
@@ -1115,7 +1113,7 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
-    NonnullRefPtrVector<Expression> m_expressions;
+    NonnullRefPtrVector<Expression const> m_expressions;
 };
 
 class Literal : public Expression {
@@ -1314,7 +1312,7 @@ public:
         Setter,
     };
 
-    ClassMethod(SourceRange source_range, NonnullRefPtr<Expression> key, NonnullRefPtr<FunctionExpression> function, Kind kind, bool is_static)
+    ClassMethod(SourceRange source_range, NonnullRefPtr<Expression const> key, NonnullRefPtr<FunctionExpression const> function, Kind kind, bool is_static)
         : ClassElement(source_range, is_static)
         , m_key(move(key))
         , m_function(move(function))
@@ -1332,14 +1330,14 @@ public:
 
 private:
     virtual bool is_class_method() const override { return true; }
-    NonnullRefPtr<Expression> m_key;
-    NonnullRefPtr<FunctionExpression> m_function;
+    NonnullRefPtr<Expression const> m_key;
+    NonnullRefPtr<FunctionExpression const> m_function;
     Kind m_kind;
 };
 
 class ClassField final : public ClassElement {
 public:
-    ClassField(SourceRange source_range, NonnullRefPtr<Expression> key, RefPtr<Expression> init, bool contains_direct_call_to_eval, bool is_static)
+    ClassField(SourceRange source_range, NonnullRefPtr<Expression const> key, RefPtr<Expression const> init, bool contains_direct_call_to_eval, bool is_static)
         : ClassElement(source_range, is_static)
         , m_key(move(key))
         , m_initializer(move(init))
@@ -1348,8 +1346,8 @@ public:
     }
 
     Expression const& key() const { return *m_key; }
-    RefPtr<Expression> const& initializer() const { return m_initializer; }
-    RefPtr<Expression>& initializer() { return m_initializer; }
+    RefPtr<Expression const> const& initializer() const { return m_initializer; }
+    RefPtr<Expression const>& initializer() { return m_initializer; }
 
     virtual ElementKind class_element_kind() const override { return ElementKind::Field; }
 
@@ -1358,8 +1356,8 @@ public:
     virtual Optional<DeprecatedFlyString> private_bound_identifier() const override;
 
 private:
-    NonnullRefPtr<Expression> m_key;
-    RefPtr<Expression> m_initializer;
+    NonnullRefPtr<Expression const> m_key;
+    RefPtr<Expression const> m_initializer;
     bool m_contains_direct_call_to_eval { false };
 };
 
@@ -1397,7 +1395,7 @@ public:
 
 class ClassExpression final : public Expression {
 public:
-    ClassExpression(SourceRange source_range, DeprecatedString name, DeprecatedString source_text, RefPtr<FunctionExpression> constructor, RefPtr<Expression> super_class, NonnullRefPtrVector<ClassElement> elements)
+    ClassExpression(SourceRange source_range, DeprecatedString name, DeprecatedString source_text, RefPtr<FunctionExpression const> constructor, RefPtr<Expression const> super_class, NonnullRefPtrVector<ClassElement const> elements)
         : Expression(source_range)
         , m_name(move(name))
         , m_source_text(move(source_text))
@@ -1409,7 +1407,7 @@ public:
 
     StringView name() const { return m_name; }
     DeprecatedString const& source_text() const { return m_source_text; }
-    RefPtr<FunctionExpression> constructor() const { return m_constructor; }
+    RefPtr<FunctionExpression const> constructor() const { return m_constructor; }
 
     virtual Completion execute(Interpreter&) const override;
     virtual void dump(int indent) const override;
@@ -1424,14 +1422,14 @@ private:
 
     DeprecatedString m_name;
     DeprecatedString m_source_text;
-    RefPtr<FunctionExpression> m_constructor;
-    RefPtr<Expression> m_super_class;
-    NonnullRefPtrVector<ClassElement> m_elements;
+    RefPtr<FunctionExpression const> m_constructor;
+    RefPtr<Expression const> m_super_class;
+    NonnullRefPtrVector<ClassElement const> m_elements;
 };
 
 class ClassDeclaration final : public Declaration {
 public:
-    ClassDeclaration(SourceRange source_range, NonnullRefPtr<ClassExpression> class_expression)
+    ClassDeclaration(SourceRange source_range, NonnullRefPtr<ClassExpression const> class_expression)
         : Declaration(source_range)
         , m_class_expression(move(class_expression))
     {
@@ -1452,12 +1450,12 @@ private:
 
     friend ExportStatement;
 
-    NonnullRefPtr<ClassExpression> m_class_expression;
+    NonnullRefPtr<ClassExpression const> m_class_expression;
 };
 
 class SpreadExpression final : public Expression {
 public:
-    explicit SpreadExpression(SourceRange source_range, NonnullRefPtr<Expression> target)
+    explicit SpreadExpression(SourceRange source_range, NonnullRefPtr<Expression const> target)
         : Expression(source_range)
         , m_target(move(target))
     {
@@ -1468,7 +1466,7 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
-    NonnullRefPtr<Expression> m_target;
+    NonnullRefPtr<Expression const> m_target;
 };
 
 class ThisExpression final : public Expression {
@@ -1483,7 +1481,7 @@ public:
 };
 
 struct CallExpressionArgument {
-    NonnullRefPtr<Expression> value;
+    NonnullRefPtr<Expression const> value;
     bool is_spread;
 };
 
@@ -1493,7 +1491,7 @@ class CallExpression : public ASTNodeWithTailArray<CallExpression, Expression, C
 public:
     using Argument = CallExpressionArgument;
 
-    static NonnullRefPtr<CallExpression> create(SourceRange, NonnullRefPtr<Expression> callee, ReadonlySpan<Argument> arguments);
+    static NonnullRefPtr<CallExpression> create(SourceRange, NonnullRefPtr<Expression const> callee, ReadonlySpan<Argument> arguments);
 
     virtual Completion execute(Interpreter&) const override;
     virtual void dump(int indent) const override;
@@ -1504,7 +1502,7 @@ public:
     ReadonlySpan<Argument> arguments() const { return tail_span(); }
 
 protected:
-    CallExpression(SourceRange source_range, NonnullRefPtr<Expression> callee, ReadonlySpan<Argument> arguments)
+    CallExpression(SourceRange source_range, NonnullRefPtr<Expression const> callee, ReadonlySpan<Argument> arguments)
         : ASTNodeWithTailArray(move(source_range), arguments)
         , m_callee(move(callee))
     {
@@ -1523,21 +1521,21 @@ protected:
     Completion throw_type_error_for_callee(Interpreter&, Value callee_value, StringView call_type) const;
     Optional<DeprecatedString> expression_string() const;
 
-    NonnullRefPtr<Expression> m_callee;
+    NonnullRefPtr<Expression const> m_callee;
 };
 
 class NewExpression final : public CallExpression {
     friend class ASTNodeWithTailArray;
 
 public:
-    static NonnullRefPtr<NewExpression> create(SourceRange, NonnullRefPtr<Expression> callee, ReadonlySpan<Argument> arguments);
+    static NonnullRefPtr<NewExpression> create(SourceRange, NonnullRefPtr<Expression const> callee, ReadonlySpan<Argument> arguments);
 
     virtual Completion execute(Interpreter&) const override;
 
     virtual bool is_new_expression() const override { return true; }
 
 private:
-    NewExpression(SourceRange source_range, NonnullRefPtr<Expression> callee, ReadonlySpan<Argument> arguments)
+    NewExpression(SourceRange source_range, NonnullRefPtr<Expression const> callee, ReadonlySpan<Argument> arguments)
         : CallExpression(move(source_range), move(callee), arguments)
     {
     }
@@ -1599,7 +1597,7 @@ enum class AssignmentOp {
 
 class AssignmentExpression final : public Expression {
 public:
-    AssignmentExpression(SourceRange source_range, AssignmentOp op, NonnullRefPtr<Expression> lhs, NonnullRefPtr<Expression> rhs)
+    AssignmentExpression(SourceRange source_range, AssignmentOp op, NonnullRefPtr<Expression const> lhs, NonnullRefPtr<Expression const> rhs)
         : Expression(source_range)
         , m_op(op)
         , m_lhs(move(lhs))
@@ -1607,7 +1605,7 @@ public:
     {
     }
 
-    AssignmentExpression(SourceRange source_range, AssignmentOp op, NonnullRefPtr<BindingPattern> lhs, NonnullRefPtr<Expression> rhs)
+    AssignmentExpression(SourceRange source_range, AssignmentOp op, NonnullRefPtr<BindingPattern const> lhs, NonnullRefPtr<Expression const> rhs)
         : Expression(source_range)
         , m_op(op)
         , m_lhs(move(lhs))
@@ -1621,8 +1619,8 @@ public:
 
 private:
     AssignmentOp m_op;
-    Variant<NonnullRefPtr<Expression>, NonnullRefPtr<BindingPattern>> m_lhs;
-    NonnullRefPtr<Expression> m_rhs;
+    Variant<NonnullRefPtr<Expression const>, NonnullRefPtr<BindingPattern const>> m_lhs;
+    NonnullRefPtr<Expression const> m_rhs;
 };
 
 enum class UpdateOp {
@@ -1632,7 +1630,7 @@ enum class UpdateOp {
 
 class UpdateExpression final : public Expression {
 public:
-    UpdateExpression(SourceRange source_range, UpdateOp op, NonnullRefPtr<Expression> argument, bool prefixed = false)
+    UpdateExpression(SourceRange source_range, UpdateOp op, NonnullRefPtr<Expression const> argument, bool prefixed = false)
         : Expression(source_range)
         , m_op(op)
         , m_argument(move(argument))
@@ -1648,7 +1646,7 @@ private:
     virtual bool is_update_expression() const override { return true; }
 
     UpdateOp m_op;
-    NonnullRefPtr<Expression> m_argument;
+    NonnullRefPtr<Expression const> m_argument;
     bool m_prefixed;
 };
 
@@ -1660,20 +1658,20 @@ enum class DeclarationKind {
 
 class VariableDeclarator final : public ASTNode {
 public:
-    VariableDeclarator(SourceRange source_range, NonnullRefPtr<Identifier> id)
+    VariableDeclarator(SourceRange source_range, NonnullRefPtr<Identifier const> id)
         : ASTNode(source_range)
         , m_target(move(id))
     {
     }
 
-    VariableDeclarator(SourceRange source_range, NonnullRefPtr<Identifier> target, RefPtr<Expression> init)
+    VariableDeclarator(SourceRange source_range, NonnullRefPtr<Identifier const> target, RefPtr<Expression const> init)
         : ASTNode(source_range)
         , m_target(move(target))
         , m_init(move(init))
     {
     }
 
-    VariableDeclarator(SourceRange source_range, Variant<NonnullRefPtr<Identifier>, NonnullRefPtr<BindingPattern>> target, RefPtr<Expression> init)
+    VariableDeclarator(SourceRange source_range, Variant<NonnullRefPtr<Identifier const>, NonnullRefPtr<BindingPattern const>> target, RefPtr<Expression const> init)
         : ASTNode(source_range)
         , m_target(move(target))
         , m_init(move(init))
@@ -1687,13 +1685,13 @@ public:
     virtual void dump(int indent) const override;
 
 private:
-    Variant<NonnullRefPtr<Identifier>, NonnullRefPtr<BindingPattern>> m_target;
-    RefPtr<Expression> m_init;
+    Variant<NonnullRefPtr<Identifier const>, NonnullRefPtr<BindingPattern const>> m_target;
+    RefPtr<Expression const> m_init;
 };
 
 class VariableDeclaration final : public Declaration {
 public:
-    VariableDeclaration(SourceRange source_range, DeclarationKind declaration_kind, NonnullRefPtrVector<VariableDeclarator> declarations)
+    VariableDeclaration(SourceRange source_range, DeclarationKind declaration_kind, NonnullRefPtrVector<VariableDeclarator const> declarations)
         : Declaration(source_range)
         , m_declaration_kind(declaration_kind)
         , m_declarations(move(declarations))
@@ -1706,7 +1704,7 @@ public:
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
-    NonnullRefPtrVector<VariableDeclarator> const& declarations() const { return m_declarations; }
+    NonnullRefPtrVector<VariableDeclarator const> const& declarations() const { return m_declarations; }
 
     virtual ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const override;
 
@@ -1718,12 +1716,12 @@ private:
     virtual bool is_variable_declaration() const override { return true; }
 
     DeclarationKind m_declaration_kind;
-    NonnullRefPtrVector<VariableDeclarator> m_declarations;
+    NonnullRefPtrVector<VariableDeclarator const> m_declarations;
 };
 
 class UsingDeclaration final : public Declaration {
 public:
-    UsingDeclaration(SourceRange source_range, NonnullRefPtrVector<VariableDeclarator> declarations)
+    UsingDeclaration(SourceRange source_range, NonnullRefPtrVector<VariableDeclarator const> declarations)
         : Declaration(move(source_range))
         , m_declarations(move(declarations))
     {
@@ -1738,10 +1736,10 @@ public:
 
     virtual bool is_lexical_declaration() const override { return true; }
 
-    NonnullRefPtrVector<VariableDeclarator> const& declarations() const { return m_declarations; }
+    NonnullRefPtrVector<VariableDeclarator const> const& declarations() const { return m_declarations; }
 
 private:
-    NonnullRefPtrVector<VariableDeclarator> m_declarations;
+    NonnullRefPtrVector<VariableDeclarator const> m_declarations;
 };
 
 class ObjectProperty final : public ASTNode {
@@ -1754,7 +1752,7 @@ public:
         ProtoSetter,
     };
 
-    ObjectProperty(SourceRange source_range, NonnullRefPtr<Expression> key, RefPtr<Expression> value, Type property_type, bool is_method)
+    ObjectProperty(SourceRange source_range, NonnullRefPtr<Expression const> key, RefPtr<Expression const> value, Type property_type, bool is_method)
         : ASTNode(source_range)
         , m_property_type(property_type)
         , m_is_method(is_method)
@@ -1779,8 +1777,8 @@ public:
 private:
     Type m_property_type;
     bool m_is_method { false };
-    NonnullRefPtr<Expression> m_key;
-    RefPtr<Expression> m_value;
+    NonnullRefPtr<Expression const> m_key;
+    RefPtr<Expression const> m_value;
 };
 
 class ObjectExpression final : public Expression {
@@ -1803,13 +1801,13 @@ private:
 
 class ArrayExpression final : public Expression {
 public:
-    ArrayExpression(SourceRange source_range, Vector<RefPtr<Expression>> elements)
+    ArrayExpression(SourceRange source_range, Vector<RefPtr<Expression const>> elements)
         : Expression(source_range)
         , m_elements(move(elements))
     {
     }
 
-    Vector<RefPtr<Expression>> const& elements() const { return m_elements; }
+    Vector<RefPtr<Expression const>> const& elements() const { return m_elements; }
 
     virtual Completion execute(Interpreter&) const override;
     virtual void dump(int indent) const override;
@@ -1818,18 +1816,18 @@ public:
 private:
     virtual bool is_array_expression() const override { return true; }
 
-    Vector<RefPtr<Expression>> m_elements;
+    Vector<RefPtr<Expression const>> m_elements;
 };
 
 class TemplateLiteral final : public Expression {
 public:
-    TemplateLiteral(SourceRange source_range, NonnullRefPtrVector<Expression> expressions)
+    TemplateLiteral(SourceRange source_range, NonnullRefPtrVector<Expression const> expressions)
         : Expression(source_range)
         , m_expressions(move(expressions))
     {
     }
 
-    TemplateLiteral(SourceRange source_range, NonnullRefPtrVector<Expression> expressions, NonnullRefPtrVector<Expression> raw_strings)
+    TemplateLiteral(SourceRange source_range, NonnullRefPtrVector<Expression const> expressions, NonnullRefPtrVector<Expression const> raw_strings)
         : Expression(source_range)
         , m_expressions(move(expressions))
         , m_raw_strings(move(raw_strings))
@@ -1840,17 +1838,17 @@ public:
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
-    NonnullRefPtrVector<Expression> const& expressions() const { return m_expressions; }
-    NonnullRefPtrVector<Expression> const& raw_strings() const { return m_raw_strings; }
+    NonnullRefPtrVector<Expression const> const& expressions() const { return m_expressions; }
+    NonnullRefPtrVector<Expression const> const& raw_strings() const { return m_raw_strings; }
 
 private:
-    NonnullRefPtrVector<Expression> const m_expressions;
-    NonnullRefPtrVector<Expression> const m_raw_strings;
+    NonnullRefPtrVector<Expression const> const m_expressions;
+    NonnullRefPtrVector<Expression const> const m_raw_strings;
 };
 
 class TaggedTemplateLiteral final : public Expression {
 public:
-    TaggedTemplateLiteral(SourceRange source_range, NonnullRefPtr<Expression> tag, NonnullRefPtr<TemplateLiteral> template_literal)
+    TaggedTemplateLiteral(SourceRange source_range, NonnullRefPtr<Expression const> tag, NonnullRefPtr<TemplateLiteral const> template_literal)
         : Expression(source_range)
         , m_tag(move(tag))
         , m_template_literal(move(template_literal))
@@ -1864,14 +1862,14 @@ public:
     ThrowCompletionOr<Value> get_template_object(Interpreter&) const;
 
 private:
-    NonnullRefPtr<Expression> const m_tag;
-    NonnullRefPtr<TemplateLiteral> const m_template_literal;
+    NonnullRefPtr<Expression const> const m_tag;
+    NonnullRefPtr<TemplateLiteral const> const m_template_literal;
     mutable HashMap<Realm*, Handle<Array>> m_cached_values;
 };
 
 class MemberExpression final : public Expression {
 public:
-    MemberExpression(SourceRange source_range, NonnullRefPtr<Expression> object, NonnullRefPtr<Expression> property, bool computed = false)
+    MemberExpression(SourceRange source_range, NonnullRefPtr<Expression const> object, NonnullRefPtr<Expression const> property, bool computed = false)
         : Expression(source_range)
         , m_computed(computed)
         , m_object(move(object))
@@ -1896,8 +1894,8 @@ private:
     virtual bool is_member_expression() const override { return true; }
 
     bool m_computed { false };
-    NonnullRefPtr<Expression> m_object;
-    NonnullRefPtr<Expression> m_property;
+    NonnullRefPtr<Expression const> m_object;
+    NonnullRefPtr<Expression const> m_property;
 };
 
 class OptionalChain final : public Expression {
@@ -1912,21 +1910,21 @@ public:
         Mode mode;
     };
     struct ComputedReference {
-        NonnullRefPtr<Expression> expression;
+        NonnullRefPtr<Expression const> expression;
         Mode mode;
     };
     struct MemberReference {
-        NonnullRefPtr<Identifier> identifier;
+        NonnullRefPtr<Identifier const> identifier;
         Mode mode;
     };
     struct PrivateMemberReference {
-        NonnullRefPtr<PrivateIdentifier> private_identifier;
+        NonnullRefPtr<PrivateIdentifier const> private_identifier;
         Mode mode;
     };
 
     using Reference = Variant<Call, ComputedReference, MemberReference, PrivateMemberReference>;
 
-    OptionalChain(SourceRange source_range, NonnullRefPtr<Expression> base, Vector<Reference> references)
+    OptionalChain(SourceRange source_range, NonnullRefPtr<Expression const> base, Vector<Reference> references)
         : Expression(source_range)
         , m_base(move(base))
         , m_references(move(references))
@@ -1944,7 +1942,7 @@ private:
     };
     ThrowCompletionOr<ReferenceAndValue> to_reference_and_value(Interpreter&) const;
 
-    NonnullRefPtr<Expression> m_base;
+    NonnullRefPtr<Expression const> m_base;
     Vector<Reference> m_references;
 };
 
@@ -1971,7 +1969,7 @@ private:
 
 class ImportCall final : public Expression {
 public:
-    ImportCall(SourceRange source_range, NonnullRefPtr<Expression> specifier, RefPtr<Expression> options)
+    ImportCall(SourceRange source_range, NonnullRefPtr<Expression const> specifier, RefPtr<Expression const> options)
         : Expression(source_range)
         , m_specifier(move(specifier))
         , m_options(move(options))
@@ -1984,13 +1982,13 @@ public:
 private:
     virtual bool is_import_call() const override { return true; }
 
-    NonnullRefPtr<Expression> m_specifier;
-    RefPtr<Expression> m_options;
+    NonnullRefPtr<Expression const> m_specifier;
+    RefPtr<Expression const> m_options;
 };
 
 class ConditionalExpression final : public Expression {
 public:
-    ConditionalExpression(SourceRange source_range, NonnullRefPtr<Expression> test, NonnullRefPtr<Expression> consequent, NonnullRefPtr<Expression> alternate)
+    ConditionalExpression(SourceRange source_range, NonnullRefPtr<Expression const> test, NonnullRefPtr<Expression const> consequent, NonnullRefPtr<Expression const> alternate)
         : Expression(source_range)
         , m_test(move(test))
         , m_consequent(move(consequent))
@@ -2003,21 +2001,21 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
-    NonnullRefPtr<Expression> m_test;
-    NonnullRefPtr<Expression> m_consequent;
-    NonnullRefPtr<Expression> m_alternate;
+    NonnullRefPtr<Expression const> m_test;
+    NonnullRefPtr<Expression const> m_consequent;
+    NonnullRefPtr<Expression const> m_alternate;
 };
 
 class CatchClause final : public ASTNode {
 public:
-    CatchClause(SourceRange source_range, DeprecatedFlyString parameter, NonnullRefPtr<BlockStatement> body)
+    CatchClause(SourceRange source_range, DeprecatedFlyString parameter, NonnullRefPtr<BlockStatement const> body)
         : ASTNode(source_range)
         , m_parameter(move(parameter))
         , m_body(move(body))
     {
     }
 
-    CatchClause(SourceRange source_range, NonnullRefPtr<BindingPattern> parameter, NonnullRefPtr<BlockStatement> body)
+    CatchClause(SourceRange source_range, NonnullRefPtr<BindingPattern const> parameter, NonnullRefPtr<BlockStatement const> body)
         : ASTNode(source_range)
         , m_parameter(move(parameter))
         , m_body(move(body))
@@ -2031,13 +2029,13 @@ public:
     virtual Completion execute(Interpreter&) const override;
 
 private:
-    Variant<DeprecatedFlyString, NonnullRefPtr<BindingPattern>> m_parameter;
-    NonnullRefPtr<BlockStatement> m_body;
+    Variant<DeprecatedFlyString, NonnullRefPtr<BindingPattern const>> m_parameter;
+    NonnullRefPtr<BlockStatement const> m_body;
 };
 
 class TryStatement final : public Statement {
 public:
-    TryStatement(SourceRange source_range, NonnullRefPtr<BlockStatement> block, RefPtr<CatchClause> handler, RefPtr<BlockStatement> finalizer)
+    TryStatement(SourceRange source_range, NonnullRefPtr<BlockStatement const> block, RefPtr<CatchClause const> handler, RefPtr<BlockStatement const> finalizer)
         : Statement(source_range)
         , m_block(move(block))
         , m_handler(move(handler))
@@ -2054,14 +2052,14 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
-    NonnullRefPtr<BlockStatement> m_block;
-    RefPtr<CatchClause> m_handler;
-    RefPtr<BlockStatement> m_finalizer;
+    NonnullRefPtr<BlockStatement const> m_block;
+    RefPtr<CatchClause const> m_handler;
+    RefPtr<BlockStatement const> m_finalizer;
 };
 
 class ThrowStatement final : public Statement {
 public:
-    explicit ThrowStatement(SourceRange source_range, NonnullRefPtr<Expression> argument)
+    explicit ThrowStatement(SourceRange source_range, NonnullRefPtr<Expression const> argument)
         : Statement(source_range)
         , m_argument(move(argument))
     {
@@ -2074,12 +2072,12 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
-    NonnullRefPtr<Expression> m_argument;
+    NonnullRefPtr<Expression const> m_argument;
 };
 
 class SwitchCase final : public ScopeNode {
 public:
-    SwitchCase(SourceRange source_range, RefPtr<Expression> test)
+    SwitchCase(SourceRange source_range, RefPtr<Expression const> test)
         : ScopeNode(source_range)
         , m_test(move(test))
     {
@@ -2091,12 +2089,12 @@ public:
     virtual Completion execute(Interpreter&) const override;
 
 private:
-    RefPtr<Expression> m_test;
+    RefPtr<Expression const> m_test;
 };
 
 class SwitchStatement final : public ScopeNode {
 public:
-    SwitchStatement(SourceRange source_range, NonnullRefPtr<Expression> discriminant)
+    SwitchStatement(SourceRange source_range, NonnullRefPtr<Expression const> discriminant)
         : ScopeNode(source_range)
         , m_discriminant(move(discriminant))
     {
@@ -2108,11 +2106,11 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&) const;
 
     Completion execute_impl(Interpreter&) const;
-    void add_case(NonnullRefPtr<SwitchCase> switch_case) { m_cases.append(move(switch_case)); }
+    void add_case(NonnullRefPtr<SwitchCase const> switch_case) { m_cases.append(move(switch_case)); }
 
 private:
-    NonnullRefPtr<Expression> m_discriminant;
-    NonnullRefPtrVector<SwitchCase> m_cases;
+    NonnullRefPtr<Expression const> m_discriminant;
+    NonnullRefPtrVector<SwitchCase const> m_cases;
 };
 
 class BreakStatement final : public Statement {

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, Stephan Unverwerth <s.unverwerth@serenityos.org>
  * Copyright (c) 2021-2022, David Tuin <davidot@serenityos.org>
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -70,34 +71,34 @@ public:
         No
     };
 
-    RefPtr<BindingPattern> parse_binding_pattern(AllowDuplicates is_var_declaration = AllowDuplicates::No, AllowMemberExpressions allow_member_expressions = AllowMemberExpressions::No);
+    RefPtr<BindingPattern const> parse_binding_pattern(AllowDuplicates is_var_declaration = AllowDuplicates::No, AllowMemberExpressions allow_member_expressions = AllowMemberExpressions::No);
 
     struct PrimaryExpressionParseResult {
-        NonnullRefPtr<Expression> result;
+        NonnullRefPtr<Expression const> result;
         bool should_continue_parsing_as_expression { true };
     };
 
-    NonnullRefPtr<Declaration> parse_declaration();
+    NonnullRefPtr<Declaration const> parse_declaration();
 
     enum class AllowLabelledFunction {
         No,
         Yes
     };
 
-    NonnullRefPtr<Statement> parse_statement(AllowLabelledFunction allow_labelled_function = AllowLabelledFunction::No);
-    NonnullRefPtr<BlockStatement> parse_block_statement();
-    NonnullRefPtr<FunctionBody> parse_function_body(Vector<FunctionParameter> const& parameters, FunctionKind function_kind, bool& contains_direct_call_to_eval);
-    NonnullRefPtr<ReturnStatement> parse_return_statement();
+    NonnullRefPtr<Statement const> parse_statement(AllowLabelledFunction allow_labelled_function = AllowLabelledFunction::No);
+    NonnullRefPtr<BlockStatement const> parse_block_statement();
+    NonnullRefPtr<FunctionBody const> parse_function_body(Vector<FunctionParameter> const& parameters, FunctionKind function_kind, bool& contains_direct_call_to_eval);
+    NonnullRefPtr<ReturnStatement const> parse_return_statement();
 
     enum class IsForLoopVariableDeclaration {
         No,
         Yes
     };
 
-    NonnullRefPtr<VariableDeclaration> parse_variable_declaration(IsForLoopVariableDeclaration is_for_loop_variable_declaration = IsForLoopVariableDeclaration::No);
-    RefPtr<Identifier> parse_lexical_binding();
-    NonnullRefPtr<UsingDeclaration> parse_using_declaration(IsForLoopVariableDeclaration is_for_loop_variable_declaration = IsForLoopVariableDeclaration::No);
-    NonnullRefPtr<Statement> parse_for_statement();
+    NonnullRefPtr<VariableDeclaration const> parse_variable_declaration(IsForLoopVariableDeclaration is_for_loop_variable_declaration = IsForLoopVariableDeclaration::No);
+    RefPtr<Identifier const> parse_lexical_binding();
+    NonnullRefPtr<UsingDeclaration const> parse_using_declaration(IsForLoopVariableDeclaration is_for_loop_variable_declaration = IsForLoopVariableDeclaration::No);
+    NonnullRefPtr<Statement const> parse_for_statement();
 
     enum class IsForAwaitLoop {
         No,
@@ -122,36 +123,43 @@ public:
 
     struct ExpressionResult {
         template<typename T>
-        ExpressionResult(NonnullRefPtr<T> expression, ForbiddenTokens forbidden = {})
-            : expression(expression)
+        ExpressionResult(NonnullRefPtr<T const> expression, ForbiddenTokens forbidden = {})
+            : expression(move(expression))
             , forbidden(forbidden)
         {
         }
-        NonnullRefPtr<Expression> expression;
+
+        template<typename T>
+        ExpressionResult(NonnullRefPtr<T> expression, ForbiddenTokens forbidden = {})
+            : expression(move(expression))
+            , forbidden(forbidden)
+        {
+        }
+        NonnullRefPtr<Expression const> expression;
         ForbiddenTokens forbidden;
     };
 
-    NonnullRefPtr<Statement> parse_for_in_of_statement(NonnullRefPtr<ASTNode> lhs, IsForAwaitLoop is_await);
-    NonnullRefPtr<IfStatement> parse_if_statement();
-    NonnullRefPtr<ThrowStatement> parse_throw_statement();
-    NonnullRefPtr<TryStatement> parse_try_statement();
-    NonnullRefPtr<CatchClause> parse_catch_clause();
-    NonnullRefPtr<SwitchStatement> parse_switch_statement();
-    NonnullRefPtr<SwitchCase> parse_switch_case();
-    NonnullRefPtr<BreakStatement> parse_break_statement();
-    NonnullRefPtr<ContinueStatement> parse_continue_statement();
-    NonnullRefPtr<DoWhileStatement> parse_do_while_statement();
-    NonnullRefPtr<WhileStatement> parse_while_statement();
-    NonnullRefPtr<WithStatement> parse_with_statement();
-    NonnullRefPtr<DebuggerStatement> parse_debugger_statement();
-    NonnullRefPtr<ConditionalExpression> parse_conditional_expression(NonnullRefPtr<Expression> test, ForbiddenTokens);
-    NonnullRefPtr<OptionalChain> parse_optional_chain(NonnullRefPtr<Expression> base);
-    NonnullRefPtr<Expression> parse_expression(int min_precedence, Associativity associate = Associativity::Right, ForbiddenTokens forbidden = {});
+    NonnullRefPtr<Statement const> parse_for_in_of_statement(NonnullRefPtr<ASTNode const> lhs, IsForAwaitLoop is_await);
+    NonnullRefPtr<IfStatement const> parse_if_statement();
+    NonnullRefPtr<ThrowStatement const> parse_throw_statement();
+    NonnullRefPtr<TryStatement const> parse_try_statement();
+    NonnullRefPtr<CatchClause const> parse_catch_clause();
+    NonnullRefPtr<SwitchStatement const> parse_switch_statement();
+    NonnullRefPtr<SwitchCase const> parse_switch_case();
+    NonnullRefPtr<BreakStatement const> parse_break_statement();
+    NonnullRefPtr<ContinueStatement const> parse_continue_statement();
+    NonnullRefPtr<DoWhileStatement const> parse_do_while_statement();
+    NonnullRefPtr<WhileStatement const> parse_while_statement();
+    NonnullRefPtr<WithStatement const> parse_with_statement();
+    NonnullRefPtr<DebuggerStatement const> parse_debugger_statement();
+    NonnullRefPtr<ConditionalExpression const> parse_conditional_expression(NonnullRefPtr<Expression const> test, ForbiddenTokens);
+    NonnullRefPtr<OptionalChain const> parse_optional_chain(NonnullRefPtr<Expression const> base);
+    NonnullRefPtr<Expression const> parse_expression(int min_precedence, Associativity associate = Associativity::Right, ForbiddenTokens forbidden = {});
     PrimaryExpressionParseResult parse_primary_expression();
-    NonnullRefPtr<Expression> parse_unary_prefixed_expression();
-    NonnullRefPtr<RegExpLiteral> parse_regexp_literal();
-    NonnullRefPtr<ObjectExpression> parse_object_expression();
-    NonnullRefPtr<ArrayExpression> parse_array_expression();
+    NonnullRefPtr<Expression const> parse_unary_prefixed_expression();
+    NonnullRefPtr<RegExpLiteral const> parse_regexp_literal();
+    NonnullRefPtr<ObjectExpression const> parse_object_expression();
+    NonnullRefPtr<ArrayExpression const> parse_array_expression();
 
     enum class StringLiteralType {
         Normal,
@@ -159,26 +167,26 @@ public:
         TaggedTemplate
     };
 
-    NonnullRefPtr<StringLiteral> parse_string_literal(Token const& token, StringLiteralType string_literal_type = StringLiteralType::Normal, bool* contains_invalid_escape = nullptr);
-    NonnullRefPtr<TemplateLiteral> parse_template_literal(bool is_tagged);
-    ExpressionResult parse_secondary_expression(NonnullRefPtr<Expression>, int min_precedence, Associativity associate = Associativity::Right, ForbiddenTokens forbidden = {});
-    NonnullRefPtr<Expression> parse_call_expression(NonnullRefPtr<Expression>);
-    NonnullRefPtr<NewExpression> parse_new_expression();
-    NonnullRefPtr<ClassDeclaration> parse_class_declaration();
-    NonnullRefPtr<ClassExpression> parse_class_expression(bool expect_class_name);
-    NonnullRefPtr<YieldExpression> parse_yield_expression();
-    NonnullRefPtr<AwaitExpression> parse_await_expression();
-    NonnullRefPtr<Expression> parse_property_key();
-    NonnullRefPtr<AssignmentExpression> parse_assignment_expression(AssignmentOp, NonnullRefPtr<Expression> lhs, int min_precedence, Associativity, ForbiddenTokens forbidden = {});
-    NonnullRefPtr<Identifier> parse_identifier();
-    NonnullRefPtr<ImportStatement> parse_import_statement(Program& program);
-    NonnullRefPtr<ExportStatement> parse_export_statement(Program& program);
+    NonnullRefPtr<StringLiteral const> parse_string_literal(Token const& token, StringLiteralType string_literal_type = StringLiteralType::Normal, bool* contains_invalid_escape = nullptr);
+    NonnullRefPtr<TemplateLiteral const> parse_template_literal(bool is_tagged);
+    ExpressionResult parse_secondary_expression(NonnullRefPtr<Expression const>, int min_precedence, Associativity associate = Associativity::Right, ForbiddenTokens forbidden = {});
+    NonnullRefPtr<Expression const> parse_call_expression(NonnullRefPtr<Expression const>);
+    NonnullRefPtr<NewExpression const> parse_new_expression();
+    NonnullRefPtr<ClassDeclaration const> parse_class_declaration();
+    NonnullRefPtr<ClassExpression const> parse_class_expression(bool expect_class_name);
+    NonnullRefPtr<YieldExpression const> parse_yield_expression();
+    NonnullRefPtr<AwaitExpression const> parse_await_expression();
+    NonnullRefPtr<Expression const> parse_property_key();
+    NonnullRefPtr<AssignmentExpression const> parse_assignment_expression(AssignmentOp, NonnullRefPtr<Expression const> lhs, int min_precedence, Associativity, ForbiddenTokens forbidden = {});
+    NonnullRefPtr<Identifier const> parse_identifier();
+    NonnullRefPtr<ImportStatement const> parse_import_statement(Program& program);
+    NonnullRefPtr<ExportStatement const> parse_export_statement(Program& program);
 
-    RefPtr<FunctionExpression> try_parse_arrow_function_expression(bool expect_parens, bool is_async = false);
-    RefPtr<LabelledStatement> try_parse_labelled_statement(AllowLabelledFunction allow_function);
-    RefPtr<MetaProperty> try_parse_new_target_expression();
-    RefPtr<MetaProperty> try_parse_import_meta_expression();
-    NonnullRefPtr<ImportCall> parse_import_call();
+    RefPtr<FunctionExpression const> try_parse_arrow_function_expression(bool expect_parens, bool is_async = false);
+    RefPtr<LabelledStatement const> try_parse_labelled_statement(AllowLabelledFunction allow_function);
+    RefPtr<MetaProperty const> try_parse_new_target_expression();
+    RefPtr<MetaProperty const> try_parse_import_meta_expression();
+    NonnullRefPtr<ImportCall const> parse_import_call();
 
     Vector<CallExpression::Argument> parse_arguments();
 
@@ -246,7 +254,7 @@ private:
     void discard_saved_state();
     Position position() const;
 
-    RefPtr<BindingPattern> synthesize_binding_pattern(Expression const& expression);
+    RefPtr<BindingPattern const> synthesize_binding_pattern(Expression const& expression);
 
     Token next_token(size_t steps = 1) const;
 
@@ -333,7 +341,7 @@ private:
         }
     };
 
-    NonnullRefPtr<SourceCode> m_source_code;
+    NonnullRefPtr<SourceCode const> m_source_code;
     Vector<Position> m_rule_starts;
     ParserState m_state;
     DeprecatedFlyString m_filename;

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, Stephan Unverwerth <s.unverwerth@serenityos.org>
  * Copyright (c) 2020-2022, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -350,7 +351,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
                 if (parameter_names.set(name) != AK::HashSetResult::InsertedNewEntry)
                     has_duplicates = true;
             },
-            [&](NonnullRefPtr<BindingPattern> const& pattern) {
+            [&](NonnullRefPtr<BindingPattern const> const& pattern) {
                 if (pattern->contains_expression())
                     has_parameter_expressions = true;
 
@@ -472,7 +473,8 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
                         return reference.put_value(vm, argument_value);
                     else
                         return reference.initialize_referenced_binding(vm, argument_value);
-                } else if (IsSame<NonnullRefPtr<BindingPattern> const&, decltype(param)>) {
+                }
+                if constexpr (IsSame<NonnullRefPtr<BindingPattern const> const&, decltype(param)>) {
                     // Here the difference from hasDuplicates is important
                     return vm.binding_initialization(param, argument_value, used_environment);
                 }
@@ -728,7 +730,7 @@ void ECMAScriptFunctionObject::async_function_start(PromiseCapability const& pro
 }
 
 // 27.7.5.2 AsyncBlockStart ( promiseCapability, asyncBody, asyncContext ), https://tc39.es/ecma262/#sec-asyncblockstart
-void async_block_start(VM& vm, NonnullRefPtr<Statement> const& async_body, PromiseCapability const& promise_capability, ExecutionContext& async_context)
+void async_block_start(VM& vm, NonnullRefPtr<Statement const> const& async_body, PromiseCapability const& promise_capability, ExecutionContext& async_context)
 {
     auto& realm = *vm.current_realm();
 

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2020-2022, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,7 +15,7 @@
 
 namespace JS {
 
-void async_block_start(VM&, NonnullRefPtr<Statement> const& parse_node, PromiseCapability const&, ExecutionContext&);
+void async_block_start(VM&, NonnullRefPtr<Statement const> const& parse_node, PromiseCapability const&, ExecutionContext&);
 
 // 10.2 ECMAScript Function Objects, https://tc39.es/ecma262/#sec-ecmascript-function-objects
 class ECMAScriptFunctionObject final : public FunctionObject {
@@ -114,7 +115,7 @@ private:
     Environment* m_environment { nullptr };                                  // [[Environment]]
     PrivateEnvironment* m_private_environment { nullptr };                   // [[PrivateEnvironment]]
     Vector<FunctionParameter> const m_formal_parameters;                     // [[FormalParameters]]
-    NonnullRefPtr<Statement> m_ecmascript_code;                              // [[ECMAScriptCode]]
+    NonnullRefPtr<Statement const> m_ecmascript_code;                        // [[ECMAScriptCode]]
     Realm* m_realm { nullptr };                                              // [[Realm]]
     ScriptOrModule m_script_or_module;                                       // [[ScriptOrModule]]
     Object* m_home_object { nullptr };                                       // [[HomeObject]]

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2020-2023, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021-2022, David Tuin <davidot@serenityos.org>
  *
@@ -235,9 +235,9 @@ public:
 
     CustomData* custom_data() { return m_custom_data; }
 
-    ThrowCompletionOr<void> destructuring_assignment_evaluation(NonnullRefPtr<BindingPattern> const& target, Value value);
+    ThrowCompletionOr<void> destructuring_assignment_evaluation(NonnullRefPtr<BindingPattern const> const& target, Value value);
     ThrowCompletionOr<void> binding_initialization(DeprecatedFlyString const& target, Value value, Environment* environment);
-    ThrowCompletionOr<void> binding_initialization(NonnullRefPtr<BindingPattern> const& target, Value value, Environment* environment);
+    ThrowCompletionOr<void> binding_initialization(NonnullRefPtr<BindingPattern const> const& target, Value value, Environment* environment);
 
     ThrowCompletionOr<Value> named_evaluation_if_anonymous_function(ASTNode const& expression, DeprecatedFlyString const& name);
 

--- a/Userland/Libraries/LibJS/SourceCode.cpp
+++ b/Userland/Libraries/LibJS/SourceCode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,7 +12,7 @@
 
 namespace JS {
 
-NonnullRefPtr<SourceCode> SourceCode::create(String filename, String code)
+NonnullRefPtr<SourceCode const> SourceCode::create(String filename, String code)
 {
     return adopt_ref(*new SourceCode(move(filename), move(code)));
 }

--- a/Userland/Libraries/LibJS/SourceCode.h
+++ b/Userland/Libraries/LibJS/SourceCode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,7 +14,7 @@ namespace JS {
 
 class SourceCode : public RefCounted<SourceCode> {
 public:
-    static NonnullRefPtr<SourceCode> create(String filename, String code);
+    static NonnullRefPtr<SourceCode const> create(String filename, String code);
 
     String const& filename() const;
     String const& code() const;

--- a/Userland/Libraries/LibJS/SourceRange.h
+++ b/Userland/Libraries/LibJS/SourceRange.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -21,7 +22,7 @@ struct Position {
 struct SourceRange {
     [[nodiscard]] bool contains(Position const& position) const { return position.offset <= end.offset && position.offset >= start.offset; }
 
-    NonnullRefPtr<SourceCode> code;
+    NonnullRefPtr<SourceCode const> code;
     Position start;
     Position end;
 

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, David Tuin <davidot@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -49,7 +49,7 @@ static Vector<ModuleRequest> module_requests(Program& program, Vector<Deprecated
     // Note: The List is source text occurrence ordered!
     struct RequestedModuleAndSourceIndex {
         u32 source_offset { 0 };
-        ModuleRequest* module_request { nullptr };
+        ModuleRequest const* module_request { nullptr };
     };
 
     Vector<RequestedModuleAndSourceIndex> requested_modules_with_indices;
@@ -89,7 +89,7 @@ static Vector<ModuleRequest> module_requests(Program& program, Vector<Deprecated
             // 2. Let assertions be AssertClauseToAssertions of AssertClause.
             auto assertions = assert_clause_to_assertions(module.module_request->assertions, supported_import_assertions);
             // Note: We have to modify the assertions in place because else it might keep non supported ones
-            module.module_request->assertions = move(assertions);
+            const_cast<ModuleRequest*>(module.module_request)->assertions = move(assertions);
 
             // 3. Return a ModuleRequest Record { [[Specifer]]: specifier, [[Assertions]]: assertions }.
             requested_modules_in_source_order.empend(module.module_request->module_specifier, module.module_request->assertions);
@@ -102,7 +102,7 @@ static Vector<ModuleRequest> module_requests(Program& program, Vector<Deprecated
 SourceTextModule::SourceTextModule(Realm& realm, StringView filename, Script::HostDefined* host_defined, bool has_top_level_await, NonnullRefPtr<Program> body, Vector<ModuleRequest> requested_modules,
     Vector<ImportEntry> import_entries, Vector<ExportEntry> local_export_entries,
     Vector<ExportEntry> indirect_export_entries, Vector<ExportEntry> star_export_entries,
-    RefPtr<ExportStatement> default_export)
+    RefPtr<ExportStatement const> default_export)
     : CyclicModule(realm, filename, has_top_level_await, move(requested_modules), host_defined)
     , m_ecmascript_code(move(body))
     , m_execution_context(realm.heap())
@@ -157,7 +157,7 @@ Result<NonnullGCPtr<SourceTextModule>, Vector<ParserError>> SourceTextModule::pa
     Vector<ExportEntry> star_export_entries;
 
     // Note: Not in the spec but makes it easier to find the default.
-    RefPtr<ExportStatement> default_export;
+    RefPtr<ExportStatement const> default_export;
 
     // 9. Let exportEntries be ExportEntries of body.
     // 10. For each ExportEntry Record ee of exportEntries, do

--- a/Userland/Libraries/LibJS/SourceTextModule.h
+++ b/Userland/Libraries/LibJS/SourceTextModule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, David Tuin <davidot@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -36,7 +36,7 @@ private:
     SourceTextModule(Realm&, StringView filename, Script::HostDefined* host_defined, bool has_top_level_await, NonnullRefPtr<Program> body, Vector<ModuleRequest> requested_modules,
         Vector<ImportEntry> import_entries, Vector<ExportEntry> local_export_entries,
         Vector<ExportEntry> indirect_export_entries, Vector<ExportEntry> star_export_entries,
-        RefPtr<ExportStatement> default_export);
+        RefPtr<ExportStatement const> default_export);
 
     virtual void visit_edges(Cell::Visitor&) override;
 
@@ -48,7 +48,7 @@ private:
     Vector<ExportEntry> m_indirect_export_entries; // [[IndirectExportEntries]]
     Vector<ExportEntry> m_star_export_entries;     // [[StarExportEntries]]
 
-    RefPtr<ExportStatement> m_default_export; // Note: Not from the spec
+    RefPtr<ExportStatement const> m_default_export; // Note: Not from the spec
 };
 
 }

--- a/Userland/Libraries/LibManual/Node.cpp
+++ b/Userland/Libraries/LibManual/Node.cpp
@@ -17,7 +17,7 @@
 
 namespace Manual {
 
-ErrorOr<NonnullRefPtr<PageNode>> Node::try_create_from_query(Vector<StringView, 2> const& query_parameters)
+ErrorOr<NonnullRefPtr<PageNode const>> Node::try_create_from_query(Vector<StringView, 2> const& query_parameters)
 {
     if (query_parameters.size() > 2)
         return Error::from_string_literal("Queries longer than 2 strings are not supported yet");
@@ -66,7 +66,7 @@ ErrorOr<NonnullRefPtr<PageNode>> Node::try_create_from_query(Vector<StringView, 
     return Error::from_string_literal("Page doesn't exist in section");
 }
 
-ErrorOr<NonnullRefPtr<Node>> Node::try_find_from_help_url(URL const& url)
+ErrorOr<NonnullRefPtr<Node const>> Node::try_find_from_help_url(URL const& url)
 {
     if (url.host() != "man")
         return Error::from_string_view("Bad help operation"sv);
@@ -82,7 +82,7 @@ ErrorOr<NonnullRefPtr<Node>> Node::try_find_from_help_url(URL const& url)
     if (section_number > number_of_sections)
         return Error::from_string_view("Section number out of bounds"sv);
 
-    NonnullRefPtr<Node> current_node = sections[section_number - 1];
+    NonnullRefPtr<Node const> current_node = sections[section_number - 1];
 
     while (!paths.is_empty()) {
         auto next_path_segment = TRY(String::from_deprecated_string(paths.take_first()));

--- a/Userland/Libraries/LibManual/Node.h
+++ b/Userland/Libraries/LibManual/Node.h
@@ -20,7 +20,7 @@ class Node : public RefCounted<Node> {
 public:
     virtual ~Node() = default;
 
-    virtual ErrorOr<Span<NonnullRefPtr<Node>>> children() const = 0;
+    virtual ErrorOr<Span<NonnullRefPtr<Node const>>> children() const = 0;
     virtual Node const* parent() const = 0;
     virtual ErrorOr<String> name() const = 0;
     virtual bool is_page() const { return false; }
@@ -33,11 +33,11 @@ public:
     // [page] (no second argument) - will find first section with that page
     // [section] [page]
     // Help can also (externally) handle search queries, which is not possible (yet) in man.
-    static ErrorOr<NonnullRefPtr<PageNode>> try_create_from_query(Vector<StringView, 2> const& query_parameters);
+    static ErrorOr<NonnullRefPtr<PageNode const>> try_create_from_query(Vector<StringView, 2> const& query_parameters);
 
     // Finds a page via the help://man/<number>/<subsections...>/page URLs.
     // This will automatically start discovering pages by inspecting the filesystem.
-    static ErrorOr<NonnullRefPtr<Node>> try_find_from_help_url(URL const&);
+    static ErrorOr<NonnullRefPtr<Node const>> try_find_from_help_url(URL const&);
 };
 
 }

--- a/Userland/Libraries/LibManual/PageNode.cpp
+++ b/Userland/Libraries/LibManual/PageNode.cpp
@@ -16,9 +16,9 @@ Node const* PageNode::parent() const
     return m_section.ptr();
 }
 
-ErrorOr<Span<NonnullRefPtr<Node>>> PageNode::children() const
+ErrorOr<Span<NonnullRefPtr<Node const>>> PageNode::children() const
 {
-    static NonnullRefPtrVector<Node> empty_vector;
+    static NonnullRefPtrVector<Node const> empty_vector;
     return empty_vector.span();
 }
 

--- a/Userland/Libraries/LibManual/PageNode.h
+++ b/Userland/Libraries/LibManual/PageNode.h
@@ -17,13 +17,13 @@ class PageNode : public Node {
 public:
     virtual ~PageNode() override = default;
 
-    PageNode(NonnullRefPtr<SectionNode> section, String page)
+    PageNode(NonnullRefPtr<SectionNode const> section, String page)
         : m_section(move(section))
         , m_page(move(page))
     {
     }
 
-    virtual ErrorOr<Span<NonnullRefPtr<Node>>> children() const override;
+    virtual ErrorOr<Span<NonnullRefPtr<Node const>>> children() const override;
     virtual Node const* parent() const override;
     virtual ErrorOr<String> name() const override { return m_page; };
     virtual bool is_page() const override { return true; }
@@ -34,7 +34,7 @@ public:
     static ErrorOr<NonnullRefPtr<PageNode>> help_index_page();
 
 private:
-    NonnullRefPtr<SectionNode> m_section;
+    NonnullRefPtr<SectionNode const> m_section;
     String m_page;
 };
 

--- a/Userland/Libraries/LibManual/SectionNode.cpp
+++ b/Userland/Libraries/LibManual/SectionNode.cpp
@@ -46,7 +46,7 @@ ErrorOr<void> SectionNode::reify_if_needed() const
     Core::DirIterator dir_iter { own_path.to_deprecated_string(), Core::DirIterator::Flags::SkipDots };
 
     struct Child {
-        NonnullRefPtr<Node> node;
+        NonnullRefPtr<Node const> node;
         String name_for_sorting;
     };
     Vector<Child> children;

--- a/Userland/Libraries/LibManual/SectionNode.h
+++ b/Userland/Libraries/LibManual/SectionNode.h
@@ -23,7 +23,7 @@ public:
     {
     }
 
-    virtual ErrorOr<Span<NonnullRefPtr<Node>>> children() const override
+    virtual ErrorOr<Span<NonnullRefPtr<Node const>>> children() const override
     {
         TRY(reify_if_needed());
         return m_children.span();
@@ -48,7 +48,7 @@ protected:
 private:
     ErrorOr<void> reify_if_needed() const;
 
-    mutable NonnullRefPtrVector<Node> m_children;
+    mutable NonnullRefPtrVector<Node const> m_children;
     mutable bool m_reified { false };
     bool m_open { false };
 };

--- a/Userland/Libraries/LibManual/SubsectionNode.cpp
+++ b/Userland/Libraries/LibManual/SubsectionNode.cpp
@@ -10,7 +10,7 @@
 
 namespace Manual {
 
-SubsectionNode::SubsectionNode(NonnullRefPtr<SectionNode> parent, StringView name)
+SubsectionNode::SubsectionNode(NonnullRefPtr<SectionNode const> parent, StringView name)
     : SectionNode(name, name)
     , m_parent(move(parent))
 {
@@ -31,7 +31,7 @@ PageNode const* SubsectionNode::document() const
         if (sibling_name.is_error())
             continue;
         if (sibling_name.value() == m_name && is<PageNode>(*sibling))
-            return static_cast<PageNode*>(&*sibling);
+            return static_cast<PageNode const*>(&*sibling);
     }
     return nullptr;
 }

--- a/Userland/Libraries/LibManual/SubsectionNode.h
+++ b/Userland/Libraries/LibManual/SubsectionNode.h
@@ -13,7 +13,7 @@ namespace Manual {
 // A non-toplevel (i.e. not numbered) manual section.
 class SubsectionNode : public SectionNode {
 public:
-    SubsectionNode(NonnullRefPtr<SectionNode> parent, StringView name);
+    SubsectionNode(NonnullRefPtr<SectionNode const> parent, StringView name);
     virtual ~SubsectionNode() = default;
 
     virtual Node const* parent() const override;
@@ -22,7 +22,7 @@ public:
     virtual PageNode const* document() const override;
 
 protected:
-    NonnullRefPtr<SectionNode> m_parent;
+    NonnullRefPtr<SectionNode const> m_parent;
 };
 
 }

--- a/Userland/Libraries/LibPDF/Object.h
+++ b/Userland/Libraries/LibPDF/Object.h
@@ -61,7 +61,7 @@ public:
 #ifdef PDF_DEBUG
         SourceLocation loc = SourceLocation::current()
 #endif
-    ) const
+            )
     requires(!IsSame<T, Object>)
     {
 #ifdef PDF_DEBUG
@@ -71,7 +71,7 @@ public:
         }
 #endif
 
-        return NonnullRefPtr<T>(static_cast<T const&>(*this));
+        return NonnullRefPtr<T>(static_cast<T&>(*this));
     }
 
     virtual char const* type_name() const = 0;

--- a/Userland/Libraries/LibPartition/EBRPartitionTable.cpp
+++ b/Userland/Libraries/LibPartition/EBRPartitionTable.cpp
@@ -13,7 +13,7 @@
 namespace Partition {
 
 #ifdef KERNEL
-ErrorOr<NonnullOwnPtr<EBRPartitionTable>> EBRPartitionTable::try_to_initialize(Kernel::StorageDevice const& device)
+ErrorOr<NonnullOwnPtr<EBRPartitionTable>> EBRPartitionTable::try_to_initialize(Kernel::StorageDevice& device)
 {
     auto table = TRY(adopt_nonnull_own_or_enomem(new (nothrow) EBRPartitionTable(device)));
 #else
@@ -29,7 +29,7 @@ ErrorOr<NonnullOwnPtr<EBRPartitionTable>> EBRPartitionTable::try_to_initialize(N
 }
 
 #ifdef KERNEL
-void EBRPartitionTable::search_extended_partition(Kernel::StorageDevice const& device, MBRPartitionTable& checked_ebr, u64 current_block_offset, size_t limit)
+void EBRPartitionTable::search_extended_partition(Kernel::StorageDevice& device, MBRPartitionTable& checked_ebr, u64 current_block_offset, size_t limit)
 #else
 void EBRPartitionTable::search_extended_partition(NonnullRefPtr<Core::DeprecatedFile> device, MBRPartitionTable& checked_ebr, u64 current_block_offset, size_t limit)
 #endif
@@ -53,7 +53,7 @@ void EBRPartitionTable::search_extended_partition(NonnullRefPtr<Core::Deprecated
 }
 
 #ifdef KERNEL
-EBRPartitionTable::EBRPartitionTable(Kernel::StorageDevice const& device)
+EBRPartitionTable::EBRPartitionTable(Kernel::StorageDevice& device)
 #else
 EBRPartitionTable::EBRPartitionTable(NonnullRefPtr<Core::DeprecatedFile> device)
 #endif

--- a/Userland/Libraries/LibPartition/EBRPartitionTable.h
+++ b/Userland/Libraries/LibPartition/EBRPartitionTable.h
@@ -16,8 +16,8 @@ public:
     ~EBRPartitionTable();
 
 #ifdef KERNEL
-    static ErrorOr<NonnullOwnPtr<EBRPartitionTable>> try_to_initialize(Kernel::StorageDevice const&);
-    explicit EBRPartitionTable(Kernel::StorageDevice const&);
+    static ErrorOr<NonnullOwnPtr<EBRPartitionTable>> try_to_initialize(Kernel::StorageDevice&);
+    explicit EBRPartitionTable(Kernel::StorageDevice&);
 #else
     static ErrorOr<NonnullOwnPtr<EBRPartitionTable>> try_to_initialize(NonnullRefPtr<Core::DeprecatedFile>);
     explicit EBRPartitionTable(NonnullRefPtr<Core::DeprecatedFile>);
@@ -30,7 +30,7 @@ public:
 
 private:
 #ifdef KERNEL
-    void search_extended_partition(Kernel::StorageDevice const&, MBRPartitionTable&, u64, size_t limit);
+    void search_extended_partition(Kernel::StorageDevice&, MBRPartitionTable&, u64, size_t limit);
 #else
     void search_extended_partition(NonnullRefPtr<Core::DeprecatedFile>, MBRPartitionTable&, u64, size_t limit);
 #endif

--- a/Userland/Libraries/LibPartition/GUIDPartitionTable.cpp
+++ b/Userland/Libraries/LibPartition/GUIDPartitionTable.cpp
@@ -49,7 +49,7 @@ struct [[gnu::packed]] GUIDPartitionHeader {
 };
 
 #ifdef KERNEL
-ErrorOr<NonnullOwnPtr<GUIDPartitionTable>> GUIDPartitionTable::try_to_initialize(Kernel::StorageDevice const& device)
+ErrorOr<NonnullOwnPtr<GUIDPartitionTable>> GUIDPartitionTable::try_to_initialize(Kernel::StorageDevice& device)
 {
     auto table = TRY(adopt_nonnull_own_or_enomem(new (nothrow) GUIDPartitionTable(device)));
 #else
@@ -63,7 +63,7 @@ ErrorOr<NonnullOwnPtr<GUIDPartitionTable>> GUIDPartitionTable::try_to_initialize
 }
 
 #ifdef KERNEL
-GUIDPartitionTable::GUIDPartitionTable(Kernel::StorageDevice const& device)
+GUIDPartitionTable::GUIDPartitionTable(Kernel::StorageDevice& device)
     : MBRPartitionTable(device)
 #else
 GUIDPartitionTable::GUIDPartitionTable(NonnullRefPtr<Core::DeprecatedFile> device_file)

--- a/Userland/Libraries/LibPartition/GUIDPartitionTable.h
+++ b/Userland/Libraries/LibPartition/GUIDPartitionTable.h
@@ -16,8 +16,8 @@ public:
     virtual ~GUIDPartitionTable() = default;
 
 #ifdef KERNEL
-    static ErrorOr<NonnullOwnPtr<GUIDPartitionTable>> try_to_initialize(Kernel::StorageDevice const&);
-    explicit GUIDPartitionTable(Kernel::StorageDevice const&);
+    static ErrorOr<NonnullOwnPtr<GUIDPartitionTable>> try_to_initialize(Kernel::StorageDevice&);
+    explicit GUIDPartitionTable(Kernel::StorageDevice&);
 #else
     static ErrorOr<NonnullOwnPtr<GUIDPartitionTable>> try_to_initialize(NonnullRefPtr<Core::DeprecatedFile>);
     explicit GUIDPartitionTable(NonnullRefPtr<Core::DeprecatedFile>);

--- a/Userland/Libraries/LibPartition/MBRPartitionTable.cpp
+++ b/Userland/Libraries/LibPartition/MBRPartitionTable.cpp
@@ -19,7 +19,7 @@ namespace Partition {
 #define EBR_LBA_CONTAINER 0x0F
 
 #ifdef KERNEL
-ErrorOr<NonnullOwnPtr<MBRPartitionTable>> MBRPartitionTable::try_to_initialize(Kernel::StorageDevice const& device)
+ErrorOr<NonnullOwnPtr<MBRPartitionTable>> MBRPartitionTable::try_to_initialize(Kernel::StorageDevice& device)
 {
     auto table = TRY(adopt_nonnull_own_or_enomem(new (nothrow) MBRPartitionTable(device)));
 #else
@@ -37,7 +37,7 @@ ErrorOr<NonnullOwnPtr<MBRPartitionTable>> MBRPartitionTable::try_to_initialize(N
 }
 
 #ifdef KERNEL
-OwnPtr<MBRPartitionTable> MBRPartitionTable::try_to_initialize(Kernel::StorageDevice const& device, u32 start_lba)
+OwnPtr<MBRPartitionTable> MBRPartitionTable::try_to_initialize(Kernel::StorageDevice& device, u32 start_lba)
 {
     auto table = adopt_nonnull_own_or_enomem(new (nothrow) MBRPartitionTable(device, start_lba)).release_value_but_fixme_should_propagate_errors();
 #else
@@ -66,7 +66,7 @@ bool MBRPartitionTable::read_boot_record()
 }
 
 #ifdef KERNEL
-MBRPartitionTable::MBRPartitionTable(Kernel::StorageDevice const& device, u32 start_lba)
+MBRPartitionTable::MBRPartitionTable(Kernel::StorageDevice& device, u32 start_lba)
     : PartitionTable(device)
 #else
 MBRPartitionTable::MBRPartitionTable(NonnullRefPtr<Core::DeprecatedFile> device_file, u32 start_lba)
@@ -92,7 +92,7 @@ MBRPartitionTable::MBRPartitionTable(NonnullRefPtr<Core::DeprecatedFile> device_
 }
 
 #ifdef KERNEL
-MBRPartitionTable::MBRPartitionTable(Kernel::StorageDevice const& device)
+MBRPartitionTable::MBRPartitionTable(Kernel::StorageDevice& device)
     : PartitionTable(device)
 #else
 MBRPartitionTable::MBRPartitionTable(NonnullRefPtr<Core::DeprecatedFile> device_file)

--- a/Userland/Libraries/LibPartition/MBRPartitionTable.h
+++ b/Userland/Libraries/LibPartition/MBRPartitionTable.h
@@ -39,10 +39,10 @@ public:
     ~MBRPartitionTable();
 
 #ifdef KERNEL
-    static ErrorOr<NonnullOwnPtr<MBRPartitionTable>> try_to_initialize(Kernel::StorageDevice const&);
-    static OwnPtr<MBRPartitionTable> try_to_initialize(Kernel::StorageDevice const&, u32 start_lba);
-    explicit MBRPartitionTable(Kernel::StorageDevice const&);
-    MBRPartitionTable(Kernel::StorageDevice const&, u32 start_lba);
+    static ErrorOr<NonnullOwnPtr<MBRPartitionTable>> try_to_initialize(Kernel::StorageDevice&);
+    static OwnPtr<MBRPartitionTable> try_to_initialize(Kernel::StorageDevice&, u32 start_lba);
+    explicit MBRPartitionTable(Kernel::StorageDevice&);
+    MBRPartitionTable(Kernel::StorageDevice&, u32 start_lba);
 #else
     static ErrorOr<NonnullOwnPtr<MBRPartitionTable>> try_to_initialize(NonnullRefPtr<Core::DeprecatedFile>);
     static OwnPtr<MBRPartitionTable> try_to_initialize(NonnullRefPtr<Core::DeprecatedFile>, u32 start_lba);

--- a/Userland/Libraries/LibPartition/PartitionTable.cpp
+++ b/Userland/Libraries/LibPartition/PartitionTable.cpp
@@ -14,7 +14,7 @@
 namespace Partition {
 
 #ifdef KERNEL
-PartitionTable::PartitionTable(Kernel::StorageDevice const& device)
+PartitionTable::PartitionTable(Kernel::StorageDevice& device)
     : m_device(device)
     , m_block_size(device.block_size())
 {

--- a/Userland/Libraries/LibPartition/PartitionTable.h
+++ b/Userland/Libraries/LibPartition/PartitionTable.h
@@ -29,7 +29,7 @@ public:
 
 protected:
 #ifdef KERNEL
-    explicit PartitionTable(Kernel::StorageDevice const&);
+    explicit PartitionTable(Kernel::StorageDevice&);
     NonnullRefPtr<Kernel::StorageDevice> m_device;
 #else
     explicit PartitionTable(NonnullRefPtr<Core::DeprecatedFile>);

--- a/Userland/Libraries/LibSQL/AST/Select.cpp
+++ b/Userland/Libraries/LibSQL/AST/Select.cpp
@@ -39,7 +39,7 @@ static DeprecatedString result_column_name(ResultColumn const& column, size_t co
 
 ResultOr<ResultSet> Select::execute(ExecutionContext& context) const
 {
-    NonnullRefPtrVector<ResultColumn> columns;
+    NonnullRefPtrVector<ResultColumn const> columns;
     Vector<DeprecatedString> column_names;
 
     auto const& result_column_list = this->result_column_list();

--- a/Userland/Libraries/LibSQL/Database.cpp
+++ b/Userland/Libraries/LibSQL/Database.cpp
@@ -170,7 +170,7 @@ ResultOr<NonnullRefPtr<TableDef>> Database::get_table(DeprecatedString const& sc
     return table_def;
 }
 
-ErrorOr<Vector<Row>> Database::select_all(TableDef const& table)
+ErrorOr<Vector<Row>> Database::select_all(TableDef& table)
 {
     VERIFY(m_table_cache.get(table.key().hash()).has_value());
     Vector<Row> ret;
@@ -180,7 +180,7 @@ ErrorOr<Vector<Row>> Database::select_all(TableDef const& table)
     return ret;
 }
 
-ErrorOr<Vector<Row>> Database::match(TableDef const& table, Key const& key)
+ErrorOr<Vector<Row>> Database::match(TableDef& table, Key const& key)
 {
     VERIFY(m_table_cache.get(table.key().hash()).has_value());
     Vector<Row> ret;

--- a/Userland/Libraries/LibSQL/Database.h
+++ b/Userland/Libraries/LibSQL/Database.h
@@ -41,8 +41,8 @@ public:
     static Key get_table_key(DeprecatedString const&, DeprecatedString const&);
     ResultOr<NonnullRefPtr<TableDef>> get_table(DeprecatedString const&, DeprecatedString const&);
 
-    ErrorOr<Vector<Row>> select_all(TableDef const&);
-    ErrorOr<Vector<Row>> match(TableDef const&, Key const&);
+    ErrorOr<Vector<Row>> select_all(TableDef&);
+    ErrorOr<Vector<Row>> match(TableDef&, Key const&);
     ErrorOr<void> insert(Row&);
     ErrorOr<void> remove(Row&);
     ErrorOr<void> update(Row&);

--- a/Userland/Libraries/LibTest/TestSuite.cpp
+++ b/Userland/Libraries/LibTest/TestSuite.cpp
@@ -94,7 +94,7 @@ int TestSuite::main(DeprecatedString const& suite_name, int argc, char** argv)
 NonnullRefPtrVector<TestCase> TestSuite::find_cases(DeprecatedString const& search, bool find_tests, bool find_benchmarks)
 {
     NonnullRefPtrVector<TestCase> matches;
-    for (auto const& t : m_cases) {
+    for (auto& t : m_cases) {
         if (!search.is_empty() && !t.name().matches(search, CaseSensitivity::CaseInsensitive)) {
             continue;
         }

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -172,7 +172,7 @@ void ElementInlineCSSStyleDeclaration::update_style_attribute()
 }
 
 // https://drafts.csswg.org/cssom/#set-a-css-declaration
-bool PropertyOwningCSSStyleDeclaration::set_a_css_declaration(PropertyID property_id, NonnullRefPtr<StyleValue> value, Important important)
+bool PropertyOwningCSSStyleDeclaration::set_a_css_declaration(PropertyID property_id, NonnullRefPtr<StyleValue const> value, Important important)
 {
     // FIXME: Handle logical property groups.
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -21,7 +21,7 @@ enum class Important {
 struct StyleProperty {
     Important important { Important::No };
     CSS::PropertyID property_id;
-    NonnullRefPtr<StyleValue> value;
+    NonnullRefPtr<StyleValue const> value;
     DeprecatedString custom_name {};
 };
 
@@ -92,7 +92,7 @@ protected:
     void set_the_declarations(Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties);
 
 private:
-    bool set_a_css_declaration(PropertyID, NonnullRefPtr<StyleValue>, Important);
+    bool set_a_css_declaration(PropertyID, NonnullRefPtr<StyleValue const>, Important);
 
     Vector<StyleProperty> m_properties;
     HashMap<DeprecatedString, StyleProperty> m_custom_properties;

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -77,7 +77,7 @@ public:
 };
 
 struct BackgroundLayerData {
-    RefPtr<CSS::AbstractImageStyleValue> background_image { nullptr };
+    RefPtr<CSS::AbstractImageStyleValue const> background_image { nullptr };
     CSS::BackgroundAttachment attachment { CSS::BackgroundAttachment::Scroll };
     CSS::BackgroundBox origin { CSS::BackgroundBox::PaddingBox };
     CSS::BackgroundBox clip { CSS::BackgroundBox::BorderBox };

--- a/Userland/Libraries/LibWeb/CSS/MediaList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaList.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
- * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -64,11 +64,21 @@ DeprecatedString MediaList::item(u32 index) const
 // https://www.w3.org/TR/cssom-1/#dom-medialist-appendmedium
 void MediaList::append_medium(DeprecatedString medium)
 {
+    // 1. Let m be the result of parsing the given value.
     auto m = parse_media_query({}, medium);
+
+    // 2. If m is null, then return.
     if (!m)
         return;
-    if (m_media.contains_slow(*m))
-        return;
+
+    // 3. If comparing m with any of the media queries in the collection of media queries returns true, then return.
+    auto serialized = m->to_string().release_value_but_fixme_should_propagate_errors();
+    for (auto& existing_medium : m_media) {
+        if (existing_medium.to_string().release_value_but_fixme_should_propagate_errors() == serialized)
+            return;
+    }
+
+    // 4. Append m to the collection of media queries.
     m_media.append(m.release_nonnull());
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020-2021, the SerenityOS developers.
  * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -23,10 +24,10 @@ public:
     ~ComponentValue();
 
     bool is_block() const { return m_value.has<NonnullRefPtr<Block>>(); }
-    Block const& block() const { return m_value.get<NonnullRefPtr<Block>>(); }
+    Block& block() const { return m_value.get<NonnullRefPtr<Block>>(); }
 
     bool is_function() const { return m_value.has<NonnullRefPtr<Function>>(); }
-    Function const& function() const { return m_value.get<NonnullRefPtr<Function>>(); }
+    Function& function() const { return m_value.get<NonnullRefPtr<Function>>(); }
 
     bool is_token() const { return m_value.has<Token>(); }
     bool is(Token::Type type) const { return is_token() && token().is(type); }

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
  * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
  *
@@ -122,14 +122,14 @@ static RefPtr<StyleValue> style_value_for_display(CSS::Display display)
     TODO();
 }
 
-static NonnullRefPtr<StyleValue> value_or_default(Optional<StyleProperty> property, NonnullRefPtr<StyleValue> default_style)
+static NonnullRefPtr<StyleValue const> value_or_default(Optional<StyleProperty> property, NonnullRefPtr<StyleValue> default_style)
 {
     if (property.has_value())
         return property.value().value;
     return default_style;
 }
 
-static NonnullRefPtr<StyleValue> style_value_for_length_percentage(LengthPercentage const& length_percentage)
+static NonnullRefPtr<StyleValue const> style_value_for_length_percentage(LengthPercentage const& length_percentage)
 {
     if (length_percentage.is_percentage())
         return PercentageStyleValue::create(length_percentage.percentage());
@@ -138,7 +138,7 @@ static NonnullRefPtr<StyleValue> style_value_for_length_percentage(LengthPercent
     return length_percentage.calculated();
 }
 
-static NonnullRefPtr<StyleValue> style_value_for_size(CSS::Size const& size)
+static NonnullRefPtr<StyleValue const> style_value_for_size(CSS::Size const& size)
 {
     if (size.is_none())
         return IdentifierStyleValue::create(ValueID::None);
@@ -156,7 +156,7 @@ static NonnullRefPtr<StyleValue> style_value_for_size(CSS::Size const& size)
     TODO();
 }
 
-RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout::NodeWithStyle const& layout_node, PropertyID property_id) const
+RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(Layout::NodeWithStyle const& layout_node, PropertyID property_id) const
 {
     switch (property_id) {
     case CSS::PropertyID::Background: {
@@ -222,7 +222,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         auto maybe_top_right_radius = property(CSS::PropertyID::BorderTopRightRadius);
         auto maybe_bottom_left_radius = property(CSS::PropertyID::BorderBottomLeftRadius);
         auto maybe_bottom_right_radius = property(CSS::PropertyID::BorderBottomRightRadius);
-        RefPtr<BorderRadiusStyleValue> top_left_radius, top_right_radius, bottom_left_radius, bottom_right_radius;
+        RefPtr<BorderRadiusStyleValue const> top_left_radius, top_right_radius, bottom_left_radius, bottom_right_radius;
         if (maybe_top_left_radius.has_value()) {
             VERIFY(maybe_top_left_radius.value().value->is_border_radius());
             top_left_radius = maybe_top_left_radius.value().value->as_border_radius();
@@ -337,7 +337,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         auto maybe_grid_column_start = property(CSS::PropertyID::GridColumnStart);
         auto maybe_grid_row_end = property(CSS::PropertyID::GridRowEnd);
         auto maybe_grid_column_end = property(CSS::PropertyID::GridColumnEnd);
-        RefPtr<GridTrackPlacementStyleValue> grid_row_start, grid_column_start, grid_row_end, grid_column_end;
+        RefPtr<GridTrackPlacementStyleValue const> grid_row_start, grid_column_start, grid_row_end, grid_column_end;
         if (maybe_grid_row_start.has_value()) {
             VERIFY(maybe_grid_row_start.value().value->is_grid_track_placement());
             grid_row_start = maybe_grid_row_start.value().value->as_grid_track_placement();
@@ -363,7 +363,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
     case CSS::PropertyID::GridColumn: {
         auto maybe_grid_column_end = property(CSS::PropertyID::GridColumnEnd);
         auto maybe_grid_column_start = property(CSS::PropertyID::GridColumnStart);
-        RefPtr<GridTrackPlacementStyleValue> grid_column_start, grid_column_end;
+        RefPtr<GridTrackPlacementStyleValue const> grid_column_start, grid_column_end;
         if (maybe_grid_column_end.has_value()) {
             VERIFY(maybe_grid_column_end.value().value->is_grid_track_placement());
             grid_column_end = maybe_grid_column_end.value().value->as_grid_track_placement();
@@ -381,7 +381,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
     case CSS::PropertyID::GridRow: {
         auto maybe_grid_row_end = property(CSS::PropertyID::GridRowEnd);
         auto maybe_grid_row_start = property(CSS::PropertyID::GridRowStart);
-        RefPtr<GridTrackPlacementStyleValue> grid_row_start, grid_row_end;
+        RefPtr<GridTrackPlacementStyleValue const> grid_row_start, grid_row_end;
         if (maybe_grid_row_end.has_value()) {
             VERIFY(maybe_grid_row_end.value().value->is_grid_track_placement());
             grid_row_end = maybe_grid_row_end.value().value->as_grid_track_placement();

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -32,7 +32,7 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    RefPtr<StyleValue> style_value_for_property(Layout::NodeWithStyle const&, PropertyID) const;
+    RefPtr<StyleValue const> style_value_for_property(Layout::NodeWithStyle const&, PropertyID) const;
 
     JS::NonnullGCPtr<DOM::Element> m_element;
 };

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -38,9 +38,9 @@ public:
     auto& properties() { return m_property_values; }
     auto const& properties() const { return m_property_values; }
 
-    void set_property(CSS::PropertyID, NonnullRefPtr<StyleValue> value);
-    NonnullRefPtr<StyleValue> property(CSS::PropertyID) const;
-    RefPtr<StyleValue> maybe_null_property(CSS::PropertyID) const;
+    void set_property(CSS::PropertyID, NonnullRefPtr<StyleValue const> value);
+    NonnullRefPtr<StyleValue const> property(CSS::PropertyID) const;
+    RefPtr<StyleValue const> maybe_null_property(CSS::PropertyID) const;
 
     CSS::Size size_value(CSS::PropertyID) const;
     LengthPercentage length_percentage_or_fallback(CSS::PropertyID, LengthPercentage const& fallback) const;
@@ -103,7 +103,7 @@ public:
         return *m_font;
     }
 
-    void set_computed_font(NonnullRefPtr<Gfx::Font> font)
+    void set_computed_font(NonnullRefPtr<Gfx::Font const> font)
     {
         m_font = move(font);
     }
@@ -115,16 +115,16 @@ public:
     Optional<CSS::Position> position() const;
     Optional<int> z_index() const;
 
-    static NonnullRefPtr<Gfx::Font> font_fallback(bool monospace, bool bold);
+    static NonnullRefPtr<Gfx::Font const> font_fallback(bool monospace, bool bold);
 
 private:
     friend class StyleComputer;
 
-    Array<RefPtr<StyleValue>, to_underlying(CSS::last_property_id) + 1> m_property_values;
+    Array<RefPtr<StyleValue const>, to_underlying(CSS::last_property_id) + 1> m_property_values;
     Optional<CSS::Overflow> overflow(CSS::PropertyID) const;
     Vector<CSS::ShadowData> shadow(CSS::PropertyID) const;
 
-    mutable RefPtr<Gfx::Font> m_font;
+    mutable RefPtr<Gfx::Font const> m_font;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -291,14 +291,14 @@ StyleValueList const& StyleValue::as_value_list() const
 }
 
 BackgroundStyleValue::BackgroundStyleValue(
-    ValueComparingNonnullRefPtr<StyleValue> color,
-    ValueComparingNonnullRefPtr<StyleValue> image,
-    ValueComparingNonnullRefPtr<StyleValue> position,
-    ValueComparingNonnullRefPtr<StyleValue> size,
-    ValueComparingNonnullRefPtr<StyleValue> repeat,
-    ValueComparingNonnullRefPtr<StyleValue> attachment,
-    ValueComparingNonnullRefPtr<StyleValue> origin,
-    ValueComparingNonnullRefPtr<StyleValue> clip)
+    ValueComparingNonnullRefPtr<StyleValue const> color,
+    ValueComparingNonnullRefPtr<StyleValue const> image,
+    ValueComparingNonnullRefPtr<StyleValue const> position,
+    ValueComparingNonnullRefPtr<StyleValue const> size,
+    ValueComparingNonnullRefPtr<StyleValue const> repeat,
+    ValueComparingNonnullRefPtr<StyleValue const> attachment,
+    ValueComparingNonnullRefPtr<StyleValue const> origin,
+    ValueComparingNonnullRefPtr<StyleValue const> clip)
     : StyleValueWithDefaultOperators(Type::Background)
     , m_properties {
         .color = move(color),
@@ -335,7 +335,7 @@ ErrorOr<String> BackgroundStyleValue::to_string() const
         return String::formatted("{} {} {} {} {} {} {} {}", TRY(m_properties.color->to_string()), TRY(m_properties.image->to_string()), TRY(m_properties.position->to_string()), TRY(m_properties.size->to_string()), TRY(m_properties.repeat->to_string()), TRY(m_properties.attachment->to_string()), TRY(m_properties.origin->to_string()), TRY(m_properties.clip->to_string()));
     }
 
-    auto get_layer_value_string = [](ValueComparingNonnullRefPtr<StyleValue> const& style_value, size_t index) {
+    auto get_layer_value_string = [](ValueComparingNonnullRefPtr<StyleValue const> const& style_value, size_t index) {
         if (style_value->is_value_list())
             return style_value->as_value_list().value_at(index, true)->to_string();
         return style_value->to_string();
@@ -2236,19 +2236,19 @@ static Optional<CSS::Length> absolutized_length(CSS::Length const& length, CSSPi
     return {};
 }
 
-ValueComparingNonnullRefPtr<StyleValue> StyleValue::absolutized(CSSPixelRect const&, Gfx::FontPixelMetrics const&, CSSPixels, CSSPixels) const
+ValueComparingNonnullRefPtr<StyleValue const> StyleValue::absolutized(CSSPixelRect const&, Gfx::FontPixelMetrics const&, CSSPixels, CSSPixels) const
 {
     return *this;
 }
 
-ValueComparingNonnullRefPtr<StyleValue> LengthStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
+ValueComparingNonnullRefPtr<StyleValue const> LengthStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
 {
     if (auto length = absolutized_length(m_length, viewport_rect, font_metrics, font_size, root_font_size); length.has_value())
         return LengthStyleValue::create(length.release_value());
     return *this;
 }
 
-ValueComparingNonnullRefPtr<StyleValue> ShadowStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
+ValueComparingNonnullRefPtr<StyleValue const> ShadowStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
 {
     auto absolutized_offset_x = absolutized_length(m_properties.offset_x, viewport_rect, font_metrics, font_size, root_font_size).value_or(m_properties.offset_x);
     auto absolutized_offset_y = absolutized_length(m_properties.offset_y, viewport_rect, font_metrics, font_size, root_font_size).value_or(m_properties.offset_y);
@@ -2257,7 +2257,7 @@ ValueComparingNonnullRefPtr<StyleValue> ShadowStyleValue::absolutized(CSSPixelRe
     return ShadowStyleValue::create(m_properties.color, absolutized_offset_x, absolutized_offset_y, absolutized_blur_radius, absolutized_spread_distance, m_properties.placement);
 }
 
-ValueComparingNonnullRefPtr<StyleValue> BorderRadiusStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
+ValueComparingNonnullRefPtr<StyleValue const> BorderRadiusStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
 {
     if (m_properties.horizontal_radius.is_percentage() && m_properties.vertical_radius.is_percentage())
         return *this;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -269,7 +269,7 @@ private:
 
 template<typename T>
 using ValueComparingNonnullRefPtrVector = AK::NonnullPtrVector<ValueComparingNonnullRefPtr<T>>;
-using StyleValueVector = ValueComparingNonnullRefPtrVector<StyleValue>;
+using StyleValueVector = ValueComparingNonnullRefPtrVector<StyleValue const>;
 
 class StyleValue : public RefCounted<StyleValue> {
 public:
@@ -469,7 +469,7 @@ public:
     virtual bool has_number() const { return false; }
     virtual bool has_integer() const { return false; }
 
-    virtual ValueComparingNonnullRefPtr<StyleValue> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const;
 
     virtual Color to_color(Layout::NodeWithStyle const&) const { return {}; }
     virtual EdgeRect to_rect() const { VERIFY_NOT_REACHED(); }
@@ -533,14 +533,14 @@ private:
 class BackgroundStyleValue final : public StyleValueWithDefaultOperators<BackgroundStyleValue> {
 public:
     static ValueComparingNonnullRefPtr<BackgroundStyleValue> create(
-        ValueComparingNonnullRefPtr<StyleValue> color,
-        ValueComparingNonnullRefPtr<StyleValue> image,
-        ValueComparingNonnullRefPtr<StyleValue> position,
-        ValueComparingNonnullRefPtr<StyleValue> size,
-        ValueComparingNonnullRefPtr<StyleValue> repeat,
-        ValueComparingNonnullRefPtr<StyleValue> attachment,
-        ValueComparingNonnullRefPtr<StyleValue> origin,
-        ValueComparingNonnullRefPtr<StyleValue> clip)
+        ValueComparingNonnullRefPtr<StyleValue const> color,
+        ValueComparingNonnullRefPtr<StyleValue const> image,
+        ValueComparingNonnullRefPtr<StyleValue const> position,
+        ValueComparingNonnullRefPtr<StyleValue const> size,
+        ValueComparingNonnullRefPtr<StyleValue const> repeat,
+        ValueComparingNonnullRefPtr<StyleValue const> attachment,
+        ValueComparingNonnullRefPtr<StyleValue const> origin,
+        ValueComparingNonnullRefPtr<StyleValue const> clip)
     {
         return adopt_ref(*new BackgroundStyleValue(move(color), move(image), move(position), move(size), move(repeat), move(attachment), move(origin), move(clip)));
     }
@@ -548,14 +548,14 @@ public:
 
     size_t layer_count() const { return m_properties.layer_count; }
 
-    ValueComparingNonnullRefPtr<StyleValue> attachment() const { return m_properties.attachment; }
-    ValueComparingNonnullRefPtr<StyleValue> clip() const { return m_properties.clip; }
-    ValueComparingNonnullRefPtr<StyleValue> color() const { return m_properties.color; }
-    ValueComparingNonnullRefPtr<StyleValue> image() const { return m_properties.image; }
-    ValueComparingNonnullRefPtr<StyleValue> origin() const { return m_properties.origin; }
-    ValueComparingNonnullRefPtr<StyleValue> position() const { return m_properties.position; }
-    ValueComparingNonnullRefPtr<StyleValue> repeat() const { return m_properties.repeat; }
-    ValueComparingNonnullRefPtr<StyleValue> size() const { return m_properties.size; }
+    auto attachment() const { return m_properties.attachment; }
+    auto clip() const { return m_properties.clip; }
+    auto color() const { return m_properties.color; }
+    auto image() const { return m_properties.image; }
+    auto origin() const { return m_properties.origin; }
+    auto position() const { return m_properties.position; }
+    auto repeat() const { return m_properties.repeat; }
+    auto size() const { return m_properties.size; }
 
     virtual ErrorOr<String> to_string() const override;
 
@@ -563,24 +563,24 @@ public:
 
 private:
     BackgroundStyleValue(
-        ValueComparingNonnullRefPtr<StyleValue> color,
-        ValueComparingNonnullRefPtr<StyleValue> image,
-        ValueComparingNonnullRefPtr<StyleValue> position,
-        ValueComparingNonnullRefPtr<StyleValue> size,
-        ValueComparingNonnullRefPtr<StyleValue> repeat,
-        ValueComparingNonnullRefPtr<StyleValue> attachment,
-        ValueComparingNonnullRefPtr<StyleValue> origin,
-        ValueComparingNonnullRefPtr<StyleValue> clip);
+        ValueComparingNonnullRefPtr<StyleValue const> color,
+        ValueComparingNonnullRefPtr<StyleValue const> image,
+        ValueComparingNonnullRefPtr<StyleValue const> position,
+        ValueComparingNonnullRefPtr<StyleValue const> size,
+        ValueComparingNonnullRefPtr<StyleValue const> repeat,
+        ValueComparingNonnullRefPtr<StyleValue const> attachment,
+        ValueComparingNonnullRefPtr<StyleValue const> origin,
+        ValueComparingNonnullRefPtr<StyleValue const> clip);
 
     struct Properties {
-        ValueComparingNonnullRefPtr<StyleValue> color;
-        ValueComparingNonnullRefPtr<StyleValue> image;
-        ValueComparingNonnullRefPtr<StyleValue> position;
-        ValueComparingNonnullRefPtr<StyleValue> size;
-        ValueComparingNonnullRefPtr<StyleValue> repeat;
-        ValueComparingNonnullRefPtr<StyleValue> attachment;
-        ValueComparingNonnullRefPtr<StyleValue> origin;
-        ValueComparingNonnullRefPtr<StyleValue> clip;
+        ValueComparingNonnullRefPtr<StyleValue const> color;
+        ValueComparingNonnullRefPtr<StyleValue const> image;
+        ValueComparingNonnullRefPtr<StyleValue const> position;
+        ValueComparingNonnullRefPtr<StyleValue const> size;
+        ValueComparingNonnullRefPtr<StyleValue const> repeat;
+        ValueComparingNonnullRefPtr<StyleValue const> attachment;
+        ValueComparingNonnullRefPtr<StyleValue const> origin;
+        ValueComparingNonnullRefPtr<StyleValue const> clip;
         size_t layer_count;
         bool operator==(Properties const&) const = default;
     } m_properties;
@@ -705,7 +705,7 @@ private:
     {
     }
 
-    virtual ValueComparingNonnullRefPtr<StyleValue> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const override;
 
     struct Properties {
         bool is_elliptical;
@@ -717,33 +717,41 @@ private:
 
 class BorderRadiusShorthandStyleValue final : public StyleValueWithDefaultOperators<BorderRadiusShorthandStyleValue> {
 public:
-    static ValueComparingNonnullRefPtr<BorderRadiusShorthandStyleValue> create(ValueComparingNonnullRefPtr<BorderRadiusStyleValue> top_left, ValueComparingNonnullRefPtr<BorderRadiusStyleValue> top_right, ValueComparingNonnullRefPtr<BorderRadiusStyleValue> bottom_right, ValueComparingNonnullRefPtr<BorderRadiusStyleValue> bottom_left)
+    static ValueComparingNonnullRefPtr<BorderRadiusShorthandStyleValue> create(
+        ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> top_left,
+        ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> top_right,
+        ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> bottom_right,
+        ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> bottom_left)
     {
         return adopt_ref(*new BorderRadiusShorthandStyleValue(move(top_left), move(top_right), move(bottom_right), move(bottom_left)));
     }
     virtual ~BorderRadiusShorthandStyleValue() override = default;
 
-    ValueComparingNonnullRefPtr<BorderRadiusStyleValue> top_left() const { return m_properties.top_left; }
-    ValueComparingNonnullRefPtr<BorderRadiusStyleValue> top_right() const { return m_properties.top_right; }
-    ValueComparingNonnullRefPtr<BorderRadiusStyleValue> bottom_right() const { return m_properties.bottom_right; }
-    ValueComparingNonnullRefPtr<BorderRadiusStyleValue> bottom_left() const { return m_properties.bottom_left; }
+    auto top_left() const { return m_properties.top_left; }
+    auto top_right() const { return m_properties.top_right; }
+    auto bottom_right() const { return m_properties.bottom_right; }
+    auto bottom_left() const { return m_properties.bottom_left; }
 
     virtual ErrorOr<String> to_string() const override;
 
     bool properties_equal(BorderRadiusShorthandStyleValue const& other) const { return m_properties == other.m_properties; }
 
 private:
-    BorderRadiusShorthandStyleValue(ValueComparingNonnullRefPtr<BorderRadiusStyleValue> top_left, ValueComparingNonnullRefPtr<BorderRadiusStyleValue> top_right, ValueComparingNonnullRefPtr<BorderRadiusStyleValue> bottom_right, ValueComparingNonnullRefPtr<BorderRadiusStyleValue> bottom_left)
+    BorderRadiusShorthandStyleValue(
+        ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> top_left,
+        ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> top_right,
+        ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> bottom_right,
+        ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> bottom_left)
         : StyleValueWithDefaultOperators(Type::BorderRadiusShorthand)
         , m_properties { .top_left = move(top_left), .top_right = move(top_right), .bottom_right = move(bottom_right), .bottom_left = move(bottom_left) }
     {
     }
 
     struct Properties {
-        ValueComparingNonnullRefPtr<BorderRadiusStyleValue> top_left;
-        ValueComparingNonnullRefPtr<BorderRadiusStyleValue> top_right;
-        ValueComparingNonnullRefPtr<BorderRadiusStyleValue> bottom_right;
-        ValueComparingNonnullRefPtr<BorderRadiusStyleValue> bottom_left;
+        ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> top_left;
+        ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> top_right;
+        ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> bottom_right;
+        ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> bottom_left;
         bool operator==(Properties const&) const = default;
     } m_properties;
 };
@@ -1206,7 +1214,7 @@ private:
 
 class GridTrackPlacementShorthandStyleValue final : public StyleValueWithDefaultOperators<GridTrackPlacementShorthandStyleValue> {
 public:
-    static ValueComparingNonnullRefPtr<GridTrackPlacementShorthandStyleValue> create(ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> start, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> end)
+    static ValueComparingNonnullRefPtr<GridTrackPlacementShorthandStyleValue> create(ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> start, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> end)
     {
         return adopt_ref(*new GridTrackPlacementShorthandStyleValue(move(start), move(end)));
     }
@@ -1216,30 +1224,34 @@ public:
     }
     virtual ~GridTrackPlacementShorthandStyleValue() override = default;
 
-    ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> start() const { return m_properties.start; }
-    ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> end() const { return m_properties.end; }
+    auto start() const { return m_properties.start; }
+    auto end() const { return m_properties.end; }
 
     virtual ErrorOr<String> to_string() const override;
 
     bool properties_equal(GridTrackPlacementShorthandStyleValue const& other) const { return m_properties == other.m_properties; };
 
 private:
-    GridTrackPlacementShorthandStyleValue(ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> start, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> end)
+    GridTrackPlacementShorthandStyleValue(ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> start, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> end)
         : StyleValueWithDefaultOperators(Type::GridTrackPlacementShorthand)
         , m_properties { .start = move(start), .end = move(end) }
     {
     }
 
     struct Properties {
-        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> start;
-        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> end;
+        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> start;
+        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> end;
         bool operator==(Properties const&) const = default;
     } m_properties;
 };
 
 class GridAreaShorthandStyleValue final : public StyleValueWithDefaultOperators<GridAreaShorthandStyleValue> {
 public:
-    static ValueComparingNonnullRefPtr<GridAreaShorthandStyleValue> create(ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> row_start, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> column_start, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> row_end, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> column_end)
+    static ValueComparingNonnullRefPtr<GridAreaShorthandStyleValue> create(
+        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> row_start,
+        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> column_start,
+        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> row_end,
+        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> column_end)
     {
         return adopt_ref(*new GridAreaShorthandStyleValue(row_start, column_start, row_end, column_end));
     }
@@ -1249,27 +1261,27 @@ public:
     }
     virtual ~GridAreaShorthandStyleValue() override = default;
 
-    ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> row_start() const { return m_properties.row_start; }
-    ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> column_start() const { return m_properties.column_start; }
-    ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> row_end() const { return m_properties.row_end; }
-    ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> column_end() const { return m_properties.column_end; }
+    auto row_start() const { return m_properties.row_start; }
+    auto column_start() const { return m_properties.column_start; }
+    auto row_end() const { return m_properties.row_end; }
+    auto column_end() const { return m_properties.column_end; }
 
     virtual ErrorOr<String> to_string() const override;
 
     bool properties_equal(GridAreaShorthandStyleValue const& other) const { return m_properties == other.m_properties; }
 
 private:
-    GridAreaShorthandStyleValue(ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> row_start, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> column_start, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> row_end, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> column_end)
+    GridAreaShorthandStyleValue(ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> row_start, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> column_start, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> row_end, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> column_end)
         : StyleValueWithDefaultOperators(Type::GridAreaShorthand)
         , m_properties { .row_start = move(row_start), .column_start = move(column_start), .row_end = move(row_end), .column_end = move(column_end) }
     {
     }
 
     struct Properties {
-        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> row_start;
-        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> column_start;
-        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> row_end;
-        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> column_end;
+        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> row_start;
+        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> column_start;
+        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> row_end;
+        ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> column_end;
         bool operator==(Properties const&) const = default;
     } m_properties;
 };
@@ -1623,7 +1635,7 @@ public:
     virtual ErrorOr<String> to_string() const override { return m_length.to_string(); }
     virtual Length to_length() const override { return m_length; }
     virtual ValueID to_identifier() const override { return has_auto() ? ValueID::Auto : ValueID::Invalid; }
-    virtual ValueComparingNonnullRefPtr<StyleValue> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const override;
 
     bool properties_equal(LengthStyleValue const& other) const { return m_length == other.m_length; }
 
@@ -1852,7 +1864,7 @@ private:
     {
     }
 
-    virtual ValueComparingNonnullRefPtr<StyleValue> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const override;
 
     struct Properties {
         Color color;
@@ -2038,7 +2050,7 @@ public:
 
     size_t size() const { return m_properties.values.size(); }
     StyleValueVector const& values() const { return m_properties.values; }
-    ValueComparingNonnullRefPtr<StyleValue> value_at(size_t i, bool allow_loop) const
+    ValueComparingNonnullRefPtr<StyleValue const> value_at(size_t i, bool allow_loop) const
     {
         if (allow_loop)
             return m_properties.values[i % size()];

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -122,6 +122,7 @@ public:
 
     DeprecatedString name() const { return attribute(HTML::AttributeNames::name); }
 
+    CSS::StyleProperties* computed_css_values() { return m_computed_css_values.ptr(); }
     CSS::StyleProperties const* computed_css_values() const { return m_computed_css_values.ptr(); }
     void set_computed_css_values(RefPtr<CSS::StyleProperties> style) { m_computed_css_values = move(style); }
     NonnullRefPtr<CSS::StyleProperties> resolved_css_values();

--- a/Userland/Libraries/LibWeb/FontCache.cpp
+++ b/Userland/Libraries/LibWeb/FontCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,7 +13,7 @@ FontCache& FontCache::the()
     return cache;
 }
 
-RefPtr<Gfx::Font> FontCache::get(FontSelector const& font_selector) const
+RefPtr<Gfx::Font const> FontCache::get(FontSelector const& font_selector) const
 {
     auto cached_font = m_fonts.get(font_selector);
     if (cached_font.has_value())
@@ -21,7 +21,7 @@ RefPtr<Gfx::Font> FontCache::get(FontSelector const& font_selector) const
     return nullptr;
 }
 
-void FontCache::set(FontSelector const& font_selector, NonnullRefPtr<Gfx::Font> font)
+void FontCache::set(FontSelector const& font_selector, NonnullRefPtr<Gfx::Font const> font)
 {
     m_fonts.set(font_selector, move(font));
 }

--- a/Userland/Libraries/LibWeb/FontCache.h
+++ b/Userland/Libraries/LibWeb/FontCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -34,10 +34,10 @@ struct Traits<FontSelector> : public GenericTraits<FontSelector> {
 class FontCache {
 public:
     static FontCache& the();
-    RefPtr<Gfx::Font> get(FontSelector const&) const;
-    void set(FontSelector const&, NonnullRefPtr<Gfx::Font>);
+    RefPtr<Gfx::Font const> get(FontSelector const&) const;
+    void set(FontSelector const&, NonnullRefPtr<Gfx::Font const>);
 
 private:
     FontCache() = default;
-    mutable HashMap<FontSelector, NonnullRefPtr<Gfx::Font>> m_fonts;
+    mutable HashMap<FontSelector, NonnullRefPtr<Gfx::Font const>> m_fonts;
 };

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -277,7 +277,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
                 return 1;
         };
 
-        auto value_for_layer = [](auto& style_value, size_t layer_index) -> RefPtr<CSS::StyleValue> {
+        auto value_for_layer = [](auto& style_value, size_t layer_index) -> RefPtr<CSS::StyleValue const> {
             if (style_value->is_value_list())
                 return style_value->as_value_list().value_at(layer_index, true);
             return style_value;
@@ -301,7 +301,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
             if (auto image_value = value_for_layer(images, layer_index); image_value) {
                 if (image_value->is_abstract_image()) {
                     layer.background_image = image_value->as_abstract_image();
-                    layer.background_image->load_any_resources(document());
+                    const_cast<CSS::AbstractImageStyleValue&>(*layer.background_image).load_any_resources(document());
                 }
             }
 
@@ -517,7 +517,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     auto list_style_image = computed_style.property(CSS::PropertyID::ListStyleImage);
     if (list_style_image->is_abstract_image()) {
         m_list_style_image = list_style_image->as_abstract_image();
-        m_list_style_image->load_any_resources(document());
+        const_cast<CSS::AbstractImageStyleValue&>(*m_list_style_image).load_any_resources(document());
     }
 
     computed_values.set_color(computed_style.color_or_fallback(CSS::PropertyID::Color, *this, CSS::InitialValues::color()));
@@ -574,7 +574,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
             auto resolve_border_width = [&]() {
                 auto value = computed_style.property(width_property);
                 if (value->is_calculated())
-                    return CSS::Length::make_calculated(value->as_calculated()).to_px(*this).value();
+                    return CSS::Length::make_calculated(const_cast<CSS::CalculatedStyleValue&>(value->as_calculated())).to_px(*this).value();
                 if (value->has_length())
                     return value->to_length().to_px(*this).value();
                 if (value->is_identifier()) {

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -195,9 +195,9 @@ protected:
 
 private:
     CSS::ComputedValues m_computed_values;
-    RefPtr<Gfx::Font> m_font;
+    RefPtr<Gfx::Font const> m_font;
     CSSPixels m_line_height { 0 };
-    RefPtr<CSS::AbstractImageStyleValue> m_list_style_image;
+    RefPtr<CSS::AbstractImageStyleValue const> m_list_style_image;
 };
 
 class NodeWithStyleAndBoxModelMetrics : public NodeWithStyle {

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -513,7 +513,7 @@ static void paint_text_fragment(PaintContext& context, Layout::TextNode const& t
         Utf8View view { text.substring_view(fragment.start(), fragment.length()) };
 
         auto& font = fragment.layout_node().font();
-        auto scaled_font = [&]() -> RefPtr<Gfx::Font> {
+        auto scaled_font = [&]() -> RefPtr<Gfx::Font const> {
             auto device_font_pt_size = context.enclosing_device_pixels(font.presentation_size());
             FontSelector font_selector = { FlyString::from_utf8(font.family()).release_value_but_fixme_should_propagate_errors(), static_cast<float>(device_font_pt_size.value()), font.weight(), font.width(), font.slope() };
             if (auto cached_font = FontCache::the().get(font_selector)) {

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2021-2023, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
@@ -117,7 +117,7 @@ void ConnectionFromClient::set_viewport_rect(Gfx::IntRect const& rect)
 
 void ConnectionFromClient::add_backing_store(i32 backing_store_id, Gfx::ShareableBitmap const& bitmap)
 {
-    m_backing_stores.set(backing_store_id, *bitmap.bitmap());
+    m_backing_stores.set(backing_store_id, *const_cast<Gfx::ShareableBitmap&>(bitmap).bitmap());
 }
 
 void ConnectionFromClient::remove_backing_store(i32 backing_store_id)

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021-2022, Linus Groh <linusg@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -60,7 +60,7 @@ Gfx::Palette PageHost::palette() const
     return Gfx::Palette(*m_palette_impl);
 }
 
-void PageHost::set_palette_impl(Gfx::PaletteImpl const& impl)
+void PageHost::set_palette_impl(Gfx::PaletteImpl& impl)
 {
     m_palette_impl = impl;
     if (auto* document = page().top_level_browsing_context().active_document())

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021-2023, Linus Groh <linusg@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -29,7 +29,7 @@ public:
 
     virtual void paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap&) override;
 
-    void set_palette_impl(Gfx::PaletteImpl const&);
+    void set_palette_impl(Gfx::PaletteImpl&);
     void set_viewport_rect(Web::DevicePixelRect const&);
     void set_screen_rects(Vector<Gfx::IntRect, 4> const& rects, size_t main_screen_index) { m_screen_rect = rects[main_screen_index].to_type<Web::DevicePixels>(); }
     void set_device_pixels_per_css_pixel(float device_pixels_per_css_pixel) { m_device_pixels_per_css_pixel = device_pixels_per_css_pixel; }

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -820,7 +820,7 @@ bool Compositor::set_wallpaper_mode(DeprecatedString const& mode)
     return succeeded;
 }
 
-bool Compositor::set_wallpaper(RefPtr<Gfx::Bitmap> bitmap)
+bool Compositor::set_wallpaper(RefPtr<Gfx::Bitmap const> bitmap)
 {
     if (!bitmap)
         m_wallpaper = nullptr;
@@ -869,11 +869,12 @@ void Compositor::update_wallpaper_bitmap()
             // If the screen size is equal to the wallpaper size, we don't actually need to scale it
             screen_data.m_wallpaper_bitmap = m_wallpaper;
         } else {
-            if (!screen_data.m_wallpaper_bitmap)
-                screen_data.m_wallpaper_bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, screen.size(), screen.scale_factor()).release_value_but_fixme_should_propagate_errors();
+            auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, screen.size(), screen.scale_factor()).release_value_but_fixme_should_propagate_errors();
 
-            Gfx::Painter painter(*screen_data.m_wallpaper_bitmap);
-            painter.draw_scaled_bitmap(screen_data.m_wallpaper_bitmap->rect(), *m_wallpaper, m_wallpaper->rect());
+            Gfx::Painter painter(*bitmap);
+            painter.draw_scaled_bitmap(bitmap->rect(), *m_wallpaper, m_wallpaper->rect());
+
+            screen_data.m_wallpaper_bitmap = move(bitmap);
         }
         return IterationDecision::Continue;
     });

--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -36,7 +36,7 @@ struct CompositorScreenData {
     RefPtr<Gfx::Bitmap> m_front_bitmap;
     RefPtr<Gfx::Bitmap> m_back_bitmap;
     RefPtr<Gfx::Bitmap> m_temp_bitmap;
-    RefPtr<Gfx::Bitmap> m_wallpaper_bitmap;
+    RefPtr<Gfx::Bitmap const> m_wallpaper_bitmap;
     OwnPtr<Gfx::Painter> m_back_painter;
     OwnPtr<Gfx::Painter> m_front_painter;
     OwnPtr<Gfx::Painter> m_temp_painter;
@@ -107,8 +107,8 @@ public:
 
     bool set_wallpaper_mode(DeprecatedString const& mode);
 
-    bool set_wallpaper(RefPtr<Gfx::Bitmap>);
-    RefPtr<Gfx::Bitmap> wallpaper_bitmap() const { return m_wallpaper; }
+    bool set_wallpaper(RefPtr<Gfx::Bitmap const>);
+    RefPtr<Gfx::Bitmap const> wallpaper_bitmap() const { return m_wallpaper; }
 
     void invalidate_cursor(bool = false);
     Gfx::IntRect current_cursor_rect() const;
@@ -231,7 +231,7 @@ private:
     Gfx::DisjointIntRectSet m_transparent_wallpaper_rects;
 
     WallpaperMode m_wallpaper_mode { WallpaperMode::Unchecked };
-    RefPtr<Gfx::Bitmap> m_wallpaper;
+    RefPtr<Gfx::Bitmap const> m_wallpaper;
 
     Cursor const* m_current_cursor { nullptr };
     Screen* m_current_cursor_screen { nullptr };

--- a/Userland/Services/WindowServer/Cursor.cpp
+++ b/Userland/Services/WindowServer/Cursor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,7 +11,7 @@
 
 namespace WindowServer {
 
-Cursor::Cursor(NonnullRefPtr<Gfx::Bitmap>&& bitmap, int scale_factor, Gfx::CursorParams const& cursor_params)
+Cursor::Cursor(NonnullRefPtr<Gfx::Bitmap const>&& bitmap, int scale_factor, Gfx::CursorParams const& cursor_params)
     : m_params(cursor_params.constrained(*bitmap))
     , m_rect(bitmap->rect())
 {
@@ -27,13 +27,13 @@ void Cursor::update_rect_if_animated()
     }
 }
 
-NonnullRefPtr<Cursor> Cursor::create(NonnullRefPtr<Gfx::Bitmap>&& bitmap, int scale_factor)
+NonnullRefPtr<Cursor const> Cursor::create(NonnullRefPtr<Gfx::Bitmap const>&& bitmap, int scale_factor)
 {
     auto hotspot = bitmap->rect().center();
     return adopt_ref(*new Cursor(move(bitmap), scale_factor, Gfx::CursorParams(hotspot)));
 }
 
-RefPtr<Cursor> Cursor::create(StringView filename, StringView default_filename)
+RefPtr<Cursor const> Cursor::create(StringView filename, StringView default_filename)
 {
     auto cursor = adopt_ref(*new Cursor());
     if (cursor->load(filename, default_filename))
@@ -72,7 +72,7 @@ bool Cursor::load(StringView filename, StringView default_filename)
     return did_load_any;
 }
 
-RefPtr<Cursor> Cursor::create(Gfx::StandardCursor standard_cursor)
+RefPtr<Cursor const> Cursor::create(Gfx::StandardCursor standard_cursor)
 {
     switch (standard_cursor) {
     case Gfx::StandardCursor::None:

--- a/Userland/Services/WindowServer/Cursor.h
+++ b/Userland/Services/WindowServer/Cursor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -15,9 +15,9 @@ namespace WindowServer {
 
 class Cursor : public RefCounted<Cursor> {
 public:
-    static RefPtr<Cursor> create(StringView, StringView);
-    static NonnullRefPtr<Cursor> create(NonnullRefPtr<Gfx::Bitmap>&&, int);
-    static RefPtr<Cursor> create(Gfx::StandardCursor);
+    static RefPtr<Cursor const> create(StringView, StringView);
+    static NonnullRefPtr<Cursor const> create(NonnullRefPtr<Gfx::Bitmap const>&&, int);
+    static RefPtr<Cursor const> create(Gfx::StandardCursor);
     ~Cursor() = default;
 
     Gfx::CursorParams const& params() const { return m_params; }
@@ -47,12 +47,12 @@ public:
 
 private:
     Cursor() = default;
-    Cursor(NonnullRefPtr<Gfx::Bitmap>&&, int, Gfx::CursorParams const&);
+    Cursor(NonnullRefPtr<Gfx::Bitmap const>&&, int, Gfx::CursorParams const&);
 
     bool load(StringView, StringView);
     void update_rect_if_animated();
 
-    HashMap<int, NonnullRefPtr<Gfx::Bitmap>> m_bitmaps;
+    HashMap<int, NonnullRefPtr<Gfx::Bitmap const>> m_bitmaps;
     Gfx::CursorParams m_params;
     Gfx::IntRect m_rect;
 };

--- a/Userland/Services/WindowServer/MenuItem.h
+++ b/Userland/Services/WindowServer/MenuItem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -80,7 +80,7 @@ private:
     DeprecatedString m_text;
     DeprecatedString m_shortcut_text;
     Gfx::IntRect m_rect;
-    RefPtr<Gfx::Bitmap> m_icon;
+    RefPtr<Gfx::Bitmap const> m_icon;
     int m_submenu_id { -1 };
     bool m_exclusive { false };
 };

--- a/Userland/Services/WindowServer/Overlays.h
+++ b/Userland/Services/WindowServer/Overlays.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, the SerenityOS developers.
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -165,7 +166,7 @@ private:
     Gfx::Font const& font();
     void update_rect();
 
-    RefPtr<Gfx::Bitmap> m_bitmap;
+    RefPtr<Gfx::Bitmap const> m_bitmap;
     DeprecatedString m_text;
     Gfx::IntRect m_label_rect;
 };

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -279,13 +279,13 @@ public:
     void set_base_size(Gfx::IntSize size) { m_base_size = size; }
 
     Gfx::Bitmap const& icon() const { return *m_icon; }
-    void set_icon(NonnullRefPtr<Gfx::Bitmap>&& icon) { m_icon = move(icon); }
+    void set_icon(NonnullRefPtr<Gfx::Bitmap const>&& icon) { m_icon = move(icon); }
 
     void set_default_icon();
 
     Cursor const* cursor() const { return (m_cursor_override ? m_cursor_override : m_cursor).ptr(); }
-    void set_cursor(RefPtr<Cursor> cursor) { m_cursor = move(cursor); }
-    void set_cursor_override(RefPtr<Cursor> cursor) { m_cursor_override = move(cursor); }
+    void set_cursor(RefPtr<Cursor const> cursor) { m_cursor = move(cursor); }
+    void set_cursor_override(RefPtr<Cursor const> cursor) { m_cursor_override = move(cursor); }
     void remove_cursor_override() { m_cursor_override = nullptr; }
 
     void request_update(Gfx::IntRect const&, bool ignore_occlusion = false);
@@ -445,9 +445,9 @@ private:
     Gfx::IntSize m_size_increment;
     Gfx::IntSize m_base_size;
     Gfx::IntSize m_minimum_size { 0, 0 };
-    NonnullRefPtr<Gfx::Bitmap> m_icon;
-    RefPtr<Cursor> m_cursor;
-    RefPtr<Cursor> m_cursor_override;
+    NonnullRefPtr<Gfx::Bitmap const> m_icon;
+    RefPtr<Cursor const> m_cursor;
+    RefPtr<Cursor const> m_cursor_override;
     WindowFrame m_frame;
     Gfx::DisjointIntRectSet m_pending_paint_rects;
     Gfx::IntRect m_rect_in_applet_area;

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -35,7 +35,7 @@ WindowManager& WindowManager::the()
     return *s_the;
 }
 
-WindowManager::WindowManager(Gfx::PaletteImpl const& palette)
+WindowManager::WindowManager(Gfx::PaletteImpl& palette)
     : m_switcher(WindowSwitcher::construct())
     , m_keymap_switcher(KeymapSwitcher::construct())
     , m_palette(palette)
@@ -2242,7 +2242,7 @@ void WindowManager::apply_cursor_theme(DeprecatedString const& theme_name)
     auto cursor_theme_config = cursor_theme_config_or_error.release_value();
 
     auto* current_cursor = Compositor::the().current_cursor();
-    auto reload_cursor = [&](RefPtr<Cursor>& cursor, DeprecatedString const& name) {
+    auto reload_cursor = [&](RefPtr<Cursor const>& cursor, DeprecatedString const& name) {
         bool is_current_cursor = current_cursor && current_cursor == cursor.ptr();
 
         static auto const s_default_cursor_path = "/res/cursor-themes/Default/arrow.x2y2.png"sv;

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -339,7 +339,7 @@ public:
     u8 last_processed_buttons() { return m_last_processed_buttons; }
 
 private:
-    explicit WindowManager(Gfx::PaletteImpl const&);
+    explicit WindowManager(Gfx::PaletteImpl&);
 
     void notify_new_active_window(Window&);
     void notify_previous_active_window(Window&);
@@ -371,25 +371,25 @@ private:
 
     [[nodiscard]] static WindowStack& get_rendering_window_stacks(WindowStack*&);
 
-    RefPtr<Cursor> m_hidden_cursor;
-    RefPtr<Cursor> m_arrow_cursor;
-    RefPtr<Cursor> m_hand_cursor;
-    RefPtr<Cursor> m_help_cursor;
-    RefPtr<Cursor> m_resize_horizontally_cursor;
-    RefPtr<Cursor> m_resize_vertically_cursor;
-    RefPtr<Cursor> m_resize_diagonally_tlbr_cursor;
-    RefPtr<Cursor> m_resize_diagonally_bltr_cursor;
-    RefPtr<Cursor> m_resize_column_cursor;
-    RefPtr<Cursor> m_resize_row_cursor;
-    RefPtr<Cursor> m_i_beam_cursor;
-    RefPtr<Cursor> m_disallowed_cursor;
-    RefPtr<Cursor> m_move_cursor;
-    RefPtr<Cursor> m_drag_cursor;
-    RefPtr<Cursor> m_drag_copy_cursor;
-    RefPtr<Cursor> m_wait_cursor;
-    RefPtr<Cursor> m_crosshair_cursor;
-    RefPtr<Cursor> m_eyedropper_cursor;
-    RefPtr<Cursor> m_zoom_cursor;
+    RefPtr<Cursor const> m_hidden_cursor;
+    RefPtr<Cursor const> m_arrow_cursor;
+    RefPtr<Cursor const> m_hand_cursor;
+    RefPtr<Cursor const> m_help_cursor;
+    RefPtr<Cursor const> m_resize_horizontally_cursor;
+    RefPtr<Cursor const> m_resize_vertically_cursor;
+    RefPtr<Cursor const> m_resize_diagonally_tlbr_cursor;
+    RefPtr<Cursor const> m_resize_diagonally_bltr_cursor;
+    RefPtr<Cursor const> m_resize_column_cursor;
+    RefPtr<Cursor const> m_resize_row_cursor;
+    RefPtr<Cursor const> m_i_beam_cursor;
+    RefPtr<Cursor const> m_disallowed_cursor;
+    RefPtr<Cursor const> m_move_cursor;
+    RefPtr<Cursor const> m_drag_cursor;
+    RefPtr<Cursor const> m_drag_copy_cursor;
+    RefPtr<Cursor const> m_wait_cursor;
+    RefPtr<Cursor const> m_crosshair_cursor;
+    RefPtr<Cursor const> m_eyedropper_cursor;
+    RefPtr<Cursor const> m_zoom_cursor;
     int m_cursor_highlight_radius { 0 };
     Gfx::Color m_cursor_highlight_color;
     bool m_cursor_highlight_enabled { false };
@@ -477,7 +477,7 @@ private:
     DeprecatedString m_dnd_text;
     bool m_dnd_accepts_drag { false };
 
-    RefPtr<Core::MimeData> m_dnd_mime_data;
+    RefPtr<Core::MimeData const> m_dnd_mime_data;
 
     WindowStack* m_switching_to_window_stack { nullptr };
     Vector<WeakPtr<Window>, 4> m_carry_window_to_new_stack;

--- a/Userland/Shell/AST.h
+++ b/Userland/Shell/AST.h
@@ -220,9 +220,9 @@ struct Command {
 };
 
 struct HitTestResult {
-    RefPtr<Node> matching_node;
-    RefPtr<Node> closest_node_with_semantic_meaning; // This is used if matching_node is a bareword
-    RefPtr<Node> closest_command_node;               // This is used if matching_node is a bareword, and it is not the first in a list
+    RefPtr<Node const> matching_node;
+    RefPtr<Node const> closest_node_with_semantic_meaning; // This is used if matching_node is a bareword
+    RefPtr<Node const> closest_command_node;               // This is used if matching_node is a bareword, and it is not the first in a list
 };
 
 class Value : public RefCounted<Value> {
@@ -424,7 +424,7 @@ public:
     virtual void for_each_entry(RefPtr<Shell> shell, Function<IterationDecision(NonnullRefPtr<Value>)> callback);
     virtual RefPtr<Value> run(RefPtr<Shell>) = 0;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) = 0;
-    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&);
+    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) const;
     Vector<Line::CompletionSuggestion> complete_for_editor(Shell& shell, size_t offset);
     virtual HitTestResult hit_test_position(size_t offset) const
     {
@@ -451,14 +451,14 @@ public:
 
     Position const& position() const { return m_position; }
     virtual void clear_syntax_error();
-    virtual void set_is_syntax_error(SyntaxError const& error_node);
-    virtual SyntaxError const& syntax_error_node() const
+    virtual void set_is_syntax_error(SyntaxError& error_node);
+    virtual SyntaxError& syntax_error_node()
     {
         VERIFY(is_syntax_error());
         return *m_syntax_error_node;
     }
 
-    virtual RefPtr<Node> leftmost_trivial_literal() const { return nullptr; }
+    virtual RefPtr<Node const> leftmost_trivial_literal() const { return nullptr; }
 
     Vector<Command> to_lazy_evaluated_commands(RefPtr<Shell> shell);
 
@@ -534,7 +534,7 @@ public:
     PathRedirectionNode(Position, int, NonnullRefPtr<Node>);
     virtual ~PathRedirectionNode();
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
-    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) override;
+    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) const override;
     virtual HitTestResult hit_test_position(size_t offset) const override;
     virtual bool is_command() const override { return true; }
     virtual bool is_list() const override { return true; }
@@ -585,7 +585,7 @@ private:
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
     virtual HitTestResult hit_test_position(size_t) const override;
     virtual bool is_list() const override { return true; }
-    virtual RefPtr<Node> leftmost_trivial_literal() const override;
+    virtual RefPtr<Node const> leftmost_trivial_literal() const override;
 
     Vector<NonnullRefPtr<Node>> m_list;
 };
@@ -622,7 +622,7 @@ private:
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
     virtual bool is_bareword() const override { return true; }
-    virtual RefPtr<Node> leftmost_trivial_literal() const override { return this; }
+    virtual RefPtr<Node const> leftmost_trivial_literal() const override { return this; }
 
     DeprecatedString m_text;
 };
@@ -659,10 +659,10 @@ private:
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
     virtual HitTestResult hit_test_position(size_t) const override;
-    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) override;
+    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) const override;
     virtual bool is_command() const override { return true; }
     virtual bool is_list() const override { return true; }
-    virtual RefPtr<Node> leftmost_trivial_literal() const override;
+    virtual RefPtr<Node const> leftmost_trivial_literal() const override;
 
     NonnullRefPtr<Node> m_inner;
 };
@@ -683,7 +683,7 @@ private:
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
     virtual HitTestResult hit_test_position(size_t) const override;
     virtual bool is_list() const override { return true; }
-    virtual RefPtr<Node> leftmost_trivial_literal() const override;
+    virtual RefPtr<Node const> leftmost_trivial_literal() const override;
 
     RefPtr<Node> m_inner;
 };
@@ -849,7 +849,7 @@ private:
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
     virtual HitTestResult hit_test_position(size_t) const override;
-    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) override;
+    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) const override;
     virtual bool would_execute() const override { return true; }
     virtual bool should_override_execution_in_current_process() const override { return true; }
 
@@ -982,7 +982,7 @@ private:
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
     virtual HitTestResult hit_test_position(size_t) const override;
-    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) override;
+    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) const override;
     virtual bool is_execute() const override { return true; }
     virtual bool would_execute() const override { return true; }
 
@@ -1034,7 +1034,7 @@ private:
     virtual void dump(int level) const override;
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
-    Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) override;
+    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) const override;
     virtual HitTestResult hit_test_position(size_t) const override;
 
     NonnullRefPtrVector<AST::Node> m_arguments;
@@ -1059,7 +1059,7 @@ private:
     virtual HitTestResult hit_test_position(size_t) const override;
     virtual bool is_command() const override { return true; }
     virtual bool is_list() const override { return true; }
-    virtual RefPtr<Node> leftmost_trivial_literal() const override;
+    virtual RefPtr<Node const> leftmost_trivial_literal() const override;
 
     NonnullRefPtr<Node> m_left;
     NonnullRefPtr<Node> m_right;
@@ -1204,7 +1204,7 @@ private:
     virtual HitTestResult hit_test_position(size_t) const override;
     virtual bool is_list() const override { return true; }
     virtual bool should_override_execution_in_current_process() const override { return true; }
-    virtual RefPtr<Node> leftmost_trivial_literal() const override;
+    virtual RefPtr<Node const> leftmost_trivial_literal() const override;
 
     NonnullRefPtrVector<Node> m_entries;
     Vector<Position> m_separator_positions;
@@ -1242,7 +1242,7 @@ public:
     virtual void dump(int level) const override;
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
-    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) override;
+    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) const override;
     virtual HitTestResult hit_test_position(size_t) const override;
 
 protected:
@@ -1284,7 +1284,7 @@ private:
     virtual void dump(int level) const override;
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
-    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) override;
+    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) const override;
     virtual HitTestResult hit_test_position(size_t) const override;
     virtual bool is_simple_variable() const override { return true; }
 
@@ -1304,7 +1304,7 @@ private:
     virtual void dump(int level) const override;
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
-    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) override;
+    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) const override;
     virtual HitTestResult hit_test_position(size_t) const override;
 
     char m_name { 0 };
@@ -1329,7 +1329,7 @@ private:
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
     virtual HitTestResult hit_test_position(size_t) const override;
-    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) override;
+    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) const override;
 
     NonnullRefPtr<Node> m_left;
     NonnullRefPtr<Node> m_right;
@@ -1363,7 +1363,7 @@ private:
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
     virtual HitTestResult hit_test_position(size_t) const override;
-    virtual RefPtr<Node> leftmost_trivial_literal() const override { return this; };
+    virtual RefPtr<Node const> leftmost_trivial_literal() const override { return this; };
 
     DeprecatedString m_end;
     bool m_allows_interpolation { false };
@@ -1392,7 +1392,7 @@ private:
     virtual void dump(int level) const override;
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
-    virtual RefPtr<Node> leftmost_trivial_literal() const override { return this; };
+    virtual RefPtr<Node const> leftmost_trivial_literal() const override { return this; };
 
     DeprecatedString m_text;
     EnclosureType m_enclosure_type;
@@ -1431,7 +1431,7 @@ public:
     {
         m_is_cleared = true;
     }
-    virtual void set_is_syntax_error(SyntaxError const& error) override
+    virtual void set_is_syntax_error(SyntaxError& error) override
     {
         m_position = error.position();
         m_is_cleared = error.m_is_cleared;
@@ -1447,7 +1447,7 @@ private:
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
     virtual HitTestResult hit_test_position(size_t) const override { return { nullptr, nullptr, nullptr }; }
-    virtual SyntaxError const& syntax_error_node() const override;
+    virtual SyntaxError& syntax_error_node() override;
 
     DeprecatedString m_syntax_error_text;
     bool m_is_continuable { false };
@@ -1484,7 +1484,7 @@ private:
     virtual void dump(int level) const override;
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
-    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) override;
+    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, HitTestResult const&) const override;
     virtual HitTestResult hit_test_position(size_t) const override;
     virtual bool is_tilde() const override { return true; }
 

--- a/Userland/Shell/Formatter.h
+++ b/Userland/Shell/Formatter.h
@@ -117,8 +117,8 @@ private:
     StringView m_source;
     size_t m_output_cursor { 0 };
     ssize_t m_cursor { -1 };
-    RefPtr<AST::Node> m_root_node;
-    AST::Node* m_hit_node { nullptr };
+    RefPtr<AST::Node const> m_root_node;
+    AST::Node const* m_hit_node { nullptr };
 
     const AST::Node* m_parent_node { nullptr };
     const AST::Node* m_last_visited_node { nullptr };

--- a/Userland/Shell/Job.cpp
+++ b/Userland/Shell/Job.cpp
@@ -96,7 +96,7 @@ void Job::set_signalled(int sig)
         on_exit(*this);
 }
 
-void Job::unblock() const
+void Job::unblock()
 {
     if (!m_exited && on_exit)
         on_exit(*this);

--- a/Userland/Shell/Job.h
+++ b/Userland/Shell/Job.h
@@ -63,7 +63,7 @@ public:
     bool should_announce_signal() const { return m_should_announce_signal; }
     bool is_suspended() const { return m_is_suspended; }
     bool shell_did_continue() const { return m_shell_did_continue; }
-    void unblock() const;
+    void unblock();
 
     Core::ElapsedTimer& timer() { return m_command_timer; }
 

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -170,8 +170,8 @@ public:
 
     static bool has_history_event(StringView);
 
-    RefPtr<AST::Value> get_argument(size_t) const;
-    RefPtr<AST::Value> lookup_local_variable(StringView) const;
+    RefPtr<AST::Value const> get_argument(size_t) const;
+    RefPtr<AST::Value const> lookup_local_variable(StringView) const;
     DeprecatedString local_variable_or(StringView, DeprecatedString const&) const;
     void set_local_variable(DeprecatedString const&, RefPtr<AST::Value>, bool only_in_current_frame = false);
     void unset_local_variable(StringView, bool only_in_current_frame = false);
@@ -290,8 +290,8 @@ public:
     void restore_ios();
 
     u64 find_last_job_id() const;
-    Job const* find_job(u64 id, bool is_pid = false);
-    Job const* current_job() const { return m_current_job; }
+    Job* find_job(u64 id, bool is_pid = false);
+    Job* current_job() const { return m_current_job; }
     void kill_job(Job const*, int sig);
 
     DeprecatedString get_history_path();
@@ -406,7 +406,7 @@ private:
     void add_entry_to_cache(RunnablePath const&);
     void remove_entry_from_cache(StringView);
     void stop_all_jobs();
-    Job const* m_current_job { nullptr };
+    Job* m_current_job { nullptr };
     LocalFrame* find_frame_containing_local_variable(StringView name);
     LocalFrame const* find_frame_containing_local_variable(StringView name) const
     {


### PR DESCRIPTION
Our `RefPtr` and `NonnullRefPtr` smart pointers currently allow assignment from `Ptr<T const>` to `Ptr<T>`.

This washes away the constness of the pointee type, and ruins our ability to enforce invariants with this.

I tried making `RefPtr` and `NonnullRefPtr` strict about this, and it exposed a *lot* of problems. This PR fixes (or papers over with `const_cast` in some cases that we'll have to come back to) all of those issues separately, and then finally makes the smart pointers strict.