### PR TITLE
HackStudio+LibGUI: Gutter indicator extravaganza

### DIFF
--- a/Userland/DevTools/HackStudio/CodeDocument.cpp
+++ b/Userland/DevTools/HackStudio/CodeDocument.cpp
@@ -32,4 +32,14 @@ CodeDocument::CodeDocument(Client* client)
 {
 }
 
+CodeDocument::DiffType CodeDocument::line_difference(size_t line) const
+{
+    return m_line_differences[line];
+}
+
+void CodeDocument::set_line_differences(Badge<HackStudio::Editor>, Vector<HackStudio::CodeDocument::DiffType> line_differences)
+{
+    m_line_differences = move(line_differences);
+}
+
 }

--- a/Userland/DevTools/HackStudio/CodeDocument.h
+++ b/Userland/DevTools/HackStudio/CodeDocument.h
@@ -13,6 +13,8 @@
 
 namespace HackStudio {
 
+class Editor;
+
 class CodeDocument final : public GUI::TextDocument {
 public:
     virtual ~CodeDocument() override = default;
@@ -29,6 +31,15 @@ public:
 
     virtual bool is_code_document() const override final { return true; }
 
+    enum class DiffType {
+        None,
+        AddedLine,
+        ModifiedLine,
+        DeletedLinesBefore,
+    };
+    DiffType line_difference(size_t line) const;
+    void set_line_differences(Badge<Editor>, Vector<DiffType>);
+
 private:
     explicit CodeDocument(DeprecatedString const& file_path, Client* client = nullptr);
     explicit CodeDocument(Client* client = nullptr);
@@ -37,6 +48,8 @@ private:
     Optional<Syntax::Language> m_language;
     Vector<size_t> m_breakpoint_lines;
     Optional<size_t> m_execution_position;
+
+    Vector<DiffType> m_line_differences;
 };
 
 }

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -86,6 +86,24 @@ Editor::Editor()
         add_breakpoint(line).release_value_but_fixme_should_propagate_errors();
     };
 
+    m_git_diff_indicator_id = register_gutter_indicator(
+        [&](auto& painter, Gfx::IntRect rect, size_t line) {
+            auto diff_type = code_document().line_difference(line);
+            switch (diff_type) {
+            case CodeDocument::DiffType::AddedLine:
+                painter.draw_text(rect, "+"sv, font(), Gfx::TextAlignment::Center);
+                break;
+            case CodeDocument::DiffType::ModifiedLine:
+                painter.draw_text(rect, "!"sv, font(), Gfx::TextAlignment::Center);
+                break;
+            case CodeDocument::DiffType::DeletedLinesBefore:
+                painter.draw_text(rect, "-"sv, font(), Gfx::TextAlignment::Center);
+                break;
+            case CodeDocument::DiffType::None:
+                VERIFY_NOT_REACHED();
+            }
+        }).release_value_but_fixme_should_propagate_errors();
+
     m_breakpoint_indicator_id = register_gutter_indicator(
         [&](auto& painter, Gfx::IntRect rect, size_t) {
             auto const& icon = breakpoint_icon_bitmap();
@@ -158,36 +176,6 @@ void Editor::paint_event(GUI::PaintEvent& event)
         if (horizontal_scrollbar().is_visible())
             rect.set_height(rect.height() - horizontal_scrollbar().height());
         painter.draw_rect(rect, palette().selection());
-    }
-
-    if (gutter_visible()) {
-        size_t first_visible_line = text_position_at(event.rect().top_left()).line();
-        size_t last_visible_line = text_position_at(event.rect().bottom_right()).line();
-
-        if (wrapper().git_repo()) {
-            for (auto& hunk : wrapper().hunks()) {
-                auto start_line = hunk.target_start_line;
-                auto finish_line = start_line + hunk.added_lines.size();
-
-                auto additions = hunk.added_lines.size();
-                auto deletions = hunk.removed_lines.size();
-
-                for (size_t line_offset = 0; line_offset < additions; line_offset++) {
-                    auto line = start_line + line_offset;
-                    if (line < first_visible_line || line > last_visible_line) {
-                        continue;
-                    }
-                    auto sign = (line_offset < deletions) ? "!"sv : "+"sv;
-                    painter.draw_text(gutter_icon_rect(line), sign, font(), Gfx::TextAlignment::Center);
-                }
-                if (additions < deletions) {
-                    auto deletions_line = min(finish_line, line_count() - 1);
-                    if (deletions_line <= last_visible_line) {
-                        painter.draw_text(gutter_icon_rect(deletions_line), "-"sv, font(), Gfx::TextAlignment::Center);
-                    }
-                }
-            }
-        }
     }
 }
 
