### PR TITLE
LibWeb: Port URL and URLSearchParams to new String

### DIFF
--- a/AK/URL.h
+++ b/AK/URL.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 
@@ -45,6 +46,10 @@ public:
     URL(StringView);
     URL(DeprecatedString const& string)
         : URL(string.view())
+    {
+    }
+    URL(String const& string)
+        : URL(string.bytes_as_string_view())
     {
     }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1314,9 +1314,15 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
 )~~~");
                 } else {
                     if (optional_default_value == "\"\"") {
-                        union_generator.append(R"~~~(
+                        if (!interface.extended_attributes.contains("UseNewAKString")) {
+                            union_generator.append(R"~~~(
     @union_type@ @cpp_name@ = @js_name@@js_suffix@.is_undefined() ? DeprecatedString::empty() : TRY(@js_name@@js_suffix@_to_variant(@js_name@@js_suffix@));
 )~~~");
+                        } else {
+                            union_generator.append(R"~~~(
+    @union_type@ @cpp_name@ = @js_name@@js_suffix@.is_undefined() ? String {} : TRY(@js_name@@js_suffix@_to_variant(@js_name@@js_suffix@));
+)~~~");
+                        }
                     } else if (optional_default_value == "{}") {
                         VERIFY(dictionary_type);
                         union_generator.append(R"~~~(

--- a/Userland/Libraries/LibWeb/Fetch/BodyInit.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/BodyInit.cpp
@@ -90,7 +90,8 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm,
         },
         [&](JS::Handle<URL::URLSearchParams> const& url_search_params) -> WebIDL::ExceptionOr<void> {
             // Set source to the result of running the application/x-www-form-urlencoded serializer with object’s list.
-            source = url_search_params->to_deprecated_string().to_byte_buffer();
+            auto search_params_bytes = TRY(url_search_params->to_string()).bytes();
+            source = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(search_params_bytes));
             // Set type to `application/x-www-form-urlencoded;charset=UTF-8`.
             type = TRY_OR_THROW_OOM(vm, ByteBuffer::copy("application/x-www-form-urlencoded;charset=UTF-8"sv.bytes()));
             return {};

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -32,7 +32,7 @@ HTMLButtonElement::HTMLButtonElement(DOM::Document& document, DOM::QualifiedName
         case TypeAttributeState::Submit:
             // Submit Button
             // Submit element's form owner from element.
-            form()->submit_form(this);
+            form()->submit_form(this).release_value_but_fixme_should_propagate_errors();
             break;
         case TypeAttributeState::Reset:
             // Reset Button

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -22,12 +22,12 @@ public:
     DeprecatedString action() const;
     DeprecatedString method() const { return attribute(HTML::AttributeNames::method); }
 
-    void submit_form(JS::GCPtr<HTMLElement> submitter, bool from_submit_binding = false);
+    ErrorOr<void> submit_form(JS::GCPtr<HTMLElement> submitter, bool from_submit_binding = false);
 
     void reset_form();
 
     // NOTE: This is for the JS bindings. Use submit_form instead.
-    void submit();
+    WebIDL::ExceptionOr<void> submit();
 
     // NOTE: This is for the JS bindings. Use submit_form instead.
     void reset();

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -139,7 +139,7 @@ private:
 
     static TypeAttributeState parse_type_attribute(StringView);
     void create_shadow_tree_if_needed();
-    void run_input_activation_behavior();
+    ErrorOr<void> run_input_activation_behavior();
     void set_checked_within_group();
 
     // https://html.spec.whatwg.org/multipage/input.html#value-sanitization-algorithm

--- a/Userland/Libraries/LibWeb/URL/URL.h
+++ b/Userland/Libraries/LibWeb/URL/URL.h
@@ -20,47 +20,47 @@ class URL : public Bindings::PlatformObject {
 
 public:
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<URL>> create(JS::Realm&, AK::URL url, JS::NonnullGCPtr<URLSearchParams> query);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<URL>> construct_impl(JS::Realm&, DeprecatedString const& url, DeprecatedString const& base);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<URL>> construct_impl(JS::Realm&, String const& url, Optional<String> const& base = {});
 
     virtual ~URL() override;
 
-    DeprecatedString href() const;
-    WebIDL::ExceptionOr<void> set_href(DeprecatedString const&);
+    WebIDL::ExceptionOr<String> href() const;
+    WebIDL::ExceptionOr<void> set_href(String const&);
 
-    DeprecatedString origin() const;
+    WebIDL::ExceptionOr<String> origin() const;
 
-    DeprecatedString protocol() const;
-    void set_protocol(DeprecatedString const&);
+    WebIDL::ExceptionOr<String> protocol() const;
+    WebIDL::ExceptionOr<void> set_protocol(String const&);
 
-    DeprecatedString username() const;
-    void set_username(DeprecatedString const&);
+    WebIDL::ExceptionOr<String> username() const;
+    void set_username(String const&);
 
-    DeprecatedString password() const;
-    void set_password(DeprecatedString const&);
+    WebIDL::ExceptionOr<String> password() const;
+    void set_password(String const&);
 
-    DeprecatedString host() const;
-    void set_host(DeprecatedString const&);
+    WebIDL::ExceptionOr<String> host() const;
+    void set_host(String const&);
 
-    DeprecatedString hostname() const;
-    void set_hostname(DeprecatedString const&);
+    WebIDL::ExceptionOr<String> hostname() const;
+    void set_hostname(String const&);
 
-    DeprecatedString port() const;
-    void set_port(DeprecatedString const&);
+    WebIDL::ExceptionOr<String> port() const;
+    void set_port(String const&);
 
-    DeprecatedString pathname() const;
-    void set_pathname(DeprecatedString const&);
+    WebIDL::ExceptionOr<String> pathname() const;
+    void set_pathname(String const&);
 
-    DeprecatedString search() const;
-    void set_search(DeprecatedString const&);
+    WebIDL::ExceptionOr<String> search() const;
+    WebIDL::ExceptionOr<void> set_search(String const&);
 
     URLSearchParams const* search_params() const;
 
-    DeprecatedString hash() const;
-    void set_hash(DeprecatedString const&);
+    WebIDL::ExceptionOr<String> hash() const;
+    void set_hash(String const&);
 
-    DeprecatedString to_json() const;
+    WebIDL::ExceptionOr<String> to_json() const;
 
-    void set_query(Badge<URLSearchParams>, DeprecatedString query) { m_url.set_query(move(query)); }
+    void set_query(Badge<URLSearchParams>, String query) { m_url.set_query(query.to_deprecated_string()); }
 
 private:
     URL(JS::Realm&, AK::URL, JS::NonnullGCPtr<URLSearchParams> query);

--- a/Userland/Libraries/LibWeb/URL/URL.idl
+++ b/Userland/Libraries/LibWeb/URL/URL.idl
@@ -1,7 +1,7 @@
 #import <URL/URLSearchParams.idl>
 
 // https://url.spec.whatwg.org/#url
-[Exposed=*, LegacyWindowAlias=webkitURL]
+[Exposed=*, LegacyWindowAlias=webkitURL, UseNewAKString]
 interface URL {
     constructor(USVString url, optional USVString base);
 

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.h
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.h
@@ -13,34 +13,34 @@
 namespace Web::URL {
 
 struct QueryParam {
-    DeprecatedString name;
-    DeprecatedString value;
+    String name;
+    String value;
 };
-DeprecatedString url_encode(Vector<QueryParam> const&, AK::URL::PercentEncodeSet);
-Vector<QueryParam> url_decode(StringView);
+ErrorOr<String> url_encode(Vector<QueryParam> const&, AK::URL::PercentEncodeSet);
+ErrorOr<Vector<QueryParam>> url_decode(StringView);
 
 class URLSearchParams : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(URLSearchParams, Bindings::PlatformObject);
 
 public:
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<URLSearchParams>> create(JS::Realm&, Vector<QueryParam> list);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<URLSearchParams>> construct_impl(JS::Realm&, Variant<Vector<Vector<DeprecatedString>>, OrderedHashMap<DeprecatedString, DeprecatedString>, DeprecatedString> const& init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<URLSearchParams>> construct_impl(JS::Realm&, Variant<Vector<Vector<String>>, OrderedHashMap<String, String>, String> const& init);
 
     virtual ~URLSearchParams() override;
 
     size_t size() const;
-    void append(DeprecatedString const& name, DeprecatedString const& value);
-    void delete_(DeprecatedString const& name);
-    DeprecatedString get(DeprecatedString const& name);
-    Vector<DeprecatedString> get_all(DeprecatedString const& name);
-    bool has(DeprecatedString const& name);
-    void set(DeprecatedString const& name, DeprecatedString const& value);
+    WebIDL::ExceptionOr<void> append(String const& name, String const& value);
+    WebIDL::ExceptionOr<void> delete_(String const& name);
+    Optional<String> get(String const& name);
+    WebIDL::ExceptionOr<Vector<String>> get_all(String const& name);
+    bool has(String const& name);
+    WebIDL::ExceptionOr<void> set(String const& name, String const& value);
 
-    void sort();
+    WebIDL::ExceptionOr<void> sort();
 
-    DeprecatedString to_deprecated_string() const;
+    WebIDL::ExceptionOr<String> to_string() const;
 
-    using ForEachCallback = Function<JS::ThrowCompletionOr<void>(DeprecatedString const&, DeprecatedString const&)>;
+    using ForEachCallback = Function<JS::ThrowCompletionOr<void>(String const&, String const&)>;
     JS::ThrowCompletionOr<void> for_each(ForEachCallback);
 
 private:
@@ -52,7 +52,7 @@ private:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    void update();
+    WebIDL::ExceptionOr<void> update();
 
     Vector<QueryParam> m_list;
     JS::GCPtr<URL> m_url;

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.idl
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.idl
@@ -1,5 +1,5 @@
 // https://url.spec.whatwg.org/#urlsearchparams
-[Exposed=*]
+[Exposed=*, UseNewAKString]
 interface URLSearchParams {
 
   constructor(optional (sequence<sequence<USVString>> or record<USVString, USVString> or USVString) init = "");


### PR DESCRIPTION
Follwing changes to BindingsGenerator:
- LibWeb: Add new String support for parameters with empty string defaults
- LibWeb: Handle optional return values for getters returning new String
