### PR TITLE
LibGfx: Add test for serialized bytes of built-in sRGB profile

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.cpp
+++ b/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.cpp
@@ -62,7 +62,7 @@ ErrorOr<NonnullRefPtr<Profile>> sRGB()
     TRY(tag_table.try_set(blueTRCTag, curve));
 
     // White point.
-    // ICC v4, 9.2.36 mediaWhitePointTag: " For displays, the values specified shall be those of the PCS illuminant as defined in 7.2.16."
+    // ICC v4, 9.2.36 mediaWhitePointTag: "For displays, the values specified shall be those of the PCS illuminant as defined in 7.2.16."
     TRY(tag_table.try_set(mediaWhitePointTag, TRY(XYZ_data(header.pcs_illuminant))));
 
     // The chromatic_adaptation_matrix values are from https://www.color.org/chadtag.xalter


### PR DESCRIPTION
I don't want to accidentally change these bytes, so let's add a test for them.