### PR TITLE
keymap: Remember configured keymap after reboot

### DIFF
--- a/Userland/Services/KeyboardPreferenceLoader/main.cpp
+++ b/Userland/Services/KeyboardPreferenceLoader/main.cpp
@@ -20,18 +20,10 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto keyboard_settings_config = TRY(Core::ConfigFile::open_for_app("KeyboardSettings"));
 
     TRY(Core::System::unveil("/bin/keymap", "x"));
-    TRY(Core::System::unveil("/etc/Keyboard.ini", "r"));
     TRY(Core::System::unveil("/dev/input/keyboard/0", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
-    auto mapper_config = TRY(Core::ConfigFile::open("/etc/Keyboard.ini"));
-    auto keymaps = mapper_config->read_entry("Mapping", "Keymaps", "");
-
-    auto keymaps_vector = keymaps.split(',');
-    if (keymaps_vector.size() == 0)
-        exit(1);
-
     pid_t child_pid;
-    char const* argv[] = { "/bin/keymap", "-m", keymaps_vector.first().characters(), nullptr };
+    char const* argv[] = { "/bin/keymap", "-r", nullptr };
     if ((errno = posix_spawn(&child_pid, "/bin/keymap", nullptr, nullptr, const_cast<char**>(argv), environ))) {
         perror("posix_spawn");
         exit(1);

--- a/Userland/Services/WindowServer/KeymapSwitcher.cpp
+++ b/Userland/Services/WindowServer/KeymapSwitcher.cpp
@@ -47,12 +47,14 @@ void KeymapSwitcher::refresh()
 
     auto current_keymap = get_current_keymap();
 
+    auto new_keymap = mapper_config->read_entry("Mapping", "Keymap", current_keymap);
+
     // Refresh might indicate that some external program has changed the keymap,
     // so better notify our clients that we may have a new keymap
     if (on_keymap_change)
-        on_keymap_change(current_keymap);
+        on_keymap_change(new_keymap);
 
-    if (m_keymaps.find(current_keymap).is_end()) {
+    if (m_keymaps.find(new_keymap).is_end()) {
         set_keymap(m_keymaps.first());
     }
 }


### PR DESCRIPTION
Changing the keymap was forgotten after reboot. This change stores the chosen keymap in /etc/Keyboard.ini next to the list of enabled keymaps, so that it too can be recovered after reboot.

The keymap program was chosen as the place to write the keymap into the configuration file, as it already had the responsibility of reading and writing the list of configured keymaps.

The code was restructured a bit to avoid multiple writes to the config file, which is especially useful since the KeyMapSwitcher auto-reloads on changes.

A --refresh (-r) flag was added to the keymap program, so that the KeyboardPreferenceLoader doesn't also have to know about the contents of the config file.