### PR TITLE
Lagom: Look for clang the same way serenity.sh does in BuildFuzzers.sh

### DIFF
--- a/Meta/Lagom/BuildFuzzers.sh
+++ b/Meta/Lagom/BuildFuzzers.sh
@@ -14,11 +14,12 @@ die() {
 
 pick_clang() {
     local BEST_VERSION=0
-    for CLANG_CANDIDATE in clang clang-13 clang-14 /usr/local/bin/clang-13 /usr/local/bin/clang-14; do
+    for CLANG_CANDIDATE in clang clang-13 clang-14 clang-15 /opt/homebrew/opt/llvm/bin/clang ; do
         if ! command -v $CLANG_CANDIDATE >/dev/null 2>&1; then
             continue
         fi
         if $CLANG_CANDIDATE --version 2>&1 | grep "Apple clang" >/dev/null; then
+            echo "Skipping Apple clang, as Apple does not ship libfuzzer with Xcode..."
             continue
         fi
         if ! $CLANG_CANDIDATE -dumpversion >/dev/null 2>&1; then


### PR DESCRIPTION
Also note that Xcode does not ship libfuzzer and is not usable for a fuzzer build.

As seen here:

```
andrew@Andrews-MacBook-Air:~/Source/serenity/Meta/Lagom$ find /Applications/Xcode.app/Contents/Developer  -name "*fuzz*"
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/share/man/mann/fuzzy.n
/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/lib-dynload/_xxtestfuzz.cpython-39-darwin.so
/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/lib-dynload/_xxtestfuzz.cpython-38-darwin.so
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/fuzzer
andrew@Andrews-MacBook-Air:~/Source/serenity/Meta/Lagom$ find /opt/homebrew/opt/llvm/lib -name "*fuzz*"
/opt/homebrew/opt/llvm/lib/clang/15.0.7/include/fuzzer
/opt/homebrew/opt/llvm/lib/clang/15.0.7/lib/darwin/libclang_rt.fuzzer_interceptors_osx.a
/opt/homebrew/opt/llvm/lib/clang/15.0.7/lib/darwin/libclang_rt.fuzzer_osx.a
/opt/homebrew/opt/llvm/lib/clang/15.0.7/lib/darwin/libclang_rt.fuzzer_no_main_osx.a
andrew@Andrews-MacBook-Air:~/Source/serenity/Meta/Lagom$ 
```
