### PR TITLE
LibDeviceTree: Use unchecked_append() in path parsing

### DIFF
--- a/Userland/Libraries/LibDeviceTree/FlattenedDeviceTree.cpp
+++ b/Userland/Libraries/LibDeviceTree/FlattenedDeviceTree.cpp
@@ -117,7 +117,7 @@ static ErrorOr<ReadonlyBytes> slow_get_property_raw(StringView name, FlattenedDe
             return Error::from_errno(ENAMETOOLONG);
         }
         // This can never fail as all entries go into the inline buffer, enforced by the check above.
-        MUST(path.try_append(view));
+        path.unchecked_append(view);
         return {};
     }));
 


### PR DESCRIPTION
`try_append()` checks if the vector should increase capacity and if so grows the vector. `unchecked_append()` verifies the vector already has enough capacity, and will never grow the vector.