### PR TITLE
LibGUI+LibSyntax: Add code folding :tada: 

### DIFF
--- a/Userland/Libraries/LibGUI/GML/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibGUI/GML/SyntaxHighlighter.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -44,7 +45,11 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
     Lexer lexer(text);
     auto tokens = lexer.lex();
 
+    Vector<Token> folding_region_start_tokens;
+
     Vector<GUI::TextDocumentSpan> spans;
+    Vector<GUI::TextDocumentFoldingRegion> folding_regions;
+
     for (auto& token : tokens) {
         GUI::TextDocumentSpan span;
         span.range.set_start({ token.m_start.line, token.m_start.column });
@@ -55,8 +60,22 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
         span.is_skippable = false;
         span.data = static_cast<u64>(token.m_type);
         spans.append(span);
+
+        // Create folding regions for {} blocks
+        if (token.m_type == Token::Type::LeftCurly) {
+            folding_region_start_tokens.append(token);
+        } else if (token.m_type == Token::Type::RightCurly) {
+            if (!folding_region_start_tokens.is_empty()) {
+                auto left_curly = folding_region_start_tokens.take_last();
+                GUI::TextDocumentFoldingRegion region;
+                region.range.set_start({ left_curly.m_end.line, left_curly.m_end.column });
+                region.range.set_end({ token.m_start.line, token.m_start.column });
+                folding_regions.append(region);
+            }
+        }
     }
     m_client->do_set_spans(move(spans));
+    m_client->do_set_folding_regions(move(folding_regions));
 
     m_has_brace_buddies = false;
     highlight_matching_token_pair();

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -2467,4 +2467,10 @@ void TextEditor::on_search_results(GUI::TextRange current, Vector<GUI::TextRange
     update();
 }
 
+void TextEditor::highlighter_did_set_folding_regions(Vector<GUI::TextDocumentFoldingRegion> folding_regions)
+{
+    document().set_folding_regions(move(folding_regions));
+    recompute_all_visual_lines();
+}
+
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -530,7 +530,7 @@ void TextEditor::paint_event(PaintEvent& event)
                 first_visual_line_with_selection = visual_line_containing(line_index, selection.start().column());
 
             if (selection.end().line() > line_index)
-                last_visual_line_with_selection = m_line_visual_data[line_index].visual_line_breaks.size();
+                last_visual_line_with_selection = m_line_visual_data[line_index].visual_lines.size();
             else
                 last_visual_line_with_selection = visual_line_containing(line_index, selection.end().column());
         }
@@ -1875,27 +1875,33 @@ void TextEditor::recompute_visual_lines(size_t line_index)
     size_t line_width_so_far = 0;
 
     auto& visual_data = m_line_visual_data[line_index];
-    visual_data.visual_line_breaks.clear_with_capacity();
+    visual_data.visual_lines.clear_with_capacity();
 
     auto available_width = visible_text_rect_in_inner_coordinates().width();
     auto glyph_spacing = font().glyph_spacing();
 
     auto wrap_visual_lines_anywhere = [&]() {
+        size_t start_of_visual_line = 0;
         for (auto it = line.view().begin(); it != line.view().end(); ++it) {
             auto it_before_computing_glyph_width = it;
             auto glyph_width = font().glyph_or_emoji_width(it);
 
             if (line_width_so_far + glyph_width + glyph_spacing > available_width) {
-                visual_data.visual_line_breaks.append(line.view().iterator_offset(it_before_computing_glyph_width));
+                auto start_of_next_visual_line = line.view().iterator_offset(it_before_computing_glyph_width);
+                visual_data.visual_lines.append(line.view().substring_view(start_of_visual_line, start_of_next_visual_line - start_of_visual_line));
                 line_width_so_far = 0;
+                start_of_visual_line = start_of_next_visual_line;
             }
 
             line_width_so_far += glyph_width + glyph_spacing;
         }
+
+        visual_data.visual_lines.append(line.view().substring_view(start_of_visual_line, line.view().length() - start_of_visual_line));
     };
 
     auto wrap_visual_lines_at_words = [&]() {
         size_t last_boundary = 0;
+        size_t start_of_visual_line = 0;
 
         Unicode::for_each_word_segmentation_boundary(line.view(), [&](auto boundary) {
             if (boundary == 0)
@@ -1905,8 +1911,9 @@ void TextEditor::recompute_visual_lines(size_t line_index)
             auto word_width = font().width(word);
 
             if (line_width_so_far + word_width + glyph_spacing > available_width) {
-                visual_data.visual_line_breaks.append(last_boundary);
+                visual_data.visual_lines.append(line.view().substring_view(start_of_visual_line, last_boundary - start_of_visual_line));
                 line_width_so_far = 0;
+                start_of_visual_line = last_boundary;
             }
 
             line_width_so_far += word_width + glyph_spacing;
@@ -1914,10 +1921,13 @@ void TextEditor::recompute_visual_lines(size_t line_index)
 
             return IterationDecision::Continue;
         });
+
+        visual_data.visual_lines.append(line.view().substring_view(start_of_visual_line, line.view().length() - start_of_visual_line));
     };
 
     switch (wrapping_mode()) {
     case WrappingMode::NoWrap:
+        visual_data.visual_lines.append(line.view());
         break;
     case WrappingMode::WrapAnywhere:
         wrap_visual_lines_anywhere();
@@ -1927,10 +1937,8 @@ void TextEditor::recompute_visual_lines(size_t line_index)
         break;
     }
 
