### PR TITLE
PixelPaint: Do not change layers when scaling with the move tool

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -374,7 +374,7 @@ void ImageEditor::mousedown_event(GUI::MouseEvent& event)
         return;
 
     if (auto* tool = dynamic_cast<MoveTool*>(m_active_tool); tool && tool->layer_selection_mode() == MoveTool::LayerSelectionMode::ForegroundLayer) {
-        if (auto* foreground_layer = layer_at_editor_position(event.position()))
+        if (auto* foreground_layer = layer_at_editor_position(event.position()); foreground_layer && !tool->cursor_is_within_resize_anchor())
             set_active_layer(foreground_layer);
     }
 

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.h
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.h
@@ -39,6 +39,7 @@ public:
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override;
     virtual bool is_overriding_alt() override { return true; }
     LayerSelectionMode layer_selection_mode() const { return m_layer_selection_mode; }
+    bool cursor_is_within_resize_anchor() { return m_resize_anchor_location.has_value(); }
 
 private:
     static int resize_anchor_size(Gfx::IntRect layer_rect_in_frame_coordinates);


### PR DESCRIPTION
The move tool will no longer change the foreground layer if the cursor is currently hovering over a resize anchor.

Video:

https://user-images.githubusercontent.com/2817754/222009981-4b23203c-7de0-4a07-bd70-6f4a0bd59714.mp4

