### PR TITLE
CI: Bump Android NDK version used in CI to 25.2.9519653

### DIFF
--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -36,7 +36,7 @@ jobs:
         value: g++-12
 
     - name: ndk_version # only relevant for Android
-      value: '24.0.8215888'
+      value: '25.2.9519653'
 
     pool:
       vmImage: $(job_pool)


### PR DESCRIPTION
The previous version is no longer able to compile Lagom

Clang version 14.0.1 in NDK 24.0.8215888 crashes trying to build Core::Process

As seen in https://dev.azure.com/SerenityOS/SerenityOS/_build/results?buildId=28760&view=logs&j=c594ab08-254a-504b-ac6a-9b26227a2e9a&t=4632a97b-d9fe-5c3a-6c30-4faef192d0a1&l=49

25.2.9519653 is the current default on GA and ADO images per https://github.com/actions/runner-images/blob/1261bad465162f908c6138bf12a0ca112ad96b9f/images/linux/Ubuntu2204-Readme.md#android

```
FAILED: Userland/Libraries/LibCore/CMakeFiles/LibCore.dir/Process.cpp.o 
/usr/bin/ccache /usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=aarch64-none-linux-android30 --sysroot=/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/sysroot  -I/home/vsts/work/1/s/Meta/Lagom/../.. -I/home/vsts/work/1/s/Meta/Lagom/../../Userland -I/home/vsts/work/1/s/Meta/Lagom/../../Userland/Libraries -I/home/vsts/work/1/s/Meta/Lagom/../../Userland/Services -I/home/vsts/work/1/s/Meta/Lagom/Build -I/home/vsts/work/1/s/Meta/Lagom/Build/Userland/Libraries -I/home/vsts/work/1/s/Meta/Lagom/Build/Userland/Services -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fexceptions -frtti -stdlib=libc++ -O2 -g -DNDEBUG -fPIC -Wall -Wextra -Werror -Wno-implicit-const-int-float-conversion -Wno-literal-suffix -Wno-maybe-uninitialized -Wno-unknown-warning-option -Wno-unused-command-line-argument -fsigned-char -fno-exceptions -fdiagnostics-color=always -g1 -O2 -fno-semantic-interposition -fPIC -Wno-overloaded-virtual -Wno-user-defined-literals -fconstexpr-steps=16777216 -Wno-unused-private-field -pthread -std=c++20 -MD -MT Userland/Libraries/LibCore/CMakeFiles/LibCore.dir/Process.cpp.o -MF Userland/Libraries/LibCore/CMakeFiles/LibCore.dir/Process.cpp.o.d -o Userland/Libraries/LibCore/CMakeFiles/LibCore.dir/Process.cpp.o -c /home/vsts/work/1/s/Userland/Libraries/LibCore/Process.cpp
PLEASE submit a bug report to https://github.com/android-ndk/ndk/issues and include the crash backtrace, preprocessed source, and associated run script.
Stack dump:
0.	Program arguments: /usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=aarch64-none-linux-android30 --sysroot=/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/sysroot -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -Wformat -Werror=format-security -fexceptions -frtti -O2 -g -fPIC -Wall -Wextra -Wno-implicit-const-int-float-conversion -Wno-literal-suffix -Wno-maybe-uninitialized -Wno-unknown-warning-option -Wno-unused-command-line-argument -fsigned-char -fno-exceptions -g1 -O2 -fno-semantic-interposition -fPIC -Wno-overloaded-virtual -Wno-user-defined-literals -fconstexpr-steps=16777216 -Wno-unused-private-field -pthread -std=c++20 -fdiagnostics-color=always -Werror -I/home/vsts/work/1/s/Meta/Lagom/../.. -I/home/vsts/work/1/s/Meta/Lagom/../../Userland -I/home/vsts/work/1/s/Meta/Lagom/../../Userland/Libraries -I/home/vsts/work/1/s/Meta/Lagom/../../Userland/Services -I/home/vsts/work/1/s/Meta/Lagom/Build -I/home/vsts/work/1/s/Meta/Lagom/Build/Userland/Libraries -I/home/vsts/work/1/s/Meta/Lagom/Build/Userland/Services -DANDROID -D_FORTIFY_SOURCE=2 -stdlib=libc++ -DNDEBUG -c -MD -MT Userland/Libraries/LibCore/CMakeFiles/LibCore.dir/Process.cpp.o -MF Userland/Libraries/LibCore/CMakeFiles/LibCore.dir/Process.cpp.o.d -fcolor-diagnostics -o Userland/Libraries/LibCore/CMakeFiles/LibCore.dir/Process.cpp.o /home/vsts/work/1/s/Userland/Libraries/LibCore/Process.cpp
1.	<eof> parser at end of file
2.	Optimizer
 #0 0x000000000456d858 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x456d858)
 #1 0x000000000456d6e0 llvm::sys::RunSignalHandlers() (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x456d6e0)
 #2 0x000000000453d363 (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x453d363)
 #3 0x000000000453d6c1 (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x453d6c1)
 #4 0x00007f5ea8c52520 (/lib/x86_64-linux-gnu/libc.so.6+0x42520)
 #5 0x00000000032528f5 llvm::PointerType::get(llvm::Type*, unsigned int) (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x32528f5)
 #6 0x0000000002bd5fdf (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x2bd5fdf)
 #7 0x0000000002b0cbf1 (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x2b0cbf1)
 #8 0x0000000002afe493 (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x2afe493)
 #9 0x0000000002afcf8c llvm::InstCombinePass::run(llvm::Function&, llvm::AnalysisManager<llvm::Function>&) (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x2afcf8c)
#10 0x0000000002afcd7d (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x2afcd7d)
#11 0x00000000033172ec llvm::PassManager<llvm::Function, llvm::AnalysisManager<llvm::Function> >::run(llvm::Function&, llvm::AnalysisManager<llvm::Function>&) (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x33172ec)
#12 0x0000000003316f7d (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x3316f7d)
#13 0x0000000002ff6673 llvm::ModuleToFunctionPassAdaptor::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x2ff6673)
#14 0x0000000002ff649d (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x2ff649d)
#15 0x0000000003b46c61 llvm::PassManager<llvm::Module, llvm::AnalysisManager<llvm::Module> >::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x3b46c61)
#16 0x0000000003b43cea (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x3b43cea)
#17 0x0000000003b42361 clang::EmitBackendOutput(clang::DiagnosticsEngine&, clang::HeaderSearchOptions const&, clang::CodeGenOptions const&, clang::TargetOptions const&, clang::LangOptions const&, llvm::StringRef, llvm::Module*, clang::BackendAction, std::__1::unique_ptr<llvm::raw_pwrite_stream, std::__1::default_delete<llvm::raw_pwrite_stream> >) (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x3b42361)
#18 0x0000000003b41b40 (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x3b41b40)
#19 0x000000000389e066 clang::ParseAST(clang::Sema&, bool, bool) (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x389e066)
#20 0x00000000039383d1 clang::FrontendAction::Execute() (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x39383d1)
#21 0x0000000003937fcb clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x3937fcb)
#22 0x0000000003937bc1 clang::ExecuteCompilerInvocation(clang::CompilerInstance*) (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x3937bc1)
#23 0x0000000003936bff cc1_main(llvm::ArrayRef<char const*>, char const*, void*) (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x3936bff)
#24 0x0000000003e8b9b7 (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x3e8b9b7)
#25 0x0000000005912b02 clang::driver::CC1Command::setEnvironment(llvm::ArrayRef<char const*>) (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x5912b02)
#26 0x0000000003c35e67 llvm::CrashRecoveryContext::RunSafely(llvm::function_ref<void ()>) (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x3c35e67)
#27 0x0000000003c35c4d clang::driver::CC1Command::Execute(llvm::ArrayRef<llvm::Optional<llvm::StringRef> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, bool*) const (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x3c35c4d)
#28 0x0000000003acc724 clang::driver::Compilation::ExecuteCommand(clang::driver::Command const&, clang::driver::Command const*&) const (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x3acc724)
#29 0x000000000383e033 clang::driver::Driver::ExecuteCompilation(clang::driver::Compilation&, llvm::SmallVectorImpl<std::__1::pair<int, clang::driver::Command const*> >&) (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x383e033)
#30 0x000000000383a5b7 main (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x383a5b7)
#31 0x00007f5ea8c39d90 (/lib/x86_64-linux-gnu/libc.so.6+0x29d90)
#32 0x00007f5ea8c39e40 __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e40)
#33 0x000000000582fa99 _start (/usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin/clang+++0x582fa99)
clang++: error: clang frontend command failed with exit code 139 (use -v to see invocation)
Android (8075178, based on r437112b) clang version 14.0.1 (https://android.googlesource.com/toolchain/llvm-project 8671348b81b95fc603505dfc881b45103bee1731)
Target: aarch64-none-linux-android30
Thread model: posix
InstalledDir: /usr/local/lib/android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/linux-x86_64/bin
clang++: note: diagnostic msg: 
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang++: note: diagnostic msg: /tmp/Process-20342a.cpp
clang++: note: diagnostic msg: /tmp/Process-20342a.sh
clang++: note: diagnostic msg: 

********************
```