### PR TITLE
LibJS and Friends: Wrap all fields of JS::Cell type in GCPtr/NonnullGCPtr

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1663,12 +1663,12 @@ static void generate_wrap_statement(SourceGenerator& generator, DeprecatedString
   if (!@value@) {
       @result_expression@ JS::js_null();
   } else {
-      @result_expression@ &@value@->callback;
+      @result_expression@ @value@->callback;
   }
 )~~~");
         } else {
             scoped_generator.append(R"~~~(
-  @result_expression@ &@value@->callback;
+  @result_expression@ @value@->callback;
 )~~~");
         }
     } else if (interface.dictionaries.contains(type.name())) {

--- a/Meta/Lagom/Tools/LibJSGCVerifier/src/main.py
+++ b/Meta/Lagom/Tools/LibJSGCVerifier/src/main.py
@@ -46,9 +46,6 @@ for containing_path in PATHS_TO_SEARCH:
                 paths.append(Path(root) / file)
 
 
-# paths = ['/home/matthew/code/serenity/Userland/Libraries/LibJS/Runtime/Set.h']
-
-
 def thread_init():
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 

--- a/Userland/Applications/Spreadsheet/Spreadsheet.h
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.h
@@ -155,7 +155,7 @@ private:
     HashTable<Position> m_selected_cells;
 
     Workbook& m_workbook;
-    mutable SheetGlobalObject* m_global_object;
+    mutable JS::GCPtr<SheetGlobalObject> m_global_object;
 
     NonnullOwnPtr<JS::Interpreter> m_interpreter;
 

--- a/Userland/Applications/Spreadsheet/Workbook.h
+++ b/Userland/Applications/Spreadsheet/Workbook.h
@@ -46,7 +46,7 @@ private:
     NonnullRefPtr<JS::VM> m_vm;
     NonnullOwnPtr<JS::Interpreter> m_interpreter;
     JS::VM::InterpreterExecutionScope m_interpreter_scope;
-    WorkbookObject* m_workbook_object { nullptr };
+    JS::GCPtr<WorkbookObject> m_workbook_object;
     JS::ExecutionContext m_main_execution_context;
     GUI::Window& m_parent_window;
 

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1863,7 +1863,7 @@ public:
 private:
     NonnullRefPtr<Expression const> const m_tag;
     NonnullRefPtr<TemplateLiteral const> const m_template_literal;
-    mutable HashMap<Realm*, Handle<Array>> m_cached_values;
+    mutable HashMap<GCPtr<Realm>, Handle<Array>> m_cached_values;
 };
 
 class MemberExpression final : public Expression {

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -51,12 +51,12 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable const& e
     ExecutionContext execution_context(vm().heap());
     if (vm().execution_context_stack().is_empty() || !vm().running_execution_context().lexical_environment) {
         // The "normal" interpreter pushes an execution context without environment so in that case we also want to push one.
-        execution_context.this_value = &m_realm.global_object();
+        execution_context.this_value = &m_realm->global_object();
         static DeprecatedFlyString global_execution_context_name = "(*BC* global execution context)";
         execution_context.function_name = global_execution_context_name;
-        execution_context.lexical_environment = &m_realm.global_environment();
-        execution_context.variable_environment = &m_realm.global_environment();
-        execution_context.realm = &m_realm;
+        execution_context.lexical_environment = &m_realm->global_environment();
+        execution_context.variable_environment = &m_realm->global_environment();
+        execution_context.realm = m_realm;
         execution_context.is_strict_mode = executable.is_strict_mode;
         vm().push_execution_context(execution_context);
         pushed_execution_context = true;
@@ -67,7 +67,7 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable const& e
     if (in_frame)
         m_register_windows.append(in_frame);
     else
-        m_register_windows.append(make<RegisterWindow>(MarkedVector<Value>(vm().heap()), MarkedVector<Environment*>(vm().heap()), MarkedVector<Environment*>(vm().heap()), Vector<UnwindInfo> {}));
+        m_register_windows.append(make<RegisterWindow>(MarkedVector<Value>(vm().heap()), MarkedVector<GCPtr<Environment>>(vm().heap()), MarkedVector<GCPtr<Environment>>(vm().heap()), Vector<UnwindInfo> {}));
 
     registers().resize(executable.number_of_registers);
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -20,8 +20,8 @@ namespace JS::Bytecode {
 
 struct RegisterWindow {
     MarkedVector<Value> registers;
-    MarkedVector<Environment*> saved_lexical_environments;
-    MarkedVector<Environment*> saved_variable_environments;
+    MarkedVector<GCPtr<Environment>> saved_lexical_environments;
+    MarkedVector<GCPtr<Environment>> saved_variable_environments;
     Vector<UnwindInfo> unwind_contexts;
 };
 
@@ -109,7 +109,7 @@ private:
     static AK::Array<OwnPtr<PassManager>, static_cast<UnderlyingType<Interpreter::OptimizationLevel>>(Interpreter::OptimizationLevel::__Count)> s_optimization_pipelines;
 
     VM& m_vm;
-    Realm& m_realm;
+    NonnullGCPtr<Realm> m_realm;
     Vector<Variant<NonnullOwnPtr<RegisterWindow>, RegisterWindow*>> m_register_windows;
     Optional<BasicBlock const*> m_pending_jump;
     BasicBlock const* m_scheduled_jump { nullptr };

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -413,8 +413,8 @@ ThrowCompletionOr<void> DeleteVariable::execute_impl(Bytecode::Interpreter& inte
 
 ThrowCompletionOr<void> CreateEnvironment::execute_impl(Bytecode::Interpreter& interpreter) const
 {
-    auto make_and_swap_envs = [&](auto*& old_environment) {
-        Environment* environment = new_declarative_environment(*old_environment).ptr();
+    auto make_and_swap_envs = [&](auto& old_environment) {
+        GCPtr<Environment> environment = new_declarative_environment(*old_environment).ptr();
         swap(old_environment, environment);
         return environment;
     };

--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -89,7 +89,7 @@ private:
     ThrowCompletionOr<String> value_vector_to_string(MarkedVector<Value> const&);
     ThrowCompletionOr<String> format_time_since(Core::ElapsedTimer timer);
 
-    Realm& m_realm;
+    NonnullGCPtr<Realm> m_realm;
     ConsoleClient* m_client { nullptr };
 
     HashMap<String, unsigned> m_counters;

--- a/Userland/Libraries/LibJS/Contrib/Test262/$262Object.h
+++ b/Userland/Libraries/LibJS/Contrib/Test262/$262Object.h
@@ -25,8 +25,8 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    AgentObject* m_agent { nullptr };
-    IsHTMLDDA* m_is_htmldda { nullptr };
+    GCPtr<AgentObject> m_agent;
+    GCPtr<IsHTMLDDA> m_is_htmldda;
 
     JS_DECLARE_NATIVE_FUNCTION(clear_kept_objects);
     JS_DECLARE_NATIVE_FUNCTION(create_realm);

--- a/Userland/Libraries/LibJS/Contrib/Test262/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Contrib/Test262/GlobalObject.h
@@ -28,7 +28,7 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    $262Object* m_$262 { nullptr };
+    GCPtr<$262Object> m_$262;
 
     JS_DECLARE_NATIVE_FUNCTION(print);
 };

--- a/Userland/Libraries/LibJS/CyclicModule.cpp
+++ b/Userland/Libraries/LibJS/CyclicModule.cpp
@@ -25,7 +25,7 @@ void CyclicModule::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_cycle_root);
-    for (auto* module : m_async_parent_modules)
+    for (auto module : m_async_parent_modules)
         visitor.visit(module);
 }
 
@@ -204,7 +204,7 @@ ThrowCompletionOr<Promise*> CyclicModule::evaluate(VM& vm)
         VERIFY(m_cycle_root);
         VERIFY(this != m_cycle_root);
         VERIFY(m_cycle_root->m_status == ModuleStatus::Linked);
-        dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] evaluate[{}](vm) deferring to cycle root at {}", this, m_cycle_root);
+        dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] evaluate[{}](vm) deferring to cycle root at {}", this, m_cycle_root.ptr());
         return m_cycle_root->evaluate(vm);
     }
 
@@ -502,7 +502,7 @@ void CyclicModule::execute_async_module(VM& vm)
 void CyclicModule::gather_available_ancestors(Vector<CyclicModule*>& exec_list)
 {
     // 1. For each Cyclic Module Record m of module.[[AsyncParentModules]], do
-    for (auto* module : m_async_parent_modules) {
+    for (auto module : m_async_parent_modules) {
         // a. If execList does not contain m and m.[[CycleRoot]].[[EvaluationError]] is empty, then
         if (!exec_list.contains_slow(module) && !module->m_cycle_root->m_evaluation_error.is_error()) {
             // i. Assert: m.[[Status]] is evaluating-async.
@@ -653,8 +653,7 @@ void CyclicModule::async_module_execution_rejected(VM& vm, Value error)
     m_status = ModuleStatus::Evaluated;
 
     // 7. For each Cyclic Module Record m of module.[[AsyncParentModules]], do
-    for (auto* module : m_async_parent_modules) {
-
+    for (auto module : m_async_parent_modules) {
         // a. Perform AsyncModuleExecutionRejected(m, error).
         module->async_module_execution_rejected(vm, error);
     }

--- a/Userland/Libraries/LibJS/CyclicModule.h
+++ b/Userland/Libraries/LibJS/CyclicModule.h
@@ -48,17 +48,17 @@ protected:
     void async_module_execution_fulfilled(VM& vm);
     void async_module_execution_rejected(VM& vm, Value error);
 
-    ModuleStatus m_status { ModuleStatus::Unlinked }; // [[Status]]
-    ThrowCompletionOr<void> m_evaluation_error;       // [[EvaluationError]]
-    Optional<u32> m_dfs_index;                        // [[DFSIndex]]
-    Optional<u32> m_dfs_ancestor_index;               // [[DFSAncestorIndex]]
-    Vector<ModuleRequest> m_requested_modules;        // [[RequestedModules]]
-    CyclicModule* m_cycle_root { nullptr };           // [[CycleRoot]]
-    bool m_has_top_level_await { false };             // [[HasTLA]]
-    bool m_async_evaluation { false };                // [[AsyncEvaluation]]
-    GCPtr<PromiseCapability> m_top_level_capability;  // [[TopLevelCapability]]
-    Vector<CyclicModule*> m_async_parent_modules;     // [[AsyncParentModules]]
-    Optional<u32> m_pending_async_dependencies;       // [[PendingAsyncDependencies]]
+    ModuleStatus m_status { ModuleStatus::Unlinked };   // [[Status]]
+    ThrowCompletionOr<void> m_evaluation_error;         // [[EvaluationError]]
+    Optional<u32> m_dfs_index;                          // [[DFSIndex]]
+    Optional<u32> m_dfs_ancestor_index;                 // [[DFSAncestorIndex]]
+    Vector<ModuleRequest> m_requested_modules;          // [[RequestedModules]]
+    GCPtr<CyclicModule> m_cycle_root;                   // [[CycleRoot]]
+    bool m_has_top_level_await { false };               // [[HasTLA]]
+    bool m_async_evaluation { false };                  // [[AsyncEvaluation]]
+    GCPtr<PromiseCapability> m_top_level_capability;    // [[TopLevelCapability]]
+    Vector<GCPtr<CyclicModule>> m_async_parent_modules; // [[AsyncParentModules]]
+    Optional<u32> m_pending_async_dependencies;         // [[PendingAsyncDependencies]]
 };
 
 }

--- a/Userland/Libraries/LibJS/Heap/GCPtr.h
+++ b/Userland/Libraries/LibJS/Heap/GCPtr.h
@@ -100,6 +100,18 @@ public:
     {
     }
 
+    GCPtr(GCPtr<T> const& other)
+        : m_ptr(other.ptr())
+    {
+    }
+
+    template<typename U>
+    GCPtr(GCPtr<U> const& other)
+    requires(IsConvertible<U*, T*>)
+        : m_ptr(other.ptr())
+    {
+    }
+
     GCPtr(NonnullGCPtr<T> const& other)
         : m_ptr(other.ptr())
     {
@@ -117,7 +129,6 @@ public:
     {
     }
 
-    GCPtr(GCPtr const&) = default;
     GCPtr& operator=(GCPtr const&) = default;
 
     template<typename U>

--- a/Userland/Libraries/LibJS/Heap/GCPtr.h
+++ b/Userland/Libraries/LibJS/Heap/GCPtr.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Traits.h>
 #include <AK/Types.h>
 
 namespace JS {
@@ -215,5 +216,25 @@ inline bool operator==(NonnullGCPtr<T> const& a, GCPtr<U> const& b)
 {
     return a.ptr() == b.ptr();
 }
+
+}
+
+namespace AK {
+
+template<typename T>
+struct Traits<JS::GCPtr<T>> : public GenericTraits<JS::GCPtr<T>> {
+    static unsigned hash(JS::GCPtr<T> const& value)
+    {
+        return Traits<T*>::hash(value.ptr());
+    }
+};
+
+template<typename T>
+struct Traits<JS::NonnullGCPtr<T>> : public GenericTraits<JS::NonnullGCPtr<T>> {
+    static unsigned hash(JS::NonnullGCPtr<T> const& value)
+    {
+        return Traits<T*>::hash(value.ptr());
+    }
+};
 
 }

--- a/Userland/Libraries/LibJS/Heap/Handle.h
+++ b/Userland/Libraries/LibJS/Heap/Handle.h
@@ -31,7 +31,7 @@ private:
     friend class Handle;
 
     explicit HandleImpl(Cell*);
-    Cell* m_cell { nullptr };
+    GCPtr<Cell> m_cell;
 
     IntrusiveListNode<HandleImpl> m_list_node;
 

--- a/Userland/Libraries/LibJS/Heap/Handle.h
+++ b/Userland/Libraries/LibJS/Heap/Handle.h
@@ -60,6 +60,16 @@ public:
     {
     }
 
+    Handle(GCPtr<T> cell)
+        : Handle(cell.ptr())
+    {
+    }
+
+    Handle(NonnullGCPtr<T> cell)
+        : Handle(*cell)
+    {
+    }
+
     T* cell() const
     {
         if (!m_impl)

--- a/Userland/Libraries/LibJS/Heap/Heap.h
+++ b/Userland/Libraries/LibJS/Heap/Heap.h
@@ -113,7 +113,7 @@ private:
     MarkedVectorBase::List m_marked_vectors;
     WeakContainer::List m_weak_containers;
 
-    Vector<Cell*> m_uprooted_cells;
+    Vector<GCPtr<Cell>> m_uprooted_cells;
 
     BlockAllocator m_block_allocator;
 

--- a/Userland/Libraries/LibJS/Heap/HeapBlock.h
+++ b/Userland/Libraries/LibJS/Heap/HeapBlock.h
@@ -99,7 +99,7 @@ private:
     struct FreelistEntry final : public Cell {
         JS_CELL(FreelistEntry, Cell);
 
-        FreelistEntry* next { nullptr };
+        GCPtr<FreelistEntry> next;
     };
 
     Cell* cell(size_t index)
@@ -110,7 +110,7 @@ private:
     Heap& m_heap;
     size_t m_cell_size { 0 };
     size_t m_next_lazy_freelist_index { 0 };
-    FreelistEntry* m_freelist { nullptr };
+    GCPtr<FreelistEntry> m_freelist;
     alignas(Cell) u8 m_storage[];
 
 public:

--- a/Userland/Libraries/LibJS/Module.h
+++ b/Userland/Libraries/LibJS/Module.h
@@ -36,7 +36,7 @@ struct ResolvedBinding {
     }
 
     Type type { Null };
-    Module* module { nullptr };
+    GCPtr<Module> module;
     DeprecatedFlyString export_name;
 
     bool is_valid() const

--- a/Userland/Libraries/LibJS/Print.cpp
+++ b/Userland/Libraries/LibJS/Print.cpp
@@ -356,7 +356,7 @@ ErrorOr<void> print_weak_ref(JS::PrintContext& print_context, JS::WeakRef const&
 {
     TRY(print_type(print_context, "WeakRef"sv));
     TRY(js_out(print_context, " "));
-    TRY(print_value(print_context, weak_ref.value().visit([](Empty) -> JS::Value { return JS::js_undefined(); }, [](auto* value) -> JS::Value { return value; }), seen_objects));
+    TRY(print_value(print_context, weak_ref.value().visit([](Empty) -> JS::Value { return JS::js_undefined(); }, [](auto value) -> JS::Value { return value; }), seen_objects));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -345,8 +345,8 @@ bool validate_and_apply_property_descriptor(Object* object, PropertyKey const& p
             // i. For each field of Desc, set the corresponding attribute of the property named P of object O to the value of the field.
             Value value;
             if (descriptor.is_accessor_descriptor() || (current->is_accessor_descriptor() && !descriptor.is_data_descriptor())) {
-                auto* getter = descriptor.get.value_or(current->get.value_or(nullptr));
-                auto* setter = descriptor.set.value_or(current->set.value_or(nullptr));
+                auto getter = descriptor.get.value_or(current->get.value_or(nullptr));
+                auto setter = descriptor.set.value_or(current->set.value_or(nullptr));
                 value = Accessor::create(object->vm(), getter, setter);
             } else {
                 value = descriptor.value.value_or(current->value.value_or({}));

--- a/Userland/Libraries/LibJS/Runtime/Accessor.h
+++ b/Userland/Libraries/LibJS/Runtime/Accessor.h
@@ -41,8 +41,8 @@ private:
     {
     }
 
-    FunctionObject* m_getter { nullptr };
-    FunctionObject* m_setter { nullptr };
+    GCPtr<FunctionObject> m_getter;
+    GCPtr<FunctionObject> m_setter;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
@@ -28,7 +28,7 @@ ThrowCompletionOr<void> ArgumentsObject::initialize(Realm& realm)
 void ArgumentsObject::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_environment);
+    visitor.visit(m_environment);
     visitor.visit(m_parameter_map);
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
@@ -35,8 +35,8 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    Environment& m_environment;
-    Object* m_parameter_map { nullptr };
+    NonnullGCPtr<Environment> m_environment;
+    GCPtr<Object> m_parameter_map;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.cpp
@@ -108,7 +108,7 @@ JS_DEFINE_NATIVE_FUNCTION(AsyncFromSyncIteratorPrototype::return_)
     auto promise_capability = MUST(new_promise_capability(vm, realm.intrinsics().promise_constructor()));
 
     // 4. Let syncIterator be O.[[SyncIteratorRecord]].[[Iterator]].
-    auto* sync_iterator = this_object->sync_iterator_record().iterator;
+    auto sync_iterator = this_object->sync_iterator_record().iterator;
 
     // 5. Let return be Completion(GetMethod(syncIterator, "return")).
     // 6. IfAbruptRejectPromise(return, promiseCapability).
@@ -161,7 +161,7 @@ JS_DEFINE_NATIVE_FUNCTION(AsyncFromSyncIteratorPrototype::throw_)
     auto promise_capability = MUST(new_promise_capability(vm, realm.intrinsics().promise_constructor()));
 
     // 4. Let syncIterator be O.[[SyncIteratorRecord]].[[Iterator]].
-    auto* sync_iterator = this_object->sync_iterator_record().iterator;
+    auto sync_iterator = this_object->sync_iterator_record().iterator;
 
     // 5. Let throw be Completion(GetMethod(syncIterator, "throw")).
     // 6. IfAbruptRejectPromise(throw, promiseCapability).

--- a/Userland/Libraries/LibJS/Runtime/BigIntObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntObject.cpp
@@ -23,7 +23,7 @@ BigIntObject::BigIntObject(BigInt& bigint, Object& prototype)
 void BigIntObject::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_bigint);
+    visitor.visit(m_bigint);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/BigIntObject.h
+++ b/Userland/Libraries/LibJS/Runtime/BigIntObject.h
@@ -27,7 +27,7 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    BigInt& m_bigint;
+    NonnullGCPtr<BigInt> m_bigint;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/BoundFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/BoundFunction.h
@@ -35,9 +35,9 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    FunctionObject* m_bound_target_function { nullptr }; // [[BoundTargetFunction]]
-    Value m_bound_this;                                  // [[BoundThis]]
-    Vector<Value> m_bound_arguments;                     // [[BoundArguments]]
+    GCPtr<FunctionObject> m_bound_target_function; // [[BoundTargetFunction]]
+    Value m_bound_this;                            // [[BoundThis]]
+    Vector<Value> m_bound_arguments;               // [[BoundArguments]]
 
     DeprecatedFlyString m_name;
 };

--- a/Userland/Libraries/LibJS/Runtime/DataView.h
+++ b/Userland/Libraries/LibJS/Runtime/DataView.h
@@ -29,7 +29,7 @@ private:
 
     virtual void visit_edges(Visitor& visitor) override;
 
-    ArrayBuffer* m_viewed_array_buffer { nullptr };
+    GCPtr<ArrayBuffer> m_viewed_array_buffer;
     size_t m_byte_length { 0 };
     size_t m_byte_offset { 0 };
 };

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -247,7 +247,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ECMAScriptFunctionObject::internal_const
     }
 
     // 7. Let constructorEnv be the LexicalEnvironment of calleeContext.
-    auto* constructor_env = callee_context.lexical_environment;
+    auto constructor_env = callee_context.lexical_environment;
 
     // 8. Let result be Completion(OrdinaryCallEvaluateBody(F, argumentsList)).
     auto result = ordinary_call_evaluate_body();
@@ -587,7 +587,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
         }));
     }
 
-    auto* private_environment = callee_context.private_environment;
+    auto private_environment = callee_context.private_environment;
     for (auto& declaration : functions_to_initialize) {
         auto function = ECMAScriptFunctionObject::create(realm, declaration.name(), declaration.source_text(), declaration.body(), declaration.parameters(), declaration.function_length(), lex_environment, private_environment, declaration.kind(), declaration.is_strict_mode(), declaration.might_need_arguments_object(), declaration.contains_direct_call_to_eval());
         MUST(var_environment->set_mutable_binding(vm, declaration.name(), function, false));
@@ -621,7 +621,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::prepare_for_ordinary_call(Exec
     callee_context.function_name = m_name;
 
     // 4. Let calleeRealm be F.[[Realm]].
-    auto* callee_realm = m_realm;
+    auto callee_realm = m_realm;
     // NOTE: This non-standard fallback is needed until we can guarantee that literally
     // every function has a realm - especially in LibWeb that's sometimes not the case
     // when a function is created while no JS is running, as we currently need to rely on
@@ -674,7 +674,7 @@ void ECMAScriptFunctionObject::ordinary_call_bind_this(ExecutionContext& callee_
         return;
 
     // 3. Let calleeRealm be F.[[Realm]].
-    auto* callee_realm = m_realm;
+    auto callee_realm = m_realm;
     // NOTE: This non-standard fallback is needed until we can guarantee that literally
     // every function has a realm - especially in LibWeb that's sometimes not the case
     // when a function is created while no JS is running, as we currently need to rely on
@@ -685,7 +685,7 @@ void ECMAScriptFunctionObject::ordinary_call_bind_this(ExecutionContext& callee_
     VERIFY(callee_realm);
 
     // 4. Let localEnv be the LexicalEnvironment of calleeContext.
-    auto* local_env = callee_context.lexical_environment;
+    auto local_env = callee_context.lexical_environment;
 
     Value this_value;
 
@@ -717,7 +717,7 @@ void ECMAScriptFunctionObject::ordinary_call_bind_this(ExecutionContext& callee_
     // 7. Assert: localEnv is a function Environment Record.
     // 8. Assert: The next step never returns an abrupt completion because localEnv.[[ThisBindingStatus]] is not initialized.
     // 9. Perform ! localEnv.BindThisValue(thisValue).
-    MUST(verify_cast<FunctionEnvironment>(local_env)->bind_this_value(vm, this_value));
+    MUST(verify_cast<FunctionEnvironment>(*local_env).bind_this_value(vm, this_value));
 
     // 10. Return unused.
 }
@@ -762,11 +762,11 @@ void async_block_start(VM& vm, NonnullRefPtr<Statement const> const& async_body,
         vm.pop_execution_context();
 
         // d. Let env be asyncContext's LexicalEnvironment.
-        auto* env = async_context.lexical_environment;
-        VERIFY(is<DeclarativeEnvironment>(env));
+        auto env = async_context.lexical_environment;
+        VERIFY(is<DeclarativeEnvironment>(*env));
 
         // e. Set result to DisposeResources(env, result).
-        result = dispose_resources(vm, static_cast<DeclarativeEnvironment*>(env), result);
+        result = dispose_resources(vm, static_cast<DeclarativeEnvironment*>(env.ptr()), result);
 
         // f. If result.[[Type]] is normal, then
         if (result.type() == Completion::Type::Normal) {
@@ -909,11 +909,11 @@ Completion ECMAScriptFunctionObject::ordinary_call_evaluate_body()
             auto result = m_ecmascript_code->execute(*ast_interpreter);
 
             // 3. Let env be the running execution context's LexicalEnvironment.
-            auto* env = vm.running_execution_context().lexical_environment;
-            VERIFY(is<DeclarativeEnvironment>(env));
+            auto env = vm.running_execution_context().lexical_environment;
+            VERIFY(is<DeclarativeEnvironment>(*env));
 
             // 4. Return ? DisposeResources(env, result).
-            return dispose_resources(vm, static_cast<DeclarativeEnvironment*>(env), result);
+            return dispose_resources(vm, static_cast<DeclarativeEnvironment*>(env.ptr()), result);
         }
         // AsyncFunctionBody : FunctionBody
         else if (m_kind == FunctionKind::Async) {

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -112,13 +112,13 @@ private:
     i32 m_function_length { 0 };
 
     // Internal Slots of ECMAScript Function Objects, https://tc39.es/ecma262/#table-internal-slots-of-ecmascript-function-objects
-    Environment* m_environment { nullptr };                                  // [[Environment]]
-    PrivateEnvironment* m_private_environment { nullptr };                   // [[PrivateEnvironment]]
+    GCPtr<Environment> m_environment;                                        // [[Environment]]
+    GCPtr<PrivateEnvironment> m_private_environment;                         // [[PrivateEnvironment]]
     Vector<FunctionParameter> const m_formal_parameters;                     // [[FormalParameters]]
     NonnullRefPtr<Statement const> m_ecmascript_code;                        // [[ECMAScriptCode]]
-    Realm* m_realm { nullptr };                                              // [[Realm]]
+    GCPtr<Realm> m_realm;                                                    // [[Realm]]
     ScriptOrModule m_script_or_module;                                       // [[ScriptOrModule]]
-    Object* m_home_object { nullptr };                                       // [[HomeObject]]
+    GCPtr<Object> m_home_object;                                             // [[HomeObject]]
     DeprecatedString m_source_text;                                          // [[SourceText]]
     Vector<ClassFieldDefinition> m_fields;                                   // [[Fields]]
     Vector<PrivateElement> m_private_methods;                                // [[PrivateMethods]]

--- a/Userland/Libraries/LibJS/Runtime/Environment.h
+++ b/Userland/Libraries/LibJS/Runtime/Environment.h
@@ -67,7 +67,7 @@ private:
 
     bool m_permanently_screwed_by_eval { false };
 
-    Environment* m_outer_environment { nullptr };
+    GCPtr<Environment> m_outer_environment;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Error.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Error.cpp
@@ -65,7 +65,7 @@ void Error::populate_stack()
     auto& vm = this->vm();
     m_traceback.ensure_capacity(vm.execution_context_stack().size());
     for (ssize_t i = vm.execution_context_stack().size() - 1; i >= 0; i--) {
-        auto* context = vm.execution_context_stack()[i];
+        auto context = vm.execution_context_stack()[i];
         auto function_name = context->function_name;
         if (function_name.is_empty())
             function_name = "<unknown>"sv;

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -32,15 +32,15 @@ private:
     explicit ExecutionContext(MarkedVector<Value> existing_arguments);
 
 public:
-    FunctionObject* function { nullptr };                // [[Function]]
-    Realm* realm { nullptr };                            // [[Realm]]
-    ScriptOrModule script_or_module;                     // [[ScriptOrModule]]
-    Environment* lexical_environment { nullptr };        // [[LexicalEnvironment]]
-    Environment* variable_environment { nullptr };       // [[VariableEnvironment]]
-    PrivateEnvironment* private_environment { nullptr }; // [[PrivateEnvironment]]
+    GCPtr<FunctionObject> function;                // [[Function]]
+    GCPtr<Realm> realm;                            // [[Realm]]
+    ScriptOrModule script_or_module;               // [[ScriptOrModule]]
+    GCPtr<Environment> lexical_environment;        // [[LexicalEnvironment]]
+    GCPtr<Environment> variable_environment;       // [[VariableEnvironment]]
+    GCPtr<PrivateEnvironment> private_environment; // [[PrivateEnvironment]]
 
     // Non-standard: This points at something that owns this ExecutionContext, in case it needs to be protected from GC.
-    Cell* context_owner { nullptr };
+    GCPtr<Cell> context_owner;
 
     ASTNode const* current_node { nullptr };
     DeprecatedFlyString function_name;

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.h
@@ -46,9 +46,9 @@ private:
     JobCallback m_cleanup_callback;
 
     struct FinalizationRecord {
-        Cell* target { nullptr };
+        GCPtr<Cell> target;
         Value held_value;
-        Cell* unregister_token { nullptr };
+        GCPtr<Cell> unregister_token;
     };
     SinglyLinkedList<FinalizationRecord> m_records;
 };

--- a/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.h
@@ -52,7 +52,7 @@ private:
 
     Value m_this_value;                                                           // [[ThisValue]]
     ThisBindingStatus m_this_binding_status { ThisBindingStatus::Uninitialized }; // [[ThisBindingStatus]]
-    ECMAScriptFunctionObject* m_function_object { nullptr };                      // [[FunctionObject]]
+    GCPtr<ECMAScriptFunctionObject> m_function_object;                            // [[FunctionObject]]
     Value m_new_target { js_undefined() };                                        // [[NewTarget]]
 };
 

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
@@ -38,7 +38,7 @@ private:
     ThrowCompletionOr<Value> execute(VM&, JS::Completion const& completion);
 
     ExecutionContext m_execution_context;
-    ECMAScriptFunctionObject* m_generating_function { nullptr };
+    GCPtr<ECMAScriptFunctionObject> m_generating_function;
     Value m_previous_value;
     Optional<Bytecode::RegisterWindow> m_frame;
     GeneratorState m_generator_state { GeneratorState::SuspendedStart };

--- a/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.h
@@ -43,10 +43,10 @@ private:
     virtual bool is_global_environment() const override { return true; }
     virtual void visit_edges(Visitor&) override;
 
-    ObjectEnvironment* m_object_record { nullptr };           // [[ObjectRecord]]
-    Object* m_global_this_value { nullptr };                  // [[GlobalThisValue]]
-    DeclarativeEnvironment* m_declarative_record { nullptr }; // [[DeclarativeRecord]]
-    Vector<DeprecatedFlyString> m_var_names;                  // [[VarNames]]
+    GCPtr<ObjectEnvironment> m_object_record;           // [[ObjectRecord]]
+    GCPtr<Object> m_global_this_value;                  // [[GlobalThisValue]]
+    GCPtr<DeclarativeEnvironment> m_declarative_record; // [[DeclarativeRecord]]
+    Vector<DeprecatedFlyString> m_var_names;            // [[VarNames]]
 };
 
 template<>

--- a/Userland/Libraries/LibJS/Runtime/Intl/Collator.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Collator.h
@@ -77,14 +77,14 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    String m_locale;                                      // [[Locale]]
-    Usage m_usage { Usage::Sort };                        // [[Usage]]
-    Sensitivity m_sensitivity { Sensitivity::Variant };   // [[Sensitivity]]
-    CaseFirst m_case_first { CaseFirst::False };          // [[CaseFirst]]
-    String m_collation;                                   // [[Collation]]
-    bool m_ignore_punctuation { false };                  // [[IgnorePunctuation]]
-    bool m_numeric { false };                             // [[Numeric]]
-    CollatorCompareFunction* m_bound_compare { nullptr }; // [[BoundCompare]]
+    String m_locale;                                    // [[Locale]]
+    Usage m_usage { Usage::Sort };                      // [[Usage]]
+    Sensitivity m_sensitivity { Sensitivity::Variant }; // [[Sensitivity]]
+    CaseFirst m_case_first { CaseFirst::False };        // [[CaseFirst]]
+    String m_collation;                                 // [[Collation]]
+    bool m_ignore_punctuation { false };                // [[IgnorePunctuation]]
+    bool m_numeric { false };                           // [[Numeric]]
+    GCPtr<CollatorCompareFunction> m_bound_compare;     // [[BoundCompare]]
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.cpp
@@ -71,7 +71,7 @@ ThrowCompletionOr<Value> CollatorCompareFunction::call()
 void CollatorCompareFunction::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_collator);
+    visitor.visit(m_collator);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.h
@@ -26,7 +26,7 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    Collator& m_collator; // [[Collator]]
+    NonnullGCPtr<Collator> m_collator; // [[Collator]]
 };
 
 double compare_strings(Collator&, Utf8View const& x, Utf8View const& y);

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -142,7 +142,7 @@ private:
     Optional<Style> m_date_style;                            // [[DateStyle]]
     Optional<Style> m_time_style;                            // [[TimeStyle]]
     Vector<::Locale::CalendarRangePattern> m_range_patterns; // [[RangePatterns]]
-    NativeFunction* m_bound_format { nullptr };              // [[BoundFormat]]
+    GCPtr<NativeFunction> m_bound_format;                    // [[BoundFormat]]
 
     String m_data_locale;
 };

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.cpp
@@ -67,7 +67,7 @@ ThrowCompletionOr<Value> DateTimeFormatFunction::call()
 void DateTimeFormatFunction::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_date_time_format);
