### PR TITLE
AK+LibAudio: Remove UFixedBigInt::my_size

### DIFF
--- a/AK/FloatingPointStringConversions.cpp
+++ b/AK/FloatingPointStringConversions.cpp
@@ -434,8 +434,7 @@ constexpr static u128 compute_power_of_five(i64 exponent)
             base *= 5u;
         }
 
-        auto z = u4096::my_size() * 8
-            - base.clz();
+        auto z = 4096 - base.clz();
 
         auto b = z + 127;
         u4096 base2 { 1u };
@@ -457,8 +456,7 @@ constexpr static u128 compute_power_of_five(i64 exponent)
         base *= 5u;
     }
 
-    auto z = u4096::my_size() * 8
-        - base.clz();
+    auto z = 4096 - base.clz();
 
     auto b = 2 * z + 128;
 

--- a/AK/UFixedBigInt.h
+++ b/AK/UFixedBigInt.h
@@ -441,12 +441,6 @@ public:
     constexpr auto& operator%=(U const& other) { return *this = *this % other; }
     constexpr auto& operator%=(IntegerWrapper const& other) { return *this = *this % other; }
 
-    // FIXME: Replace uses with more general `assumed_bit_size<T>`.
-    static constexpr size_t my_size()
-    {
-        return sizeof(Storage);
-    }
-
     // Note: If there ever be need for non side-channel proof sqrt/pow/pow_mod of UFixedBigInt, you
     //       can restore them from Git history.
 

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -112,7 +112,7 @@ MaybeLoaderError FlacLoaderPlugin::parse_header()
     [[maybe_unused]] u128 md5_checksum;
     VERIFY(streaminfo_data.is_aligned_to_byte_boundary());
     auto md5_bytes_read = LOADER_TRY(streaminfo_data.read(md5_checksum.bytes()));
-    FLAC_VERIFY(md5_bytes_read.size() == md5_checksum.my_size(), LoaderError::Category::IO, "MD5 Checksum size");
+    FLAC_VERIFY(md5_bytes_read.size() == sizeof(md5_checksum), LoaderError::Category::IO, "MD5 Checksum size");
     md5_checksum.bytes().copy_to({ m_md5_checksum, sizeof(m_md5_checksum) });
 
     // Parse other blocks


### PR DESCRIPTION
This removes an awkward function, left in my previous PR for compatibility reasons, as well as the FIXME about that. :^)