### PR TITLE
man: Skip shellrc when invoking pager using sh

### DIFF
--- a/Userland/Utilities/man.cpp
+++ b/Userland/Utilities/man.cpp
@@ -23,7 +23,7 @@
 
 static ErrorOr<pid_t> pipe_to_pager(DeprecatedString const& command)
 {
-    char const* argv[] = { "sh", "-c", command.characters(), nullptr };
+    char const* argv[] = { "sh", "--skip-shellrc", "-c", command.characters(), nullptr };
 
     auto stdout_pipe = TRY(Core::System::pipe2(O_CLOEXEC));
 


### PR DESCRIPTION
man invokes the pager command via `sh` which, since beaae6b420cbe85a2d382f8f75447fb49514c20f launches `Shell` in posix mode. As the referenced commits message indicates, launching `Shell` in posix mode while interactive, makes it choke on the default `.shellrc`. This made `man` spew out some shell syntax errors to stderr every time it invoked the pager.

To fix that, invoke `sh` with `--skip-shellrc` for now as suggested by the aforementioned commit.