### PR TITLE
PixelPaint: Display color information on mousemove with the PickerTool

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -118,6 +118,7 @@ public:
 
     Core::EventLoop& gui_event_loop() { return m_gui_event_loop; }
 
+    void set_status_info_to_color_at_mouse_position(Gfx::IntPoint position, bool sample_all_layers);
     void set_editor_color_to_color_at_mouse_position(GUI::MouseEvent const& event, bool sample_all_layers);
 
     void set_modified(DeprecatedString action_text);
@@ -160,6 +161,8 @@ private:
     Gfx::IntRect mouse_indicator_rect_y() const;
 
     void paint_selection(Gfx::Painter&);
+
+    Optional<Color> color_from_position(Gfx::IntPoint position, bool sample_all_layers);
 
     NonnullRefPtr<Image> m_image;
     RefPtr<Layer> m_active_layer;

--- a/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
@@ -27,7 +27,6 @@ void PickerTool::on_mouseup(Layer*, MouseEvent& event)
     auto layer_event = event.layer_event();
     if (layer_event.buttons() & GUI::MouseButton::Primary || layer_event.buttons() & GUI::MouseButton::Secondary)
         return;
-    m_editor->set_appended_status_info(DeprecatedString::empty());
 }
 
 void PickerTool::on_mousemove(Layer* layer, MouseEvent& event)
@@ -35,6 +34,8 @@ void PickerTool::on_mousemove(Layer* layer, MouseEvent& event)
     if (!layer)
         return;
     auto layer_event = event.layer_event();
+    m_editor->set_status_info_to_color_at_mouse_position(layer_event.position(), m_sample_all_layers);
+
     if (!(layer_event.buttons() & GUI::MouseButton::Primary || layer_event.buttons() & GUI::MouseButton::Secondary))
         return;
     m_editor->set_editor_color_to_color_at_mouse_position(layer_event, m_sample_all_layers);


### PR DESCRIPTION
Per-channel values of the pixel color are now displayed in the status bar when the PickerTool is selected. This information obviously updates on mousemove.

A must-have to debug JPEG's colors :smile: