### PR TITLE
AK+Spreadsheet: Fix number to column index conversion functions

### DIFF
--- a/Tests/AK/TestDeprecatedString.cpp
+++ b/Tests/AK/TestDeprecatedString.cpp
@@ -290,7 +290,10 @@ TEST_CASE(bijective_base)
     EXPECT_EQ(DeprecatedString::bijective_base_from(25), "Z");
     EXPECT_EQ(DeprecatedString::bijective_base_from(26), "AA");
     EXPECT_EQ(DeprecatedString::bijective_base_from(52), "BA");
-    EXPECT_EQ(DeprecatedString::bijective_base_from(704), "ABC");
+    EXPECT_EQ(DeprecatedString::bijective_base_from(701), "ZZ");
+    EXPECT_EQ(DeprecatedString::bijective_base_from(702), "AAA");
+    EXPECT_EQ(DeprecatedString::bijective_base_from(730), "ABC");
+    EXPECT_EQ(DeprecatedString::bijective_base_from(18277), "ZZZ");
 }
 
 TEST_CASE(roman_numerals)

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -98,6 +98,9 @@ static Optional<size_t> convert_from_string(StringView str, unsigned base = 26, 
 
     VERIFY(base >= 2 && base <= map.length());
 
+    if (str.is_empty())
+        return {};
+
     size_t value = 0;
     auto const len = str.length();
     for (auto i = 0u; i < len; i++) {
@@ -105,13 +108,10 @@ static Optional<size_t> convert_from_string(StringView str, unsigned base = 26, 
         if (!maybe_index.has_value())
             return {};
         size_t digit_value = maybe_index.value();
-        // NOTE: Refer to the note in `String::bijective_base_from()'.
-        if (i == 0 && len > 1)
-            ++digit_value;
-        value += digit_value * AK::pow<float>(base, len - 1 - i);
+        value += (digit_value + 1) * AK::pow<float>(base, len - 1 - i);
     }
 
-    return value;
+    return value - 1;
 }
 
 DeprecatedString Sheet::add_column()


### PR DESCRIPTION
This PR corrects the output of `DeprecatedString::bijective_base_from()` and `Spreadsheet::convert_from_string()` for numbers larger than `base^2`.

This fixes the display of column index values in Spreadsheet.

![spreadsheet_column_index_broken](https://user-images.githubusercontent.com/2817754/221315756-7634ac76-6b97-4ab6-abad-9fbd44330c7c.png)

NB: AFAICT the test case for `bijective_base_from()` value "ABC" was incorrect. I have updated it, as well as adding more test cases.