### PR TITLE
LibCore: Make directory iteration more comfy

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
@@ -348,12 +348,8 @@ inline ErrorOr<Core::DirIterator> path_to_dir_iterator(DeprecatedString path, St
         lexical_path = lexical_path.append(subpath);
 
     Core::DirIterator iterator(lexical_path.string(), Core::DirIterator::SkipParentAndBaseDir);
-    if (iterator.has_error()) {
-        // FIXME: Make Core::DirIterator return a StringView for its error
-        //        string.
-        auto const* error_string_ptr = iterator.error_string();
-        return Error::from_string_view({ error_string_ptr, strlen(error_string_ptr) });
-    }
+    if (iterator.has_error())
+        return iterator.error();
 
     return iterator;
 }
@@ -361,12 +357,8 @@ inline ErrorOr<Core::DirIterator> path_to_dir_iterator(DeprecatedString path, St
 inline ErrorOr<DeprecatedString> next_path_from_dir_iterator(Core::DirIterator& iterator)
 {
     auto next_path = iterator.next_full_path();
-    if (iterator.has_error()) {
-        // FIXME: Make Core::DirIterator return a StringView for its error
-        //        string.
-        auto const* error_string_ptr = iterator.error_string();
-        return Error::from_string_view({ error_string_ptr, strlen(error_string_ptr) });
-    }
+    if (iterator.has_error())
+        return iterator.error();
 
     return next_path;
 }

--- a/Tests/LibCpp/test-cpp-parser.cpp
+++ b/Tests/LibCpp/test-cpp-parser.cpp
@@ -5,13 +5,13 @@
  */
 
 #include <AK/LexicalPath.h>
-#include <LibCore/DirIterator.h>
+#include <LibCore/Directory.h>
 #include <LibCore/File.h>
 #include <LibCpp/Parser.h>
 #include <LibTest/TestCase.h>
 #include <unistd.h>
 
-constexpr char TESTS_ROOT_DIR[] = "/home/anon/Tests/cpp-tests/parser";
+constexpr StringView TESTS_ROOT_DIR = "/home/anon/Tests/cpp-tests/parser"sv;
 
 static DeprecatedString read_all(DeprecatedString const& path)
 {
@@ -24,16 +24,13 @@ static DeprecatedString read_all(DeprecatedString const& path)
 
 TEST_CASE(test_regression)
 {
-    Core::DirIterator directory_iterator(TESTS_ROOT_DIR, Core::DirIterator::Flags::SkipDots);
-
-    while (directory_iterator.has_next()) {
-        auto file_path = directory_iterator.next_full_path();
-
-        auto path = LexicalPath { file_path };
+    MUST(Core::Directory::for_each_entry(TESTS_ROOT_DIR, Core::DirIterator::Flags::SkipDots, [](auto const& entry, auto const& directory) -> ErrorOr<IterationDecision> {
+        auto path = LexicalPath::join(directory.path().string(), entry.name);
         if (!path.has_extension(".cpp"sv))
-            continue;
+            return IterationDecision::Continue;
 
         outln("Checking {}...", path.basename());
+        auto file_path = path.string();
 
         auto ast_file_path = DeprecatedString::formatted("{}.ast", file_path.substring(0, file_path.length() - sizeof(".cpp") + 1));
 
@@ -75,5 +72,6 @@ TEST_CASE(test_regression)
 
         auto equal = content == target_ast;
         EXPECT(equal);
-    }
+        return IterationDecision::Continue;
+    }));
 }

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -61,7 +61,7 @@ private:
 
         Core::DirIterator iterator("/res/keymaps/", Core::DirIterator::Flags::SkipDots);
         if (iterator.has_error()) {
-            GUI::MessageBox::show(nullptr, DeprecatedString::formatted("Error on reading mapping file list: {}", iterator.error_string()), "Keyboard settings"sv, GUI::MessageBox::Type::Error);
+            GUI::MessageBox::show(nullptr, DeprecatedString::formatted("Error on reading mapping file list: {}", iterator.error()), "Keyboard settings"sv, GUI::MessageBox::Type::Error);
             GUI::Application::the()->quit(-1);
         }
 

--- a/Userland/Applications/SpaceAnalyzer/Tree.cpp
+++ b/Userland/Applications/SpaceAnalyzer/Tree.cpp
@@ -13,7 +13,6 @@
 
 #include <fcntl.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 static constexpr size_t FILES_ENCOUNTERED_UPDATE_STEP_SIZE = 25;
 
@@ -93,8 +92,9 @@ HashMap<int, int> TreeNode::populate_filesize_tree(Vector<MountInfo>& mounts, Fu
 
         Core::DirIterator dir_iterator(builder.to_deprecated_string(), Core::DirIterator::SkipParentAndBaseDir);
         if (dir_iterator.has_error()) {
-            int error_sum = error_accumulator.get(dir_iterator.error()).value_or(0);
-            error_accumulator.set(dir_iterator.error(), error_sum + 1);
+            auto error_code = dir_iterator.error().code();
+            int error_sum = error_accumulator.get(error_code).value_or(0);
+            error_accumulator.set(error_code, error_sum + 1);
         } else {
             queue_entry.node->m_children = make<Vector<TreeNode>>();
             while (dir_iterator.has_next()) {

--- a/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.cpp
@@ -111,7 +111,7 @@ void ProjectTemplatesModel::rescan_templates()
     // Iterate over template manifest INI files in the templates path
     Core::DirIterator di(ProjectTemplate::templates_path(), Core::DirIterator::SkipDots);
     if (di.has_error()) {
-        warnln("DirIterator: {}", di.error_string());
+        warnln("DirIterator: {}", di.error());
         return;
     }
 

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     DateTime.cpp
     DeprecatedFile.cpp
     Directory.cpp
+    DirectoryEntry.cpp
     DirIterator.cpp
     ElapsedTimer.cpp
     Event.cpp

--- a/Userland/Libraries/LibCore/DeprecatedFile.cpp
+++ b/Userland/Libraries/LibCore/DeprecatedFile.cpp
@@ -583,7 +583,7 @@ ErrorOr<void> DeprecatedFile::remove(StringView path, RecursionMode mode)
     if (S_ISDIR(path_stat.st_mode) && mode == RecursionMode::Allowed) {
         auto di = DirIterator(path, DirIterator::SkipParentAndBaseDir);
         if (di.has_error())
-            return Error::from_errno(di.error());
+            return di.error();
 
         while (di.has_next()) {
             TRY(remove(di.next_full_path(), RecursionMode::Allowed));

--- a/Userland/Libraries/LibCore/DirIterator.cpp
+++ b/Userland/Libraries/LibCore/DirIterator.cpp
@@ -17,7 +17,7 @@ DirIterator::DirIterator(DeprecatedString path, Flags flags)
 {
     m_dir = opendir(m_path.characters());
     if (!m_dir) {
-        m_error = errno;
+        m_error = Error::from_errno(errno);
     }
 }
 
@@ -31,7 +31,7 @@ DirIterator::~DirIterator()
 
 DirIterator::DirIterator(DirIterator&& other)
     : m_dir(other.m_dir)
-    , m_error(other.m_error)
+    , m_error(move(other.m_error))
     , m_next(move(other.m_next))
     , m_path(move(other.m_path))
     , m_flags(other.m_flags)
@@ -48,7 +48,7 @@ bool DirIterator::advance_next()
         errno = 0;
         auto* de = readdir(m_dir);
         if (!de) {
-            m_error = errno;
+            m_error = Error::from_errno(errno);
             m_next.clear();
             return false;
         }

--- a/Userland/Libraries/LibCore/DirIterator.h
+++ b/Userland/Libraries/LibCore/DirIterator.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,6 +8,7 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
+#include <LibCore/DirectoryEntry.h>
 #include <dirent.h>
 #include <string.h>
 
@@ -30,6 +32,7 @@ public:
     int error() const { return m_error; }
     char const* error_string() const { return strerror(m_error); }
     bool has_next();
+    Optional<DirectoryEntry> next();
     DeprecatedString next_path();
     DeprecatedString next_full_path();
     int fd() const;
@@ -37,7 +40,7 @@ public:
 private:
     DIR* m_dir = nullptr;
     int m_error = 0;
-    DeprecatedString m_next;
+    Optional<DirectoryEntry> m_next;
     DeprecatedString m_path;
     int m_flags;
 

--- a/Userland/Libraries/LibCore/DirIterator.h
+++ b/Userland/Libraries/LibCore/DirIterator.h
@@ -28,9 +28,8 @@ public:
     DirIterator(DirIterator&&);
     DirIterator(DirIterator const&) = delete;
 
-    bool has_error() const { return m_error != 0; }
-    int error() const { return m_error; }
-    char const* error_string() const { return strerror(m_error); }
+    bool has_error() const { return m_error.has_value(); }
+    Error error() const { return Error::copy(m_error.value()); }
     bool has_next();
     Optional<DirectoryEntry> next();
     DeprecatedString next_path();
@@ -39,7 +38,7 @@ public:
 
 private:
     DIR* m_dir = nullptr;
-    int m_error = 0;
+    Optional<Error> m_error;
     Optional<DirectoryEntry> m_next;
     DeprecatedString m_path;
     int m_flags;

--- a/Userland/Libraries/LibCore/Directory.cpp
+++ b/Userland/Libraries/LibCore/Directory.cpp
@@ -93,9 +93,4 @@ ErrorOr<struct stat> Directory::stat() const
     return System::fstat(m_directory_fd);
 }
 
-ErrorOr<DirIterator> Directory::create_iterator() const
-{
-    return DirIterator { path().string() };
-}
-
 }

--- a/Userland/Libraries/LibCore/Directory.cpp
+++ b/Userland/Libraries/LibCore/Directory.cpp
@@ -12,7 +12,7 @@
 namespace Core {
 
 // We assume that the fd is a valid directory.
-Directory::Directory(int fd, Optional<LexicalPath> path)
+Directory::Directory(int fd, LexicalPath path)
     : m_path(move(path))
     , m_directory_fd(fd)
 {
@@ -45,7 +45,7 @@ ErrorOr<bool> Directory::is_valid_directory(int fd)
     return stat.st_mode & S_IFDIR;
 }
 
-ErrorOr<Directory> Directory::adopt_fd(int fd, Optional<LexicalPath> path)
+ErrorOr<Directory> Directory::adopt_fd(int fd, LexicalPath path)
 {
     // This will also fail if the fd is invalid in the first place.
     if (!TRY(Directory::is_valid_directory(fd)))
@@ -82,13 +82,6 @@ ErrorOr<void> Directory::ensure_directory(LexicalPath const& path, mode_t creati
     return {};
 }
 
-ErrorOr<LexicalPath> Directory::path() const
-{
-    if (!m_path.has_value())
-        return Error::from_string_literal("Directory wasn't created with a path");
-    return m_path.value();
-}
-
 ErrorOr<NonnullOwnPtr<File>> Directory::open(StringView filename, File::OpenMode mode) const
 {
     auto fd = TRY(System::openat(m_directory_fd, filename, File::open_mode_to_options(mode)));
@@ -102,7 +95,7 @@ ErrorOr<struct stat> Directory::stat() const
 
 ErrorOr<DirIterator> Directory::create_iterator() const
 {
-    return DirIterator { TRY(path()).string() };
+    return DirIterator { path().string() };
 }
 
 }

--- a/Userland/Libraries/LibCore/Directory.h
+++ b/Userland/Libraries/LibCore/Directory.h
@@ -35,23 +35,23 @@ public:
 
     static ErrorOr<Directory> create(LexicalPath path, CreateDirectories, mode_t creation_mode = 0755);
     static ErrorOr<Directory> create(DeprecatedString path, CreateDirectories, mode_t creation_mode = 0755);
-    static ErrorOr<Directory> adopt_fd(int fd, Optional<LexicalPath> path = {});
+    static ErrorOr<Directory> adopt_fd(int fd, LexicalPath path);
 
     ErrorOr<NonnullOwnPtr<File>> open(StringView filename, File::OpenMode mode) const;
     ErrorOr<struct stat> stat() const;
     ErrorOr<DirIterator> create_iterator() const;
 
-    ErrorOr<LexicalPath> path() const;
+    LexicalPath const& path() const { return m_path; }
 
     ErrorOr<void> chown(uid_t, gid_t);
 
     static ErrorOr<bool> is_valid_directory(int fd);
 
 private:
-    Directory(int directory_fd, Optional<LexicalPath> path);
+    Directory(int directory_fd, LexicalPath path);
     static ErrorOr<void> ensure_directory(LexicalPath const& path, mode_t creation_mode = 0755);
 
-    Optional<LexicalPath> m_path;
+    LexicalPath m_path;
     int m_directory_fd;
 };
 
@@ -62,10 +62,7 @@ template<>
 struct Formatter<Core::Directory> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Core::Directory const& directory)
     {
-        auto path = directory.path();
-        if (path.is_error())
-            TRY(builder.put_string("<unknown>"sv));
-        TRY(builder.put_string(path.release_value().string()));
+        TRY(builder.put_string(directory.path().string()));
         return {};
     }
 };

--- a/Userland/Libraries/LibCore/Directory.h
+++ b/Userland/Libraries/LibCore/Directory.h
@@ -39,6 +39,7 @@ public:
 
     ErrorOr<NonnullOwnPtr<File>> open(StringView filename, File::OpenMode mode) const;
     ErrorOr<struct stat> stat() const;
+    int fd() const { return m_directory_fd; }
     ErrorOr<DirIterator> create_iterator() const;
 
     LexicalPath const& path() const { return m_path; }

--- a/Userland/Libraries/LibCore/Directory.h
+++ b/Userland/Libraries/LibCore/Directory.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,16 +9,18 @@
 
 #include <AK/Error.h>
 #include <AK/Format.h>
+#include <AK/Function.h>
+#include <AK/IterationDecision.h>
 #include <AK/LexicalPath.h>
 #include <AK/Noncopyable.h>
 #include <AK/Optional.h>
+#include <LibCore/DirIterator.h>
+#include <LibCore/DirectoryEntry.h>
 #include <LibCore/File.h>
 #include <dirent.h>
 #include <sys/stat.h>
 
 namespace Core {
-
-class DirIterator;
 
 // Deal with real system directories. Any Directory instance always refers to a valid existing directory.
 class Directory {
@@ -42,6 +45,10 @@ public:
     int fd() const { return m_directory_fd; }
 
     LexicalPath const& path() const { return m_path; }
+
+    using ForEachEntryCallback = Function<ErrorOr<IterationDecision>(DirectoryEntry const&, Directory const& parent)>;
+    static ErrorOr<void> for_each_entry(StringView path, DirIterator::Flags, ForEachEntryCallback);
+    ErrorOr<void> for_each_entry(DirIterator::Flags, ForEachEntryCallback);
 
     ErrorOr<void> chown(uid_t, gid_t);
 

--- a/Userland/Libraries/LibCore/Directory.h
+++ b/Userland/Libraries/LibCore/Directory.h
@@ -40,7 +40,6 @@ public:
     ErrorOr<NonnullOwnPtr<File>> open(StringView filename, File::OpenMode mode) const;
     ErrorOr<struct stat> stat() const;
     int fd() const { return m_directory_fd; }
-    ErrorOr<DirIterator> create_iterator() const;
 
     LexicalPath const& path() const { return m_path; }
 

--- a/Userland/Libraries/LibCore/DirectoryEntry.cpp
+++ b/Userland/Libraries/LibCore/DirectoryEntry.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "DirectoryEntry.h"
+#include <dirent.h>
+
+namespace Core {
+
+static DirectoryEntry::Type directory_entry_type_from_posix(unsigned char dt_constant)
+{
+    switch (dt_constant) {
+    case DT_UNKNOWN:
+        return DirectoryEntry::Type::Unknown;
+    case DT_FIFO:
+        return DirectoryEntry::Type::NamedPipe;
+    case DT_CHR:
+        return DirectoryEntry::Type::CharacterDevice;
+    case DT_DIR:
+        return DirectoryEntry::Type::Directory;
+    case DT_BLK:
+        return DirectoryEntry::Type::BlockDevice;
+    case DT_REG:
+        return DirectoryEntry::Type::File;
+    case DT_LNK:
+        return DirectoryEntry::Type::SymbolicLink;
+    case DT_SOCK:
+        return DirectoryEntry::Type::Socket;
+    case DT_WHT:
+        return DirectoryEntry::Type::Whiteout;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+DirectoryEntry DirectoryEntry::from_dirent(dirent const& de)
+{
+    return DirectoryEntry {
+        .type = directory_entry_type_from_posix(de.d_type),
+        .name = de.d_name,
+    };
+};
+
+}

--- a/Userland/Libraries/LibCore/DirectoryEntry.h
+++ b/Userland/Libraries/LibCore/DirectoryEntry.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/DeprecatedString.h>
+
+struct dirent;
+
+namespace Core {
+
+struct DirectoryEntry {
+    enum class Type {
+        BlockDevice,
+        CharacterDevice,
+        Directory,
+        File,
+        NamedPipe,
+        Socket,
+        SymbolicLink,
+        Unknown,
+        Whiteout,
+    };
+    Type type;
+    // FIXME: Once we have a special Path string class, use that.
+    DeprecatedString name;
+
+    static DirectoryEntry from_dirent(dirent const&);
+};
+
+}

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -99,8 +99,9 @@ void FileSystemModel::Node::traverse_if_needed()
     auto full_path = this->full_path();
     Core::DirIterator di(full_path, m_model.should_show_dotfiles() ? Core::DirIterator::SkipParentAndBaseDir : Core::DirIterator::SkipDots);
     if (di.has_error()) {
-        m_error = di.error();
-        warnln("DirIterator: {}", di.error_string());
+        auto error = di.error();
+        m_error = error.code();
+        warnln("DirIterator: {}", error);
         return;
     }
 

--- a/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -130,7 +130,7 @@ void FontDatabase::load_all_fonts_from_path(DeprecatedString const& root)
         auto current_directory = path_queue.dequeue();
         Core::DirIterator dir_iterator(current_directory, Core::DirIterator::SkipParentAndBaseDir);
         if (dir_iterator.has_error()) {
-            dbgln("FontDatabase::load_all_fonts_from_path: {}", dir_iterator.error_string());
+            dbgln("FontDatabase::load_all_fonts_from_path: {}", dir_iterator.error());
             continue;
         }
         while (dir_iterator.has_next()) {

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -158,8 +158,9 @@ static ErrorOr<void> populate_devtmpfs_char_devices_based_on_sysfs()
 {
     Core::DirIterator di("/sys/dev/char/", Core::DirIterator::SkipParentAndBaseDir);
     if (di.has_error()) {
-        warnln("Failed to open /sys/dev/char - {}", di.error());
-        return Error::from_errno(di.error());
+        auto error = di.error();
+        warnln("Failed to open /sys/dev/char - {}", error);
+        return error;
     }
     while (di.has_next()) {
         auto entry_name = di.next_path().split(':');

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -142,8 +142,9 @@ ErrorOr<u64> print_space_usage(DeprecatedString const& path, DuOption const& du_
     if (is_directory) {
         auto di = Core::DirIterator(path, Core::DirIterator::SkipParentAndBaseDir);
         if (di.has_error()) {
-            outln("du: cannot read directory '{}': {}", path, di.error_string());
-            return Error::from_string_literal("An error occurred. See previous error.");
+            auto error = di.error();
+            outln("du: cannot read directory '{}': {}", path, error);
+            return error;
         }
 
         while (di.has_next()) {

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -170,7 +170,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
             if (di.has_error()) {
                 status = 1;
-                fprintf(stderr, "%s: %s\n", path.characters(), di.error_string());
+                fprintf(stderr, "%s: %s\n", path.characters(), strerror(di.error().code()));
             }
 
             while (di.has_next()) {
@@ -396,7 +396,8 @@ static int do_file_system_object_long(char const* path)
     Core::DirIterator di(path, flags);
 
     if (di.has_error()) {
-        if (di.error() == ENOTDIR) {
+        auto error = di.error();
+        if (error.code() == ENOTDIR) {
             struct stat stat {
             };
             int rc = lstat(path, &stat);
@@ -406,7 +407,7 @@ static int do_file_system_object_long(char const* path)
                 return 0;
             return 2;
         }
-        fprintf(stderr, "%s: %s\n", path, di.error_string());
+        fprintf(stderr, "%s: %s\n", path, strerror(di.error().code()));
         return 1;
     }
 
@@ -510,7 +511,8 @@ int do_file_system_object_short(char const* path)
 
     Core::DirIterator di(path, flags);
     if (di.has_error()) {
-        if (di.error() == ENOTDIR) {
+        auto error = di.error();
+        if (error.code() == ENOTDIR) {
             size_t nprinted = 0;
             bool status = print_filesystem_object_short(path, path, &nprinted);
             printf("\n");
@@ -518,7 +520,7 @@ int do_file_system_object_short(char const* path)
                 return 0;
             return 2;
         }
-        fprintf(stderr, "%s: %s\n", path, di.error_string());
+        fprintf(stderr, "%s: %s\n", path, strerror(di.error().code()));
         return 1;
     }
 

--- a/Userland/Utilities/lsblk.cpp
+++ b/Userland/Utilities/lsblk.cpp
@@ -27,8 +27,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::DirIterator di("/sys/devices/storage/", Core::DirIterator::SkipParentAndBaseDir);
     if (di.has_error()) {
-        warnln("Failed to open /sys/devices/storage - {}", di.error());
-        return 1;
+        auto error = di.error();
+        warnln("Failed to open /sys/devices/storage - {}", error);
+        return error;
     }
 
     outln(format_row, "LUN"sv, "Command set"sv, "Block Size"sv, "Last LBA"sv);

--- a/Userland/Utilities/lspci.cpp
+++ b/Userland/Utilities/lspci.cpp
@@ -70,8 +70,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::DirIterator di("/sys/bus/pci/", Core::DirIterator::SkipParentAndBaseDir);
     if (di.has_error()) {
-        warnln("Failed to open /sys/bus/pci - {}", di.error());
-        return 1;
+        auto error = di.error();
+        warnln("Failed to open /sys/bus/pci - {}", error);
+        return error;
     }
 
     TRY(Core::System::pledge("stdio rpath"));

--- a/Userland/Utilities/mount.cpp
+++ b/Userland/Utilities/mount.cpp
@@ -129,8 +129,8 @@ static ErrorOr<void> mount_all()
 
     auto fstab_directory_iterator = Core::DirIterator("/etc/fstab.d", Core::DirIterator::SkipDots);
 
-    if (fstab_directory_iterator.has_error() && fstab_directory_iterator.error() != ENOENT) {
-        dbgln("Failed to open /etc/fstab.d: {}", fstab_directory_iterator.error_string());
+    if (fstab_directory_iterator.has_error() && fstab_directory_iterator.error().code() != ENOENT) {
+        dbgln("Failed to open /etc/fstab.d: {}", fstab_directory_iterator.error());
     } else if (!fstab_directory_iterator.has_error()) {
         while (fstab_directory_iterator.has_next()) {
             auto path = fstab_directory_iterator.next_full_path();

--- a/Userland/Utilities/sysctl.cpp
+++ b/Userland/Utilities/sysctl.cpp
@@ -82,7 +82,7 @@ static int handle_show_all()
 {
     Core::DirIterator di("/sys/kernel/variables", Core::DirIterator::SkipDots);
     if (di.has_error()) {
-        outln("DirIterator: {}", di.error_string());
+        outln("DirIterator: {}", di.error());
         return 1;
     }
 

--- a/Userland/Utilities/tree.cpp
+++ b/Userland/Utilities/tree.cpp
@@ -48,7 +48,7 @@ static void print_directory_tree(DeprecatedString const& root_path, int depth, D
 
     Core::DirIterator di(root_path, flag_show_hidden_files ? Core::DirIterator::SkipParentAndBaseDir : Core::DirIterator::SkipDots);
     if (di.has_error()) {
-        warnln("{}: {}", root_path, di.error_string());
+        warnln("{}: {}", root_path, di.error());
         return;
     }
 
@@ -56,7 +56,7 @@ static void print_directory_tree(DeprecatedString const& root_path, int depth, D
     while (di.has_next()) {
         DeprecatedString name = di.next_path();
         if (di.has_error()) {
-            warnln("{}: {}", root_path, di.error_string());
+            warnln("{}: {}", root_path, di.error());
             continue;
         }
         names.append(name);


### PR DESCRIPTION
This first makes DirIterator a little nicer (returning an Error, and exposing the type of the entry), then builds on that with a new `Core::Directory::for_each_entry()` API. I've migrated a few things to it as examples. I think it's nice. :^)

The callback gets given both a `DirectoryEntry` struct with the name and type of the entry, and the `Directory` itself. This should cover all cases, whereas the previous `DirIterator` did not expose the entry type and `find` had to manually implement its own iteration.

As a simple example, this:

```c++
Core::DirIterator piece_set_iterator { "/res/icons/chess/sets/", Core::DirIterator::SkipParentAndBaseDir };
while (piece_set_iterator.has_next())
    m_piece_sets.append(piece_set_iterator.next_path());
```

becomes this:

```c++
TRY(Core::Directory::for_each_entry("/res/icons/chess/sets/"sv, Core::DirIterator::SkipParentAndBaseDir, [&](auto const& entry, auto&) -> ErrorOr<IterationDecision> {
    TRY(m_piece_sets.try_append(entry.name));
    return IterationDecision::Continue;
}));
```

