### PR TITLE
Everywhere: Use '_{short_,}string' literals more

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2448,11 +2448,11 @@ inline ErrorOr<String> idl_enum_to_string(@enum.type.name@ value) {
                 enum_generator.set("enum.entry", entry.value);
                 enum_generator.set("enum.string", entry.key);
                 enum_generator.append(R"~~~(
-    case @enum.type.name@::@enum.entry@: return String::from_utf8("@enum.string@"sv);
+    case @enum.type.name@::@enum.entry@: return "@enum.string@"_string;
 )~~~");
             }
             enum_generator.append(R"~~~(
-    default: return String::from_utf8("<unknown>"sv);
+    default: return "<unknown>"_string;
     };
 }
 )~~~");

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -43,7 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Config::pledge_domain("ImageViewer");
 
-    app->set_config_domain(TRY(String::from_utf8("ImageViewer"sv)));
+    app->set_config_domain(TRY("ImageViewer"_string));
 
     TRY(Desktop::Launcher::add_allowed_handler_with_any_url("/bin/ImageViewer"));
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man1/ImageViewer.md") }));

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Config::pledge_domain("TextEditor");
 
-    app->set_config_domain(TRY(String::from_utf8("TextEditor"sv)));
+    app->set_config_domain(TRY("TextEditor"_string));
 
     auto preview_mode = "auto"sv;
     char const* file_to_edit = nullptr;

--- a/Userland/Libraries/LibCodeComprehension/Shell/ShellComprehensionEngine.cpp
+++ b/Userland/Libraries/LibCodeComprehension/Shell/ShellComprehensionEngine.cpp
@@ -108,7 +108,7 @@ NonnullRefPtr<::Shell::AST::Node> ShellComprehensionEngine::DocumentData::parse(
     if (auto node = parser.parse())
         return node.release_nonnull();
 
-    return ::Shell::AST::make_ref_counted<::Shell::AST::SyntaxError>(::Shell::AST::Position {}, String::from_utf8("Unable to parse file"sv).release_value_but_fixme_should_propagate_errors());
+    return ::Shell::AST::make_ref_counted<::Shell::AST::SyntaxError>(::Shell::AST::Position {}, "Unable to parse file"_string.release_value_but_fixme_should_propagate_errors());
 }
 
 size_t ShellComprehensionEngine::resolve(ShellComprehensionEngine::DocumentData const& document, const GUI::TextPosition& position)

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -152,7 +152,7 @@ VM::VM(OwnPtr<CustomData> custom_data)
     };
 
 #define __JS_ENUMERATE(SymbolName, snake_name) \
-    m_well_known_symbol_##snake_name = Symbol::create(*this, String::from_utf8("Symbol." #SymbolName##sv).release_value_but_fixme_should_propagate_errors(), false);
+    m_well_known_symbol_##snake_name = Symbol::create(*this, "Symbol." #SymbolName##_string.release_value_but_fixme_should_propagate_errors(), false);
     JS_ENUMERATE_WELL_KNOWN_SYMBOLS
 #undef __JS_ENUMERATE
 

--- a/Userland/Libraries/LibWeb/HTML/Plugin.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Plugin.cpp
@@ -39,7 +39,7 @@ String const& Plugin::name() const
 JS::ThrowCompletionOr<String> Plugin::description() const
 {
     // The Plugin interface's description getter steps are to return "Portable Document Format".
-    static String description_string = TRY_OR_THROW_OOM(vm(), String::from_utf8("Portable Document Format"sv));
+    static String description_string = TRY_OR_THROW_OOM(vm(), "Portable Document Format"_string);
     return description_string;
 }
 
