### PR TITLE
image: Preserve ICC profiles in PNG output

### DIFF
--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -36,8 +36,7 @@ public:
 
     ErrorOr<void> add_u8(u8);
 
-    template<typename T>
-    ErrorOr<void> add(T*, size_t);
+    ErrorOr<void> add(ReadonlyBytes);
 
     ErrorOr<void> store_type();
     void store_data_length();
@@ -84,10 +83,9 @@ ErrorOr<void> PNGChunk::add(T data)
     return {};
 }
 
-template<typename T>
-ErrorOr<void> PNGChunk::add(T* data, size_t size)
+ErrorOr<void> PNGChunk::add(ReadonlyBytes bytes)
 {
-    TRY(m_data.try_append(data, size));
+    TRY(m_data.try_append(bytes));
     return {};
 }
 
@@ -266,7 +264,7 @@ ErrorOr<void> PNGWriter::add_IDAT_chunk(Gfx::Bitmap const& bitmap)
 
     auto zlib_buffer = TRY(Compress::ZlibCompressor::compress_all(uncompressed_block_data, Compress::ZlibCompressionLevel::Best));
 
-    TRY(png_chunk.add(zlib_buffer.data(), zlib_buffer.size()));
+    TRY(png_chunk.add(zlib_buffer));
     TRY(add_chunk(png_chunk));
     return {};
 }

--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -48,6 +48,8 @@ private:
 PNGChunk::PNGChunk(String type)
     : m_type(move(type))
 {
+    VERIFY(m_type.bytes().size() == 4);
+
     // NOTE: These are MUST() because they should always be able to fit in m_data's inline capacity.
     MUST(add_as_big_endian<data_length_type>(0));
     MUST(store_type());

--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -31,9 +31,6 @@ public:
     template<typename T>
     ErrorOr<void> add_as_big_endian(T);
 
-    template<typename T>
-    ErrorOr<void> add_as_little_endian(T);
-
     ErrorOr<void> add_u8(u8);
 
     ErrorOr<void> compress_and_add(ReadonlyBytes);
@@ -92,14 +89,6 @@ ErrorOr<void> PNGChunk::compress_and_add(ReadonlyBytes uncompressed_bytes)
 ErrorOr<void> PNGChunk::add(ReadonlyBytes bytes)
 {
     TRY(m_data.try_append(bytes));
-    return {};
-}
-
-template<typename T>
-ErrorOr<void> PNGChunk::add_as_little_endian(T data)
-{
-    auto data_out = AK::convert_between_host_and_little_endian(data);
-    TRY(add(data_out));
     return {};
 }
 

--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -55,7 +55,7 @@ PNGChunk::PNGChunk(DeprecatedString type)
 
 ErrorOr<void> PNGChunk::store_type()
 {
-    TRY(m_data.try_append(type().bytes()));
+    TRY(add(type().bytes()));
     return {};
 }
 

--- a/Userland/Libraries/LibGfx/PNGWriter.h
+++ b/Userland/Libraries/LibGfx/PNGWriter.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <AK/Vector.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/PNGShared.h>
@@ -15,9 +16,18 @@ namespace Gfx {
 
 class PNGChunk;
 
+// This is not a nested struct to work around https://llvm.org/PR36684
+struct PNGWriterOptions {
+    // Data for the iCCP chunk.
+    // FIXME: Allow writing cICP, sRGB, or gAMA instead too.
+    Optional<ReadonlyBytes> icc_data;
+};
+
 class PNGWriter {
 public:
-    static ErrorOr<ByteBuffer> encode(Gfx::Bitmap const&);
+    using Options = PNGWriterOptions;
+
+    static ErrorOr<ByteBuffer> encode(Gfx::Bitmap const&, Options options = Options {});
 
 private:
     PNGWriter() = default;
@@ -26,6 +36,7 @@ private:
     ErrorOr<void> add_chunk(PNGChunk&);
     ErrorOr<void> add_png_header();
     ErrorOr<void> add_IHDR_chunk(u32 width, u32 height, u8 bit_depth, PNG::ColorType color_type, u8 compression_method, u8 filter_method, u8 interlace_method);
+    ErrorOr<void> add_iCCP_chunk(ReadonlyBytes icc_data);
     ErrorOr<void> add_IDAT_chunk(Gfx::Bitmap const&);
     ErrorOr<void> add_IEND_chunk();
 };

--- a/Userland/Utilities/image.cpp
+++ b/Userland/Utilities/image.cpp
@@ -48,7 +48,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         bytes = TRY(Gfx::PNGWriter::encode(*frame, { .icc_data = icc_data }));
     } else if (out_path.ends_with(".ppm"sv, CaseSensitivity::CaseInsensitive)) {
         auto const format = ppm_ascii ? Gfx::PortableFormatWriter::Options::Format::ASCII : Gfx::PortableFormatWriter::Options::Format::Raw;
-        bytes = TRY(Gfx::PortableFormatWriter::encode(*frame, Gfx::PortableFormatWriter::Options { .format = format }));
+        bytes = TRY(Gfx::PortableFormatWriter::encode(*frame, { .format = format }));
     } else if (out_path.ends_with(".qoi"sv, CaseSensitivity::CaseInsensitive)) {
         bytes = TRY(Gfx::QOIWriter::encode(*frame));
     } else {

--- a/Userland/Utilities/image.cpp
+++ b/Userland/Utilities/image.cpp
@@ -39,12 +39,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // This uses ImageDecoder instead of Bitmap::load_from_file() to have more control
     // over selecting a frame, access color profile data, and so on in the future.
     auto frame = TRY(decoder->frame(0)).image;
+    Optional<ReadonlyBytes> icc_data = TRY(decoder->icc_data());
 
     ByteBuffer bytes;
     if (out_path.ends_with(".bmp"sv, CaseSensitivity::CaseInsensitive)) {
         bytes = TRY(Gfx::BMPWriter::encode(*frame));
     } else if (out_path.ends_with(".png"sv, CaseSensitivity::CaseInsensitive)) {
-        bytes = TRY(Gfx::PNGWriter::encode(*frame));
+        bytes = TRY(Gfx::PNGWriter::encode(*frame, { .icc_data = icc_data }));
     } else if (out_path.ends_with(".ppm"sv, CaseSensitivity::CaseInsensitive)) {
         auto const format = ppm_ascii ? Gfx::PortableFormatWriter::Options::Format::ASCII : Gfx::PortableFormatWriter::Options::Format::Raw;
         bytes = TRY(Gfx::PortableFormatWriter::encode(*frame, Gfx::PortableFormatWriter::Options { .format = format }));


### PR DESCRIPTION
This probably does strange things for CMYK jpegs, since JPEGLoader
converts those from CMYK to RGB but the ICC profile is still an CMYK
profile. The Right Fix for that is probably for JPEGLoader to consume
the profile when it does CMYK->RGB conversion and then not hand out
the profile data. (Or we could add a CMYK bitmap type.)

But most of the time, this is a progression :^)

…and modernize PNGWriter internals a bit.