### PR TITLE
LibCore+Everywhere: Remove ArgsParser::add*(char const*&)

### DIFF
--- a/Tests/Kernel/stress-truncate.cpp
+++ b/Tests/Kernel/stress-truncate.cpp
@@ -18,7 +18,7 @@ int main(int argc, char** argv)
     for (auto i = 0; i < argc; ++i)
         arguments.append({ argv[i], strlen(argv[i]) });
 
-    char const* target = nullptr;
+    DeprecatedString target;
     int max_file_size = 1024 * 1024;
     int count = 1024;
 
@@ -28,7 +28,7 @@ int main(int argc, char** argv)
     args_parser.add_positional_argument(target, "Target file path", "target");
     args_parser.parse(arguments);
 
-    int fd = creat(target, 0666);
+    int fd = creat(target.characters(), 0666);
     if (fd < 0) {
         perror("Couldn't create target file");
         return EXIT_FAILURE;
@@ -38,13 +38,13 @@ int main(int argc, char** argv)
     for (int i = 0; i < count; i++) {
         auto new_file_size = AK::get_random<uint64_t>() % (max_file_size + 1);
         printf("(%d/%d)\tTruncating to %" PRIu64 " bytes...\n", i + 1, count, new_file_size);
-        if (truncate(target, new_file_size) < 0) {
+        if (truncate(target.characters(), new_file_size) < 0) {
             perror("Couldn't truncate target file");
             return EXIT_FAILURE;
         }
     }
 
-    if (unlink(target) < 0) {
+    if (unlink(target.characters()) < 0) {
         perror("Couldn't remove target file");
         return EXIT_FAILURE;
     }

--- a/Tests/Kernel/stress-writeread.cpp
+++ b/Tests/Kernel/stress-writeread.cpp
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
     for (auto i = 0; i < argc; ++i)
         arguments.append({ argv[i], strlen(argv[i]) });
 
-    char const* target = nullptr;
+    DeprecatedString target;
     int min_block_offset = 0;
     int block_length = 2048;
     int block_size = 512;
@@ -96,7 +96,7 @@ int main(int argc, char** argv)
     }
     auto buffer = buffer_result.release_value();
 
-    int fd = open(target, O_CREAT | O_RDWR, 0666);
+    int fd = open(target.characters(), O_CREAT | O_RDWR, 0666);
     if (fd < 0) {
         perror("Couldn't create target file");
         return EXIT_FAILURE;

--- a/Tests/LibJS/test-test262.cpp
+++ b/Tests/LibJS/test-test262.cpp
@@ -305,7 +305,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView per_file_location;
     StringView pass_through_parameters;
     StringView runner_command = "test262-runner"sv;
-    char const* test_directory = nullptr;
+    StringView test_directory;
     bool dont_print_progress = false;
     bool dont_disable_core_dump = false;
 

--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -173,14 +173,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil(nullptr, nullptr));
 
     bool display_notifications = false;
-    char const* name = nullptr;
+    StringView name;
     Core::ArgsParser args_parser;
     args_parser.add_option(display_notifications, "Display notifications", "display-notifications", 'd');
     args_parser.add_option(name, "Applet name used by WindowServer.ini to set the applet order", "name", 'n', "name");
     args_parser.parse(arguments);
 
-    if (name == nullptr)
-        name = "Network";
+    if (name.is_empty())
+        name = "Network"sv;
 
     auto window = TRY(GUI::Window::try_create());
     window->set_title(name);

--- a/Userland/Applications/FontEditor/main.cpp
+++ b/Userland/Applications/FontEditor/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Config::pledge_domain("FontEditor");
     TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath"));
 
-    char const* path = nullptr;
+    StringView path;
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(path, "The font file for editing.", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
@@ -42,7 +42,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto font_editor = TRY(window->set_main_widget<FontEditor::MainWidget>());
     TRY(font_editor->initialize_menubar(*window));
 
-    if (path) {
+    if (!path.is_empty()) {
         TRY(font_editor->open_file(path));
     } else {
         auto mutable_font = TRY(TRY(Gfx::BitmapFont::try_load_from_file("/res/fonts/KaticaRegular10.font"))->unmasked_character_set());

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -51,7 +51,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = GUI::Icon::default_icon("filetype-image"sv);
 
-    char const* path = nullptr;
+    StringView path;
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(path, "The image file to be displayed.", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
@@ -68,7 +68,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto main_toolbar = TRY(toolbar_container->try_add<GUI::Toolbar>());
 
     auto widget = TRY(root_widget->try_add<ViewWidget>());
-    if (path) {
+    if (!path.is_empty()) {
         widget->set_path(path);
     }
     widget->on_scale_change = [&](float scale) {

--- a/Userland/Applications/PDFViewer/main.cpp
+++ b/Userland/Applications/PDFViewer/main.cpp
@@ -18,7 +18,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    char const* file_path = nullptr;
+    StringView file_path;
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(file_path, "PDF file to open", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
@@ -45,7 +45,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->show();
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    if (file_path) {
+    if (!file_path.is_empty()) {
         auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window, file_path);
         if (response.is_error())
             return 1;

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -26,7 +26,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("PixelPaint");
 
-    char const* image_file = nullptr;
+    StringView image_file;
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(image_file, "Image file to open", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
@@ -72,7 +72,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     window->show();
 
-    if (image_file) {
+    if (!image_file.is_empty()) {
         auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window, image_file);
         if (response.is_error())
             return 1;

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -26,15 +26,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    char const* filename = nullptr;
+    StringView filename;
 
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(filename, "File to read from", "file", Core::ArgsParser::Required::No);
 
     args_parser.parse(arguments);
 
-    if (filename) {
-        if (!Core::DeprecatedFile::exists({ filename, strlen(filename) }) || Core::DeprecatedFile::is_directory(filename)) {
+    if (!filename.is_empty()) {
+        if (!Core::DeprecatedFile::exists(filename) || Core::DeprecatedFile::is_directory(filename)) {
             warnln("File does not exist or is a directory: {}", filename);
             return 1;
         }
@@ -51,7 +51,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(640, 480);
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    auto spreadsheet_widget = TRY(window->set_main_widget<Spreadsheet::SpreadsheetWidget>(*window, NonnullRefPtrVector<Spreadsheet::Sheet> {}, filename == nullptr));
+    auto spreadsheet_widget = TRY(window->set_main_widget<Spreadsheet::SpreadsheetWidget>(*window, NonnullRefPtrVector<Spreadsheet::Sheet> {}, filename.is_empty()));
 
     spreadsheet_widget->initialize_menubar(*window);
     spreadsheet_widget->update_window_title();
@@ -64,7 +64,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     window->show();
 
-    if (filename) {
+    if (!filename.is_empty()) {
         auto file = TRY(FileSystemAccessClient::Client::the().request_file_read_only_approved(window, filename));
         spreadsheet_widget->load_file(file.filename(), file.stream());
     }

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -251,7 +251,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Config::pledge_domain("Terminal");
 
-    char const* command_to_execute = nullptr;
+    StringView command_to_execute;
     bool keep_open = false;
 
     Core::ArgsParser args_parser;
@@ -260,7 +260,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     args_parser.parse(arguments);
 
-    if (keep_open && !command_to_execute) {
+    if (keep_open && command_to_execute.is_empty()) {
         warnln("Option -k can only be used in combination with -e.");
         return 1;
     }
@@ -273,7 +273,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
     if (shell_pid == 0) {
         close(ptm_fd);
-        if (command_to_execute)
+        if (!command_to_execute.is_empty())
             TRY(run_command(command_to_execute, keep_open));
         else
             TRY(run_command(Config::read_string("Terminal"sv, "Startup"sv, "Command"sv, ""sv), false));

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -27,7 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     app->set_config_domain(TRY("TextEditor"_string));
 
     auto preview_mode = "auto"sv;
-    char const* file_to_edit = nullptr;
+    StringView file_to_edit;
     Core::ArgsParser parser;
     parser.add_option(preview_mode, "Preview mode, one of 'none', 'html', 'markdown', 'auto'", "preview-mode", '\0', "mode");
     parser.add_positional_argument(file_to_edit, "File to edit, with optional starting line and column number", "file[:line[:column]]", Core::ArgsParser::Required::No);
@@ -73,8 +73,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->show();
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    if (file_to_edit) {
-        auto filename = TRY(String::from_utf8(StringView(file_to_edit, strlen(file_to_edit))));
+    if (!file_to_edit.is_empty()) {
+        auto filename = TRY(String::from_utf8(file_to_edit));
         FileArgument parsed_argument(filename);
         auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window, parsed_argument.filename().to_deprecated_string());
 

--- a/Userland/DevTools/GMLPlayground/main.cpp
+++ b/Userland/DevTools/GMLPlayground/main.cpp
@@ -75,7 +75,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man1/GMLPlayground.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    char const* path = nullptr;
+    StringView path;
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(path, "GML file to edit", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -54,7 +54,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         TRY(notify_make_not_available());
     }
 
-    char const* path_argument = nullptr;
+    StringView path_argument;
     bool mode_coredump = false;
     pid_t pid_to_debug = -1;
     Core::ArgsParser args_parser;

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -47,13 +47,13 @@ static bool generate_profile(pid_t& pid);
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     int pid = 0;
-    char const* perfcore_file_arg = nullptr;
+    StringView perfcore_file_arg;
     Core::ArgsParser args_parser;
     args_parser.add_option(pid, "PID to profile", "pid", 'p', "PID");
     args_parser.add_positional_argument(perfcore_file_arg, "Path of perfcore file", "perfcore-file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    if (pid && perfcore_file_arg) {
+    if (pid && !perfcore_file_arg.is_empty()) {
         warnln("-p/--pid option and perfcore-file argument must not be used together!");
         return 1;
     }
@@ -62,7 +62,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-profiler"sv));
 
     DeprecatedString perfcore_file;
-    if (!perfcore_file_arg) {
+    if (perfcore_file_arg.is_empty()) {
         if (!generate_profile(pid))
             return 0;
         perfcore_file = DeprecatedString::formatted("/proc/{}/perf_events", pid);

--- a/Userland/DevTools/SQLStudio/main.cpp
+++ b/Userland/DevTools/SQLStudio/main.cpp
@@ -15,7 +15,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    char const* file_to_open = nullptr;
+    StringView file_to_open;
 
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(file_to_open, "Path to SQL script or DB", "file", Core::ArgsParser::Required::No);
@@ -39,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return GUI::Window::CloseRequestDecision::StayOpen;
     };
 
-    if (file_to_open) {
+    if (!file_to_open.is_empty()) {
         auto path = LexicalPath(file_to_open);
         main_widget->open_script_from_file(path);
     } else {

--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -406,24 +406,6 @@ void ArgsParser::add_option(bool& value, char const* help_string, char const* lo
     add_option(move(option));
 }
 
-void ArgsParser::add_option(char const*& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode)
-{
-    Option option {
-        OptionArgumentMode::Required,
-        help_string,
-        long_name,
-        short_name,
-        value_name,
-        [&value](StringView s) {
-            VERIFY(s.length() == strlen(s.characters_without_null_termination()));
-            value = s.characters_without_null_termination();
-            return true;
-        },
-        hide_mode,
-    };
-    add_option(move(option));
-}
-
 void ArgsParser::add_option(DeprecatedString& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode)
 {
     Option option {
@@ -587,22 +569,6 @@ void ArgsParser::add_option(Vector<DeprecatedString>& values, char const* help_s
 void ArgsParser::add_positional_argument(Arg&& arg)
 {
     m_positional_args.append(move(arg));
-}
-
-void ArgsParser::add_positional_argument(char const*& value, char const* help_string, char const* name, Required required)
-{
-    Arg arg {
-        help_string,
-        name,
-        required == Required::Yes ? 1 : 0,
-        1,
-        [&value](StringView s) {
-            VERIFY(s.length() == strlen(s.characters_without_null_termination()));
-            value = s.characters_without_null_termination();
-            return true;
-        }
-    };
-    add_positional_argument(move(arg));
 }
 
 void ArgsParser::add_positional_argument(DeprecatedString& value, char const* help_string, char const* name, Required required)

--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -649,22 +649,6 @@ void ArgsParser::add_positional_argument(double& value, char const* help_string,
     add_positional_argument(move(arg));
 }
 
-void ArgsParser::add_positional_argument(Vector<char const*>& values, char const* help_string, char const* name, Required required)
-{
-    Arg arg {
-        help_string,
-        name,
-        required == Required::Yes ? 1 : 0,
-        INT_MAX,
-        [&values](StringView s) {
-            VERIFY(s.length() == strlen(s.characters_without_null_termination()));
-            values.append(s.characters_without_null_termination());
-            return true;
-        }
-    };
-    add_positional_argument(move(arg));
-}
-
 void ArgsParser::add_positional_argument(Vector<DeprecatedString>& values, char const* help_string, char const* name, Required required)
 {
     Arg arg {

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -87,7 +87,6 @@ public:
     void add_option(Option&&);
     void add_ignored(char const* long_name, char short_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(bool& value, char const* help_string, char const* long_name, char short_name, OptionHideMode hide_mode = OptionHideMode::None);
-    void add_option(char const*& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(DeprecatedString& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(StringView& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     template<Integral I>
@@ -101,7 +100,6 @@ public:
     void add_option(Vector<DeprecatedString>& values, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
 
     void add_positional_argument(Arg&&);
-    void add_positional_argument(char const*& value, char const* help_string, char const* name, Required required = Required::Yes);
     void add_positional_argument(DeprecatedString& value, char const* help_string, char const* name, Required required = Required::Yes);
     void add_positional_argument(StringView& value, char const* help_string, char const* name, Required required = Required::Yes);
     void add_positional_argument(int& value, char const* help_string, char const* name, Required required = Required::Yes);

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -105,7 +105,6 @@ public:
     void add_positional_argument(int& value, char const* help_string, char const* name, Required required = Required::Yes);
     void add_positional_argument(unsigned& value, char const* help_string, char const* name, Required required = Required::Yes);
     void add_positional_argument(double& value, char const* help_string, char const* name, Required required = Required::Yes);
-    void add_positional_argument(Vector<char const*>& value, char const* help_string, char const* name, Required required = Required::Yes);
     void add_positional_argument(Vector<DeprecatedString>& value, char const* help_string, char const* name, Required required = Required::Yes);
     void add_positional_argument(Vector<StringView>& value, char const* help_string, char const* name, Required required = Required::Yes);
 

--- a/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
@@ -94,7 +94,7 @@ int main(int argc, char** argv)
 #endif
     bool print_json = false;
     bool per_file = false;
-    char const* specified_test_root = nullptr;
+    StringView specified_test_root;
     DeprecatedString common_path;
     DeprecatedString test_glob;
 
@@ -143,7 +143,7 @@ int main(int argc, char** argv)
 
     DeprecatedString test_root;
 
-    if (specified_test_root) {
+    if (!specified_test_root.is_empty()) {
         test_root = DeprecatedString { specified_test_root };
     } else {
 #ifdef AK_OS_SERENITY

--- a/Userland/Libraries/LibTest/TestSuite.cpp
+++ b/Userland/Libraries/LibTest/TestSuite.cpp
@@ -65,7 +65,7 @@ int TestSuite::main(DeprecatedString const& suite_name, Span<StringView> argumen
     bool do_tests_only = getenv("TESTS_ONLY") != nullptr;
     bool do_benchmarks_only = false;
     bool do_list_cases = false;
-    char const* search_string = "*";
+    StringView search_string = "*"sv;
 
     args_parser.add_option(do_tests_only, "Only run tests.", "tests", 0);
     args_parser.add_option(do_benchmarks_only, "Only run benchmarks.", "bench", 0);

--- a/Userland/Services/TelnetServer/main.cpp
+++ b/Userland/Services/TelnetServer/main.cpp
@@ -86,7 +86,7 @@ static void run_command(int ptm_fd, DeprecatedString command)
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     int port = 23;
-    char const* command = "";
+    StringView command = ""sv;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(port, "Port to listen on", nullptr, 'p', "port");

--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -167,7 +167,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView file_to_read_from = {};
     Vector<StringView> script_args;
     bool skip_rc_files = false;
-    char const* format = nullptr;
+    StringView format;
     bool should_format_live = false;
     bool keep_open = false;
     bool posix_mode = false;
@@ -185,7 +185,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     parser.set_stop_on_first_non_option(true);
     parser.parse(arguments);
 
-    if (format) {
+    if (!format.is_empty()) {
         auto file = TRY(Core::DeprecatedFile::open(format, Core::OpenMode::ReadOnly));
 
         initialize(posix_mode);

--- a/Userland/Utilities/cksum.cpp
+++ b/Userland/Utilities/cksum.cpp
@@ -15,14 +15,14 @@
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     Vector<DeprecatedString> paths;
-    char const* opt_algorithm = nullptr;
+    StringView opt_algorithm;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(opt_algorithm, "Checksum algorithm (default 'crc32', use 'list' to list available algorithms)", "algorithm", '\0', nullptr);
     args_parser.add_positional_argument(paths, "File", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    auto algorithm = (opt_algorithm == nullptr) ? "crc32" : DeprecatedString(opt_algorithm).to_lowercase();
+    auto algorithm = opt_algorithm.is_empty() ? "crc32" : DeprecatedString(opt_algorithm).to_lowercase();
 
     auto available_algorithms = Vector<DeprecatedString> { "crc32", "adler32" };
 

--- a/Userland/Utilities/date.cpp
+++ b/Userland/Utilities/date.cpp
@@ -19,7 +19,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool print_iso_8601 = false;
     bool print_rfc_3339 = false;
     bool print_rfc_5322 = false;
-    char const* set_date = nullptr;
+    StringView set_date;
     StringView format_string;
 
     Core::ArgsParser args_parser;
@@ -31,8 +31,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(format_string, "Custom format to print the date in", "format-string", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    if (set_date != nullptr) {
-        auto number = DeprecatedString(set_date).to_uint();
+    if (!set_date.is_empty()) {
+        auto number = set_date.to_uint();
 
         if (!number.has_value()) {
             warnln("date: Invalid timestamp value");

--- a/Userland/Utilities/groupdel.cpp
+++ b/Userland/Utilities/groupdel.cpp
@@ -20,14 +20,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/etc/", "rwc"));
     TRY(Core::System::unveil("/bin/rm", "x"));
 
-    char const* groupname = nullptr;
+    DeprecatedString groupname;
 
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(groupname, "Group name", "group");
     args_parser.parse(arguments);
 
     setgrent();
-    auto* g = getgrnam(groupname);
+    auto* g = getgrnam(groupname.characters());
 
     // Check if the group exists
     if (!g) {

--- a/Userland/Utilities/nc.cpp
+++ b/Userland/Utilities/nc.cpp
@@ -49,7 +49,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool verbose = false;
     bool should_close = false;
     bool udp_mode = false;
-    char const* target = nullptr;
+    DeprecatedString target;
     int port = 0;
     int maximum_tcp_receive_buffer_size_input = -1;
 
@@ -96,8 +96,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         sa.sin_family = AF_INET;
         sa.sin_port = htons(port);
         sa.sin_addr.s_addr = htonl(INADDR_ANY);
-        if (target) {
-            if (inet_pton(AF_INET, target, &sa.sin_addr) <= 0) {
+        if (!target.is_empty()) {
+            if (inet_pton(AF_INET, target.characters(), &sa.sin_addr) <= 0) {
                 perror("inet_pton");
                 return 1;
             }
@@ -125,7 +125,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         TRY(Core::System::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)));
         TRY(Core::System::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)));
 
-        auto* hostent = gethostbyname(target);
+        auto* hostent = gethostbyname(target.characters());
         if (!hostent) {
             warnln("Socket::connect: Unable to resolve '{}'", target);
             return 1;

--- a/Userland/Utilities/nl.cpp
+++ b/Userland/Utilities/nl.cpp
@@ -22,7 +22,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     NumberStyle number_style = NumberNonEmptyLines;
     int increment = 1;
-    char const* separator = "  ";
+    StringView separator = "  "sv;
     int start_number = 1;
     int number_width = 6;
     Vector<DeprecatedString> files;

--- a/Userland/Utilities/ntpquery.cpp
+++ b/Userland/Utilities/ntpquery.cpp
@@ -107,7 +107,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // Leap seconds smearing NTP servers:
     // - time.facebook.com , https://engineering.fb.com/production-engineering/ntp-service/ , sine-smears over 18 hours
     // - time.google.com , https://developers.google.com/time/smear , linear-smears over 24 hours
-    char const* host = "time.google.com";
+    DeprecatedString host = "time.google.com"sv;
     Core::ArgsParser args_parser;
     args_parser.add_option(adjust_time, "Gradually adjust system time (requires root)", "adjust", 'a');
     args_parser.add_option(set_time, "Immediately set system time (requires root)", "set", 's');
@@ -128,7 +128,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         TRY(Core::System::pledge("stdio inet unix rpath"));
     }
 
-    auto* hostent = gethostbyname(host);
+    auto* hostent = gethostbyname(host.characters());
     if (!hostent) {
         warnln("Lookup failed for '{}'", host);
         return 1;

--- a/Userland/Utilities/pgrep.cpp
+++ b/Userland/Utilities/pgrep.cpp
@@ -21,7 +21,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     bool case_insensitive = false;
     bool invert_match = false;
-    char const* pattern = nullptr;
+    StringView pattern;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(case_insensitive, "Make matches case-insensitive", nullptr, 'i');

--- a/Userland/Utilities/pidof.cpp
+++ b/Userland/Utilities/pidof.cpp
@@ -45,8 +45,8 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     TRY(Core::System::unveil(nullptr, nullptr));
 
     bool single_shot = false;
-    char const* omit_pid_value = nullptr;
-    char const* process_name = nullptr;
+    StringView omit_pid_value;
+    StringView process_name;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(single_shot, "Only return one pid", nullptr, 's');
@@ -56,11 +56,11 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     args_parser.parse(args);
 
     pid_t pid_to_omit = 0;
-    if (omit_pid_value) {
-        if (!strcmp(omit_pid_value, "%PPID")) {
+    if (!omit_pid_value.is_empty()) {
+        if (omit_pid_value == "%PPID"sv) {
             pid_to_omit = getppid();
         } else {
-            auto number = StringView { omit_pid_value, strlen(omit_pid_value) }.to_uint();
+            auto number = omit_pid_value.to_uint();
             if (!number.has_value()) {
                 warnln("Invalid value for -o");
                 args_parser.print_usage(stderr, args.strings[0]);
@@ -69,5 +69,5 @@ ErrorOr<int> serenity_main(Main::Arguments args)
             pid_to_omit = number.value();
         }
     }
-    return pid_of(process_name, single_shot, omit_pid_value != nullptr, pid_to_omit);
+    return pid_of(process_name, single_shot, !omit_pid_value.is_empty(), pid_to_omit);
 }

--- a/Userland/Utilities/ping.cpp
+++ b/Userland/Utilities/ping.cpp
@@ -30,7 +30,7 @@ static Optional<size_t> count;
 static uint32_t total_ms;
 static int min_ms;
 static int max_ms;
-static char const* host;
+static DeprecatedString host;
 static int payload_size = -1;
 // variable part of header can be 0 to 40 bytes
 // https://datatracker.ietf.org/doc/html/rfc791#section-3.1
@@ -88,7 +88,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)));
 
-    auto* hostent = gethostbyname(host);
+    auto* hostent = gethostbyname(host.characters());
     if (!hostent) {
         warnln("Lookup failed for '{}'", host);
         return 1;

--- a/Userland/Utilities/pkill.cpp
+++ b/Userland/Utilities/pkill.cpp
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     bool case_insensitive = false;
     bool echo = false;
-    char const* pattern = nullptr;
+    StringView pattern;
     int signal = SIGTERM;
 
     Core::ArgsParser args_parser;

--- a/Userland/Utilities/pmap.cpp
+++ b/Userland/Utilities/pmap.cpp
@@ -18,7 +18,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/proc", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    char const* pid;
+    StringView pid;
     static bool extended = false;
 
     Core::ArgsParser args_parser;

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -151,7 +151,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool save_at_provided_name = false;
     bool should_follow_url = false;
     bool verbose_output = false;
-    char const* data = nullptr;
+    StringView data;
     StringView proxy_spec;
     DeprecatedString method = "GET";
     StringView method_override;
@@ -209,7 +209,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (!method_override.is_empty()) {
         method = method_override;
-    } else if (data) {
+    } else if (!data.is_empty()) {
         method = "POST";
         // FIXME: Content-Type?
     }
@@ -399,7 +399,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         request->stream_into(output_stream);
     };
 
-    request = protocol_client->start_request(method, url, request_headers, data ? StringView { data, strlen(data) }.bytes() : ReadonlyBytes {}, proxy_data);
+    request = protocol_client->start_request(method, url, request_headers, data.bytes(), proxy_data);
     setup_request();
 
     dbgln("started request with id {}", request->id());

--- a/Userland/Utilities/realpath.cpp
+++ b/Userland/Utilities/realpath.cpp
@@ -14,7 +14,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath"));
 
-    char const* path;
+    DeprecatedString path;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help(
@@ -22,7 +22,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(path, "Path to resolve", "path");
     args_parser.parse(arguments);
 
-    char* value = realpath(path, nullptr);
+    char* value = realpath(path.characters(), nullptr);
     if (value == nullptr) {
         perror("realpath");
         return 1;

--- a/Userland/Utilities/run-tests.cpp
+++ b/Userland/Utilities/run-tests.cpp
@@ -315,7 +315,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool print_all_output = false;
     bool run_benchmarks = false;
     bool run_skipped_tests = false;
-    char const* specified_test_root = nullptr;
+    StringView specified_test_root;
     DeprecatedString test_glob;
     DeprecatedString exclude_pattern;
     DeprecatedString config_file;
@@ -360,7 +360,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     DeprecatedString test_root;
 
-    if (specified_test_root) {
+    if (!specified_test_root.is_empty()) {
         test_root = DeprecatedString { specified_test_root };
     } else {
         test_root = "/usr/Tests";

--- a/Userland/Utilities/seq.cpp
+++ b/Userland/Utilities/seq.cpp
@@ -27,20 +27,21 @@ static void print_usage(FILE* stream)
     fputs(g_usage, stream);
 }
 
-static double get_double(char const* name, char const* d_string, size_t* number_of_decimals)
+static double get_double(char const* name, StringView d_string, size_t* number_of_decimals)
 {
-    char* end;
-    double d = strtod(d_string, &end);
-    if (d == 0 && end == d_string) {
+    auto d = d_string.to_double();
+    if (!d.has_value()) {
         warnln("{}: invalid argument \"{}\"", name, d_string);
         print_usage(stderr);
         exit(1);
     }
-    if (char const* dot = strchr(d_string, '.'))
-        *number_of_decimals = strlen(dot + 1);
+
+    if (auto dot = d_string.find('.'); dot.has_value())
+        *number_of_decimals = d_string.length() - *dot - 1;
     else
         *number_of_decimals = 0;
-    return d;
+
+    return *d;
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
@@ -50,7 +51,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     StringView separator = "\n"sv;
     StringView terminator = ""sv;
-    Vector<char const*> parameters;
+    Vector<StringView> parameters;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(separator, "Characters to print after each number (default: \\n)", "separator", 's', "separator");

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -819,8 +819,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Vector<StringView> child_argv;
 
     StringView output_filename;
-    char const* exclude_syscalls_option = nullptr;
-    char const* include_syscalls_option = nullptr;
+    StringView exclude_syscalls_option;
+    StringView include_syscalls_option;
     HashTable<StringView> exclude_syscalls;
     HashTable<StringView> include_syscalls;
 
@@ -840,9 +840,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         ? TRY(Core::File::standard_error())
         : TRY(Core::File::open(output_filename, Core::File::OpenMode::Write));
 
-    auto parse_syscalls = [](char const* option, auto& hash_table) {
-        if (option != nullptr) {
-            for (auto syscall : StringView { option, strlen(option) }.split_view(','))
+    auto parse_syscalls = [](StringView option, auto& hash_table) {
+        if (!option.is_empty()) {
+            for (auto syscall : option.split_view(','))
                 hash_table.set(syscall);
         }
     };

--- a/Userland/Utilities/traceroute.cpp
+++ b/Userland/Utilities/traceroute.cpp
@@ -25,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio id inet unix"));
 
-    char const* host_name;
+    DeprecatedString host_name;
     int max_hops = 30;
     int max_retries = 3;
     int echo_timeout = 5;
@@ -45,7 +45,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return Error::from_string_literal("Invalid maximum retries amount");
     }
 
-    auto* hostent = gethostbyname(host_name);
+    auto* hostent = gethostbyname(host_name.characters());
     if (!hostent) {
         warnln("Lookup failed for '{}'", host_name);
         return 1;

--- a/Userland/Utilities/tt.cpp
+++ b/Userland/Utilities/tt.cpp
@@ -24,7 +24,7 @@ static int kill_test();
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    char const* test_name = "n";
+    StringView test_name = "n"sv;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help(
@@ -33,21 +33,21 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(test_name, "Test to run (m = mutex, d = detached, p = priority, s = stack size, t = simple thread test, x = set stack, k = kill, nothing = join race)", "test-name", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    if (*test_name == 'm')
+    if (test_name[0] == 'm')
         return mutex_test();
-    if (*test_name == 'd')
+    if (test_name[0] == 'd')
         return detached_test();
-    if (*test_name == 'p')
+    if (test_name[0] == 'p')
         return priority_test();
-    if (*test_name == 's')
+    if (test_name[0] == 's')
         return stack_size_test();
-    if (*test_name == 't')
+    if (test_name[0] == 't')
         return staying_alive_test();
-    if (*test_name == 'x')
+    if (test_name[0] == 'x')
         return set_stack_test();
-    if (*test_name == 'k')
+    if (test_name[0] == 'k')
         return kill_test();
-    if (*test_name != 'n') {
+    if (test_name[0] != 'n') {
         args_parser.print_usage(stdout, arguments.strings[0]);
         return 1;
     }

--- a/Userland/Utilities/useradd.cpp
+++ b/Userland/Utilities/useradd.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio wpath rpath cpath chown"));
 
-    char const* home_path = nullptr;
+    StringView home_path;
     int uid = 0;
     int gid = USERS_GID;
     bool create_home_dir = false;
@@ -108,7 +108,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     DeprecatedString home;
-    if (!home_path)
+    if (home_path.is_empty())
         home = DeprecatedString::formatted("/home/{}", username);
     else
         home = home_path;

--- a/Userland/Utilities/which.cpp
+++ b/Userland/Utilities/which.cpp
@@ -14,13 +14,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath"));
 
-    char const* filename = nullptr;
+    StringView filename;
 
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(filename, "Name of executable", "executable");
     args_parser.parse(arguments);
 
-    auto fullpath = Core::DeprecatedFile::resolve_executable_from_environment({ filename, strlen(filename) });
+    auto fullpath = Core::DeprecatedFile::resolve_executable_from_environment(filename);
     if (!fullpath.has_value()) {
         warnln("no '{}' in path", filename);
         return 1;

--- a/Userland/Utilities/xargs.cpp
+++ b/Userland/Utilities/xargs.cpp
@@ -44,10 +44,10 @@ ErrorOr<int> serenity_main(Main::Arguments main_arguments)
 
     StringView placeholder;
     bool split_with_nulls = false;
-    char const* specified_delimiter = "\n";
+    DeprecatedString specified_delimiter = "\n"sv;
     Vector<DeprecatedString> arguments;
     bool verbose = false;
-    char const* file_to_read = "-";
+    DeprecatedString file_to_read = "-"sv;
     int max_lines_for_one_command = 0;
     int max_bytes_for_one_command = ARG_MAX;
 
@@ -67,12 +67,12 @@ ErrorOr<int> serenity_main(Main::Arguments main_arguments)
     size_t max_bytes = min(ARG_MAX, max_bytes_for_one_command);
     size_t max_lines = max(max_lines_for_one_command, 0);
 
-    if (!split_with_nulls && strlen(specified_delimiter) > 1) {
+    if (!split_with_nulls && specified_delimiter.length() > 1) {
         warnln("xargs: the delimiter must be a single byte");
         return 1;
     }
 
-    char entry_separator = split_with_nulls ? '\0' : *specified_delimiter;
+    char entry_separator = split_with_nulls ? '\0' : specified_delimiter[0];
 
     if (!placeholder.is_empty())
         max_lines = 1;
@@ -87,7 +87,7 @@ ErrorOr<int> serenity_main(Main::Arguments main_arguments)
 
     if ("-"sv != file_to_read) {
         // A file was specified, try to open it.
-        fp = fopen(file_to_read, "re");
+        fp = fopen(file_to_read.characters(), "re");
         if (!fp) {
             perror("fopen");
             return 1;

--- a/Userland/Utilities/yes.cpp
+++ b/Userland/Utilities/yes.cpp
@@ -13,12 +13,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio"));
 
-    char const* string = "yes";
+    StringView string = "yes"sv;
 
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(string, "String to output (defaults to 'yes')", "string", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
     for (;;)
-        puts(string);
+        outln("{}", string);
 }


### PR DESCRIPTION
This is not guaranteed to always work correctly as ArgsParser deals in StringViews and might have a non-properly-null-terminated string as a value. As a bonus, using StringView (and DeprecatedString where necessary) leads to nicer looking code too :^)