### PR TITLE
CharacterMap: Search characters as you type

### DIFF
--- a/Userland/Applications/CharacterMap/CMakeLists.txt
+++ b/Userland/Applications/CharacterMap/CMakeLists.txt
@@ -10,6 +10,7 @@ compile_gml(CharacterSearchWindow.gml CharacterSearchWindowGML.h character_searc
 set(SOURCES
     CharacterMapWidget.cpp
     CharacterSearchWidget.cpp
+    SearchCharacters.cpp
     main.cpp
 )
 

--- a/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
@@ -8,6 +8,7 @@
 #include "CharacterSearchWidget.h"
 #include "SearchCharacters.h"
 #include <Applications/CharacterMap/CharacterSearchWindowGML.h>
+#include <LibCore/Debounce.h>
 
 struct SearchResult {
     u32 code_point;
@@ -56,14 +57,12 @@ CharacterSearchWidget::CharacterSearchWidget()
     load_from_gml(character_search_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_search_input = find_descendant_of_type_named<GUI::TextBox>("search_input");
-    m_search_button = find_descendant_of_type_named<GUI::Button>("search_button");
     m_results_table = find_descendant_of_type_named<GUI::TableView>("results_table");
 
     m_search_input->on_up_pressed = [this] { m_results_table->move_cursor(GUI::AbstractView::CursorMovement::Up, GUI::AbstractView::SelectionUpdate::Set); };
     m_search_input->on_down_pressed = [this] { m_results_table->move_cursor(GUI::AbstractView::CursorMovement::Down, GUI::AbstractView::SelectionUpdate::Set); };
 
-    m_search_input->on_return_pressed = [this] { search(); };
-    m_search_button->on_click = [this](auto) { search(); };
+    m_search_input->on_change = Core::debounce([this] { search(); }, 100);
 
     m_results_table->horizontal_scrollbar().set_visible(false);
     m_results_table->set_column_headers_visible(false);

--- a/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
@@ -84,6 +84,7 @@ void CharacterSearchWidget::search()
 
     // TODO: Sort the results nicely. They're sorted by code-point for now, which is easy, but not the most useful.
     //       Sorting intelligently in a style similar to Assistant would be nicer.
+    //       Note that this will mean limiting the number of results some other way.
     auto& model = static_cast<CharacterSearchModel&>(*m_results_table->model());
     model.clear();
     auto query = m_search_input->text();
@@ -94,5 +95,11 @@ void CharacterSearchWidget::search()
         builder.append_code_point(code_point);
 
         model.add_result({ code_point, builder.to_deprecated_string(), move(display_name) });
+
+        // Stop when we reach 250 results.
+        // This is already too many for the search to be useful, and means we don't spend forever recalculating the column size.
+        if (model.row_count({}) >= 250)
+            return IterationDecision::Break;
+        return IterationDecision::Continue;
     });
 }

--- a/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -79,6 +79,9 @@ CharacterSearchWidget::CharacterSearchWidget()
 
 void CharacterSearchWidget::search()
 {
+    ScopeGuard guard { [&] { m_results_table->set_updates_enabled(true); } };
+    m_results_table->set_updates_enabled(false);
+
     // TODO: Sort the results nicely. They're sorted by code-point for now, which is easy, but not the most useful.
     //       Sorting intelligently in a style similar to Assistant would be nicer.
     auto& model = static_cast<CharacterSearchModel&>(*m_results_table->model());

--- a/Userland/Applications/CharacterMap/CharacterSearchWidget.h
+++ b/Userland/Applications/CharacterMap/CharacterSearchWidget.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -26,6 +26,5 @@ private:
     void search();
 
     RefPtr<GUI::TextBox> m_search_input;
-    RefPtr<GUI::Button> m_search_button;
     RefPtr<GUI::TableView> m_results_table;
 };

