### PR TITLE
Start adding a built-in sRGB color profile

### DIFF
--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SOURCES
     ICC/Profile.cpp
     ICC/Tags.cpp
     ICC/TagTypes.cpp
+    ICC/WellKnownProfiles.cpp
     ICOLoader.cpp
     ImageDecoder.cpp
     JPEGLoader.cpp

--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -1316,7 +1316,12 @@ ErrorOr<NonnullRefPtr<Profile>> Profile::try_load_from_externally_owned_memory(R
     bytes = bytes.trim(header.on_disk_size);
     auto tag_table = TRY(read_tag_table(bytes));
 
-    auto profile = TRY(try_make_ref_counted<Profile>(header, move(tag_table)));
+    return create(header, move(tag_table));
+}
+
+ErrorOr<NonnullRefPtr<Profile>> Profile::create(ProfileHeader const& header, OrderedHashMap<TagSignature, NonnullRefPtr<TagData>> tag_table)
+{
+    auto profile = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) Profile(header, move(tag_table))));
 
     TRY(profile->check_required_tags());
     TRY(profile->check_tag_types());

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -211,12 +211,7 @@ struct ProfileHeader {
 class Profile : public RefCounted<Profile> {
 public:
     static ErrorOr<NonnullRefPtr<Profile>> try_load_from_externally_owned_memory(ReadonlyBytes);
-
-    Profile(ProfileHeader const& header, OrderedHashMap<TagSignature, NonnullRefPtr<TagData>> tag_table)
-        : m_header(header)
-        , m_tag_table(move(tag_table))
-    {
-    }
+    static ErrorOr<NonnullRefPtr<Profile>> create(ProfileHeader const& header, OrderedHashMap<TagSignature, NonnullRefPtr<TagData>> tag_table);
 
     Optional<PreferredCMMType> preferred_cmm_type() const { return m_header.preferred_cmm_type; }
     Version version() const { return m_header.version; }
@@ -262,6 +257,12 @@ public:
     bool is_v4() const { return version().major_version() == 4; }
 
 private:
+    Profile(ProfileHeader const& header, OrderedHashMap<TagSignature, NonnullRefPtr<TagData>> tag_table)
+        : m_header(header)
+        , m_tag_table(move(tag_table))
+    {
+    }
+
     ErrorOr<void> check_required_tags();
     ErrorOr<void> check_tag_types();
 

--- a/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.cpp
+++ b/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/ICC/Profile.h>
+#include <LibGfx/ICC/Tags.h>
+#include <LibGfx/ICC/WellKnownProfiles.h>
+#include <time.h>
+
+namespace Gfx::ICC {
+
+static ProfileHeader rgb_header()
+{
+    ProfileHeader header;
+    header.version = Version(4, 0x40);
+    header.device_class = DeviceClass::DisplayDevice;
+    header.data_color_space = ColorSpace::RGB;
+    header.connection_space = ColorSpace::PCSXYZ;
+    header.creation_timestamp = time(NULL);
+    header.rendering_intent = RenderingIntent::Perceptual;
+    header.pcs_illuminant = XYZ { 0.9642, 1.0, 0.8249 };
+    return header;
+}
+
+static ErrorOr<NonnullRefPtr<MultiLocalizedUnicodeTagData>> en_US(StringView text)
+{
+    Vector<MultiLocalizedUnicodeTagData::Record> records;
+    TRY(records.try_append({ ('e' << 8) | 'n', ('U' << 8) | 'S', TRY(String::from_utf8(text)) }));
+    return try_make_ref_counted<MultiLocalizedUnicodeTagData>(0, 0, records);
+}
+
+static ErrorOr<NonnullRefPtr<XYZTagData>> XYZ_data(XYZ xyz)
+{
+    Vector<XYZ> xyzs;
+    TRY(xyzs.try_append(xyz));
+    return try_make_ref_counted<XYZTagData>(0, 0, move(xyzs));
+}
+
+ErrorOr<NonnullRefPtr<Profile>> sRGB()
+{
+    // Returns an sRGB profile.
+    // https://en.wikipedia.org/wiki/SRGB
+
+    // FIXME: There's a surprising amount of variety in sRGB ICC profiles in the wild.
+    //        Explain why, and why this picks the numbers it does.
+
+    auto header = rgb_header();
+
+    OrderedHashMap<TagSignature, NonnullRefPtr<TagData>> tag_table;
+
+    TRY(tag_table.try_set(profileDescriptionTag, TRY(en_US("SerenityOS sRGB"sv))));
+    TRY(tag_table.try_set(copyrightTag, TRY(en_US("Public Domain"sv))));
+
+    // Transfer function.
+    // Numbers from https://en.wikipedia.org/wiki/SRGB#From_sRGB_to_CIE_XYZ
+    Array<S15Fixed16, 7> curve_parameters = { 2.4, 1 / 1.055, 0.055 / 1.055, 1 / 12.92, 0.04045 };
+    auto curve = TRY(try_make_ref_counted<ParametricCurveTagData>(0, 0, ParametricCurveTagData::FunctionType::sRGB, curve_parameters));
+    TRY(tag_table.try_set(redTRCTag, curve));
+    TRY(tag_table.try_set(greenTRCTag, curve));
+    TRY(tag_table.try_set(blueTRCTag, curve));
+
+    // Chromatic adaptation matrix, chromacities and whitepoint.
+    // FIXME: Actual values for chromatic adaptation matrix and chromacities.
+    TRY(tag_table.try_set(mediaWhitePointTag, TRY(XYZ_data(XYZ { 0, 0, 0 }))));
+    TRY(tag_table.try_set(redMatrixColumnTag, TRY(XYZ_data(XYZ { 0, 0, 0 }))));
+    TRY(tag_table.try_set(greenMatrixColumnTag, TRY(XYZ_data(XYZ { 0, 0, 0 }))));
+    TRY(tag_table.try_set(blueMatrixColumnTag, TRY(XYZ_data(XYZ { 0, 0, 0 }))));
+
+    Vector<S15Fixed16, 9> chromatic_adaptation_matrix = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    TRY(tag_table.try_set(chromaticAdaptationTag, TRY(try_make_ref_counted<S15Fixed16ArrayTagData>(0, 0, move(chromatic_adaptation_matrix)))));
+
+    return Profile::create(header, move(tag_table));
+}
+
+}

--- a/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.h
+++ b/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/NonnullRefPtr.h>
+
+namespace Gfx::ICC {
+
+class Profile;
+
+ErrorOr<NonnullRefPtr<Profile>> sRGB();
+
+}


### PR DESCRIPTION
This has a rough ratio of bytes-in-output-file to words-read-about-the-profile.

I'll write a long comment with a summary at some point. In the meantime, here's a link dump for anyone curious:

https://www.w3.org/Graphics/Color/sRGB.html – early version of the spec

https://web.archive.org/web/20141225172302/http://www2.units.it/ipl/students_area/imm2/files/Colore1/sRGB.pdf – actual spec I think, but not public (but the numbers seem to match what's on Wikipedia).

https://www.color.org/sRGB.pdf (nobody does the "However, when making ICC v4 profiles…" bit though and people seem to think it's a bad idea from what I can tell)

https://ninedegreesbelow.com/photography/srgb-profile-comparison.html – an old survey of many v2 sRGB ICC profiles
https://ninedegreesbelow.com/photography/well-behaved-profile.html
https://ninedegreesbelow.com/photography/srgb-color-space-to-profile.html – worked example of how to come up with an sRGB profile (C3 is a bit confused about what fixed-point numbers are though)

These posts by the author of https://github.com/saucecontrol/Compact-ICC-Profiles:
https://photosauce.net/blog/post/making-a-minimal-srgb-icc-profile-part-3-choose-your-colors-carefully
https://photosauce.net/blog/post/what-makes-srgb-a-special-color-space
https://photosauce.net/blog/post/making-a-minimal-srgb-icc-profile-part-4-final-results
They're fairly verbose but they're a decent overview and have good ideas (the first part of that last-linked post for example mentions why the alpha value that the GIMP profile and – now – the serenity profile might not be the ideal one).

http://web.archive.org/web/20030212204955/http://www.srgb.com/basicsofsrgb.htm – summary of just the numbers.

https://discuss.pixls.us/t/feature-request-save-as-floating-point/5696/134 and onward has a discussion between the authors of these two blog post series and the author of Argyll CMS.