### PR TITLE
AK(+Everywhere): Introduce StringBuilder::try_to_byte_buffer

### DIFF
--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -111,6 +111,11 @@ ByteBuffer StringBuilder::to_byte_buffer() const
     return ByteBuffer::copy(data(), length()).release_value_but_fixme_should_propagate_errors();
 }
 
+ErrorOr<ByteBuffer> StringBuilder::try_to_byte_buffer() const
+{
+    return TRY(ByteBuffer::copy(data(), length()));
+}
+
 #ifndef KERNEL
 DeprecatedString StringBuilder::to_deprecated_string() const
 {

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -69,6 +69,7 @@ public:
     ErrorOr<FlyString> to_fly_string() const;
 
     [[nodiscard]] ByteBuffer to_byte_buffer() const;
+    [[nodiscard]] ErrorOr<ByteBuffer> try_to_byte_buffer() const;
 
     [[nodiscard]] StringView string_view() const;
     void clear();

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
@@ -50,7 +50,7 @@ ErrorOr<void> DomainListModel::save()
         TRY(builder.try_appendff("{}\n", domain));
 
     auto file = TRY(Core::File::open(filter_list_file_path(), Core::File::OpenMode::Write));
-    TRY(file->write(builder.to_byte_buffer().bytes()));
+    TRY(file->write(TRY(builder.try_to_byte_buffer()).bytes()));
     return {};
 }
 

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -31,14 +31,16 @@ Vector<URL> MimeData::urls() const
     return urls;
 }
 
-void MimeData::set_urls(Vector<URL> const& urls)
+ErrorOr<void> MimeData::set_urls(Vector<URL> const& urls)
 {
     StringBuilder builder;
     for (auto& url : urls) {
         builder.append(url.to_deprecated_string());
         builder.append('\n');
     }
-    set_data("text/uri-list", builder.to_byte_buffer());
+    set_data("text/uri-list", TRY(builder.try_to_byte_buffer()));
+
+    return {};
 }
 
 DeprecatedString MimeData::text() const

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -35,8 +35,8 @@ ErrorOr<void> MimeData::set_urls(Vector<URL> const& urls)
 {
     StringBuilder builder;
     for (auto& url : urls) {
-        builder.append(url.to_deprecated_string());
-        builder.append('\n');
+        TRY(builder.try_append(url.to_deprecated_string()));
+        TRY(builder.try_append('\n'));
     }
     set_data("text/uri-list", TRY(builder.try_to_byte_buffer()));
 

--- a/Userland/Libraries/LibCore/MimeData.h
+++ b/Userland/Libraries/LibCore/MimeData.h
@@ -34,7 +34,7 @@ public:
     // Convenience helpers for "text/uri-list"
     bool has_urls() const { return has_format("text/uri-list"); }
     Vector<URL> urls() const;
-    void set_urls(Vector<URL> const&);
+    ErrorOr<void> set_urls(Vector<URL> const&);
 
     HashMap<DeprecatedString, ByteBuffer> const& all_data() const { return m_data; }
 

--- a/Userland/Libraries/LibGL/GLContext.cpp
+++ b/Userland/Libraries/LibGL/GLContext.cpp
@@ -952,7 +952,7 @@ ErrorOr<ByteBuffer> GLContext::build_extension_string()
     TRY(string_builder.try_join(' ', extensions));
 
     // Create null-terminated string
-    auto extensions_bytes = string_builder.to_byte_buffer();
+    auto extensions_bytes = TRY(string_builder.try_to_byte_buffer());
     TRY(extensions_bytes.try_append(0));
     return extensions_bytes;
 }

--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -220,7 +220,7 @@ ErrorOr<void, Client::WrappedError> Client::on_ready_to_read()
             break;
     }
 
-    m_request = HTTP::HttpRequest::from_raw_request(builder.to_byte_buffer());
+    m_request = HTTP::HttpRequest::from_raw_request(TRY(builder.try_to_byte_buffer()));
     if (!m_request.has_value())
         return {};
 
