### PR TITLE
LibJS+Lagom: Add a Clang tool to enforce proper use of GCPtr/NonnullGCPtr

### DIFF
--- a/Meta/Lagom/Tools/LibJSGCVerifier/.gitignore
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/.gitignore
@@ -1,0 +1,3 @@
+build/
+cmake-build-debug/
+venv/

--- a/Meta/Lagom/Tools/LibJSGCVerifier/CMakeLists.txt
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.24)
+
+project(LibJSGCVerifier C CXX)
+
+find_package(Clang CONFIG REQUIRED HINTS "../../../../Toolchain/Local/clang")
+
+add_executable(LibJSGCVerifier src/main.cpp src/CellsHandler.cpp)
+
+target_include_directories(LibJSGCVerifier SYSTEM PRIVATE ${CLANG_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS})
+target_compile_features(LibJSGCVerifier PRIVATE cxx_std_20)
+target_link_libraries(LibJSGCVerifier PRIVATE clangTooling)
+
+target_compile_options(LibJSGCVerifier PRIVATE
+    -Wall
+    -Wextra
+    -Werror
+    -Wno-unused
+    -fno-rtti
+)

--- a/Meta/Lagom/Tools/LibJSGCVerifier/README.md
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/README.md
@@ -1,0 +1,15 @@
+### LibJSGCVerifier
+
+This is a simple Clang tool to validate certain behavior relating to LibJS's GC. It currently validates
+two things:
+
+- For all types wrapped by `GCPtr` or `NonnullGCPtr`, that the wrapped type inherits from `Cell`
+- For all types not wrapped by `GCPtr` or `NonnullGCPtr`, that the wrapped type does not inherit from `Cell`
+  (otherwise it should be wrapped).
+
+Usage:
+```
+cmake -GNinja -B build
+cmake --build build
+src/main.py -b <path to serenity>/Build
+```

--- a/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "CellsHandler.h"
+#include <clang/AST/DeclCXX.h>
+#include <clang/AST/Type.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/Basic/Diagnostic.h>
+#include <clang/Basic/Specifiers.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <filesystem>
+#include <llvm/Support/Casting.h>
+#include <llvm/Support/raw_ostream.h>
+#include <unordered_set>
+#include <vector>
+
+CollectCellsHandler::CollectCellsHandler()
+{
+    using namespace clang::ast_matchers;
+
+    m_finder.addMatcher(
+        traverse(
+            clang::TK_IgnoreUnlessSpelledInSource,
+            cxxRecordDecl(decl().bind("record-decl"))),
+        this);
+}
+
+bool CollectCellsHandler::handleBeginSource(clang::CompilerInstance& ci)
+{
+    auto const& source_manager = ci.getSourceManager();
+    ci.getFileManager().getNumUniqueRealFiles();
+    auto file_id = source_manager.getMainFileID();
+    auto const* file_entry = source_manager.getFileEntryForID(file_id);
+    if (!file_entry)
+        return false;
+
+    auto current_filepath = std::filesystem::canonical(file_entry->getName().str());
+    llvm::outs() << "Processing " << current_filepath.string() << "\n";
+
+    return true;
+}
+
+bool record_inherits_from_cell(clang::CXXRecordDecl const& record)
+{
+    if (!record.isCompleteDefinition())
+        return false;
+
+    bool inherits_from_cell = record.getQualifiedNameAsString() == "JS::Cell";
+    record.forallBases([&](clang::CXXRecordDecl const* base) -> bool {
+        if (base->getQualifiedNameAsString() == "JS::Cell") {
+            inherits_from_cell = true;
+            return false;
+        }
+        return true;
+    });
+    return inherits_from_cell;
+}
+
+std::vector<clang::QualType> get_all_qualified_types(clang::QualType const& type)
+{
+    std::vector<clang::QualType> qualified_types;
+
+    if (auto const* template_specialization = type->getAs<clang::TemplateSpecializationType>()) {
+        auto specialization_name = template_specialization->getTemplateName().getAsTemplateDecl()->getQualifiedNameAsString();
+        // Do not unwrap GCPtr/NonnullGCPtr
+        if (specialization_name == "JS::GCPtr" || specialization_name == "JS::NonnullGCPtr") {
+            qualified_types.push_back(type);
+        } else {
+            for (size_t i = 0; i < template_specialization->getNumArgs(); i++) {
+                auto const& template_arg = template_specialization->getArg(i);
+                if (template_arg.getKind() == clang::TemplateArgument::Type) {
+                    auto template_qualified_types = get_all_qualified_types(template_arg.getAsType());
+                    std::move(template_qualified_types.begin(), template_qualified_types.end(), std::back_inserter(qualified_types));
+                }
+            }
+        }
+    } else {
+        qualified_types.push_back(type);
+    }
+
+    return qualified_types;
+}
+
+struct FieldValidationResult {
+    bool is_valid { false };
+    bool is_wrapped_in_gcptr { false };
+};
+
+FieldValidationResult validate_field(clang::FieldDecl const* field_decl)
+{
+    auto type = field_decl->getType();
+    if (auto const* elaborated_type = llvm::dyn_cast<clang::ElaboratedType>(type.getTypePtr()))
+        type = elaborated_type->desugar();
+
+    FieldValidationResult result { .is_valid = true };
+
+    for (auto const& qualified_type : get_all_qualified_types(type)) {
+        if (auto const* pointer_decl = qualified_type->getAs<clang::PointerType>()) {
+            if (auto const* pointee = pointer_decl->getPointeeCXXRecordDecl()) {
+                if (record_inherits_from_cell(*pointee)) {
+                    result.is_valid = false;
+                    result.is_wrapped_in_gcptr = false;
+                    return result;
+                }
+            }
+        } else if (auto const* reference_decl = qualified_type->getAs<clang::ReferenceType>()) {
+            if (auto const* pointee = reference_decl->getPointeeCXXRecordDecl()) {
+                if (record_inherits_from_cell(*pointee)) {
+                    result.is_valid = false;
+                    result.is_wrapped_in_gcptr = false;
+                    return result;
+                }
+            }
+        } else if (auto const* specialization = qualified_type->getAs<clang::TemplateSpecializationType>()) {
+            auto template_type_name = specialization->getTemplateName().getAsTemplateDecl()->getName();
+            if (template_type_name != "GCPtr" && template_type_name != "NonnullGCPtr")
+                return result;
+
+            if (specialization->getNumArgs() != 1)
+                return result; // Not really valid, but will produce a compilation error anyway
+
+            auto const& type_arg = specialization->getArg(0);
+            auto const* record_type = type_arg.getAsType()->getAs<clang::RecordType>();
+            if (!record_type)
+                return result;
+
+            auto const* record_decl = record_type->getAsCXXRecordDecl();
+            if (!record_decl->hasDefinition())
+                return result;
+
+            result.is_wrapped_in_gcptr = true;
+            result.is_valid = record_inherits_from_cell(*record_decl);
+        }
+    }
+
+    return result;
+}
+
+void CollectCellsHandler::run(clang::ast_matchers::MatchFinder::MatchResult const& result)
+{
+    clang::CXXRecordDecl const* record = result.Nodes.getNodeAs<clang::CXXRecordDecl>("record-decl");
+    if (!record || !record->isCompleteDefinition() || (!record->isClass() && !record->isStruct()))
+        return;
+
+    auto& diag_engine = result.Context->getDiagnostics();
+
+    for (clang::FieldDecl const* field : record->fields()) {
+        auto const& type = field->getType();
+
+        auto validation_results = validate_field(field);
+        if (!validation_results.is_valid) {
+            if (validation_results.is_wrapped_in_gcptr) {
+                auto diag_id = diag_engine.getCustomDiagID(clang::DiagnosticsEngine::Warning, "Specialization type must inherit from JS::Cell");
+                diag_engine.Report(field->getLocation(), diag_id);
+            } else {
+                auto diag_id = diag_engine.getCustomDiagID(clang::DiagnosticsEngine::Warning, "%0 to JS::Cell type should be wrapped in %1");
+                auto builder = diag_engine.Report(field->getLocation(), diag_id);
+                if (type->isReferenceType()) {
+                    builder << "reference"
+                            << "JS::NonnullGCPtr";
+                } else {
+                    builder << "pointer"
+                            << "JS::GCPtr";
+                }
+            }
+        }
+    }
+}

--- a/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.h
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/src/CellsHandler.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/Tooling/Tooling.h>
+#include <unordered_set>
+
+class CollectCellsHandler
+    : public clang::tooling::SourceFileCallbacks
+    , public clang::ast_matchers::MatchFinder::MatchCallback {
+public:
+    CollectCellsHandler();
+    virtual ~CollectCellsHandler() override = default;
+
+    virtual bool handleBeginSource(clang::CompilerInstance&) override;
+
+    virtual void run(clang::ast_matchers::MatchFinder::MatchResult const& result) override;
+
+    clang::ast_matchers::MatchFinder& finder() { return m_finder; }
+
+private:
+    std::unordered_set<std::string> m_visited_classes;
+    clang::ast_matchers::MatchFinder m_finder;
+};

--- a/Meta/Lagom/Tools/LibJSGCVerifier/src/main.cpp
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/src/main.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "CellsHandler.h"
+#include <clang/Tooling/CommonOptionsParser.h>
+#include <clang/Tooling/Tooling.h>
+#include <llvm/Support/CommandLine.h>
+
+int main(int argc, char const** argv)
+{
+    llvm::cl::OptionCategory s_tool_category("LibJSGCVerifier options");
+    auto maybe_parser = clang::tooling::CommonOptionsParser::create(argc, argv, s_tool_category);
+    if (!maybe_parser) {
+        llvm::errs() << maybe_parser.takeError();
+        return 1;
+    }
+
+    auto& parser = maybe_parser.get();
+    clang::tooling::ClangTool tool(parser.getCompilations(), parser.getSourcePathList());
+
+    CollectCellsHandler collect_handler;
+    auto collect_action = clang::tooling::newFrontendActionFactory(&collect_handler.finder(), &collect_handler);
+    return tool.run(collect_action.get());
+}

