### PR TITLE
AudioServer+Userland: Decouple client sample rates from device rate

### DIFF
--- a/Base/usr/share/man/man1/asctl.md
+++ b/Base/usr/share/man/man1/asctl.md
@@ -30,7 +30,7 @@ There are two commands available: `get` reports the state of audio variables, an
 The available variables are:
 * `(v)olume`: Audio server volume, in percent. Integer value.
 * `(m)ute`: Mute state. Boolean value, may be set with `0`, `false` or `1`, `true`.
-* `sample(r)ate`: Sample rate of the sound card. **Attention:** Most audio applications need to be restarted after changing the sample rate. Integer value.
+* `sample(r)ate`: Sample rate of the sound card. Integer value.
 
 Both commands and arguments can be abbreviated: Commands by their first letter, arguments by the letter in parenthesis.
 

--- a/Ladybird/AudioCodecPluginLadybird.cpp
+++ b/Ladybird/AudioCodecPluginLadybird.cpp
@@ -163,7 +163,7 @@ private:
 
                 case AudioTask::Type::Seek:
                     VERIFY(task.data.has_value());
-                    m_position = Web::Platform::AudioCodecPlugin::set_loader_position(m_loader, *task.data, m_duration, audio_output->format().sampleRate());
+                    m_position = Web::Platform::AudioCodecPlugin::set_loader_position(m_loader, *task.data, m_duration);
 
                     if (paused == Paused::Yes)
                         Q_EMIT playback_position_updated(m_position);
@@ -211,10 +211,10 @@ private:
         auto channel_count = audio_output.format().channelCount();
         auto samples_to_load = bytes_available / bytes_per_sample / channel_count;
 
-        auto samples = TRY(Web::Platform::AudioCodecPlugin::read_samples_from_loader(*m_loader, samples_to_load, audio_output.format().sampleRate()));
+        auto samples = TRY(Web::Platform::AudioCodecPlugin::read_samples_from_loader(*m_loader, samples_to_load));
         enqueue_samples(audio_output, io_device, move(samples));
 
-        m_position = Web::Platform::AudioCodecPlugin::current_loader_position(m_loader, audio_output.format().sampleRate());
+        m_position = Web::Platform::AudioCodecPlugin::current_loader_position(m_loader);
         return Paused::No;
     }
 

--- a/Userland/Applications/Piano/AudioPlayerLoop.h
+++ b/Userland/Applications/Piano/AudioPlayerLoop.h
@@ -39,10 +39,8 @@ private:
 
     TrackManager& m_track_manager;
     FixedArray<DSP::Sample> m_buffer;
-    Optional<Audio::ResampleHelper<DSP::Sample>> m_resampler;
     RefPtr<Audio::ConnectionToServer> m_audio_client;
     NonnullRefPtr<Threading::Thread> m_pipeline_thread;
-    Vector<Audio::Sample, Audio::AUDIO_BUFFER_SIZE> m_remaining_samples {};
 
     Atomic<bool> m_should_play_audio { true };
     Atomic<bool> m_exit_requested { false };

