### PR TITLE
VideoPlayer: Add button and menu item to toggle fullscreen

### DIFF
--- a/Userland/Applications/VideoPlayer/VideoFrameWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoFrameWidget.cpp
@@ -45,6 +45,12 @@ void VideoFrameWidget::mousedown_event(GUI::MouseEvent&)
         on_click();
 }
 
+void VideoFrameWidget::doubleclick_event(GUI::MouseEvent&)
+{
+    if (on_doubleclick)
+        on_doubleclick();
+}
+
 void VideoFrameWidget::paint_event(GUI::PaintEvent& event)
 {
     Frame::paint_event(event);

--- a/Userland/Applications/VideoPlayer/VideoFrameWidget.h
+++ b/Userland/Applications/VideoPlayer/VideoFrameWidget.h
@@ -35,11 +35,13 @@ public:
     bool auto_resize() const { return m_auto_resize; }
 
     Function<void()> on_click;
+    Function<void()> on_doubleclick;
 
 protected:
     explicit VideoFrameWidget();
 
     virtual void mousedown_event(GUI::MouseEvent&) override;
+    virtual void doubleclick_event(GUI::MouseEvent&) override;
     virtual void paint_event(GUI::PaintEvent&) override;
 
 private:

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
@@ -49,6 +49,8 @@ private:
 
     void cycle_sizing_modes();
 
+    void toggle_fullscreen();
+
     void event(Core::Event&) override;
 
     DeprecatedString m_path;
@@ -65,6 +67,8 @@ private:
     RefPtr<GUI::HorizontalSlider> m_volume_slider;
 
     RefPtr<GUI::Action> m_use_fast_seeking;
+
+    RefPtr<GUI::Action> m_toggle_fullscreen_action;
 
     OwnPtr<Video::PlaybackManager> m_playback_manager;
 

--- a/Userland/Applications/VideoPlayer/VideoPlayerWindow.gml
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWindow.gml
@@ -8,6 +8,7 @@
     }
 
     @GUI::Widget {
+        name: "bottom_container"
         max_height: 50
         layout: @GUI::VerticalBoxLayout {}
 
@@ -52,6 +53,15 @@
                     min: 0
                     max: 100
                     fixed_width: 100
+                }
+
+                @GUI::VerticalSeparator {}
+
+                @GUI::Button {
+                    name: "fullscreen"
+                    icon: "/res/icons/16x16/fullscreen.png"
+                    fixed_width: 24
+                    button_style: "Coolbar"
                 }
             }
         }


### PR DESCRIPTION
Add a button to the bottom toolbar and a menu item to toggle fullscreen. Also implement toggling fullscreen mode by double-clicking the video.

Fixes: #17588 