### PR TITLE
LibGfx: Still not support for progressive JPEGs

### DIFF
--- a/Userland/Libraries/LibGfx/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPEGLoader.cpp
@@ -1217,15 +1217,15 @@ static ErrorOr<void> scan_huffman_stream(AK::SeekableStream& stream, JPEGLoading
                 continue;
             }
             Marker marker = 0xFF00 | current_byte;
-            if (marker == JPEG_EOI)
-                return {};
             if (marker >= JPEG_RST0 && marker <= JPEG_RST7) {
                 context.huffman_stream.stream.append(marker);
                 current_byte = TRY(stream.read_value<u8>());
                 continue;
             }
-            dbgln_if(JPEG_DEBUG, "{}: Invalid marker: {:x}!", TRY(stream.tell()), marker);
-            return Error::from_string_literal("Invalid marker");
+
+            // Rollback the marker we just read
+            TRY(stream.seek(-2, AK::SeekMode::FromCurrentPosition));
+            return {};
         } else {
             context.huffman_stream.stream.append(last_byte);
         }

--- a/Userland/Libraries/LibGfx/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPEGLoader.cpp
@@ -194,6 +194,9 @@ struct JPEGLoadingContext {
     StartOfFrame frame;
     u8 hsample_factor { 0 };
     u8 vsample_factor { 0 };
+    u8 spectral_selection_start {};
+    u8 spectral_selection_end {};
+    u8 successive_approximation {};
     Vector<ComponentSpec, 3> components;
     RefPtr<Gfx::Bitmap> bitmap;
     u16 dc_restart_interval { 0 };
@@ -565,17 +568,17 @@ static ErrorOr<void> read_start_of_scan(AK::SeekableStream& stream, JPEGLoadingC
         }
     }
 
-    u8 spectral_selection_start = TRY(stream.read_value<u8>());
-    u8 spectral_selection_end = TRY(stream.read_value<u8>());
-    u8 successive_approximation = TRY(stream.read_value<u8>());
+    context.spectral_selection_start = TRY(stream.read_value<u8>());
+    context.spectral_selection_end = TRY(stream.read_value<u8>());
+    context.successive_approximation = TRY(stream.read_value<u8>());
 
     // The three values should be fixed for baseline JPEGs utilizing sequential DCT.
-    if (spectral_selection_start != 0 || spectral_selection_end != 63 || successive_approximation != 0) {
+    if (context.spectral_selection_start != 0 || context.spectral_selection_end != 63 || context.successive_approximation != 0) {
         dbgln_if(JPEG_DEBUG, "{}: ERROR! Start of Selection: {}, End of Selection: {}, Successive Approximation: {}!",
             TRY(stream.tell()),
-            spectral_selection_start,
-            spectral_selection_end,
-            successive_approximation);
+            context.spectral_selection_start,
+            context.spectral_selection_end,
+            context.successive_approximation);
         return Error::from_string_literal("Spectral selection is not [0,63] or successive approximation is not null");
     }
     return {};

--- a/Userland/Libraries/LibGfx/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPEGLoader.cpp
@@ -851,7 +851,7 @@ static ErrorOr<void> read_quantization_table(AK::SeekableStream& stream, JPEGLoa
     return {};
 }
 
