### PR TITLE
LibGfx: Bubble up allocation failure instead of panicking

### DIFF
--- a/Userland/Libraries/LibGfx/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPEGLoader.cpp
@@ -1332,7 +1332,7 @@ static ErrorOr<Vector<Macroblock>> construct_macroblocks(JPEGLoadingContext& con
     // This function handles the "Multi-scan" loop.
 
     Vector<Macroblock> macroblocks;
-    macroblocks.resize(context.mblock_meta.padded_total);
+    TRY(macroblocks.try_resize(context.mblock_meta.padded_total));
 
     Marker marker = TRY(read_marker_at_cursor(*context.stream));
     while (true) {


### PR DESCRIPTION
Fixes #10162.

It turns out that the image is just too big and, in its current shape, JPEGLoader is not very memory-efficient. Propagating the allocation failure instead of panicking makes the fuzzer happy :^)