### PR TITLE
AK+FileManager: Add option to string formatter to use a digit separator (and use it in PropertiesWindow)

### DIFF
--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -443,7 +443,7 @@ struct Formatter<FixedPoint<precision, Underlying>> : StandardFormatter {
         i64 integer = value.ltrunk();
         constexpr u64 one = static_cast<Underlying>(1) << precision;
         u64 fraction_raw = value.raw() & (one - 1);
-        return builder.put_fixed_point(is_negative, integer, fraction_raw, one, base, upper_case, m_zero_pad, m_align, m_width.value(), m_precision.value(), m_fill, m_sign_mode, real_number_display_mode);
+        return builder.put_fixed_point(is_negative, integer, fraction_raw, one, base, upper_case, m_zero_pad, m_use_separator, m_align, m_width.value(), m_precision.value(), m_fill, m_sign_mode, real_number_display_mode);
     }
 };
 

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -191,6 +191,7 @@ public:
         bool prefix = false,
         bool upper_case = false,
         bool zero_pad = false,
+        bool use_separator = false,
         Align align = Align::Right,
         size_t min_width = 0,
         char fill = ' ',
@@ -203,6 +204,7 @@ public:
         bool prefix = false,
         bool upper_case = false,
         bool zero_pad = false,
+        bool use_separator = false,
         Align align = Align::Right,
         size_t min_width = 0,
         char fill = ' ',
@@ -216,6 +218,7 @@ public:
         u8 base = 10,
         bool upper_case = false,
         bool zero_pad = false,
+        bool use_separator = false,
         Align align = Align::Right,
         size_t min_width = 0,
         size_t precision = 6,
@@ -228,6 +231,7 @@ public:
         long double value,
         u8 base = 10,
         bool upper_case = false,
+        bool use_separator = false,
         Align align = Align::Right,
         size_t min_width = 0,
         size_t precision = 6,
@@ -240,6 +244,7 @@ public:
         u8 base = 10,
         bool upper_case = false,
         bool zero_pad = false,
+        bool use_separator = false,
         Align align = Align::Right,
         size_t min_width = 0,
         size_t precision = 6,
@@ -328,6 +333,7 @@ struct StandardFormatter {
     FormatBuilder::SignMode m_sign_mode = FormatBuilder::SignMode::OnlyIfNeeded;
     Mode m_mode = Mode::Default;
     bool m_alternative_form = false;
+    bool m_use_separator = false;
     char m_fill = ' ';
     bool m_zero_pad = false;
     Optional<size_t> m_width;

--- a/AK/NumberFormat.h
+++ b/AK/NumberFormat.h
@@ -15,10 +15,15 @@ enum class HumanReadableBasedOn {
     Base10
 };
 
-DeprecatedString human_readable_size(u64 size, HumanReadableBasedOn based_on = HumanReadableBasedOn::Base2);
-DeprecatedString human_readable_quantity(u64 quantity, HumanReadableBasedOn based_on = HumanReadableBasedOn::Base2, StringView unit = "B"sv);
+enum class UseThousandsSeparator {
+    Yes,
+    No
+};
 
-DeprecatedString human_readable_size_long(u64 size);
+DeprecatedString human_readable_size(u64 size, HumanReadableBasedOn based_on = HumanReadableBasedOn::Base2, UseThousandsSeparator use_thousands_separator = UseThousandsSeparator::No);
+DeprecatedString human_readable_quantity(u64 quantity, HumanReadableBasedOn based_on = HumanReadableBasedOn::Base2, StringView unit = "B"sv, UseThousandsSeparator use_thousands_separator = UseThousandsSeparator::No);
+
+DeprecatedString human_readable_size_long(u64 size, UseThousandsSeparator use_thousands_separator = UseThousandsSeparator::No);
 DeprecatedString human_readable_time(i64 time_in_seconds);
 DeprecatedString human_readable_digital_time(i64 time_in_seconds);
 
@@ -30,4 +35,5 @@ using AK::human_readable_quantity;
 using AK::human_readable_size;
 using AK::human_readable_size_long;
 using AK::human_readable_time;
+using AK::UseThousandsSeparator;
 #endif

--- a/Tests/AK/TestFormat.cpp
+++ b/Tests/AK/TestFormat.cpp
@@ -35,6 +35,17 @@ TEST_CASE(format_integers)
     EXPECT_EQ(DeprecatedString::formatted("{:08x}", 4096), "00001000");
     EXPECT_EQ(DeprecatedString::formatted("{:x}", 0x1111222233334444ull), "1111222233334444");
     EXPECT_EQ(DeprecatedString::formatted("{:4}", 12345678), "12345678");
+    EXPECT_EQ(DeprecatedString::formatted("{:'}", 0), "0");
+    EXPECT_EQ(DeprecatedString::formatted("{:'}", 4096), "4,096");
+    EXPECT_EQ(DeprecatedString::formatted("{:'}", 16777216), "16,777,216");
+    EXPECT_EQ(DeprecatedString::formatted("{:'}", AK::NumericLimits<u64>::max()), "18,446,744,073,709,551,615");
+    EXPECT_EQ(DeprecatedString::formatted("{:'}", AK::NumericLimits<u64>::max()), "18,446,744,073,709,551,615");
+    EXPECT_EQ(DeprecatedString::formatted("{:'}", AK::NumericLimits<i64>::min() + 1), "-9,223,372,036,854,775,807");
+    EXPECT_EQ(DeprecatedString::formatted("{:'x}", 0), "0");
+    EXPECT_EQ(DeprecatedString::formatted("{:'x}", 16777216), "1,000,000");
+    EXPECT_EQ(DeprecatedString::formatted("{:'x}", AK::NumericLimits<u64>::max()), "f,fff,fff,fff,fff,fff");
+    EXPECT_EQ(DeprecatedString::formatted("{:'x}", AK::NumericLimits<i64>::min() + 1), "-7,fff,fff,fff,fff,fff");
+    EXPECT_EQ(DeprecatedString::formatted("{:'b}", AK::NumericLimits<u64>::max()), "1,111,111,111,111,111,111,111,111,111,111,111,111,111,111,111,111,111,111,111,111,111");
 }
 
 TEST_CASE(reorder_format_arguments)
