### PR TITLE
PixelPaint: Fix crashes caused by no ImageEditor being present

### DIFF
--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -691,7 +691,8 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         if (!visible)
             return;
 
-        bool image_has_selection = !current_image_editor()->active_layer()->image().selection().is_empty();
+        auto* editor = current_image_editor();
+        bool image_has_selection = editor && editor->active_layer() && !editor->active_layer()->image().selection().is_empty();
 
         m_layer_via_copy->set_enabled(image_has_selection);
         m_layer_via_cut->set_enabled(image_has_selection);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1137,6 +1137,8 @@ void MainWidget::set_actions_enabled(bool enabled)
     m_filter_menu->set_children_actions_enabled(enabled);
 
     m_zoom_combobox->set_enabled(enabled);
+
+    m_levels_dialog_action->set_enabled(enabled);
 }
 
 void MainWidget::set_mask_actions_for_layer(Layer* layer)


### PR DESCRIPTION
This PR fixes 2 crashes that occur when no image is loaded. 

Previously, the program would crash when no image was loaded and the user:
* clicked on the Levels icon
* attempted to open the Layer menu

NB: The Levels dialog appears to be broken at the moment. I'm not sure what's causing this but I think its outside the scope of this PR.