### PR TITLE
LibJS: Use a pseudo top-level UnwindFrame in GenerateCFG

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Pass/GenerateCFG.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/GenerateCFG.cpp
@@ -160,6 +160,9 @@ void GenerateCFG::perform(PassPipelineExecutable& executable)
 
     seen_blocks.clear();
     unwind_frames.clear();
+    UnwindFrame top_level_frame = {};
+
+    unwind_frames.append(&top_level_frame);
 
     generate_cfg_for_block(executable.executable.basic_blocks.first(), executable);
 


### PR DESCRIPTION
Previously we assumed that there is always one such frame, now there is.

----

Fixes LibJS optimized builds