### PR TITLE
AK: Ensure short strings are valid UTF-8, detect overlong UTF-8 encodings

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -11,7 +11,6 @@
 #include <AK/MemMem.h>
 #include <AK/Stream.h>
 #include <AK/String.h>
-#include <AK/Utf8View.h>
 #include <AK/Vector.h>
 #include <stdlib.h>
 
@@ -132,15 +131,21 @@ ErrorOr<NonnullRefPtr<StringData>> StringData::from_utf8(char const* utf8_data, 
     // Strings of MAX_SHORT_STRING_BYTE_COUNT bytes or less should be handled by the String short string optimization.
     VERIFY(byte_count > String::MAX_SHORT_STRING_BYTE_COUNT);
 
-    Utf8View view(StringView(utf8_data, byte_count));
-    if (!view.validate())
-        return Error::from_string_literal("StringData::from_utf8: Input was not valid UTF-8");
-
     VERIFY(utf8_data);
     u8* buffer = nullptr;
     auto new_string_data = TRY(create_uninitialized(byte_count, buffer));
     memcpy(buffer, utf8_data, byte_count * sizeof(char));
     return new_string_data;
+}
+
+static ErrorOr<void> read_stream_into_buffer(Stream& stream, Bytes buffer)
+{
+    TRY(stream.read_entire_buffer(buffer));
+
+    if (!Utf8View { StringView { buffer } }.validate())
+        return Error::from_string_literal("String::from_stream: Input was not valid UTF-8");
+
+    return {};
 }
 
 ErrorOr<NonnullRefPtr<StringData>> StringData::from_stream(Stream& stream, size_t byte_count)
@@ -150,12 +155,7 @@ ErrorOr<NonnullRefPtr<StringData>> StringData::from_stream(Stream& stream, size_
 
     u8* buffer = nullptr;
     auto new_string_data = TRY(create_uninitialized(byte_count, buffer));
-    Bytes new_string_bytes = { buffer, byte_count };
-    TRY(stream.read_entire_buffer(new_string_bytes));
-
-    Utf8View view(StringView { new_string_bytes });
-    if (!view.validate())
-        return Error::from_string_literal("StringData::from_stream: Input was not valid UTF-8");
+    TRY(read_stream_into_buffer(stream, { buffer, byte_count }));
 
     return new_string_data;
 }