@@ -822,6 +810,43 @@ void Editor::remove_breakpoint(size_t line_number)
     remove_gutter_indicator(m_breakpoint_indicator_id, line_number);
     breakpoint_lines().remove_first_matching([&](size_t line) { return line == line_number; });
     Debugger::the().on_breakpoint_change(wrapper().filename_title(), line_number, BreakpointChange::Removed);
+}
+
+ErrorOr<void> Editor::update_git_diff_indicators()
+{
+    clear_gutter_indicators(m_git_diff_indicator_id);
+
+    if (!wrapper().git_repo())
+        return {};
+
+    Vector<CodeDocument::DiffType> line_differences;
+    TRY(line_differences.try_ensure_capacity(document().line_count()));
+    for (auto i = 0u; i < document().line_count(); ++i)
+        line_differences.unchecked_append(CodeDocument::DiffType::None);
+
+    for (auto& hunk : wrapper().hunks()) {
+        auto start_line = hunk.target_start_line;
+        auto finish_line = start_line + hunk.added_lines.size();
+
+        auto additions = hunk.added_lines.size();
+        auto deletions = hunk.removed_lines.size();
+
+        for (size_t line_offset = 0; line_offset < additions; line_offset++) {
+            auto line = start_line + line_offset;
+            auto difference = (line_offset < deletions) ? CodeDocument::DiffType::ModifiedLine : CodeDocument::DiffType::AddedLine;
+            line_differences[line] = difference;
+            add_gutter_indicator(m_git_diff_indicator_id, line);
+        }
+        if (additions < deletions) {
+            auto deletions_line = min(finish_line, line_count() - 1);
+            line_differences[deletions_line] = CodeDocument::DiffType::DeletedLinesBefore;
+            add_gutter_indicator(m_git_diff_indicator_id, deletions_line);
+        }
+    }
+    code_document().set_line_differences({}, move(line_differences));
+    update();
+
+    return {};
 }
 
 }

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -82,6 +82,18 @@ Editor::Editor()
     add_custom_context_menu_action(*m_move_execution_to_line_action);
 
     set_gutter_visible(true);
