### PR TITLE
LibGfx+LibSyntax: Replace TextStyle with TextAttributes, and make that a little nicer

### DIFF
--- a/Userland/Applications/Spreadsheet/CellSyntaxHighlighter.cpp
+++ b/Userland/Applications/Spreadsheet/CellSyntaxHighlighter.cpp
@@ -29,7 +29,6 @@ void CellSyntaxHighlighter::rehighlight(Palette const& palette)
             palette.syntax_keyword(),
             Optional<Color> {},
             false,
-            false,
         },
         (u64)-1,
         false);
@@ -46,7 +45,6 @@ void CellSyntaxHighlighter::rehighlight(Palette const& palette)
                     Gfx::TextAttributes {
                         Color::Black,
                         Color::Red,
-                        false,
                         false,
                     },
                     (u64)-1,

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -292,8 +292,8 @@ void Editor::mousemove_event(GUI::MouseEvent& event)
     for (auto& span : document().spans()) {
         bool is_clickable = (highlighter->is_navigatable(span.data) || highlighter->is_identifier(span.data));
         if (span.range.contains(m_previous_text_position) && !span.range.contains(text_position)) {
-            if (is_clickable && span.attributes.underline) {
-                span.attributes.underline = false;
+            if (is_clickable && span.attributes.underline_style.has_value()) {
+                span.attributes.underline_style.clear();
                 wrapper().editor().update();
             }
         }
@@ -304,9 +304,12 @@ void Editor::mousemove_event(GUI::MouseEvent& event)
 
             if (is_clickable) {
                 is_over_clickable = true;
-                bool was_underlined = span.attributes.underline;
-                span.attributes.underline = event.modifiers() & Mod_Ctrl;
-                if (span.attributes.underline != was_underlined) {
+                bool was_underlined = span.attributes.underline_style.has_value();
+                bool now_underlined = event.modifiers() & Mod_Ctrl;
+                span.attributes.underline_style.clear();
+                if (now_underlined)
+                    span.attributes.underline_style = Gfx::TextAttributes::UnderlineStyle::Solid;
+                if (now_underlined != was_underlined) {
                     wrapper().editor().update();
                 }
             }

--- a/Userland/Libraries/LibCMake/CMakeCache/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibCMake/CMakeCache/SyntaxHighlighter.cpp
@@ -54,7 +54,6 @@ void SyntaxHighlighter::rehighlight(Gfx::Palette const& palette)
         span.attributes.color = style.color;
         span.attributes.bold = style.bold;
         if (type == Token::Type::Garbage) {
-            span.attributes.underline = true;
             span.attributes.underline_color = palette.red();
             span.attributes.underline_style = Gfx::TextAttributes::UnderlineStyle::Wavy;
         }

--- a/Userland/Libraries/LibCMake/CMakeCache/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibCMake/CMakeCache/SyntaxHighlighter.cpp
@@ -9,7 +9,7 @@
 
 namespace CMake::Cache {
 
-static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, Token::Type type)
+static Gfx::TextAttributes style_for_token_type(Gfx::Palette const& palette, Token::Type type)
 {
     switch (type) {
     case Token::Type::Comment:
@@ -25,7 +25,7 @@ static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, Token
     case Token::Type::Value:
         return { palette.syntax_string() };
     case Token::Type::Garbage:
-        return { palette.red() };
+        return { palette.red(), {}, false, Gfx::TextAttributes::UnderlineStyle::Wavy, palette.red() };
     default:
         return { palette.base_text() };
     }
@@ -50,13 +50,7 @@ void SyntaxHighlighter::rehighlight(Gfx::Palette const& palette)
         if (!span.range.is_valid())
             return;
 
-        auto style = style_for_token_type(palette, type);
-        span.attributes.color = style.color;
-        span.attributes.bold = style.bold;
-        if (type == Token::Type::Garbage) {
-            span.attributes.underline_color = palette.red();
-            span.attributes.underline_style = Gfx::TextAttributes::UnderlineStyle::Wavy;
-        }
+        span.attributes = style_for_token_type(palette, type);
         span.is_skippable = false;
         span.data = static_cast<u64>(type);
         spans.append(move(span));

--- a/Userland/Libraries/LibCMake/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibCMake/SyntaxHighlighter.cpp
@@ -10,7 +10,7 @@
 
 namespace CMake {
 
-static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, Token::Type type)
+static Gfx::TextAttributes style_for_token_type(Gfx::Palette const& palette, Token::Type type)
 {
     switch (type) {
     case Token::Type::BracketComment:
@@ -30,7 +30,7 @@ static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, Token
     case Token::Type::UnquotedArgument:
         return { palette.syntax_parameter() };
     case Token::Type::Garbage:
-        return { palette.red() };
+        return { palette.red(), {}, false, Gfx::TextAttributes::UnderlineStyle::Wavy, palette.red() };
     case Token::Type::VariableReference:
         // This is a bit arbitrary, since we don't have a color specifically for this.
         return { palette.syntax_preprocessor_value() };
@@ -66,13 +66,7 @@ void SyntaxHighlighter::rehighlight(Gfx::Palette const& palette)
         if (!span.range.is_valid())
             return;
 
-        auto style = style_for_token_type(palette, type);
-        span.attributes.color = style.color;
-        span.attributes.bold = style.bold;
-        if (type == Token::Type::Garbage) {
-            span.attributes.underline_color = palette.red();
-            span.attributes.underline_style = Gfx::TextAttributes::UnderlineStyle::Wavy;
-        }
+        span.attributes = style_for_token_type(palette, type);
         span.is_skippable = false;
         span.data = static_cast<u64>(type);
         spans.append(move(span));

--- a/Userland/Libraries/LibCMake/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibCMake/SyntaxHighlighter.cpp
@@ -70,7 +70,6 @@ void SyntaxHighlighter::rehighlight(Gfx::Palette const& palette)
         span.attributes.color = style.color;
         span.attributes.bold = style.bold;
         if (type == Token::Type::Garbage) {
-            span.attributes.underline = true;
             span.attributes.underline_color = palette.red();
             span.attributes.underline_style = Gfx::TextAttributes::UnderlineStyle::Wavy;
         }

--- a/Userland/Libraries/LibCpp/SemanticSyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibCpp/SemanticSyntaxHighlighter.cpp
@@ -85,44 +85,44 @@ void SemanticSyntaxHighlighter::rehighlight(Palette const& palette)
     update_spans(new_tokens_info, palette);
 }
 
-static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, CodeComprehension::TokenInfo::SemanticType type)
+static Gfx::TextAttributes style_for_token_type(Gfx::Palette const& palette, CodeComprehension::TokenInfo::SemanticType type)
 {
     switch (type) {
     case CodeComprehension::TokenInfo::SemanticType::Unknown:
-        return { palette.base_text(), false };
+        return { palette.base_text() };
     case CodeComprehension::TokenInfo::SemanticType::Keyword:
-        return { palette.syntax_keyword(), true };
+        return { palette.syntax_keyword(), {}, true };
     case CodeComprehension::TokenInfo::SemanticType::Type:
-        return { palette.syntax_type(), true };
+        return { palette.syntax_type(), {}, true };
     case CodeComprehension::TokenInfo::SemanticType::Identifier:
-        return { palette.syntax_identifier(), false };
+        return { palette.syntax_identifier() };
     case CodeComprehension::TokenInfo::SemanticType::String:
-        return { palette.syntax_string(), false };
+        return { palette.syntax_string() };
     case CodeComprehension::TokenInfo::SemanticType::Number:
-        return { palette.syntax_number(), false };
+        return { palette.syntax_number() };
     case CodeComprehension::TokenInfo::SemanticType::IncludePath:
-        return { palette.syntax_preprocessor_value(), false };
+        return { palette.syntax_preprocessor_value() };
     case CodeComprehension::TokenInfo::SemanticType::PreprocessorStatement:
-        return { palette.syntax_preprocessor_statement(), false };
+        return { palette.syntax_preprocessor_statement() };
     case CodeComprehension::TokenInfo::SemanticType::Comment:
-        return { palette.syntax_comment(), false };
+        return { palette.syntax_comment() };
     case CodeComprehension::TokenInfo::SemanticType::Function:
-        return { palette.syntax_function(), false };
+        return { palette.syntax_function() };
     case CodeComprehension::TokenInfo::SemanticType::Variable:
-        return { palette.syntax_variable(), false };
+        return { palette.syntax_variable() };
     case CodeComprehension::TokenInfo::SemanticType::CustomType:
-        return { palette.syntax_custom_type(), false };
+        return { palette.syntax_custom_type() };
     case CodeComprehension::TokenInfo::SemanticType::Namespace:
-        return { palette.syntax_namespace(), false };
+        return { palette.syntax_namespace() };
     case CodeComprehension::TokenInfo::SemanticType::Member:
-        return { palette.syntax_member(), false };
+        return { palette.syntax_member() };
     case CodeComprehension::TokenInfo::SemanticType::Parameter:
-        return { palette.syntax_parameter(), false };
+        return { palette.syntax_parameter() };
     case CodeComprehension::TokenInfo::SemanticType::PreprocessorMacro:
-        return { palette.syntax_preprocessor_value(), false };
+        return { palette.syntax_preprocessor_value() };
     default:
         VERIFY_NOT_REACHED();
-        return { palette.base_text(), false };
+        return { palette.base_text() };
     }
 }
 void SemanticSyntaxHighlighter::update_spans(Vector<CodeComprehension::TokenInfo> const& tokens_info, Gfx::Palette const& palette)
@@ -133,9 +133,7 @@ void SemanticSyntaxHighlighter::update_spans(Vector<CodeComprehension::TokenInfo
         GUI::TextDocumentSpan span;
         span.range.set_start({ token.start_line, token.start_column });
         span.range.set_end({ token.end_line, token.end_column + 1 });
-        auto style = style_for_token_type(palette, token.type);
-        span.attributes.color = style.color;
-        span.attributes.bold = style.bold;
+        span.attributes = style_for_token_type(palette, token.type);
         span.is_skippable = token.type == CodeComprehension::TokenInfo::SemanticType::Whitespace;
         span.data = static_cast<u64>(token.type);
         spans.append(span);

--- a/Userland/Libraries/LibCpp/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibCpp/SyntaxHighlighter.cpp
@@ -13,33 +13,33 @@
 
 namespace Cpp {
 
-static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, Cpp::Token::Type type)
+static Gfx::TextAttributes style_for_token_type(Gfx::Palette const& palette, Cpp::Token::Type type)
 {
     switch (type) {
     case Cpp::Token::Type::Keyword:
-        return { palette.syntax_keyword(), true };
+        return { palette.syntax_keyword(), {}, true };
     case Cpp::Token::Type::KnownType:
-        return { palette.syntax_type(), true };
+        return { palette.syntax_type(), {}, true };
     case Cpp::Token::Type::Identifier:
-        return { palette.syntax_identifier(), false };
+        return { palette.syntax_identifier() };
     case Cpp::Token::Type::DoubleQuotedString:
     case Cpp::Token::Type::SingleQuotedString:
     case Cpp::Token::Type::RawString:
-        return { palette.syntax_string(), false };
+        return { palette.syntax_string() };
     case Cpp::Token::Type::Integer:
     case Cpp::Token::Type::Float:
-        return { palette.syntax_number(), false };
+        return { palette.syntax_number() };
     case Cpp::Token::Type::IncludePath:
-        return { palette.syntax_preprocessor_value(), false };
+        return { palette.syntax_preprocessor_value() };
     case Cpp::Token::Type::EscapeSequence:
-        return { palette.syntax_keyword(), true };
+        return { palette.syntax_keyword(), {}, true };
     case Cpp::Token::Type::PreprocessorStatement:
     case Cpp::Token::Type::IncludeStatement:
-        return { palette.syntax_preprocessor_statement(), false };
+        return { palette.syntax_preprocessor_statement() };
     case Cpp::Token::Type::Comment:
-        return { palette.syntax_comment(), false };
+        return { palette.syntax_comment() };
     default:
-        return { palette.base_text(), false };
+        return { palette.base_text() };
     }
 }
 
@@ -69,9 +69,7 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
         GUI::TextDocumentSpan span;
         span.range.set_start({ token.start().line, token.start().column });
         span.range.set_end({ token.end().line, token.end().column + 1 });
-        auto style = style_for_token_type(palette, token.type());
-        span.attributes.color = style.color;
-        span.attributes.bold = style.bold;
+        span.attributes = style_for_token_type(palette, token.type());
         span.is_skippable = token.type() == Cpp::Token::Type::Whitespace;
         span.data = static_cast<u64>(token.type());
         spans.append(span);

--- a/Userland/Libraries/LibGUI/GML/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibGUI/GML/SyntaxHighlighter.cpp
@@ -12,7 +12,7 @@
 
 namespace GUI::GML {
 
-static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, Token::Type type)
+static Gfx::TextAttributes style_for_token_type(Gfx::Palette const& palette, Token::Type type)
 {
     switch (type) {
     case Token::Type::LeftCurly:
@@ -21,7 +21,7 @@ static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, Token
     case Token::Type::ClassMarker:
         return { palette.syntax_keyword() };
     case Token::Type::ClassName:
-        return { palette.syntax_identifier(), true };
+        return { palette.syntax_identifier(), {}, true };
     case Token::Type::Identifier:
         return { palette.syntax_identifier() };
     case Token::Type::JsonValue:
@@ -54,9 +54,7 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
         GUI::TextDocumentSpan span;
         span.range.set_start({ token.m_start.line, token.m_start.column });
         span.range.set_end({ token.m_end.line, token.m_end.column });
-        auto style = style_for_token_type(palette, token.m_type);
-        span.attributes.color = style.color;
-        span.attributes.bold = style.bold;
+        span.attributes = style_for_token_type(palette, token.m_type);
         span.is_skippable = false;
         span.data = static_cast<u64>(token.m_type);
         spans.append(span);

--- a/Userland/Libraries/LibGUI/GitCommitSyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibGUI/GitCommitSyntaxHighlighter.cpp
@@ -10,7 +10,7 @@
 #include <LibGfx/Palette.h>
 
 namespace GUI {
-static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, GitCommitToken::Type type)
+static Gfx::TextAttributes style_for_token_type(Gfx::Palette const& palette, GitCommitToken::Type type)
 {
     switch (type) {
     case GitCommitToken::Type::Comment:
@@ -31,9 +31,7 @@ void GitCommitSyntaxHighlighter::rehighlight(Palette const& palette)
         GUI::TextDocumentSpan span;
         span.range.set_start({ token.m_start.line, token.m_start.column });
         span.range.set_end({ token.m_end.line, token.m_end.column });
-        auto style = style_for_token_type(palette, token.m_type);
-        span.attributes.color = style.color;
-        span.attributes.bold = style.bold;
+        span.attributes = style_for_token_type(palette, token.m_type);
         span.is_skippable = false;
         span.data = static_cast<u64>(token.m_type);
         spans.append(span);

--- a/Userland/Libraries/LibGUI/INISyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibGUI/INISyntaxHighlighter.cpp
@@ -11,13 +11,13 @@
 
 namespace GUI {
 
-static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, IniToken::Type type)
+static Gfx::TextAttributes style_for_token_type(Gfx::Palette const& palette, IniToken::Type type)
 {
     switch (type) {
     case IniToken::Type::LeftBracket:
     case IniToken::Type::RightBracket:
     case IniToken::Type::Section:
-        return { palette.syntax_keyword(), true };
+        return { palette.syntax_keyword(), {}, true };
     case IniToken::Type::Name:
         return { palette.syntax_identifier() };
     case IniToken::Type::Value:
@@ -25,7 +25,7 @@ static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, IniTo
     case IniToken::Type::Comment:
         return { palette.syntax_comment() };
     case IniToken::Type::Equal:
-        return { palette.syntax_operator(), true };
+        return { palette.syntax_operator(), {}, true };
     default:
         return { palette.base_text() };
     }
@@ -52,9 +52,7 @@ void IniSyntaxHighlighter::rehighlight(Palette const& palette)
         GUI::TextDocumentSpan span;
         span.range.set_start({ token.m_start.line, token.m_start.column });
         span.range.set_end({ token.m_end.line, token.m_end.column });
-        auto style = style_for_token_type(palette, token.m_type);
-        span.attributes.color = style.color;
-        span.attributes.bold = style.bold;
+        span.attributes = style_for_token_type(palette, token.m_type);
         span.is_skippable = token.m_type == IniToken::Type::Whitespace;
         span.data = static_cast<u64>(token.m_type);
         spans.append(span);

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -1391,9 +1391,8 @@ void TextDocument::merge_span_collections()
         merged_span.span.attributes.color = span_and_collection_index.collection_index > last_span_and_collection_index.collection_index ? span.attributes.color : last_span.attributes.color;
         merged_span.span.attributes.bold = span.attributes.bold | last_span.attributes.bold;
         merged_span.span.attributes.background_color = span.attributes.background_color.has_value() ? span.attributes.background_color.value() : last_span.attributes.background_color;
-        merged_span.span.attributes.underline = span.attributes.underline | last_span.attributes.underline;
         merged_span.span.attributes.underline_color = span.attributes.underline_color.has_value() ? span.attributes.underline_color.value() : last_span.attributes.underline_color;
-        merged_span.span.attributes.underline_style = span.attributes.underline_style;
+        merged_span.span.attributes.underline_style = span.attributes.underline_style.has_value() ? span.attributes.underline_style : last_span.attributes.underline_style;
         merged_spans.append(move(merged_span));
 
         if (span.range.end() == last_span.range.end())

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -503,7 +503,7 @@ void TextEditor::paint_event(PaintEvent& event)
         } else {
             painter.draw_text(rect, raw_text, font, alignment, attributes.color);
         }
-        if (attributes.underline) {
+        if (attributes.underline_style.has_value()) {
             auto bottom_left = [&]() {
                 auto point = rect.bottom_left().translated(0, 1);
 
@@ -2493,7 +2493,7 @@ void TextEditor::on_search_results(GUI::TextRange current, Vector<GUI::TextRange
         span.attributes.color = Color::from_argb(0xff000000); // So text without spans from a highlighter will have color
         if (i == m_search_result_index) {
             span.attributes.bold = true;
-            span.attributes.underline = true;
+            span.attributes.underline_style = Gfx::TextAttributes::UnderlineStyle::Solid;
         }
         spans.append(move(span));
     }

--- a/Userland/Libraries/LibGfx/TextAttributes.h
+++ b/Userland/Libraries/LibGfx/TextAttributes.h
@@ -20,11 +20,10 @@ struct TextAttributes {
 
     Color color;
     Optional<Color> background_color {};
-    bool underline { false };
     bool bold { false };
 
+    Optional<UnderlineStyle> underline_style {};
     Optional<Color> underline_color {};
-    UnderlineStyle underline_style { UnderlineStyle::Solid };
 };
 
 }

--- a/Userland/Libraries/LibJS/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibJS/SyntaxHighlighter.cpp
@@ -13,7 +13,7 @@
 
 namespace JS {
 
-static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, TokenType type)
+static Gfx::TextAttributes style_for_token_type(Gfx::Palette const& palette, TokenType type)
 {
     switch (Token::category(type)) {
     case TokenCategory::Invalid:
@@ -27,9 +27,9 @@ static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, Token
     case TokenCategory::Operator:
         return { palette.syntax_operator() };
     case TokenCategory::Keyword:
-        return { palette.syntax_keyword(), true };
+        return { palette.syntax_keyword(), {}, true };
     case TokenCategory::ControlKeyword:
-        return { palette.syntax_control_keyword(), true };
+        return { palette.syntax_control_keyword(), {}, true };
     case TokenCategory::Identifier:
         return { palette.syntax_identifier() };
     default:
@@ -79,9 +79,7 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
         span.range.set_start(start);
         span.range.set_end({ position.line(), position.column() });
         auto type = is_trivia ? TokenType::Invalid : token.type();
-        auto style = style_for_token_type(palette, type);
-        span.attributes.color = style.color;
-        span.attributes.bold = style.bold;
+        span.attributes = style_for_token_type(palette, type);
         span.is_skippable = is_trivia;
         span.data = static_cast<u64>(type);
         spans.append(span);

--- a/Userland/Libraries/LibSQL/AST/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibSQL/AST/SyntaxHighlighter.cpp
@@ -12,25 +12,25 @@
 
 namespace SQL::AST {
 
-static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, TokenType type)
+static Gfx::TextAttributes style_for_token_type(Gfx::Palette const& palette, TokenType type)
 {
     switch (Token::category(type)) {
     case TokenCategory::Keyword:
-        return { palette.syntax_keyword(), true };
+        return { palette.syntax_keyword(), {}, true };
     case TokenCategory::Identifier:
-        return { palette.syntax_identifier(), false };
+        return { palette.syntax_identifier() };
     case TokenCategory::Number:
-        return { palette.syntax_number(), false };
+        return { palette.syntax_number() };
     case TokenCategory::Blob:
     case TokenCategory::String:
-        return { palette.syntax_string(), false };
+        return { palette.syntax_string() };
     case TokenCategory::Operator:
-        return { palette.syntax_operator(), false };
+        return { palette.syntax_operator() };
     case TokenCategory::Punctuation:
-        return { palette.syntax_punctuation(), false };
+        return { palette.syntax_punctuation() };
     case TokenCategory::Invalid:
     default:
-        return { palette.base_text(), false };
+        return { palette.base_text() };
     }
 }
 
@@ -54,9 +54,7 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
         GUI::TextDocumentSpan span;
         span.range.set_start({ token.start_position().line - 1, token.start_position().column - 1 });
         span.range.set_end({ token.end_position().line - 1, token.end_position().column - 1 });
-        auto style = style_for_token_type(palette, token.type());
-        span.attributes.color = style.color;
-        span.attributes.bold = style.bold;
+        span.attributes = style_for_token_type(palette, token.type());
         span.data = static_cast<u64>(token.type());
         spans.append(span);
 

--- a/Userland/Libraries/LibSyntax/Highlighter.h
+++ b/Userland/Libraries/LibSyntax/Highlighter.h
@@ -15,11 +15,6 @@
 
 namespace Syntax {
 
-struct TextStyle {
-    const Gfx::Color color;
-    bool const bold { false };
-};
-
 class Highlighter {
     AK_MAKE_NONCOPYABLE(Highlighter);
     AK_MAKE_NONMOVABLE(Highlighter);

--- a/Userland/Libraries/LibWeb/CSS/SyntaxHighlighter/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SyntaxHighlighter/SyntaxHighlighter.cpp
@@ -131,7 +131,7 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
         case Parser::Token::Type::BadUrl:
         case Parser::Token::Type::BadString:
             // FIXME: Error highlighting color in palette?
-            highlight(token.start_position().line, token.start_position().column, token.end_position().line, token.end_position().column, { Color(Color::NamedColor::Red), {}, false, true }, token.type());
+            highlight(token.start_position().line, token.start_position().column, token.end_position().line, token.end_position().column, { Color(Color::NamedColor::Red), {}, true }, token.type());
             break;
 
         case Parser::Token::Type::EndOfFile:

--- a/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
@@ -153,7 +153,7 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
                 token->start_position().column + token_start_offset,
                 token->start_position().line,
                 token->start_position().column + token_start_offset + token->tag_name().length(),
-                { palette.syntax_keyword(), {}, false, true },
+                { palette.syntax_keyword(), {}, true },
                 token->is_start_tag() ? AugmentedTokenKind::OpenTag : AugmentedTokenKind::CloseTag);
 
             token->for_each_attribute([&](auto& attribute) {

--- a/Userland/Shell/SyntaxHighlighter.cpp
+++ b/Userland/Shell/SyntaxHighlighter.cpp
@@ -80,7 +80,7 @@ private:
         if (node->path()->is_bareword()) {
             auto& span = span_for_node(node->path());
             span.attributes.color = m_palette.link();
-            span.attributes.underline = true;
+            span.attributes.underline_style = Gfx::TextAttributes::UnderlineStyle::Solid;
         } else {
             NodeVisitor::visit(node);
         }
@@ -479,7 +479,7 @@ private:
         NodeVisitor::visit(node);
 
         auto& span = span_for_node(node);
-        span.attributes.underline = true;
+        span.attributes.underline_style = Gfx::TextAttributes::UnderlineStyle::Solid;
         span.attributes.background_color = Color(Color::NamedColor::MidRed).lightened(1.3f).with_alpha(128);
         span.attributes.color = m_palette.base_text();
     }


### PR DESCRIPTION
`Syntax::TextStyle` was just a poor imitation of `Gfx::TextAttributes`, and SyntaxHighlighters had to convert the former to the latter anyway, so let's use it directly. While I was at it, adjust the TextAttributes struct to be a bit less redundant.