### PR TITLE
LibWeb: Implement the [PutForwards] IDL extended attribute

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -233,8 +233,6 @@ private:
 
     // [[CrossOriginPropertyDescriptorMap]], https://html.spec.whatwg.org/multipage/browsers.html#crossoriginpropertydescriptormap
     CrossOriginPropertyDescriptorMap m_cross_origin_property_descriptor_map;
-
-    JS_DECLARE_NATIVE_FUNCTION(location_setter);
 };
 
 void run_animation_frame_callbacks(DOM::Document&, double now);


### PR DESCRIPTION
For example, setting a `classList` attribute previously had no effect:
![before](https://user-images.githubusercontent.com/5600524/225110826-18096552-67b9-42a3-b9c4-aa4f0f366f67.png)

Now it's value is updated:
![after](https://user-images.githubusercontent.com/5600524/225110869-278c3587-41f4-4c2c-8680-b41c71427179.png)

We can similarly use this to set `window.location`, though that already worked before due to the manual implementation on `HTML::Window`:

[Screencast from 2023-03-14 15-04-10.webm](https://user-images.githubusercontent.com/5600524/225110996-08db46af-eb58-4ec4-8c10-b760ea3b28db.webm)