+    on_gutter_click = [&](auto line, auto) {
+        add_breakpoint(line).release_value_but_fixme_should_propagate_errors();
+    };
+
+    m_breakpoint_indicator_id = register_gutter_indicator(
+        [&](auto& painter, Gfx::IntRect rect, size_t) {
+            auto const& icon = breakpoint_icon_bitmap();
+            painter.draw_scaled_bitmap(rect, icon, icon.rect());
+        },
+        [&](size_t line_index, auto) {
+            remove_breakpoint(line_index);
+        }).release_value_but_fixme_should_propagate_errors();
 
     if (Config::read_string("HackStudio"sv, "Global"sv, "DocumentationSearchPaths"sv).is_empty()) {
         Config::write_string("HackStudio"sv, "Global"sv, "DocumentationSearchPaths"sv, "[\"/usr/share/man/man2\", \"/usr/share/man/man3\"]"sv);
@@ -146,13 +158,6 @@ void Editor::paint_event(GUI::PaintEvent& event)
         size_t first_visible_line = text_position_at(event.rect().top_left()).line();
         size_t last_visible_line = text_position_at(event.rect().bottom_right()).line();
 
-        for (size_t line : breakpoint_lines()) {
-            if (line < first_visible_line || line > last_visible_line) {
-                continue;
-            }
-            auto const& icon = breakpoint_icon_bitmap();
-            painter.blit(gutter_icon_rect(line).top_left(), icon, icon.rect());
-        }
         if (execution_position().has_value()) {
             auto const& icon = current_position_icon_bitmap();
             painter.blit(gutter_icon_rect(execution_position().value()).top_left(), icon, icon.rect());
@@ -341,16 +346,6 @@ void Editor::mousedown_event(GUI::MouseEvent& event)
     }
 
     auto text_position = text_position_at(event.position());
-    auto ruler_line_rect = ruler_content_rect(text_position.line());
-    if (event.button() == GUI::MouseButton::Primary && event.position().x() < ruler_line_rect.width()) {
-        if (!breakpoint_lines().contains_slow(text_position.line())) {
-            breakpoint_lines().append(text_position.line());
-            Debugger::the().on_breakpoint_change(wrapper().filename_title(), text_position.line(), BreakpointChange::Added);
-        } else {
-            breakpoint_lines().remove_first_matching([&](size_t line) { return line == text_position.line(); });
-            Debugger::the().on_breakpoint_change(wrapper().filename_title(), text_position.line(), BreakpointChange::Removed);
-        }
-    }
 
     if (!(event.modifiers() & Mod_Ctrl)) {
         GUI::TextEditor::mousedown_event(event);
@@ -805,6 +800,24 @@ void Editor::set_semantic_syntax_highlighting(bool value)
 {
     m_use_semantic_syntax_highlighting = value;
     set_syntax_highlighter_for(code_document());
+}
+
+ErrorOr<void> Editor::add_breakpoint(size_t line_number)
+{
+    if (!breakpoint_lines().contains_slow(line_number)) {
+        add_gutter_indicator(m_breakpoint_indicator_id, line_number);
+        TRY(breakpoint_lines().try_append(line_number));
+        Debugger::the().on_breakpoint_change(wrapper().filename_title(), line_number, BreakpointChange::Added);
+    }
+
+    return {};
+}
+
+void Editor::remove_breakpoint(size_t line_number)
+{
+    remove_gutter_indicator(m_breakpoint_indicator_id, line_number);
+    breakpoint_lines().remove_first_matching([&](size_t line) { return line == line_number; });
+    Debugger::the().on_breakpoint_change(wrapper().filename_title(), line_number, BreakpointChange::Removed);
 }
 
 }

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -95,6 +95,12 @@ Editor::Editor()
             remove_breakpoint(line_index);
         }).release_value_but_fixme_should_propagate_errors();
 
+    m_execution_indicator_id = register_gutter_indicator(
+        [&](auto& painter, Gfx::IntRect rect, size_t) {
+            auto const& icon = current_position_icon_bitmap();
+            painter.draw_scaled_bitmap(rect, icon, icon.rect());
+        }).release_value_but_fixme_should_propagate_errors();
+
     if (Config::read_string("HackStudio"sv, "Global"sv, "DocumentationSearchPaths"sv).is_empty()) {
         Config::write_string("HackStudio"sv, "Global"sv, "DocumentationSearchPaths"sv, "[\"/usr/share/man/man2\", \"/usr/share/man/man3\"]"sv);
     }
