### PR TITLE
LibCore: Don't use DT_WHT in DirectoryEntry on OpenBSD

### DIFF
--- a/Userland/Libraries/LibCore/DirectoryEntry.cpp
+++ b/Userland/Libraries/LibCore/DirectoryEntry.cpp
@@ -28,8 +28,10 @@ static DirectoryEntry::Type directory_entry_type_from_posix(unsigned char dt_con
         return DirectoryEntry::Type::SymbolicLink;
     case DT_SOCK:
         return DirectoryEntry::Type::Socket;
+#ifndef AK_OS_OPENBSD
     case DT_WHT:
         return DirectoryEntry::Type::Whiteout;
+#endif
     }
     VERIFY_NOT_REACHED();
 }


### PR DESCRIPTION
OpenBSD doesn't support the DT_WHT file type,as you can see in https://github.com/openbsd/src/blob/master/sys/sys/dirent.h
The simplest solution seems to be to just not check for the DT_WHT type in DirectoryEntry.cpp on OpenBSD.
It's a OpenBSD specific limitation,I also checked FreeBSD,NetBSD and Illumos,they all support it.