### PR TITLE
LibWebView+WebContent+Ladybird: Handle browsing context close event

### DIFF
--- a/Ladybird/Tab.cpp
+++ b/Ladybird/Tab.cpp
@@ -64,6 +64,10 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path)
     m_toolbar->addAction(m_home_action);
     m_toolbar->addWidget(m_location_edit);
 
+    QObject::connect(m_view, &WebContentView::close, [this] {
+        m_window->close_tab(tab_index());
+    });
+
     QObject::connect(m_view, &WebContentView::link_hovered, [this](QString const& title) {
         m_hover_label->setText(title);
         update_hover_label();

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -964,6 +964,10 @@ void WebContentView::notify_server_did_set_cookie(Badge<WebContentClient>, AK::U
         on_set_cookie(url, cookie, source);
 }
 
+void WebContentView::notify_server_did_close_browsing_context(Badge<WebContentClient>)
+{
+}
+
 void WebContentView::notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie)
 {
     if (on_update_cookie)

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -966,6 +966,7 @@ void WebContentView::notify_server_did_set_cookie(Badge<WebContentClient>, AK::U
 
 void WebContentView::notify_server_did_close_browsing_context(Badge<WebContentClient>)
 {
+    emit close();
 }
 
 void WebContentView::notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie)

--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -142,6 +142,7 @@ public:
     virtual DeprecatedString notify_server_did_request_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::Source source) override;
     virtual void notify_server_did_set_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source) override;
     virtual void notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie) override;
+    virtual void notify_server_did_close_browsing_context(Badge<WebContentClient>) override;
     virtual void notify_server_did_update_resource_count(i32 count_waiting) override;
     virtual void notify_server_did_request_restore_window() override;
     virtual Gfx::IntPoint notify_server_did_request_reposition_window(Gfx::IntPoint) override;

--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -49,6 +49,7 @@ public:
     explicit WebContentView(StringView webdriver_content_ipc_path);
     virtual ~WebContentView() override;
 
+    Function<void()> on_close;
     Function<void(Gfx::IntPoint screen_position)> on_context_menu_request;
     Function<void(const AK::URL&, DeprecatedString const& target, unsigned modifiers)> on_link_click;
     Function<void(const AK::URL&, Gfx::IntPoint screen_position)> on_link_context_menu_request;
@@ -154,6 +155,7 @@ public:
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
 
 signals:
+    void close();
     void link_hovered(QString, int timeout = 0);
     void link_unhovered();
     void back_mouse_button();

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -468,6 +468,10 @@ Tab::Tab(BrowserWindow& window)
             go_forward();
     };
 
+    view().on_close = [this] {
+        on_tab_close_request(*this);
+    };
+
     m_tab_context_menu = GUI::Menu::construct();
     m_tab_context_menu->add_action(GUI::CommonActions::make_reload_action([this](auto&) {
         reload();

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -459,6 +459,12 @@ void OutOfProcessWebView::notify_server_did_set_cookie(Badge<WebContentClient>, 
         on_set_cookie(url, cookie, source);
 }
 
+void OutOfProcessWebView::notify_server_did_close_browsing_context(Badge<WebContentClient>)
+{
+    if (on_close)
+        on_close();
+}
+
 void OutOfProcessWebView::notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie)
 {
     if (on_update_cookie)

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -57,6 +57,7 @@ public:
     // In practice, this means that OOPWV may render scaled stale versions of the content while resizing.
     void set_content_scales_to_viewport(bool);
 
+    Function<void()> on_close;
     Function<void(Gfx::IntPoint screen_position)> on_context_menu_request;
     Function<void(const AK::URL&, DeprecatedString const& target, unsigned modifiers)> on_link_click;
     Function<void(const AK::URL&, Gfx::IntPoint screen_position)> on_link_context_menu_request;
@@ -160,6 +161,7 @@ private:
     virtual DeprecatedString notify_server_did_request_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::Source source) override;
     virtual void notify_server_did_set_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source) override;
     virtual void notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie) override;
+    virtual void notify_server_did_close_browsing_context(Badge<WebContentClient>) override;
     virtual void notify_server_did_update_resource_count(i32 count_waiting) override;
     virtual void notify_server_did_request_restore_window() override;
     virtual Gfx::IntPoint notify_server_did_request_reposition_window(Gfx::IntPoint) override;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -96,6 +96,7 @@ public:
     virtual DeprecatedString notify_server_did_request_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::Source source) = 0;
     virtual void notify_server_did_set_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source) = 0;
     virtual void notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie) = 0;
+    virtual void notify_server_did_close_browsing_context(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_update_resource_count(i32 count_waiting) = 0;
     virtual void notify_server_did_request_restore_window() = 0;
     virtual Gfx::IntPoint notify_server_did_request_reposition_window(Gfx::IntPoint) = 0;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -240,6 +240,11 @@ void WebContentClient::did_update_cookie(Web::Cookie::Cookie const& cookie)
     m_view.notify_server_did_update_cookie({}, cookie);
 }
 
+void WebContentClient::did_close_browsing_context()
+{
+    m_view.notify_server_did_close_browsing_context({});
+}
+
 void WebContentClient::did_update_resource_count(i32 count_waiting)
 {
     m_view.notify_server_did_update_resource_count(count_waiting);

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -69,6 +69,7 @@ private:
     virtual Messages::WebContentClient::DidRequestCookieResponse did_request_cookie(AK::URL const&, u8) override;
     virtual void did_set_cookie(AK::URL const&, Web::Cookie::ParsedCookie const&, u8) override;
     virtual void did_update_cookie(Web::Cookie::Cookie const&) override;
+    virtual void did_close_browsing_context() override;
     virtual void did_update_resource_count(i32 count_waiting) override;
     virtual void did_request_restore_window() override;
     virtual Messages::WebContentClient::DidRequestRepositionWindowResponse did_request_reposition_window(Gfx::IntPoint) override;

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -373,6 +373,11 @@ void PageHost::page_did_update_resource_count(i32 count_waiting)
     m_client.async_did_update_resource_count(count_waiting);
 }
 
+void PageHost::page_did_close_browsing_context(Web::HTML::BrowsingContext const&)
+{
+    m_client.async_did_close_browsing_context();
+}
+
 void PageHost::request_file(Web::FileRequest file_request)
 {
     m_client.request_file(move(file_request));

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -97,6 +97,7 @@ private:
     virtual void page_did_set_cookie(const URL&, Web::Cookie::ParsedCookie const&, Web::Cookie::Source) override;
     virtual void page_did_update_cookie(Web::Cookie::Cookie) override;
     virtual void page_did_update_resource_count(i32) override;
+    virtual void page_did_close_browsing_context(Web::HTML::BrowsingContext const&) override;
     virtual void request_file(Web::FileRequest) override;
 
     explicit PageHost(ConnectionFromClient&);

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -46,6 +46,7 @@ endpoint WebContentClient
     did_set_cookie(URL url, Web::Cookie::ParsedCookie cookie, u8 source) =|
     did_update_cookie(Web::Cookie::Cookie cookie) =|
     did_update_resource_count(i32 count_waiting) =|
+    did_close_browsing_context() =|
     did_request_restore_window() =|
     did_request_reposition_window(Gfx::IntPoint position) => (Gfx::IntPoint window_position)
     did_request_resize_window(Gfx::IntSize size) => (Gfx::IntSize window_size)


### PR DESCRIPTION
These changes add handling for browsing context close IPC call to make Ladybird actually close a tab when requested.