### PR TITLE
PixelPaint: Add the ability to apply and delete layer masks

### DIFF
--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -317,6 +317,13 @@ ErrorOr<void> Layer::create_mask()
     return {};
 }
 
+void Layer::delete_mask()
+{
+    m_mask_bitmap = nullptr;
+    set_edit_mode(EditMode::Content);
+    update_cached_bitmap();
+}
+
 Gfx::Bitmap& Layer::currently_edited_bitmap()
 {
     switch (edit_mode()) {

--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -324,6 +324,14 @@ void Layer::delete_mask()
     update_cached_bitmap();
 }
 
+void Layer::apply_mask()
+{
+    m_content_bitmap->fill(Color::Transparent);
+    Gfx::Painter painter(m_content_bitmap);
+    painter.blit({}, m_cached_display_bitmap, m_cached_display_bitmap->rect());
+    delete_mask();
+}
+
 Gfx::Bitmap& Layer::currently_edited_bitmap()
 {
     switch (edit_mode()) {

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -47,6 +47,8 @@ public:
 
     ErrorOr<void> create_mask();
     void delete_mask();
+    void apply_mask();
+
     Gfx::Bitmap& get_scratch_edited_bitmap();
 
     Gfx::IntSize size() const { return content_bitmap().size(); }

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -46,6 +46,7 @@ public:
     Gfx::Bitmap* mask_bitmap() { return m_mask_bitmap; }
 
     ErrorOr<void> create_mask();
+    void delete_mask();
     Gfx::Bitmap& get_scratch_edited_bitmap();
 
     Gfx::IntSize size() const { return content_bitmap().size(); }

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -774,6 +774,13 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         }));
     m_layer_menu->add_action(*m_delete_mask_action);
 
+    m_apply_mask_action = GUI::Action::create(
+        "Apply Mask", create_layer_mask_callback("Apply Mask", [&](Layer* active_layer) {
+            VERIFY(active_layer->is_masked());
+            active_layer->apply_mask();
+        }));
+    m_layer_menu->add_action(*m_apply_mask_action);
+
     m_layer_menu->add_separator();
 
     m_layer_menu->add_action(GUI::Action::create(
@@ -1137,6 +1144,7 @@ void MainWidget::set_mask_actions_for_layer(Layer* layer)
     if (!layer) {
         m_add_mask_action->set_visible(true);
         m_delete_mask_action->set_visible(false);
+        m_apply_mask_action->set_visible(false);
         m_add_mask_action->set_enabled(false);
         return;
     }
@@ -1146,6 +1154,7 @@ void MainWidget::set_mask_actions_for_layer(Layer* layer)
     auto masked = layer->is_masked();
     m_add_mask_action->set_visible(!masked);
     m_delete_mask_action->set_visible(masked);
+    m_apply_mask_action->set_visible(masked);
 }
 
 void MainWidget::open_image(FileSystemAccessClient::File file)

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -56,6 +56,7 @@ private:
     void image_editor_did_update_undo_stack();
 
     void set_actions_enabled(bool enabled);
+    void set_mask_actions_for_layer(Layer* active_layer);
 
     virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
@@ -109,6 +110,9 @@ private:
 
     RefPtr<GUI::Action> m_layer_via_copy;
     RefPtr<GUI::Action> m_layer_via_cut;
+
+    RefPtr<GUI::Action> m_add_mask_action;
+    RefPtr<GUI::Action> m_delete_mask_action;
 
     Gfx::IntPoint m_last_image_editor_mouse_position;
 };

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -113,6 +113,7 @@ private:
 
     RefPtr<GUI::Action> m_add_mask_action;
     RefPtr<GUI::Action> m_delete_mask_action;
+    RefPtr<GUI::Action> m_apply_mask_action;
 
     Gfx::IntPoint m_last_image_editor_mouse_position;
 };


### PR DESCRIPTION
This PR adds a "Delete Mask" and an "Apply Mask" action to the layer menu.

The delete action will remove the layer mask for the active layer, while the apply action will merge the layer mask with the layer bitmap. Both these options only appear if the active layer has a layer mask. 

The Add Mask action is now only displayed if the active layer does not have a layer mask.

Video:

https://user-images.githubusercontent.com/2817754/221343679-c9034c83-270c-4a51-af01-277461dbfe96.mp4

