### PR TITLE
LibGfx+PixelPaint: Constrain selection to the bounds of the image

### DIFF
--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -418,7 +418,8 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         VERIFY(editor);
         if (!editor->active_layer())
             return;
-        editor->image().selection().merge(editor->active_layer()->relative_rect(), PixelPaint::Selection::MergeMode::Set);
+        auto layer_rect = editor->active_layer()->relative_rect();
+        editor->image().selection().merge(layer_rect.intersected(editor->image().rect()), PixelPaint::Selection::MergeMode::Set);
         editor->did_complete_action("Select All"sv);
     })));
     TRY(m_edit_menu->try_add_action(GUI::Action::create(
@@ -660,6 +661,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                     GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to resize image: {}", image_resize_or_error.release_error())));
                     return;
                 }
+                // FIXME: We should ensure the selection is within the bounds of the image here.
                 editor->did_complete_action("Resize Image"sv);
             }
         })));

--- a/Userland/Applications/PixelPaint/Selection.cpp
+++ b/Userland/Applications/PixelPaint/Selection.cpp
@@ -31,6 +31,8 @@ void Selection::invert()
 
 void Selection::merge(Mask const& mask, MergeMode mode)
 {
+    VERIFY(m_image.rect().contains(mask.bounding_rect()));
+
     switch (mode) {
     case MergeMode::Set:
         m_mask = mask;

--- a/Userland/Applications/PixelPaint/Tools/LassoSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/LassoSelectTool.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Timothy Slater <tslater2006@gmail.com>
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -19,42 +20,31 @@
 
 namespace PixelPaint {
 
-void LassoSelectTool::on_mousedown(Layer* layer, MouseEvent& event)
+void LassoSelectTool::on_mousedown(Layer*, MouseEvent& event)
 {
-    if (!layer)
+    if (!m_editor)
         return;
 
-    auto& layer_event = event.layer_event();
-    if (!layer->rect().contains(layer_event.position()))
-        return;
-
-    auto selection_bitmap_result = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, layer->content_bitmap().size());
-    if (selection_bitmap_result.is_error())
-        return;
-
-    m_selection_bitmap = selection_bitmap_result.release_value();
-    m_start_position = layer_event.position();
-    m_most_recent_position = layer_event.position();
+    auto const& image_event = event.image_event();
+    m_start_position = image_event.position();
+    m_most_recent_position = image_event.position();
     m_top_left = m_start_position;
     m_bottom_right = m_start_position;
-    m_preview_coords.clear();
-    m_preview_coords.append(m_most_recent_position);
-    m_selection_bitmap->set_pixel(m_most_recent_position, Gfx::Color::Black);
+    m_path_points.clear();
+    m_path_points.append(m_most_recent_position);
 
     m_selecting = true;
 
     m_editor->image().selection().begin_interactive_selection();
 }
 
-void LassoSelectTool::on_mousemove(Layer* layer, MouseEvent& event)
+void LassoSelectTool::on_mousemove(Layer*, MouseEvent& event)
 {
     if (!m_selecting)
         return;
 
-    auto& layer_event = event.layer_event();
-    auto new_position = layer_event.position();
-    if (!layer->rect().contains(new_position))
-        return;
+    auto const& image_event = event.image_event();
+    auto new_position = image_event.position();
 
     if (new_position == m_most_recent_position)
         return;
@@ -69,10 +59,7 @@ void LassoSelectTool::on_mousemove(Layer* layer, MouseEvent& event)
     if (new_position.y() > m_bottom_right.y())
         m_bottom_right.set_y(new_position.y());
 
-    m_preview_coords.append(new_position);
-
-    auto selection_painter = Gfx::Painter(*m_selection_bitmap);
-    selection_painter.draw_line(m_most_recent_position, new_position, Gfx::Color::Black);
+    m_path_points.append(new_position);
 
     m_most_recent_position = new_position;
 }
@@ -82,72 +69,56 @@ void LassoSelectTool::on_mouseup(Layer*, MouseEvent&)
     if (!m_selecting)
         return;
 
-    if (m_selection_bitmap.is_null())
-        return;
-
     m_selecting = false;
-    m_bottom_right.translate_by(1);
+    m_top_left.translate_by(-1);
 
-    if (m_most_recent_position != m_start_position) {
-        auto selection_painter = Gfx::Painter(*m_selection_bitmap);
-        selection_painter.draw_line(m_most_recent_position, m_start_position, Gfx::Color::Black, 1);
-    }
-
-    auto cropped_selection_result = m_selection_bitmap->cropped(Gfx::Rect<int>::from_two_points(m_top_left, m_bottom_right));
-    if (cropped_selection_result.is_error())
-        return;
-    auto cropped_selection = cropped_selection_result.release_value();
+    if (m_path_points.last() != m_start_position)
+        m_path_points.append(m_start_position);
 
     // We create a bitmap that is bigger by 1 pixel on each side
-    auto lasso_bitmap_or_error = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { (m_bottom_right.x() - m_top_left.x()) + 2, (m_bottom_right.y() - m_top_left.y()) + 2 });
+    auto lasso_bitmap_rect = Gfx::IntRect::from_two_points(m_top_left, m_bottom_right).inflated(2, 2);
+    auto lasso_bitmap_or_error = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, lasso_bitmap_rect.size());
     if (lasso_bitmap_or_error.is_error())
         return;
 
     auto lasso_bitmap = lasso_bitmap_or_error.release_value();
