### PR TITLE
WebDriver: Implement enough `window.open()` to have /window/new endpoint

### DIFF
--- a/Ladybird/BrowserWindow.h
+++ b/Ladybird/BrowserWindow.h
@@ -39,7 +39,7 @@ public:
 public slots:
     void tab_title_changed(int index, QString const&);
     void tab_favicon_changed(int index, QIcon icon);
-    void new_tab(QString const&, Activate);
+    Tab& new_tab(QString const&, Activate);
     void close_tab(int index);
     void close_current_tab();
     void open_next_tab();

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -975,6 +975,11 @@ void WebContentView::notify_server_did_close_browsing_context(Badge<WebContentCl
     emit close();
 }
 
+String WebContentView::notify_request_open_new_tab(Badge<WebContentClient>)
+{
+    return {};
+}
+
 void WebContentView::notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie)
 {
     if (on_update_cookie)

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -36,6 +36,7 @@
 #include <LibGfx/SystemTheme.h>
 #include <LibJS/Runtime/ConsoleObject.h>
 #include <LibMain/Main.h>
+#include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/Loader/ContentFilter.h>
 #include <LibWebView/WebContentClient.h>
 #include <QApplication>
@@ -629,6 +630,9 @@ void WebContentView::create_client()
             handle_web_content_process_crash();
         });
     };
+
+    m_client_state.client_handle = Web::Crypto::generate_random_uuid().release_value_but_fixme_should_propagate_errors();
+    client().async_set_window_handle(m_client_state.client_handle);
 
     client().async_set_device_pixels_per_css_pixel(m_device_pixel_ratio);
     update_palette();

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -977,6 +977,9 @@ void WebContentView::notify_server_did_close_browsing_context(Badge<WebContentCl
 
 String WebContentView::notify_request_open_new_tab(Badge<WebContentClient>)
 {
+    if (on_new_tab)
+        return on_new_tab();
+
     return {};
 }
 

--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -145,6 +145,7 @@ public:
     virtual DeprecatedString notify_server_did_request_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::Source source) override;
     virtual void notify_server_did_set_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source) override;
     virtual void notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie) override;
+    virtual String notify_request_open_new_tab(Badge<WebContentClient>) override;
     virtual void notify_server_did_close_browsing_context(Badge<WebContentClient>) override;
     virtual void notify_server_did_update_resource_count(i32 count_waiting) override;
     virtual void notify_server_did_request_restore_window() override;

--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -49,6 +49,7 @@ public:
     explicit WebContentView(StringView webdriver_content_ipc_path);
     virtual ~WebContentView() override;
 
+    Function<String()> on_new_tab;
     Function<void()> on_close;
     Function<void(Gfx::IntPoint screen_position)> on_context_menu_request;
     Function<void(const AK::URL&, DeprecatedString const& target, unsigned modifiers)> on_link_click;

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -565,7 +565,7 @@ void BrowserWindow::set_window_title_for_tab(Tab const& tab)
     set_title(DeprecatedString::formatted("{} - Browser", title.is_empty() ? url.to_deprecated_string() : title));
 }
 
-void BrowserWindow::create_new_tab(URL url, bool activate)
+Tab& BrowserWindow::create_new_tab(URL url, bool activate)
 {
     auto& new_tab = m_tab_widget->add_tab<Browser::Tab>("New tab"_short_string, *this);
 
@@ -652,6 +652,8 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
 
     if (activate)
         m_tab_widget->set_active_widget(&new_tab);
+
+    return new_tab;
 }
 
 void BrowserWindow::create_new_window(URL url)

--- a/Userland/Applications/Browser/BrowserWindow.h
+++ b/Userland/Applications/Browser/BrowserWindow.h
@@ -28,7 +28,7 @@ public:
 
     GUI::TabWidget& tab_widget();
     Tab& active_tab();
-    void create_new_tab(URL, bool activate);
+    Tab& create_new_tab(URL, bool activate);
     void create_new_window(URL);
 
     GUI::Action& go_back_action() { return *m_go_back_action; }

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -468,6 +468,11 @@ Tab::Tab(BrowserWindow& window)
             go_forward();
     };
 