@@ -47,7 +47,7 @@ JS::ThrowCompletionOr<String> Plugin::description() const
 JS::ThrowCompletionOr<String> Plugin::filename() const
 {
     // The Plugin interface's filename getter steps are to return "internal-pdf-viewer".
-    static String filename_string = TRY_OR_THROW_OOM(vm(), String::from_utf8("internal-pdf-viewer"sv));
+    static String filename_string = TRY_OR_THROW_OOM(vm(), "internal-pdf-viewer"_string);
     return filename_string;
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1104,9 +1104,8 @@ Vector<JS::NonnullGCPtr<MimeType>> Window::pdf_viewer_mime_type_objects()
         return {};
 
     if (m_pdf_viewer_mime_type_objects.is_empty()) {
-        // FIXME: Remove the MUSTs and propagate the errors instead.
-        m_pdf_viewer_mime_type_objects.append(realm().heap().allocate<MimeType>(realm(), realm(), MUST(String::from_utf8("application/pdf"sv))).release_allocated_value_but_fixme_should_propagate_errors());
-        m_pdf_viewer_mime_type_objects.append(realm().heap().allocate<MimeType>(realm(), realm(), MUST(String::from_utf8("text/pdf"sv))).release_allocated_value_but_fixme_should_propagate_errors());
+        m_pdf_viewer_mime_type_objects.append(realm().heap().allocate<MimeType>(realm(), realm(), "application/pdf"_string.release_value_but_fixme_should_propagate_errors()).release_allocated_value_but_fixme_should_propagate_errors());
+        m_pdf_viewer_mime_type_objects.append(realm().heap().allocate<MimeType>(realm(), realm(), "text/pdf"_string.release_value_but_fixme_should_propagate_errors()).release_allocated_value_but_fixme_should_propagate_errors());
     }
 
     return m_pdf_viewer_mime_type_objects;

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -1259,7 +1259,7 @@ ErrorOr<RefPtr<Value>> ForLoop::run(RefPtr<Shell> shell)
     };
 
     if (m_iterated_expression) {
-        auto variable_name = m_variable.has_value() ? m_variable->name : String::from_utf8_short_string("it"sv);
+        auto variable_name = m_variable.has_value() ? m_variable->name : "it"_short_string;
         Optional<StringView> index_name = m_index_variable.has_value() ? Optional<StringView>(m_index_variable->name) : Optional<StringView>();
         size_t i = 0;
         TRY(m_iterated_expression->for_each_entry(shell, [&](auto value) -> ErrorOr<IterationDecision> {
@@ -3877,11 +3877,11 @@ ErrorOr<Vector<String>> SpecialVariableValue::resolve_as_list(RefPtr<Shell> shel
                 auto list_argv = static_cast<AST::ListValue const*>(argv.ptr());
                 return { resolve_slices(shell, Vector { TRY(String::number(list_argv->values().size())) }, m_slices) };
             }
-            return { resolve_slices(shell, Vector { String::from_utf8_short_string("1"sv) }, m_slices) };
+            return { resolve_slices(shell, Vector { "1"_short_string }, m_slices) };
         }
-        return { resolve_slices(shell, Vector { String::from_utf8_short_string("0"sv) }, m_slices) };
+        return { resolve_slices(shell, Vector { "0"_short_string }, m_slices) };
     default:
-        return { resolve_slices(shell, Vector { String::from_utf8_short_string(""sv) }, m_slices) };
+        return { resolve_slices(shell, Vector { String {} }, m_slices) };
     }
 }
 

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -1314,7 +1314,7 @@ ErrorOr<int> Shell::builtin_argsparser_parse(Main::Arguments arguments)
     auto try_convert = [](StringView value, Type type) -> ErrorOr<Optional<RefPtr<AST::Value>>> {
         switch (type) {
         case Type::Bool:
-            return AST::make_ref_counted<AST::StringValue>(TRY(String::from_utf8("true"sv)));
+            return AST::make_ref_counted<AST::StringValue>(TRY("true"_string));
         case Type::String:
             return AST::make_ref_counted<AST::StringValue>(TRY(String::from_utf8(value)));
         case Type::I32:
@@ -1498,7 +1498,7 @@ ErrorOr<int> Shell::builtin_argsparser_parse(Main::Arguments arguments)
             if (type == Type::Bool) {
                 set_local_variable(
                     current_variable,
-                    make_ref_counted<AST::StringValue>(MUST(String::from_utf8("false"sv))),
+                    make_ref_counted<AST::StringValue>(MUST("false"_string)),
                     true);
             }
             return true;

--- a/Userland/Shell/ImmediateFunctions.cpp
+++ b/Userland/Shell/ImmediateFunctions.cpp
@@ -80,7 +80,7 @@ ErrorOr<RefPtr<AST::Node>> Shell::immediate_length_impl(AST::ImmediateExpression
             // ImmediateExpression(length <mode_name> <entry>)
             resulting_nodes.unchecked_append(AST::make_ref_counted<AST::ImmediateExpression>(
                 expr_node->position(),
-                AST::NameWithPosition { TRY(String::from_utf8("length"sv)), invoking_node.function_position() },
+                AST::NameWithPosition { TRY("length"_string), invoking_node.function_position() },
                 NonnullRefPtrVector<AST::Node> { Vector<NonnullRefPtr<AST::Node>> {
                     static_cast<NonnullRefPtr<AST::Node>>(AST::make_ref_counted<AST::BarewordLiteral>(expr_node->position(), TRY(String::from_utf8(mode_name)))),
                     AST::make_ref_counted<AST::SyntheticNode>(expr_node->position(), NonnullRefPtr<AST::Value>(entry)),

--- a/Userland/Shell/Parser.cpp
+++ b/Userland/Shell/Parser.cpp
@@ -132,7 +132,7 @@ RefPtr<AST::Node> Parser::parse()
         auto error_start = push_start();
         while (!at_end())
             consume();
-        auto syntax_error_node = create<AST::SyntaxError>(String::from_utf8("Unexpected tokens past the end"sv).release_value_but_fixme_should_propagate_errors());
+        auto syntax_error_node = create<AST::SyntaxError>("Unexpected tokens past the end"_string.release_value_but_fixme_should_propagate_errors());
         if (!toplevel)
             toplevel = move(syntax_error_node);
         else if (!toplevel->is_syntax_error())
@@ -326,7 +326,7 @@ RefPtr<AST::Node> Parser::parse_variable_decls()
             if (!command)
                 restore_to(*start);
             else if (!expect(')'))
-                command->set_is_syntax_error(*create<AST::SyntaxError>(String::from_utf8("Expected a terminating close paren"sv).release_value_but_fixme_should_propagate_errors(), true));
+                command->set_is_syntax_error(*create<AST::SyntaxError>("Expected a terminating close paren"_string.release_value_but_fixme_should_propagate_errors(), true));
             expression = command;
         }
     }
@@ -400,7 +400,7 @@ RefPtr<AST::Node> Parser::parse_function_decl()
         RefPtr<AST::Node> syntax_error;
         {
             auto obrace_error_start = push_start();
-            syntax_error = create<AST::SyntaxError>(String::from_utf8("Expected an open brace '{' to start a function body"sv).release_value_but_fixme_should_propagate_errors(), true);
+            syntax_error = create<AST::SyntaxError>("Expected an open brace '{' to start a function body"_string.release_value_but_fixme_should_propagate_errors(), true);
         }
         if (!expect('{')) {
             return create<AST::FunctionDeclaration>(
@@ -419,7 +419,7 @@ RefPtr<AST::Node> Parser::parse_function_decl()
         RefPtr<AST::SyntaxError> syntax_error;
         {
             auto cbrace_error_start = push_start();
-            syntax_error = create<AST::SyntaxError>(String::from_utf8("Expected a close brace '}' to end a function body"sv).release_value_but_fixme_should_propagate_errors(), true);
+            syntax_error = create<AST::SyntaxError>("Expected a close brace '}' to end a function body"_string.release_value_but_fixme_should_propagate_errors(), true);
         }
         if (!expect('}')) {
             if (body)
@@ -460,7 +460,7 @@ RefPtr<AST::Node> Parser::parse_or_logical_sequence()
 
     auto right_and_sequence = parse_and_logical_sequence();
     if (!right_and_sequence)
-        right_and_sequence = create<AST::SyntaxError>(String::from_utf8("Expected an expression after '||'"sv).release_value_but_fixme_should_propagate_errors(), true);
+        right_and_sequence = create<AST::SyntaxError>("Expected an expression after '||'"_string.release_value_but_fixme_should_propagate_errors(), true);
 
     return create<AST::Or>(
         and_sequence.release_nonnull(),
@@ -484,7 +484,7 @@ RefPtr<AST::Node> Parser::parse_and_logical_sequence()
 
     auto right_and_sequence = parse_and_logical_sequence();
     if (!right_and_sequence)
-        right_and_sequence = create<AST::SyntaxError>(String::from_utf8("Expected an expression after '&&'"sv).release_value_but_fixme_should_propagate_errors(), true);
+        right_and_sequence = create<AST::SyntaxError>("Expected an expression after '&&'"_string.release_value_but_fixme_should_propagate_errors(), true);
 
     return create<AST::And>(
         pipe_sequence.release_nonnull(),
@@ -666,7 +666,7 @@ RefPtr<AST::Node> Parser::parse_for_loop()
         consume_while(is_whitespace);
         auto in_error_start = push_start();
         if (!expect("in"sv)) {
-            auto syntax_error = create<AST::SyntaxError>(String::from_utf8("Expected 'in' after a variable name in a 'for' loop"sv).release_value_but_fixme_should_propagate_errors(), true);
+            auto syntax_error = create<AST::SyntaxError>("Expected 'in' after a variable name in a 'for' loop"_string.release_value_but_fixme_should_propagate_errors(), true);
             return create<AST::ForLoop>(move(variable_name), move(index_variable_name), move(syntax_error), nullptr); // ForLoop Var Iterated Block
         }
         in_start_position = AST::Position { in_error_start->offset, m_offset, in_error_start->line, line() };
@@ -678,14 +678,14 @@ RefPtr<AST::Node> Parser::parse_for_loop()
         auto iter_error_start = push_start();
         iterated_expression = parse_expression();
         if (!iterated_expression)
-            iterated_expression = create<AST::SyntaxError>(String::from_utf8("Expected an expression in 'for' loop"sv).release_value_but_fixme_should_propagate_errors(), true);
+            iterated_expression = create<AST::SyntaxError>("Expected an expression in 'for' loop"_string.release_value_but_fixme_should_propagate_errors(), true);
     }
 
     consume_while(is_any_of(" \t\n"sv));
     {
         auto obrace_error_start = push_start();
         if (!expect('{')) {
-            auto syntax_error = create<AST::SyntaxError>(String::from_utf8("Expected an open brace '{' to start a 'for' loop body"sv).release_value_but_fixme_should_propagate_errors(), true);
+            auto syntax_error = create<AST::SyntaxError>("Expected an open brace '{' to start a 'for' loop body"_string.release_value_but_fixme_should_propagate_errors(), true);
             return create<AST::ForLoop>(move(variable_name), move(index_variable_name), move(iterated_expression), move(syntax_error), move(in_start_position), move(index_start_position)); // ForLoop Var Iterated Block
         }
     }
@@ -697,7 +697,7 @@ RefPtr<AST::Node> Parser::parse_for_loop()
         auto cbrace_error_start = push_start();
         if (!expect('}')) {
             auto error_start = push_start();
-            auto syntax_error = create<AST::SyntaxError>(String::from_utf8("Expected a close brace '}' to end a 'for' loop body"sv).release_value_but_fixme_should_propagate_errors(), true);
+            auto syntax_error = create<AST::SyntaxError>("Expected a close brace '}' to end a 'for' loop body"_string.release_value_but_fixme_should_propagate_errors(), true);
             if (body)
                 body->set_is_syntax_error(*syntax_error);
             else
@@ -722,7 +722,7 @@ RefPtr<AST::Node> Parser::parse_loop_loop()
     {
         auto obrace_error_start = push_start();
         if (!expect('{')) {
-            auto syntax_error = create<AST::SyntaxError>(String::from_utf8("Expected an open brace '{' to start a 'loop' loop body"sv).release_value_but_fixme_should_propagate_errors(), true);
+            auto syntax_error = create<AST::SyntaxError>("Expected an open brace '{' to start a 'loop' loop body"_string.release_value_but_fixme_should_propagate_errors(), true);
             return create<AST::ForLoop>(AST::NameWithPosition {}, AST::NameWithPosition {}, nullptr, move(syntax_error)); // ForLoop null null Block
         }
     }
@@ -734,7 +734,7 @@ RefPtr<AST::Node> Parser::parse_loop_loop()
         auto cbrace_error_start = push_start();
         if (!expect('}')) {
             auto error_start = push_start();
-            auto syntax_error = create<AST::SyntaxError>(String::from_utf8("Expected a close brace '}' to end a 'loop' loop body"sv).release_value_but_fixme_should_propagate_errors(), true);
+            auto syntax_error = create<AST::SyntaxError>("Expected a close brace '}' to end a 'loop' loop body"_string.release_value_but_fixme_should_propagate_errors(), true);
             if (body)
                 body->set_is_syntax_error(*syntax_error);
             else
@@ -761,7 +761,7 @@ RefPtr<AST::Node> Parser::parse_if_expr()
         auto cond_error_start = push_start();
         condition = parse_or_logical_sequence();
         if (!condition)
-            condition = create<AST::SyntaxError>(String::from_utf8("Expected a logical sequence after 'if'"sv).release_value_but_fixme_should_propagate_errors(), true);
+            condition = create<AST::SyntaxError>("Expected a logical sequence after 'if'"_string.release_value_but_fixme_should_propagate_errors(), true);
     }
 
     auto parse_braced_toplevel = [&]() -> RefPtr<AST::Node> {
@@ -769,7 +769,7 @@ RefPtr<AST::Node> Parser::parse_if_expr()
         {
             auto obrace_error_start = push_start();
             if (!expect('{')) {
-                body = create<AST::SyntaxError>(String::from_utf8("Expected an open brace '{' to start an 'if' true branch"sv).release_value_but_fixme_should_propagate_errors(), true);
+                body = create<AST::SyntaxError>("Expected an open brace '{' to start an 'if' true branch"_string.release_value_but_fixme_should_propagate_errors(), true);
             }
         }
 
@@ -780,7 +780,7 @@ RefPtr<AST::Node> Parser::parse_if_expr()
             auto cbrace_error_start = push_start();
             if (!expect('}')) {
                 auto error_start = push_start();
-                RefPtr<AST::SyntaxError> syntax_error = create<AST::SyntaxError>(String::from_utf8("Expected a close brace '}' to end an 'if' true branch"sv).release_value_but_fixme_should_propagate_errors(), true);
+                RefPtr<AST::SyntaxError> syntax_error = create<AST::SyntaxError>("Expected a close brace '}' to end an 'if' true branch"_string.release_value_but_fixme_should_propagate_errors(), true);
                 if (body)
                     body->set_is_syntax_error(*syntax_error);
                 else
@@ -832,7 +832,7 @@ RefPtr<AST::Node> Parser::parse_subshell()
         auto cbrace_error_start = push_start();
         if (!expect('}')) {
             auto error_start = push_start();
-            RefPtr<AST::SyntaxError> syntax_error = create<AST::SyntaxError>(String::from_utf8("Expected a close brace '}' to end a subshell"sv).release_value_but_fixme_should_propagate_errors(), true);
+            RefPtr<AST::SyntaxError> syntax_error = create<AST::SyntaxError>("Expected a close brace '}' to end a subshell"_string.release_value_but_fixme_should_propagate_errors(), true);
             if (body)
                 body->set_is_syntax_error(*syntax_error);
             else
@@ -857,7 +857,7 @@ RefPtr<AST::Node> Parser::parse_match_expr()
     auto match_expression = parse_expression();
     if (!match_expression) {
         return create<AST::MatchExpr>(
-            create<AST::SyntaxError>(String::from_utf8("Expected an expression after 'match'"sv).release_value_but_fixme_should_propagate_errors(), true),
+            create<AST::SyntaxError>("Expected an expression after 'match'"_string.release_value_but_fixme_should_propagate_errors(), true),
             String {}, Optional<AST::Position> {}, Vector<AST::MatchEntry> {});
     }
 
@@ -874,7 +874,7 @@ RefPtr<AST::Node> Parser::parse_match_expr()
             auto node = create<AST::MatchExpr>(
                 match_expression.release_nonnull(),
                 String {}, move(as_position), Vector<AST::MatchEntry> {});
-            node->set_is_syntax_error(create<AST::SyntaxError>(String::from_utf8("Expected whitespace after 'as' in 'match'"sv).release_value_but_fixme_should_propagate_errors(), true));
+            node->set_is_syntax_error(create<AST::SyntaxError>("Expected whitespace after 'as' in 'match'"_string.release_value_but_fixme_should_propagate_errors(), true));
             return node;
         }
 
@@ -883,7 +883,7 @@ RefPtr<AST::Node> Parser::parse_match_expr()
             auto node = create<AST::MatchExpr>(
                 match_expression.release_nonnull(),
                 String {}, move(as_position), Vector<AST::MatchEntry> {});
-            node->set_is_syntax_error(create<AST::SyntaxError>(String::from_utf8("Expected an identifier after 'as' in 'match'"sv).release_value_but_fixme_should_propagate_errors(), true));
+            node->set_is_syntax_error(create<AST::SyntaxError>("Expected an identifier after 'as' in 'match'"_string.release_value_but_fixme_should_propagate_errors(), true));
             return node;
         }
     }
@@ -894,7 +894,7 @@ RefPtr<AST::Node> Parser::parse_match_expr()
         auto node = create<AST::MatchExpr>(
             match_expression.release_nonnull(),
             move(match_name), move(as_position), Vector<AST::MatchEntry> {});
-        node->set_is_syntax_error(create<AST::SyntaxError>(String::from_utf8("Expected an open brace '{' to start a 'match' entry list"sv).release_value_but_fixme_should_propagate_errors(), true));
+        node->set_is_syntax_error(create<AST::SyntaxError>("Expected an open brace '{' to start a 'match' entry list"_string.release_value_but_fixme_should_propagate_errors(), true));
         return node;
     }
 
@@ -916,7 +916,7 @@ RefPtr<AST::Node> Parser::parse_match_expr()
         auto node = create<AST::MatchExpr>(
             match_expression.release_nonnull(),
             move(match_name), move(as_position), move(entries));
-        node->set_is_syntax_error(create<AST::SyntaxError>(String::from_utf8("Expected a close brace '}' to end a 'match' entry list"sv).release_value_but_fixme_should_propagate_errors(), true));
+        node->set_is_syntax_error(create<AST::SyntaxError>("Expected a close brace '}' to end a 'match' entry list"_string.release_value_but_fixme_should_propagate_errors(), true));
         return node;
     }
 
@@ -949,7 +949,7 @@ AST::MatchEntry Parser::parse_match_entry()
     } else {
         auto glob_pattern = parse_match_pattern();
         if (!glob_pattern)
-            return { NonnullRefPtrVector<AST::Node> {}, {}, {}, {}, create<AST::SyntaxError>(String::from_utf8("Expected a pattern in 'match' body"sv).release_value_but_fixme_should_propagate_errors(), true) };
+            return { NonnullRefPtrVector<AST::Node> {}, {}, {}, {}, create<AST::SyntaxError>("Expected a pattern in 'match' body"_string.release_value_but_fixme_should_propagate_errors(), true) };
 
         pattern_kind = Glob;
         patterns.append(glob_pattern.release_nonnull());
@@ -967,7 +967,7 @@ AST::MatchEntry Parser::parse_match_entry()
         case Regex: {
             auto pattern = parse_regex_pattern();
             if (!pattern.has_value()) {
-                error = create<AST::SyntaxError>(String::from_utf8("Expected a regex pattern to follow '|' in 'match' body"sv).release_value_but_fixme_should_propagate_errors(), true);
+                error = create<AST::SyntaxError>("Expected a regex pattern to follow '|' in 'match' body"_string.release_value_but_fixme_should_propagate_errors(), true);
                 break;
             }
             regexps.append(pattern.release_value());
@@ -976,7 +976,7 @@ AST::MatchEntry Parser::parse_match_entry()
         case Glob: {
             auto pattern = parse_match_pattern();
             if (!pattern) {
-                error = create<AST::SyntaxError>(String::from_utf8("Expected a pattern to follow '|' in 'match' body"sv).release_value_but_fixme_should_propagate_errors(), true);
+                error = create<AST::SyntaxError>("Expected a pattern to follow '|' in 'match' body"_string.release_value_but_fixme_should_propagate_errors(), true);
                 break;
             }
             patterns.append(pattern.release_nonnull());
@@ -999,7 +999,7 @@ AST::MatchEntry Parser::parse_match_entry()
         consume_while(is_any_of(" \t\n"sv));
         if (!expect('(')) {
             if (!error)
-                error = create<AST::SyntaxError>(String::from_utf8("Expected an explicit list of identifiers after a pattern 'as'"sv).release_value_but_fixme_should_propagate_errors());
+                error = create<AST::SyntaxError>("Expected an explicit list of identifiers after a pattern 'as'"_string.release_value_but_fixme_should_propagate_errors());
         } else {
             match_names = Vector<String>();
             for (;;) {
@@ -1012,7 +1012,7 @@ AST::MatchEntry Parser::parse_match_entry()
 
             if (!expect(')')) {
                 if (!error)
-                    error = create<AST::SyntaxError>(String::from_utf8("Expected a close paren ')' to end the identifier list of pattern 'as'"sv).release_value_but_fixme_should_propagate_errors(), true);
+                    error = create<AST::SyntaxError>("Expected a close paren ')' to end the identifier list of pattern 'as'"_string.release_value_but_fixme_should_propagate_errors(), true);
             }
         }
         consume_while(is_any_of(" \t\n"sv));
@@ -1034,7 +1034,7 @@ AST::MatchEntry Parser::parse_match_entry()
 
                     if (names[index] != name.view()) {
                         if (!error)
-                            error = create<AST::SyntaxError>(String::from_utf8("Alternative regex patterns must have the same capture groups"sv).release_value_but_fixme_should_propagate_errors(), false);
+                            error = create<AST::SyntaxError>("Alternative regex patterns must have the same capture groups"_string.release_value_but_fixme_should_propagate_errors(), false);
                         break;
                     }
                 }
@@ -1045,14 +1045,14 @@ AST::MatchEntry Parser::parse_match_entry()
 
     if (!expect('{')) {
         if (!error)
-            error = create<AST::SyntaxError>(String::from_utf8("Expected an open brace '{' to start a match entry body"sv).release_value_but_fixme_should_propagate_errors(), true);
+            error = create<AST::SyntaxError>("Expected an open brace '{' to start a match entry body"_string.release_value_but_fixme_should_propagate_errors(), true);
     }
 
     auto body = parse_toplevel();
 
     if (!expect('}')) {
         if (!error)
-            error = create<AST::SyntaxError>(String::from_utf8("Expected a close brace '}' to end a match entry body"sv).release_value_but_fixme_should_propagate_errors(), true);
+            error = create<AST::SyntaxError>("Expected a close brace '}' to end a match entry body"_string.release_value_but_fixme_should_propagate_errors(), true);
     }
 
     if (body && error)
@@ -1131,7 +1131,7 @@ RefPtr<AST::Node> Parser::parse_redirection()
                     // Eat a character and hope the problem goes away
                     consume();
                 }
-                path = create<AST::SyntaxError>(String::from_utf8("Expected a path after redirection"sv).release_value_but_fixme_should_propagate_errors(), true);
+                path = create<AST::SyntaxError>("Expected a path after redirection"_string.release_value_but_fixme_should_propagate_errors(), true);
             }
             return create<AST::WriteAppendRedirection>(pipe_fd, path.release_nonnull()); // Redirection WriteAppend
         }
@@ -1154,7 +1154,7 @@ RefPtr<AST::Node> Parser::parse_redirection()
             }
             auto redir = create<AST::Fd2FdRedirection>(pipe_fd, dest_pipe_fd); // Redirection Fd2Fd
             if (dest_pipe_fd == -1)
-                redir->set_is_syntax_error(*create<AST::SyntaxError>(String::from_utf8("Expected a file descriptor"sv).release_value_but_fixme_should_propagate_errors()));
+                redir->set_is_syntax_error(*create<AST::SyntaxError>("Expected a file descriptor"_string.release_value_but_fixme_should_propagate_errors()));
             return redir;
         }
         consume_while(is_whitespace);
@@ -1165,7 +1165,7 @@ RefPtr<AST::Node> Parser::parse_redirection()
                 // Eat a character and hope the problem goes away
                 consume();
             }
-            path = create<AST::SyntaxError>(String::from_utf8("Expected a path after redirection"sv).release_value_but_fixme_should_propagate_errors(), true);
+            path = create<AST::SyntaxError>("Expected a path after redirection"_string.release_value_but_fixme_should_propagate_errors(), true);
         }
         return create<AST::WriteRedirection>(pipe_fd, path.release_nonnull()); // Redirection Write
     }
@@ -1189,7 +1189,7 @@ RefPtr<AST::Node> Parser::parse_redirection()
                 // Eat a character and hope the problem goes away
                 consume();
             }
-            path = create<AST::SyntaxError>(String::from_utf8("Expected a path after redirection"sv).release_value_but_fixme_should_propagate_errors(), true);
+            path = create<AST::SyntaxError>("Expected a path after redirection"_string.release_value_but_fixme_should_propagate_errors(), true);
         }
         if (mode == Read)
             return create<AST::ReadRedirection>(pipe_fd, path.release_nonnull()); // Redirection Read
@@ -1362,10 +1362,10 @@ RefPtr<AST::Node> Parser::parse_string()
         consume();
         auto inner = parse_string_inner(StringEndCondition::DoubleQuote);
         if (!inner)
-            inner = create<AST::SyntaxError>(String::from_utf8("Unexpected EOF in string"sv).release_value_but_fixme_should_propagate_errors(), true);
+            inner = create<AST::SyntaxError>("Unexpected EOF in string"_string.release_value_but_fixme_should_propagate_errors(), true);
         if (!expect('"')) {
             inner = create<AST::DoubleQuotedString>(move(inner));
-            inner->set_is_syntax_error(*create<AST::SyntaxError>(String::from_utf8("Expected a terminating double quote"sv).release_value_but_fixme_should_propagate_errors(), true));
+            inner->set_is_syntax_error(*create<AST::SyntaxError>("Expected a terminating double quote"_string.release_value_but_fixme_should_propagate_errors(), true));
             return inner;
         }
         return create<AST::DoubleQuotedString>(move(inner)); // Double Quoted String
@@ -1379,7 +1379,7 @@ RefPtr<AST::Node> Parser::parse_string()
             is_error = true;
         auto result = create<AST::StringLiteral>(String::from_utf8(text).release_value_but_fixme_should_propagate_errors(), AST::StringLiteral::EnclosureType::SingleQuotes); // String Literal
         if (is_error)
-            result->set_is_syntax_error(*create<AST::SyntaxError>(String::from_utf8("Expected a terminating single quote"sv).release_value_but_fixme_should_propagate_errors(), true));
+            result->set_is_syntax_error(*create<AST::SyntaxError>("Expected a terminating single quote"_string.release_value_but_fixme_should_propagate_errors(), true));
         return result;
     }
 
