### PR TITLE
LibWeb: Fix `is<HTML::HTMLProgressElement>()` check

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.h
@@ -40,7 +40,7 @@ private:
     HTMLProgressElement(DOM::Document&, DOM::QualifiedName);
 
     // ^DOM::Node
-    virtual bool is_html_input_element() const final { return true; }
+    virtual bool is_html_progress_element() const final { return true; }
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 


### PR DESCRIPTION
Previously HTMLProgressElement implemented `is_html_input_element()` not `is_html_progress_element()`, so `is_html_progress_element()` defaulted to always returning false. This broke `is<HTML::HTMLProgressElement>()`.

P.s. Took a while to bisect this, then a few minutes to spot the typo :sweat_smile: 