### PR TITLE
BrickGame: Allow player to pause

### DIFF
--- a/Base/usr/share/man/man6/BrickGame.md
+++ b/Base/usr/share/man/man6/BrickGame.md
@@ -19,6 +19,8 @@ You can control where and how a piece falls, by moving it left or right, making 
 - A: Move left, D: Move right, W: Rotate right, E: Rotate left, S: Move down
 - H: Move left, L: Move right, K: Rotate right
 
+The Escape and P keys pause and unpause the game.
+
 The seven pieces are commonly named "T", "J", "L", "O", "S", "Z", and "I". Note that while "J" and "L" as well as "S" and "Z" are mirrors of each other, they cannot be used interchangeably since you can only rotate pieces.
 
 ```

--- a/Base/usr/share/man/man6/BrickGame.md
+++ b/Base/usr/share/man/man6/BrickGame.md
@@ -14,12 +14,12 @@ $ BrickGame
 
 BrickGame is a classic game. Pieces consisting of four small squares each fall from the top of the screen, being fixed in place once they land at the very bottom or on top of other pieces. Once a piece has landed, the next piece will start falling; you can preview this piece on the right side of the screen. By filling an entire row (or line) of squares, that row will be removed and the rows above will shift down. It is also possible to clear multiple lines at once.
 
-You can control where and how a piece falls, by moving it left or right, making it move down faster, dropping it down instantly, or rotating it left and right. There are multiple control schemes available for these six basic actions; and the space bar always serves as the instant drop key.
-- Left: Move left, Right: Move right, Up: Rotate right, Down: Move down
-- A: Move left, D: Move right, W: Rotate right, E: Rotate left, S: Move down
-- H: Move left, L: Move right, K: Rotate right
+You can control where and how a piece falls, by moving it left or right, making it move down faster, dropping it down instantly, or rotating it left and right. There are multiple control schemes available for these six basic actions; and the `space bar` always serves as the instant drop key.
+- `Left`: Move left, `Right`: Move right, `Up`: Rotate right, `Down`: Move down
+- `A`: Move left, `D`: Move right, `W`: Rotate right, `E`: Rotate left, `S`: Move down
+- `H`: Move left, `L`: Move right, `K`: Rotate right
 
-The Escape and P keys pause and unpause the game.
+The `Escape` and `P` keys pause and unpause the game.
 
 The seven pieces are commonly named "T", "J", "L", "O", "S", "Z", and "I". Note that while "J" and "L" as well as "S" and "Z" are mirrors of each other, they cannot be used interchangeably since you can only rotate pieces.
 

--- a/Userland/Games/BrickGame/BrickGame.cpp
+++ b/Userland/Games/BrickGame/BrickGame.cpp
@@ -446,6 +446,12 @@ void BrickGame::reset()
     update();
 }
 
+void BrickGame::toggle_pause()
+{
+    m_brick_game->toggle_pause();
+    update();
+}
+
 void BrickGame::timer_event(Core::TimerEvent&)
 {
     switch (m_brick_game->state()) {
@@ -466,8 +472,7 @@ void BrickGame::keydown_event(GUI::KeyEvent& event)
     switch (event.key()) {
     case KeyCode::Key_Escape:
     case KeyCode::Key_P:
-        m_brick_game->toggle_pause();
-        update();
+        toggle_pause();
         return;
     default:
         break;

--- a/Userland/Games/BrickGame/BrickGame.cpp
+++ b/Userland/Games/BrickGame/BrickGame.cpp
@@ -246,6 +246,7 @@ class Bricks final {
 public:
     enum class GameState {
         Active,
+        Paused,
         GameOver
     };
 
@@ -314,6 +315,20 @@ public:
             m_block = block;
         }
         return RenderRequest::RequestUpdate;
+    }
+
+    void toggle_pause()
+    {
+        switch (m_state) {
+        case GameState::Active:
+            m_state = GameState::Paused;
+            break;
+        case GameState::Paused:
+            m_state = GameState::Active;
+            break;
+        case GameState::GameOver:
+            break;
+        }
     }
 
     [[nodiscard]] RenderRequest update()
@@ -433,12 +448,17 @@ void BrickGame::reset()
 
 void BrickGame::timer_event(Core::TimerEvent&)
 {
-    if (m_brick_game->state() == Bricks::GameState::GameOver) {
+    switch (m_brick_game->state()) {
+    case Bricks::GameState::GameOver:
         game_over();
-        return;
+        break;
+    case Bricks::GameState::Active:
+        if (m_brick_game->update() == Bricks::RenderRequest::RequestUpdate)
+            update();
+        break;
+    case Bricks::GameState::Paused:
+        break;
     }
-    if (m_brick_game->update() == Bricks::RenderRequest::RequestUpdate)
-        update();
 }
 
 void BrickGame::keydown_event(GUI::KeyEvent& event)
@@ -469,6 +489,10 @@ void BrickGame::keydown_event(GUI::KeyEvent& event)
         break;
     case KeyCode::Key_Space:
         render_request = m_brick_game->move_down_fast();
+        break;
+    case KeyCode::Key_Escape:
+    case KeyCode::Key_P:
+        m_brick_game->toggle_pause();
         break;
     default:
         event.ignore();

--- a/Userland/Games/BrickGame/BrickGame.cpp
+++ b/Userland/Games/BrickGame/BrickGame.cpp
@@ -463,6 +463,18 @@ void BrickGame::timer_event(Core::TimerEvent&)
 
 void BrickGame::keydown_event(GUI::KeyEvent& event)
 {
+    switch (event.key()) {
+    case KeyCode::Key_Escape:
+    case KeyCode::Key_P:
+        m_brick_game->toggle_pause();
+        return;
+    default:
+        break;
+    }
+
+    if (m_brick_game->state() == Bricks::GameState::Paused)
+        return;
+
     Bricks::RenderRequest render_request { Bricks::RenderRequest::SkipRender };
     switch (event.key()) {
     case KeyCode::Key_A:
@@ -489,10 +501,6 @@ void BrickGame::keydown_event(GUI::KeyEvent& event)
         break;
     case KeyCode::Key_Space:
         render_request = m_brick_game->move_down_fast();
-        break;
-    case KeyCode::Key_Escape:
-    case KeyCode::Key_P:
-        m_brick_game->toggle_pause();
         break;
     default:
         event.ignore();

--- a/Userland/Games/BrickGame/BrickGame.h
+++ b/Userland/Games/BrickGame/BrickGame.h
@@ -25,7 +25,8 @@ private:
     virtual void keydown_event(GUI::KeyEvent&) override;
     virtual void timer_event(Core::TimerEvent&) override;
 
-    void paint_text(GUI::Painter&, int row, DeprecatedString const&);
+    void paint_sidebar_text(GUI::Painter&, int row, DeprecatedString const&);
+    void paint_paused_text(GUI::Painter&);
     void paint_cell(GUI::Painter&, Gfx::IntRect, bool);
     void paint_game(GUI::Painter&, Gfx::IntRect const&);
     void game_over();

--- a/Userland/Games/BrickGame/BrickGame.h
+++ b/Userland/Games/BrickGame/BrickGame.h
@@ -18,6 +18,7 @@ public:
     virtual ~BrickGame() override = default;
 
     void reset();
+    void toggle_pause();
 
 private:
     BrickGame(StringView app_name);

--- a/Userland/Games/BrickGame/main.cpp
+++ b/Userland/Games/BrickGame/main.cpp
@@ -56,6 +56,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(game_menu->try_add_action(GUI::Action::create("&New Game", { Mod_None, Key_F2 }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/reload.png"sv)), [&](auto&) {
         game->reset();
     })));
+    TRY(game_menu->try_add_action(GUI::Action::create("Toggle &pause", { Mod_None, Key_P }, [&](auto&) {
+        game->toggle_pause();
+    })));
     TRY(game_menu->try_add_separator());
     TRY(game_menu->try_add_action(GUI::CommonActions::make_quit_action([](auto&) {
         GUI::Application::the()->quit();


### PR DESCRIPTION
Allow the player to pause a `BrickGame` session, by pressing either `P` or `Escape`.

This PR also adds a sentence about this functionality to the manual, and shows it in the context menu.

<img width="399" alt="Screenshot 2023-03-09 at 10 02 09" src="https://user-images.githubusercontent.com/6043048/223972426-cb24a796-5c95-4eff-8dad-870e0d3a63a6.png">

<img width="236" alt="Screenshot 2023-03-09 at 10 02 23" src="https://user-images.githubusercontent.com/6043048/223972490-fe2cff05-bc51-43f7-8046-66621604a4c0.png">
