### PR TITLE
Everywhere: Add support for Solaris-based systems

### DIFF
--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -16,6 +16,11 @@
 #    include <AK/Math.h>
 #endif
 
+// Solaris' definition of signbit in math_c99.h conflicts with our implementation.
+#ifdef AK_OS_SOLARIS
+#    undef signbit
+#endif
+
 namespace AK {
 
 // FIXME: this always uses round to nearest break-tie to even

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -68,6 +68,11 @@
 #    define AK_OS_DRAGONFLY
 #endif
 
+#if defined(__sun)
+#    define AK_OS_BSD_GENERIC
+#    define AK_OS_SOLARIS
+#endif
+
 #if defined(_WIN32) || defined(_WIN64)
 #    define AK_OS_WINDOWS
 #endif

--- a/AK/StackInfo.cpp
+++ b/AK/StackInfo.cpp
@@ -12,7 +12,7 @@
 
 #ifdef AK_OS_SERENITY
 #    include <serenity.h>
-#elif defined(AK_OS_LINUX) or defined(AK_OS_MACOS) or defined(AK_OS_NETBSD)
+#elif defined(AK_OS_LINUX) or defined(AK_OS_MACOS) or defined(AK_OS_NETBSD) or defined(AK_OS_SOLARIS)
 #    include <pthread.h>
 #elif defined(AK_OS_FREEBSD) or defined(AK_OS_OPENBSD)
 #    include <pthread.h>
@@ -28,7 +28,7 @@ StackInfo::StackInfo()
         perror("get_stack_bounds");
         VERIFY_NOT_REACHED();
     }
-#elif defined(AK_OS_LINUX) or defined(AK_OS_FREEBSD) or defined(AK_OS_NETBSD)
+#elif defined(AK_OS_LINUX) or defined(AK_OS_FREEBSD) or defined(AK_OS_NETBSD) or defined(AK_OS_SOLARIS)
     int rc;
     pthread_attr_t attr;
     pthread_attr_init(&attr);

--- a/Documentation/LadybirdBuildInstructions.md
+++ b/Documentation/LadybirdBuildInstructions.md
@@ -41,6 +41,14 @@ xcode-select --install
 brew install cmake qt ninja
 ```
 
+On OpenIndiana:
+
+Note that OpenIndianas latest GCC port (GCC 11) is too old to build Ladybird, so you need Clang, which is available in the repository.
+
+```
+pfexec pkg install cmake ninja clang-15 libglvnd qt6
+```
+
 On Windows:
 
 WSL2/WSLg are preferred, as they provide a linux environment that matches one of the above distributions.
@@ -109,6 +117,23 @@ To run without ninja rule:
 ```
 export SERENITY_SOURCE_DIR=$(realpath ../)
 ./Build/ladybird/ladybird # or, in macOS: open ./Build/ladybird/ladybird.app
