### PR TITLE
Meta+CMake: Remove "image" ninja target in favor of "qemu-image"

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -194,7 +194,7 @@ jobs:
       - name: Create Serenity Rootfs
         if: ${{ matrix.debug-options == 'NORMAL_DEBUG'}}
         working-directory: ${{ github.workspace }}/Build/${{ matrix.arch }}
-        run: ninja install && ninja image
+        run: ninja install && ninja qemu-image
 
       - name: Run On-Target Tests
         if: ${{ matrix.debug-options == 'NORMAL_DEBUG'}}
@@ -236,6 +236,6 @@ jobs:
         run: |
           # Running the tests apparently leaves the image sufficiently broken
           rm _disk_image
-          ninja image
+          ninja qemu-image
           /usr/bin/time ../../Meta/export-argsparser-manpages.sh --verify-git-state
         timeout-minutes: 10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,13 +73,9 @@ add_custom_target(run
 # out forcing re-builds when they might not want them.
 add_custom_target(setup-and-run
     COMMAND ${CMAKE_MAKE_PROGRAM} install
-    COMMAND ${CMAKE_MAKE_PROGRAM} image
+    COMMAND ${CMAKE_MAKE_PROGRAM} qemu-image
     COMMAND ${CMAKE_MAKE_PROGRAM} run
     USES_TERMINAL
-)
-
-add_custom_target(image
-    DEPENDS qemu-image
 )
 
 add_custom_target(qemu-image

--- a/Documentation/RunningTests.md
+++ b/Documentation/RunningTests.md
@@ -79,7 +79,7 @@ For completeness, a basic on-target test run will need the SerenityOS image buil
 cmake -GNinja -S Meta/CMake/Superbuild -B Build/superbuild-x86_64
 cmake --build Build/superbuild-x86_64
 cd Build/x86_64
-ninja install && ninja image && ninja run
+ninja install && ninja qemu-image && ninja run
 ```
 
 In the initial terminal, one can easily run the test runner script:

--- a/Meta/Azure/Serenity.yml
+++ b/Meta/Azure/Serenity.yml
@@ -65,7 +65,7 @@ jobs:
         CCACHE_DIR: '$(SERENITY_CCACHE_DIR)'
 
     - script: |
-        ninja install && ninja image
+        ninja install && ninja qemu-image
       displayName: 'Create RootFS'
       workingDirectory: $(Build.SourcesDirectory)/Build/${{ parameters.arch }}clang
 

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -283,7 +283,7 @@ build_image() {
     if [ "$SERENITY_RUN" = "limine" ]; then
         build_target limine-image
     else
-        build_target image
+        build_target qemu-image
     fi
 }
 


### PR DESCRIPTION
"image" was an alias for "qemu-image".

I want to add an `image` userland utility, which clashes with that
shortname.

So remove the existing "image" target. It was just an alias for 
"qemu-image". 

If you use serenity.sh to build, nothing changes. This only affects you
if you run ninja manually -- you now have to say `ninja qemu-image` to
build the disk image.