### PR TITLE
LibGUI: Don't show non-visible actions in CommandPalette

### DIFF
--- a/Userland/Libraries/LibGUI/CommandPalette.cpp
+++ b/Userland/Libraries/LibGUI/CommandPalette.cpp
@@ -232,14 +232,14 @@ void CommandPalette::collect_actions(GUI::Window& parent_window)
 
     auto collect_action_children = [&](Core::Object& action_parent) {
         action_parent.for_each_child_of_type<GUI::Action>([&](GUI::Action& action) {
-            if (action.is_enabled())
+            if (action.is_enabled() && action.is_visible())
                 actions.set(action);
             return IterationDecision::Continue;
         });
     };
 
     Function<bool(GUI::Action*)> should_show_action = [&](GUI::Action* action) {
-        return action && action->is_enabled() && action->shortcut() != Shortcut(Mod_Ctrl | Mod_Shift, Key_A);
+        return action && action->is_enabled() && action->is_visible() && action->shortcut() != Shortcut(Mod_Ctrl | Mod_Shift, Key_A);
     };
 
     Function<void(Menu&)> collect_actions_from_menu = [&](Menu& menu) {


### PR DESCRIPTION
This PR ensures that actions that are not currently visible are not displayed in the CommandPalette.

An example of where this was an issue is PixelPaint, where clicking the Apply Mask and Delete Mask actions for a non masked layer would cause the program to crash.