### PR TITLE
Userland: Use standard WAV MIME type

### DIFF
--- a/Base/res/apps/SoundPlayer.af
+++ b/Base/res/apps/SoundPlayer.af
@@ -5,4 +5,4 @@ Category=Media
 
 [Launcher]
 FileTypes=mp3,flac,m3u,m3u8,qoa,wav
-MimeTypes=audio/mpeg,audio/wave,audio/flac,audio/qoa
+MimeTypes=audio/mpeg,audio/wav,audio/flac,audio/qoa

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -156,7 +156,7 @@ StringView guess_mime_type_based_on_filename(StringView path)
     __ENUMERATE_MIME_TYPE_HEADER(tiff, "image/tiff", 0, 4, 'I', 'I', '*', 0x00)                                                                  \
     __ENUMERATE_MIME_TYPE_HEADER(tiff_bigendian, "image/tiff", 0, 4, 'M', 'M', 0x00, '*')                                                        \
     __ENUMERATE_MIME_TYPE_HEADER(wasm, "application/wasm", 0, 4, 0x00, 'a', 's', 'm')                                                            \
-    __ENUMERATE_MIME_TYPE_HEADER(wav, "audio/wave", 8, 4, 'W', 'A', 'V', 'E')                                                                    \
+    __ENUMERATE_MIME_TYPE_HEADER(wav, "audio/wav", 8, 4, 'W', 'A', 'V', 'E')                                                                     \
     __ENUMERATE_MIME_TYPE_HEADER(webp, "image/webp", 8, 4, 'W', 'E', 'B', 'P')                                                                   \
     __ENUMERATE_MIME_TYPE_HEADER(win_31x_archive, "extra/win-31x-compressed", 0, 4, 'K', 'W', 'A', 'J')                                          \
     __ENUMERATE_MIME_TYPE_HEADER(win_95_archive, "extra/win-95-compressed", 0, 4, 'S', 'Z', 'D', 'D')                                            \

--- a/Userland/Utilities/file.cpp
+++ b/Userland/Utilities/file.cpp
@@ -160,7 +160,7 @@ static Optional<DeprecatedString> elf_details(StringView description, StringView
     __ENUMERATE_MIME_TYPE_DESCRIPTION("audio/midi"sv, "MIDI notes"sv, audio_details)                                    \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("audio/mpeg"sv, "MP3 audio"sv, audio_details)                                     \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("audio/qoa"sv, "Quite OK Audio"sv, audio_details)                                 \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("audio/wave"sv, "WAVE audio"sv, audio_details)                                    \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("audio/wav"sv, "WAVE audio"sv, audio_details)                                     \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/blender"sv, "Blender project file"sv, description_only)                    \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/elf"sv, "ELF"sv, elf_details)                                              \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/ext"sv, "ext filesystem"sv, description_only)                              \


### PR DESCRIPTION
There is no official IANA MIME type for WAV (see https://www.iana.org/assignments/media-types/media-types.xhtml#audio), so this will always be subjective. While https://www.rfc-editor.org/rfc/rfc2361 suggests audio/vnd.wave, we use audio/wav since that seems to be most common across the internet.