### PR TITLE
AK+Everywhere: Make GenericLexer::ignore_until() stop before the value

### DIFF
--- a/AK/GenericLexer.h
+++ b/AK/GenericLexer.h
@@ -142,7 +142,6 @@ public:
         while (!is_eof() && peek() != stop) {
             ++m_index;
         }
-        ignore();
     }
 
     constexpr void ignore_until(char const* stop)
@@ -150,7 +149,6 @@ public:
         while (!is_eof() && !next_is(stop)) {
             ++m_index;
         }
-        ignore(__builtin_strlen(stop));
     }
 
     /*
@@ -205,8 +203,7 @@ public:
             ++m_index;
     }
 
-    // Ignore characters until `pred` return true
-    // We don't skip the stop character as it may not be a unique value
+    // Ignore characters until `pred` returns true
     template<typename TPredicate>
     constexpr void ignore_until(TPredicate pred)
     {

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -105,7 +105,7 @@ Vector<Endpoint> parse(ByteBuffer const& file_contents)
     auto consume_whitespace = [&lexer] {
         lexer.ignore_while([](char ch) { return isspace(ch); });
         if (lexer.peek() == '/' && lexer.peek(1) == '/')
-            lexer.ignore_until([](char ch) { return ch == '\n'; });
+            lexer.ignore_until('\n');
     };
 
     auto parse_parameter = [&](Vector<Parameter>& storage) {

--- a/Tests/AK/TestGenericLexer.cpp
+++ b/Tests/AK/TestGenericLexer.cpp
@@ -107,7 +107,7 @@ TEST_CASE(should_constexpr_ignore_until)
         sut.ignore_until('d');
         return sut;
     }();
-    static_assert(sut.peek() == 'e');
+    static_assert(sut.peek() == 'd');
 }
 
 TEST_CASE(should_constexpr_ignore_until_cstring)
@@ -117,7 +117,7 @@ TEST_CASE(should_constexpr_ignore_until_cstring)
         sut.ignore_until("cde");
         return sut;
     }();
-    static_assert(sut.peek() == 'f');
+    static_assert(sut.peek() == 'c');
 }
 
 TEST_CASE(should_constexpr_next_is_pred)

--- a/Userland/Libraries/LibCpp/Preprocessor.cpp
+++ b/Userland/Libraries/LibCpp/Preprocessor.cpp
@@ -72,21 +72,24 @@ static void consume_whitespace(GenericLexer& lexer)
                 lexer.ignore(2);
             } else {
                 lexer.ignore_until('\n');
+                lexer.ignore();
                 break;
             }
         }
     };
     for (;;) {
-        if (lexer.consume_specific("//"sv))
+        if (lexer.consume_specific("//"sv)) {
             ignore_line();
-        else if (lexer.consume_specific("/*"sv))
+        } else if (lexer.consume_specific("/*"sv)) {
             lexer.ignore_until("*/");
-        else if (lexer.next_is("\\\n"sv))
             lexer.ignore(2);
-        else if (lexer.is_eof() || !lexer.next_is(isspace))
+        } else if (lexer.next_is("\\\n"sv)) {
+            lexer.ignore(2);
+        } else if (lexer.is_eof() || !lexer.next_is(isspace)) {
             break;
-        else
+        } else {
             lexer.ignore();
+        }
     }
 }
 

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -139,10 +139,7 @@ Optional<MimeType> MimeType::from_string(StringView string)
             parameter_value = Fetch::Infrastructure::collect_an_http_quoted_string(lexer, Fetch::Infrastructure::HttpQuotedStringExtractValue::Yes);
 
             // 2. Collect a sequence of code points that are not U+003B (;) from input, given position.
-            // NOTE: This uses the predicate version as the ignore_until(char) version will also ignore the ';'.
-            lexer.ignore_until([](char ch) {
-                return ch == ';';
-            });
+            lexer.ignore_until(';');
         }
 
         // 9. Otherwise:


### PR DESCRIPTION
`consume_until(foo)` stops before foo, and so does `ignore_until(Predicate)`, so let's make the other `ignore_until()` overloads consistent with that so they're less confusing.