### PR TITLE
AK+LibWeb: Start porting Web API events to new String

### DIFF
--- a/AK/FlyString.cpp
+++ b/AK/FlyString.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/DeprecatedFlyString.h>
 #include <AK/FlyString.h>
 #include <AK/HashMap.h>
 #include <AK/Singleton.h>
@@ -160,6 +161,11 @@ uintptr_t FlyString::data(Badge<String>) const
 size_t FlyString::number_of_fly_strings()
 {
     return all_fly_strings().size();
+}
+
+DeprecatedFlyString FlyString::to_deprecated_fly_string() const
+{
+    return DeprecatedFlyString(bytes_as_string_view());
 }
 
 unsigned Traits<FlyString>::hash(FlyString const& fly_string)

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -51,6 +51,9 @@ public:
     // This is primarily interesting to unit tests.
     [[nodiscard]] static size_t number_of_fly_strings();
 
+    // FIXME: Remove this once all code has been ported to FlyString
+    [[nodiscard]] DeprecatedFlyString to_deprecated_fly_string() const;
+
 private:
     // This will hold either the pointer to the Detail::StringData it represents or the raw bytes of
     // an inlined short string.

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -138,7 +138,7 @@ JS::VM& main_thread_vm()
                         /* .promise = */ promise,
                         /* .reason = */ promise.result(),
                     };
-                    auto promise_rejection_event = HTML::PromiseRejectionEvent::create(HTML::relevant_realm(global), HTML::EventNames::rejectionhandled, event_init).release_value_but_fixme_should_propagate_errors();
+                    auto promise_rejection_event = HTML::PromiseRejectionEvent::create(HTML::relevant_realm(global), String::from_deprecated_string(HTML::EventNames::rejectionhandled).release_value_but_fixme_should_propagate_errors(), event_init).release_value_but_fixme_should_propagate_errors();
                     window.dispatch_event(promise_rejection_event);
                 });
                 break;

--- a/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.cpp
@@ -10,13 +10,13 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<MediaQueryListEvent>> MediaQueryListEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, MediaQueryListEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<MediaQueryListEvent>> MediaQueryListEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, MediaQueryListEventInit const& event_init)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<MediaQueryListEvent>(realm, realm, event_name, event_init));
 }
 
-MediaQueryListEvent::MediaQueryListEvent(JS::Realm& realm, DeprecatedFlyString const& event_name, MediaQueryListEventInit const& event_init)
-    : DOM::Event(realm, event_name, event_init)
+MediaQueryListEvent::MediaQueryListEvent(JS::Realm& realm, FlyString const& event_name, MediaQueryListEventInit const& event_init)
+    : DOM::Event(realm, event_name.to_deprecated_fly_string(), event_init)
     , m_media(event_init.media)
     , m_matches(event_init.matches)
 {

--- a/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <LibWeb/DOM/Event.h>
 
 namespace Web::CSS {
 
 struct MediaQueryListEventInit : public DOM::EventInit {
-    DeprecatedString media { "" };
+    String media;
     bool matches { false };
 };
 
@@ -19,19 +20,19 @@ class MediaQueryListEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(MediaQueryListEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MediaQueryListEvent>> construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, MediaQueryListEventInit const& event_init = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MediaQueryListEvent>> construct_impl(JS::Realm&, FlyString const& event_name, MediaQueryListEventInit const& event_init = {});
 
     virtual ~MediaQueryListEvent() override;
 
-    DeprecatedString const& media() const { return m_media; }
+    String const& media() const { return m_media; }
     bool matches() const { return m_matches; }
 
 private:
-    MediaQueryListEvent(JS::Realm&, DeprecatedFlyString const& event_name, MediaQueryListEventInit const& event_init);
+    MediaQueryListEvent(JS::Realm&, FlyString const& event_name, MediaQueryListEventInit const& event_init);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
-    DeprecatedString m_media;
+    String m_media;
     bool m_matches;
 };
 }

--- a/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.idl
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.idl
@@ -1,7 +1,7 @@
 #import <DOM/Event.idl>
 
 // https://w3c.github.io/csswg-drafts/cssom-view-1/#mediaquerylistevent
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface MediaQueryListEvent : Event {
     constructor(CSSOMString type, optional MediaQueryListEventInit eventInitDict = {});
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1801,7 +1801,7 @@ void Document::evaluate_media_queries_and_report_changes()
 
         if (did_match != now_matches) {
             CSS::MediaQueryListEventInit init;
-            init.media = media_query_list->media();
+            init.media = String::from_deprecated_string(media_query_list->media()).release_value_but_fixme_should_propagate_errors();
             init.matches = now_matches;
             auto event = CSS::MediaQueryListEvent::create(realm(), HTML::EventNames::change, init).release_value_but_fixme_should_propagate_errors();
             event->set_is_trusted(true);

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1298,7 +1298,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Document::create_event(DeprecatedSt
     } else if (Infra::is_ascii_case_insensitive_match(interface, "keyboardevent"sv)) {
         event = TRY(UIEvents::KeyboardEvent::create(realm, ""));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "messageevent"sv)) {
-        event = TRY(HTML::MessageEvent::create(realm, ""));
+        event = TRY(HTML::MessageEvent::create(realm, String {}));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "mouseevent"sv)
         || Infra::is_ascii_case_insensitive_match(interface, "mouseevents"sv)) {
         event = TRY(UIEvents::MouseEvent::create(realm, ""));

--- a/Userland/Libraries/LibWeb/HTML/CloseEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CloseEvent.cpp
@@ -9,18 +9,18 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CloseEvent>> CloseEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, CloseEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<CloseEvent>> CloseEvent::create(JS::Realm& realm, FlyString const& event_name, CloseEventInit const& event_init)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<CloseEvent>(realm, realm, event_name, event_init));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CloseEvent>> CloseEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, CloseEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<CloseEvent>> CloseEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, CloseEventInit const& event_init)
 {
     return create(realm, event_name, event_init);
 }
 
