### PR TITLE
AK: Make `String::{starts,ends}_with(code_point)` and `String::contains(code_point)` handle non-ASCII 

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -489,9 +489,10 @@ bool String::contains(StringView needle, CaseSensitivity case_sensitivity) const
     return StringUtils::contains(bytes_as_string_view(), needle, case_sensitivity);
 }
 
-bool String::contains(char needle, CaseSensitivity case_sensitivity) const
+bool String::contains(u32 needle, CaseSensitivity case_sensitivity) const
 {
-    return contains(StringView { &needle, 1 }, case_sensitivity);
+    auto needle_as_string = String::from_code_point(needle);
+    return contains(needle_as_string.bytes_as_string_view(), case_sensitivity);
 }
 
 bool String::starts_with(u32 code_point) const

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -496,7 +496,10 @@ bool String::contains(char needle, CaseSensitivity case_sensitivity) const
 
 bool String::starts_with(u32 code_point) const
 {
-    return bytes_as_string_view().starts_with(code_point);
+    if (is_empty())
+        return false;
+
+    return *code_points().begin() == code_point;
 }
 
 bool String::starts_with_bytes(StringView bytes) const
@@ -506,7 +509,14 @@ bool String::starts_with_bytes(StringView bytes) const
 
 bool String::ends_with(u32 code_point) const
 {
-    return bytes_as_string_view().ends_with(code_point);
+    if (is_empty())
+        return false;
+
+    u32 last_code_point = 0;
+    for (auto it = code_points().begin(); it != code_points().end(); ++it)
+        last_code_point = *it;
+
+    return last_code_point == code_point;
 }
 
 bool String::ends_with_bytes(StringView bytes) const

--- a/AK/String.h
+++ b/AK/String.h
@@ -172,7 +172,7 @@ public:
     }
 
     [[nodiscard]] bool contains(StringView, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
-    [[nodiscard]] bool contains(char, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
+    [[nodiscard]] bool contains(u32, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
 
     [[nodiscard]] u32 hash() const;
 

--- a/AK/String.h
+++ b/AK/String.h
@@ -111,11 +111,11 @@ public:
     // Compare this String against another string with caseless matching. Using this method requires linking LibUnicode into your application.
     ErrorOr<bool> equals_ignoring_case(String const&) const;
 
-    bool starts_with(u32 code_point) const;
-    bool starts_with_bytes(StringView) const;
+    [[nodiscard]] bool starts_with(u32 code_point) const;
+    [[nodiscard]] bool starts_with_bytes(StringView) const;
 
-    bool ends_with(u32 code_point) const;
-    bool ends_with_bytes(StringView) const;
+    [[nodiscard]] bool ends_with(u32 code_point) const;
+    [[nodiscard]] bool ends_with_bytes(StringView) const;
 
     // Creates a substring with a deep copy of the specified data window.
     ErrorOr<String> substring_from_byte_offset(size_t start, size_t byte_count) const;

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -712,6 +712,52 @@ TEST_CASE(trim)
     }
 }
 
+TEST_CASE(contains)
+{
+    EXPECT(!String {}.contains({}));
+    EXPECT(!String {}.contains(" "sv));
+    EXPECT(!String {}.contains(0));
+
+    EXPECT("a"_short_string.contains("a"sv));
+    EXPECT(!"a"_short_string.contains({}));
+    EXPECT(!"a"_short_string.contains("b"sv));
+    EXPECT(!"a"_short_string.contains("ab"sv));
+
+    EXPECT("a"_short_string.contains(0x0061));
+    EXPECT(!"a"_short_string.contains(0x0062));
+
+    EXPECT("abc"_short_string.contains("a"sv));
+    EXPECT("abc"_short_string.contains("b"sv));
+    EXPECT("abc"_short_string.contains("c"sv));
+    EXPECT("abc"_short_string.contains("ab"sv));
+    EXPECT("abc"_short_string.contains("bc"sv));
+    EXPECT("abc"_short_string.contains("abc"sv));
+    EXPECT(!"abc"_short_string.contains({}));
+    EXPECT(!"abc"_short_string.contains("ac"sv));
+    EXPECT(!"abc"_short_string.contains("abcd"sv));
+
+    EXPECT("abc"_short_string.contains(0x0061));
+    EXPECT("abc"_short_string.contains(0x0062));
+    EXPECT("abc"_short_string.contains(0x0063));
+    EXPECT(!"abc"_short_string.contains(0x0064));
+
+    auto emoji = MUST("😀"_string);
+    EXPECT(emoji.contains("\xF0"sv));
+    EXPECT(emoji.contains("\x9F"sv));
+    EXPECT(emoji.contains("\x98"sv));
+    EXPECT(emoji.contains("\x80"sv));
+    EXPECT(emoji.contains("\xF0\x9F"sv));
+    EXPECT(emoji.contains("\xF0\x9F\x98"sv));
+    EXPECT(emoji.contains("\xF0\x9F\x98\x80"sv));
+    EXPECT(emoji.contains("\x9F\x98\x80"sv));
+    EXPECT(emoji.contains("\x98\x80"sv));
+    EXPECT(!emoji.contains("a"sv));
+    EXPECT(!emoji.contains("🙃"sv));
+
+    EXPECT(emoji.contains(0x1F600));
+    EXPECT(!emoji.contains(0x1F643));
+}
+
 TEST_CASE(starts_with)
 {
     EXPECT(String {}.starts_with_bytes({}));

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -711,3 +711,85 @@ TEST_CASE(trim)
         EXPECT(result.is_empty());
     }
 }
