### PR TITLE
Toolchain: Don't abuse crt{begin,end}.o for shared or PIE binaries

### DIFF
--- a/Toolchain/Patches/gcc/0001-Add-a-gcc-driver-for-SerenityOS.patch
+++ b/Toolchain/Patches/gcc/0001-Add-a-gcc-driver-for-SerenityOS.patch
@@ -101,11 +101,11 @@ index 0000000000000000000000000000000000000000..17551aaa1a07e6c0b7365f9889937512
 +/* Files that are linked before user code.
 +   The %s tells GCC to look for these files in the library directory. */
 +#undef STARTFILE_SPEC
-+#define STARTFILE_SPEC "%{!shared:crt0.o%s} crti.o%s %{shared: %{!fbuilding-libgcc:crt0_shared.o%s}} %{shared|static-pie|!no-pie:%:if-exists-else(crtbeginS.o%s crtbegin.o%s); :crtbegin.o%s}"
++#define STARTFILE_SPEC "%{!shared:crt0.o%s} crti.o%s %{shared: %{!fbuilding-libgcc:crt0_shared.o%s}} %{shared|static-pie|!no-pie:crtbeginS.o%s; :crtbegin.o%s}"
 +
 +/* Files that are linked after user code. */
 +#undef ENDFILE_SPEC
-+#define ENDFILE_SPEC "%{shared|static-pie|!no-pie:%:if-exists-else(crtendS.o%s crtend.o%s); :crtend.o%s} crtn.o%s"
++#define ENDFILE_SPEC "%{shared|static-pie|!no-pie:crtendS.o%s; :crtend.o%s} crtn.o%s"
 +
 +#undef LINK_SPEC
 +#define LINK_SPEC "%{shared:-shared} %{static:-static} %{!static: %{rdynamic:-export-dynamic} -dynamic-linker /usr/lib/Loader.so}"

--- a/Toolchain/Patches/gcc/0003-libgcc-Build-for-SerenityOS.patch
+++ b/Toolchain/Patches/gcc/0003-libgcc-Build-for-SerenityOS.patch
@@ -50,7 +50,7 @@ index 8c56fcae5d2fdfcc8d1f9b2614f0c41ad44f258f..f5855cfa66d7950c3d7565ad938b4e47
 +	tmake_file="$tmake_file i386/t-crtstuff t-crtstuff-pic t-libgcc-pic t-slibgcc t-eh-dw2-dip"
 +	;;
 +aarch64-*-serenity*)
-+	extra_parts="$extra_parts crti.o crtbegin.o crtend.o crtn.o"
++	extra_parts="$extra_parts crti.o crtbegin.o crtbeginS.o crtend.o crtendS.o crtn.o"
 +	extra_parts="$extra_parts crtfastmath.o"
 +	tmake_file="$tmake_file ${cpu_type}/t-aarch64"
 +	tmake_file="$tmake_file ${cpu_type}/t-lse t-slibgcc t-slibgcc-libgcc t-slibgcc-gld-nover"


### PR DESCRIPTION
aarch64 required this to successfully build, but the actual fix to that is to just make sure that crtbeginS and crtendS get built as a part of the toolchain.

This fixes building the GCC port on x86_64.