### PR TITLE
 Kernel+Userland: Get rid of LibC headers in kernel (part 2)

### DIFF
--- a/Kernel/API/POSIX/select.h
+++ b/Kernel/API/POSIX/select.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2023, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define FD_SETSIZE 1024

--- a/Kernel/API/ttydefaults.h
+++ b/Kernel/API/ttydefaults.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, Daniel Bertalan <dani@danielbertalan.dev>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define TTYDEF_IFLAG (ICRNL)
+#define TTYDEF_OFLAG (OPOST | ONLCR)
+#define TTYDEF_LFLAG_NOECHO (ISIG | ICANON)
+#define TTYDEF_LFLAG_ECHO (TTYDEF_LFLAG_NOECHO | ECHO | ECHOE | ECHOK | ECHONL)
+#define TTYDEF_LFLAG TTYDEF_LFLAG_ECHO
+#define TTYDEF_CFLAG (CS8)
+#define TTYDEF_SPEED (B9600)
+
+#define CTRL(c) (c & 0x1F)
+#define CINTR CTRL('c')
+#define CQUIT 034
+#define CERASE 010
+#define CKILL CTRL('u')
+#define CEOF CTRL('d')
+#define CTIME 0
+#define CMIN 1
+#define CSWTC 0
+#define CSTART CTRL('q')
+#define CSTOP CTRL('s')
+#define CSUSP CTRL('z')
+#define CEOL 0
+#define CREPRINT CTRL('r')
+#define CDISCARD CTRL('o')
+#define CWERASE CTRL('w')
+#define CLNEXT CTRL('v')
+#define CEOL2 CEOL
+
+#define CEOT CEOF
+#define CBRK CEOL
+#define CRPRNT CREPRINT
+#define CFLUSH CDISCARD

--- a/Kernel/API/ttydefaultschars.h
+++ b/Kernel/API/ttydefaultschars.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, Daniel Bertalan <dani@danielbertalan.dev>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/API/POSIX/termios.h>
+#include <Kernel/API/ttydefaults.h>
+
+#ifdef __clang__
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wc99-designator"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static const cc_t ttydefchars[NCCS] = {
+    [VINTR] = CINTR,
+    [VQUIT] = CQUIT,
+    [VERASE] = CERASE,
+    [VKILL] = CKILL,
+    [VEOF] = CEOF,
+    [VTIME] = CTIME,
+    [VMIN] = CMIN,
+    [VSWTC] = CSWTC,
+    [VSTART] = CSTART,
+    [VSTOP] = CSTOP,
+    [VSUSP] = CSUSP,
+    [VEOL] = CEOL,
+    [VREPRINT] = CREPRINT,
+    [VDISCARD] = CDISCARD,
+    [VWERASE] = CWERASE,
+    [VLNEXT] = CLNEXT,
+    [VEOL2] = CEOL2
+};
+
+#ifdef __clang__
+#    pragma clang diagnostic pop
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/Kernel/Arch/PageFault.cpp
+++ b/Kernel/Arch/PageFault.cpp
@@ -11,7 +11,6 @@
 #include <Kernel/Arch/SafeMem.h>
 #include <Kernel/PerformanceManager.h>
 #include <Kernel/Thread.h>
-#include <LibC/mallocdefs.h>
 
 namespace Kernel {
 
@@ -82,16 +81,10 @@ void PageFault::handle(RegisterState& regs)
             is_instruction_fetch() ? "instruction fetch / " : "",
             is_write() ? "write to" : "read from",
             VirtualAddress(fault_address));
