### PR TITLE
LibWeb: Fix regressed `overflow: hidden`

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2573,9 +2573,4 @@ void Painter::draw_scaled_bitmap_with_transform(IntRect const& dst_rect, Bitmap 
     }
 }
 
-void Painter::set_clip_rect(IntRect const& rect)
-{
-    state().clip_rect = rect.intersected(m_target->rect());
-}
-
 }

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -177,7 +177,6 @@ public:
     }
 
     IntRect clip_rect() const { return state().clip_rect; }
-    void set_clip_rect(IntRect const&);
 
     int scale() const { return state().scale; }
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -59,7 +59,18 @@ bool Node::is_out_of_flow(FormattingContext const& formatting_context) const
 
 bool Node::can_contain_boxes_with_position_absolute() const
 {
-    return computed_values().position() != CSS::Position::Static || is<InitialContainingBlock>(*this);
+    if (computed_values().position() != CSS::Position::Static)
+        return true;
+
+    if (is<InitialContainingBlock>(*this))
+        return true;
+
+    // https://w3c.github.io/csswg-drafts/css-transforms-1/#propdef-transform
+    // Any computed value other than none for the transform affects containing block and stacking context
+    if (!computed_values().transformations().is_empty())
+        return true;
+
+    return false;
 }
 
 static Box const* nearest_ancestor_capable_of_forming_a_containing_block(Node const& node)

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -314,8 +314,24 @@ BorderRadiiData PaintableBox::normalized_border_radii_data(ShrinkRadiiForBorders
     return border_radius_data;
 }
 
-Optional<Gfx::IntRect> PaintableBox::clip_rect() const
+Optional<CSSPixelRect> PaintableBox::clip_rect() const
 {
+    if (!m_clip_rect.has_value()) {
+        if (containing_block() && containing_block()->paint_box())
+            m_clip_rect = containing_block()->paint_box()->clip_rect();
+
+        auto overflow_x = computed_values().overflow_x();
+        auto overflow_y = computed_values().overflow_y();
+
+        if (overflow_x == CSS::Overflow::Hidden && overflow_y == CSS::Overflow::Hidden) {
+            if (m_clip_rect.has_value()) {
+                m_clip_rect->intersect(absolute_padding_box_rect());
+            } else {
+                m_clip_rect = absolute_padding_box_rect();
+            }
+        }
+    }
+
     return m_clip_rect;
 }
 
@@ -324,36 +340,27 @@ void PaintableBox::apply_clip_overflow_rect(PaintContext& context, PaintPhase ph
     if (!AK::first_is_one_of(phase, PaintPhase::Background, PaintPhase::Border, PaintPhase::Foreground))
         return;
 
-    auto clip_rect = context.painter().clip_rect();
-    if (containing_block() && containing_block()->paint_box()) {
-        if (containing_block()->paint_box()->clip_rect().has_value()) {
-            clip_rect = *containing_block()->paint_box()->clip_rect();
-        }
-    }
-    context.painter().set_clip_rect(clip_rect);
-
+    // FIXME: Support more overflow variations.
+    auto clip_rect = this->clip_rect();
     auto overflow_x = computed_values().overflow_x();
     auto overflow_y = computed_values().overflow_y();
 
     auto clip_overflow = [&] {
         if (!m_clipping_overflow) {
             context.painter().save();
-            context.painter().add_clip_rect(context.rounded_device_rect(absolute_padding_box_rect()).to_type<int>());
+            context.painter().add_clip_rect(context.rounded_device_rect(*clip_rect).to_type<int>());
             m_clipping_overflow = true;
         }
     };
 
-    // FIXME: Support more overflow variations.
-    if (overflow_x == CSS::Overflow::Hidden && overflow_y == CSS::Overflow::Hidden) {
+    if (clip_rect.has_value()) {
         clip_overflow();
     }
-
-    m_clip_rect = context.painter().clip_rect();
 
     if (overflow_y == CSS::Overflow::Hidden || overflow_x == CSS::Overflow::Hidden) {
         auto border_radii_data = normalized_border_radii_data(ShrinkRadiiForBorders::Yes);
         if (border_radii_data.has_any_radius()) {
-            auto corner_clipper = BorderRadiusCornerClipper::create(context, context.rounded_device_rect(absolute_padding_box_rect()), border_radii_data, CornerClip::Outside, BorderRadiusCornerClipper::UseCachedBitmap::No);
+            auto corner_clipper = BorderRadiusCornerClipper::create(context, context.rounded_device_rect(*clip_rect), border_radii_data, CornerClip::Outside, BorderRadiusCornerClipper::UseCachedBitmap::No);
             if (corner_clipper.is_error()) {
                 dbgln("Failed to create overflow border-radius corner clipper: {}", corner_clipper.error());
                 return;

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -317,8 +317,14 @@ BorderRadiiData PaintableBox::normalized_border_radii_data(ShrinkRadiiForBorders
 Optional<CSSPixelRect> PaintableBox::clip_rect() const
 {
     if (!m_clip_rect.has_value()) {
-        if (containing_block() && containing_block()->paint_box())
+        // NOTE: stacking context should not be crossed while aggregating rectangle to
+        // clip `overflow: hidden` because intersecting rectangles with different
+        // transforms doesn't make sense
+        // TODO: figure out if there are cases when stacking context should be
+        // crossed to calculate correct clip rect
+        if (!stacking_context() && containing_block() && containing_block()->paint_box()) {
             m_clip_rect = containing_block()->paint_box()->clip_rect();
+        }
 
         auto overflow_x = computed_values().overflow_x();
         auto overflow_y = computed_values().overflow_y();

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -98,7 +98,7 @@ public:
         return m_overflow_data->scrollable_overflow_rect;
     }
 
-    Optional<Gfx::IntRect> clip_rect() const;
+    Optional<CSSPixelRect> clip_rect() const;
 
     void set_overflow_data(Optional<OverflowData> data) { m_overflow_data = move(data); }
     void set_containing_line_box_fragment(Optional<Layout::LineBoxFragmentCoordinate>);
@@ -157,7 +157,7 @@ private:
     Optional<CSSPixelRect> mutable m_absolute_rect;
     Optional<CSSPixelRect> mutable m_absolute_paint_rect;
 
-    Gfx::IntRect mutable m_clip_rect;
+    Optional<CSSPixelRect> mutable m_clip_rect;
 
     mutable bool m_clipping_overflow { false };
     Optional<BorderRadiusCornerClipper> mutable m_overflow_corner_radius_clipper;


### PR DESCRIPTION
With these changes https://xkcd.com/ is no longer blank, twitter avatars are round and crappy `set_clip_rect` method no longer needed in painter.

Example that is got fixed by making `transform` affect containing block calculation:
```html
<style>
  .box1 {
    width: 400px;
    height: 400px;
    background-color: slateblue;
    position: absolute;
    overflow: hidden;
  }

  .translate {
    width: 200px;
    height: 200px;
    background-color: black;
    transform: translate(150px, 150px);
  }

  .box2 {
    width: 100px;
    height: 100px;
    background-color: orangered;
    position: absolute;
  }

  .box3 {
    position: relative;
    width: 100px;
    height: 100px;
    background-color: greenyellow;
    top: -90px;
    left: -120px;
  }
</style>
<div class="box1">
  <div class="translate">
    <div class="box2"><div class="box3"></div></div>
  </div>
</div>
```