### PR TITLE
Meta: Add automatic way to update our `ca_certs.ini` file

### DIFF
--- a/.github/workflows/ca-update.yaml
+++ b/.github/workflows/ca-update.yaml
@@ -1,0 +1,30 @@
+name: CA Update
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * 0"
+jobs:
+  Step-1:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+        
+      - name: Download and Parse
+        run: |
+          python3.10 -m pip install cryptography
+          wget https://curl.se/ca/cacert.pem
+          python3.10 Meta/ca-update.py
+          mv ca_certs.ini Base/etc/
+          rm -f cacert.pem
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: 'Base: Update `certs.ini`'
+          branch: 'ca-update'
+          delete-branch: true
+          title: 'Base: Automcatic update for `certs.ini`'
+      

--- a/Meta/ca-update.py
+++ b/Meta/ca-update.py
@@ -1,0 +1,52 @@
+import configparser
+import fileinput
+from base64 import b64encode
+
+from cryptography import x509
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.x509.oid import NameOID
+
+
+def main():
+    with open("cacert.pem", "rb") as source, open("ca_certs.ini", "w", encoding="utf-8") as dest:
+        certs = x509.load_pem_x509_certificates(source.read())
+        output = configparser.RawConfigParser()
+        output.optionxform = lambda option: option
+
+        for cert in certs:
+
+            # We can only parse RSA, so trash everything else
+            if not isinstance(cert.public_key(), rsa.RSAPublicKey):
+                continue
+
+            commonName = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+            if not commonName:
+                commonName = cert.subject.get_attributes_for_oid(NameOID.ORGANIZATIONAL_UNIT_NAME)
+
+            if not commonName:
+                continue
+
+            commonName = commonName[0].value
+
+            organizationName = cert.subject.get_attributes_for_oid(NameOID.ORGANIZATION_NAME)
+            if organizationName:
+                organizationName = organizationName[0].value
+            else:
+                organizationName = ""
+
+            raw_cert = b64encode(cert.public_bytes(Encoding.DER))
+            if not output.has_section(organizationName):
+                output.add_section(organizationName)
+            output.set(organizationName, commonName, raw_cert.decode("utf-8"))
+
+        output.write(dest)
+
+    # This could be removed if it is ok to keep [DEFAULT] instead of [], configparser does not allow empty section names
+    with fileinput.FileInput("ca_certs.ini", inplace=True) as file:
+        for line in file:
+            print(line.replace("[DEFAULT]", "[]"), end='')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR consists of two commits:

1)

This commit indroduces a new script called `ca-update.py` that will parse a `cacert.pem` file from https://curl.se into our `ca_certs.ini` file format.

2)

This commit adds a now action that will automate this process:

- Download the cacerts.pem
- Convert it
- Put it in place
- Open a new PR

This action would run every sunday and could be triggered manually if needed.

For this action to work, runners needs to have write access and be allowed to open PRs. Both settings are disabled by default.