@@ -1548,7 +1548,7 @@ RefPtr<AST::Slice> Parser::parse_slice()
     RefPtr<AST::SyntaxError> error;
 
     if (peek() != ']')
-        error = create<AST::SyntaxError>(String::from_utf8("Expected a close bracket ']' to end a variable slice"sv).release_value_but_fixme_should_propagate_errors());
+        error = create<AST::SyntaxError>("Expected a close bracket ']' to end a variable slice"_string.release_value_but_fixme_should_propagate_errors());
     else
         consume();
 
@@ -1556,7 +1556,7 @@ RefPtr<AST::Slice> Parser::parse_slice()
         if (error)
             spec = move(error);
         else
-            spec = create<AST::SyntaxError>(String::from_utf8("Expected either a range, or a comma-seprated list of selectors"sv).release_value_but_fixme_should_propagate_errors());
+            spec = create<AST::SyntaxError>("Expected either a range, or a comma-seprated list of selectors"_string.release_value_but_fixme_should_propagate_errors());
     }
 
     auto node = create<AST::Slice>(spec.release_nonnull());
@@ -1579,16 +1579,16 @@ RefPtr<AST::Node> Parser::parse_evaluate()
         consume();
         auto inner = parse_pipe_sequence();
         if (!inner)
-            inner = create<AST::SyntaxError>(String::from_utf8("Unexpected EOF in list"sv).release_value_but_fixme_should_propagate_errors(), true);
+            inner = create<AST::SyntaxError>("Unexpected EOF in list"_string.release_value_but_fixme_should_propagate_errors(), true);
         if (!expect(')'))
