### PR TITLE
Meta: Use default ext2 inode size of 256 bytes

### DIFF
--- a/Meta/build-image-extlinux.sh
+++ b/Meta/build-image-extlinux.sh
@@ -83,7 +83,7 @@ dd if=/dev/zero of="${dev}${partition_number}" bs=1M count=1 status=none || die 
 echo "done"
 
 printf "creating new filesystem... "
-mke2fs -q -I 128 "${dev}${partition_number}" || die "couldn't create filesystem"
+mke2fs -q "${dev}${partition_number}" || die "couldn't create filesystem"
 echo "done"
 
 printf "mounting filesystem... "

--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -101,7 +101,7 @@ dd if=/dev/zero of="${dev}${partition_number}" bs=1M count=1 status=none || die 
 echo "done"
 
 printf "creating new filesystem... "
-mke2fs -q -I 128 "${dev}${partition_number}" || die "couldn't create filesystem"
+mke2fs -q "${dev}${partition_number}" || die "couldn't create filesystem"
 echo "done"
 
 printf "mounting filesystem... "

--- a/Meta/build-image-limine.sh
+++ b/Meta/build-image-limine.sh
@@ -85,7 +85,7 @@ echo "done"
 
 printf "creating new filesystems... "
 mkfs.vfat -F 32 "${dev}p1" || die "couldn't create efi filesystem"
-mke2fs -q -I 128 "${dev}p2" || die "couldn't create root filesystem"
+mke2fs -q "${dev}p2" || die "couldn't create root filesystem"
 echo "done"
 
 printf "mounting filesystems... "

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -49,7 +49,7 @@ inode_usage() {
     find "$1" | wc -l
 }
 
-INODE_SIZE=128
+INODE_SIZE=256
 INODE_COUNT=$(($(inode_usage "$SERENITY_SOURCE_DIR/Base") + $(inode_usage Root)))
 INODE_COUNT=$((INODE_COUNT + 2000))  # Some additional inodes for toolchain files, could probably also be calculated
 DISK_SIZE_BYTES=$((($(disk_usage "$SERENITY_SOURCE_DIR/Base") + $(disk_usage Root)) * 1024))


### PR DESCRIPTION
It seems like everything still works correctly with the default inode size, so drop the 128-byte setting where applicable.

On a 10GiB disk image, this increased the total disk size by ~4MiB for me. Not a bad tradeoff, since we can now use the default inode size and we get rid of the warning during image creation. :^)