### PR TITLE
AK+LibWeb: Add FlyString::from_deprecated_fly_string() and use it

### DIFF
--- a/AK/FlyString.cpp
+++ b/AK/FlyString.cpp
@@ -168,6 +168,11 @@ DeprecatedFlyString FlyString::to_deprecated_fly_string() const
     return DeprecatedFlyString(bytes_as_string_view());
 }
 
+ErrorOr<FlyString> FlyString::from_deprecated_fly_string(DeprecatedFlyString const& deprecated_fly_string)
+{
+    return FlyString::from_utf8(deprecated_fly_string.view());
+}
+
 unsigned Traits<FlyString>::hash(FlyString const& fly_string)
 {
     return fly_string.hash();

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -51,8 +51,9 @@ public:
     // This is primarily interesting to unit tests.
     [[nodiscard]] static size_t number_of_fly_strings();
 
-    // FIXME: Remove this once all code has been ported to FlyString
+    // FIXME: Remove these once all code has been ported to FlyString
     [[nodiscard]] DeprecatedFlyString to_deprecated_fly_string() const;
+    static ErrorOr<FlyString> from_deprecated_fly_string(DeprecatedFlyString const&);
 
     // Compare this FlyString against another string with ASCII caseless matching.
     [[nodiscard]] bool equals_ignoring_ascii_case(FlyString const&) const;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -291,7 +291,7 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_attribute_simple_se
             // they are converted to lowercase, so we do that here too. If we want to be
             // correct with XML later, we'll need to keep the original case and then do
             // a case-insensitive compare later.
-            .name = FlyString::from_utf8(attribute_part.token().ident().to_lowercase_string()).release_value_but_fixme_should_propagate_errors(),
+            .name = FlyString::from_deprecated_fly_string(attribute_part.token().ident().to_lowercase_string()).release_value_but_fixme_should_propagate_errors(),
             .case_type = Selector::SimpleSelector::Attribute::CaseType::DefaultMatch,
         }
     };

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -32,7 +32,7 @@ static inline bool matches_lang_pseudo_class(DOM::Element const& element, Vector
     for (auto const* e = &element; e; e = e->parent_element()) {
         auto lang = e->attribute(HTML::AttributeNames::lang);
         if (!lang.is_null()) {
-            element_language = FlyString::from_utf8(lang).release_value_but_fixme_should_propagate_errors();
+            element_language = FlyString::from_deprecated_fly_string(lang).release_value_but_fixme_should_propagate_errors();
             break;
         }
     }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -175,14 +175,14 @@ Vector<MatchingRule> StyleComputer::collect_matching_rules(DOM::Element const& e
     };
 
     for (auto const& class_name : element.class_names()) {
-        if (auto it = rule_cache.rules_by_class.find(FlyString::from_utf8(class_name).release_value_but_fixme_should_propagate_errors()); it != rule_cache.rules_by_class.end())
+        if (auto it = rule_cache.rules_by_class.find(class_name); it != rule_cache.rules_by_class.end())
             add_rules_to_run(it->value);
     }
     if (auto id = element.get_attribute(HTML::AttributeNames::id); !id.is_null()) {
-        if (auto it = rule_cache.rules_by_id.find(FlyString::from_utf8(id).release_value_but_fixme_should_propagate_errors()); it != rule_cache.rules_by_id.end())
+        if (auto it = rule_cache.rules_by_id.find(FlyString::from_deprecated_fly_string(id).release_value_but_fixme_should_propagate_errors()); it != rule_cache.rules_by_id.end())
             add_rules_to_run(it->value);
     }
-    if (auto it = rule_cache.rules_by_tag_name.find(FlyString::from_utf8(element.local_name()).release_value_but_fixme_should_propagate_errors()); it != rule_cache.rules_by_tag_name.end())
+    if (auto it = rule_cache.rules_by_tag_name.find(FlyString::from_deprecated_fly_string(element.local_name()).release_value_but_fixme_should_propagate_errors()); it != rule_cache.rules_by_tag_name.end())
         add_rules_to_run(it->value);
     add_rules_to_run(rule_cache.other_rules);
 
@@ -699,7 +699,7 @@ bool StyleComputer::expand_unresolved_values(DOM::Element& element, StringView p
                 // 1. If the attr() function has a substitution value, replace the attr() function by the substitution value.
                 if (!attr_value.is_null()) {
                     // FIXME: attr() should also accept an optional type argument, not just strings.
-                    dest.empend(Parser::Token::of_string(FlyString::from_utf8(attr_value).release_value_but_fixme_should_propagate_errors()));
+                    dest.empend(Parser::Token::of_string(FlyString::from_deprecated_fly_string(attr_value).release_value_but_fixme_should_propagate_errors()));
                     continue;
                 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -528,7 +528,7 @@ static void paint_text_fragment(PaintContext& context, Layout::TextNode const& t
         auto& font = fragment.layout_node().font();
         auto scaled_font = [&]() -> RefPtr<Gfx::Font const> {
             auto device_font_pt_size = context.enclosing_device_pixels(font.presentation_size());
-            FontSelector font_selector = { FlyString::from_utf8(font.family()).release_value_but_fixme_should_propagate_errors(), static_cast<float>(device_font_pt_size.value()), font.weight(), font.width(), font.slope() };
+            FontSelector font_selector = { FlyString::from_deprecated_fly_string(font.family()).release_value_but_fixme_should_propagate_errors(), static_cast<float>(device_font_pt_size.value()), font.weight(), font.width(), font.slope() };
             if (auto cached_font = FontCache::the().get(font_selector)) {
                 return cached_font;
             }


### PR DESCRIPTION
Let's add FlyString::from_deprecated_fly_string() so we can use it instead of FlyString::from_utf8(). This will make it easier to detect potential unncessary allocations as we transfer to FlyString.