-            inner->set_is_syntax_error(*create<AST::SyntaxError>(String::from_utf8("Expected a terminating close paren"sv).release_value_but_fixme_should_propagate_errors(), true));
+            inner->set_is_syntax_error(*create<AST::SyntaxError>("Expected a terminating close paren"_string.release_value_but_fixme_should_propagate_errors(), true));
 
         return create<AST::Execute>(inner.release_nonnull(), true);
     }
     auto inner = parse_expression();
 
     if (!inner) {
-        inner = create<AST::SyntaxError>(String::from_utf8("Expected a command"sv).release_value_but_fixme_should_propagate_errors(), true);
+        inner = create<AST::SyntaxError>("Expected a command"_string.release_value_but_fixme_should_propagate_errors(), true);
     } else {
         if (inner->is_list()) {
             auto execute_inner = create<AST::Execute>(inner.release_nonnull(), true);
@@ -1664,9 +1664,9 @@ RefPtr<AST::Node> Parser::parse_immediate_expression()
         ending_brace_position);
 
     if (!ending_brace_position.has_value())
-        node->set_is_syntax_error(create<AST::SyntaxError>(String::from_utf8("Expected a closing brace '}' to end an immediate expression"sv).release_value_but_fixme_should_propagate_errors(), true));
+        node->set_is_syntax_error(create<AST::SyntaxError>("Expected a closing brace '}' to end an immediate expression"_string.release_value_but_fixme_should_propagate_errors(), true));
     else if (node->function_name().is_empty())
-        node->set_is_syntax_error(create<AST::SyntaxError>(String::from_utf8("Expected an immediate function name"sv).release_value_but_fixme_should_propagate_errors()));
+        node->set_is_syntax_error(create<AST::SyntaxError>("Expected an immediate function name"_string.release_value_but_fixme_should_propagate_errors()));
 
     return node;
 }
