### PR TITLE
LibAudio: Implement metadata loading for WAV

### DIFF
--- a/Userland/Libraries/LibAudio/CMakeLists.txt
+++ b/Userland/Libraries/LibAudio/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     GenericTypes.cpp
     SampleFormats.cpp
     Loader.cpp
+    RIFFTypes.cpp
     WavLoader.cpp
     FlacLoader.cpp
     WavWriter.cpp

--- a/Userland/Libraries/LibAudio/RIFFTypes.cpp
+++ b/Userland/Libraries/LibAudio/RIFFTypes.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "RIFFTypes.h"
+#include <AK/Endian.h>
+#include <AK/Stream.h>
+#include <AK/Try.h>
+
+namespace Audio::RIFF {
+
+ErrorOr<ChunkID> ChunkID::read_from_stream(Stream& stream)
+{
+    Array<u8, chunk_id_size> id;
+    TRY(stream.read_until_filled(id.span()));
+    return ChunkID { id };
+}
+
+ErrorOr<Chunk> Chunk::read_from_stream(Stream& stream)
+{
+    auto id = TRY(stream.read_value<ChunkID>());
+
+    u32 size = TRY(stream.read_value<LittleEndian<u32>>());
+    auto data = TRY(FixedArray<u8>::create(size));
+    TRY(stream.read_until_filled(data.span()));
+
+    return Chunk {
+        id,
+        size,
+        move(data),
+    };
+}
+
+StringView ChunkID::as_ascii_string() const
+{
+    return StringView { id_data.span() };
+}
+
+bool ChunkID::operator==(StringView const& other_string) const
+{
+    return as_ascii_string() == other_string;
+}
+
+FixedMemoryStream Chunk::data_stream()
+{
+    return FixedMemoryStream { data.span() };
+}
+
+}

--- a/Userland/Libraries/LibAudio/RIFFTypes.h
+++ b/Userland/Libraries/LibAudio/RIFFTypes.h
@@ -52,4 +52,12 @@ struct Chunk {
     FixedArray<u8> data;
 };
 
+// http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/Docs/riffmci.pdf page 23 (LIST type)
+struct List {
+    static ErrorOr<List> read_from_stream(Stream& stream);
+
+    ChunkID type;
+    Vector<Chunk> chunks;
+};
+
 }

--- a/Userland/Libraries/LibAudio/RIFFTypes.h
+++ b/Userland/Libraries/LibAudio/RIFFTypes.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018-2023, the SerenityOS developers.
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FixedArray.h>
+#include <AK/Forward.h>
+#include <AK/MemoryStream.h>
+#include <AK/Types.h>
+
+// RIFF-specific type definitions necessary for handling WAVE files.
+namespace Audio::RIFF {
+
+static constexpr StringView const riff_magic = "RIFF"sv;
+static constexpr StringView const wave_subformat_id = "WAVE"sv;
+static constexpr StringView const data_chunk_id = "data"sv;
+static constexpr StringView const list_chunk_id = "LIST"sv;
+static constexpr StringView const info_chunk_id = "INFO"sv;
+static constexpr StringView const format_chunk_id = "fmt "sv;
+
+// Constants for handling WAVE header data.
+enum class WaveFormat : u32 {
+    Pcm = 0x0001,        // WAVE_FORMAT_PCM
+    IEEEFloat = 0x0003,  // WAVE_FORMAT_IEEE_FLOAT
+    ALaw = 0x0006,       // 8-bit ITU-T G.711 A-law
+    MuLaw = 0x0007,      // 8-bit ITU-T G.711 µ-law
+    Extensible = 0xFFFE, // Determined by SubFormat
+};
+
+static constexpr size_t const chunk_id_size = 4;
+
+struct ChunkID {
+    static ErrorOr<ChunkID> read_from_stream(Stream& stream);
+    StringView as_ascii_string() const;
+    bool operator==(ChunkID const&) const = default;
+    bool operator==(StringView const&) const;
+
+    Array<u8, chunk_id_size> id_data;
+};
+
+// http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/Docs/riffmci.pdf page 11 (Chunks)
+struct Chunk {
+    static ErrorOr<Chunk> read_from_stream(Stream& stream);
+    FixedMemoryStream data_stream();
+
+    ChunkID id;
+    u32 size;
+    FixedArray<u8> data;
+};
+
+}

--- a/Userland/Libraries/LibAudio/WavLoader.h
+++ b/Userland/Libraries/LibAudio/WavLoader.h
@@ -14,6 +14,7 @@
 #include <AK/Span.h>
 #include <AK/StringView.h>
 #include <LibAudio/Loader.h>
+#include <LibAudio/RIFFTypes.h>
 
 namespace Audio {
 
@@ -46,6 +47,7 @@ private:
     MaybeLoaderError initialize();
 
     MaybeLoaderError parse_header();
+    MaybeLoaderError load_wav_info_block(Vector<RIFF::Chunk> info_chunks);
 
     LoaderSamples samples_from_pcm_data(Bytes const& data, size_t samples_to_read) const;
     template<typename SampleReader>

--- a/Userland/Libraries/LibAudio/WavLoader.h
+++ b/Userland/Libraries/LibAudio/WavLoader.h
@@ -17,14 +17,10 @@
 
 namespace Audio {
 
-// constants for handling the WAV header data
-static constexpr unsigned const WAVE_FORMAT_PCM = 0x0001;        // PCM
-static constexpr unsigned const WAVE_FORMAT_IEEE_FLOAT = 0x0003; // IEEE float
-static constexpr unsigned const WAVE_FORMAT_ALAW = 0x0006;       // 8-bit ITU-T G.711 A-law
-static constexpr unsigned const WAVE_FORMAT_MULAW = 0x0007;      // 8-bit ITU-T G.711 µ-law
-static constexpr unsigned const WAVE_FORMAT_EXTENSIBLE = 0xFFFE; // Determined by SubFormat
-
-// Parses and reads audio data from a WAV file.
+// Loader for the WAVE (file extension .wav) uncompressed audio file format.
+// WAVE uses the Microsoft RIFF container.
+// Original RIFF Spec, without later extensions: https://www.aelius.com/njh/wavemetatools/doc/riffmci.pdf
+// More concise WAVE information plus various spec links: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
 class WavLoaderPlugin : public LoaderPlugin {
 public:
     explicit WavLoaderPlugin(NonnullOwnPtr<SeekableStream> stream);


### PR DESCRIPTION
To make this less painful, this commit also greatly modernizes the WAV loader.

![screenshot-2023-03-16-00-45-09](https://user-images.githubusercontent.com/28656157/225460611-75e59fa7-d9a5-42ce-8a3f-003244eba9c8.png)