@@ -157,11 +163,6 @@ void Editor::paint_event(GUI::PaintEvent& event)
     if (gutter_visible()) {
         size_t first_visible_line = text_position_at(event.rect().top_left()).line();
         size_t last_visible_line = text_position_at(event.rect().bottom_right()).line();
-
-        if (execution_position().has_value()) {
-            auto const& icon = current_position_icon_bitmap();
-            painter.blit(gutter_icon_rect(execution_position().value()).top_left(), icon, icon.rect());
-        }
 
         if (wrapper().git_repo()) {
             for (auto& hunk : wrapper().hunks()) {
@@ -449,9 +450,11 @@ void Editor::navigate_to_include_if_available(DeprecatedString path)
 
 void Editor::set_execution_position(size_t line_number)
 {
+    if (execution_position().has_value())
+        remove_gutter_indicator(m_execution_indicator_id, execution_position().value());
+    add_gutter_indicator(m_execution_indicator_id, line_number);
     code_document().set_execution_position(line_number);
     scroll_position_into_view({ line_number, 0 });
-    update(gutter_icon_rect(line_number));
 }
 
 void Editor::clear_execution_position()
@@ -461,6 +464,7 @@ void Editor::clear_execution_position()
     }
     size_t previous_position = execution_position().value();
     code_document().clear_execution_position();
+    remove_gutter_indicator(m_execution_indicator_id, previous_position);
     update(gutter_icon_rect(previous_position));
 }
 

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -36,6 +36,8 @@ public:
 
     Vector<size_t> const& breakpoint_lines() const { return code_document().breakpoint_lines(); }
     Vector<size_t>& breakpoint_lines() { return code_document().breakpoint_lines(); }
+    ErrorOr<void> add_breakpoint(size_t line_number);
+    void remove_breakpoint(size_t line_number);
     Optional<size_t> execution_position() const { return code_document().execution_position(); }
     bool is_program_running() const { return execution_position().has_value(); }
     void set_execution_position(size_t line_number);
@@ -120,6 +122,8 @@ private:
     RefPtr<Core::Timer> m_tokens_info_timer; // Used for querying language server for syntax highlighting info
     OwnPtr<LanguageClient> m_language_client;
     bool m_use_semantic_syntax_highlighting { false };
+
+    GutterIndicatorID m_breakpoint_indicator_id;
 };
 
 }

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -124,6 +124,7 @@ private:
     bool m_use_semantic_syntax_highlighting { false };
 
     GutterIndicatorID m_breakpoint_indicator_id;
+    GutterIndicatorID m_execution_indicator_id;
 };
 
 }

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -44,6 +44,8 @@ public:
     void clear_execution_position();
     void set_debug_mode(bool);
 
+    ErrorOr<void> update_git_diff_indicators();
+
     CodeDocument const& code_document() const;
     CodeDocument& code_document();
 
@@ -125,6 +127,7 @@ private:
 
     GutterIndicatorID m_breakpoint_indicator_id;
     GutterIndicatorID m_execution_indicator_id;
+    GutterIndicatorID m_git_diff_indicator_id;
 };
 
 }

