### PR TITLE
LibC: Correctly reset the getopt state on `optind = 1`

### DIFF
--- a/Userland/Libraries/LibC/getopt.cpp
+++ b/Userland/Libraries/LibC/getopt.cpp
@@ -33,7 +33,7 @@ int getopt(int argc, char* const* argv, char const* short_options)
     for (auto i = 1; i < argc; ++i)
         s_args.append({ argv[i], strlen(argv[i]) });
 
-    if (optind == 0 || optreset == 1) {
+    if (optind == 1 || optreset == 1) {
         s_parser.reset_state();
         optind = 1;
         optreset = 0;
@@ -75,7 +75,7 @@ int getopt_long(int argc, char* const* argv, char const* short_options, const st
         });
     }
 
-    if (optind == 0 || optreset == 1) {
+    if (optind == 1 || optreset == 1) {
         s_parser.reset_state();
         optind = 1;
         optreset = 0;

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -166,8 +166,7 @@ extern int optopt;
 // Index of the next argument to process upon a getopt*() call.
 extern int optind;
 // If set, reset the internal state kept by getopt*(). You may also want to set
-// optind to 1 in that case. Alternatively, setting optind to 0 is treated like
-// doing both of the above.
+// optind to 1 in that case.
 extern int optreset;
 // After parsing an option that accept an argument, set to point to the argument
 // value.


### PR DESCRIPTION
The Linux `getopt_long` manpage tells users to reset `optind` to 1 when scanning the same argument vector or a new argument vector again. This makes sense, since `optind` denotes the _next_ option to be processed.

The behavior of setting `optind` to 0 doesn't seem to be specified anywhere, so let's also remove that comment from `unistd.h`.