### PR TITLE
LibGUI: Do not attempt to close non-existent notifications

### DIFF
--- a/Userland/Libraries/LibGUI/Notification.cpp
+++ b/Userland/Libraries/LibGUI/Notification.cpp
@@ -22,7 +22,8 @@ class ConnectionToNotificationServer final
 public:
     virtual void die() override
     {
-        m_notification->connection_closed();
+        if (!m_notification->m_destroyed)
+            m_notification->connection_closed();
     }
 
 private:


### PR DESCRIPTION
This fixes a crash that would occur if ```die()``` was called on ```ConnectionToNotificationServer``` and its ```m_notification``` had already been destroyed.