### PR TITLE
Kernel+Userland: Split bind-mounting and re-mounting from mount syscall

### DIFF
--- a/Base/usr/share/man/man2/bindmount.md
+++ b/Base/usr/share/man/man2/bindmount.md
@@ -1,0 +1,39 @@
+## Name
+
+bindmount - create a bindmount from `source_fd` to a target path.
+
+## Synopsis
+
+```**c++
+#include <LibCore/System.h>
+
+ErrorOr<void> bindmount(int source_fd, StringView target, int flags);
+```
+
+## Description
+
+`bindmount()` create a bindmount from `source_fd` to a target path `target`, with mount flags of `flags`.
+
+The following `flags` are supported:
+
+* `MS_NODEV`: Disallow opening any devices from this file system.
+* `MS_NOEXEC`: Disallow executing any executables from this file system.
+* `MS_NOSUID`: Ignore set-user-id bits on executables from this file system.
+* `MS_RDONLY`: Mount the filesystem read-only.
+* `MS_WXALLOWED`: Allow W^X protection circumvention for executables on this file system.
+* `MS_AXALLOWED`: Allow anonymous executable mappings for executables on this file system.
+* `MS_NOREGULAR`: Disallow opening any regular files from this file system.
+
+These flags can be used as a security measure to limit the possible abuses of the mounted file system.
+
+## Errors
+
+* `EINVAL`: The `flags` value contains deprecated flags such as `MS_REMOUNT` or `MS_BIND`.
+* `EPERM`: The current process does not have superuser privileges.
+* `ENODEV`: The `source_fd` is not an open file descriptor to a valid filesystem inode.
+
+All of the usual path resolution errors may also occur.
+
+## See also
+
+* [`mount`(2)](help://man/2/mount)

--- a/Base/usr/share/man/man2/mount.md
+++ b/Base/usr/share/man/man2/mount.md
@@ -34,9 +34,7 @@ The following `flags` are supported:
 * `MS_NODEV`: Disallow opening any devices from this file system.
 * `MS_NOEXEC`: Disallow executing any executables from this file system.
 * `MS_NOSUID`: Ignore set-user-id bits on executables from this file system.
-* `MS_BIND`: Perform a bind-mount (see below).
 * `MS_RDONLY`: Mount the filesystem read-only.
-* `MS_REMOUNT`: Remount an already mounted filesystem (see below).
 * `MS_WXALLOWED`: Allow W^X protection circumvention for executables on this file system.
 * `MS_AXALLOWED`: Allow anonymous executable mappings for executables on this file system.
 * `MS_NOREGULAR`: Disallow opening any regular files from this file system.
@@ -57,11 +55,6 @@ itself, which may be useful for changing mount flags for a part of a filesystem.
 
 ### Remounting
 
-If `MS_REMOUNT` is specified in `flags`, `source_fd` and `fs_type` are ignored,
-and a remount is performed instead. `target` must point to an existing mount
-point. The mount flags for that mount point are reset to `flags` (except the
-`MS_REMOUNT` flag itself, which is stripped from the value).
-
 Note that remounting a file system will only affect future operations with the
 file system, not any already opened files. For example, if you open a directory
 on a filesystem that's mounted with `MS_NODEV`, then remount the filesystem to
@@ -74,14 +67,9 @@ in mount flags of the underlying file system. To "refresh" the working directory
 to use the new mount flags after remounting a filesystem, a process can call
 `chdir()` with the path to the same directory.
 
-Similarly, to change the mount flags used by the root directory, a process can
-remount the root filesystem using `MS_REMOUNT`.
-However, it only have a noticeable effect if
-the kernel was to launch more userspace processes directly, the way it does
-launch the initial userspace process.
-
 ## Errors
 
+* `EINVAL`: The `flags` value contains deprecated flags such as `MS_REMOUNT` or `MS_BIND`.
 * `EFAULT`: The `fs_type` or `target` are invalid strings.
 * `EPERM`: The current process does not have superuser privileges.
 * `ENODEV`: The `fs_type` is unrecognized, or the file descriptor to source is
@@ -99,3 +87,5 @@ All of the usual path resolution errors may also occur.
 ## See also
 
 * [`mount`(8)](help://man/8/mount)
+* [`remount`(2)](help://man/2/remount)
+* [`bindmount`(2)](help://man/2/bindmount)

--- a/Base/usr/share/man/man2/remount.md
+++ b/Base/usr/share/man/man2/remount.md
@@ -1,0 +1,39 @@
+## Name
+
+remount - remount a filesystem with new mount flags
+
+## Synopsis
+
+```**c++
+#include <LibCore/System.h>
+
+ErrorOr<void> remount(StringView target, int flags);
+```
+
+## Description
+
+`remount()` mounts a filesystem that is mounted at `target` with new mount flags of `flags`.
+
+The following `flags` are supported:
+
+* `MS_NODEV`: Disallow opening any devices from this file system.
+* `MS_NOEXEC`: Disallow executing any executables from this file system.
+* `MS_NOSUID`: Ignore set-user-id bits on executables from this file system.
+* `MS_RDONLY`: Mount the filesystem read-only.
+* `MS_WXALLOWED`: Allow W^X protection circumvention for executables on this file system.
+* `MS_AXALLOWED`: Allow anonymous executable mappings for executables on this file system.
+* `MS_NOREGULAR`: Disallow opening any regular files from this file system.
+
+These flags can be used as a security measure to limit the possible abuses of the mounted file system.
+
+## Errors
+
+* `EINVAL`: The `flags` value contains deprecated flags such as `MS_REMOUNT` or `MS_BIND`.
+* `EPERM`: The current process does not have superuser privileges.
+* `ENODEV`: No mount point was found for `target` path target.
+
+All of the usual path resolution errors may also occur.
+
+## See also
+
+* [`mount`(2)](help://man/2/mount)

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -53,6 +53,7 @@ enum class NeedsBigProcessLock {
     S(annotate_mapping, NeedsBigProcessLock::No)           \
     S(beep, NeedsBigProcessLock::No)                       \
     S(bind, NeedsBigProcessLock::No)                       \
+    S(bindmount, NeedsBigProcessLock::No)                  \
     S(chdir, NeedsBigProcessLock::No)                      \
     S(chmod, NeedsBigProcessLock::No)                      \
     S(chown, NeedsBigProcessLock::No)                      \
@@ -153,6 +154,7 @@ enum class NeedsBigProcessLock {
     S(recvfd, NeedsBigProcessLock::No)                     \
     S(recvmsg, NeedsBigProcessLock::Yes)                   \
     S(rename, NeedsBigProcessLock::No)                     \
+    S(remount, NeedsBigProcessLock::No)                    \
     S(rmdir, NeedsBigProcessLock::No)                      \
     S(scheduler_get_parameters, NeedsBigProcessLock::No)   \
     S(scheduler_set_parameters, NeedsBigProcessLock::No)   \
@@ -433,6 +435,17 @@ struct SC_rename_params {
 struct SC_mount_params {
     StringArgument target;
     StringArgument fs_type;
+    int source_fd;
+    int flags;
+};
+
+struct SC_remount_params {
+    StringArgument target;
+    int flags;
+};
+
+struct SC_bindmount_params {
+    StringArgument target;
     int source_fd;
     int flags;
 };

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -454,6 +454,8 @@ public:
     ErrorOr<FlatPtr> sys$jail_create(Userspace<Syscall::SC_jail_create_params*> user_params);
     ErrorOr<FlatPtr> sys$jail_attach(Userspace<Syscall::SC_jail_attach_params const*> user_params);
     ErrorOr<FlatPtr> sys$get_root_session_id(pid_t force_sid);
+    ErrorOr<FlatPtr> sys$remount(Userspace<Syscall::SC_remount_params const*> user_params);
+    ErrorOr<FlatPtr> sys$bindmount(Userspace<Syscall::SC_bindmount_params const*> user_params);
 
     enum SockOrPeerName {
         SockName,

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -232,6 +232,33 @@ ErrorOr<void> ptrace_peekbuf(pid_t tid, void const* tracee_addr, Bytes destinati
     HANDLE_SYSCALL_RETURN_VALUE("ptrace_peekbuf", rc, {});
 }
 
+ErrorOr<void> bindmount(int source_fd, StringView target, int flags)
+{
+    if (target.is_null())
+        return Error::from_errno(EFAULT);
+
+    Syscall::SC_bindmount_params params {
+        { target.characters_without_null_termination(), target.length() },
+        source_fd,
+        flags,
+    };
+    int rc = syscall(SC_bindmount, &params);
+    HANDLE_SYSCALL_RETURN_VALUE("bindmount", rc, {});
+}
+
+ErrorOr<void> remount(StringView target, int flags)
+{
+    if (target.is_null())
+        return Error::from_errno(EFAULT);
+
+    Syscall::SC_remount_params params {
+        { target.characters_without_null_termination(), target.length() },
+        flags
+    };
+    int rc = syscall(SC_remount, &params);
+    HANDLE_SYSCALL_RETURN_VALUE("remount", rc, {});
+}
+
 ErrorOr<void> mount(int source_fd, StringView target, StringView fs_type, int flags)
 {
     if (target.is_null() || fs_type.is_null())

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -59,6 +59,8 @@ ErrorOr<void> sendfd(int sockfd, int fd);
 ErrorOr<int> recvfd(int sockfd, int options);
 ErrorOr<void> ptrace_peekbuf(pid_t tid, void const* tracee_addr, Bytes destination_buf);
 ErrorOr<void> mount(int source_fd, StringView target, StringView fs_type, int flags);
+ErrorOr<void> bindmount(int source_fd, StringView target, int flags);
+ErrorOr<void> remount(StringView target, int flags);
 ErrorOr<void> umount(StringView mount_point);
 ErrorOr<long> ptrace(int request, pid_t tid, void* address, void* data);
 ErrorOr<void> disown(pid_t pid);

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -383,10 +383,7 @@ static ErrorOr<void> populate_devtmpfs()
 
 static ErrorOr<void> prepare_synthetic_filesystems()
 {
-    // FIXME: Don't hardcode the fs type as the ext2 filesystem and once there's
-    // more than this filesystem implementation (which is suitable for usage on
-    // physical storage), find a way to detect it.
-    TRY(Core::System::mount(-1, "/"sv, "ext2"sv, MS_REMOUNT | MS_NODEV | MS_NOSUID | MS_RDONLY));
+    TRY(Core::System::remount("/"sv, MS_NODEV | MS_NOSUID | MS_RDONLY));
     // FIXME: Find a better way to all of this stuff, without hardcoding all of this!
     TRY(Core::System::mount(-1, "/proc"sv, "proc"sv, MS_NOSUID));
     TRY(Core::System::mount(-1, "/sys"sv, "sys"sv, 0));


### PR DESCRIPTION
These 2 are an actual separate types of syscalls, so let's stop using special flags for bind mounting or re-mounting and instead let userspace calling directly for this kind of actions.