### PR TITLE
Kernel+Meta: Ignore suboptimal VirtIO configuration type, use longer timeouts for sync VirtIO GPU commands, use non-VGA VirtIO GPU variants when running on macOS

### DIFF
--- a/Kernel/Bus/VirtIO/Device.h
+++ b/Kernel/Bus/VirtIO/Device.h
@@ -70,7 +70,7 @@ enum class ConfigurationType : u8 {
     Notify = 2,
     ISR = 3,
     Device = 4,
-    PCI = 5
+    PCICapabilitiesAccess = 5
 };
 
 struct Configuration {

--- a/Kernel/Graphics/VirtIOGPU/DisplayConnector.h
+++ b/Kernel/Graphics/VirtIOGPU/DisplayConnector.h
@@ -37,8 +37,6 @@ public:
     Graphics::VirtIOGPU::ScanoutID scanout_id() const { return m_scanout_id; }
     Graphics::VirtIOGPU::Protocol::DisplayInfoResponse::Display display_information(Badge<VirtIOGraphicsAdapter>) const;
 
-    void draw_ntsc_test_pattern(Badge<VirtIOGraphicsAdapter>);
-
     void initialize_console(Badge<VirtIOGraphicsAdapter>);
 
 private:

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
@@ -121,12 +121,6 @@ ErrorOr<void> VirtIOGraphicsAdapter::attach_physical_range_to_framebuffer(VirtIO
     TRY(ensure_backing_storage(buffer.resource_id, connector.framebuffer_region(), buffer.framebuffer_offset, framebuffer_size));
     // 3. Use VIRTIO_GPU_CMD_SET_SCANOUT to link the framebuffer to a display scanout.
     TRY(set_scanout_resource(connector.scanout_id(), buffer.resource_id, display_info.rect));
-    // 4. Render our test pattern
-    connector.draw_ntsc_test_pattern({});
-    // 5. Use VIRTIO_GPU_CMD_TRANSFER_TO_HOST_2D to update the host resource from guest memory.
-    TRY(transfer_framebuffer_data_to_host(connector.scanout_id(), buffer.resource_id, display_info.rect));
-    // 6. Use VIRTIO_GPU_CMD_RESOURCE_FLUSH to flush the updated resource to the display.
-    TRY(flush_displayed_image(buffer.resource_id, display_info.rect));
 
     // Make sure we constrain the existing dirty rect (if any)
     if (buffer.dirty_rect.width != 0 || buffer.dirty_rect.height != 0) {

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
@@ -226,7 +226,7 @@ ErrorOr<void> VirtIOGraphicsAdapter::query_and_set_edid(u32 scanout_id, VirtIODi
     request.scanout_id = scanout_id;
     request.padding = 0;
 
-    TRY(synchronous_virtio_gpu_command(100, start_of_scratch_space(), sizeof(request), sizeof(response)));
+    TRY(synchronous_virtio_gpu_command(10000, start_of_scratch_space(), sizeof(request), sizeof(response)));
 
     if (response.header.type != to_underlying(Graphics::VirtIOGPU::Protocol::CommandType::VIRTIO_GPU_RESP_OK_EDID)) {
         dmesgln("VirtIO::GraphicsAdapter: Failed to get EDID");
@@ -259,7 +259,7 @@ ErrorOr<Graphics::VirtIOGPU::ResourceID> VirtIOGraphicsAdapter::create_2d_resour
     request.height = rect.height;
     request.format = to_underlying(Graphics::VirtIOGPU::Protocol::TextureFormat::VIRTIO_GPU_FORMAT_B8G8R8X8_UNORM);
 
-    TRY(synchronous_virtio_gpu_command(100, start_of_scratch_space(), sizeof(request), sizeof(response)));
+    TRY(synchronous_virtio_gpu_command(10000, start_of_scratch_space(), sizeof(request), sizeof(response)));
 
     if (response.type == to_underlying(Graphics::VirtIOGPU::Protocol::CommandType::VIRTIO_GPU_RESP_OK_NODATA)) {
         dbgln_if(VIRTIO_DEBUG, "VirtIO::GraphicsAdapter: Allocated 2d resource with id {}", resource_id.value());
@@ -288,7 +288,7 @@ ErrorOr<Graphics::VirtIOGPU::ResourceID> VirtIOGraphicsAdapter::create_3d_resour
     static_assert((sizeof(request) - offsetof(Graphics::VirtIOGPU::Protocol::ResourceCreate3D, target) == sizeof(resource_3d_specification)));
     memcpy(start_of_copied_fields, &resource_3d_specification, sizeof(resource_3d_specification));
 
-    TRY(synchronous_virtio_gpu_command(100, start_of_scratch_space(), sizeof(request), sizeof(response)));
+    TRY(synchronous_virtio_gpu_command(10000, start_of_scratch_space(), sizeof(request), sizeof(response)));
 
     if (response.type == to_underlying(Graphics::VirtIOGPU::Protocol::CommandType::VIRTIO_GPU_RESP_OK_NODATA)) {
         dbgln_if(VIRTIO_DEBUG, "VirtIO::GraphicsAdapter: Allocated 3d resource with id {}", resource_id.value());
@@ -321,7 +321,7 @@ ErrorOr<void> VirtIOGraphicsAdapter::ensure_backing_storage(Graphics::VirtIOGPU:
 
     auto& response = writer.append_structure<Graphics::VirtIOGPU::Protocol::ControlHeader>();
 
-    TRY(synchronous_virtio_gpu_command(100, start_of_scratch_space(), header_block_size, sizeof(response)));
+    TRY(synchronous_virtio_gpu_command(10000, start_of_scratch_space(), header_block_size, sizeof(response)));
 
     if (response.type == to_underlying(Graphics::VirtIOGPU::Protocol::CommandType::VIRTIO_GPU_RESP_OK_NODATA)) {
         dbgln_if(VIRTIO_DEBUG, "VirtIO::GraphicsAdapter: Allocated backing storage");
@@ -340,7 +340,7 @@ ErrorOr<void> VirtIOGraphicsAdapter::detach_backing_storage(Graphics::VirtIOGPU:
     populate_virtio_gpu_request_header(request.header, Graphics::VirtIOGPU::Protocol::CommandType::VIRTIO_GPU_CMD_RESOURCE_DETACH_BACKING, 0);
     request.resource_id = resource_id.value();
 
-    TRY(synchronous_virtio_gpu_command(100, start_of_scratch_space(), sizeof(request), sizeof(response)));
+    TRY(synchronous_virtio_gpu_command(10000, start_of_scratch_space(), sizeof(request), sizeof(response)));
 
     if (response.type == to_underlying(Graphics::VirtIOGPU::Protocol::CommandType::VIRTIO_GPU_RESP_OK_NODATA)) {
         dbgln_if(VIRTIO_DEBUG, "VirtIO::GraphicsAdapter: Detached backing storage");
@@ -362,7 +362,7 @@ ErrorOr<void> VirtIOGraphicsAdapter::set_scanout_resource(Graphics::VirtIOGPU::S
     request.scanout_id = scanout.value();
     request.rect = rect;
 
-    TRY(synchronous_virtio_gpu_command(100, start_of_scratch_space(), sizeof(request), sizeof(response)));
+    TRY(synchronous_virtio_gpu_command(10000, start_of_scratch_space(), sizeof(request), sizeof(response)));
 
     if (response.type == to_underlying(Graphics::VirtIOGPU::Protocol::CommandType::VIRTIO_GPU_RESP_OK_NODATA)) {
         dbgln_if(VIRTIO_DEBUG, "VirtIO::GraphicsAdapter: Set backing scanout");
@@ -383,7 +383,7 @@ ErrorOr<void> VirtIOGraphicsAdapter::transfer_framebuffer_data_to_host(Graphics:
     request.resource_id = resource_id.value();
     request.rect = dirty_rect;
 
-    TRY(synchronous_virtio_gpu_command(100, start_of_scratch_space(), sizeof(request), sizeof(response)));
+    TRY(synchronous_virtio_gpu_command(10000, start_of_scratch_space(), sizeof(request), sizeof(response)));
 
     if (response.type == to_underlying(Graphics::VirtIOGPU::Protocol::CommandType::VIRTIO_GPU_RESP_OK_NODATA))
         return {};
@@ -401,7 +401,7 @@ ErrorOr<void> VirtIOGraphicsAdapter::flush_displayed_image(Graphics::VirtIOGPU::
     request.resource_id = resource_id.value();
     request.rect = dirty_rect;
 
-    TRY(synchronous_virtio_gpu_command(100, start_of_scratch_space(), sizeof(request), sizeof(response)));
+    TRY(synchronous_virtio_gpu_command(10000, start_of_scratch_space(), sizeof(request), sizeof(response)));
 
     if (response.type == to_underlying(Graphics::VirtIOGPU::Protocol::CommandType::VIRTIO_GPU_RESP_OK_NODATA))
         return {};
@@ -457,7 +457,7 @@ ErrorOr<void> VirtIOGraphicsAdapter::delete_resource(Graphics::VirtIOGPU::Resour
     populate_virtio_gpu_request_header(request.header, Graphics::VirtIOGPU::Protocol::CommandType::VIRTIO_GPU_CMD_RESOURCE_UNREF, 0);
     request.resource_id = resource_id.value();
 
-    TRY(synchronous_virtio_gpu_command(100, start_of_scratch_space(), sizeof(request), sizeof(response)));
+    TRY(synchronous_virtio_gpu_command(10000, start_of_scratch_space(), sizeof(request), sizeof(response)));
 
     if (response.type == to_underlying(Graphics::VirtIOGPU::Protocol::CommandType::VIRTIO_GPU_RESP_OK_NODATA))
         return {};
@@ -496,7 +496,7 @@ ErrorOr<Graphics::VirtIOGPU::ContextID> VirtIOGraphicsAdapter::create_context()
         VERIFY(request.name_length <= 64);
         memcpy(request.debug_name.data(), region_name, request.name_length);
 
-        TRY(synchronous_virtio_gpu_command(100, start_of_scratch_space(), sizeof(request), sizeof(response)));
+        TRY(synchronous_virtio_gpu_command(10000, start_of_scratch_space(), sizeof(request), sizeof(response)));
 
         if (response.type == to_underlying(Graphics::VirtIOGPU::Protocol::CommandType::VIRTIO_GPU_RESP_OK_NODATA)) {
             active_context_ids.set(maybe_available_id.value(), true);
@@ -531,7 +531,7 @@ ErrorOr<void> VirtIOGraphicsAdapter::submit_command_buffer(Graphics::VirtIOGPU::
     dbgln_if(VIRTIO_DEBUG, "VirtIO::GraphicsAdapter: Sending command buffer of length {}", request.size);
     auto& response = writer.append_structure<Graphics::VirtIOGPU::Protocol::ControlHeader>();
 
-    TRY(synchronous_virtio_gpu_command(100, start_of_scratch_space(), sizeof(request) + request.size, sizeof(response)));
+    TRY(synchronous_virtio_gpu_command(10000, start_of_scratch_space(), sizeof(request) + request.size, sizeof(response)));
 
     if (response.type == to_underlying(Graphics::VirtIOGPU::Protocol::CommandType::VIRTIO_GPU_RESP_OK_NODATA))
         return {};
@@ -548,7 +548,7 @@ ErrorOr<void> VirtIOGraphicsAdapter::attach_resource_to_context(Graphics::VirtIO
     request.header.context_id = context_id.value();
     request.resource_id = resource_id.value();
 
-    TRY(synchronous_virtio_gpu_command(100, start_of_scratch_space(), sizeof(request), sizeof(response)));
+    TRY(synchronous_virtio_gpu_command(10000, start_of_scratch_space(), sizeof(request), sizeof(response)));
 
     if (response.type == to_underlying(Graphics::VirtIOGPU::Protocol::CommandType::VIRTIO_GPU_RESP_OK_NODATA))
         return {};

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -200,12 +200,26 @@ fi
 SERENITY_GL="${SERENITY_GL:-0}"
 if [ -z "$SERENITY_QEMU_DISPLAY_DEVICE" ]; then
     if [ "$SERENITY_GL" = "1" ]; then
-        SERENITY_QEMU_DISPLAY_DEVICE="virtio-vga-gl "
+        # QEMU appears to not support the GL backend for VirtIO GPU variant on macOS.
+        if [ "$(uname)" = "Darwin" ]; then
+            die "SERENITY_GL is not supported since there's no GL backend on macOS"
+        else
+            SERENITY_QEMU_DISPLAY_DEVICE="virtio-vga-gl "
+        fi
+        
         if [ "$SERENITY_SCREENS" -gt 1 ]; then
             die "SERENITY_GL and multi-monitor support cannot be setup simultaneously"
         fi
     elif [ "$SERENITY_SCREENS" -gt 1 ]; then
-        SERENITY_QEMU_DISPLAY_DEVICE="virtio-vga,max_outputs=$SERENITY_SCREENS "
+        # QEMU appears to not support the virtio-vga VirtIO GPU variant on macOS.
+        # To ensure we can still boot on macOS with VirtIO GPU, use the virtio-gpu-pci
+        # variant, which lacks any VGA compatibility (which is not relevant for us anyway).
+        if [ "$(uname)" = "Darwin" ]; then
+            SERENITY_QEMU_DISPLAY_DEVICE="virtio-gpu-pci,max_outputs=$SERENITY_SCREENS "
+        else
+            SERENITY_QEMU_DISPLAY_DEVICE="virtio-vga,max_outputs=$SERENITY_SCREENS "
+        fi
+
         # QEMU appears to always relay absolute mouse coordinates relative to the screen that the mouse is
         # pointed to, without any way for us to know what screen it was. So, when dealing with multiple
         # displays force using relative coordinates only


### PR DESCRIPTION
It appears that QEMU doesn't have the VirtIO GPU variants that support VGA functionality for macOS. Those variants are not especially important to us, because we don't use any kind of VGA functionality in our kernel anyway. Therefore, for macOS, we could decide to use virtio-gpu-gl-pci and virtio-gpu-pci devices instead.

Fixes #17613.