### PR TITLE
Kernel/Storage+Meta: Fix boot using an NVMe device

### DIFF
--- a/Base/usr/share/man/man7/boot_device_addressing.md
+++ b/Base/usr/share/man/man7/boot_device_addressing.md
@@ -30,7 +30,7 @@ to address raw `StorageDevice`s:
 
 ```
 ata0:0:0 [First ATA controller, ATA first primary channel, master device]
-nvme0:0 [First NVMe Controller, First NVMe Namespace]
+nvme0:1:0 [First NVMe Controller, First NVMe Namespace, Not Applicable]
 ramdisk0 [First Ramdisk]
 ```
 

--- a/Kernel/Storage/StorageDevice.h
+++ b/Kernel/Storage/StorageDevice.h
@@ -46,7 +46,7 @@ public:
     // For example, on a legacy ATA instance, one might connect an harddrive to the second IDE controller,
     // to the Primary channel as a slave device, which translates to LUN 1:0:1.
     // On NVMe, for example, connecting a second PCIe NVMe storage device as a sole NVMe namespace translates
-    // to LUN 1:0:0.
+    // to LUN 1:1:0.
     struct LUNAddress {
         u32 controller_id;
         u32 target_id;

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -223,7 +223,7 @@ else
         SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk,if=none,id=disk"
         SERENITY_BOOT_DRIVE="$SERENITY_BOOT_DRIVE -device i82801b11-bridge,id=bridge4 -device sdhci-pci,bus=bridge4"
         SERENITY_BOOT_DRIVE="$SERENITY_BOOT_DRIVE -device nvme,serial=deadbeef,drive=disk,bus=bridge4,logical_block_size=4096,physical_block_size=4096"
-        SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE root=/dev/nvme0n1"
+        SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE root=nvme0:1:0"
     else
         SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk,id=disk"
     fi


### PR DESCRIPTION
### Updating NVMe boot device addressing (Fixed)
I couldn't start serenity using an NVMe boot device.
Commit: 2c84466ad8 ("Kernel/Storage: Introduce new boot device addressing modes") changed the way we pass the boot device parameter. This series updates the Meta/run.sh plus the documentation on how we address an NVMe device.

## UB issue (Still unresolved)
Even though this series fixes one problem while bringing up serenity with an NVMe device, the kernel still panics for **some UB**, for which I have no idea how to fix it. **Any help would be appreciated**.

I bisected the issue to this commit:
288a73ea0e ("Kernel: Add dmesgln_pci logging for Kernel::PCI")

I don't understand how the above commit results in the following behavior. I was able to **test my changes before this commit**.

#### Kernel Panic dmesg:
[init_stage2(1:1)]: KUBSAN: reference binding to misaligned address 0xbbbbbbbc1449cafb of type 'const struct VisibleType'
[init_stage2(1:1)]: KUBSAN: at /home/panky/personal/serenity/./AK/Vector.h, line 143, column: 26
[init_stage2(1:1)]: Kernel + 0x00000000014aef31  print_location +0x211
[init_stage2(1:1)]: Kernel + 0x00000000014b338a  __ubsan_handle_type_mismatch_v1 +0x20a
[init_stage2(1:1)]: Kernel + 0x00000000004ca91d  Kernel::NVMeController::device(unsigned int) const +0x67d
[init_stage2(1:1)]: Kernel + 0x0000000001880394  Kernel::StorageManagement::enumerate_storage_devices() [clone .localalias] +0x2e4
[init_stage2(1:1)]: Kernel + 0x000000000188ee71  Kernel::StorageManagement::initialize(AK::StringView, bool, bool) +0x7c1
[init_stage2(1:1)]: Kernel + 0x00000000014c6b98  Kernel::init_stage2(void*) +0x17f8

#### How to reproduce this issue:
```
SERENITY_NVME_ENABLE=1 Meta/serenity.sh run
```