### PR TITLE
CI: Remove stale dependence on Toolchain.yml from nightly job

### DIFF
--- a/Meta/Azure/nightly-pipeline.yml
+++ b/Meta/Azure/nightly-pipeline.yml
@@ -12,13 +12,8 @@ pr: none
 trigger: none
 
 stages:
-  - stage: Toolchain
-    dependsOn: []
-    jobs:
-      - template: Toolchain.yml
-
   - stage: SerenityOS_Coverage
-    dependsOn: Toolchain
+    dependsOn: []
     jobs:
       - template: Serenity.yml
         parameters:


### PR DESCRIPTION
We removed this file in 0a7d0362eaf08cec03e648c08d4d5fca84668ae5 but forgot to update the nightly job.