### PR TITLE
AK: Implement human readable integer formatting separated by thousands

### DIFF
--- a/AK/NumberFormat.h
+++ b/AK/NumberFormat.h
@@ -21,11 +21,13 @@ DeprecatedString human_readable_quantity(u64 quantity, HumanReadableBasedOn base
 DeprecatedString human_readable_size_long(u64 size);
 DeprecatedString human_readable_time(i64 time_in_seconds);
 DeprecatedString human_readable_digital_time(i64 time_in_seconds);
+DeprecatedString human_readable_integer(i64 number);
 
 }
 
 #if USING_AK_GLOBALLY
 using AK::human_readable_digital_time;
+using AK::human_readable_integer;
 using AK::human_readable_quantity;
 using AK::human_readable_size;
 using AK::human_readable_size_long;

--- a/Tests/AK/TestNumberFormat.cpp
+++ b/Tests/AK/TestNumberFormat.cpp
@@ -133,3 +133,20 @@ TEST_CASE(base10_units)
     EXPECT_EQ(human_readable_size(1100, AK::HumanReadableBasedOn::Base10), "1.1 KB");
     EXPECT_EQ(human_readable_size(1000000, AK::HumanReadableBasedOn::Base10), "1.0 MB");
 }
+
+TEST_CASE(human_readable_integers)
+{
+    EXPECT_EQ(human_readable_integer(0), "0");
+    EXPECT_EQ(human_readable_integer(1), "1");
+    EXPECT_EQ(human_readable_integer(12), "12");
+    EXPECT_EQ(human_readable_integer(123), "123");
+    EXPECT_EQ(human_readable_integer(1234), "1,234");
+    EXPECT_EQ(human_readable_integer(12345), "12,345");
+    EXPECT_EQ(human_readable_integer(123456), "123,456");
+    EXPECT_EQ(human_readable_integer(1234567), "1,234,567");
+    EXPECT_EQ(human_readable_integer(1234567890123456789LL), "1,234,567,890,123,456,789");
+    // Non-leading sections must have leading zeros.
+    EXPECT_EQ(human_readable_integer(12003), "12,003");
+    // Negative numbers should work.
+    EXPECT_EQ(human_readable_integer(-1234), "-1,234");
+}


### PR DESCRIPTION
Also, enable it for displaying byte amounts in the file manager.

Before:
![Screenshot from 2023-03-04 18-46-32](https://user-images.githubusercontent.com/10389042/222933939-a78f274a-96bd-4aa8-b4bf-ae499e87af64.png)

After:
![Screenshot from 2023-03-04 18-07-14](https://user-images.githubusercontent.com/10389042/222933700-97f6f32e-01e6-4a78-a181-397aa57929ba.png)