### PR TITLE
headless-browser+Ladybird: Move the running of layout tests to headless-browser

### DIFF
--- a/Ladybird/main.cpp
+++ b/Ladybird/main.cpp
@@ -67,13 +67,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     StringView raw_url;
     StringView webdriver_content_ipc_path;
-    bool dump_layout_tree = false;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("The Ladybird web browser :^)");
     args_parser.add_positional_argument(raw_url, "URL to open", "url", Core::ArgsParser::Required::No);
     args_parser.add_option(webdriver_content_ipc_path, "Path to WebDriver IPC for WebContent", "webdriver-content-path", 0, "path");
-    args_parser.add_option(dump_layout_tree, "Dump layout tree and exit", "dump-layout-tree", 'd');
     args_parser.parse(arguments);
 
     auto get_formatted_url = [&](StringView const& raw_url) -> URL {
@@ -84,22 +82,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             url = DeprecatedString::formatted("http://{}", raw_url);
         return url;
     };
-
-    if (dump_layout_tree) {
-        WebContentView view({});
-        view.set_viewport_rect(Gfx::IntRect({}, { 800, 600 }));
-        view.on_load_finish = [&](auto&) {
-            auto dump = view.dump_layout_tree().release_value_but_fixme_should_propagate_errors();
-            outln("{}", dump);
-            fflush(stdout);
-
-            event_loop.quit(0);
-            app.quit();
-        };
-
-        view.load(get_formatted_url(raw_url));
-        return app.exec();
-    }
 
     auto sql_server_paths = TRY(get_paths_for_helper_process("SQLServer"sv));
     auto sql_client = TRY(SQL::SQLClient::launch_server_and_create_client(move(sql_server_paths)));

--- a/Tests/LibWeb/Layout/layout_test.sh
+++ b/Tests/LibWeb/Layout/layout_test.sh
@@ -10,16 +10,12 @@ if [[ -z "${LADYBIRD_BUILD_DIR}" ]] ; then
     exit 1
 fi
 
-if [[ "$(uname -s)" = "Darwin" ]] ; then
-    LADYBIRD_BINARY="./ladybird.app/Contents/MacOS/ladybird"
-else
-    LADYBIRD_BINARY="./ladybird"
-fi
+BROWSER_BINARY="./headless-browser"
 
 for input_html_path in "${SCRIPT_DIR}"/input/*.html; do
     input_html_file="$(basename "${input_html_path}" .html)"
 
-    output_layout_dump=$(cd "${LADYBIRD_BUILD_DIR}"; "${LADYBIRD_BINARY}" -d "${input_html_path}")
+    output_layout_dump=$(cd "${LADYBIRD_BUILD_DIR}"; "${BROWSER_BINARY}" -d "${input_html_path}")
     expected_layout_dump_path="${SCRIPT_DIR}/expected/${input_html_file}.txt"
 
     if cmp <(echo "${output_layout_dump}") "${expected_layout_dump_path}"; then

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -15,6 +15,7 @@
 #include <AK/DeprecatedString.h>
 #include <AK/LexicalPath.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/String.h>
 #include <AK/URL.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
@@ -159,6 +160,15 @@ static ErrorOr<NonnullRefPtr<Core::Timer>> load_page_for_screenshot_and_exit(Cor
     return timer;
 }
 
+static ErrorOr<URL> format_url(StringView url)
+{
+    URL formatted_url { url };
+    if (!formatted_url.is_valid())
+        formatted_url = TRY(String::formatted("http://{}", url));
+
+    return formatted_url;
+}
+
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
 #if !defined(AK_OS_SERENITY)
@@ -193,7 +203,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     static constexpr Gfx::IntSize window_size { 800, 600 };
 
     auto view = TRY(HeadlessWebContentView::create(move(theme), window_size, web_driver_ipc_path));
-    view->load(URL { url });
+    view->load(TRY(format_url(url)));
 
     RefPtr<Core::Timer> timer;
     if (web_driver_ipc_path.is_empty())


### PR DESCRIPTION
Rather than having a one-off mode in Ladybird, let's use headless-browser for headlessly running these layout tests