@@ -278,7 +278,7 @@ ErrorOr<void, Client::WrappedError> Client::send_success_response(JsonValue resu
     builder.appendff("Content-Length: {}\r\n", content.length());
     builder.append("\r\n"sv);
 
-    auto builder_contents = builder.to_byte_buffer();
+    auto builder_contents = TRY(builder.try_to_byte_buffer());
     TRY(m_socket->write(builder_contents));
 
     while (!content.is_empty()) {
@@ -319,8 +319,8 @@ ErrorOr<void, Client::WrappedError> Client::send_error_response(Error const& err
     header_builder.appendff("Content-Length: {}\r\n", content_builder.length());
     header_builder.append("\r\n"sv);
 
-    TRY(m_socket->write(header_builder.to_byte_buffer()));
-    TRY(m_socket->write(content_builder.to_byte_buffer()));
+    TRY(m_socket->write(TRY(header_builder.try_to_byte_buffer())));
+    TRY(m_socket->write(TRY(content_builder.try_to_byte_buffer())));
 
     log_response(error.http_status);
     return {};

--- a/Userland/Services/TelnetServer/Client.cpp
+++ b/Userland/Services/TelnetServer/Client.cpp
@@ -182,7 +182,7 @@ ErrorOr<void> Client::send_data(StringView data)
         }
     }
 
-    auto builder_contents = builder.to_byte_buffer();
+    auto builder_contents = TRY(builder.try_to_byte_buffer());
     TRY(m_socket->write(builder_contents));
     return {};
 }

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -191,7 +191,7 @@ ErrorOr<void> Client::send_response(Stream& response, HTTP::HttpRequest const& r
     builder.appendff("Content-Length: {}\r\n", content_info.length);
     builder.append("\r\n"sv);
 
-    auto builder_contents = builder.to_byte_buffer();
+    auto builder_contents = TRY(builder.try_to_byte_buffer());
     TRY(m_socket->write(builder_contents));
     log_response(200, request);
 
@@ -233,7 +233,7 @@ ErrorOr<void> Client::send_redirect(StringView redirect_path, HTTP::HttpRequest 
     builder.append("\r\n"sv);
     builder.append("\r\n"sv);
 
-    auto builder_contents = builder.to_byte_buffer();
+    auto builder_contents = TRY(builder.try_to_byte_buffer());
     TRY(m_socket->write(builder_contents));
 
     log_response(301, request);
@@ -363,8 +363,8 @@ ErrorOr<void> Client::send_error_response(unsigned code, HTTP::HttpRequest const
     header_builder.append("Content-Type: text/html; charset=UTF-8\r\n"sv);
     header_builder.appendff("Content-Length: {}\r\n", content_builder.length());
     header_builder.append("\r\n"sv);
-    TRY(m_socket->write(header_builder.to_byte_buffer()));
-    TRY(m_socket->write(content_builder.to_byte_buffer()));
+    TRY(m_socket->write(TRY(header_builder.try_to_byte_buffer())));
+    TRY(m_socket->write(TRY(content_builder.try_to_byte_buffer())));
 
     log_response(code, request);
     return {};


### PR DESCRIPTION
Introduce a new fallible version of `StringBuilder::to_byte_buffer` and use it where possible without major refactoring.

Places where I've left `StringBuilder::to_byte_buffer` invocations as-is:

- CrashReporter: used in a LibGUI callback: https://github.com/SerenityOS/serenity/blob/5c117cdcec640b2149a98916a4bc1118e6f59c83/Userland/Applications/CrashReporter/main.cpp#L280
- LibGUI `Model.cpp`: https://github.com/SerenityOS/serenity/blob/5c117cdcec640b2149a98916a4bc1118e6f59c83/Userland/Libraries/LibGUI/Model.cpp#L128
- LibGemini GeminiRequest: https://github.com/SerenityOS/serenity/blob/5c117cdcec640b2149a98916a4bc1118e6f59c83/Userland/Libraries/LibGemini/GeminiRequest.cpp#L18
- LibHTTP `HttpRequest.cpp`: https://github.com/SerenityOS/serenity/blob/5c117cdcec640b2149a98916a4bc1118e6f59c83/Userland/Libraries/LibHTTP/HttpRequest.cpp#L75
- LibIMAP `QuotedPrintable.cpp`: https://github.com/SerenityOS/serenity/blob/5c117cdcec640b2149a98916a4bc1118e6f59c83/Userland/Libraries/LibIMAP/QuotedPrintable.cpp#L83