### PR TITLE
PixelPaint: Make wand tool work when layer and image rects differ

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/WandSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/WandSelectTool.cpp
@@ -25,7 +25,7 @@ static void set_flood_selection(Gfx::Bitmap& bitmap, Image& image, Gfx::IntPoint
 {
     VERIFY(bitmap.bpp() == 32);
 
-    Mask selection_mask = Mask::empty(bitmap.rect());
+    auto selection_mask = Mask::empty({ selection_offset, bitmap.size() });
 
     auto pixel_reached = [&](Gfx::IntPoint location) {
         selection_mask.set(selection_offset.x() + location.x(), selection_offset.y() + location.y(), 0xFF);


### PR DESCRIPTION
Previously, the position of the mask used to calculate the new selection did not match the position of the active layer. The program would crash when trying to set a mask pixel outside the bounds of the active layer.

Minimal steps required to reproduce the issue on `master`:

1. Open PixelPaint with the default blank image.
2. Use the arrow keys with the Move Tool to move the Background layer one pixel in any direction.
3. Click the Wand Select Tool and click anywhere on the image.