+    view().on_new_tab = [this] {
+        auto& tab = this->window().create_new_tab(URL("about:blank"), true);
+        return tab.view().handle();
+    };
+
     view().on_close = [this] {
         on_tab_close_request(*this);
     };

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -283,6 +283,7 @@ set(SOURCES
     HTML/Plugin.cpp
     HTML/PluginArray.cpp
     HTML/PromiseRejectionEvent.cpp
+    HTML/RemoteBrowsingContext.cpp
     HTML/Scripting/ClassicScript.cpp
     HTML/Scripting/Environments.cpp
     HTML/Scripting/ExceptionReporter.cpp

--- a/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
@@ -72,6 +72,18 @@ WebIDL::ExceptionOr<String> Crypto::random_uuid() const
 {
     auto& vm = realm().vm();
 
+    return TRY_OR_THROW_OOM(vm, generate_random_uuid());
+}
+
+void Crypto::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_subtle.ptr());
+}
+
+// https://w3c.github.io/webcrypto/#dfn-generate-a-random-uuid
+ErrorOr<String> generate_random_uuid()
+{
     // 1. Let bytes be a byte sequence of length 16.
     u8 bytes[16];
 
@@ -113,18 +125,13 @@ WebIDL::ExceptionOr<String> Crypto::random_uuid() const
         ».
         */
     StringBuilder builder;
-    TRY_OR_THROW_OOM(vm, builder.try_appendff("{:02x}{:02x}{:02x}{:02x}-", bytes[0], bytes[1], bytes[2], bytes[3]));
-    TRY_OR_THROW_OOM(vm, builder.try_appendff("{:02x}{:02x}-", bytes[4], bytes[5]));
-    TRY_OR_THROW_OOM(vm, builder.try_appendff("{:02x}{:02x}-", bytes[6], bytes[7]));
-    TRY_OR_THROW_OOM(vm, builder.try_appendff("{:02x}{:02x}-", bytes[8], bytes[9]));
-    TRY_OR_THROW_OOM(vm, builder.try_appendff("{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}", bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]));
-    return TRY_OR_THROW_OOM(vm, builder.to_string());
-}
+    TRY(builder.try_appendff("{:02x}{:02x}{:02x}{:02x}-", bytes[0], bytes[1], bytes[2], bytes[3]));
+    TRY(builder.try_appendff("{:02x}{:02x}-", bytes[4], bytes[5]));
+    TRY(builder.try_appendff("{:02x}{:02x}-", bytes[6], bytes[7]));
+    TRY(builder.try_appendff("{:02x}{:02x}-", bytes[8], bytes[9]));
+    TRY(builder.try_appendff("{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}", bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]));
 
-void Crypto::visit_edges(Cell::Visitor& visitor)
-{
-    Base::visit_edges(visitor);
-    visitor.visit(m_subtle.ptr());
-}
+    return builder.to_string();
+};
 
 }

--- a/Userland/Libraries/LibWeb/Crypto/Crypto.h
+++ b/Userland/Libraries/LibWeb/Crypto/Crypto.h
@@ -35,4 +35,6 @@ private:
     JS::GCPtr<SubtleCrypto> m_subtle;
 };
 
+ErrorOr<String> generate_random_uuid();
+
 }