-
     auto lasso_painter = Gfx::Painter(lasso_bitmap);
+    for (size_t i = 0; i < m_path_points.size() - 1; i++) {
+        auto start = m_path_points.at(i) - m_top_left;
+        auto end = m_path_points.at(i + 1) - m_top_left;
+        lasso_painter.draw_line(start, end, Color::Black, 1);
+    }
 
-    // We want to paint the lasso into the bitmap such that there is an empty 1px border on each side
-    // this ensures that we have a known pixel (0,0) that is outside the lasso.
-    // Because we want a 1 px offset to the right and down, we blit the cropped selection bitmap starting at (1,1).
-    lasso_painter.blit({ 1, 1 }, cropped_selection, cropped_selection->rect());
-
-    // Delta to use for mapping the bitmap back to layer coordinates. -1 to account for the right and down offset.
-    auto bitmap_to_layer_delta = Gfx::IntPoint(m_top_left.x() + m_editor->active_layer()->location().x() - 1, m_top_left.y() + m_editor->active_layer()->location().y() - 1);
-    flood_lasso_selection(lasso_bitmap, bitmap_to_layer_delta);
+    flood_lasso_selection(lasso_bitmap);
 }
 
-void LassoSelectTool::flood_lasso_selection(Gfx::Bitmap& lasso_bitmap, Gfx::IntPoint lasso_delta)
+void LassoSelectTool::flood_lasso_selection(Gfx::Bitmap& lasso_bitmap)
 {
     VERIFY(lasso_bitmap.bpp() == 32);
 
     // Create Mask which will track already-processed pixels
-    Mask selection_mask = Mask::full(lasso_bitmap.rect().translated(lasso_delta));
-
+    auto selection_mask = Mask::full({ m_top_left, lasso_bitmap.size() });
     auto pixel_reached = [&](Gfx::IntPoint location) {
-        selection_mask.set(Gfx::IntPoint(location.x(), location.y()).translated(lasso_delta), 0);
+        selection_mask.set(Gfx::IntPoint(m_top_left.x() + location.x(), m_top_left.y() + location.y()), 0);
     };
 
     lasso_bitmap.flood_visit_from_point({ 0, 0 }, 0, move(pixel_reached));
 
     selection_mask.shrink_to_fit();
-    selection_mask.bounding_rect().translate_by(m_editor->active_layer()->location());
     m_editor->image().selection().merge(selection_mask, m_merge_mode);
 }
 
