### PR TITLE
AK: Rename CaseInsensitiveStringViewTraits to CaseInsensitiveASCIIStringViewTraits

### DIFF
--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -359,8 +359,7 @@ struct Traits<StringView> : public GenericTraits<StringView> {
     static unsigned hash(StringView s) { return s.hash(); }
 };
 
-// FIXME: Rename this to indicate that it's about ASCII-only case insensitivity.
-struct CaseInsensitiveStringViewTraits : public Traits<StringView> {
+struct CaseInsensitiveASCIIStringViewTraits : public Traits<StringView> {
     static unsigned hash(StringView s)
     {
         if (s.is_empty())
@@ -386,6 +385,6 @@ struct CaseInsensitiveStringViewTraits : public Traits<StringView> {
 }
 
 #if USING_AK_GLOBALLY
-using AK::CaseInsensitiveStringViewTraits;
+using AK::CaseInsensitiveASCIIStringViewTraits;
 using AK::StringView;
 #endif

--- a/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
@@ -613,7 +613,7 @@ static constexpr Array<Location, @size@> s_time_zone_locations { {
         TRY(hashes.try_ensure_capacity(values.size()));
 
         auto hash = [](auto const& value) {
-            return CaseInsensitiveStringViewTraits::hash(value);
+            return CaseInsensitiveASCIIStringViewTraits::hash(value);
         };
 
         for (auto const& value : values)

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -1316,7 +1316,7 @@ bool code_point_has_@enum_snake@(u32 code_point, @enum_title@ @enum_snake@)
 
         for (auto const& prop : prop_list) {
             if constexpr (IsSame<RemoveCVReference<decltype(prop)>, DeprecatedString>) {
-                hashes.set(CaseInsensitiveStringViewTraits::hash(prop), prop);
+                hashes.set(CaseInsensitiveASCIIStringViewTraits::hash(prop), prop);
                 options.sensitivity = CaseSensitivity::CaseInsensitive;
             } else {
                 hashes.set(prop.key.hash(), prop.key);

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
@@ -454,7 +454,7 @@ Optional<@return_type@> @method_name@(StringView key)
 )~~~");
     } else {
         generator.append(R"~~~(
-    auto hash = CaseInsensitiveStringViewTraits::hash(key);
+    auto hash = CaseInsensitiveASCIIStringViewTraits::hash(key);
 )~~~");
     }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
@@ -90,7 +90,7 @@ ErrorOr<void> generate_implementation_file(JsonArray& identifier_data, Core::Fil
 
 namespace Web::CSS {
 
-HashMap<StringView, ValueID, AK::CaseInsensitiveStringViewTraits> g_stringview_to_value_id_map {
+HashMap<StringView, ValueID, AK::CaseInsensitiveASCIIStringViewTraits> g_stringview_to_value_id_map {
 )~~~");
 
     identifier_data.for_each([&](auto& name) {

--- a/Tests/AK/TestHashMap.cpp
+++ b/Tests/AK/TestHashMap.cpp
@@ -111,7 +111,7 @@ TEST_CASE(case_insensitive)
 
 TEST_CASE(case_insensitive_stringview)
 {
-    HashMap<StringView, int, CaseInsensitiveStringViewTraits> casemap;
+    HashMap<StringView, int, CaseInsensitiveASCIIStringViewTraits> casemap;
     EXPECT_EQ(casemap.set("nickserv"sv, 3), AK::HashSetResult::InsertedNewEntry);
     EXPECT_EQ(casemap.set("NickServ"sv, 3), AK::HashSetResult::ReplacedExistingEntry);
     EXPECT_EQ(casemap.size(), 1u);

--- a/Tests/AK/TestStringView.cpp
+++ b/Tests/AK/TestStringView.cpp
@@ -196,7 +196,7 @@ TEST_CASE(case_insensitive_hash)
     auto string3 = "aBcDeF"sv;
     auto string4 = "foo"sv;
 
-    EXPECT_EQ(CaseInsensitiveStringViewTraits::hash(string1), CaseInsensitiveStringViewTraits::hash(string2));
-    EXPECT_EQ(CaseInsensitiveStringViewTraits::hash(string1), CaseInsensitiveStringViewTraits::hash(string3));
-    EXPECT_NE(CaseInsensitiveStringViewTraits::hash(string1), CaseInsensitiveStringViewTraits::hash(string4));
+    EXPECT_EQ(CaseInsensitiveASCIIStringViewTraits::hash(string1), CaseInsensitiveASCIIStringViewTraits::hash(string2));
+    EXPECT_EQ(CaseInsensitiveASCIIStringViewTraits::hash(string1), CaseInsensitiveASCIIStringViewTraits::hash(string3));
+    EXPECT_NE(CaseInsensitiveASCIIStringViewTraits::hash(string1), CaseInsensitiveASCIIStringViewTraits::hash(string4));
 }


### PR DESCRIPTION
Since an ascii environment is assumed, we should be explicit about it :^)
This is my first PR in the project :)
