### PR TITLE
AK+Everywhere: Rename Stream `read` and `write` functions to prevent confusion and fix up unintentional partial reads and writes

### DIFF
--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -90,11 +90,7 @@ public:
                         m_current_byte.clear();
                 }
             } else {
-                auto temp_buffer = TRY(ByteBuffer::create_uninitialized(1));
-                // FIXME: This should read the entire span.
-                // FIXME: This should just write into m_current_byte directly.
-                TRY(m_stream->read_some(temp_buffer.bytes()));
-                m_current_byte = temp_buffer[0];
+                m_current_byte = TRY(m_stream->read_value<u8>());
                 m_bit_offset = 0;
             }
         }
@@ -192,13 +188,7 @@ public:
                         m_current_byte.clear();
                 }
             } else {
-                auto temp_buffer = TRY(ByteBuffer::create_uninitialized(1));
-                // FIXME: This should read the entire span.
-                // FIXME: This should just write into m_current_byte directly.
-                auto read_bytes = TRY(m_stream->read_some(temp_buffer.bytes()));
-                if (read_bytes.is_empty())
-                    return Error::from_string_literal("eof");
-                m_current_byte = temp_buffer[0];
+                m_current_byte = TRY(m_stream->read_value<u8>());
                 m_bit_offset = 0;
             }
         }
@@ -259,8 +249,7 @@ public:
             m_bit_offset++;
 
             if (m_bit_offset > 7) {
-                // FIXME: This should write the entire span.
-                TRY(m_stream->write_some({ &m_current_byte, sizeof(m_current_byte) }));
+                TRY(m_stream->write_value(m_current_byte));
                 m_bit_offset = 0;
                 m_current_byte = 0;
             }
@@ -338,8 +327,7 @@ public:
             m_bit_offset++;
 
             if (m_bit_offset > 7) {
-                // FIXME: This should write the entire span.
-                TRY(m_stream->write_some({ &m_current_byte, sizeof(m_current_byte) }));
+                TRY(m_stream->write_value(m_current_byte));
                 m_bit_offset = 0;
                 m_current_byte = 0;
             }

--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -34,7 +34,6 @@ public:
         return m_stream->read_some(bytes);
     }
     virtual ErrorOr<size_t> write_some(ReadonlyBytes bytes) override { return m_stream->write_some(bytes); }
-    virtual ErrorOr<void> write_until_depleted(ReadonlyBytes bytes) override { return m_stream->write_until_depleted(bytes); }
     virtual bool is_eof() const override { return m_stream->is_eof() && !m_current_byte.has_value(); }
     virtual bool is_open() const override { return m_stream->is_open(); }
     virtual void close() override
@@ -141,7 +140,6 @@ public:
         return m_stream->read_some(bytes);
     }
     virtual ErrorOr<size_t> write_some(ReadonlyBytes bytes) override { return m_stream->write_some(bytes); }
-    virtual ErrorOr<void> write_until_depleted(ReadonlyBytes bytes) override { return m_stream->write_until_depleted(bytes); }
     virtual bool is_eof() const override { return m_stream->is_eof() && !m_current_byte.has_value(); }
     virtual bool is_open() const override { return m_stream->is_open(); }
     virtual void close() override

--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -34,7 +34,7 @@ public:
         return m_stream->read_some(bytes);
     }
     virtual ErrorOr<size_t> write_some(ReadonlyBytes bytes) override { return m_stream->write_some(bytes); }
-    virtual ErrorOr<void> write_entire_buffer(ReadonlyBytes bytes) override { return m_stream->write_entire_buffer(bytes); }
+    virtual ErrorOr<void> write_until_depleted(ReadonlyBytes bytes) override { return m_stream->write_until_depleted(bytes); }
     virtual bool is_eof() const override { return m_stream->is_eof() && !m_current_byte.has_value(); }
     virtual bool is_open() const override { return m_stream->is_open(); }
     virtual void close() override
@@ -141,7 +141,7 @@ public:
         return m_stream->read_some(bytes);
     }
     virtual ErrorOr<size_t> write_some(ReadonlyBytes bytes) override { return m_stream->write_some(bytes); }
-    virtual ErrorOr<void> write_entire_buffer(ReadonlyBytes bytes) override { return m_stream->write_entire_buffer(bytes); }
+    virtual ErrorOr<void> write_until_depleted(ReadonlyBytes bytes) override { return m_stream->write_until_depleted(bytes); }
     virtual bool is_eof() const override { return m_stream->is_eof() && !m_current_byte.has_value(); }
     virtual bool is_open() const override { return m_stream->is_open(); }
     virtual void close() override

--- a/AK/BufferedStream.h
+++ b/AK/BufferedStream.h
@@ -236,7 +236,7 @@ private:
         auto const fillable_slice = temporary_buffer.span().trim(min(temporary_buffer.size(), m_buffer.empty_space()));
         size_t nread = 0;
         do {
-            auto result = stream().read(fillable_slice);
+            auto result = stream().read_some(fillable_slice);
             if (result.is_error()) {
                 if (!result.error().is_errno())
                     return result.release_error();
@@ -274,8 +274,8 @@ public:
     BufferedSeekable(BufferedSeekable&& other) = default;
     BufferedSeekable& operator=(BufferedSeekable&& other) = default;
 
-    virtual ErrorOr<Bytes> read(Bytes buffer) override { return m_helper.read(move(buffer)); }
-    virtual ErrorOr<size_t> write(ReadonlyBytes buffer) override { return m_helper.stream().write(buffer); }
+    virtual ErrorOr<Bytes> read_some(Bytes buffer) override { return m_helper.read(move(buffer)); }
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes buffer) override { return m_helper.stream().write_some(buffer); }
     virtual bool is_eof() const override { return m_helper.is_eof(); }
     virtual bool is_open() const override { return m_helper.stream().is_open(); }
     virtual void close() override { m_helper.stream().close(); }

--- a/AK/MemoryStream.cpp
+++ b/AK/MemoryStream.cpp
@@ -89,7 +89,7 @@ ErrorOr<size_t> FixedMemoryStream::write_some(ReadonlyBytes bytes)
     return nwritten;
 }
 
-ErrorOr<void> FixedMemoryStream::write_entire_buffer(ReadonlyBytes bytes)
+ErrorOr<void> FixedMemoryStream::write_until_depleted(ReadonlyBytes bytes)
 {
     if (remaining() < bytes.size())
         return Error::from_string_view_or_print_error_and_return_errno("Write of entire buffer ends past the memory area"sv, EINVAL);

--- a/AK/MemoryStream.cpp
+++ b/AK/MemoryStream.cpp
@@ -43,7 +43,7 @@ ErrorOr<void> FixedMemoryStream::truncate(size_t)
     return Error::from_errno(EBADF);
 }
 
-ErrorOr<Bytes> FixedMemoryStream::read(Bytes bytes)
+ErrorOr<Bytes> FixedMemoryStream::read_some(Bytes bytes)
 {
     auto to_read = min(remaining(), bytes.size());
     if (to_read == 0)
@@ -79,7 +79,7 @@ ErrorOr<size_t> FixedMemoryStream::seek(i64 offset, SeekMode seek_mode)
     return m_offset;
 }
 
-ErrorOr<size_t> FixedMemoryStream::write(ReadonlyBytes bytes)
+ErrorOr<size_t> FixedMemoryStream::write_some(ReadonlyBytes bytes)
 {
     VERIFY(m_writing_enabled);
 
@@ -94,7 +94,7 @@ ErrorOr<void> FixedMemoryStream::write_entire_buffer(ReadonlyBytes bytes)
     if (remaining() < bytes.size())
         return Error::from_string_view_or_print_error_and_return_errno("Write of entire buffer ends past the memory area"sv, EINVAL);
 
-    TRY(write(bytes));
+    TRY(write_some(bytes));
     return {};
 }
 
@@ -118,7 +118,7 @@ size_t FixedMemoryStream::remaining() const
     return m_bytes.size() - m_offset;
 }
 
-ErrorOr<Bytes> AllocatingMemoryStream::read(Bytes bytes)
+ErrorOr<Bytes> AllocatingMemoryStream::read_some(Bytes bytes)
 {
     size_t read_bytes = 0;
 
@@ -140,7 +140,7 @@ ErrorOr<Bytes> AllocatingMemoryStream::read(Bytes bytes)
     return bytes.trim(read_bytes);
 }
 
-ErrorOr<size_t> AllocatingMemoryStream::write(ReadonlyBytes bytes)
+ErrorOr<size_t> AllocatingMemoryStream::write_some(ReadonlyBytes bytes)
 {
     size_t written_bytes = 0;
 

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -23,11 +23,11 @@ public:
     virtual bool is_open() const override;
     virtual void close() override;
     virtual ErrorOr<void> truncate(size_t) override;
-    virtual ErrorOr<Bytes> read(Bytes bytes) override;
+    virtual ErrorOr<Bytes> read_some(Bytes bytes) override;
 
     virtual ErrorOr<size_t> seek(i64 offset, SeekMode seek_mode = SeekMode::SetPosition) override;
 
-    virtual ErrorOr<size_t> write(ReadonlyBytes bytes) override;
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes bytes) override;
     virtual ErrorOr<void> write_entire_buffer(ReadonlyBytes bytes) override;
 
     Bytes bytes();
