### PR TITLE
PixelPaint: Make layer masks work with the UndoStack

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -237,6 +237,7 @@ ErrorOr<void> Image::restore_snapshot(Image const& snapshot)
             select_layer(layer.ptr());
             layer_selected = true;
         }
+        layer->did_modify_bitmap({}, Layer::NotifyClients::No);
         add_layer(*layer);
     }
 

--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -41,6 +41,10 @@ ErrorOr<NonnullRefPtr<Layer>> Layer::create_snapshot(Image& image, Layer const& 
 {
     auto bitmap = TRY(layer.content_bitmap().clone());
     auto snapshot = TRY(create_with_bitmap(image, move(bitmap), layer.name()));
+    if (layer.is_masked()) {
+        snapshot->m_mask_bitmap = TRY(layer.mask_bitmap()->clone());
+        snapshot->m_edit_mode = layer.m_edit_mode;
+    }
 
     /*
         We set these properties directly because calling the setters might

--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -309,11 +309,12 @@ void Layer::update_cached_bitmap()
     }
 }
 
-void Layer::create_mask()
+ErrorOr<void> Layer::create_mask()
 {
-    m_mask_bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, size()));
+    m_mask_bitmap = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, size()));
     m_mask_bitmap->fill(Gfx::Color::White);
     update_cached_bitmap();
+    return {};
 }
 
 Gfx::Bitmap& Layer::currently_edited_bitmap()

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -45,7 +45,7 @@ public:
     Gfx::Bitmap const* mask_bitmap() const { return m_mask_bitmap; }
     Gfx::Bitmap* mask_bitmap() { return m_mask_bitmap; }
 
-    void create_mask();
+    ErrorOr<void> create_mask();
     Gfx::Bitmap& get_scratch_edited_bitmap();
 
     Gfx::IntSize size() const { return content_bitmap().size(); }

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -746,7 +746,12 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             auto active_layer = editor->active_layer();
             if (!active_layer)
                 return;
-            active_layer->create_mask();
+
+            if (auto maybe_error = active_layer->create_mask(); maybe_error.is_error()) {
+                GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to create layer mask: {}", maybe_error.release_error()));
+                return;
+            }
+
             editor->did_complete_action("Add Mask");
             editor->update();
             m_layer_list_widget->repaint();

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -747,6 +747,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             if (!active_layer)
                 return;
             active_layer->create_mask();
+            editor->did_complete_action("Add Mask");
             editor->update();
             m_layer_list_widget->repaint();
         }));


### PR DESCRIPTION
The changes introduced in this PR allow the user to undo changes made while editing a layer mask. 

Previously the layer mask wasn't saved when updating the UndoStack.