### PR TITLE
Meta+Everywhere: Add a clang plugin to ensure we inherit from RefCounted the right way

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,12 @@ if (NOT HACKSTUDIO_BUILD)
         )
     endif()
 
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")    
+        message("Enabling RefPtr Clang plugin")
+        message(${CMAKE_BINARY_DIR})
+        add_compile_options("-fplugin=${CMAKE_BINARY_DIR}/../lagom/Tools/RefPtrClangPlugin/libRefPtrClangPlugin.so")
+    endif()
+
 endif()
 
 # Meta target to run all code-gen steps in the build.

--- a/Kernel/Arch/x86_64/ISABus/HID/PS2KeyboardDevice.cpp
+++ b/Kernel/Arch/x86_64/ISABus/HID/PS2KeyboardDevice.cpp
@@ -104,7 +104,6 @@ UNMAP_AFTER_INIT ErrorOr<void> PS2KeyboardDevice::initialize()
 // are hot pluggable.
 UNMAP_AFTER_INIT PS2KeyboardDevice::PS2KeyboardDevice(I8042Controller const& ps2_controller)
     : IRQHandler(IRQ_KEYBOARD)
-    , KeyboardDevice()
     , I8042Device(ps2_controller)
 {
 }

--- a/Kernel/Arch/x86_64/ISABus/HID/PS2KeyboardDevice.h
+++ b/Kernel/Arch/x86_64/ISABus/HID/PS2KeyboardDevice.h
@@ -16,8 +16,8 @@
 
 namespace Kernel {
 
-class PS2KeyboardDevice final : public IRQHandler
-    , public KeyboardDevice
+class PS2KeyboardDevice final : public KeyboardDevice
+    , public IRQHandler
     , public I8042Device {
     friend class DeviceManagement;
 

--- a/Kernel/Arch/x86_64/ISABus/HID/PS2MouseDevice.cpp
+++ b/Kernel/Arch/x86_64/ISABus/HID/PS2MouseDevice.cpp
@@ -19,7 +19,6 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT PS2MouseDevice::PS2MouseDevice(I8042Controller const& ps2_controller)
     : IRQHandler(IRQ_MOUSE)
-    , MouseDevice()
     , I8042Device(ps2_controller)
 {
 }

--- a/Kernel/Arch/x86_64/ISABus/HID/PS2MouseDevice.h
+++ b/Kernel/Arch/x86_64/ISABus/HID/PS2MouseDevice.h
@@ -14,8 +14,8 @@
 #include <Kernel/Random.h>
 
 namespace Kernel {
-class PS2MouseDevice : public IRQHandler
-    , public MouseDevice
+class PS2MouseDevice : public MouseDevice
+    , public IRQHandler
     , public I8042Device {
     friend class DeviceManagement;
 

--- a/Kernel/Bus/VirtIO/Console.h
+++ b/Kernel/Bus/VirtIO/Console.h
@@ -13,8 +13,8 @@
 
 namespace Kernel::VirtIO {
 class Console
-    : public VirtIO::Device
-    , public AtomicRefCounted<Console> {
+    : public AtomicRefCounted<Console>
+    , public VirtIO::Device {
     friend VirtIO::ConsolePort;
 
 public:

--- a/Kernel/Storage/NVMe/NVMeController.cpp
+++ b/Kernel/Storage/NVMe/NVMeController.cpp
@@ -27,8 +27,8 @@ UNMAP_AFTER_INIT ErrorOr<NonnullLockRefPtr<NVMeController>> NVMeController::try_
 }
 
 UNMAP_AFTER_INIT NVMeController::NVMeController(const PCI::DeviceIdentifier& device_identifier, u32 hardware_relative_controller_id)
-    : PCI::Device(const_cast<PCI::DeviceIdentifier&>(device_identifier))
-    , StorageController(hardware_relative_controller_id)
+    : StorageController(hardware_relative_controller_id)
+    , PCI::Device(const_cast<PCI::DeviceIdentifier&>(device_identifier))
 {
 }
 

--- a/Kernel/Storage/NVMe/NVMeController.h
+++ b/Kernel/Storage/NVMe/NVMeController.h
@@ -22,8 +22,8 @@
 
 namespace Kernel {
 
-class NVMeController : public PCI::Device
-    , public StorageController {
+class NVMeController : public StorageController
+    , public PCI::Device {
 public:
     static ErrorOr<NonnullLockRefPtr<NVMeController>> try_initialize(PCI::DeviceIdentifier const&, bool is_queue_polled);
     ErrorOr<void> initialize(bool is_queue_polled);

--- a/Meta/Lagom/Tools/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CMakeLists.txt
@@ -14,6 +14,8 @@ endfunction()
 add_subdirectory(CodeGenerators)
 add_subdirectory(ConfigureComponents)
 add_subdirectory(IPCMagicLinter)
+add_subdirectory(RefPtrClangPlugin)
+
 
 if (ENABLE_JAKT)
     include(jakt)

--- a/Meta/Lagom/Tools/RefPtrClangPlugin/CMakeLists.txt
+++ b/Meta/Lagom/Tools/RefPtrClangPlugin/CMakeLists.txt
@@ -1,0 +1,18 @@
+if (EXISTS "${CMAKE_BINARY_DIR}/../../Toolchain/Local/clang")
+    find_package(Clang CONFIG REQUIRED HINTS "${CMAKE_BINARY_DIR}/../../Toolchain/Local/clang")
+
+    add_library(RefPtrClangPlugin main.cpp)
+    add_library(Lagom::RefPtrClangPlugin ALIAS RefPtrClangPlugin)
+
+    target_include_directories(RefPtrClangPlugin SYSTEM PRIVATE ${CLANG_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS})
+    target_compile_features(RefPtrClangPlugin PRIVATE cxx_std_20)
+    target_link_libraries(RefPtrClangPlugin PRIVATE clangTooling)
+
+    target_compile_options(RefPtrClangPlugin PRIVATE
+        -Wall
+        -Wextra
+        -Werror
+        -Wno-unused
+        -fno-rtti
+    )
+endif()

--- a/Meta/Lagom/Tools/RefPtrClangPlugin/main.cpp
+++ b/Meta/Lagom/Tools/RefPtrClangPlugin/main.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2023, Leon Albrecht <leon.a@serenityos.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <clang/AST/ASTConsumer.h>
+#include <clang/AST/DeclCXX.h>
+#include <clang/AST/DeclTemplate.h>
+#include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/Basic/DiagnosticFrontend.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <clang/Frontend/FrontendAction.h>
+#include <clang/Frontend/FrontendPluginRegistry.h>
+#include <clang/Tooling/Tooling.h>
+
+#include <AK/CharacterTypes.h>
+
+bool type_inherits_from_refcounted(clang::QualType const& type)
+{
+    if (auto const* template_type = type->getAs<clang::TemplateSpecializationType>()) {
+        if (auto const* class_decl = template_type->getAsCXXRecordDecl()) {
+            auto bases = class_decl->bases();
+            for (auto const& base : bases) {
+                if (type_inherits_from_refcounted(base.getType()))
+                    return true;
+            }
+        }
+    } else if (auto const* decl = type->getAsCXXRecordDecl()) {
+        if (decl->getDeclName().getAsString() == "RefCountedBase")
+            return true;
+        if (decl->getDeclName().getAsString() == "AtomicRefCountedBase")
+            return true;
+
+        for (auto const& base : decl->bases()) {
+            if (type_inherits_from_refcounted(base.getType()))
+                return true;
+        }
+    }
+    return false;
+}
+
+class FindRefPtrClassVisitor
+    : public clang::RecursiveASTVisitor<FindRefPtrClassVisitor> {
+public:
+    explicit FindRefPtrClassVisitor(clang::ASTContext* Context)
+        : Context(Context)
+    {
+    }
+
+    bool VisitCXXRecordDecl(clang::CXXRecordDecl const* Declaration)
+    {
+        // FIXME: This does not seem to work with clangd
+        if (!Declaration->getDefinition())
+            return true;
+        if (Declaration->getNumBases() == 0)
+            return true;
+
+        // Only check serenity Types, which are always TitleCase
+        // Also ignore anonymous declarations
+        if (Declaration->getName().empty() || !AK::is_ascii_upper_alpha(Declaration->getName().front()))
+            return true;
+
+        auto bases = Declaration->bases();
+
+        int index = 0;
+        for (auto const& base : bases) {
+            if (type_inherits_from_refcounted(base.getType())) {
+                if (index != 0) {
+                    std::string err = Declaration->getNameAsString();
+                    err.append(" inherits from [Atomic]RefCountedBase, but [Atomic]RefCountedBase is not the first inherited class, inherited through: '");
+                    err.append(base.getType().getAsString());
+                    err.append("'.");
+                    Context->getDiagnostics().Report(base.getBeginLoc(), clang::diag::warn_fe_backend_plugin) << err;
+                    return false;
+                }
+            }
+            index++;
+        }
+        return true;
+    }
+
+private:
+    clang::ASTContext* Context;
+};
+
+class FindNamedClassConsumer : public clang::ASTConsumer {
+public:
+    explicit FindNamedClassConsumer(clang::ASTContext* Context)
+        : Visitor(Context)
+    {
+    }
+
+    virtual void HandleTranslationUnit(clang::ASTContext& Context)
+    {
+        Visitor.TraverseDecl(Context.getTranslationUnitDecl());
+    }
+
+private:
+    FindRefPtrClassVisitor Visitor;
+};
+
+class CheckRefPtrs : public clang::PluginASTAction {
+public:
+    virtual std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance& Compiler, llvm::StringRef InFile) override
+    {
+        (void)InFile;
+        return std::make_unique<FindNamedClassConsumer>(&Compiler.getASTContext());
+    }
+
+    virtual bool ParseArgs(clang::CompilerInstance const&, std::vector<std::string> const&) override
+    {
+        return true;
+    };
+    PluginASTAction::ActionType getActionType() override
+    {
+        return AddBeforeMainAction;
+    }
+};
+
+static clang::FrontendPluginRegistry::Add<CheckRefPtrs> X("Check RefPtrs", "Check if RefPtr inheritance is done in the correct order");

--- a/Tests/AK/TestWeakPtr.cpp
+++ b/Tests/AK/TestWeakPtr.cpp
@@ -15,8 +15,8 @@
 #    pragma clang diagnostic ignored "-Wunused-private-field"
 #endif
 
-class SimpleWeakable : public Weakable<SimpleWeakable>
-    , public RefCounted<SimpleWeakable> {
+class SimpleWeakable : public RefCounted<SimpleWeakable>
+    , public Weakable<SimpleWeakable> {
 public:
     SimpleWeakable() = default;
 

--- a/Userland/Libraries/LibCore/FileWatcher.h
+++ b/Userland/Libraries/LibCore/FileWatcher.h
@@ -69,8 +69,8 @@ public:
     Optional<FileWatcherEvent> wait_for_event();
 };
 
-class FileWatcher : public FileWatcherBase
-    , public RefCounted<FileWatcher> {
+class FileWatcher : public RefCounted<FileWatcher>
+    , public FileWatcherBase {
     AK_MAKE_NONCOPYABLE(FileWatcher);
 
 public:

--- a/Userland/Libraries/LibSQL/TupleDescriptor.h
+++ b/Userland/Libraries/LibSQL/TupleDescriptor.h
@@ -45,9 +45,8 @@ struct TupleElementDescriptor {
     }
 };
 
-class TupleDescriptor
-    : public Vector<TupleElementDescriptor>
-    , public RefCounted<TupleDescriptor> {
+class TupleDescriptor : public RefCounted<TupleDescriptor>
+    , public Vector<TupleElementDescriptor> {
 public:
     TupleDescriptor() = default;
     ~TupleDescriptor() = default;

--- a/Userland/Libraries/LibWeb/HTML/WorkerDebugConsoleClient.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerDebugConsoleClient.h
@@ -15,9 +15,9 @@ namespace Web::HTML {
 // NOTE: Temporary class to handle console messages from inside Workers
 
 class WorkerDebugConsoleClient final
-    : public JS::ConsoleClient
-    , public RefCounted<WorkerDebugConsoleClient>
-    , public Weakable<WorkerDebugConsoleClient> {
+    : public RefCounted<WorkerDebugConsoleClient>
+    , public Weakable<WorkerDebugConsoleClient>
+    , public JS::ConsoleClient {
 public:
     WorkerDebugConsoleClient(JS::Console& console);
 


### PR DESCRIPTION
An alternative implementation to #17697, with fully static checking

SC7 you are listed as co author, because I stole your idea and half of the commit messages