--- a/Userland/Applications/Piano/Music.h
+++ b/Userland/Applications/Piano/Music.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Types.h>
+#include <LibAudio/Queue.h>
 #include <LibGfx/Color.h>
 
 namespace Music {
@@ -23,8 +24,7 @@ struct Sample {
     i16 right;
 };
 
-// HACK: needs to increase with device sample rate, but all of the sample_count stuff is static for now
-constexpr int sample_count = 1 << 10;
+constexpr int sample_count = Audio::AUDIO_BUFFER_SIZE * 10;
 
 constexpr double sample_rate = 44100;
 

--- a/Userland/Applications/SoundPlayer/PlaybackManager.h
+++ b/Userland/Applications/SoundPlayer/PlaybackManager.h
@@ -29,7 +29,6 @@ public:
     bool toggle_pause();
     void set_loader(NonnullRefPtr<Audio::Loader>&&);
     RefPtr<Audio::Loader> loader() const { return m_loader; }
-    size_t device_sample_rate() const { return m_device_sample_rate; }
 
     bool is_paused() const { return m_paused; }
     float total_length() const { return m_total_length; }
@@ -50,13 +49,10 @@ private:
     bool m_paused { true };
     bool m_loop = { false };
     float m_total_length { 0 };
-    size_t m_device_sample_rate { 44100 };
-    size_t m_device_samples_per_buffer { 0 };
     size_t m_samples_to_load_per_buffer { 0 };
     RefPtr<Audio::Loader> m_loader { nullptr };
     NonnullRefPtr<Audio::ConnectionToServer> m_connection;
     FixedArray<Audio::Sample> m_current_buffer;
-    Optional<Audio::ResampleHelper<Audio::Sample>> m_resampler;
     RefPtr<Core::Timer> m_timer;
 
     // Controls the GUI update rate. A smaller value makes the visualizations nicer.

--- a/Userland/Libraries/LibAudio/ConnectionToServer.h
+++ b/Userland/Libraries/LibAudio/ConnectionToServer.h
@@ -55,6 +55,8 @@ public:
     // Non-realtime code needn't worry about this.
     size_t remaining_buffers() const;
 
+    void set_self_sample_rate(u32 sample_rate);
+
     virtual void die() override;
 
     Function<void(double volume)> on_client_volume_change;
@@ -67,7 +69,6 @@ private:
     // We use this to perform the audio enqueuing on the background thread's event loop
     virtual void custom_event(Core::CustomEvent&) override;
 
-    // FIXME: This should be called every time the sample rate changes, but we just cautiously call it on every non-realtime enqueue.
     void update_good_sleep_time();
 
     // Shared audio buffer: both server and client constantly read and write to/from this.

--- a/Userland/Libraries/LibWeb/Platform/AudioCodecPlugin.h
+++ b/Userland/Libraries/LibWeb/Platform/AudioCodecPlugin.h
@@ -23,9 +23,9 @@ public:
 
     virtual ~AudioCodecPlugin();
 
-    static ErrorOr<FixedArray<Audio::Sample>> read_samples_from_loader(Audio::Loader&, size_t samples_to_load, size_t device_sample_rate);
-    static Duration set_loader_position(Audio::Loader&, double position, Duration duration, size_t device_sample_rate);
-    static Duration current_loader_position(Audio::Loader const&, size_t device_sample_rate);
+    static ErrorOr<FixedArray<Audio::Sample>> read_samples_from_loader(Audio::Loader&, size_t samples_to_load);
+    static Duration set_loader_position(Audio::Loader&, double position, Duration duration);
+    static Duration current_loader_position(Audio::Loader const&);
 
     virtual void resume_playback() = 0;
     virtual void pause_playback() = 0;

--- a/Userland/Services/AudioServer/AudioServer.ipc
+++ b/Userland/Services/AudioServer/AudioServer.ipc
@@ -8,9 +8,8 @@ endpoint AudioServer
     get_self_volume() => (double volume)
     set_self_volume(double volume) => ()
 
-    // FIXME: Decouple client sample rate from device sample rate, then remove this API
-    get_sample_rate() => (u32 sample_rate)
-
+    set_self_sample_rate(u32 sample_rate) => ()
+    get_self_sample_rate() => (u32 sample_rate)
     // Buffer playback
     set_buffer(Audio::AudioQueue buffer) => ()
     clear_buffer() =|

--- a/Userland/Services/AudioServer/ConnectionFromClient.h
+++ b/Userland/Services/AudioServer/ConnectionFromClient.h
@@ -40,11 +40,12 @@ private:
     virtual void pause_playback() override;
     virtual Messages::AudioServer::IsSelfMutedResponse is_self_muted() override;
     virtual void set_self_muted(bool) override;
-    // FIXME: Decouple client sample rate from device sample rate, then remove this endpoint
-    virtual Messages::AudioServer::GetSampleRateResponse get_sample_rate() override;
+    virtual Messages::AudioServer::GetSelfSampleRateResponse get_self_sample_rate() override;
+    virtual void set_self_sample_rate(u32 sample_rate) override;
 
     Mixer& m_mixer;
     RefPtr<ClientAudioStream> m_queue;
+    Optional<u32> m_saved_sample_rate {};
 };
 
 }