--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -87,8 +87,10 @@ void EditorWrapper::save()
 
 void EditorWrapper::update_diff()
 {
-    if (m_git_repo)
+    if (m_git_repo) {
         m_hunks = Diff::parse_hunks(m_git_repo->unstaged_diff(filename()).value());
+        editor().update_git_diff_indicators().release_value_but_fixme_should_propagate_errors();
+    }
 }
 
 void EditorWrapper::set_project_root(DeprecatedString const& project_root)

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -132,7 +132,7 @@ void TextEditor::update_content_size()
 {
     int content_width = 0;
     int content_height = 0;
-    for (auto& line : m_line_visual_data) {
+    for (auto& line : m_line_data) {
         content_width = max(line->visual_rect.width(), content_width);
         content_height += line->visual_rect.height();
     }
@@ -167,7 +167,7 @@ TextPosition TextEditor::text_position_at_content_position(Gfx::IntPoint content
             if (!document().line_is_visible(i))
                 continue;
 
-            auto& rect = m_line_visual_data[i]->visual_rect;
+            auto& rect = m_line_data[i]->visual_rect;
             if (position.y() >= rect.top() && position.y() <= rect.bottom()) {
                 line_index = i;
                 break;
@@ -634,7 +634,7 @@ void TextEditor::paint_event(PaintEvent& event)
                 first_visual_line_with_selection = visual_line_containing(line_index, selection.start().column());
 
             if (selection.end().line() > line_index)
-                last_visual_line_with_selection = m_line_visual_data[line_index]->visual_lines.size();
+                last_visual_line_with_selection = m_line_data[line_index]->visual_lines.size();
             else
                 last_visual_line_with_selection = visual_line_containing(line_index, selection.end().column());
         }
@@ -1441,7 +1441,7 @@ Gfx::IntRect TextEditor::line_content_rect(size_t line_index) const
         line_rect.center_vertically_within({ {}, frame_inner_rect().size() });
         return line_rect;
     }
-    return m_line_visual_data[line_index]->visual_rect;
+    return m_line_data[line_index]->visual_rect;
 }
 
 void TextEditor::set_cursor_and_focus_line(size_t line, size_t column)
@@ -1451,7 +1451,7 @@ void TextEditor::set_cursor_and_focus_line(size_t line, size_t column)
     if (line > 1 && line < index_max) {
         int headroom = frame_inner_rect().height() / 3;
         do {
-            auto const& line_data = m_line_visual_data[line];
+            auto const& line_data = m_line_data[line];
             headroom -= line_data->visual_rect.height();
             line--;
         } while (line > 0 && headroom > 0);
@@ -1972,8 +1972,8 @@ void TextEditor::recompute_all_visual_lines()
     auto folded_region_iterator = folded_regions.begin();
     for (size_t line_index = 0; line_index < line_count(); ++line_index) {
         recompute_visual_lines(line_index, folded_region_iterator);
-        m_line_visual_data[line_index]->visual_rect.set_y(y_offset);
-        y_offset += m_line_visual_data[line_index]->visual_rect.height();
+        m_line_data[line_index]->visual_rect.set_y(y_offset);
+        y_offset += m_line_data[line_index]->visual_rect.height();
     }
 
     update_content_size();
@@ -2007,7 +2007,7 @@ void TextEditor::recompute_visual_lines(size_t line_index, Vector<TextDocumentFo
     auto const& line = document().line(line_index);
     size_t line_width_so_far = 0;
 
-    auto& visual_data = m_line_visual_data[line_index];
+    auto& visual_data = m_line_data[line_index];
     visual_data->visual_lines.clear_with_capacity();
 
     auto available_width = visible_text_rect_in_inner_coordinates().width();
@@ -2098,7 +2098,7 @@ void TextEditor::for_each_visual_line(size_t line_index, Callback callback) cons
     size_t visual_line_index = 0;
 
     auto& line = document().line(line_index);
-    auto& visual_data = m_line_visual_data[line_index];
+    auto& visual_data = m_line_data[line_index];
 
     for (auto visual_line_view : visual_data->visual_lines) {
         Gfx::IntRect visual_line_rect {
@@ -2148,28 +2148,28 @@ void TextEditor::did_change_font()
 
 void TextEditor::document_did_append_line()
 {
-    m_line_visual_data.append(make<LineVisualData>());
+    m_line_data.append(make<LineData>());
     recompute_all_visual_lines();
     update();
 }
 
 void TextEditor::document_did_remove_line(size_t line_index)
 {
-    m_line_visual_data.remove(line_index);
+    m_line_data.remove(line_index);
     recompute_all_visual_lines();
     update();
 }
 
 void TextEditor::document_did_remove_all_lines()
 {
-    m_line_visual_data.clear();
+    m_line_data.clear();
     recompute_all_visual_lines();
     update();
 }
 
 void TextEditor::document_did_insert_line(size_t line_index)
 {
-    m_line_visual_data.insert(line_index, make<LineVisualData>());
+    m_line_data.insert(line_index, make<LineData>());
     recompute_all_visual_lines();
     update();
 }
@@ -2206,11 +2206,11 @@ void TextEditor::document_did_update_undo_stack()
 
 void TextEditor::populate_line_data()
 {
-    m_line_visual_data.clear();
-    m_line_visual_data.ensure_capacity(m_document->line_count());
+    m_line_data.clear();
+    m_line_data.ensure_capacity(m_document->line_count());
 
     for (size_t i = 0; i < m_document->line_count(); ++i) {
-        m_line_visual_data.unchecked_append(make<LineVisualData>());
+        m_line_data.unchecked_append(make<LineData>());
     }
 }
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -291,6 +291,28 @@ void TextEditor::mousedown_event(MouseEvent& event)
         }
     }
 
+    if (gutter_content_rect(text_position.line()).contains(event.position())) {
+        auto& gutter_indicators = m_line_data[text_position.line()]->gutter_indicators;
+        auto indicator_position = 0;
+        for (auto i = 0u; i < m_gutter_indicators.size(); ++i) {
+            if ((gutter_indicators & (1 << i)) == 0)
+                continue;
+
+            if (gutter_indicator_rect(text_position.line(), indicator_position).contains(event.position())) {
+                auto& indicator_data = m_gutter_indicators[i];
+                if (indicator_data.on_click)
+                    indicator_data.on_click(text_position.line(), event.modifiers());
+                return;
+            }
+            indicator_position++;
+        }
+
+        // We didn't click on an indicator
+        if (on_gutter_click)
+            on_gutter_click(text_position.line(), event.modifiers());
+        return;
+    }
+
     if (on_mousedown)
         on_mousedown();
 
@@ -405,7 +427,7 @@ int TextEditor::gutter_width() const
 {
     if (!m_gutter_visible)
         return 0;
-    return line_height(); // square gutter
+    return line_height() * (m_most_gutter_indicators_displayed_on_one_line + 1);
 }
 
 Gfx::IntRect TextEditor::gutter_content_rect(size_t line_index) const
@@ -444,6 +466,18 @@ Gfx::IntRect TextEditor::folding_indicator_rect(size_t line_index) const
         line_content_rect(line_index).y() - vertical_scrollbar().value(),
         folding_indicator_width(),
         line_content_rect(line_index).height()
+    };
+}
+
+Gfx::IntRect TextEditor::gutter_indicator_rect(size_t line_number, int indicator_position) const
+{
+    auto gutter_rect = gutter_content_rect(line_number);
+    auto indicator_size = gutter_rect.height();
+    return Gfx::IntRect {
+        gutter_rect.right() - static_cast<int>(lroundf(indicator_size * (indicator_position + 1.5f))),
+        gutter_rect.top(),
+        indicator_size,
+        indicator_size
     };
 }
 
@@ -597,6 +631,28 @@ void TextEditor::paint_event(PaintEvent& event)
                 is_current_line ? font().bold_variant() : font(),
                 Gfx::TextAlignment::CenterRight,
                 is_current_line ? palette().ruler_active_text() : palette().ruler_inactive_text());