@@ -230,6 +230,9 @@ void String::destroy_string()
 
 ErrorOr<String> String::from_utf8(StringView view)
 {
+    if (!Utf8View { view }.validate())
+        return Error::from_string_literal("String::from_utf8: Input was not valid UTF-8");
+
     if (view.length() <= MAX_SHORT_STRING_BYTE_COUNT) {
         ShortString short_string;
         if (!view.is_empty())
@@ -246,7 +249,7 @@ ErrorOr<String> String::from_stream(Stream& stream, size_t byte_count)
     if (byte_count <= MAX_SHORT_STRING_BYTE_COUNT) {
         ShortString short_string;
         if (byte_count > 0)
-            TRY(stream.read_entire_buffer({ short_string.storage, byte_count }));
+            TRY(Detail::read_stream_into_buffer(stream, { short_string.storage, byte_count }));
         short_string.byte_count_and_short_string_flag = (byte_count << 1) | SHORT_STRING_FLAG;
         return String { short_string };
     }
@@ -587,9 +590,6 @@ DeprecatedString String::to_deprecated_string() const
 
 ErrorOr<String> String::from_deprecated_string(DeprecatedString const& deprecated_string)
 {
-    Utf8View view(deprecated_string);
-    if (!view.validate())
-        return Error::from_string_literal("String::from_deprecated_string: Input was not valid UTF-8");
     return String::from_utf8(deprecated_string.view());
 }
 

--- a/AK/String.h
+++ b/AK/String.h
@@ -20,6 +20,7 @@
 #include <AK/Traits.h>
 #include <AK/Types.h>
 #include <AK/UnicodeUtils.h>
+#include <AK/Utf8View.h>
 #include <AK/Vector.h>
 
 namespace AK {
@@ -72,6 +73,7 @@ public:
     static AK_SHORT_STRING_CONSTEVAL String from_utf8_short_string(StringView string)
     {
         VERIFY(string.length() <= MAX_SHORT_STRING_BYTE_COUNT);
+        VERIFY(Utf8View { string }.validate());
 
         ShortString short_string;
         for (size_t i = 0; i < string.length(); ++i)

--- a/AK/Utf8View.h
+++ b/AK/Utf8View.h
@@ -7,10 +7,13 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/Format.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
+
+#ifndef KERNEL
+#    include <AK/DeprecatedString.h>
+#endif
 
 namespace AK {
 
@@ -61,19 +64,21 @@ public:
 
     Utf8View() = default;
 
-    explicit Utf8View(DeprecatedString& string)
-        : m_string(string.view())
-    {
-    }
-
     explicit constexpr Utf8View(StringView string)
         : m_string(string)
     {
     }
 
-    ~Utf8View() = default;
+#ifndef KERNEL
+    explicit Utf8View(DeprecatedString& string)
+        : m_string(string.view())
+    {
+    }
 
     explicit Utf8View(DeprecatedString&&) = delete;
+#endif
+
+    ~Utf8View() = default;
 
     StringView as_string() const { return m_string; }
 
@@ -224,6 +229,7 @@ private:
     mutable bool m_have_length { false };
 };
 
+#ifndef KERNEL
 class DeprecatedStringCodePointIterator {
 public:
     Optional<u32> next()
@@ -257,6 +263,7 @@ private:
     DeprecatedString m_string;
     Utf8CodePointIterator m_it;
 };
+#endif
 
 template<>
 struct Formatter<Utf8View> : Formatter<StringView> {
@@ -266,7 +273,9 @@ struct Formatter<Utf8View> : Formatter<StringView> {
 }
 
 #if USING_AK_GLOBALLY
+#    ifndef KERNEL
 using AK::DeprecatedStringCodePointIterator;
+#    endif
 using AK::Utf8CodePointIterator;
 using AK::Utf8View;
 #endif

--- a/Tests/AK/TestUtf8.cpp
+++ b/Tests/AK/TestUtf8.cpp
@@ -82,6 +82,47 @@ TEST_CASE(validate_invalid_ut8)
     EXPECT(valid_bytes == 0);
 }
 
+TEST_CASE(validate_overlong_utf8)
+{
+    size_t valid_bytes = 0;
+
+    // Overlong 2-byte encoding of U+002F
+    char invalid_utf8_1[] = { 42, 35, static_cast<char>(0xc0), static_cast<char>(0xaf) };
+    Utf8View utf8_1 { StringView { invalid_utf8_1, sizeof(invalid_utf8_1) } };
+    EXPECT(!utf8_1.validate(valid_bytes));
+    EXPECT(valid_bytes == 2);
+
+    // Overlong 3-byte encoding of U+002F
+    char invalid_utf8_2[] = { 42, 35, static_cast<char>(0xe0), static_cast<char>(0x80), static_cast<char>(0xaf) };
+    Utf8View utf8_2 { StringView { invalid_utf8_2, sizeof(invalid_utf8_2) } };
+    EXPECT(!utf8_2.validate(valid_bytes));
+    EXPECT(valid_bytes == 2);
+
+    // Overlong 4-byte encoding of U+002F
+    char invalid_utf8_3[] = { 42, 35, static_cast<char>(0xf0), static_cast<char>(0x80), static_cast<char>(0x80), static_cast<char>(0xaf) };
+    Utf8View utf8_3 { StringView { invalid_utf8_3, sizeof(invalid_utf8_3) } };
+    EXPECT(!utf8_3.validate(valid_bytes));
+    EXPECT(valid_bytes == 2);
+
+    // Overlong 3-byte encoding of U+00FF
+    char invalid_utf8_4[] = { 42, 35, static_cast<char>(0xe0), static_cast<char>(0x83), static_cast<char>(0xbf) };
+    Utf8View utf8_4 { StringView { invalid_utf8_4, sizeof(invalid_utf8_4) } };
+    EXPECT(!utf8_4.validate(valid_bytes));
+    EXPECT(valid_bytes == 2);
+
+    // Overlong 4-byte encoding of U+00FF
+    char invalid_utf8_5[] = { 42, 35, static_cast<char>(0xf0), static_cast<char>(0x80), static_cast<char>(0x83), static_cast<char>(0xbf) };
+    Utf8View utf8_5 { StringView { invalid_utf8_5, sizeof(invalid_utf8_5) } };
+    EXPECT(!utf8_5.validate(valid_bytes));
+    EXPECT(valid_bytes == 2);
+
+    // Overlong 4-byte encoding of U+0FFF
+    char invalid_utf8_6[] = { 42, 35, static_cast<char>(0xf0), static_cast<char>(0x8f), static_cast<char>(0xbf), static_cast<char>(0xbf) };
+    Utf8View utf8_6 { StringView { invalid_utf8_6, sizeof(invalid_utf8_6) } };
+    EXPECT(!utf8_6.validate(valid_bytes));
+    EXPECT(valid_bytes == 2);
+}
+
 TEST_CASE(iterate_utf8)
 {
     Utf8View view("Some weird characters \u00A9\u266A\uA755"sv);


### PR DESCRIPTION
We currently only validate long strings are UTF-8. This makes UTF-8 validation available at compile time (for constexpr short strings), and also extends the validation to check for overlong encodings.