### PR TITLE
LibGfx: Make BMPWriter::dump() return ErrorOr

### DIFF
--- a/Userland/Libraries/LibGfx/BMPWriter.h
+++ b/Userland/Libraries/LibGfx/BMPWriter.h
@@ -30,7 +30,7 @@ public:
 private:
     BMPWriter() = default;
 
-    ByteBuffer dump(Bitmap const&, Options options);
+    ErrorOr<ByteBuffer> dump(Bitmap const&, Options options);
 
     enum class Compression : u32 {
         BI_RGB = 0,


### PR DESCRIPTION
...and use TRY() consistently in BMPWriter.cpp