### PR TITLE
LibGUI: Fix missing parent in LinkLabel open action

### DIFF
--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -124,7 +124,7 @@ Action::Action(DeprecatedString text, Shortcut const& shortcut, Shortcut const& 
 
 Action::~Action()
 {
-    if (m_shortcut.is_valid() && m_scope == ShortcutScope::ApplicationGlobal) {
+    if (m_scope == ShortcutScope::ApplicationGlobal) {
         if (auto* app = Application::the())
             app->unregister_global_shortcut_action({}, *this);
     }

--- a/Userland/Libraries/LibGUI/LinkLabel.cpp
+++ b/Userland/Libraries/LibGUI/LinkLabel.cpp
@@ -29,10 +29,12 @@ LinkLabel::LinkLabel(DeprecatedString text)
 
 void LinkLabel::setup_actions()
 {
-    m_open_action = GUI::Action::create("Show in File Manager", {}, Gfx::Bitmap::load_from_file("/res/icons/16x16/app-file-manager.png"sv).release_value_but_fixme_should_propagate_errors(), [&](const GUI::Action&) {
-        if (on_click)
-            on_click();
-    });
+    m_open_action = GUI::Action::create(
+        "Show in File Manager", Gfx::Bitmap::load_from_file("/res/icons/16x16/app-file-manager.png"sv).release_value_but_fixme_should_propagate_errors(), [&](const GUI::Action&) {
+            if (on_click)
+                on_click();
+        },
+        this);
 
     m_copy_action = CommonActions::make_copy_action([this](auto&) { Clipboard::the().set_plain_text(text()); }, this);
 }


### PR DESCRIPTION
Without this parameter, this action was being registered in the global shortcut scope, which was a problem when opening the command palette after destroying the widget.

Before:

[Screencast from 2023-02-20 22-37-55.webm](https://user-images.githubusercontent.com/2660905/220208652-68bc0e71-ae9d-4f0f-8c95-ae13d918d7a5.webm)

After fix:

[Screencast from 2023-02-20 22-39-45.webm](https://user-images.githubusercontent.com/2660905/220208661-8bd3ccb8-d759-46f2-93f7-e11c5c26d1d3.webm)

