### PR TITLE
LibWeb: Establish a stacking context for root element

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -117,7 +117,7 @@ bool Node::establishes_stacking_context() const
 
     if (!has_style())
         return false;
-    if (dom_node() == &document().root())
+    if (is_root_element() || dom_node() == &document().root())
         return true;
     auto position = computed_values().position();
 


### PR DESCRIPTION
Until now, we were just creating a stacking context for the tree root, which usually is the viewport element. This lead to weird painting behavior, when negative z-index children of the HTML element that established their own stacking context were drawn below the canvas background.

Now we establish a stacking context for both, the root element and the viewport.

I tested all relevant combinations of sticky, relative and fixed positioned children in the root stacking context I could think of, and I think we now behave like other browsers and comply with the spec. 🎉

<details>
  <summary>Basic example</summary>

```html
<style>
  body {
    font-family: "SerenitySans";
  }

  .box {
    border: 1px solid salmon;
    background-color: aqua;
    width: 100px;
    height: 100px;

    /* Problematic properties */
    z-index: -10;
    position: relative;
  }
</style>
<div class="box">
```

</details>