### PR TITLE
Kernel: Mark sys$prctl() as not needing the big lock

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -136,7 +136,7 @@ enum class NeedsBigProcessLock {
     S(pledge, NeedsBigProcessLock::No)                      \
     S(poll, NeedsBigProcessLock::Yes)                       \
     S(posix_fallocate, NeedsBigProcessLock::No)             \
-    S(prctl, NeedsBigProcessLock::Yes)                      \
+    S(prctl, NeedsBigProcessLock::No)                       \
     S(profiling_disable, NeedsBigProcessLock::Yes)          \
     S(profiling_enable, NeedsBigProcessLock::Yes)           \
     S(profiling_free_buffer, NeedsBigProcessLock::Yes)      \

--- a/Kernel/Syscalls/prctl.cpp
+++ b/Kernel/Syscalls/prctl.cpp
@@ -11,7 +11,7 @@ namespace Kernel {
 
 ErrorOr<FlatPtr> Process::sys$prctl(int option, FlatPtr arg1, [[maybe_unused]] FlatPtr arg2)
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
     return with_mutable_protected_data([&](auto& protected_data) -> ErrorOr<FlatPtr> {
         switch (option) {
         case PR_GET_DUMPABLE:


### PR DESCRIPTION
This syscall has sufficient locking and therefore it doesn't need the big lock being taken.