### PR TITLE
Kernel: Add `_SC_PHYS_PAGES` to sys$sysconf

### DIFF
--- a/Kernel/API/POSIX/unistd.h
+++ b/Kernel/API/POSIX/unistd.h
@@ -45,6 +45,7 @@ enum {
     _SC_MAPPED_FILES,
     _SC_ARG_MAX,
     _SC_IOV_MAX,
+    _SC_PHYS_PAGES,
 };
 
 #define _SC_MONOTONIC_CLOCK _SC_MONOTONIC_CLOCK
@@ -60,6 +61,7 @@ enum {
 #define _SC_MAPPED_FILES _SC_MAPPED_FILES
 #define _SC_ARG_MAX _SC_ARG_MAX
 #define _SC_IOV_MAX _SC_IOV_MAX
+#define _SC_PHYS_PAGES _SC_PHYS_PAGES
 
 #ifdef __cplusplus
 }

--- a/Kernel/Syscalls/sysconf.cpp
+++ b/Kernel/Syscalls/sysconf.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <Kernel/FileSystem/VirtualFileSystem.h>
+#include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/Process.h>
 #include <Kernel/Time/TimeManagement.h>
 
@@ -37,6 +38,8 @@ ErrorOr<FlatPtr> Process::sys$sysconf(int name)
         return Process::max_arguments_size;
     case _SC_IOV_MAX:
         return IOV_MAX;
+    case _SC_PHYS_PAGES:
+        return MM.get_system_memory_info().physical_pages;
     default:
         return EINVAL;
     }


### PR DESCRIPTION
Add `_SC_PHYS_PAGES` to sys$sysconf syscall. This value is needed for a port I'm working on.

While this value is non standard, we already support other non standard values like `_SC_NPROCESSORS_CONF` so it should be fine to add this.

The syscall simply returns the number of physical pages that the system has.