### PR TITLE
PixelPaint: Remove shrink_to_fit property from LevelsDialog GML

### DIFF
--- a/Userland/Applications/PixelPaint/LevelsDialog.gml
+++ b/Userland/Applications/PixelPaint/LevelsDialog.gml
@@ -5,7 +5,6 @@
     }
 
     @GUI::Widget {
-        shrink_to_fit: true
         layout: @GUI::VerticalBoxLayout {}
 
         @GUI::Label {


### PR DESCRIPTION
This was causing the levels dialog to be displayed incorrectly.

Before:
![image](https://user-images.githubusercontent.com/2817754/221746142-8b2f792a-ff16-4fb9-8165-f102ed07a4c8.png)


After:
![image](https://user-images.githubusercontent.com/2817754/221746287-d31c6bf8-de54-47a7-a7c1-718ffa5809bb.png)