--- a/Meta/Lagom/Tools/LibJSGCVerifier/src/main.py
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/src/main.py
@@ -1,0 +1,75 @@
+#!/bin/python3
+
+import argparse
+import multiprocessing
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+
+# Relative to Userland directory
+PATHS_TO_SEARCH = [
+    'Applications/Assistant',
+    'Applications/Browser',
+    'Applications/Spreadsheet',
+    'Applications/TextEditor',
+    'DevTools/HackStudio',
+    'Libraries/LibJS',
+    'Libraries/LibMarkdown',
+    'Libraries/LibWeb',
+    'Services/WebContent',
+]
+
+parser = argparse.ArgumentParser('LibJSGCVerifier', description='A Clang tool to validate usage of the LibJS GC')
+parser.add_argument('-b', '--build-path', required=True, help='Path to the project Build folder')
+args = parser.parse_args()
+
+build_path = Path(args.build_path).resolve()
+userland_path = build_path / '..' / 'Userland'
+include_path = build_path / 'x86_64clang' / 'Root' / 'usr' / 'include'
+compile_commands_path = build_path / 'x86_64clang' / 'compile_commands.json'
+
+if not compile_commands_path.exists():
+    print(f'Could not find compile_commands.json in {compile_commands_path.parent}')
+    exit(1)
+
+paths = []
+
+for containing_path in PATHS_TO_SEARCH:
+    for root, dirs, files in os.walk(userland_path / containing_path):
+        for file in files:
+            # FIXME: The dollar sign in $262Object.cpp gets corrupted in compile_commands.json somehow, and
+            #        ends up as "\\$$262Object.cpp". This results in a clang error, so we just ignore the
+            #        file here
+            if file.endswith('.cpp') and not file.endswith('262Object.cpp'):
+                paths.append(Path(root) / file)
+
+
+# paths = ['/home/matthew/code/serenity/Userland/Libraries/LibJS/Runtime/Set.h']
+
+
+def thread_init():
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
+def thread_execute(file_path):
+    clang_args = [
+        './build/LibJSGCVerifier',
+        '--extra-arg',
+        '-DUSING_AK_GLOBALLY=1',  # To avoid errors about USING_AK_GLOBALLY not being defined at all
+        '-p',
+        compile_commands_path,
+        file_path
+    ]
+    proc = subprocess.Popen(clang_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    sys.stdout.buffer.write(proc.communicate()[0])
+    sys.stdout.buffer.flush()
+
+
+with multiprocessing.Pool(processes=multiprocessing.cpu_count() - 2, initializer=thread_init) as pool:
+    try:
+        pool.map(thread_execute, paths)
+    except KeyboardInterrupt:
+        pool.terminate()
+        pool.join()

--- a/Userland/Applications/Browser/InspectorWidget.h
+++ b/Userland/Applications/Browser/InspectorWidget.h
@@ -15,6 +15,8 @@
 #include <LibWeb/Forward.h>
 #include <LibWeb/Layout/BoxModelMetrics.h>
 #include <LibWebView/Forward.h>
+#include <LibWebView/OutOfProcessWebView.h>
+
 namespace Browser {
 
 class InspectorWidget final : public GUI::Widget {

--- a/Userland/Libraries/LibGfx/VectorN.h
+++ b/Userland/Libraries/LibGfx/VectorN.h
@@ -296,7 +296,7 @@ public:
     constexpr auto const& data() const { return m_data; }
 
 private:
-    AK::Array<T, N> m_data;
+    Array<T, N> m_data;
 };
 
 }

--- a/Userland/Libraries/LibJS/Heap/Cell.h
+++ b/Userland/Libraries/LibJS/Heap/Cell.h
@@ -65,13 +65,13 @@ public:
         void visit(GCPtr<T> cell)
         {
             if (cell)
-                visit_impl(*cell.ptr());
+                visit_impl(const_cast<RemoveConst<T>&>(*cell.ptr()));
         }
 
         template<typename T>
         void visit(NonnullGCPtr<T> cell)
         {
-            visit_impl(*cell.ptr());
+            visit_impl(const_cast<RemoveConst<T>&>(*cell.ptr()));
         }
 
         void visit(Value value)

--- a/Userland/Libraries/LibJS/Heap/GCPtr.h
+++ b/Userland/Libraries/LibJS/Heap/GCPtr.h
@@ -24,6 +24,7 @@ public:
     }
 
     NonnullGCPtr(T const& ptr)
+    requires(!IsConst<T>)
         : m_ptr(&const_cast<T&>(ptr))
     {
     }
@@ -37,7 +38,7 @@ public:
 
     template<typename U>
     NonnullGCPtr(U const& ptr)
-    requires(IsConvertible<U*, T*>)
+    requires(IsConvertible<U*, T*> && !IsConst<T>)
         : m_ptr(&const_cast<T&>(static_cast<T const&>(ptr)))
     {
     }
@@ -96,6 +97,7 @@ public:
     }
 
     GCPtr(T const& ptr)
+    requires(!IsConst<T>)
         : m_ptr(&const_cast<T&>(ptr))
     {
     }
@@ -106,6 +108,7 @@ public:
     }
 
     GCPtr(T const* ptr)
+    requires(!IsConst<T>)
         : m_ptr(const_cast<T*>(ptr))
     {
     }

--- a/Userland/Libraries/LibJS/Heap/GCPtr.h
+++ b/Userland/Libraries/LibJS/Heap/GCPtr.h
@@ -23,12 +23,6 @@ public:
     {
     }
 
-    NonnullGCPtr(T const& ptr)
-    requires(!IsConst<T>)
-        : m_ptr(&const_cast<T&>(ptr))
-    {
-    }
-
     template<typename U>
     NonnullGCPtr(U& ptr)
     requires(IsConvertible<U*, T*>)
@@ -36,31 +30,21 @@ public:
     {
     }
 
-    template<typename U>
-    NonnullGCPtr(U const& ptr)
-    requires(IsConvertible<U*, T*> && !IsConst<T>)
-        : m_ptr(&const_cast<T&>(static_cast<T const&>(ptr)))
+    NonnullGCPtr(NonnullGCPtr const& other)
+        : m_ptr(other.ptr())
     {
     }
 
     template<typename U>
-    NonnullGCPtr(NonnullGCPtr<U> ptr)
+    NonnullGCPtr(NonnullGCPtr<U> const& other)
     requires(IsConvertible<U*, T*>)
-        : m_ptr(ptr)
+        : m_ptr(other.ptr())
     {
     }
 
-    NonnullGCPtr& operator=(T const& other)
+    NonnullGCPtr& operator=(NonnullGCPtr const& other)
     {
-        m_ptr = &const_cast<T&>(other);
-        return *this;
-    }
-
-    template<typename U>
-    NonnullGCPtr& operator=(U const& other)
-    requires(IsConvertible<U*, T*>)
-    {
-        m_ptr = &const_cast<T&>(static_cast<T const&>(other));
+        m_ptr = other.ptr();
         return *this;
     }
 
@@ -68,7 +52,21 @@ public:
     NonnullGCPtr& operator=(NonnullGCPtr<U> const& other)
     requires(IsConvertible<U*, T*>)
     {
-        m_ptr = const_cast<T*>(static_cast<T const*>(other.ptr()));
+        m_ptr = static_cast<T*>(other.ptr());
+        return *this;
+    }
+
+    NonnullGCPtr& operator=(T& other)
+    {
+        m_ptr = &other;
+        return *this;
+    }
+
+    template<typename U>
+    NonnullGCPtr& operator=(U& other)
+    requires(IsConvertible<U*, T*>)
+    {
+        m_ptr = &static_cast<T&>(other);
         return *this;
     }
 
@@ -96,32 +94,20 @@ public:
     {
     }
 
-    GCPtr(T const& ptr)
-    requires(!IsConst<T>)
-        : m_ptr(&const_cast<T&>(ptr))
-    {
-    }
-
     GCPtr(T* ptr)
         : m_ptr(ptr)
     {
     }
 
-    GCPtr(T const* ptr)
-    requires(!IsConst<T>)
-        : m_ptr(const_cast<T*>(ptr))
-    {
-    }
-
-    GCPtr(NonnullGCPtr<T> ptr)
-        : m_ptr(ptr)
+    GCPtr(NonnullGCPtr<T> const& other)
+        : m_ptr(other.ptr())
     {
     }
 
     template<typename U>
-    GCPtr(NonnullGCPtr<U> ptr)
+    GCPtr(NonnullGCPtr<U> const& other)
     requires(IsConvertible<U*, T*>)
-        : m_ptr(ptr)
+        : m_ptr(other.ptr())
     {
     }
 
@@ -137,13 +123,13 @@ public:
     GCPtr& operator=(GCPtr<U> const& other)
     requires(IsConvertible<U*, T*>)
     {
-        m_ptr = const_cast<T*>(static_cast<T const*>(other.ptr()));
+        m_ptr = static_cast<T*>(other.ptr());
         return *this;
     }
 
     GCPtr& operator=(NonnullGCPtr<T> const& other)
     {
-        m_ptr = const_cast<T*>(other.ptr());
+        m_ptr = other.ptr();
         return *this;
     }
 
@@ -151,35 +137,35 @@ public:
     GCPtr& operator=(NonnullGCPtr<U> const& other)
     requires(IsConvertible<U*, T*>)
     {
-        m_ptr = const_cast<T*>(static_cast<T const*>(other.ptr()));
+        m_ptr = static_cast<T*>(other.ptr());
         return *this;
     }
 
-    GCPtr& operator=(T const& other)
+    GCPtr& operator=(T& other)
     {
-        m_ptr = &const_cast<T&>(other);
-        return *this;
-    }
-
-    template<typename U>
-    GCPtr& operator=(U const& other)
-    requires(IsConvertible<U*, T*>)
-    {
-        m_ptr = &const_cast<T&>(static_cast<T const&>(other));
-        return *this;
-    }
-
-    GCPtr& operator=(T const* other)
-    {
-        m_ptr = const_cast<T*>(other);
+        m_ptr = &other;
         return *this;
     }
 
     template<typename U>
-    GCPtr& operator=(U const* other)
+    GCPtr& operator=(U& other)
     requires(IsConvertible<U*, T*>)
     {
-        m_ptr = const_cast<T*>(static_cast<T const*>(other));
+        m_ptr = &static_cast<T&>(other);
+        return *this;
+    }
+
+    GCPtr& operator=(T* other)
+    {
+        m_ptr = other;
+        return *this;
+    }
+
+    template<typename U>
+    GCPtr& operator=(U* other)
+    requires(IsConvertible<U*, T*>)
+    {
+        m_ptr = static_cast<T*>(other);
         return *this;
     }
 

--- a/Userland/Libraries/LibJS/Heap/Handle.h
+++ b/Userland/Libraries/LibJS/Heap/Handle.h
@@ -46,7 +46,7 @@ public:
 
     static Handle create(T* cell)
     {
-        return Handle(adopt_ref(*new HandleImpl(cell)));
+        return Handle(adopt_ref(*new HandleImpl(const_cast<RemoveConst<T>*>(cell))));
     }
 
     Handle(T* cell)

--- a/Userland/Libraries/LibJS/Runtime/Completion.h
+++ b/Userland/Libraries/LibJS/Runtime/Completion.h
@@ -307,7 +307,7 @@ public:
     // Most commonly: Value from Object* or similar, so we can omit the curly braces from "return { TRY(...) };".
     // Disabled for POD types to avoid weird conversion shenanigans.
     template<typename WrappedValueType>
