### PR TITLE
LibCore+Utilities: Replace uses of strpbrk with find_any_of()

### DIFF
--- a/Userland/Libraries/LibCore/Group.cpp
+++ b/Userland/Libraries/LibCore/Group.cpp
@@ -74,7 +74,7 @@ ErrorOr<void> Group::add_group(Group& group)
         return Error::from_string_literal("Group name can not be empty.");
 
     // A quick sanity check on group name
-    if (strpbrk(group.name().characters(), "\\/!@#$%^&*()~+=`:\n"))
+    if (group.name().find_any_of("\\/!@#$%^&*()~+=`:\n"sv, DeprecatedString::SearchDirection::Forward).has_value())
         return Error::from_string_literal("Group name has invalid characters.");
 
     // Disallow names starting with '_', '-' or other non-alpha characters.

--- a/Userland/Utilities/useradd.cpp
+++ b/Userland/Utilities/useradd.cpp
@@ -53,7 +53,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.parse(arguments);
 
     // Let's run a quick sanity check on username
-    if (strpbrk(username.characters(), "\\/!@#$%^&*()~+=`:\n")) {
+    if (username.find_any_of("\\/!@#$%^&*()~+=`:\n"sv, DeprecatedString::SearchDirection::Forward).has_value()) {
         warnln("invalid character in username, {}", username);
         return 1;
     }


### PR DESCRIPTION
We don't need to use scary C string POSIX APIs when we have nicer ones on String/DeprecatedString.