### PR TITLE
FileManager: Add option to collapse home

### DIFF
--- a/Userland/Libraries/LibGUI/PathBreadcrumbbar.h
+++ b/Userland/Libraries/LibGUI/PathBreadcrumbbar.h
@@ -19,6 +19,7 @@ public:
     virtual ~PathBreadcrumbbar() override;
 
     void set_current_path(DeprecatedString const&);
+    void rebuild_path(DeprecatedString const& new_path, bool collapse_home);
 
     void show_location_text_box();
     void hide_location_text_box();


### PR DESCRIPTION
When the breadcrumb bar displays a path within the user's home, if this option is checked, only show the segments from the home on. For example, the path `/home/anon/Source/js` will result in the segments "anon", "Source", and "js".
![output](https://user-images.githubusercontent.com/52355319/220971780-ae32f99c-5b78-41d0-a990-22316a9d9104.gif)
