### PR TITLE
LibTest: Add option to run each benchmark several times

### DIFF
--- a/Userland/Libraries/LibTest/TestSuite.h
+++ b/Userland/Libraries/LibTest/TestSuite.h
@@ -50,6 +50,7 @@ private:
     u64 m_testtime = 0;
     u64 m_benchtime = 0;
     DeprecatedString m_suite_name;
+    u64 m_benchmark_repetitions = 1;
     bool m_current_test_case_passed = true;
     Function<void()> m_setup;
 };


### PR DESCRIPTION
This allows to print statistical information (minimum, average, maximum execution time) about benchmark execution time. Such information is especially helpful when dealing with small relative execution time changes.

Sample output:
```
> taskset -c 0 Build/lagom/Tests/AK/TestFloatingPointParsing --bench --benchmark_repetitions 10 
Running 4 cases out of 11.
Running benchmark 'one'.
Completed benchmark 'one' on average in 72.9±1.9ms (min=69ms, max=76ms, total=729ms)
Running benchmark 'long_float_without_exponent'.
Completed benchmark 'long_float_without_exponent' on average in 78.2±1.2ms (min=76ms, max=81ms, total=783ms)
Running benchmark 'float_with_exponent'.
Completed benchmark 'float_with_exponent' on average in 82.7±1.7ms (min=81ms, max=87ms, total=827ms)
Running benchmark 'inadequate_float'.
Completed benchmark 'inadequate_float' on average in 86.9±0.3ms (min=86ms, max=87ms, total=869ms)
Finished 0 tests and 4 benchmarks in 3227ms (0ms tests, 3208ms benchmarks, 19ms other).
Out of 0 tests, 0 passed and 0 failed.
```

Standard deviation estimation is calculated for sample (not average), since in this particular case it seems more reasonable to do so (we usually want to know how unstable execution time is and not how accurate the average is).