### PR TITLE
LibGfx: Speed up fill_path() with per scanline clipping & fast fills

### DIFF
--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -213,8 +213,7 @@ void AntiAliasingPainter::draw_line(FloatPoint actual_from, FloatPoint actual_to
 
 void AntiAliasingPainter::fill_path(Path const& path, Color color, Painter::WindingRule rule)
 {
-    Detail::fill_path<Detail::FillPathMode::AllowFloatingPoints>(
-        m_underlying_painter, path, [=](IntPoint) { return color; }, rule, m_transform.translation());
+    Detail::fill_path<Detail::FillPathMode::AllowFloatingPoints>(m_underlying_painter, path, color, rule, m_transform.translation());
 }
 
 void AntiAliasingPainter::fill_path(Path const& path, PaintStyle const& paint_style, Painter::WindingRule rule)

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -10,7 +10,6 @@
 #    pragma GCC optimize("O3")
 #endif
 
-#include "FillPathImplementation.h"
 #include <AK/Function.h>
 #include <AK/NumericLimits.h>
 #include <LibGfx/AntiAliasingPainter.h>
@@ -213,14 +212,12 @@ void AntiAliasingPainter::draw_line(FloatPoint actual_from, FloatPoint actual_to
 
 void AntiAliasingPainter::fill_path(Path const& path, Color color, Painter::WindingRule rule)
 {
-    Detail::fill_path<Detail::FillPathMode::AllowFloatingPoints>(m_underlying_painter, path, color, rule, m_transform.translation());
+    m_underlying_painter.antialiased_fill_path(path, color, rule, m_transform.translation());
 }
 
 void AntiAliasingPainter::fill_path(Path const& path, PaintStyle const& paint_style, Painter::WindingRule rule)
 {
-    paint_style.paint(enclosing_int_rect(path.bounding_box()), [&](PaintStyle::SamplerFunction sampler) {
-        Detail::fill_path<Detail::FillPathMode::AllowFloatingPoints>(m_underlying_painter, path, move(sampler), rule, m_transform.translation());
-    });
+    m_underlying_painter.antialiased_fill_path(path, paint_style, rule, m_transform.translation());
 }
 
 void AntiAliasingPainter::stroke_path(Path const& path, Color color, float thickness)

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
     Color.cpp
     CursorParams.cpp
     DDSLoader.cpp
+    FillPathImplementation.cpp
     Filters/ColorBlindnessFilter.cpp
     Filters/FastBoxBlurFilter.cpp
     Filters/LumaFilter.cpp

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -27,7 +27,6 @@
 #include <AK/Utf32View.h>
 #include <AK/Utf8View.h>
 #include <LibGfx/CharacterBitmap.h>
-#include <LibGfx/FillPathImplementation.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/Path.h>
 #include <LibGfx/Quad.h>
@@ -2388,20 +2387,6 @@ void Painter::stroke_path(Path const& path, Color color, int thickness)
             break;
         }
     }
-}
-
-void Painter::fill_path(Path const& path, Color color, WindingRule winding_rule)
-{
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-    Detail::fill_path<Detail::FillPathMode::PlaceOnIntGrid>(*this, path, color, winding_rule);
-}
-
-void Painter::fill_path(Path const& path, PaintStyle const& paint_style, Painter::WindingRule rule)
-{
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-    paint_style.paint(enclosing_int_rect(path.bounding_box()), [&](PaintStyle::SamplerFunction sampler) {
-        Detail::fill_path<Detail::FillPathMode::PlaceOnIntGrid>(*this, path, move(sampler), rule);
-    });
 }
 
 void Painter::blit_disabled(IntPoint location, Gfx::Bitmap const& bitmap, IntRect const& rect, Palette const& palette)

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2393,8 +2393,7 @@ void Painter::stroke_path(Path const& path, Color color, int thickness)
 void Painter::fill_path(Path const& path, Color color, WindingRule winding_rule)
 {
     VERIFY(scale() == 1); // FIXME: Add scaling support.
-    Detail::fill_path<Detail::FillPathMode::PlaceOnIntGrid>(
-        *this, path, [=](IntPoint) { return color; }, winding_rule);
+    Detail::fill_path<Detail::FillPathMode::PlaceOnIntGrid>(*this, path, color, winding_rule);
 }
 
 void Painter::fill_path(Path const& path, PaintStyle const& paint_style, Painter::WindingRule rule)

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/Memory.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Utf8View.h>
 #include <AK/Vector.h>
