### PR TITLE
Ladybird+LibGfx: Render emoji with our emoji images :^)

### DIFF
--- a/Ladybird/FontPluginQt.cpp
+++ b/Ladybird/FontPluginQt.cpp
@@ -11,6 +11,7 @@
 #include <AK/DeprecatedString.h>
 #include <AK/String.h>
 #include <LibCore/StandardPaths.h>
+#include <LibGfx/Font/Emoji.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <QFont>
 #include <QFontInfo>
@@ -30,6 +31,8 @@ FontPluginQt::FontPluginQt()
 
     Gfx::FontDatabase::set_default_font_query("Katica 10 400 0");
     Gfx::FontDatabase::set_fixed_width_font_query("Csilla 10 400 0");
+
+    Gfx::Emoji::set_emoji_lookup_path(String::formatted("{}/res/emoji", s_serenity_resource_root).release_value_but_fixme_should_propagate_errors());
 
     update_generic_fonts();
 

--- a/Meta/CMake/unicode_data.cmake
+++ b/Meta/CMake/unicode_data.cmake
@@ -64,8 +64,7 @@ set(SENTENCE_BREAK_PROP_PATH "${UCD_PATH}/${SENTENCE_BREAK_PROP_SOURCE}")
 string(REGEX REPLACE "([0-9]+\\.[0-9]+)\\.[0-9]+" "\\1" EMOJI_VERSION "${UCD_VERSION}")
 set(EMOJI_TEST_URL "https://www.unicode.org/Public/emoji/${EMOJI_VERSION}/emoji-test.txt")
 set(EMOJI_TEST_PATH "${UCD_PATH}/emoji-test.txt")
-set(EMOJI_BASE_PATH "${SerenityOS_SOURCE_DIR}/Base")
-set(EMOJI_RES_PATH "${EMOJI_BASE_PATH}/res/emoji")
+set(EMOJI_RES_PATH "${SerenityOS_SOURCE_DIR}/Base/res/emoji")
 set(EMOJI_SERENITY_PATH "${SerenityOS_SOURCE_DIR}/Base/home/anon/Documents/emoji-serenity.txt")
 set(EMOJI_INSTALL_PATH "${CMAKE_BINARY_DIR}/Root/home/anon/Documents/emoji.txt")
 
@@ -118,7 +117,7 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
         "${UCD_VERSION_FILE}"
         "${EMOJI_DATA_HEADER}"
         "${EMOJI_DATA_IMPLEMENTATION}"
-        arguments "${EMOJI_INSTALL_ARG}" -e "${EMOJI_TEST_PATH}" -s "${EMOJI_SERENITY_PATH}" -b "${EMOJI_BASE_PATH}" -r "${EMOJI_RES_PATH}"
+        arguments "${EMOJI_INSTALL_ARG}" -e "${EMOJI_TEST_PATH}" -s "${EMOJI_SERENITY_PATH}" -r "${EMOJI_RES_PATH}"
 
         # This will make this command only run when the modified time of the directory changes,
         # which only happens if files within it are added or deleted, but not when a file is modified.

--- a/Userland/Libraries/LibGfx/Font/Emoji.h
+++ b/Userland/Libraries/LibGfx/Font/Emoji.h
@@ -9,6 +9,7 @@
 
 #include <AK/Forward.h>
 #include <AK/Span.h>
+#include <AK/String.h>
 #include <AK/Types.h>
 
 namespace Gfx {
@@ -17,6 +18,8 @@ class Bitmap;
 
 class Emoji {
 public:
+    static void set_emoji_lookup_path(String);
+
     static Gfx::Bitmap const* emoji_for_code_point(u32 code_point);
     static Gfx::Bitmap const* emoji_for_code_points(ReadonlySpan<u32> const&);
     static Gfx::Bitmap const* emoji_for_code_point_iterator(Utf8CodePointIterator&);


### PR DESCRIPTION
From:
![Screenshot from 2023-03-01 08-45-53](https://user-images.githubusercontent.com/5600524/222156820-27b1097d-4692-415e-ad26-376cc074f6cd.png)

To:
![Screenshot from 2023-03-01 08-45-40](https://user-images.githubusercontent.com/5600524/222156789-975ceb59-e93c-47c3-9891-146953b5dd44.png)

Note that some of the painting / keyboard events / mouse events are a bit wonky due to this FIXME (we've so far been fixing emoji things for bitmap fonts, primarily):
https://github.com/SerenityOS/serenity/blob/34567bc145da7c569f3afb8179670c1035d7173e/Userland/Libraries/LibGfx/Font/ScaledFont.cpp#L103