+    visitor.visit(m_date_time_format);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.h
@@ -28,7 +28,7 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    DateTimeFormat& m_date_time_format; // [[DateTimeFormat]]
+    NonnullGCPtr<DateTimeFormat> m_date_time_format; // [[DateTimeFormat]]
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -251,7 +251,7 @@ private:
     Notation m_notation { Notation::Invalid };           // [[Notation]]
     Optional<CompactDisplay> m_compact_display {};       // [[CompactDisplay]]
     SignDisplay m_sign_display { SignDisplay::Invalid }; // [[SignDisplay]]
-    NativeFunction* m_bound_format { nullptr };          // [[BoundFormat]]
+    GCPtr<NativeFunction> m_bound_format;                // [[BoundFormat]]
 
     // Non-standard. Stores the resolved currency display string based on [[Locale]], [[Currency]], and [[CurrencyDisplay]].
     Optional<StringView> m_resolved_currency_display;

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.cpp
@@ -54,7 +54,7 @@ ThrowCompletionOr<Value> NumberFormatFunction::call()
 void NumberFormatFunction::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_number_format);
+    visitor.visit(m_number_format);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.h
@@ -28,7 +28,7 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    NumberFormat& m_number_format; // [[NumberFormat]]
+    NonnullGCPtr<NumberFormat> m_number_format; // [[NumberFormat]]
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
@@ -68,8 +68,8 @@ private:
     String m_numbering_system;                         // [[NumberingSystem]]
     ::Locale::Style m_style { ::Locale::Style::Long }; // [[Style]]
     Numeric m_numeric { Numeric::Always };             // [[Numeric]]
-    NumberFormat* m_number_format { nullptr };         // [[NumberFormat]]
-    PluralRules* m_plural_rules { nullptr };           // [[PluralRules]]
+    GCPtr<NumberFormat> m_number_format;               // [[NumberFormat]]
+    GCPtr<PluralRules> m_plural_rules;                 // [[PluralRules]]
 };
 
 struct PatternPartitionWithUnit : public PatternPartition {

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.cpp
@@ -34,8 +34,8 @@ SegmentIterator::SegmentIterator(Realm& realm, Segmenter& segmenter, Utf16View c
 void SegmentIterator::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_iterating_segmenter);
-    visitor.visit(&m_segments);
+    visitor.visit(m_iterating_segmenter);
+    visitor.visit(m_segments);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.h
@@ -32,11 +32,11 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    Segmenter& m_iterating_segmenter;                            // [[IteratingSegmenter]]
+    NonnullGCPtr<Segmenter> m_iterating_segmenter;               // [[IteratingSegmenter]]
     Utf16View m_iterated_string;                                 // [[IteratedString]]
     size_t m_iterated_string_next_segment_code_unit_index { 0 }; // [[IteratedStringNextSegmentCodeUnitIndex]]
 
-    Segments const& m_segments;
+    NonnullGCPtr<Segments const> m_segments;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/Segments.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Segments.cpp
@@ -32,7 +32,7 @@ Segments::Segments(Realm& realm, Segmenter& segmenter, Utf16String string)
 void Segments::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_segments_segmenter);
+    visitor.visit(m_segments_segmenter);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/Segments.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Segments.h
@@ -29,8 +29,8 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    Segmenter& m_segments_segmenter; // [[SegmentsSegmenter]]
-    Utf16String m_segments_string;   // [[SegmentsString]]
+    NonnullGCPtr<Segmenter> m_segments_segmenter; // [[SegmentsSegmenter]]
+    Utf16String m_segments_string;                // [[SegmentsString]]
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
@@ -184,8 +184,8 @@ ThrowCompletionOr<void> Intrinsics::initialize_intrinsics(Realm& realm)
     m_new_ordinary_function_prototype_object_shape->add_property_without_transition(vm.names.constructor, Attribute::Writable | Attribute::Configurable);
 
     // Normally Heap::allocate() takes care of this, but these are allocated via allocate_without_realm().
-    MUST_OR_THROW_OOM(static_cast<FunctionPrototype*>(m_function_prototype)->initialize(realm));
-    MUST_OR_THROW_OOM(static_cast<ObjectPrototype*>(m_object_prototype)->initialize(realm));
+    MUST_OR_THROW_OOM(m_function_prototype->initialize(realm));
+    MUST_OR_THROW_OOM(m_object_prototype->initialize(realm));
 
 #define __JS_ENUMERATE(ClassName, snake_name) \
     VERIFY(!m_##snake_name##_prototype);      \

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.h
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.h
@@ -115,69 +115,69 @@ private:
     JS_ENUMERATE_TEMPORAL_OBJECTS
 #undef __JS_ENUMERATE
 
-    Realm& m_realm;
+    NonnullGCPtr<Realm> m_realm;
 
-    Shape* m_empty_object_shape { nullptr };
-    Shape* m_new_object_shape { nullptr };
-    Shape* m_new_ordinary_function_prototype_object_shape { nullptr };
+    GCPtr<Shape> m_empty_object_shape;
+    GCPtr<Shape> m_new_object_shape;
+    GCPtr<Shape> m_new_ordinary_function_prototype_object_shape;
 
     // Not included in JS_ENUMERATE_NATIVE_OBJECTS due to missing distinct prototype
-    ProxyConstructor* m_proxy_constructor { nullptr };
+    GCPtr<ProxyConstructor> m_proxy_constructor;
 
     // Not included in JS_ENUMERATE_NATIVE_OBJECTS due to missing distinct constructor
-    Object* m_async_from_sync_iterator_prototype { nullptr };
-    Object* m_async_generator_prototype { nullptr };
-    Object* m_generator_prototype { nullptr };
+    GCPtr<Object> m_async_from_sync_iterator_prototype;
+    GCPtr<Object> m_async_generator_prototype;
+    GCPtr<Object> m_generator_prototype;
 
     // Not included in JS_ENUMERATE_INTL_OBJECTS due to missing distinct constructor
-    Object* m_intl_segments_prototype { nullptr };
+    GCPtr<Object> m_intl_segments_prototype;
 
     // Global object functions
-    FunctionObject* m_eval_function { nullptr };
-    FunctionObject* m_is_finite_function { nullptr };
-    FunctionObject* m_is_nan_function { nullptr };
-    FunctionObject* m_parse_float_function { nullptr };
-    FunctionObject* m_parse_int_function { nullptr };
-    FunctionObject* m_decode_uri_function { nullptr };
-    FunctionObject* m_decode_uri_component_function { nullptr };
-    FunctionObject* m_encode_uri_function { nullptr };
-    FunctionObject* m_encode_uri_component_function { nullptr };
-    FunctionObject* m_escape_function { nullptr };
-    FunctionObject* m_unescape_function { nullptr };
+    GCPtr<FunctionObject> m_eval_function;
+    GCPtr<FunctionObject> m_is_finite_function;
+    GCPtr<FunctionObject> m_is_nan_function;
+    GCPtr<FunctionObject> m_parse_float_function;
+    GCPtr<FunctionObject> m_parse_int_function;
+    GCPtr<FunctionObject> m_decode_uri_function;
+    GCPtr<FunctionObject> m_decode_uri_component_function;
+    GCPtr<FunctionObject> m_encode_uri_function;
+    GCPtr<FunctionObject> m_encode_uri_component_function;
+    GCPtr<FunctionObject> m_escape_function;
+    GCPtr<FunctionObject> m_unescape_function;
 
     // Namespace/constructor object functions
-    FunctionObject* m_array_prototype_values_function { nullptr };
-    FunctionObject* m_date_constructor_now_function { nullptr };
-    FunctionObject* m_json_parse_function { nullptr };
-    FunctionObject* m_json_stringify_function { nullptr };
-    FunctionObject* m_object_prototype_to_string_function { nullptr };
-    FunctionObject* m_throw_type_error_function { nullptr };
+    GCPtr<FunctionObject> m_array_prototype_values_function;
+    GCPtr<FunctionObject> m_date_constructor_now_function;
+    GCPtr<FunctionObject> m_json_parse_function;
+    GCPtr<FunctionObject> m_json_stringify_function;
+    GCPtr<FunctionObject> m_object_prototype_to_string_function;
+    GCPtr<FunctionObject> m_throw_type_error_function;
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
-    ConstructorName* m_##snake_name##_constructor { nullptr };                           \
-    Object* m_##snake_name##_prototype { nullptr };
+    GCPtr<ConstructorName> m_##snake_name##_constructor;                                 \
+    GCPtr<Object> m_##snake_name##_prototype;
     JS_ENUMERATE_BUILTIN_TYPES
 #undef __JS_ENUMERATE
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName) \
-    Intl::ConstructorName* m_intl_##snake_name##_constructor { nullptr };     \
-    Object* m_intl_##snake_name##_prototype { nullptr };
+    GCPtr<Intl::ConstructorName> m_intl_##snake_name##_constructor;           \
+    GCPtr<Object> m_intl_##snake_name##_prototype;
     JS_ENUMERATE_INTL_OBJECTS
 #undef __JS_ENUMERATE
 
-#define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName)     \
-    Temporal::ConstructorName* m_temporal_##snake_name##_constructor { nullptr }; \
-    Object* m_temporal_##snake_name##_prototype { nullptr };
+#define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName) \
+    GCPtr<Temporal::ConstructorName> m_temporal_##snake_name##_constructor;   \
+    GCPtr<Object> m_temporal_##snake_name##_prototype;
     JS_ENUMERATE_TEMPORAL_OBJECTS
 #undef __JS_ENUMERATE
 
 #define __JS_ENUMERATE(ClassName, snake_name) \
-    ClassName* m_##snake_name##_object { nullptr };
+    GCPtr<ClassName> m_##snake_name##_object;
     JS_ENUMERATE_BUILTIN_NAMESPACE_OBJECTS
 #undef __JS_ENUMERATE
 
 #define __JS_ENUMERATE(ClassName, snake_name) \
-    Object* m_##snake_name##_prototype { nullptr };
+    GCPtr<Object> m_##snake_name##_prototype;
     JS_ENUMERATE_ITERATOR_PROTOTYPES
 #undef __JS_ENUMERATE
 };