@@ -1711,7 +1711,7 @@ RefPtr<AST::Node> Parser::parse_history_designator()
         consume();
         selector.event.kind = AST::HistorySelector::EventKind::IndexFromEnd;
         selector.event.index = 0;
-        selector.event.text = String::from_utf8_short_string("!"sv);
+        selector.event.text = "!"_short_string;
         break;
     case '?':
         consume();
@@ -1744,7 +1744,7 @@ RefPtr<AST::Node> Parser::parse_history_designator()
             if (number != 0)
                 selector.event.index = number - 1;
             else
-                syntax_error = create<AST::SyntaxError>(String::from_utf8("History entry index value invalid or out of range"sv).release_value_but_fixme_should_propagate_errors());
+                syntax_error = create<AST::SyntaxError>("History entry index value invalid or out of range"_string.release_value_but_fixme_should_propagate_errors());
         }
         if (":^$*"sv.contains(peek())) {
             is_word_selector = true;
@@ -1804,7 +1804,7 @@ RefPtr<AST::Node> Parser::parse_history_designator()
     auto first_char = peek();
     if (!(is_digit(first_char) || "^$-*"sv.contains(first_char))) {
         if (!syntax_error)
-            syntax_error = create<AST::SyntaxError>(String::from_utf8("Expected a word selector after ':' in a history event designator"sv).release_value_but_fixme_should_propagate_errors(), true);
+            syntax_error = create<AST::SyntaxError>("Expected a word selector after ':' in a history event designator"_string.release_value_but_fixme_should_propagate_errors(), true);
     } else if (first_char == '*') {
         consume();
         selector.word_selector_range.start = make_word_selector(AST::HistorySelector::WordSelectorKind::Index, 1);
@@ -2004,7 +2004,7 @@ RefPtr<AST::Node> Parser::parse_brace_expansion()
 
     if (auto spec = parse_brace_expansion_spec()) {
         if (!expect('}'))
-            spec->set_is_syntax_error(create<AST::SyntaxError>(String::from_utf8("Expected a close brace '}' to end a brace expansion"sv).release_value_but_fixme_should_propagate_errors(), true));
+            spec->set_is_syntax_error(create<AST::SyntaxError>("Expected a close brace '}' to end a brace expansion"_string.release_value_but_fixme_should_propagate_errors(), true));
 
         return spec;
     }
@@ -2032,12 +2032,12 @@ RefPtr<AST::Node> Parser::parse_brace_expansion_spec()
             if (expect(".."sv)) {
                 if (auto end_expr = parse_expression()) {
                     if (end_expr->position().start_offset != start_expr->position().end_offset + 2)
-                        end_expr->set_is_syntax_error(create<AST::SyntaxError>(String::from_utf8("Expected no whitespace between '..' and the following expression in brace expansion"sv).release_value_but_fixme_should_propagate_errors()));
+                        end_expr->set_is_syntax_error(create<AST::SyntaxError>("Expected no whitespace between '..' and the following expression in brace expansion"_string.release_value_but_fixme_should_propagate_errors()));
 
                     return create<AST::Range>(start_expr.release_nonnull(), end_expr.release_nonnull());
                 }
 
-                return create<AST::Range>(start_expr.release_nonnull(), create<AST::SyntaxError>(String::from_utf8("Expected an expression to end range brace expansion with"sv).release_value_but_fixme_should_propagate_errors(), true));
+                return create<AST::Range>(start_expr.release_nonnull(), create<AST::SyntaxError>("Expected an expression to end range brace expansion with"_string.release_value_but_fixme_should_propagate_errors(), true));
             }
         }
 
@@ -2072,7 +2072,7 @@ RefPtr<AST::Node> Parser::parse_heredoc_initiation_record()
     consume();
 
     HeredocInitiationRecord record;
-    record.end = String::from_utf8("<error>"sv).release_value_but_fixme_should_propagate_errors();
+    record.end = "<error>"_string.release_value_but_fixme_should_propagate_errors();
 
     RefPtr<AST::SyntaxError> syntax_error_node;
 
@@ -2110,12 +2110,12 @@ RefPtr<AST::Node> Parser::parse_heredoc_initiation_record()
         if (!expect('\''))
             is_error = true;
         if (is_error)
-            syntax_error_node = create<AST::SyntaxError>(String::from_utf8("Expected a terminating single quote"sv).release_value_but_fixme_should_propagate_errors(), true);
+            syntax_error_node = create<AST::SyntaxError>("Expected a terminating single quote"_string.release_value_but_fixme_should_propagate_errors(), true);
 
         record.end = String::from_utf8(text).release_value_but_fixme_should_propagate_errors();
         record.interpolate = false;
     } else {
-        syntax_error_node = create<AST::SyntaxError>(String::from_utf8("Expected a bareword or a single-quoted string literal for heredoc end key"sv).release_value_but_fixme_should_propagate_errors(), true);
+        syntax_error_node = create<AST::SyntaxError>("Expected a bareword or a single-quoted string literal for heredoc end key"_string.release_value_but_fixme_should_propagate_errors(), true);
     }
 
     auto node = create<AST::Heredoc>(record.end, record.interpolate, record.deindent);

