### PR TITLE
LibDSP: Get rid of DeprecatedString

### DIFF
--- a/Userland/Applications/Piano/ProcessorParameterWidget/ParameterWidget.cpp
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/ParameterWidget.cpp
@@ -15,7 +15,7 @@ ProcessorParameterWidget::ProcessorParameterWidget(DSP::ProcessorParameter& raw_
     : m_parameter(raw_parameter)
 {
     set_layout<GUI::VerticalBoxLayout>();
-    m_label = add<GUI::Label>(raw_parameter.name());
+    m_label = add<GUI::Label>(raw_parameter.name().to_deprecated_string());
     switch (raw_parameter.type()) {
     case DSP::ParameterType::Range: {
         auto& parameter = static_cast<DSP::ProcessorRangeParameter&>(raw_parameter);

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
@@ -26,7 +26,7 @@ ProcessorParameterSlider::ProcessorParameterSlider(Orientation orientation, DSP:
         set_value(value_log);
         set_step((min_log - max_log) / slider_steps);
     }
-    set_tooltip(m_parameter.name());
+    set_tooltip(m_parameter.name().to_deprecated_string());
     m_value_label->set_text(DeprecatedString::formatted("{:.2f}", static_cast<double>(m_parameter)));
 
     on_change = [this](auto value) {

--- a/Userland/Libraries/LibDSP/Effects.cpp
+++ b/Userland/Libraries/LibDSP/Effects.cpp
@@ -12,9 +12,9 @@ namespace DSP::Effects {
 
 Delay::Delay(NonnullRefPtr<Transport> transport)
     : EffectProcessor(move(transport))
-    , m_delay_decay("Decay"sv, 0.01, 0.99, 0.33, Logarithmic::No)
-    , m_delay_time("Delay Time"sv, 3, 2000, 900, Logarithmic::Yes)
-    , m_dry_gain("Dry"sv, 0, 1, 0.9, Logarithmic::No)
+    , m_delay_decay(String::from_utf8_short_string("Decay"sv), 0.01, 0.99, 0.33, Logarithmic::No)
+    , m_delay_time(String::from_utf8("Delay Time"sv), 3, 2000, 900, Logarithmic::Yes)
+    , m_dry_gain(String::from_utf8_short_string("Dry"sv), 0, 1, 0.9, Logarithmic::No)
 {
 
     m_parameters.append(m_delay_decay);
@@ -59,9 +59,9 @@ void Delay::process_impl(Signal const& input_signal, Signal& output_signal)
 
 Mastering::Mastering(NonnullRefPtr<Transport> transport)
     : EffectProcessor(move(transport))
-    , m_pan("Pan", -1, 1, 0, Logarithmic::No)
-    , m_volume("Volume", 0, 1, 1, Logarithmic::No)
-    , m_muted("Mute", false)
+    , m_pan(String::from_utf8_short_string("Pan"sv), -1, 1, 0, Logarithmic::No)
+    , m_volume(String::from_utf8_short_string("Volume"sv), 0, 1, 1, Logarithmic::No)
+    , m_muted(String::from_utf8_short_string("Mute"sv), false)
 {
     m_parameters.append(m_muted);
     m_parameters.append(m_volume);

--- a/Userland/Libraries/LibDSP/Processor.h
+++ b/Userland/Libraries/LibDSP/Processor.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/Function.h>
 #include <AK/Noncopyable.h>
 #include <AK/RefCounted.h>

--- a/Userland/Libraries/LibDSP/ProcessorParameter.h
+++ b/Userland/Libraries/LibDSP/ProcessorParameter.h
@@ -7,11 +7,11 @@
 #pragma once
 
 #include <AK/Concepts.h>
-#include <AK/DeprecatedString.h>
 #include <AK/FixedPoint.h>
 #include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/Function.h>
+#include <AK/String.h>
 #include <AK/Types.h>
 #include <LibDSP/Music.h>
 
@@ -36,17 +36,18 @@ enum class Logarithmic : bool {
 // Processors have modifiable parameters that should be presented to the UI in a uniform way without requiring the processor itself to implement custom interfaces.
 class ProcessorParameter {
 public:
-    ProcessorParameter(DeprecatedString name, ParameterType type)
-        : m_name(move(name))
-        , m_type(type)
+    ProcessorParameter(ErrorOr<String> name, ParameterType type)
+        : m_type(type)
     {
+        if (!name.is_error())
+            m_name = name.release_value();
     }
 
-    DeprecatedString const& name() const { return m_name; }
+    String const& name() const { return m_name; }
     ParameterType type() const { return m_type; }
 
 private:
-    DeprecatedString const m_name;
+    String m_name {};
     ParameterType const m_type;
 };
 
@@ -60,7 +61,7 @@ template<typename ParameterT>
 class ProcessorParameterSingleValue : public ProcessorParameter {
 
 public:
-    ProcessorParameterSingleValue(DeprecatedString name, ParameterType type, ParameterT initial_value)
+    ProcessorParameterSingleValue(ErrorOr<String> name, ParameterType type, ParameterT initial_value)
         : ProcessorParameter(move(name), type)
         , m_value(move(initial_value))
     {
@@ -106,7 +107,7 @@ protected:
 
 class ProcessorBooleanParameter final : public Detail::ProcessorParameterSingleValue<bool> {
 public:
-    ProcessorBooleanParameter(DeprecatedString name, bool initial_value)
+    ProcessorBooleanParameter(String name, bool initial_value)
         : Detail::ProcessorParameterSingleValue<bool>(move(name), ParameterType::Boolean, move(initial_value))
     {
     }
@@ -114,7 +115,7 @@ public:
 
 class ProcessorRangeParameter final : public Detail::ProcessorParameterSingleValue<ParameterFixedPoint> {
 public:
-    ProcessorRangeParameter(DeprecatedString name, ParameterFixedPoint min_value, ParameterFixedPoint max_value, ParameterFixedPoint initial_value, Logarithmic logarithmic)
+    ProcessorRangeParameter(ErrorOr<String> name, ParameterFixedPoint min_value, ParameterFixedPoint max_value, ParameterFixedPoint initial_value, Logarithmic logarithmic)
         : Detail::ProcessorParameterSingleValue<ParameterFixedPoint>(move(name), ParameterType::Range, move(initial_value))
         , m_min_value(move(min_value))
         , m_max_value(move(max_value))
@@ -150,7 +151,7 @@ private:
 template<Enum EnumT>
 class ProcessorEnumParameter final : public Detail::ProcessorParameterSingleValue<EnumT> {
 public:
-    ProcessorEnumParameter(DeprecatedString name, EnumT initial_value)
+    ProcessorEnumParameter(ErrorOr<String> name, EnumT initial_value)
         : Detail::ProcessorParameterSingleValue<EnumT>(move(name), ParameterType::Enum, initial_value)
     {
     }
@@ -186,7 +187,7 @@ struct AK::Formatter<DSP::ProcessorRangeParameter> : AK::StandardFormatter {
         m_width = m_width.value_or(0);
         m_precision = m_precision.value_or(NumericLimits<size_t>::max());
 
-        TRY(builder.put_literal(DeprecatedString::formatted("[{} - {}]: {}", value.min_value(), value.max_value(), value.value())));
+        TRY(builder.put_literal(TRY(String::formatted("[{} - {}]: {}", value.min_value(), value.max_value(), value.value())).bytes_as_string_view()));
         return {};
     }
 };

--- a/Userland/Libraries/LibDSP/Synthesizers.cpp
+++ b/Userland/Libraries/LibDSP/Synthesizers.cpp
@@ -18,12 +18,12 @@
 namespace DSP::Synthesizers {
 
 Classic::Classic(NonnullRefPtr<Transport> transport)
-    : DSP::SynthesizerProcessor(transport)
-    , m_waveform("Waveform"sv, Waveform::Saw)
-    , m_attack("Attack"sv, 0.01, 2000, 5, Logarithmic::Yes)
-    , m_decay("Decay"sv, 0.01, 20'000, 80, Logarithmic::Yes)
-    , m_sustain("Sustain"sv, 0.001, 1, 0.725, Logarithmic::No)
-    , m_release("Release", 0.01, 6'000, 120, Logarithmic::Yes)
+    : DSP::SynthesizerProcessor(move(transport))
+    , m_waveform(String::from_utf8("Waveform"sv), Waveform::Saw)
+    , m_attack(String::from_utf8_short_string("Attack"sv), 0.01, 2000, 5, Logarithmic::Yes)
+    , m_decay(String::from_utf8_short_string("Decay"sv), 0.01, 20'000, 80, Logarithmic::Yes)
+    , m_sustain(String::from_utf8_short_string("Sustain"sv), 0.001, 1, 0.725, Logarithmic::No)
+    , m_release(String::from_utf8_short_string("Release"sv), 0.01, 6'000, 120, Logarithmic::Yes)
 {
     m_parameters.append(m_waveform);
     m_parameters.append(m_attack);

--- a/Userland/Libraries/LibDSP/Window.h
+++ b/Userland/Libraries/LibDSP/Window.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Arne Elster (arne@elster.li)
+ * Copyright (c) 2021, Arne Elster <arne@elster.li>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */


### PR DESCRIPTION
This was a rather easy change, since only parameter names make use of strings in the first place.

This also improves OOM resistance: If we can't create a parameter name, we will just set it to the empty string.

Contributes to #17128.