--- a/Userland/Libraries/LibWeb/HTML/AbstractBrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/AbstractBrowsingContext.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Forward.h>
+#include <LibJS/Heap/Cell.h>
+#include <LibWeb/HTML/HistoryHandlingBehavior.h>
+#include <LibWeb/HTML/PolicyContainers.h>
+#include <LibWeb/HTML/WindowProxy.h>
+
+namespace Web::HTML {
+
+class AbstractBrowsingContext : public JS::Cell {
+    JS_CELL(AbstractBrowsingContext, Cell);
+
+public:
+    virtual HTML::WindowProxy* window_proxy() = 0;
+    virtual HTML::WindowProxy const* window_proxy() const = 0;
+
+    DeprecatedString const& name() const { return m_name; }
+    void set_name(DeprecatedString const& name) { m_name = name; }
+
+    JS::GCPtr<BrowsingContext> opener_browsing_context() const { return m_opener_browsing_context; }
+    void set_opener_browsing_context(JS::GCPtr<BrowsingContext> browsing_context) { m_opener_browsing_context = browsing_context; }
+
+    virtual WebIDL::ExceptionOr<void> navigate(
+        JS::NonnullGCPtr<Fetch::Infrastructure::Request> resource,
+        BrowsingContext& source_browsing_context,
+        bool exceptions_enabled = false,
+        HistoryHandlingBehavior history_handling = HistoryHandlingBehavior::Default,
+        Optional<PolicyContainer> history_policy_container = {},
+        DeprecatedString navigation_type = "other",
+        Optional<DeprecatedString> navigation_id = {},
+        Function<void(JS::NonnullGCPtr<Fetch::Infrastructure::Response>)> process_response_end_of_body = {})
+        = 0;
+
+    void set_is_popup(bool is_popup) { m_is_popup = is_popup; }
+
+    virtual String const& window_handle() const = 0;
+    virtual void set_window_handle(String handle) = 0;
+
+protected:
+    DeprecatedString m_name;
+
+    // https://html.spec.whatwg.org/multipage/browsers.html#is-popup
+    bool m_is_popup { false };
+
+    // https://html.spec.whatwg.org/multipage/browsers.html#opener-browsing-context
+    JS::GCPtr<BrowsingContext> m_opener_browsing_context;
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -620,7 +620,7 @@ BrowsingContext::ChosenBrowsingContext BrowsingContext::choose_a_browsing_contex
     // a boolean noopener are as follows:
 
     // 1. Let chosen be null.
-    JS::GCPtr<BrowsingContext> chosen = nullptr;
+    JS::GCPtr<AbstractBrowsingContext> chosen = nullptr;
 
     // 2. Let windowType be "existing or none".
     auto window_type = WindowType::ExistingOrNone;
@@ -734,7 +734,7 @@ BrowsingContext::ChosenBrowsingContext BrowsingContext::choose_a_browsing_contex
     }
 
     // 9. Return chosen and windowType.
-    return { chosen, window_type };
+    return { chosen.ptr(), window_type };
 }
 
 // https://html.spec.whatwg.org/multipage/browsers.html#document-tree-child-browsing-context

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -17,6 +17,7 @@
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/HTMLAnchorElement.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
+#include <LibWeb/HTML/RemoteBrowsingContext.h>
 #include <LibWeb/HTML/SandboxingFlagSet.h>
 #include <LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h>
 #include <LibWeb/HTML/Window.h>
@@ -698,7 +699,8 @@ BrowsingContext::ChosenBrowsingContext BrowsingContext::choose_a_browsing_contex
 
             // 3. If noopener is true, then set chosen to the result of creating a new top-level browsing context.
             if (no_opener) {
-                chosen = HTML::BrowsingContext::create_a_new_top_level_browsing_context(*m_page);
+                auto handle = m_page->client().page_did_request_new_tab();
+                chosen = RemoteBrowsingContext::create_a_new_remote_browsing_context(handle);
             }
 
             // 4. Otherwise:

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -268,6 +268,7 @@ public:
     Optional<AK::URL> const& creator_url() const { return m_creator_url; }
 
     String const& window_handle() const { return m_window_handle; }
+    void set_window_handle(String handle) { m_window_handle = move(handle); }
 
 private:
     explicit BrowsingContext(Page&, HTML::BrowsingContextContainer*);

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -267,6 +267,8 @@ public:
 
     Optional<AK::URL> const& creator_url() const { return m_creator_url; }
 
+    String const& window_handle() const { return m_window_handle; }
+
 private:
     explicit BrowsingContext(Page&, HTML::BrowsingContextContainer*);
 
