### PR TITLE
sort: Add -r option to reverse sort lines

### DIFF
--- a/Base/usr/share/man/man1/sort.md
+++ b/Base/usr/share/man/man1/sort.md
@@ -12,6 +12,14 @@ $ sort [INPUT]
 
 Sort each lines of INPUT (or standard input). A quick sort algorithm is used.
 
+## Options
+
+* `-k keydef`, `--key-field keydef`: The field to sort by
+* `-u`, `--unique`: Don't emit duplicate lines
+* `-n`, `--numeric`: Treat the key field as a number
+* `-t char`, `--sep char`: The separator to split fields by
+* `-r`, `--reverse`: Sort in reverse order
+
 ## Examples
 
 ```sh

--- a/Userland/Utilities/sort.cpp
+++ b/Userland/Utilities/sort.cpp
@@ -55,6 +55,7 @@ struct Options {
     size_t key_field { 0 };
     bool unique { false };
     bool numeric { false };
+    bool reverse { false };
     StringView separator { "\0", 1 };
     Vector<DeprecatedString> files;
 };
@@ -104,6 +105,7 @@ ErrorOr<int> serenity_main([[maybe_unused]] Main::Arguments arguments)
     args_parser.add_option(options.unique, "Don't emit duplicate lines", "unique", 'u');
     args_parser.add_option(options.numeric, "treat the key field as a number", "numeric", 'n');
     args_parser.add_option(options.separator, "The separator to split fields by", "sep", 't', "char");
+    args_parser.add_option(options.reverse, "Sort in reverse order", "reverse", 'r');
     args_parser.add_positional_argument(options.files, "Files to sort", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
@@ -120,9 +122,15 @@ ErrorOr<int> serenity_main([[maybe_unused]] Main::Arguments arguments)
 
     quick_sort(lines);
 
-    for (auto& line : lines) {
-        outln("{}", line.line);
-    }
+    auto print_lines = [](auto const& lines) {
+        for (auto& line : lines)
+            outln("{}", line.line);
+    };
+
+    if (options.reverse)
+        print_lines(lines.in_reverse());
+    else
+        print_lines(lines);
 
     return 0;
 }


### PR DESCRIPTION
With this PR lines can now be sorted in reverse order by specifying the `-r` option.

Example:

![sort_reversed](https://user-images.githubusercontent.com/2817754/224511358-80b467f7-29ae-42a6-bd4b-878344e3827f.png)
