### PR TITLE
LibPDF: Assorted parsing and stability fixes

### DIFF
--- a/Userland/Libraries/LibPDF/Filter.h
+++ b/Userland/Libraries/LibPDF/Filter.h
@@ -15,20 +15,20 @@ namespace PDF {
 
 class Filter {
 public:
-    static ErrorOr<ByteBuffer> decode(ReadonlyBytes bytes, DeprecatedFlyString const& encoding_type, RefPtr<DictObject> decode_parms);
+    static PDFErrorOr<ByteBuffer> decode(ReadonlyBytes bytes, DeprecatedFlyString const& encoding_type, RefPtr<DictObject> decode_parms);
 
 private:
-    static ErrorOr<ByteBuffer> decode_ascii_hex(ReadonlyBytes bytes);
-    static ErrorOr<ByteBuffer> decode_ascii85(ReadonlyBytes bytes);
-    static ErrorOr<ByteBuffer> decode_png_prediction(Bytes bytes, int bytes_per_row);
-    static ErrorOr<ByteBuffer> decode_lzw(ReadonlyBytes bytes);
-    static ErrorOr<ByteBuffer> decode_flate(ReadonlyBytes bytes, int predictor, int columns, int colors, int bits_per_component);
-    static ErrorOr<ByteBuffer> decode_run_length(ReadonlyBytes bytes);
-    static ErrorOr<ByteBuffer> decode_ccitt(ReadonlyBytes bytes);
-    static ErrorOr<ByteBuffer> decode_jbig2(ReadonlyBytes bytes);
-    static ErrorOr<ByteBuffer> decode_dct(ReadonlyBytes bytes);
-    static ErrorOr<ByteBuffer> decode_jpx(ReadonlyBytes bytes);
-    static ErrorOr<ByteBuffer> decode_crypt(ReadonlyBytes bytes);
+    static PDFErrorOr<ByteBuffer> decode_ascii_hex(ReadonlyBytes bytes);
+    static PDFErrorOr<ByteBuffer> decode_ascii85(ReadonlyBytes bytes);
+    static PDFErrorOr<ByteBuffer> decode_png_prediction(Bytes bytes, int bytes_per_row);
+    static PDFErrorOr<ByteBuffer> decode_lzw(ReadonlyBytes bytes);
+    static PDFErrorOr<ByteBuffer> decode_flate(ReadonlyBytes bytes, int predictor, int columns, int colors, int bits_per_component);
+    static PDFErrorOr<ByteBuffer> decode_run_length(ReadonlyBytes bytes);
+    static PDFErrorOr<ByteBuffer> decode_ccitt(ReadonlyBytes bytes);
+    static PDFErrorOr<ByteBuffer> decode_jbig2(ReadonlyBytes bytes);
+    static PDFErrorOr<ByteBuffer> decode_dct(ReadonlyBytes bytes);
+    static PDFErrorOr<ByteBuffer> decode_jpx(ReadonlyBytes bytes);
+    static PDFErrorOr<ByteBuffer> decode_crypt(ReadonlyBytes bytes);
 };
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -412,7 +412,9 @@ PDFErrorOr<Vector<CFF::Glyph>> CFF::parse_charstrings(Reader&& reader, Vector<By
 PDFErrorOr<Vector<u8>> CFF::parse_encoding(Reader&& reader)
 {
     Vector<u8> encoding_codes;
-    auto format = TRY(reader.try_read<Card8>());
+    auto format_raw = TRY(reader.try_read<Card8>());
+    // TODO: support encoding supplements when highest bit is set
+    auto format = format_raw & 0x7f;
     if (format == 0) {
         auto n_codes = TRY(reader.try_read<Card8>());
         for (u8 i = 0; i < n_codes; i++) {

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
@@ -271,7 +271,7 @@ PDFErrorOr<Type1FontProgram::Glyph> Type1FontProgram::parse_glyph(ReadonlyBytes 
 
             // hints operators
             case HStemHM:
-                state.n_hints++;
+                state.n_hints += state.sp / 2;
                 [[fallthrough]];
             case HStem:
                 maybe_read_width(Odd);
@@ -279,7 +279,7 @@ PDFErrorOr<Type1FontProgram::Glyph> Type1FontProgram::parse_glyph(ReadonlyBytes 
                 break;
 
             case VStemHM:
-                state.n_hints++;
+                state.n_hints += state.sp / 2;
                 [[fallthrough]];
             case VStem:
                 maybe_read_width(Odd);
@@ -289,9 +289,11 @@ PDFErrorOr<Type1FontProgram::Glyph> Type1FontProgram::parse_glyph(ReadonlyBytes 
             case Hintmask:
             case Cntrmask: {
                 maybe_read_width(Odd);
+                state.n_hints += state.sp / 2;
                 auto hint_bytes = (state.n_hints + 8 - 1) / 8;
                 TRY(require(hint_bytes));
                 i += hint_bytes;
+                state.sp = 0;
                 break;
             }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
@@ -74,7 +74,7 @@ protected:
         Array<float, 14> flex_sequence;
 
         size_t sp { 0 };
-        Array<float, 24> stack;
+        Array<float, 48> stack;
         u8 n_hints { 0 };
 
         size_t postscript_sp { 0 };

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -619,8 +619,8 @@ RENDERER_HANDLER(paint_xobject)
     VERIFY(args.size() > 0);
     auto resources = extra_resources.value_or(m_page.resources);
     auto xobject_name = args[0].get<NonnullRefPtr<Object>>()->cast<NameObject>()->name();
-    auto xobjects_dict = MUST(resources->get_dict(m_document, CommonNames::XObject));
-    auto xobject = MUST(xobjects_dict->get_stream(m_document, xobject_name));
+    auto xobjects_dict = TRY(resources->get_dict(m_document, CommonNames::XObject));
+    auto xobject = TRY(xobjects_dict->get_stream(m_document, xobject_name));
 
     Optional<NonnullRefPtr<DictObject>> xobject_resources {};
     if (xobject->dict()->contains(CommonNames::Resources)) {

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -726,6 +726,9 @@ PDFErrorOr<void> Renderer::set_graphics_state_from_dict(NonnullRefPtr<DictObject
 
 PDFErrorOr<void> Renderer::show_text(DeprecatedString const& string)
 {
+    if (!text_state().font)
+        return Error::rendering_unsupported_error("Can't draw text because an invalid font was in use");
+
     auto& text_rendering_matrix = calculate_text_rendering_matrix();
 
     auto font_size = text_rendering_matrix.x_scale() * text_state().font_size;


### PR DESCRIPTION
This PR contains some assorted minor fixes and stability improvements:

 * XObject rendering acknowledges that reading the XObject stream can fail (i.e., `TRY` instead of `MUST`).
 * Filters that haven't been implemented issued a `TODO()` that ended up in an `abort`, they return `PDFErrorOr` instead so they will report the issue back to the top-level application.
 * Text rendering would produce a crash if there had been no successfully loaded font yet, no crashes now
 * Type2 hint counting was not correctly counting all hints in the hint commands, and was missing hints in the `hintmask` and `ctrlmask` operators. This meant that the latter were not always consuming some bytes from the CharString, breaking the rest of the decoding of the CharString (and hence making the font loading fail as a whole).
 * Type2 stack size is allowed to be 48 elements deep compared to Type1's 24 elements. The two cases share the saame code, so the common size has been upgraded to 48.
 * CFF encoding tables can specify a supplement section, which wasn't being taken into account, making the font loading fail.