### PR TITLE
Applets/Keymap: Repaint applet on keymap change

### DIFF
--- a/Userland/Applets/Keymap/KeymapStatusWidget.cpp
+++ b/Userland/Applets/Keymap/KeymapStatusWidget.cpp
@@ -67,6 +67,7 @@ void KeymapStatusWidget::set_current_keymap(DeprecatedString const& keymap)
 {
     m_current_keymap = keymap;
     set_tooltip(keymap);
+    update();
 }
 
 void KeymapStatusWidget::paint_event(GUI::PaintEvent& event)


### PR DESCRIPTION
The applet wasn't redrawn after a keymap change, keeping its old value.

This fixes a regression from 5979ce83.

