### PR TITLE
LibGUI: Don't run TextDocument change callbacks for every character

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -146,7 +146,7 @@ public:
     void notify_did_change();
     void set_all_cursors(TextPosition const&);
 
-    TextPosition insert_at(TextPosition const&, u32, Client const* = nullptr);
+    TextPosition insert_at(TextPosition const&, u32, Client const* = nullptr, AllowCallback allow_callback = AllowCallback::Yes);
     TextPosition insert_at(TextPosition const&, StringView, Client const* = nullptr);
     void remove(TextRange const&);
 
@@ -194,10 +194,10 @@ public:
     void set_text(TextDocument&, Vector<u32>);
     void append(TextDocument&, u32);
     void prepend(TextDocument&, u32);
-    void insert(TextDocument&, size_t index, u32);
+    void insert(TextDocument&, size_t index, u32, AllowCallback allow_callback = AllowCallback::Yes);
     void remove(TextDocument&, size_t index);
     void append(TextDocument&, u32 const*, size_t);
-    void truncate(TextDocument&, size_t length);
+    void truncate(TextDocument&, size_t length, AllowCallback allow_callback = AllowCallback::Yes);
     void clear(TextDocument&);
     void remove_range(TextDocument&, size_t start, size_t length);
     void keep_range(TextDocument&, size_t start_index, size_t end_index);


### PR DESCRIPTION
The insert_at(string) method calls into the insert_at(character) method for each character, and that in turn runs the change callbacks. Some applications, such as GMLPlayground, have decently expensive callbacks, such as one which performs a linear time codepoint iteration of the current text content. Combined with the linear amount of callbacks, this means that the time of insert_at scales quadratically with the amount of text, which is a problem for automatic actions that insert a lot of text, such as auto-formatting.

This commit fixes that by simply omitting the change callbacks when the string insertion method calls its helper function per character, and then running the change callback once at the end.

For GMLPlayground, the time to format a 300-line GML reduces from ~20s to 500ms and over 25% of the time is now spent in GML parsing and widget creation. Unfortunately, the did_insert_line callbacks have to be called for every single inserted line, which is now about 60% of the runtime.