-CloseEvent::CloseEvent(JS::Realm& realm, DeprecatedFlyString const& event_name, CloseEventInit const& event_init)
-    : DOM::Event(realm, event_name, event_init)
+CloseEvent::CloseEvent(JS::Realm& realm, FlyString const& event_name, CloseEventInit const& event_init)
+    : DOM::Event(realm, event_name.to_deprecated_fly_string(), event_init)
     , m_was_clean(event_init.was_clean)
     , m_code(event_init.code)
     , m_reason(event_init.reason)

--- a/Userland/Libraries/LibWeb/HTML/CloseEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/CloseEvent.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <LibWeb/DOM/Event.h>
 
 namespace Web::HTML {
@@ -14,30 +15,30 @@ namespace Web::HTML {
 struct CloseEventInit : public DOM::EventInit {
     bool was_clean { false };
     u16 code { 0 };
-    DeprecatedString reason { "" };
+    String reason;
 };
 
 class CloseEvent : public DOM::Event {
     WEB_PLATFORM_OBJECT(CloseEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CloseEvent>> create(JS::Realm&, DeprecatedFlyString const& event_name, CloseEventInit const& event_init = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CloseEvent>> construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, CloseEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CloseEvent>> create(JS::Realm&, FlyString const& event_name, CloseEventInit const& event_init = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CloseEvent>> construct_impl(JS::Realm&, FlyString const& event_name, CloseEventInit const& event_init);
 
     virtual ~CloseEvent() override;
 
     bool was_clean() const { return m_was_clean; }
     u16 code() const { return m_code; }
-    DeprecatedString reason() const { return m_reason; }
+    String reason() const { return m_reason; }
 
 private:
-    CloseEvent(JS::Realm&, DeprecatedFlyString const& event_name, CloseEventInit const& event_init);
+    CloseEvent(JS::Realm&, FlyString const& event_name, CloseEventInit const& event_init);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
     bool m_was_clean { false };
     u16 m_code { 0 };
-    DeprecatedString m_reason;
+    String m_reason;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/CloseEvent.idl
+++ b/Userland/Libraries/LibWeb/HTML/CloseEvent.idl
@@ -1,6 +1,6 @@
 #import <DOM/Event.idl>
 
-[Exposed=*]
+[Exposed=*, UseNewAKString]
 interface CloseEvent : Event {
     constructor(DOMString type, optional CloseEventInit eventInitDict = {});
 

--- a/Userland/Libraries/LibWeb/HTML/ErrorEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ErrorEvent.cpp
@@ -9,18 +9,18 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<ErrorEvent>> ErrorEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, ErrorEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<ErrorEvent>> ErrorEvent::create(JS::Realm& realm, FlyString const& event_name, ErrorEventInit const& event_init)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<ErrorEvent>(realm, realm, event_name, event_init));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<ErrorEvent>> ErrorEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, ErrorEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<ErrorEvent>> ErrorEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, ErrorEventInit const& event_init)
 {
     return create(realm, event_name, event_init);
 }
 
-ErrorEvent::ErrorEvent(JS::Realm& realm, DeprecatedFlyString const& event_name, ErrorEventInit const& event_init)
-    : DOM::Event(realm, event_name)
+ErrorEvent::ErrorEvent(JS::Realm& realm, FlyString const& event_name, ErrorEventInit const& event_init)
+    : DOM::Event(realm, event_name.to_deprecated_fly_string())
     , m_message(event_init.message)
     , m_filename(event_init.filename)
     , m_lineno(event_init.lineno)

--- a/Userland/Libraries/LibWeb/HTML/ErrorEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/ErrorEvent.h
@@ -6,14 +6,15 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <LibWeb/DOM/Event.h>
 
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#erroreventinit
 struct ErrorEventInit : public DOM::EventInit {
-    DeprecatedString message { "" };
-    DeprecatedString filename { "" }; // FIXME: This should be a USVString.
+    String message;
+    String filename; // FIXME: This should be a USVString.
     u32 lineno { 0 };
     u32 colno { 0 };
     JS::Value error { JS::js_null() };
@@ -24,16 +25,16 @@ class ErrorEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(ErrorEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ErrorEvent>> create(JS::Realm&, DeprecatedFlyString const& event_name, ErrorEventInit const& event_init = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ErrorEvent>> construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, ErrorEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ErrorEvent>> create(JS::Realm&, FlyString const& event_name, ErrorEventInit const& event_init = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ErrorEvent>> construct_impl(JS::Realm&, FlyString const& event_name, ErrorEventInit const& event_init);
 
     virtual ~ErrorEvent() override;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-message
-    DeprecatedString const& message() const { return m_message; }
+    String const& message() const { return m_message; }
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-filename
-    DeprecatedString const& filename() const { return m_filename; }
+    String const& filename() const { return m_filename; }
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-lineno
     u32 lineno() const { return m_lineno; }
@@ -45,13 +46,13 @@ public:
     JS::Value error() const { return m_error; }
 
 private:
-    ErrorEvent(JS::Realm&, DeprecatedFlyString const& event_name, ErrorEventInit const& event_init);
+    ErrorEvent(JS::Realm&, FlyString const& event_name, ErrorEventInit const& event_init);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    DeprecatedString m_message { "" };
-    DeprecatedString m_filename { "" }; // FIXME: This should be a USVString.
+    String m_message;
+    String m_filename; // FIXME: This should be a USVString.
     u32 m_lineno { 0 };
     u32 m_colno { 0 };
     JS::Value m_error;

--- a/Userland/Libraries/LibWeb/HTML/ErrorEvent.idl
+++ b/Userland/Libraries/LibWeb/HTML/ErrorEvent.idl
@@ -1,6 +1,6 @@
 #import <DOM/Event.idl>
 
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), UseNewAKString]
 interface ErrorEvent : Event {
     constructor(DOMString type, optional ErrorEventInit eventInitDict = {});
 

--- a/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
@@ -164,7 +164,7 @@ WebIDL::ExceptionOr<Optional<Vector<XHR::FormDataEntry>>> construct_entry_list(J
     // 7. Fire an event named formdata at form using FormDataEvent, with the formData attribute initialized to form data and the bubbles attribute initialized to true.
     FormDataEventInit init {};
     init.form_data = form_data;
-    auto form_data_event = TRY(FormDataEvent::construct_impl(realm, HTML::EventNames::formdata, init));
+    auto form_data_event = TRY(FormDataEvent::construct_impl(realm, String::from_deprecated_string(HTML::EventNames::formdata).release_value_but_fixme_should_propagate_errors(), init));
     form_data_event->set_bubbles(true);
     form.dispatch_event(form_data_event);
 

--- a/Userland/Libraries/LibWeb/HTML/FormDataEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormDataEvent.cpp
@@ -10,13 +10,13 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<FormDataEvent>> FormDataEvent::construct_impl(JS::Realm& realm, DeprecatedString const& event_name, FormDataEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<FormDataEvent>> FormDataEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, FormDataEventInit const& event_init)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<FormDataEvent>(realm, realm, event_name, event_init));
 }
 
-FormDataEvent::FormDataEvent(JS::Realm& realm, DeprecatedString const& event_name, FormDataEventInit const& event_init)
-    : DOM::Event(realm, event_name, event_init)
+FormDataEvent::FormDataEvent(JS::Realm& realm, FlyString const& event_name, FormDataEventInit const& event_init)
+    : DOM::Event(realm, event_name.to_deprecated_fly_string(), event_init)
     , m_form_data(event_init.form_data)
 {
 }

--- a/Userland/Libraries/LibWeb/HTML/FormDataEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/FormDataEvent.h
@@ -19,14 +19,14 @@ class FormDataEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(FormDataEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<FormDataEvent>> construct_impl(JS::Realm&, DeprecatedString const& event_name, FormDataEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<FormDataEvent>> construct_impl(JS::Realm&, FlyString const& event_name, FormDataEventInit const& event_init);
 
     virtual ~FormDataEvent() override;
 
     JS::GCPtr<XHR::FormData> form_data() const { return m_form_data; }
 
 private:
-    FormDataEvent(JS::Realm&, DeprecatedString const& event_name, FormDataEventInit const& event_init);
+    FormDataEvent(JS::Realm&, FlyString const& event_name, FormDataEventInit const& event_init);
 
     JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 

--- a/Userland/Libraries/LibWeb/HTML/FormDataEvent.idl
+++ b/Userland/Libraries/LibWeb/HTML/FormDataEvent.idl
@@ -2,7 +2,7 @@
 #import <XHR/FormData.idl>
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-formdataevent-interface
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface FormDataEvent : Event {
     constructor(DOMString type, FormDataEventInit eventInitDict);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -83,7 +83,7 @@ ErrorOr<void> HTMLFormElement::submit_form(JS::GCPtr<HTMLElement> submitter, boo
 
         SubmitEventInit event_init {};
         event_init.submitter = submitter_button;
-        auto submit_event = SubmitEvent::create(realm(), EventNames::submit, event_init).release_value_but_fixme_should_propagate_errors();
+        auto submit_event = SubmitEvent::create(realm(), String::from_deprecated_string(EventNames::submit).release_value_but_fixme_should_propagate_errors(), event_init).release_value_but_fixme_should_propagate_errors();
         submit_event->set_bubbles(true);
         submit_event->set_cancelable(true);
         bool continue_ = dispatch_event(*submit_event);

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
@@ -9,18 +9,18 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<MessageEvent>> MessageEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, MessageEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<MessageEvent>> MessageEvent::create(JS::Realm& realm, FlyString const& event_name, MessageEventInit const& event_init)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<MessageEvent>(realm, realm, event_name, event_init));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<MessageEvent>> MessageEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, MessageEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<MessageEvent>> MessageEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, MessageEventInit const& event_init)
 {
     return create(realm, event_name, event_init);
 }
 
-MessageEvent::MessageEvent(JS::Realm& realm, DeprecatedFlyString const& event_name, MessageEventInit const& event_init)
-    : DOM::Event(realm, event_name, event_init)
+MessageEvent::MessageEvent(JS::Realm& realm, FlyString const& event_name, MessageEventInit const& event_init)
+    : DOM::Event(realm, event_name.to_deprecated_fly_string(), event_init)
     , m_data(event_init.data)
     , m_origin(event_init.origin)
     , m_last_event_id(event_init.last_event_id)

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.h
@@ -7,37 +7,38 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <LibWeb/DOM/Event.h>
 
 namespace Web::HTML {
 
 struct MessageEventInit : public DOM::EventInit {
     JS::Value data { JS::js_null() };
-    DeprecatedString origin { "" };
-    DeprecatedString last_event_id { "" };
+    String origin;
+    String last_event_id;
 };
 
 class MessageEvent : public DOM::Event {
     WEB_PLATFORM_OBJECT(MessageEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MessageEvent>> create(JS::Realm&, DeprecatedFlyString const& event_name, MessageEventInit const& event_init = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MessageEvent>> construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, MessageEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MessageEvent>> create(JS::Realm&, FlyString const& event_name, MessageEventInit const& event_init = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MessageEvent>> construct_impl(JS::Realm&, FlyString const& event_name, MessageEventInit const& event_init);
 
-    MessageEvent(JS::Realm&, DeprecatedFlyString const& event_name, MessageEventInit const& event_init);
+    MessageEvent(JS::Realm&, FlyString const& event_name, MessageEventInit const& event_init);
     virtual ~MessageEvent() override;
 
     JS::Value data() const { return m_data; }
-    DeprecatedString const& origin() const { return m_origin; }
-    DeprecatedString const& last_event_id() const { return m_last_event_id; }
+    String const& origin() const { return m_origin; }
+    String const& last_event_id() const { return m_last_event_id; }
 
 private:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
     JS::Value m_data;
-    DeprecatedString m_origin;
-    DeprecatedString m_last_event_id;
+    String m_origin;
+    String m_last_event_id;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.idl
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.idl
@@ -1,7 +1,7 @@
 #import <DOM/Event.idl>
 
 // https://html.spec.whatwg.org/multipage/comms.html#messageevent
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), UseNewAKString]
 interface MessageEvent : Event {
     constructor(DOMString type, optional MessageEventInit eventInitDict = {});
 

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -98,8 +98,8 @@ void MessagePort::post_message(JS::Value message)
     main_thread_event_loop().task_queue().add(HTML::Task::create(HTML::Task::Source::PostedMessage, nullptr, [target_port, message] {
         MessageEventInit event_init {};
         event_init.data = message;
-        event_init.origin = "<origin>";
-        target_port->dispatch_event(MessageEvent::create(target_port->realm(), HTML::EventNames::message, event_init).release_value_but_fixme_should_propagate_errors());
+        event_init.origin = "<origin>"_string.release_value_but_fixme_should_propagate_errors();
+        target_port->dispatch_event(MessageEvent::create(target_port->realm(), String::from_deprecated_string(HTML::EventNames::message).release_value_but_fixme_should_propagate_errors(), event_init).release_value_but_fixme_should_propagate_errors());
     }));
 }
 

--- a/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.cpp
@@ -9,18 +9,18 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<PageTransitionEvent>> PageTransitionEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, PageTransitionEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<PageTransitionEvent>> PageTransitionEvent::create(JS::Realm& realm, FlyString const& event_name, PageTransitionEventInit const& event_init)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<PageTransitionEvent>(realm, realm, event_name, event_init));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<PageTransitionEvent>> PageTransitionEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, PageTransitionEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<PageTransitionEvent>> PageTransitionEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, PageTransitionEventInit const& event_init)
 {
     return create(realm, event_name, event_init);
 }
 
-PageTransitionEvent::PageTransitionEvent(JS::Realm& realm, DeprecatedFlyString const& event_name, PageTransitionEventInit const& event_init)
-    : DOM::Event(realm, event_name, event_init)
+PageTransitionEvent::PageTransitionEvent(JS::Realm& realm, FlyString const& event_name, PageTransitionEventInit const& event_init)
+    : DOM::Event(realm, event_name.to_deprecated_fly_string(), event_init)
     , m_persisted(event_init.persisted)
 {
 }

--- a/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <LibWeb/DOM/Event.h>
 
 namespace Web::HTML {
@@ -18,10 +19,10 @@ class PageTransitionEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(PageTransitionEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PageTransitionEvent>> create(JS::Realm&, DeprecatedFlyString const& event_name, PageTransitionEventInit const& event_init);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PageTransitionEvent>> construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, PageTransitionEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PageTransitionEvent>> create(JS::Realm&, FlyString const& event_name, PageTransitionEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PageTransitionEvent>> construct_impl(JS::Realm&, FlyString const& event_name, PageTransitionEventInit const& event_init);
 
-    PageTransitionEvent(JS::Realm&, DeprecatedFlyString const& event_name, PageTransitionEventInit const& event_init);
+    PageTransitionEvent(JS::Realm&, FlyString const& event_name, PageTransitionEventInit const& event_init);
 
     virtual ~PageTransitionEvent() override;
 

--- a/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.idl
+++ b/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.idl
@@ -1,7 +1,7 @@
 #import <DOM/Event.idl>
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#pagetransitionevent
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface PageTransitionEvent : Event {
     constructor(DOMString type, optional PageTransitionEventInit eventInitDict = {});
 

--- a/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.cpp
@@ -9,18 +9,18 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<PromiseRejectionEvent>> PromiseRejectionEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, PromiseRejectionEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<PromiseRejectionEvent>> PromiseRejectionEvent::create(JS::Realm& realm, FlyString const& event_name, PromiseRejectionEventInit const& event_init)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<PromiseRejectionEvent>(realm, realm, event_name, event_init));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<PromiseRejectionEvent>> PromiseRejectionEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, PromiseRejectionEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<PromiseRejectionEvent>> PromiseRejectionEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, PromiseRejectionEventInit const& event_init)
 {
     return create(realm, event_name, event_init);
 }
 
-PromiseRejectionEvent::PromiseRejectionEvent(JS::Realm& realm, DeprecatedFlyString const& event_name, PromiseRejectionEventInit const& event_init)
-    : DOM::Event(realm, event_name, event_init)
+PromiseRejectionEvent::PromiseRejectionEvent(JS::Realm& realm, FlyString const& event_name, PromiseRejectionEventInit const& event_init)
+    : DOM::Event(realm, event_name.to_deprecated_fly_string(), event_init)
     , m_promise(const_cast<JS::Promise*>(event_init.promise.cell()))
     , m_reason(event_init.reason)
 {

--- a/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <LibJS/Heap/Handle.h>
 #include <LibJS/Runtime/Promise.h>
 #include <LibJS/Runtime/Value.h>
@@ -23,8 +24,8 @@ class PromiseRejectionEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(PromiseRejectionEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PromiseRejectionEvent>> create(JS::Realm&, DeprecatedFlyString const& event_name, PromiseRejectionEventInit const& event_init = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PromiseRejectionEvent>> construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, PromiseRejectionEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PromiseRejectionEvent>> create(JS::Realm&, FlyString const& event_name, PromiseRejectionEventInit const& event_init = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PromiseRejectionEvent>> construct_impl(JS::Realm&, FlyString const& event_name, PromiseRejectionEventInit const& event_init);
 
     virtual ~PromiseRejectionEvent() override;
 
@@ -33,7 +34,7 @@ public:
     JS::Value reason() const { return m_reason; }
 
 private:
-    PromiseRejectionEvent(JS::Realm&, DeprecatedFlyString const& event_name, PromiseRejectionEventInit const& event_init);
+    PromiseRejectionEvent(JS::Realm&, FlyString const& event_name, PromiseRejectionEventInit const& event_init);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.idl
+++ b/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.idl
@@ -1,6 +1,6 @@
 #import <DOM/Event.idl>
 
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), UseNewAKString]
 interface PromiseRejectionEvent : Event {
     constructor(DOMString type, PromiseRejectionEventInit eventInitDict);
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -251,7 +251,7 @@ void EnvironmentSettingsObject::notify_about_rejected_promises(Badge<EventLoop>)
             // FIXME: This currently assumes that global is a WindowObject.
             auto& window = verify_cast<HTML::Window>(global);
 
-            auto promise_rejection_event = PromiseRejectionEvent::create(window.realm(), HTML::EventNames::unhandledrejection, event_init).release_value_but_fixme_should_propagate_errors();
+            auto promise_rejection_event = PromiseRejectionEvent::create(window.realm(), String::from_deprecated_string(HTML::EventNames::unhandledrejection).release_value_but_fixme_should_propagate_errors(), event_init).release_value_but_fixme_should_propagate_errors();
 
             bool not_handled = window.dispatch_event(*promise_rejection_event);
 

--- a/Userland/Libraries/LibWeb/HTML/SubmitEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SubmitEvent.cpp
@@ -9,18 +9,18 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<SubmitEvent>> SubmitEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, SubmitEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<SubmitEvent>> SubmitEvent::create(JS::Realm& realm, FlyString const& event_name, SubmitEventInit const& event_init)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<SubmitEvent>(realm, realm, event_name, event_init));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<SubmitEvent>> SubmitEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, SubmitEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<SubmitEvent>> SubmitEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, SubmitEventInit const& event_init)
 {
     return create(realm, event_name, event_init);
 }
 
-SubmitEvent::SubmitEvent(JS::Realm& realm, DeprecatedFlyString const& event_name, SubmitEventInit const& event_init)
-    : DOM::Event(realm, event_name, event_init)
+SubmitEvent::SubmitEvent(JS::Realm& realm, FlyString const& event_name, SubmitEventInit const& event_init)
+    : DOM::Event(realm, event_name.to_deprecated_fly_string(), event_init)
     , m_submitter(event_init.submitter)
 {
 }

--- a/Userland/Libraries/LibWeb/HTML/SubmitEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/SubmitEvent.h
@@ -19,15 +19,15 @@ class SubmitEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(SubmitEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<SubmitEvent>> create(JS::Realm&, DeprecatedFlyString const& event_name, SubmitEventInit const& event_init);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<SubmitEvent>> construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, SubmitEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<SubmitEvent>> create(JS::Realm&, FlyString const& event_name, SubmitEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<SubmitEvent>> construct_impl(JS::Realm&, FlyString const& event_name, SubmitEventInit const& event_init);
 
     virtual ~SubmitEvent() override;
 
     JS::GCPtr<HTMLElement> submitter() const { return m_submitter; }
 
 private:
-    SubmitEvent(JS::Realm&, DeprecatedFlyString const& event_name, SubmitEventInit const& event_init);
+    SubmitEvent(JS::Realm&, FlyString const& event_name, SubmitEventInit const& event_init);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/HTML/SubmitEvent.idl
+++ b/Userland/Libraries/LibWeb/HTML/SubmitEvent.idl
@@ -2,7 +2,7 @@
 #import <HTML/HTMLElement.idl>
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#submitevent
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface SubmitEvent : Event {
     constructor(DOMString type, optional SubmitEventInit eventInitDict = {});
 

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -793,7 +793,7 @@ void Window::fire_a_page_transition_event(DeprecatedFlyString const& event_name,
     // with the persisted attribute initialized to persisted,
     HTML::PageTransitionEventInit event_init {};
     event_init.persisted = persisted;
-    auto event = HTML::PageTransitionEvent::create(associated_document().realm(), event_name, event_init).release_value_but_fixme_should_propagate_errors();
+    auto event = HTML::PageTransitionEvent::create(associated_document().realm(), String::from_deprecated_string(event_name).release_value_but_fixme_should_propagate_errors(), event_init).release_value_but_fixme_should_propagate_errors();
 
     // ...the cancelable attribute initialized to true,
     event->set_cancelable(true);

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -916,8 +916,8 @@ WebIDL::ExceptionOr<void> Window::post_message_impl(JS::Value message, Deprecate
     HTML::queue_global_task(HTML::Task::Source::PostedMessage, *this, [this, message] {
         HTML::MessageEventInit event_init {};
         event_init.data = message;
-        event_init.origin = "<origin>";
-        dispatch_event(HTML::MessageEvent::create(realm(), HTML::EventNames::message, event_init).release_value_but_fixme_should_propagate_errors());
+        event_init.origin = "<origin>"_string.release_value_but_fixme_should_propagate_errors();
+        dispatch_event(HTML::MessageEvent::create(realm(), String::from_deprecated_string(HTML::EventNames::message).release_value_but_fixme_should_propagate_errors(), event_init).release_value_but_fixme_should_propagate_errors());
     });
     return {};
 }

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -165,8 +165,8 @@ void Worker::run_a_worker(AK::URL& url, EnvironmentSettingsObject& outside_setti
             event_loop.task_queue().add(HTML::Task::create(HTML::Task::Source::PostedMessage, nullptr, [this, message] {
                 MessageEventInit event_init {};
                 event_init.data = message;
-                event_init.origin = "<origin>";
-                dispatch_event(MessageEvent::create(*m_worker_realm, HTML::EventNames::message, event_init).release_value_but_fixme_should_propagate_errors());
+                event_init.origin = "<origin>"_string.release_value_but_fixme_should_propagate_errors();
+                dispatch_event(MessageEvent::create(*m_worker_realm, String::from_deprecated_string(HTML::EventNames::message).release_value_but_fixme_should_propagate_errors(), event_init).release_value_but_fixme_should_propagate_errors());
             }));
 
             return JS::js_undefined();

--- a/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.cpp
@@ -9,18 +9,18 @@
 
 namespace Web::WebGL {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> WebGLContextEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, WebGLContextEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> WebGLContextEvent::create(JS::Realm& realm, FlyString const& event_name, WebGLContextEventInit const& event_init)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<WebGLContextEvent>(realm, realm, event_name, event_init));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> WebGLContextEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, WebGLContextEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> WebGLContextEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, WebGLContextEventInit const& event_init)
 {
     return create(realm, event_name, event_init);
 }
 
-WebGLContextEvent::WebGLContextEvent(JS::Realm& realm, DeprecatedFlyString const& type, WebGLContextEventInit const& event_init)
-    : DOM::Event(realm, type, event_init)
+WebGLContextEvent::WebGLContextEvent(JS::Realm& realm, FlyString const& type, WebGLContextEventInit const& event_init)
+    : DOM::Event(realm, type.to_deprecated_fly_string(), event_init)
     , m_status_message(event_init.status_message)
 {
 }

--- a/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.h
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.h
@@ -7,31 +7,32 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <LibWeb/DOM/Event.h>
 
 namespace Web::WebGL {
 
 struct WebGLContextEventInit final : public DOM::EventInit {
-    DeprecatedString status_message { DeprecatedString::empty() };
+    String status_message;
 };
 
 class WebGLContextEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(WebGLContextEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> create(JS::Realm&, DeprecatedFlyString const& type, WebGLContextEventInit const& event_init);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> construct_impl(JS::Realm&, DeprecatedFlyString const& type, WebGLContextEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> create(JS::Realm&, FlyString const& type, WebGLContextEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> construct_impl(JS::Realm&, FlyString const& type, WebGLContextEventInit const& event_init);
 
     virtual ~WebGLContextEvent() override;
 
-    DeprecatedString const& status_message() const { return m_status_message; }
+    String const& status_message() const { return m_status_message; }
 
 private:
-    WebGLContextEvent(JS::Realm&, DeprecatedFlyString const& type, WebGLContextEventInit const& event_init);
+    WebGLContextEvent(JS::Realm&, FlyString const& type, WebGLContextEventInit const& event_init);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
-    DeprecatedString m_status_message { DeprecatedString::empty() };
+    String m_status_message;
 };
 
 }

--- a/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.idl
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.idl
@@ -1,6 +1,6 @@
 #import <DOM/Event.idl>
 
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), UseNewAKString]
 interface WebGLContextEvent : Event {
     constructor(DOMString type, optional WebGLContextEventInit eventInit = {});
     readonly attribute DOMString statusMessage;

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
@@ -17,7 +17,7 @@ static void fire_webgl_context_event(HTML::HTMLCanvasElement& canvas_element, De
 {
     // To fire a WebGL context event named e means that an event using the WebGLContextEvent interface, with its type attribute [DOM4] initialized to e, its cancelable attribute initialized to true, and its isTrusted attribute [DOM4] initialized to true, is to be dispatched at the given object.
     // FIXME: Consider setting a status message.
-    auto event = WebGLContextEvent::create(canvas_element.realm(), type, WebGLContextEventInit {}).release_value_but_fixme_should_propagate_errors();
+    auto event = WebGLContextEvent::create(canvas_element.realm(), String::from_deprecated_string(type).release_value_but_fixme_should_propagate_errors(), WebGLContextEventInit {}).release_value_but_fixme_should_propagate_errors();
     event->set_is_trusted(true);
     event->set_cancelable(true);
     canvas_element.dispatch_event(*event);

--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -221,8 +221,8 @@ void WebSocket::on_close(u16 code, DeprecatedString reason, bool was_clean)
     HTML::CloseEventInit event_init {};
     event_init.was_clean = was_clean;
     event_init.code = code;
-    event_init.reason = move(reason);
-    dispatch_event(HTML::CloseEvent::create(realm(), HTML::EventNames::close, event_init).release_value_but_fixme_should_propagate_errors());
+    event_init.reason = String::from_deprecated_string(reason).release_value_but_fixme_should_propagate_errors();
+    dispatch_event(HTML::CloseEvent::create(realm(), String::from_deprecated_string(HTML::EventNames::close.view()).release_value_but_fixme_should_propagate_errors(), event_init).release_value_but_fixme_should_propagate_errors());
 }
 
 // https://websockets.spec.whatwg.org/#feedback-from-the-protocol

--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -234,8 +234,8 @@ void WebSocket::on_message(ByteBuffer message, bool is_text)
         auto text_message = DeprecatedString(ReadonlyBytes(message));
         HTML::MessageEventInit event_init;
         event_init.data = JS::PrimitiveString::create(vm(), text_message);
-        event_init.origin = url();
-        dispatch_event(HTML::MessageEvent::create(realm(), HTML::EventNames::message, event_init).release_value_but_fixme_should_propagate_errors());
+        event_init.origin = String::from_deprecated_string(url()).release_value_but_fixme_should_propagate_errors();
+        dispatch_event(HTML::MessageEvent::create(realm(), String::from_deprecated_string(HTML::EventNames::message).release_value_but_fixme_should_propagate_errors(), event_init).release_value_but_fixme_should_propagate_errors());
         return;
     }
 
@@ -246,8 +246,8 @@ void WebSocket::on_message(ByteBuffer message, bool is_text)
         // type indicates that the data is Binary and binaryType is "arraybuffer"
         HTML::MessageEventInit event_init;
         event_init.data = JS::ArrayBuffer::create(realm(), message);
-        event_init.origin = url();
-        dispatch_event(HTML::MessageEvent::create(realm(), HTML::EventNames::message, event_init).release_value_but_fixme_should_propagate_errors());
+        event_init.origin = String::from_deprecated_string(url()).release_value_but_fixme_should_propagate_errors();
+        dispatch_event(HTML::MessageEvent::create(realm(), String::from_deprecated_string(HTML::EventNames::message).release_value_but_fixme_should_propagate_errors(), event_init).release_value_but_fixme_should_propagate_errors());
         return;
     }
 

--- a/Userland/Libraries/LibWeb/XHR/ProgressEvent.cpp
+++ b/Userland/Libraries/LibWeb/XHR/ProgressEvent.cpp
@@ -9,18 +9,18 @@
 
 namespace Web::XHR {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<ProgressEvent>> ProgressEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, ProgressEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<ProgressEvent>> ProgressEvent::create(JS::Realm& realm, FlyString const& event_name, ProgressEventInit const& event_init)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<ProgressEvent>(realm, realm, event_name, event_init));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<ProgressEvent>> ProgressEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, ProgressEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<ProgressEvent>> ProgressEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, ProgressEventInit const& event_init)
 {
     return create(realm, event_name, event_init);
 }
 
-ProgressEvent::ProgressEvent(JS::Realm& realm, DeprecatedFlyString const& event_name, ProgressEventInit const& event_init)
-    : Event(realm, event_name, event_init)
+ProgressEvent::ProgressEvent(JS::Realm& realm, FlyString const& event_name, ProgressEventInit const& event_init)
+    : Event(realm, event_name.to_deprecated_fly_string(), event_init)
     , m_length_computable(event_init.length_computable)
     , m_loaded(event_init.loaded)
     , m_total(event_init.total)

--- a/Userland/Libraries/LibWeb/XHR/ProgressEvent.h
+++ b/Userland/Libraries/LibWeb/XHR/ProgressEvent.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <LibWeb/DOM/Event.h>
 
 namespace Web::XHR {
@@ -23,8 +24,8 @@ class ProgressEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(ProgressEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ProgressEvent>> create(JS::Realm&, DeprecatedFlyString const& event_name, ProgressEventInit const& event_init);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ProgressEvent>> construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, ProgressEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ProgressEvent>> create(JS::Realm&, FlyString const& event_name, ProgressEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ProgressEvent>> construct_impl(JS::Realm&, FlyString const& event_name, ProgressEventInit const& event_init);
 
     virtual ~ProgressEvent() override;
 
@@ -33,7 +34,7 @@ public:
     u64 total() const { return m_total; }
 
 private:
-    ProgressEvent(JS::Realm&, DeprecatedFlyString const& event_name, ProgressEventInit const& event_init);
+    ProgressEvent(JS::Realm&, FlyString const& event_name, ProgressEventInit const& event_init);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 

--- a/Userland/Libraries/LibWeb/XHR/ProgressEvent.idl
+++ b/Userland/Libraries/LibWeb/XHR/ProgressEvent.idl
@@ -1,7 +1,7 @@
 #import <DOM/Event.idl>
 
 // https://xhr.spec.whatwg.org/#interface-progressevent
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), UseNewAKString]
 interface ProgressEvent : Event {
     constructor(DOMString type, optional ProgressEventInit eventInitDict = {});
 

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -83,7 +83,7 @@ void XMLHttpRequest::fire_progress_event(DeprecatedString const& event_name, u64
     event_init.length_computable = true;
     event_init.loaded = transmitted;
     event_init.total = length;
-    dispatch_event(*ProgressEvent::create(realm(), event_name, event_init).release_value_but_fixme_should_propagate_errors());
+    dispatch_event(*ProgressEvent::create(realm(), String::from_deprecated_string(event_name).release_value_but_fixme_should_propagate_errors(), event_init).release_value_but_fixme_should_propagate_errors());
 }
 
 // https://xhr.spec.whatwg.org/#dom-xmlhttprequest-responsetext


### PR DESCRIPTION
Includes a conversion function to convert from FlyString to DeprecatedString.