+        }
+    }
+
+    // Draw gutter indicators
+    if (m_gutter_visible) {
+        for (size_t line_index = first_visible_line; line_index <= last_visible_line; ++line_index) {
+            if (!document().line_is_visible(line_index))
+                continue;
+
+            auto& gutter_indicators = m_line_data[line_index]->gutter_indicators;
+            if (gutter_indicators == 0)
+                continue;
+
+            auto indicator_position = 0;
+            for (auto i = 0u; i < m_gutter_indicators.size(); ++i) {
+                if ((gutter_indicators & (1 << i)) == 0)
+                    continue;
+
+                auto rect = gutter_indicator_rect(line_index, indicator_position);
+                m_gutter_indicators[i].draw_indicator(painter, rect, line_index);
+                indicator_position++;
+            }
         }
     }
 
@@ -2510,6 +2566,48 @@ void TextEditor::highlighter_did_set_folding_regions(Vector<GUI::TextDocumentFol
 {
     document().set_folding_regions(move(folding_regions));
     recompute_all_visual_lines();
+}
+
+ErrorOr<TextEditor::GutterIndicatorID> TextEditor::register_gutter_indicator(PaintGutterIndicator draw_indicator, OnGutterIndicatorClick on_click)
+{
+    // We use a u32 to store a line's active gutter indicators, so that's the limit of how many we can have.
+    VERIFY(m_gutter_indicators.size() < 32);
+
+    GutterIndicatorID id = m_gutter_indicators.size();
+    TRY(m_gutter_indicators.try_empend(move(draw_indicator), move(on_click)));
+    return id;
+}
+
+void TextEditor::add_gutter_indicator(GutterIndicatorID id, size_t line)
+{
+    auto& line_indicators = m_line_data[line]->gutter_indicators;
+    if (line_indicators & (1 << id.value()))
+        return;
+    line_indicators |= (1 << id.value());
+
+    // Ensure the gutter is at least wide enough to display all the indicators on this line.
+    if (m_most_gutter_indicators_displayed_on_one_line < m_gutter_indicators.size()) {
+        unsigned indicators_on_line = popcount(line_indicators);
+        if (indicators_on_line > m_most_gutter_indicators_displayed_on_one_line) {
+            m_most_gutter_indicators_displayed_on_one_line = indicators_on_line;
+            update();
+        }
+    }
+
+    update(gutter_content_rect(line));
+}
+
+void TextEditor::remove_gutter_indicator(GutterIndicatorID id, size_t line)
+{
+    m_line_data[line]->gutter_indicators &= ~(1 << id.value());
+    update(gutter_content_rect(line));
+}
+
+void TextEditor::clear_gutter_indicators(GutterIndicatorID id)
+{
+    for (auto line = 0u; line < line_count(); ++line)
+        remove_gutter_indicator(id, line);
+    update();
 }
 
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -2204,11 +2204,19 @@ void TextEditor::document_did_update_undo_stack()
         on_modified_change(document().is_modified());
 }
 