-void LassoSelectTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
+void LassoSelectTool::on_second_paint(Layer const*, GUI::PaintEvent& event)
 {
-    if (!m_selecting || m_preview_coords.size() < 2)
+    if (!m_selecting || m_path_points.size() < 2)
         return;
     GUI::Painter painter(*m_editor);
     painter.add_clip_rect(event.rect());
-    if (layer)
-        painter.translate(editor_layer_location(*layer));
 
     auto draw_preview_lines = [&](auto color, auto thickness) {
-        for (size_t i = 0; i < m_preview_coords.size() - 1; i++) {
-            auto preview_start = editor_stroke_position(m_preview_coords.at(i), 1);
-            auto preview_end = editor_stroke_position(m_preview_coords.at(i + 1), 1);
+        for (size_t i = 0; i < m_path_points.size() - 1; i++) {
+            auto preview_start = editor_stroke_position(m_path_points.at(i), 1);
+            auto preview_end = editor_stroke_position(m_path_points.at(i + 1), 1);
             painter.draw_line(preview_start, preview_end, color, thickness);
         }
     };
@@ -162,8 +133,7 @@ bool LassoSelectTool::on_keydown(GUI::KeyEvent& key_event)
     if (key_event.key() == KeyCode::Key_Escape) {
         if (m_selecting) {
             m_selecting = false;
-            m_selection_bitmap.clear();
-            m_preview_coords.clear();
+            m_path_points.clear();
             return true;
         }
     }

--- a/Userland/Applications/PixelPaint/Tools/LassoSelectTool.h
+++ b/Userland/Applications/PixelPaint/Tools/LassoSelectTool.h
@@ -26,6 +26,7 @@ public:
     virtual bool on_keydown(GUI::KeyEvent&) override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     virtual StringView tool_name() const override { return "Lasso Select Tool"sv; }

--- a/Userland/Applications/PixelPaint/Tools/LassoSelectTool.h
+++ b/Userland/Applications/PixelPaint/Tools/LassoSelectTool.h
@@ -30,15 +30,14 @@ public:
 
 private:
     virtual StringView tool_name() const override { return "Lasso Select Tool"sv; }
-    void flood_lasso_selection(Gfx::Bitmap&, Gfx::IntPoint);
+    void flood_lasso_selection(Gfx::Bitmap&);
 
     RefPtr<GUI::Widget> m_properties_widget;
     Selection::MergeMode m_merge_mode { Selection::MergeMode::Set };
 
     Gfx::IntPoint m_start_position;
     Gfx::IntPoint m_most_recent_position;
-    RefPtr<Gfx::Bitmap> m_selection_bitmap;
-    Vector<Gfx::IntPoint> m_preview_coords;
+    Vector<Gfx::IntPoint> m_path_points;
 
     Gfx::IntPoint m_top_left;
     Gfx::IntPoint m_bottom_right;

--- a/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022-2023, the SerenityOS developers.
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -24,14 +25,16 @@ void PolygonalSelectTool::flood_polygon_selection(Gfx::Bitmap& polygon_bitmap, G
     VERIFY(polygon_bitmap.bpp() == 32);
 
     // Create Mask which will track already-processed pixels.
-    Mask selection_mask = Mask::full(polygon_bitmap.rect().translated(polygon_delta));
+    auto mask_rect = Gfx::IntRect(polygon_delta, polygon_bitmap.size()).intersected(m_editor->image().rect());
+    auto selection_mask = Mask::full(mask_rect);
 
     auto pixel_reached = [&](Gfx::IntPoint location) {
-        selection_mask.set(Gfx::IntPoint(location.x(), location.y()).translated(polygon_delta), 0);
+        auto point_to_set = location.translated(polygon_delta);
+        if (mask_rect.contains(point_to_set))
+            selection_mask.set(point_to_set, 0);
     };
 
-    polygon_bitmap.flood_visit_from_point({ polygon_bitmap.width() - 1, polygon_bitmap.height() - 1 }, 0, move(pixel_reached));
-
+    polygon_bitmap.flood_visit_from_point({ 0, 0 }, 0, move(pixel_reached));
     selection_mask.shrink_to_fit();
     m_editor->image().selection().merge(selection_mask, m_merge_mode);
 }
@@ -39,60 +42,65 @@ void PolygonalSelectTool::flood_polygon_selection(Gfx::Bitmap& polygon_bitmap, G
 void PolygonalSelectTool::process_polygon()
 {
     // Determine minimum bounding box that can hold the polygon.
-    auto min_x_seen = m_polygon_points.at(0).x();
-    auto max_x_seen = m_polygon_points.at(0).x();
-    auto min_y_seen = m_polygon_points.at(0).y();
-    auto max_y_seen = m_polygon_points.at(0).y();
+    auto top_left = m_polygon_points.at(0);
+    auto bottom_right = m_polygon_points.at(0);
 
     for (auto point : m_polygon_points) {
-        if (point.x() < min_x_seen)
-            min_x_seen = point.x();
-        if (point.x() > max_x_seen)
-            max_x_seen = point.x();
-        if (point.y() < min_y_seen)
-            min_y_seen = point.y();
-        if (point.y() > max_y_seen)
-            max_y_seen = point.y();
+        if (point.x() < top_left.x())
+            top_left.set_x(point.x());
+        if (point.x() > bottom_right.x())
+            bottom_right.set_x(point.x());
+        if (point.y() < top_left.y())
+            top_left.set_y(point.y());
+        if (point.y() > bottom_right.y())
+            bottom_right.set_y(point.y());
     }
 
-    // We create a bitmap that is bigger by 1 pixel on each side (+2) and need to account for the 0 indexed
-    // pixel positions (+1) so we make the bitmap size the delta of x/y min/max + 3.
-    auto polygon_bitmap_or_error = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { (max_x_seen - min_x_seen) + 3, (max_y_seen - min_y_seen) + 3 });
+    top_left.translate_by(-1);
+    auto polygon_rect = Gfx::IntRect::from_two_points(top_left, bottom_right);
+    auto image_rect = m_editor->image().rect();
+    if (!polygon_rect.intersects(image_rect)) {
+        m_editor->image().selection().merge(Gfx::IntRect {}, m_merge_mode);
+        return;
+    }
+
+    if (m_polygon_points.last() != m_polygon_points.first())
+        m_polygon_points.append(m_polygon_points.first());
+
+    // We want to paint the polygon into the bitmap such that there is an empty 1px border all the way around it
+    // this ensures that we have a known pixel (0,0) that is outside the polygon.
+    auto bitmap_rect = polygon_rect.inflated(2, 2);
+    // FIXME: It should be possible to limit the size of the polygon bitmap to the size of the canvas, as that is
+    //        the maximum possible size of the selection.
+    auto polygon_bitmap_or_error = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, bitmap_rect.size());
     if (polygon_bitmap_or_error.is_error())
         return;
 
     auto polygon_bitmap = polygon_bitmap_or_error.release_value();
-
-    auto polygon_painter = Gfx::Painter(polygon_bitmap);
-    // We want to paint the polygon into the bitmap such that there is an empty 1px border all the way around it
-    // this ensures that we have a known pixel (0,0) that is outside the polygon. Since the coordinates are relative
-    // to the layer but the bitmap is cropped to the bounding rect of the polygon we need to offset our
-    // points by the the negative of min x/y. And because we want a 1 px offset to the right and down, we + 1 this.
-    auto polygon_bitmap_delta = Gfx::IntPoint(-min_x_seen + 1, -min_y_seen + 1);
-    polygon_painter.translate(polygon_bitmap_delta);
+    Gfx::Painter polygon_painter(polygon_bitmap);
     for (size_t i = 0; i < m_polygon_points.size() - 1; i++) {
-        polygon_painter.draw_line(m_polygon_points.at(i), m_polygon_points.at(i + 1), Color::Black);
+        auto line_start = m_polygon_points.at(i) - top_left;
+        auto line_end = m_polygon_points.at(i + 1) - top_left;
+        polygon_painter.draw_line(line_start, line_end, Color::Black);
     }
-    polygon_painter.draw_line(m_polygon_points.at(m_polygon_points.size() - 1), m_polygon_points.at(0), Color::Black);
 
-    // Delta to use for mapping the bitmap back to layer coordinates. -1 to account for the right and down offset.
-    auto bitmap_to_layer_delta = Gfx::IntPoint(min_x_seen + m_editor->active_layer()->location().x() - 1, min_y_seen + m_editor->active_layer()->location().y() - 1);
-    flood_polygon_selection(polygon_bitmap, bitmap_to_layer_delta);
+    flood_polygon_selection(polygon_bitmap, top_left);
 }
+
 void PolygonalSelectTool::on_mousedown(Layer*, MouseEvent& event)
 {
-    auto& image_event = event.image_event();
+    auto const& image_event = event.image_event();
     if (image_event.button() != GUI::MouseButton::Primary)
         return;
     if (!m_selecting) {
         m_polygon_points.clear();
-        m_last_selecting_cursor_position = event.layer_event().position();
+        m_last_selecting_cursor_position = image_event.position();
     }
 
     m_selecting = true;
 
-    auto new_point = event.layer_event().position();
-    if (!m_polygon_points.is_empty() && event.layer_event().shift())
+    auto new_point = image_event.position();
+    if (!m_polygon_points.is_empty() && image_event.shift())
         new_point = Tool::constrain_line_angle(m_polygon_points.last(), new_point);
 
     // This point matches the first point exactly. Consider this polygon finished.
@@ -120,10 +128,11 @@ void PolygonalSelectTool::on_mousemove(Layer*, MouseEvent& event)
     if (!m_selecting)
         return;
 
-    if (event.layer_event().shift())
-        m_last_selecting_cursor_position = Tool::constrain_line_angle(m_polygon_points.last(), event.layer_event().position());
+    auto const& image_event = event.image_event();
+    if (image_event.shift())
+        m_last_selecting_cursor_position = Tool::constrain_line_angle(m_polygon_points.last(), image_event.position());
     else
-        m_last_selecting_cursor_position = event.layer_event().position();
+        m_last_selecting_cursor_position = image_event.position();
 
     m_editor->update();
 }
@@ -137,15 +146,13 @@ void PolygonalSelectTool::on_doubleclick(Layer*, MouseEvent&)
     m_editor->update();
 }
 