@@ -301,6 +303,9 @@ private:
     JS::GCPtr<HTML::BrowsingContextContainer> m_container;
     CSSPixelSize m_size;
     CSSPixelPoint m_viewport_scroll_offset;
+
+    // https://w3c.github.io/webdriver/#dfn-window-handles
+    String m_window_handle;
 
     // https://html.spec.whatwg.org/multipage/browsers.html#browsing-context
     JS::GCPtr<HTML::WindowProxy> m_window_proxy;

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -537,7 +537,7 @@ void HTMLHyperlinkElementUtils::follow_the_hyperlink(Optional<DeprecatedString> 
     // FIXME: "navigate" means implementing the navigation algorithm here:
     //        https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate
     hyperlink_element_utils_queue_an_element_task(Task::Source::DOMManipulation, [url_string, target] {
-        target->loader().load(url_string, FrameLoader::Type::Navigation);
+        verify_cast<BrowsingContext>(*target).loader().load(url_string, FrameLoader::Type::Navigation);
     });
 }
 

--- a/Userland/Libraries/LibWeb/HTML/RemoteBrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/RemoteBrowsingContext.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/HTML/RemoteBrowsingContext.h>
+
+namespace Web::HTML {
+
+JS::NonnullGCPtr<RemoteBrowsingContext> RemoteBrowsingContext::create_a_new_remote_browsing_context(String handle)
+{
+    auto browsing_context = Bindings::main_thread_vm().heap().allocate_without_realm<RemoteBrowsingContext>(handle);
+    return browsing_context;
+};
+
+HTML::WindowProxy* RemoteBrowsingContext::window_proxy()
+{
+    return nullptr;
+}
+
+HTML::WindowProxy const* RemoteBrowsingContext::window_proxy() const
+{
+    return nullptr;
+}
+
+RemoteBrowsingContext::RemoteBrowsingContext(String handle)
+    : m_window_handle(handle) {};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/RemoteBrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/RemoteBrowsingContext.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/HTML/AbstractBrowsingContext.h>
+
+namespace Web::HTML {
+
+class RemoteBrowsingContext final
+    : public AbstractBrowsingContext
+    , public Weakable<RemoteBrowsingContext> {
+    JS_CELL(RemoteBrowsingContext, AbstractBrowsingContext);
+
+public:
+    static JS::NonnullGCPtr<RemoteBrowsingContext> create_a_new_remote_browsing_context(String handle);
+
+    virtual HTML::WindowProxy* window_proxy() override;
+    virtual HTML::WindowProxy const* window_proxy() const override;
+
+    virtual WebIDL::ExceptionOr<void> navigate(
+        JS::NonnullGCPtr<Fetch::Infrastructure::Request>,
+        BrowsingContext&,
+        bool,
+        HistoryHandlingBehavior,
+        Optional<PolicyContainer>,
+        DeprecatedString,
+        Optional<DeprecatedString>,
+        Function<void(JS::NonnullGCPtr<Fetch::Infrastructure::Response>)>) override
+    {
+        return {};
+    };
+
+    virtual String const& window_handle() const override { return m_window_handle; }
+    virtual void set_window_handle(String handle) override { m_window_handle = handle; };
+
+private:
+    explicit RemoteBrowsingContext(String);
+
+    String m_window_handle;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -201,6 +201,7 @@ public:
     virtual void page_did_set_cookie(const AK::URL&, Cookie::ParsedCookie const&, Cookie::Source) { }
     virtual void page_did_update_cookie(Web::Cookie::Cookie) { }
     virtual void page_did_update_resource_count(i32) { }
+    virtual String page_did_request_new_tab() { return {}; }
     virtual void page_did_close_browsing_context(HTML::BrowsingContext const&) { }
 
     virtual void request_file(FileRequest) = 0;

--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -65,6 +65,7 @@ static constexpr auto s_webdriver_endpoints = Array {
     ROUTE(DELETE, "/session/:session_id/window"sv, close_window),
     ROUTE(POST, "/session/:session_id/window"sv, switch_to_window),
     ROUTE(GET, "/session/:session_id/window/handles"sv, get_window_handles),
+    ROUTE(POST, "/session/:session_id/window/new"sv, new_window),
     ROUTE(GET, "/session/:session_id/window/rect"sv, get_window_rect),
     ROUTE(POST, "/session/:session_id/window/rect"sv, set_window_rect),
     ROUTE(POST, "/session/:session_id/window/maximize"sv, maximize_window),

--- a/Userland/Libraries/LibWeb/WebDriver/Client.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.h
@@ -50,6 +50,7 @@ public:
     // 11. Contexts, https://w3c.github.io/webdriver/#contexts
     virtual Response get_window_handle(Parameters parameters, JsonValue payload) = 0;
     virtual Response close_window(Parameters parameters, JsonValue payload) = 0;
+    virtual Response new_window(Parameters parameters, JsonValue payload) = 0;
     virtual Response switch_to_window(Parameters parameters, JsonValue payload) = 0;
     virtual Response get_window_handles(Parameters parameters, JsonValue payload) = 0;
     virtual Response get_window_rect(Parameters parameters, JsonValue payload) = 0;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -59,6 +59,14 @@ void OutOfProcessWebView::handle_web_content_process_crash()
     load_html(builder.to_deprecated_string(), m_url);
 }
 
+String OutOfProcessWebView::notify_request_open_new_tab(Badge<WebContentClient>)
+{
+    if (on_new_tab)
+        return on_new_tab();
+
+    return {};
+}
+
 void OutOfProcessWebView::create_client()
 {
     m_client_state = {};

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -19,6 +19,7 @@
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/SystemTheme.h>
+#include <LibWeb/Crypto/Crypto.h>
 
 REGISTER_WIDGET(WebView, OutOfProcessWebView)
 
@@ -68,6 +69,9 @@ void OutOfProcessWebView::create_client()
             handle_web_content_process_crash();
         });
     };
+
+    m_client_state.client_handle = Web::Crypto::generate_random_uuid().release_value_but_fixme_should_propagate_errors();
+    client().async_set_window_handle(m_client_state.client_handle);
 
     client().async_update_system_theme(Gfx::current_system_theme_buffer());
     client().async_update_system_fonts(Gfx::FontDatabase::default_font_query(), Gfx::FontDatabase::fixed_width_font_query(), Gfx::FontDatabase::window_title_font_query());

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -57,6 +57,7 @@ public:
     // In practice, this means that OOPWV may render scaled stale versions of the content while resizing.
     void set_content_scales_to_viewport(bool);
 
+    Function<String()> on_new_tab;
     Function<void()> on_close;
     Function<void(Gfx::IntPoint screen_position)> on_context_menu_request;
     Function<void(const AK::URL&, DeprecatedString const& target, unsigned modifiers)> on_link_click;
@@ -161,6 +162,7 @@ private:
     virtual DeprecatedString notify_server_did_request_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::Source source) override;
     virtual void notify_server_did_set_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source) override;
     virtual void notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie) override;