-static ErrorOr<void> skip_marker_with_length(Stream& stream)
+static ErrorOr<void> skip_segment(Stream& stream)
 {
     u16 bytes_to_skip = TRY(stream.read_value<BigEndian<u16>>()) - 2;
     TRY(stream.discard(bytes_to_skip));
@@ -1161,7 +1161,7 @@ static ErrorOr<void> parse_header(AK::SeekableStream& stream, JPEGLoadingContext
         case JPEG_SOS:
             return read_start_of_scan(stream, context);
         default:
-            if (auto result = skip_marker_with_length(stream); result.is_error()) {
+            if (auto result = skip_segment(stream); result.is_error()) {
                 dbgln_if(JPEG_DEBUG, "{}: Error skipping marker: {:x}!", TRY(stream.tell()), marker);
                 return result.release_error();
             }

--- a/Userland/Libraries/LibGfx/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPEGLoader.cpp
@@ -450,7 +450,7 @@ static ErrorOr<void> decode_huffman_stream(JPEGLoadingContext& context, Vector<M
 
             if (auto result = build_macroblocks(context, macroblocks, hcursor, vcursor); result.is_error()) {
                 if constexpr (JPEG_DEBUG) {
-                    dbgln("Failed to build Macroblock {}", i);
+                    dbgln("Failed to build Macroblock {}: {}", i, result.error());
                     dbgln("Huffman stream byte offset {}", context.huffman_stream.byte_offset);
                     dbgln("Huffman stream bit offset {}", context.huffman_stream.bit_offset);
                 }


### PR DESCRIPTION
The goal of this PR is to bring the decoder closer to spec by changing some code that assumed that the JPEG was a Baseline-DCT. It also comes with its number of rename and refactor that should help us down the road.

One of the main functionalities added in this PR is to be able to read multiples scans. Even if we still quit after the first one, it is now straightforward to read several.

Also, when filling macroblocks, we don't assume that the scan has all coefficients.

These changes combined allows us to read the first scan of a progressive JPEG. 

In its current state, the decoder still refuses to decode a progressive image and assumes that the image is a Baseline-DCT in some places (mostly correctness checks). And I didn't touch these places for now, but you can remove those limitations with this patch:

<details>
<summary>Details</summary>

```diff
diff --git a/Userland/Libraries/LibGfx/JPEGLoader.cpp b/Userland/Libraries/LibGfx/JPEGLoader.cpp
index 74ff397d13..ec2a3900d5 100644
--- a/Userland/Libraries/LibGfx/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPEGLoader.cpp
@@ -365,10 +365,12 @@ static ErrorOr<void> build_macroblocks(JPEGLoadingContext& context, Vector<Macro
     for (unsigned component_i = 0; component_i < context.components.size(); component_i++) {
         auto& component = context.components[component_i];
 
-        if (component.dc_destination_id >= context.dc_tables.size())
-            return Error::from_string_literal("DC destination ID is greater than number of DC tables");
-        if (component.ac_destination_id >= context.ac_tables.size())
-            return Error::from_string_literal("AC destination ID is greater than number of AC tables");
+        if (context.frame.type == StartOfFrame::FrameType::Baseline_DCT) {
+            if (component.dc_destination_id >= context.dc_tables.size())
+                return Error::from_string_literal("DC destination ID is greater than number of DC tables");
+            if (component.ac_destination_id >= context.ac_tables.size())
+                return Error::from_string_literal("AC destination ID is greater than number of AC tables");
+        }
 
         for (u8 vfactor_i = 0; vfactor_i < component.vsample_factor; vfactor_i++) {
             for (u8 hfactor_i = 0; hfactor_i < component.hsample_factor; hfactor_i++) {
@@ -501,6 +503,7 @@ static inline bool is_supported_marker(Marker const marker)
     case JPEG_DQT:
     case JPEG_DRI:
     case JPEG_SOF0:
+    case JPEG_SOF2:
     case JPEG_SOI:
     case JPEG_SOS:
         return true;
@@ -557,19 +560,21 @@ static ErrorOr<void> read_start_of_scan(AK::SeekableStream& stream, JPEGLoadingC
         component.dc_destination_id = table_ids >> 4;
         component.ac_destination_id = table_ids & 0x0F;
 
-        if (context.dc_tables.size() != context.ac_tables.size()) {
-            dbgln_if(JPEG_DEBUG, "{}: DC & AC table count mismatch!", TRY(stream.tell()));
-            return Error::from_string_literal("DC & AC table count mismatch");
-        }
+        if (context.frame.type == StartOfFrame::FrameType::Baseline_DCT) {
+            if (context.dc_tables.size() != context.ac_tables.size()) {
+                dbgln_if(JPEG_DEBUG, "{}: DC & AC table count mismatch!", TRY(stream.tell()));
+                return Error::from_string_literal("DC & AC table count mismatch");
+            }
 
-        if (!context.dc_tables.contains(component.dc_destination_id)) {
-            dbgln_if(JPEG_DEBUG, "DC table (id: {}) does not exist!", component.dc_destination_id);
-            return Error::from_string_literal("DC table does not exist");
-        }
+            if (!context.dc_tables.contains(component.dc_destination_id)) {
+                dbgln_if(JPEG_DEBUG, "DC table (id: {}) does not exist!", component.dc_destination_id);
+                return Error::from_string_literal("DC table does not exist");
+            }
 
-        if (!context.ac_tables.contains(component.ac_destination_id)) {
-            dbgln_if(JPEG_DEBUG, "AC table (id: {}) does not exist!", component.ac_destination_id);
-            return Error::from_string_literal("AC table does not exist");
+            if (!context.ac_tables.contains(component.ac_destination_id)) {
+                dbgln_if(JPEG_DEBUG, "AC table (id: {}) does not exist!", component.ac_destination_id);
+                return Error::from_string_literal("AC table does not exist");
+            }
         }
     }
 
@@ -577,14 +582,18 @@ static ErrorOr<void> read_start_of_scan(AK::SeekableStream& stream, JPEGLoadingC
     context.spectral_selection_end = TRY(stream.read_value<u8>());
     context.successive_approximation = TRY(stream.read_value<u8>());
 
-    // The three values should be fixed for baseline JPEGs utilizing sequential DCT.
-    if (context.spectral_selection_start != 0 || context.spectral_selection_end != 63 || context.successive_approximation != 0) {
-        dbgln_if(JPEG_DEBUG, "{}: ERROR! Start of Selection: {}, End of Selection: {}, Successive Approximation: {}!",
-            TRY(stream.tell()),
-            context.spectral_selection_start,
-            context.spectral_selection_end,
-            context.successive_approximation);
-        return Error::from_string_literal("Spectral selection is not [0,63] or successive approximation is not null");
+    dbgln_if(JPEG_DEBUG, "Start of Selection: {}, End of Selection: {}, Successive Approximation: {}", context.spectral_selection_start, context.spectral_selection_end, context.successive_approximation);
+
+    if (context.frame.type == StartOfFrame::FrameType::Baseline_DCT) {
+        // The three values should be fixed for baseline JPEGs utilizing sequential DCT.
+        if (context.spectral_selection_start != 0 || context.spectral_selection_end != 63 || context.successive_approximation != 0) {
+            dbgln_if(JPEG_DEBUG, "{}: ERROR! Start of Selection: {}, End of Selection: {}, Successive Approximation: {}!",
+                TRY(stream.tell()),
+                context.spectral_selection_start,
+                context.spectral_selection_end,
+                context.successive_approximation);
+            return Error::from_string_literal("Spectral selection is not [0,63] or successive approximation is not null");
+        }
     }
     return {};
 }
@@ -1222,6 +1231,7 @@ static ErrorOr<void> parse_header(AK::SeekableStream& stream, JPEGLoadingContext
             dbgln_if(JPEG_DEBUG, "{}: Unexpected marker {:x}!", TRY(stream.tell()), marker);
             return Error::from_string_literal("Unexpected marker");
         case JPEG_SOF0:
+        case JPEG_SOF2:
             TRY(read_start_of_frame(stream, context));
             context.state = JPEGLoadingContext::FrameDecoded;
             return {};

```

</details>

Which finally gives us some results :smile::

![WHF](https://user-images.githubusercontent.com/26030965/220445582-ba7fc056-29fd-4709-b0cc-0ec9fe65bd02.png)

