### PR TITLE
LibGUI: Give SeparatorWidget a minimum size

### DIFF
--- a/Userland/Libraries/LibGUI/SeparatorWidget.cpp
+++ b/Userland/Libraries/LibGUI/SeparatorWidget.cpp
@@ -12,6 +12,8 @@
 REGISTER_WIDGET(GUI, HorizontalSeparator)
 REGISTER_WIDGET(GUI, VerticalSeparator)
 
+constexpr int minimum_size = 8;
+
 namespace GUI {
 
 SeparatorWidget::SeparatorWidget(Gfx::Orientation orientation)
@@ -39,8 +41,15 @@ void SeparatorWidget::paint_event(PaintEvent& event)
 Optional<UISize> SeparatorWidget::calculated_preferred_size() const
 {
     if (m_orientation == Gfx::Orientation::Vertical)
-        return UISize { 8, SpecialDimension::OpportunisticGrow };
-    return UISize { SpecialDimension::OpportunisticGrow, 8 };
+        return UISize { minimum_size, SpecialDimension::OpportunisticGrow };
+    return UISize { SpecialDimension::OpportunisticGrow, minimum_size };
+}
+
+Optional<UISize> SeparatorWidget::calculated_min_size() const
+{
+    if (m_orientation == Gfx::Orientation::Vertical)
+        return UISize { minimum_size, 0 };
+    return UISize { 0, minimum_size };
 }
 
 }

--- a/Userland/Libraries/LibGUI/SeparatorWidget.h
+++ b/Userland/Libraries/LibGUI/SeparatorWidget.h
@@ -23,6 +23,7 @@ protected:
 private:
     virtual void paint_event(PaintEvent&) override;
     virtual Optional<UISize> calculated_preferred_size() const override;
+    virtual Optional<UISize> calculated_min_size() const override;
 
     const Gfx::Orientation m_orientation;
 };


### PR DESCRIPTION
Without this, it can be squished down into nothing, which looks really odd.

Minimum TextEditor window before:
![image](https://user-images.githubusercontent.com/222642/221958366-3cbb4a7d-41b9-4164-91dd-080b29480113.png)

Minimum TextEditor window after:
![image](https://user-images.githubusercontent.com/222642/221958128-99ce8c96-ea86-4ade-b3ef-a61df869b961.png)
