### PR TITLE
LibWeb: Fix row-height bug in Grid when there is a column gap

### DIFF
--- a/Base/res/html/misc/display-grid.html
+++ b/Base/res/html/misc/display-grid.html
@@ -6,7 +6,12 @@
   .grid-item {
     background-color: lightblue;
   }
+  .with-border {
+    border: 1px solid black;
+  }
 </style>
+
+<body style="margin-bottom: 2rem;">
 
 <!-- A basic grid -->
 <p>Should render a 2x2 grid</p>
@@ -587,4 +592,13 @@ class="grid-container"
   <div class="grid-item" style="grid-area: one; min-width: 25%; max-width: 50%;">min-content</div>
   <div class="grid-item" style="grid-area: two;">max-content</div>
   <div class="grid-item" style="grid-area: three;">1fr</div>
+</div>
+
+<p>Bug with column gaps - grid items should have normal height</p>
+<div class="grid-container with-border" style="
+      grid-column-gap: 10px;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    ">
+    <div class="grid-item with-border">left side text</div>
+    <div class="grid-item with-border">right side text right side text right side text</div>
 </div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Martin Falisse <mfalisse@outlook.com>
+ * Copyright (c) 2022-2023, Martin Falisse <mfalisse@outlook.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -29,6 +29,33 @@ private:
     Vector<Vector<bool>> m_occupation_grid;
 };
 
+class PositionedBox {
+public:
+    PositionedBox(Box const& box, int row, int row_span, int column, int column_span)
+        : m_box(box)
+        , m_row(row)
+        , m_row_span(row_span)
+        , m_column(column)
+        , m_column_span(column_span)
+    {
+    }
+
+    Box const& box() { return m_box; }
+
+    int raw_row_span() { return m_row_span; }
+    int raw_column_span() { return m_column_span; }
+
+    int gap_adjusted_row(Box const& parent_box);
+    int gap_adjusted_column(Box const& parent_box);
+
+private:
+    Box const& m_box;
+    int m_row { 0 };
+    int m_row_span { 1 };
+    int m_column { 0 };
+    int m_column_span { 1 };
+};
+
 class GridFormattingContext final : public FormattingContext {
 public:
     explicit GridFormattingContext(LayoutState&, Box const& grid_container, FormattingContext* parent);
@@ -42,14 +69,6 @@ private:
     bool is_auto_positioned_row(CSS::GridTrackPlacement const&, CSS::GridTrackPlacement const&) const;
     bool is_auto_positioned_column(CSS::GridTrackPlacement const&, CSS::GridTrackPlacement const&) const;
     bool is_auto_positioned_track(CSS::GridTrackPlacement const&, CSS::GridTrackPlacement const&) const;
-
-    struct PositionedBox {
-        Box const& box;
-        int row { 0 };
-        int row_span { 1 };
-        int column { 0 };
-        int column_span { 1 };
-    };
 
     struct TemporaryTrack {
         CSS::GridSize min_track_sizing_function;


### PR DESCRIPTION
This fixes a bug in the CSS Grid when there is a column gap, as previously it would take the index of the incorrect column when finding the `AvailableSize`.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/45781926/224374655-fc80ac6f-156a-4ab3-915d-2495ebb2119c.png"></td>
<td><img src="https://user-images.githubusercontent.com/45781926/224374699-871cb55a-c576-426a-a741-72c2e0d3fa21.png"></td>
</tr>
</table>

Fixes #17782 