### PR TITLE
Kernel/Storage: Use NonnullRefPtr for storage controller instead of the lock variant

### DIFF
--- a/Kernel/Arch/x86_64/ISABus/IDEController.cpp
+++ b/Kernel/Arch/x86_64/ISABus/IDEController.cpp
@@ -15,9 +15,9 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT ErrorOr<NonnullLockRefPtr<ISAIDEController>> ISAIDEController::initialize()
+UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<ISAIDEController>> ISAIDEController::initialize()
 {
-    auto controller = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) ISAIDEController()));
+    auto controller = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ISAIDEController()));
     TRY(controller->initialize_channels());
     return controller;
 }

--- a/Kernel/Arch/x86_64/ISABus/IDEController.h
+++ b/Kernel/Arch/x86_64/ISABus/IDEController.h
@@ -18,7 +18,7 @@ class AsyncBlockDeviceRequest;
 
 class ISAIDEController final : public IDEController {
 public:
-    static ErrorOr<NonnullLockRefPtr<ISAIDEController>> initialize();
+    static ErrorOr<NonnullRefPtr<ISAIDEController>> initialize();
 
 private:
     ISAIDEController();

--- a/Kernel/Arch/x86_64/PCI/IDELegacyModeController.cpp
+++ b/Kernel/Arch/x86_64/PCI/IDELegacyModeController.cpp
@@ -15,9 +15,9 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT ErrorOr<NonnullLockRefPtr<PCIIDELegacyModeController>> PCIIDELegacyModeController::initialize(PCI::DeviceIdentifier const& device_identifier, bool force_pio)
+UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<PCIIDELegacyModeController>> PCIIDELegacyModeController::initialize(PCI::DeviceIdentifier const& device_identifier, bool force_pio)
 {
-    auto controller = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) PCIIDELegacyModeController(device_identifier)));
+    auto controller = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) PCIIDELegacyModeController(device_identifier)));
     PCI::enable_io_space(device_identifier);
     PCI::enable_memory_space(device_identifier);
     PCI::enable_bus_mastering(device_identifier);

