### PR TITLE
LibJS: Use std namespace for isnan() on NetBSD

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -212,6 +212,10 @@ public:
             VERIFY(!(SHIFTED_INT32_TAG & (static_cast<i32>(value) & 0xFFFFFFFFul)));
             m_value.encoded = SHIFTED_INT32_TAG | (static_cast<i32>(value) & 0xFFFFFFFFul);
         } else {
+#ifdef AK_OS_NETBSD
+            // Use standard namespace, otherwise it won't find isnan() on NetBSD.
+            using namespace std;
+#endif
             if (isnan(value)) [[unlikely]]
                 m_value.encoded = CANON_NAN_BITS;
             else


### PR DESCRIPTION
On NetBSD the compiler can't find isnan() at this position in the code and exits with an error.
At dozens of other locations in the code,isnan() works just fine.
I guess it's somehow related to isnan() being used within a Class here that it's not found,but I'm not sure about that.
If I tell it to use the namespace std,it works as expected.
So far that problem only appeared on NetBSD,using the latest Clang 15.
On the other BSDs (using Clang 13) and on Illumos (also Clang 15),the use of isnan() at this point didn't cause any trouble,so I have put the namespace definition into an #ifdef only of NetBSD.
I already tried to work-around this bug by using isnanf() instead,see #17550 ,but I think this one is a cleaner solution.