+    virtual String notify_request_open_new_tab(Badge<WebContentClient>) override;
     virtual void notify_server_did_close_browsing_context(Badge<WebContentClient>) override;
     virtual void notify_server_did_update_resource_count(i32 count_waiting) override;
     virtual void notify_server_did_request_restore_window() override;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -30,6 +30,8 @@ public:
 
     AK::URL const& url() const { return m_url; }
 
+    String const& handle() const { return m_client_state.client_handle; }
+
     void load(AK::URL const&);
     void load_html(StringView, AK::URL const&);
     void load_empty_document();
@@ -129,6 +131,7 @@ protected:
 
     struct ClientState {
         RefPtr<WebContentClient> client;
+        String client_handle;
         SharedBitmap front_bitmap;
         SharedBitmap back_bitmap;
         i32 next_bitmap_id { 0 };

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -98,6 +98,7 @@ public:
     virtual DeprecatedString notify_server_did_request_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::Source source) = 0;
     virtual void notify_server_did_set_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source) = 0;
     virtual void notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie) = 0;
+    virtual String notify_request_open_new_tab(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_close_browsing_context(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_update_resource_count(i32 count_waiting) = 0;
     virtual void notify_server_did_request_restore_window() = 0;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -240,6 +240,11 @@ void WebContentClient::did_update_cookie(Web::Cookie::Cookie const& cookie)
     m_view.notify_server_did_update_cookie({}, cookie);
 }
 
+Messages::WebContentClient::DidRequestNewTabResponse WebContentClient::did_request_new_tab()
+{
+    return m_view.notify_request_open_new_tab({});
+}
+
 void WebContentClient::did_close_browsing_context()
 {
     m_view.notify_server_did_close_browsing_context({});

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -79,6 +79,7 @@ private:
     virtual Messages::WebContentClient::DidRequestFullscreenWindowResponse did_request_fullscreen_window() override;
     virtual void did_request_file(DeprecatedString const& path, i32) override;
     virtual void did_finish_handling_input_event(bool event_was_accepted) override;
+    virtual Messages::WebContentClient::DidRequestNewTabResponse did_request_new_tab() override;
 
     ViewImplementation& m_view;
 };

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -66,6 +66,11 @@ Messages::WebContentServer::GetWindowHandleResponse ConnectionFromClient::get_wi
     return m_page_host->page().top_level_browsing_context().window_handle();
 }
 
