### PR TITLE
less: Stop adding extra blank lines

### DIFF
--- a/Userland/Utilities/less.cpp
+++ b/Userland/Utilities/less.cpp
@@ -62,7 +62,6 @@ static Vector<StringView> wrap_line(DeprecatedString const& string, size_t width
         spans.append(string.substring_view(span_start, bit_length));
         span_start += bit_length;
     }
-    spans.append(string.substring_view(span_start));
 
     return spans;
 }


### PR DESCRIPTION
Each time we wrapped a line, we were appending an extra blank span which wasn't needed. This was leading to an extra blank line after every single line.

Before:
![before](https://user-images.githubusercontent.com/222642/223125444-d2711618-057e-4acc-8855-0218e7b7f9dc.png)

After:
![after](https://user-images.githubusercontent.com/222642/223125419-5764c800-0190-4bd7-a4f5-a4b67cc483c5.png)