@@ -45,8 +45,8 @@ private:
 /// and reading back the written data afterwards.
 class AllocatingMemoryStream final : public Stream {
 public:
-    virtual ErrorOr<Bytes> read(Bytes) override;
-    virtual ErrorOr<size_t> write(ReadonlyBytes) override;
+    virtual ErrorOr<Bytes> read_some(Bytes) override;
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
     virtual ErrorOr<void> discard(size_t) override;
     virtual bool is_eof() const override;
     virtual bool is_open() const override;

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -28,7 +28,7 @@ public:
     virtual ErrorOr<size_t> seek(i64 offset, SeekMode seek_mode = SeekMode::SetPosition) override;
 
     virtual ErrorOr<size_t> write_some(ReadonlyBytes bytes) override;
-    virtual ErrorOr<void> write_entire_buffer(ReadonlyBytes bytes) override;
+    virtual ErrorOr<void> write_until_depleted(ReadonlyBytes bytes) override;
 
     Bytes bytes();
     ReadonlyBytes bytes() const;

--- a/AK/Stream.cpp
+++ b/AK/Stream.cpp
@@ -11,7 +11,7 @@
 
 namespace AK {
 
-ErrorOr<void> Stream::read_entire_buffer(Bytes buffer)
+ErrorOr<void> Stream::read_until_filled(Bytes buffer)
 {
     size_t nread = 0;
     while (nread < buffer.size()) {

--- a/AK/Stream.cpp
+++ b/AK/Stream.cpp
@@ -78,7 +78,7 @@ ErrorOr<void> Stream::discard(size_t discarded_bytes)
     return {};
 }
 
-ErrorOr<void> Stream::write_entire_buffer(ReadonlyBytes buffer)
+ErrorOr<void> Stream::write_until_depleted(ReadonlyBytes buffer)
 {
     size_t nwritten = 0;
     while (nwritten < buffer.size()) {

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -26,13 +26,13 @@ public:
     virtual ErrorOr<Bytes> read_some(Bytes) = 0;
     /// Tries to fill the entire buffer through reading. Returns whether the
     /// buffer was filled without an error.
-    virtual ErrorOr<void> read_entire_buffer(Bytes);
+    virtual ErrorOr<void> read_until_filled(Bytes);
     /// Reads the stream until EOF, storing the contents into a ByteBuffer which
     /// is returned once EOF is encountered. The block size determines the size
     /// of newly allocated chunks while reading.
     virtual ErrorOr<ByteBuffer> read_until_eof(size_t block_size = 4096);
     /// Discards the given number of bytes from the stream. As this is usually used
-    /// as an efficient version of `read_entire_buffer`, it returns an error
+    /// as an efficient version of `read_until_filled`, it returns an error
     /// if reading failed or if not all bytes could be discarded.
     /// Unless specifically overwritten, this just uses read() to read into an
     /// internal stack-based buffer.
@@ -58,7 +58,7 @@ public:
     ErrorOr<T> read_value()
     {
         alignas(T) u8 buffer[sizeof(T)] = {};
-        TRY(read_entire_buffer({ &buffer, sizeof(buffer) }));
+        TRY(read_until_filled({ &buffer, sizeof(buffer) }));
         return bit_cast<T>(buffer);
     }
 

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -44,7 +44,7 @@ public:
     virtual ErrorOr<size_t> write_some(ReadonlyBytes) = 0;
     /// Same as write, but does not return until either the entire buffer
     /// contents are written or an error occurs.
-    virtual ErrorOr<void> write_entire_buffer(ReadonlyBytes);
+    virtual ErrorOr<void> write_until_depleted(ReadonlyBytes);
 
     template<typename T>
     requires(requires(Stream& stream) { { T::read_from_stream(stream) } -> SameAs<ErrorOr<T>>; })
@@ -73,7 +73,7 @@ public:
     requires(Traits<T>::is_trivially_serializable())
     ErrorOr<void> write_value(T const& value)
     {
-        return write_entire_buffer({ &value, sizeof(value) });
+        return write_until_depleted({ &value, sizeof(value) });
     }
 
     /// Returns whether the stream has reached the end of file. For sockets,

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -23,7 +23,7 @@ public:
     /// The amount of bytes read can be smaller than the size of the buffer.
     /// Returns either the bytes that were read, or an errno in the case of
     /// failure.
-    virtual ErrorOr<Bytes> read(Bytes) = 0;
+    virtual ErrorOr<Bytes> read_some(Bytes) = 0;
     /// Tries to fill the entire buffer through reading. Returns whether the
     /// buffer was filled without an error.
     virtual ErrorOr<void> read_entire_buffer(Bytes);
@@ -41,7 +41,7 @@ public:
     /// Tries to write the entire contents of the buffer. It is possible for
     /// less than the full buffer to be written. Returns either the amount of
     /// bytes written into the stream, or an errno in the case of failure.
-    virtual ErrorOr<size_t> write(ReadonlyBytes) = 0;
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes) = 0;
     /// Same as write, but does not return until either the entire buffer
     /// contents are written or an error occurs.
     virtual ErrorOr<void> write_entire_buffer(ReadonlyBytes);

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -140,7 +140,7 @@ ErrorOr<NonnullRefPtr<StringData>> StringData::from_utf8(char const* utf8_data, 
 
 static ErrorOr<void> read_stream_into_buffer(Stream& stream, Bytes buffer)
 {
-    TRY(stream.read_entire_buffer(buffer));
+    TRY(stream.read_until_filled(buffer));
 
     if (!Utf8View { StringView { buffer } }.validate())
         return Error::from_string_literal("String::from_stream: Input was not valid UTF-8");

--- a/Kernel/FileSystem/Ext2FS/Inode.cpp
+++ b/Kernel/FileSystem/Ext2FS/Inode.cpp
@@ -796,7 +796,7 @@ ErrorOr<void> Ext2FSInode::write_directory(Vector<Ext2FSDirectoryEntry>& entries
         MUST(stream.write_value<u16>(entry.record_length));
         MUST(stream.write_value<u8>(entry.name->length()));
         MUST(stream.write_value<u8>(entry.file_type));
-        MUST(stream.write_entire_buffer(entry.name->bytes()));
+        MUST(stream.write_until_depleted(entry.name->bytes()));
         int padding = entry.record_length - entry.name->length() - 8;
         for (int j = 0; j < padding; ++j)
             MUST(stream.write_value<u8>(0));

--- a/Kernel/FileSystem/OpenFileDescription.cpp
+++ b/Kernel/FileSystem/OpenFileDescription.cpp
@@ -249,7 +249,7 @@ ErrorOr<size_t> OpenFileDescription::get_dir_entries(UserOrKernelBuffer& output_
         MUST(stream.write_value<u64>(entry.inode.index().value()));
         MUST(stream.write_value(m_inode->fs().internal_file_type_to_directory_entry_type(entry)));
         MUST(stream.write_value<u32>(entry.name.length()));
-        MUST(stream.write_entire_buffer(entry.name.bytes()));
+        MUST(stream.write_until_depleted(entry.name.bytes()));
         return {};
     });
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibEDID/GeneratePnpIDs.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibEDID/GeneratePnpIDs.cpp
@@ -211,7 +211,8 @@ namespace PnpIDs {
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -265,7 +266,8 @@ IterationDecision for_each(Function<IterationDecision(PnpIDData const&)> callbac
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibEDID/GeneratePnpIDs.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibEDID/GeneratePnpIDs.cpp
@@ -211,8 +211,7 @@ namespace PnpIDs {
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -266,8 +265,7 @@ IterationDecision for_each(Function<IterationDecision(PnpIDData const&)> callbac
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibGL/GenerateGLAPIWrapper.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibGL/GenerateGLAPIWrapper.cpp
@@ -405,7 +405,8 @@ ErrorOr<void> generate_header_file(JsonObject& api_data, Core::File& file)
     generator.appendln("}");
     generator.appendln("#endif");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -529,7 +530,8 @@ ErrorOr<void> generate_implementation_file(JsonObject& api_data, Core::File& fil
         }
     });
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibGL/GenerateGLAPIWrapper.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibGL/GenerateGLAPIWrapper.cpp
@@ -540,7 +540,7 @@ ErrorOr<JsonValue> read_entire_file_as_json(StringView filename)
     auto file = TRY(Core::File::open(filename, Core::File::OpenMode::Read));
     auto json_size = TRY(file->size());
     auto json_data = TRY(ByteBuffer::create_uninitialized(json_size));
-    TRY(file->read_entire_buffer(json_data.bytes()));
+    TRY(file->read_until_filled(json_data.bytes()));
     return JsonValue::from_string(json_data);
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibGL/GenerateGLAPIWrapper.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibGL/GenerateGLAPIWrapper.cpp
@@ -405,8 +405,7 @@ ErrorOr<void> generate_header_file(JsonObject& api_data, Core::File& file)
     generator.appendln("}");
     generator.appendln("#endif");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -530,8 +529,7 @@ ErrorOr<void> generate_implementation_file(JsonObject& api_data, Core::File& fil
         }
     });
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
@@ -1724,8 +1724,7 @@ namespace Locale {
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -2398,8 +2397,7 @@ Optional<StringView> get_time_zone_name(StringView locale, StringView time_zone,
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
@@ -1724,7 +1724,8 @@ namespace Locale {
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -2397,7 +2398,8 @@ Optional<StringView> get_time_zone_name(StringView locale, StringView time_zone,
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
@@ -1047,8 +1047,7 @@ namespace Locale {
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -1748,8 +1747,7 @@ ErrorOr<Optional<String>> resolve_most_likely_territory(LanguageID const& langua
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
@@ -1047,7 +1047,8 @@ namespace Locale {
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -1747,7 +1748,8 @@ ErrorOr<Optional<String>> resolve_most_likely_territory(LanguageID const& langua
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
@@ -763,8 +763,7 @@ namespace Locale {
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -1108,8 +1107,7 @@ ErrorOr<Vector<NumberFormat>> get_unit_formats(StringView locale, StringView uni
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
@@ -763,7 +763,8 @@ namespace Locale {
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -1107,7 +1108,8 @@ ErrorOr<Vector<NumberFormat>> get_unit_formats(StringView locale, StringView uni
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
@@ -442,7 +442,8 @@ namespace Locale {
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -654,7 +655,8 @@ PluralCategory determine_plural_range(StringView locale, PluralCategory start, P
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
@@ -442,8 +442,7 @@ namespace Locale {
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -655,8 +654,7 @@ PluralCategory determine_plural_range(StringView locale, PluralCategory start, P
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateRelativeTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateRelativeTimeFormatData.cpp
@@ -180,7 +180,8 @@ namespace Locale {
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -276,7 +277,8 @@ ErrorOr<Vector<RelativeTimeFormat>> get_relative_time_format_patterns(StringView
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateRelativeTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateRelativeTimeFormatData.cpp
@@ -180,8 +180,7 @@ namespace Locale {
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -277,8 +276,7 @@ ErrorOr<Vector<RelativeTimeFormat>> get_relative_time_format_patterns(StringView
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
@@ -469,7 +469,8 @@ namespace TimeZone {
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -801,7 +802,8 @@ Vector<StringView> time_zones_in_region(StringView region)
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
@@ -469,8 +469,7 @@ namespace TimeZone {
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -802,8 +801,7 @@ Vector<StringView> time_zones_in_region(StringView region)
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateEmojiData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateEmojiData.cpp
@@ -213,7 +213,8 @@ static ErrorOr<void> generate_emoji_data_header(Core::BufferedFile& file, EmojiD
     StringBuilder builder;
     SourceGenerator generator { builder };
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -334,7 +335,8 @@ Optional<Emoji> find_emoji_for_code_points(ReadonlySpan<u32> code_points)
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -379,7 +381,8 @@ static ErrorOr<void> generate_emoji_installation(Core::BufferedFile& file, Emoji
         generator.append(" @name@ (@status@)\n"sv);
     }
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateEmojiData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateEmojiData.cpp
@@ -213,8 +213,7 @@ static ErrorOr<void> generate_emoji_data_header(Core::BufferedFile& file, EmojiD
     StringBuilder builder;
     SourceGenerator generator { builder };
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -335,8 +334,7 @@ Optional<Emoji> find_emoji_for_code_points(ReadonlySpan<u32> code_points)
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -381,8 +379,7 @@ static ErrorOr<void> generate_emoji_installation(Core::BufferedFile& file, Emoji
         generator.append(" @name@ (@status@)\n"sv);
     }
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -866,7 +866,8 @@ ReadonlySpan<CaseFolding const*> case_folding_mapping(u32 code_point);
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -1354,7 +1355,8 @@ bool code_point_has_@enum_snake@(u32 code_point, @enum_title@ @enum_snake@)
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -866,8 +866,7 @@ ReadonlySpan<CaseFolding const*> case_folding_mapping(u32 code_point);
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -1355,8 +1354,7 @@ bool code_point_has_@enum_snake@(u32 code_point, @enum_title@ @enum_snake@)
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
@@ -160,8 +160,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (global_mixin_implementation_mode)
         IDL::generate_global_mixin_implementation(interface, output_builder);
 
-    // FIXME: This should write the entire span.
-    TRY(output_file->write_some(output_builder.string_view().bytes()));
+    TRY(output_file->write_until_depleted(output_builder.string_view().bytes()));
 
     if (!depfile_path.is_null()) {
         auto depfile = TRY(Core::File::open_file_or_standard_stream(depfile_path, Core::File::OpenMode::Write));
@@ -174,8 +173,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             depfile_builder.append(path);
         }
         depfile_builder.append('\n');
-        // FIXME: This should write the entire span.
-        TRY(depfile->write_some(depfile_builder.string_view().bytes()));
+        TRY(depfile->write_until_depleted(depfile_builder.string_view().bytes()));
     }
     return 0;
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
@@ -160,7 +160,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (global_mixin_implementation_mode)
         IDL::generate_global_mixin_implementation(interface, output_builder);
 
-    TRY(output_file->write(output_builder.string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(output_file->write_some(output_builder.string_view().bytes()));
 
     if (!depfile_path.is_null()) {
         auto depfile = TRY(Core::File::open_file_or_standard_stream(depfile_path, Core::File::OpenMode::Write));
@@ -173,7 +174,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             depfile_builder.append(path);
         }
         depfile_builder.append('\n');
-        TRY(depfile->write(depfile_builder.string_view().bytes()));
+        // FIXME: This should write the entire span.
+        TRY(depfile->write_some(depfile_builder.string_view().bytes()));
     }
     return 0;
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
@@ -95,8 +95,7 @@ enum class ValueID;
 
     generator.appendln("}");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -200,7 +199,6 @@ StringView to_string(@name:titlecase@ value)
 
     generator.appendln("}");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
@@ -95,7 +95,8 @@ enum class ValueID;
 
     generator.appendln("}");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -199,6 +200,7 @@ StringView to_string(@name:titlecase@ value)
 
     generator.appendln("}");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
@@ -80,8 +80,7 @@ bool media_feature_accepts_identifier(MediaFeatureID, ValueID);
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -291,7 +290,6 @@ bool media_feature_accepts_identifier(MediaFeatureID media_feature_id, ValueID i
 }
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
@@ -80,7 +80,8 @@ bool media_feature_accepts_identifier(MediaFeatureID, ValueID);
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -290,6 +291,7 @@ bool media_feature_accepts_identifier(MediaFeatureID media_feature_id, ValueID i
 }
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -140,8 +140,7 @@ struct Traits<Web::CSS::PropertyID> : public GenericTraits<Web::CSS::PropertyID>
 } // namespace AK
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -606,7 +605,6 @@ size_t property_maximum_value_count(PropertyID property_id)
 
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -140,7 +140,8 @@ struct Traits<Web::CSS::PropertyID> : public GenericTraits<Web::CSS::PropertyID>
 } // namespace AK
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -605,6 +606,7 @@ size_t property_maximum_value_count(PropertyID property_id)
 
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
@@ -96,7 +96,8 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction);
 
     generator.appendln("\n}");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -205,6 +206,7 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction transfor
 
     generator.appendln("\n}");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
@@ -96,8 +96,7 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction);
 
     generator.appendln("\n}");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -206,7 +205,6 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction transfor
 
     generator.appendln("\n}");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
@@ -74,8 +74,7 @@ StringView string_from_value_id(ValueID);
 
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -135,7 +134,6 @@ StringView string_from_value_id(ValueID value_id) {
 } // namespace Web::CSS
 )~~~");
 
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(generator.as_string_view().bytes()));
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
@@ -74,7 +74,8 @@ StringView string_from_value_id(ValueID);
 
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }
 
@@ -134,6 +135,7 @@ StringView string_from_value_id(ValueID value_id) {
 } // namespace Web::CSS
 )~~~");
 
-    TRY(file.write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(generator.as_string_view().bytes()));
     return {};
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
@@ -105,8 +105,7 @@ class @legacy_constructor_class@;)~~~");
 
     auto generated_forward_path = LexicalPath(output_path).append("Forward.h"sv).string();
     auto generated_forward_file = TRY(Core::File::open(generated_forward_path, Core::File::OpenMode::Write));
-    // FIXME: This should write the entire span.
-    TRY(generated_forward_file->write_some(generator.as_string_view().bytes()));
+    TRY(generated_forward_file->write_until_depleted(generator.as_string_view().bytes()));
 
     return {};
 }
@@ -209,8 +208,7 @@ void Intrinsics::create_web_prototype_and_constructor<@prototype_class@>(JS::Rea
 
     auto generated_intrinsics_path = LexicalPath(output_path).append("IntrinsicDefinitions.cpp"sv).string();
     auto generated_intrinsics_file = TRY(Core::File::open(generated_intrinsics_path, Core::File::OpenMode::Write));
-    // FIXME: This should write the entire span.
-    TRY(generated_intrinsics_file->write_some(generator.as_string_view().bytes()));
+    TRY(generated_intrinsics_file->write_until_depleted(generator.as_string_view().bytes()));
 
     return {};
 }
@@ -236,8 +234,7 @@ void add_@global_object_snake_name@_exposed_interfaces(JS::Object&);
 
     auto generated_header_path = LexicalPath(output_path).append(DeprecatedString::formatted("{}ExposedInterfaces.h", class_name)).string();
     auto generated_header_file = TRY(Core::File::open(generated_header_path, Core::File::OpenMode::Write));
-    // FIXME: This should write the entire span.
-    TRY(generated_header_file->write_some(generator.as_string_view().bytes()));
+    TRY(generated_header_file->write_until_depleted(generator.as_string_view().bytes()));
 
     return {};
 }
@@ -306,8 +303,7 @@ void add_@global_object_snake_name@_exposed_interfaces(JS::Object& global)
 
     auto generated_implementation_path = LexicalPath(output_path).append(DeprecatedString::formatted("{}ExposedInterfaces.cpp", class_name)).string();
     auto generated_implementation_file = TRY(Core::File::open(generated_implementation_path, Core::File::OpenMode::Write));
-    // FIXME: This should write the entire span.
-    TRY(generated_implementation_file->write_some(generator.as_string_view().bytes()));
+    TRY(generated_implementation_file->write_until_depleted(generator.as_string_view().bytes()));
 
     return {};
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
@@ -105,7 +105,8 @@ class @legacy_constructor_class@;)~~~");
 
     auto generated_forward_path = LexicalPath(output_path).append("Forward.h"sv).string();
     auto generated_forward_file = TRY(Core::File::open(generated_forward_path, Core::File::OpenMode::Write));
-    TRY(generated_forward_file->write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(generated_forward_file->write_some(generator.as_string_view().bytes()));
 
     return {};
 }
@@ -208,7 +209,8 @@ void Intrinsics::create_web_prototype_and_constructor<@prototype_class@>(JS::Rea
 
     auto generated_intrinsics_path = LexicalPath(output_path).append("IntrinsicDefinitions.cpp"sv).string();
     auto generated_intrinsics_file = TRY(Core::File::open(generated_intrinsics_path, Core::File::OpenMode::Write));
-    TRY(generated_intrinsics_file->write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(generated_intrinsics_file->write_some(generator.as_string_view().bytes()));
 
     return {};
 }
@@ -234,7 +236,8 @@ void add_@global_object_snake_name@_exposed_interfaces(JS::Object&);
 
     auto generated_header_path = LexicalPath(output_path).append(DeprecatedString::formatted("{}ExposedInterfaces.h", class_name)).string();
     auto generated_header_file = TRY(Core::File::open(generated_header_path, Core::File::OpenMode::Write));
-    TRY(generated_header_file->write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(generated_header_file->write_some(generator.as_string_view().bytes()));
 
     return {};
 }
@@ -303,7 +306,8 @@ void add_@global_object_snake_name@_exposed_interfaces(JS::Object& global)
 
     auto generated_implementation_path = LexicalPath(output_path).append(DeprecatedString::formatted("{}ExposedInterfaces.cpp", class_name)).string();
     auto generated_implementation_file = TRY(Core::File::open(generated_implementation_path, Core::File::OpenMode::Write));
-    TRY(generated_implementation_file->write(generator.as_string_view().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(generated_implementation_file->write_some(generator.as_string_view().bytes()));
 
     return {};
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GeneratorUtil.h
@@ -59,6 +59,6 @@ ErrorOr<JsonValue> read_entire_file_as_json(StringView filename)
     auto file = TRY(Core::File::open(filename, Core::File::OpenMode::Read));
     auto json_size = TRY(file->size());
     auto json_data = TRY(ByteBuffer::create_uninitialized(json_size));
-    TRY(file->read_entire_buffer(json_data.bytes()));
+    TRY(file->read_until_filled(json_data.bytes()));
     return JsonValue::from_string(json_data);
 }

--- a/Meta/Lagom/Wasm/js_repl.cpp
+++ b/Meta/Lagom/Wasm/js_repl.cpp
@@ -63,8 +63,8 @@ void displayln(CheckedFormatString<Args...> format_string, Args const&... args)
 void displayln() { user_display("\n", 1); }
 
 class UserDisplayStream final : public Stream {
-    virtual ErrorOr<Bytes> read(Bytes) override { return Error::from_string_view("Not readable"sv); };
-    virtual ErrorOr<size_t> write(ReadonlyBytes bytes) override
+    virtual ErrorOr<Bytes> read_some(Bytes) override { return Error::from_string_view("Not readable"sv); };
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes bytes) override
     {
         user_display(bit_cast<char const*>(bytes.data()), bytes.size());
         return bytes.size();

--- a/Tests/AK/TestMemoryStream.cpp
+++ b/Tests/AK/TestMemoryStream.cpp
@@ -29,7 +29,7 @@ TEST_CASE(allocating_memory_stream_empty)
 TEST_CASE(allocating_memory_stream_offset_of)
 {
     AllocatingMemoryStream stream;
-    MUST(stream.write_entire_buffer("Well Hello Friends! :^)"sv.bytes()));
+    MUST(stream.write_until_depleted("Well Hello Friends! :^)"sv.bytes()));
 
     {
         auto offset = MUST(stream.offset_of(" "sv.bytes()));
@@ -79,12 +79,12 @@ TEST_CASE(allocating_memory_stream_offset_of_oob)
 
     // First, fill exactly one chunk.
     for (size_t i = 0; i < 256; ++i)
-        MUST(stream.write_entire_buffer("AAAAAAAAAAAAAAAA"sv.bytes()));
+        MUST(stream.write_until_depleted("AAAAAAAAAAAAAAAA"sv.bytes()));
 
     // Then discard it all.
     MUST(stream.discard(4096));
     // Now we can write into this chunk again, knowing that it's initialized to all 'A's.
-    MUST(stream.write_entire_buffer("Well Hello Friends! :^)"sv.bytes()));
+    MUST(stream.write_until_depleted("Well Hello Friends! :^)"sv.bytes()));
 
     {
         auto offset = MUST(stream.offset_of("A"sv.bytes()));

--- a/Tests/AK/TestMemoryStream.cpp
+++ b/Tests/AK/TestMemoryStream.cpp
@@ -16,7 +16,7 @@ TEST_CASE(allocating_memory_stream_empty)
 
     {
         Array<u8, 32> array;
-        auto read_bytes = MUST(stream.read(array));
+        auto read_bytes = MUST(stream.read_some(array));
         EXPECT_EQ(read_bytes.size(), 0ul);
     }
 

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -98,7 +98,8 @@ TEST_CASE(long_streams)
         u8 bytes[64] = {};
         constexpr auto test_view = "Well, hello friends"sv;
         FixedMemoryStream stream(Bytes { bytes, sizeof(bytes) });
-        MUST(stream.write(test_view.bytes()));
+        // FIXME: This should write the entire span.
+        MUST(stream.write_some(test_view.bytes()));
         MUST(stream.seek(0));
 
         auto string = MUST(String::from_stream(stream, test_view.length()));
@@ -110,7 +111,8 @@ TEST_CASE(long_streams)
 
     {
         AllocatingMemoryStream stream;
-        MUST(stream.write(("abc"sv).bytes()));
+        // FIXME: This should write the entire span.
+        MUST(stream.write_some(("abc"sv).bytes()));
 
         auto string = MUST(String::from_stream(stream, 3u));
 
@@ -121,7 +123,8 @@ TEST_CASE(long_streams)
 
     {
         AllocatingMemoryStream stream;
-        MUST(stream.write(("0123456789"sv).bytes()));
+        // FIXME: This should write the entire span.
+        MUST(stream.write_some(("0123456789"sv).bytes()));
 
         auto string = MUST(String::from_stream(stream, 9u));
 

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -98,8 +98,7 @@ TEST_CASE(long_streams)
         u8 bytes[64] = {};
         constexpr auto test_view = "Well, hello friends"sv;
         FixedMemoryStream stream(Bytes { bytes, sizeof(bytes) });
-        // FIXME: This should write the entire span.
-        MUST(stream.write_some(test_view.bytes()));
+        MUST(stream.write_until_depleted(test_view.bytes()));
         MUST(stream.seek(0));
 
         auto string = MUST(String::from_stream(stream, test_view.length()));
@@ -111,8 +110,7 @@ TEST_CASE(long_streams)
 
     {
         AllocatingMemoryStream stream;
-        // FIXME: This should write the entire span.
-        MUST(stream.write_some(("abc"sv).bytes()));
+        MUST(stream.write_until_depleted(("abc"sv).bytes()));
 
         auto string = MUST(String::from_stream(stream, 3u));
 
@@ -123,8 +121,7 @@ TEST_CASE(long_streams)
 
     {
         AllocatingMemoryStream stream;
-        // FIXME: This should write the entire span.
-        MUST(stream.write_some(("0123456789"sv).bytes()));
+        MUST(stream.write_until_depleted(("0123456789"sv).bytes()));
 
         auto string = MUST(String::from_stream(stream, 9u));
 

--- a/Tests/LibCompress/TestBrotli.cpp
+++ b/Tests/LibCompress/TestBrotli.cpp
@@ -104,7 +104,7 @@ TEST_CASE(brotli_decompress_zero_one_bin)
 
     size_t bytes_read = 0;
     while (true) {
-        size_t nread = MUST(brotli_stream.read(buffer)).size();
+        size_t nread = MUST(brotli_stream.read_some(buffer)).size();
         if (nread == 0)
             break;
 

--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -90,17 +90,17 @@ TEST_CASE(file_seeking_around)
 
     EXPECT(!file->seek(500, SeekMode::SetPosition).is_error());
     EXPECT_EQ(file->tell().release_value(), 500ul);
-    EXPECT(!file->read_entire_buffer(buffer).is_error());
+    EXPECT(!file->read_until_filled(buffer).is_error());
     EXPECT_EQ(buffer_contents, expected_seek_contents1);
 
     EXPECT(!file->seek(234, SeekMode::FromCurrentPosition).is_error());
     EXPECT_EQ(file->tell().release_value(), 750ul);
-    EXPECT(!file->read_entire_buffer(buffer).is_error());
+    EXPECT(!file->read_until_filled(buffer).is_error());
     EXPECT_EQ(buffer_contents, expected_seek_contents2);
 
     EXPECT(!file->seek(-105, SeekMode::FromEndPosition).is_error());
     EXPECT_EQ(file->tell().release_value(), 8597ul);
-    EXPECT(!file->read_entire_buffer(buffer).is_error());
+    EXPECT(!file->read_until_filled(buffer).is_error());
     EXPECT_EQ(buffer_contents, expected_seek_contents3);
 }
 
@@ -123,7 +123,7 @@ TEST_CASE(file_adopt_fd)
 
     EXPECT(!file->seek(500, SeekMode::SetPosition).is_error());
     EXPECT_EQ(file->tell().release_value(), 500ul);
-    EXPECT(!file->read_entire_buffer(buffer).is_error());
+    EXPECT(!file->read_until_filled(buffer).is_error());
     EXPECT_EQ(buffer_contents, expected_seek_contents1);
 
     // A single seek & read test should be fine for now.

--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -221,7 +221,7 @@ TEST_CASE(tcp_socket_write)
     auto server_socket = maybe_server_socket.release_value();
     EXPECT(!server_socket->set_blocking(true).is_error());
 
-    EXPECT(!client_socket->write_entire_buffer({ sent_data.characters_without_null_termination(), sent_data.length() }).is_error());
+    EXPECT(!client_socket->write_until_depleted({ sent_data.characters_without_null_termination(), sent_data.length() }).is_error());
     client_socket->close();
 
     auto maybe_receive_buffer = ByteBuffer::create_uninitialized(64);
@@ -285,7 +285,7 @@ TEST_CASE(udp_socket_read_write)
     auto client_socket = maybe_client_socket.release_value();
 
     EXPECT(client_socket->is_open());
-    EXPECT(!client_socket->write_entire_buffer({ sent_data.characters_without_null_termination(), sent_data.length() }).is_error());
+    EXPECT(!client_socket->write_until_depleted({ sent_data.characters_without_null_termination(), sent_data.length() }).is_error());
 
     // FIXME: UDPServer::receive sadly doesn't give us a way to block on it,
     // currently.
@@ -405,7 +405,7 @@ TEST_CASE(local_socket_write)
             EXPECT(!maybe_client_socket.is_error());
             auto client_socket = maybe_client_socket.release_value();
 
-            EXPECT(!client_socket->write_entire_buffer({ sent_data.characters_without_null_termination(), sent_data.length() }).is_error());
+            EXPECT(!client_socket->write_until_depleted({ sent_data.characters_without_null_termination(), sent_data.length() }).is_error());
             client_socket->close();
 
             return 0;

--- a/Tests/LibCpp/test-cpp-parser.cpp
+++ b/Tests/LibCpp/test-cpp-parser.cpp
@@ -18,7 +18,7 @@ static DeprecatedString read_all(DeprecatedString const& path)
     auto file = MUST(Core::File::open(path, Core::File::OpenMode::Read));
     auto file_size = MUST(file->size());
     auto content = MUST(ByteBuffer::create_uninitialized(file_size));
-    MUST(file->read_entire_buffer(content.bytes()));
+    MUST(file->read_until_filled(content.bytes()));
     return DeprecatedString { content.bytes() };
 }
 

--- a/Tests/LibCpp/test-cpp-preprocessor.cpp
+++ b/Tests/LibCpp/test-cpp-preprocessor.cpp
@@ -17,7 +17,7 @@ static DeprecatedString read_all(DeprecatedString const& path)
     auto file = MUST(Core::File::open(path, Core::File::OpenMode::Read));
     auto file_size = MUST(file->size());
     auto content = MUST(ByteBuffer::create_uninitialized(file_size));
-    MUST(file->read_entire_buffer(content.bytes()));
+    MUST(file->read_until_filled(content.bytes()));
     return DeprecatedString { content.bytes() };
 }
 

--- a/Tests/LibGL/TestRender.cpp
+++ b/Tests/LibGL/TestRender.cpp
@@ -37,7 +37,7 @@ static void expect_bitmap_equals_reference(Gfx::Bitmap const& bitmap, StringView
         auto target_path = LexicalPath("/home/anon").append(reference_filename);
         auto qoi_buffer = MUST(Gfx::QOIWriter::encode(bitmap));
         auto qoi_output_stream = MUST(Core::File::open(target_path.string(), Core::File::OpenMode::Write));
-        MUST(qoi_output_stream->write_entire_buffer(qoi_buffer));
+        MUST(qoi_output_stream->write_until_depleted(qoi_buffer));
     }
 
     auto reference_image_path = DeprecatedString::formatted(REFERENCE_IMAGE_DIR "/{}", reference_filename);

--- a/Tests/LibJS/test-test262.cpp
+++ b/Tests/LibJS/test-test262.cpp
@@ -161,7 +161,7 @@ public:
         }
 
         for (DeprecatedString const& line : lines) {
-            if (m_output->write_entire_buffer(DeprecatedString::formatted("{}\n", line).bytes()).is_error())
+            if (m_output->write_until_depleted(DeprecatedString::formatted("{}\n", line).bytes()).is_error())
                 break;
         }
 
@@ -427,7 +427,7 @@ void write_per_file(HashMap<size_t, TestResult> const& result_map, Vector<Deprec
     complete_results.set("duration", time_taken_in_ms / 1000.);
     complete_results.set("results", result_object);
 
-    if (file->write_entire_buffer(complete_results.to_deprecated_string().bytes()).is_error())
+    if (file->write_until_depleted(complete_results.to_deprecated_string().bytes()).is_error())
         warnln("Failed to write per-file");
     file->close();
 }

--- a/Tests/LibMarkdown/TestCommonmark.cpp
+++ b/Tests/LibMarkdown/TestCommonmark.cpp
@@ -22,7 +22,7 @@ TEST_SETUP
     auto file = file_or_error.release_value();
     auto file_size = MUST(file->size());
     auto content = MUST(ByteBuffer::create_uninitialized(file_size));
-    MUST(file->read_entire_buffer(content.bytes()));
+    MUST(file->read_until_filled(content.bytes()));
     DeprecatedString test_data { content.bytes() };
 
     auto tests = JsonParser(test_data).parse().value().as_array();

--- a/Tests/LibTLS/TestTLSHandshake.cpp
+++ b/Tests/LibTLS/TestTLSHandshake.cpp
@@ -96,17 +96,17 @@ TEST_CASE(test_TLS_hello_handshake)
         loop.quit(0);
     };
 
-    if (tls->write_entire_buffer("GET / HTTP/1.1\r\nHost: "_b).is_error()) {
+    if (tls->write_until_depleted("GET / HTTP/1.1\r\nHost: "_b).is_error()) {
         FAIL("write(0) failed");
         return;
     }
 
     auto the_server = DEFAULT_SERVER;
-    if (tls->write_entire_buffer(the_server.bytes()).is_error()) {
+    if (tls->write_until_depleted(the_server.bytes()).is_error()) {
         FAIL("write(1) failed");
         return;
     }
-    if (tls->write_entire_buffer("\r\nConnection : close\r\n\r\n"_b).is_error()) {
+    if (tls->write_until_depleted("\r\nConnection : close\r\n\r\n"_b).is_error()) {
         FAIL("write(2) failed");
         return;
     }

--- a/Tests/LibTLS/TestTLSHandshake.cpp
+++ b/Tests/LibTLS/TestTLSHandshake.cpp
@@ -88,7 +88,7 @@ TEST_CASE(test_TLS_hello_handshake)
     auto tls = MUST(TLS::TLSv12::connect(DEFAULT_SERVER, port, move(options)));
     ByteBuffer contents;
     tls->on_ready_to_read = [&] {
-        auto read_bytes = MUST(tls->read(contents.must_get_bytes_for_writing(4 * KiB)));
+        auto read_bytes = MUST(tls->read_some(contents.must_get_bytes_for_writing(4 * KiB)));
         if (read_bytes.is_empty()) {
             FAIL("No data received");
             loop.quit(1);

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -32,8 +32,7 @@ TESTJS_GLOBAL_FUNCTION(read_binary_wasm_file, readBinaryWasmFile)
 
     auto array = TRY(JS::Uint8Array::create(realm, file_size.value()));
 
-    // FIXME: This should read the entire span.
-    auto read = file.value()->read_some(array->data());
+    auto read = file.value()->read_until_filled(array->data());
     if (read.is_error())
         return vm.throw_completion<JS::TypeError>(error_code_to_string(read.error().code()));
 

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -32,7 +32,8 @@ TESTJS_GLOBAL_FUNCTION(read_binary_wasm_file, readBinaryWasmFile)
 
     auto array = TRY(JS::Uint8Array::create(realm, file_size.value()));
 
-    auto read = file.value()->read(array->data());
+    // FIXME: This should read the entire span.
+    auto read = file.value()->read_some(array->data());
     if (read.is_error())
         return vm.throw_completion<JS::TypeError>(error_code_to_string(read.error().code()));
 

--- a/Tests/LibWeb/TestHTMLTokenizer.cpp
+++ b/Tests/LibWeb/TestHTMLTokenizer.cpp
@@ -211,8 +211,7 @@ TEST_CASE(regression)
     auto file = MUST(Core::File::open(path, Core::File::OpenMode::Read));
     auto file_size = MUST(file->size());
     auto content = MUST(ByteBuffer::create_uninitialized(file_size));
-    // FIXME: This should read the entire span.
-    MUST(file->read_some(content.bytes()));
+    MUST(file->read_until_filled(content.bytes()));
     DeprecatedString file_contents { content.bytes() };
     auto tokens = run_tokenizer(file_contents);
     u32 hash = hash_tokens(tokens);

--- a/Tests/LibWeb/TestHTMLTokenizer.cpp
+++ b/Tests/LibWeb/TestHTMLTokenizer.cpp
@@ -211,7 +211,8 @@ TEST_CASE(regression)
     auto file = MUST(Core::File::open(path, Core::File::OpenMode::Read));
     auto file_size = MUST(file->size());
     auto content = MUST(ByteBuffer::create_uninitialized(file_size));
-    MUST(file->read(content.bytes()));
+    // FIXME: This should read the entire span.
+    MUST(file->read_some(content.bytes()));
     DeprecatedString file_contents { content.bytes() };
     auto tokens = run_tokenizer(file_contents);
     u32 hash = hash_tokens(tokens);

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -490,7 +490,7 @@ ErrorOr<void> BrowserWindow::load_search_engines(GUI::Menu& settings_menu)
     auto search_engines_file = TRY(Core::File::open(Browser::search_engines_file_path(), Core::File::OpenMode::Read));
     auto file_size = TRY(search_engines_file->size());
     auto buffer = TRY(ByteBuffer::create_uninitialized(file_size));
-    if (!search_engines_file->read_entire_buffer(buffer).is_error()) {
+    if (!search_engines_file->read_until_filled(buffer).is_error()) {
         StringView buffer_contents { buffer.bytes() };
         if (auto json = TRY(JsonValue::from_string(buffer_contents)); json.is_array()) {
             auto json_array = json.as_array();

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -775,8 +775,7 @@ ErrorOr<void> BrowserWindow::take_screenshot(ScreenshotType type)
     auto encoded = TRY(Gfx::PNGWriter::encode(*bitmap.bitmap()));
 
     auto screenshot_file = TRY(Core::File::open(path.string(), Core::File::OpenMode::Write));
-    // FIXME: This should write the entire span.
-    TRY(screenshot_file->write_some(encoded));
+    TRY(screenshot_file->write_until_depleted(encoded));
 
     return {};
 }

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -775,7 +775,8 @@ ErrorOr<void> BrowserWindow::take_screenshot(ScreenshotType type)
     auto encoded = TRY(Gfx::PNGWriter::encode(*bitmap.bitmap()));
 
     auto screenshot_file = TRY(Core::File::open(path.string(), Core::File::OpenMode::Write));
-    TRY(screenshot_file->write(encoded));
+    // FIXME: This should write the entire span.
+    TRY(screenshot_file->write_some(encoded));
 
     return {};
 }

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
@@ -50,8 +50,7 @@ ErrorOr<void> DomainListModel::save()
         TRY(builder.try_appendff("{}\n", domain));
 
     auto file = TRY(Core::File::open(filter_list_file_path(), Core::File::OpenMode::Write));
-    // FIXME: This should write the entire span.
-    TRY(file->write_some(TRY(builder.to_byte_buffer()).bytes()));
+    TRY(file->write_until_depleted(TRY(builder.to_byte_buffer()).bytes()));
     return {};
 }
 

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
@@ -50,7 +50,8 @@ ErrorOr<void> DomainListModel::save()
         TRY(builder.try_appendff("{}\n", domain));
 
     auto file = TRY(Core::File::open(filter_list_file_path(), Core::File::OpenMode::Write));
-    TRY(file->write(TRY(builder.to_byte_buffer()).bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file->write_some(TRY(builder.to_byte_buffer()).bytes()));
     return {};
 }
 

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -284,7 +284,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
         auto byte_buffer = byte_buffer_or_error.release_value();
 
-        if (auto result = file->write(byte_buffer); result.is_error())
+        // FIXME: This should write the entire span.
+        if (auto result = file->write_some(byte_buffer); result.is_error())
             GUI::MessageBox::show(window, DeprecatedString::formatted("Couldn't save file: {}.", result.release_error()), "Saving backtrace failed"sv, GUI::MessageBox::Type::Error);
     };
     save_backtrace_button.set_enabled(false);

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -284,8 +284,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
         auto byte_buffer = byte_buffer_or_error.release_value();
 
-        // FIXME: This should write the entire span.
-        if (auto result = file->write_some(byte_buffer); result.is_error())
+        if (auto result = file->write_until_depleted(byte_buffer); result.is_error())
             GUI::MessageBox::show(window, DeprecatedString::formatted("Couldn't save file: {}.", result.release_error()), "Saving backtrace failed"sv, GUI::MessageBox::Type::Error);
     };
     save_backtrace_button.set_enabled(false);

--- a/Userland/Applications/HexEditor/HexDocument.cpp
+++ b/Userland/Applications/HexEditor/HexDocument.cpp
@@ -62,12 +62,10 @@ void HexDocumentMemory::clear_changes()
 ErrorOr<void> HexDocumentMemory::write_to_file(Core::File& file)
 {
     TRY(file.seek(0, SeekMode::SetPosition));
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(m_buffer));
+    TRY(file.write_until_depleted(m_buffer));
     for (auto& change : m_changes) {
         TRY(file.seek(change.key, SeekMode::SetPosition));
-        // FIXME: This should write the entire span.
-        TRY(file.write_some({ &change.value, 1 }));
+        TRY(file.write_until_depleted({ &change.value, 1 }));
     }
     return {};
 }
@@ -89,8 +87,7 @@ ErrorOr<void> HexDocumentFile::write_to_file()
 {
     for (auto& change : m_changes) {
         TRY(m_file->seek(change.key, SeekMode::SetPosition));
-        // FIXME: This should write the entire span.
-        TRY(m_file->write_some({ &change.value, 1 }));
+        TRY(m_file->write_until_depleted({ &change.value, 1 }));
     }
     clear_changes();
     // make sure the next get operation triggers a read
@@ -110,14 +107,12 @@ ErrorOr<void> HexDocumentFile::write_to_file(Core::File& file)
         auto copy_buffer = TRY(m_file->read_some(buffer));
         if (copy_buffer.size() == 0)
             break;
-       // FIXME: This should write the entire span.
-        TRY(file.write_some(copy_buffer));
+        TRY(file.write_until_depleted(copy_buffer));
     }
 
     for (auto& change : m_changes) {
         TRY(file.seek(change.key, SeekMode::SetPosition));
-        // FIXME: This should write the entire span.
-        TRY(file.write_some({ &change.value, 1 }));
+        TRY(file.write_until_depleted({ &change.value, 1 }));
     }
 
     return {};

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -191,7 +191,8 @@ ErrorOr<void> KeyboardMapperWidget::save_to_file(StringView filename)
     // Write to file.
     DeprecatedString file_content = map_json.to_deprecated_string();
     auto file = TRY(Core::File::open(filename, Core::File::OpenMode::Write));
-    TRY(file->write(file_content.bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file->write_some(file_content.bytes()));
     file->close();
 
     window()->set_modified(false);

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -191,8 +191,7 @@ ErrorOr<void> KeyboardMapperWidget::save_to_file(StringView filename)
     // Write to file.
     DeprecatedString file_content = map_json.to_deprecated_string();
     auto file = TRY(Core::File::open(filename, Core::File::OpenMode::Write));
-    // FIXME: This should write the entire span.
-    TRY(file->write_some(file_content.bytes()));
+    TRY(file->write_until_depleted(file_content.bytes()));
     file->close();
 
     window()->set_modified(false);

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -73,7 +73,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             filename = path.basename();
             auto encoded = TRY(dump_bitmap(magnifier->current_bitmap(), path.extension()));
 
-            TRY(file->write(encoded));
+            // FIXME: This should write the entire span.
+            TRY(file->write_some(encoded));
             return {};
         };
 

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -73,8 +73,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             filename = path.basename();
             auto encoded = TRY(dump_bitmap(magnifier->current_bitmap(), path.extension()));
 
-            // FIXME: This should write the entire span.
-            TRY(file->write_some(encoded));
+            TRY(file->write_until_depleted(encoded));
             return {};
         };
 

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -177,7 +177,7 @@ ErrorOr<void> Image::export_bmp_to_file(NonnullOwnPtr<Stream> stream, bool prese
     auto bitmap = TRY(compose_bitmap(bitmap_format));
 
     auto encoded_data = TRY(Gfx::BMPWriter::encode(*bitmap));
-    TRY(stream->write_entire_buffer(encoded_data));
+    TRY(stream->write_until_depleted(encoded_data));
     return {};
 }
 
@@ -187,7 +187,7 @@ ErrorOr<void> Image::export_png_to_file(NonnullOwnPtr<Stream> stream, bool prese
     auto bitmap = TRY(compose_bitmap(bitmap_format));
 
     auto encoded_data = TRY(Gfx::PNGWriter::encode(*bitmap));
-    TRY(stream->write_entire_buffer(encoded_data));
+    TRY(stream->write_until_depleted(encoded_data));
     return {};
 }
 
@@ -196,7 +196,7 @@ ErrorOr<void> Image::export_qoi_to_file(NonnullOwnPtr<Stream> stream) const
     auto bitmap = TRY(compose_bitmap(Gfx::BitmapFormat::BGRA8888));
 
     auto encoded_data = TRY(Gfx::QOIWriter::encode(bitmap));
-    TRY(stream->write_entire_buffer(encoded_data));
+    TRY(stream->write_until_depleted(encoded_data));
     return {};
 }
 

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -793,7 +793,7 @@ ErrorOr<void> ImageEditor::save_project_to_file(NonnullOwnPtr<Core::File> file) 
     TRY(json_guides.finish());
     TRY(json.finish());
 
-    TRY(file->write_entire_buffer(builder.string_view().bytes()));
+    TRY(file->write_until_depleted(builder.string_view().bytes()));
     return {};
 }
 

--- a/Userland/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Userland/Applications/PixelPaint/PaletteWidget.cpp
@@ -248,8 +248,8 @@ ErrorOr<Vector<Color>> PaletteWidget::load_palette_path(DeprecatedString const& 
 ErrorOr<void> PaletteWidget::save_palette_file(Vector<Color> palette, NonnullOwnPtr<Core::File> file)
 {
     for (auto& color : palette) {
-        TRY(file->write_entire_buffer(color.to_deprecated_string_without_alpha().bytes()));
-        TRY(file->write_entire_buffer({ "\n", 1 }));
+        TRY(file->write_until_depleted(color.to_deprecated_string_without_alpha().bytes()));
+        TRY(file->write_until_depleted({ "\n", 1 }));
     }
     return {};
 }

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -187,7 +187,8 @@ ErrorOr<void> RunWindow::save_history()
 
     // Write the first 25 items of history
     for (int i = 0; i < min(static_cast<int>(m_path_history.size()), 25); i++)
-        TRY(file->write(DeprecatedString::formatted("{}\n", m_path_history[i]).bytes()));
+        // FIXME: This should write the entire span.
+        TRY(file->write_some(DeprecatedString::formatted("{}\n", m_path_history[i]).bytes()));
 
     return {};
 }

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -187,8 +187,7 @@ ErrorOr<void> RunWindow::save_history()
 
     // Write the first 25 items of history
     for (int i = 0; i < min(static_cast<int>(m_path_history.size()), 25); i++)
-        // FIXME: This should write the entire span.
-        TRY(file->write_some(DeprecatedString::formatted("{}\n", m_path_history[i]).bytes()));
+        TRY(file->write_until_depleted(DeprecatedString::formatted("{}\n", m_path_history[i]).bytes()));
 
     return {};
 }

--- a/Userland/Applications/Spreadsheet/ExportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ExportDialog.cpp
@@ -205,7 +205,7 @@ ErrorOr<void> ExportDialog::make_and_run_for(StringView mime, Core::File& file, 
             array.append(sheet->to_json());
 
         auto file_content = array.to_deprecated_string();
-        return file.write_entire_buffer(file_content.bytes());
+        return file.write_until_depleted(file_content.bytes());
     };
 
     if (mime == "text/csv") {

--- a/Userland/Applications/Spreadsheet/Writers/XSV.h
+++ b/Userland/Applications/Spreadsheet/Writers/XSV.h
@@ -48,7 +48,7 @@ public:
         auto with_headers = has_flag(writer.m_behaviors, WriterBehavior::WriteHeaders);
         if (with_headers) {
             TRY(writer.write_row(writer.m_names));
-            TRY(writer.m_output.write_entire_buffer({ "\n", 1 }));
+            TRY(writer.m_output.write_until_depleted({ "\n", 1 }));
         }
 
         for (auto&& row : writer.m_data) {
@@ -58,7 +58,7 @@ public:
             }
 
             TRY(writer.write_row(row));
-            TRY(writer.m_output.write_entire_buffer({ "\n", 1 }));
+            TRY(writer.m_output.write_until_depleted({ "\n", 1 }));
         }
         return {};
     }
@@ -72,7 +72,7 @@ public:
         auto with_headers = has_flag(writer.m_behaviors, WriterBehavior::WriteHeaders);
         if (with_headers) {
             TRY(writer.write_row(writer.m_names));
-            TRY(writer.m_output.write_entire_buffer({ "\n", 1 }));
+            TRY(writer.m_output.write_until_depleted({ "\n", 1 }));
             ++lines_written;
         }
 
@@ -83,7 +83,7 @@ public:
             }
 
             TRY(writer.write_row(row));
-            TRY(writer.m_output.write_entire_buffer({ "\n", 1 }));
+            TRY(writer.m_output.write_until_depleted({ "\n", 1 }));
             ++lines_written;
 
             if (lines_written >= max_preview_lines)
@@ -110,7 +110,7 @@ private:
         bool first = true;
         for (auto&& entry : row) {
             if (!first) {
-                TRY(m_output.write_entire_buffer(m_traits.separator.bytes()));
+                TRY(m_output.write_until_depleted(m_traits.separator.bytes()));
             }
             first = false;
             TRY(write_entry(entry));
@@ -136,33 +136,33 @@ private:
 
         if (safe_to_write_normally) {
             if (!string.is_empty())
-                TRY(m_output.write_entire_buffer(string.bytes()));
+                TRY(m_output.write_until_depleted(string.bytes()));
             return {};
         }
 
-        TRY(m_output.write_entire_buffer(m_traits.quote.bytes()));
+        TRY(m_output.write_until_depleted(m_traits.quote.bytes()));
 
         GenericLexer lexer(string);
         while (!lexer.is_eof()) {
             if (lexer.consume_specific(m_traits.quote)) {
                 switch (m_traits.quote_escape) {
                 case WriterTraits::Repeat:
-                    TRY(m_output.write_entire_buffer(m_traits.quote.bytes()));
-                    TRY(m_output.write_entire_buffer(m_traits.quote.bytes()));
+                    TRY(m_output.write_until_depleted(m_traits.quote.bytes()));
+                    TRY(m_output.write_until_depleted(m_traits.quote.bytes()));
                     break;
                 case WriterTraits::Backslash:
-                    TRY(m_output.write_entire_buffer({ "\\", 1 }));
-                    TRY(m_output.write_entire_buffer(m_traits.quote.bytes()));
+                    TRY(m_output.write_until_depleted({ "\\", 1 }));
+                    TRY(m_output.write_until_depleted(m_traits.quote.bytes()));
                     break;
                 }
                 continue;
             }
 
             auto ch = lexer.consume();
-            TRY(m_output.write_entire_buffer({ &ch, 1 }));
+            TRY(m_output.write_until_depleted({ &ch, 1 }));
         }
 
-        TRY(m_output.write_entire_buffer(m_traits.quote.bytes()));
+        TRY(m_output.write_until_depleted(m_traits.quote.bytes()));
         return {};
     }
 

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1807,7 +1807,7 @@ ErrorOr<NonnullRefPtr<GUI::Action>> HackStudioWidget::create_open_project_config
                 return maybe_error.release_error();
 
             auto file = TRY(Core::File::open(absolute_config_file_path, Core::File::OpenMode::Write));
-            TRY(file->write_entire_buffer(
+            TRY(file->write_until_depleted(
                 "{\n"
                 "    \"build_command\": \"your build command here\",\n"
                 "    \"run_command\": \"your run command here\"\n"

--- a/Userland/DevTools/HackStudio/ProjectBuilder.cpp
+++ b/Userland/DevTools/HackStudio/ProjectBuilder.cpp
@@ -135,7 +135,7 @@ ErrorOr<void> ProjectBuilder::initialize_build_directory()
         MUST(Core::DeprecatedFile::remove(cmake_file_path, Core::DeprecatedFile::RecursionMode::Disallowed));
 
     auto cmake_file = TRY(Core::File::open(cmake_file_path, Core::File::OpenMode::Write));
-    TRY(cmake_file->write_entire_buffer(generate_cmake_file_content().bytes()));
+    TRY(cmake_file->write_until_depleted(generate_cmake_file_content().bytes()));
 
     TRY(m_terminal->run_command(DeprecatedString::formatted("cmake -S {} -DHACKSTUDIO_BUILD=ON -DHACKSTUDIO_BUILD_CMAKE_FILE={}"
                                                             " -DENABLE_UNICODE_DATABASE_DOWNLOAD=OFF",

--- a/Userland/DevTools/SQLStudio/ScriptEditor.cpp
+++ b/Userland/DevTools/SQLStudio/ScriptEditor.cpp
@@ -42,7 +42,7 @@ static ErrorOr<void> save_text_to_file(StringView filename, DeprecatedString tex
     auto file = TRY(Core::File::open(filename, Core::File::OpenMode::Write));
 
     if (!text.is_empty())
-        TRY(file->write_entire_buffer(text.bytes()));
+        TRY(file->write_until_depleted(text.bytes()));
 
     return {};
 }

--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -509,7 +509,7 @@ void Emulator::emit_profile_sample(Stream& output)
     builder.appendff(R"~(, {{"type": "sample", "pid": {}, "tid": {}, "timestamp": {}, "lost_samples": 0, "stack": [)~", getpid(), gettid(), tv.tv_sec * 1000 + tv.tv_usec / 1000);
     builder.join(',', raw_backtrace());
     builder.append("]}\n"sv);
-    output.write_entire_buffer(builder.string_view().bytes()).release_value_but_fixme_should_propagate_errors();
+    output.write_until_depleted(builder.string_view().bytes()).release_value_but_fixme_should_propagate_errors();
 }
 
 void Emulator::emit_profile_event(Stream& output, StringView event_name, DeprecatedString const& contents)
@@ -519,7 +519,7 @@ void Emulator::emit_profile_event(Stream& output, StringView event_name, Depreca
     gettimeofday(&tv, nullptr);
     builder.appendff(R"~(, {{"type": "{}", "pid": {}, "tid": {}, "timestamp": {}, "lost_samples": 0, "stack": [], {}}})~", event_name, getpid(), gettid(), tv.tv_sec * 1000 + tv.tv_usec / 1000, contents);
     builder.append('\n');
-    output.write_entire_buffer(builder.string_view().bytes()).release_value_but_fixme_should_propagate_errors();
+    output.write_until_depleted(builder.string_view().bytes()).release_value_but_fixme_should_propagate_errors();
 }
 
 DeprecatedString Emulator::create_instruction_line(FlatPtr address, X86::Instruction const& insn)

--- a/Userland/DevTools/UserspaceEmulator/main.cpp
+++ b/Userland/DevTools/UserspaceEmulator/main.cpp
@@ -70,10 +70,10 @@ int main(int argc, char** argv, char** env)
         profile_strings = make<Vector<NonnullOwnPtr<DeprecatedString>>>();
         profile_string_id_map = make<Vector<int>>();
 
-        profile_stream->write_entire_buffer(R"({"events":[)"sv.bytes()).release_value_but_fixme_should_propagate_errors();
+        profile_stream->write_until_depleted(R"({"events":[)"sv.bytes()).release_value_but_fixme_should_propagate_errors();
         timeval tv {};
         gettimeofday(&tv, nullptr);
-        profile_stream->write_entire_buffer(
+        profile_stream->write_until_depleted(
                           DeprecatedString::formatted(
                               R"~({{"type": "process_create", "parent_pid": 1, "executable": "{}", "pid": {}, "tid": {}, "timestamp": {}, "lost_samples": 0, "stack": []}})~",
                               executable_path, getpid(), gettid(), tv.tv_sec * 1000 + tv.tv_usec / 1000)
@@ -109,13 +109,13 @@ int main(int argc, char** argv, char** env)
     int rc = emulator.exec();
 
     if (dump_profile) {
-        emulator.profile_stream().write_entire_buffer("], \"strings\": ["sv.bytes()).release_value_but_fixme_should_propagate_errors();
+        emulator.profile_stream().write_until_depleted("], \"strings\": ["sv.bytes()).release_value_but_fixme_should_propagate_errors();
         if (emulator.profiler_strings().size()) {
             for (size_t i = 0; i < emulator.profiler_strings().size() - 1; ++i)
-                emulator.profile_stream().write_entire_buffer(DeprecatedString::formatted("\"{}\", ", emulator.profiler_strings().at(i)).bytes()).release_value_but_fixme_should_propagate_errors();
-            emulator.profile_stream().write_entire_buffer(DeprecatedString::formatted("\"{}\"", emulator.profiler_strings().last()).bytes()).release_value_but_fixme_should_propagate_errors();
+                emulator.profile_stream().write_until_depleted(DeprecatedString::formatted("\"{}\", ", emulator.profiler_strings().at(i)).bytes()).release_value_but_fixme_should_propagate_errors();
+            emulator.profile_stream().write_until_depleted(DeprecatedString::formatted("\"{}\"", emulator.profiler_strings().last()).bytes()).release_value_but_fixme_should_propagate_errors();
         }
-        emulator.profile_stream().write_entire_buffer("]}"sv.bytes()).release_value_but_fixme_should_propagate_errors();
+        emulator.profile_stream().write_until_depleted("]}"sv.bytes()).release_value_but_fixme_should_propagate_errors();
     }
     return rc;
 }

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -632,25 +632,24 @@ ErrorOr<void> ChessWidget::import_pgn(Core::File& file)
 ErrorOr<void> ChessWidget::export_pgn(Core::File& file) const
 {
     // Tag Pair Section
-    // FIXME: This should write the entire span.
-    TRY(file.write_some("[Event \"Casual Game\"]\n"sv.bytes()));
-    TRY(file.write_some("[Site \"SerenityOS Chess\"]\n"sv.bytes()));
-    TRY(file.write_some(DeprecatedString::formatted("[Date \"{}\"]\n", Core::DateTime::now().to_deprecated_string("%Y.%m.%d"sv)).bytes()));
-    TRY(file.write_some("[Round \"1\"]\n"sv.bytes()));
+    TRY(file.write_until_depleted("[Event \"Casual Game\"]\n"sv.bytes()));
+    TRY(file.write_until_depleted("[Site \"SerenityOS Chess\"]\n"sv.bytes()));
+    TRY(file.write_until_depleted(DeprecatedString::formatted("[Date \"{}\"]\n", Core::DateTime::now().to_deprecated_string("%Y.%m.%d"sv)).bytes()));
+    TRY(file.write_until_depleted("[Round \"1\"]\n"sv.bytes()));
 
     DeprecatedString username(getlogin());
     auto const player1 = (!username.is_empty() ? username.view() : "?"sv.bytes());
     auto const player2 = (!m_engine.is_null() ? "SerenityOS ChessEngine"sv.bytes() : "?"sv.bytes());
-    TRY(file.write_some(DeprecatedString::formatted("[White \"{}\"]\n", m_side == Chess::Color::White ? player1 : player2).bytes()));
-    TRY(file.write_some(DeprecatedString::formatted("[Black \"{}\"]\n", m_side == Chess::Color::Black ? player1 : player2).bytes()));
+    TRY(file.write_until_depleted(DeprecatedString::formatted("[White \"{}\"]\n", m_side == Chess::Color::White ? player1 : player2).bytes()));
+    TRY(file.write_until_depleted(DeprecatedString::formatted("[Black \"{}\"]\n", m_side == Chess::Color::Black ? player1 : player2).bytes()));
 
-    TRY(file.write_some(DeprecatedString::formatted("[Result \"{}\"]\n", Chess::Board::result_to_points_string(m_board.game_result(), m_board.turn())).bytes()));
-    TRY(file.write_some("[WhiteElo \"?\"]\n"sv.bytes()));
-    TRY(file.write_some("[BlackElo \"?\"]\n"sv.bytes()));
-    TRY(file.write_some("[Variant \"Standard\"]\n"sv.bytes()));
-    TRY(file.write_some("[TimeControl \"-\"]\n"sv.bytes()));
-    TRY(file.write_some("[Annotator \"SerenityOS Chess\"]\n"sv.bytes()));
-    TRY(file.write_some("\n"sv.bytes()));
+    TRY(file.write_until_depleted(DeprecatedString::formatted("[Result \"{}\"]\n", Chess::Board::result_to_points_string(m_board.game_result(), m_board.turn())).bytes()));
+    TRY(file.write_until_depleted("[WhiteElo \"?\"]\n"sv.bytes()));
+    TRY(file.write_until_depleted("[BlackElo \"?\"]\n"sv.bytes()));
+    TRY(file.write_until_depleted("[Variant \"Standard\"]\n"sv.bytes()));
+    TRY(file.write_until_depleted("[TimeControl \"-\"]\n"sv.bytes()));
+    TRY(file.write_until_depleted("[Annotator \"SerenityOS Chess\"]\n"sv.bytes()));
+    TRY(file.write_until_depleted("\n"sv.bytes()));
 
     // Movetext Section
     for (size_t i = 0, move_no = 1; i < m_board.moves().size(); i += 2, move_no++) {
@@ -658,17 +657,17 @@ ErrorOr<void> ChessWidget::export_pgn(Core::File& file) const
 
         if (i + 1 < m_board.moves().size()) {
             const DeprecatedString black = m_board.moves().at(i + 1).to_algebraic();
-            TRY(file.write_some(DeprecatedString::formatted("{}. {} {} ", move_no, white, black).bytes()));
+            TRY(file.write_until_depleted(DeprecatedString::formatted("{}. {} {} ", move_no, white, black).bytes()));
         } else {
-            TRY(file.write_some(DeprecatedString::formatted("{}. {} ", move_no, white).bytes()));
+            TRY(file.write_until_depleted(DeprecatedString::formatted("{}. {} ", move_no, white).bytes()));
         }
     }
 
-    TRY(file.write_some("{ "sv.bytes()));
-    TRY(file.write_some(Chess::Board::result_to_string(m_board.game_result(), m_board.turn()).bytes()));
-    TRY(file.write_some(" } "sv.bytes()));
-    TRY(file.write_some(Chess::Board::result_to_points_string(m_board.game_result(), m_board.turn()).bytes()));
-    TRY(file.write_some("\n"sv.bytes()));
+    TRY(file.write_until_depleted("{ "sv.bytes()));
+    TRY(file.write_until_depleted(Chess::Board::result_to_string(m_board.game_result(), m_board.turn()).bytes()));
+    TRY(file.write_until_depleted(" } "sv.bytes()));
+    TRY(file.write_until_depleted(Chess::Board::result_to_points_string(m_board.game_result(), m_board.turn()).bytes()));
+    TRY(file.write_until_depleted("\n"sv.bytes()));
 
     return {};
 }

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -632,24 +632,25 @@ ErrorOr<void> ChessWidget::import_pgn(Core::File& file)
 ErrorOr<void> ChessWidget::export_pgn(Core::File& file) const
 {
     // Tag Pair Section
-    TRY(file.write("[Event \"Casual Game\"]\n"sv.bytes()));
-    TRY(file.write("[Site \"SerenityOS Chess\"]\n"sv.bytes()));
-    TRY(file.write(DeprecatedString::formatted("[Date \"{}\"]\n", Core::DateTime::now().to_deprecated_string("%Y.%m.%d"sv)).bytes()));
-    TRY(file.write("[Round \"1\"]\n"sv.bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some("[Event \"Casual Game\"]\n"sv.bytes()));
+    TRY(file.write_some("[Site \"SerenityOS Chess\"]\n"sv.bytes()));
+    TRY(file.write_some(DeprecatedString::formatted("[Date \"{}\"]\n", Core::DateTime::now().to_deprecated_string("%Y.%m.%d"sv)).bytes()));
+    TRY(file.write_some("[Round \"1\"]\n"sv.bytes()));
 
     DeprecatedString username(getlogin());
     auto const player1 = (!username.is_empty() ? username.view() : "?"sv.bytes());
     auto const player2 = (!m_engine.is_null() ? "SerenityOS ChessEngine"sv.bytes() : "?"sv.bytes());
-    TRY(file.write(DeprecatedString::formatted("[White \"{}\"]\n", m_side == Chess::Color::White ? player1 : player2).bytes()));
-    TRY(file.write(DeprecatedString::formatted("[Black \"{}\"]\n", m_side == Chess::Color::Black ? player1 : player2).bytes()));
+    TRY(file.write_some(DeprecatedString::formatted("[White \"{}\"]\n", m_side == Chess::Color::White ? player1 : player2).bytes()));
+    TRY(file.write_some(DeprecatedString::formatted("[Black \"{}\"]\n", m_side == Chess::Color::Black ? player1 : player2).bytes()));
 
-    TRY(file.write(DeprecatedString::formatted("[Result \"{}\"]\n", Chess::Board::result_to_points_string(m_board.game_result(), m_board.turn())).bytes()));
-    TRY(file.write("[WhiteElo \"?\"]\n"sv.bytes()));
-    TRY(file.write("[BlackElo \"?\"]\n"sv.bytes()));
-    TRY(file.write("[Variant \"Standard\"]\n"sv.bytes()));
-    TRY(file.write("[TimeControl \"-\"]\n"sv.bytes()));
-    TRY(file.write("[Annotator \"SerenityOS Chess\"]\n"sv.bytes()));
-    TRY(file.write("\n"sv.bytes()));
+    TRY(file.write_some(DeprecatedString::formatted("[Result \"{}\"]\n", Chess::Board::result_to_points_string(m_board.game_result(), m_board.turn())).bytes()));
+    TRY(file.write_some("[WhiteElo \"?\"]\n"sv.bytes()));
+    TRY(file.write_some("[BlackElo \"?\"]\n"sv.bytes()));
+    TRY(file.write_some("[Variant \"Standard\"]\n"sv.bytes()));
+    TRY(file.write_some("[TimeControl \"-\"]\n"sv.bytes()));
+    TRY(file.write_some("[Annotator \"SerenityOS Chess\"]\n"sv.bytes()));
+    TRY(file.write_some("\n"sv.bytes()));
 
     // Movetext Section
     for (size_t i = 0, move_no = 1; i < m_board.moves().size(); i += 2, move_no++) {
@@ -657,17 +658,17 @@ ErrorOr<void> ChessWidget::export_pgn(Core::File& file) const
 
         if (i + 1 < m_board.moves().size()) {
             const DeprecatedString black = m_board.moves().at(i + 1).to_algebraic();
-            TRY(file.write(DeprecatedString::formatted("{}. {} {} ", move_no, white, black).bytes()));
+            TRY(file.write_some(DeprecatedString::formatted("{}. {} {} ", move_no, white, black).bytes()));
         } else {
-            TRY(file.write(DeprecatedString::formatted("{}. {} ", move_no, white).bytes()));
+            TRY(file.write_some(DeprecatedString::formatted("{}. {} ", move_no, white).bytes()));
         }
     }
 
-    TRY(file.write("{ "sv.bytes()));
-    TRY(file.write(Chess::Board::result_to_string(m_board.game_result(), m_board.turn()).bytes()));
-    TRY(file.write(" } "sv.bytes()));
-    TRY(file.write(Chess::Board::result_to_points_string(m_board.game_result(), m_board.turn()).bytes()));
-    TRY(file.write("\n"sv.bytes()));
+    TRY(file.write_some("{ "sv.bytes()));
+    TRY(file.write_some(Chess::Board::result_to_string(m_board.game_result(), m_board.turn()).bytes()));
+    TRY(file.write_some(" } "sv.bytes()));
+    TRY(file.write_some(Chess::Board::result_to_points_string(m_board.game_result(), m_board.turn()).bytes()));
+    TRY(file.write_some("\n"sv.bytes()));
 
     return {};
 }

--- a/Userland/Libraries/LibArchive/Tar.h
+++ b/Userland/Libraries/LibArchive/Tar.h
@@ -155,3 +155,8 @@ private:
 };
 
 }
+
+template<>
+struct AK::Traits<Archive::TarFileHeader> : public AK::GenericTraits<Archive::TarFileHeader> {
+    static constexpr bool is_trivially_serializable() { return true; }
+};

--- a/Userland/Libraries/LibArchive/TarStream.cpp
+++ b/Userland/Libraries/LibArchive/TarStream.cpp
@@ -92,10 +92,7 @@ ErrorOr<void> TarInputStream::load_next_header()
 {
     size_t number_of_consecutive_zero_blocks = 0;
     while (true) {
-        // FIXME: This should read the entire span.
-        auto header_span = TRY(m_stream->read_some(Bytes(&m_header, sizeof(m_header))));
-        if (header_span.size() != sizeof(m_header))
-            return Error::from_string_literal("Failed to read the entire header");
+        m_header = TRY(m_stream->read_value<TarFileHeader>());
 
         // Discard the rest of the header block.
         TRY(m_stream->discard(block_size - sizeof(TarFileHeader)));

--- a/Userland/Libraries/LibArchive/TarStream.h
+++ b/Userland/Libraries/LibArchive/TarStream.h
@@ -18,8 +18,8 @@ class TarInputStream;
 
 class TarFileStream : public Stream {
 public:
-    virtual ErrorOr<Bytes> read(Bytes) override;
-    virtual ErrorOr<size_t> write(ReadonlyBytes) override;
+    virtual ErrorOr<Bytes> read_some(Bytes) override;
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
     virtual bool is_eof() const override;
     virtual bool is_open() const override { return true; };
     virtual void close() override {};

--- a/Userland/Libraries/LibArchive/TarStream.h
+++ b/Userland/Libraries/LibArchive/TarStream.h
@@ -81,7 +81,7 @@ inline ErrorOr<void> TarInputStream::for_each_extended_header(F func)
 
     auto header_size = TRY(header().size());
     ByteBuffer file_contents_buffer = TRY(ByteBuffer::create_zeroed(header_size));
-    TRY(file_stream.read_entire_buffer(file_contents_buffer));
+    TRY(file_stream.read_until_filled(file_contents_buffer));
 
     StringView file_contents { file_contents_buffer };
 

--- a/Userland/Libraries/LibArchive/Zip.h
+++ b/Userland/Libraries/LibArchive/Zip.h
@@ -60,10 +60,10 @@ struct [[gnu::packed]] EndOfCentralDirectory {
     ErrorOr<void> write(Stream& stream) const
     {
         auto write_value = [&stream](auto value) {
-            return stream.write_entire_buffer({ &value, sizeof(value) });
+            return stream.write_until_depleted({ &value, sizeof(value) });
         };
 
-        TRY(stream.write_entire_buffer(signature));
+        TRY(stream.write_until_depleted(signature));
         TRY(write_value(disk_number));
         TRY(write_value(central_directory_start_disk));
         TRY(write_value(disk_records_count));
@@ -72,7 +72,7 @@ struct [[gnu::packed]] EndOfCentralDirectory {
         TRY(write_value(central_directory_offset));
         TRY(write_value(comment_length));
         if (comment_length > 0)
-            TRY(stream.write_entire_buffer({ comment, comment_length }));
+            TRY(stream.write_until_depleted({ comment, comment_length }));
         return {};
     }
 };
@@ -146,10 +146,10 @@ struct [[gnu::packed]] CentralDirectoryRecord {
     ErrorOr<void> write(Stream& stream) const
     {
         auto write_value = [&stream](auto value) {
-            return stream.write_entire_buffer({ &value, sizeof(value) });
+            return stream.write_until_depleted({ &value, sizeof(value) });
         };
 
-        TRY(stream.write_entire_buffer(signature));
+        TRY(stream.write_until_depleted(signature));
         TRY(write_value(made_by_version));
         TRY(write_value(minimum_version));
         TRY(write_value(general_purpose_flags.flags));
@@ -167,11 +167,11 @@ struct [[gnu::packed]] CentralDirectoryRecord {
         TRY(write_value(external_attributes));
         TRY(write_value(local_file_header_offset));
         if (name_length > 0)
-            TRY(stream.write_entire_buffer({ name, name_length }));
+            TRY(stream.write_until_depleted({ name, name_length }));
         if (extra_data_length > 0)
-            TRY(stream.write_entire_buffer({ extra_data, extra_data_length }));
+            TRY(stream.write_until_depleted({ extra_data, extra_data_length }));
         if (comment_length > 0)
-            TRY(stream.write_entire_buffer({ comment, comment_length }));
+            TRY(stream.write_until_depleted({ comment, comment_length }));
         return {};
     }
 
@@ -215,10 +215,10 @@ struct [[gnu::packed]] LocalFileHeader {
     ErrorOr<void> write(Stream& stream) const
     {
         auto write_value = [&stream](auto value) {
-            return stream.write_entire_buffer({ &value, sizeof(value) });
+            return stream.write_until_depleted({ &value, sizeof(value) });
         };
 
-        TRY(stream.write_entire_buffer(signature));
+        TRY(stream.write_until_depleted(signature));
         TRY(write_value(minimum_version));
         TRY(write_value(general_purpose_flags.flags));
         TRY(write_value(compression_method));
@@ -230,11 +230,11 @@ struct [[gnu::packed]] LocalFileHeader {
         TRY(write_value(name_length));
         TRY(write_value(extra_data_length));
         if (name_length > 0)
-            TRY(stream.write_entire_buffer({ name, name_length }));
+            TRY(stream.write_until_depleted({ name, name_length }));
         if (extra_data_length > 0)
-            TRY(stream.write_entire_buffer({ extra_data, extra_data_length }));
+            TRY(stream.write_until_depleted({ extra_data, extra_data_length }));
         if (compressed_size > 0)
-            TRY(stream.write_entire_buffer({ compressed_data, compressed_size }));
+            TRY(stream.write_until_depleted({ compressed_data, compressed_size }));
         return {};
     }
 };

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -108,13 +108,9 @@ MaybeLoaderError FlacLoaderPlugin::parse_header()
 
     m_total_samples = LOADER_TRY(streaminfo_data.read_bits<u64>(36));
     FLAC_VERIFY(m_total_samples > 0, LoaderError::Category::Format, "Number of samples is zero");
-    // Parse checksum into a buffer first
-    [[maybe_unused]] u128 md5_checksum;
+
     VERIFY(streaminfo_data.is_aligned_to_byte_boundary());
-    // FIXME: This should read the entire span.
-    auto md5_bytes_read = LOADER_TRY(streaminfo_data.read_some(md5_checksum.bytes()));
-    FLAC_VERIFY(md5_bytes_read.size() == sizeof(md5_checksum), LoaderError::Category::IO, "MD5 Checksum size");
-    md5_checksum.bytes().copy_to({ m_md5_checksum, sizeof(m_md5_checksum) });
+    LOADER_TRY(streaminfo_data.read_until_filled({ m_md5_checksum, sizeof(m_md5_checksum) }));
 
     // Parse other blocks
     [[maybe_unused]] u16 meta_blocks_parsed = 1;
@@ -142,7 +138,7 @@ MaybeLoaderError FlacLoaderPlugin::parse_header()
         ++total_meta_blocks;
     }
 
-    dbgln_if(AFLACLOADER_DEBUG, "Parsed FLAC header: blocksize {}-{}{}, framesize {}-{}, {}Hz, {}bit, {} channels, {} samples total ({:.2f}s), MD5 {}, data start at {:x} bytes, {} headers total (skipped {})", m_min_block_size, m_max_block_size, is_fixed_blocksize_stream() ? " (constant)" : "", m_min_frame_size, m_max_frame_size, m_sample_rate, pcm_bits_per_sample(m_sample_format), m_num_channels, m_total_samples, static_cast<float>(m_total_samples) / static_cast<float>(m_sample_rate), md5_checksum, m_data_start_location, total_meta_blocks, total_meta_blocks - meta_blocks_parsed);
+    dbgln_if(AFLACLOADER_DEBUG, "Parsed FLAC header: blocksize {}-{}{}, framesize {}-{}, {}Hz, {}bit, {} channels, {} samples total ({:.2f}s), MD5 {}, data start at {:x} bytes, {} headers total (skipped {})", m_min_block_size, m_max_block_size, is_fixed_blocksize_stream() ? " (constant)" : "", m_min_frame_size, m_max_frame_size, m_sample_rate, pcm_bits_per_sample(m_sample_format), m_num_channels, m_total_samples, static_cast<float>(m_total_samples) / static_cast<float>(m_sample_rate), m_md5_checksum, m_data_start_location, total_meta_blocks, total_meta_blocks - meta_blocks_parsed);
 
     return {};
 }
@@ -903,11 +899,7 @@ ALWAYS_INLINE ErrorOr<i32> decode_unsigned_exp_golomb(u8 k, BigEndianInputBitStr
 ErrorOr<u64> read_utf8_char(BigEndianInputBitStream& input)
 {
     u64 character;
-    u8 buffer = 0;
-    Bytes buffer_bytes { &buffer, 1 };
-    // FIXME: This should read the entire span.
-    TRY(input.read_some(buffer_bytes));
-    u8 start_byte = buffer_bytes[0];
+    u8 start_byte = TRY(input.read_value<u8>());
     // Signal byte is zero: ASCII character
     if ((start_byte & 0b10000000) == 0) {
         return start_byte;
@@ -922,9 +914,7 @@ ErrorOr<u64> read_utf8_char(BigEndianInputBitStream& input)
     u8 start_byte_bitmask = AK::exp2(bits_from_start_byte) - 1;
     character = start_byte_bitmask & start_byte;
     for (u8 i = length - 1; i > 0; --i) {
-        // FIXME: This should read the entire span.
-        TRY(input.read_some(buffer_bytes));
-        u8 current_byte = buffer_bytes[0];
+        u8 current_byte = TRY(input.read_value<u8>());
         character = (character << 6) | (current_byte & 0b00111111);
     }
     return character;

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -111,7 +111,8 @@ MaybeLoaderError FlacLoaderPlugin::parse_header()
     // Parse checksum into a buffer first
     [[maybe_unused]] u128 md5_checksum;
     VERIFY(streaminfo_data.is_aligned_to_byte_boundary());
-    auto md5_bytes_read = LOADER_TRY(streaminfo_data.read(md5_checksum.bytes()));
+    // FIXME: This should read the entire span.
+    auto md5_bytes_read = LOADER_TRY(streaminfo_data.read_some(md5_checksum.bytes()));
     FLAC_VERIFY(md5_bytes_read.size() == sizeof(md5_checksum), LoaderError::Category::IO, "MD5 Checksum size");
     md5_checksum.bytes().copy_to({ m_md5_checksum, sizeof(m_md5_checksum) });
 
@@ -228,7 +229,7 @@ ErrorOr<FlacRawMetadataBlock, LoaderError> FlacLoaderPlugin::next_meta_block(Big
     // Blocks might exceed our buffer size.
     auto bytes_left_to_read = block_data.bytes();
     while (bytes_left_to_read.size()) {
-        auto read_bytes = LOADER_TRY(bit_input.read(bytes_left_to_read));
+        auto read_bytes = LOADER_TRY(bit_input.read_some(bytes_left_to_read));
         bytes_left_to_read = bytes_left_to_read.slice(read_bytes.size());
     }
 
@@ -904,7 +905,8 @@ ErrorOr<u64> read_utf8_char(BigEndianInputBitStream& input)
     u64 character;
     u8 buffer = 0;
     Bytes buffer_bytes { &buffer, 1 };
-    TRY(input.read(buffer_bytes));
+    // FIXME: This should read the entire span.
+    TRY(input.read_some(buffer_bytes));
     u8 start_byte = buffer_bytes[0];
     // Signal byte is zero: ASCII character
     if ((start_byte & 0b10000000) == 0) {
@@ -920,7 +922,8 @@ ErrorOr<u64> read_utf8_char(BigEndianInputBitStream& input)
     u8 start_byte_bitmask = AK::exp2(bits_from_start_byte) - 1;
     character = start_byte_bitmask & start_byte;
     for (u8 i = length - 1; i > 0; --i) {
-        TRY(input.read(buffer_bytes));
+        // FIXME: This should read the entire span.
+        TRY(input.read_some(buffer_bytes));
         u8 current_byte = buffer_bytes[0];
         character = (character << 6) | (current_byte & 0b00111111);
     }

--- a/Userland/Libraries/LibAudio/MP3Loader.cpp
+++ b/Userland/Libraries/LibAudio/MP3Loader.cpp
@@ -234,7 +234,8 @@ ErrorOr<MP3::MP3Frame, LoaderError> MP3LoaderPlugin::read_frame_data(MP3::Header
 
     size_t old_reservoir_size = m_bit_reservoir.used_buffer_size();
     LOADER_TRY(m_bitstream->read_entire_buffer(buffer));
-    if (LOADER_TRY(m_bit_reservoir.write(buffer)) != header.slot_count)
+    // FIXME: This should write the entire span.
+    if (LOADER_TRY(m_bit_reservoir.write_some(buffer)) != header.slot_count)
         return LoaderError { LoaderError::Category::IO, m_loaded_samples, "Could not write frame into bit reservoir." };
 
     // If we don't have enough data in the reservoir to process this frame, skip it (but keep the data).

--- a/Userland/Libraries/LibAudio/MP3Loader.cpp
+++ b/Userland/Libraries/LibAudio/MP3Loader.cpp
@@ -233,7 +233,7 @@ ErrorOr<MP3::MP3Frame, LoaderError> MP3LoaderPlugin::read_frame_data(MP3::Header
     auto& buffer = maybe_buffer.value();
 
     size_t old_reservoir_size = m_bit_reservoir.used_buffer_size();
-    LOADER_TRY(m_bitstream->read_entire_buffer(buffer));
+    LOADER_TRY(m_bitstream->read_until_filled(buffer));
     // FIXME: This should write the entire span.
     if (LOADER_TRY(m_bit_reservoir.write_some(buffer)) != header.slot_count)
         return LoaderError { LoaderError::Category::IO, m_loaded_samples, "Could not write frame into bit reservoir." };

--- a/Userland/Libraries/LibAudio/MP3Loader.cpp
+++ b/Userland/Libraries/LibAudio/MP3Loader.cpp
@@ -234,9 +234,7 @@ ErrorOr<MP3::MP3Frame, LoaderError> MP3LoaderPlugin::read_frame_data(MP3::Header
 
     size_t old_reservoir_size = m_bit_reservoir.used_buffer_size();
     LOADER_TRY(m_bitstream->read_until_filled(buffer));
-    // FIXME: This should write the entire span.
-    if (LOADER_TRY(m_bit_reservoir.write_some(buffer)) != header.slot_count)
-        return LoaderError { LoaderError::Category::IO, m_loaded_samples, "Could not write frame into bit reservoir." };
+    LOADER_TRY(m_bit_reservoir.write_until_depleted(buffer));
 
     // If we don't have enough data in the reservoir to process this frame, skip it (but keep the data).
     if (old_reservoir_size < static_cast<size_t>(frame.main_data_begin))

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -93,7 +93,7 @@ template<typename T>
 static ErrorOr<double> read_sample(Stream& stream)
 {
     T sample { 0 };
-    TRY(stream.read_entire_buffer(Bytes { &sample, sizeof(T) }));
+    TRY(stream.read_until_filled(Bytes { &sample, sizeof(T) }));
     // Remap integer samples to normalized floating-point range of -1 to 1.
     if constexpr (IsIntegral<T>) {
         if constexpr (NumericLimits<T>::is_signed()) {
@@ -159,7 +159,7 @@ LoaderSamples WavLoaderPlugin::get_more_samples(size_t max_samples_to_read_from_
         pcm_bits_per_sample(m_sample_format), sample_format_name(m_sample_format));
 
     auto sample_data = LOADER_TRY(ByteBuffer::create_zeroed(bytes_to_read));
-    LOADER_TRY(m_stream->read_entire_buffer(sample_data.bytes()));
+    LOADER_TRY(m_stream->read_until_filled(sample_data.bytes()));
 
     // m_loaded_samples should contain the amount of actually loaded samples
     m_loaded_samples += samples_to_read;

--- a/Userland/Libraries/LibCompress/Brotli.cpp
+++ b/Userland/Libraries/LibCompress/Brotli.cpp
@@ -573,7 +573,7 @@ size_t BrotliDecompressionStream::literal_code_index_from_context()
     return literal_code_index;
 }
 
-ErrorOr<Bytes> BrotliDecompressionStream::read(Bytes output_buffer)
+ErrorOr<Bytes> BrotliDecompressionStream::read_some(Bytes output_buffer)
 {
     size_t bytes_read = 0;
     while (bytes_read < output_buffer.size()) {
@@ -653,7 +653,7 @@ ErrorOr<Bytes> BrotliDecompressionStream::read(Bytes output_buffer)
                 Bytes temp_bytes { temp_buffer, 4096 };
                 while (skip_length > 0) {
                     Bytes temp_bytes_slice = temp_bytes.slice(0, min(4096, skip_length));
-                    auto metadata_bytes = TRY(m_input_stream.read(temp_bytes_slice));
+                    auto metadata_bytes = TRY(m_input_stream.read_some(temp_bytes_slice));
                     if (metadata_bytes.is_empty())
                         return Error::from_string_literal("eof");
                     if (metadata_bytes.last() == 0)
@@ -741,7 +741,7 @@ ErrorOr<Bytes> BrotliDecompressionStream::read(Bytes output_buffer)
             size_t number_of_fitting_bytes = min(output_buffer.size() - bytes_read, m_bytes_left);
             VERIFY(number_of_fitting_bytes > 0);
 
-            auto uncompressed_bytes = TRY(m_input_stream.read(output_buffer.slice(bytes_read, number_of_fitting_bytes)));
+            auto uncompressed_bytes = TRY(m_input_stream.read_some(output_buffer.slice(bytes_read, number_of_fitting_bytes)));
             if (uncompressed_bytes.is_empty())
                 return Error::from_string_literal("eof");
 

--- a/Userland/Libraries/LibCompress/Brotli.h
+++ b/Userland/Libraries/LibCompress/Brotli.h
@@ -104,8 +104,8 @@ public:
 public:
     BrotliDecompressionStream(Stream&);
 
-    ErrorOr<Bytes> read(Bytes output_buffer) override;
-    ErrorOr<size_t> write(ReadonlyBytes bytes) override { return m_input_stream.write(bytes); }
+    ErrorOr<Bytes> read_some(Bytes output_buffer) override;
+    ErrorOr<size_t> write_some(ReadonlyBytes bytes) override { return m_input_stream.write_some(bytes); }
     bool is_eof() const override;
     bool is_open() const override { return m_input_stream.is_open(); }
     void close() override { m_input_stream.close(); }

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -225,10 +225,8 @@ ErrorOr<Bytes> DeflateDecompressor::read_some(Bytes bytes)
             if (block_type == 0b00) {
                 m_input_stream->align_to_byte_boundary();
 
-                // FIXME: This should read the entire span.
-                LittleEndian<u16> length, negated_length;
-                TRY(m_input_stream->read_some(length.bytes()));
-                TRY(m_input_stream->read_some(negated_length.bytes()));
+                u16 length = TRY(m_input_stream->read_value<LittleEndian<u16>>());
+                u16 negated_length = TRY(m_input_stream->read_value<LittleEndian<u16>>());
 
                 if ((length ^ 0xffff) != negated_length)
                     return Error::from_string_literal("Calculated negated length does not equal stored negated length");

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -329,7 +329,7 @@ ErrorOr<ByteBuffer> DeflateDecompressor::decompress_all(ReadonlyBytes bytes)
     }
 
     auto output_buffer = TRY(ByteBuffer::create_uninitialized(output_stream.used_buffer_size()));
-    TRY(output_stream.read_entire_buffer(output_buffer));
+    TRY(output_stream.read_until_filled(output_buffer));
     return output_buffer;
 }
 
@@ -1027,7 +1027,7 @@ ErrorOr<ByteBuffer> DeflateCompressor::compress_all(ReadonlyBytes bytes, Compres
     TRY(deflate_stream->final_flush());
 
     auto buffer = TRY(ByteBuffer::create_uninitialized(output_stream->used_buffer_size()));
-    TRY(output_stream->read_entire_buffer(buffer));
+    TRY(output_stream->read_until_filled(buffer));
 
     return buffer;
 }

--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -79,8 +79,8 @@ public:
     static ErrorOr<NonnullOwnPtr<DeflateDecompressor>> construct(MaybeOwned<Stream> stream);
     ~DeflateDecompressor();
 
-    virtual ErrorOr<Bytes> read(Bytes) override;
-    virtual ErrorOr<size_t> write(ReadonlyBytes) override;
+    virtual ErrorOr<Bytes> read_some(Bytes) override;
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
     virtual bool is_eof() const override;
     virtual bool is_open() const override;
     virtual void close() override;
@@ -144,8 +144,8 @@ public:
     static ErrorOr<NonnullOwnPtr<DeflateCompressor>> construct(MaybeOwned<Stream>, CompressionLevel = CompressionLevel::GOOD);
     ~DeflateCompressor();
 
-    virtual ErrorOr<Bytes> read(Bytes) override;
-    virtual ErrorOr<size_t> write(ReadonlyBytes) override;
+    virtual ErrorOr<Bytes> read_some(Bytes) override;
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
     virtual bool is_eof() const override;
     virtual bool is_open() const override;
     virtual void close() override;

--- a/Userland/Libraries/LibCompress/Gzip.cpp
+++ b/Userland/Libraries/LibCompress/Gzip.cpp
@@ -179,7 +179,7 @@ ErrorOr<ByteBuffer> GzipDecompressor::decompress_all(ReadonlyBytes bytes)
     }
 
     auto output_buffer = TRY(ByteBuffer::create_uninitialized(output_stream.used_buffer_size()));
-    TRY(output_stream.read_entire_buffer(output_buffer));
+    TRY(output_stream.read_until_filled(output_buffer));
     return output_buffer;
 }
 
@@ -245,7 +245,7 @@ ErrorOr<ByteBuffer> GzipCompressor::compress_all(ReadonlyBytes bytes)
     TRY(gzip_stream.write_entire_buffer(bytes));
 
     auto buffer = TRY(ByteBuffer::create_uninitialized(output_stream->used_buffer_size()));
-    TRY(output_stream->read_entire_buffer(buffer.bytes()));
+    TRY(output_stream->read_until_filled(buffer.bytes()));
     return buffer;
 }
 

--- a/Userland/Libraries/LibCompress/Gzip.h
+++ b/Userland/Libraries/LibCompress/Gzip.h
@@ -45,8 +45,8 @@ public:
     GzipDecompressor(NonnullOwnPtr<Stream>);
     ~GzipDecompressor();
 
-    virtual ErrorOr<Bytes> read(Bytes) override;
-    virtual ErrorOr<size_t> write(ReadonlyBytes) override;
+    virtual ErrorOr<Bytes> read_some(Bytes) override;
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
     virtual bool is_eof() const override;
     virtual bool is_open() const override { return true; }
     virtual void close() override {};
@@ -84,8 +84,8 @@ class GzipCompressor final : public Stream {
 public:
     GzipCompressor(MaybeOwned<Stream>);
 
-    virtual ErrorOr<Bytes> read(Bytes) override;
-    virtual ErrorOr<size_t> write(ReadonlyBytes) override;
+    virtual ErrorOr<Bytes> read_some(Bytes) override;
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
     virtual bool is_eof() const override;
     virtual bool is_open() const override;
     virtual void close() override;

--- a/Userland/Libraries/LibCompress/Zlib.cpp
+++ b/Userland/Libraries/LibCompress/Zlib.cpp
@@ -168,7 +168,7 @@ ErrorOr<ByteBuffer> ZlibCompressor::compress_all(ReadonlyBytes bytes, ZlibCompre
     auto output_stream = TRY(try_make<AllocatingMemoryStream>());
     auto zlib_stream = TRY(ZlibCompressor::construct(MaybeOwned<Stream>(*output_stream), compression_level));
 
-    TRY(zlib_stream->write_entire_buffer(bytes));
+    TRY(zlib_stream->write_until_depleted(bytes));
 
     TRY(zlib_stream->finish());
 

--- a/Userland/Libraries/LibCompress/Zlib.cpp
+++ b/Userland/Libraries/LibCompress/Zlib.cpp
@@ -173,7 +173,7 @@ ErrorOr<ByteBuffer> ZlibCompressor::compress_all(ReadonlyBytes bytes, ZlibCompre
     TRY(zlib_stream->finish());
 
     auto buffer = TRY(ByteBuffer::create_uninitialized(output_stream->used_buffer_size()));
-    TRY(output_stream->read_entire_buffer(buffer.bytes()));
+    TRY(output_stream->read_until_filled(buffer.bytes()));
 
     return buffer;
 }

--- a/Userland/Libraries/LibCompress/Zlib.cpp
+++ b/Userland/Libraries/LibCompress/Zlib.cpp
@@ -113,8 +113,7 @@ ErrorOr<void> ZlibCompressor::write_header(ZlibCompressionMethod compression_met
 
     // FIXME: Support pre-defined dictionaries.
 
-    // FIXME: This should write the entire span.
-    TRY(m_output_stream->write_some(header.as_u16.bytes()));
+    TRY(m_output_stream->write_until_depleted(header.as_u16.bytes()));
 
     return {};
 }
@@ -155,8 +154,7 @@ ErrorOr<void> ZlibCompressor::finish()
         TRY(static_cast<DeflateCompressor*>(m_compressor.ptr())->final_flush());
 
     NetworkOrdered<u32> adler_sum = m_adler32_checksum.digest();
-    // FIXME: This should write the entire span.
-    TRY(m_output_stream->write_some(adler_sum.bytes()));
+    TRY(m_output_stream->write_value(adler_sum));
 
     m_finished = true;
 

--- a/Userland/Libraries/LibCompress/Zlib.h
+++ b/Userland/Libraries/LibCompress/Zlib.h
@@ -67,8 +67,8 @@ public:
     static ErrorOr<NonnullOwnPtr<ZlibCompressor>> construct(MaybeOwned<Stream>, ZlibCompressionLevel = ZlibCompressionLevel::Default);
     ~ZlibCompressor();
 
-    virtual ErrorOr<Bytes> read(Bytes) override;
-    virtual ErrorOr<size_t> write(ReadonlyBytes) override;
+    virtual ErrorOr<Bytes> read_some(Bytes) override;
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
     virtual bool is_eof() const override;
     virtual bool is_open() const override;
     virtual void close() override;

--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -179,11 +179,10 @@ ErrorOr<void> ConfigFile::sync()
     TRY(m_file->seek(0, SeekMode::SetPosition));
 
     for (auto& it : m_groups) {
-        // FIXME: This should write the entire span.
-        TRY(m_file->write_some(DeprecatedString::formatted("[{}]\n", it.key).bytes()));
+        TRY(m_file->write_until_depleted(DeprecatedString::formatted("[{}]\n", it.key).bytes()));
         for (auto& jt : it.value)
-            TRY(m_file->write_some(DeprecatedString::formatted("{}={}\n", jt.key, jt.value).bytes()));
-        TRY(m_file->write_some("\n"sv.bytes()));
+            TRY(m_file->write_until_depleted(DeprecatedString::formatted("{}={}\n", jt.key, jt.value).bytes()));
+        TRY(m_file->write_until_depleted("\n"sv.bytes()));
     }
 
     m_dirty = false;

--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -179,10 +179,11 @@ ErrorOr<void> ConfigFile::sync()
     TRY(m_file->seek(0, SeekMode::SetPosition));
 
     for (auto& it : m_groups) {
-        TRY(m_file->write(DeprecatedString::formatted("[{}]\n", it.key).bytes()));
+        // FIXME: This should write the entire span.
+        TRY(m_file->write_some(DeprecatedString::formatted("[{}]\n", it.key).bytes()));
         for (auto& jt : it.value)
-            TRY(m_file->write(DeprecatedString::formatted("{}={}\n", jt.key, jt.value).bytes()));
-        TRY(m_file->write("\n"sv.bytes()));
+            TRY(m_file->write_some(DeprecatedString::formatted("{}={}\n", jt.key, jt.value).bytes()));
+        TRY(m_file->write_some("\n"sv.bytes()));
     }
 
     m_dirty = false;

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -166,7 +166,7 @@ private:
 #ifdef AK_OS_SERENITY
         m_socket->on_ready_to_read = [this] {
             u32 length;
-            auto maybe_bytes_read = m_socket->read({ (u8*)&length, sizeof(length) });
+            auto maybe_bytes_read = m_socket->read_some({ (u8*)&length, sizeof(length) });
             if (maybe_bytes_read.is_error()) {
                 dbgln("InspectorServerConnection: Failed to read message length from inspector server connection: {}", maybe_bytes_read.error());
                 shutdown();
@@ -183,7 +183,7 @@ private:
             VERIFY(bytes_read.size() == sizeof(length));
 
             auto request_buffer = ByteBuffer::create_uninitialized(length).release_value();
-            maybe_bytes_read = m_socket->read(request_buffer.bytes());
+            maybe_bytes_read = m_socket->read_some(request_buffer.bytes());
             if (maybe_bytes_read.is_error()) {
                 dbgln("InspectorServerConnection: Failed to read message content from inspector server connection: {}", maybe_bytes_read.error());
                 shutdown();
@@ -218,10 +218,11 @@ public:
         auto bytes_to_send = serialized.bytes();
         u32 length = bytes_to_send.size();
         // FIXME: Propagate errors
-        auto sent = MUST(m_socket->write({ (u8 const*)&length, sizeof(length) }));
+        // FIXME: This should write the entire span.
+        auto sent = MUST(m_socket->write_some({ (u8 const*)&length, sizeof(length) }));
         VERIFY(sent == sizeof(length));
         while (!bytes_to_send.is_empty()) {
-            size_t bytes_sent = MUST(m_socket->write(bytes_to_send));
+            size_t bytes_sent = MUST(m_socket->write_some(bytes_to_send));
             bytes_to_send = bytes_to_send.slice(bytes_sent);
         }
     }

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -218,9 +218,7 @@ public:
         auto bytes_to_send = serialized.bytes();
         u32 length = bytes_to_send.size();
         // FIXME: Propagate errors
-        // FIXME: This should write the entire span.
-        auto sent = MUST(m_socket->write_some({ (u8 const*)&length, sizeof(length) }));
-        VERIFY(sent == sizeof(length));
+        MUST(m_socket->write_value(length));
         while (!bytes_to_send.is_empty()) {
             size_t bytes_sent = MUST(m_socket->write_some(bytes_to_send));
             bytes_to_send = bytes_to_send.slice(bytes_sent);

--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -99,7 +99,7 @@ ErrorOr<void> File::open_path(StringView filename, mode_t permissions)
     return {};
 }
 
-ErrorOr<Bytes> File::read(Bytes buffer)
+ErrorOr<Bytes> File::read_some(Bytes buffer)
 {
     if (!has_flag(m_mode, OpenMode::Read)) {
         // NOTE: POSIX says that if the fd is not open for reading, the call
@@ -121,7 +121,7 @@ ErrorOr<ByteBuffer> File::read_until_eof(size_t block_size)
     return read_until_eof_impl(block_size, potential_file_size);
 }
 
-ErrorOr<size_t> File::write(ReadonlyBytes buffer)
+ErrorOr<size_t> File::write_some(ReadonlyBytes buffer)
 {
     if (!has_flag(m_mode, OpenMode::Write)) {
         // NOTE: Same deal as Read.

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -59,9 +59,9 @@ public:
         return *this;
     }
 
-    virtual ErrorOr<Bytes> read(Bytes) override;
+    virtual ErrorOr<Bytes> read_some(Bytes) override;
     virtual ErrorOr<ByteBuffer> read_until_eof(size_t block_size = 4096) override;
-    virtual ErrorOr<size_t> write(ReadonlyBytes) override;
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
     virtual bool is_eof() const override;
     virtual bool is_open() const override;
     virtual void close() override;

--- a/Userland/Libraries/LibCore/NetworkJob.h
+++ b/Userland/Libraries/LibCore/NetworkJob.h
@@ -57,7 +57,7 @@ protected:
     void did_fail(Error);
     void did_progress(Optional<u32> total_size, u32 downloaded);
 
-    ErrorOr<size_t> do_write(ReadonlyBytes bytes) { return m_output_stream.write(bytes); }
+    ErrorOr<size_t> do_write(ReadonlyBytes bytes) { return m_output_stream.write_some(bytes); }
 
 private:
     RefPtr<NetworkResponse> m_response;

--- a/Userland/Libraries/LibCore/SOCKSProxyClient.cpp
+++ b/Userland/Libraries/LibCore/SOCKSProxyClient.cpp
@@ -171,7 +171,7 @@ ErrorOr<Reply> send_connect_request_message(Core::Socket& socket, Core::SOCKSPro
         return Error::from_string_literal("SOCKS negotiation failed: Failed to send connect request trailer");
 
     auto buffer = TRY(ByteBuffer::create_uninitialized(stream.used_buffer_size()));
-    TRY(stream.read_entire_buffer(buffer.bytes()));
+    TRY(stream.read_until_filled(buffer.bytes()));
 
     // FIXME: This should write the entire span.
     size = TRY(socket.write_some({ buffer.data(), buffer.size() }));
@@ -263,7 +263,7 @@ ErrorOr<u8> send_username_password_authentication_message(Core::Socket& socket, 
         return Error::from_string_literal("SOCKS negotiation failed: Failed to send username/password authentication message");
 
     auto buffer = TRY(ByteBuffer::create_uninitialized(stream.used_buffer_size()));
-    TRY(stream.read_entire_buffer(buffer.bytes()));
+    TRY(stream.read_until_filled(buffer.bytes()));
 
     // FIXME: This should write the entire span.
     size = TRY(socket.write_some(buffer));

--- a/Userland/Libraries/LibCore/SOCKSProxyClient.h
+++ b/Userland/Libraries/LibCore/SOCKSProxyClient.h
@@ -37,8 +37,8 @@ public:
     virtual ~SOCKSProxyClient() override;
 
     // ^Stream::Stream
-    virtual ErrorOr<Bytes> read(Bytes bytes) override { return m_socket.read(bytes); }
-    virtual ErrorOr<size_t> write(ReadonlyBytes bytes) override { return m_socket.write(bytes); }
+    virtual ErrorOr<Bytes> read_some(Bytes bytes) override { return m_socket.read_some(bytes); }
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes bytes) override { return m_socket.write_some(bytes); }
     virtual bool is_eof() const override { return m_socket.is_eof(); }
     virtual bool is_open() const override { return m_socket.is_open(); }
     virtual void close() override { m_socket.close(); }

--- a/Userland/Libraries/LibCore/Socket.h
+++ b/Userland/Libraries/LibCore/Socket.h
@@ -176,8 +176,8 @@ public:
         return *this;
     }
 
-    virtual ErrorOr<Bytes> read(Bytes buffer) override { return m_helper.read(buffer, default_flags()); }
-    virtual ErrorOr<size_t> write(ReadonlyBytes buffer) override { return m_helper.write(buffer, default_flags()); }
+    virtual ErrorOr<Bytes> read_some(Bytes buffer) override { return m_helper.read(buffer, default_flags()); }
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes buffer) override { return m_helper.write(buffer, default_flags()); }
     virtual bool is_eof() const override { return m_helper.is_eof(); }
     virtual bool is_open() const override { return m_helper.is_open(); };
     virtual void close() override { m_helper.close(); };
@@ -236,7 +236,7 @@ public:
         return *this;
     }
 
-    virtual ErrorOr<Bytes> read(Bytes buffer) override
+    virtual ErrorOr<Bytes> read_some(Bytes buffer) override
     {
         auto pending_bytes = TRY(this->pending_bytes());
         if (pending_bytes > buffer.size()) {
@@ -251,7 +251,7 @@ public:
         return m_helper.read(buffer, default_flags());
     }
 
-    virtual ErrorOr<size_t> write(ReadonlyBytes buffer) override { return m_helper.write(buffer, default_flags()); }
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes buffer) override { return m_helper.write(buffer, default_flags()); }
     virtual bool is_eof() const override { return m_helper.is_eof(); }
     virtual bool is_open() const override { return m_helper.is_open(); }
     virtual void close() override { m_helper.close(); }
@@ -310,8 +310,8 @@ public:
         return *this;
     }
 
-    virtual ErrorOr<Bytes> read(Bytes buffer) override { return m_helper.read(buffer, default_flags()); }
-    virtual ErrorOr<size_t> write(ReadonlyBytes buffer) override { return m_helper.write(buffer, default_flags()); }
+    virtual ErrorOr<Bytes> read_some(Bytes buffer) override { return m_helper.read(buffer, default_flags()); }
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes buffer) override { return m_helper.write(buffer, default_flags()); }
     virtual bool is_eof() const override { return m_helper.is_eof(); }
     virtual bool is_open() const override { return m_helper.is_open(); }
     virtual void close() override { m_helper.close(); }
@@ -398,8 +398,8 @@ public:
         return *this;
     }
 
-    virtual ErrorOr<Bytes> read(Bytes buffer) override { return m_helper.read(move(buffer)); }
-    virtual ErrorOr<size_t> write(ReadonlyBytes buffer) override { return m_helper.stream().write(buffer); }
+    virtual ErrorOr<Bytes> read_some(Bytes buffer) override { return m_helper.read(move(buffer)); }
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes buffer) override { return m_helper.stream().write_some(buffer); }
     virtual bool is_eof() const override { return m_helper.is_eof(); }
     virtual bool is_open() const override { return m_helper.stream().is_open(); }
     virtual void close() override { m_helper.stream().close(); }
@@ -483,8 +483,8 @@ public:
         return {};
     }
 
-    virtual ErrorOr<Bytes> read(Bytes buffer) override { return m_socket.read(move(buffer)); }
-    virtual ErrorOr<size_t> write(ReadonlyBytes buffer) override { return m_socket.write(buffer); }
+    virtual ErrorOr<Bytes> read_some(Bytes buffer) override { return m_socket.read(move(buffer)); }
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes buffer) override { return m_socket.write(buffer); }
     virtual bool is_eof() const override { return m_socket.is_eof(); }
     virtual bool is_open() const override { return m_socket.is_open(); }
     virtual void close() override { m_socket.close(); }

--- a/Userland/Libraries/LibCrypto/ASN1/DER.cpp
+++ b/Userland/Libraries/LibCrypto/ASN1/DER.cpp
@@ -238,7 +238,7 @@ ErrorOr<void> pretty_print(Decoder& decoder, Stream& stream, int indent)
             TRY(decoder.enter());
 
             builder.append('\n');
-            TRY(stream.write_entire_buffer(builder.string_view().bytes()));
+            TRY(stream.write_until_depleted(builder.string_view().bytes()));
 
             TRY(pretty_print(decoder, stream, indent + 2));
 
@@ -314,7 +314,7 @@ ErrorOr<void> pretty_print(Decoder& decoder, Stream& stream, int indent)
         }
 
         builder.append('\n');
-        TRY(stream.write_entire_buffer(builder.string_view().bytes()));
+        TRY(stream.write_until_depleted(builder.string_view().bytes()));
     }
 
     return {};

--- a/Userland/Libraries/LibDNS/Name.cpp
+++ b/Userland/Libraries/LibDNS/Name.cpp
@@ -81,7 +81,7 @@ ErrorOr<void> Name::write_to_stream(Stream& stream) const
     auto parts = as_string().split_view('.');
     for (auto& part : parts) {
         TRY(stream.write_value<u8>(part.length()));
-        TRY(stream.write_entire_buffer(part.bytes()));
+        TRY(stream.write_until_depleted(part.bytes()));
     }
     TRY(stream.write_value('\0'));
     return {};

--- a/Userland/Libraries/LibDNS/Packet.cpp
+++ b/Userland/Libraries/LibDNS/Packet.cpp
@@ -72,7 +72,7 @@ ErrorOr<ByteBuffer> Packet::to_byte_buffer() const
     }
 
     auto buffer = TRY(ByteBuffer::create_uninitialized(stream.used_buffer_size()));
-    TRY(stream.read_entire_buffer(buffer));
+    TRY(stream.read_until_filled(buffer));
     return buffer;
 }
 

--- a/Userland/Libraries/LibDNS/Packet.cpp
+++ b/Userland/Libraries/LibDNS/Packet.cpp
@@ -67,7 +67,7 @@ ErrorOr<ByteBuffer> Packet::to_byte_buffer() const
             TRY(stream.write_value(name));
         } else {
             TRY(stream.write_value(htons(answer.record_data().length())));
-            TRY(stream.write_entire_buffer(answer.record_data().bytes()));
+            TRY(stream.write_until_depleted(answer.record_data().bytes()));
         }
     }
 

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfTypes.h
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfTypes.h
@@ -58,11 +58,11 @@ struct [[gnu::packed]] CompilationUnitHeader {
     static ErrorOr<CompilationUnitHeader> read_from_stream(Stream& stream)
     {
         CompilationUnitHeader header;
-        TRY(stream.read_entire_buffer(Bytes { &header.common, sizeof(header.common) }));
+        TRY(stream.read_until_filled(Bytes { &header.common, sizeof(header.common) }));
         if (header.common.version <= 4)
-            TRY(stream.read_entire_buffer(Bytes { &header.v4, sizeof(header.v4) }));
+            TRY(stream.read_until_filled(Bytes { &header.v4, sizeof(header.v4) }));
         else
-            TRY(stream.read_entire_buffer(Bytes { &header.v5, sizeof(header.v5) }));
+            TRY(stream.read_until_filled(Bytes { &header.v5, sizeof(header.v5) }));
         return header;
     }
 };

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
@@ -68,12 +68,12 @@ struct [[gnu::packed]] LineProgramUnitHeader32 {
     static ErrorOr<LineProgramUnitHeader32> read_from_stream(Stream& stream)
     {
         LineProgramUnitHeader32 header;
-        TRY(stream.read_entire_buffer(Bytes { &header.common, sizeof(header.common) }));
+        TRY(stream.read_until_filled(Bytes { &header.common, sizeof(header.common) }));
         if (header.common.version <= 4)
-            TRY(stream.read_entire_buffer(Bytes { &header.v4, sizeof(header.v4) }));
+            TRY(stream.read_until_filled(Bytes { &header.v4, sizeof(header.v4) }));
         else
-            TRY(stream.read_entire_buffer(Bytes { &header.v5, sizeof(header.v5) }));
-        TRY(stream.read_entire_buffer(Bytes { &header.std_opcode_lengths, min(sizeof(header.std_opcode_lengths), (header.opcode_base() - 1) * sizeof(header.std_opcode_lengths[0])) }));
+            TRY(stream.read_until_filled(Bytes { &header.v5, sizeof(header.v5) }));
+        TRY(stream.read_until_filled(Bytes { &header.std_opcode_lengths, min(sizeof(header.std_opcode_lengths), (header.opcode_base() - 1) * sizeof(header.std_opcode_lengths[0])) }));
         return header;
     }
 };

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1593,8 +1593,9 @@ ErrorOr<void> TextEditor::write_to_file(Core::File& file)
         // A size 0 file doesn't need a data copy.
     } else {
         for (size_t i = 0; i < line_count(); ++i) {
-            TRY(file.write(line(i).to_utf8().bytes()));
-            TRY(file.write("\n"sv.bytes()));
+            // FIXME: This should write the entire span.
+            TRY(file.write_some(line(i).to_utf8().bytes()));
+            TRY(file.write_some("\n"sv.bytes()));
         }
     }
     document().set_unmodified();

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1593,9 +1593,8 @@ ErrorOr<void> TextEditor::write_to_file(Core::File& file)
         // A size 0 file doesn't need a data copy.
     } else {
         for (size_t i = 0; i < line_count(); ++i) {
-            // FIXME: This should write the entire span.
-            TRY(file.write_some(line(i).to_utf8().bytes()));
-            TRY(file.write_some("\n"sv.bytes()));
+            TRY(file.write_until_depleted(line(i).to_utf8().bytes()));
+            TRY(file.write_until_depleted("\n"sv.bytes()));
         }
     }
     document().set_unmodified();

--- a/Userland/Libraries/LibGemini/Job.cpp
+++ b/Userland/Libraries/LibGemini/Job.cpp
@@ -76,7 +76,7 @@ bool Job::can_read() const
 
 bool Job::write(ReadonlyBytes bytes)
 {
-    return !m_socket->write_entire_buffer(bytes).is_error();
+    return !m_socket->write_until_depleted(bytes).is_error();
 }
 
 void Job::flush_received_buffers()

--- a/Userland/Libraries/LibGemini/Job.cpp
+++ b/Userland/Libraries/LibGemini/Job.cpp
@@ -65,7 +65,7 @@ ErrorOr<String> Job::read_line(size_t size)
 ErrorOr<ByteBuffer> Job::receive(size_t size)
 {
     ByteBuffer buffer = TRY(ByteBuffer::create_uninitialized(size));
-    auto nread = TRY(m_socket->read(buffer)).size();
+    auto nread = TRY(m_socket->read_some(buffer)).size();
     return buffer.slice(0, nread);
 }
 

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -267,7 +267,7 @@ ErrorOr<ByteBuffer> Bitmap::serialize_to_byte_buffer() const
     }
 
     auto size = size_in_bytes();
-    TRY(stream.write_entire_buffer({ scanline(0), size }));
+    TRY(stream.write_until_depleted({ scanline(0), size }));
 
     VERIFY(TRY(stream.tell()) == TRY(stream.size()));
 

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
@@ -259,10 +259,10 @@ ErrorOr<void> BitmapFont::write_to_file(DeprecatedString const& path)
 
     auto stream = TRY(Core::File::open(path, Core::File::OpenMode::Write));
     size_t bytes_per_glyph = sizeof(u32) * m_glyph_height;
-    TRY(stream->write_entire_buffer({ &header, sizeof(header) }));
-    TRY(stream->write_entire_buffer({ m_range_mask, m_range_mask_size }));
-    TRY(stream->write_entire_buffer({ m_rows, m_glyph_count * bytes_per_glyph }));
-    TRY(stream->write_entire_buffer({ m_glyph_widths, m_glyph_count }));
+    TRY(stream->write_until_depleted({ &header, sizeof(header) }));
+    TRY(stream->write_until_depleted({ m_range_mask, m_range_mask_size }));
+    TRY(stream->write_until_depleted({ m_rows, m_glyph_count * bytes_per_glyph }));
+    TRY(stream->write_until_depleted({ m_glyph_widths, m_glyph_count }));
 
     return {};
 }

--- a/Userland/Libraries/LibGfx/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/GIFLoader.cpp
@@ -94,7 +94,7 @@ static ErrorOr<GIFFormat> decode_gif_header(Stream& stream)
     static auto valid_header_89 = "GIF89a"sv;
 
     Array<u8, 6> header;
-    TRY(stream.read_entire_buffer(header));
+    TRY(stream.read_until_filled(header));
 
     if (header.span() == valid_header_87.bytes())
         return GIFFormat::GIF87a;
@@ -424,7 +424,7 @@ static ErrorOr<void> load_gif_frame_descriptors(GIFLoadingContext& context)
                     break;
 
                 TRY(sub_block.try_resize(sub_block.size() + sub_block_length));
-                TRY(stream.read_entire_buffer(sub_block.span().slice_from_end(sub_block_length)));
+                TRY(stream.read_until_filled(sub_block.span().slice_from_end(sub_block_length)));
             }
 
             if (extension_type == 0xF9) {
@@ -501,7 +501,7 @@ static ErrorOr<void> load_gif_frame_descriptors(GIFLoadingContext& context)
                     break;
 
                 Array<u8, 256> buffer;
-                TRY(stream.read_entire_buffer(buffer.span().trim(lzw_encoded_bytes_expected)));
+                TRY(stream.read_until_filled(buffer.span().trim(lzw_encoded_bytes_expected)));
 
                 for (int i = 0; i < lzw_encoded_bytes_expected; ++i) {
                     image->lzw_encoded_bytes.append(buffer[i]);

--- a/Userland/Libraries/LibGfx/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPEGLoader.cpp
@@ -769,7 +769,7 @@ static ErrorOr<void> read_icc_profile(SeekableStream& stream, JPEGLoadingContext
         return Error::from_string_literal("Duplicate ICC chunk at sequence number");
 
     chunk_state->chunks[index] = TRY(ByteBuffer::create_zeroed(bytes_to_read));
-    TRY(stream.read_entire_buffer(chunk_state->chunks[index]));
+    TRY(stream.read_until_filled(chunk_state->chunks[index]));
 
     chunk_state->seen_number_of_icc_chunks++;
 

--- a/Userland/Libraries/LibGfx/QOILoader.cpp
+++ b/Userland/Libraries/LibGfx/QOILoader.cpp
@@ -35,7 +35,7 @@ static ErrorOr<Color> decode_qoi_op_rgb(Stream& stream, u8 first_byte, Color pix
 {
     VERIFY(first_byte == QOI_OP_RGB);
     u8 bytes[3];
-    TRY(stream.read_entire_buffer({ &bytes, array_size(bytes) }));
+    TRY(stream.read_until_filled({ &bytes, array_size(bytes) }));
 
     // The alpha value remains unchanged from the previous pixel.
     return Color { bytes[0], bytes[1], bytes[2], pixel.alpha() };
@@ -45,7 +45,7 @@ static ErrorOr<Color> decode_qoi_op_rgba(Stream& stream, u8 first_byte)
 {
     VERIFY(first_byte == QOI_OP_RGBA);
     u8 bytes[4];
-    TRY(stream.read_entire_buffer({ &bytes, array_size(bytes) }));
+    TRY(stream.read_until_filled({ &bytes, array_size(bytes) }));
     return Color { bytes[0], bytes[1], bytes[2], bytes[3] };
 }
 
@@ -110,7 +110,7 @@ static ErrorOr<u8> decode_qoi_op_run(Stream&, u8 first_byte)
 static ErrorOr<void> decode_qoi_end_marker(Stream& stream)
 {
     u8 bytes[array_size(END_MARKER)];
-    TRY(stream.read_entire_buffer({ &bytes, array_size(bytes) }));
+    TRY(stream.read_until_filled({ &bytes, array_size(bytes) }));
     if (!stream.is_eof())
         return Error::from_string_literal("Invalid QOI image: expected end of stream but more bytes are available");
     if (memcmp(&END_MARKER, &bytes, array_size(bytes)) != 0)

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -184,7 +184,7 @@ ErrorOr<ByteBuffer> Job::receive(size_t size)
     auto buffer = TRY(ByteBuffer::create_uninitialized(size));
     size_t nread;
     do {
-        auto result = m_socket->read(buffer);
+        auto result = m_socket->read_some(buffer);
         if (result.is_error() && result.error().is_errno() && result.error().code() == EINTR)
             continue;
         nread = TRY(result).size();

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -202,7 +202,7 @@ void Job::on_socket_connected()
         dbgln("{}", DeprecatedString::copy(raw_request));
     }
 
-    bool success = !m_socket->write_entire_buffer(raw_request).is_error();
+    bool success = !m_socket->write_until_depleted(raw_request).is_error();
     if (!success)
         deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
 

--- a/Userland/Libraries/LibIMAP/Client.cpp
+++ b/Userland/Libraries/LibIMAP/Client.cpp
@@ -60,8 +60,7 @@ ErrorOr<void> Client::on_ready_to_receive()
 
     auto pending_bytes = TRY(m_socket->pending_bytes());
     auto receive_buffer = TRY(m_buffer.get_bytes_for_writing(pending_bytes));
-    // FIXME: This should read the entire span.
-    TRY(m_socket->read_some(receive_buffer));
+    TRY(m_socket->read_until_filled(receive_buffer));
 
     // Once we get server hello we can start sending.
     if (m_connect_pending) {
@@ -146,9 +145,8 @@ static ReadonlyBytes command_byte_buffer(CommandType command)
 
 ErrorOr<void> Client::send_raw(StringView data)
 {
-    // FIXME: This should write the entire span.
-    TRY(m_socket->write_some(data.bytes()));
-    TRY(m_socket->write_some("\r\n"sv.bytes()));
+    TRY(m_socket->write_until_depleted(data.bytes()));
+    TRY(m_socket->write_until_depleted("\r\n"sv.bytes()));
 
     return {};
 }

--- a/Userland/Libraries/LibIMAP/Client.cpp
+++ b/Userland/Libraries/LibIMAP/Client.cpp
@@ -60,7 +60,8 @@ ErrorOr<void> Client::on_ready_to_receive()
 
     auto pending_bytes = TRY(m_socket->pending_bytes());
     auto receive_buffer = TRY(m_buffer.get_bytes_for_writing(pending_bytes));
-    TRY(m_socket->read(receive_buffer));
+    // FIXME: This should read the entire span.
+    TRY(m_socket->read_some(receive_buffer));
 
     // Once we get server hello we can start sending.
     if (m_connect_pending) {
@@ -145,8 +146,9 @@ static ReadonlyBytes command_byte_buffer(CommandType command)
 
 ErrorOr<void> Client::send_raw(StringView data)
 {
-    TRY(m_socket->write(data.bytes()));
-    TRY(m_socket->write("\r\n"sv.bytes()));
+    // FIXME: This should write the entire span.
+    TRY(m_socket->write_some(data.bytes()));
+    TRY(m_socket->write_some("\r\n"sv.bytes()));
 
     return {};
 }

--- a/Userland/Libraries/LibIPC/Connection.cpp
+++ b/Userland/Libraries/LibIPC/Connection.cpp
@@ -74,7 +74,7 @@ ErrorOr<void> ConnectionBase::post_message(MessageBuffer buffer)
     int writes_done = 0;
     size_t initial_size = bytes_to_write.size();
     while (!bytes_to_write.is_empty()) {
-        auto maybe_nwritten = m_socket->write(bytes_to_write);
+        auto maybe_nwritten = m_socket->write_some(bytes_to_write);
         writes_done++;
         if (maybe_nwritten.is_error()) {
             auto error = maybe_nwritten.release_error();

--- a/Userland/Libraries/LibIPC/Decoder.h
+++ b/Userland/Libraries/LibIPC/Decoder.h
@@ -52,7 +52,7 @@ public:
 
     ErrorOr<void> decode_into(Bytes bytes)
     {
-        TRY(m_stream.read_entire_buffer(bytes));
+        TRY(m_stream.read_until_filled(bytes));
         return {};
     }
 

--- a/Userland/Libraries/LibJS/Console.cpp
+++ b/Userland/Libraries/LibJS/Console.cpp
@@ -680,8 +680,7 @@ ThrowCompletionOr<String> ConsoleClient::generically_format_values(MarkedVector<
     bool first = true;
     for (auto const& value : values) {
         if (!first)
-            // FIXME: This should write the entire span.
-            TRY_OR_THROW_OOM(vm, stream.write_some(" "sv.bytes()));
+            TRY_OR_THROW_OOM(vm, stream.write_until_depleted(" "sv.bytes()));
         TRY_OR_THROW_OOM(vm, JS::print(value, ctx));
         first = false;
     }

--- a/Userland/Libraries/LibJS/Console.cpp
+++ b/Userland/Libraries/LibJS/Console.cpp
@@ -680,7 +680,8 @@ ThrowCompletionOr<String> ConsoleClient::generically_format_values(MarkedVector<
     bool first = true;
     for (auto const& value : values) {
         if (!first)
-            TRY_OR_THROW_OOM(vm, stream.write(" "sv.bytes()));
+            // FIXME: This should write the entire span.
+            TRY_OR_THROW_OOM(vm, stream.write_some(" "sv.bytes()));
         TRY_OR_THROW_OOM(vm, JS::print(value, ctx));
         first = false;
     }

--- a/Userland/Libraries/LibJS/Print.cpp
+++ b/Userland/Libraries/LibJS/Print.cpp
@@ -148,7 +148,7 @@ ErrorOr<void> js_out(JS::PrintContext& print_context, CheckedFormatString<Args..
 
     auto bytes = formatted.bytes();
     while (!bytes.is_empty())
-        bytes = bytes.slice(TRY(print_context.stream.write(bytes)));
+        bytes = bytes.slice(TRY(print_context.stream.write_some(bytes)));
 
     return {};
 }

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -1346,7 +1346,7 @@ ErrorOr<void> Editor::refresh_display()
                 return;
 
             auto buffer = ByteBuffer::create_uninitialized(output_stream.used_buffer_size()).release_value_but_fixme_should_propagate_errors();
-            output_stream.read_entire_buffer(buffer).release_value_but_fixme_should_propagate_errors();
+            output_stream.read_until_filled(buffer).release_value_but_fixme_should_propagate_errors();
             fwrite(buffer.data(), sizeof(char), buffer.size(), stderr);
         }
     };

--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -534,7 +534,7 @@ void Editor::edit_in_external_editor()
         builder.append(Utf32View { m_buffer.data(), m_buffer.size() });
         auto bytes = builder.string_view().bytes();
         while (!bytes.is_empty()) {
-            auto nwritten = stream->write(bytes).release_value_but_fixme_should_propagate_errors();
+            auto nwritten = stream->write_some(bytes).release_value_but_fixme_should_propagate_errors();
             bytes = bytes.slice(nwritten);
         }
         lseek(fd, 0, SEEK_SET);

--- a/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -51,8 +51,7 @@ ErrorOr<void> XtermSuggestionDisplay::display(SuggestionManager const& manager)
         // the suggestion list to fit in the prompt line.
         auto start = max_line_count - m_prompt_lines_at_suggestion_initiation;
         for (size_t i = start; i < max_line_count; ++i)
-            // FIXME: This should write the entire span.
-            TRY(stderr_stream->write_some("\n"sv.bytes()));
+            TRY(stderr_stream->write_until_depleted("\n"sv.bytes()));
         lines_used += max_line_count;
         longest_suggestion_length = 0;
     }
@@ -100,8 +99,7 @@ ErrorOr<void> XtermSuggestionDisplay::display(SuggestionManager const& manager)
         if (next_column > m_num_columns) {
             auto lines = (suggestion.text_view.length() + m_num_columns - 1) / m_num_columns;
             lines_used += lines;
-            // FIXME: This should write the entire span.
-            TRY(stderr_stream->write_some("\n"sv.bytes()));
+            TRY(stderr_stream->write_until_depleted("\n"sv.bytes()));
             num_printed = 0;
         }
 
@@ -117,13 +115,11 @@ ErrorOr<void> XtermSuggestionDisplay::display(SuggestionManager const& manager)
 
         if (spans_entire_line) {
             num_printed += m_num_columns;
-            // FIXME: This should write the entire span.
-            TRY(stderr_stream->write_some(suggestion.text_string.bytes()));
-            TRY(stderr_stream->write_some(suggestion.display_trivia_string.bytes()));
+            TRY(stderr_stream->write_until_depleted(suggestion.text_string.bytes()));
+            TRY(stderr_stream->write_until_depleted(suggestion.display_trivia_string.bytes()));
         } else {
             auto field = DeprecatedString::formatted("{: <{}}  {}", suggestion.text_string, longest_suggestion_byte_length_without_trivia, suggestion.display_trivia_string);
-            // FIXME: This should write the entire span.
-            TRY(stderr_stream->write_some(DeprecatedString::formatted("{: <{}}", field, longest_suggestion_byte_length + 2).bytes()));
+            TRY(stderr_stream->write_until_depleted(DeprecatedString::formatted("{: <{}}", field, longest_suggestion_byte_length + 2).bytes()));
             num_printed += longest_suggestion_length + 2;
         }
 
@@ -154,8 +150,7 @@ ErrorOr<void> XtermSuggestionDisplay::display(SuggestionManager const& manager)
 
         TRY(VT::move_absolute(m_origin_row + lines_used, m_num_columns - string.length() - 1, *stderr_stream));
         TRY(VT::apply_style({ Style::Background(Style::XtermColor::Green) }, *stderr_stream));
-        // FIXME: This should write the entire span.
-        TRY(stderr_stream->write_some(string.bytes()));
+        TRY(stderr_stream->write_until_depleted(string.bytes()));
         TRY(VT::apply_style(Style::reset_style(), *stderr_stream));
     }
 

--- a/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -51,7 +51,8 @@ ErrorOr<void> XtermSuggestionDisplay::display(SuggestionManager const& manager)
         // the suggestion list to fit in the prompt line.
         auto start = max_line_count - m_prompt_lines_at_suggestion_initiation;
         for (size_t i = start; i < max_line_count; ++i)
-            TRY(stderr_stream->write("\n"sv.bytes()));
+            // FIXME: This should write the entire span.
+            TRY(stderr_stream->write_some("\n"sv.bytes()));
         lines_used += max_line_count;
         longest_suggestion_length = 0;
     }
@@ -99,7 +100,8 @@ ErrorOr<void> XtermSuggestionDisplay::display(SuggestionManager const& manager)
         if (next_column > m_num_columns) {
             auto lines = (suggestion.text_view.length() + m_num_columns - 1) / m_num_columns;
             lines_used += lines;
-            TRY(stderr_stream->write("\n"sv.bytes()));
+            // FIXME: This should write the entire span.
+            TRY(stderr_stream->write_some("\n"sv.bytes()));
             num_printed = 0;
         }
 
@@ -115,11 +117,13 @@ ErrorOr<void> XtermSuggestionDisplay::display(SuggestionManager const& manager)
 
         if (spans_entire_line) {
             num_printed += m_num_columns;
-            TRY(stderr_stream->write(suggestion.text_string.bytes()));
-            TRY(stderr_stream->write(suggestion.display_trivia_string.bytes()));
+            // FIXME: This should write the entire span.
+            TRY(stderr_stream->write_some(suggestion.text_string.bytes()));
+            TRY(stderr_stream->write_some(suggestion.display_trivia_string.bytes()));
         } else {
             auto field = DeprecatedString::formatted("{: <{}}  {}", suggestion.text_string, longest_suggestion_byte_length_without_trivia, suggestion.display_trivia_string);
-            TRY(stderr_stream->write(DeprecatedString::formatted("{: <{}}", field, longest_suggestion_byte_length + 2).bytes()));
+            // FIXME: This should write the entire span.
+            TRY(stderr_stream->write_some(DeprecatedString::formatted("{: <{}}", field, longest_suggestion_byte_length + 2).bytes()));
             num_printed += longest_suggestion_length + 2;
         }
 
@@ -150,7 +154,8 @@ ErrorOr<void> XtermSuggestionDisplay::display(SuggestionManager const& manager)
 
         TRY(VT::move_absolute(m_origin_row + lines_used, m_num_columns - string.length() - 1, *stderr_stream));
         TRY(VT::apply_style({ Style::Background(Style::XtermColor::Green) }, *stderr_stream));
-        TRY(stderr_stream->write(string.bytes()));
+        // FIXME: This should write the entire span.
+        TRY(stderr_stream->write_some(string.bytes()));
         TRY(VT::apply_style(Style::reset_style(), *stderr_stream));
     }
 

--- a/Userland/Libraries/LibProtocol/Request.cpp
+++ b/Userland/Libraries/LibProtocol/Request.cpp
@@ -90,7 +90,7 @@ void Request::set_should_buffer_all_input(bool value)
 
     on_finish = [this](auto success, u32 total_size) {
         auto output_buffer = ByteBuffer::create_uninitialized(m_internal_buffered_data->payload_stream.used_buffer_size()).release_value_but_fixme_should_propagate_errors();
-        m_internal_buffered_data->payload_stream.read_entire_buffer(output_buffer).release_value_but_fixme_should_propagate_errors();
+        m_internal_buffered_data->payload_stream.read_until_filled(output_buffer).release_value_but_fixme_should_propagate_errors();
         on_buffered_request_finish(
             success,
             total_size,

--- a/Userland/Libraries/LibProtocol/Request.cpp
+++ b/Userland/Libraries/LibProtocol/Request.cpp
@@ -45,7 +45,7 @@ void Request::stream_into(Stream& stream)
         constexpr size_t buffer_size = 256 * KiB;
         static char buf[buffer_size];
         do {
-            auto result = m_internal_stream_data->read_stream->read({ buf, buffer_size });
+            auto result = m_internal_stream_data->read_stream->read_some({ buf, buffer_size });
             if (result.is_error() && (!result.error().is_errno() || (result.error().is_errno() && result.error().code() != EINTR)))
                 break;
             if (result.is_error())

--- a/Userland/Libraries/LibProtocol/Request.cpp
+++ b/Userland/Libraries/LibProtocol/Request.cpp
@@ -54,7 +54,7 @@ void Request::stream_into(Stream& stream)
             if (read_bytes.is_empty())
                 break;
             // FIXME: What do we do if this fails?
-            stream.write_entire_buffer(read_bytes).release_value_but_fixme_should_propagate_errors();
+            stream.write_until_depleted(read_bytes).release_value_but_fixme_should_propagate_errors();
             break;
         } while (true);
 

--- a/Userland/Libraries/LibSQL/Heap.cpp
+++ b/Userland/Libraries/LibSQL/Heap.cpp
@@ -91,11 +91,9 @@ ErrorOr<ByteBuffer> Heap::read_block(u32 block)
     TRY(seek_block(block));
 
     auto buffer = TRY(ByteBuffer::create_uninitialized(BLOCKSIZE));
-    // FIXME: This should read the entire span.
-    auto bytes = TRY(m_file->read_some(buffer));
+    TRY(m_file->read_until_filled(buffer));
 
-    dbgln_if(SQL_DEBUG, "{:hex-dump}", bytes.trim(8));
-    TRY(buffer.try_resize(bytes.size()));
+    dbgln_if(SQL_DEBUG, "{:hex-dump}", buffer.bytes().trim(8));
 
     return buffer;
 }
@@ -124,8 +122,7 @@ ErrorOr<void> Heap::write_block(u32 block, ByteBuffer& buffer)
     }
 
     dbgln_if(SQL_DEBUG, "{:hex-dump}", buffer.bytes().trim(8));
-    // FIXME: This should write the entire span.
-    TRY(m_file->write_some(buffer));
+    TRY(m_file->write_until_depleted(buffer));
 
     if (block == m_end_of_file)
         m_end_of_file++;

--- a/Userland/Libraries/LibSQL/Heap.cpp
+++ b/Userland/Libraries/LibSQL/Heap.cpp
@@ -91,7 +91,8 @@ ErrorOr<ByteBuffer> Heap::read_block(u32 block)
     TRY(seek_block(block));
 
     auto buffer = TRY(ByteBuffer::create_uninitialized(BLOCKSIZE));
-    auto bytes = TRY(m_file->read(buffer));
+    // FIXME: This should read the entire span.
+    auto bytes = TRY(m_file->read_some(buffer));
 
     dbgln_if(SQL_DEBUG, "{:hex-dump}", bytes.trim(8));
     TRY(buffer.try_resize(bytes.size()));
@@ -123,7 +124,8 @@ ErrorOr<void> Heap::write_block(u32 block, ByteBuffer& buffer)
     }
 
     dbgln_if(SQL_DEBUG, "{:hex-dump}", buffer.bytes().trim(8));
-    TRY(m_file->write(buffer));
+    // FIXME: This should write the entire span.
+    TRY(m_file->write_some(buffer));
 
     if (block == m_end_of_file)
         m_end_of_file++;

--- a/Userland/Libraries/LibSQL/SQLClient.cpp
+++ b/Userland/Libraries/LibSQL/SQLClient.cpp
@@ -67,8 +67,7 @@ static ErrorOr<void> launch_server(DeprecatedString const& socket_path, Deprecat
 
         if (server_pid != 0) {
             auto server_pid_file = TRY(Core::File::open(pid_path, Core::File::OpenMode::Write));
-            // FIXME: This should write the entire span.
-            TRY(server_pid_file->write_some(DeprecatedString::number(server_pid).bytes()));
+            TRY(server_pid_file->write_until_depleted(DeprecatedString::number(server_pid).bytes()));
 
             TRY(Core::System::kill(getpid(), SIGTERM));
         }

--- a/Userland/Libraries/LibSQL/SQLClient.cpp
+++ b/Userland/Libraries/LibSQL/SQLClient.cpp
@@ -67,7 +67,8 @@ static ErrorOr<void> launch_server(DeprecatedString const& socket_path, Deprecat
 
         if (server_pid != 0) {
             auto server_pid_file = TRY(Core::File::open(pid_path, Core::File::OpenMode::Write));
-            TRY(server_pid_file->write(DeprecatedString::number(server_pid).bytes()));
+            // FIXME: This should write the entire span.
+            TRY(server_pid_file->write_some(DeprecatedString::number(server_pid).bytes()));
 
             TRY(Core::System::kill(getpid(), SIGTERM));
         }

--- a/Userland/Libraries/LibTLS/HandshakeClient.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeClient.cpp
@@ -141,11 +141,11 @@ bool TLSv12::compute_master_secret_from_pre_master_secret(size_t length)
 
     if constexpr (TLS_SSL_KEYLOG_DEBUG) {
         auto file = MUST(Core::File::open("/home/anon/ssl_keylog"sv, Core::File::OpenMode::Append | Core::File::OpenMode::Write));
-        MUST(file->write_entire_buffer("CLIENT_RANDOM "sv.bytes()));
-        MUST(file->write_entire_buffer(encode_hex({ m_context.local_random, 32 }).bytes()));
-        MUST(file->write_entire_buffer(" "sv.bytes()));
-        MUST(file->write_entire_buffer(encode_hex(m_context.master_key).bytes()));
-        MUST(file->write_entire_buffer("\n"sv.bytes()));
+        MUST(file->write_until_depleted("CLIENT_RANDOM "sv.bytes()));
+        MUST(file->write_until_depleted(encode_hex({ m_context.local_random, 32 }).bytes()));
+        MUST(file->write_until_depleted(" "sv.bytes()));
+        MUST(file->write_until_depleted(encode_hex(m_context.master_key).bytes()));
+        MUST(file->write_until_depleted("\n"sv.bytes()));
     }
 
     expand_key();

--- a/Userland/Libraries/LibTLS/Record.cpp
+++ b/Userland/Libraries/LibTLS/Record.cpp
@@ -146,9 +146,9 @@ void TLSv12::update_packet(ByteBuffer& packet)
                         u64 seq_no = AK::convert_between_host_and_network_endian(m_context.local_sequence_number);
                         u16 len = AK::convert_between_host_and_network_endian((u16)(packet.size() - header_size));
 
-                        MUST(aad_stream.write_value(seq_no));                             // sequence number
-                        MUST(aad_stream.write_entire_buffer(packet.bytes().slice(0, 3))); // content-type + version
-                        MUST(aad_stream.write_value(len));                                // length
+                        MUST(aad_stream.write_value(seq_no));                              // sequence number
+                        MUST(aad_stream.write_until_depleted(packet.bytes().slice(0, 3))); // content-type + version
+                        MUST(aad_stream.write_value(len));                                 // length
                         VERIFY(MUST(aad_stream.tell()) == MUST(aad_stream.size()));
 
                         // AEAD IV (12)
@@ -387,9 +387,9 @@ ssize_t TLSv12::handle_message(ReadonlyBytes buffer)
                 u64 seq_no = AK::convert_between_host_and_network_endian(m_context.remote_sequence_number);
                 u16 len = AK::convert_between_host_and_network_endian((u16)packet_length);
 
-                MUST(aad_stream.write_value(seq_no));                                   // sequence number
-                MUST(aad_stream.write_entire_buffer(buffer.slice(0, header_size - 2))); // content-type + version
-                MUST(aad_stream.write_value(len));                                      // length
+                MUST(aad_stream.write_value(seq_no));                                    // sequence number
+                MUST(aad_stream.write_until_depleted(buffer.slice(0, header_size - 2))); // content-type + version
+                MUST(aad_stream.write_value(len));                                       // length
                 VERIFY(MUST(aad_stream.tell()) == MUST(aad_stream.size()));
 
                 auto nonce = payload.slice(0, iv_length());

--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -18,7 +18,7 @@ constexpr static size_t MaximumApplicationDataChunkSize = 16 * KiB;
 
 namespace TLS {
 
-ErrorOr<Bytes> TLSv12::read(Bytes bytes)
+ErrorOr<Bytes> TLSv12::read_some(Bytes bytes)
 {
     m_eof = false;
     auto size_to_read = min(bytes.size(), m_context.application_buffer.size());
@@ -53,7 +53,7 @@ DeprecatedString TLSv12::read_line(size_t max_size)
     return line;
 }
 
-ErrorOr<size_t> TLSv12::write(ReadonlyBytes bytes)
+ErrorOr<size_t> TLSv12::write_some(ReadonlyBytes bytes)
 {
     if (m_context.connection_status != ConnectionStatus::Established) {
         dbgln_if(TLS_DEBUG, "write request while not connected");
@@ -190,7 +190,7 @@ ErrorOr<void> TLSv12::read_from_socket()
     Bytes read_bytes {};
     auto& stream = underlying_stream();
     do {
-        auto result = stream.read(bytes);
+        auto result = stream.read_some(bytes);
         if (result.is_error()) {
             if (result.error().is_errno() && result.error().code() != EINTR) {
                 if (result.error().code() != EAGAIN)
@@ -291,7 +291,7 @@ ErrorOr<bool> TLSv12::flush()
     Optional<AK::Error> error;
     size_t written;
     do {
-        auto result = stream.write(out_bytes);
+        auto result = stream.write_some(out_bytes);
         if (result.is_error() && result.error().code() != EINTR && result.error().code() != EAGAIN) {
             error = result.release_error();
             dbgln("TLS Socket write error: {}", *error);

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -360,12 +360,12 @@ public:
     /// The amount of bytes read can be smaller than the size of the buffer.
     /// Returns either the bytes that were read, or an errno in the case of
     /// failure.
-    virtual ErrorOr<Bytes> read(Bytes) override;
+    virtual ErrorOr<Bytes> read_some(Bytes) override;
 
     /// Tries to write the entire contents of the buffer. It is possible for
     /// less than the full buffer to be written. Returns either the amount of
     /// bytes written into the stream, or an errno in the case of failure.
-    virtual ErrorOr<size_t> write(ReadonlyBytes) override;
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
 
     virtual bool is_eof() const override { return m_context.application_buffer.is_empty() && (m_context.connection_finished || underlying_stream().is_eof()); }
 

--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -220,7 +220,8 @@ inline ByteBuffer load_entire_file(StringView path)
         auto file = TRY(Core::File::open(path, Core::File::OpenMode::Read));
         auto file_size = TRY(file->size());
         auto content = TRY(ByteBuffer::create_uninitialized(file_size));
-        TRY(file->read(content.bytes()));
+        // FIXME: This should read the entire span.
+        TRY(file->read_some(content.bytes()));
         return content;
     };
 

--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -220,8 +220,7 @@ inline ByteBuffer load_entire_file(StringView path)
         auto file = TRY(Core::File::open(path, Core::File::OpenMode::Read));
         auto file_size = TRY(file->size());
         auto content = TRY(ByteBuffer::create_uninitialized(file_size));
-        // FIXME: This should read the entire span.
-        TRY(file->read_some(content.bytes()));
+        TRY(file->read_until_filled(content.bytes()));
         return content;
     };
 

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -210,7 +210,7 @@ struct ConvertToRaw<float> {
         LittleEndian<u32> res;
         ReadonlyBytes bytes { &value, sizeof(float) };
         FixedMemoryStream stream { bytes };
-        stream.read_entire_buffer(res.bytes()).release_value_but_fixme_should_propagate_errors();
+        stream.read_until_filled(res.bytes()).release_value_but_fixme_should_propagate_errors();
         return static_cast<u32>(res);
     }
 };
@@ -222,7 +222,7 @@ struct ConvertToRaw<double> {
         LittleEndian<u64> res;
         ReadonlyBytes bytes { &value, sizeof(double) };
         FixedMemoryStream stream { bytes };
-        stream.read_entire_buffer(res.bytes()).release_value_but_fixme_should_propagate_errors();
+        stream.read_until_filled(res.bytes()).release_value_but_fixme_should_propagate_errors();
         return static_cast<u64>(res);
     }
 };
@@ -260,7 +260,7 @@ T BytecodeInterpreter::read_value(ReadonlyBytes data)
 {
     LittleEndian<T> value;
     FixedMemoryStream stream { data };
-    auto maybe_error = stream.read_entire_buffer(value.bytes());
+    auto maybe_error = stream.read_until_filled(value.bytes());
     if (maybe_error.is_error()) {
         dbgln("Read from {} failed", data.data());
         m_trap = Trap { "Read from memory failed" };
@@ -273,7 +273,7 @@ float BytecodeInterpreter::read_value<float>(ReadonlyBytes data)
 {
     LittleEndian<u32> raw_value;
     FixedMemoryStream stream { data };
-    auto maybe_error = stream.read_entire_buffer(raw_value.bytes());
+    auto maybe_error = stream.read_until_filled(raw_value.bytes());
     if (maybe_error.is_error())
         m_trap = Trap { "Read from memory failed" };
     return bit_cast<float>(static_cast<u32>(raw_value));
@@ -284,7 +284,7 @@ double BytecodeInterpreter::read_value<double>(ReadonlyBytes data)
 {
     LittleEndian<u64> raw_value;
     FixedMemoryStream stream { data };
-    auto maybe_error = stream.read_entire_buffer(raw_value.bytes());
+    auto maybe_error = stream.read_until_filled(raw_value.bytes());
     if (maybe_error.is_error())
         m_trap = Trap { "Read from memory failed" };
     return bit_cast<double>(static_cast<u64>(raw_value));

--- a/Userland/Libraries/LibWasm/AbstractMachine/Configuration.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Configuration.cpp
@@ -89,7 +89,7 @@ void Configuration::dump_stack()
         AllocatingMemoryStream memory_stream;
         Printer { memory_stream }.print(vs...);
         auto buffer = ByteBuffer::create_uninitialized(memory_stream.used_buffer_size()).release_value_but_fixme_should_propagate_errors();
-        memory_stream.read_entire_buffer(buffer).release_value_but_fixme_should_propagate_errors();
+        memory_stream.read_until_filled(buffer).release_value_but_fixme_should_propagate_errors();
         dbgln(format.view(), StringView(buffer).trim_whitespace());
     };
     for (auto const& entry : stack().entries()) {

--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -795,7 +795,7 @@ ParseResult<CustomSection> CustomSection::parse(Stream& stream)
 
     while (!stream.is_eof()) {
         char buf[16];
-        auto span_or_error = stream.read({ buf, 16 });
+        auto span_or_error = stream.read_some({ buf, 16 });
         if (span_or_error.is_error())
             break;
         auto size = span_or_error.release_value().size();

--- a/Userland/Libraries/LibWasm/Printer/Printer.cpp
+++ b/Userland/Libraries/LibWasm/Printer/Printer.cpp
@@ -34,7 +34,7 @@ Optional<OpCode> instruction_from_name(StringView name)
 void Printer::print_indent()
 {
     for (size_t i = 0; i < m_indent; ++i)
-        m_stream.write_entire_buffer("  "sv.bytes()).release_value_but_fixme_should_propagate_errors();
+        m_stream.write_until_depleted("  "sv.bytes()).release_value_but_fixme_should_propagate_errors();
 }
 
 void Printer::print(Wasm::BlockType const& type)

--- a/Userland/Libraries/LibWasm/Printer/Printer.h
+++ b/Userland/Libraries/LibWasm/Printer/Printer.h
@@ -68,7 +68,7 @@ private:
     {
         StringBuilder builder;
         builder.appendff(fmt.view(), forward<Args>(args)...);
-        m_stream.write_entire_buffer(builder.string_view().bytes()).release_value_but_fixme_should_propagate_errors();
+        m_stream.write_until_depleted(builder.string_view().bytes()).release_value_but_fixme_should_propagate_errors();
     }
 
     Stream& m_stream;

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -81,7 +81,7 @@ public:
     void unread(ReadonlyBytes data) { m_buffer.append(data.data(), data.size()); }
 
 private:
-    virtual ErrorOr<Bytes> read(Bytes bytes) override
+    virtual ErrorOr<Bytes> read_some(Bytes bytes) override
     {
         auto original_bytes = bytes;
 
@@ -95,7 +95,7 @@ private:
             bytes_read_from_buffer = read_size;
         }
 
-        return original_bytes.trim(TRY(m_stream.read(bytes)).size() + bytes_read_from_buffer);
+        return original_bytes.trim(TRY(m_stream.read_some(bytes)).size() + bytes_read_from_buffer);
     }
 
     virtual bool is_eof() const override
@@ -116,7 +116,7 @@ private:
         return m_stream.discard(count - bytes_discarded_from_buffer);
     }
 
-    virtual ErrorOr<size_t> write(ReadonlyBytes) override
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes) override
     {
         return Error::from_errno(EBADF);
     }
@@ -144,10 +144,10 @@ public:
     }
 
 private:
-    ErrorOr<Bytes> read(Bytes bytes) override
+    ErrorOr<Bytes> read_some(Bytes bytes) override
     {
         auto to_read = min(m_bytes_left, bytes.size());
-        auto read_bytes = TRY(m_stream.read(bytes.slice(0, to_read)));
+        auto read_bytes = TRY(m_stream.read_some(bytes.slice(0, to_read)));
         m_bytes_left -= read_bytes.size();
         return read_bytes;
     }
@@ -165,7 +165,7 @@ private:
         return m_stream.discard(count);
     }
 
-    virtual ErrorOr<size_t> write(ReadonlyBytes) override
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes) override
     {
         return Error::from_errno(EBADF);
     }

--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -213,7 +213,7 @@ ErrorOr<void, Client::WrappedError> Client::on_ready_to_read()
         if (!TRY(m_socket->can_read_without_blocking()))
             break;
 
-        auto data = TRY(m_socket->read(buffer));
+        auto data = TRY(m_socket->read_some(buffer));
         TRY(builder.try_append(StringView { data }));
 
         if (m_socket->is_eof())
@@ -279,10 +279,11 @@ ErrorOr<void, Client::WrappedError> Client::send_success_response(JsonValue resu
     builder.append("\r\n"sv);
 
     auto builder_contents = TRY(builder.to_byte_buffer());
-    TRY(m_socket->write(builder_contents));
+    // FIXME: This should write the entire span.
+    TRY(m_socket->write_some(builder_contents));
 
     while (!content.is_empty()) {
-        auto bytes_sent = TRY(m_socket->write(content.bytes()));
+        auto bytes_sent = TRY(m_socket->write_some(content.bytes()));
         content = content.substring_view(bytes_sent);
     }
 
@@ -319,8 +320,9 @@ ErrorOr<void, Client::WrappedError> Client::send_error_response(Error const& err
     header_builder.appendff("Content-Length: {}\r\n", content_builder.length());
     header_builder.append("\r\n"sv);
 
-    TRY(m_socket->write(TRY(header_builder.to_byte_buffer())));
-    TRY(m_socket->write(TRY(content_builder.to_byte_buffer())));
+    // FIXME: This should write the entire span.
+    TRY(m_socket->write_some(TRY(header_builder.to_byte_buffer())));
+    TRY(m_socket->write_some(TRY(content_builder.to_byte_buffer())));
 
     log_response(error.http_status);
     return {};

--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -279,8 +279,7 @@ ErrorOr<void, Client::WrappedError> Client::send_success_response(JsonValue resu
     builder.append("\r\n"sv);
 
     auto builder_contents = TRY(builder.to_byte_buffer());
-    // FIXME: This should write the entire span.
-    TRY(m_socket->write_some(builder_contents));
+    TRY(m_socket->write_until_depleted(builder_contents));
 
     while (!content.is_empty()) {
         auto bytes_sent = TRY(m_socket->write_some(content.bytes()));
@@ -320,9 +319,8 @@ ErrorOr<void, Client::WrappedError> Client::send_error_response(Error const& err
     header_builder.appendff("Content-Length: {}\r\n", content_builder.length());
     header_builder.append("\r\n"sv);
 
-    // FIXME: This should write the entire span.
-    TRY(m_socket->write_some(TRY(header_builder.to_byte_buffer())));
-    TRY(m_socket->write_some(TRY(content_builder.to_byte_buffer())));
+    TRY(m_socket->write_until_depleted(TRY(header_builder.to_byte_buffer())));
+    TRY(m_socket->write_until_depleted(TRY(content_builder.to_byte_buffer())));
 
     log_response(error.http_status);
     return {};

--- a/Userland/Libraries/LibWebSocket/Impl/WebSocketImplSerenity.cpp
+++ b/Userland/Libraries/LibWebSocket/Impl/WebSocketImplSerenity.cpp
@@ -22,7 +22,7 @@ bool WebSocketImplSerenity::can_read_line()
 
 bool WebSocketImplSerenity::send(ReadonlyBytes bytes)
 {
-    return !m_socket->write_entire_buffer(bytes).is_error();
+    return !m_socket->write_until_depleted(bytes).is_error();
 }
 
 bool WebSocketImplSerenity::eof()

--- a/Userland/Libraries/LibWebSocket/Impl/WebSocketImplSerenity.cpp
+++ b/Userland/Libraries/LibWebSocket/Impl/WebSocketImplSerenity.cpp
@@ -76,7 +76,7 @@ void WebSocketImplSerenity::connect(ConnectionInfo const& connection_info)
 ErrorOr<ByteBuffer> WebSocketImplSerenity::read(int max_size)
 {
     auto buffer = TRY(ByteBuffer::create_uninitialized(max_size));
-    auto read_bytes = TRY(m_socket->read(buffer));
+    auto read_bytes = TRY(m_socket->read_some(buffer));
     return buffer.slice(0, read_bytes.size());
 }
 

--- a/Userland/Services/EchoServer/Client.cpp
+++ b/Userland/Services/EchoServer/Client.cpp
@@ -40,8 +40,7 @@ ErrorOr<void> Client::drain_socket()
             break;
         }
 
-        // FIXME: This should write the entire span.
-        TRY(m_socket->write_some(bytes_read));
+        TRY(m_socket->write_until_depleted(bytes_read));
     }
 
     return {};

--- a/Userland/Services/EchoServer/Client.cpp
+++ b/Userland/Services/EchoServer/Client.cpp
@@ -31,7 +31,7 @@ ErrorOr<void> Client::drain_socket()
     auto buffer = TRY(ByteBuffer::create_uninitialized(1024));
 
     while (TRY(m_socket->can_read_without_blocking())) {
-        auto bytes_read = TRY(m_socket->read(buffer));
+        auto bytes_read = TRY(m_socket->read_some(buffer));
 
         dbgln("Read {} bytes.", bytes_read.size());
 
@@ -40,7 +40,8 @@ ErrorOr<void> Client::drain_socket()
             break;
         }
 
-        TRY(m_socket->write(bytes_read));
+        // FIXME: This should write the entire span.
+        TRY(m_socket->write_some(bytes_read));
     }
 
     return {};

--- a/Userland/Services/FileOperation/main.cpp
+++ b/Userland/Services/FileOperation/main.cpp
@@ -240,8 +240,7 @@ ErrorOr<int> execute_work_items(Vector<WorkItem> const& items)
                 auto bytes_read = TRY(source_file->read_some(buffer.bytes()));
                 if (bytes_read.is_empty())
                     break;
-                // FIXME: This should write the entire span.
-                if (auto result = destination_file->write_some(bytes_read); result.is_error()) {
+                if (auto result = destination_file->write_until_depleted(bytes_read); result.is_error()) {
                     // FIXME: Return the formatted string directly. There is no way to do this right now without the temporary going out of scope and being destroyed.
                     report_warning(DeprecatedString::formatted("Failed to write to destination file: {}", result.error()));
                     return result.release_error();

--- a/Userland/Services/FileOperation/main.cpp
+++ b/Userland/Services/FileOperation/main.cpp
@@ -237,10 +237,11 @@ ErrorOr<int> execute_work_items(Vector<WorkItem> const& items)
 
             while (true) {
                 print_progress();
-                auto bytes_read = TRY(source_file->read(buffer.bytes()));
+                auto bytes_read = TRY(source_file->read_some(buffer.bytes()));
                 if (bytes_read.is_empty())
                     break;
-                if (auto result = destination_file->write(bytes_read); result.is_error()) {
+                // FIXME: This should write the entire span.
+                if (auto result = destination_file->write_some(bytes_read); result.is_error()) {
                     // FIXME: Return the formatted string directly. There is no way to do this right now without the temporary going out of scope and being destroyed.
                     report_warning(DeprecatedString::formatted("Failed to write to destination file: {}", result.error()));
                     return result.release_error();

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -239,10 +239,11 @@ ErrorOr<Vector<Answer>> LookupServer::lookup(Name const& name, DeprecatedString 
     auto udp_socket = TRY(Core::UDPSocket::connect(nameserver, 53, Time::from_seconds(1)));
     TRY(udp_socket->set_blocking(true));
 
-    TRY(udp_socket->write(buffer));
+    // FIXME: This should write the entire span.
+    TRY(udp_socket->write_some(buffer));
 
     u8 response_buffer[4096];
-    int nrecv = TRY(udp_socket->read({ response_buffer, sizeof(response_buffer) })).size();
+    int nrecv = TRY(udp_socket->read_some({ response_buffer, sizeof(response_buffer) })).size();
     if (udp_socket->is_eof())
         return Vector<Answer> {};
 

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -239,8 +239,7 @@ ErrorOr<Vector<Answer>> LookupServer::lookup(Name const& name, DeprecatedString 
     auto udp_socket = TRY(Core::UDPSocket::connect(nameserver, 53, Time::from_seconds(1)));
     TRY(udp_socket->set_blocking(true));
 
-    // FIXME: This should write the entire span.
-    TRY(udp_socket->write_some(buffer));
+    TRY(udp_socket->write_until_depleted(buffer));
 
     u8 response_buffer[4096];
     int nrecv = TRY(udp_socket->read_some({ response_buffer, sizeof(response_buffer) })).size();

--- a/Userland/Services/TelnetServer/Client.cpp
+++ b/Userland/Services/TelnetServer/Client.cpp
@@ -161,8 +161,7 @@ ErrorOr<void> Client::send_data(StringView data)
     }
 
     if (fast) {
-        // FIXME: This should write the entire span.
-        TRY(m_socket->write_some({ data.characters_without_null_termination(), data.length() }));
+        TRY(m_socket->write_until_depleted({ data.characters_without_null_termination(), data.length() }));
         return {};
     }
 
@@ -184,8 +183,7 @@ ErrorOr<void> Client::send_data(StringView data)
     }
 
     auto builder_contents = TRY(builder.to_byte_buffer());
-    // FIXME: This should write the entire span.
-    TRY(m_socket->write_some(builder_contents));
+    TRY(m_socket->write_until_depleted(builder_contents));
     return {};
 }
 
@@ -206,8 +204,7 @@ ErrorOr<void> Client::send_commands(Vector<Command> commands)
     }
 
     VERIFY(TRY(stream.tell()) == buffer.size());
-    // FIXME: This should write the entire span.
-    TRY(m_socket->write_some({ buffer.data(), buffer.size() }));
+    TRY(m_socket->write_until_depleted({ buffer.data(), buffer.size() }));
     return {};
 }
 

--- a/Userland/Services/TelnetServer/Client.cpp
+++ b/Userland/Services/TelnetServer/Client.cpp
@@ -77,7 +77,7 @@ ErrorOr<void> Client::drain_socket()
     auto buffer = TRY(ByteBuffer::create_uninitialized(1024));
 
     while (TRY(m_socket->can_read_without_blocking())) {
-        auto read_bytes = TRY(m_socket->read(buffer));
+        auto read_bytes = TRY(m_socket->read_some(buffer));
 
         m_parser.write(StringView { read_bytes });
 
@@ -161,7 +161,8 @@ ErrorOr<void> Client::send_data(StringView data)
     }
 
     if (fast) {
-        TRY(m_socket->write({ data.characters_without_null_termination(), data.length() }));
+        // FIXME: This should write the entire span.
+        TRY(m_socket->write_some({ data.characters_without_null_termination(), data.length() }));
         return {};
     }
 
@@ -183,7 +184,8 @@ ErrorOr<void> Client::send_data(StringView data)
     }
 
     auto builder_contents = TRY(builder.to_byte_buffer());
-    TRY(m_socket->write(builder_contents));
+    // FIXME: This should write the entire span.
+    TRY(m_socket->write_some(builder_contents));
     return {};
 }
 
@@ -204,7 +206,8 @@ ErrorOr<void> Client::send_commands(Vector<Command> commands)
     }
 
     VERIFY(TRY(stream.tell()) == buffer.size());
-    TRY(m_socket->write({ buffer.data(), buffer.size() }));
+    // FIXME: This should write the entire span.
+    TRY(m_socket->write_some({ buffer.data(), buffer.size() }));
     return {};
 }
 

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -192,8 +192,7 @@ ErrorOr<void> Client::send_response(Stream& response, HTTP::HttpRequest const& r
     builder.append("\r\n"sv);
 
     auto builder_contents = TRY(builder.to_byte_buffer());
-    // FIXME: This should write the entire span.
-    TRY(m_socket->write_some(builder_contents));
+    TRY(m_socket->write_until_depleted(builder_contents));
     log_response(200, request);
 
     char buffer[PAGE_SIZE];
@@ -235,8 +234,7 @@ ErrorOr<void> Client::send_redirect(StringView redirect_path, HTTP::HttpRequest 
     builder.append("\r\n"sv);
 
     auto builder_contents = TRY(builder.to_byte_buffer());
-    // FIXME: This should write the entire span.
-    TRY(m_socket->write_some(builder_contents));
+    TRY(m_socket->write_until_depleted(builder_contents));
 
     log_response(301, request);
     return {};
@@ -365,9 +363,8 @@ ErrorOr<void> Client::send_error_response(unsigned code, HTTP::HttpRequest const
     header_builder.append("Content-Type: text/html; charset=UTF-8\r\n"sv);
     header_builder.appendff("Content-Length: {}\r\n", content_builder.length());
     header_builder.append("\r\n"sv);
-    // FIXME: This should write the entire span.
-    TRY(m_socket->write_some(TRY(header_builder.to_byte_buffer())));
-    TRY(m_socket->write_some(TRY(content_builder.to_byte_buffer())));
+    TRY(m_socket->write_until_depleted(TRY(header_builder.to_byte_buffer())));
+    TRY(m_socket->write_until_depleted(TRY(content_builder.to_byte_buffer())));
 
     log_response(code, request);
     return {};

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -1823,7 +1823,7 @@ ErrorOr<void> Execute::for_each_entry(RefPtr<Shell> shell, Function<ErrorOr<Iter
                     break;
 
                 should_enable_notifier = true;
-                stream.write_entire_buffer({ buffer, (size_t)read_size }).release_value_but_fixme_should_propagate_errors();
+                stream.write_until_depleted({ buffer, (size_t)read_size }).release_value_but_fixme_should_propagate_errors();
             }
 
             loop.quit(NothingLeft);

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -1772,7 +1772,7 @@ ErrorOr<void> Execute::for_each_entry(RefPtr<Shell> shell, Function<ErrorOr<Iter
                         return Break;
                     }
                     auto entry = entry_result.release_value();
-                    TRY(stream.read_entire_buffer(entry));
+                    TRY(stream.read_until_filled(entry));
 
                     auto str = TRY(String::from_utf8(StringView(entry.data(), entry.size() - ifs.length())));
                     if (TRY(callback(make_ref_counted<StringValue>(move(str)))) == IterationDecision::Break) {
@@ -1862,7 +1862,7 @@ ErrorOr<void> Execute::for_each_entry(RefPtr<Shell> shell, Function<ErrorOr<Iter
                     return {};
                 }
                 auto entry = entry_result.release_value();
-                TRY(stream.read_entire_buffer(entry));
+                TRY(stream.read_until_filled(entry));
                 TRY(callback(make_ref_counted<StringValue>(TRY(String::from_utf8(entry)))));
             }
         }

--- a/Userland/Utilities/cat.cpp
+++ b/Userland/Utilities/cat.cpp
@@ -40,7 +40,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Array<u8, 32768> buffer;
     for (auto const& file : files) {
         while (!file->is_eof()) {
-            auto const buffer_span = TRY(file->read(buffer));
+            auto const buffer_span = TRY(file->read_some(buffer));
             out("{:s}", buffer_span);
         }
     }

--- a/Userland/Utilities/checksum.cpp
+++ b/Userland/Utilities/checksum.cpp
@@ -66,13 +66,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         Array<u8, PAGE_SIZE> buffer;
         if (!verify_from_paths) {
             while (!file->is_eof())
-                hash.update(TRY(file->read(buffer)));
+                hash.update(TRY(file->read_some(buffer)));
             outln("{:hex-dump}  {}", hash.digest().bytes(), path);
         } else {
             StringBuilder checksum_list_contents;
             Array<u8, 1> checksum_list_buffer;
             while (!file->is_eof())
-                checksum_list_contents.append(TRY(file->read(checksum_list_buffer)).data()[0]);
+                checksum_list_contents.append(TRY(file->read_some(checksum_list_buffer)).data()[0]);
             Vector<StringView> const lines = checksum_list_contents.string_view().split_view("\n"sv);
 
             for (size_t i = 0; i < lines.size(); ++i) {
@@ -96,7 +96,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 auto file_from_filename = file_from_filename_or_error.release_value();
                 hash.reset();
                 while (!file_from_filename->is_eof())
-                    hash.update(TRY(file_from_filename->read(buffer)));
+                    hash.update(TRY(file_from_filename->read_some(buffer)));
                 if (DeprecatedString::formatted("{:hex-dump}", hash.digest().bytes()) == line[0])
                     outln("{}: OK", filename);
                 else {

--- a/Userland/Utilities/cksum.cpp
+++ b/Userland/Utilities/cksum.cpp
@@ -59,7 +59,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         if (algorithm == "crc32") {
             Crypto::Checksum::CRC32 crc32;
             while (!file->is_eof()) {
-                auto data_or_error = file->read(buffer);
+                auto data_or_error = file->read_some(buffer);
                 if (data_or_error.is_error()) {
                     warnln("{}: Failed to read {}: {}", arguments.strings[0], filepath, data_or_error.error());
                     fail = true;
@@ -72,7 +72,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         } else if (algorithm == "adler32") {
             Crypto::Checksum::Adler32 adler32;
             while (!file->is_eof()) {
-                auto data_or_error = file->read(buffer);
+                auto data_or_error = file->read_some(buffer);
                 if (data_or_error.is_error()) {
                     warnln("{}: Failed to read {}: {}", arguments.strings[0], filepath, data_or_error.error());
                     fail = true;

--- a/Userland/Utilities/cmp.cpp
+++ b/Userland/Utilities/cmp.cpp
@@ -75,8 +75,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     while (true) {
-        TRY(file1->read(buffer1));
-        TRY(file2->read(buffer2));
+        TRY(file1->read_some(buffer1));
+        TRY(file2->read_some(buffer2));
 
         if (file1->is_eof() && file2->is_eof())
             break;

--- a/Userland/Utilities/file.cpp
+++ b/Userland/Utilities/file.cpp
@@ -187,7 +187,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         } else if (!file_size_in_bytes) {
             outln("{}: empty", path);
         } else {
-            auto bytes = TRY(file->read(buffer));
+            auto bytes = TRY(file->read_some(buffer));
             auto file_name_guess = Core::guess_mime_type_based_on_filename(path);
             auto mime_type = Core::guess_mime_type_based_on_sniffed_bytes(bytes).value_or(file_name_guess);
             auto human_readable_description = get_description_from_mime_type(mime_type, path).value_or(mime_type);

--- a/Userland/Utilities/gml-format.cpp
+++ b/Userland/Utilities/gml-format.cpp
@@ -28,7 +28,8 @@ static ErrorOr<bool> format_file(StringView path, bool inplace)
             return true;
         TRY(file->seek(0, SeekMode::SetPosition));
         TRY(file->truncate(0));
-        TRY(file->write(formatted_gml.bytes()));
+        // FIXME: This should write the entire span.
+        TRY(file->write_some(formatted_gml.bytes()));
     } else {
         out("{}", formatted_gml);
     }

--- a/Userland/Utilities/gml-format.cpp
+++ b/Userland/Utilities/gml-format.cpp
@@ -28,8 +28,7 @@ static ErrorOr<bool> format_file(StringView path, bool inplace)
             return true;
         TRY(file->seek(0, SeekMode::SetPosition));
         TRY(file->truncate(0));
-        // FIXME: This should write the entire span.
-        TRY(file->write_some(formatted_gml.bytes()));
+        TRY(file->write_until_depleted(formatted_gml.bytes()));
     } else {
         out("{}", formatted_gml);
     }

--- a/Userland/Utilities/gunzip.cpp
+++ b/Userland/Utilities/gunzip.cpp
@@ -18,7 +18,7 @@ static ErrorOr<void> decompress_file(NonnullOwnPtr<Core::File> input_stream, Str
     auto buffer = TRY(ByteBuffer::create_uninitialized(4096));
     while (!gzip_stream.is_eof()) {
         auto span = TRY(gzip_stream.read_some(buffer));
-        TRY(output_stream.write_entire_buffer(span));
+        TRY(output_stream.write_until_depleted(span));
     }
 
     return {};

--- a/Userland/Utilities/gunzip.cpp
+++ b/Userland/Utilities/gunzip.cpp
@@ -17,7 +17,7 @@ static ErrorOr<void> decompress_file(NonnullOwnPtr<Core::File> input_stream, Str
 
     auto buffer = TRY(ByteBuffer::create_uninitialized(4096));
     while (!gzip_stream.is_eof()) {
-        auto span = TRY(gzip_stream.read(buffer));
+        auto span = TRY(gzip_stream.read_some(buffer));
         TRY(output_stream.write_entire_buffer(span));
     }
 

--- a/Userland/Utilities/gzip.cpp
+++ b/Userland/Utilities/gzip.cpp
@@ -57,7 +57,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             output_bytes = TRY(Compress::GzipCompressor::compress_all(input_bytes));
 
         auto output_stream = write_to_stdout ? TRY(Core::File::standard_output()) : TRY(Core::File::open(output_filename, Core::File::OpenMode::Write));
-        TRY(output_stream->write_entire_buffer(output_bytes));
+        TRY(output_stream->write_until_depleted(output_bytes));
 
         if (!keep_input_files) {
             TRY(Core::System::unlink(input_filename));

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -147,7 +147,8 @@ static ErrorOr<NonnullRefPtr<Core::Timer>> load_page_for_screenshot_and_exit(Cor
 
                 auto output_file = MUST(Core::File::open(output_file_path, Core::File::OpenMode::Write));
                 auto image_buffer = MUST(Gfx::PNGWriter::encode(*screenshot));
-                MUST(output_file->write(image_buffer.bytes()));
+                // FIXME: This should write the entire buffer.
+                MUST(output_file->write_some(image_buffer.bytes()));
             } else {
                 warnln("No screenshot available");
             }

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -147,8 +147,7 @@ static ErrorOr<NonnullRefPtr<Core::Timer>> load_page_for_screenshot_and_exit(Cor
 
                 auto output_file = MUST(Core::File::open(output_file_path, Core::File::OpenMode::Write));
                 auto image_buffer = MUST(Gfx::PNGWriter::encode(*screenshot));
-                // FIXME: This should write the entire buffer.
-                MUST(output_file->write_some(image_buffer.bytes()));
+                MUST(output_file->write_until_depleted(image_buffer.bytes()));
             } else {
                 warnln("No screenshot available");
             }

--- a/Userland/Utilities/hexdump.cpp
+++ b/Userland/Utilities/hexdump.cpp
@@ -86,7 +86,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         }
 
         bytes = contents.span().slice(0, bytes_to_read);
-        bytes = TRY(file->read(bytes));
+        bytes = TRY(file->read_some(bytes));
 
         total_bytes_read += bytes.size();
 

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -145,7 +145,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         if (!dump_out_path.is_empty()) {
             auto output_stream = TRY(Core::File::open(dump_out_path, Core::File::OpenMode::Write));
-            TRY(output_stream->write_entire_buffer(icc_bytes));
+            TRY(output_stream->write_until_depleted(icc_bytes));
         }
         return Gfx::ICC::Profile::try_load_from_externally_owned_memory(icc_bytes);
     }());
@@ -153,7 +153,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (!reencode_out_path.is_empty()) {
         auto reencoded_bytes = TRY(Gfx::ICC::encode(profile));
         auto output_stream = TRY(Core::File::open(reencode_out_path, Core::File::OpenMode::Write));
-        TRY(output_stream->write_entire_buffer(reencoded_bytes));
+        TRY(output_stream->write_until_depleted(reencoded_bytes));
     }
 
     bool do_print = (dump_out_path.is_empty() && reencode_out_path.is_empty()) || force_print;

--- a/Userland/Utilities/image.cpp
+++ b/Userland/Utilities/image.cpp
@@ -49,7 +49,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     auto output_stream = TRY(Core::File::open(out_path, Core::File::OpenMode::Write));
-    TRY(output_stream->write_entire_buffer(bytes));
+    TRY(output_stream->write_until_depleted(bytes));
 
     return 0;
 }

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -188,8 +188,7 @@ static ErrorOr<void> write_to_file(String const& path)
     for (size_t i = 0; i < g_repl_statements.size(); i++) {
         auto line = g_repl_statements[i].bytes();
         if (line.size() > 0 && i != g_repl_statements.size() - 1) {
-            // FIXME: This should write the entire span.
-            TRY(file->write_some(line));
+            TRY(file->write_until_depleted(line));
         }
         if (i != g_repl_statements.size() - 1) {
             TRY(file->write_value('\n'));

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -188,7 +188,8 @@ static ErrorOr<void> write_to_file(String const& path)
     for (size_t i = 0; i < g_repl_statements.size(); i++) {
         auto line = g_repl_statements[i].bytes();
         if (line.size() > 0 && i != g_repl_statements.size() - 1) {
-            TRY(file->write(line));
+            // FIXME: This should write the entire span.
+            TRY(file->write_some(line));
         }
         if (i != g_repl_statements.size() - 1) {
             TRY(file->write_value('\n'));

--- a/Userland/Utilities/nc.cpp
+++ b/Userland/Utilities/nc.cpp
@@ -82,7 +82,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto nread = TRY(Core::System::read(STDIN_FILENO, buffer_span));
             buffer_span = buffer_span.trim(nread);
 
-            TRY(socket->write({ buffer_span.data(), static_cast<size_t>(nread) }));
+            // FIXME: This should write the entire span.
+            TRY(socket->write_some({ buffer_span.data(), static_cast<size_t>(nread) }));
         }
     }
 

--- a/Userland/Utilities/nc.cpp
+++ b/Userland/Utilities/nc.cpp
@@ -82,8 +82,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto nread = TRY(Core::System::read(STDIN_FILENO, buffer_span));
             buffer_span = buffer_span.trim(nread);
 
-            // FIXME: This should write the entire span.
-            TRY(socket->write_some({ buffer_span.data(), static_cast<size_t>(nread) }));
+            TRY(socket->write_until_depleted({ buffer_span.data(), static_cast<size_t>(nread) }));
         }
     }
 

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -112,18 +112,18 @@ public:
     {
     }
 
-    virtual ErrorOr<Bytes> read(Bytes) override
+    virtual ErrorOr<Bytes> read_some(Bytes) override
     {
         return Error::from_errno(EBADF);
     }
 
-    virtual ErrorOr<size_t> write(ReadonlyBytes bytes) override
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes bytes) override
     {
         // Pretend that we wrote the whole buffer if the condition is untrue.
         if (!m_condition())
             return bytes.size();
 
-        return m_stream->write(bytes);
+        return m_stream->write_some(bytes);
     }
 
     virtual bool is_eof() const override

--- a/Userland/Utilities/reboot.cpp
+++ b/Userland/Utilities/reboot.cpp
@@ -14,8 +14,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto file = TRY(Core::File::open("/sys/kernel/power_state"sv, Core::File::OpenMode::Write));
 
     const DeprecatedString file_contents = "1";
-    // FIXME: This should write the entire span.
-    TRY(file->write_some(file_contents.bytes()));
+    TRY(file->write_until_depleted(file_contents.bytes()));
     file->close();
 
     return 0;

--- a/Userland/Utilities/reboot.cpp
+++ b/Userland/Utilities/reboot.cpp
@@ -14,7 +14,8 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto file = TRY(Core::File::open("/sys/kernel/power_state"sv, Core::File::OpenMode::Write));
 
     const DeprecatedString file_contents = "1";
-    TRY(file->write(file_contents.bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file->write_some(file_contents.bytes()));
     file->close();
 
     return 0;

--- a/Userland/Utilities/sed.cpp
+++ b/Userland/Utilities/sed.cpp
@@ -141,9 +141,8 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
             if (maybe_output_file.has_value()) {
                 auto const& output_file = maybe_output_file.value();
-                // FIXME: This should write the entire span.
-                TRY(output_file->write_some(result.bytes()));
-                TRY(output_file->write_some("\n"sv.bytes()));
+                TRY(output_file->write_until_depleted(result.bytes()));
+                TRY(output_file->write_until_depleted("\n"sv.bytes()));
             }
         }
     }

--- a/Userland/Utilities/sed.cpp
+++ b/Userland/Utilities/sed.cpp
@@ -141,8 +141,9 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
             if (maybe_output_file.has_value()) {
                 auto const& output_file = maybe_output_file.value();
-                TRY(output_file->write(result.bytes()));
-                TRY(output_file->write("\n"sv.bytes()));
+                // FIXME: This should write the entire span.
+                TRY(output_file->write_some(result.bytes()));
+                TRY(output_file->write_some("\n"sv.bytes()));
             }
         }
     }

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -167,8 +167,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     auto& file = *file_or_error.value();
-    // FIXME: This should write the entire span.
-    TRY(file.write_some(encoded_bitmap.bytes()));
+    TRY(file.write_until_depleted(encoded_bitmap.bytes()));
 
     if (edit_image)
         TRY(Core::Process::spawn("/bin/PixelPaint"sv, Array { output_path }));

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -167,7 +167,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     auto& file = *file_or_error.value();
-    TRY(file.write(encoded_bitmap.bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file.write_some(encoded_bitmap.bytes()));
 
     if (edit_image)
         TRY(Core::Process::spawn("/bin/PixelPaint"sv, Array { output_path }));

--- a/Userland/Utilities/shutdown.cpp
+++ b/Userland/Utilities/shutdown.cpp
@@ -18,7 +18,8 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto file = TRY(Core::File::open("/sys/kernel/power_state"sv, Core::File::OpenMode::Write));
 
     const DeprecatedString file_contents = "2";
-    TRY(file->write(file_contents.bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file->write_some(file_contents.bytes()));
     file->close();
 
     return 0;

--- a/Userland/Utilities/shutdown.cpp
+++ b/Userland/Utilities/shutdown.cpp
@@ -18,8 +18,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto file = TRY(Core::File::open("/sys/kernel/power_state"sv, Core::File::OpenMode::Write));
 
     const DeprecatedString file_contents = "2";
-    // FIXME: This should write the entire span.
-    TRY(file->write_some(file_contents.bytes()));
+    TRY(file->write_until_depleted(file_contents.bytes()));
     file->close();
 
     return 0;

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -932,6 +932,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         FormattedSyscallBuilder builder(syscall_name);
         TRY(format_syscall(builder, syscall_function, arg1, arg2, arg3, res));
 
-        TRY(trace_file->write(builder.string_view().bytes()));
+        // FIXME: This should write the entire span.
+        TRY(trace_file->write_some(builder.string_view().bytes()));
     }
 }

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -932,7 +932,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         FormattedSyscallBuilder builder(syscall_name);
         TRY(format_syscall(builder, syscall_function, arg1, arg2, arg3, res));
 
-        // FIXME: This should write the entire span.
-        TRY(trace_file->write_some(builder.string_view().bytes()));
+        TRY(trace_file->write_until_depleted(builder.string_view().bytes()));
     }
 }

--- a/Userland/Utilities/strings.cpp
+++ b/Userland/Utilities/strings.cpp
@@ -72,7 +72,7 @@ static ErrorOr<void> process_strings_in_file(StringView path, bool show_paths, S
     size_t string_offset_position = 0;
     bool did_show_path = false;
     while (!file->is_eof()) {
-        auto buffer_span = TRY(file->read(buffer));
+        auto buffer_span = TRY(file->read_some(buffer));
         while (!buffer_span.is_empty()) {
             string_offset_position += processed_characters;
             processed_characters = process_characters_in_span(output_characters, buffer_span);

--- a/Userland/Utilities/sysctl.cpp
+++ b/Userland/Utilities/sysctl.cpp
@@ -48,7 +48,8 @@ static bool write_variable(StringView name, StringView value)
         warnln("Failed to open {}: {}", path, file.error());
         return false;
     }
-    if (auto result = file.value()->write(value.bytes()); result.is_error()) {
+    // FIXME: This should write the entire span.
+    if (auto result = file.value()->write_some(value.bytes()); result.is_error()) {
         warnln("Failed to write {}: {}", path, result.error());
         return false;
     }

--- a/Userland/Utilities/sysctl.cpp
+++ b/Userland/Utilities/sysctl.cpp
@@ -48,8 +48,7 @@ static bool write_variable(StringView name, StringView value)
         warnln("Failed to open {}: {}", path, file.error());
         return false;
     }
-    // FIXME: This should write the entire span.
-    if (auto result = file.value()->write_some(value.bytes()); result.is_error()) {
+    if (auto result = file.value()->write_until_depleted(value.bytes()); result.is_error()) {
         warnln("Failed to write {}: {}", path, result.error());
         return false;
     }

--- a/Userland/Utilities/tail.cpp
+++ b/Userland/Utilities/tail.cpp
@@ -35,7 +35,8 @@ static ErrorOr<off_t> find_seek_pos(Core::File& file, int wanted_lines)
         if (file.is_eof())
             break;
         Array<u8, 1> buffer;
-        auto ch = TRY(file.read(buffer));
+        // FIXME: This should read the entire span.
+        auto ch = TRY(file.read_some(buffer));
         if (*ch.data() == '\n' && (end - pos) > 1) {
             lines++;
             if (lines == wanted_lines)

--- a/Userland/Utilities/tail.cpp
+++ b/Userland/Utilities/tail.cpp
@@ -34,10 +34,8 @@ static ErrorOr<off_t> find_seek_pos(Core::File& file, int wanted_lines)
 
         if (file.is_eof())
             break;
-        Array<u8, 1> buffer;
-        // FIXME: This should read the entire span.
-        auto ch = TRY(file.read_some(buffer));
-        if (*ch.data() == '\n' && (end - pos) > 1) {
+        auto ch = TRY(file.read_value<u8>());
+        if (ch == '\n' && (end - pos) > 1) {
             lines++;
             if (lines == wanted_lines)
                 break;

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -127,7 +127,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 Array<u8, buffer_size> buffer;
 
                 while (!file_stream.is_eof()) {
-                    auto slice = TRY(file_stream.read(buffer));
+                    auto slice = TRY(file_stream.read_some(buffer));
                     long_name.append(reinterpret_cast<char*>(slice.data()), slice.size());
                 }
 
@@ -162,7 +162,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
                     Array<u8, buffer_size> buffer;
                     while (!file_stream.is_eof()) {
-                        auto slice = TRY(file_stream.read(buffer));
+                        auto slice = TRY(file_stream.read_some(buffer));
                         TRY(Core::System::write(fd, slice));
                     }
 

--- a/Userland/Utilities/uniq.cpp
+++ b/Userland/Utilities/uniq.cpp
@@ -17,11 +17,10 @@ static ErrorOr<void> write_line_content(StringView line, size_t count, bool dupl
     if (duplicates_only && count <= 1)
         return {};
 
-    // FIXME: This should write the entire span.
     if (print_count)
-        TRY(outfile.write_some(DeprecatedString::formatted("{} {}\n", count, line).bytes()));
+        TRY(outfile.write_until_depleted(DeprecatedString::formatted("{} {}\n", count, line).bytes()));
     else
-        TRY(outfile.write_some(DeprecatedString::formatted("{}\n", line).bytes()));
+        TRY(outfile.write_until_depleted(DeprecatedString::formatted("{}\n", line).bytes()));
     return {};
 }
 

--- a/Userland/Utilities/uniq.cpp
+++ b/Userland/Utilities/uniq.cpp
@@ -17,10 +17,11 @@ static ErrorOr<void> write_line_content(StringView line, size_t count, bool dupl
     if (duplicates_only && count <= 1)
         return {};
 
+    // FIXME: This should write the entire span.
     if (print_count)
-        TRY(outfile.write(DeprecatedString::formatted("{} {}\n", count, line).bytes()));
+        TRY(outfile.write_some(DeprecatedString::formatted("{} {}\n", count, line).bytes()));
     else
-        TRY(outfile.write(DeprecatedString::formatted("{}\n", line).bytes()));
+        TRY(outfile.write_some(DeprecatedString::formatted("{}\n", line).bytes()));
     return {};
 }
 

--- a/Userland/Utilities/uptime.cpp
+++ b/Userland/Utilities/uptime.cpp
@@ -19,7 +19,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::pledge("stdio"));
 
     Array<u8, BUFSIZ> buffer;
-    auto read_buffer = TRY(file->read(buffer));
+    auto read_buffer = TRY(file->read_some(buffer));
     auto maybe_seconds = AK::StringUtils::convert_to_uint(StringView(read_buffer));
     if (!maybe_seconds.has_value())
         return Error::from_string_literal("Couldn't convert to number");

--- a/Userland/Utilities/utmpupdate.cpp
+++ b/Userland/Utilities/utmpupdate.cpp
@@ -72,7 +72,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(file->seek(0, SeekMode::SetPosition));
     TRY(file->truncate(0));
-    TRY(file->write(json.to_deprecated_string().bytes()));
+    // FIXME: This should write the entire span.
+    TRY(file->write_some(json.to_deprecated_string().bytes()));
 
     return 0;
 }

--- a/Userland/Utilities/utmpupdate.cpp
+++ b/Userland/Utilities/utmpupdate.cpp
@@ -72,8 +72,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(file->seek(0, SeekMode::SetPosition));
     TRY(file->truncate(0));
-    // FIXME: This should write the entire span.
-    TRY(file->write_some(json.to_deprecated_string().bytes()));
+    TRY(file->write_until_depleted(json.to_deprecated_string().bytes()));
 
     return 0;
 }

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -53,12 +53,14 @@ static bool pre_interpret_hook(Wasm::Configuration& config, Wasm::InstructionPoi
     if (always_print_stack)
         config.dump_stack();
     if (always_print_instruction) {
-        g_stdout->write(DeprecatedString::formatted("{:0>4} ", ip.value()).bytes()).release_value_but_fixme_should_propagate_errors();
+        // FIXME: This should write the entire span.
+        g_stdout->write_some(DeprecatedString::formatted("{:0>4} ", ip.value()).bytes()).release_value_but_fixme_should_propagate_errors();
         g_printer->print(instr);
     }
     if (g_continue)
         return true;
-    g_stdout->write(DeprecatedString::formatted("{:0>4} ", ip.value()).bytes()).release_value_but_fixme_should_propagate_errors();
+    // FIXME: This should write the entire span.
+    g_stdout->write_some(DeprecatedString::formatted("{:0>4} ", ip.value()).bytes()).release_value_but_fixme_should_propagate_errors();
     g_printer->print(instr);
     DeprecatedString last_command = "";
     for (;;) {
@@ -214,7 +216,8 @@ static bool pre_interpret_hook(Wasm::Configuration& config, Wasm::InstructionPoi
                 if (!result.values().is_empty())
                     warnln("Returned:");
                 for (auto& value : result.values()) {
-                    g_stdout->write("  -> "sv.bytes()).release_value_but_fixme_should_propagate_errors();
+                    // FIXME: This should write the entire span.
+                    g_stdout->write_some("  -> "sv.bytes()).release_value_but_fixme_should_propagate_errors();
                     g_printer->print(value);
                 }
             }
@@ -454,15 +457,18 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         auto print_func = [&](auto const& address) {
             Wasm::FunctionInstance* fn = machine.store().get(address);
-            g_stdout->write(DeprecatedString::formatted("- Function with address {}, ptr = {}\n", address.value(), fn).bytes()).release_value_but_fixme_should_propagate_errors();
+            // FIXME: This should write the entire span.
+            g_stdout->write_some(DeprecatedString::formatted("- Function with address {}, ptr = {}\n", address.value(), fn).bytes()).release_value_but_fixme_should_propagate_errors();
             if (fn) {
-                g_stdout->write(DeprecatedString::formatted("    wasm function? {}\n", fn->has<Wasm::WasmFunction>()).bytes()).release_value_but_fixme_should_propagate_errors();
+                // FIXME: This should write the entire span.
+                g_stdout->write_some(DeprecatedString::formatted("    wasm function? {}\n", fn->has<Wasm::WasmFunction>()).bytes()).release_value_but_fixme_should_propagate_errors();
                 fn->visit(
                     [&](Wasm::WasmFunction const& func) {
                         Wasm::Printer printer { *g_stdout, 3 };
-                        g_stdout->write("    type:\n"sv.bytes()).release_value_but_fixme_should_propagate_errors();
+                        // FIXME: This should write the entire span.
+                        g_stdout->write_some("    type:\n"sv.bytes()).release_value_but_fixme_should_propagate_errors();
                         printer.print(func.type());
-                        g_stdout->write("    code:\n"sv.bytes()).release_value_but_fixme_should_propagate_errors();
+                        g_stdout->write_some("    code:\n"sv.bytes()).release_value_but_fixme_should_propagate_errors();
                         printer.print(func.code());
                     },
                     [](Wasm::HostFunction const&) {});
@@ -526,7 +532,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 if (!result.values().is_empty())
                     warnln("Returned:");
                 for (auto& value : result.values()) {
-                    g_stdout->write("  -> "sv.bytes()).release_value_but_fixme_should_propagate_errors();
+                    // FIXME: This should write the entire span.
+                    g_stdout->write_some("  -> "sv.bytes()).release_value_but_fixme_should_propagate_errors();
                     g_printer->print(value);
                 }
             }

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -410,7 +410,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                             else
                                 argument_builder.append(", "sv);
                             auto buffer = ByteBuffer::create_uninitialized(stream.used_buffer_size()).release_value_but_fixme_should_propagate_errors();
-                            stream.read_entire_buffer(buffer).release_value_but_fixme_should_propagate_errors();
+                            stream.read_until_filled(buffer).release_value_but_fixme_should_propagate_errors();
                             argument_builder.append(StringView(buffer).trim_whitespace());
                         }
                         dbgln("[wasm runtime] Stub function {} was called with the following arguments: {}", name, argument_builder.to_deprecated_string());

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -53,14 +53,12 @@ static bool pre_interpret_hook(Wasm::Configuration& config, Wasm::InstructionPoi
     if (always_print_stack)
         config.dump_stack();
     if (always_print_instruction) {
-        // FIXME: This should write the entire span.
-        g_stdout->write_some(DeprecatedString::formatted("{:0>4} ", ip.value()).bytes()).release_value_but_fixme_should_propagate_errors();
+        g_stdout->write_until_depleted(DeprecatedString::formatted("{:0>4} ", ip.value()).bytes()).release_value_but_fixme_should_propagate_errors();
         g_printer->print(instr);
     }
     if (g_continue)
         return true;
-    // FIXME: This should write the entire span.
-    g_stdout->write_some(DeprecatedString::formatted("{:0>4} ", ip.value()).bytes()).release_value_but_fixme_should_propagate_errors();
+    g_stdout->write_until_depleted(DeprecatedString::formatted("{:0>4} ", ip.value()).bytes()).release_value_but_fixme_should_propagate_errors();
     g_printer->print(instr);
     DeprecatedString last_command = "";
     for (;;) {
@@ -216,8 +214,7 @@ static bool pre_interpret_hook(Wasm::Configuration& config, Wasm::InstructionPoi
                 if (!result.values().is_empty())
                     warnln("Returned:");
                 for (auto& value : result.values()) {
-                    // FIXME: This should write the entire span.
-                    g_stdout->write_some("  -> "sv.bytes()).release_value_but_fixme_should_propagate_errors();
+                    g_stdout->write_until_depleted("  -> "sv.bytes()).release_value_but_fixme_should_propagate_errors();
                     g_printer->print(value);
                 }
             }
@@ -457,18 +454,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         auto print_func = [&](auto const& address) {
             Wasm::FunctionInstance* fn = machine.store().get(address);
-            // FIXME: This should write the entire span.
-            g_stdout->write_some(DeprecatedString::formatted("- Function with address {}, ptr = {}\n", address.value(), fn).bytes()).release_value_but_fixme_should_propagate_errors();
+            g_stdout->write_until_depleted(DeprecatedString::formatted("- Function with address {}, ptr = {}\n", address.value(), fn).bytes()).release_value_but_fixme_should_propagate_errors();
             if (fn) {
-                // FIXME: This should write the entire span.
-                g_stdout->write_some(DeprecatedString::formatted("    wasm function? {}\n", fn->has<Wasm::WasmFunction>()).bytes()).release_value_but_fixme_should_propagate_errors();
+                g_stdout->write_until_depleted(DeprecatedString::formatted("    wasm function? {}\n", fn->has<Wasm::WasmFunction>()).bytes()).release_value_but_fixme_should_propagate_errors();
                 fn->visit(
                     [&](Wasm::WasmFunction const& func) {
                         Wasm::Printer printer { *g_stdout, 3 };
-                        // FIXME: This should write the entire span.
-                        g_stdout->write_some("    type:\n"sv.bytes()).release_value_but_fixme_should_propagate_errors();
+                        g_stdout->write_until_depleted("    type:\n"sv.bytes()).release_value_but_fixme_should_propagate_errors();
                         printer.print(func.type());
-                        g_stdout->write_some("    code:\n"sv.bytes()).release_value_but_fixme_should_propagate_errors();
+                        g_stdout->write_until_depleted("    code:\n"sv.bytes()).release_value_but_fixme_should_propagate_errors();
                         printer.print(func.code());
                     },
                     [](Wasm::HostFunction const&) {});
@@ -532,8 +526,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 if (!result.values().is_empty())
                     warnln("Returned:");
                 for (auto& value : result.values()) {
-                    // FIXME: This should write the entire span.
-                    g_stdout->write_some("  -> "sv.bytes()).release_value_but_fixme_should_propagate_errors();
+                    g_stdout->write_until_depleted("  -> "sv.bytes()).release_value_but_fixme_should_propagate_errors();
                     g_printer->print(value);
                 }
             }


### PR DESCRIPTION
The commits are split up semi-arbitrarily, since I put everything that I was unsure about or where the change isn't really a simple change from `read_some` to `read_until_filled` or `read_value` (or - respectively - `write_some`, `write_until_depleted`, and `write_value`) into its own commit. All the changes that were simple enough and too small to be split up by subsystem are in the last commit.

As usual, feel free to suggest squashing/splitting commits (or even better function names :thousandyakstare:).