@@ -95,6 +106,8 @@ TEST_CASE(format_octal)
 {
     EXPECT_EQ(DeprecatedString::formatted("{:o}", 0744), "744");
     EXPECT_EQ(DeprecatedString::formatted("{:#o}", 0744), "0744");
+    EXPECT_EQ(DeprecatedString::formatted("{:'o}", 054321), "54,321");
+    EXPECT_EQ(DeprecatedString::formatted("{:'o}", 0567012340), "567,012,340");
 }
 
 TEST_CASE(zero_pad)
@@ -244,6 +257,8 @@ TEST_CASE(floating_point_numbers)
     EXPECT_EQ(DeprecatedString::formatted("{:.3}", 1.12), "1.12");
     EXPECT_EQ(DeprecatedString::formatted("{:.1}", 1.12), "1.1");
     EXPECT_EQ(DeprecatedString::formatted("{}", -1.12), "-1.12");
+    EXPECT_EQ(DeprecatedString::formatted("{:'.4}", 1234.5678), "1,234.5678");
+    EXPECT_EQ(DeprecatedString::formatted("{:'.4}", -1234.5678), "-1,234.5678");
 
     EXPECT_EQ(DeprecatedString::formatted("{}", NAN), "nan");
     EXPECT_EQ(DeprecatedString::formatted("{}", INFINITY), "inf");

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -119,7 +119,7 @@ ErrorOr<void> PropertiesWindow::create_widgets(bool disable_rename)
     }
 
     m_size_label = general_tab->find_descendant_of_type_named<GUI::Label>("size");
-    m_size_label->set_text(S_ISDIR(st.st_mode) ? "Calculating..." : human_readable_size_long(st.st_size));
+    m_size_label->set_text(S_ISDIR(st.st_mode) ? "Calculating..." : human_readable_size_long(st.st_size, UseThousandsSeparator::Yes));
 
     auto* owner = general_tab->find_descendant_of_type_named<GUI::Label>("owner");
     owner->set_text(DeprecatedString::formatted("{} ({})", owner_name, st.st_uid));
@@ -173,7 +173,7 @@ ErrorOr<void> PropertiesWindow::create_widgets(bool disable_rename)
         m_directory_statistics_calculator->on_update = [this, origin_event_loop = &Core::EventLoop::current()](off_t total_size_in_bytes, size_t file_count, size_t directory_count) {
             origin_event_loop->deferred_invoke([=, weak_this = make_weak_ptr<PropertiesWindow>()] {
                 if (auto strong_this = weak_this.strong_ref())
-                    strong_this->m_size_label->set_text(DeprecatedString::formatted("{}\n{} files, {} subdirectories", human_readable_size_long(total_size_in_bytes), file_count, directory_count));
+                    strong_this->m_size_label->set_text(DeprecatedString::formatted("{}\n{:'d} files, {:'d} subdirectories", human_readable_size_long(total_size_in_bytes, UseThousandsSeparator::Yes), file_count, directory_count));
             });
         };
         m_directory_statistics_calculator->start();

--- a/Userland/Libraries/LibCrypto/Hash/HashFunction.h
+++ b/Userland/Libraries/LibCrypto/Hash/HashFunction.h
@@ -70,7 +70,7 @@ struct AK::Formatter<Crypto::Hash::Digest<DigestS>> : StandardFormatter {
         for (size_t i = 0; i < digest.Size; ++i) {
             if (i > 0 && i % 4 == 0)
                 TRY(builder.put_padding('-', 1));
-            TRY(builder.put_u64(digest.data[i], 16, false, false, true, FormatBuilder::Align::Right, 2));
+            TRY(builder.put_u64(digest.data[i], 16, false, false, true, false, FormatBuilder::Align::Right, 2));
         }
         return {};
     }


### PR DESCRIPTION
With this PR, `vformat()` can now accept format specifiers of the form  `{:'[numeric-type]}`. This will output a number with a comma separator every 3 digits.

For example:

`dbgln("{:'d}", 9999999);` will output 9,999,999.

Binary, octal and hexadecimal numbers can also use this feature, for
example:

`dbgln("{:'x}", 0xffffffff);` will output ff,fff,fff.

The type specifier can also be omitted, so:

`dbgln("{:'}", 9999999);` will output 9,999,999

I used the apostrophe for this option, as that is what `printf()` uses. I'm not a huge fan though, so I'm open to suggestions if there is something better.

As part of this PR I've updated the FileManager's PropertiesWindow to use the new option.

![propertieswindow_updated](https://user-images.githubusercontent.com/2817754/230227492-a96016cb-6428-43c8-a67e-8c4ef3360d7e.png)