### PR TITLE
LibWeb: Use browsing context creator URL for about:blank documents

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -777,7 +777,10 @@ JS::GCPtr<HTML::HTMLBaseElement> Document::first_base_element_with_href_in_tree_
 AK::URL Document::fallback_base_url() const
 {
     // FIXME: 1. If document is an iframe srcdoc document, then return the document base URL of document's browsing context's container document.
-    // FIXME: 2. If document's URL is about:blank, and document's browsing context's creator base URL is non-null, then return that creator base URL.
+
+    // 2. If document's URL is about:blank, and document's browsing context's creator base URL is non-null, then return that creator base URL.
+    if (m_url == "about:blank"sv && browsing_context() && browsing_context()->creator_url().has_value())
+        return browsing_context()->creator_url().value();
 
     // 3. Return document's URL.
     return m_url;

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -265,6 +265,8 @@ public:
     // https://html.spec.whatwg.org/multipage/window-object.html#close-a-browsing-context
     void close();
 
+    Optional<AK::URL> const& creator_url() const { return m_creator_url; }
+
 private:
     explicit BrowsingContext(Page&, HTML::BrowsingContextContainer*);
 


### PR DESCRIPTION
In about:blank documents, we should use the browsing context's creator URL as the base URL, if it exists and there is no `<base>` element. This means that any about:blank frames will have URLs parse relative to their parent frame's URL.

Fixes #17394.