### PR TITLE
LibJS: Use a Variant instead of two Optionals for ThrowCompletionOr

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2020-2022, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2020-2023, Linus Groh <linusg@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -184,7 +184,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from)
                 auto error = vm.throw_completion<TypeError>(ErrorType::ArrayMaxSize);
 
                 // 2. Return ? IteratorClose(iteratorRecord, error).
-                return TRY(iterator_close(vm, iterator, move(error)));
+                return *TRY(iterator_close(vm, iterator, move(error)));
             }
 
             // ii. Let Pk be ! ToString(𝔽(k)).
@@ -214,7 +214,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from)
 
                 // 2. IfAbruptCloseIterator(mappedValue, iteratorRecord).
                 if (mapped_value_or_error.is_error())
-                    return TRY(iterator_close(vm, iterator, mapped_value_or_error.release_error()));
+                    return *TRY(iterator_close(vm, iterator, mapped_value_or_error.release_error()));
                 mapped_value = mapped_value_or_error.release_value();
             }
             // vii. Else, let mappedValue be nextValue.
@@ -227,7 +227,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from)
 
             // IfAbruptCloseIterator(defineStatus, iteratorRecord).
             if (result_or_error.is_error())
-                return TRY(iterator_close(vm, iterator, result_or_error.release_error()));
+                return *TRY(iterator_close(vm, iterator, result_or_error.release_error()));
 
             // x. Set k to k + 1.
         }

--- a/Userland/Libraries/LibJS/Runtime/Date.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Date.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2020-2023, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -570,7 +570,7 @@ double parse_time_zone_offset_string(StringView offset_string)
     auto parsed_hours = *parse_result->time_zone_utc_offset_hour;
 
     // 10. Let hours be ℝ(StringToNumber(CodePointsToString(parsedHours))).
-    auto hours = string_to_number(parsed_hours)->as_double();
+    auto hours = string_to_number(parsed_hours);
 
     double minutes { 0 };
     double seconds { 0 };
@@ -587,7 +587,7 @@ double parse_time_zone_offset_string(StringView offset_string)
         auto parsed_minutes = *parse_result->time_zone_utc_offset_minute;
 
         // b. Let minutes be ℝ(StringToNumber(CodePointsToString(parsedMinutes))).
-        minutes = string_to_number(parsed_minutes)->as_double();
+        minutes = string_to_number(parsed_minutes);
     }
 
     // 13. If parseResult does not contain two MinuteSecond Parse Nodes, then
@@ -601,7 +601,7 @@ double parse_time_zone_offset_string(StringView offset_string)
         auto parsed_seconds = *parse_result->time_zone_utc_offset_second;
 
         // b. Let seconds be ℝ(StringToNumber(CodePointsToString(parsedSeconds))).
-        seconds = string_to_number(parsed_seconds)->as_double();
+        seconds = string_to_number(parsed_seconds);
     }
 
     // 15. If parseResult does not contain a TemporalDecimalFraction Parse Node, then
@@ -621,7 +621,7 @@ double parse_time_zone_offset_string(StringView offset_string)
         auto nanoseconds_string = fraction.substring_view(1, 9);
 
         // d. Let nanoseconds be ℝ(StringToNumber(nanosecondsString)).
-        nanoseconds = string_to_number(nanoseconds_string)->as_double();
+        nanoseconds = string_to_number(nanoseconds_string);
     }
 
     // 17. Return sign × (((hours × 60 + minutes) × 60 + seconds) × 10^9 + nanoseconds).

--- a/Userland/Libraries/LibJS/Runtime/DisposableStackPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DisposableStackPrototype.cpp
@@ -69,7 +69,7 @@ JS_DEFINE_NATIVE_FUNCTION(DisposableStackPrototype::dispose)
     disposable_stack->set_disposed();
 
     // 5. Return DisposeResources(disposableStack, NormalCompletion(undefined)).
