### PR TITLE
LibWeb: Fix currentColor as a background-color (and maybe other places)

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -262,6 +262,9 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
 {
     auto& computed_values = static_cast<CSS::MutableComputedValues&>(m_computed_values);
 
+    // NOTE: color must be set first to ensure currentColor can be resolved in other properties (e.g. background-color).
+    computed_values.set_color(computed_style.color_or_fallback(CSS::PropertyID::Color, *this, CSS::InitialValues::color()));
+
     // NOTE: We have to be careful that font-related properties get set in the right order.
     //       m_font is used by Length::to_px() when resolving sizes against this layout node.
     //       That's why it has to be set before everything else.
@@ -530,8 +533,6 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
         m_list_style_image = list_style_image->as_abstract_image();
         const_cast<CSS::AbstractImageStyleValue&>(*m_list_style_image).load_any_resources(document());
     }
-
-    computed_values.set_color(computed_style.color_or_fallback(CSS::PropertyID::Color, *this, CSS::InitialValues::color()));
 
     // FIXME: The default text decoration color value is `currentcolor`, but since we can't resolve that easily,
     //        we just manually grab the value from `color`. This makes it dependent on `color` being


### PR DESCRIPTION
This moves color to be the first value resolved, this ensures that calls to `.to_color()` on style values for other properties will always be able to resolve the current color.

This change fixes the `background-color: currentColor` example in colors.html.

**Before**
![image](https://user-images.githubusercontent.com/11597044/222989891-848f9f6c-0293-47f9-ae3b-72852e956216.png)
**After**
![image](https://user-images.githubusercontent.com/11597044/222989913-1e3b6862-6d06-4285-8346-14243490e943.png)