### PR TITLE
CI+Lagom: Use the same options for running test-wasm in ctest and CI

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Run test-wasm
         working-directory: libjs-test262/Build
         run: |
-          _deps/lagom-build/test-wasm --per-file > ../../libjs-website/wasm/data/per-file-master.json || true
+          _deps/lagom-build/test-wasm --per-file _deps/lagom-build/Userland/Libraries/LibWasm/Tests > ../../libjs-website/wasm/data/per-file-master.json || true
           jq -nc -f /dev/stdin <<-EOF --slurpfile previous ../../libjs-website/wasm/data/results.json --slurpfile details ../../libjs-website/wasm/data/per-file-master.json > wasm-new-results.json
             \$details[0] as \$details | \$previous[0] + [{
               "commit_timestamp": $(git -C ../.. log -1 --format=%ct),

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -640,12 +640,14 @@ if (BUILD_LAGOM)
             ../../Tests/LibWasm/test-wasm.cpp
             ../../Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp)
         target_link_libraries(test-wasm LibCore LibTest LibWasm LibJS)
-        # FIXME: Don't require passing test-common.js path if you only want to pass a custom Test root path
         add_test(
             NAME WasmParser
-            COMMAND test-wasm --show-progress=false ${CMAKE_CURRENT_BINARY_DIR}/Userland/Libraries/LibWasm/Tests ${SERENITY_PROJECT_ROOT}/Userland/Libraries/LibJS/Tests/test-common.js
+            COMMAND test-wasm --show-progress=false ${CMAKE_CURRENT_BINARY_DIR}/Userland/Libraries/LibWasm/Tests
         )
-        set_tests_properties(WasmParser PROPERTIES SKIP_RETURN_CODE 1)
+        set_tests_properties(WasmParser PROPERTIES
+            SKIP_RETURN_CODE 1
+            ENVIRONMENT SERENITY_SOURCE_DIR=${SERENITY_PROJECT_ROOT}
+        )
 
         # Tests that are not LibTest based
         # Shell


### PR DESCRIPTION
Make sure that we set SERENITY_SOURCE_DIR in ctest, and make sure to pass the test root to the CI job.

More overhaul of test-js 'test root' finding is needed however.

@alimpfard  this should finally fix the website reporting of spec tests. It was able to create the per-file results when I ran locally from inside a libjs-test262 build directory at least.