### PR TITLE
PixelPaint: Make image cropping actions work with multiple layers

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -665,13 +665,18 @@ Optional<Gfx::IntRect> Image::nonempty_content_bounding_rect() const
     for (auto const& layer : m_layers) {
         auto layer_content_rect_in_layer_coordinates = layer->nonempty_content_bounding_rect();
         if (!layer_content_rect_in_layer_coordinates.has_value())
-            continue;
+            layer_content_rect_in_layer_coordinates = layer->rect();
+
         auto layer_content_rect_in_image_coordinates = layer_content_rect_in_layer_coordinates->translated(layer->location());
         if (!bounding_rect.has_value())
             bounding_rect = layer_content_rect_in_image_coordinates;
         else
             bounding_rect = bounding_rect->united(layer_content_rect_in_image_coordinates);
     }
+
+    bounding_rect->intersect(rect());
+    if (bounding_rect == rect())
+        return OptionalNone {};
 
     return bounding_rect;
 }

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -673,6 +673,10 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             if (editor->image().selection().is_empty())
                 return;
             auto crop_rect = editor->image().rect().intersected(editor->image().selection().bounding_rect());
+            // FIXME: It is only possible to hit this condition, as transforming the image (crop, rotate etc.), does not update the selection.
+            //        We should ensure that image transformations also transform the selection, so that its relative size and position are maintained.
+            if (crop_rect.is_empty())
+                return;
             auto image_crop_or_error = editor->image().crop(crop_rect);
             if (image_crop_or_error.is_error()) {
                 GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to crop image: {}", image_crop_or_error.release_error())));


### PR DESCRIPTION
This PR modifies the behavior of the "Crop Image to Selection" and "Crop Image to Content" actions, so that they work when an image has multiple disjoint layers that don't cover the entire image.

Previously these actions wouldn't work if the selection did not encompass all the layers in the image.

NB: Crop Image to Selection will now delete layers that fall entirely outside of the current selection. This matches how GIMP behaves (I also tried this in Photoshop, which doesn't delete these layers, but resizes them to 0x0.)

Video:

https://user-images.githubusercontent.com/2817754/221109059-18d80d54-e27d-4783-a664-dc4bbd332826.mp4
