### PR TITLE
LibSyntax: Add a CMakeCache.txt syntax highlighter

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -10,6 +10,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/URL.h>
 #include <Applications/TextEditor/TextEditorWindowGML.h>
+#include <LibCMake/CMakeCache/SyntaxHighlighter.h>
 #include <LibCMake/SyntaxHighlighter.h>
 #include <LibConfig/Client.h>
 #include <LibCore/Debounce.h>
@@ -623,6 +624,13 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     syntax_actions.add_action(*m_cmake_highlight);
     syntax_menu.add_action(*m_cmake_highlight);
 
+    m_cmakecache_highlight = GUI::Action::create_checkable("CM&akeCache", [&](auto&) {
+        m_editor->set_syntax_highlighter(make<CMake::Cache::SyntaxHighlighter>());
+        m_editor->update();
+    });
+    syntax_actions.add_action(*m_cmakecache_highlight);
+    syntax_menu.add_action(*m_cmakecache_highlight);
+
     m_js_highlight = GUI::Action::create_checkable("&JavaScript", [&](auto&) {
         m_editor->set_syntax_highlighter(make<JS::SyntaxHighlighter>());
         m_editor->update();
@@ -704,6 +712,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     m_syntax_statusbar_menu->add_action(*m_plain_text_highlight);
     m_syntax_statusbar_menu->add_action(*m_cpp_highlight);
     m_syntax_statusbar_menu->add_action(*m_cmake_highlight);
+    m_syntax_statusbar_menu->add_action(*m_cmakecache_highlight);
     m_syntax_statusbar_menu->add_action(*m_css_highlight);
     m_syntax_statusbar_menu->add_action(*m_git_highlight);
     m_syntax_statusbar_menu->add_action(*m_gml_highlight);
@@ -732,6 +741,8 @@ void MainWidget::set_path(StringView path)
         m_cpp_highlight->activate();
     } else if (m_extension == "cmake" || (m_extension == "txt" && m_name == "CMakeLists")) {
         m_cmake_highlight->activate();
+    } else if (m_extension == "txt" && m_name == "CMakeCache") {
+        m_cmakecache_highlight->activate();
     } else if (m_extension == "js" || m_extension == "mjs" || m_extension == "json") {
         m_js_highlight->activate();
     } else if (m_name == "COMMIT_EDITMSG") {

--- a/Userland/Applications/TextEditor/MainWidget.h
+++ b/Userland/Applications/TextEditor/MainWidget.h
@@ -128,6 +128,7 @@ private:
     GUI::ActionGroup syntax_actions;
     RefPtr<GUI::Action> m_plain_text_highlight;
     RefPtr<GUI::Action> m_cmake_highlight;
+    RefPtr<GUI::Action> m_cmakecache_highlight;
     RefPtr<GUI::Action> m_cpp_highlight;
     RefPtr<GUI::Action> m_css_highlight;
     RefPtr<GUI::Action> m_js_highlight;

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -14,6 +14,7 @@
 #include <AK/Debug.h>
 #include <AK/JsonParser.h>
 #include <AK/LexicalPath.h>
+#include <LibCMake/CMakeCache/SyntaxHighlighter.h>
 #include <LibCMake/SyntaxHighlighter.h>
 #include <LibConfig/Client.h>
 #include <LibCore/DeprecatedFile.h>
@@ -640,6 +641,9 @@ void Editor::set_syntax_highlighter_for(CodeDocument const& document)
         break;
     case Language::CMake:
         set_syntax_highlighter(make<CMake::SyntaxHighlighter>());
+        break;
+    case Language::CMakeCache:
+        set_syntax_highlighter(make<CMake::Cache::SyntaxHighlighter>());
         break;
     case Language::CSS:
         set_syntax_highlighter(make<Web::CSS::SyntaxHighlighter>());

--- a/Userland/DevTools/HackStudio/Language.cpp
+++ b/Userland/DevTools/HackStudio/Language.cpp
@@ -20,6 +20,8 @@ Language language_from_file(LexicalPath const& file)
         return Language::Cpp;
     if (extension == "cmake" || (extension == "txt" && file.title() == "CMakeLists"))
         return Language::CMake;
+    if (extension == "txt" && file.title() == "CMakeCache")
+        return Language::CMakeCache;
     if (extension == "js" || extension == "mjs" || extension == "json")
         return Language::JavaScript;
     if (extension == "html" || extension == "htm")
@@ -64,6 +66,8 @@ DeprecatedString language_name_from_file(LexicalPath const& file)
         return "C++";
     if (extension == "cmake" || (extension == "txt" && file.title() == "CMakeLists"))
         return "CMake";
+    if (extension == "txt" && file.title() == "CMakeCache")
+        return "CMakeCache";
     if (extension == "js" || extension == "mjs" || extension == "json")
         return "JavaScript";
     if (extension == "gml")

--- a/Userland/DevTools/HackStudio/Language.h
+++ b/Userland/DevTools/HackStudio/Language.h
@@ -13,6 +13,7 @@ namespace HackStudio {
 enum class Language {
     Unknown,
     CMake,
+    CMakeCache,
     Cpp,
     CSS,
     JavaScript,

--- a/Userland/Libraries/LibCMake/CMakeCache/Lexer.cpp
+++ b/Userland/Libraries/LibCMake/CMakeCache/Lexer.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Lexer.h"
+#include <AK/CharacterTypes.h>
+#include <AK/Debug.h>
+#include <AK/ScopeLogger.h>
+
+namespace CMake::Cache {
+
+static bool is_identifier_start_character(u32 c)
+{
+    return AK::is_ascii_alpha(c) || c == '_' || c == '-';
+}
+
+static bool is_identifier_character(u32 c)
+{
+    return AK::is_ascii_alphanumeric(c) || c == '_' || c == '-';
+}
+
+Lexer::Lexer(StringView input)
+    : GenericLexer(input)
+{
+}
+
+ErrorOr<Vector<Token>> Lexer::lex(StringView input)
+{
+    Lexer lexer { input };
+    return lexer.lex_file();
+}
+
+ErrorOr<Vector<Token>> Lexer::lex_file()
+{
+    ScopeLogger<CMAKE_DEBUG> logger;
+
+    while (!is_eof()) {
+        skip_whitespace();
+
+        if (is_eof())
+            break;
+
+        if (next_is('#')) {
+            consume_comment();
+            continue;
+        }
+
+        if (next_is("//"sv)) {
+            consume_help_text();
+            continue;
+        }
+
+        if (next_is(is_identifier_start_character)) {
+            consume_variable_definition();
+            continue;
+        }
+
+        consume_garbage();
+    }
+
+    return m_tokens;
+}
+
+void Lexer::skip_whitespace()
+{
+    ScopeLogger<CMAKE_DEBUG> log;
+
+    while (!is_eof()) {
+        if (next_is('\n')) {
+            next_line();
+            continue;
+        }
+        auto consumed = consume_while(AK::is_ascii_space);
+        if (consumed.is_empty())
+            break;
+    }
+}
+
+void Lexer::consume_comment()
+{
+    ScopeLogger<CMAKE_DEBUG> log;
+
+    auto start = position();
+    VERIFY(consume_specific('#'));
+    auto comment = consume_until('\n');
+    emit_token(Token::Type::Comment, comment, start, position());
+}
+
+void Lexer::consume_help_text()
+{
+    ScopeLogger<CMAKE_DEBUG> log;
+
+    auto start = position();
+    VERIFY(consume_specific("//"sv));
+    auto help_text = consume_until('\n');
+    emit_token(Token::Type::HelpText, help_text, start, position());
+}
+
+void Lexer::consume_variable_definition()
+{
+    ScopeLogger<CMAKE_DEBUG> log;
+
+    consume_key();
+
+    if (!next_is(':')) {
+        consume_garbage();
+        return;
+    }
+    consume_colon();
+
+    if (!next_is(is_identifier_start_character)) {
+        consume_garbage();
+        return;
+    }
+    consume_type();
+
+    if (!next_is('=')) {
+        consume_garbage();
+        return;
+    }
+    consume_equals();
+
+    consume_value();
+}
+
+void Lexer::consume_key()
+{
+    ScopeLogger<CMAKE_DEBUG> log;
+
+    auto start = position();
+    auto key = consume_while(is_identifier_character);
+    emit_token(Token::Type::Key, key, start, position());
+}
+
+void Lexer::consume_colon()
+{
+    ScopeLogger<CMAKE_DEBUG> log;
+
+    auto start = position();
+    VERIFY(consume_specific(':'));
+    emit_token(Token::Type::Colon, ":"sv, start, position());
+}
+
+void Lexer::consume_type()
+{
+    ScopeLogger<CMAKE_DEBUG> log;
+
+    auto start = position();
+    auto type = consume_while(is_identifier_character);
+    emit_token(Token::Type::Type, type, start, position());
+}
+
+void Lexer::consume_equals()
+{
+    ScopeLogger<CMAKE_DEBUG> log;
+
+    auto start = position();
+    VERIFY(consume_specific('='));
+    emit_token(Token::Type::Colon, "="sv, start, position());
+}
+
+void Lexer::consume_value()
+{
+    ScopeLogger<CMAKE_DEBUG> log;
+
+    auto start = position();
+    auto value = consume_until('\n');
+    emit_token(Token::Type::Value, value, start, position());
+}
+
+void Lexer::consume_garbage()
+{
+    ScopeLogger<CMAKE_DEBUG> log;
+
+    auto start = position();
+    auto garbage = consume_until('\n');
+    emit_token(Token::Type::Garbage, garbage, start, position());
+}
+
+Position Lexer::position() const
+{
+    return Position {
+        .line = m_line,
+        .column = tell() - m_string_offset_after_previous_newline,
+    };
+}
+
+void Lexer::next_line()
+{
+    VERIFY(consume_specific('\n'));
+    m_string_offset_after_previous_newline = tell();
+    m_line++;
+}
+
+void Lexer::emit_token(Token::Type type, StringView value, Position start, Position end)
+{
+    dbgln_if(CMAKE_DEBUG, "Emitting {} token: `{}` ({}:{} to {}:{})", to_string(type), value, start.line, start.column, end.line, end.column);
+    m_tokens.empend(type, value, start, end);
+}
+
+}

--- a/Userland/Libraries/LibCMake/CMakeCache/Lexer.h
+++ b/Userland/Libraries/LibCMake/CMakeCache/Lexer.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/GenericLexer.h>
+#include <AK/Vector.h>
+#include <LibCMake/CMakeCache/Token.h>
+
+namespace CMake::Cache {
+
+class Lexer : private GenericLexer {
+public:
+    static ErrorOr<Vector<Token>> lex(StringView input);
+
+private:
+    Lexer(StringView input);
+
+    ErrorOr<Vector<Token>> lex_file();
+
+    void skip_whitespace();
+
+    void consume_comment();
+    void consume_help_text();
+    void consume_variable_definition();
+    void consume_key();
+    void consume_colon();
+    void consume_type();
+    void consume_equals();
+    void consume_value();
+    void consume_garbage();
+
+    Position position() const;
+    void next_line();
+
+    void emit_token(Token::Type, StringView value, Position start, Position end);
+
+    Vector<Token> m_tokens;
+    size_t m_line { 0 };
+    size_t m_string_offset_after_previous_newline { 0 };
+};
+
+}

--- a/Userland/Libraries/LibCMake/CMakeCache/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibCMake/CMakeCache/SyntaxHighlighter.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "SyntaxHighlighter.h"
+#include <LibCMake/CMakeCache/Lexer.h>
+
+namespace CMake::Cache {
+
+static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, Token::Type type)
+{
+    switch (type) {
+    case Token::Type::Comment:
+    case Token::Type::HelpText:
+        return { palette.syntax_comment() };
+    case Token::Type::Key:
+        return { palette.syntax_identifier() };
+    case Token::Type::Type:
+        return { palette.syntax_type() };
+    case Token::Type::Colon:
+    case Token::Type::Equals:
+        return { palette.syntax_punctuation() };
+    case Token::Type::Value:
+        return { palette.syntax_string() };
+    case Token::Type::Garbage:
+        return { palette.red() };
+    default:
+        return { palette.base_text() };
+    }
+}
+
+bool SyntaxHighlighter::is_identifier(u64 token_type) const
+{
+    auto cmake_token = static_cast<Token::Type>(token_type);
+    return cmake_token == Token::Type::Key;
+}
+
+void SyntaxHighlighter::rehighlight(Gfx::Palette const& palette)
+{
+    auto text = m_client->get_text();
+    auto tokens = Lexer::lex(text).release_value_but_fixme_should_propagate_errors();
+
+    Vector<GUI::TextDocumentSpan> spans;
+    auto highlight_span = [&](Token::Type type, Position const& start, Position const& end) {
+        GUI::TextDocumentSpan span;
+        span.range.set_start({ start.line, start.column });
+        span.range.set_end({ end.line, end.column });
+        if (!span.range.is_valid())
+            return;
+
+        auto style = style_for_token_type(palette, type);
+        span.attributes.color = style.color;
+        span.attributes.bold = style.bold;
+        if (type == Token::Type::Garbage) {
+            span.attributes.underline = true;
+            span.attributes.underline_color = palette.red();
+            span.attributes.underline_style = Gfx::TextAttributes::UnderlineStyle::Wavy;
+        }
+        span.is_skippable = false;
+        span.data = static_cast<u64>(type);
+        spans.append(move(span));
+    };
+
+    for (auto const& token : tokens) {
+        highlight_span(token.type, token.start, token.end);
+    }
+
+    m_client->do_set_spans(move(spans));
+
+    m_has_brace_buddies = false;
+    highlight_matching_token_pair();
+
+    m_client->do_update();
+}
+
+Vector<SyntaxHighlighter::MatchingTokenPair> SyntaxHighlighter::matching_token_pairs_impl() const
+{
+    static Vector<MatchingTokenPair> empty;
+    return empty;
+}
+
+bool SyntaxHighlighter::token_types_equal(u64 token1, u64 token2) const
+{
+    return static_cast<Token::Type>(token1) == static_cast<Token::Type>(token2);
+}
+
+}

--- a/Userland/Libraries/LibCMake/CMakeCache/SyntaxHighlighter.h
+++ b/Userland/Libraries/LibCMake/CMakeCache/SyntaxHighlighter.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibSyntax/Highlighter.h>
+
+namespace CMake::Cache {
+
+class SyntaxHighlighter final : public Syntax::Highlighter {
+public:
+    SyntaxHighlighter() = default;
+    virtual ~SyntaxHighlighter() override = default;
+
+    virtual bool is_identifier(u64) const override;
+
+    virtual Syntax::Language language() const override { return Syntax::Language::CMakeCache; }
+    virtual Optional<StringView> comment_prefix() const override { return "#"sv; }
+    virtual Optional<StringView> comment_suffix() const override { return {}; }
+    virtual void rehighlight(Palette const&) override;
+
+protected:
+    virtual Vector<MatchingTokenPair> matching_token_pairs_impl() const override;
+    virtual bool token_types_equal(u64, u64) const override;
+};
+
+}

--- a/Userland/Libraries/LibCMake/CMakeCache/Token.h
+++ b/Userland/Libraries/LibCMake/CMakeCache/Token.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCMake/Position.h>
+
+namespace CMake::Cache {
+
+struct Token {
+    enum class Type {
+        Comment,
+        HelpText,
+        Key,
+        Colon,
+        Type,
+        Equals,
+        Value,
+        Garbage,
+    };
+    Type type;
+    StringView value;
+
+    Position start;
+    Position end;
+};
+
+static constexpr StringView to_string(Token::Type type)
+{
+    switch (type) {
+    case Token::Type::Comment:
+        return "Comment"sv;
+    case Token::Type::HelpText:
+        return "HelpText"sv;
+    case Token::Type::Key:
+        return "Key"sv;
+    case Token::Type::Colon:
+        return "Colon"sv;
+    case Token::Type::Type:
+        return "Type"sv;
+    case Token::Type::Equals:
+        return "Equals"sv;
+    case Token::Type::Value:
+        return "Value"sv;
+    case Token::Type::Garbage:
+        return "Garbage"sv;
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
+}

--- a/Userland/Libraries/LibCMake/CMakeLists.txt
+++ b/Userland/Libraries/LibCMake/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    CMakeCache/Lexer.cpp
     Lexer.cpp
     SyntaxHighlighter.cpp
     Token.cpp

--- a/Userland/Libraries/LibCMake/CMakeLists.txt
+++ b/Userland/Libraries/LibCMake/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     CMakeCache/Lexer.cpp
+    CMakeCache/SyntaxHighlighter.cpp
     Lexer.cpp
     SyntaxHighlighter.cpp
     Token.cpp

--- a/Userland/Libraries/LibCMake/Position.h
+++ b/Userland/Libraries/LibCMake/Position.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace CMake {
+
+struct Position {
+    size_t line { 0 };
+    size_t column { 0 };
+};
+
+}

--- a/Userland/Libraries/LibCMake/Token.h
+++ b/Userland/Libraries/LibCMake/Token.h
@@ -8,13 +8,9 @@
 
 #include <AK/StringView.h>
 #include <AK/Vector.h>
+#include <LibCMake/Position.h>
 
 namespace CMake {
-
-struct Position {
-    size_t line { 0 };
-    size_t column { 0 };
-};
 
 struct VariableReference {
     StringView value;

--- a/Userland/Libraries/LibSyntax/Highlighter.cpp
+++ b/Userland/Libraries/LibSyntax/Highlighter.cpp
@@ -143,6 +143,8 @@ StringView language_to_string(Language language)
     switch (language) {
     case Language::CMake:
         return "CMake"sv;
+    case Language::CMakeCache:
+        return "CMakeCache"sv;
     case Language::Cpp:
         return "C++"sv;
     case Language::CSS:
@@ -172,6 +174,8 @@ StringView common_language_extension(Language language)
     switch (language) {
     case Language::CMake:
         return "cmake"sv;
+    case Language::CMakeCache:
+        return {};
     case Language::Cpp:
         return "cpp"sv;
     case Language::CSS:

--- a/Userland/Libraries/LibSyntax/Highlighter.h
+++ b/Userland/Libraries/LibSyntax/Highlighter.h
@@ -16,6 +16,7 @@ namespace Syntax {
 
 enum class Language {
     CMake,
+    CMakeCache,
     Cpp,
     CSS,
     GitCommit,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/222642/223550338-2c8710b9-e06a-42b1-9d31-51dae59bdb6c.png)

CMakeCache.txt has its own special syntax, that's unrelated to regular CMake syntax. But it's nice and simple, so that's fine. :^)

As for the bonus first commit: I'm not 100% convinced on combining the various `struct Position {}`s together. The duplication has been bothering me for a while but it doesn't actually make much difference.