### PR TITLE
Ladybird+CI: Move layout_test.sh test runner from CI yml into CMake

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -137,3 +137,12 @@ add_dependencies(ladybird SQLServer WebContent WebDriver)
 if(NOT CMAKE_SKIP_INSTALL_RULES)
     include(cmake/InstallRules.cmake)
 endif()
+
+include(CTest)
+if (BUILD_TESTING)
+    add_test(
+        NAME Layout
+        COMMAND ${SERENITY_SOURCE_DIR}/Tests/LibWeb/Layout/layout_test.sh ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    set_tests_properties(Layout PROPERTIES ENVIRONMENT QT_QPA_PLATFORM=offscreen)
+endif()

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -145,16 +145,6 @@ jobs:
           ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1'
           UBSAN_OPTIONS: 'print_stacktrace=1:print_summary=1:halt_on_error=1'
 
-      - script: |
-          $(Build.SourcesDirectory)/Tests/LibWeb/Layout/layout_test.sh "$(Build.SourcesDirectory)/Meta/Lagom/Build/Ladybird"
-        displayName: 'LibWeb Layout Tests'
-        env:
-          SERENITY_SOURCE_DIR: '$(Build.SourcesDirectory)'
-          QT_QPA_PLATFORM: 'offscreen'
-          # FIXME: enable detect_stack_use_after_return=1 #7420
-          ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1'
-          UBSAN_OPTIONS: 'print_stacktrace=1:print_summary=1:halt_on_error=1'
-
     - ${{ if eq(parameters.lagom_lints, true) }}:
       - script: |
           set -e


### PR DESCRIPTION
We should be able to run this locally, as long as ENABLE_LAGOM_LADYBIRD is true, or if building ladybird from the ladybird source directory.

This removes a special case from the Lagom CI yml file.