### PR TITLE
LibWeb: Add size to URLSearchParams

### DIFF
--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
@@ -149,6 +149,13 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<URLSearchParams>> URLSearchParams::construc
     return URLSearchParams::create(realm, url_decode(stripped_init));
 }
 
+// https://url.spec.whatwg.org/#dom-urlsearchparams-size
+size_t URLSearchParams::size() const
+{
+    // The size getter steps are to return this’s list’s size.
+    return m_list.size();
+}
+
 void URLSearchParams::append(DeprecatedString const& name, DeprecatedString const& value)
 {
     // 1. Append a new name-value pair whose name is name and value is value, to list.

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.h
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.h
@@ -28,6 +28,7 @@ public:
 
     virtual ~URLSearchParams() override;
 
+    size_t size() const;
     void append(DeprecatedString const& name, DeprecatedString const& value);
     void delete_(DeprecatedString const& name);
     DeprecatedString get(DeprecatedString const& name);

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.idl
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.idl
@@ -4,6 +4,8 @@ interface URLSearchParams {
 
   constructor(optional (sequence<sequence<USVString>> or record<USVString, USVString> or USVString) init = "");
 
+  readonly attribute unsigned long size;
+
   undefined append(USVString name, USVString value);
   undefined delete(USVString name);
   USVString? get(USVString name);


### PR DESCRIPTION
Added new size parameter to URLSearchParams.

Spec: https://url.spec.whatwg.org/#dom-urlsearchparams-size

![Screenshot of trying URLSearchParams.size](https://user-images.githubusercontent.com/19228318/220925757-c25ab853-1b1f-4f3d-973b-4dadf429d77d.png)
