### PR TITLE
Browser: Have the bookmark button use the editor dialog

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.h
+++ b/Userland/Applications/Browser/BookmarksBarWidget.h
@@ -34,11 +34,18 @@ public:
 
     Function<void(DeprecatedString const& url, Open)> on_bookmark_click;
     Function<void(DeprecatedString const&, DeprecatedString const&)> on_bookmark_hover;
+    Function<void(DeprecatedString const& url)> on_bookmark_add;
 
     bool contains_bookmark(DeprecatedString const& url);
     bool remove_bookmark(DeprecatedString const& url);
     bool add_bookmark(DeprecatedString const& url, DeprecatedString const& title);
-    bool edit_bookmark(DeprecatedString const& url);
+
+    enum class PerformEditOn {
+        NewBookmark,
+        ExistingBookmark
+    };
+
+    bool edit_bookmark(DeprecatedString const& url, PerformEditOn perform_edit_on = PerformEditOn::ExistingBookmark);
 
     virtual Optional<GUI::UISize> calculated_min_size() const override
     {
@@ -56,6 +63,8 @@ private:
     virtual void resize_event(GUI::ResizeEvent&) override;
 
     void update_content_size();
+
+    bool update_model(Vector<JsonValue>& values, Function<bool(GUI::JsonArrayModel& model, Vector<JsonValue>&& values)> perform_model_change);
 
     RefPtr<GUI::Model> m_model;
     RefPtr<GUI::Button> m_additional;

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -601,6 +601,12 @@ void Tab::did_become_active()
         m_statusbar->set_text(url);
     };
 
+    BookmarksBarWidget::the().on_bookmark_add = [this](auto& url) {
+        auto current_url = this->url().to_deprecated_string();
+        if (current_url == url)
+            update_bookmark_button(current_url);
+    };
+
     BookmarksBarWidget::the().remove_from_parent();
     m_toolbar_container->add_child(BookmarksBarWidget::the());
 


### PR DESCRIPTION
Now when the bookmark button that has not yet bookmarked the current URL is pressed, it will add the bookmark but also prompt the user with the BookmarkEditor dialog in case they wish to make final touches to their bookmark title or URL.

Before adding a new bookmark:
<img src="https://user-images.githubusercontent.com/60799661/221141204-6414f28e-bf51-463e-9a62-0c5c067061a8.png" width="616" height="405">

Adding a new bookmark using the bookmark button:
<img src="https://user-images.githubusercontent.com/60799661/221141990-493a4a53-660b-453f-8843-abe68854ccfd.png" width="616" height="405">