--- a/Kernel/Arch/x86_64/PCI/IDELegacyModeController.h
+++ b/Kernel/Arch/x86_64/PCI/IDELegacyModeController.h
@@ -19,7 +19,7 @@ class AsyncBlockDeviceRequest;
 class PCIIDELegacyModeController final : public IDEController
     , public PCI::Device {
 public:
-    static ErrorOr<NonnullLockRefPtr<PCIIDELegacyModeController>> initialize(PCI::DeviceIdentifier const&, bool force_pio);
+    static ErrorOr<NonnullRefPtr<PCIIDELegacyModeController>> initialize(PCI::DeviceIdentifier const&, bool force_pio);
 
     virtual StringView device_name() const override { return "PCIIDELegacyModeController"sv; }
 

--- a/Kernel/Storage/ATA/AHCI/Controller.cpp
+++ b/Kernel/Storage/ATA/AHCI/Controller.cpp
@@ -18,9 +18,9 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<AHCIController> AHCIController::initialize(PCI::DeviceIdentifier const& pci_device_identifier)
+UNMAP_AFTER_INIT NonnullRefPtr<AHCIController> AHCIController::initialize(PCI::DeviceIdentifier const& pci_device_identifier)
 {
-    auto controller = adopt_lock_ref_if_nonnull(new (nothrow) AHCIController(pci_device_identifier)).release_nonnull();
+    auto controller = adopt_ref_if_nonnull(new (nothrow) AHCIController(pci_device_identifier)).release_nonnull();
     controller->initialize_hba(pci_device_identifier);
     return controller;
 }

--- a/Kernel/Storage/ATA/AHCI/Controller.h
+++ b/Kernel/Storage/ATA/AHCI/Controller.h
@@ -24,7 +24,7 @@ class AHCIController final : public ATAController
     friend class AHCIInterruptHandler;
 
 public:
-    static NonnullLockRefPtr<AHCIController> initialize(PCI::DeviceIdentifier const& pci_device_identifier);
+    static NonnullRefPtr<AHCIController> initialize(PCI::DeviceIdentifier const& pci_device_identifier);
     virtual ~AHCIController() override;
 
     virtual StringView device_name() const override { return "AHCI"sv; }

--- a/Kernel/Storage/NVMe/NVMeController.cpp
+++ b/Kernel/Storage/NVMe/NVMeController.cpp
@@ -19,9 +19,9 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT ErrorOr<NonnullLockRefPtr<NVMeController>> NVMeController::try_initialize(Kernel::PCI::DeviceIdentifier const& device_identifier, bool is_queue_polled)
+UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<NVMeController>> NVMeController::try_initialize(Kernel::PCI::DeviceIdentifier const& device_identifier, bool is_queue_polled)
 {
-    auto controller = TRY(adopt_nonnull_lock_ref_or_enomem(new NVMeController(device_identifier, StorageManagement::generate_relative_nvme_controller_id({}))));
+    auto controller = TRY(adopt_nonnull_ref_or_enomem(new NVMeController(device_identifier, StorageManagement::generate_relative_nvme_controller_id({}))));
     TRY(controller->initialize(is_queue_polled));
     return controller;
 }

--- a/Kernel/Storage/NVMe/NVMeController.h
+++ b/Kernel/Storage/NVMe/NVMeController.h
@@ -25,7 +25,7 @@ namespace Kernel {
 class NVMeController : public PCI::Device
     , public StorageController {
 public:
-    static ErrorOr<NonnullLockRefPtr<NVMeController>> try_initialize(PCI::DeviceIdentifier const&, bool is_queue_polled);
+    static ErrorOr<NonnullRefPtr<NVMeController>> try_initialize(PCI::DeviceIdentifier const&, bool is_queue_polled);
     ErrorOr<void> initialize(bool is_queue_polled);
     LockRefPtr<StorageDevice> device(u32 index) const override;
     size_t devices_count() const override;

--- a/Kernel/Storage/Ramdisk/Controller.cpp
+++ b/Kernel/Storage/Ramdisk/Controller.cpp
@@ -11,9 +11,9 @@
 
 namespace Kernel {
 
-NonnullLockRefPtr<RamdiskController> RamdiskController::initialize()
+NonnullRefPtr<RamdiskController> RamdiskController::initialize()
 {
-    return adopt_lock_ref(*new RamdiskController());
+    return adopt_ref(*new RamdiskController());
 }
 
 bool RamdiskController::reset()

--- a/Kernel/Storage/Ramdisk/Controller.cpp
+++ b/Kernel/Storage/Ramdisk/Controller.cpp
@@ -11,9 +11,9 @@
 
 namespace Kernel {
 
-NonnullRefPtr<RamdiskController> RamdiskController::initialize()
+ErrorOr<NonnullRefPtr<RamdiskController>> RamdiskController::try_initialize()
 {
-    return adopt_ref(*new RamdiskController());
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) RamdiskController()));
 }
 
 bool RamdiskController::reset()

--- a/Kernel/Storage/Ramdisk/Controller.h
+++ b/Kernel/Storage/Ramdisk/Controller.h
@@ -19,7 +19,7 @@ class AsyncBlockDeviceRequest;
 
 class RamdiskController final : public StorageController {
 public:
-    static NonnullRefPtr<RamdiskController> initialize();
+    static ErrorOr<NonnullRefPtr<RamdiskController>> try_initialize();
     virtual ~RamdiskController() override;
 
     virtual LockRefPtr<StorageDevice> device(u32 index) const override;

--- a/Kernel/Storage/Ramdisk/Controller.h
+++ b/Kernel/Storage/Ramdisk/Controller.h
@@ -19,7 +19,7 @@ class AsyncBlockDeviceRequest;
 
 class RamdiskController final : public StorageController {
 public:
-    static NonnullLockRefPtr<RamdiskController> initialize();
+    static NonnullRefPtr<RamdiskController> initialize();
     virtual ~RamdiskController() override;
 
     virtual LockRefPtr<StorageDevice> device(u32 index) const override;

--- a/Kernel/Storage/StorageManagement.cpp
+++ b/Kernel/Storage/StorageManagement.cpp
@@ -444,7 +444,12 @@ UNMAP_AFTER_INIT void StorageManagement::initialize(StringView root_device, bool
     }
     // Note: Whether PCI bus is present on the system or not, always try to attach
     // a given ramdisk.
-    m_controllers.append(RamdiskController::initialize());
+    auto controller = RamdiskController::try_initialize();
+    if (controller.is_error()) {
+        dmesgln("Unable to initialize RAM controller: {}", controller.error());
+    } else {
+        m_controllers.append(controller.release_value());
+    }
     enumerate_storage_devices();
     enumerate_disk_partitions();
 

--- a/Kernel/Storage/StorageManagement.h
+++ b/Kernel/Storage/StorageManagement.h
@@ -66,7 +66,7 @@ private:
 
     StringView m_boot_argument;
     LockWeakPtr<BlockDevice> m_boot_block_device;
-    Vector<NonnullLockRefPtr<StorageController>> m_controllers;
+    Vector<NonnullRefPtr<StorageController>> m_controllers;
     IntrusiveList<&StorageDevice::m_list_node> m_storage_devices;
 };
 


### PR DESCRIPTION
Storage controllers are initialized during init and are never modified.
`NonnullRefPtr` can be safely used instead of the NonnullLockRefPtr.
This also fixes one of the UB issues that were there when using an NVMe device
because of NonnullLockRefPtr.

We can add proper locking when we need to modify the storage controllers
after init.

There is also a small cleanup in the Ramdisk init code to propagate error.