### PR TITLE
Documentation: Update VS Code docs for tone, add query-driver directions

### DIFF
--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -213,6 +213,8 @@ Once the build script finishes, you can use it to compile SerenityOS. Either set
 option to `Clang` as shown [above](#cmake-build-options), or pass `Clang` as the TOOLCHAIN option to
 `Meta/serenity.sh`, for example: `Meta/serenity.sh run x86_64 Clang`.
 
+### Serenity-aware clang tools
+
 Building the clang-based toolchain also builds libTooling-based tools such as clang-format, clang-tidy and (optionally)
 clangd that are aware of SerenityOS as a valid target. These tools will be installed into ``Toolchain/Local/clang/bin`` by
 the script. Pointing your editor's plugins to the custom-built clang tools and a ``compile_commands.json`` from a clang build

--- a/Documentation/NvimConfiguration.md
+++ b/Documentation/NvimConfiguration.md
@@ -47,6 +47,7 @@ system and customize the `inlayHints.sep` based on your preference.
 ```json
 {
     "clangd.fallbackFlags": ["-std=c++20"],
+    "clangd.arguments": ["--query-driver=${workspaceFolder}/Toolchain/Local/**/*"],
     "semanticTokens.enable": true,
     "inlayHint.subSeparator": "︴",
     "inlayHints.enableParameter": true,


### PR DESCRIPTION
cc @kleinesfilmroellchen and @Hendiadyoin1 

These updates worked for me on Ubuntu. the `--query-driver` argument makes it so we don't have to put those dirty manual include paths into `.clangd`