### PR TITLE
LibWeb: Define navigator/clientInformation with define_native_accessor (The Great Upstream 6/n)

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1146,8 +1146,8 @@ void Window::initialize_web_interfaces(Badge<WindowEnvironmentSettingsObject>)
     m_location = heap().allocate<HTML::Location>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
 
     m_navigator = heap().allocate<HTML::Navigator>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
-    define_direct_property("navigator", m_navigator, JS::Attribute::Enumerable | JS::Attribute::Configurable);
-    define_direct_property("clientInformation", m_navigator, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_accessor(realm, "navigator", navigator_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_accessor(realm, "clientInformation", navigator_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
 
     // NOTE: location is marked as [LegacyUnforgeable], meaning it isn't configurable.
     define_native_accessor(realm, "location", location_getter, location_setter, JS::Attribute::Enumerable);
@@ -1896,6 +1896,12 @@ JS_DEFINE_NATIVE_FUNCTION(Window::name_setter)
     auto* impl = TRY(impl_from(vm));
     impl->set_name(TRY(vm.argument(0).to_deprecated_string(vm)));
     return JS::js_undefined();
+}
+
+JS_DEFINE_NATIVE_FUNCTION(Window::navigator_getter)
+{
+    auto* impl = TRY(impl_from(vm));
+    return impl->m_navigator;
 }
 
 #define __ENUMERATE(attribute, event_name)                                      \

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -275,6 +275,8 @@ private:
 
     JS_DECLARE_NATIVE_FUNCTION(crypto_getter);
 
+    JS_DECLARE_NATIVE_FUNCTION(navigator_getter);
+
 #define __ENUMERATE(attribute, event_name)          \
     JS_DECLARE_NATIVE_FUNCTION(attribute##_getter); \
     JS_DECLARE_NATIVE_FUNCTION(attribute##_setter);


### PR DESCRIPTION
Defining it as a direct property causes it to have no getter/setter function, which causes an empty Optional crash when attempting to access such getter on a cross-origin iframe.

Fixes amazon.com crashing on this particular crash.