### PR TITLE
LibWeb+Ladybird: Render HTML content if present for HTTP error pages

### DIFF
--- a/Ladybird/RequestManagerQt.cpp
+++ b/Ladybird/RequestManagerQt.cpp
@@ -84,7 +84,6 @@ RequestManagerQt::Request::~Request() = default;
 
 void RequestManagerQt::Request::did_finish()
 {
-    bool success = m_reply.error() == QNetworkReply::NetworkError::NoError;
     auto buffer = m_reply.readAll();
     auto http_status_code = m_reply.attribute(QNetworkRequest::Attribute::HttpStatusCodeAttribute).toInt();
     HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> response_headers;
@@ -106,5 +105,6 @@ void RequestManagerQt::Request::did_finish()
     if (!set_cookie_headers.is_empty()) {
         response_headers.set("set-cookie"sv, JsonArray { set_cookie_headers }.to_deprecated_string());
     }
+    bool success = http_status_code != 0;
     on_buffered_request_finish(success, buffer.length(), response_headers, http_status_code, ReadonlyBytes { buffer.data(), (size_t)buffer.size() });
 }

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -322,7 +322,7 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, Has
                     store_response_cookies(request.page().value(), request.url(), *set_cookie);
             }
 
-            if (!success || (status_code.has_value() && *status_code >= 400 && *status_code <= 599)) {
+            if (!success || (status_code.has_value() && *status_code >= 400 && *status_code <= 599 && payload.is_empty())) {
                 StringBuilder error_builder;
                 if (status_code.has_value())
                     error_builder.appendff("Load failed: {}", *status_code);


### PR DESCRIPTION
If an HTTP response fails with an error code (e.g 403) but still has
body content, we now render the content.

We only fall back to our own built-in error page if there's no body.

This required a tweak in Ladybird's Qt networking glue, since it was honoring the goofy `QNetworkReply::NetworkError` enum. It already worked fine with `LibProtocol`.