--- a/Userland/Services/WebContent/AudioCodecPluginSerenity.cpp
+++ b/Userland/Services/WebContent/AudioCodecPluginSerenity.cpp
@@ -38,16 +38,16 @@ AudioCodecPluginSerenity::AudioCodecPluginSerenity(NonnullRefPtr<Audio::Connecti
     auto duration = static_cast<double>(m_loader->total_samples()) / static_cast<double>(m_loader->sample_rate());
     m_duration = Duration::from_milliseconds(static_cast<i64>(duration * 1000.0));
 
-    m_device_sample_rate = m_connection->get_sample_rate();
-    m_device_samples_per_buffer = static_cast<size_t>(BUFFER_SIZE_MS / 1000.0 * static_cast<double>(m_device_sample_rate));
     m_samples_to_load_per_buffer = static_cast<size_t>(BUFFER_SIZE_MS / 1000.0 * static_cast<double>(m_loader->sample_rate()));
+
+    m_connection->set_self_sample_rate(m_loader->sample_rate());
 }
 
 AudioCodecPluginSerenity::~AudioCodecPluginSerenity() = default;
 
 ErrorOr<void> AudioCodecPluginSerenity::play_next_samples()
 {
-    while (m_connection->remaining_samples() < m_device_samples_per_buffer * ALWAYS_ENQUEUED_BUFFER_COUNT) {
+    while (m_connection->remaining_samples() < m_samples_to_load_per_buffer * ALWAYS_ENQUEUED_BUFFER_COUNT) {
         bool all_samples_loaded = m_loader->loaded_samples() >= m_loader->total_samples();
         bool audio_server_done = m_connection->remaining_samples() == 0;
 
@@ -62,10 +62,10 @@ ErrorOr<void> AudioCodecPluginSerenity::play_next_samples()
             break;
         }
 
-        auto samples = TRY(read_samples_from_loader(m_loader, m_samples_to_load_per_buffer, m_device_sample_rate));
+        auto samples = TRY(read_samples_from_loader(m_loader, m_samples_to_load_per_buffer));
         TRY(m_connection->async_enqueue(move(samples)));
 
-        m_position = current_loader_position(m_loader, m_device_sample_rate);
+        m_position = current_loader_position(m_loader);
     }
 
     return {};
@@ -90,7 +90,7 @@ void AudioCodecPluginSerenity::set_volume(double volume)
 
 void AudioCodecPluginSerenity::seek(double position)
 {
-    m_position = set_loader_position(m_loader, position, m_duration, m_device_sample_rate);
+    m_position = set_loader_position(m_loader, position, m_duration);
 
     if (on_playback_position_updated)
         on_playback_position_updated(m_position);

--- a/Userland/Services/WebContent/AudioCodecPluginSerenity.h
+++ b/Userland/Services/WebContent/AudioCodecPluginSerenity.h
@@ -40,8 +40,6 @@ private:
     Duration m_duration;
     Duration m_position;
 
-    size_t m_device_sample_rate { 0 };
-    size_t m_device_samples_per_buffer { 0 };
     size_t m_samples_to_load_per_buffer { 0 };
 };
 

--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -8,7 +8,6 @@
 #include <AK/Types.h>
 #include <LibAudio/ConnectionToServer.h>
 #include <LibAudio/Loader.h>
-#include <LibAudio/Resampler.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/System.h>
@@ -17,8 +16,6 @@
 #include <math.h>
 #include <stdio.h>
 
-// The Kernel has issues with very large anonymous buffers.
-// FIXME: This appears to be fine for now, but it's really a hack.
 constexpr size_t LOAD_CHUNK_SIZE = 128 * KiB;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
@@ -62,10 +59,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         loader->num_channels() == 1 ? "Mono" : "Stereo");
     out("\033[34;1mProgress\033[0m: \033[s");
 
-    auto resampler = Audio::ResampleHelper<Audio::Sample>(loader->sample_rate(), audio_client->get_sample_rate());
-
-    // If we're downsampling, we need to appropriately load more samples at once.
-    size_t const load_size = static_cast<size_t>(LOAD_CHUNK_SIZE * static_cast<double>(loader->sample_rate()) / static_cast<double>(audio_client->get_sample_rate()));
+    audio_client->set_self_sample_rate(loader->sample_rate());
 
     auto print_playback_update = [&]() {
         out("\033[u");
@@ -94,14 +88,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     for (;;) {
-        auto samples = loader->get_more_samples(load_size);
+        auto samples = loader->get_more_samples(LOAD_CHUNK_SIZE);
         if (!samples.is_error()) {
             if (samples.value().size() > 0) {
                 print_playback_update();
                 // We can read and enqueue more samples
-                resampler.reset();
-                auto resampled_samples = resampler.resample(move(samples.value()));
-                TRY(audio_client->async_enqueue(move(resampled_samples)));
+                TRY(audio_client->async_enqueue(samples.release_value()));
             } else if (should_loop) {
                 // We're done: now loop
                 auto result = loader->reset();
@@ -113,7 +105,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 // We're done and the server is done
                 break;
             }
-            while (audio_client->remaining_samples() > load_size) {
+            while (audio_client->remaining_samples() > LOAD_CHUNK_SIZE) {
                 // The server has enough data for now
                 print_playback_update();
                 usleep(1'000'000 / 10);


### PR DESCRIPTION
Depends on #17656

This change was a long time in the making ever since we obtained sample rate awareness in the system. Now, each client has its own sample rate, accessible via new IPC APIs, and the device sample rate is only accessible via the management interface. AudioServer takes care of resampling client streams into the device sample rate. Therefore, the main improvement introduced with this commit is full responsiveness to sample rate changes; all open audio programs will continue to play at correct speed with the audio resampled to the new device rate.

The immediate benefits are manifold:
- Gets rid of the legacy hardware sample rate IPC message in the non-managing client
- Removes duplicate resampling and sample index rescaling code everywhere
- Avoids potential sample index scaling bugs in SoundPlayer (which have happened many times before) and fixes a sample index scaling bug in aplay
- Removes several FIXMEs
- Reduces amount of sample copying in all applications (especially Piano, where this is critical), improving performance
- Reduces number of resampling users, making future API changes (which will need to happen for correct resampling to be implemented) easier

I also threw in a simple race condition fix for Piano's audio player loop.

https://user-images.githubusercontent.com/28656157/223491224-eeb8efbc-a754-4c6a-b071-004409ee124d.mp4