-void TextEditor::document_did_set_text(AllowCallback allow_callback)
+void TextEditor::populate_line_data()
 {
     m_line_visual_data.clear();
-    for (size_t i = 0; i < m_document->line_count(); ++i)
-        m_line_visual_data.append(make<LineVisualData>());
+    m_line_visual_data.ensure_capacity(m_document->line_count());
+
+    for (size_t i = 0; i < m_document->line_count(); ++i) {
+        m_line_visual_data.unchecked_append(make<LineVisualData>());
+    }
+}
+
+void TextEditor::document_did_set_text(AllowCallback allow_callback)
+{
+    populate_line_data();
     document_did_change(allow_callback);
 }
 
@@ -2234,10 +2242,7 @@ void TextEditor::set_document(TextDocument& document)
     if (m_document)
         m_document->unregister_client(*this);
     m_document = document;
-    m_line_visual_data.clear();
-    for (size_t i = 0; i < m_document->line_count(); ++i) {
-        m_line_visual_data.append(make<LineVisualData>());
-    }
+    populate_line_data();
     set_cursor(0, 0);
     if (has_selection())
         m_selection.clear();

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -363,6 +363,7 @@ private:
 
     size_t visual_line_containing(size_t line_index, size_t column) const;
     void recompute_visual_lines(size_t line_index, Vector<TextDocumentFoldingRegion const&>::Iterator& folded_region_iterator);
+    void populate_line_data();
 
     template<class T, class... Args>
     inline void execute(Args&&... args)

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -427,12 +427,12 @@ private:
     template<typename Callback>
     void for_each_visual_line(size_t line_index, Callback) const;
 
-    struct LineVisualData {
+    struct LineData {
         Vector<Utf32View> visual_lines;
         Gfx::IntRect visual_rect;
     };
 
-    Vector<NonnullOwnPtr<LineVisualData>> m_line_visual_data;
+    Vector<NonnullOwnPtr<LineData>> m_line_data;
 
     OwnPtr<Syntax::Highlighter> m_highlighter;
     OwnPtr<AutocompleteProvider> m_autocomplete_provider;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/222642/225297496-ff0a42ef-5291-477f-959a-7f1cc09e15bc.png)

Not visible is the fact that the gutter starts small, and only expands when needed to accommodate the line with the most indicators on it. It does not auto-shrink. This matches CLion's behaviour and seems reasonable.

And now, the description from the **LibGUI: Add gutter indicators to TextEditor :^)** commit, since that already explains things:

HackStudio's Editor has displayed indicators in its gutter for a long
time, but each required manual code to paint them in the right place
and respond to click events. All indicators on a line would be painted
in the same location. If any other applications wanted to have gutter
indicators, they would also need to manually implement the same code.

This commit adds an API to GUI::TextEditor so it deals with these
indicators. It makes sure that multiple indicators on the same line
each have their own area to paint in, and provides a callback for when
one is clicked.

- `register_gutter_indicator()` should be called early on. It returns a
  `GutterIndicatorID` that is then used by the other methods.
  Indicators on a line are painted from right to left, in the order
  they were registered.
- `add_gutter_indicator()` and `remove_gutter_indicator()` add the
  indicator to the given line.
- `clear_gutter_indicators()` removes a given indicator from every line.
- The `on_gutter_click` callback is called whenever the user clicks on
  the gutter, but *not* on an indicator.