### PR TITLE
LibGfx: Change BMPWriter API to be consistent with other image writers

### DIFF
--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -27,8 +27,7 @@
 static ErrorOr<ByteBuffer> dump_bitmap(RefPtr<Gfx::Bitmap> bitmap, AK::StringView extension)
 {
     if (extension == "bmp") {
-        Gfx::BMPWriter dumper;
-        return dumper.dump(bitmap);
+        return Gfx::BMPWriter::encode(*bitmap);
     } else if (extension == "png") {
         return Gfx::PNGWriter::encode(*bitmap);
     } else if (extension == "qoi") {

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -176,8 +176,7 @@ ErrorOr<void> Image::export_bmp_to_file(NonnullOwnPtr<Stream> stream, bool prese
     auto bitmap_format = preserve_alpha_channel ? Gfx::BitmapFormat::BGRA8888 : Gfx::BitmapFormat::BGRx8888;
     auto bitmap = TRY(compose_bitmap(bitmap_format));
 
-    Gfx::BMPWriter dumper;
-    auto encoded_data = dumper.dump(bitmap);
+    auto encoded_data = TRY(Gfx::BMPWriter::encode(*bitmap));
     TRY(stream->write_entire_buffer(encoded_data));
     return {};
 }

--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -371,11 +371,9 @@ ErrorOr<void> Mandelbrot::export_image(DeprecatedString const& export_path, Imag
     m_set.resize(Gfx::IntSize { 1920, 1080 });
     ByteBuffer encoded_data;
     switch (image_type) {
-    case ImageType::BMP: {
-        Gfx::BMPWriter dumper;
-        encoded_data = dumper.dump(m_set.bitmap());
+    case ImageType::BMP:
+        encoded_data = TRY(Gfx::BMPWriter::encode(m_set.bitmap()));
         break;
-    }
     case ImageType::PNG:
         encoded_data = TRY(Gfx::PNGWriter::encode(m_set.bitmap()));
         break;

--- a/Userland/Libraries/LibGfx/BMPWriter.cpp
+++ b/Userland/Libraries/LibGfx/BMPWriter.cpp
@@ -67,7 +67,7 @@ static ByteBuffer write_pixel_data(RefPtr<Bitmap const> bitmap, int pixel_row_da
     return buffer;
 }
 
-static ByteBuffer compress_pixel_data(ByteBuffer const& pixel_data, BMPWriter::Compression compression)
+ByteBuffer BMPWriter::compress_pixel_data(ByteBuffer const& pixel_data, BMPWriter::Compression compression)
 {
     switch (compression) {
     case BMPWriter::Compression::BI_BITFIELDS:

--- a/Userland/Libraries/LibGfx/BMPWriter.cpp
+++ b/Userland/Libraries/LibGfx/BMPWriter.cpp
@@ -67,6 +67,11 @@ static ByteBuffer write_pixel_data(RefPtr<Bitmap const> bitmap, int pixel_row_da
     return buffer;
 }
 
+ErrorOr<ByteBuffer> BMPWriter::encode(Bitmap const& bitmap, Options options)
+{
+    return BMPWriter().dump(bitmap, options);
+}
+
 ByteBuffer BMPWriter::compress_pixel_data(ByteBuffer const& pixel_data, BMPWriter::Compression compression)
 {
     switch (compression) {

--- a/Userland/Libraries/LibGfx/BMPWriter.cpp
+++ b/Userland/Libraries/LibGfx/BMPWriter.cpp
@@ -78,17 +78,18 @@ ByteBuffer BMPWriter::compress_pixel_data(ByteBuffer const& pixel_data, BMPWrite
     VERIFY_NOT_REACHED();
 }
 
-ByteBuffer BMPWriter::dump(RefPtr<Bitmap const> bitmap, DibHeader dib_header)
+ByteBuffer BMPWriter::dump(RefPtr<Bitmap const> bitmap, Options options)
 {
+    Options::DibHeader dib_header = options.dib_header;
 
     switch (dib_header) {
-    case DibHeader::Info:
+    case Options::DibHeader::Info:
         m_compression = Compression::BI_RGB;
         m_bytes_per_pixel = 3;
         m_include_alpha_channel = false;
         break;
-    case DibHeader::V3:
-    case DibHeader::V4:
+    case Options::DibHeader::V3:
+    case Options::DibHeader::V4:
         m_compression = Compression::BI_BITFIELDS;
         m_bytes_per_pixel = 4;
         m_include_alpha_channel = true;
@@ -128,14 +129,14 @@ ByteBuffer BMPWriter::dump(RefPtr<Bitmap const> bitmap, DibHeader dib_header)
     streamer.write_u32(0);                     // TotalColors
     streamer.write_u32(0);                     // ImportantColors
 
-    if (dib_header == DibHeader::V3 || dib_header == DibHeader::V4) {
+    if (dib_header == Options::DibHeader::V3 || dib_header == Options::DibHeader::V4) {
         streamer.write_u32(0x00ff0000); // Red bitmask
         streamer.write_u32(0x0000ff00); // Green bitmask
         streamer.write_u32(0x000000ff); // Blue bitmask
         streamer.write_u32(0xff000000); // Alpha bitmask
     }
 
-    if (dib_header == DibHeader::V4) {
+    if (dib_header == Options::DibHeader::V4) {
         streamer.write_u32(0); // Colorspace
 
         for (int i = 0; i < 12; i++) {

--- a/Userland/Libraries/LibGfx/BMPWriter.cpp
+++ b/Userland/Libraries/LibGfx/BMPWriter.cpp
@@ -72,7 +72,7 @@ ErrorOr<ByteBuffer> BMPWriter::encode(Bitmap const& bitmap, Options options)
     return BMPWriter().dump(bitmap, options);
 }
 
-ByteBuffer BMPWriter::compress_pixel_data(ByteBuffer const& pixel_data, BMPWriter::Compression compression)
+ByteBuffer BMPWriter::compress_pixel_data(ByteBuffer pixel_data, BMPWriter::Compression compression)
 {
     switch (compression) {
     case BMPWriter::Compression::BI_BITFIELDS:
@@ -112,7 +112,7 @@ ByteBuffer BMPWriter::dump(RefPtr<Bitmap const> bitmap, Options options)
     auto buffer = buffer_result.release_value();
 
     auto pixel_data = write_pixel_data(bitmap, pixel_row_data_size, m_bytes_per_pixel, m_include_alpha_channel);
-    pixel_data = compress_pixel_data(pixel_data, m_compression);
+    pixel_data = compress_pixel_data(move(pixel_data), m_compression);
 
     size_t file_size = pixel_data_offset + pixel_data.size();
     OutputStreamer streamer(buffer.data());

--- a/Userland/Libraries/LibGfx/BMPWriter.cpp
+++ b/Userland/Libraries/LibGfx/BMPWriter.cpp
@@ -42,9 +42,9 @@ private:
     u8* m_data;
 };
 
-static ByteBuffer write_pixel_data(RefPtr<Bitmap const> bitmap, int pixel_row_data_size, int bytes_per_pixel, bool include_alpha_channel)
+static ByteBuffer write_pixel_data(Bitmap const& bitmap, int pixel_row_data_size, int bytes_per_pixel, bool include_alpha_channel)
 {
-    int image_size = pixel_row_data_size * bitmap->height();
+    int image_size = pixel_row_data_size * bitmap.height();
     auto buffer_result = ByteBuffer::create_uninitialized(image_size);
     if (buffer_result.is_error())
         return {};
@@ -52,10 +52,10 @@ static ByteBuffer write_pixel_data(RefPtr<Bitmap const> bitmap, int pixel_row_da
     auto buffer = buffer_result.release_value();
 
     int current_row = 0;
-    for (int y = bitmap->physical_height() - 1; y >= 0; --y) {
+    for (int y = bitmap.physical_height() - 1; y >= 0; --y) {
         auto* row = buffer.data() + (pixel_row_data_size * current_row++);
-        for (int x = 0; x < bitmap->physical_width(); x++) {
-            auto pixel = bitmap->get_pixel(x, y);
+        for (int x = 0; x < bitmap.physical_width(); x++) {
+            auto pixel = bitmap.get_pixel(x, y);
             row[x * bytes_per_pixel + 0] = pixel.blue();
             row[x * bytes_per_pixel + 1] = pixel.green();
             row[x * bytes_per_pixel + 2] = pixel.red();
@@ -83,7 +83,7 @@ ByteBuffer BMPWriter::compress_pixel_data(ByteBuffer pixel_data, BMPWriter::Comp
     VERIFY_NOT_REACHED();
 }
 
-ByteBuffer BMPWriter::dump(RefPtr<Bitmap const> bitmap, Options options)
+ByteBuffer BMPWriter::dump(Bitmap const& bitmap, Options options)
 {
     Options::DibHeader dib_header = options.dib_header;
 
@@ -103,8 +103,8 @@ ByteBuffer BMPWriter::dump(RefPtr<Bitmap const> bitmap, Options options)
     const size_t file_header_size = 14;
     size_t pixel_data_offset = file_header_size + (u32)dib_header;
 
-    int pixel_row_data_size = (m_bytes_per_pixel * 8 * bitmap->width() + 31) / 32 * 4;
-    int image_size = pixel_row_data_size * bitmap->height();
+    int pixel_row_data_size = (m_bytes_per_pixel * 8 * bitmap.width() + 31) / 32 * 4;
+    int image_size = pixel_row_data_size * bitmap.height();
     auto buffer_result = ByteBuffer::create_uninitialized(pixel_data_offset);
     if (buffer_result.is_error())
         return {};
@@ -123,8 +123,8 @@ ByteBuffer BMPWriter::dump(RefPtr<Bitmap const> bitmap, Options options)
     streamer.write_u32(pixel_data_offset);
 
     streamer.write_u32((u32)dib_header);       // Header size
-    streamer.write_i32(bitmap->width());       // ImageWidth
-    streamer.write_i32(bitmap->height());      // ImageHeight
+    streamer.write_i32(bitmap.width());        // ImageWidth
+    streamer.write_i32(bitmap.height());       // ImageHeight
     streamer.write_u16(1);                     // Planes
     streamer.write_u16(m_bytes_per_pixel * 8); // BitsPerPixel
     streamer.write_u32((u32)m_compression);    // Compression

--- a/Userland/Libraries/LibGfx/BMPWriter.h
+++ b/Userland/Libraries/LibGfx/BMPWriter.h
@@ -16,11 +16,6 @@ class BMPWriter {
 public:
     BMPWriter() = default;
 
-    enum class Compression : u32 {
-        BI_RGB = 0,
-        BI_BITFIELDS = 3,
-    };
-
     enum class DibHeader : u32 {
         Info = 40,
         V3 = 56,
@@ -29,10 +24,16 @@ public:
 
     ByteBuffer dump(RefPtr<Bitmap const>, DibHeader dib_header = DibHeader::V4);
 
-    inline void set_compression(Compression compression) { m_compression = compression; }
-
 private:
+    enum class Compression : u32 {
+        BI_RGB = 0,
+        BI_BITFIELDS = 3,
+    };
+
+    static ByteBuffer compress_pixel_data(ByteBuffer const&, Compression);
+
     Compression m_compression { Compression::BI_BITFIELDS };
+
     int m_bytes_per_pixel { 4 };
     bool m_include_alpha_channel { true };
 };

--- a/Userland/Libraries/LibGfx/BMPWriter.h
+++ b/Userland/Libraries/LibGfx/BMPWriter.h
@@ -30,7 +30,7 @@ public:
 private:
     BMPWriter() = default;
 
-    ByteBuffer dump(RefPtr<Bitmap const>, Options options);
+    ByteBuffer dump(Bitmap const&, Options options);
 
     enum class Compression : u32 {
         BI_RGB = 0,

--- a/Userland/Libraries/LibGfx/BMPWriter.h
+++ b/Userland/Libraries/LibGfx/BMPWriter.h
@@ -37,7 +37,7 @@ private:
         BI_BITFIELDS = 3,
     };
 
-    static ByteBuffer compress_pixel_data(ByteBuffer const&, Compression);
+    static ByteBuffer compress_pixel_data(ByteBuffer, Compression);
 
     Compression m_compression { Compression::BI_BITFIELDS };
 

--- a/Userland/Libraries/LibGfx/BMPWriter.h
+++ b/Userland/Libraries/LibGfx/BMPWriter.h
@@ -25,11 +25,13 @@ struct BMPWriterOptions {
 class BMPWriter {
 public:
     using Options = BMPWriterOptions;
-    BMPWriter() = default;
-
-    ByteBuffer dump(RefPtr<Bitmap const>, Options options = Options {});
+    static ErrorOr<ByteBuffer> encode(Bitmap const&, Options options = Options {});
 
 private:
+    BMPWriter() = default;
+
+    ByteBuffer dump(RefPtr<Bitmap const>, Options options);
+
     enum class Compression : u32 {
         BI_RGB = 0,
         BI_BITFIELDS = 3,

--- a/Userland/Libraries/LibGfx/BMPWriter.h
+++ b/Userland/Libraries/LibGfx/BMPWriter.h
@@ -12,17 +12,22 @@ namespace Gfx {
 
 class Bitmap;
 
-class BMPWriter {
-public:
-    BMPWriter() = default;
-
+// This is not a nested struct to work around https://llvm.org/PR36684
+struct BMPWriterOptions {
     enum class DibHeader : u32 {
         Info = 40,
         V3 = 56,
         V4 = 108,
     };
+    DibHeader dib_header = DibHeader::V4;
+};
 
-    ByteBuffer dump(RefPtr<Bitmap const>, DibHeader dib_header = DibHeader::V4);
+class BMPWriter {
+public:
+    using Options = BMPWriterOptions;
+    BMPWriter() = default;
+
+    ByteBuffer dump(RefPtr<Bitmap const>, Options options = Options {});
 
 private:
     enum class Compression : u32 {

--- a/Userland/Utilities/image.cpp
+++ b/Userland/Utilities/image.cpp
@@ -38,7 +38,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     ByteBuffer bytes;
     if (out_path.ends_with(".bmp"sv, CaseSensitivity::CaseInsensitive)) {
-        bytes = Gfx::BMPWriter().dump(frame);
+        bytes = TRY(Gfx::BMPWriter::encode(*frame));
     } else if (out_path.ends_with(".png"sv, CaseSensitivity::CaseInsensitive)) {
         bytes = TRY(Gfx::PNGWriter::encode(*frame));
     } else if (out_path.ends_with(".qoi"sv, CaseSensitivity::CaseInsensitive)) {


### PR DESCRIPTION
Also remove a redundant copy of all data to be written while here.