### PR TITLE
HackStudio: Store correct address in ClassViewModel's ModelIndices

### DIFF
--- a/Userland/DevTools/HackStudio/ClassViewWidget.cpp
+++ b/Userland/DevTools/HackStudio/ClassViewWidget.cpp
@@ -91,9 +91,9 @@ GUI::ModelIndex ClassViewModel::parent_index(const GUI::ModelIndex& index) const
 GUI::ModelIndex ClassViewModel::index(int row, int column, const GUI::ModelIndex& parent_index) const
 {
     if (!parent_index.is_valid())
-        return create_index(row, column, &m_root_scope[row]);
+        return create_index(row, column, m_root_scope[row].ptr());
     auto* parent = static_cast<ClassViewNode const*>(parent_index.internal_data());
-    auto* child = &parent->children[row];
+    auto* child = parent->children[row].ptr();
     return create_index(row, column, child);
 }
 


### PR DESCRIPTION
When 359d6e7b0b0ef7add9eb2015d0dd664a82cf73d7 happened, the return value of `children[row]` went from being `ClassViewNode&` to `NonnullOwnPtr<ClassViewNode>&`, so we were putting the wrong address into the ModelIndex's data.

Fixes #17755.