-    return TRY(dispose_resources(vm, disposable_stack->disposable_resource_stack(), Completion { js_undefined() }));
+    return *TRY(dispose_resources(vm, disposable_stack->disposable_resource_stack(), Completion { js_undefined() }));
 }
 
 // 11.3.3.3 DisposableStack.prototype.use( value ), https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.use

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Stephan Unverwerth <s.unverwerth@serenityos.org>
- * Copyright (c) 2020-2022, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2020-2023, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -183,7 +183,7 @@ ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(Value this_argu
 
     // 8. If result.[[Type]] is return, return result.[[Value]].
     if (result.type() == Completion::Type::Return)
-        return result.value();
+        return *result.value();
 
     // 9. ReturnIfAbrupt(result).
     if (result.is_abrupt()) {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
@@ -558,7 +558,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::fields)
             auto completion = vm.throw_completion<TypeError>(ErrorType::TemporalInvalidCalendarFieldValue, TRY_OR_THROW_OOM(vm, next_value.to_string_without_side_effects()));
 
             // 2. Return ? IteratorClose(iteratorRecord, completion).
-            return TRY(iterator_close(vm, iterator_record, move(completion)));
+            return *TRY(iterator_close(vm, iterator_record, move(completion)));
         }
 
         auto next_value_string = TRY(next_value.as_string().utf8_string());
@@ -569,7 +569,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::fields)
             auto completion = vm.throw_completion<RangeError>(ErrorType::TemporalDuplicateCalendarField, next_value_string);
 
             // 2. Return ? IteratorClose(iteratorRecord, completion).
-            return TRY(iterator_close(vm, iterator_record, move(completion)));
+            return *TRY(iterator_close(vm, iterator_record, move(completion)));
         }
 
         // iv. If nextValue is not one of "year", "month", "monthCode", "day", "hour", "minute", "second", "millisecond", "microsecond", "nanosecond", then
@@ -578,7 +578,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::fields)
             auto completion = vm.throw_completion<RangeError>(ErrorType::TemporalInvalidCalendarFieldName, next_value_string);
 
             // 2. Return ? IteratorClose(iteratorRecord, completion).
-            return TRY(iterator_close(vm, iterator_record, move(completion)));
+            return *TRY(iterator_close(vm, iterator_record, move(completion)));
         }
 
         // v. Append nextValue to the end of the List fieldNames.

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -664,36 +664,36 @@ static Optional<NumberParseResult> parse_number_text(StringView text)
 }
 
 // 7.1.4.1.1 StringToNumber ( str ), https://tc39.es/ecma262/#sec-stringtonumber
-Optional<Value> string_to_number(StringView string)
+double string_to_number(StringView string)
 {
     // 1. Let text be StringToCodePoints(str).
     DeprecatedString text = Utf8View(string).trim(whitespace_characters, AK::TrimMode::Both).as_string();
 
     // 2. Let literal be ParseText(text, StringNumericLiteral).
     if (text.is_empty())
-        return Value(0);
+        return 0;
     if (text == "Infinity" || text == "+Infinity")
-        return js_infinity();
+        return INFINITY;
     if (text == "-Infinity")
-        return js_negative_infinity();
+        return -INFINITY;
 
     auto result = parse_number_text(text);
 
     // 3. If literal is a List of errors, return NaN.
     if (!result.has_value())
-        return js_nan();
+        return NAN;
 
     // 4. Return StringNumericValue of literal.
     if (result->base != 10) {
         auto bigint = Crypto::UnsignedBigInteger::from_base(result->base, result->literal);
-        return Value(bigint.to_double());
+        return bigint.to_double();
     }
 
     auto maybe_double = text.to_double(AK::TrimWhitespace::No);
     if (!maybe_double.has_value())
-        return js_nan();
+        return NAN;
 
-    return Value(*maybe_double);
+    return *maybe_double;
 }
 
 // 7.1.4 ToNumber ( argument ), https://tc39.es/ecma262/#sec-tonumber

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -563,7 +563,7 @@ enum class NumberToStringMode {
 };
 ErrorOr<String> number_to_string(double, NumberToStringMode = NumberToStringMode::WithExponent);
 DeprecatedString number_to_deprecated_string(double, NumberToStringMode = NumberToStringMode::WithExponent);
-Optional<Value> string_to_number(StringView);
+double string_to_number(StringView);
 
 inline bool Value::operator==(Value const& value) const { return same_value(*this, value); }
 

--- a/Userland/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
@@ -186,7 +186,7 @@ JS::ThrowCompletionOr<JS::Value> cross_origin_get(JS::VM& vm, JS::Object const& 
 
     // 3. If IsDataDescriptor(desc) is true, then return desc.[[Value]].
     if (descriptor->is_data_descriptor())
-        return descriptor->value;
+        return *descriptor->value;
 
     // 4. Assert: IsAccessorDescriptor(desc) is true.
     VERIFY(descriptor->is_accessor_descriptor());


### PR DESCRIPTION
First commit might seem unrelated but is a requirement for the second due to no longer accepting an `Optional<Value>` for `ThrowCompletionOr<Value>`.