### PR TITLE
LibWeb: Invalidate styles on font load

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1582,7 +1582,7 @@ CSSPixelRect StyleComputer::viewport_rect() const
 
 void StyleComputer::did_load_font([[maybe_unused]] FlyString const& family_name)
 {
-    document().invalidate_layout();
+    document().invalidate_style();
 }
 
 void StyleComputer::load_fonts_from_sheet(CSSStyleSheet const& sheet)


### PR DESCRIPTION
It is not sufficient to just invalidate layout when a new font has loaded, because while it was loading we might have chosen a fallback font-family value instead.

Invalidate style instead.