+
+TEST_CASE(starts_with)
+{
+    EXPECT(String {}.starts_with_bytes({}));
+    EXPECT(!String {}.starts_with_bytes(" "sv));
+    EXPECT(!String {}.starts_with(0));
+
+    EXPECT("a"_short_string.starts_with_bytes({}));
+    EXPECT("a"_short_string.starts_with_bytes("a"sv));
+    EXPECT(!"a"_short_string.starts_with_bytes("b"sv));
+    EXPECT(!"a"_short_string.starts_with_bytes("ab"sv));
+
+    EXPECT("a"_short_string.starts_with(0x0061));
+    EXPECT(!"a"_short_string.starts_with(0x0062));
+
+    EXPECT("abc"_short_string.starts_with_bytes({}));
+    EXPECT("abc"_short_string.starts_with_bytes("a"sv));
+    EXPECT("abc"_short_string.starts_with_bytes("ab"sv));
+    EXPECT("abc"_short_string.starts_with_bytes("abc"sv));
+    EXPECT(!"abc"_short_string.starts_with_bytes("b"sv));
+    EXPECT(!"abc"_short_string.starts_with_bytes("bc"sv));
+
+    EXPECT("abc"_short_string.starts_with(0x0061));
+    EXPECT(!"abc"_short_string.starts_with(0x0062));
+    EXPECT(!"abc"_short_string.starts_with(0x0063));
+
+    auto emoji = MUST("😀🙃"_string);
+    EXPECT(emoji.starts_with_bytes("\xF0"sv));
+    EXPECT(emoji.starts_with_bytes("\xF0\x9F"sv));
+    EXPECT(emoji.starts_with_bytes("\xF0\x9F\x98"sv));
+    EXPECT(emoji.starts_with_bytes("\xF0\x9F\x98\x80"sv));
+    EXPECT(emoji.starts_with_bytes("\xF0\x9F\x98\x80\xF0"sv));
+    EXPECT(emoji.starts_with_bytes("\xF0\x9F\x98\x80\xF0\x9F"sv));
+    EXPECT(emoji.starts_with_bytes("\xF0\x9F\x98\x80\xF0\x9F\x99"sv));
+    EXPECT(emoji.starts_with_bytes("\xF0\x9F\x98\x80\xF0\x9F\x99\x83"sv));
+    EXPECT(!emoji.starts_with_bytes("a"sv));
+    EXPECT(!emoji.starts_with_bytes("🙃"sv));
+
+    EXPECT(emoji.starts_with(0x1F600));
+    EXPECT(!emoji.starts_with(0x1F643));
+}
+
+TEST_CASE(ends_with)
+{
+    EXPECT(String {}.ends_with_bytes({}));
+    EXPECT(!String {}.ends_with_bytes(" "sv));
+    EXPECT(!String {}.ends_with(0));
+
+    EXPECT("a"_short_string.ends_with_bytes({}));
+    EXPECT("a"_short_string.ends_with_bytes("a"sv));
+    EXPECT(!"a"_short_string.ends_with_bytes("b"sv));
+    EXPECT(!"a"_short_string.ends_with_bytes("ba"sv));
+
+    EXPECT("a"_short_string.ends_with(0x0061));
+    EXPECT(!"a"_short_string.ends_with(0x0062));
+
+    EXPECT("abc"_short_string.ends_with_bytes({}));
+    EXPECT("abc"_short_string.ends_with_bytes("c"sv));
+    EXPECT("abc"_short_string.ends_with_bytes("bc"sv));
+    EXPECT("abc"_short_string.ends_with_bytes("abc"sv));
+    EXPECT(!"abc"_short_string.ends_with_bytes("b"sv));
+    EXPECT(!"abc"_short_string.ends_with_bytes("ab"sv));
+
+    EXPECT("abc"_short_string.ends_with(0x0063));
+    EXPECT(!"abc"_short_string.ends_with(0x0062));
+    EXPECT(!"abc"_short_string.ends_with(0x0061));
+
+    auto emoji = MUST("😀🙃"_string);
+    EXPECT(emoji.ends_with_bytes("\x83"sv));
+    EXPECT(emoji.ends_with_bytes("\x99\x83"sv));
+    EXPECT(emoji.ends_with_bytes("\x9F\x99\x83"sv));
+    EXPECT(emoji.ends_with_bytes("\xF0\x9F\x99\x83"sv));
+    EXPECT(emoji.ends_with_bytes("\x80\xF0\x9F\x99\x83"sv));
+    EXPECT(emoji.ends_with_bytes("\x98\x80\xF0\x9F\x99\x83"sv));
+    EXPECT(emoji.ends_with_bytes("\x9F\x98\x80\xF0\x9F\x99\x83"sv));
+    EXPECT(emoji.ends_with_bytes("\xF0\x9F\x98\x80\xF0\x9F\x99\x83"sv));
+    EXPECT(!emoji.ends_with_bytes("a"sv));
+    EXPECT(!emoji.ends_with_bytes("😀"sv));
+
+    EXPECT(emoji.ends_with(0x1F643));
+    EXPECT(!emoji.ends_with(0x1F600));
+}


### PR DESCRIPTION
A couple warnings from clangd I came across passing u32's around these.