### PR TITLE
Kernel/VirtIO: Ignore Configurations that have length of zero bytes

### DIFF
--- a/Kernel/Bus/VirtIO/Device.cpp
+++ b/Kernel/Bus/VirtIO/Device.cpp
@@ -113,6 +113,9 @@ UNMAP_AFTER_INIT void Device::initialize()
             }
             config.offset = capability.read32(0x8);
             config.length = capability.read32(0xc);
+            // NOTE: Configuration length of zero is an invalid configuration that should be ignored.
+            if (config.length == 0)
+                continue;
             dbgln_if(VIRTIO_DEBUG, "{}: Found configuration {}, bar: {}, offset: {}, length: {}", m_class_name, (u32)config.cfg_type, config.bar, config.offset, config.length);
             if (config.cfg_type == ConfigurationType::Common)
                 m_use_mmio = true;


### PR DESCRIPTION
These configurations are simply invalid. Ignoring those allow us to boot with the virtio-gpu-pci device (in addition to the already supported virtio-vga PCI device).

Partially fixes #17613. We still need to ensure that on macOS we choose virtio-gpu-pci over virtio-vga somehow :)