+```
+
+### Building on OpenIndiana
+
+OpenIndiana needs some extra environment variables set to make sure it finds all the executables
+and directories it needs for the build to work. The cmake files are in a non-standard path that
+contains the Qt version (replace 6.2 with the Qt version you have installed) and you need to tell
+it to use clang and clang++, or it will use gcc and g++ from GCC 10 which is currently the default
+to build packages on OpenIndiana.
+
+When running Ladybird, make sure that XDG_RUNTIME_DIR is set, or it will immediately crash as it
+doesn't find a writable directory for its sockets.
+
+```
+CMAKE_PREFIX_PATH=/usr/lib/qt/6.2/lib/amd64/cmake cmake -GNinja -S Ladybird -B Build/ladybird -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
+cmake --build Build/ladybird
+XDG_RUNTIME_DIR=/var/tmp ninja -C Build/ladybird run
 ```
 
 ## Experimental Android Build Steps

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -337,6 +337,10 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "NetBSD")
     # NetBSD has its shm_open and shm_unlink functions in librt so we need to link that
     target_link_libraries(LibCore PRIVATE librt.so)
 endif()
+if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
+    # Solaris has socket and networking related functions in two extra libraries
+    target_link_libraries(LibCore PRIVATE nsl socket)
+endif()
 target_sources(LibCore PRIVATE ${AK_SOURCES})
 
 # LibMain

--- a/Userland/Libraries/LibCore/Socket.cpp
+++ b/Userland/Libraries/LibCore/Socket.cpp
@@ -370,6 +370,9 @@ ErrorOr<pid_t> LocalSocket::peer_pid() const
 #elif defined(AK_OS_NETBSD)
     struct sockcred creds = {};
     socklen_t creds_size = sizeof(creds);
+#elif defined(AK_OS_SOLARIS)
+    ucred_t* creds = NULL;
+    socklen_t creds_size = sizeof(creds);
 #else
     struct ucred creds = {};
     socklen_t creds_size = sizeof(creds);
@@ -384,6 +387,9 @@ ErrorOr<pid_t> LocalSocket::peer_pid() const
 #elif defined(AK_OS_NETBSD)
     TRY(System::getsockopt(m_helper.fd(), SOL_SOCKET, SCM_CREDS, &creds, &creds_size));
     return creds.sc_pid;
+#elif defined(AK_OS_SOLARIS)
+    TRY(System::getsockopt(m_helper.fd(), SOL_SOCKET, SO_RECVUCRED, &creds, &creds_size));
+    return ucred_getpid(creds);
 #else
     TRY(System::getsockopt(m_helper.fd(), SOL_SOCKET, SO_PEERCRED, &creds, &creds_size));
     return creds.pid;

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -576,7 +576,11 @@ ErrorOr<DeprecatedString> gethostname()
 
 ErrorOr<void> sethostname(StringView hostname)
 {
+#if defined(AK_OS_SOLARIS)
+    int rc = ::sethostname(const_cast<char*>(hostname.characters_without_null_termination()), hostname.length());
+#else
     int rc = ::sethostname(hostname.characters_without_null_termination(), hostname.length());
+#endif
     if (rc < 0)
         return Error::from_syscall("sethostname"sv, -errno);
     return {};

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1197,7 +1197,7 @@ ErrorOr<void> exec(StringView filename, ReadonlySpan<StringView> arguments, Sear
         envp[environment->size()] = nullptr;
 
         if (search_in_path == SearchInPath::Yes && !filename.contains('/')) {
-#    if defined(AK_OS_MACOS) || defined(AK_OS_FREEBSD)
+#    if defined(AK_OS_MACOS) || defined(AK_OS_FREEBSD) || defined(AK_OS_SOLARIS)
             // These BSDs don't support execvpe(), so we'll have to manually search the PATH.
             ScopedValueRollback errno_rollback(errno);
 

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -405,7 +405,7 @@ ErrorOr<int> anon_create([[maybe_unused]] size_t size, [[maybe_unused]] int opti
         TRY(close(fd));
         return Error::from_errno(saved_errno);
     }
-#elif defined(AK_OS_MACOS) || defined(AK_OS_EMSCRIPTEN) || defined(AK_OS_OPENBSD) || defined(AK_OS_NETBSD)
+#elif defined(AK_OS_BSD_GENERIC) || defined(AK_OS_EMSCRIPTEN)
     struct timespec time;
     clock_gettime(CLOCK_REALTIME, &time);
     auto name = DeprecatedString::formatted("/shm-{}{}", (unsigned long)time.tv_sec, (unsigned long)time.tv_nsec);

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1057,7 +1057,7 @@ ErrorOr<void> utime(StringView path, Optional<struct utimbuf> maybe_buf)
 
 ErrorOr<struct utsname> uname()
 {
-    utsname uts;
+    struct utsname uts;
 #ifdef AK_OS_SERENITY
     int rc = syscall(SC_uname, &uts);
     HANDLE_SYSCALL_RETURN_VALUE("uname", rc, uts);

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -330,7 +330,9 @@ ErrorOr<void> sigaction(int signal, struct sigaction const* action, struct sigac
     return {};
 }
 
-#if defined(AK_OS_BSD_GENERIC)
+#if defined(AK_OS_SOLARIS)
+ErrorOr<SIG_TYP> signal(int signal, SIG_TYP handler)
+#elif defined(AK_OS_BSD_GENERIC)
 ErrorOr<sig_t> signal(int signal, sig_t handler)
 #else
 ErrorOr<sighandler_t> signal(int signal, sighandler_t handler)

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -37,6 +37,7 @@
 
 #ifdef AK_OS_SOLARIS
 #    include <sys/filio.h>
+#    include <ucred.h>
 #endif
 
 namespace Core::System {

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -35,6 +35,10 @@
 #    include <shadow.h>
 #endif
 
+#ifdef AK_OS_SOLARIS
+#    include <sys/filio.h>
+#endif
+
 namespace Core::System {
 
 #ifdef AK_OS_SERENITY

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -93,7 +93,9 @@ ErrorOr<int> accept4(int sockfd, struct sockaddr*, socklen_t*, int flags);
 #endif
 
 ErrorOr<void> sigaction(int signal, struct sigaction const* action, struct sigaction* old_action);
-#if defined(AK_OS_BSD_GENERIC)
+#if defined(AK_OS_SOLARIS)
+ErrorOr<SIG_TYP> signal(int signal, SIG_TYP handler);
+#elif defined(AK_OS_BSD_GENERIC)
 ErrorOr<sig_t> signal(int signal, sig_t handler);
 #else
 ErrorOr<sighandler_t> signal(int signal, sighandler_t handler);

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -40,6 +40,8 @@ namespace Web {
 #    define OS_STRING "NetBSD"
 #elif defined(AK_OS_DRAGONFLY)
 #    define OS_STRING "DragonFly"
+#elif defined(AK_OS_SOLARIS)
+#    define OS_STRING "SunOS"
 #else
 #    error Unknown OS
 #endif


### PR DESCRIPTION
This set of patches makes Ladybird build and run on Solaris-based operating systems.
I tested it on the latest OpenIndiana (a distribution of Illumos),but it should work on others as well.
Solaris/Illumos needs special handling in some cases,as you may see,but it behaves very similar to BSD,so I defined it as BSD_GENERIC,too.
Most fixes are needed at the same places where I already fixed the BSDs.
This pull request should solve issue #17555