### PR TITLE
Ladybird: Send window size and position to WebContent process

### DIFF
--- a/Ladybird/BrowserWindow.cpp
+++ b/Ladybird/BrowserWindow.cpp
@@ -507,6 +507,22 @@ void BrowserWindow::copy_selected_text()
     }
 }
 
+void BrowserWindow::resizeEvent(QResizeEvent* event)
+{
+    QWidget::resizeEvent(event);
+    for (auto& tab : m_tabs) {
+        tab->view().set_window_size({ frameSize().width(), frameSize().height() });
+    }
+}
+
+void BrowserWindow::moveEvent(QMoveEvent* event)
+{
+    QWidget::moveEvent(event);
+    for (auto& tab : m_tabs) {
+        tab->view().set_window_position({ event->pos().x(), event->pos().y() });
+    }
+}
+
 bool BrowserWindow::eventFilter(QObject* obj, QEvent* event)
 {
     if (event->type() == QEvent::MouseButtonRelease) {

--- a/Ladybird/BrowserWindow.h
+++ b/Ladybird/BrowserWindow.h
@@ -54,9 +54,12 @@ public slots:
     void copy_selected_text();
 
 protected:
-    bool eventFilter(QObject* obj, QEvent* event);
+    bool eventFilter(QObject* obj, QEvent* event) override;
 
 private:
+    virtual void resizeEvent(QResizeEvent*) override;
+    virtual void moveEvent(QMoveEvent*) override;
+
     void debug_request(DeprecatedString const& request, DeprecatedString const& argument = "");
 
     QTabWidget* m_tabs_container { nullptr };

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -452,6 +452,16 @@ void WebContentView::set_viewport_rect(Gfx::IntRect rect)
     client().async_set_viewport_rect(rect);
 }
 
+void WebContentView::set_window_size(Gfx::IntSize size)
+{
+    client().async_set_window_size(size);
+}
+
+void WebContentView::set_window_position(Gfx::IntPoint position)
+{
+    client().async_set_window_position(position);
+}
+
 void WebContentView::update_viewport_rect()
 {
     auto scaled_width = int(viewport()->width() / m_inverse_pixel_scaling_ratio);

--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -98,6 +98,8 @@ public:
     ErrorOr<String> dump_layout_tree();
 
     void set_viewport_rect(Gfx::IntRect);
+    void set_window_size(Gfx::IntSize);
+    void set_window_position(Gfx::IntPoint);
 
     Gfx::IntPoint to_content(Gfx::IntPoint) const;
     Gfx::IntPoint to_widget(Gfx::IntPoint) const;


### PR DESCRIPTION
With these changes `outerWindow`, `outerHeight`, `screenTop` etc are non always zero inside ladybird.