--- a/Userland/Applications/CharacterMap/CharacterSearchWindow.gml
+++ b/Userland/Applications/CharacterMap/CharacterSearchWindow.gml
@@ -4,20 +4,8 @@
     }
     fill_with_background_color: true
 
-    @GUI::Widget {
-        layout: @GUI::HorizontalBoxLayout {}
-        preferred_height: "fit"
-
-        @GUI::TextBox {
-            name: "search_input"
-        }
-
-        @GUI::Button {
-            name: "search_button"
-            icon: "/res/icons/16x16/find.png"
-            button_style: "Coolbar"
-            fixed_width: 22
-        }
+    @GUI::TextBox {
+        name: "search_input"
     }
 
     @GUI::TableView {

--- a/Userland/Applications/CharacterMap/SearchCharacters.cpp
+++ b/Userland/Applications/CharacterMap/SearchCharacters.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "SearchCharacters.h"
+#include <LibUnicode/CharacterTypes.h>
+
+void for_each_character_containing(StringView query, Function<IterationDecision(u32 code_point, DeprecatedString const& display_name)> callback)
+{
+    DeprecatedString uppercase_query = query.to_uppercase_string();
+    StringView uppercase_query_view = uppercase_query.view();
+    constexpr u32 maximum_code_point = 0x10FFFF;
+    // FIXME: There's probably a better way to do this than just looping, but it still only takes ~150ms to run for me!
+    for (u32 code_point = 1; code_point <= maximum_code_point; ++code_point) {
+        if (auto maybe_display_name = Unicode::code_point_display_name(code_point); maybe_display_name.has_value()) {
+            auto display_name = maybe_display_name.release_value();
+            if (display_name.contains(uppercase_query_view, AK::CaseSensitivity::CaseSensitive)) {
+                if (callback(code_point, move(display_name)) == IterationDecision::Break)
+                    break;
+            }
+        }
+    }
+}

--- a/Userland/Applications/CharacterMap/SearchCharacters.h
+++ b/Userland/Applications/CharacterMap/SearchCharacters.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,20 +7,7 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
-#include <LibUnicode/CharacterTypes.h>
+#include <AK/Function.h>
+#include <AK/IterationDecision.h>
 
-template<typename Callback>
-void for_each_character_containing(StringView query, Callback callback)
-{
-    DeprecatedString uppercase_query = query.to_uppercase_string();
-    StringView uppercase_query_view = uppercase_query.view();
-    constexpr u32 maximum_code_point = 0x10FFFF;
-    // FIXME: There's probably a better way to do this than just looping, but it still only takes ~150ms to run for me!
-    for (u32 code_point = 1; code_point <= maximum_code_point; ++code_point) {
-        if (auto maybe_display_name = Unicode::code_point_display_name(code_point); maybe_display_name.has_value()) {
-            auto display_name = maybe_display_name.release_value();
-            if (display_name.contains(uppercase_query_view, AK::CaseSensitivity::CaseSensitive))
-                callback(code_point, move(display_name));
-        }
-    }
-}
+void for_each_character_containing(StringView query, Function<IterationDecision(u32 code_point, DeprecatedString const& display_name)> callback);

--- a/Userland/Applications/CharacterMap/main.cpp
+++ b/Userland/Applications/CharacterMap/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -28,6 +28,7 @@ static void search_and_print_results(DeprecatedString const& query)
         builder.append(display_name);
         outln(builder.string_view());
         result_count++;
+        return IterationDecision::Continue;
     });
 
     if (result_count == 0)


### PR DESCRIPTION
As requested by @awesomekling on Office Hours, this replaces the :mag: button on the search window with automatic searching as you type in a query. It turned out though, that this was *very slow*, like, several minutes waiting per keypress slow. To counteract this, we now pause updating the widgets while collecting the search results, debounce responding to key input, and limit the number of search results to an arbitrarily-chosen 250. This keeps things snappy, but should still be more than enough results to be useful - hundreds is already too many for you to want to scroll through instead of modifying the search query.