### PR TITLE
PixelPaint: Add recently opened files to file menu (+ error propagation)

### DIFF
--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -264,6 +264,14 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
 
     TRY(file_menu->try_add_separator());
 
+    TRY(file_menu->add_recent_files_list([&](auto& action) {
+        auto path = action.text();
+        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(&window, path);
+        if (response.is_error())
+            return;
+        open_image(response.release_value());
+    }));
+
     m_close_image_action = GUI::Action::create("&Close Image", { Mod_Ctrl, Key_W }, g_icon_bag.close_image, [&](auto&) {
         auto* active_widget = m_tab_widget->active_widget();
         VERIFY(active_widget);
@@ -1174,6 +1182,7 @@ void MainWidget::open_image(FileSystemAccessClient::File file)
     editor.set_path(file.filename().to_deprecated_string());
     editor.set_unmodified();
     m_layer_list_widget->set_image(&image);
+    GUI::Application::the()->set_most_recently_open_file(file.filename());
 }
 
 ErrorOr<void> MainWidget::create_default_image()

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -25,6 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("PixelPaint");
+    app->set_config_domain(TRY(String::from_utf8("PixelPaint"sv)));
 
     StringView image_file;
     Core::ArgsParser args_parser;


### PR DESCRIPTION
This PR adds a list of recently opened files to the file menu.

I've also replaced non-fallible menu initialization methods with their fallible equivalents.

NB: Clicking on a recent file will not prompt for permission before opening. This differs from the behavior of TextEditor.

![pixelpaint_recently_opened_files](https://user-images.githubusercontent.com/2817754/223810254-88921e36-9b09-4257-baea-df68bb49402d.png)

