### PR TITLE
DisplaySettings: Use FileSystemAccessServer instead of FilePicker

### DIFF
--- a/Userland/Applications/DisplaySettings/CMakeLists.txt
+++ b/Userland/Applications/DisplaySettings/CMakeLists.txt
@@ -33,4 +33,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_app(DisplaySettings ICON app-display-settings)
-target_link_libraries(DisplaySettings PRIVATE LibCore LibDesktop LibGfx LibGUI LibConfig LibIPC LibMain LibEDID LibThreading)
+target_link_libraries(DisplaySettings PRIVATE LibCore LibDesktop LibGfx LibGUI LibConfig LibIPC LibMain LibEDID LibThreading LibFileSystemAccessClient)


### PR DESCRIPTION
Use `FileSystemAccessServer` instead of `FilePicker` to select wallpaper in BackgroundSettings.

Fixes crash in DisplaySettings introduced in #17777