### PR TITLE
LibGUI: Allow blocking modals and popups to handle their own shortcuts

### DIFF
--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -479,7 +479,7 @@ void Window::handle_multi_paint_event(MultiPaintEvent& event)
         ConnectionToWindowServer::the().async_did_finish_painting(m_window_id, rects);
 }
 
-void Window::propagate_shortcuts_up_to_application(KeyEvent& event, Widget* widget)
+void Window::propagate_shortcuts(KeyEvent& event, Widget* widget, ShortcutPropagationBoundary boundary)
 {
     VERIFY(event.type() == Event::KeyDown);
     auto shortcut = Shortcut(event.modifiers(), event.key());
@@ -497,9 +497,9 @@ void Window::propagate_shortcuts_up_to_application(KeyEvent& event, Widget* widg
         } while (widget);
     }
 
-    if (!action)
+    if (!action && boundary >= ShortcutPropagationBoundary::Window)
         action = action_for_shortcut(shortcut);
-    if (!action)
+    if (!action && boundary >= ShortcutPropagationBoundary::Application)
         action = Application::the()->action_for_shortcut(shortcut);
 
     if (action) {
@@ -533,7 +533,7 @@ void Window::handle_key_event(KeyEvent& event)
 
     // Only process shortcuts if this is a keydown event.
     if (event.type() == Event::KeyDown)
-        propagate_shortcuts_up_to_application(event, nullptr);
+        propagate_shortcuts(event, nullptr, PropagationLimit::Application);
 }
 
 void Window::handle_resize_event(ResizeEvent& event)

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -528,12 +528,11 @@ void Window::handle_key_event(KeyEvent& event)
     if (event.is_accepted())
         return;
 
-    if (is_blocking() || is_popup())
-        return;
-
     // Only process shortcuts if this is a keydown event.
-    if (event.type() == Event::KeyDown)
-        propagate_shortcuts(event, nullptr, PropagationLimit::Application);
+    if (event.type() == Event::KeyDown) {
+        auto const boundary = (is_blocking() || is_popup()) ? ShortcutPropagationBoundary::Window : ShortcutPropagationBoundary::Application;
+        propagate_shortcuts(event, nullptr, boundary);
+    }
 }
 
 void Window::handle_resize_event(ResizeEvent& event)

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -229,7 +229,12 @@ public:
 
     void set_always_on_top(bool always_on_top = true);
 
-    void propagate_shortcuts_up_to_application(KeyEvent& event, Widget* widget);
+    enum class ShortcutPropagationBoundary {
+        Window,
+        Application,
+    };
+
+    void propagate_shortcuts(KeyEvent& event, Widget* widget, ShortcutPropagationBoundary = ShortcutPropagationBoundary::Application);
 
 protected:
     Window(Core::Object* parent = nullptr);

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -208,7 +208,7 @@ void TerminalWidget::keydown_event(GUI::KeyEvent& event)
 {
     // We specifically need to process shortcuts before input to the Terminal is done
     // since otherwise escape sequences will eat all our shortcuts for dinner.
-    window()->propagate_shortcuts_up_to_application(event, this);
+    window()->propagate_shortcuts(event, this);
     if (event.is_accepted())
         return;
 

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -734,7 +734,7 @@ void OutOfProcessWebView::notify_server_did_finish_handling_input_event(bool eve
 
                     // NOTE: If other events can ever trigger shortcuts, propagate those here.
                     if (!event.is_accepted() && event.type() == GUI::Event::Type::KeyDown)
-                        window()->propagate_shortcuts_up_to_application(event, this);
+                        window()->propagate_shortcuts(event, this);
                 }
             },
             [this](GUI::MouseEvent& event) {


### PR DESCRIPTION
If you ever wondered why `Ctrl-H` wasn't working in `FilePicker`, here is a fix :smile:.