-    visual_data.visual_line_breaks.append(line.length());
-
     if (is_wrapping_enabled())
-        visual_data.visual_rect = { m_horizontal_content_padding, 0, available_width, static_cast<int>(visual_data.visual_line_breaks.size()) * line_height() };
+        visual_data.visual_rect = { m_horizontal_content_padding, 0, available_width, static_cast<int>(visual_data.visual_lines.size()) * line_height() };
     else
         visual_data.visual_rect = { m_horizontal_content_padding, 0, text_width_for_font(line.view(), font()), line_height() };
 }
@@ -1939,14 +1947,12 @@ template<typename Callback>
 void TextEditor::for_each_visual_line(size_t line_index, Callback callback) const
 {
     auto editor_visible_text_rect = visible_text_rect_in_inner_coordinates();
-    size_t start_of_line = 0;
     size_t visual_line_index = 0;
 
     auto& line = document().line(line_index);
     auto& visual_data = m_line_visual_data[line_index];
 
-    for (auto visual_line_break : visual_data.visual_line_breaks) {
-        auto visual_line_view = Utf32View(line.code_points() + start_of_line, visual_line_break - start_of_line);
+    for (auto visual_line_view : visual_data.visual_lines) {
         Gfx::IntRect visual_line_rect {
             visual_data.visual_rect.x(),
             visual_data.visual_rect.y() + ((int)visual_line_index * line_height()),
@@ -1960,9 +1966,9 @@ void TextEditor::for_each_visual_line(size_t line_index, Callback callback) cons
             if (m_icon)
                 visual_line_rect.translate_by(icon_size() + icon_padding(), 0);
         }
-        if (callback(visual_line_rect, visual_line_view, start_of_line, visual_line_index == visual_data.visual_line_breaks.size() - 1) == IterationDecision::Break)
+        size_t start_of_line = visual_line_view.code_points() - line.code_points();
+        if (callback(visual_line_rect, visual_line_view, start_of_line, visual_line_index == visual_data.visual_lines.size() - 1) == IterationDecision::Break)
             break;
-        start_of_line = visual_line_break;
         ++visual_line_index;
     }
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -582,6 +582,10 @@ void TextEditor::paint_event(PaintEvent& event)
                 };
                 while (span_index < document().spans().size()) {
                     auto& span = document().spans()[span_index];
+                    if (span.range.end().line() < line_index) {
+                        ++span_index;
+                        continue;
+                    }
                     if (span.range.start().line() > line_index
                         || (span.range.start().line() == line_index && span.range.start().column() >= start_of_visual_line + visual_line_text.length())) {
                         // no more spans in this line, moving on
@@ -620,16 +624,6 @@ void TextEditor::paint_event(PaintEvent& event)
                 // draw unspanned text after last span
                 if (next_column < visual_line_text.length()) {
                     draw_text_helper(next_column, visual_line_text.length(), unspanned_font, { unspanned_color });
-                }
-                // consume all spans that should end this line
-                // this is necessary since the spans can include the new line character
-                while (is_last_visual_line && span_index < document().spans().size()) {
-                    auto& span = document().spans()[span_index];
-                    if (span.range.end().line() == line_index) {
-                        ++span_index;
-                    } else {
-                        break;
-                    }
                 }
             }
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -42,6 +42,8 @@ REGISTER_WIDGET(GUI, TextEditor)
 
 namespace GUI {
 
+static constexpr StringView folded_region_summary_text = " ..."sv;
+
 TextEditor::TextEditor(Type type)
     : m_type(type)
 {
@@ -151,16 +153,29 @@ TextPosition TextEditor::text_position_at_content_position(Gfx::IntPoint content
     size_t line_index = 0;
 
     if (position.y() >= 0) {
+        size_t last_visible_line_index = 0;
+        // FIXME: Oh boy is this a slow way of calculating this!
+        // NOTE: Offset by 1 in calculations is because we can't do `i >= 0` with an unsigned type.
+        for (size_t i = line_count(); i > 0; --i) {
+            if (document().line_is_visible(i - 1)) {
+                last_visible_line_index = i - 1;
+                break;
+            }
+        }
+
         for (size_t i = 0; i < line_count(); ++i) {
+            if (!document().line_is_visible(i))
+                continue;
+
             auto& rect = m_line_visual_data[i].visual_rect;
             if (position.y() >= rect.top() && position.y() <= rect.bottom()) {
                 line_index = i;
                 break;
             }
             if (position.y() > rect.bottom())
-                line_index = line_count() - 1;
+                line_index = last_visible_line_index;
         }
-        line_index = max((size_t)0, min(line_index, line_count() - 1));
+        line_index = max((size_t)0, min(line_index, last_visible_line_index));
     }
 
     size_t column_index = 0;
@@ -256,6 +271,23 @@ void TextEditor::mousedown_event(MouseEvent& event)
         return;
     }
 
+    auto text_position = text_position_at(event.position());
+    if (event.modifiers() == 0 && folding_indicator_rect(text_position.line()).contains(event.position())) {
+        if (auto folding_region = document().folding_region_starting_on_line(text_position.line()); folding_region.has_value()) {
+            folding_region->is_folded = !folding_region->is_folded;
+            dbgln_if(TEXTEDITOR_DEBUG, "TextEditor: {} region {}.", folding_region->is_folded ? "Folding"sv : "Unfolding"sv, folding_region->range);
+
+            if (folding_region->is_folded && folding_region->range.contains(cursor())) {
+                // Cursor is now within a hidden range, so move it outside.
+                set_cursor(folding_region->range.start());
+            }
+
+            recompute_all_visual_lines();
+            update();
+            return;
+        }
+    }
+
     if (on_mousedown)
         on_mousedown();
 
@@ -316,6 +348,14 @@ void TextEditor::mousemove_event(MouseEvent& event)
 
     if (m_ruler_visible && ruler_rect_in_inner_coordinates().contains(event.position())) {
         set_override_cursor(Gfx::StandardCursor::None);
+    } else if (m_ruler_visible && folding_indicator_rect_in_inner_coordinates().contains(event.position())) {
+        auto text_position = text_position_at(event.position());
+        if (document().folding_region_starting_on_line(text_position.line()).has_value()
+            && folding_indicator_rect(text_position.line()).contains(event.position())) {
+            set_override_cursor(Gfx::StandardCursor::Hand);
+        } else {
+            set_override_cursor(Gfx::StandardCursor::None);
+        }
     } else if (m_gutter_visible && gutter_rect_in_inner_coordinates().contains(event.position())) {
         set_override_cursor(Gfx::StandardCursor::None);
     } else {
@@ -343,6 +383,11 @@ void TextEditor::automatic_scrolling_timer_did_fire()
     update();
 }
 
+int TextEditor::folding_indicator_width() const
+{
+    return document().has_folding_regions() ? line_height() : 0;
+}
+
 int TextEditor::ruler_width() const
 {
     if (!m_ruler_visible)
@@ -364,6 +409,7 @@ Gfx::IntRect TextEditor::gutter_content_rect(size_t line_index) const
 {
     if (!m_gutter_visible)
         return {};
+
     return {
         0,
         line_content_rect(line_index).y() - vertical_scrollbar().value(),
@@ -376,10 +422,24 @@ Gfx::IntRect TextEditor::ruler_content_rect(size_t line_index) const
 {
     if (!m_ruler_visible)
         return {};
+
     return {
         gutter_width(),
         line_content_rect(line_index).y() - vertical_scrollbar().value(),
         ruler_width(),
+        line_content_rect(line_index).height()
+    };
+}
+
+Gfx::IntRect TextEditor::folding_indicator_rect(size_t line_index) const
+{
+    if (!m_ruler_visible || !document().has_folding_regions())
+        return {};
+
+    return {
+        gutter_width() + ruler_width(),
+        line_content_rect(line_index).y() - vertical_scrollbar().value(),
+        folding_indicator_width(),
         line_content_rect(line_index).height()
     };
 }
@@ -392,6 +452,11 @@ Gfx::IntRect TextEditor::gutter_rect_in_inner_coordinates() const
 Gfx::IntRect TextEditor::ruler_rect_in_inner_coordinates() const
 {
     return { gutter_width(), 0, ruler_width(), widget_inner_rect().height() };
+}
+
+Gfx::IntRect TextEditor::folding_indicator_rect_in_inner_coordinates() const
+{
+    return { gutter_width() + ruler_width(), 0, folding_indicator_width(), widget_inner_rect().height() };
 }
 
 Gfx::IntRect TextEditor::visible_text_rect_in_inner_coordinates() const
@@ -423,6 +488,9 @@ void TextEditor::paint_event(PaintEvent& event)
     } else {
         unspanned_text_attributes.color = palette().color(is_enabled() ? foreground_role() : Gfx::ColorRole::DisabledText);
     }
+
+    auto& folded_region_summary_font = font().bold_variant();
+    Gfx::TextAttributes folded_region_summary_attributes { palette().color(Gfx::ColorRole::SyntaxComment) };
 
     // NOTE: This lambda and TextEditor::text_width_for_font() are used to substitute all glyphs with m_substitution_code_point if necessary.
     //       Painter::draw_text() and Gfx::Font::width() should not be called directly, but using this lambda and TextEditor::text_width_for_font().
@@ -466,9 +534,21 @@ void TextEditor::paint_event(PaintEvent& event)
     }
 
     if (m_ruler_visible) {
-        auto ruler_rect = ruler_rect_in_inner_coordinates();
+        auto ruler_rect = ruler_rect_in_inner_coordinates().inflated(0, folding_indicator_width(), 0, 0);
         painter.fill_rect(ruler_rect, palette().ruler());
         painter.draw_line(ruler_rect.top_right(), ruler_rect.bottom_right(), palette().ruler_border());
+
+        // Paint +/- buttons for folding regions
+        for (auto const& folding_region : document().folding_regions()) {
+            auto start_line = folding_region.range.start().line();
+            if (!document().line_is_visible(start_line))
+                continue;
+            auto fold_indicator_rect = folding_indicator_rect(start_line).shrunken(4, 4);
+            fold_indicator_rect.set_height(fold_indicator_rect.width());
+            painter.draw_rect(fold_indicator_rect, palette().ruler_inactive_text());
+            auto fold_symbol = folding_region.is_folded ? "+"sv : "-"sv;
+            painter.draw_text(fold_indicator_rect, fold_symbol, font(), Gfx::TextAlignment::Center, palette().ruler_inactive_text());
+        }
     }
 
     size_t first_visible_line = text_position_at(event.rect().top_left()).line();
@@ -479,6 +559,9 @@ void TextEditor::paint_event(PaintEvent& event)
 
     if (m_ruler_visible) {
         for (size_t i = first_visible_line; i <= last_visible_line; ++i) {
+            if (!document().line_is_visible(i))
+                continue;
+
             bool is_current_line = i == m_cursor.line();
             auto ruler_line_rect = ruler_content_rect(i);
             // NOTE: Shrink the rectangle to be only on the first visual line.
@@ -579,9 +662,14 @@ void TextEditor::paint_event(PaintEvent& event)
                     draw_text(span_rect, text, font, m_text_alignment, text_attributes);
                     span_rect.translate_by(span_rect.width(), 0);
                 };
+
+                bool started_new_folded_region = false;
                 while (span_index < document().spans().size()) {
                     auto& span = document().spans()[span_index];
-                    if (span.range.end().line() < line_index) {
+                    // Skip spans that have ended before this point.
+                    // That is, for spans that are for lines inside a folded region.
+                    if ((span.range.end().line() < line_index)
+                        || (span.range.end().line() == line_index && span.range.end().column() <= start_of_visual_line)) {
                         ++span_index;
                         continue;
                     }
@@ -621,8 +709,17 @@ void TextEditor::paint_event(PaintEvent& event)
                     }
                 }
                 // draw unspanned text after last span
-                if (next_column < visual_line_text.length()) {
+                if (!started_new_folded_region && next_column < visual_line_text.length()) {
                     draw_text_helper(next_column, visual_line_text.length(), font(), unspanned_text_attributes);
+                }
+
+                // Paint "..." at the end of the line if it starts a folded region.
+                // FIXME: This doesn't wrap.
+                if (is_last_visual_line) {
+                    if (auto folded_region = document().folding_region_starting_on_line(line_index); folded_region.has_value() && folded_region->is_folded) {
+                        span_rect.set_width(folded_region_summary_font.width(folded_region_summary_text));
+                        draw_text(span_rect, folded_region_summary_text, folded_region_summary_font, m_text_alignment, folded_region_summary_attributes);
+                    }
                 }
             }
 
@@ -1837,8 +1934,10 @@ void TextEditor::recompute_all_visual_lines()
     m_reflow_requested = false;
 
     int y_offset = 0;
+    auto folded_regions = document().currently_folded_regions();
+    auto folded_region_iterator = folded_regions.begin();
     for (size_t line_index = 0; line_index < line_count(); ++line_index) {
-        recompute_visual_lines(line_index);
+        recompute_visual_lines(line_index, folded_region_iterator);
         m_line_visual_data[line_index].visual_rect.set_y(y_offset);
         y_offset += m_line_visual_data[line_index].visual_rect.height();
     }
@@ -1869,7 +1968,7 @@ size_t TextEditor::visual_line_containing(size_t line_index, size_t column) cons
     return visual_line_index;
 }
 
-void TextEditor::recompute_visual_lines(size_t line_index)
+void TextEditor::recompute_visual_lines(size_t line_index, Vector<TextDocumentFoldingRegion const&>::Iterator& folded_region_iterator)
 {
     auto const& line = document().line(line_index);
     size_t line_width_so_far = 0;
@@ -1879,6 +1978,19 @@ void TextEditor::recompute_visual_lines(size_t line_index)
 
     auto available_width = visible_text_rect_in_inner_coordinates().width();
     auto glyph_spacing = font().glyph_spacing();
+
+    while (!folded_region_iterator.is_end() && folded_region_iterator->range.end() < TextPosition { line_index, 0 })
+        ++folded_region_iterator;
+    bool line_is_visible = true;
+    if (!folded_region_iterator.is_end()) {
+        if (folded_region_iterator->range.start().line() < line_index) {
+            if (folded_region_iterator->range.end().line() > line_index) {
+                line_is_visible = false;
+            } else if (folded_region_iterator->range.end().line() == line_index) {
+                ++folded_region_iterator;
+            }
+        }
+    }
 
     auto wrap_visual_lines_anywhere = [&]() {
         size_t start_of_visual_line = 0;
@@ -1925,16 +2037,18 @@ void TextEditor::recompute_visual_lines(size_t line_index)
         visual_data.visual_lines.append(line.view().substring_view(start_of_visual_line, line.view().length() - start_of_visual_line));
     };
 
-    switch (wrapping_mode()) {
-    case WrappingMode::NoWrap:
-        visual_data.visual_lines.append(line.view());
-        break;
-    case WrappingMode::WrapAnywhere:
-        wrap_visual_lines_anywhere();
-        break;
-    case WrappingMode::WrapAtWords:
-        wrap_visual_lines_at_words();
-        break;
+    if (line_is_visible) {
+        switch (wrapping_mode()) {
+        case WrappingMode::NoWrap:
+            visual_data.visual_lines.append(line.view());
+            break;
+        case WrappingMode::WrapAnywhere:
+            wrap_visual_lines_anywhere();
+            break;
+        case WrappingMode::WrapAtWords:
+            wrap_visual_lines_at_words();
+            break;
+        }
     }
 
     if (is_wrapping_enabled())

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -417,6 +417,13 @@ void TextEditor::paint_event(PaintEvent& event)
     painter.add_clip_rect(event.rect());
     painter.fill_rect(event.rect(), widget_background_color);
 
+    Gfx::TextAttributes unspanned_text_attributes;
+    if (is_displayonly() && is_focused()) {
+        unspanned_text_attributes.color = palette().color(is_enabled() ? Gfx::ColorRole::SelectionText : Gfx::ColorRole::DisabledText);
+    } else {
+        unspanned_text_attributes.color = palette().color(is_enabled() ? foreground_role() : Gfx::ColorRole::DisabledText);
+    }
+
     // NOTE: This lambda and TextEditor::text_width_for_font() are used to substitute all glyphs with m_substitution_code_point if necessary.
     //       Painter::draw_text() and Gfx::Font::width() should not be called directly, but using this lambda and TextEditor::text_width_for_font().
     auto draw_text = [&](Gfx::IntRect const& rect, auto const& raw_text, Gfx::Font const& font, Gfx::TextAlignment alignment, Gfx::TextAttributes attributes, bool substitute = true) {
@@ -555,29 +562,21 @@ void TextEditor::paint_event(PaintEvent& event)
                 draw_text(line_rect, placeholder(), font(), m_text_alignment, { palette().color(Gfx::ColorRole::PlaceholderText) }, false);
             } else if (!document().has_spans()) {
                 // Fast-path for plain text
-                auto color = palette().color(is_enabled() ? foreground_role() : Gfx::ColorRole::DisabledText);
-                if (is_displayonly() && is_focused())
-                    color = palette().color(is_enabled() ? Gfx::ColorRole::SelectionText : Gfx::ColorRole::DisabledText);
-                draw_text(visual_line_rect, visual_line_text, font(), m_text_alignment, { color });
+                draw_text(visual_line_rect, visual_line_text, font(), m_text_alignment, unspanned_text_attributes);
             } else {
-                auto unspanned_color = palette().color(is_enabled() ? foreground_role() : Gfx::ColorRole::DisabledText);
-                if (is_displayonly() && is_focused())
-                    unspanned_color = palette().color(is_enabled() ? Gfx::ColorRole::SelectionText : Gfx::ColorRole::DisabledText);
-                RefPtr<Gfx::Font const> unspanned_font = this->font();
-
                 size_t next_column = 0;
                 Gfx::IntRect span_rect = { visual_line_rect.location(), { 0, line_height() } };
 
-                auto draw_text_helper = [&](size_t start, size_t end, RefPtr<Gfx::Font const>& font, Gfx::TextAttributes text_attributes) {
+                auto draw_text_helper = [&](size_t start, size_t end, Gfx::Font const& font, Gfx::TextAttributes text_attributes) {
                     size_t length = end - start;
                     if (length == 0)
                         return;
                     auto text = visual_line_text.substring_view(start, length);
-                    span_rect.set_width(font->width(text) + font->glyph_spacing());
+                    span_rect.set_width(font.width(text) + font.glyph_spacing());
                     if (text_attributes.background_color.has_value()) {
                         painter.fill_rect(span_rect, text_attributes.background_color.value());
                     }
-                    draw_text(span_rect, text, *font, m_text_alignment, text_attributes);
+                    draw_text(span_rect, text, font, m_text_alignment, text_attributes);
                     span_rect.translate_by(span_rect.width(), 0);
                 };
                 while (span_index < document().spans().size()) {
@@ -609,10 +608,10 @@ void TextEditor::paint_event(PaintEvent& event)
 
                     if (span_start != next_column) {
                         // draw unspanned text between spans
-                        draw_text_helper(next_column, span_start, unspanned_font, { unspanned_color });
+                        draw_text_helper(next_column, span_start, font(), unspanned_text_attributes);
                     }
-                    auto font = span.attributes.bold ? unspanned_font->bold_variant() : unspanned_font;
-                    draw_text_helper(span_start, span_end, font, span.attributes);
+                    auto& span_font = span.attributes.bold ? font().bold_variant() : font();
+                    draw_text_helper(span_start, span_end, span_font, span.attributes);
                     next_column = span_end;
                     if (!span_consumed) {
                         // continue with same span on next line
@@ -623,7 +622,7 @@ void TextEditor::paint_event(PaintEvent& event)
                 }
                 // draw unspanned text after last span
                 if (next_column < visual_line_text.length()) {
-                    draw_text_helper(next_column, visual_line_text.length(), unspanned_font, { unspanned_color });
+                    draw_text_helper(next_column, visual_line_text.length(), font(), unspanned_text_attributes);
                 }
             }
 

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -280,6 +280,7 @@ protected:
     int fixed_elements_width() const { return gutter_width() + ruler_width() + folding_indicator_width(); }
 
     virtual void highlighter_did_set_spans(Vector<TextDocumentSpan> spans) final { document().set_spans(Syntax::HighlighterClient::span_collection_index, move(spans)); }
+    virtual void highlighter_did_set_folding_regions(Vector<TextDocumentFoldingRegion> folding_regions) final;
 
 private:
     friend class TextDocumentLine;
@@ -298,6 +299,8 @@ private:
     virtual Vector<TextDocumentSpan>& spans() final { return document().spans(); }
     virtual Vector<TextDocumentSpan> const& spans() const final { return document().spans(); }
     virtual void set_span_at_index(size_t index, TextDocumentSpan span) final { document().set_span_at_index(index, move(span)); }
+    virtual Vector<GUI::TextDocumentFoldingRegion>& folding_regions() final { return document().folding_regions(); };
+    virtual Vector<GUI::TextDocumentFoldingRegion> const& folding_regions() const final { return document().folding_regions(); };
     virtual void highlighter_did_request_update() final { update(); }
     virtual DeprecatedString highlighter_did_request_text() const final { return text(); }
     virtual GUI::TextDocument& highlighter_did_request_document() final { return document(); }

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -422,7 +422,7 @@ private:
     void for_each_visual_line(size_t line_index, Callback) const;
 
     struct LineVisualData {
-        Vector<size_t, 1> visual_line_breaks;
+        Vector<Utf32View> visual_lines;
         Gfx::IntRect visual_rect;
     };
 

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -268,6 +268,7 @@ protected:
     virtual void cursor_did_change();
     Gfx::IntRect gutter_content_rect(size_t line) const;
     Gfx::IntRect ruler_content_rect(size_t line) const;
+    Gfx::IntRect folding_indicator_rect(size_t line) const;
 
     TextPosition text_position_at(Gfx::IntPoint) const;
     bool ruler_visible() const { return m_ruler_visible; }
@@ -275,7 +276,8 @@ protected:
     Gfx::IntRect content_rect_for_position(TextPosition const&) const;
     int gutter_width() const;
     int ruler_width() const;
-    int fixed_elements_width() const { return gutter_width() + ruler_width(); }
+    int folding_indicator_width() const;
+    int fixed_elements_width() const { return gutter_width() + ruler_width() + folding_indicator_width(); }
 
     virtual void highlighter_did_set_spans(Vector<TextDocumentSpan> spans) final { document().set_spans(Syntax::HighlighterClient::span_collection_index, move(spans)); }
 
@@ -351,13 +353,14 @@ private:
     int content_x_for_position(TextPosition const&) const;
     Gfx::IntRect gutter_rect_in_inner_coordinates() const;
     Gfx::IntRect ruler_rect_in_inner_coordinates() const;
+    Gfx::IntRect folding_indicator_rect_in_inner_coordinates() const;
     Gfx::IntRect visible_text_rect_in_inner_coordinates() const;
     void recompute_all_visual_lines();
     void ensure_cursor_is_valid();
     void rehighlight_if_needed();
 
     size_t visual_line_containing(size_t line_index, size_t column) const;
-    void recompute_visual_lines(size_t line_index);
+    void recompute_visual_lines(size_t line_index, Vector<TextDocumentFoldingRegion const&>::Iterator& folded_region_iterator);
 
     template<class T, class... Args>
     inline void execute(Args&&... args)

--- a/Userland/Libraries/LibGUI/TextRange.h
+++ b/Userland/Libraries/LibGUI/TextRange.h
@@ -32,6 +32,8 @@ public:
     TextPosition const& start() const { return m_start; }
     TextPosition const& end() const { return m_end; }
 
+    size_t line_count() const { return normalized_end().line() - normalized_start().line() + 1; }
+
     TextRange normalized() const { return TextRange(normalized_start(), normalized_end()); }
 
     void set_start(TextPosition const& position) { m_start = position; }

--- a/Userland/Libraries/LibSyntax/Highlighter.h
+++ b/Userland/Libraries/LibSyntax/Highlighter.h
@@ -132,13 +132,18 @@ private:
     virtual Vector<GUI::TextDocumentSpan> const& spans() const override { return m_spans; }
     virtual void set_span_at_index(size_t index, GUI::TextDocumentSpan span) override { m_spans.at(index) = move(span); }
 
+    virtual Vector<GUI::TextDocumentFoldingRegion>& folding_regions() override { return m_folding_regions; }
+    virtual Vector<GUI::TextDocumentFoldingRegion> const& folding_regions() const override { return m_folding_regions; }
+
     virtual DeprecatedString highlighter_did_request_text() const override { return m_text; }
     virtual void highlighter_did_request_update() override { }
     virtual GUI::TextDocument& highlighter_did_request_document() override { return m_document; }
     virtual GUI::TextPosition highlighter_did_request_cursor() const override { return {}; }
     virtual void highlighter_did_set_spans(Vector<GUI::TextDocumentSpan> spans) override { m_spans = move(spans); }
+    virtual void highlighter_did_set_folding_regions(Vector<GUI::TextDocumentFoldingRegion> folding_regions) override { m_folding_regions = folding_regions; }
 
     Vector<GUI::TextDocumentSpan> m_spans;
+    Vector<GUI::TextDocumentFoldingRegion> m_folding_regions;
     GUI::TextDocument& m_document;
     StringView m_text;
     GUI::TextPosition m_start;

--- a/Userland/Libraries/LibSyntax/HighlighterClient.h
+++ b/Userland/Libraries/LibSyntax/HighlighterClient.h
@@ -21,13 +21,18 @@ public:
     virtual Vector<GUI::TextDocumentSpan> const& spans() const = 0;
     virtual void set_span_at_index(size_t index, GUI::TextDocumentSpan span) = 0;
 
+    virtual Vector<GUI::TextDocumentFoldingRegion>& folding_regions() = 0;
+    virtual Vector<GUI::TextDocumentFoldingRegion> const& folding_regions() const = 0;
+
     virtual DeprecatedString highlighter_did_request_text() const = 0;
     virtual void highlighter_did_request_update() = 0;
     virtual GUI::TextDocument& highlighter_did_request_document() = 0;
     virtual GUI::TextPosition highlighter_did_request_cursor() const = 0;
     virtual void highlighter_did_set_spans(Vector<GUI::TextDocumentSpan>) = 0;
+    virtual void highlighter_did_set_folding_regions(Vector<GUI::TextDocumentFoldingRegion>) = 0;
 
     void do_set_spans(Vector<GUI::TextDocumentSpan> spans) { highlighter_did_set_spans(move(spans)); }
+    void do_set_folding_regions(Vector<GUI::TextDocumentFoldingRegion> folding_regions) { highlighter_did_set_folding_regions(move(folding_regions)); }
     void do_update() { highlighter_did_request_update(); }
 
     DeprecatedString get_text() const { return highlighter_did_request_text(); }


### PR DESCRIPTION
Adds support for code-folding, where sections of a text document can be collapsed and expanded:

![Peek 2023-02-23 15-38 folding-nice](https://user-images.githubusercontent.com/222642/220955831-158ac48c-5e63-401b-9d44-2263111ad0a0.gif)

It's definitely not perfect, but I think it works well enough as a starting point. :^)

Any syntax highlighter can assign a list of folding regions. I've added this to the JS and GML syntax-highlighters for now, but the rest will follow. It works anywhere a `GUI::TextEditor` is used with a supported syntax highlighter, and has a visible ruler.