### PR TITLE
Kernel: Actually check Process unveil data when creating perfcore dump

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -61,7 +61,9 @@ public:
     ErrorOr<void> unmount(Custody& mount_point);
 
     ErrorOr<NonnullLockRefPtr<OpenFileDescription>> open(Credentials const&, StringView path, int options, mode_t mode, Custody& base, Optional<UidAndGid> = {});
+    ErrorOr<NonnullLockRefPtr<OpenFileDescription>> open(Process const&, Credentials const&, StringView path, int options, mode_t mode, Custody& base, Optional<UidAndGid> = {});
     ErrorOr<NonnullLockRefPtr<OpenFileDescription>> create(Credentials const&, StringView path, int options, mode_t mode, Custody& parent_custody, Optional<UidAndGid> = {});
+    ErrorOr<NonnullLockRefPtr<OpenFileDescription>> create(Process const&, Credentials const&, StringView path, int options, mode_t mode, Custody& parent_custody, Optional<UidAndGid> = {});
     ErrorOr<void> mkdir(Credentials const&, StringView path, mode_t mode, Custody& base);
     ErrorOr<void> link(Credentials const&, StringView old_path, StringView new_path, Custody& base);
     ErrorOr<void> unlink(Credentials const&, StringView path, Custody& base);
@@ -92,12 +94,15 @@ public:
 
     NonnullRefPtr<Custody> root_custody();
     ErrorOr<NonnullRefPtr<Custody>> resolve_path(Credentials const&, StringView path, NonnullRefPtr<Custody> base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0);
+    ErrorOr<NonnullRefPtr<Custody>> resolve_path(Process const&, Credentials const&, StringView path, NonnullRefPtr<Custody> base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0);
     ErrorOr<NonnullRefPtr<Custody>> resolve_path_without_veil(Credentials const&, StringView path, NonnullRefPtr<Custody> base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0);
 
 private:
     friend class OpenFileDescription;
 
-    UnveilNode const& find_matching_unveiled_path(StringView path);
+    UnveilNode const& find_matching_unveiled_path(Process const&, StringView path);
+    ErrorOr<void> validate_path_against_process_veil(Process const&, StringView path, int options);
+    ErrorOr<void> validate_path_against_process_veil(Process const& process, Custody const& custody, int options);
     ErrorOr<void> validate_path_against_process_veil(Custody const& path, int options);
     ErrorOr<void> validate_path_against_process_veil(StringView path, int options);
 

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -709,7 +709,7 @@ ErrorOr<void> Process::dump_perfcore()
     LockRefPtr<OpenFileDescription> description;
     auto credentials = this->credentials();
     for (size_t attempt = 1; attempt <= 10; ++attempt) {
-        auto description_or_error = VirtualFileSystem::the().open(credentials, perfcore_filename->view(), O_CREAT | O_EXCL, 0400, current_directory(), UidAndGid { 0, 0 });
+        auto description_or_error = VirtualFileSystem::the().open(*this, credentials, perfcore_filename->view(), O_CREAT | O_EXCL, 0400, current_directory(), UidAndGid { 0, 0 });
         if (!description_or_error.is_error()) {
             description = description_or_error.release_value();
             break;


### PR DESCRIPTION
Before of this patch, we looked at the unveil data of the FinalizerTask, which naturally doesn't have any unveil restrictions, therefore allowing an unveil bypass for a process that enabled performance coredumps.

To ensure we always check the dumped process unveil data, an option to pass a Process& has been added to a couple of methods in the class of VirtualFileSystem.

Fixes last problem in #15996, hence should close #15996.