### PR TITLE
SoundPlayer: Add action with icon for toggling mute

### DIFF
--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -46,6 +46,8 @@ SoundPlayerWidgetAdvancedView::SoundPlayerWidgetAdvancedView(GUI::Window& window
     m_stop_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/stop.png"sv).release_value_but_fixme_should_propagate_errors();
     m_back_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/go-back.png"sv).release_value_but_fixme_should_propagate_errors();
     m_next_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/go-forward.png"sv).release_value_but_fixme_should_propagate_errors();
+    m_volume_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/audio-volume-medium.png"sv).release_value_but_fixme_should_propagate_errors();
+    m_muted_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/audio-volume-muted.png"sv).release_value_but_fixme_should_propagate_errors();
 
     m_visualization = m_player_view->add<BarsVisualizationWidget>();
 
@@ -98,6 +100,12 @@ SoundPlayerWidgetAdvancedView::SoundPlayerWidgetAdvancedView(GUI::Window& window
 
     menubar.add_separator();
 
+    m_mute_action = GUI::Action::create("Mute", { Key_M }, m_volume_icon, [&](auto&) {
+        toggle_mute();
+    });
+    m_mute_action->set_enabled(true);
+    menubar.add_action(*m_mute_action);
+
     m_volume_label = &menubar.add<GUI::Label>();
     m_volume_label->set_fixed_width(30);
 
@@ -145,9 +153,6 @@ void SoundPlayerWidgetAdvancedView::drop_event(GUI::DropEvent& event)
 
 void SoundPlayerWidgetAdvancedView::keydown_event(GUI::KeyEvent& event)
 {
-    if (event.key() == Key_M)
-        toggle_mute();
-
     if (event.key() == Key_Up)
         m_volume_slider->increase_slider_by_page_steps(1);
 
@@ -184,9 +189,11 @@ void SoundPlayerWidgetAdvancedView::loop_mode_changed(Player::LoopMode)
 {
 }
 
-void SoundPlayerWidgetAdvancedView::mute_changed(bool)
+void SoundPlayerWidgetAdvancedView::mute_changed(bool muted)
 {
-    // FIXME: Update the volume slider when player is muted
+    m_mute_action->set_text(muted ? "Unmute"sv : "Mute"sv);
+    m_mute_action->set_icon(muted ? m_muted_icon : m_volume_icon);
+    m_volume_slider->set_enabled(!muted);
 }
 
 void SoundPlayerWidgetAdvancedView::sync_previous_next_actions()

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
@@ -71,11 +71,14 @@ private:
     RefPtr<Gfx::Bitmap> m_stop_icon;
     RefPtr<Gfx::Bitmap> m_back_icon;
     RefPtr<Gfx::Bitmap> m_next_icon;
+    RefPtr<Gfx::Bitmap> m_volume_icon;
+    RefPtr<Gfx::Bitmap> m_muted_icon;
 
     RefPtr<GUI::Action> m_play_action;
     RefPtr<GUI::Action> m_stop_action;
     RefPtr<GUI::Action> m_back_action;
     RefPtr<GUI::Action> m_next_action;
+    RefPtr<GUI::Action> m_mute_action;
 
     RefPtr<GUI::HorizontalSlider> m_playback_progress_slider;
     RefPtr<GUI::Label> m_volume_label;


### PR DESCRIPTION
This adds a button on the menubar next to the volume slider to indicate mute state and allow toggling the mute. Pressing the M key will still toggle the mute, as before. When muted, the volume scroll bar now gets disabled.