-    ThrowCompletionOr(WrappedValueType const& value)
+    ThrowCompletionOr(WrappedValueType&& value)
     requires(!IsPOD<ValueType>)
         : m_value_or_throw_completion(ValueType { value })
     {

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -190,7 +190,7 @@ static ThrowCompletionOr<Value> perform_promise_all_settled(VM& vm, Iterator& it
 }
 
 // 27.2.4.3.1 PerformPromiseAny ( iteratorRecord, constructor, resultCapability, promiseResolve ), https://tc39.es/ecma262/#sec-performpromiseany
-static ThrowCompletionOr<Value> perform_promise_any(VM& vm, Iterator& iterator_record, Value constructor, PromiseCapability const& result_capability, Value promise_resolve)
+static ThrowCompletionOr<Value> perform_promise_any(VM& vm, Iterator& iterator_record, Value constructor, PromiseCapability& result_capability, Value promise_resolve)
 {
     auto& realm = *vm.current_realm();
 

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
@@ -20,7 +20,7 @@ void PromiseValueList::visit_edges(Visitor& visitor)
         visitor.visit(val);
 }
 
-PromiseResolvingElementFunction::PromiseResolvingElementFunction(size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability> capability, RemainingElements& remaining_elements, Object& prototype)
+PromiseResolvingElementFunction::PromiseResolvingElementFunction(size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements, Object& prototype)
     : NativeFunction(prototype)
     , m_index(index)
     , m_values(values)
@@ -55,12 +55,12 @@ void PromiseResolvingElementFunction::visit_edges(Cell::Visitor& visitor)
     visitor.visit(&m_remaining_elements);
 }
 
-NonnullGCPtr<PromiseAllResolveElementFunction> PromiseAllResolveElementFunction::create(Realm& realm, size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability> capability, RemainingElements& remaining_elements)
+NonnullGCPtr<PromiseAllResolveElementFunction> PromiseAllResolveElementFunction::create(Realm& realm, size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements)
 {
     return realm.heap().allocate<PromiseAllResolveElementFunction>(realm, index, values, capability, remaining_elements, *realm.intrinsics().function_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
 }
 
-PromiseAllResolveElementFunction::PromiseAllResolveElementFunction(size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability> capability, RemainingElements& remaining_elements, Object& prototype)
+PromiseAllResolveElementFunction::PromiseAllResolveElementFunction(size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements, Object& prototype)
     : PromiseResolvingElementFunction(index, values, capability, remaining_elements, prototype)
 {
 }
@@ -87,12 +87,12 @@ ThrowCompletionOr<Value> PromiseAllResolveElementFunction::resolve_element()
     return js_undefined();
 }
 
-NonnullGCPtr<PromiseAllSettledResolveElementFunction> PromiseAllSettledResolveElementFunction::create(Realm& realm, size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability> capability, RemainingElements& remaining_elements)
+NonnullGCPtr<PromiseAllSettledResolveElementFunction> PromiseAllSettledResolveElementFunction::create(Realm& realm, size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements)
 {
     return realm.heap().allocate<PromiseAllSettledResolveElementFunction>(realm, index, values, capability, remaining_elements, *realm.intrinsics().function_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
 }
 
-PromiseAllSettledResolveElementFunction::PromiseAllSettledResolveElementFunction(size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability> capability, RemainingElements& remaining_elements, Object& prototype)
+PromiseAllSettledResolveElementFunction::PromiseAllSettledResolveElementFunction(size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements, Object& prototype)
     : PromiseResolvingElementFunction(index, values, capability, remaining_elements, prototype)
 {
 }
@@ -128,12 +128,12 @@ ThrowCompletionOr<Value> PromiseAllSettledResolveElementFunction::resolve_elemen
     return js_undefined();
 }
 
-NonnullGCPtr<PromiseAllSettledRejectElementFunction> PromiseAllSettledRejectElementFunction::create(Realm& realm, size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability> capability, RemainingElements& remaining_elements)
+NonnullGCPtr<PromiseAllSettledRejectElementFunction> PromiseAllSettledRejectElementFunction::create(Realm& realm, size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements)
 {
     return realm.heap().allocate<PromiseAllSettledRejectElementFunction>(realm, index, values, capability, remaining_elements, *realm.intrinsics().function_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
 }
 
-PromiseAllSettledRejectElementFunction::PromiseAllSettledRejectElementFunction(size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability> capability, RemainingElements& remaining_elements, Object& prototype)
+PromiseAllSettledRejectElementFunction::PromiseAllSettledRejectElementFunction(size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements, Object& prototype)
     : PromiseResolvingElementFunction(index, values, capability, remaining_elements, prototype)
 {
 }
@@ -169,12 +169,12 @@ ThrowCompletionOr<Value> PromiseAllSettledRejectElementFunction::resolve_element
     return js_undefined();
 }
 
-NonnullGCPtr<PromiseAnyRejectElementFunction> PromiseAnyRejectElementFunction::create(Realm& realm, size_t index, PromiseValueList& errors, NonnullGCPtr<PromiseCapability> capability, RemainingElements& remaining_elements)
+NonnullGCPtr<PromiseAnyRejectElementFunction> PromiseAnyRejectElementFunction::create(Realm& realm, size_t index, PromiseValueList& errors, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements)
 {
     return realm.heap().allocate<PromiseAnyRejectElementFunction>(realm, index, errors, capability, remaining_elements, *realm.intrinsics().function_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
 }
 
-PromiseAnyRejectElementFunction::PromiseAnyRejectElementFunction(size_t index, PromiseValueList& errors, NonnullGCPtr<PromiseCapability> capability, RemainingElements& remaining_elements, Object& prototype)
+PromiseAnyRejectElementFunction::PromiseAnyRejectElementFunction(size_t index, PromiseValueList& errors, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements, Object& prototype)
     : PromiseResolvingElementFunction(index, errors, capability, remaining_elements, prototype)
 {
 }

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
@@ -51,13 +51,13 @@ public:
     virtual ThrowCompletionOr<Value> call() override;
 
 protected:
-    explicit PromiseResolvingElementFunction(size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability>, RemainingElements&, Object& prototype);
+    explicit PromiseResolvingElementFunction(size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability const>, RemainingElements&, Object& prototype);
 
     virtual ThrowCompletionOr<Value> resolve_element() = 0;
 
     size_t m_index { 0 };
     PromiseValueList& m_values;
-    NonnullGCPtr<PromiseCapability> m_capability;
+    NonnullGCPtr<PromiseCapability const> m_capability;
     RemainingElements& m_remaining_elements;
 
 private:
@@ -71,12 +71,12 @@ class PromiseAllResolveElementFunction final : public PromiseResolvingElementFun
     JS_OBJECT(PromiseResolvingFunction, NativeFunction);
 
 public:
-    static NonnullGCPtr<PromiseAllResolveElementFunction> create(Realm&, size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability>, RemainingElements&);
+    static NonnullGCPtr<PromiseAllResolveElementFunction> create(Realm&, size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability const>, RemainingElements&);
 
     virtual ~PromiseAllResolveElementFunction() override = default;
 
 private:
-    explicit PromiseAllResolveElementFunction(size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability>, RemainingElements&, Object& prototype);
+    explicit PromiseAllResolveElementFunction(size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability const>, RemainingElements&, Object& prototype);
 
     virtual ThrowCompletionOr<Value> resolve_element() override;
 };
@@ -86,12 +86,12 @@ class PromiseAllSettledResolveElementFunction final : public PromiseResolvingEle
     JS_OBJECT(PromiseResolvingFunction, NativeFunction);
 
 public:
-    static NonnullGCPtr<PromiseAllSettledResolveElementFunction> create(Realm&, size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability>, RemainingElements&);
+    static NonnullGCPtr<PromiseAllSettledResolveElementFunction> create(Realm&, size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability const>, RemainingElements&);
 
     virtual ~PromiseAllSettledResolveElementFunction() override = default;
 
 private:
-    explicit PromiseAllSettledResolveElementFunction(size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability>, RemainingElements&, Object& prototype);
+    explicit PromiseAllSettledResolveElementFunction(size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability const>, RemainingElements&, Object& prototype);
 
     virtual ThrowCompletionOr<Value> resolve_element() override;
 };
@@ -101,12 +101,12 @@ class PromiseAllSettledRejectElementFunction final : public PromiseResolvingElem
     JS_OBJECT(PromiseResolvingFunction, PromiseResolvingElementFunction);
 
 public:
-    static NonnullGCPtr<PromiseAllSettledRejectElementFunction> create(Realm&, size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability>, RemainingElements&);
+    static NonnullGCPtr<PromiseAllSettledRejectElementFunction> create(Realm&, size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability const>, RemainingElements&);
 
     virtual ~PromiseAllSettledRejectElementFunction() override = default;
 
 private:
-    explicit PromiseAllSettledRejectElementFunction(size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability>, RemainingElements&, Object& prototype);
+    explicit PromiseAllSettledRejectElementFunction(size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability const>, RemainingElements&, Object& prototype);
 
     virtual ThrowCompletionOr<Value> resolve_element() override;
 };
@@ -116,12 +116,12 @@ class PromiseAnyRejectElementFunction final : public PromiseResolvingElementFunc
     JS_OBJECT(PromiseResolvingFunction, PromiseResolvingElementFunction);
 
 public:
-    static NonnullGCPtr<PromiseAnyRejectElementFunction> create(Realm&, size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability>, RemainingElements&);
+    static NonnullGCPtr<PromiseAnyRejectElementFunction> create(Realm&, size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability const>, RemainingElements&);
 
     virtual ~PromiseAnyRejectElementFunction() override = default;
 
 private:
-    explicit PromiseAnyRejectElementFunction(size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability>, RemainingElements&, Object& prototype);
+    explicit PromiseAnyRejectElementFunction(size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability const>, RemainingElements&, Object& prototype);
 
     virtual ThrowCompletionOr<Value> resolve_element() override;
 };

--- a/Userland/Libraries/LibJS/Runtime/SetPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetPrototype.cpp
@@ -126,7 +126,7 @@ JS_DEFINE_NATIVE_FUNCTION(SetPrototype::size_getter)
 
 // 8 Set Records, https://tc39.es/proposal-set-methods/#sec-set-records
 struct SetRecord {
-    NonnullGCPtr<Object> set;          // [[Set]]
+    NonnullGCPtr<Object const> set;    // [[Set]]
     double size { 0 };                 // [[Size]
     NonnullGCPtr<FunctionObject> has;  // [[Has]]
     NonnullGCPtr<FunctionObject> keys; // [[Keys]]

--- a/Userland/Libraries/LibJS/SourceRange.h
+++ b/Userland/Libraries/LibJS/SourceRange.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/NonnullRefPtr.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
 #include <LibJS/SourceCode.h>

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -395,7 +395,7 @@ JS::VM& main_thread_vm()
 }
 
 // https://dom.spec.whatwg.org/#queue-a-mutation-observer-compound-microtask
