### PR TITLE
LibGUI+SpaceAnalyzer: Improve shortcut invocation for non-visible actions

### DIFF
--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -132,7 +132,7 @@ Action::~Action()
 
 void Action::process_event(Window& window, Event& event)
 {
-    if (is_enabled()) {
+    if (is_enabled() && is_visible()) {
         flash_menubar_menu(window);
         activate();
         event.accept();


### PR DESCRIPTION
This PR fixes two seperate but related issues around the handling of shortcuts for non-visible actions.

1. Non-visible shortcuts are no longer invokable - this fixes an issue in PixelPaint, where the "Add Mask" action could be invoked with its shortcut key when non-visible.
2. Multiple globally scoped actions can be registered which share the same shortcut. This fixes an issue in SpaceAnalyzer, where the wrong action was invoked when using the Open In File Manager shortcut, while a directory was selected.