--- a/Userland/Libraries/LibJS/Runtime/Iterator.h
+++ b/Userland/Libraries/LibJS/Runtime/Iterator.h
@@ -13,9 +13,9 @@ namespace JS {
 
 // 7.4.1 Iterator Records, https://tc39.es/ecma262/#sec-iterator-records
 struct Iterator {
-    Object* iterator { nullptr }; // [[Iterator]]
-    Value next_method;            // [[NextMethod]]
-    bool done { false };          // [[Done]]
+    GCPtr<Object> iterator; // [[Iterator]]
+    Value next_method;      // [[NextMethod]]
+    bool done { false };    // [[Done]]
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/IteratorOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorOperations.cpp
@@ -128,7 +128,7 @@ static Completion iterator_close_impl(VM& vm, Iterator const& iterator_record, C
     // 1. Assert: Type(iteratorRecord.[[Iterator]]) is Object.
 
     // 2. Let iterator be iteratorRecord.[[Iterator]].
-    auto* iterator = iterator_record.iterator;
+    auto iterator = iterator_record.iterator;
 
     // 3. Let innerResult be Completion(GetMethod(iterator, "return")).
     auto inner_result = ThrowCompletionOr<Value> { js_undefined() };

--- a/Userland/Libraries/LibJS/Runtime/JSONObject.h
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.h
@@ -27,8 +27,8 @@ private:
     explicit JSONObject(Realm&);
 
     struct StringifyState {
-        FunctionObject* replacer_function { nullptr };
-        HashTable<Object*> seen_objects;
+        GCPtr<FunctionObject> replacer_function;
+        HashTable<GCPtr<Object>> seen_objects;
         DeprecatedString indent { DeprecatedString::empty() };
         DeprecatedString gap;
         Optional<Vector<DeprecatedString>> property_list;

--- a/Userland/Libraries/LibJS/Runtime/Map.h
+++ b/Userland/Libraries/LibJS/Runtime/Map.h
@@ -37,8 +37,8 @@ public:
     struct IteratorImpl {
         bool is_end() const
         {
-            return m_map.m_keys.begin_from(m_index).is_end()
-                && m_map.m_keys.find_smallest_not_below_iterator(m_index).is_end();
+            return m_map->m_keys.begin_from(m_index).is_end()
+                && m_map->m_keys.find_smallest_not_below_iterator(m_index).is_end();
         }
 
         IteratorImpl& operator++()
@@ -50,13 +50,13 @@ public:
         decltype(auto) operator*()
         {
             ensure_next_element();
-            return *m_map.m_entries.find(*m_map.m_keys.begin_from(m_index));
+            return *m_map->m_entries.find(*m_map->m_keys.begin_from(m_index));
         }
 
         decltype(auto) operator*() const
         {
             ensure_next_element();
-            return *m_map.m_entries.find(*m_map.m_keys.begin_from(m_index));
+            return *m_map->m_entries.find(*m_map->m_keys.begin_from(m_index));
         }
 
         bool operator==(IteratorImpl const& other) const { return m_index == other.m_index && &m_map == &other.m_map; }
@@ -80,21 +80,21 @@ public:
 
         void ensure_index() const
         {
-            if (m_map.m_keys.is_empty())
-                m_index = m_map.m_next_insertion_id;
+            if (m_map->m_keys.is_empty())
+                m_index = m_map->m_next_insertion_id;
             else
-                m_index = m_map.m_keys.begin().key();
+                m_index = m_map->m_keys.begin().key();
         }
 
         void ensure_next_element() const
         {
-            if (auto it = m_map.m_keys.find_smallest_not_below_iterator(m_index); it.is_end())
-                m_index = m_map.m_next_insertion_id;
+            if (auto it = m_map->m_keys.find_smallest_not_below_iterator(m_index); it.is_end())
+                m_index = m_map->m_next_insertion_id;
             else
                 m_index = it.key();
         }
 
-        Conditional<IsConst, Map const&, Map&> m_map;
+        Conditional<IsConst, NonnullGCPtr<Map const>, NonnullGCPtr<Map>> m_map;
         mutable size_t m_index { 0 };
     };
 

--- a/Userland/Libraries/LibJS/Runtime/MapIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapIterator.cpp
@@ -25,7 +25,7 @@ MapIterator::MapIterator(Map& map, Object::PropertyKind iteration_kind, Object& 
 void MapIterator::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_map);
+    visitor.visit(m_map);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/MapIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/MapIterator.h
@@ -31,7 +31,7 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    Map& m_map;
+    NonnullGCPtr<Map> m_map;
     bool m_done { false };
     Object::PropertyKind m_iteration_kind;
     Map::ConstIterator m_iterator;

--- a/Userland/Libraries/LibJS/Runtime/ModuleEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/ModuleEnvironment.h
@@ -34,7 +34,7 @@ private:
 
     struct IndirectBinding {
         DeprecatedFlyString name;
-        Module* module;
+        GCPtr<Module> module;
         DeprecatedFlyString binding_name;
     };
     IndirectBinding const* get_indirect_binding(DeprecatedFlyString const& name) const;

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
@@ -160,7 +160,7 @@ ThrowCompletionOr<Value> ModuleNamespaceObject::internal_get(PropertyKey const& 
     VERIFY(binding.is_valid());
 
     // 7. Let targetModule be binding.[[Module]].
-    auto* target_module = binding.module;
+    auto target_module = binding.module;
 
     // 8. Assert: targetModule is not undefined.
     VERIFY(target_module);

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
@@ -35,7 +35,7 @@ private:
     ModuleNamespaceObject(Realm&, Module* module, Vector<DeprecatedFlyString> exports);
 
     // FIXME: UHHH how do we want to store this to avoid cycles but be safe??
-    Module* m_module;                      // [[Module]]
+    GCPtr<Module> m_module;                // [[Module]]
     Vector<DeprecatedFlyString> m_exports; // [[Exports]]
 };
 

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -111,7 +111,7 @@ ThrowCompletionOr<Value> NativeFunction::internal_call(Value this_argument, Mark
     callee_context.function_name = m_name;
 
     // 5. Let calleeRealm be F.[[Realm]].
-    auto* callee_realm = m_realm;
+    auto callee_realm = m_realm;
     // NOTE: This non-standard fallback is needed until we can guarantee that literally
     // every function has a realm - especially in LibWeb that's sometimes not the case
     // when a function is created while no JS is running, as we currently need to rely on
@@ -178,7 +178,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> NativeFunction::internal_construct(Marke
     callee_context.function_name = m_name;
 
     // 5. Let calleeRealm be F.[[Realm]].
-    auto* callee_realm = m_realm;
+    auto callee_realm = m_realm;
     // NOTE: This non-standard fallback is needed until we can guarantee that literally
     // every function has a realm - especially in LibWeb that's sometimes not the case
     // when a function is created while no JS is running, as we currently need to rely on

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.h
@@ -54,7 +54,7 @@ private:
     DeprecatedFlyString m_name;
     Optional<DeprecatedFlyString> m_initial_name; // [[InitialName]]
     SafeFunction<ThrowCompletionOr<Value>(VM&)> m_native_function;
-    Realm* m_realm { nullptr };
+    GCPtr<Realm> m_realm;
 };
 
 template<>

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -24,7 +24,7 @@
 
 namespace JS {
 
-static HashMap<Object const*, HashMap<DeprecatedFlyString, Object::IntrinsicAccessor>> s_intrinsics;
+static HashMap<GCPtr<Object const>, HashMap<DeprecatedFlyString, Object::IntrinsicAccessor>> s_intrinsics;
 
 // 10.1.12 OrdinaryObjectCreate ( proto [ , additionalInternalSlotsList ] ), https://tc39.es/ecma262/#sec-ordinaryobjectcreate
 NonnullGCPtr<Object> Object::create(Realm& realm, Object* prototype)
@@ -813,7 +813,7 @@ ThrowCompletionOr<Value> Object::internal_get(PropertyKey const& property_key, V
     VERIFY(descriptor->is_accessor_descriptor());
 
     // 5. Let getter be desc.[[Get]].
-    auto* getter = *descriptor->get;
+    auto getter = *descriptor->get;
 
     // 6. If getter is undefined, return undefined.
     if (!getter)
@@ -911,7 +911,7 @@ ThrowCompletionOr<bool> Object::ordinary_set_with_own_descriptor(PropertyKey con
     VERIFY(own_descriptor->is_accessor_descriptor());
 
     // 4. Let setter be ownDesc.[[Set]].
-    auto* setter = *own_descriptor->set;
+    auto setter = *own_descriptor->set;
 
     // 5. If setter is undefined, return false.
     if (!setter)

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -213,7 +213,7 @@ private:
     Object* prototype() { return shape().prototype(); }
     Object const* prototype() const { return shape().prototype(); }
 
-    Shape* m_shape { nullptr };
+    GCPtr<Shape> m_shape;
     Vector<Value> m_storage;
     IndexedProperties m_indexed_properties;
     OwnPtr<Vector<PrivateElement>> m_private_elements; // [[PrivateElements]]

--- a/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.h
@@ -31,7 +31,7 @@ public:
     virtual Object* with_base_object() const override
     {
         if (is_with_environment())
-            return &m_binding_object;
+            return m_binding_object;
         return nullptr;
     }
 
@@ -46,7 +46,7 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    Object& m_binding_object;
+    NonnullGCPtr<Object> m_binding_object;
     bool m_with_environment { false };
 };
 

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -62,8 +62,8 @@ private:
 
     mutable bool m_is_rope { false };
 
-    mutable PrimitiveString* m_lhs { nullptr };
-    mutable PrimitiveString* m_rhs { nullptr };
+    mutable GCPtr<PrimitiveString> m_lhs;
+    mutable GCPtr<PrimitiveString> m_rhs;
 
     mutable Optional<String> m_utf8_string;
     mutable Optional<DeprecatedString> m_deprecated_string;

--- a/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.h
@@ -49,8 +49,8 @@ private:
 
     static u64 s_next_id;
 
-    PrivateEnvironment* m_outer_environment { nullptr }; // [[OuterEnv]]
-    Vector<PrivateName> m_private_names;                 // [[Names]]
+    GCPtr<PrivateEnvironment> m_outer_environment; // [[OuterEnv]]
+    Vector<PrivateName> m_private_names;           // [[Names]]
     u64 m_unique_id;
 };
 

--- a/Userland/Libraries/LibJS/Runtime/Promise.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Promise.cpp
@@ -151,7 +151,7 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
         auto job = create_promise_resolve_thenable_job(vm, promise, resolution, move(then_job_callback));
 
         // 15. Perform HostEnqueuePromiseJob(job.[[Job]], job.[[Realm]]).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Enqueuing job @ {} in realm {}", &promise, &job.job, job.realm);
+        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Enqueuing job @ {} in realm {}", &promise, &job.job, job.realm.ptr());
         vm.host_enqueue_promise_job(move(job.job), job.realm);
 
         // 16. Return undefined.
@@ -275,7 +275,7 @@ void Promise::trigger_reactions() const
         auto [job, realm] = create_promise_reaction_job(vm, *reaction, m_result);
 
         // b. Perform HostEnqueuePromiseJob(job.[[Job]], job.[[Realm]]).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / trigger_reactions()]: Enqueuing job @ {} in realm {}", this, &job, realm);
+        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / trigger_reactions()]: Enqueuing job @ {} in realm {}", this, &job, realm.ptr());
         vm.host_enqueue_promise_job(move(job), realm);
     }
 
@@ -345,7 +345,7 @@ Value Promise::perform_then(Value on_fulfilled, Value on_rejected, GCPtr<Promise
         auto [fulfill_job, realm] = create_promise_reaction_job(vm, fulfill_reaction, value);
 
         // c. Perform HostEnqueuePromiseJob(fulfillJob.[[Job]], fulfillJob.[[Realm]]).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: Enqueuing job @ {} in realm {}", this, &fulfill_job, realm);
+        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: Enqueuing job @ {} in realm {}", this, &fulfill_job, realm.ptr());
         vm.host_enqueue_promise_job(move(fulfill_job), realm);
         break;
     }
@@ -365,7 +365,7 @@ Value Promise::perform_then(Value on_fulfilled, Value on_rejected, GCPtr<Promise
         auto [reject_job, realm] = create_promise_reaction_job(vm, *reject_reaction, reason);
 
         // e. Perform HostEnqueuePromiseJob(rejectJob.[[Job]], rejectJob.[[Realm]]).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: Enqueuing job @ {} in realm {}", this, &reject_job, realm);
+        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: Enqueuing job @ {} in realm {}", this, &reject_job, realm.ptr());
         vm.host_enqueue_promise_job(move(reject_job), realm);
         break;
     }

--- a/Userland/Libraries/LibJS/Runtime/Promise.h
+++ b/Userland/Libraries/LibJS/Runtime/Promise.h
@@ -35,8 +35,8 @@ public:
     Value result() const { return m_result; }
 
     struct ResolvingFunctions {
-        FunctionObject& resolve;
-        FunctionObject& reject;
+        NonnullGCPtr<FunctionObject> resolve;
+        NonnullGCPtr<FunctionObject> reject;
     };
     ResolvingFunctions create_resolving_functions();
 
@@ -58,11 +58,11 @@ private:
     void trigger_reactions() const;
 
     // 27.2.6 Properties of Promise Instances, https://tc39.es/ecma262/#sec-properties-of-promise-instances
-    State m_state { State::Pending };             // [[PromiseState]]
-    Value m_result;                               // [[PromiseResult]]
-    Vector<PromiseReaction*> m_fulfill_reactions; // [[PromiseFulfillReactions]]
-    Vector<PromiseReaction*> m_reject_reactions;  // [[PromiseRejectReactions]]
-    bool m_is_handled { false };                  // [[PromiseIsHandled]]
+    State m_state { State::Pending };                   // [[PromiseState]]
+    Value m_result;                                     // [[PromiseResult]]
+    Vector<GCPtr<PromiseReaction>> m_fulfill_reactions; // [[PromiseFulfillReactions]]
+    Vector<GCPtr<PromiseReaction>> m_reject_reactions;  // [[PromiseRejectReactions]]
+    bool m_is_handled { false };                        // [[PromiseIsHandled]]
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -298,12 +298,12 @@ ThrowCompletionOr<NonnullGCPtr<Object>> PromiseConstructor::construct(FunctionOb
     auto [resolve_function, reject_function] = promise->create_resolving_functions();
 
     // 9. Let completion be Completion(Call(executor, undefined, « resolvingFunctions.[[Resolve]], resolvingFunctions.[[Reject]] »)).
-    auto completion = JS::call(vm, executor.as_function(), js_undefined(), &resolve_function, &reject_function);
+    auto completion = JS::call(vm, executor.as_function(), js_undefined(), resolve_function, reject_function);
 
     // 10. If completion is an abrupt completion, then
     if (completion.is_error()) {
         // a. Perform ? Call(resolvingFunctions.[[Reject]], undefined, « completion.[[Value]] »).
-        TRY(JS::call(vm, reject_function, js_undefined(), *completion.release_error().value()));
+        TRY(JS::call(vm, *reject_function, js_undefined(), *completion.release_error().value()));
     }
 
     // 11. Return promise.

--- a/Userland/Libraries/LibJS/Runtime/PromiseJobs.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseJobs.cpp
@@ -129,15 +129,15 @@ static ThrowCompletionOr<Value> run_resolve_thenable_job(VM& vm, Promise& promis
     // b. Let thenCallResult be Completion(HostCallJobCallback(then, thenable, « resolvingFunctions.[[Resolve]], resolvingFunctions.[[Reject]] »)).
     dbgln_if(PROMISE_DEBUG, "run_resolve_thenable_job: Calling then job callback for thenable {}", &thenable);
     MarkedVector<Value> arguments(vm.heap());
-    arguments.append(Value(&resolve_function));
-    arguments.append(Value(&reject_function));
+    arguments.append(Value(resolve_function));
+    arguments.append(Value(reject_function));
     auto then_call_result = vm.host_call_job_callback(then, thenable, move(arguments));
 
     // c. If thenCallResult is an abrupt completion, then
     if (then_call_result.is_error()) {
         // i. Return ? Call(resolvingFunctions.[[Reject]], undefined, « thenCallResult.[[Value]] »).
         dbgln_if(PROMISE_DEBUG, "run_resolve_thenable_job: then_call_result is an abrupt completion, calling reject function with value {}", *then_call_result.throw_completion().value());
-        return call(vm, &reject_function, js_undefined(), *then_call_result.throw_completion().value());
+        return call(vm, *reject_function, js_undefined(), *then_call_result.throw_completion().value());
     }
 
     // d. Return ? thenCallResult.

--- a/Userland/Libraries/LibJS/Runtime/PromiseJobs.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseJobs.h
@@ -16,7 +16,7 @@ namespace JS {
 
 struct PromiseJob {
     Function<ThrowCompletionOr<Value>()> job;
-    Realm* realm { nullptr };
+    GCPtr<Realm> realm;
 };
 
 // NOTE: These return a PromiseJob to prevent awkward casting at call sites.

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
@@ -50,9 +50,9 @@ void PromiseResolvingElementFunction::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
 
-    visitor.visit(&m_values);
+    visitor.visit(m_values);
     visitor.visit(m_capability);
-    visitor.visit(&m_remaining_elements);
+    visitor.visit(m_remaining_elements);
 }
 
 NonnullGCPtr<PromiseAllResolveElementFunction> PromiseAllResolveElementFunction::create(Realm& realm, size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements)
@@ -71,13 +71,13 @@ ThrowCompletionOr<Value> PromiseAllResolveElementFunction::resolve_element()
     auto& realm = *vm.current_realm();
 
     // 8. Set values[index] to x.
-    m_values.values()[m_index] = vm.argument(0);
+    m_values->values()[m_index] = vm.argument(0);
 
     // 9. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
     // 10. If remainingElementsCount.[[Value]] is 0, then
-    if (--m_remaining_elements.value == 0) {
+    if (--m_remaining_elements->value == 0) {
         // a. Let valuesArray be CreateArrayFromList(values).
-        auto values_array = Array::create_from(realm, m_values.values());
+        auto values_array = Array::create_from(realm, m_values->values());
 
         // b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
         return JS::call(vm, *m_capability->resolve(), js_undefined(), values_array);
@@ -112,13 +112,13 @@ ThrowCompletionOr<Value> PromiseAllSettledResolveElementFunction::resolve_elemen
     MUST(object->create_data_property_or_throw(vm.names.value, vm.argument(0)));
 
     // 12. Set values[index] to obj.
-    m_values.values()[m_index] = object;
+    m_values->values()[m_index] = object;
 
     // 13. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
     // 14. If remainingElementsCount.[[Value]] is 0, then
-    if (--m_remaining_elements.value == 0) {
+    if (--m_remaining_elements->value == 0) {
         // a. Let valuesArray be CreateArrayFromList(values).
-        auto values_array = Array::create_from(realm, m_values.values());
+        auto values_array = Array::create_from(realm, m_values->values());
 
         // b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
         return JS::call(vm, *m_capability->resolve(), js_undefined(), values_array);
@@ -153,13 +153,13 @@ ThrowCompletionOr<Value> PromiseAllSettledRejectElementFunction::resolve_element
     MUST(object->create_data_property_or_throw(vm.names.reason, vm.argument(0)));
 
     // 12. Set values[index] to obj.
-    m_values.values()[m_index] = object;
+    m_values->values()[m_index] = object;
 
     // 13. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
     // 14. If remainingElementsCount.[[Value]] is 0, then
-    if (--m_remaining_elements.value == 0) {
+    if (--m_remaining_elements->value == 0) {
         // a. Let valuesArray be CreateArrayFromList(values).
-        auto values_array = Array::create_from(realm, m_values.values());
+        auto values_array = Array::create_from(realm, m_values->values());
 
         // b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
         return JS::call(vm, *m_capability->resolve(), js_undefined(), values_array);
@@ -185,16 +185,16 @@ ThrowCompletionOr<Value> PromiseAnyRejectElementFunction::resolve_element()
     auto& realm = *vm.current_realm();
 
     // 8. Set errors[index] to x.
-    m_values.values()[m_index] = vm.argument(0);
+    m_values->values()[m_index] = vm.argument(0);
 
     // 9. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
     // 10. If remainingElementsCount.[[Value]] is 0, then
-    if (--m_remaining_elements.value == 0) {
+    if (--m_remaining_elements->value == 0) {
         // a. Let error be a newly created AggregateError object.
         auto error = AggregateError::create(realm);
 
         // b. Perform ! DefinePropertyOrThrow(error, "errors", PropertyDescriptor { [[Configurable]]: true, [[Enumerable]]: false, [[Writable]]: true, [[Value]]: CreateArrayFromList(errors) }).
-        auto errors_array = Array::create_from(realm, m_values.values());
+        auto errors_array = Array::create_from(realm, m_values->values());
         MUST(error->define_property_or_throw(vm.names.errors, { .value = errors_array, .writable = true, .enumerable = false, .configurable = true }));
 
         // c. Return ? Call(promiseCapability.[[Reject]], undefined, « error »).

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
@@ -56,9 +56,9 @@ protected:
     virtual ThrowCompletionOr<Value> resolve_element() = 0;
 
     size_t m_index { 0 };
-    PromiseValueList& m_values;
+    NonnullGCPtr<PromiseValueList> m_values;
     NonnullGCPtr<PromiseCapability const> m_capability;
-    RemainingElements& m_remaining_elements;
+    NonnullGCPtr<RemainingElements> m_remaining_elements;
 
 private:
     virtual void visit_edges(Visitor&) override;

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.cpp
@@ -40,8 +40,8 @@ ThrowCompletionOr<Value> PromiseResolvingFunction::call()
 void PromiseResolvingFunction::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_promise);
-    visitor.visit(&m_already_resolved);
+    visitor.visit(m_promise);
+    visitor.visit(m_already_resolved);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.h
@@ -40,8 +40,8 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    Promise& m_promise;
-    AlreadyResolved& m_already_resolved;
+    NonnullGCPtr<Promise> m_promise;
+    NonnullGCPtr<AlreadyResolved> m_already_resolved;
     FunctionType m_native_function;
 };
 

--- a/Userland/Libraries/LibJS/Runtime/PropertyDescriptor.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyDescriptor.h
@@ -35,8 +35,8 @@ public:
     }
 
     Optional<Value> value {};
-    Optional<FunctionObject*> get {};
-    Optional<FunctionObject*> set {};
+    Optional<GCPtr<FunctionObject>> get {};
+    Optional<GCPtr<FunctionObject>> set {};
     Optional<bool> writable {};
     Optional<bool> enumerable {};
     Optional<bool> configurable {};
@@ -54,9 +54,9 @@ struct Formatter<JS::PropertyDescriptor> : Formatter<StringView> {
         if (property_descriptor.value.has_value())
             TRY(parts.try_append(TRY(String::formatted("[[Value]]: {}", TRY(property_descriptor.value->to_string_without_side_effects())))));
         if (property_descriptor.get.has_value())
-            TRY(parts.try_append(TRY(String::formatted("[[Get]]: JS::Function* @ {:p}", *property_descriptor.get))));
+            TRY(parts.try_append(TRY(String::formatted("[[Get]]: JS::Function* @ {:p}", property_descriptor.get->ptr()))));
         if (property_descriptor.set.has_value())
-            TRY(parts.try_append(TRY(String::formatted("[[Set]]: JS::Function* @ {:p}", *property_descriptor.set))));
+            TRY(parts.try_append(TRY(String::formatted("[[Set]]: JS::Function* @ {:p}", property_descriptor.set->ptr()))));
         if (property_descriptor.writable.has_value())
             TRY(parts.try_append(TRY(String::formatted("[[Writable]]: {}", *property_descriptor.writable))));
         if (property_descriptor.enumerable.has_value())

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -55,30 +55,30 @@ ThrowCompletionOr<Object*> ProxyObject::internal_get_prototype_of() const
     // 4. Let target be O.[[ProxyTarget]].
 
     // 5. Let trap be ? GetMethod(handler, "getPrototypeOf").
-    auto trap = TRY(Value(&m_handler).get_method(vm, vm.names.getPrototypeOf));
+    auto trap = TRY(Value(m_handler).get_method(vm, vm.names.getPrototypeOf));
 
     // 6. If trap is undefined, then
     if (!trap) {
         // a. Return ? target.[[GetPrototypeOf]]().
-        return TRY(m_target.internal_get_prototype_of());
+        return TRY(m_target->internal_get_prototype_of());
     }
 
     // 7. Let handlerProto be ? Call(trap, handler, « target »).
-    auto handler_proto = TRY(call(vm, *trap, &m_handler, &m_target));
+    auto handler_proto = TRY(call(vm, *trap, m_handler, m_target));
 
     // 8. If Type(handlerProto) is neither Object nor Null, throw a TypeError exception.
     if (!handler_proto.is_object() && !handler_proto.is_null())
         return vm.throw_completion<TypeError>(ErrorType::ProxyGetPrototypeOfReturn);
 
     // 9. Let extensibleTarget be ? IsExtensible(target).
-    auto extensible_target = TRY(m_target.is_extensible());
+    auto extensible_target = TRY(m_target->is_extensible());
 
     // 10. If extensibleTarget is true, return handlerProto.
     if (extensible_target)
         return handler_proto.is_null() ? nullptr : &handler_proto.as_object();
 
     // 11. Let targetProto be ? target.[[GetPrototypeOf]]().
-    auto* target_proto = TRY(m_target.internal_get_prototype_of());
+    auto* target_proto = TRY(m_target->internal_get_prototype_of());
 
     // 12. If SameValue(handlerProto, targetProto) is false, throw a TypeError exception.
     if (!same_value(handler_proto, target_proto))
@@ -103,30 +103,30 @@ ThrowCompletionOr<bool> ProxyObject::internal_set_prototype_of(Object* prototype
     // 4. Let target be O.[[ProxyTarget]].
 
     // 5. Let trap be ? GetMethod(handler, "setPrototypeOf").
-    auto trap = TRY(Value(&m_handler).get_method(vm, vm.names.setPrototypeOf));
+    auto trap = TRY(Value(m_handler).get_method(vm, vm.names.setPrototypeOf));
 
     // 6. If trap is undefined, then
     if (!trap) {
         // a. Return ? target.[[SetPrototypeOf]](V).
-        return m_target.internal_set_prototype_of(prototype);
+        return m_target->internal_set_prototype_of(prototype);
     }
 
     // 7. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target, V »)).
-    auto trap_result = TRY(call(vm, *trap, &m_handler, &m_target, prototype)).to_boolean();
+    auto trap_result = TRY(call(vm, *trap, m_handler, m_target, prototype)).to_boolean();
 
     // 8. If booleanTrapResult is false, return false.
     if (!trap_result)
         return false;
 
     // 9. Let extensibleTarget be ? IsExtensible(target).
-    auto extensible_target = TRY(m_target.is_extensible());
+    auto extensible_target = TRY(m_target->is_extensible());
 
     // 10. If extensibleTarget is true, return true.
     if (extensible_target)
         return true;
 
     // 11. Let targetProto be ? target.[[GetPrototypeOf]]().
-    auto* target_proto = TRY(m_target.internal_get_prototype_of());
+    auto* target_proto = TRY(m_target->internal_get_prototype_of());
 
     // 12. If SameValue(V, targetProto) is false, throw a TypeError exception.
     if (!same_value(prototype, target_proto))
@@ -151,19 +151,19 @@ ThrowCompletionOr<bool> ProxyObject::internal_is_extensible() const
     // 4. Let target be O.[[ProxyTarget]].
 
     // 5. Let trap be ? GetMethod(handler, "isExtensible").
-    auto trap = TRY(Value(&m_handler).get_method(vm, vm.names.isExtensible));
+    auto trap = TRY(Value(m_handler).get_method(vm, vm.names.isExtensible));
 
     // 6. If trap is undefined, then
     if (!trap) {
         // a. Return ? IsExtensible(target).
-        return m_target.is_extensible();
+        return m_target->is_extensible();
     }
 
     // 7. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target »)).
-    auto trap_result = TRY(call(vm, *trap, &m_handler, &m_target)).to_boolean();
+    auto trap_result = TRY(call(vm, *trap, m_handler, m_target)).to_boolean();
 
     // 8. Let targetResult be ? IsExtensible(target).
-    auto target_result = TRY(m_target.is_extensible());
+    auto target_result = TRY(m_target->is_extensible());
 
     // 9. If SameValue(booleanTrapResult, targetResult) is false, throw a TypeError exception.
     if (trap_result != target_result)
@@ -188,21 +188,21 @@ ThrowCompletionOr<bool> ProxyObject::internal_prevent_extensions()
     // 4. Let target be O.[[ProxyTarget]].
 
     // 5. Let trap be ? GetMethod(handler, "preventExtensions").
-    auto trap = TRY(Value(&m_handler).get_method(vm, vm.names.preventExtensions));
+    auto trap = TRY(Value(m_handler).get_method(vm, vm.names.preventExtensions));
 
     // 6. If trap is undefined, then
     if (!trap) {
         // a. Return ? target.[[PreventExtensions]]().
-        return m_target.internal_prevent_extensions();
+        return m_target->internal_prevent_extensions();
     }
 
     // 7. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target »)).
-    auto trap_result = TRY(call(vm, *trap, &m_handler, &m_target)).to_boolean();
+    auto trap_result = TRY(call(vm, *trap, m_handler, m_target)).to_boolean();
 
     // 8. If booleanTrapResult is true, then
     if (trap_result) {
         // a. Let extensibleTarget be ? IsExtensible(target).
-        auto extensible_target = TRY(m_target.is_extensible());
+        auto extensible_target = TRY(m_target->is_extensible());
 
         // b. If extensibleTarget is true, throw a TypeError exception.
         if (extensible_target)
@@ -230,23 +230,23 @@ ThrowCompletionOr<Optional<PropertyDescriptor>> ProxyObject::internal_get_own_pr
     // 4. Let target be O.[[ProxyTarget]].
 
     // 5. Let trap be ? GetMethod(handler, "getOwnPropertyDescriptor").
-    auto trap = TRY(Value(&m_handler).get_method(vm, vm.names.getOwnPropertyDescriptor));
+    auto trap = TRY(Value(m_handler).get_method(vm, vm.names.getOwnPropertyDescriptor));
 
     // 6. If trap is undefined, then
     if (!trap) {
         // a. Return ? target.[[GetOwnProperty]](P).
-        return m_target.internal_get_own_property(property_key);
+        return m_target->internal_get_own_property(property_key);
     }
 
     // 7. Let trapResultObj be ? Call(trap, handler, « target, P »).
-    auto trap_result = TRY(call(vm, *trap, &m_handler, &m_target, property_key_to_value(vm, property_key)));
+    auto trap_result = TRY(call(vm, *trap, m_handler, m_target, property_key_to_value(vm, property_key)));
 
     // 8. If Type(trapResultObj) is neither Object nor Undefined, throw a TypeError exception.
     if (!trap_result.is_object() && !trap_result.is_undefined())
         return vm.throw_completion<TypeError>(ErrorType::ProxyGetOwnDescriptorReturn);
 
     // 9. Let targetDesc be ? target.[[GetOwnProperty]](P).
-    auto target_descriptor = TRY(m_target.internal_get_own_property(property_key));
+    auto target_descriptor = TRY(m_target->internal_get_own_property(property_key));
 
     // 10. If trapResultObj is undefined, then
     if (trap_result.is_undefined()) {
@@ -259,7 +259,7 @@ ThrowCompletionOr<Optional<PropertyDescriptor>> ProxyObject::internal_get_own_pr
             return vm.throw_completion<TypeError>(ErrorType::ProxyGetOwnDescriptorNonConfigurable);
 
         // c. Let extensibleTarget be ? IsExtensible(target).
-        auto extensible_target = TRY(m_target.is_extensible());
+        auto extensible_target = TRY(m_target->is_extensible());
 
         // d. If extensibleTarget is false, throw a TypeError exception.
         if (!extensible_target)
@@ -270,7 +270,7 @@ ThrowCompletionOr<Optional<PropertyDescriptor>> ProxyObject::internal_get_own_pr
     }
 
     // 11. Let extensibleTarget be ? IsExtensible(target).
-    auto extensible_target = TRY(m_target.is_extensible());
+    auto extensible_target = TRY(m_target->is_extensible());
 
     // 12. Let resultDesc be ? ToPropertyDescriptor(trapResultObj).
     auto result_desc = TRY(to_property_descriptor(vm, trap_result));
@@ -321,29 +321,29 @@ ThrowCompletionOr<bool> ProxyObject::internal_define_own_property(PropertyKey co
     // 4. Let target be O.[[ProxyTarget]].
 
     // 5. Let trap be ? GetMethod(handler, "defineProperty").
-    auto trap = TRY(Value(&m_handler).get_method(vm, vm.names.defineProperty));
+    auto trap = TRY(Value(m_handler).get_method(vm, vm.names.defineProperty));
 
     // 6. If trap is undefined, then
     if (!trap) {
         // a. Return ? target.[[DefineOwnProperty]](P, Desc).
-        return m_target.internal_define_own_property(property_key, property_descriptor);
+        return m_target->internal_define_own_property(property_key, property_descriptor);
     }
 
     // 7. Let descObj be FromPropertyDescriptor(Desc).
     auto descriptor_object = from_property_descriptor(vm, property_descriptor);
 
     // 8. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target, P, descObj »)).
-    auto trap_result = TRY(call(vm, *trap, &m_handler, &m_target, property_key_to_value(vm, property_key), descriptor_object)).to_boolean();
+    auto trap_result = TRY(call(vm, *trap, m_handler, m_target, property_key_to_value(vm, property_key), descriptor_object)).to_boolean();
 
     // 9. If booleanTrapResult is false, return false.
     if (!trap_result)
         return false;
 
     // 10. Let targetDesc be ? target.[[GetOwnProperty]](P).
-    auto target_descriptor = TRY(m_target.internal_get_own_property(property_key));
+    auto target_descriptor = TRY(m_target->internal_get_own_property(property_key));
 
     // 11. Let extensibleTarget be ? IsExtensible(target).
-    auto extensible_target = TRY(m_target.is_extensible());
+    auto extensible_target = TRY(m_target->is_extensible());
 
     // 12. Else, let settingConfigFalse be false.
     bool setting_config_false = false;
@@ -403,21 +403,21 @@ ThrowCompletionOr<bool> ProxyObject::internal_has_property(PropertyKey const& pr
     // 4. Let target be O.[[ProxyTarget]].
 
     // 5. Let trap be ? GetMethod(handler, "has").
-    auto trap = TRY(Value(&m_handler).get_method(vm, vm.names.has));
+    auto trap = TRY(Value(m_handler).get_method(vm, vm.names.has));
 
     // 6. If trap is undefined, then
     if (!trap) {
         // a. Return ? target.[[HasProperty]](P).
-        return m_target.internal_has_property(property_key);
+        return m_target->internal_has_property(property_key);
     }
 
     // 7. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target, P »)).
-    auto trap_result = TRY(call(vm, *trap, &m_handler, &m_target, property_key_to_value(vm, property_key))).to_boolean();
+    auto trap_result = TRY(call(vm, *trap, m_handler, m_target, property_key_to_value(vm, property_key))).to_boolean();
 
     // 8. If booleanTrapResult is false, then
     if (!trap_result) {
         // a. Let targetDesc be ? target.[[GetOwnProperty]](P).
-        auto target_descriptor = TRY(m_target.internal_get_own_property(property_key));
+        auto target_descriptor = TRY(m_target->internal_get_own_property(property_key));
 
         // b. If targetDesc is not undefined, then
         if (target_descriptor.has_value()) {
@@ -426,7 +426,7 @@ ThrowCompletionOr<bool> ProxyObject::internal_has_property(PropertyKey const& pr
                 return vm.throw_completion<TypeError>(ErrorType::ProxyHasExistingNonConfigurable);
 
             // ii. Let extensibleTarget be ? IsExtensible(target).
-            auto extensible_target = TRY(m_target.is_extensible());
+            auto extensible_target = TRY(m_target->is_extensible());
 
             // iii. If extensibleTarget is false, throw a TypeError exception.
             if (!extensible_target)
@@ -474,19 +474,19 @@ ThrowCompletionOr<Value> ProxyObject::internal_get(PropertyKey const& property_k
         return vm.throw_completion<InternalError>(ErrorType::CallStackSizeExceeded);
 
     // 5. Let trap be ? GetMethod(handler, "get").
-    auto trap = TRY(Value(&m_handler).get_method(vm, vm.names.get));
+    auto trap = TRY(Value(m_handler).get_method(vm, vm.names.get));
 
     // 6. If trap is undefined, then
     if (!trap) {
         // a. Return ? target.[[Get]](P, Receiver).
-        return m_target.internal_get(property_key, receiver);
+        return m_target->internal_get(property_key, receiver);
     }
 
     // 7. Let trapResult be ? Call(trap, handler, « target, P, Receiver »).
-    auto trap_result = TRY(call(vm, *trap, &m_handler, &m_target, property_key_to_value(vm, property_key), receiver));
+    auto trap_result = TRY(call(vm, *trap, m_handler, m_target, property_key_to_value(vm, property_key), receiver));
 
     // 8. Let targetDesc be ? target.[[GetOwnProperty]](P).
-    auto target_descriptor = TRY(m_target.internal_get_own_property(property_key));
+    auto target_descriptor = TRY(m_target->internal_get_own_property(property_key));
 
     // 9. If targetDesc is not undefined and targetDesc.[[Configurable]] is false, then
     if (target_descriptor.has_value() && !*target_descriptor->configurable) {
@@ -527,23 +527,23 @@ ThrowCompletionOr<bool> ProxyObject::internal_set(PropertyKey const& property_ke
     // 4. Let target be O.[[ProxyTarget]].
 
     // 5. Let trap be ? GetMethod(handler, "set").
-    auto trap = TRY(Value(&m_handler).get_method(vm, vm.names.set));
+    auto trap = TRY(Value(m_handler).get_method(vm, vm.names.set));
 
     // 6. If trap is undefined, then
     if (!trap) {
         // a. Return ? target.[[Set]](P, V, Receiver).
-        return m_target.internal_set(property_key, value, receiver);
+        return m_target->internal_set(property_key, value, receiver);
     }
 
     // 7. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target, P, V, Receiver »)).
-    auto trap_result = TRY(call(vm, *trap, &m_handler, &m_target, property_key_to_value(vm, property_key), value, receiver)).to_boolean();
+    auto trap_result = TRY(call(vm, *trap, m_handler, m_target, property_key_to_value(vm, property_key), value, receiver)).to_boolean();
 
     // 8. If booleanTrapResult is false, return false.
     if (!trap_result)
         return false;
 
     // 9. Let targetDesc be ? target.[[GetOwnProperty]](P).
-    auto target_descriptor = TRY(m_target.internal_get_own_property(property_key));
+    auto target_descriptor = TRY(m_target->internal_get_own_property(property_key));
 
     // 10. If targetDesc is not undefined and targetDesc.[[Configurable]] is false, then
     if (target_descriptor.has_value() && !*target_descriptor->configurable) {
@@ -582,23 +582,23 @@ ThrowCompletionOr<bool> ProxyObject::internal_delete(PropertyKey const& property
     // 4. Let target be O.[[ProxyTarget]].
 
     // 5. Let trap be ? GetMethod(handler, "deleteProperty").
-    auto trap = TRY(Value(&m_handler).get_method(vm, vm.names.deleteProperty));
+    auto trap = TRY(Value(m_handler).get_method(vm, vm.names.deleteProperty));
 
     // 6. If trap is undefined, then
     if (!trap) {
         // a. Return ? target.[[Delete]](P).
-        return m_target.internal_delete(property_key);
+        return m_target->internal_delete(property_key);
     }
 
     // 7. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target, P »)).
-    auto trap_result = TRY(call(vm, *trap, &m_handler, &m_target, property_key_to_value(vm, property_key))).to_boolean();
+    auto trap_result = TRY(call(vm, *trap, m_handler, m_target, property_key_to_value(vm, property_key))).to_boolean();
 
     // 8. If booleanTrapResult is false, return false.
     if (!trap_result)
         return false;
 
     // 9. Let targetDesc be ? target.[[GetOwnProperty]](P).
-    auto target_descriptor = TRY(m_target.internal_get_own_property(property_key));
+    auto target_descriptor = TRY(m_target->internal_get_own_property(property_key));
 
     // 10. If targetDesc is undefined, return true.
     if (!target_descriptor.has_value())
@@ -609,7 +609,7 @@ ThrowCompletionOr<bool> ProxyObject::internal_delete(PropertyKey const& property
         return vm.throw_completion<TypeError>(ErrorType::ProxyDeleteNonConfigurable);
 
     // 12. Let extensibleTarget be ? IsExtensible(target).
-    auto extensible_target = TRY(m_target.is_extensible());
+    auto extensible_target = TRY(m_target->is_extensible());
 
     // 13. If extensibleTarget is false, throw a TypeError exception.
     if (!extensible_target)
@@ -634,16 +634,16 @@ ThrowCompletionOr<MarkedVector<Value>> ProxyObject::internal_own_property_keys()
     // 4. Let target be O.[[ProxyTarget]].
 
     // 5. Let trap be ? GetMethod(handler, "ownKeys").
-    auto trap = TRY(Value(&m_handler).get_method(vm, vm.names.ownKeys));
+    auto trap = TRY(Value(m_handler).get_method(vm, vm.names.ownKeys));
 
     // 6. If trap is undefined, then
     if (!trap) {
         // a. Return ? target.[[OwnPropertyKeys]]().
-        return m_target.internal_own_property_keys();
+        return m_target->internal_own_property_keys();
     }
 
     // 7. Let trapResultArray be ? Call(trap, handler, « target »).
-    auto trap_result_array = TRY(call(vm, *trap, &m_handler, &m_target));
+    auto trap_result_array = TRY(call(vm, *trap, m_handler, m_target));
 
     // 8. Let trapResult be ? CreateListFromArrayLike(trapResultArray, « String, Symbol »).
     HashTable<PropertyKey> unique_keys;
@@ -660,10 +660,10 @@ ThrowCompletionOr<MarkedVector<Value>> ProxyObject::internal_own_property_keys()
         return vm.throw_completion<TypeError>(ErrorType::ProxyOwnPropertyKeysDuplicates);
 
     // 10. Let extensibleTarget be ? IsExtensible(target).
-    auto extensible_target = TRY(m_target.is_extensible());
+    auto extensible_target = TRY(m_target->is_extensible());
 
     // 11. Let targetKeys be ? target.[[OwnPropertyKeys]]().
-    auto target_keys = TRY(m_target.internal_own_property_keys());
+    auto target_keys = TRY(m_target->internal_own_property_keys());
 
     // 12. Assert: targetKeys is a List of property keys.
     // 13. Assert: targetKeys contains no duplicate entries.
@@ -679,7 +679,7 @@ ThrowCompletionOr<MarkedVector<Value>> ProxyObject::internal_own_property_keys()
         auto property_key = MUST(PropertyKey::from_value(vm, key));
 
         // a. Let desc be ? target.[[GetOwnProperty]](key).
-        auto descriptor = TRY(m_target.internal_get_own_property(property_key));
+        auto descriptor = TRY(m_target->internal_get_own_property(property_key));
 
         // b. If desc is not undefined and desc.[[Configurable]] is false, then
         if (descriptor.has_value() && !*descriptor->configurable) {
@@ -758,19 +758,19 @@ ThrowCompletionOr<Value> ProxyObject::internal_call(Value this_argument, MarkedV
     // 4. Let target be O.[[ProxyTarget]].
 
     // 5. Let trap be ? GetMethod(handler, "apply").
-    auto trap = TRY(Value(&m_handler).get_method(vm, vm.names.apply));
+    auto trap = TRY(Value(m_handler).get_method(vm, vm.names.apply));
 
     // 6. If trap is undefined, then
     if (!trap) {
         // a. Return ? Call(target, thisArgument, argumentsList).
-        return call(vm, &m_target, this_argument, move(arguments_list));
+        return call(vm, m_target, this_argument, move(arguments_list));
     }
 
     // 7. Let argArray be CreateArrayFromList(argumentsList).
     auto arguments_array = Array::create_from(realm, arguments_list);
 
     // 8. Return ? Call(trap, handler, « target, thisArgument, argArray »).
-    return call(vm, trap, &m_handler, &m_target, this_argument, arguments_array);
+    return call(vm, trap, m_handler, m_target, this_argument, arguments_array);
 }
 
 bool ProxyObject::has_constructor() const
@@ -780,7 +780,7 @@ bool ProxyObject::has_constructor() const
     if (!is_function())
         return false;
 
-    return static_cast<FunctionObject&>(m_target).has_constructor();
+    return static_cast<FunctionObject&>(*m_target).has_constructor();
 }
 
 // 10.5.13 [[Construct]] ( argumentsList, newTarget ), https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget
@@ -803,19 +803,19 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ProxyObject::internal_construct(MarkedVe
     // 5. Assert: IsConstructor(target) is true.
 
     // 6. Let trap be ? GetMethod(handler, "construct").
-    auto trap = TRY(Value(&m_handler).get_method(vm, vm.names.construct));
+    auto trap = TRY(Value(m_handler).get_method(vm, vm.names.construct));
 
     // 7. If trap is undefined, then
     if (!trap) {
         // a. Return ? Construct(target, argumentsList, newTarget).
-        return construct(vm, static_cast<FunctionObject&>(m_target), move(arguments_list), &new_target);
+        return construct(vm, static_cast<FunctionObject&>(*m_target), move(arguments_list), &new_target);
     }
 
     // 8. Let argArray be CreateArrayFromList(argumentsList).
     auto arguments_array = Array::create_from(realm, arguments_list);
 
     // 9. Let newObj be ? Call(trap, handler, « target, argArray, newTarget »).
-    auto new_object = TRY(call(vm, trap, &m_handler, &m_target, arguments_array, &new_target));
+    auto new_object = TRY(call(vm, trap, m_handler, m_target, arguments_array, &new_target));
 
     // 10. If Type(newObj) is not Object, throw a TypeError exception.
     if (!new_object.is_object())
@@ -828,14 +828,14 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ProxyObject::internal_construct(MarkedVe
 void ProxyObject::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_target);
-    visitor.visit(&m_handler);
+    visitor.visit(m_target);
+    visitor.visit(m_handler);
 }
 
 DeprecatedFlyString const& ProxyObject::name() const
 {
     VERIFY(is_function());
-    return static_cast<FunctionObject&>(m_target).name();
+    return static_cast<FunctionObject&>(*m_target).name();
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.h
@@ -50,11 +50,11 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    virtual bool is_function() const override { return m_target.is_function(); }
+    virtual bool is_function() const override { return m_target->is_function(); }
     virtual bool is_proxy_object() const final { return true; }
 
-    Object& m_target;
-    Object& m_handler;
+    NonnullGCPtr<Object> m_target;
+    NonnullGCPtr<Object> m_handler;
     bool m_is_revoked { false };
 };
 

--- a/Userland/Libraries/LibJS/Runtime/Realm.h
+++ b/Userland/Libraries/LibJS/Runtime/Realm.h
@@ -53,10 +53,10 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    Intrinsics* m_intrinsics { nullptr };                // [[Intrinsics]]
-    Object* m_global_object { nullptr };                 // [[GlobalObject]]
-    GlobalEnvironment* m_global_environment { nullptr }; // [[GlobalEnv]]
-    OwnPtr<HostDefined> m_host_defined;                  // [[HostDefined]]
+    GCPtr<Intrinsics> m_intrinsics;                // [[Intrinsics]]
+    GCPtr<Object> m_global_object;                 // [[GlobalObject]]
+    GCPtr<GlobalEnvironment> m_global_environment; // [[GlobalEnv]]
+    OwnPtr<HostDefined> m_host_defined;            // [[HostDefined]]
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Reference.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Reference.cpp
@@ -207,7 +207,7 @@ ThrowCompletionOr<void> Reference::initialize_referenced_binding(VM& vm, Value v
 Reference make_private_reference(VM& vm, Value base_value, DeprecatedFlyString const& private_identifier)
 {
     // 1. Let privEnv be the running execution context's PrivateEnvironment.
-    auto* private_environment = vm.running_execution_context().private_environment;
+    auto private_environment = vm.running_execution_context().private_environment;
 
     // 2. Assert: privEnv is not null.
     VERIFY(private_environment);

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
@@ -27,7 +27,7 @@ RegExpStringIterator::RegExpStringIterator(Object& prototype, Object& regexp_obj
 void RegExpStringIterator::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_regexp_object);
+    visitor.visit(m_regexp_object);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.h
@@ -33,7 +33,7 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    Object& m_regexp_object;
+    NonnullGCPtr<Object> m_regexp_object;
     Utf16String m_string;
     bool m_global { false };
     bool m_unicode { false };

--- a/Userland/Libraries/LibJS/Runtime/SetIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetIterator.cpp
@@ -25,7 +25,7 @@ SetIterator::SetIterator(Set& set, Object::PropertyKind iteration_kind, Object& 
 void SetIterator::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_set);
+    visitor.visit(m_set);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/SetIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/SetIterator.h
@@ -31,7 +31,7 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    Set& m_set;
+    NonnullGCPtr<Set> m_set;
     bool m_done { false };
     Object::PropertyKind m_iteration_kind;
     Map::ConstIterator m_iterator;

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
@@ -30,7 +30,7 @@ void ShadowRealm::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
 
-    visitor.visit(&m_shadow_realm);
+    visitor.visit(m_shadow_realm);
 }
 
 // 3.1.2 CopyNameAndLength ( F: a function object, Target: a function object, optional prefix: a String, optional argCount: a Number, ), https://tc39.es/proposal-shadowrealm/#sec-copynameandlength
@@ -239,7 +239,7 @@ ThrowCompletionOr<Value> shadow_realm_import_value(VM& vm, DeprecatedString spec
         VERIFY(is<ModuleNamespaceObject>(exports));
 
         // 2. Let f be the active function object.
-        auto* function = vm.running_execution_context().function;
+        auto function = vm.running_execution_context().function;
 
         // 3. Let string be f.[[ExportNameString]].
         // 4. Assert: Type(string) is String.

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealm.h
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealm.h
@@ -30,7 +30,7 @@ private:
     virtual void visit_edges(Visitor&) override;
 
     // 3.5 Properties of ShadowRealm Instances, https://tc39.es/proposal-shadowrealm/#sec-properties-of-shadowrealm-instances
-    Realm& m_shadow_realm;                // [[ShadowRealm]]
+    NonnullGCPtr<Realm> m_shadow_realm;   // [[ShadowRealm]]
     ExecutionContext m_execution_context; // [[ExecutionContext]]
 };
 

--- a/Userland/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Shape.cpp
@@ -82,7 +82,7 @@ Shape* Shape::create_prototype_transition(Object* new_prototype)
         return existing_shape;
     auto new_shape = heap().allocate_without_realm<Shape>(*this, new_prototype);
     if (!m_prototype_transitions)
-        m_prototype_transitions = make<HashMap<Object*, WeakPtr<Shape>>>();
+        m_prototype_transitions = make<HashMap<GCPtr<Object>, WeakPtr<Shape>>>();
     m_prototype_transitions->set(new_prototype, new_shape.ptr());
     return new_shape;
 }
@@ -115,7 +115,7 @@ Shape::Shape(Shape& previous_shape, Object* new_prototype)
 void Shape::visit_edges(Cell::Visitor& visitor)
 {
     Cell::visit_edges(visitor);
-    visitor.visit(&m_realm);
+    visitor.visit(m_realm);
     visitor.visit(m_prototype);
     visitor.visit(m_previous);
     m_property_key.visit_edges(visitor);
@@ -162,7 +162,7 @@ void Shape::ensure_property_table() const
     u32 next_offset = 0;
 
     Vector<Shape const&, 64> transition_chain;
-    for (auto* shape = m_previous; shape; shape = shape->m_previous) {
+    for (auto shape = m_previous; shape; shape = shape->m_previous) {
         if (shape->m_property_table) {
             *m_property_table = *shape->m_property_table;
             next_offset = shape->m_property_count;

--- a/Userland/Libraries/LibJS/Runtime/Shape.h
+++ b/Userland/Libraries/LibJS/Runtime/Shape.h
@@ -93,15 +93,15 @@ private:
 
     void ensure_property_table() const;
 
-    Realm& m_realm;
+    NonnullGCPtr<Realm> m_realm;
 
     mutable OwnPtr<HashMap<StringOrSymbol, PropertyMetadata>> m_property_table;
 
     OwnPtr<HashMap<TransitionKey, WeakPtr<Shape>>> m_forward_transitions;
-    OwnPtr<HashMap<Object*, WeakPtr<Shape>>> m_prototype_transitions;
-    Shape* m_previous { nullptr };
+    OwnPtr<HashMap<GCPtr<Object>, WeakPtr<Shape>>> m_prototype_transitions;
+    GCPtr<Shape> m_previous;
     StringOrSymbol m_property_key;
-    Object* m_prototype { nullptr };
+    GCPtr<Object> m_prototype;
     u32 m_property_count { 0 };
 
     PropertyAttributes m_attributes { 0 };

--- a/Userland/Libraries/LibJS/Runtime/StringObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.cpp
@@ -31,7 +31,7 @@ ThrowCompletionOr<void> StringObject::initialize(Realm& realm)
     auto& vm = this->vm();
     MUST_OR_THROW_OOM(Base::initialize(realm));
 
-    define_direct_property(vm.names.length, Value(MUST_OR_THROW_OOM(m_string.utf16_string_view()).length_in_code_units()), 0);
+    define_direct_property(vm.names.length, Value(MUST_OR_THROW_OOM(m_string->utf16_string_view()).length_in_code_units()), 0);
 
     return {};
 }
@@ -39,7 +39,7 @@ ThrowCompletionOr<void> StringObject::initialize(Realm& realm)
 void StringObject::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_string);
+    visitor.visit(m_string);
 }
 
 // 10.4.3.5 StringGetOwnProperty ( S, P ), https://tc39.es/ecma262/#sec-stringgetownproperty
@@ -133,7 +133,7 @@ ThrowCompletionOr<MarkedVector<Value>> StringObject::internal_own_property_keys(
     auto keys = MarkedVector<Value> { heap() };
 
     // 2. Let str be O.[[StringData]].
-    auto str = TRY(m_string.utf16_string_view());
+    auto str = TRY(m_string->utf16_string_view());
 
     // 3. Assert: Type(str) is String.
 

--- a/Userland/Libraries/LibJS/Runtime/StringObject.h
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.h
@@ -33,7 +33,7 @@ private:
     virtual bool is_string_object() const final { return true; }
     virtual void visit_edges(Visitor&) override;
 
-    PrimitiveString& m_string;
+    NonnullGCPtr<PrimitiveString> m_string;
 };
 
 template<>

--- a/Userland/Libraries/LibJS/Runtime/SymbolObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolObject.cpp
@@ -24,7 +24,7 @@ SymbolObject::SymbolObject(Symbol& symbol, Object& prototype)
 void SymbolObject::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_symbol);
+    visitor.visit(m_symbol);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/SymbolObject.h
+++ b/Userland/Libraries/LibJS/Runtime/SymbolObject.h
@@ -27,7 +27,7 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    Symbol& m_symbol;
+    NonnullGCPtr<Symbol> m_symbol;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
@@ -122,7 +122,7 @@ struct DifferenceSettings {
     String largest_unit;
     String rounding_mode;
     u64 rounding_increment;
-    Object& options;
+    NonnullGCPtr<Object> options;
 };
 
 struct TemporalUnitRequired { };

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Instant.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Instant.cpp
@@ -33,7 +33,7 @@ void Instant::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
 
-    visitor.visit(&m_nanoseconds);
+    visitor.visit(m_nanoseconds);
 }
 
 // 8.5.1 IsValidEpochNanoseconds ( epochNanoseconds ), https://tc39.es/proposal-temporal/#sec-temporal-isvalidepochnanoseconds

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Instant.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Instant.h
@@ -30,7 +30,7 @@ private:
     virtual void visit_edges(Visitor&) override;
 
     // 8.4 Properties of Temporal.Instant Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-instant-instances
-    BigInt const& m_nanoseconds; // [[Nanoseconds]]
+    NonnullGCPtr<BigInt const> m_nanoseconds; // [[Nanoseconds]]
 };
 
 // https://tc39.es/proposal-temporal/#eqn-nsMaxInstant

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
@@ -35,7 +35,7 @@ PlainDate::PlainDate(i32 year, u8 month, u8 day, Object& calendar, Object& proto
 void PlainDate::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_calendar);
+    visitor.visit(m_calendar);
 }
 
 // 3.5.2 CreateISODateRecord ( year, month, day ), https://tc39.es/proposal-temporal/#sec-temporal-create-iso-date-record

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.h
@@ -32,10 +32,10 @@ private:
     virtual void visit_edges(Visitor&) override;
 
     // 3.4 Properties of Temporal.PlainDate Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-plaindate-instances
-    i32 m_iso_year { 0 }; // [[ISOYear]]
-    u8 m_iso_month { 1 }; // [[ISOMonth]]
-    u8 m_iso_day { 1 };   // [[ISODay]]
-    Object& m_calendar;   // [[Calendar]]
+    i32 m_iso_year { 0 };            // [[ISOYear]]
+    u8 m_iso_month { 1 };            // [[ISOMonth]]
+    u8 m_iso_day { 1 };              // [[ISODay]]
+    NonnullGCPtr<Object> m_calendar; // [[Calendar]]
 };
 
 // 3.5.1 ISO Date Records, https://tc39.es/proposal-temporal/#sec-temporal-iso-date-records

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
@@ -42,7 +42,7 @@ PlainDateTime::PlainDateTime(i32 iso_year, u8 iso_month, u8 iso_day, u8 iso_hour
 void PlainDateTime::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_calendar);
+    visitor.visit(m_calendar);
 }
 
 // nsMinInstant - nsPerDay

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
@@ -39,16 +39,16 @@ private:
     virtual void visit_edges(Visitor&) override;
 
     // 5.4 Properties of Temporal.PlainDateTime Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-plaindatetime-instances
-    i32 m_iso_year { 0 };        // [[ISOYear]]
-    u8 m_iso_month { 0 };        // [[ISOMonth]]
-    u8 m_iso_day { 0 };          // [[ISODay]]
-    u8 m_iso_hour { 0 };         // [[ISOHour]]
-    u8 m_iso_minute { 0 };       // [[ISOMinute]]
-    u8 m_iso_second { 0 };       // [[ISOSecond]]
-    u16 m_iso_millisecond { 0 }; // [[ISOMillisecond]]
-    u16 m_iso_microsecond { 0 }; // [[ISOMicrosecond]]
-    u16 m_iso_nanosecond { 0 };  // [[ISONanosecond]]
-    Object& m_calendar;          // [[Calendar]]
+    i32 m_iso_year { 0 };            // [[ISOYear]]
+    u8 m_iso_month { 0 };            // [[ISOMonth]]
+    u8 m_iso_day { 0 };              // [[ISODay]]
+    u8 m_iso_hour { 0 };             // [[ISOHour]]
+    u8 m_iso_minute { 0 };           // [[ISOMinute]]
+    u8 m_iso_second { 0 };           // [[ISOSecond]]
+    u16 m_iso_millisecond { 0 };     // [[ISOMillisecond]]
+    u16 m_iso_microsecond { 0 };     // [[ISOMicrosecond]]
+    u16 m_iso_nanosecond { 0 };      // [[ISONanosecond]]
+    NonnullGCPtr<Object> m_calendar; // [[Calendar]]
 };
 
 // Used by AddDateTime to temporarily hold values

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.cpp
@@ -31,7 +31,7 @@ PlainMonthDay::PlainMonthDay(u8 iso_month, u8 iso_day, i32 iso_year, Object& cal
 void PlainMonthDay::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_calendar);
+    visitor.visit(m_calendar);
 }
 
 // 10.5.1 ToTemporalMonthDay ( item [ , options ] ), https://tc39.es/proposal-temporal/#sec-temporal-totemporalmonthday

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.h
@@ -28,10 +28,10 @@ private:
     virtual void visit_edges(Visitor&) override;
 
     // 10.4 Properties of Temporal.PlainMonthDay Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-plainmonthday-instances
-    i32 m_iso_year { 0 }; // [[ISOYear]]
-    u8 m_iso_month { 0 }; // [[ISOMonth]]
-    u8 m_iso_day { 0 };   // [[ISODay]]
-    Object& m_calendar;   // [[Calendar]]
+    i32 m_iso_year { 0 };            // [[ISOYear]]
+    u8 m_iso_month { 0 };            // [[ISOMonth]]
+    u8 m_iso_day { 0 };              // [[ISODay]]
+    NonnullGCPtr<Object> m_calendar; // [[Calendar]]
 };
 
 struct ISOMonthDay {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.cpp
@@ -38,7 +38,7 @@ PlainTime::PlainTime(u8 iso_hour, u8 iso_minute, u8 iso_second, u16 iso_millisec
 void PlainTime::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_calendar);
+    visitor.visit(m_calendar);
 }
 
 // 4.5.1 DifferenceTime ( h1, min1, s1, ms1, mus1, ns1, h2, min2, s2, ms2, mus2, ns2 ), https://tc39.es/proposal-temporal/#sec-temporal-differencetime

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.h
@@ -36,13 +36,13 @@ private:
     virtual void visit_edges(Visitor&) override;
 
     // 4.4 Properties of Temporal.PlainTime Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-plaintime-instances
-    u8 m_iso_hour { 0 };         // [[ISOHour]]
-    u8 m_iso_minute { 0 };       // [[ISOMinute]]
-    u8 m_iso_second { 0 };       // [[ISOSecond]]
-    u16 m_iso_millisecond { 0 }; // [[ISOMillisecond]]
-    u16 m_iso_microsecond { 0 }; // [[ISOMicrosecond]]
-    u16 m_iso_nanosecond { 0 };  // [[ISONanosecond]]
-    Calendar& m_calendar;        // [[Calendar]] (always the built-in ISO 8601 calendar)
+    u8 m_iso_hour { 0 };               // [[ISOHour]]
+    u8 m_iso_minute { 0 };             // [[ISOMinute]]
+    u8 m_iso_second { 0 };             // [[ISOSecond]]
+    u16 m_iso_millisecond { 0 };       // [[ISOMillisecond]]
+    u16 m_iso_microsecond { 0 };       // [[ISOMicrosecond]]
+    u16 m_iso_nanosecond { 0 };        // [[ISONanosecond]]
+    NonnullGCPtr<Calendar> m_calendar; // [[Calendar]] (always the built-in ISO 8601 calendar)
 };
 
 struct DaysAndTime {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
@@ -30,7 +30,7 @@ PlainYearMonth::PlainYearMonth(i32 iso_year, u8 iso_month, u8 iso_day, Object& c
 void PlainYearMonth::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_calendar);
+    visitor.visit(m_calendar);
 }
 
 // 9.5.1 ToTemporalYearMonth ( item [ , options ] ), https://tc39.es/proposal-temporal/#sec-temporal-totemporalyearmonth

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.h
@@ -29,10 +29,10 @@ private:
     virtual void visit_edges(Visitor&) override;
 
     // 9.4 Properties of Temporal.PlainYearMonth Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-plainyearmonth-instances
-    i32 m_iso_year { 0 }; // [[ISOYear]]
-    u8 m_iso_month { 0 }; // [[ISOMonth]]
-    u8 m_iso_day { 0 };   // [[ISODay]]
-    Object& m_calendar;   // [[Calendar]]
+    i32 m_iso_year { 0 };            // [[ISOYear]]
+    u8 m_iso_month { 0 };            // [[ISOMonth]]
+    u8 m_iso_day { 0 };              // [[ISODay]]
+    NonnullGCPtr<Object> m_calendar; // [[Calendar]]
 };
 
 struct ISOYearMonth {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -33,9 +33,9 @@ void ZonedDateTime::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
 
-    visitor.visit(&m_nanoseconds);
-    visitor.visit(&m_time_zone);
-    visitor.visit(&m_calendar);
+    visitor.visit(m_nanoseconds);
+    visitor.visit(m_time_zone);
+    visitor.visit(m_calendar);
 }
 
 // 6.5.1 InterpretISODateTimeOffset ( year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, offsetBehaviour, offsetNanoseconds, timeZone, disambiguation, offsetOption, matchBehaviour ), https://tc39.es/proposal-temporal/#sec-temporal-interpretisodatetimeoffset

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.h
@@ -30,9 +30,9 @@ private:
     virtual void visit_edges(Visitor&) override;
 
     // 6.4 Properties of Temporal.ZonedDateTime Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-zoneddatetime-instances
-    BigInt const& m_nanoseconds; // [[Nanoseconds]]
-    Object& m_time_zone;         // [[TimeZone]]
-    Object& m_calendar;          // [[Calendar]]
+    NonnullGCPtr<BigInt const> m_nanoseconds; // [[Nanoseconds]]
+    NonnullGCPtr<Object> m_time_zone;         // [[TimeZone]]
+    NonnullGCPtr<Object> m_calendar;          // [[Calendar]]
 };
 
 struct NanosecondsToDaysResult {

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -71,7 +71,7 @@ protected:
     u32 m_byte_length { 0 };
     u32 m_byte_offset { 0 };
     ContentType m_content_type { ContentType::Number };
-    ArrayBuffer* m_viewed_array_buffer { nullptr };
+    GCPtr<ArrayBuffer> m_viewed_array_buffer;
     IntrinsicConstructor m_intrinsic_constructor { nullptr };
 
 private:

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -215,7 +215,7 @@ VM::InterpreterExecutionScope::~InterpreterExecutionScope()
 void VM::gather_roots(HashTable<Cell*>& roots)
 {
     roots.set(m_empty_string);
-    for (auto* string : m_single_ascii_character_strings)
+    for (auto string : m_single_ascii_character_strings)
         roots.set(string);
 
     auto gather_roots_from_execution_context_stack = [&roots](Vector<ExecutionContext*> const& stack) {
@@ -229,7 +229,7 @@ void VM::gather_roots(HashTable<Cell*>& roots)
             roots.set(execution_context->lexical_environment);
             roots.set(execution_context->variable_environment);
             roots.set(execution_context->private_environment);
-            if (auto* context_owner = execution_context->context_owner)
+            if (auto context_owner = execution_context->context_owner)
                 roots.set(context_owner);
             execution_context->script_or_module.visit(
                 [](Empty) {},
@@ -251,7 +251,7 @@ void VM::gather_roots(HashTable<Cell*>& roots)
     for (auto& symbol : m_global_symbol_registry)
         roots.set(symbol.value);
 
-    for (auto* finalization_registry : m_finalization_registry_cleanup_jobs)
+    for (auto finalization_registry : m_finalization_registry_cleanup_jobs)
         roots.set(finalization_registry);
 }
 
@@ -687,7 +687,7 @@ void VM::enqueue_promise_job(Function<ThrowCompletionOr<Value>()> job, Realm*)
 void VM::run_queued_finalization_registry_cleanup_jobs()
 {
     while (!m_finalization_registry_cleanup_jobs.is_empty()) {
-        auto* registry = m_finalization_registry_cleanup_jobs.take_first();
+        auto registry = m_finalization_registry_cleanup_jobs.take_first();
         // FIXME: Handle any uncatched exceptions here.
         (void)registry->cleanup();
     }

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -73,12 +73,12 @@ public:
     JS_ENUMERATE_WELL_KNOWN_SYMBOLS
 #undef __JS_ENUMERATE
 
-    HashMap<String, PrimitiveString*>& string_cache()
+    HashMap<String, GCPtr<PrimitiveString>>& string_cache()
     {
         return m_string_cache;
     }
 
-    HashMap<DeprecatedString, PrimitiveString*>& deprecated_string_cache()
+    HashMap<DeprecatedString, GCPtr<PrimitiveString>>& deprecated_string_cache()
     {
         return m_deprecated_string_cache;
     }
@@ -280,8 +280,8 @@ private:
     ThrowCompletionOr<void> import_module_dynamically(ScriptOrModule referencing_script_or_module, ModuleRequest module_request, PromiseCapability const& promise_capability);
     void finish_dynamic_import(ScriptOrModule referencing_script_or_module, ModuleRequest module_request, PromiseCapability const& promise_capability, Promise* inner_promise);
 
-    HashMap<String, PrimitiveString*> m_string_cache;
-    HashMap<DeprecatedString, PrimitiveString*> m_deprecated_string_cache;
+    HashMap<String, GCPtr<PrimitiveString>> m_string_cache;
+    HashMap<DeprecatedString, GCPtr<PrimitiveString>> m_deprecated_string_cache;
 
     Heap m_heap;
     Vector<Interpreter*> m_interpreters;
@@ -297,10 +297,10 @@ private:
 
     Vector<Function<ThrowCompletionOr<Value>()>> m_promise_jobs;
 
-    Vector<FinalizationRegistry*> m_finalization_registry_cleanup_jobs;
+    Vector<GCPtr<FinalizationRegistry>> m_finalization_registry_cleanup_jobs;
 
-    PrimitiveString* m_empty_string { nullptr };
-    PrimitiveString* m_single_ascii_character_strings[128] {};
+    GCPtr<PrimitiveString> m_empty_string;
+    GCPtr<PrimitiveString> m_single_ascii_character_strings[128] {};
     AK::Array<String, to_underlying(ErrorMessage::__Count)> m_error_messages;
 
     struct StoredModule {
@@ -316,7 +316,7 @@ private:
     Vector<StoredModule> m_loaded_modules;
 
 #define __JS_ENUMERATE(SymbolName, snake_name) \
-    Symbol* m_well_known_symbol_##snake_name { nullptr };
+    GCPtr<Symbol> m_well_known_symbol_##snake_name;
     JS_ENUMERATE_WELL_KNOWN_SYMBOLS
 #undef __JS_ENUMERATE
 

--- a/Userland/Libraries/LibJS/Runtime/WeakMap.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakMap.h
@@ -23,8 +23,8 @@ public:
 
     virtual ~WeakMap() override = default;
 
-    HashMap<Cell*, Value> const& values() const { return m_values; };
-    HashMap<Cell*, Value>& values() { return m_values; };
+    HashMap<GCPtr<Cell>, Value> const& values() const { return m_values; };
+    HashMap<GCPtr<Cell>, Value>& values() { return m_values; };
 
     virtual void remove_dead_cells(Badge<Heap>) override;
 
@@ -33,7 +33,7 @@ private:
 
     void visit_edges(Visitor&) override;
 
-    HashMap<Cell*, Value> m_values; // This stores Cell pointers instead of Object pointers to aide with sweeping
+    HashMap<GCPtr<Cell>, Value> m_values; // This stores Cell pointers instead of Object pointers to aide with sweeping
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/WeakRef.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRef.h
@@ -35,7 +35,7 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    Variant<Object*, Symbol*, Empty> m_value;
+    Variant<GCPtr<Object>, GCPtr<Symbol>, Empty> m_value;
     u32 m_last_execution_generation { 0 };
 };
 

--- a/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
@@ -34,7 +34,7 @@ JS_DEFINE_NATIVE_FUNCTION(WeakRefPrototype::deref)
     weak_ref->update_execution_generation();
     return weak_ref->value().visit(
         [](Empty) -> Value { return js_undefined(); },
-        [](auto* value) -> Value { return value; });
+        [](auto value) -> Value { return value; });
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/WeakSet.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSet.h
@@ -23,15 +23,15 @@ public:
 
     virtual ~WeakSet() override = default;
 
-    HashTable<Cell*> const& values() const { return m_values; };
-    HashTable<Cell*>& values() { return m_values; };
+    HashTable<GCPtr<Cell>> const& values() const { return m_values; };
+    HashTable<GCPtr<Cell>>& values() { return m_values; };
 
     virtual void remove_dead_cells(Badge<Heap>) override;
 
 private:
     explicit WeakSet(Object& prototype);
 
-    HashTable<Cell*> m_values; // This stores Cell pointers instead of Object pointers to aide with sweeping
+    HashTable<GCPtr<Cell>> m_values; // This stores Cell pointers instead of Object pointers to aide with sweeping
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/WrappedFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WrappedFunction.cpp
@@ -47,8 +47,8 @@ void WrappedFunction::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
 
-    visitor.visit(&m_wrapped_target_function);
-    visitor.visit(&m_realm);
+    visitor.visit(m_wrapped_target_function);
+    visitor.visit(m_realm);
 }
 
 // 2.1 [[Call]] ( thisArgument, argumentsList ), https://tc39.es/proposal-shadowrealm/#sec-wrapped-function-exotic-objects-call-thisargument-argumentslist

--- a/Userland/Libraries/LibJS/Runtime/WrappedFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/WrappedFunction.h
@@ -22,9 +22,9 @@ public:
     virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;
 
     // FIXME: Remove this (and stop inventing random internal slots that shouldn't exist, jeez)
-    virtual DeprecatedFlyString const& name() const override { return m_wrapped_target_function.name(); }
+    virtual DeprecatedFlyString const& name() const override { return m_wrapped_target_function->name(); }
 
-    virtual Realm* realm() const override { return &m_realm; }
+    virtual Realm* realm() const override { return m_realm; }
 
     FunctionObject const& wrapped_target_function() const { return m_wrapped_target_function; }
     FunctionObject& wrapped_target_function() { return m_wrapped_target_function; }
@@ -35,8 +35,8 @@ private:
     virtual void visit_edges(Visitor&) override;
 
     // Internal Slots of Wrapped Function Exotic Objects, https://tc39.es/proposal-shadowrealm/#table-internal-slots-of-wrapped-function-exotic-objects
-    FunctionObject& m_wrapped_target_function; // [[WrappedTargetFunction]]
-    Realm& m_realm;                            // [[Realm]]
+    NonnullGCPtr<FunctionObject> m_wrapped_target_function; // [[WrappedTargetFunction]]
+    NonnullGCPtr<Realm> m_realm;                            // [[Realm]]
 };
 
 ThrowCompletionOr<Value> ordinary_wrapped_function_call(WrappedFunction const&, Value this_argument, MarkedVector<Value> const& arguments_list);

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -693,11 +693,11 @@ ThrowCompletionOr<void> SourceTextModule::execute_module(VM& vm, GCPtr<PromiseCa
         auto result = m_ecmascript_code->execute(vm.interpreter());
 
         // d. Let env be moduleContext's LexicalEnvironment.
-        auto* env = module_context.lexical_environment;
+        auto env = module_context.lexical_environment;
         VERIFY(is<DeclarativeEnvironment>(*env));
 
         // e. Set result to DisposeResources(env, result).
-        result = dispose_resources(vm, static_cast<DeclarativeEnvironment*>(env), result);
+        result = dispose_resources(vm, static_cast<DeclarativeEnvironment*>(env.ptr()), result);
 
         // f. Suspend moduleContext and remove it from the execution context stack.
         vm.pop_execution_context();

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -156,7 +156,7 @@ JS::VM& main_thread_vm()
             // 2. Let script execution context be callback.[[HostDefined]].[[ActiveScriptContext]]. (NOTE: Not necessary)
 
             // 3. Prepare to run a callback with incumbent settings.
-            callback_host_defined.incumbent_settings.prepare_to_run_callback();
+            callback_host_defined.incumbent_settings->prepare_to_run_callback();
 
             // 4. If script execution context is not null, then push script execution context onto the JavaScript execution context stack.
             if (callback_host_defined.active_script_context)
@@ -172,7 +172,7 @@ JS::VM& main_thread_vm()
             }
 
             // 7. Clean up after running a callback with incumbent settings.
-            callback_host_defined.incumbent_settings.clean_up_after_running_callback();
+            callback_host_defined.incumbent_settings->clean_up_after_running_callback();
 
             // 8. Return result.
             return result;
@@ -419,7 +419,7 @@ void queue_mutation_observer_microtask(DOM::Document const& document)
             // 4. If records is not empty, then invoke mo’s callback with « records, mo », and mo. If this throws an exception, catch it, and report the exception.
             if (!records.is_empty()) {
                 auto& callback = mutation_observer->callback();
-                auto& realm = callback.callback_context.realm();
+                auto& realm = callback.callback_context->realm();
 
                 auto wrapped_records = MUST(JS::Array::create(realm, 0));
                 for (size_t i = 0; i < records.size(); ++i) {
@@ -446,7 +446,7 @@ NonnullOwnPtr<JS::ExecutionContext> create_a_new_javascript_realm(JS::VM& vm, Fu
     auto realm_execution_context = MUST(JS::Realm::initialize_host_defined_realm(vm, move(create_global_object), move(create_global_this_value)));
 
     // 3. Remove realm execution context from the JavaScript execution context stack.
-    vm.execution_context_stack().remove_first_matching([&realm_execution_context](auto* execution_context) {
+    vm.execution_context_stack().remove_first_matching([&realm_execution_context](auto execution_context) {
         return execution_context == realm_execution_context.ptr();
     });
 

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.h
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.h
@@ -45,7 +45,7 @@ struct WebEngineCustomJobCallbackData final : public JS::JobCallback::CustomData
 
     virtual ~WebEngineCustomJobCallbackData() override = default;
 
-    HTML::EnvironmentSettingsObject& incumbent_settings;
+    JS::NonnullGCPtr<HTML::EnvironmentSettingsObject> incumbent_settings;
     OwnPtr<JS::ExecutionContext> active_script_context;
 };
 

--- a/Userland/Libraries/LibWeb/CSS/CSSGroupingRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSGroupingRule.cpp
@@ -18,8 +18,8 @@ CSSGroupingRule::CSSGroupingRule(JS::Realm& realm, CSSRuleList& rules)
     : CSSRule(realm)
     , m_rules(rules)
 {
-    for (auto& rule : m_rules)
-        rule.set_parent_rule(this);
+    for (auto& rule : *m_rules)
+        rule->set_parent_rule(this);
 }
 
 JS::ThrowCompletionOr<void> CSSGroupingRule::initialize(JS::Realm& realm)
@@ -33,32 +33,32 @@ JS::ThrowCompletionOr<void> CSSGroupingRule::initialize(JS::Realm& realm)
 void CSSGroupingRule::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_rules);
+    visitor.visit(m_rules);
 }
 
 WebIDL::ExceptionOr<u32> CSSGroupingRule::insert_rule(StringView rule, u32 index)
 {
-    TRY(m_rules.insert_a_css_rule(rule, index));
+    TRY(m_rules->insert_a_css_rule(rule, index));
     // NOTE: The spec doesn't say where to set the parent rule, so we'll do it here.
-    m_rules.item(index)->set_parent_rule(this);
+    m_rules->item(index)->set_parent_rule(this);
     return index;
 }
 
 WebIDL::ExceptionOr<void> CSSGroupingRule::delete_rule(u32 index)
 {
-    return m_rules.remove_a_css_rule(index);
+    return m_rules->remove_a_css_rule(index);
 }
 
 void CSSGroupingRule::for_each_effective_style_rule(Function<void(CSSStyleRule const&)> const& callback) const
 {
-    m_rules.for_each_effective_style_rule(callback);
+    m_rules->for_each_effective_style_rule(callback);
 }
 
 void CSSGroupingRule::set_parent_style_sheet(CSSStyleSheet* parent_style_sheet)
 {
     CSSRule::set_parent_style_sheet(parent_style_sheet);
-    for (auto& rule : m_rules)
-        rule.set_parent_style_sheet(parent_style_sheet);
+    for (auto& rule : *m_rules)
+        rule->set_parent_style_sheet(parent_style_sheet);
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSGroupingRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSGroupingRule.h
@@ -22,7 +22,7 @@ public:
 
     CSSRuleList const& css_rules() const { return m_rules; }
     CSSRuleList& css_rules() { return m_rules; }
-    CSSRuleList* css_rules_for_bindings() { return &m_rules; }
+    CSSRuleList* css_rules_for_bindings() { return m_rules; }
     WebIDL::ExceptionOr<u32> insert_rule(StringView rule, u32 index = 0);
     WebIDL::ExceptionOr<void> delete_rule(u32 index);
 
@@ -37,7 +37,7 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
-    CSSRuleList& m_rules;
+    JS::NonnullGCPtr<CSSRuleList> m_rules;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
@@ -34,17 +34,17 @@ JS::ThrowCompletionOr<void> CSSMediaRule::initialize(JS::Realm& realm)
 void CSSMediaRule::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_media);
+    visitor.visit(m_media);
 }
 
 DeprecatedString CSSMediaRule::condition_text() const
 {
-    return m_media.media_text();
+    return m_media->media_text();
 }
 
 void CSSMediaRule::set_condition_text(DeprecatedString text)
 {
-    m_media.set_media_text(text);
+    m_media->set_media_text(text);
 }
 
 // https://www.w3.org/TR/cssom-1/#serialize-a-css-rule

--- a/Userland/Libraries/LibWeb/CSS/CSSMediaRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSMediaRule.h
@@ -26,11 +26,11 @@ public:
 
     virtual DeprecatedString condition_text() const override;
     virtual void set_condition_text(DeprecatedString) override;
-    virtual bool condition_matches() const override { return m_media.matches(); }
+    virtual bool condition_matches() const override { return m_media->matches(); }
 
-    MediaList* media() const { return &m_media; }
+    MediaList* media() const { return m_media; }
 
-    bool evaluate(HTML::Window const& window) { return m_media.evaluate(window); }
+    bool evaluate(HTML::Window const& window) { return m_media->evaluate(window); }
 
 private:
     CSSMediaRule(JS::Realm&, MediaList&, CSSRuleList&);
@@ -39,7 +39,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
     virtual DeprecatedString serialized() const override;
 
-    MediaList& m_media;
+    JS::NonnullGCPtr<MediaList> m_media;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/CSS/CSSRuleList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSRuleList.cpp
@@ -47,7 +47,7 @@ void CSSRuleList::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     for (auto& rule : m_rules)
-        visitor.visit(&rule);
+        visitor.visit(rule);
 }
 
 bool CSSRuleList::is_supported_property_index(u32 index) const
@@ -123,23 +123,23 @@ WebIDL::ExceptionOr<void> CSSRuleList::remove_a_css_rule(u32 index)
 void CSSRuleList::for_each_effective_style_rule(Function<void(CSSStyleRule const&)> const& callback) const
 {
     for (auto const& rule : m_rules) {
-        switch (rule.type()) {
+        switch (rule->type()) {
         case CSSRule::Type::FontFace:
             break;
         case CSSRule::Type::Import: {
-            auto const& import_rule = static_cast<CSSImportRule const&>(rule);
+            auto const& import_rule = static_cast<CSSImportRule const&>(*rule);
             if (import_rule.has_import_result() && import_rule.loaded_style_sheet())
                 import_rule.loaded_style_sheet()->for_each_effective_style_rule(callback);
             break;
         }
         case CSSRule::Type::Media:
-            static_cast<CSSMediaRule const&>(rule).for_each_effective_style_rule(callback);
+            static_cast<CSSMediaRule const&>(*rule).for_each_effective_style_rule(callback);
             break;
         case CSSRule::Type::Style:
-            callback(static_cast<CSSStyleRule const&>(rule));
+            callback(static_cast<CSSStyleRule const&>(*rule));
             break;
         case CSSRule::Type::Supports:
-            static_cast<CSSSupportsRule const&>(rule).for_each_effective_style_rule(callback);
+            static_cast<CSSSupportsRule const&>(*rule).for_each_effective_style_rule(callback);
             break;
         }
     }
@@ -150,17 +150,17 @@ bool CSSRuleList::evaluate_media_queries(HTML::Window const& window)
     bool any_media_queries_changed_match_state = false;
 
     for (auto& rule : m_rules) {
-        switch (rule.type()) {
+        switch (rule->type()) {
         case CSSRule::Type::FontFace:
             break;
         case CSSRule::Type::Import: {
-            auto& import_rule = verify_cast<CSSImportRule>(rule);
+            auto& import_rule = verify_cast<CSSImportRule>(*rule);
             if (import_rule.has_import_result() && import_rule.loaded_style_sheet() && import_rule.loaded_style_sheet()->evaluate_media_queries(window))
                 any_media_queries_changed_match_state = true;
             break;
         }
         case CSSRule::Type::Media: {
-            auto& media_rule = verify_cast<CSSMediaRule>(rule);
+            auto& media_rule = verify_cast<CSSMediaRule>(*rule);
             bool did_match = media_rule.condition_matches();
             bool now_matches = media_rule.evaluate(window);
             if (did_match != now_matches)
@@ -172,7 +172,7 @@ bool CSSRuleList::evaluate_media_queries(HTML::Window const& window)
         case CSSRule::Type::Style:
             break;
         case CSSRule::Type::Supports: {
-            auto& supports_rule = verify_cast<CSSSupportsRule>(rule);
+            auto& supports_rule = verify_cast<CSSSupportsRule>(*rule);
             if (supports_rule.condition_matches() && supports_rule.css_rules().evaluate_media_queries(window))
                 any_media_queries_changed_match_state = true;
             break;

--- a/Userland/Libraries/LibWeb/CSS/CSSRuleList.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSRuleList.h
@@ -32,26 +32,23 @@ public:
     {
         if (index >= length())
             return nullptr;
-        return &m_rules[index];
+        return m_rules[index];
     }
 
     CSSRule* item(size_t index)
     {
         if (index >= length())
             return nullptr;
-        return &m_rules[index];
+        return m_rules[index];
     }
 
     size_t length() const { return m_rules.size(); }
 
-    using ConstIterator = AK::SimpleIterator<Vector<CSSRule&> const, CSSRule const>;
-    using Iterator = AK::SimpleIterator<Vector<CSSRule&>, CSSRule>;
+    auto begin() const { return m_rules.begin(); }
+    auto begin() { return m_rules.begin(); }
 
-    ConstIterator const begin() const { return m_rules.begin(); }
-    Iterator begin() { return m_rules.begin(); }
-
-    ConstIterator const end() const { return m_rules.end(); }
-    Iterator end() { return m_rules.end(); }
+    auto end() const { return m_rules.end(); }
+    auto end() { return m_rules.end(); }
 
     virtual bool is_supported_property_index(u32 index) const override;
     virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const override;
@@ -82,7 +79,7 @@ private:
     virtual bool named_property_setter_has_identifier() const override { return false; }
     virtual bool named_property_deleter_has_identifier() const override { return false; }
 
-    Vector<CSSRule&> m_rules;
+    Vector<JS::NonnullGCPtr<CSSRule>> m_rules;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
@@ -35,13 +35,13 @@ JS::ThrowCompletionOr<void> CSSStyleRule::initialize(JS::Realm& realm)
 void CSSStyleRule::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_declaration);
+    visitor.visit(m_declaration);
 }
 
 // https://www.w3.org/TR/cssom/#dom-cssstylerule-style
 CSSStyleDeclaration* CSSStyleRule::style()
 {
-    return &m_declaration;
+    return m_declaration;
 }
 
 // https://www.w3.org/TR/cssom/#serialize-a-css-rule

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.h
@@ -40,7 +40,7 @@ private:
     virtual DeprecatedString serialized() const override;
 
     Vector<NonnullRefPtr<Selector>> m_selectors;
-    CSSStyleDeclaration& m_declaration;
+    JS::NonnullGCPtr<CSSStyleDeclaration> m_declaration;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -27,7 +27,7 @@ CSSStyleSheet::CSSStyleSheet(JS::Realm& realm, CSSRuleList& rules, MediaList& me
         set_location(location->to_deprecated_string());
 
     for (auto& rule : *m_rules)
-        rule.set_parent_style_sheet(this);
+        rule->set_parent_style_sheet(this);
 }
 
 JS::ThrowCompletionOr<void> CSSStyleSheet::initialize(JS::Realm& realm)
@@ -106,7 +106,7 @@ WebIDL::ExceptionOr<void> CSSStyleSheet::remove_rule(unsigned index)
 
 void CSSStyleSheet::for_each_effective_style_rule(Function<void(CSSStyleRule const&)> const& callback) const
 {
-    if (m_media.matches()) {
+    if (m_media->matches()) {
         m_rules->for_each_effective_style_rule(callback);
     }
 }
@@ -115,8 +115,8 @@ bool CSSStyleSheet::evaluate_media_queries(HTML::Window const& window)
 {
     bool any_media_queries_changed_match_state = false;
 
-    bool did_match = m_media.matches();
-    bool now_matches = m_media.evaluate(window);
+    bool did_match = m_media->matches();
+    bool now_matches = m_media->evaluate(window);
     if (did_match != now_matches)
         any_media_queries_changed_match_state = true;
     if (now_matches && m_rules->evaluate_media_queries(window))

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -54,10 +54,10 @@ private:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    CSSRuleList* m_rules { nullptr };
+    JS::GCPtr<CSSRuleList> m_rules;
 
     JS::GCPtr<StyleSheetList> m_style_sheet_list;
-    CSSRule* m_owner_css_rule { nullptr };
+    JS::GCPtr<CSSRule> m_owner_css_rule;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -48,8 +48,8 @@ public:
     JS::Realm& realm() const { return m_realm; }
 
 private:
-    JS::Realm& m_realm;
-    DOM::Document const* m_document { nullptr };
+    JS::NonnullGCPtr<JS::Realm> m_realm;
+    JS::GCPtr<DOM::Document const> m_document;
     PropertyID m_current_property_id { PropertyID::Invalid };
     AK::URL m_url;
 };

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -136,8 +136,8 @@ static void collect_style_sheets(CSSStyleSheet const& sheet, Vector<JS::NonnullG
 {
     sheets.append(sheet);
     for (auto const& rule : sheet.rules()) {
-        if (rule.type() == CSSRule::Type::Import) {
-            auto const& import_rule = static_cast<CSSImportRule const&>(rule);
+        if (rule->type() == CSSRule::Type::Import) {
+            auto const& import_rule = static_cast<CSSImportRule const&>(*rule);
             if (auto const* imported_sheet = import_rule.loaded_style_sheet()) {
                 collect_style_sheets(*imported_sheet, sheets);
             }
@@ -982,7 +982,7 @@ CSSPixels StyleComputer::root_element_font_size() const
 {
     constexpr float default_root_element_font_size = 16;
 
-    auto const* root_element = m_document.first_child_of_type<HTML::HTMLHtmlElement>();
+    auto const* root_element = m_document->first_child_of_type<HTML::HTMLHtmlElement>();
     if (!root_element)
         return default_root_element_font_size;
 
@@ -1564,9 +1564,9 @@ void StyleComputer::did_load_font([[maybe_unused]] FlyString const& family_name)
 void StyleComputer::load_fonts_from_sheet(CSSStyleSheet const& sheet)
 {
     for (auto const& rule : static_cast<CSSStyleSheet const&>(sheet).rules()) {
-        if (!is<CSSFontFaceRule>(rule))
+        if (!is<CSSFontFaceRule>(*rule))
             continue;
-        auto const& font_face = static_cast<CSSFontFaceRule const&>(rule).font_face();
+        auto const& font_face = static_cast<CSSFontFaceRule const&>(*rule).font_face();
         if (font_face.sources().is_empty())
             continue;
         if (m_loaded_fonts.contains(font_face.font_family()))
@@ -1596,7 +1596,7 @@ void StyleComputer::load_fonts_from_sheet(CSSStyleSheet const& sheet)
             continue;
 
         LoadRequest request;
-        auto url = m_document.parse_url(candidate_url.value().to_deprecated_string());
+        auto url = m_document->parse_url(candidate_url.value().to_deprecated_string());
         auto loader = make<FontLoader>(const_cast<StyleComputer&>(*this), font_face.font_family(), move(url));
         const_cast<StyleComputer&>(*this).m_loaded_fonts.set(font_face.font_family().to_string(), move(loader));
     }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -21,7 +21,7 @@
 namespace Web::CSS {
 
 struct MatchingRule {
-    CSSStyleRule const* rule { nullptr };
+    JS::GCPtr<CSSStyleRule const> rule;
     size_t style_sheet_index { 0 };
     size_t rule_index { 0 };
     size_t selector_index { 0 };
@@ -106,7 +106,7 @@ private:
     void build_rule_cache();
     void build_rule_cache_if_needed() const;
 
-    DOM::Document& m_document;
+    JS::NonnullGCPtr<DOM::Document> m_document;
 
     struct RuleCache {
         HashMap<FlyString, Vector<MatchingRule>> rules_by_id;

--- a/Userland/Libraries/LibWeb/CSS/StyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheet.h
@@ -36,12 +36,12 @@ public:
 
     MediaList* media() const
     {
-        return &m_media;
+        return m_media;
     }
 
     void set_media(DeprecatedString media)
     {
-        m_media.set_media_text(media);
+        m_media->set_media_text(media);
     }
 
     bool is_alternate() const { return m_alternate; }
@@ -59,7 +59,7 @@ protected:
     explicit StyleSheet(JS::Realm&, MediaList& media);
     virtual void visit_edges(Cell::Visitor&) override;
 
-    MediaList& m_media;
+    JS::NonnullGCPtr<MediaList> m_media;
 
 private:
     JS::GCPtr<DOM::Element> m_owner_node;

--- a/Userland/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -24,9 +24,9 @@ void StyleSheetList::add_sheet(CSSStyleSheet& sheet)
         return;
     }
 
-    m_document.style_computer().invalidate_rule_cache();
-    m_document.style_computer().load_fonts_from_sheet(sheet);
-    m_document.invalidate_style();
+    m_document->style_computer().invalidate_rule_cache();
+    m_document->style_computer().load_fonts_from_sheet(sheet);
+    m_document->invalidate_style();
 }
 
 void StyleSheetList::remove_sheet(CSSStyleSheet& sheet)
@@ -41,8 +41,8 @@ void StyleSheetList::remove_sheet(CSSStyleSheet& sheet)
 
     sort_sheets();
 
-    m_document.style_computer().invalidate_rule_cache();
-    m_document.invalidate_style();
+    m_document->style_computer().invalidate_rule_cache();
+    m_document->invalidate_style();
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<StyleSheetList>> StyleSheetList::create(DOM::Document& document)

--- a/Userland/Libraries/LibWeb/CSS/StyleSheetList.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheetList.h
@@ -60,7 +60,7 @@ private:
 
     void sort_sheets();
 
-    DOM::Document& m_document;
+    JS::NonnullGCPtr<DOM::Document> m_document;
     Vector<JS::NonnullGCPtr<CSSStyleSheet>> m_sheets;
 };
 

--- a/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
@@ -59,7 +59,7 @@ void AccessibilityTreeNode::serialize_tree_as_json(JsonObjectSerializer<StringBu
 
     if (value()->has_child_nodes()) {
         auto node_children = MUST(object.add_array("children"sv));
-        for (auto* child : children()) {
+        for (auto& child : children()) {
             if (child->value()->is_uninteresting_whitespace_node())
                 continue;
             JsonObjectSerializer<StringBuilder> child_object = MUST(node_children.add_object());

--- a/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.h
+++ b/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.h
@@ -22,7 +22,7 @@ public:
 
     JS::GCPtr<DOM::Node const> value() const { return m_value; }
     void set_value(JS::GCPtr<DOM::Node const> value) { m_value = value; }
-    Vector<AccessibilityTreeNode*> children() const { return m_children; }
+    Vector<JS::GCPtr<AccessibilityTreeNode>> children() const { return m_children; }
     void append_child(AccessibilityTreeNode* child) { m_children.append(child); }
 
     void serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object, Document const&) const;
@@ -34,7 +34,7 @@ private:
     explicit AccessibilityTreeNode(JS::GCPtr<DOM::Node const>);
 
     JS::GCPtr<DOM::Node const> m_value;
-    Vector<AccessibilityTreeNode*> m_children;
+    Vector<JS::GCPtr<AccessibilityTreeNode>> m_children;
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.h
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.h
@@ -36,7 +36,7 @@ private:
     Document& document() { return m_document; }
     Document const& document() const { return m_document; }
 
-    Document& m_document;
+    JS::NonnullGCPtr<Document> m_document;
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -567,7 +567,7 @@ private:
 
     bool m_needs_full_style_update { false };
 
-    HashTable<NodeIterator*> m_node_iterators;
+    HashTable<JS::GCPtr<NodeIterator>> m_node_iterators;
 
     // https://html.spec.whatwg.org/multipage/dom.html#is-initial-about:blank
     bool m_is_initial_about_blank { false };

--- a/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
@@ -83,7 +83,7 @@ bool EventDispatcher::inner_invoke(Event& event, Vector<JS::Handle<DOM::DOMEvent
 
         // 6. Let global be listener callback’s associated Realm’s global object.
         auto& callback = listener->callback->callback();
-        auto& realm = callback.callback.shape().realm();
+        auto& realm = callback.callback->shape().realm();
         auto& global = realm.global_object();
 
         // 7. Let currentEvent be undefined.

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -464,12 +464,12 @@ WebIDL::CallbackType* EventTarget::get_current_value_of_event_handler(Deprecated
         function->set_script_or_module({});
 
         // 12. Set eventHandler's value to the result of creating a Web IDL EventHandler callback function object whose object reference is function and whose callback context is settings object.
-        event_handler->value = realm.heap().allocate_without_realm<WebIDL::CallbackType>(*function, settings_object).ptr();
+        event_handler->value = JS::GCPtr(realm.heap().allocate_without_realm<WebIDL::CallbackType>(*function, settings_object));
     }
 
     // 4. Return eventHandler's value.
-    VERIFY(event_handler->value.has<WebIDL::CallbackType*>());
-    return *event_handler->value.get_pointer<WebIDL::CallbackType*>();
+    VERIFY(event_handler->value.has<JS::GCPtr<WebIDL::CallbackType>>());
+    return *event_handler->value.get_pointer<JS::GCPtr<WebIDL::CallbackType>>();
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-attributes:event-handler-idl-attributes-3
@@ -512,7 +512,7 @@ void EventTarget::set_event_handler_attribute(DeprecatedFlyString const& name, W
 
     auto& event_handler = event_handler_iterator->value;
 
-    event_handler->value = value;
+    event_handler->value = JS::GCPtr(value);
 
     //  4. Activate an event handler given eventTarget and name.
     //  NOTE: See the optimization comment above.

--- a/Userland/Libraries/LibWeb/DOM/MutationObserver.cpp
+++ b/Userland/Libraries/LibWeb/DOM/MutationObserver.cpp
@@ -80,7 +80,7 @@ WebIDL::ExceptionOr<void> MutationObserver::observe(Node& target, MutationObserv
     // 7. For each registered of target’s registered observer list, if registered’s observer is this:
     bool updated_existing_observer = false;
     for (auto& registered_observer : target.registered_observers_list()) {
-        if (registered_observer.observer().ptr() != this)
+        if (registered_observer->observer().ptr() != this)
             continue;
 
         updated_existing_observer = true;
@@ -92,12 +92,12 @@ WebIDL::ExceptionOr<void> MutationObserver::observe(Node& target, MutationObserv
                 continue;
 
             node->registered_observers_list().remove_all_matching([&registered_observer](RegisteredObserver& observer) {
-                return is<TransientRegisteredObserver>(observer) && verify_cast<TransientRegisteredObserver>(observer).source().ptr() == &registered_observer;
+                return is<TransientRegisteredObserver>(observer) && verify_cast<TransientRegisteredObserver>(observer).source().ptr() == registered_observer;
             });
         }
 
         // 2. Set registered’s options to options.
-        registered_observer.set_options(options);
+        registered_observer->set_options(options);
         break;
     }
 

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -602,8 +602,8 @@ void Node::remove(bool suppress_observers)
     //     whose observer is registered’s observer, options is registered’s options, and source is registered to node’s registered observer list.
     for (auto* inclusive_ancestor = parent; inclusive_ancestor; inclusive_ancestor = inclusive_ancestor->parent()) {
         for (auto& registered : inclusive_ancestor->m_registered_observer_list) {
-            if (registered.options().subtree) {
-                auto transient_observer = TransientRegisteredObserver::create(registered.observer(), registered.options(), registered);
+            if (registered->options().subtree) {
+                auto transient_observer = TransientRegisteredObserver::create(registered->observer(), registered->options(), registered);
                 m_registered_observer_list.append(move(transient_observer));
             }
         }
@@ -1411,7 +1411,7 @@ void Node::queue_mutation_record(DeprecatedFlyString const& type, DeprecatedStri
     for (auto& node : nodes) {
         for (auto& registered_observer : node->m_registered_observer_list) {
             // 1. Let options be registered’s options.
-            auto& options = registered_observer.options();
+            auto& options = registered_observer->options();
 
             // 2. If none of the following are true
             //      - node is not target and options["subtree"] is false
@@ -1426,7 +1426,7 @@ void Node::queue_mutation_record(DeprecatedFlyString const& type, DeprecatedStri
                 && !(type == MutationType::characterData && (!options.character_data.has_value() || !options.character_data.value()))
                 && !(type == MutationType::childList && !options.child_list)) {
                 // 1. Let mo be registered’s observer.
-                auto mutation_observer = registered_observer.observer();
+                auto mutation_observer = registered_observer->observer();
 
                 // 2. If interestedObservers[mo] does not exist, then set interestedObservers[mo] to null.
                 if (!interested_observers.contains(mutation_observer))

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -645,7 +645,7 @@ protected:
 
     // https://dom.spec.whatwg.org/#registered-observer-list
     // "Nodes have a strong reference to registered observers in their registered observer list." https://dom.spec.whatwg.org/#garbage-collection
-    Vector<RegisteredObserver&> m_registered_observer_list;
+    Vector<JS::NonnullGCPtr<RegisteredObserver>> m_registered_observer_list;
 
     void build_accessibility_tree(AccessibilityTreeNode& parent);
 

--- a/Userland/Libraries/LibWeb/DOM/NodeFilter.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeFilter.cpp
@@ -24,7 +24,7 @@ NodeFilter::NodeFilter(JS::Realm& realm, WebIDL::CallbackType& callback)
 void NodeFilter::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_callback);
+    visitor.visit(m_callback);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/NodeFilter.h
+++ b/Userland/Libraries/LibWeb/DOM/NodeFilter.h
@@ -46,7 +46,7 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    WebIDL::CallbackType& m_callback;
+    JS::NonnullGCPtr<WebIDL::CallbackType> m_callback;
 };
 
 AK_ENUM_BITWISE_OPERATORS(NodeFilter::WhatToShow);

--- a/Userland/Libraries/LibWeb/DOM/StaticNodeList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/StaticNodeList.cpp
@@ -42,7 +42,7 @@ Node const* StaticNodeList::item(u32 index) const
     // The item(index) method must return the indexth node in the collection. If there is no indexth node in the collection, then the method must return null.
     if (index >= m_static_nodes.size())
         return nullptr;
-    return &m_static_nodes[index];
+    return m_static_nodes[index];
 }
 
 // https://dom.spec.whatwg.org/#ref-for-dfn-supported-property-indices

--- a/Userland/Libraries/LibWeb/DOM/StaticNodeList.h
+++ b/Userland/Libraries/LibWeb/DOM/StaticNodeList.h
@@ -29,7 +29,7 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    Vector<Node&> m_static_nodes;
+    Vector<JS::NonnullGCPtr<Node>> m_static_nodes;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -519,7 +519,7 @@ WebIDL::ExceptionOr<void> fetch_response_handover(JS::Realm& realm, Infrastructu
     //    timingInfo’s server-timing headers to the result of getting, decoding, and splitting `Server-Timing` from
     //    response’s header list.
     //    The user agent may decide to expose `Server-Timing` headers to non-secure contexts requests as well.
-    auto* client = fetch_params.request()->client();
+    auto client = fetch_params.request()->client();
     if (!response.is_network_error() && client != nullptr && HTML::is_secure_context(*client)) {
         auto server_timing_headers = TRY_OR_THROW_OOM(vm, response.header_list()->get_decode_and_split("Server-Timing"sv.bytes()));
         if (server_timing_headers.has_value())
@@ -588,7 +588,7 @@ WebIDL::ExceptionOr<void> fetch_response_handover(JS::Realm& realm, Infrastructu
             // 3. If fetchParams’s request’s initiator type is non-null and fetchParams’s request’s client’s global
             //    object is fetchParams’s task destination, then run fetchParams’s controller’s report timing steps
             //    given fetchParams’s request’s client’s global object.
-            auto* client = fetch_params.request()->client();
+            auto client = fetch_params.request()->client();
             auto const* task_destination_global_object = fetch_params.task_destination().get_pointer<JS::NonnullGCPtr<JS::Object>>();
             if (client != nullptr && task_destination_global_object != nullptr) {
                 if (fetch_params.request()->initiator_type().has_value() && &client->global_object() == task_destination_global_object->ptr())
@@ -1459,7 +1459,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_network_or_cache_fet
         if (response->status() == 401
             && http_request->response_tainting() != Infrastructure::Request::ResponseTainting::CORS
             && include_credentials == IncludeCredentials::Yes
-            && request->window().has<HTML::EnvironmentSettingsObject*>()) {
+            && request->window().has<JS::GCPtr<HTML::EnvironmentSettingsObject>>()) {
             // 1. Needs testing: multiple `WWW-Authenticate` headers, missing, parsing issues.
             // (Red box in the spec, no-op)
 

--- a/Userland/Libraries/LibWeb/Fetch/HeadersIterator.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/HeadersIterator.cpp
@@ -48,7 +48,7 @@ JS::ThrowCompletionOr<void> HeadersIterator::initialize(JS::Realm& realm)
 void HeadersIterator::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_headers);
+    visitor.visit(m_headers);
 }
 
 // https://webidl.spec.whatwg.org/#es-iterable, Step 2
@@ -56,7 +56,7 @@ JS::ThrowCompletionOr<JS::Object*> HeadersIterator::next()
 {
     // The value pairs to iterate over are the return value of running sort and combine with this’s header list.
     auto value_pairs_to_iterate_over = [&]() -> JS::ThrowCompletionOr<Vector<Fetch::Infrastructure::Header>> {
-        auto headers_or_error = m_headers.m_header_list->sort_and_combine();
+        auto headers_or_error = m_headers->m_header_list->sort_and_combine();
         if (headers_or_error.is_error())
             return vm().throw_completion<JS::InternalError>(JS::ErrorType::NotEnoughMemoryToAllocate);
         return headers_or_error.release_value();

--- a/Userland/Libraries/LibWeb/Fetch/HeadersIterator.h
+++ b/Userland/Libraries/LibWeb/Fetch/HeadersIterator.h
@@ -28,7 +28,7 @@ private:
 
     HeadersIterator(Headers const&, JS::Object::PropertyKind iteration_kind);
 
-    Headers const& m_headers;
+    JS::NonnullGCPtr<Headers const> m_headers;
     JS::Object::PropertyKind m_iteration_kind;
     size_t m_index { 0 };
 };

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
@@ -157,8 +157,8 @@ public:
     using OriginType = Variant<Origin, HTML::Origin>;
     using PolicyContainerType = Variant<PolicyContainer, HTML::PolicyContainer>;
     using ReferrerType = Variant<Referrer, AK::URL>;
-    using ReservedClientType = Variant<Empty, HTML::Environment*, HTML::EnvironmentSettingsObject*>;
-    using WindowType = Variant<Window, HTML::EnvironmentSettingsObject*>;
+    using ReservedClientType = Variant<Empty, JS::GCPtr<HTML::Environment>, JS::GCPtr<HTML::EnvironmentSettingsObject>>;
+    using WindowType = Variant<Window, JS::GCPtr<HTML::EnvironmentSettingsObject>>;
 
     [[nodiscard]] static JS::NonnullGCPtr<Request> create(JS::VM&);
 
@@ -178,8 +178,8 @@ public:
     [[nodiscard]] BodyType& body() { return m_body; }
     void set_body(BodyType body) { m_body = move(body); }
 
-    [[nodiscard]] HTML::EnvironmentSettingsObject const* client() const { return m_client; }
-    [[nodiscard]] HTML::EnvironmentSettingsObject* client() { return m_client; }
+    [[nodiscard]] JS::GCPtr<HTML::EnvironmentSettingsObject const> client() const { return m_client; }
+    [[nodiscard]] JS::GCPtr<HTML::EnvironmentSettingsObject> client() { return m_client; }
     void set_client(HTML::EnvironmentSettingsObject* client) { m_client = client; }
 
     [[nodiscard]] ReservedClientType const& reserved_client() const { return m_reserved_client; }
@@ -343,7 +343,7 @@ private:
 
     // https://fetch.spec.whatwg.org/#concept-request-client
     // A request has an associated client (null or an environment settings object).
-    HTML::EnvironmentSettingsObject* m_client { nullptr };
+    JS::GCPtr<HTML::EnvironmentSettingsObject> m_client;
 
     // https://fetch.spec.whatwg.org/#concept-request-reserved-client
     // A request has an associated reserved client (null, an environment, or an environment settings object). Unless

--- a/Userland/Libraries/LibWeb/Fetch/Request.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Request.cpp
@@ -157,8 +157,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::construct_impl(JS::Realm
     auto window = Infrastructure::Request::WindowType { Infrastructure::Request::Window::Client };
 
     // 9. If request’s window is an environment settings object and its origin is same origin with origin, then set window to request’s window.
-    if (input_request->window().has<HTML::EnvironmentSettingsObject*>()) {
-        auto* eso = input_request->window().get<HTML::EnvironmentSettingsObject*>();
+    if (input_request->window().has<JS::GCPtr<HTML::EnvironmentSettingsObject>>()) {
+        auto eso = input_request->window().get<JS::GCPtr<HTML::EnvironmentSettingsObject>>();
         if (eso->origin().is_same_origin(origin))
             window = input_request->window();
     }

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContextGroup.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContextGroup.h
@@ -35,7 +35,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     // https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-group-set
-    OrderedHashTable<BrowsingContext*> m_browsing_context_set;
+    OrderedHashTable<JS::GCPtr<BrowsingContext>> m_browsing_context_set;
 
     WeakPtr<Page> m_page;
 };

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPath.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPath.cpp
@@ -38,17 +38,17 @@ void CanvasPath::bezier_curve_to(double cp1x, double cp1y, double cp2x, double c
 WebIDL::ExceptionOr<void> CanvasPath::arc(float x, float y, float radius, float start_angle, float end_angle, bool counter_clockwise)
 {
     if (radius < 0)
-        return WebIDL::IndexSizeError::create(m_self.realm(), DeprecatedString::formatted("The radius provided ({}) is negative.", radius));
+        return WebIDL::IndexSizeError::create(m_self->realm(), DeprecatedString::formatted("The radius provided ({}) is negative.", radius));
     return ellipse(x, y, radius, radius, 0, start_angle, end_angle, counter_clockwise);
 }
 
 WebIDL::ExceptionOr<void> CanvasPath::ellipse(float x, float y, float radius_x, float radius_y, float rotation, float start_angle, float end_angle, bool counter_clockwise)
 {
     if (radius_x < 0)
-        return WebIDL::IndexSizeError::create(m_self.realm(), DeprecatedString::formatted("The major-axis radius provided ({}) is negative.", radius_x));
+        return WebIDL::IndexSizeError::create(m_self->realm(), DeprecatedString::formatted("The major-axis radius provided ({}) is negative.", radius_x));
 
     if (radius_y < 0)
-        return WebIDL::IndexSizeError::create(m_self.realm(), DeprecatedString::formatted("The minor-axis radius provided ({}) is negative.", radius_y));
+        return WebIDL::IndexSizeError::create(m_self->realm(), DeprecatedString::formatted("The minor-axis radius provided ({}) is negative.", radius_y));
 
     if (constexpr float tau = M_TAU; (!counter_clockwise && (end_angle - start_angle) >= tau)
         || (counter_clockwise && (start_angle - end_angle) >= tau)) {

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPath.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPath.h
@@ -36,7 +36,7 @@ protected:
     }
 
 private:
-    Bindings::PlatformObject& m_self;
+    JS::NonnullGCPtr<Bindings::PlatformObject> m_self;
     Gfx::Path m_path;
 };
 

--- a/Userland/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
@@ -137,7 +137,7 @@ Optional<JS::PropertyDescriptor> cross_origin_get_own_property_helper(Variant<HT
         // 5. Otherwise:
         else {
             // 1. Let crossOriginGet be undefined.
-            Optional<JS::FunctionObject*> cross_origin_get;
+            Optional<JS::GCPtr<JS::FunctionObject>> cross_origin_get;
 
             // 2. If e.[[NeedsGet]] is true, then set crossOriginGet to an anonymous built-in function, created in the current Realm Record, that performs the same steps as the getter of the IDL attribute P on object O.
             if (*entry.needs_get) {
@@ -149,7 +149,7 @@ Optional<JS::PropertyDescriptor> cross_origin_get_own_property_helper(Variant<HT
             }
 
             // 3. Let crossOriginSet be undefined.
-            Optional<JS::FunctionObject*> cross_origin_set;
+            Optional<JS::GCPtr<JS::FunctionObject>> cross_origin_set;
 
             // If e.[[NeedsSet]] is true, then set crossOriginSet to an anonymous built-in function, created in the current Realm Record, that performs the same steps as the setter of the IDL attribute P on object O.
             if (*entry.needs_set) {

--- a/Userland/Libraries/LibWeb/HTML/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventHandler.cpp
@@ -24,7 +24,7 @@ void EventHandler::visit_edges(Cell::Visitor& visitor)
     Cell::visit_edges(visitor);
     visitor.visit(listener);
 
-    if (auto* callback = value.get_pointer<WebIDL::CallbackType*>())
+    if (auto* callback = value.get_pointer<JS::GCPtr<WebIDL::CallbackType>>())
         visitor.visit(*callback);
 }
 

--- a/Userland/Libraries/LibWeb/HTML/EventHandler.h
+++ b/Userland/Libraries/LibWeb/HTML/EventHandler.h
@@ -23,10 +23,10 @@ public:
     // NOTE: This does not contain Empty as part of the optimization of not allocating all event handler attributes up front.
     // FIXME: The string should actually be an "internal raw uncompiled handler" struct. This struct is just the uncompiled source code plus a source location for reporting parse errors.
     //        https://html.spec.whatwg.org/multipage/webappapis.html#internal-raw-uncompiled-handler
-    Variant<DeprecatedString, WebIDL::CallbackType*> value;
+    Variant<DeprecatedString, JS::GCPtr<WebIDL::CallbackType>> value;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-listener
-    DOM::DOMEventListener* listener { nullptr };
+    JS::GCPtr<DOM::DOMEventListener> listener;
 
 private:
     virtual StringView class_name() const override { return "EventHandler"sv; }

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -308,7 +308,7 @@ void EventLoop::perform_a_microtask_checkpoint()
 
     // 4. For each environment settings object whose responsible event loop is this event loop, notify about rejected promises on that environment settings object.
     for (auto& environment_settings_object : m_related_environment_settings_objects)
-        environment_settings_object.notify_about_rejected_promises({});
+        environment_settings_object->notify_about_rejected_promises({});
 
     // FIXME: 5. Cleanup Indexed Database transactions.
 
@@ -362,7 +362,7 @@ void EventLoop::register_environment_settings_object(Badge<EnvironmentSettingsOb
 
 void EventLoop::unregister_environment_settings_object(Badge<EnvironmentSettingsObject>, EnvironmentSettingsObject& environment_settings_object)
 {
-    bool did_remove = m_related_environment_settings_objects.remove_first_matching([&](auto& entry) { return &entry == &environment_settings_object; });
+    bool did_remove = m_related_environment_settings_objects.remove_first_matching([&](auto& entry) { return entry.ptr() == &environment_settings_object; });
     VERIFY(did_remove);
 }
 

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -101,10 +101,10 @@ private:
     Vector<WeakPtr<DOM::Document>> m_documents;
 
     // Used to implement step 4 of "perform a microtask checkpoint".
-    Vector<EnvironmentSettingsObject&> m_related_environment_settings_objects;
+    Vector<JS::NonnullGCPtr<EnvironmentSettingsObject>> m_related_environment_settings_objects;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#backup-incumbent-settings-object-stack
-    Vector<EnvironmentSettingsObject&> m_backup_incumbent_settings_object_stack;
+    Vector<JS::NonnullGCPtr<EnvironmentSettingsObject>> m_backup_incumbent_settings_object_stack;
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#termination-nesting-level
     size_t m_termination_nesting_level { 0 };

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -12,6 +12,7 @@
 #include <AK/StringView.h>
 #include <AK/Types.h>
 #include <AK/Utf8View.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/Parser/HTMLToken.h>
 
@@ -176,7 +177,7 @@ private:
     void restore_to(Utf8CodePointIterator const& new_iterator);
     HTMLToken::Position nth_last_position(size_t n = 0);
 
-    HTMLParser* m_parser { nullptr };
+    JS::GCPtr<HTMLParser> m_parser;
 
     State m_state { State::Data };
     State m_return_state { State::Data };

--- a/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
@@ -39,7 +39,7 @@ private:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    JS::Promise* m_promise { nullptr };
+    JS::GCPtr<JS::Promise> m_promise;
     JS::Value m_reason;
 };
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -259,7 +259,7 @@ void EnvironmentSettingsObject::notify_about_rejected_promises(Badge<EventLoop>)
 
             // 4. If p's [[PromiseIsHandled]] internal slot is false, add p to settings object's outstanding rejected promises weak set.
             if (!promise->is_handled())
-                m_outstanding_rejected_promises_weak_set.append(promise);
+                m_outstanding_rejected_promises_weak_set.append(*promise);
 
             // This algorithm results in promise rejections being marked as handled or not handled. These concepts parallel handled and not handled script errors.
             // If a rejection is still not handled after this, then the rejection may be reported to a developer console.

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -130,7 +130,7 @@ private:
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#outstanding-rejected-promises-weak-set
     // The outstanding rejected promises weak set must not create strong references to any of its members, and implementations are free to limit its size, e.g. by removing old entries from it when new ones are added.
-    Vector<JS::Promise*> m_outstanding_rejected_promises_weak_set;
+    Vector<JS::GCPtr<JS::Promise>> m_outstanding_rejected_promises_weak_set;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#about-to-be-notified-rejected-promises-list
     Vector<JS::Handle<JS::Promise>> m_about_to_be_notified_rejected_promises_list;

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ModuleMap.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ModuleMap.h
@@ -48,7 +48,7 @@ public:
 
     struct Entry {
         EntryType type;
-        JavaScriptModuleScript* module_script;
+        JS::GCPtr<JavaScriptModuleScript> module_script;
     };
 
     bool is_fetching(AK::URL const& url, DeprecatedString const& type) const;

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Script.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Script.h
@@ -35,7 +35,7 @@ private:
 
     AK::URL m_base_url;
     DeprecatedString m_filename;
-    EnvironmentSettingsObject& m_settings_object;
+    JS::NonnullGCPtr<EnvironmentSettingsObject> m_settings_object;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
@@ -30,7 +30,7 @@ void WindowEnvironmentSettingsObject::visit_edges(JS::Cell::Visitor& visitor)
 WebIDL::ExceptionOr<void> WindowEnvironmentSettingsObject::setup(AK::URL const& creation_url, NonnullOwnPtr<JS::ExecutionContext> execution_context, Optional<Environment> reserved_environment, AK::URL top_level_creation_url, Origin top_level_origin)
 {
     // 1. Let realm be the value of execution context's Realm component.
-    auto* realm = execution_context->realm;
+    auto realm = execution_context->realm;
     VERIFY(realm);
 
     // 2. Let window be realm's global object.

--- a/Userland/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h
@@ -25,7 +25,7 @@ public:
 
     static JS::NonnullGCPtr<WorkerEnvironmentSettingsObject> setup(NonnullOwnPtr<JS::ExecutionContext> execution_context /* FIXME: null or an environment reservedEnvironment, a URL topLevelCreationURL, and an origin topLevelOrigin */)
     {
-        auto* realm = execution_context->realm;
+        auto realm = execution_context->realm;
         VERIFY(realm);
         auto settings_object = realm->heap().allocate<WorkerEnvironmentSettingsObject>(*realm, move(execution_context)).release_allocated_value_but_fixme_should_propagate_errors();
         settings_object->target_browsing_context = nullptr;

--- a/Userland/Libraries/LibWeb/HTML/WorkerLocation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerLocation.cpp
@@ -15,7 +15,7 @@ WebIDL::ExceptionOr<String> WorkerLocation::href() const
 {
     auto& vm = realm().vm();
     // The href getter steps are to return this's WorkerGlobalScope object's url, serialized.
-    return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(m_global_scope.url().serialize()));
+    return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(m_global_scope->url().serialize()));
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-origin
@@ -23,7 +23,7 @@ WebIDL::ExceptionOr<String> WorkerLocation::origin() const
 {
     auto& vm = realm().vm();
     // The origin getter steps are to return the serialization of this's WorkerGlobalScope object's url's origin.
-    return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(m_global_scope.url().serialize_origin()));
+    return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(m_global_scope->url().serialize_origin()));
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-protocol
@@ -31,7 +31,7 @@ WebIDL::ExceptionOr<String> WorkerLocation::protocol() const
 {
     auto& vm = realm().vm();
     // The protocol getter steps are to return this's WorkerGlobalScope object's url's scheme, followed by ":".
-    return TRY_OR_THROW_OOM(vm, String::formatted("{}:", m_global_scope.url().scheme().view()));
+    return TRY_OR_THROW_OOM(vm, String::formatted("{}:", m_global_scope->url().scheme().view()));
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-host
@@ -41,7 +41,7 @@ WebIDL::ExceptionOr<String> WorkerLocation::host() const
 
     // The host getter steps are:
     // 1. Let url be this's WorkerGlobalScope object's url.
-    auto const& url = m_global_scope.url();
+    auto const& url = m_global_scope->url();
 
     // 2. If url's host is null, return the empty string.
     if (url.host().is_empty())
@@ -62,7 +62,7 @@ WebIDL::ExceptionOr<String> WorkerLocation::hostname() const
 
     // The hostname getter steps are:
     // 1. Let host be this's WorkerGlobalScope object's url's host.
-    auto const& host = m_global_scope.url().host();
+    auto const& host = m_global_scope->url().host();
 
     // 2. If host is null, return the empty string.
     if (host.is_empty())
@@ -79,7 +79,7 @@ WebIDL::ExceptionOr<String> WorkerLocation::port() const
 
     // The port getter steps are:
     // 1. Let port be this's WorkerGlobalScope object's url's port.
-    auto const& port = m_global_scope.url().port();
+    auto const& port = m_global_scope->url().port();
 
     // 2. If port is null, return the empty string.
     if (!port.has_value())
@@ -93,7 +93,7 @@ WebIDL::ExceptionOr<String> WorkerLocation::pathname() const
 {
     auto& vm = realm().vm();
     // The pathname getter steps are to return the result of URL path serializing this's WorkerGlobalScope object's url.
-    return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(m_global_scope.url().path()));
+    return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(m_global_scope->url().path()));
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-search
@@ -103,7 +103,7 @@ WebIDL::ExceptionOr<String> WorkerLocation::search() const
 
     // The search getter steps are:
     // 1. Let query be this's WorkerGlobalScope object's url's query.
-    auto const& query = m_global_scope.url().query();
+    auto const& query = m_global_scope->url().query();
 
     // 2. If query is either null or the empty string, return the empty string.
     if (query.is_empty())
@@ -120,7 +120,7 @@ WebIDL::ExceptionOr<String> WorkerLocation::hash() const
 
     // The hash getter steps are:
     // 1. Let fragment be this's WorkerGlobalScope object's url's fragment.
-    auto const& fragment = m_global_scope.url().fragment();
+    auto const& fragment = m_global_scope->url().fragment();
 
     // 2. If fragment is either null or the empty string, return the empty string.
     if (fragment.is_empty())

--- a/Userland/Libraries/LibWeb/HTML/WorkerLocation.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerLocation.h
@@ -32,7 +32,7 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    WorkerGlobalScope& m_global_scope;
+    JS::NonnullGCPtr<WorkerGlobalScope> m_global_scope;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -85,7 +85,7 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
 
     // We can also layout absolutely positioned boxes within this BFC.
     for (auto& box : m_absolutely_positioned_boxes) {
-        auto& cb_state = m_state.get(*box.containing_block());
+        auto& cb_state = m_state.get(*box->containing_block());
         auto available_width = AvailableSize::make_definite(cb_state.content_width() + cb_state.padding_left + cb_state.padding_right);
         auto available_height = AvailableSize::make_definite(cb_state.content_height() + cb_state.padding_top + cb_state.padding_bottom);
         layout_absolutely_positioned_element(box, AvailableSpace(available_width, available_height));

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -76,7 +76,7 @@ private:
     };
 
     struct FloatingBox {
-        Box const& box;
+        JS::NonnullGCPtr<Box const> box;
         // Offset from left/right edge to the left content edge of `box`.
         CSSPixels offset_from_edge { 0 };
 
@@ -155,7 +155,7 @@ private:
     FloatSideData m_left_floats;
     FloatSideData m_right_floats;
 
-    Vector<Box const&> m_absolutely_positioned_boxes;
+    Vector<JS::NonnullGCPtr<Box const>> m_absolutely_positioned_boxes;
 
     bool m_was_notified_after_parent_dimensioned_my_root_box { false };
 };

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -131,9 +131,9 @@ void FlexFormattingContext::run(Box const& run_box, LayoutMode, AvailableSpace c
 
     // 3. Determine the flex base size and hypothetical main size of each item
     for (auto& item : m_flex_items) {
-        if (item.box.is_replaced_box()) {
+        if (item.box->is_replaced_box()) {
             // FIXME: Get rid of prepare_for_replaced_layout() and make replaced elements figure out their intrinsic size lazily.
-            static_cast<ReplacedBox&>(item.box).prepare_for_replaced_layout();
+            static_cast<ReplacedBox&>(*item.box).prepare_for_replaced_layout();
         }
         determine_flex_base_size_and_hypothetical_main_size(item);
     }
@@ -242,49 +242,49 @@ void FlexFormattingContext::parent_context_did_dimension_child_root_box()
 
 void FlexFormattingContext::populate_specified_margins(FlexItem& item, CSS::FlexDirection flex_direction) const
 {
-    auto width_of_containing_block = m_state.get(*item.box.containing_block()).content_width();
+    auto width_of_containing_block = m_state.get(*item.box->containing_block()).content_width();
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
     // FIXME: This should also take reverse-ness into account
     if (flex_direction == CSS::FlexDirection::Row || flex_direction == CSS::FlexDirection::RowReverse) {
-        item.borders.main_before = item.box.computed_values().border_left().width;
-        item.borders.main_after = item.box.computed_values().border_right().width;
-        item.borders.cross_before = item.box.computed_values().border_top().width;
-        item.borders.cross_after = item.box.computed_values().border_bottom().width;
+        item.borders.main_before = item.box->computed_values().border_left().width;
+        item.borders.main_after = item.box->computed_values().border_right().width;
+        item.borders.cross_before = item.box->computed_values().border_top().width;
+        item.borders.cross_after = item.box->computed_values().border_bottom().width;
 
-        item.padding.main_before = item.box.computed_values().padding().left().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.padding.main_after = item.box.computed_values().padding().right().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.padding.cross_before = item.box.computed_values().padding().top().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.padding.cross_after = item.box.computed_values().padding().bottom().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.main_before = item.box->computed_values().padding().left().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.main_after = item.box->computed_values().padding().right().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.cross_before = item.box->computed_values().padding().top().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.cross_after = item.box->computed_values().padding().bottom().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
 
-        item.margins.main_before = item.box.computed_values().margin().left().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.margins.main_after = item.box.computed_values().margin().right().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.margins.cross_before = item.box.computed_values().margin().top().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.margins.cross_after = item.box.computed_values().margin().bottom().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.main_before = item.box->computed_values().margin().left().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.main_after = item.box->computed_values().margin().right().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.cross_before = item.box->computed_values().margin().top().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.cross_after = item.box->computed_values().margin().bottom().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
 
-        item.margins.main_before_is_auto = item.box.computed_values().margin().left().is_auto();
-        item.margins.main_after_is_auto = item.box.computed_values().margin().right().is_auto();
-        item.margins.cross_before_is_auto = item.box.computed_values().margin().top().is_auto();
-        item.margins.cross_after_is_auto = item.box.computed_values().margin().bottom().is_auto();
+        item.margins.main_before_is_auto = item.box->computed_values().margin().left().is_auto();
+        item.margins.main_after_is_auto = item.box->computed_values().margin().right().is_auto();
+        item.margins.cross_before_is_auto = item.box->computed_values().margin().top().is_auto();
+        item.margins.cross_after_is_auto = item.box->computed_values().margin().bottom().is_auto();
     } else {
-        item.borders.main_before = item.box.computed_values().border_top().width;
-        item.borders.main_after = item.box.computed_values().border_bottom().width;
-        item.borders.cross_before = item.box.computed_values().border_left().width;
-        item.borders.cross_after = item.box.computed_values().border_right().width;
+        item.borders.main_before = item.box->computed_values().border_top().width;
+        item.borders.main_after = item.box->computed_values().border_bottom().width;
+        item.borders.cross_before = item.box->computed_values().border_left().width;
+        item.borders.cross_after = item.box->computed_values().border_right().width;
 
-        item.padding.main_before = item.box.computed_values().padding().top().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.padding.main_after = item.box.computed_values().padding().bottom().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.padding.cross_before = item.box.computed_values().padding().left().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.padding.cross_after = item.box.computed_values().padding().right().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.main_before = item.box->computed_values().padding().top().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.main_after = item.box->computed_values().padding().bottom().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.cross_before = item.box->computed_values().padding().left().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.padding.cross_after = item.box->computed_values().padding().right().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
 
-        item.margins.main_before = item.box.computed_values().margin().top().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.margins.main_after = item.box.computed_values().margin().bottom().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.margins.cross_before = item.box.computed_values().margin().left().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
-        item.margins.cross_after = item.box.computed_values().margin().right().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.main_before = item.box->computed_values().margin().top().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.main_after = item.box->computed_values().margin().bottom().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.cross_before = item.box->computed_values().margin().left().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.cross_after = item.box->computed_values().margin().right().resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
 
-        item.margins.main_before_is_auto = item.box.computed_values().margin().top().is_auto();
-        item.margins.main_after_is_auto = item.box.computed_values().margin().bottom().is_auto();
-        item.margins.cross_before_is_auto = item.box.computed_values().margin().left().is_auto();
-        item.margins.cross_after_is_auto = item.box.computed_values().margin().right().is_auto();
+        item.margins.main_before_is_auto = item.box->computed_values().margin().top().is_auto();
+        item.margins.main_after_is_auto = item.box->computed_values().margin().bottom().is_auto();
+        item.margins.cross_before_is_auto = item.box->computed_values().margin().left().is_auto();
+        item.margins.cross_after_is_auto = item.box->computed_values().margin().right().is_auto();
     }
 };
 
@@ -588,13 +588,13 @@ CSSPixels FlexFormattingContext::calculate_indefinite_main_size(FlexItem const& 
 // https://drafts.csswg.org/css-flexbox-1/#propdef-flex-basis
 CSS::FlexBasisData FlexFormattingContext::used_flex_basis_for_item(FlexItem const& item) const
 {
-    auto flex_basis = item.box.computed_values().flex_basis();
+    auto flex_basis = item.box->computed_values().flex_basis();
 
     if (flex_basis.type == CSS::FlexBasis::Auto) {
         // https://drafts.csswg.org/css-flexbox-1/#valdef-flex-basis-auto
         // When specified on a flex item, the auto keyword retrieves the value of the main size property as the used flex-basis.
         // If that value is itself auto, then the used value is content.
-        auto const& main_size = is_row_layout() ? item.box.computed_values().width() : item.box.computed_values().height();
+        auto const& main_size = is_row_layout() ? item.box->computed_values().width() : item.box->computed_values().height();
 
         if (main_size.is_auto()) {
             flex_basis.type = CSS::FlexBasis::Content;
@@ -650,11 +650,11 @@ void FlexFormattingContext::determine_flex_base_size_and_hypothetical_main_size(
         //    - an intrinsic aspect ratio,
         //    - a used flex basis of content, and
         //    - a definite cross size,
-        if (item.box.has_intrinsic_aspect_ratio()
+        if (item.box->has_intrinsic_aspect_ratio()
             && item.used_flex_basis.type == CSS::FlexBasis::Content
             && has_definite_cross_size(item.box)) {
             // flex_base_size is calculated from definite cross size and intrinsic aspect ratio
-            return resolved_definite_cross_size(item) * item.box.intrinsic_aspect_ratio().value();
+            return resolved_definite_cross_size(item) * item.box->intrinsic_aspect_ratio().value();
         }
 
         // C. If the used flex basis is content or depends on its available space,
@@ -738,8 +738,8 @@ Optional<CSSPixels> FlexFormattingContext::transferred_size_suggestion(FlexItem 
     // If the item has a preferred aspect ratio and its preferred cross size is definite,
     // then the transferred size suggestion is that size
     // (clamped by its minimum and maximum cross sizes if they are definite), converted through the aspect ratio.
-    if (item.box.has_intrinsic_aspect_ratio() && has_definite_cross_size(item.box)) {
-        auto aspect_ratio = item.box.intrinsic_aspect_ratio().value();
+    if (item.box->has_intrinsic_aspect_ratio() && has_definite_cross_size(item.box)) {
+        auto aspect_ratio = item.box->intrinsic_aspect_ratio().value();
         // FIXME: Clamp cross size to min/max cross size before this conversion.
         return resolved_definite_cross_size(item) * aspect_ratio;
     }
@@ -760,7 +760,7 @@ CSSPixels FlexFormattingContext::content_based_minimum_size(FlexItem const& item
 
         // otherwise, the smaller of its transferred size suggestion and its content size suggestion
         // if the element is replaced and its transferred size suggestion exists;
-        if (item.box.is_replaced_box()) {
+        if (item.box->is_replaced_box()) {
             if (auto transferred_size_suggestion = this->transferred_size_suggestion(item); transferred_size_suggestion.has_value()) {
                 return min(transferred_size_suggestion.value(), content_size_suggestion(item));
             }
@@ -902,9 +902,9 @@ void FlexFormattingContext::resolve_flexible_lengths_for_line(FlexLine& line)
 
     for (FlexItem& item : line.items) {
         if (used_flex_factor == FlexFactor::FlexGrowFactor) {
-            item.flex_factor = item.box.computed_values().flex_grow();
+            item.flex_factor = item.box->computed_values().flex_grow();
         } else if (used_flex_factor == FlexFactor::FlexShrinkFactor) {
-            item.flex_factor = item.box.computed_values().flex_shrink();
+            item.flex_factor = item.box->computed_values().flex_shrink();
         }
         // Freeze, setting its target main size to its hypothetical main size…
         // - any item that has a flex factor of zero
@@ -1095,7 +1095,7 @@ void FlexFormattingContext::determine_hypothetical_cross_size_of_item(FlexItem& 
         }
 
         auto cross_size = [&]() {
-            if (item.box.computed_values().box_sizing() == CSS::BoxSizing::BorderBox) {
+            if (item.box->computed_values().box_sizing() == CSS::BoxSizing::BorderBox) {
                 return max(CSSPixels(0.0f), resolved_definite_cross_size(item) - item.padding.cross_before - item.padding.cross_after - item.borders.cross_before - item.borders.cross_after);
             }
 
@@ -1361,7 +1361,7 @@ void FlexFormattingContext::dump_items() const
         dbgln("{} flex-line #{}:", flex_container().debug_description(), i);
         for (size_t j = 0; j < m_flex_lines[i].items.size(); ++j) {
             auto& item = m_flex_lines[i].items[j];
-            dbgln("{}   flex-item #{}: {} (main:{}, cross:{})", flex_container().debug_description(), j, item.box.debug_description(), item.main_size.value_or(-1), item.cross_size.value_or(-1));
+            dbgln("{}   flex-item #{}: {} (main:{}, cross:{})", flex_container().debug_description(), j, item.box->debug_description(), item.main_size.value_or(-1), item.cross_size.value_or(-1));
         }
     }
 }
@@ -1536,20 +1536,20 @@ void FlexFormattingContext::copy_dimensions_from_flex_items_to_boxes()
         auto const& box = item.box;
         auto& box_state = m_state.get_mutable(box);
 
-        box_state.padding_left = box.computed_values().padding().left().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
-        box_state.padding_right = box.computed_values().padding().right().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
-        box_state.padding_top = box.computed_values().padding().top().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
-        box_state.padding_bottom = box.computed_values().padding().bottom().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.padding_left = box->computed_values().padding().left().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.padding_right = box->computed_values().padding().right().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.padding_top = box->computed_values().padding().top().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.padding_bottom = box->computed_values().padding().bottom().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
 
-        box_state.margin_left = box.computed_values().margin().left().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
-        box_state.margin_right = box.computed_values().margin().right().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
-        box_state.margin_top = box.computed_values().margin().top().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
-        box_state.margin_bottom = box.computed_values().margin().bottom().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.margin_left = box->computed_values().margin().left().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.margin_right = box->computed_values().margin().right().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.margin_top = box->computed_values().margin().top().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
+        box_state.margin_bottom = box->computed_values().margin().bottom().resolved(box, CSS::Length::make_px(m_flex_container_state.content_width())).to_px(box);
 
-        box_state.border_left = box.computed_values().border_left().width;
-        box_state.border_right = box.computed_values().border_right().width;
-        box_state.border_top = box.computed_values().border_top().width;
-        box_state.border_bottom = box.computed_values().border_bottom().width;
+        box_state.border_left = box->computed_values().border_left().width;
+        box_state.border_right = box->computed_values().border_right().width;
+        box_state.border_top = box->computed_values().border_top().width;
+        box_state.border_bottom = box->computed_values().border_bottom().width;
 
         set_main_size(box, item.main_size.value());
         set_cross_size(box, item.cross_size.value());
@@ -1607,10 +1607,10 @@ CSSPixels FlexFormattingContext::calculate_intrinsic_main_size_of_flex_container
 
         CSSPixels result = contribution - outer_flex_base_size;
         if (result > 0) {
-            if (item.box.computed_values().flex_grow() >= 1) {
-                result /= item.box.computed_values().flex_grow();
+            if (item.box->computed_values().flex_grow() >= 1) {
+                result /= item.box->computed_values().flex_grow();
             } else {
-                result *= item.box.computed_values().flex_grow();
+                result *= item.box->computed_values().flex_grow();
             }
         } else if (result < 0) {
             if (item.scaled_flex_shrink_factor == 0)
@@ -1639,8 +1639,8 @@ CSSPixels FlexFormattingContext::calculate_intrinsic_main_size_of_flex_container
         float sum_of_flex_shrink_factors = 0;
         for (auto& item : flex_line.items) {
             greatest_desired_flex_fraction = max(greatest_desired_flex_fraction, item.desired_flex_fraction);
-            sum_of_flex_grow_factors += item.box.computed_values().flex_grow();
-            sum_of_flex_shrink_factors += item.box.computed_values().flex_shrink();
+            sum_of_flex_grow_factors += item.box->computed_values().flex_grow();
+            sum_of_flex_shrink_factors += item.box->computed_values().flex_shrink();
         }
         float chosen_flex_fraction = greatest_desired_flex_fraction;
 
@@ -1666,7 +1666,7 @@ CSSPixels FlexFormattingContext::calculate_intrinsic_main_size_of_flex_container
             for (auto& item : flex_line.items) {
                 float product = 0;
                 if (item.desired_flex_fraction > 0)
-                    product = flex_line.chosen_flex_fraction * item.box.computed_values().flex_grow();
+                    product = flex_line.chosen_flex_fraction * item.box->computed_values().flex_grow();
                 else if (item.desired_flex_fraction < 0)
                     product = flex_line.chosen_flex_fraction * item.scaled_flex_shrink_factor;
                 auto result = item.flex_base_size + product;
@@ -1926,7 +1926,7 @@ bool FlexFormattingContext::flex_item_is_stretched(FlexItem const& item) const
     if (alignment != CSS::AlignItems::Stretch)
         return false;
     // If the cross size property of the flex item computes to auto, and neither of the cross-axis margins are auto, the flex item is stretched.
-    auto const& computed_cross_size = is_row_layout() ? item.box.computed_values().height() : item.box.computed_values().width();
+    auto const& computed_cross_size = is_row_layout() ? item.box->computed_values().height() : item.box->computed_values().width();
     return computed_cross_size.is_auto() && !item.margins.cross_before_is_auto && !item.margins.cross_after_is_auto;
 }
 

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -48,7 +48,7 @@ private:
     };
 
     struct FlexItem {
-        Box& box;
+        JS::NonnullGCPtr<Box> box;
         CSS::FlexBasisData used_flex_basis {};
         bool used_flex_basis_is_definite { false };
         CSSPixels flex_base_size { 0 };

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -321,7 +321,7 @@ CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_ro
     // In addition, if the element has any floating descendants
     // whose bottom margin edge is below the element's bottom content edge,
     // then the height is increased to include those edges.
-    for (auto* floating_box : m_state.get(root).floating_descendants()) {
+    for (auto floating_box : m_state.get(root).floating_descendants()) {
         // NOTE: Floating box coordinates are relative to their own containing block,
         //       which may or may not be the BFC root.
         auto margin_box = margin_box_rect_in_ancestor_coordinate_space(*floating_box, root, m_state);

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -123,7 +123,7 @@ protected:
     Type m_type {};
 
     FormattingContext* m_parent { nullptr };
-    Box const& m_context_box;
+    JS::NonnullGCPtr<Box const> m_context_box;
 
     LayoutState& m_state;
 };

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1680,8 +1680,8 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
     // 1. Position anything that's not auto-positioned.
     for (size_t i = 0; i < m_boxes_to_place.size(); i++) {
         auto const& child_box = m_boxes_to_place[i];
-        if (is_auto_positioned_row(child_box.computed_values().grid_row_start(), child_box.computed_values().grid_row_end())
-            || is_auto_positioned_column(child_box.computed_values().grid_column_start(), child_box.computed_values().grid_column_end()))
+        if (is_auto_positioned_row(child_box->computed_values().grid_row_start(), child_box->computed_values().grid_row_end())
+            || is_auto_positioned_column(child_box->computed_values().grid_column_start(), child_box->computed_values().grid_column_end()))
             continue;
         place_item_with_row_and_column_position(box, child_box);
         m_boxes_to_place.remove(i);
@@ -1692,7 +1692,7 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
     // FIXME: Do "dense" packing
     for (size_t i = 0; i < m_boxes_to_place.size(); i++) {
         auto const& child_box = m_boxes_to_place[i];
-        if (is_auto_positioned_row(child_box.computed_values().grid_row_start(), child_box.computed_values().grid_row_end()))
+        if (is_auto_positioned_row(child_box->computed_values().grid_row_start(), child_box->computed_values().grid_row_end()))
             continue;
         place_item_with_row_position(box, child_box);
         m_boxes_to_place.remove(i);
@@ -1723,7 +1723,7 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
         // FIXME: no distinction made. See #4.2
 
         // 4.1.1. If the item has a definite column position:
-        if (!is_auto_positioned_column(child_box.computed_values().grid_column_start(), child_box.computed_values().grid_column_end()))
+        if (!is_auto_positioned_column(child_box->computed_values().grid_column_start(), child_box->computed_values().grid_column_end()))
             place_item_with_column_position(box, child_box, auto_placement_cursor_x, auto_placement_cursor_y);
 
         // 4.1.2. If the item has an automatic grid position in both axes:

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -49,7 +49,7 @@ public:
     int gap_adjusted_column(Box const& parent_box);
 
 private:
-    Box const& m_box;
+    JS::NonnullGCPtr<Box const> m_box;
     int m_row { 0 };
     int m_row_span { 1 };
     int m_column { 0 };
@@ -120,7 +120,7 @@ private:
 
     OccupationGrid m_occupation_grid;
     Vector<PositionedBox> m_positioned_boxes;
-    Vector<Box const&> m_boxes_to_place;
+    Vector<JS::NonnullGCPtr<Box const>> m_boxes_to_place;
 
     CSSPixels get_free_space_x(AvailableSpace const& available_space);
     CSSPixels get_free_space_y(Box const&);

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -52,7 +52,7 @@ void InlineLevelIterator::exit_node_with_box_model_metrics()
 
     auto& node = m_box_model_node_stack.last();
     auto& used_values = m_layout_state.get_mutable(node);
-    auto const& computed_values = node.computed_values();
+    auto const& computed_values = node->computed_values();
 
     used_values.margin_right = computed_values.margin().right().resolved(node, CSS::Length::make_px(m_container_state.content_width())).to_px(node);
     used_values.border_right = computed_values.border_right().width;
@@ -83,7 +83,7 @@ Layout::Node const* InlineLevelIterator::next_inline_node_in_pre_order(Layout::N
 
         // If node is the last node on the "box model node stack", pop it off.
         if (!m_box_model_node_stack.is_empty()
-            && &m_box_model_node_stack.last() == node) {
+            && m_box_model_node_stack.last() == node) {
             exit_node_with_box_model_metrics();
         }
         if (!node || node == stay_within)
@@ -92,7 +92,7 @@ Layout::Node const* InlineLevelIterator::next_inline_node_in_pre_order(Layout::N
 
     // If node is the last node on the "box model node stack", pop it off.
     if (!m_box_model_node_stack.is_empty()
-        && &m_box_model_node_stack.last() == node) {
+        && m_box_model_node_stack.last() == node) {
         exit_node_with_box_model_metrics();
     }
 
@@ -104,7 +104,7 @@ void InlineLevelIterator::compute_next()
     if (m_next_node == nullptr)
         return;
     do {
-        m_next_node = next_inline_node_in_pre_order(*m_next_node, &m_container);
+        m_next_node = next_inline_node_in_pre_order(*m_next_node, m_container);
     } while (m_next_node && (!m_next_node->is_inline() && !m_next_node->is_out_of_flow(m_inline_formatting_context)));
 }
 

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.h
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.h
@@ -31,7 +31,7 @@ public:
             FloatingElement,
         };
         Type type {};
-        Layout::Node const* node { nullptr };
+        JS::GCPtr<Layout::Node const> node {};
         size_t offset_in_node { 0 };
         size_t length_in_node { 0 };
         CSSPixels width { 0.0f };
@@ -68,10 +68,10 @@ private:
 
     Layout::InlineFormattingContext& m_inline_formatting_context;
     Layout::LayoutState& m_layout_state;
-    Layout::BlockContainer const& m_container;
+    JS::NonnullGCPtr<Layout::BlockContainer const> m_container;
     Layout::LayoutState::UsedValues const& m_container_state;
-    Layout::Node const* m_current_node { nullptr };
-    Layout::Node const* m_next_node { nullptr };
+    JS::GCPtr<Layout::Node const> m_current_node;
+    JS::GCPtr<Layout::Node const> m_next_node;
     LayoutMode const m_layout_mode;
 
     struct TextNodeContext {
@@ -95,7 +95,7 @@ private:
     Optional<ExtraBoxMetrics> m_extra_leading_metrics;
     Optional<ExtraBoxMetrics> m_extra_trailing_metrics;
 
-    Vector<NodeWithStyleAndBoxModelMetrics const&> m_box_model_node_stack;
+    Vector<JS::NonnullGCPtr<NodeWithStyleAndBoxModelMetrics const>> m_box_model_node_stack;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -131,7 +131,7 @@ struct LayoutState {
         AvailableSize available_width_inside() const;
         AvailableSize available_height_inside() const;
 
-        Layout::NodeWithStyleAndBoxModelMetrics* m_node { nullptr };
+        JS::GCPtr<Layout::NodeWithStyleAndBoxModelMetrics> m_node { nullptr };
 
         CSSPixels m_content_width { 0 };
         CSSPixels m_content_height { 0 };
@@ -139,7 +139,7 @@ struct LayoutState {
         bool m_has_definite_width { false };
         bool m_has_definite_height { false };
 
-        HashTable<Box const*> m_floating_descendants;
+        HashTable<JS::GCPtr<Box const>> m_floating_descendants;
     };
 
     CSSPixels resolved_definite_width(Box const&) const;
@@ -171,7 +171,7 @@ struct LayoutState {
         Optional<CSSPixels> max_content_height_with_max_content_available_width;
     };
 
-    HashMap<NodeWithStyleAndBoxModelMetrics const*, NonnullOwnPtr<IntrinsicSizes>> mutable intrinsic_sizes;
+    HashMap<JS::GCPtr<NodeWithStyleAndBoxModelMetrics const>, NonnullOwnPtr<IntrinsicSizes>> mutable intrinsic_sizes;
 
     LayoutState const* m_parent { nullptr };
     LayoutState const& m_root;

--- a/Userland/Libraries/LibWeb/Layout/LineBoxFragment.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBoxFragment.cpp
@@ -37,7 +37,7 @@ StringView LineBoxFragment::text() const
 CSSPixelRect const LineBoxFragment::absolute_rect() const
 {
     CSSPixelRect rect { {}, size() };
-    rect.set_location(m_layout_node.containing_block()->paint_box()->absolute_position());
+    rect.set_location(m_layout_node->containing_block()->paint_box()->absolute_position());
     rect.translate_by(offset());
     return rect;
 }

--- a/Userland/Libraries/LibWeb/Layout/LineBoxFragment.h
+++ b/Userland/Libraries/LibWeb/Layout/LineBoxFragment.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibGfx/Rect.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/PixelUnits.h>
 
@@ -77,7 +78,7 @@ public:
     CSSPixelRect selection_rect(Gfx::Font const&) const;
 
 private:
-    Node const& m_layout_node;
+    JS::NonnullGCPtr<Node const> m_layout_node;
     int m_start { 0 };
     int m_length { 0 };
     CSSPixelPoint m_offset;

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -108,13 +108,13 @@ void TableFormattingContext::compute_table_measures()
     for (auto& cell : m_cells) {
         auto width_of_containing_block = m_state.get(*table_wrapper().containing_block()).content_width();
         auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
-        auto& computed_values = cell.box.computed_values();
+        auto& computed_values = cell.box->computed_values();
         CSSPixels padding_left = computed_values.padding().left().resolved(cell.box, width_of_containing_block_as_length).to_px(cell.box);
         CSSPixels padding_right = computed_values.padding().right().resolved(cell.box, width_of_containing_block_as_length).to_px(cell.box);
 
         auto is_left_most_cell = cell.column_index == 0;
         auto is_right_most_cell = cell.column_index == m_columns.size() - 1;
-        auto should_hide_borders = cell.box.computed_values().border_collapse() == CSS::BorderCollapse::Collapse;
+        auto should_hide_borders = cell.box->computed_values().border_collapse() == CSS::BorderCollapse::Collapse;
         CSSPixels border_left = should_hide_borders && !is_left_most_cell ? 0 : computed_values.border_left().width;
         CSSPixels border_right = should_hide_borders && !is_right_most_cell ? 0 : computed_values.border_right().width;
 
@@ -392,24 +392,24 @@ void TableFormattingContext::calculate_row_heights(LayoutMode layout_mode)
         for (size_t i = 0; i < cell.column_span; ++i)
             span_width += m_columns[cell.column_index + i].used_width;
 
-        auto width_of_containing_block = m_state.get(*cell.box.containing_block()).content_width();
+        auto width_of_containing_block = m_state.get(*cell.box->containing_block()).content_width();
         auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
 
-        cell_state.padding_top = cell.box.computed_values().padding().top().resolved(cell.box, width_of_containing_block_as_length).to_px(cell.box);
-        cell_state.padding_bottom = cell.box.computed_values().padding().bottom().resolved(cell.box, width_of_containing_block_as_length).to_px(cell.box);
-        cell_state.padding_left = cell.box.computed_values().padding().left().resolved(cell.box, width_of_containing_block_as_length).to_px(cell.box);
-        cell_state.padding_right = cell.box.computed_values().padding().right().resolved(cell.box, width_of_containing_block_as_length).to_px(cell.box);
+        cell_state.padding_top = cell.box->computed_values().padding().top().resolved(cell.box, width_of_containing_block_as_length).to_px(cell.box);
+        cell_state.padding_bottom = cell.box->computed_values().padding().bottom().resolved(cell.box, width_of_containing_block_as_length).to_px(cell.box);
+        cell_state.padding_left = cell.box->computed_values().padding().left().resolved(cell.box, width_of_containing_block_as_length).to_px(cell.box);
+        cell_state.padding_right = cell.box->computed_values().padding().right().resolved(cell.box, width_of_containing_block_as_length).to_px(cell.box);
 
         auto is_top_most_cell = cell.row_index == 0;
         auto is_left_most_cell = cell.column_index == 0;
         auto is_right_most_cell = cell.column_index == m_columns.size() - 1;
         auto is_bottom_most_cell = cell.row_index == m_rows.size() - 1;
-        auto should_hide_borders = cell.box.computed_values().border_collapse() == CSS::BorderCollapse::Collapse;
+        auto should_hide_borders = cell.box->computed_values().border_collapse() == CSS::BorderCollapse::Collapse;
 
-        cell_state.border_top = (should_hide_borders && is_top_most_cell) ? 0 : cell.box.computed_values().border_top().width;
-        cell_state.border_bottom = (should_hide_borders && is_bottom_most_cell) ? 0 : cell.box.computed_values().border_bottom().width;
-        cell_state.border_left = (should_hide_borders && is_left_most_cell) ? 0 : cell.box.computed_values().border_left().width;
-        cell_state.border_right = (should_hide_borders && is_right_most_cell) ? 0 : cell.box.computed_values().border_right().width;
+        cell_state.border_top = (should_hide_borders && is_top_most_cell) ? 0 : cell.box->computed_values().border_top().width;
+        cell_state.border_bottom = (should_hide_borders && is_bottom_most_cell) ? 0 : cell.box->computed_values().border_bottom().width;
+        cell_state.border_left = (should_hide_borders && is_left_most_cell) ? 0 : cell.box->computed_values().border_left().width;
+        cell_state.border_right = (should_hide_borders && is_right_most_cell) ? 0 : cell.box->computed_values().border_right().width;
 
         cell_state.set_content_width((span_width - cell_state.border_box_left() - cell_state.border_box_right()));
         if (auto independent_formatting_context = layout_inside(cell.box, layout_mode, cell_state.available_inner_space_or_constraints_from(*m_available_space))) {
@@ -484,7 +484,7 @@ void TableFormattingContext::position_cell_boxes()
         auto& row_state = m_state.get(m_rows[cell.row_index].box);
         CSSPixels const cell_border_box_height = cell_state.content_height() + cell_state.border_box_top() + cell_state.border_box_bottom();
         CSSPixels const row_content_height = row_state.content_height();
-        auto const& vertical_align = cell.box.computed_values().vertical_align();
+        auto const& vertical_align = cell.box->computed_values().vertical_align();
         if (vertical_align.has<CSS::VerticalAlign>()) {
             switch (vertical_align.get<CSS::VerticalAlign>()) {
             case CSS::VerticalAlign::Middle: {

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -57,13 +57,13 @@ private:
     };
 
     struct Row {
-        Box& box;
+        JS::NonnullGCPtr<Box> box;
         CSSPixels used_height { 0 };
         CSSPixels baseline { 0 };
     };
 
     struct Cell {
-        Box& box;
+        JS::NonnullGCPtr<Box> box;
         size_t column_index;
         size_t row_index;
         size_t column_span;

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -128,11 +128,11 @@ void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, 
         // Non-inlines can't be inserted into an inline parent, so find the nearest non-inline ancestor.
         auto& nearest_non_inline_ancestor = [&]() -> Layout::NodeWithStyle& {
             for (auto& ancestor : m_ancestor_stack.in_reverse()) {
-                if (!ancestor.display().is_inline_outside())
+                if (!ancestor->display().is_inline_outside())
                     return ancestor;
-                if (!ancestor.display().is_flow_inside())
+                if (!ancestor->display().is_flow_inside())
                     return ancestor;
-                if (ancestor.dom_node() && is<SVG::SVGForeignObjectElement>(*ancestor.dom_node()))
+                if (ancestor->dom_node() && is<SVG::SVGForeignObjectElement>(*ancestor->dom_node()))
                     return ancestor;
             }
             VERIFY_NOT_REACHED();
@@ -234,7 +234,7 @@ ErrorOr<void> TreeBuilder::create_layout_tree(DOM::Node& dom_node, TreeBuilder::
     if (!dom_node.parent_or_shadow_host()) {
         m_layout_root = layout_node;
     } else if (layout_node->is_svg_box()) {
-        m_ancestor_stack.last().append_child(*layout_node);
+        m_ancestor_stack.last()->append_child(*layout_node);
     } else {
         insert_node_into_inline_or_block_ancestor(*layout_node, display, AppendOrPrepend::Append);
     }

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -49,7 +49,7 @@ private:
     ErrorOr<void> create_pseudo_element_if_needed(DOM::Element&, CSS::Selector::PseudoElement, AppendOrPrepend);
 
     JS::GCPtr<Layout::Node> m_layout_root;
-    Vector<Layout::NodeWithStyle&> m_ancestor_stack;
+    Vector<JS::NonnullGCPtr<Layout::NodeWithStyle>> m_ancestor_stack;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -207,7 +207,7 @@ bool FrameLoader::load(LoadRequest& request, Type type)
         return false;
     }
 
-    if (!m_browsing_context.is_frame_nesting_allowed(request.url())) {
+    if (!m_browsing_context->is_frame_nesting_allowed(request.url())) {
         dbgln("No further recursion is allowed for the frame, abort load!");
         return false;
     }
@@ -216,7 +216,7 @@ bool FrameLoader::load(LoadRequest& request, Type type)
 
     if (type == Type::Navigation || type == Type::Reload || type == Type::Redirect) {
         if (auto* page = browsing_context().page()) {
-            if (&page->top_level_browsing_context() == &m_browsing_context)
+            if (&page->top_level_browsing_context() == m_browsing_context)
                 page->client().page_did_start_loading(url, type == Type::Redirect);
         }
     }

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.h
@@ -47,7 +47,7 @@ private:
     void load_favicon(RefPtr<Gfx::Bitmap> bitmap = nullptr);
     bool parse_document(DOM::Document&, ByteBuffer const& data);
 
-    HTML::BrowsingContext& m_browsing_context;
+    JS::NonnullGCPtr<HTML::BrowsingContext> m_browsing_context;
     size_t m_redirects_count { 0 };
 };
 

--- a/Userland/Libraries/LibWeb/Loader/ImageLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ImageLoader.cpp
@@ -36,7 +36,7 @@ void ImageLoader::load_without_resetting_redirect_counter(AK::URL const& url)
 {
     m_loading_state = LoadingState::Loading;
 
-    auto request = LoadRequest::create_for_url_on_page(url, m_owner_element.document().page());
+    auto request = LoadRequest::create_for_url_on_page(url, m_owner_element->document().page());
     set_resource(ResourceLoader::the().load_resource(Resource::Type::Image, request));
 }
 

--- a/Userland/Libraries/LibWeb/Loader/ImageLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ImageLoader.h
@@ -53,7 +53,7 @@ private:
         Failed,
     };
 
-    DOM::Element& m_owner_element;
+    JS::NonnullGCPtr<DOM::Element> m_owner_element;
 
     mutable bool m_visible_in_viewport { false };
 

--- a/Userland/Libraries/LibWeb/Page/EditEventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EditEventHandler.cpp
@@ -36,9 +36,9 @@ void EditEventHandler::handle_delete_character_after(DOM::Position const& cursor
     // FIXME: When nodes are removed from the DOM, the associated layout nodes become stale and still
     //        remain in the layout tree. This has to be fixed, this just causes everything to be recomputed
     //        which really hurts performance.
-    m_browsing_context.active_document()->force_layout();
+    m_browsing_context->active_document()->force_layout();
 
-    m_browsing_context.did_edit({});
+    m_browsing_context->did_edit({});
 }
 
 // This method is quite convoluted but this is necessary to make editing feel intuitive.
@@ -97,9 +97,9 @@ void EditEventHandler::handle_delete(DOM::Range& range)
     // FIXME: When nodes are removed from the DOM, the associated layout nodes become stale and still
     //        remain in the layout tree. This has to be fixed, this just causes everything to be recomputed
     //        which really hurts performance.
-    m_browsing_context.active_document()->force_layout();
+    m_browsing_context->active_document()->force_layout();
 
-    m_browsing_context.did_edit({});
+    m_browsing_context->did_edit({});
 }
 
 void EditEventHandler::handle_insert(DOM::Position position, u32 code_point)
@@ -119,8 +119,8 @@ void EditEventHandler::handle_insert(DOM::Position position, u32 code_point)
     // FIXME: When nodes are removed from the DOM, the associated layout nodes become stale and still
     //        remain in the layout tree. This has to be fixed, this just causes everything to be recomputed
     //        which really hurts performance.
-    m_browsing_context.active_document()->force_layout();
+    m_browsing_context->active_document()->force_layout();
 
-    m_browsing_context.did_edit({});
+    m_browsing_context->did_edit({});
 }
 }

--- a/Userland/Libraries/LibWeb/Page/EditEventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EditEventHandler.h
@@ -25,7 +25,7 @@ public:
     virtual void handle_insert(DOM::Position, u32 code_point);
 
 private:
-    HTML::BrowsingContext& m_browsing_context;
+    JS::NonnullGCPtr<HTML::BrowsingContext> m_browsing_context;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Page/EventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.h
@@ -50,7 +50,7 @@ private:
     Painting::PaintableBox* paint_root();
     Painting::PaintableBox const* paint_root() const;
 
-    HTML::BrowsingContext& m_browsing_context;
+    JS::NonnullGCPtr<HTML::BrowsingContext> m_browsing_context;
 
     bool m_in_mouse_selection { false };
 

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.h
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.h
@@ -20,7 +20,7 @@ public:
     StackingContext* parent() { return m_parent; }
     StackingContext const* parent() const { return m_parent; }
 
-    PaintableBox const& paintable() const { return *m_box.paint_box(); }
+    PaintableBox const& paintable() const { return *m_box->paint_box(); }
 
     enum class StackingContextPaintPhase {
         BackgroundAndBorders,
@@ -42,7 +42,7 @@ public:
     void sort();
 
 private:
-    Layout::Box& m_box;
+    JS::NonnullGCPtr<Layout::Box> m_box;
     Gfx::FloatMatrix4x4 m_transform;
     Gfx::FloatPoint m_transform_origin;
     StackingContext* const m_parent { nullptr };

--- a/Userland/Libraries/LibWeb/ReferrerPolicy/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/ReferrerPolicy/AbstractOperations.cpp
@@ -23,7 +23,7 @@ Optional<AK::URL> determine_requests_referrer(Fetch::Infrastructure::Request con
     auto const& policy = request.referrer_policy();
 
     // 2. Let environment be request’s client.
-    auto* environment = request.client();
+    auto environment = request.client();
 
     // 3. Switch on request’s referrer:
     auto referrer_source = request.referrer().visit(
@@ -33,7 +33,7 @@ Optional<AK::URL> determine_requests_referrer(Fetch::Infrastructure::Request con
             VERIFY(referrer == Fetch::Infrastructure::Request::Referrer::Client);
 
             // FIXME: Add a const global_object() getter to ESO
-            auto& global_object = const_cast<HTML::EnvironmentSettingsObject*>(environment)->global_object();
+            auto& global_object = const_cast<HTML::EnvironmentSettingsObject&>(*environment).global_object();
 
             // 1. If environment’s global object is a Window object, then
             if (is<HTML::Window>(global_object)) {

--- a/Userland/Libraries/LibWeb/URL/URLSearchParamsIterator.cpp
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParamsIterator.cpp
@@ -48,15 +48,15 @@ JS::ThrowCompletionOr<void> URLSearchParamsIterator::initialize(JS::Realm& realm
 void URLSearchParamsIterator::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_url_search_params);
+    visitor.visit(m_url_search_params);
 }
 
 JS::Object* URLSearchParamsIterator::next()
 {
-    if (m_index >= m_url_search_params.m_list.size())
+    if (m_index >= m_url_search_params->m_list.size())
         return create_iterator_result_object(vm(), JS::js_undefined(), true);
 
-    auto& entry = m_url_search_params.m_list[m_index++];
+    auto& entry = m_url_search_params->m_list[m_index++];
     if (m_iteration_kind == JS::Object::PropertyKind::Key)
         return create_iterator_result_object(vm(), JS::PrimitiveString::create(vm(), entry.name), false);
     else if (m_iteration_kind == JS::Object::PropertyKind::Value)

--- a/Userland/Libraries/LibWeb/URL/URLSearchParamsIterator.h
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParamsIterator.h
@@ -27,7 +27,7 @@ private:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    URLSearchParams const& m_url_search_params;
+    JS::NonnullGCPtr<URLSearchParams const> m_url_search_params;
     JS::Object::PropertyKind m_iteration_kind;
     size_t m_index { 0 };
 };

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceObject.cpp
@@ -37,7 +37,7 @@ JS::ThrowCompletionOr<void> WebAssemblyInstanceObject::initialize(JS::Realm& rea
     for (auto& export_ : instance.exports()) {
         TRY(export_.value().visit(
             [&](Wasm::FunctionAddress const& address) -> JS::ThrowCompletionOr<void> {
-                Optional<JS::FunctionObject*> object = cache.function_instances.get(address);
+                Optional<JS::GCPtr<JS::FunctionObject>> object = cache.function_instances.get(address);
                 if (!object.has_value()) {
                     object = create_native_function(vm, address, export_.name());
                     cache.function_instances.set(address, *object);
@@ -46,7 +46,7 @@ JS::ThrowCompletionOr<void> WebAssemblyInstanceObject::initialize(JS::Realm& rea
                 return {};
             },
             [&](Wasm::MemoryAddress const& address) -> JS::ThrowCompletionOr<void> {
-                Optional<WebAssemblyMemoryObject*> object = cache.memory_instances.get(address);
+                Optional<JS::GCPtr<WebAssemblyMemoryObject>> object = cache.memory_instances.get(address);
                 if (!object.has_value()) {
                     object = MUST_OR_THROW_OOM(heap().allocate<Web::Bindings::WebAssemblyMemoryObject>(realm, realm, address));
                     cache.memory_instances.set(address, *object);
@@ -55,7 +55,7 @@ JS::ThrowCompletionOr<void> WebAssemblyInstanceObject::initialize(JS::Realm& rea
                 return {};
             },
             [&](Wasm::TableAddress const& address) -> JS::ThrowCompletionOr<void> {
-                Optional<WebAssemblyTableObject*> object = cache.table_instances.get(address);
+                Optional<JS::GCPtr<WebAssemblyTableObject>> object = cache.table_instances.get(address);
                 if (!object.has_value()) {
                     object = MUST_OR_THROW_OOM(heap().allocate<Web::Bindings::WebAssemblyTableObject>(realm, realm, address));
                     cache.table_instances.set(address, *object);

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceObject.h
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceObject.h
@@ -33,7 +33,7 @@ public:
 
 private:
     size_t m_index { 0 };
-    Object* m_exports_object { nullptr };
+    JS::GCPtr<Object> m_exports_object;
 };
 
 }

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.h
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.h
@@ -46,12 +46,12 @@ public:
     //        so ideally this would be a refcounted object, shared between
     //        WebAssemblyModuleObject's and WebAssemblyInstantiatedModuleObject's.
     struct ModuleCache {
-        HashMap<Wasm::FunctionAddress, JS::FunctionObject*> function_instances;
-        HashMap<Wasm::MemoryAddress, WebAssemblyMemoryObject*> memory_instances;
-        HashMap<Wasm::TableAddress, WebAssemblyTableObject*> table_instances;
+        HashMap<Wasm::FunctionAddress, JS::GCPtr<JS::FunctionObject>> function_instances;
+        HashMap<Wasm::MemoryAddress, JS::GCPtr<WebAssemblyMemoryObject>> memory_instances;
+        HashMap<Wasm::TableAddress, JS::GCPtr<WebAssemblyTableObject>> table_instances;
     };
     struct GlobalModuleCache {
-        HashMap<Wasm::FunctionAddress, JS::NativeFunction*> function_instances;
+        HashMap<Wasm::FunctionAddress, JS::GCPtr<JS::NativeFunction>> function_instances;
     };
 
     static Vector<NonnullOwnPtr<CompiledWebAssemblyModule>> s_compiled_modules;

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -333,7 +333,7 @@ ExecuteScriptResultSerialized execute_async_script(Web::Page& page, DeprecatedSt
         vm.pop_execution_context();
 
         // 2. Append resolvingFunctions.[[Resolve]] to arguments.
-        arguments.append(&resolving_functions.resolve);
+        arguments.append(resolving_functions.resolve);
 
         // 3. Let result be the result of calling execute a function body, with arguments body and arguments.
         // FIXME: 'result' -> 'scriptResult' (spec issue)

--- a/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -95,7 +95,7 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
     auto& function_object = callback.callback;
 
     // 4. If ! IsCallable(F) is false:
-    if (!function_object.is_function()) {
+    if (!function_object->is_function()) {
         // 1. Note: This is only possible when the callback function came from an attribute marked with [LegacyTreatNonObjectAsNull].
 
         // 2. Return the result of converting undefined to the callback function’s return type.
@@ -105,7 +105,7 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
 
     // 5. Let realm be F’s associated Realm.
     // See the comment about associated realm on step 4 of call_user_object_operation.
-    auto& realm = function_object.shape().realm();
+    auto& realm = function_object->shape().realm();
 
     // 6. Let relevant settings be realm’s settings object.
     auto& relevant_settings = Bindings::host_defined_environment_settings_object(realm);
@@ -117,14 +117,14 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
     relevant_settings.prepare_to_run_script();
 
     // 9. Prepare to run a callback with stored settings.
-    stored_settings.prepare_to_run_callback();
+    stored_settings->prepare_to_run_callback();
 
     // FIXME: 10. Let esArgs be the result of converting args to an ECMAScript arguments list. If this throws an exception, set completion to the completion value representing the thrown exception and jump to the step labeled return.
     //        For simplicity, we currently make the caller do this. However, this means we can't throw exceptions at this point like the spec wants us to.
 
     // 11. Let callResult be Call(F, thisArg, esArgs).
-    auto& vm = function_object.vm();
-    auto call_result = JS::call(vm, verify_cast<JS::FunctionObject>(function_object), this_argument.value(), move(args));
+    auto& vm = function_object->vm();
+    auto call_result = JS::call(vm, verify_cast<JS::FunctionObject>(*function_object), this_argument.value(), move(args));
 
     // 12. If callResult is an abrupt completion, set completion to callResult and jump to the step labeled return.
     if (call_result.is_throw_completion()) {

--- a/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.h
@@ -58,7 +58,7 @@ JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, Deprec
     auto& object = callback.callback;
 
     // 4. Let realm be O’s associated Realm.
-    auto& realm = object.shape().realm();
+    auto& realm = object->shape().realm();
 
     // 5. Let relevant settings be realm’s settings object.
     auto& relevant_settings = Bindings::host_defined_environment_settings_object(realm);
@@ -70,15 +70,15 @@ JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, Deprec
     relevant_settings.prepare_to_run_script();
 
     // 8. Prepare to run a callback with stored settings.
-    stored_settings.prepare_to_run_callback();
+    stored_settings->prepare_to_run_callback();
 
     // 9. Let X be O.
-    auto* actual_function_object = &object;
+    auto actual_function_object = object;
 
     // 10. If ! IsCallable(O) is false, then:
-    if (!object.is_function()) {
+    if (!object->is_function()) {
         // 1. Let getResult be Get(O, opName).
-        auto get_result = object.get(operation_name);
+        auto get_result = object->get(operation_name);
 
         // 2. If getResult is an abrupt completion, set completion to getResult and jump to the step labeled return.
         if (get_result.is_throw_completion()) {
@@ -94,10 +94,10 @@ JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, Deprec
 
         // 3. Set X to getResult.[[Value]].
         // NOTE: This is done out of order because `actual_function_object` is of type JS::Object and we cannot assign to it until we know for sure getResult.[[Value]] is a JS::Object.
-        actual_function_object = &get_result.release_value().as_object();
+        actual_function_object = get_result.release_value().as_object();
 
         // 5. Set thisArg to O (overriding the provided value).
-        this_argument = &object;
+        this_argument = object;
     }
 
     // FIXME: 11. Let esArgs be the result of converting args to an ECMAScript arguments list. If this throws an exception, set completion to the completion value representing the thrown exception and jump to the step labeled return.
@@ -105,7 +105,7 @@ JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, Deprec
 
     // 12. Let callResult be Call(X, thisArg, esArgs).
     VERIFY(actual_function_object);
-    auto& vm = object.vm();
+    auto& vm = object->vm();
     auto call_result = JS::call(vm, verify_cast<JS::FunctionObject>(*actual_function_object), this_argument.value(), forward<Args>(args)...);
 
     // 13. If callResult is an abrupt completion, set completion to callResult and jump to the step labeled return.
@@ -129,7 +129,7 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
 {
     auto& function_object = callback.callback;
 
-    JS::MarkedVector<JS::Value> arguments_list { function_object.vm().heap() };
+    JS::MarkedVector<JS::Value> arguments_list { function_object->vm().heap() };
     (arguments_list.append(forward<Args>(args)), ...);
 
     return invoke_callback(callback, move(this_argument), move(arguments_list));

--- a/Userland/Libraries/LibWeb/WebIDL/CallbackType.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/CallbackType.cpp
@@ -20,7 +20,7 @@ StringView CallbackType::class_name() const { return "CallbackType"sv; }
 void CallbackType::visit_edges(Cell::Visitor& visitor)
 {
     Cell::visit_edges(visitor);
-    visitor.visit(&callback);
+    visitor.visit(callback);
     visitor.visit(callback_context);
 }
 

--- a/Userland/Libraries/LibWeb/WebIDL/CallbackType.h
+++ b/Userland/Libraries/LibWeb/WebIDL/CallbackType.h
@@ -17,10 +17,10 @@ class CallbackType final : public JS::Cell {
 public:
     CallbackType(JS::Object& callback, HTML::EnvironmentSettingsObject& callback_context);
 
-    JS::Object& callback;
+    JS::NonnullGCPtr<JS::Object> callback;
 
     // https://webidl.spec.whatwg.org/#dfn-callback-context
-    HTML::EnvironmentSettingsObject& callback_context;
+    JS::NonnullGCPtr<HTML::EnvironmentSettingsObject> callback_context;
 
 private:
     virtual StringView class_name() const override;

--- a/Userland/Libraries/LibWeb/XHR/FormDataIterator.cpp
+++ b/Userland/Libraries/LibWeb/XHR/FormDataIterator.cpp
@@ -48,17 +48,17 @@ JS::ThrowCompletionOr<void> FormDataIterator::initialize(JS::Realm& realm)
 void FormDataIterator::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(&m_form_data);
+    visitor.visit(m_form_data);
 }
 
 JS::Object* FormDataIterator::next()
 {
     auto& vm = this->vm();
 
-    if (m_index >= m_form_data.m_entry_list.size())
+    if (m_index >= m_form_data->m_entry_list.size())
         return create_iterator_result_object(vm, JS::js_undefined(), true);
 
-    auto& entry = m_form_data.m_entry_list[m_index++];
+    auto entry = m_form_data->m_entry_list[m_index++];
     if (m_iterator_kind == JS::Object::PropertyKind::Key)
         return create_iterator_result_object(vm, JS::PrimitiveString::create(vm, entry.name), false);
 

--- a/Userland/Libraries/LibWeb/XHR/FormDataIterator.h
+++ b/Userland/Libraries/LibWeb/XHR/FormDataIterator.h
@@ -27,7 +27,7 @@ private:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    FormData const& m_form_data;
+    JS::NonnullGCPtr<FormData const> m_form_data;
     JS::Object::PropertyKind m_iterator_kind;
     size_t m_index { 0 };
 };

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.h
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.h
@@ -36,8 +36,8 @@ private:
     virtual void comment(StringView data) override;
     virtual void document_end() override;
 
-    DOM::Document& m_document;
-    DOM::Node* m_current_node { nullptr };
+    JS::NonnullGCPtr<DOM::Document> m_document;
+    JS::GCPtr<DOM::Node> m_current_node;
     XMLScriptingSupport m_scripting_support { XMLScriptingSupport::Enabled };
     bool m_has_error { false };
     StringBuilder text_builder;


### PR DESCRIPTION
This builds on #17620, using the tool's output to find all unwrapped fields and wrap them. It also includes a few extra changes to help that along, specifically adding a few constructors and making `Traits<GCPtr<T>>::hash` delegate to `Traits<T*>::hash`. 

The commit that does the wrapping is really huge, but it's all pretty much the same (changing field type and adding/removing punctuation as a result). Not sure there's really a way to split it up. 