-void queue_mutation_observer_microtask(DOM::Document& document)
+void queue_mutation_observer_microtask(DOM::Document const& document)
 {
     auto& vm = main_thread_vm();
     auto& custom_data = verify_cast<WebEngineCustomData>(*vm.custom_data());

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.h
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.h
@@ -52,7 +52,7 @@ struct WebEngineCustomJobCallbackData final : public JS::JobCallback::CustomData
 
 HTML::Script* active_script();
 JS::VM& main_thread_vm();
-void queue_mutation_observer_microtask(DOM::Document&);
+void queue_mutation_observer_microtask(DOM::Document const&);
 NonnullOwnPtr<JS::ExecutionContext> create_a_new_javascript_realm(JS::VM&, Function<JS::Object*(JS::Realm&)> create_global_object, Function<JS::Object*(JS::Realm&)> create_global_this_value);
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/TokenStream.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/TokenStream.h
@@ -9,6 +9,7 @@
 
 #include <AK/Format.h>
 #include <AK/Vector.h>
+#include <LibWeb/CSS/Parser/ComponentValue.h>
 #include <LibWeb/CSS/Parser/Tokenizer.h>
 
 namespace Web::CSS::Parser {

--- a/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
@@ -18,7 +18,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<AccessibilityTreeNode>> AccessibilityTreeNo
     return MUST_OR_THROW_OOM(document->heap().allocate<AccessibilityTreeNode>(document->realm(), value));
 }
 
-AccessibilityTreeNode::AccessibilityTreeNode(JS::GCPtr<DOM::Node> value)
+AccessibilityTreeNode::AccessibilityTreeNode(JS::GCPtr<DOM::Node const> value)
     : m_value(value)
 {
     m_children = {};
@@ -29,7 +29,7 @@ void AccessibilityTreeNode::serialize_tree_as_json(JsonObjectSerializer<StringBu
     if (value()->is_document()) {
         VERIFY_NOT_REACHED();
     } else if (value()->is_element()) {
-        auto const* element = static_cast<DOM::Element*>(value().ptr());
+        auto const* element = static_cast<DOM::Element const*>(value().ptr());
 
         if (element->include_in_accessibility_tree()) {
             MUST(object.add("type"sv, "element"sv));
@@ -53,7 +53,7 @@ void AccessibilityTreeNode::serialize_tree_as_json(JsonObjectSerializer<StringBu
     } else if (value()->is_text()) {
         MUST(object.add("type"sv, "text"sv));
 
-        auto const* text_node = static_cast<DOM::Text*>(value().ptr());
+        auto const* text_node = static_cast<DOM::Text const*>(value().ptr());
         MUST(object.add("text"sv, text_node->data()));
     }
 
@@ -73,7 +73,7 @@ void AccessibilityTreeNode::serialize_tree_as_json(JsonObjectSerializer<StringBu
 void AccessibilityTreeNode::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(*value());
+    visitor.visit(value());
     for (auto child : children())
         child->visit_edges(visitor);
 }

--- a/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.h
+++ b/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.h
@@ -20,8 +20,8 @@ public:
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<AccessibilityTreeNode>> create(Document*, DOM::Node const*);
     virtual ~AccessibilityTreeNode() override = default;
 
-    JS::GCPtr<DOM::Node> value() const { return m_value; }
-    void set_value(JS::GCPtr<DOM::Node> value) { m_value = value; }
+    JS::GCPtr<DOM::Node const> value() const { return m_value; }
+    void set_value(JS::GCPtr<DOM::Node const> value) { m_value = value; }
     Vector<AccessibilityTreeNode*> children() const { return m_children; }
     void append_child(AccessibilityTreeNode* child) { m_children.append(child); }
 
@@ -31,9 +31,9 @@ protected:
     virtual void visit_edges(Visitor&) override;
 
 private:
-    explicit AccessibilityTreeNode(JS::GCPtr<DOM::Node>);
+    explicit AccessibilityTreeNode(JS::GCPtr<DOM::Node const>);
 
-    JS::GCPtr<DOM::Node> m_value;
+    JS::GCPtr<DOM::Node const> m_value;
     Vector<AccessibilityTreeNode*> m_children;
 };
 

--- a/Userland/Libraries/LibWeb/DOM/Attr.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Attr.cpp
@@ -45,11 +45,6 @@ void Attr::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_owner_element.ptr());
 }
 
-Element* Attr::owner_element()
-{
-    return m_owner_element.ptr();
-}
-
 Element const* Attr::owner_element() const
 {
     return m_owner_element.ptr();
@@ -79,7 +74,7 @@ void Attr::set_value(DeprecatedString value)
 }
 
 // https://dom.spec.whatwg.org/#handle-attribute-changes
-void Attr::handle_attribute_changes(Element& element, DeprecatedString const& old_value, [[maybe_unused]] DeprecatedString const& new_value)
+void Attr::handle_attribute_changes(Element const& element, DeprecatedString const& old_value, [[maybe_unused]] DeprecatedString const& new_value)
 {
     // 1. Queue a mutation record of "attributes" for element with attribute’s local name, attribute’s namespace, oldValue, « », « », null, and null.
     auto added_node_list = StaticNodeList::create(realm(), {}).release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibWeb/DOM/Attr.h
+++ b/Userland/Libraries/LibWeb/DOM/Attr.h
@@ -33,14 +33,13 @@ public:
     DeprecatedString const& value() const { return m_value; }
     void set_value(DeprecatedString value);
 
-    Element* owner_element();
     Element const* owner_element() const;
     void set_owner_element(Element const* owner_element);
 
     // Always returns true: https://dom.spec.whatwg.org/#dom-attr-specified
     constexpr bool specified() const { return true; }
 
-    void handle_attribute_changes(Element&, DeprecatedString const& old_value, DeprecatedString const& new_value);
+    void handle_attribute_changes(Element const&, DeprecatedString const& old_value, DeprecatedString const& new_value);
 
 private:
     Attr(Document&, QualifiedName, DeprecatedString value, Element const*);
@@ -50,7 +49,7 @@ private:
 
     QualifiedName m_qualified_name;
     DeprecatedString m_value;
-    JS::GCPtr<Element> m_owner_element;
+    JS::GCPtr<Element const> m_owner_element;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/DOM/ChildNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ChildNode.h
@@ -117,9 +117,9 @@ protected:
     ChildNode() = default;
 
 private:
-    JS::GCPtr<Node> viable_previous_sibling_for_insertion(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes) const
+    JS::GCPtr<Node> viable_previous_sibling_for_insertion(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes)
     {
-        auto* node = static_cast<NodeType const*>(this);
+        auto* node = static_cast<NodeType*>(this);
 
         while (auto* previous_sibling = node->previous_sibling()) {
             bool contained_in_nodes = false;
@@ -142,9 +142,9 @@ private:
         return nullptr;
     }
 
-    JS::GCPtr<Node> viable_nest_sibling_for_insertion(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes) const
+    JS::GCPtr<Node> viable_nest_sibling_for_insertion(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes)
     {
-        auto* node = static_cast<NodeType const*>(this);
+        auto* node = static_cast<NodeType*>(this);
 
         while (auto* next_sibling = node->next_sibling()) {
             bool contained_in_nodes = false;

--- a/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
@@ -52,14 +52,14 @@ inline void replace_in_ordered_set(Vector<DeprecatedString>& set, StringView ite
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMTokenList>> DOMTokenList::create(Element const& associated_element, DeprecatedFlyString associated_attribute)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMTokenList>> DOMTokenList::create(Element& associated_element, DeprecatedFlyString associated_attribute)
 {
     auto& realm = associated_element.realm();
     return MUST_OR_THROW_OOM(realm.heap().allocate<DOMTokenList>(realm, associated_element, move(associated_attribute)));
 }
 
 // https://dom.spec.whatwg.org/#ref-for-domtokenlist%E2%91%A0%E2%91%A2
-DOMTokenList::DOMTokenList(Element const& associated_element, DeprecatedFlyString associated_attribute)
+DOMTokenList::DOMTokenList(Element& associated_element, DeprecatedFlyString associated_attribute)
     : Bindings::LegacyPlatformObject(associated_element.realm())
     , m_associated_element(associated_element)
     , m_associated_attribute(move(associated_attribute))

--- a/Userland/Libraries/LibWeb/DOM/DOMTokenList.h
+++ b/Userland/Libraries/LibWeb/DOM/DOMTokenList.h
@@ -24,7 +24,7 @@ class DOMTokenList final : public Bindings::LegacyPlatformObject {
     WEB_PLATFORM_OBJECT(DOMTokenList, Bindings::LegacyPlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMTokenList>> create(Element const& associated_element, DeprecatedFlyString associated_attribute);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMTokenList>> create(Element& associated_element, DeprecatedFlyString associated_attribute);
     ~DOMTokenList() = default;
 
     void associated_attribute_changed(StringView value);
@@ -44,7 +44,7 @@ public:
     void set_value(DeprecatedString value);
 
 private:
-    DOMTokenList(Element const& associated_element, DeprecatedFlyString associated_attribute);
+    DOMTokenList(Element& associated_element, DeprecatedFlyString associated_attribute);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2121,7 +2121,7 @@ Vector<JS::Handle<HTML::BrowsingContext>> Document::list_of_descendant_browsing_
     //       of this document's browsing context.
     if (browsing_context()) {
         browsing_context()->for_each_in_subtree([&](auto& context) {
-            list.append(JS::make_handle(const_cast<HTML::BrowsingContext&>(context)));
+            list.append(JS::make_handle(context));
             return IterationDecision::Continue;
         });
     }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -754,7 +754,7 @@ Vector<CSS::BackgroundLayerData> const* Document::background_layers() const
 
 void Document::update_base_element(Badge<HTML::HTMLBaseElement>)
 {
-    JS::GCPtr<HTML::HTMLBaseElement> base_element;
+    JS::GCPtr<HTML::HTMLBaseElement const> base_element;
 
     for_each_in_subtree_of_type<HTML::HTMLBaseElement>([&base_element](HTML::HTMLBaseElement const& base_element_in_tree) {
         if (base_element_in_tree.has_attribute(HTML::AttributeNames::href)) {
@@ -768,7 +768,7 @@ void Document::update_base_element(Badge<HTML::HTMLBaseElement>)
     m_first_base_element_with_href_in_tree_order = base_element;
 }
 
-JS::GCPtr<HTML::HTMLBaseElement> Document::first_base_element_with_href_in_tree_order() const
+JS::GCPtr<HTML::HTMLBaseElement const> Document::first_base_element_with_href_in_tree_order() const
 {
     return m_first_base_element_with_href_in_tree_order;
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -106,7 +106,7 @@ public:
     AK::URL base_url() const;
 
     void update_base_element(Badge<HTML::HTMLBaseElement>);
-    JS::GCPtr<HTML::HTMLBaseElement> first_base_element_with_href_in_tree_order() const;
+    JS::GCPtr<HTML::HTMLBaseElement const> first_base_element_with_href_in_tree_order() const;
 
     DeprecatedString url_string() const { return m_url.to_deprecated_string(); }
     DeprecatedString document_uri() const { return m_url.to_deprecated_string(); }
@@ -611,7 +611,7 @@ private:
     JS::GCPtr<Selection::Selection> m_selection;
 
     // NOTE: This is a cache to make finding the first <base href> element O(1).
-    JS::GCPtr<HTML::HTMLBaseElement> m_first_base_element_with_href_in_tree_order;
+    JS::GCPtr<HTML::HTMLBaseElement const> m_first_base_element_with_href_in_tree_order;
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/MutationRecord.cpp
+++ b/Userland/Libraries/LibWeb/DOM/MutationRecord.cpp
@@ -12,12 +12,12 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<MutationRecord>> MutationRecord::create(JS::Realm& realm, DeprecatedFlyString const& type, Node& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, DeprecatedString const& attribute_name, DeprecatedString const& attribute_namespace, DeprecatedString const& old_value)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<MutationRecord>> MutationRecord::create(JS::Realm& realm, DeprecatedFlyString const& type, Node const& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, DeprecatedString const& attribute_name, DeprecatedString const& attribute_namespace, DeprecatedString const& old_value)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<MutationRecord>(realm, realm, type, target, added_nodes, removed_nodes, previous_sibling, next_sibling, attribute_name, attribute_namespace, old_value));
 }
 
-MutationRecord::MutationRecord(JS::Realm& realm, DeprecatedFlyString const& type, Node& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, DeprecatedString const& attribute_name, DeprecatedString const& attribute_namespace, DeprecatedString const& old_value)
+MutationRecord::MutationRecord(JS::Realm& realm, DeprecatedFlyString const& type, Node const& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, DeprecatedString const& attribute_name, DeprecatedString const& attribute_namespace, DeprecatedString const& old_value)
     : PlatformObject(realm)
     , m_type(type)
     , m_target(JS::make_handle(target))

--- a/Userland/Libraries/LibWeb/DOM/MutationRecord.h
+++ b/Userland/Libraries/LibWeb/DOM/MutationRecord.h
@@ -15,7 +15,7 @@ class MutationRecord : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(MutationRecord, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MutationRecord>> create(JS::Realm&, DeprecatedFlyString const& type, Node& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, DeprecatedString const& attribute_name, DeprecatedString const& attribute_namespace, DeprecatedString const& old_value);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MutationRecord>> create(JS::Realm&, DeprecatedFlyString const& type, Node const& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, DeprecatedString const& attribute_name, DeprecatedString const& attribute_namespace, DeprecatedString const& old_value);
 
     virtual ~MutationRecord() override;
 
@@ -30,13 +30,13 @@ public:
     DeprecatedString const& old_value() const { return m_old_value; }
 
 private:
-    MutationRecord(JS::Realm& realm, DeprecatedFlyString const& type, Node& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, DeprecatedString const& attribute_name, DeprecatedString const& attribute_namespace, DeprecatedString const& old_value);
+    MutationRecord(JS::Realm& realm, DeprecatedFlyString const& type, Node const& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, DeprecatedString const& attribute_name, DeprecatedString const& attribute_namespace, DeprecatedString const& old_value);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
     DeprecatedFlyString m_type;
-    JS::GCPtr<Node> m_target;
+    JS::GCPtr<Node const> m_target;
     JS::GCPtr<NodeList> m_added_nodes;
     JS::GCPtr<NodeList> m_removed_nodes;
     JS::GCPtr<Node> m_previous_sibling;

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -224,7 +224,7 @@ public:
 
     void add_registered_observer(RegisteredObserver& registered_observer) { m_registered_observer_list.append(registered_observer); }
 
-    void queue_mutation_record(DeprecatedFlyString const& type, DeprecatedString attribute_name, DeprecatedString attribute_namespace, DeprecatedString old_value, JS::NonnullGCPtr<NodeList> added_nodes, JS::NonnullGCPtr<NodeList> removed_nodes, Node* previous_sibling, Node* next_sibling);
+    void queue_mutation_record(DeprecatedFlyString const& type, DeprecatedString attribute_name, DeprecatedString attribute_namespace, DeprecatedString old_value, JS::NonnullGCPtr<NodeList> added_nodes, JS::NonnullGCPtr<NodeList> removed_nodes, Node* previous_sibling, Node* next_sibling) const;
 
     // https://dom.spec.whatwg.org/#concept-shadow-including-descendant
     template<typename Callback>
@@ -434,7 +434,7 @@ public:
     template<typename U, typename Callback>
     IterationDecision for_each_in_inclusive_subtree_of_type(Callback callback)
     {
-        if (is<U>(static_cast<Node const&>(*this))) {
+        if (is<U>(static_cast<Node&>(*this))) {
             if (callback(static_cast<U&>(*this)) == IterationDecision::Break)
                 return IterationDecision::Break;
         }
@@ -644,7 +644,7 @@ protected:
     // "Nodes have a strong reference to registered observers in their registered observer list." https://dom.spec.whatwg.org/#garbage-collection
     Vector<RegisteredObserver&> m_registered_observer_list;
 
-    void build_accessibility_tree(AccessibilityTreeNode& parent) const;
+    void build_accessibility_tree(AccessibilityTreeNode& parent);
 
     ErrorOr<String> name_or_description(NameOrDescription, Document const&, HashTable<i32>&) const;
 

--- a/Userland/Libraries/LibWeb/DOM/NonElementParentNode.h
+++ b/Userland/Libraries/LibWeb/DOM/NonElementParentNode.h
@@ -17,9 +17,9 @@ namespace Web::DOM {
 template<typename NodeType>
 class NonElementParentNode {
 public:
-    JS::GCPtr<Element> get_element_by_id(DeprecatedFlyString const& id) const
+    JS::GCPtr<Element const> get_element_by_id(DeprecatedFlyString const& id) const
     {
-        JS::GCPtr<Element> found_element;
+        JS::GCPtr<Element const> found_element;
         static_cast<NodeType const*>(this)->template for_each_in_inclusive_subtree_of_type<Element>([&](auto& element) {
             if (element.attribute(HTML::AttributeNames::id) == id) {
                 found_element = &element;
@@ -29,9 +29,18 @@ public:
         });
         return found_element;
     }
+
     JS::GCPtr<Element> get_element_by_id(DeprecatedFlyString const& id)
     {
-        return const_cast<NonElementParentNode const*>(this)->get_element_by_id(id);
+        JS::GCPtr<Element> found_element;
+        static_cast<NodeType*>(this)->template for_each_in_inclusive_subtree_of_type<Element>([&](auto& element) {
+            if (element.attribute(HTML::AttributeNames::id) == id) {
+                found_element = &element;
+                return IterationDecision::Break;
+            }
+            return IterationDecision::Continue;
+        });
+        return found_element;
     }
 
 protected:

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -139,7 +139,7 @@ RelativeBoundaryPointPosition position_of_boundary_point_relative_to_other_bound
     // 4. If nodeA is an ancestor of nodeB:
     if (node_a.is_ancestor_of(node_b)) {
         // 1. Let child be nodeB.
-        JS::NonnullGCPtr<Node> child = node_b;
+        JS::NonnullGCPtr<Node const> child = node_b;
 
         // 2. While child is not a child of nodeA, set child to its parent.
         while (!node_a.is_parent_of(child)) {
@@ -405,7 +405,7 @@ void Range::collapse(bool to_start)
 }
 
 // https://dom.spec.whatwg.org/#dom-range-selectnodecontents
-WebIDL::ExceptionOr<void> Range::select_node_contents(Node const& node)
+WebIDL::ExceptionOr<void> Range::select_node_contents(Node& node)
 {
     // 1. If node is a doctype, throw an "InvalidNodeTypeError" DOMException.
     if (is<DocumentType>(node))
@@ -657,7 +657,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::extract()
 
     // 11. Let contained children be a list of all children of common ancestor that are contained in range, in tree order.
     Vector<JS::NonnullGCPtr<Node>> contained_children;
-    for (Node const* node = common_ancestor->first_child(); node; node = node->next_sibling()) {
+    for (Node* node = common_ancestor->first_child(); node; node = node->next_sibling()) {
         if (contains_node(*node))
             contained_children.append(*node);
     }
@@ -983,7 +983,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::clone_the_content
 
     // 11. Let contained children be a list of all children of common ancestor that are contained in range, in tree order.
     Vector<JS::NonnullGCPtr<Node>> contained_children;
-    for (Node const* node = common_ancestor->first_child(); node; node = node->next_sibling()) {
+    for (Node* node = common_ancestor->first_child(); node; node = node->next_sibling()) {
         if (contains_node(*node))
             contained_children.append(*node);
     }

--- a/Userland/Libraries/LibWeb/DOM/Range.h
+++ b/Userland/Libraries/LibWeb/DOM/Range.h
@@ -43,7 +43,7 @@ public:
     WebIDL::ExceptionOr<void> set_end_after(Node& node);
     WebIDL::ExceptionOr<void> select_node(Node& node);
     void collapse(bool to_start);
-    WebIDL::ExceptionOr<void> select_node_contents(Node const&);
+    WebIDL::ExceptionOr<void> select_node_contents(Node&);
 
     // https://dom.spec.whatwg.org/#dom-range-start_to_start
     enum HowToCompareBoundaryPoints : u16 {

--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
@@ -42,7 +42,7 @@ JS::ThrowCompletionOr<void> XMLSerializer::initialize(JS::Realm& realm)
 }
 
 // https://w3c.github.io/DOM-Parsing/#dom-xmlserializer-serializetostring
-WebIDL::ExceptionOr<DeprecatedString> XMLSerializer::serialize_to_string(JS::NonnullGCPtr<DOM::Node> root)
+WebIDL::ExceptionOr<DeprecatedString> XMLSerializer::serialize_to_string(JS::NonnullGCPtr<DOM::Node const> root)
 {
     // The serializeToString(root) method must produce an XML serialization of root passing a value of false for the require well-formed parameter, and return the result.
     return serialize_node_to_xml_string(root, RequireWellFormed::No);
@@ -121,10 +121,10 @@ static bool prefix_is_in_prefix_map(DeprecatedString const& prefix, HashMap<Depr
     return candidates_list_iterator->value.contains_slow(prefix);
 }
 
-WebIDL::ExceptionOr<DeprecatedString> serialize_node_to_xml_string_impl(JS::NonnullGCPtr<DOM::Node> root, Optional<DeprecatedFlyString>& namespace_, HashMap<DeprecatedFlyString, Vector<DeprecatedString>>& namespace_prefix_map, u64& prefix_index, RequireWellFormed require_well_formed);
+WebIDL::ExceptionOr<DeprecatedString> serialize_node_to_xml_string_impl(JS::NonnullGCPtr<DOM::Node const> root, Optional<DeprecatedFlyString>& namespace_, HashMap<DeprecatedFlyString, Vector<DeprecatedString>>& namespace_prefix_map, u64& prefix_index, RequireWellFormed require_well_formed);
 
 // https://w3c.github.io/DOM-Parsing/#dfn-xml-serialization
-WebIDL::ExceptionOr<DeprecatedString> serialize_node_to_xml_string(JS::NonnullGCPtr<DOM::Node> root, RequireWellFormed require_well_formed)
+WebIDL::ExceptionOr<DeprecatedString> serialize_node_to_xml_string(JS::NonnullGCPtr<DOM::Node const> root, RequireWellFormed require_well_formed)
 {
     // 1. Let namespace be a context namespace with value null. The context namespace tracks the XML serialization algorithm's current default namespace.
     //    The context namespace is changed when either an Element Node has a default namespace declaration, or the algorithm generates a default namespace declaration
@@ -157,7 +157,7 @@ static WebIDL::ExceptionOr<DeprecatedString> serialize_document_type(DOM::Docume
 static WebIDL::ExceptionOr<DeprecatedString> serialize_processing_instruction(DOM::ProcessingInstruction const& processing_instruction, RequireWellFormed require_well_formed);
 
 // https://w3c.github.io/DOM-Parsing/#dfn-xml-serialization-algorithm
-WebIDL::ExceptionOr<DeprecatedString> serialize_node_to_xml_string_impl(JS::NonnullGCPtr<DOM::Node> root, Optional<DeprecatedFlyString>& namespace_, HashMap<DeprecatedFlyString, Vector<DeprecatedString>>& namespace_prefix_map, u64& prefix_index, RequireWellFormed require_well_formed)
+WebIDL::ExceptionOr<DeprecatedString> serialize_node_to_xml_string_impl(JS::NonnullGCPtr<DOM::Node const> root, Optional<DeprecatedFlyString>& namespace_, HashMap<DeprecatedFlyString, Vector<DeprecatedString>>& namespace_prefix_map, u64& prefix_index, RequireWellFormed require_well_formed)
 {
     // Each of the following algorithms for producing an XML serialization of a DOM node take as input a node to serialize and the following arguments:
     // - A context namespace namespace
@@ -173,43 +173,43 @@ WebIDL::ExceptionOr<DeprecatedString> serialize_node_to_xml_string_impl(JS::Nonn
     if (is<DOM::Element>(*root)) {
         // -> Element
         //    Run the algorithm for XML serializing an Element node node.
-        return serialize_element(static_cast<DOM::Element&>(*root), namespace_, namespace_prefix_map, prefix_index, require_well_formed);
+        return serialize_element(static_cast<DOM::Element const&>(*root), namespace_, namespace_prefix_map, prefix_index, require_well_formed);
     }
 
     if (is<DOM::Document>(*root)) {
         // -> Document
         //    Run the algorithm for XML serializing a Document node node.
-        return serialize_document(static_cast<DOM::Document&>(*root), namespace_, namespace_prefix_map, prefix_index, require_well_formed);
+        return serialize_document(static_cast<DOM::Document const&>(*root), namespace_, namespace_prefix_map, prefix_index, require_well_formed);
     }
 
     if (is<DOM::Comment>(*root)) {
         // -> Comment
         //    Run the algorithm for XML serializing a Comment node node.
-        return serialize_comment(static_cast<DOM::Comment&>(*root), require_well_formed);
+        return serialize_comment(static_cast<DOM::Comment const&>(*root), require_well_formed);
     }
 
     if (is<DOM::Text>(*root) || is<DOM::CDATASection>(*root)) {
         // -> Text
         //    Run the algorithm for XML serializing a Text node node.
-        return serialize_text(static_cast<DOM::Text&>(*root), require_well_formed);
+        return serialize_text(static_cast<DOM::Text const&>(*root), require_well_formed);
     }
 
     if (is<DOM::DocumentFragment>(*root)) {
         // -> DocumentFragment
         //    Run the algorithm for XML serializing a DocumentFragment node node.
-        return serialize_document_fragment(static_cast<DOM::DocumentFragment&>(*root), namespace_, namespace_prefix_map, prefix_index, require_well_formed);
+        return serialize_document_fragment(static_cast<DOM::DocumentFragment const&>(*root), namespace_, namespace_prefix_map, prefix_index, require_well_formed);
     }
 
     if (is<DOM::DocumentType>(*root)) {
         // -> DocumentType
         //    Run the algorithm for XML serializing a DocumentType node node.
-        return serialize_document_type(static_cast<DOM::DocumentType&>(*root), require_well_formed);
+        return serialize_document_type(static_cast<DOM::DocumentType const&>(*root), require_well_formed);
     }
 
     if (is<DOM::ProcessingInstruction>(*root)) {
         // -> ProcessingInstruction
         //    Run the algorithm for XML serializing a ProcessingInstruction node node.
-        return serialize_processing_instruction(static_cast<DOM::ProcessingInstruction&>(*root), require_well_formed);
+        return serialize_processing_instruction(static_cast<DOM::ProcessingInstruction const&>(*root), require_well_formed);
     }
 
     if (is<DOM::Attr>(*root)) {

--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.h
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.h
@@ -18,7 +18,7 @@ public:
 
     virtual ~XMLSerializer() override;
 
-    WebIDL::ExceptionOr<DeprecatedString> serialize_to_string(JS::NonnullGCPtr<DOM::Node> root);
+    WebIDL::ExceptionOr<DeprecatedString> serialize_to_string(JS::NonnullGCPtr<DOM::Node const> root);
 
 private:
     explicit XMLSerializer(JS::Realm&);
@@ -31,6 +31,5 @@ enum class RequireWellFormed {
     Yes,
 };
 
-WebIDL::ExceptionOr<DeprecatedString> serialize_node_to_xml_string(JS::NonnullGCPtr<DOM::Node> root, RequireWellFormed require_well_formed);
-
+WebIDL::ExceptionOr<DeprecatedString> serialize_node_to_xml_string(JS::NonnullGCPtr<DOM::Node const> root, RequireWellFormed require_well_formed);
 }

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -838,7 +838,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_fetch(JS::Realm& rea
             // NOTE: Step 2 is performed in pending_preflight_response's load callback below.
         }
 
-        auto fetch_main_content = [request = JS::make_handle(request), realm = JS::make_handle(realm), fetch_params = JS::make_handle(const_cast<Infrastructure::FetchParams&>(fetch_params))]() -> WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> {
+        auto fetch_main_content = [request = JS::make_handle(request), realm = JS::make_handle(realm), fetch_params = JS::make_handle(fetch_params)]() -> WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> {
             // 2. If request’s redirect mode is "follow", then set request’s service-workers mode to "none".
             // NOTE: Redirects coming from the network (as opposed to from a service worker) are not to be exposed to a
             //       service worker.

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
@@ -31,12 +31,11 @@ ENUMERATE_BOOL_PARAMS
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Infrastructure::FetchController>> fetch(JS::Realm&, Infrastructure::Request&, Infrastructure::FetchAlgorithms const&, UseParallelQueue use_parallel_queue = UseParallelQueue::No);
 WebIDL::ExceptionOr<Optional<JS::NonnullGCPtr<PendingResponse>>> main_fetch(JS::Realm&, Infrastructure::FetchParams const&, Recursive recursive = Recursive::No);
-WebIDL::ExceptionOr<void> fetch_response_handover(JS::Realm&, Infrastructure::FetchParams const&, Infrastructure::Response const&);
+WebIDL::ExceptionOr<void> fetch_response_handover(JS::Realm&, Infrastructure::FetchParams const&, Infrastructure::Response&);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> scheme_fetch(JS::Realm&, Infrastructure::FetchParams const&);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_fetch(JS::Realm&, Infrastructure::FetchParams const&, MakeCORSPreflight make_cors_preflight = MakeCORSPreflight::No);
-WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_redirect_fetch(JS::Realm&, Infrastructure::FetchParams const&, Infrastructure::Response const&);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_redirect_fetch(JS::Realm&, Infrastructure::FetchParams const&, Infrastructure::Response&);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_network_or_cache_fetch(JS::Realm&, Infrastructure::FetchParams const&, IsAuthenticationFetch is_authentication_fetch = IsAuthenticationFetch::No, IsNewConnectionFetch is_new_connection_fetch = IsNewConnectionFetch::No);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_loader_http_network_fetch(JS::Realm&, Infrastructure::FetchParams const&, IncludeCredentials include_credentials = IncludeCredentials::No, IsNewConnectionFetch is_new_connection_fetch = IsNewConnectionFetch::No);
-WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> cors_preflight_fetch(JS::Realm&, Infrastructure::Request const&);
-
+WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> cors_preflight_fetch(JS::Realm&, Infrastructure::Request&);
 }

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/PendingResponse.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/PendingResponse.cpp
@@ -52,11 +52,11 @@ void PendingResponse::resolve(JS::NonnullGCPtr<Infrastructure::Response> respons
         run_callback();
 }
 
-void PendingResponse::run_callback() const
+void PendingResponse::run_callback()
 {
     VERIFY(m_callback);
     VERIFY(m_response);
-    Platform::EventLoopPlugin::the().deferred_invoke([strong_this = JS::make_handle(const_cast<PendingResponse&>(*this))] {
+    Platform::EventLoopPlugin::the().deferred_invoke([strong_this = JS::make_handle(*this)] {
         strong_this->m_callback(*strong_this->m_response);
         strong_this->m_request->remove_pending_response({}, *strong_this.ptr());
     });

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/PendingResponse.h
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/PendingResponse.h
@@ -35,7 +35,7 @@ private:
 
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
-    void run_callback() const;
+    void run_callback();
 
     Callback m_callback;
     JS::NonnullGCPtr<Infrastructure::Request> m_request;

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchParams.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchParams.h
@@ -34,8 +34,8 @@ public:
     [[nodiscard]] JS::NonnullGCPtr<FetchController> controller() const { return m_controller; }
     [[nodiscard]] JS::NonnullGCPtr<FetchTimingInfo> timing_info() const { return m_timing_info; }
 
-    [[nodiscard]] JS::NonnullGCPtr<FetchAlgorithms> algorithms() const { return m_algorithms; }
-    void set_algorithms(JS::NonnullGCPtr<FetchAlgorithms> algorithms) { m_algorithms = algorithms; }
+    [[nodiscard]] JS::NonnullGCPtr<FetchAlgorithms const> algorithms() const { return m_algorithms; }
+    void set_algorithms(JS::NonnullGCPtr<FetchAlgorithms const> algorithms) { m_algorithms = algorithms; }
 
     [[nodiscard]] TaskDestination& task_destination() { return m_task_destination; }
     [[nodiscard]] TaskDestination const& task_destination() const { return m_task_destination; }
@@ -74,7 +74,7 @@ private:
     // https://fetch.spec.whatwg.org/#fetch-params-process-response-consume-body
     // process response consume body (default null)
     //     Null or an algorithm.
-    JS::NonnullGCPtr<FetchAlgorithms> m_algorithms;
+    JS::NonnullGCPtr<FetchAlgorithms const> m_algorithms;
 
     // https://fetch.spec.whatwg.org/#fetch-params-task-destination
     // task destination (default null)

--- a/Userland/Libraries/LibWeb/Fetch/Request.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Request.cpp
@@ -116,7 +116,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::construct_impl(JS::Realm
     auto base_url = HTML::relevant_settings_object(*request_object).api_base_url();
 
     // 4. Let signal be null.
-    DOM::AbortSignal const* input_signal = nullptr;
+    DOM::AbortSignal* input_signal = nullptr;
 
     // 5. If input is a string, then:
     if (input.has<String>()) {

--- a/Userland/Libraries/LibWeb/FileAPI/FileList.h
+++ b/Userland/Libraries/LibWeb/FileAPI/FileList.h
@@ -25,6 +25,12 @@ public:
     unsigned long length() const { return m_files.size(); }
 
     // https://w3c.github.io/FileAPI/#dfn-item
+    File* item(size_t index)
+    {
+        return index < m_files.size() ? m_files[index].ptr() : nullptr;
+    }
+
+    // https://w3c.github.io/FileAPI/#dfn-item
     File const* item(size_t index) const
     {
         return index < m_files.size() ? m_files[index].ptr() : nullptr;

--- a/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.h
+++ b/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <AK/HashMap.h>
 #include <AK/IDAllocator.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/Platform/Timer.h>

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContextGroup.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContextGroup.h
@@ -8,6 +8,7 @@
 
 #include <AK/HashMap.h>
 #include <AK/NonnullRefPtr.h>
+#include <AK/WeakPtr.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibWeb/Forward.h>
 

--- a/Userland/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/Variant.h>
 #include <LibJS/Forward.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/CrossOrigin/CrossOriginPropertyDescriptorMap.h>

--- a/Userland/Libraries/LibWeb/HTML/CrossOrigin/CrossOriginPropertyDescriptorMap.h
+++ b/Userland/Libraries/LibWeb/HTML/CrossOrigin/CrossOriginPropertyDescriptorMap.h
@@ -6,9 +6,12 @@
 
 #pragma once
 
+#include <AK/DeprecatedString.h>
 #include <AK/Forward.h>
+#include <AK/Optional.h>
 #include <AK/Traits.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Runtime/PropertyKey.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -256,7 +256,7 @@ void queue_global_task(HTML::Task::Source source, JS::Object& global_object, JS:
 }
 
 // https://html.spec.whatwg.org/#queue-a-microtask
-void queue_a_microtask(DOM::Document* document, JS::SafeFunction<void()> steps)
+void queue_a_microtask(DOM::Document const* document, JS::SafeFunction<void()> steps)
 {
     // 1. If event loop was not given, set event loop to the implied event loop.
     auto& event_loop = HTML::main_thread_event_loop();

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -115,7 +115,7 @@ private:
 EventLoop& main_thread_event_loop();
 void old_queue_global_task_with_document(HTML::Task::Source, DOM::Document&, JS::SafeFunction<void()> steps);
 void queue_global_task(HTML::Task::Source, JS::Object&, JS::SafeFunction<void()> steps);
-void queue_a_microtask(DOM::Document*, JS::SafeFunction<void()> steps);
+void queue_a_microtask(DOM::Document const*, JS::SafeFunction<void()> steps);
 void perform_a_microtask_checkpoint();
 
 }

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/Task.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/Task.cpp
@@ -9,7 +9,7 @@
 
 namespace Web::HTML {
 
-Task::Task(Source source, DOM::Document* document, JS::SafeFunction<void()> steps)
+Task::Task(Source source, DOM::Document const* document, JS::SafeFunction<void()> steps)
     : m_source(source)
     , m_steps(move(steps))
     , m_document(JS::make_handle(document))
@@ -28,11 +28,6 @@ bool Task::is_runnable() const
 {
     // A task is runnable if its document is either null or fully active.
     return !m_document.ptr() || m_document->is_fully_active();
-}
-
-DOM::Document* Task::document()
-{
-    return m_document.ptr();
 }
 
 DOM::Document const* Task::document() const

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/Task.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/Task.h
@@ -31,7 +31,7 @@ public:
         JavaScriptEngine,
     };
 
-    static NonnullOwnPtr<Task> create(Source source, DOM::Document* document, JS::SafeFunction<void()> steps)
+    static NonnullOwnPtr<Task> create(Source source, DOM::Document const* document, JS::SafeFunction<void()> steps)
     {
         return adopt_own(*new Task(source, document, move(steps)));
     }
@@ -40,17 +40,16 @@ public:
     Source source() const { return m_source; }
     void execute();
 
-    DOM::Document* document();
     DOM::Document const* document() const;
 
     bool is_runnable() const;
 
 private:
-    Task(Source, DOM::Document*, JS::SafeFunction<void()> steps);
+    Task(Source, DOM::Document const*, JS::SafeFunction<void()> steps);
 
     Source m_source { Source::Unspecified };
     JS::SafeFunction<void()> m_steps;
-    JS::Handle<DOM::Document> m_document;
+    JS::Handle<DOM::Document const> m_document;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -350,7 +350,7 @@ void HTMLScriptElement::prepare_script()
         else if (m_script_type == ScriptType::Module) {
             // Fetch an external module script graph given url, settings object, options, and onComplete.
             // FIXME: Pass options.
-            fetch_external_module_script_graph(url, settings_object, [this](auto const* result) {
+            fetch_external_module_script_graph(url, settings_object, [this](auto* result) {
                 // 1. Mark as ready el given result.
                 if (!result)
                     mark_as_ready(ResultState::Null {});
@@ -382,7 +382,7 @@ void HTMLScriptElement::prepare_script()
 
             // 2. Fetch an inline module script graph, given source text, base URL, settings object, options, and with the following steps given result:
             // FIXME: Pass options
-            fetch_inline_module_script_graph(m_document->url().to_deprecated_string(), source_text, base_url, document().relevant_settings_object(), [this](auto const* result) {
+            fetch_inline_module_script_graph(m_document->url().to_deprecated_string(), source_text, base_url, document().relevant_settings_object(), [this](auto* result) {
                 // 1. Mark as ready el given result.
                 if (!result)
                     mark_as_ready(ResultState::Null {});

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -84,13 +84,13 @@ Vector<JS::Handle<HTMLOptionElement>> HTMLSelectElement::list_of_options() const
     // and all the option element children of all the optgroup element children of the select element, in tree order.
     Vector<JS::Handle<HTMLOptionElement>> list;
 
-    for_each_child_of_type<HTMLOptionElement>([&](HTMLOptionElement const& option_element) {
-        list.append(JS::make_handle(const_cast<HTMLOptionElement&>(option_element)));
+    for_each_child_of_type<HTMLOptionElement>([&](HTMLOptionElement& option_element) {
+        list.append(JS::make_handle(option_element));
     });
 
     for_each_child_of_type<HTMLOptGroupElement>([&](HTMLOptGroupElement const& optgroup_element) {
-        optgroup_element.for_each_child_of_type<HTMLOptionElement>([&](HTMLOptionElement const& option_element) {
-            list.append(JS::make_handle(const_cast<HTMLOptionElement&>(option_element)));
+        optgroup_element.for_each_child_of_type<HTMLOptionElement>([&](HTMLOptionElement& option_element) {
+            list.append(JS::make_handle(option_element));
         });
     });
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -616,7 +616,7 @@ HTMLParser::AdjustedInsertionLocation HTMLParser::find_appropriate_place_for_ins
     return adjusted_insertion_location;
 }
 
-JS::NonnullGCPtr<DOM::Element> HTMLParser::create_element_for(HTMLToken const& token, DeprecatedFlyString const& namespace_, DOM::Node const& intended_parent)
+JS::NonnullGCPtr<DOM::Element> HTMLParser::create_element_for(HTMLToken const& token, DeprecatedFlyString const& namespace_, DOM::Node& intended_parent)
 {
     // FIXME: 1. If the active speculative HTML parser is not null, then return the result of creating a speculative mock element given given namespace, the tag name of the given token, and the attributes of the given token.
     // FIXME: 2. Otherwise, optionally create a speculative mock element given given namespace, the tag name of the given token, and the attributes of the given token.
@@ -3562,7 +3562,7 @@ DeprecatedString HTMLParser::serialize_html_fragment(DOM::Node const& node)
 {
     // The algorithm takes as input a DOM Element, Document, or DocumentFragment referred to as the node.
     VERIFY(node.is_element() || node.is_document() || node.is_document_fragment());
-    JS::NonnullGCPtr<DOM::Node> actual_node = node;
+    JS::NonnullGCPtr<DOM::Node const> actual_node = node;
 
     if (is<DOM::Element>(node)) {
         auto& element = verify_cast<DOM::Element>(node);

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -119,7 +119,7 @@ private:
 
     void generate_implied_end_tags(DeprecatedFlyString const& exception = {});
     void generate_all_implied_end_tags_thoroughly();
-    JS::NonnullGCPtr<DOM::Element> create_element_for(HTMLToken const&, DeprecatedFlyString const& namespace_, DOM::Node const& intended_parent);
+    JS::NonnullGCPtr<DOM::Element> create_element_for(HTMLToken const&, DeprecatedFlyString const& namespace_, DOM::Node& intended_parent);
 
     struct AdjustedInsertionLocation {
         JS::GCPtr<DOM::Node> parent;

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibWeb/HTML/Scripting/ImportMap.h>
+#include <LibWeb/HTML/Scripting/ModuleMap.h>
 #include <LibWeb/HTML/Scripting/ModuleScript.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ModuleMap.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ModuleMap.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/URL.h>
 #include <LibWeb/HTML/Scripting/ModuleScript.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <LibJS/SourceTextModule.h>
-#include <LibWeb/HTML/Scripting/ModuleMap.h>
 #include <LibWeb/HTML/Scripting/Script.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Script.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Script.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Scripting/Script.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/SessionHistoryEntry.h
+++ b/Userland/Libraries/LibWeb/HTML/SessionHistoryEntry.h
@@ -8,6 +8,7 @@
 
 #include <AK/URL.h>
 #include <AK/WeakPtr.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/PolicyContainers.h>
 

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.h
@@ -38,7 +38,7 @@ public:
     // https://html.spec.whatwg.org/multipage/workers.html#the-workerglobalscope-common-interface
 
     // https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-self
-    JS::NonnullGCPtr<WorkerGlobalScope> self() const { return *this; }
+    JS::NonnullGCPtr<WorkerGlobalScope const> self() const { return *this; }
 
     JS::NonnullGCPtr<WorkerLocation> location() const;
     JS::NonnullGCPtr<WorkerNavigator> navigator() const;

--- a/Userland/Libraries/LibWeb/Infra/CharacterTypes.h
+++ b/Userland/Libraries/LibWeb/Infra/CharacterTypes.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <AK/Types.h>
 
 namespace Web::Infra {

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <LibWeb/Layout/FormattingContext.h>
+#include <LibWeb/Layout/TableBox.h>
 #include <LibWeb/Layout/TableWrapper.h>
 
 namespace Web::Layout {

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -8,7 +8,9 @@
 
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/RefPtr.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/CSS/Display.h>
+#include <LibWeb/CSS/Selector.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::Layout {

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -24,7 +24,7 @@
 
 namespace Web {
 
-static JS::GCPtr<DOM::Node> dom_node_for_event_dispatch(Painting::Paintable const& paintable)
+static JS::GCPtr<DOM::Node> dom_node_for_event_dispatch(Painting::Paintable& paintable)
 {
     if (auto node = paintable.mouse_event_target())
         return node;
@@ -35,7 +35,7 @@ static JS::GCPtr<DOM::Node> dom_node_for_event_dispatch(Painting::Paintable cons
     return nullptr;
 }
 
-static bool parent_element_for_event_dispatch(Painting::Paintable const& paintable, JS::GCPtr<DOM::Node>& node, Layout::Node const*& layout_node)
+static bool parent_element_for_event_dispatch(Painting::Paintable& paintable, JS::GCPtr<DOM::Node>& node, Layout::Node*& layout_node)
 {
     layout_node = &paintable.layout_node();
     while (layout_node && node && !node->is_element() && layout_node->parent()) {
@@ -180,7 +180,7 @@ bool EventHandler::handle_mousewheel(CSSPixelPoint position, unsigned button, un
             }
 
             // Search for the first parent of the hit target that's an element.
-            Layout::Node const* layout_node;
+            Layout::Node* layout_node;
             if (!parent_element_for_event_dispatch(*paintable, node, layout_node))
                 return false;
 
@@ -240,7 +240,7 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, unsigned button, unsig
             // Search for the first parent of the hit target that's an element.
             // "The click event type MUST be dispatched on the topmost event target indicated by the pointer." (https://www.w3.org/TR/uievents/#event-type-click)
             // "The topmost event target MUST be the element highest in the rendering order which is capable of being an event target." (https://www.w3.org/TR/uievents/#topmost-event-target)
-            Layout::Node const* layout_node;
+            Layout::Node* layout_node;
             if (!parent_element_for_event_dispatch(*paintable, node, layout_node)) {
                 // FIXME: This is pretty ugly but we need to bail out here.
                 goto after_node_use;
@@ -272,7 +272,7 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, unsigned button, unsig
                 //        implemented in BrowsingContext::choose_a_browsing_context:
                 //
                 //        https://html.spec.whatwg.org/multipage/browsers.html#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
-                if (JS::GCPtr<HTML::HTMLAnchorElement> link = node->enclosing_link_element()) {
+                if (JS::GCPtr<HTML::HTMLAnchorElement const> link = node->enclosing_link_element()) {
                     JS::NonnullGCPtr<DOM::Document> document = *m_browsing_context.active_document();
                     auto href = link->href();
                     auto url = document->parse_url(href);
@@ -364,7 +364,7 @@ bool EventHandler::handle_mousedown(CSSPixelPoint position, unsigned button, uns
         // Search for the first parent of the hit target that's an element.
         // "The click event type MUST be dispatched on the topmost event target indicated by the pointer." (https://www.w3.org/TR/uievents/#event-type-click)
         // "The topmost event target MUST be the element highest in the rendering order which is capable of being an event target." (https://www.w3.org/TR/uievents/#topmost-event-target)
-        Layout::Node const* layout_node;
+        Layout::Node* layout_node;
         if (!parent_element_for_event_dispatch(*paintable, node, layout_node))
             return false;
 
@@ -462,7 +462,7 @@ bool EventHandler::handle_mousemove(CSSPixelPoint position, unsigned buttons, un
         // Search for the first parent of the hit target that's an element.
         // "The click event type MUST be dispatched on the topmost event target indicated by the pointer." (https://www.w3.org/TR/uievents/#event-type-click)
         // "The topmost event target MUST be the element highest in the rendering order which is capable of being an event target." (https://www.w3.org/TR/uievents/#topmost-event-target)
-        Layout::Node const* layout_node;
+        Layout::Node* layout_node;
         bool found_parent_element = parent_element_for_event_dispatch(*paintable, node, layout_node);
         hovered_node_changed = node.ptr() != document.hovered_node();
         document.set_hovered_node(node);
@@ -515,7 +515,7 @@ bool EventHandler::handle_mousemove(CSSPixelPoint position, unsigned buttons, un
         page->client().page_did_request_cursor_change(hovered_node_cursor);
 
         if (hovered_node_changed) {
-            JS::GCPtr<HTML::HTMLElement> hovered_html_element = document.hovered_node() ? document.hovered_node()->enclosing_html_element_with_attribute(HTML::AttributeNames::title) : nullptr;
+            JS::GCPtr<HTML::HTMLElement const> hovered_html_element = document.hovered_node() ? document.hovered_node()->enclosing_html_element_with_attribute(HTML::AttributeNames::title) : nullptr;
             if (hovered_html_element && !hovered_html_element->title().is_null()) {
                 page->client().page_did_enter_tooltip_area(m_browsing_context.to_top_level_position(position), hovered_html_element->title());
             } else {
@@ -570,7 +570,7 @@ bool EventHandler::handle_doubleclick(CSSPixelPoint position, unsigned button, u
 
     // Search for the first parent of the hit target that's an element.
     // "The topmost event target MUST be the element highest in the rendering order which is capable of being an event target." (https://www.w3.org/TR/uievents/#topmost-event-target)
-    Layout::Node const* layout_node;
+    Layout::Node* layout_node;
     if (!parent_element_for_event_dispatch(*paintable, node, layout_node))
         return false;
 

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.h
@@ -9,6 +9,7 @@
 #include <AK/Span.h>
 #include <AK/Vector.h>
 #include <LibGfx/Color.h>
+#include <LibGfx/Gradients.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/PaintContext.h>
 

--- a/Userland/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.cpp
@@ -35,7 +35,7 @@ Paintable::DispatchEventOfSameName Paintable::handle_mousemove(Badge<EventHandle
 
 bool Paintable::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y)
 {
-    if (auto* containing_block = this->containing_block()) {
+    if (auto const* containing_block = this->containing_block()) {
         if (!containing_block->is_scrollable())
             return false;
         auto new_offset = containing_block->scroll_offset();
@@ -56,7 +56,7 @@ Optional<HitTestResult> Paintable::hit_test(CSSPixelPoint, HitTestType) const
 
 Paintable const* Paintable::first_child() const
 {
-    auto* layout_child = m_layout_node->first_child();
+    auto const* layout_child = m_layout_node->first_child();
     for (; layout_child && !layout_child->paintable(); layout_child = layout_child->next_sibling())
         ;
     return layout_child ? layout_child->paintable() : nullptr;
@@ -64,7 +64,7 @@ Paintable const* Paintable::first_child() const
 
 Paintable const* Paintable::next_sibling() const
 {
-    auto* layout_node = m_layout_node->next_sibling();
+    auto const* layout_node = m_layout_node->next_sibling();
     for (; layout_node && !layout_node->paintable(); layout_node = layout_node->next_sibling())
         ;
     return layout_node ? layout_node->paintable() : nullptr;
@@ -72,7 +72,7 @@ Paintable const* Paintable::next_sibling() const
 
 Paintable const* Paintable::last_child() const
 {
-    auto* layout_child = m_layout_node->last_child();
+    auto const* layout_child = m_layout_node->last_child();
     for (; layout_child && !layout_child->paintable(); layout_child = layout_child->previous_sibling())
         ;
     return layout_child ? layout_child->paintable() : nullptr;
@@ -80,7 +80,7 @@ Paintable const* Paintable::last_child() const
 
 Paintable const* Paintable::previous_sibling() const
 {
-    auto* layout_node = m_layout_node->previous_sibling();
+    auto const* layout_node = m_layout_node->previous_sibling();
     for (; layout_node && !layout_node->paintable(); layout_node = layout_node->previous_sibling())
         ;
     return layout_node ? layout_node->paintable() : nullptr;

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -143,8 +143,8 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
-    JS::NonnullGCPtr<Layout::Node> m_layout_node;
-    Optional<JS::GCPtr<Layout::Box>> mutable m_containing_block;
+    JS::NonnullGCPtr<Layout::Node const> m_layout_node;
+    Optional<JS::GCPtr<Layout::Box const>> mutable m_containing_block;
 };
 
 inline DOM::Node* HitTestResult::dom_node()

--- a/Userland/Libraries/LibWeb/WebIDL/Promise.h
+++ b/Userland/Libraries/LibWeb/WebIDL/Promise.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibJS/Forward.h>
+#include <LibJS/Runtime/Value.h>
 #include <LibJS/SafeFunction.h>
 #include <LibWeb/Forward.h>
 

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -12,6 +12,7 @@
 #include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/String.h>
+#include <LibGfx/Rect.h>
 #include <LibIPC/ConnectionToServer.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/MarkedVector.h>


### PR DESCRIPTION
The tool currently validates two things:
  - For all fields of type `GCPtr<T>` or `NonnullGCPtr<T>`, that `T` inherits from `JS::Cell`
  - For all fields of type `T&` or `T*` not wrapped in `GCPtr` or `NonnullGCPtr`, that `T` does not inherit from `JS::Cell` (otherwise it should be wrapped in a `GCPtr`/`NonnullGCPtr`)

This PR does not actually do any field conversions, since there are a _lot_ of unwrapped Cells around the codebase and it'd be too much for this PR. However, in order to prepare for that change, I've ported the const laundering changes from (NN)RefPtr (3c7a0ef1ac279c99bc4ee72085278ea70c210889) to (NN)GCPtr so we can properly propogate `const`. I've also fixed a bunch of compilation issues that caused the tool to error out. I'm not sure why they don't appear with a normal clang build of Serenity, but they seem like valid enough errors. 

A few notes:
  - If anyone demos it locally, I would suggest commenting out the `validate_non_gcptr_field` call in `CellHandler.cpp` as that produces a ton of output. 
  - I tried to integrate it into the Lagom build system (i.e. using `lagom_tool`) so that it could be invoked from `Meta/serenity.sh` like any other tool, but I couldn't figure out how to multithread the invocation like the python wrapper script currently does (I was getting scary internal malloc errors). So I figured this could be left until later if anyone cares to convert it. 

There are also a few errors that the tool produces:
  - [This error](https://i.imgur.com/n7TOZeK.png), not sure why it happens or what to do about it
  - The dollar sign in `$262Object.h` causes issues ([error](https://i.imgur.com/Y46UXnP.png)). I tested removing the dollar sign and it fixes it. Not sure if that's a change we're fine making for the sake of this tool, but if it's fine I'll go ahead and make that change. 
  - There is also an incomplete type error between `Web::CSS::CalculatedStyleValue` and `Web::CSS::StyleValue`. I was thinking about moving `CalculatedStyleValue` into its own file, but not sure if that's possible/if it'd be acceptable.

Closes #16988