### PR TITLE
Everywhere: Use `Core::Process::spawn()` in more places

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.h
+++ b/Userland/Applications/FileManager/DirectoryView.h
@@ -21,7 +21,7 @@
 
 namespace FileManager {
 
-void spawn_terminal(DeprecatedString const& directory);
+void spawn_terminal(GUI::Window* window, StringView directory);
 
 class LauncherHandler : public RefCounted<LauncherHandler> {
 public:

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -491,13 +491,13 @@ ErrorOr<int> run_in_desktop_mode()
     auto open_terminal_action = GUI::Action::create("Open in &Terminal", {}, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-terminal.png"sv)), [&](auto&) {
         auto paths = directory_view->selected_file_paths();
         if (paths.is_empty()) {
-            spawn_terminal(directory_view->path());
+            spawn_terminal(window, directory_view->path());
             return;
         }
 
         for (auto& path : paths) {
             if (FileSystem::is_directory(path)) {
-                spawn_terminal(path);
+                spawn_terminal(window, path);
             }
         }
     });
@@ -841,7 +841,7 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
 
                 for (auto& path : paths) {
                     if (FileSystem::is_directory(path)) {
-                        spawn_terminal(path);
+                        spawn_terminal(window, path);
                     }
                 }
             },

--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -1,12 +1,13 @@
 /*
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ * Copyright (c) 2022-2023, MacDue <macdue@dueutil.tech>
  * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/DeprecatedString.h>
+#include <AK/ScopeGuard.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibCore/Process.h>
@@ -58,6 +59,9 @@ struct ArgvList {
 #ifdef AK_OS_SERENITY
         posix_spawn_file_actions_t spawn_actions;
         posix_spawn_file_actions_init(&spawn_actions);
+        ScopeGuard cleanup_spawn_actions = [&] {
+            posix_spawn_file_actions_destroy(&spawn_actions);
+        };
         if (!m_working_directory.is_empty())
             posix_spawn_file_actions_addchdir(&spawn_actions, m_working_directory.characters());
 

--- a/Userland/Libraries/LibCore/Process.h
+++ b/Userland/Libraries/LibCore/Process.h
@@ -15,9 +15,14 @@ namespace Core {
 
 class Process {
 public:
-    static ErrorOr<pid_t> spawn(StringView path, ReadonlySpan<DeprecatedString> arguments, DeprecatedString working_directory = {});
-    static ErrorOr<pid_t> spawn(StringView path, ReadonlySpan<StringView> arguments, DeprecatedString working_directory = {});
-    static ErrorOr<pid_t> spawn(StringView path, ReadonlySpan<char const*> arguments = {}, DeprecatedString working_directory = {});
+    enum class KeepAsChild {
+        Yes,
+        No
+    };
+
+    static ErrorOr<pid_t> spawn(StringView path, ReadonlySpan<DeprecatedString> arguments, DeprecatedString working_directory = {}, KeepAsChild keep_as_child = KeepAsChild::No);
+    static ErrorOr<pid_t> spawn(StringView path, ReadonlySpan<StringView> arguments, DeprecatedString working_directory = {}, KeepAsChild keep_as_child = KeepAsChild::No);
+    static ErrorOr<pid_t> spawn(StringView path, ReadonlySpan<char const*> arguments = {}, DeprecatedString working_directory = {}, KeepAsChild keep_as_child = KeepAsChild::No);
 
     static ErrorOr<String> get_name();
     enum class SetThreadName {

--- a/Userland/Libraries/LibGUI/Process.cpp
+++ b/Userland/Libraries/LibGUI/Process.cpp
@@ -9,28 +9,28 @@
 #include <LibGUI/Process.h>
 
 template<typename StringType>
-void spawn_or_show_error(GUI::Window* parent_window, StringView path, ReadonlySpan<StringType> arguments)
+void spawn_or_show_error(GUI::Window* parent_window, StringView path, ReadonlySpan<StringType> arguments, StringView working_directory)
 {
-    auto spawn_result = Core::Process::spawn(path, arguments);
+    auto spawn_result = Core::Process::spawn(path, arguments, working_directory);
     if (spawn_result.is_error())
         GUI::MessageBox::show_error(parent_window, DeprecatedString::formatted("Failed to spawn {}: {}", path, spawn_result.error()));
 }
 
 namespace GUI {
 
-void Process::spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<DeprecatedString> arguments)
+void Process::spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<DeprecatedString> arguments, StringView working_directory)
 {
-    ::spawn_or_show_error<DeprecatedString>(parent_window, path, arguments);
+    ::spawn_or_show_error<DeprecatedString>(parent_window, path, arguments, working_directory);
 }
 
-void Process::spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<StringView> arguments)
+void Process::spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<StringView> arguments, StringView working_directory)
 {
-    ::spawn_or_show_error<StringView>(parent_window, path, arguments);
+    ::spawn_or_show_error<StringView>(parent_window, path, arguments, working_directory);
 }
 
-void Process::spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<char const*> arguments)
+void Process::spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<char const*> arguments, StringView working_directory)
 {
-    ::spawn_or_show_error<char const*>(parent_window, path, arguments);
+    ::spawn_or_show_error<char const*>(parent_window, path, arguments, working_directory);
 }
 
 }

--- a/Userland/Libraries/LibGUI/Process.h
+++ b/Userland/Libraries/LibGUI/Process.h
@@ -12,9 +12,9 @@
 namespace GUI {
 
 struct Process {
-    static void spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<DeprecatedString> arguments);
-    static void spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<StringView> arguments);
-    static void spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<char const*> arguments = {});
+    static void spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<DeprecatedString> arguments, StringView working_directory = {});
+    static void spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<StringView> arguments, StringView working_directory = {});
+    static void spawn_or_show_error(Window* parent_window, StringView path, ReadonlySpan<char const*> arguments = {}, StringView working_directory = {});
 };
 
 }

--- a/Userland/Services/KeyboardPreferenceLoader/main.cpp
+++ b/Userland/Services/KeyboardPreferenceLoader/main.cpp
@@ -6,6 +6,7 @@
 
 #include <LibCore/ConfigFile.h>
 #include <LibCore/DeprecatedFile.h>
+#include <LibCore/Process.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 #include <errno.h>
@@ -30,12 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     if (keymaps_vector.size() == 0)
         exit(1);
 
-    pid_t child_pid;
-    char const* argv[] = { "/bin/keymap", "-m", keymaps_vector.first().characters(), nullptr };
-    if ((errno = posix_spawn(&child_pid, "/bin/keymap", nullptr, nullptr, const_cast<char**>(argv), environ))) {
-        perror("posix_spawn");
-        exit(1);
-    }
+    TRY(Core::Process::spawn("/bin/keymap"sv, Array { "-m", keymaps_vector.first().characters() }, {}, Core::Process::KeepAsChild::Yes));
 
     bool enable_num_lock = keyboard_settings_config->read_bool_entry("StartupEnable", "NumLock", true);
     auto keyboard_device = TRY(Core::DeprecatedFile::open("/dev/input/keyboard/0", Core::OpenMode::ReadOnly));

--- a/Userland/Services/Taskbar/ShutdownDialog.cpp
+++ b/Userland/Services/Taskbar/ShutdownDialog.cpp
@@ -18,24 +18,23 @@
 
 struct Option {
     DeprecatedString title;
-    Vector<char const*> cmd;
+    ShutdownDialog::Command command;
     bool enabled;
     bool default_action;
 };
 
-static Vector<Option> const options = {
-    { "Power off computer", { "/bin/shutdown", "--now", nullptr }, true, true },
-    { "Reboot", { "/bin/reboot", nullptr }, true, false },
-    { "Log out", { "/bin/logout", nullptr }, true, false },
+static Array const options = {
+    Option { "Power off computer", { "/bin/shutdown"sv, { "--now" } }, true, true },
+    Option { "Reboot", { "/bin/reboot"sv, {} }, true, false },
+    Option { "Log out", { "/bin/logout"sv, {} }, true, false },
 };
 
-Vector<char const*> ShutdownDialog::show()
+Optional<ShutdownDialog::Command const&> ShutdownDialog::show()
 {
     auto dialog = ShutdownDialog::construct();
     auto rc = dialog->exec();
     if (rc == ExecResult::OK && dialog->m_selected_option != -1)
-        return options[dialog->m_selected_option].cmd;
-
+        return options[dialog->m_selected_option].command;
     return {};
 }
 

--- a/Userland/Services/Taskbar/ShutdownDialog.h
+++ b/Userland/Services/Taskbar/ShutdownDialog.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <AK/Vector.h>
 #include <LibGUI/Dialog.h>
 
@@ -13,7 +14,12 @@ class ShutdownDialog : public GUI::Dialog {
     C_OBJECT(ShutdownDialog);
 
 public:
-    static Vector<char const*> show();
+    struct Command {
+        StringView executable;
+        Vector<char const*, 2> arguments;
+    };
+
+    static Optional<Command const&> show();
 
 private:
     ShutdownDialog();

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -250,22 +250,8 @@ ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu(GUI::Window& window)
     system_menu->add_action(GUI::Action::create("&Help", TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-help.png"sv)), [&](auto&) {
         GUI::Process::spawn_or_show_error(&window, "/bin/Help"sv);
     }));
-    system_menu->add_action(GUI::Action::create("&Run...", TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-run.png"sv)), [](auto&) {
-        posix_spawn_file_actions_t spawn_actions;
-        posix_spawn_file_actions_init(&spawn_actions);
-        auto home_directory = Core::StandardPaths::home_directory();
-        posix_spawn_file_actions_addchdir(&spawn_actions, home_directory.characters());
-
-        pid_t child_pid;
-        const char* argv[] = { "/bin/Run", nullptr };
-        if ((errno = posix_spawn(&child_pid, "/bin/Run", &spawn_actions, nullptr, const_cast<char**>(argv), environ))) {
-            perror("posix_spawn");
-        } else {
-            if (disown(child_pid) < 0)
-                perror("disown");
-        }
-
-        posix_spawn_file_actions_destroy(&spawn_actions);
+    system_menu->add_action(GUI::Action::create("&Run...", TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-run.png"sv)), [&](auto&) {
+        GUI::Process::spawn_or_show_error(&window, "/bin/Run"sv, ReadonlySpan<StringView> {}, Core::StandardPaths::home_directory());
     }));
     system_menu->add_separator();
     system_menu->add_action(GUI::Action::create("E&xit...", TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/power.png"sv)), [](auto&) {

--- a/Userland/Services/WebDriver/main.cpp
+++ b/Userland/Services/WebDriver/main.cpp
@@ -7,6 +7,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/Directory.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/Process.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibCore/TCPServer.h>
@@ -15,27 +16,21 @@
 
 static ErrorOr<pid_t> launch_browser(DeprecatedString const& socket_path)
 {
-    char const* argv[] = {
-        "/bin/Browser",
-        "--webdriver-content-path",
-        socket_path.characters(),
-        nullptr,
-    };
-
-    return Core::System::posix_spawn("/bin/Browser"sv, nullptr, nullptr, const_cast<char**>(argv), environ);
+    return Core::Process::spawn("/bin/Browser"sv,
+        Array {
+            "--webdriver-content-path",
+            socket_path.characters(),
+        });
 }
 
 static ErrorOr<pid_t> launch_headless_browser(DeprecatedString const& socket_path)
 {
-    char const* argv[] = {
-        "/bin/headless-browser",
-        "--webdriver-ipc-path",
-        socket_path.characters(),
-        "about:blank",
-        nullptr,
-    };
-
-    return Core::System::posix_spawn("/bin/headless-browser"sv, nullptr, nullptr, const_cast<char**>(argv), environ);
+    return Core::Process::spawn("/bin/headless-browser"sv,
+        Array {
+            "--webdriver-ipc-path",
+            socket_path.characters(),
+            "about:blank",
+        });
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)


### PR DESCRIPTION
The removes `posix_spawn()` + manual error check (and sometimes `chdir()` setup)  that's copied around in a few more places, which is nice.