-        constexpr FlatPtr malloc_scrub_pattern = explode_byte(MALLOC_SCRUB_BYTE);
-        constexpr FlatPtr free_scrub_pattern = explode_byte(FREE_SCRUB_BYTE);
         constexpr FlatPtr kmalloc_scrub_pattern = explode_byte(KMALLOC_SCRUB_BYTE);
         constexpr FlatPtr kfree_scrub_pattern = explode_byte(KFREE_SCRUB_BYTE);
         if (response == PageFaultResponse::BusError) {
             dbgln("Note: Address {} is an access to an undefined memory range of an Inode-backed VMObject", VirtualAddress(fault_address));
-        } else if ((fault_address & 0xffff0000) == (malloc_scrub_pattern & 0xffff0000)) {
-            dbgln("Note: Address {} looks like it may be uninitialized malloc() memory", VirtualAddress(fault_address));
-        } else if ((fault_address & 0xffff0000) == (free_scrub_pattern & 0xffff0000)) {
-            dbgln("Note: Address {} looks like it may be recently free()'d memory", VirtualAddress(fault_address));
         } else if ((fault_address & 0xffff0000) == (kmalloc_scrub_pattern & 0xffff0000)) {
             dbgln("Note: Address {} looks like it may be uninitialized kmalloc() memory", VirtualAddress(fault_address));
         } else if ((fault_address & 0xffff0000) == (kfree_scrub_pattern & 0xffff0000)) {

--- a/Kernel/KBufferBuilder.h
+++ b/Kernel/KBufferBuilder.h
@@ -9,7 +9,6 @@
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <Kernel/KBuffer.h>
-#include <stdarg.h>
 
 namespace Kernel {
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -14,6 +14,7 @@
 #include <AK/RefPtr.h>
 #include <AK/Userspace.h>
 #include <AK/Variant.h>
+#include <Kernel/API/POSIX/select.h>
 #include <Kernel/API/POSIX/sys/resource.h>
 #include <Kernel/API/Syscall.h>
 #include <Kernel/Assertions.h>

--- a/Kernel/Syscalls/poll.cpp
+++ b/Kernel/Syscalls/poll.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/ScopeGuard.h>
 #include <AK/Time.h>
+#include <Kernel/API/POSIX/select.h>
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/OpenFileDescription.h>
 #include <Kernel/Process.h>

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -10,13 +10,13 @@
 #include <Kernel/API/Ioctl.h>
 #include <Kernel/API/POSIX/errno.h>
 #include <Kernel/API/POSIX/signal_numbers.h>
+#include <Kernel/API/ttydefaults.h>
+#include <Kernel/API/ttydefaultschars.h>
 #include <Kernel/Debug.h>
 #include <Kernel/InterruptDisabler.h>
 #include <Kernel/Process.h>
 #include <Kernel/TTY/TTY.h>
-#define TTYDEFCHARS
-#include <LibC/sys/ttydefaults.h>
-#undef TTYDEFCHARS
+#include <Kernel/UnixTypes.h>
 
 namespace Kernel {
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -16,6 +16,7 @@
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <Kernel/API/POSIX/sched.h>
+#include <Kernel/API/POSIX/select.h>
 #include <Kernel/API/POSIX/signal_numbers.h>
 #include <Kernel/Arch/RegisterState.h>
 #include <Kernel/Arch/ThreadRegisters.h>
@@ -31,7 +32,6 @@
 #include <Kernel/Locking/SpinlockProtected.h>
 #include <Kernel/Memory/VirtualRange.h>
 #include <Kernel/UnixTypes.h>
-#include <LibC/fd_set.h>
 
 namespace Kernel {
 

--- a/Kernel/kprintf.cpp
+++ b/Kernel/kprintf.cpp
@@ -20,8 +20,6 @@
 #include <Kernel/TTY/ConsoleManagement.h>
 #include <Kernel/kstdio.h>
 
-#include <LibC/stdarg.h>
-
 namespace Kernel {
 extern Atomic<Graphics::Console*> g_boot_console;
 }
@@ -90,49 +88,13 @@ static void console_out(char ch)
     }
 }
 
-static void buffer_putch(char*& bufptr, char ch)
-{
-    *bufptr++ = ch;
-}
-
 // Declare it, so that the symbol is exported, because libstdc++ uses it.
 // However, *only* libstdc++ uses it, and none of the rest of the Kernel.
 extern "C" int sprintf(char* buffer, char const* fmt, ...);
 
-int sprintf(char* buffer, char const* fmt, ...)
+int sprintf(char*, char const*, ...)
 {
-    va_list ap;
-    va_start(ap, fmt);
-    int ret = printf_internal(buffer_putch, buffer, fmt, ap);
-    buffer[ret] = '\0';
-    va_end(ap);
-    return ret;
-}
-
-int snprintf(char* buffer, size_t size, char const* fmt, ...)
-{
-    va_list ap;
-    va_start(ap, fmt);
-    size_t space_remaining = 0;
-    if (size) {
-        space_remaining = size - 1;
-    } else {
-        space_remaining = 0;
-    }
-    auto sized_buffer_putch = [&](char*& bufptr, char ch) {
-        if (space_remaining) {
-            *bufptr++ = ch;
-            --space_remaining;
-        }
-    };
-    int ret = printf_internal(sized_buffer_putch, buffer, fmt, ap);
-    if (space_remaining) {
-        buffer[ret] = '\0';
-    } else if (size > 0) {
-        buffer[size - 1] = '\0';
-    }
-    va_end(ap);
-    return ret;
+    VERIFY_NOT_REACHED();
 }
 
 static inline void internal_dbgputch(char ch)

--- a/Kernel/kstdio.h
+++ b/Kernel/kstdio.h
@@ -15,7 +15,6 @@ void kernelputstr(char const*, size_t);
 void kernelcriticalputstr(char const*, size_t);
 void dbgputchar(char);
 void kernelearlyputstr(char const*, size_t);
-int snprintf(char* buf, size_t, char const* fmt, ...) __attribute__((format(printf, 3, 4)));
 void set_serial_debug_enabled(bool desired_state);
 bool is_serial_debug_enabled();
 }

--- a/Userland/Libraries/LibC/fd_set.h
+++ b/Userland/Libraries/LibC/fd_set.h
@@ -6,7 +6,8 @@
 
 #pragma once
 
-#define FD_SETSIZE 1024
+#include <Kernel/API/POSIX/select.h>
+
 #define FD_ZERO(set)                      \
     do {                                  \
         memset((set), 0, sizeof(fd_set)); \

--- a/Userland/Libraries/LibC/sys/ttydefaults.h
+++ b/Userland/Libraries/LibC/sys/ttydefaults.h
@@ -6,80 +6,10 @@
 
 #pragma once
 
-#define TTYDEF_IFLAG (ICRNL)
-#define TTYDEF_OFLAG (OPOST | ONLCR)
-#define TTYDEF_LFLAG_NOECHO (ISIG | ICANON)
-#define TTYDEF_LFLAG_ECHO (TTYDEF_LFLAG_NOECHO | ECHO | ECHOE | ECHOK | ECHONL)
-#define TTYDEF_LFLAG TTYDEF_LFLAG_ECHO
-#define TTYDEF_CFLAG (CS8)
-#define TTYDEF_SPEED (B9600)
-
-#define CTRL(c) (c & 0x1F)
-#define CINTR CTRL('c')
-#define CQUIT 034
-#define CERASE 010
-#define CKILL CTRL('u')
-#define CEOF CTRL('d')
-#define CTIME 0
-#define CMIN 1
-#define CSWTC 0
-#define CSTART CTRL('q')
-#define CSTOP CTRL('s')
-#define CSUSP CTRL('z')
-#define CEOL 0
-#define CREPRINT CTRL('r')
-#define CDISCARD CTRL('o')
-#define CWERASE CTRL('w')
-#define CLNEXT CTRL('v')
-#define CEOL2 CEOL
-
-#define CEOT CEOF
-#define CBRK CEOL
-#define CRPRNT CREPRINT
-#define CFLUSH CDISCARD
+#include <Kernel/API/ttydefaults.h>
 
 #ifdef TTYDEFCHARS
-#    ifdef KERNEL
-#        include <Kernel/UnixTypes.h>
-#    else
-#        include <termios.h>
-#    endif
+#    include <termios.h>
 
-#    ifdef __clang__
-#        pragma clang diagnostic push
-#        pragma clang diagnostic ignored "-Wc99-designator"
-#    endif
-
-#    ifdef __cplusplus
-extern "C" {
-#    endif
-
-static const cc_t ttydefchars[NCCS] = {
-    [VINTR] = CINTR,
-    [VQUIT] = CQUIT,
-    [VERASE] = CERASE,
-    [VKILL] = CKILL,
-    [VEOF] = CEOF,
-    [VTIME] = CTIME,
-    [VMIN] = CMIN,
-    [VSWTC] = CSWTC,
-    [VSTART] = CSTART,
-    [VSTOP] = CSTOP,
-    [VSUSP] = CSUSP,
-    [VEOL] = CEOL,
-    [VREPRINT] = CREPRINT,
-    [VDISCARD] = CDISCARD,
-    [VWERASE] = CWERASE,
-    [VLNEXT] = CLNEXT,
-    [VEOL2] = CEOL2
-};
-
-#    ifdef __clang__
-#        pragma clang diagnostic pop
-#    endif
-
-#    ifdef __cplusplus
-}
-#    endif
-
+#    include <Kernel/API/ttydefaultschars.h>
 #endif


### PR DESCRIPTION
No functional change (maybe except for removing two debug messages that are quite useless in the Kernel).
This is part 2, part 1 was in #17599.