### PR TITLE
Meta: Lower QEMU DirectSound driver timer period to 2ms

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -164,7 +164,7 @@ fi
 if [ "$(uname)" = "Darwin" ]; then
     SERENITY_AUDIO_BACKEND="-audiodev coreaudio,id=snd0"
 elif [ "$NATIVE_WINDOWS_QEMU" -eq "1" ]; then
-    SERENITY_AUDIO_BACKEND="-audiodev dsound,id=snd0"
+    SERENITY_AUDIO_BACKEND="-audiodev dsound,id=snd0,timer-period=2000"
 elif "$SERENITY_QEMU_BIN" -audio-help 2>&1 | grep -- "-audiodev id=sdl" >/dev/null; then
     SERENITY_AUDIO_BACKEND="-audiodev sdl,id=snd0"
 else


### PR DESCRIPTION
10ms (the default) is ridiculous and causes all kinds of glitches if we actually want to have a low-latency queue. <https://gitlab.com/qemu-project/qemu/-/issues/1076#note_996636777> suggests 2ms (and no lower than 1ms). This improves audio glitch resistance at our current 512 sample buffer size, but going lower is still not possible.