@@ -179,6 +180,76 @@ public:
     IntRect clip_rect() const { return state().clip_rect; }
 
     int scale() const { return state().scale; }
+
+    template<typename T, typename TColorOrFunction>
+    ALWAYS_INLINE void draw_scanline_for_fill_path(int y, T x_start, T x_end, TColorOrFunction color)
+    {
+        // Note: This is really an internal function for FillPathImplementation.h to use.
+        // This allows fill path to clip more of the pixels and reduce the number of clipping checks
+        // to the number of scanlines (and allows for a fast fill).
+
+        // Fill path should scale the scanlines before calling this.
+        VERIFY(scale() == 1);
+
+        constexpr bool is_floating_point = IsSameIgnoringCV<T, int>;
+        constexpr bool has_constant_color = IsSameIgnoringCV<TColorOrFunction, Color>;
+
+        int x1 = 0;
+        int x2 = 0;
+        u8 left_subpixel_alpha = 0;
+        u8 right_subpixel_alpha = 0;
+        if constexpr (is_floating_point) {
+            x1 = ceilf(x_start);
+            x2 = floorf(x_end);
+            left_subpixel_alpha = (x1 - x_start) * 255;
+            right_subpixel_alpha = (x_end - x2) * 255;
+            x1 -= left_subpixel_alpha > 0;
+            x2 += right_subpixel_alpha > 0;
+        } else {
+            x1 = x_start;
+            x2 = x_end;
+        }
+
+        IntRect scanline(x1, y, x2 - x1, 1);
+        scanline = scanline.translated(translation());
+        auto clipped = scanline.intersected(clip_rect());
+        if (clipped.is_empty())
+            return;
+
+        auto get_color = [&](int offset) {
+            if constexpr (has_constant_color) {
+                return color;
+            } else {
+                return color(offset);
+            }
+        };
+
+        if constexpr (is_floating_point) {
+            // Paint left and right subpixels (then remove them from the scanline).
+            auto get_color_with_alpha = [&](int offset, u8 alpha) {
+                auto color_at_offset = get_color(offset);
+                u8 color_alpha = (alpha * color_at_offset.alpha()) / 255;
+                return color_at_offset.with_alpha(color_alpha);
+            };
+            if (clipped.left() == scanline.left() && left_subpixel_alpha)
+                set_physical_pixel(clipped.top_left(), get_color_with_alpha(0, left_subpixel_alpha), true);
+            if (clipped.right() == scanline.right() && right_subpixel_alpha)
+                set_physical_pixel(clipped.top_right(), get_color_with_alpha(scanline.width(), right_subpixel_alpha), true);
+            clipped.shrink(0, right_subpixel_alpha > 0, 0, left_subpixel_alpha > 0);
+        }
+
+        if constexpr (has_constant_color) {
+            if (color.alpha() == 255) {
+                // Speedy path: Constant color and no alpha blending.
+                fast_u32_fill(m_target->scanline(clipped.y()) + clipped.x(), color.value(), clipped.width());
+                return;
+            }
+        }
+
+        for (int x = clipped.x(); x <= clipped.right(); x++) {
+            set_physical_pixel({ x, clipped.y() }, get_color(x - scanline.x()), true);
+        }
+    }
 
 protected:
     friend GradientLine;


### PR DESCRIPTION
This improves fill_path() performance by adding an API to the painter that allows painting an entire scanline rather than just a pixel. With this paths can be clipped a scanline at a time rather than each pixel, removing a fair amount of checks.

Along with optimized clipping, this can now use a fast_u32_fill() to paint all but the subpixels of a scanline if a solid color with no alpha channel is used (which is quite common in SVGs).

This reduces scrolling around on svg.html from 21% in set_pixel() and 19% in fill_path() to just 7.8% in fill_path (with set_pixel() eliminated). Now fill_path() is far from the slowest code when scrolling the page.