### PR TITLE
LibWeb: Port IDL implementations to new String

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -729,9 +729,16 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
                 }
 
                 generate_to_cpp(dictionary_generator, member, member_property_value_name, "", member_value_name, interface, member.extended_attributes.contains("LegacyNullToEmptyString"), !member.required, member.default_value);
-                dictionary_generator.append(R"~~~(
+                if (optional && interface.extended_attributes.contains("UseNewAKString")) {
+                    dictionary_generator.append(R"~~~(
+    if (@member_value_name@.has_value())
+        @cpp_name@.@member_name@ = @member_value_name@.release_value();
+)~~~");
+                } else {
+                    dictionary_generator.append(R"~~~(
     @cpp_name@.@member_name@ = @member_value_name@;
 )~~~");
+                }
                 if (!member.required && !member.default_value.has_value()) {
                     dictionary_generator.append(R"~~~(
     }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3,6 +3,7 @@
  * Copyright (c) 2021-2023, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
  * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
+ * Copyright (c) 2023, Kenneth Myhra <kennethmyhra@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -2794,7 +2795,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::to_string)
 )~~~");
         if (interface.stringifier_attribute.has_value()) {
             stringifier_generator.append(R"~~~(
-    auto retval = impl->@attribute.cpp_getter_name@();
+    auto retval = TRY(throw_dom_exception_if_needed(vm, [&] { return impl->@attribute.cpp_getter_name@(); }));
 )~~~");
         } else {
             stringifier_generator.append(R"~~~(

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -343,7 +343,7 @@ static void generate_to_new_string(SourceGenerator& scoped_generator, ParameterT
     })~~~");
         if (optional_default_value.has_value() && (!parameter.type->is_nullable() || optional_default_value.value() != "null")) {
             scoped_generator.append(R"~~~( else {
-        @cpp_name@ = TRY_OR_THROW_OOM(vm, String::from_utf8(@parameter.optional_default_value@));
+        @cpp_name@ = TRY_OR_THROW_OOM(vm, String::from_utf8(@parameter.optional_default_value@sv));
     }
 )~~~");
         } else {

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -17,7 +17,7 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/workers.html#dedicated-workers-and-the-worker-interface
-Worker::Worker(DeprecatedFlyString const& script_url, WorkerOptions const options, DOM::Document& document)
+Worker::Worker(String const& script_url, WorkerOptions const options, DOM::Document& document)
     : DOM::EventTarget(document.realm())
     , m_script_url(script_url)
     , m_options(options)
@@ -47,7 +47,7 @@ void Worker::visit_edges(Cell::Visitor& visitor)
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-worker
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(DeprecatedFlyString const& script_url, WorkerOptions const options, DOM::Document& document)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(String const& script_url, WorkerOptions const options, DOM::Document& document)
 {
     dbgln_if(WEB_WORKER_DEBUG, "WebWorker: Creating worker with script_url = {}", script_url);
 
@@ -66,7 +66,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(DeprecatedFlyString
     auto& outside_settings = document.relevant_settings_object();
 
     // 3. Parse the scriptURL argument relative to outside settings.
-    auto url = document.parse_url(script_url);
+    auto url = document.parse_url(script_url.to_deprecated_string());
 
     // 4. If this fails, throw a "SyntaxError" DOMException.
     if (!url.is_valid()) {

--- a/Userland/Libraries/LibWeb/HTML/Worker.h
+++ b/Userland/Libraries/LibWeb/HTML/Worker.h
@@ -26,9 +26,9 @@
 namespace Web::HTML {
 
 struct WorkerOptions {
-    DeprecatedString type { "classic" };
-    DeprecatedString credentials { "same-origin" };
-    DeprecatedString name { "" };
+    String type { String::from_utf8("classic"sv).release_value_but_fixme_should_propagate_errors() };
+    String credentials { String::from_utf8("same-origin"sv).release_value_but_fixme_should_propagate_errors() };
+    String name { String {} };
 };
 
 // https://html.spec.whatwg.org/multipage/workers.html#dedicated-workers-and-the-worker-interface
@@ -36,8 +36,8 @@ class Worker : public DOM::EventTarget {
     WEB_PLATFORM_OBJECT(Worker, DOM::EventTarget);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> create(DeprecatedFlyString const& script_url, WorkerOptions const options, DOM::Document& document);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> construct_impl(JS::Realm& realm, DeprecatedFlyString const& script_url, WorkerOptions const options)
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> create(String const& script_url, WorkerOptions const options, DOM::Document& document);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> construct_impl(JS::Realm& realm, String const& script_url, WorkerOptions const options)
     {
         auto& window = verify_cast<HTML::Window>(realm.global_object());
         return Worker::create(script_url, options, window.associated_document());
@@ -60,7 +60,7 @@ public:
 #undef __ENUMERATE
 
 protected:
-    Worker(DeprecatedFlyString const&, const WorkerOptions, DOM::Document&);
+    Worker(String const&, const WorkerOptions, DOM::Document&);
 
 private:
     static HTML::EventLoop& get_vm_event_loop(JS::VM& target_vm)
@@ -71,7 +71,7 @@ private:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    DeprecatedFlyString m_script_url;
+    String m_script_url;
     WorkerOptions m_options;
 
     JS::GCPtr<DOM::Document> m_document;

--- a/Userland/Libraries/LibWeb/HTML/Worker.idl
+++ b/Userland/Libraries/LibWeb/HTML/Worker.idl
@@ -1,7 +1,7 @@
 #import <DOM/EventTarget.idl>
 #import <DOM/EventHandler.idl>
 
-[Exposed=(Window)]
+[Exposed=(Window), UseNewAKString]
 interface Worker : EventTarget {
     constructor(DOMString scriptURL, optional WorkerOptions options = {});
 

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
@@ -49,7 +49,7 @@ void WorkerGlobalScope::visit_edges(Cell::Visitor& visitor)
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#importing-scripts-and-libraries
-WebIDL::ExceptionOr<void> WorkerGlobalScope::import_scripts(Vector<DeprecatedString> urls)
+WebIDL::ExceptionOr<void> WorkerGlobalScope::import_scripts(Vector<String> urls)
 {
     // The algorithm may optionally be customized by supplying custom perform the fetch hooks,
     // which if provided will be used when invoking fetch a classic worker-imported script.
@@ -104,7 +104,7 @@ ENUMERATE_WORKER_GLOBAL_SCOPE_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#dom-origin
-DeprecatedString WorkerGlobalScope::origin() const
+String WorkerGlobalScope::origin() const
 {
     // FIXME: The origin getter steps are to return this's relevant settings object's origin, serialized.
     return {};
@@ -127,14 +127,14 @@ bool WorkerGlobalScope::cross_origin_isolated() const
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#dom-btoa
-WebIDL::ExceptionOr<DeprecatedString> WorkerGlobalScope::btoa(DeprecatedString const& data) const
+WebIDL::ExceptionOr<String> WorkerGlobalScope::btoa(String const& data) const
 {
     // FIXME: This is the same as the implementation in Bindings/WindowObject.cpp
     //     Find a way to share this implementation, since they come from the same mixin.
 
     // The btoa(data) method must throw an "InvalidCharacterError" DOMException if data contains any character whose code point is greater than U+00FF.
     Vector<u8> byte_string;
-    byte_string.ensure_capacity(data.length());
+    byte_string.ensure_capacity(data.bytes().size());
     for (u32 code_point : Utf8View(data)) {
         if (code_point > 0xff)
             return WebIDL::InvalidCharacterError::create(realm(), "Data contains characters outside the range U+0000 and U+00FF");
@@ -143,17 +143,17 @@ WebIDL::ExceptionOr<DeprecatedString> WorkerGlobalScope::btoa(DeprecatedString c
 
     // Otherwise, the user agent must convert data to a byte sequence whose nth byte is the eight-bit representation of the nth code point of data,
     // and then must apply forgiving-base64 encode to that byte sequence and return the result.
-    return TRY_OR_THROW_OOM(vm(), encode_base64(byte_string.span())).to_deprecated_string();
+    return TRY_OR_THROW_OOM(vm(), encode_base64(byte_string.span()));
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#dom-atob
-WebIDL::ExceptionOr<DeprecatedString> WorkerGlobalScope::atob(DeprecatedString const& data) const
+WebIDL::ExceptionOr<String> WorkerGlobalScope::atob(String const& data) const
 {
     // FIXME: This is the same as the implementation in Bindings/WindowObject.cpp
     //     Find a way to share this implementation, since they come from the same mixin.
 
     // 1. Let decodedData be the result of running forgiving-base64 decode on data.
-    auto decoded_data = decode_base64(data.view());
+    auto decoded_data = decode_base64(data.bytes_as_string_view());
 
     // 2. If decodedData is failure, then throw an "InvalidCharacterError" DOMException.
     if (decoded_data.is_error())

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.h
@@ -42,7 +42,7 @@ public:
 
     JS::NonnullGCPtr<WorkerLocation> location() const;
     JS::NonnullGCPtr<WorkerNavigator> navigator() const;
-    WebIDL::ExceptionOr<void> import_scripts(Vector<DeprecatedString> urls);
+    WebIDL::ExceptionOr<void> import_scripts(Vector<String> urls);
 
 #undef __ENUMERATE
 #define __ENUMERATE(attribute_name, event_name)       \
@@ -54,11 +54,11 @@ public:
     // Following methods are from the WindowOrWorkerGlobalScope mixin
     // https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope-mixin
 
-    DeprecatedString origin() const;
+    String origin() const;
     bool is_secure_context() const;
     bool cross_origin_isolated() const;
-    WebIDL::ExceptionOr<DeprecatedString> btoa(DeprecatedString const& data) const;
-    WebIDL::ExceptionOr<DeprecatedString> atob(DeprecatedString const& data) const;
+    WebIDL::ExceptionOr<String> btoa(String const& data) const;
+    WebIDL::ExceptionOr<String> atob(String const& data) const;
 
     // Non-IDL public methods
 

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.idl
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.idl
@@ -5,7 +5,7 @@
 #import <HTML/WorkerNavigator.idl>
 
 // https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope
-[Exposed=Worker]
+[Exposed=Worker, UseNewAKString]
 interface WorkerGlobalScope : EventTarget {
     readonly attribute WorkerGlobalScope self;
     readonly attribute WorkerLocation location;

--- a/Userland/Libraries/LibWeb/HTML/WorkerLocation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerLocation.cpp
@@ -11,109 +11,123 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-href
-DeprecatedString WorkerLocation::href() const
+WebIDL::ExceptionOr<String> WorkerLocation::href() const
 {
+    auto& vm = realm().vm();
     // The href getter steps are to return this's WorkerGlobalScope object's url, serialized.
-    return m_global_scope.url().serialize();
+    return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(m_global_scope.url().serialize()));
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-origin
-DeprecatedString WorkerLocation::origin() const
+WebIDL::ExceptionOr<String> WorkerLocation::origin() const
 {
+    auto& vm = realm().vm();
     // The origin getter steps are to return the serialization of this's WorkerGlobalScope object's url's origin.
-    return m_global_scope.url().serialize_origin();
+    return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(m_global_scope.url().serialize_origin()));
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-protocol
-DeprecatedString WorkerLocation::protocol() const
+WebIDL::ExceptionOr<String> WorkerLocation::protocol() const
 {
+    auto& vm = realm().vm();
     // The protocol getter steps are to return this's WorkerGlobalScope object's url's scheme, followed by ":".
-    return DeprecatedString::formatted("{}:", m_global_scope.url().scheme());
+    return TRY_OR_THROW_OOM(vm, String::formatted("{}:", m_global_scope.url().scheme().view()));
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-host
-DeprecatedString WorkerLocation::host() const
+WebIDL::ExceptionOr<String> WorkerLocation::host() const
 {
+    auto& vm = realm().vm();
+
     // The host getter steps are:
     // 1. Let url be this's WorkerGlobalScope object's url.
     auto const& url = m_global_scope.url();
 
     // 2. If url's host is null, return the empty string.
     if (url.host().is_empty())
-        return "";
+        return String {};
 
     // 3. If url's port is null, return url's host, serialized.
     if (!url.port().has_value())
-        return url.host();
+        return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(url.host()));
 
     // 4. Return url's host, serialized, followed by ":" and url's port, serialized.
-    return DeprecatedString::formatted("{}:{}", url.host(), url.port().value());
+    return TRY_OR_THROW_OOM(vm, String::formatted("{}:{}", url.host().view(), url.port().value()));
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-hostname
-DeprecatedString WorkerLocation::hostname() const
+WebIDL::ExceptionOr<String> WorkerLocation::hostname() const
 {
+    auto& vm = realm().vm();
+
     // The hostname getter steps are:
     // 1. Let host be this's WorkerGlobalScope object's url's host.
     auto const& host = m_global_scope.url().host();
 
     // 2. If host is null, return the empty string.
     if (host.is_empty())
-        return "";
+        return String {};
 
     // 3. Return host, serialized.
-    return host;
+    return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(host));
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-port
-DeprecatedString WorkerLocation::port() const
+WebIDL::ExceptionOr<String> WorkerLocation::port() const
 {
+    auto& vm = realm().vm();
+
     // The port getter steps are:
     // 1. Let port be this's WorkerGlobalScope object's url's port.
     auto const& port = m_global_scope.url().port();
 
     // 2. If port is null, return the empty string.
     if (!port.has_value())
-        return "";
+        return String {};
     // 3. Return port, serialized.
-    return DeprecatedString::number(port.value());
+    return TRY_OR_THROW_OOM(vm, String::number(port.value()));
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-pathname
-DeprecatedString WorkerLocation::pathname() const
+WebIDL::ExceptionOr<String> WorkerLocation::pathname() const
 {
+    auto& vm = realm().vm();
     // The pathname getter steps are to return the result of URL path serializing this's WorkerGlobalScope object's url.
-    return m_global_scope.url().path();
+    return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(m_global_scope.url().path()));
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-search
-DeprecatedString WorkerLocation::search() const
+WebIDL::ExceptionOr<String> WorkerLocation::search() const
 {
+    auto& vm = realm().vm();
+
     // The search getter steps are:
     // 1. Let query be this's WorkerGlobalScope object's url's query.
     auto const& query = m_global_scope.url().query();
 
     // 2. If query is either null or the empty string, return the empty string.
     if (query.is_empty())
-        return "";
+        return String {};
 
     // 3. Return "?", followed by query.
-    return DeprecatedString::formatted("?{}", query);
+    return TRY_OR_THROW_OOM(vm, String::formatted("?{}", query.view()));
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-hash
-DeprecatedString WorkerLocation::hash() const
+WebIDL::ExceptionOr<String> WorkerLocation::hash() const
 {
+    auto& vm = realm().vm();
+
     // The hash getter steps are:
     // 1. Let fragment be this's WorkerGlobalScope object's url's fragment.
     auto const& fragment = m_global_scope.url().fragment();
 
     // 2. If fragment is either null or the empty string, return the empty string.
     if (fragment.is_empty())
-        return "";
+        return String {};
 
     // 3. Return "#", followed by fragment.
-    return DeprecatedString::formatted("#{}", fragment);
+    return TRY_OR_THROW_OOM(vm, String::formatted("#{}", fragment.view()));
 }
 
 WorkerLocation::WorkerLocation(WorkerGlobalScope& global_scope)

--- a/Userland/Libraries/LibWeb/HTML/WorkerLocation.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerLocation.h
@@ -17,15 +17,15 @@ class WorkerLocation : public Bindings::PlatformObject {
 public:
     virtual ~WorkerLocation() override;
 
-    DeprecatedString href() const;
-    DeprecatedString origin() const;
-    DeprecatedString protocol() const;
-    DeprecatedString host() const;
-    DeprecatedString hostname() const;
-    DeprecatedString port() const;
-    DeprecatedString pathname() const;
-    DeprecatedString search() const;
-    DeprecatedString hash() const;
+    WebIDL::ExceptionOr<String> href() const;
+    WebIDL::ExceptionOr<String> origin() const;
+    WebIDL::ExceptionOr<String> protocol() const;
+    WebIDL::ExceptionOr<String> host() const;
+    WebIDL::ExceptionOr<String> hostname() const;
+    WebIDL::ExceptionOr<String> port() const;
+    WebIDL::ExceptionOr<String> pathname() const;
+    WebIDL::ExceptionOr<String> search() const;
+    WebIDL::ExceptionOr<String> hash() const;
 
 private:
     explicit WorkerLocation(WorkerGlobalScope&);

--- a/Userland/Libraries/LibWeb/HTML/WorkerLocation.idl
+++ b/Userland/Libraries/LibWeb/HTML/WorkerLocation.idl
@@ -1,4 +1,4 @@
-[Exposed=Worker]
+[Exposed=Worker, UseNewAKString]
 interface WorkerLocation {
     stringifier readonly attribute USVString href;
     readonly attribute USVString origin;


### PR DESCRIPTION
This ports the following IDL implementations to new String: `WorkerLocation`, `WorkerGlobalScope` and `Worker`.

BindingsGenerator has the following amendments:
- Allow stringifier to return `WebIDL::ExceptionOr<T>`
- Pass optional new String default value as a StringView to `String::from_utf8()`
- Release the value of Optional<String> when settings members of optional dictionary arguments to constructors