### PR TITLE
LibWeb+AK: Make CSS selector matching faster in two ways

### DIFF
--- a/AK/FlyString.cpp
+++ b/AK/FlyString.cpp
@@ -178,4 +178,12 @@ ErrorOr<void> Formatter<FlyString>::format(FormatBuilder& builder, FlyString con
     return Formatter<StringView>::format(builder, fly_string.bytes_as_string_view());
 }
 
+bool FlyString::equals_ignoring_ascii_case(FlyString const& other) const
+{
+    if (*this == other)
+        return true;
+    // FIXME: Rename StringUtils::equals_ignoring_case to equals_ignoring_ascii_case.
+    return StringUtils::equals_ignoring_case(bytes_as_string_view(), other.bytes_as_string_view());
+}
+
 }

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -54,6 +54,9 @@ public:
     // FIXME: Remove this once all code has been ported to FlyString
     [[nodiscard]] DeprecatedFlyString to_deprecated_fly_string() const;
 
+    // Compare this FlyString against another string with ASCII caseless matching.
+    [[nodiscard]] bool equals_ignoring_ascii_case(FlyString const&) const;
+
 private:
     // This will hold either the pointer to the Detail::StringData it represents or the raw bytes of
     // an inlined short string.

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -354,7 +354,7 @@ static inline bool matches(CSS::Selector::SimpleSelector const& component, DOM::
     case CSS::Selector::SimpleSelector::Type::Id:
         return component.name() == element.attribute(HTML::AttributeNames::id).view();
     case CSS::Selector::SimpleSelector::Type::Class:
-        return element.has_class(component.name().bytes_as_string_view());
+        return element.has_class(component.name());
     case CSS::Selector::SimpleSelector::Type::TagName:
         // See https://html.spec.whatwg.org/multipage/semantics-other.html#case-sensitivity-of-selectors
         if (element.document().document_type() == DOM::Document::Type::HTML)

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -114,7 +114,13 @@ private:
         HashMap<Selector::PseudoElement, Vector<MatchingRule>> rules_by_pseudo_element;
         Vector<MatchingRule> other_rules;
     };
-    OwnPtr<RuleCache> m_rule_cache;
+
+    NonnullOwnPtr<RuleCache> make_rule_cache_for_cascade_origin(CascadeOrigin);
+
+    RuleCache const& rule_cache_for_cascade_origin(CascadeOrigin) const;
+
+    OwnPtr<RuleCache> m_author_rule_cache;
+    OwnPtr<RuleCache> m_user_agent_rule_cache;
 
     class FontLoader;
     HashMap<String, NonnullOwnPtr<FontLoader>> m_loaded_fonts;

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1033,9 +1033,9 @@ JS::NonnullGCPtr<HTMLCollection> Document::get_elements_by_name(DeprecatedString
 
 JS::NonnullGCPtr<HTMLCollection> Document::get_elements_by_class_name(DeprecatedFlyString const& class_names)
 {
-    Vector<DeprecatedFlyString> list_of_class_names;
+    Vector<FlyString> list_of_class_names;
     for (auto& name : class_names.view().split_view(' ')) {
-        list_of_class_names.append(name);
+        list_of_class_names.append(FlyString::from_utf8(name).release_value_but_fixme_should_propagate_errors());
     }
     return HTMLCollection::create(*this, [list_of_class_names = move(list_of_class_names), quirks_mode = document().in_quirks_mode()](Element const& element) {
         for (auto& name : list_of_class_names) {

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -271,7 +271,7 @@ Vector<DeprecatedString> Element::get_attribute_names() const
     return names;
 }
 
-bool Element::has_class(DeprecatedFlyString const& class_name, CaseSensitivity case_sensitivity) const
+bool Element::has_class(FlyString const& class_name, CaseSensitivity case_sensitivity) const
 {
     if (case_sensitivity == CaseSensitivity::CaseSensitive) {
         return any_of(m_classes, [&](auto& it) {
@@ -279,7 +279,7 @@ bool Element::has_class(DeprecatedFlyString const& class_name, CaseSensitivity c
         });
     } else {
         return any_of(m_classes, [&](auto& it) {
-            return it.equals_ignoring_case(class_name);
+            return it.equals_ignoring_ascii_case(class_name);
         });
     }
 }
@@ -347,7 +347,7 @@ void Element::parse_attribute(DeprecatedFlyString const& name, DeprecatedString 
         m_classes.clear();
         m_classes.ensure_capacity(new_classes.size());
         for (auto& new_class : new_classes) {
-            m_classes.unchecked_append(new_class);
+            m_classes.unchecked_append(FlyString::from_utf8(new_class).release_value_but_fixme_should_propagate_errors());
         }
         if (m_class_list)
             m_class_list->associated_attribute_changed(value);
@@ -580,9 +580,9 @@ bool Element::is_active() const
 
 JS::NonnullGCPtr<HTMLCollection> Element::get_elements_by_class_name(DeprecatedFlyString const& class_names)
 {
-    Vector<DeprecatedFlyString> list_of_class_names;
+    Vector<FlyString> list_of_class_names;
     for (auto& name : class_names.view().split_view_if(Infra::is_ascii_whitespace)) {
-        list_of_class_names.append(name);
+        list_of_class_names.append(FlyString::from_utf8(name).release_value_but_fixme_should_propagate_errors());
     }
     return HTMLCollection::create(*this, [list_of_class_names = move(list_of_class_names), quirks_mode = document().in_quirks_mode()](Element const& element) {
         for (auto& name : list_of_class_names) {

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -104,8 +104,8 @@ public:
         }
     }
 
-    bool has_class(DeprecatedFlyString const&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
-    Vector<DeprecatedFlyString> const& class_names() const { return m_classes; }
+    bool has_class(FlyString const&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
+    Vector<FlyString> const& class_names() const { return m_classes; }
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const { }
     virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value);
@@ -287,7 +287,7 @@ private:
     RefPtr<CSS::StyleProperties> m_computed_css_values;
     HashMap<DeprecatedFlyString, CSS::StyleProperty> m_custom_properties;
 
-    Vector<DeprecatedFlyString> m_classes;
+    Vector<FlyString> m_classes;
 
     Array<JS::GCPtr<Layout::Node>, to_underlying(CSS::Selector::PseudoElement::PseudoElementCount)> m_pseudo_element_nodes;
 };


### PR DESCRIPTION
Two optimizations:
- Make `DOM::Element` store its class names as `FlyString` so it matches the way `CSS::Selector` stores them. That allows selector matching to compare them in O(1) time. (Before this, we were actually doing implicit `DeprecatedFlyString` construction *every time* in the selector matcher 😅)
- Make `StyleComputer` create a rule cache for the built-in UA style sheet as well. This reduces the number of selectors we have to run for each element (and pseudo-element).