-void PolygonalSelectTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
+void PolygonalSelectTool::on_second_paint(Layer const*, GUI::PaintEvent& event)
 {
     if (!m_selecting)
         return;
 
     GUI::Painter painter(*m_editor);
     painter.add_clip_rect(event.rect());
-
-    painter.translate(editor_layer_location(*layer));
 
     auto draw_preview_lines = [&](auto color, auto thickness) {
         for (size_t i = 0; i < m_polygon_points.size() - 1; i++) {

--- a/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.h
+++ b/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.h
@@ -27,7 +27,7 @@ public:
     virtual Gfx::IntPoint point_position_to_preferred_cell(Gfx::FloatPoint position) const override;
 
 private:
-    virtual void flood_polygon_selection(Gfx::Bitmap&, Gfx::IntPoint);
+    virtual void flood_polygon_selection(Gfx::Bitmap&, Gfx::IntPoint polygon_delta);
     virtual void process_polygon();
     virtual StringView tool_name() const override { return "Polygonal Select Tool"sv; }
 

--- a/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.h
+++ b/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.h
@@ -47,6 +47,8 @@ private:
     MovingMode m_moving_mode { MovingMode::None };
     Gfx::IntPoint m_selection_start;
     Gfx::IntPoint m_selection_end;
+
+    Gfx::IntRect selection_rect() const;
 };
 
 }

--- a/Userland/Applications/PixelPaint/Tools/WandSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/WandSelectTool.cpp
@@ -21,14 +21,18 @@
 
 namespace PixelPaint {
 
-static void set_flood_selection(Gfx::Bitmap& bitmap, Image& image, Gfx::IntPoint start_position, Gfx::IntPoint selection_offset, int threshold, Selection::MergeMode merge_mode)
+static void set_flood_selection(Gfx::Bitmap& bitmap, Image& image, Gfx::IntPoint start_position, Gfx::IntRect layer_rect, int threshold, Selection::MergeMode merge_mode)
 {
     VERIFY(bitmap.bpp() == 32);
 
-    auto selection_mask = Mask::empty({ selection_offset, bitmap.size() });
+    auto image_rect = image.rect();
+    auto mask_rect = layer_rect.intersected(image_rect);
+    auto selection_mask = Mask::empty(mask_rect);
 
     auto pixel_reached = [&](Gfx::IntPoint location) {
-        selection_mask.set(selection_offset.x() + location.x(), selection_offset.y() + location.y(), 0xFF);
+        auto point_to_set = layer_rect.top_left() + location;
+        if (selection_mask.bounding_rect().contains(point_to_set))
+            selection_mask.set(point_to_set, 0xFF);
     };
 
     bitmap.flood_visit_from_point(start_position, threshold, move(pixel_reached));
@@ -55,10 +59,8 @@ void WandSelectTool::on_mousedown(Layer* layer, MouseEvent& event)
     if (!layer->rect().contains(layer_event.position()))
         return;
 
-    auto selection_offset = layer->relative_rect().top_left();
-
     m_editor->image().selection().begin_interactive_selection();
-    set_flood_selection(layer->currently_edited_bitmap(), m_editor->image(), layer_event.position(), selection_offset, m_threshold, m_merge_mode);
+    set_flood_selection(layer->currently_edited_bitmap(), m_editor->image(), layer_event.position(), layer->relative_rect(), m_threshold, m_merge_mode);
     m_editor->image().selection().end_interactive_selection();
     m_editor->update();
     m_editor->did_complete_action(tool_name());

--- a/Userland/Libraries/LibGfx/Point.cpp
+++ b/Userland/Libraries/LibGfx/Point.cpp
@@ -15,8 +15,8 @@ namespace Gfx {
 template<typename T>
 void Point<T>::constrain(Rect<T> const& rect)
 {
-    m_x = AK::clamp<T>(x(), rect.left(), rect.right());
-    m_y = AK::clamp<T>(y(), rect.top(), rect.bottom());
+    m_x = AK::clamp<T>(x(), rect.left(), rect.left() + rect.width());
+    m_y = AK::clamp<T>(y(), rect.top(), rect.top() + rect.height());
 }
 
 template<typename T>


### PR DESCRIPTION
This PR includes several changes to selection behavior to bring it more in line with other image editing programs. It also ensures consistent behavior is across all selection tools.

The following changes have been made:

* The lasso tool can now make a selection outside of the currently active layer. This makes its behavior consistent with other selection tools.
* The lasso tool now has a crosshair cursor.
* Selections are now constrained to within the bounds of the image. The preview lines for the lasso and polygonal select tools can still be drawn outside the bounds of the image, while the rectangle tool preview is not shown outside the bounds of the image. This matches the behavior of both GIMP and Photoshop.

Video:

https://user-images.githubusercontent.com/2817754/228615024-980fd0a2-e734-48d6-8c7b-e7ada8382054.mp4
