### PR TITLE
LibGfx/PortableFormat: Add PortableFormatWriter

### DIFF
--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SOURCES
     PGMLoader.cpp
     PNGLoader.cpp
     PNGWriter.cpp
+    PortableFormatWriter.cpp
     PPMLoader.cpp
     Painter.cpp
     Palette.cpp

--- a/Userland/Libraries/LibGfx/PortableFormatWriter.cpp
+++ b/Userland/Libraries/LibGfx/PortableFormatWriter.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023, Lucas Chollet <lucas.chollet@serenityos.org  >
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "PortableFormatWriter.h"
+#include <AK/String.h>
+
+namespace Gfx {
+
+ErrorOr<ByteBuffer> PortableFormatWriter::encode(Bitmap const& bitmap, Options options)
+{
+    ByteBuffer buffer;
+
+    // FIXME: Add support for PBM and PGM
+
+    TRY(add_header(buffer, options, bitmap.width(), bitmap.height(), 255));
+    TRY(add_pixels(buffer, options, bitmap));
+
+    return buffer;
+}
+
+ErrorOr<void> PortableFormatWriter::add_header(ByteBuffer& buffer, Options const& options, u32 width, u32 height, u32 maximal_value)
+{
+    TRY(buffer.try_append(TRY(String::formatted("P{}\n", options.format == Options::Format::ASCII ? "3"sv : "6"sv)).bytes()));
+    TRY(buffer.try_append(TRY(String::formatted("# {}\n", options.comment)).bytes()));
+    TRY(buffer.try_append(TRY(String::formatted("{} {}\n", width, height)).bytes()));
+    TRY(buffer.try_append(TRY(String::formatted("{}\n", maximal_value)).bytes()));
+
+    return {};
+}
+
+ErrorOr<void> PortableFormatWriter::add_pixels(ByteBuffer& buffer, Options const& options, Bitmap const& bitmap)
+{
+    for (int i = 0; i < bitmap.height(); ++i) {
+        for (int j = 0; j < bitmap.width(); ++j) {
+            auto color = bitmap.get_pixel(j, i);
+            if (options.format == Options::Format::ASCII) {
+                TRY(buffer.try_append(TRY(String::formatted("{} {} {}\t", color.red(), color.green(), color.blue())).bytes()));
+            } else {
+                TRY(buffer.try_append(color.red()));
+                TRY(buffer.try_append(color.green()));
+                TRY(buffer.try_append(color.blue()));
+            }
+        }
+        if (options.format == Options::Format::ASCII)
+            TRY(buffer.try_append('\n'));
+    }
+
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibGfx/PortableFormatWriter.h
+++ b/Userland/Libraries/LibGfx/PortableFormatWriter.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <LibGfx/Bitmap.h>
+
+namespace Gfx {
+
+// This is not a nested struct to work around https://llvm.org/PR36684
+struct PortableFormatWriterOptions {
+    enum class Format {
+        ASCII,
+        Raw,
+    };
+
+    Format format = Format::Raw;
+    StringView comment = "Generated with SerenityOS - LibGfx."sv;
+};
+
+class PortableFormatWriter {
+public:
+    using Options = PortableFormatWriterOptions;
+
+    static ErrorOr<ByteBuffer> encode(Bitmap const&, Options options = Options {});
+
+private:
+    PortableFormatWriter() = delete;
+
+    static ErrorOr<void> add_header(ByteBuffer&, Options const& options, u32 width, u32 height, u32 max_value);
+    static ErrorOr<void> add_pixels(ByteBuffer&, Options const& options, Bitmap const&);
+};
+
+}

--- a/Userland/Utilities/image.cpp
+++ b/Userland/Utilities/image.cpp
@@ -10,6 +10,7 @@
 #include <LibGfx/BMPWriter.h>
 #include <LibGfx/ImageDecoder.h>
 #include <LibGfx/PNGWriter.h>
+#include <LibGfx/PortableFormatWriter.h>
 #include <LibGfx/QOIWriter.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
@@ -41,10 +42,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         bytes = TRY(Gfx::BMPWriter::encode(*frame));
     } else if (out_path.ends_with(".png"sv, CaseSensitivity::CaseInsensitive)) {
         bytes = TRY(Gfx::PNGWriter::encode(*frame));
+    } else if (out_path.ends_with(".ppm"sv, CaseSensitivity::CaseInsensitive)) {
+        bytes = TRY(Gfx::PortableFormatWriter::encode(*frame));
     } else if (out_path.ends_with(".qoi"sv, CaseSensitivity::CaseInsensitive)) {
         bytes = TRY(Gfx::QOIWriter::encode(*frame));
     } else {
-        warnln("can only write .bmp, .png, and .qoi");
+        warnln("can only write .bmp, .png, .ppm, and .qoi");
         return 1;
     }
 

--- a/Userland/Utilities/image.cpp
+++ b/Userland/Utilities/image.cpp
@@ -23,6 +23,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView out_path;
     args_parser.add_option(out_path, "Path to output image file", "output", 'o', "FILE");
 
+    bool ppm_ascii;
+    args_parser.add_option(ppm_ascii, "Convert to a PPM in ASCII", "ppm-ascii", {});
+
     args_parser.parse(arguments);
 
     if (out_path.is_empty()) {
@@ -43,7 +46,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     } else if (out_path.ends_with(".png"sv, CaseSensitivity::CaseInsensitive)) {
         bytes = TRY(Gfx::PNGWriter::encode(*frame));
     } else if (out_path.ends_with(".ppm"sv, CaseSensitivity::CaseInsensitive)) {
-        bytes = TRY(Gfx::PortableFormatWriter::encode(*frame));
+        auto const format = ppm_ascii ? Gfx::PortableFormatWriter::Options::Format::ASCII : Gfx::PortableFormatWriter::Options::Format::Raw;
+        bytes = TRY(Gfx::PortableFormatWriter::encode(*frame, Gfx::PortableFormatWriter::Options { .format = format }));
     } else if (out_path.ends_with(".qoi"sv, CaseSensitivity::CaseInsensitive)) {
         bytes = TRY(Gfx::QOIWriter::encode(*frame));
     } else {


### PR DESCRIPTION
I don't think that exporting to PPM is a must-have in every application, it's why I didn't add it to Magnifier or PixelPaint.
However, supporting it in `image` is a nice way to dump a freshly decoded image to a file.