--- a/Userland/Shell/PosixLexer.cpp
+++ b/Userland/Shell/PosixLexer.cpp
@@ -716,7 +716,7 @@ ErrorOr<Lexer::ReductionResult> Lexer::reduce_arithmetic_expansion()
         expansion.range.length = m_state.position.end_offset - expansion.range.start - m_state.position.start_offset;
 
         return ReductionResult {
-            .tokens = { Token::continuation(String::from_utf8_short_string("$(("sv)) },
+            .tokens = { Token::continuation("$(("_short_string) },
             .next_reduction = m_state.previous_reduction,
         };
     }
@@ -791,7 +791,7 @@ ErrorOr<Lexer::ReductionResult> Lexer::reduce_command_or_arithmetic_substitution
 {
     if (m_lexer.is_eof()) {
         return ReductionResult {
-            .tokens = { Token::continuation(String::from_utf8_short_string("$("sv)) },
+            .tokens = { Token::continuation("$("_short_string) },
             .next_reduction = m_state.previous_reduction,
         };
     }
@@ -835,7 +835,7 @@ ErrorOr<Lexer::ReductionResult> Lexer::reduce_extended_parameter_expansion()
 
     if (m_lexer.is_eof()) {
         return ReductionResult {
-            .tokens = { Token::continuation(String::from_utf8_short_string("${"sv)) },
+            .tokens = { Token::continuation("${"_short_string) },
             .next_reduction = m_state.previous_reduction,
         };
     }

--- a/Userland/Shell/PosixLexer.h
+++ b/Userland/Shell/PosixLexer.h
@@ -353,7 +353,7 @@ struct Token {
     {
         return {
             .type = Type::Newline,
-            .value = String::from_utf8_short_string("\n"sv),
+            .value = "\n"_short_string,
             .position = {},
             .expansions = {},
             .original_text = {},

--- a/Userland/Shell/PosixParser.cpp
+++ b/Userland/Shell/PosixParser.cpp
@@ -645,7 +645,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_complete_command()
         auto position = peek().position;
         auto syntax_error = make_ref_counted<AST::SyntaxError>(
             position.value_or(empty_position()),
-            String::from_utf8("Extra tokens after complete command"sv).release_value_but_fixme_should_propagate_errors());
+            "Extra tokens after complete command"_string.release_value_but_fixme_should_propagate_errors());
 
         if (list)
             list->set_is_syntax_error(*syntax_error);
@@ -923,13 +923,13 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_while_clause()
     if (!condition)
         condition = make_ref_counted<AST::SyntaxError>(
             peek().position.value_or(empty_position()),
-            String::from_utf8("Expected condition after 'while'"sv).release_value_but_fixme_should_propagate_errors());
+            "Expected condition after 'while'"_string.release_value_but_fixme_should_propagate_errors());
 
     auto do_group = TRY(parse_do_group());
     if (!do_group)
         do_group = make_ref_counted<AST::SyntaxError>(
             peek().position.value_or(empty_position()),
-            String::from_utf8("Expected 'do' after 'while'"sv).release_value_but_fixme_should_propagate_errors());
+            "Expected 'do' after 'while'"_string.release_value_but_fixme_should_propagate_errors());
 
     // while foo; bar -> loop { if foo { bar } else { break } }
     return make_ref_counted<AST::ForLoop>(
@@ -957,13 +957,13 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_until_clause()
     if (!condition)
         condition = make_ref_counted<AST::SyntaxError>(
             peek().position.value_or(empty_position()),
-            String::from_utf8("Expected condition after 'until'"sv).release_value_but_fixme_should_propagate_errors());
+            "Expected condition after 'until'"_string.release_value_but_fixme_should_propagate_errors());
 
     auto do_group = TRY(parse_do_group());
     if (!do_group)
         do_group = make_ref_counted<AST::SyntaxError>(
             peek().position.value_or(empty_position()),
-            String::from_utf8("Expected 'do' after 'until'"sv).release_value_but_fixme_should_propagate_errors());
+            "Expected 'do' after 'until'"_string.release_value_but_fixme_should_propagate_errors());
 
     // until foo; bar -> loop { if foo { break } else { bar } }
     return make_ref_counted<AST::ForLoop>(
@@ -1164,7 +1164,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_if_clause()
     skip();
     auto main_condition = TRY(parse_compound_list());
     if (!main_condition)
-        main_condition = make_ref_counted<AST::SyntaxError>(empty_position(), String::from_utf8("Expected compound list after 'if'"sv).release_value_but_fixme_should_propagate_errors());
+        main_condition = make_ref_counted<AST::SyntaxError>(empty_position(), "Expected compound list after 'if'"_string.release_value_but_fixme_should_propagate_errors());
 
     RefPtr<AST::SyntaxError> syntax_error;
     if (peek().type != Token::Type::Then) {
@@ -1177,7 +1177,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_if_clause()
 
     auto main_consequence = TRY(parse_compound_list());
     if (!main_consequence)
-        main_consequence = make_ref_counted<AST::SyntaxError>(empty_position(), String::from_utf8("Expected compound list after 'then'"sv).release_value_but_fixme_should_propagate_errors());
+        main_consequence = make_ref_counted<AST::SyntaxError>(empty_position(), "Expected compound list after 'then'"_string.release_value_but_fixme_should_propagate_errors());
 
     auto node = make_ref_counted<AST::IfCond>(start_position, Optional<AST::Position>(), main_condition.release_nonnull(), main_consequence.release_nonnull(), nullptr);
     auto active_node = node;
@@ -1186,7 +1186,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_if_clause()
         skip();
         auto condition = TRY(parse_compound_list());
         if (!condition)
-            condition = make_ref_counted<AST::SyntaxError>(empty_position(), String::from_utf8("Expected compound list after 'elif'"sv).release_value_but_fixme_should_propagate_errors());
+            condition = make_ref_counted<AST::SyntaxError>(empty_position(), "Expected compound list after 'elif'"_string.release_value_but_fixme_should_propagate_errors());
 
         if (peek().type != Token::Type::Then) {
             if (!syntax_error)
@@ -1199,7 +1199,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_if_clause()
 
         auto consequence = TRY(parse_compound_list());
         if (!consequence)
-            consequence = make_ref_counted<AST::SyntaxError>(empty_position(), String::from_utf8("Expected compound list after 'then'"sv).release_value_but_fixme_should_propagate_errors());
+            consequence = make_ref_counted<AST::SyntaxError>(empty_position(), "Expected compound list after 'then'"_string.release_value_but_fixme_should_propagate_errors());
 
         auto new_node = make_ref_counted<AST::IfCond>(start_position, Optional<AST::Position>(), condition.release_nonnull(), consequence.release_nonnull(), nullptr);
 
@@ -1213,7 +1213,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_if_clause()
         skip();
         active_node->false_branch() = TRY(parse_compound_list());
         if (!active_node->false_branch())
-            active_node->false_branch() = make_ref_counted<AST::SyntaxError>(empty_position(), String::from_utf8("Expected compound list after 'else'"sv).release_value_but_fixme_should_propagate_errors());
+            active_node->false_branch() = make_ref_counted<AST::SyntaxError>(empty_position(), "Expected compound list after 'else'"_string.release_value_but_fixme_should_propagate_errors());
         break;
     case Token::Type::Fi:
         needs_fi = false;
@@ -1254,10 +1254,10 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_subshell()
 
     auto list = TRY(parse_compound_list());
     if (!list)
-        error = make_ref_counted<AST::SyntaxError>(peek().position.value_or(empty_position()), String::from_utf8("Expected compound list after ("sv).release_value_but_fixme_should_propagate_errors());
+        error = make_ref_counted<AST::SyntaxError>(peek().position.value_or(empty_position()), "Expected compound list after ("_string.release_value_but_fixme_should_propagate_errors());
 
     if (peek().type != Token::Type::CloseParen)
-        error = make_ref_counted<AST::SyntaxError>(peek().position.value_or(empty_position()), String::from_utf8("Expected ) after compound list"sv).release_value_but_fixme_should_propagate_errors());
+        error = make_ref_counted<AST::SyntaxError>(peek().position.value_or(empty_position()), "Expected ) after compound list"_string.release_value_but_fixme_should_propagate_errors());
     else
         skip();
 
@@ -1337,7 +1337,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_for_clause()
         name_position = peek().position;
         name = consume().value;
     } else {
-        name = String::from_utf8_short_string("it"sv);
+        name = "it"_short_string;
         error(peek(), "Expected a variable name, not {}", peek().type_name());
     }
 
@@ -1533,7 +1533,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_word()
         case ResolvedParameterExpansion::Op::GetLastBackgroundPid:
             node = make_ref_counted<AST::SyntaxError>(
                 token.position.value_or(empty_position()),
-                TRY(String::from_utf8("$! not implemented"sv)));
+                TRY("$! not implemented"_string));
             break;
         case ResolvedParameterExpansion::Op::GetPositionalParameterList:
             node = make_ref_counted<AST::SpecialVariable>(
@@ -1543,7 +1543,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_word()
         case ResolvedParameterExpansion::Op::GetCurrentOptionFlags:
             node = make_ref_counted<AST::SyntaxError>(
                 token.position.value_or(empty_position()),
-                TRY(String::from_utf8("The current option flags are not available in parameter expansions"sv)));
+                TRY("The current option flags are not available in parameter expansions"_string));
             break;
         case ResolvedParameterExpansion::Op::GetPositionalParameterCount:
             node = make_ref_counted<AST::SpecialVariable>(
@@ -1558,7 +1558,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_word()
         case ResolvedParameterExpansion::Op::GetPositionalParameterListAsString:
             node = make_ref_counted<AST::SyntaxError>(
                 token.position.value_or(empty_position()),
-                TRY(String::from_utf8("$* not implemented"sv)));
+                TRY("$* not implemented"_string));
             break;
         case ResolvedParameterExpansion::Op::GetShellProcessId:
             node = make_ref_counted<AST::SpecialVariable>(
@@ -1592,7 +1592,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_word()
             node = make_ref_counted<AST::ImmediateExpression>(
                 token.position.value_or(empty_position()),
                 AST::NameWithPosition {
-                    TRY(String::from_utf8("reexpand"sv)),
+                    TRY("reexpand"_string),
                     token.position.value_or(empty_position()),
                 },
                 Vector { node.release_nonnull() },
@@ -1808,7 +1808,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_simple_command()
             // env (assignments) (command)
             nodes.append(make_ref_counted<AST::BarewordLiteral>(
                 empty_position(),
-                String::from_utf8_short_string("env"sv)));
+                "env"_short_string));
 
             nodes.append(
                 make_ref_counted<AST::BarewordLiteral>(
@@ -1911,7 +1911,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_io_here(AST::Position start_position, O
 
     auto end_keyword = consume();
     if (!is_one_of(end_keyword.type, Token::Type::Word, Token::Type::Token))
-        return make_ref_counted<AST::SyntaxError>(io_operator_token.position.value_or(start_position), String::from_utf8("Expected a heredoc keyword"sv).release_value_but_fixme_should_propagate_errors(), true);
+        return make_ref_counted<AST::SyntaxError>(io_operator_token.position.value_or(start_position), "Expected a heredoc keyword"_string.release_value_but_fixme_should_propagate_errors(), true);
 
     auto [end_keyword_text, allow_interpolation] = Lexer::process_heredoc_key(end_keyword);
     RefPtr<AST::SyntaxError> error;

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1714,7 +1714,7 @@ ErrorOr<Vector<Line::CompletionSuggestion>> Shell::complete_via_program_itself(s
     else if (!options.invoke_program_for_autocomplete)
         return Error::from_string_literal("Refusing to use the program itself as completion source");
 
-    completion_command.argv.extend({ TRY(String::from_utf8("--complete"sv)), String::from_utf8_short_string("--"sv) });
+    completion_command.argv.extend({ TRY("--complete"_string), "--"_short_string });
 
     struct Visitor : public AST::NodeVisitor {
         Visitor(Shell& shell, AST::Position position)
@@ -1883,7 +1883,7 @@ ErrorOr<Vector<Line::CompletionSuggestion>> Shell::complete_via_program_itself(s
 
     completion_command.argv.extend(visitor.list());
 
-    auto devnull = TRY(String::from_utf8("/dev/null"sv));
+    auto devnull = TRY("/dev/null"_string);
     completion_command.should_wait = true;
     completion_command.redirections.append(AST::PathRedirection::create(devnull, STDERR_FILENO, AST::PathRedirection::Write));
     completion_command.redirections.append(AST::PathRedirection::create(devnull, STDIN_FILENO, AST::PathRedirection::Read));


### PR DESCRIPTION
This mostly updates code what was written before but merged after these were added.