### PR TITLE
LibJS: Don't try to merge unterminated BasicBlocks

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Pass/MergeBlocks.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/MergeBlocks.cpp
@@ -30,6 +30,9 @@ void MergeBlocks::perform(PassPipelineExecutable& executable)
         if (executable.exported_blocks->contains(*entry.value.begin()))
             continue;
 
+        if (!entry.key->is_terminated())
+            continue;
+
         if (entry.key->terminator()->type() != Instruction::Type::Jump)
             continue;
 


### PR DESCRIPTION
This was causing a Segfault, trying to access the non-present terminator

----

This should fix the discrepancy between bytecode mode and optimized bytecode mode in test262