### PR TITLE
LibCMake: Add folding regions to syntax highlighter

### DIFF
--- a/Userland/Libraries/LibCMake/Token.cpp
+++ b/Userland/Libraries/LibCMake/Token.cpp
@@ -30,6 +30,8 @@ Optional<ControlKeywordType> control_keyword_from_string(StringView value)
         return ControlKeywordType::Break;
     if (value.equals_ignoring_case("continue"sv))
         return ControlKeywordType::Continue;
+    if (value.equals_ignoring_case("return"sv))
+        return ControlKeywordType::Return;
     if (value.equals_ignoring_case("macro"sv))
         return ControlKeywordType::Macro;
     if (value.equals_ignoring_case("endmacro"sv))
@@ -38,6 +40,10 @@ Optional<ControlKeywordType> control_keyword_from_string(StringView value)
         return ControlKeywordType::Function;
     if (value.equals_ignoring_case("endfunction"sv))
         return ControlKeywordType::EndFunction;
+    if (value.equals_ignoring_case("block"sv))
+        return ControlKeywordType::Block;
+    if (value.equals_ignoring_case("endblock"sv))
+        return ControlKeywordType::EndBlock;
     return {};
 }
 

--- a/Userland/Libraries/LibCMake/Token.h
+++ b/Userland/Libraries/LibCMake/Token.h
@@ -33,10 +33,13 @@ enum class ControlKeywordType {
     EndWhile,
     Break,
     Continue,
+    Return,
     Macro,
     EndMacro,
     Function,
     EndFunction,
+    Block,
+    EndBlock,
 };
 
 struct Token {


### PR DESCRIPTION
This creates folding regions for blocks defined by the following:
- if/elseif/else/endif
- foreach/endforeach
- while/endwhile
- macro/endmacro
- function/endfunction

Since there is no guarantee that each keyword will have a matching partner, we do our best by looking for the most recent possible start token matching the current end token. If we find one, we link to it and drop all the other start-tokens that happened in between. For example, we would define a folding region for this invalid file like so:

```
[-] if(TRUE)
 │      while()
 └─ endif()
```