### PR TITLE
TextEditor: Remove confirmation when opening from recent files list

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -388,7 +388,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
                 return;
         }
 
-        auto response = FileSystemAccessClient::Client::the().request_file(&window, action.text(), Core::File::OpenMode::Read);
+        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(&window, action.text());
         if (response.is_error())
             return;
 


### PR DESCRIPTION
If the user has clicked to open a recent file, we don't need to ask them again if they want to open it.

See reasoning here: https://github.com/SerenityOS/serenity/pull/17885#issuecomment-1472579935