+void ConnectionFromClient::set_window_handle(String const& handle)
+{
+    m_page_host->page().top_level_browsing_context().set_window_handle(handle);
+}
+
 void ConnectionFromClient::connect_to_webdriver(DeprecatedString const& webdriver_ipc_path)
 {
     // FIXME: Propagate this error back to the browser.

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -61,6 +61,11 @@ Web::Page const& ConnectionFromClient::page() const
     return m_page_host->page();
 }
 
+Messages::WebContentServer::GetWindowHandleResponse ConnectionFromClient::get_window_handle()
+{
+    return m_page_host->page().top_level_browsing_context().window_handle();
+}
+
 void ConnectionFromClient::connect_to_webdriver(DeprecatedString const& webdriver_ipc_path)
 {
     // FIXME: Propagate this error back to the browser.

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -48,6 +48,7 @@ private:
     Web::Page& page();
     Web::Page const& page() const;
 
+    virtual Messages::WebContentServer::GetWindowHandleResponse get_window_handle() override;
     virtual void connect_to_webdriver(DeprecatedString const& webdriver_ipc_path) override;
     virtual void update_system_theme(Core::AnonymousBuffer const&) override;
     virtual void update_system_fonts(DeprecatedString const&, DeprecatedString const&, DeprecatedString const&) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -49,6 +49,7 @@ private:
     Web::Page const& page() const;
 
     virtual Messages::WebContentServer::GetWindowHandleResponse get_window_handle() override;
+    virtual void set_window_handle(String const& handle) override;
     virtual void connect_to_webdriver(DeprecatedString const& webdriver_ipc_path) override;
     virtual void update_system_theme(Core::AnonymousBuffer const&) override;
     virtual void update_system_fonts(DeprecatedString const&, DeprecatedString const&, DeprecatedString const&) override;

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -377,6 +377,11 @@ void PageHost::page_did_update_resource_count(i32 count_waiting)
     m_client.async_did_update_resource_count(count_waiting);
 }
 
