### PR TITLE
BindingsGenerator+LibWeb: Port Blob and File to new String

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -729,7 +729,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
                 }
 
                 generate_to_cpp(dictionary_generator, member, member_property_value_name, "", member_value_name, interface, member.extended_attributes.contains("LegacyNullToEmptyString"), !member.required, member.default_value);
-                if (optional && interface.extended_attributes.contains("UseNewAKString")) {
+                if (member.type->is_string() && optional && interface.extended_attributes.contains("UseNewAKString")) {
                     dictionary_generator.append(R"~~~(
     if (@member_value_name@.has_value())
         @cpp_name@.@member_name@ = @member_value_name@.release_value();

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1226,9 +1226,15 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
         if (includes_string) {
             // 14. If types includes a string type, then return the result of converting V to that type.
             // NOTE: Currently all string types are converted to String.
-            union_generator.append(R"~~~(
+            if (interface.extended_attributes.contains("UseNewAKString")) {
+                union_generator.append(R"~~~(
+        return TRY(@js_name@@js_suffix@.to_string(vm));
+)~~~");
+            } else {
+                union_generator.append(R"~~~(
         return TRY(@js_name@@js_suffix@.to_deprecated_string(vm));
 )~~~");
+            }
         } else if (numeric_type && includes_bigint) {
             // 15. If types includes a numeric type and bigint, then return the result of converting V to either that numeric type or bigint.
             // https://webidl.spec.whatwg.org/#converted-to-a-numeric-type-or-bigint

--- a/Userland/Libraries/LibWeb/Fetch/Body.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Body.cpp
@@ -108,7 +108,7 @@ WebIDL::ExceptionOr<JS::Value> package_data(JS::Realm& realm, ByteBuffer bytes, 
     case PackageDataType::Blob: {
         // Return a Blob whose contents are bytes and type attribute is mimeType.
         // NOTE: If extracting the mime type returns failure, other browsers set it to an empty string - not sure if that's spec'd.
-        auto mime_type_string = mime_type.has_value() ? mime_type->serialized() : DeprecatedString::empty();
+        auto mime_type_string = mime_type.has_value() ? TRY_OR_THROW_OOM(vm, String::from_deprecated_string(mime_type->serialized())) : String {};
         return TRY(FileAPI::Blob::create(realm, move(bytes), move(mime_type_string)));
     }
     case PackageDataType::FormData:

--- a/Userland/Libraries/LibWeb/Fetch/BodyInit.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/BodyInit.cpp
@@ -75,7 +75,7 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm,
             length = blob->size();
             // If object’s type attribute is not the empty byte sequence, set type to its value.
             if (!blob->type().is_empty())
-                type = blob->type().to_byte_buffer();
+                type = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(blob->type().bytes()));
             return {};
         },
         [&](ReadonlyBytes bytes) -> WebIDL::ExceptionOr<void> {

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -1,12 +1,11 @@
 /*
- * Copyright (c) 2022, Kenneth Myhra <kennethmyhra@serenityos.org>
+ * Copyright (c) 2022-2023, Kenneth Myhra <kennethmyhra@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Vector.h>
 #include <LibWeb/Bindings/BlobPrototype.h>
@@ -16,14 +15,14 @@
 
 namespace Web::FileAPI {
 
-using BlobPart = Variant<JS::Handle<JS::Object>, JS::Handle<Blob>, DeprecatedString>;
+using BlobPart = Variant<JS::Handle<JS::Object>, JS::Handle<Blob>, String>;
 
 struct BlobPropertyBag {
-    DeprecatedString type = DeprecatedString::empty();
+    String type = String {};
     Bindings::EndingType endings;
 };
 
-[[nodiscard]] ErrorOr<DeprecatedString> convert_line_endings_to_native(DeprecatedString const& string);
+[[nodiscard]] ErrorOr<String> convert_line_endings_to_native(StringView string);
 [[nodiscard]] ErrorOr<ByteBuffer> process_blob_parts(Vector<BlobPart> const& blob_parts, Optional<BlobPropertyBag> const& options = {});
 [[nodiscard]] bool is_basic_latin(StringView view);
 
@@ -33,24 +32,24 @@ class Blob : public Bindings::PlatformObject {
 public:
     virtual ~Blob() override;
 
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> create(JS::Realm&, ByteBuffer, DeprecatedString type);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> create(JS::Realm&, ByteBuffer, String type);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> create(JS::Realm&, Optional<Vector<BlobPart>> const& blob_parts = {}, Optional<BlobPropertyBag> const& options = {});
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> construct_impl(JS::Realm&, Optional<Vector<BlobPart>> const& blob_parts = {}, Optional<BlobPropertyBag> const& options = {});
 
     // https://w3c.github.io/FileAPI/#dfn-size
     u64 size() const { return m_byte_buffer.size(); }
     // https://w3c.github.io/FileAPI/#dfn-type
-    DeprecatedString const& type() const { return m_type; }
+    String const& type() const { return m_type; }
 
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> slice(Optional<i64> start = {}, Optional<i64> end = {}, Optional<DeprecatedString> const& content_type = {});
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> slice(Optional<i64> start = {}, Optional<i64> end = {}, Optional<String> const& content_type = {});
 
-    JS::Promise* text();
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> text();
     JS::Promise* array_buffer();
 
     ReadonlyBytes bytes() const { return m_byte_buffer.bytes(); }
 
 protected:
-    Blob(JS::Realm&, ByteBuffer, DeprecatedString type);
+    Blob(JS::Realm&, ByteBuffer, String type);
     Blob(JS::Realm&, ByteBuffer);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
@@ -59,7 +58,7 @@ private:
     explicit Blob(JS::Realm&);
 
     ByteBuffer m_byte_buffer {};
-    DeprecatedString m_type {};
+    String m_type {};
 };
 
 }

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.idl
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.idl
@@ -1,4 +1,4 @@
-[Exposed=(Window,Worker), Serializable]
+[Exposed=(Window,Worker), Serializable, UseNewAKString]
 interface Blob {
     constructor(optional sequence<BlobPart> blobParts, optional BlobPropertyBag options = {});
 

--- a/Userland/Libraries/LibWeb/FileAPI/File.h
+++ b/Userland/Libraries/LibWeb/FileAPI/File.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Kenneth Myhra <kennethmyhra@serenityos.org>
+ * Copyright (c) 2022-2023, Kenneth Myhra <kennethmyhra@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -18,22 +18,22 @@ class File : public Blob {
     WEB_PLATFORM_OBJECT(File, Blob);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> create(JS::Realm&, Vector<BlobPart> const& file_bits, DeprecatedString const& file_name, Optional<FilePropertyBag> const& options = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> construct_impl(JS::Realm&, Vector<BlobPart> const& file_bits, DeprecatedString const& file_name, Optional<FilePropertyBag> const& options = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> create(JS::Realm&, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> construct_impl(JS::Realm&, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options = {});
 
     virtual ~File() override;
 
     // https://w3c.github.io/FileAPI/#dfn-name
-    DeprecatedString const& name() const { return m_name; }
+    String const& name() const { return m_name; }
     // https://w3c.github.io/FileAPI/#dfn-lastModified
     i64 last_modified() const { return m_last_modified; }
 
 private:
-    File(JS::Realm&, ByteBuffer, DeprecatedString file_name, DeprecatedString type, i64 last_modified);
+    File(JS::Realm&, ByteBuffer, String file_name, String type, i64 last_modified);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
-    DeprecatedString m_name;
+    String m_name;
     i64 m_last_modified { 0 };
 };
 

--- a/Userland/Libraries/LibWeb/FileAPI/File.idl
+++ b/Userland/Libraries/LibWeb/FileAPI/File.idl
@@ -1,6 +1,6 @@
 #import <FileAPI/Blob.idl>
 
-[Exposed=(Window,Worker), Serializable]
+[Exposed=(Window,Worker), Serializable, UseNewAKString]
 interface File : Blob {
     constructor(sequence<BlobPart> fileBits, USVString fileName, optional FilePropertyBag options = {});
 

--- a/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
@@ -36,7 +36,7 @@ WebIDL::ExceptionOr<XHR::FormDataEntry> create_entry(JS::Realm& realm, String co
                 name_attribute = filename.value();
             else
                 name_attribute = TRY_OR_THROW_OOM(vm, "blob"_string);
-            return JS::make_handle(TRY(FileAPI::File::create(realm, { JS::make_handle(*blob) }, name_attribute.to_deprecated_string(), {})));
+            return JS::make_handle(TRY(FileAPI::File::create(realm, { JS::make_handle(*blob) }, move(name_attribute), {})));
         }));
 
     // 4. Return an entry whose name is name and whose value is value.
@@ -130,8 +130,8 @@ WebIDL::ExceptionOr<Optional<Vector<XHR::FormDataEntry>>> construct_entry_list(J
             // 1. If there are no selected files, then create an entry with name and a new File object with an empty name, application/octet-stream as type, and an empty body, and append it to entry list.
             if (file_element->files()->length() == 0) {
                 FileAPI::FilePropertyBag options {};
-                options.type = "application/octet-stream";
-                auto file = TRY(FileAPI::File::create(realm, {}, "", options));
+                options.type = TRY_OR_THROW_OOM(vm, "application/octet-stream"_string);
+                auto file = TRY(FileAPI::File::create(realm, {}, String {}, options));
                 TRY_OR_THROW_OOM(vm, entry_list.try_append(XHR::FormDataEntry { .name = move(name), .value = JS::make_handle(file) }));
             }
             // 2. Otherwise, for each file in selected files, create an entry with name and a File object representing the file, and append it to entry list.

--- a/Userland/Libraries/LibWeb/Infra/Strings.cpp
+++ b/Userland/Libraries/LibWeb/Infra/Strings.cpp
@@ -120,4 +120,18 @@ ErrorOr<String> to_ascii_lower_case(StringView string)
     return string_builder.to_string();
 }
 
+// https://infra.spec.whatwg.org/#ascii-uppercase
+ErrorOr<String> to_ascii_upper_case(StringView string)
+{
+    // To ASCII uppercase a string, replace all ASCII lower alphas in the string with their
+    // corresponding code point in ASCII upper alpha.
+    StringBuilder string_builder;
+    auto utf8_view = Utf8View { string };
+    for (u32 code_point : utf8_view) {
+        code_point = to_ascii_uppercase(code_point);
+        TRY(string_builder.try_append(code_point));
+    }
+    return string_builder.to_string();
+}
+
 }

--- a/Userland/Libraries/LibWeb/Infra/Strings.cpp
+++ b/Userland/Libraries/LibWeb/Infra/Strings.cpp
@@ -106,4 +106,18 @@ ErrorOr<String> convert_to_scalar_value_string(StringView string)
     return scalar_value_builder.to_string();
 }
 
+// https://infra.spec.whatwg.org/#ascii-lowercase
+ErrorOr<String> to_ascii_lower_case(StringView string)
+{
+    // To ASCII lowercase a string, replace all ASCII upper alphas in the string with their
+    // corresponding code point in ASCII lower alpha.
+    StringBuilder string_builder;
+    auto utf8_view = Utf8View { string };
+    for (u32 code_point : utf8_view) {
+        code_point = to_ascii_lowercase(code_point);
+        TRY(string_builder.try_append(code_point));
+    }
+    return string_builder.to_string();
+}
+
 }

--- a/Userland/Libraries/LibWeb/Infra/Strings.h
+++ b/Userland/Libraries/LibWeb/Infra/Strings.h
@@ -17,5 +17,6 @@ bool is_ascii_case_insensitive_match(StringView a, StringView b);
 DeprecatedString strip_and_collapse_whitespace(StringView string);
 bool is_code_unit_prefix(StringView potential_prefix, StringView input);
 ErrorOr<String> convert_to_scalar_value_string(StringView string);
+ErrorOr<String> to_ascii_lower_case(StringView string);
 
 }

--- a/Userland/Libraries/LibWeb/Infra/Strings.h
+++ b/Userland/Libraries/LibWeb/Infra/Strings.h
@@ -18,5 +18,6 @@ DeprecatedString strip_and_collapse_whitespace(StringView string);
 bool is_code_unit_prefix(StringView potential_prefix, StringView input);
 ErrorOr<String> convert_to_scalar_value_string(StringView string);
 ErrorOr<String> to_ascii_lower_case(StringView string);
+ErrorOr<String> to_ascii_upper_case(StringView string);
 
 }

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -3,7 +3,7 @@
  * Copyright (c) 2021-2022, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
  * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
- * Copyright (c) 2022, Kenneth Myhra <kennethmyhra@serenityos.org>
+ * Copyright (c) 2022-2023, Kenneth Myhra <kennethmyhra@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -161,7 +161,8 @@ WebIDL::ExceptionOr<JS::Value> XMLHttpRequest::response()
     }
     // 6. Otherwise, if this’s response type is "blob", set this’s response object to a new Blob object representing this’s received bytes with type set to the result of get a final MIME type for this.
     else if (m_response_type == Bindings::XMLHttpRequestResponseType::Blob) {
-        auto blob_part = TRY(FileAPI::Blob::create(realm(), m_received_bytes, get_final_mime_type().type()));
+        auto mime_type_as_string = TRY_OR_THROW_OOM(vm, String::from_deprecated_string(get_final_mime_type().type()));
+        auto blob_part = TRY(FileAPI::Blob::create(realm(), m_received_bytes, move(mime_type_as_string)));
         auto blob = TRY(FileAPI::Blob::create(realm(), Vector<FileAPI::BlobPart> { JS::make_handle(*blob_part) }));
         m_response_object = JS::Value(blob.ptr());
     }


### PR DESCRIPTION
The following amendments has been done to the BindingsGenerator:

#### BindingsGenerator: Assert dictionary member is string
This adds the condition member.type->is_string() to the if statement, so
that we now assert the dictionary member is a new string and associated
with an optional constructor parameter.

#### BindingsGenerator: Use JS::Value::to_string() when new String
Make sure to use JS::Value::to_string() when the IDL interface is marked
with the extended attribute UseNewAKString.