### PR TITLE
LibGfx+LibGUI+LibWeb: Remove single-code point Font::glyph_or_emoji_width API

### DIFF
--- a/Tests/LibGfx/TestFontHandling.cpp
+++ b/Tests/LibGfx/TestFontHandling.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Utf8View.h>
 #include <LibGfx/Font/BitmapFont.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibTest/TestCase.h>
@@ -125,7 +126,10 @@ TEST_CASE(test_glyph_or_emoji_width)
     u8 glyph_width = 1;
     auto font = Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256);
 
-    EXPECT(font->glyph_or_emoji_width(0));
+    Utf8View view { " "sv };
+    auto it = view.begin();
+
+    EXPECT(font->glyph_or_emoji_width(it));
 }
 
 TEST_CASE(test_load_from_file)

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -169,20 +169,23 @@ TextPosition TextEditor::text_position_at_content_position(Gfx::IntPoint content
         for_each_visual_line(line_index, [&](Gfx::IntRect const& rect, auto& view, size_t start_of_line, [[maybe_unused]] bool is_last_visual_line) {
             if (is_multi_line() && !rect.contains_vertically(position.y()) && !is_last_visual_line)
                 return IterationDecision::Continue;
+
             column_index = start_of_line;
+            int glyph_x = 0;
+
             if (position.x() <= 0) {
                 // We're outside the text on the left side, put cursor at column 0 on this visual line.
-            } else {
-                int glyph_x = 0;
-                size_t i = 0;
-                for (; i < view.length(); ++i) {
-                    int advance = font().glyph_or_emoji_width(view.code_points()[i]) + font().glyph_spacing();
-                    if ((glyph_x + (advance / 2)) >= position.x())
-                        break;
-                    glyph_x += advance;
-                }
-                column_index += i;
+                return IterationDecision::Break;
             }
+
+            for (auto it = view.begin(); it != view.end(); ++it, ++column_index) {
+                int advance = font().glyph_or_emoji_width(it) + font().glyph_spacing();
+                if ((glyph_x + (advance / 2)) >= position.x())
+                    break;
+
+                glyph_x += advance;
+            }
+
             return IterationDecision::Break;
         });
         break;

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
@@ -326,14 +326,6 @@ static float glyph_or_emoji_width_impl(BitmapFont const& font, CodePointIterator
     return font.glyph_width(*it);
 }
 
-float BitmapFont::glyph_or_emoji_width(u32 code_point) const
-{
-    Utf32View code_point_view { &code_point, 1 };
-    auto it = code_point_view.begin();
-
-    return glyph_or_emoji_width_impl(*this, it);
-}
-
 float BitmapFont::glyph_or_emoji_width(Utf8CodePointIterator& it) const
 {
     return glyph_or_emoji_width_impl(*this, it);

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -61,7 +61,6 @@ public:
     bool contains_glyph(u32 code_point) const override;
     bool contains_raw_glyph(u32 code_point) const { return m_glyph_widths[code_point] > 0; }
 
-    virtual float glyph_or_emoji_width(u32) const override;
     virtual float glyph_or_emoji_width(Utf8CodePointIterator&) const override;
     virtual float glyph_or_emoji_width(Utf32CodePointIterator&) const override;
 

--- a/Userland/Libraries/LibGfx/Font/Font.h
+++ b/Userland/Libraries/LibGfx/Font/Font.h
@@ -167,7 +167,6 @@ public:
 
     virtual float glyph_left_bearing(u32 code_point) const = 0;
     virtual float glyph_width(u32 code_point) const = 0;
-    virtual float glyph_or_emoji_width(u32 code_point) const = 0;
     virtual float glyph_or_emoji_width(Utf8CodePointIterator&) const = 0;
     virtual float glyph_or_emoji_width(Utf32CodePointIterator&) const = 0;
     virtual float glyphs_horizontal_kerning(u32 left_code_point, u32 right_code_point) const = 0;

--- a/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
@@ -98,23 +98,20 @@ float ScaledFont::glyph_width(u32 code_point) const
     return metrics.advance_width;
 }
 
-float ScaledFont::glyph_or_emoji_width(u32 code_point) const
-{
-    auto id = glyph_id_for_code_point(code_point);
-    auto metrics = glyph_metrics(id);
-    return metrics.advance_width;
-}
-
 float ScaledFont::glyph_or_emoji_width(Utf8CodePointIterator& it) const
 {
     // FIXME: Support multi-code point emoji with scaled fonts.
-    return glyph_or_emoji_width(*it);
+    auto id = glyph_id_for_code_point(*it);
+    auto metrics = glyph_metrics(id);
+    return metrics.advance_width;
 }
 
 float ScaledFont::glyph_or_emoji_width(Utf32CodePointIterator& it) const
 {
     // FIXME: Support multi-code point emoji with scaled fonts.
-    return glyph_or_emoji_width(*it);
+    auto id = glyph_id_for_code_point(*it);
+    auto metrics = glyph_metrics(id);
+    return metrics.advance_width;
 }
 
 float ScaledFont::glyphs_horizontal_kerning(u32 left_code_point, u32 right_code_point) const

--- a/Userland/Libraries/LibGfx/Font/ScaledFont.h
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.h
@@ -46,7 +46,6 @@ public:
     virtual Glyph glyph(u32 code_point, GlyphSubpixelOffset) const override;
     virtual bool contains_glyph(u32 code_point) const override { return m_font->glyph_id_for_code_point(code_point) > 0; }
     virtual float glyph_width(u32 code_point) const override;
-    virtual float glyph_or_emoji_width(u32 code_point) const override;
     virtual float glyph_or_emoji_width(Utf8CodePointIterator&) const override;
     virtual float glyph_or_emoji_width(Utf32CodePointIterator&) const override;
     virtual float glyphs_horizontal_kerning(u32 left_code_point, u32 right_code_point) const override;

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2497,7 +2497,7 @@ void Painter::draw_text_run(FloatPoint baseline_start, Utf8View const& string, F
     auto pixel_metrics = font.pixel_metrics();
     float x = baseline_start.x();
     float y = baseline_start.y() - pixel_metrics.ascent;
-    float space_width = font.glyph_or_emoji_width(' ');
+    float space_width = font.glyph_width(' ');
 
     u32 last_code_point = 0;
 

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <AK/Variant.h>
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/AntiAliasingPainter.h>
@@ -90,7 +91,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     struct PreparedTextGlyph {
-        unsigned int c;
+        String glyph;
         Gfx::IntPoint position;
     };
 

--- a/Userland/Libraries/LibWeb/Layout/LineBoxFragment.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBoxFragment.cpp
@@ -58,11 +58,15 @@ int LineBoxFragment::text_index_at(CSSPixels x) const
 
     CSSPixels width_so_far = 0;
     for (auto it = view.begin(); it != view.end(); ++it) {
-        CSSPixels glyph_width = font.glyph_or_emoji_width(*it);
+        auto previous_it = it;
+        CSSPixels glyph_width = font.glyph_or_emoji_width(it);
+
         if ((width_so_far + (glyph_width + glyph_spacing) / 2) > relative_x)
-            return m_start + view.byte_offset_of(it);
+            return m_start + view.byte_offset_of(previous_it);
+
         width_so_far += glyph_width + glyph_spacing;
     }
+
     return m_start + m_length;
 }
 


### PR DESCRIPTION
This converts the few remaining callers to be multi-code point aware and removes the single-code point API.