+String PageHost::page_did_request_new_tab()
+{
+    return m_client.did_request_new_tab();
+}
+
 void PageHost::page_did_close_browsing_context(Web::HTML::BrowsingContext const&)
 {
     m_client.async_did_close_browsing_context();

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -98,6 +98,7 @@ private:
     virtual void page_did_set_cookie(const URL&, Web::Cookie::ParsedCookie const&, Web::Cookie::Source) override;
     virtual void page_did_update_cookie(Web::Cookie::Cookie) override;
     virtual void page_did_update_resource_count(i32) override;
+    virtual String page_did_request_new_tab() override;
     virtual void page_did_close_browsing_context(Web::HTML::BrowsingContext const&) override;
     virtual void request_file(Web::FileRequest) override;
 

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -55,6 +55,7 @@ endpoint WebContentClient
     did_request_fullscreen_window() => (Gfx::IntRect window_rect)
     did_request_file(DeprecatedString path, i32 request_id) =|
     did_finish_handling_input_event(bool event_was_accepted) =|
+    did_request_new_tab() => (String handle)
 
     did_output_js_console_message(i32 message_index) =|
     did_get_js_console_messages(i32 start_index, Vector<DeprecatedString> message_types, Vector<DeprecatedString> messages) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -9,6 +9,8 @@
 
 endpoint WebContentServer
 {
+    get_window_handle() => (String handle)
+
     connect_to_webdriver(DeprecatedString webdriver_ipc_path) =|
 
     update_system_theme(Core::AnonymousBuffer theme_buffer) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -10,6 +10,7 @@
 endpoint WebContentServer
 {
     get_window_handle() => (String handle)
+    set_window_handle(String handle) =|
 
     connect_to_webdriver(DeprecatedString webdriver_ipc_path) =|
 

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -15,6 +15,7 @@ endpoint WebDriverClient {
     forward() => (Web::WebDriver::Response response)
     refresh() => (Web::WebDriver::Response response)
     get_title() => (Web::WebDriver::Response response)
+    get_window_handle() => (String handle)
     close_window() => (Web::WebDriver::Response response)
     new_window(JsonValue payload) => (Web::WebDriver::Response response)
     get_window_rect() => (Web::WebDriver::Response response)

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -16,6 +16,7 @@ endpoint WebDriverClient {
     refresh() => (Web::WebDriver::Response response)
     get_title() => (Web::WebDriver::Response response)
     close_window() => (Web::WebDriver::Response response)
+    new_window(JsonValue payload) => (Web::WebDriver::Response response)
     get_window_rect() => (Web::WebDriver::Response response)
     set_window_rect(JsonValue payload) => (Web::WebDriver::Response response)
     maximize_window() => (Web::WebDriver::Response response)

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -522,6 +522,12 @@ Messages::WebDriverClient::GetTitleResponse WebDriverConnection::get_title()
     return title;
 }
 
+// 11.1 Get Window Handle, https://w3c.github.io/webdriver/#get-window-handle
+Messages::WebDriverClient::GetWindowHandleResponse WebDriverConnection::get_window_handle()
+{
+    return m_page_client.page().top_level_browsing_context().window_handle();
+}
+
 // 11.2 Close Window, https://w3c.github.io/webdriver/#dfn-close-window
 Messages::WebDriverClient::CloseWindowResponse WebDriverConnection::close_window()
 {

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -324,6 +324,9 @@ ErrorOr<NonnullRefPtr<WebDriverConnection>> WebDriverConnection::connect(Web::Pa
     dbgln_if(WEBDRIVER_DEBUG, "Trying to connect to {}", webdriver_ipc_path);
     auto socket = TRY(Core::LocalSocket::connect(webdriver_ipc_path));
 
+    // Allow pop-ups, or otherwise /window/new won't be able to open a new tab.
+    page_client.page().set_should_block_pop_ups(false);
+
     dbgln_if(WEBDRIVER_DEBUG, "Connected to WebDriver");
     return adopt_nonnull_ref_or_enomem(new (nothrow) WebDriverConnection(move(socket), page_client));
 }

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -53,6 +53,7 @@ private:
     virtual Messages::WebDriverClient::RefreshResponse refresh() override;
     virtual Messages::WebDriverClient::GetTitleResponse get_title() override;
     virtual Messages::WebDriverClient::CloseWindowResponse close_window() override;
+    virtual Messages::WebDriverClient::NewWindowResponse new_window(JsonValue const& payload) override;
     virtual Messages::WebDriverClient::GetWindowRectResponse get_window_rect() override;
     virtual Messages::WebDriverClient::SetWindowRectResponse set_window_rect(JsonValue const& payload) override;
     virtual Messages::WebDriverClient::MaximizeWindowResponse maximize_window() override;

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -52,6 +52,7 @@ private:
     virtual Messages::WebDriverClient::ForwardResponse forward() override;
     virtual Messages::WebDriverClient::RefreshResponse refresh() override;
     virtual Messages::WebDriverClient::GetTitleResponse get_title() override;
+    virtual Messages::WebDriverClient::GetWindowHandleResponse get_window_handle() override;
     virtual Messages::WebDriverClient::CloseWindowResponse close_window() override;
     virtual Messages::WebDriverClient::NewWindowResponse new_window(JsonValue const& payload) override;
     virtual Messages::WebDriverClient::GetWindowRectResponse get_window_rect() override;

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -335,6 +335,15 @@ Web::WebDriver::Response Client::get_window_handles(Web::WebDriver::Parameters p
     return session->get_window_handles();
 }
 
+// 11.5 New Window, https://w3c.github.io/webdriver/#dfn-new-window
+// POST /session/{session id}/window/new
+Web::WebDriver::Response Client::new_window(Web::WebDriver::Parameters parameters, JsonValue payload)
+{
+    dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/window/new");
+    auto session = TRY(find_session_with_id(parameters[0]));
+    return session->web_content_connection().new_window(payload);
+}
+
 // 11.8.1 Get Window Rect, https://w3c.github.io/webdriver/#dfn-get-window-rect
 // GET /session/{session id}/window/rect
 Web::WebDriver::Response Client::get_window_rect(Web::WebDriver::Parameters parameters, JsonValue)

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -52,6 +52,7 @@ private:
     virtual Web::WebDriver::Response close_window(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response switch_to_window(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response get_window_handles(Web::WebDriver::Parameters parameters, JsonValue payload) override;
+    virtual Web::WebDriver::Response new_window(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response get_window_rect(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response set_window_rect(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response maximize_window(Web::WebDriver::Parameters parameters, JsonValue payload) override;

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -50,12 +50,11 @@ ErrorOr<NonnullRefPtr<Core::LocalServer>> Session::create_server(NonnullRefPtr<S
         dbgln("WebDriver is connected to WebContent socket");
         auto web_content_connection = maybe_connection.release_value();
 
-        auto handle_name = String::formatted("window-{}"sv, m_next_handle_id).release_value_but_fixme_should_propagate_errors();
-        m_next_handle_id++;
-        m_windows.set(handle_name, Session::Window { handle_name, move(web_content_connection) });
+        auto window_handle = web_content_connection->get_window_handle();
+        m_windows.set(window_handle, Session::Window { window_handle, move(web_content_connection) });
 
         if (m_current_window_handle.is_empty())
-            m_current_window_handle = handle_name;
+            m_current_window_handle = window_handle;
 
         MUST(promise->resolve({}));
     };

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -64,7 +64,6 @@ private:
     bool m_started { false };
     unsigned m_id { 0 };
 
-    unsigned m_next_handle_id = 0;
     HashMap<String, Window> m_windows;
     String m_current_window_handle;
 

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -132,6 +132,7 @@ private:
     DeprecatedString notify_server_did_request_cookie(Badge<WebView::WebContentClient>, const URL&, Web::Cookie::Source) override { return {}; }
     void notify_server_did_set_cookie(Badge<WebView::WebContentClient>, const URL&, Web::Cookie::ParsedCookie const&, Web::Cookie::Source) override { }
     void notify_server_did_update_cookie(Badge<WebView::WebContentClient>, Web::Cookie::Cookie const&) override { }
+    String notify_request_open_new_tab(Badge<WebView::WebContentClient>) override { return {}; }
     void notify_server_did_close_browsing_context(Badge<WebView::WebContentClient>) override { }
     void notify_server_did_update_resource_count(i32) override { }
     void notify_server_did_request_restore_window() override { }


### PR DESCRIPTION
1) Separate BrowsingContext into "local" (running in current WebContent process) and "remote" (running in another WebContent process).
2) Introduce IPC call to open a new browser tab: required to create new top level browsing. Allows `window.open()` to spawn new tabs.
4) Implement POST `/window/new` WebDriver endpoint.