### PR TITLE
DisplaySettings: Improve error propagation and port to String

### DIFF
--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "MonitorWidget.h"
+#include <AK/String.h>
 #include <LibCore/Timer.h>
 #include <LibGUI/ColorInput.h>
 #include <LibGUI/ComboBox.h>
@@ -33,7 +34,7 @@ private:
     ErrorOr<void> create_frame();
     ErrorOr<void> load_current_settings();
 
-    Vector<DeprecatedString> m_modes;
+    Vector<String> m_modes;
 
     bool& m_background_settings_changed;
 

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.h
@@ -19,9 +19,10 @@
 namespace DisplaySettings {
 
 class BackgroundSettingsWidget : public GUI::SettingsWindow::Tab {
-    C_OBJECT(BackgroundSettingsWidget);
+    C_OBJECT_ABSTRACT(BackgroundSettingsWidget);
 
 public:
+    static ErrorOr<NonnullRefPtr<BackgroundSettingsWidget>> try_create(bool& background_settings_changed);
     virtual ~BackgroundSettingsWidget() override = default;
 
     virtual void apply_settings() override;
@@ -29,8 +30,8 @@ public:
 private:
     BackgroundSettingsWidget(bool& background_settings_changed);
 
-    void create_frame();
-    void load_current_settings();
+    ErrorOr<void> create_frame();
+    ErrorOr<void> load_current_settings();
 
     Vector<DeprecatedString> m_modes;
 

--- a/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
@@ -15,15 +15,16 @@
 
 namespace DisplaySettings {
 
-DesktopSettingsWidget::DesktopSettingsWidget()
-{
-    create_frame();
-    load_current_settings();
+ErrorOr<NonnullRefPtr<DesktopSettingsWidget>> DesktopSettingsWidget::try_create() {
+    auto desktop_settings_widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) DesktopSettingsWidget()));
+    TRY(desktop_settings_widget->create_frame());
+    desktop_settings_widget->load_current_settings();
+    return desktop_settings_widget;
 }
 
-void DesktopSettingsWidget::create_frame()
+ErrorOr<void> DesktopSettingsWidget::create_frame()
 {
-    load_from_gml(desktop_settings_gml).release_value_but_fixme_should_propagate_errors();
+    TRY(load_from_gml(desktop_settings_gml));
 
     m_workspace_rows_spinbox = *find_descendant_of_type_named<GUI::SpinBox>("workspace_rows_spinbox");
     m_workspace_rows_spinbox->on_change = [&](auto) {
@@ -36,6 +37,8 @@ void DesktopSettingsWidget::create_frame()
 
     auto& keyboard_shortcuts_label = *find_descendant_of_type_named<GUI::Label>("keyboard_shortcuts_label");
     keyboard_shortcuts_label.set_text("\xE2\x84\xB9\tCtrl+Alt+{Shift}+Arrows moves between workspaces");
+
+    return {};
 }
 
 void DesktopSettingsWidget::load_current_settings()

--- a/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
@@ -15,7 +15,8 @@
 
 namespace DisplaySettings {
 
-ErrorOr<NonnullRefPtr<DesktopSettingsWidget>> DesktopSettingsWidget::try_create() {
+ErrorOr<NonnullRefPtr<DesktopSettingsWidget>> DesktopSettingsWidget::try_create()
+{
     auto desktop_settings_widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) DesktopSettingsWidget()));
     TRY(desktop_settings_widget->create_frame());
     desktop_settings_widget->load_current_settings();
@@ -55,8 +56,7 @@ void DesktopSettingsWidget::apply_settings()
     auto& desktop = GUI::Desktop::the();
     if (workspace_rows != desktop.workspace_rows() || workspace_columns != desktop.workspace_columns()) {
         if (!GUI::ConnectionToWindowServer::the().apply_workspace_settings(workspace_rows, workspace_columns, true)) {
-            GUI::MessageBox::show(window(), DeprecatedString::formatted("Error applying workspace settings"),
-                "Workspace settings"sv, GUI::MessageBox::Type::Error);
+            GUI::MessageBox::show_error(window(), "Error applying workspace settings"sv);
         }
     }
 }

--- a/Userland/Applications/DisplaySettings/DesktopSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/DesktopSettingsWidget.h
@@ -13,17 +13,18 @@
 namespace DisplaySettings {
 
 class DesktopSettingsWidget : public GUI::SettingsWindow::Tab {
-    C_OBJECT(DesktopSettingsWidget);
+    C_OBJECT_ABSTRACT(DesktopSettingsWidget);
 
 public:
+    static ErrorOr<NonnullRefPtr<DesktopSettingsWidget>> try_create();
     virtual ~DesktopSettingsWidget() override = default;
 
     virtual void apply_settings() override;
 
 private:
-    DesktopSettingsWidget();
+    DesktopSettingsWidget() = default;
 
-    void create_frame();
+    ErrorOr<void> create_frame();
     void load_current_settings();
 
     RefPtr<GUI::SpinBox> m_workspace_rows_spinbox;

--- a/Userland/Applications/DisplaySettings/EffectsSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/EffectsSettingsWidget.cpp
@@ -16,9 +16,16 @@ namespace GUI {
 
 namespace DisplaySettings {
 
-EffectsSettingsWidget::EffectsSettingsWidget()
+ErrorOr<NonnullRefPtr<EffectsSettingsWidget>> EffectsSettingsWidget::try_create()
 {
-    load_from_gml(effects_settings_gml).release_value_but_fixme_should_propagate_errors();
+    auto effects_settings_widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) EffectsSettingsWidget()));
+    TRY(effects_settings_widget->setup_interface());
+    return effects_settings_widget;
+}
+
+ErrorOr<void> EffectsSettingsWidget::setup_interface()
+{
+    TRY(load_from_gml(effects_settings_gml));
 
     m_geometry_combobox = find_descendant_of_type_named<ComboBox>("geometry_combobox");
     m_geometry_combobox->set_only_allow_values_from_model(true);
@@ -29,7 +36,7 @@ EffectsSettingsWidget::EffectsSettingsWidget()
 
     if (auto result = load_settings(); result.is_error()) {
         warnln("Failed to load [Effects] from WindowServer.ini");
-        return;
+        return {};
     }
 
     auto& animate_menus = *find_descendant_of_type_named<GUI::CheckBox>("animate_menus_checkbox");
@@ -92,6 +99,8 @@ EffectsSettingsWidget::EffectsSettingsWidget()
         m_system_effects.effects().at(Effects::TooltipShadow) = checked;
         set_modified(true);
     };
+
+    return {};
 }
 
 ErrorOr<void> EffectsSettingsWidget::load_settings()

--- a/Userland/Applications/DisplaySettings/EffectsSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/EffectsSettingsWidget.cpp
@@ -128,8 +128,8 @@ ErrorOr<void> EffectsSettingsWidget::load_settings()
         "Never"sv
     };
     for (size_t i = 0; i < list.size(); ++i)
-        TRY(m_geometry_list.try_append(list[i]));
-    m_geometry_combobox->set_model(ItemListModel<DeprecatedString>::create(m_geometry_list));
+        TRY(m_geometry_list.try_append(TRY(String::from_utf8(list[i]))));
+    m_geometry_combobox->set_model(ItemListModel<String>::create(m_geometry_list));
     m_geometry_combobox->set_selected_index(m_system_effects.geometry());
 
     return {};

--- a/Userland/Applications/DisplaySettings/EffectsSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/EffectsSettingsWidget.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <LibGUI/SettingsWindow.h>
 #include <LibGUI/SystemEffects.h>
 
@@ -30,7 +31,7 @@ private:
     ErrorOr<void> load_settings();
 
     SystemEffects m_system_effects;
-    Vector<DeprecatedString> m_geometry_list;
+    Vector<String> m_geometry_list;
     RefPtr<ComboBox> m_geometry_combobox;
 };
 

--- a/Userland/Applications/DisplaySettings/EffectsSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/EffectsSettingsWidget.h
@@ -14,7 +14,9 @@ namespace GUI {
 namespace DisplaySettings {
 
 class EffectsSettingsWidget final : public SettingsWindow::Tab {
-    C_OBJECT(EffectsSettingsWidget);
+    C_OBJECT_ABSTRACT(EffectsSettingsWidget);
+
+    static ErrorOr<NonnullRefPtr<EffectsSettingsWidget>> try_create();
 
 public:
     virtual ~EffectsSettingsWidget() override = default;
@@ -22,7 +24,8 @@ public:
     virtual void apply_settings() override;
 
 private:
-    EffectsSettingsWidget();
+    EffectsSettingsWidget() = default;
+    ErrorOr<void> setup_interface();
 
     ErrorOr<void> load_settings();
 

--- a/Userland/Applications/DisplaySettings/FontSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/FontSettingsWidget.cpp
@@ -17,9 +17,16 @@ namespace DisplaySettings {
 
 static void update_label_with_font(GUI::Label&, Gfx::Font const&);
 
-FontSettingsWidget::FontSettingsWidget()
+ErrorOr<NonnullRefPtr<FontSettingsWidget>> FontSettingsWidget::try_create()
 {
-    load_from_gml(font_settings_gml).release_value_but_fixme_should_propagate_errors();
+    auto font_settings_widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) FontSettingsWidget()));
+    TRY(font_settings_widget->setup_interface());
+    return font_settings_widget;
+}
+
+ErrorOr<void> FontSettingsWidget::setup_interface()
+{
+    TRY(load_from_gml(font_settings_gml));
 
     auto& default_font = Gfx::FontDatabase::default_font();
     m_default_font_label = *find_descendant_of_type_named<GUI::Label>("default_font_label");
@@ -59,6 +66,8 @@ FontSettingsWidget::FontSettingsWidget()
             set_modified(true);
         }
     };
+
+    return {};
 }
 
 static void update_label_with_font(GUI::Label& label, Gfx::Font const& font)

--- a/Userland/Applications/DisplaySettings/FontSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/FontSettingsWidget.h
@@ -13,15 +13,17 @@
 namespace DisplaySettings {
 
 class FontSettingsWidget final : public GUI::SettingsWindow::Tab {
-    C_OBJECT(FontSettingsWidget);
+    C_OBJECT_ABSTRACT(FontSettingsWidget);
 
 public:
+    static ErrorOr<NonnullRefPtr<FontSettingsWidget>> try_create();
     virtual ~FontSettingsWidget() override = default;
 
     virtual void apply_settings() override;
 
 private:
-    FontSettingsWidget();
+    FontSettingsWidget() = default;
+    ErrorOr<void> setup_interface();
 
     RefPtr<GUI::Label> m_default_font_label;
     RefPtr<GUI::Label> m_window_title_font_label;

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MonitorWidget.h"
+#include <AK/String.h>
 #include <LibCore/Timer.h>
 #include <LibEDID/EDID.h>
 #include <LibGUI/ColorInput.h>
@@ -41,15 +42,15 @@ private:
     ErrorOr<void> create_frame();
     ErrorOr<void> create_resolution_list();
     ErrorOr<void> load_current_settings();
-    void selected_screen_index_or_resolution_changed();
+    ErrorOr<void> selected_screen_index_or_resolution_changed();
 
     size_t m_selected_screen_index { 0 };
 
     WindowServer::ScreenLayout m_screen_layout;
-    Vector<DeprecatedString> m_screens;
+    Vector<String> m_screens;
     Vector<Optional<EDID::Parser>> m_screen_edids;
     Vector<Gfx::IntSize> m_resolutions;
-    Vector<DeprecatedString> m_resolution_strings;
+    Vector<String> m_resolution_strings;
 
     RefPtr<DisplaySettings::MonitorWidget> m_monitor_widget;
     RefPtr<GUI::ComboBox> m_screen_combo;

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.h
@@ -21,6 +21,7 @@ class MonitorSettingsWidget final : public GUI::SettingsWindow::Tab {
     C_OBJECT(MonitorSettingsWidget);
 
 public:
+    static ErrorOr<NonnullRefPtr<MonitorSettingsWidget>> try_create();
     ~MonitorSettingsWidget() override
     {
         if (m_showing_screen_numbers)
@@ -35,11 +36,11 @@ protected:
     void hide_event(GUI::HideEvent& event) override;
 
 private:
-    MonitorSettingsWidget();
+    MonitorSettingsWidget() = default;
 
-    void create_frame();
-    void create_resolution_list();
-    void load_current_settings();
+    ErrorOr<void> create_frame();
+    ErrorOr<void> create_resolution_list();
+    ErrorOr<void> load_current_settings();
     void selected_screen_index_or_resolution_changed();
 
     size_t m_selected_screen_index { 0 };

--- a/Userland/Applications/DisplaySettings/MonitorWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.cpp
@@ -28,7 +28,7 @@ ErrorOr<NonnullRefPtr<MonitorWidget>> MonitorWidget::try_create()
     return monitor_widget;
 }
 
-bool MonitorWidget::set_wallpaper(DeprecatedString path)
+bool MonitorWidget::set_wallpaper(String path)
 {
     if (!is_different_to_current_wallpaper_path(path))
         return false;
@@ -55,19 +55,21 @@ bool MonitorWidget::set_wallpaper(DeprecatedString path)
         });
 
     if (path.is_empty())
-        m_desktop_wallpaper_path = nullptr;
+        m_desktop_wallpaper_path = OptionalNone();
     else
-        m_desktop_wallpaper_path = move(path);
+        m_desktop_wallpaper_path = path;
 
     return true;
 }
 
-StringView MonitorWidget::wallpaper() const
+Optional<StringView> MonitorWidget::wallpaper() const
 {
-    return m_desktop_wallpaper_path;
+    if (m_desktop_wallpaper_path.has_value())
+        return m_desktop_wallpaper_path->bytes_as_string_view();
+    return OptionalNone();
 }
 
-void MonitorWidget::set_wallpaper_mode(DeprecatedString mode)
+void MonitorWidget::set_wallpaper_mode(String mode)
 {
     if (m_desktop_wallpaper_mode == mode)
         return;
@@ -133,12 +135,12 @@ void MonitorWidget::redraw_desktop_if_needed()
     }
     auto scaled_bitmap = scaled_bitmap_or_error.release_value();
 
-    if (m_desktop_wallpaper_mode == "Center") {
+    if (m_desktop_wallpaper_mode == "Center"sv) {
         auto centered_rect = Gfx::IntRect({}, scaled_size).centered_within(m_desktop_bitmap->rect());
         painter.blit(centered_rect.location(), *scaled_bitmap, scaled_bitmap->rect());
-    } else if (m_desktop_wallpaper_mode == "Tile") {
+    } else if (m_desktop_wallpaper_mode == "Tile"sv) {
         painter.draw_tiled_bitmap(m_desktop_bitmap->rect(), *scaled_bitmap);
-    } else if (m_desktop_wallpaper_mode == "Stretch") {
+    } else if (m_desktop_wallpaper_mode == "Stretch"sv) {
         painter.draw_scaled_bitmap(m_desktop_bitmap->rect(), *m_wallpaper_bitmap, m_wallpaper_bitmap->rect());
     } else {
         VERIFY_NOT_REACHED();

--- a/Userland/Applications/DisplaySettings/MonitorWidget.h
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Optional.h>
+#include <AK/String.h>
 #include <LibGUI/Widget.h>
 
 namespace DisplaySettings {
@@ -15,10 +17,10 @@ class MonitorWidget final : public GUI::Widget {
 
 public:
     static ErrorOr<NonnullRefPtr<MonitorWidget>> try_create();
-    bool set_wallpaper(DeprecatedString path);
-    StringView wallpaper() const;
+    bool set_wallpaper(String path);
+    Optional<StringView> wallpaper() const;
 
-    void set_wallpaper_mode(DeprecatedString mode);
+    void set_wallpaper_mode(String mode);
     StringView wallpaper_mode() const;
 
     RefPtr<Gfx::Bitmap> wallpaper_bitmap() const { return m_wallpaper_bitmap; }
@@ -44,16 +46,23 @@ private:
     RefPtr<Gfx::Bitmap> m_desktop_bitmap;
     bool m_desktop_dirty { true };
 
-    DeprecatedString m_desktop_wallpaper_path;
+    Optional<String> m_desktop_wallpaper_path;
     RefPtr<Gfx::Bitmap> m_wallpaper_bitmap;
-    DeprecatedString m_desktop_wallpaper_mode;
+    String m_desktop_wallpaper_mode;
     Gfx::IntSize m_desktop_resolution;
     int m_desktop_scale_factor { 1 };
     Gfx::Color m_desktop_color;
 
-    bool is_different_to_current_wallpaper_path(DeprecatedString const& path)
+    bool is_different_to_current_wallpaper_path(String const& path)
     {
-        return (!path.is_empty() && path != m_desktop_wallpaper_path) || (path.is_empty() && m_desktop_wallpaper_path != nullptr);
+        if (!m_desktop_wallpaper_path.has_value()) {
+            if (path.is_empty())
+                return false;
+            return true;
+        }
+        if (m_desktop_wallpaper_path.value() == path)
+            return false;
+        return true;
     }
 };
 

--- a/Userland/Applications/DisplaySettings/MonitorWidget.h
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.h
@@ -11,9 +11,10 @@
 namespace DisplaySettings {
 
 class MonitorWidget final : public GUI::Widget {
-    C_OBJECT(MonitorWidget);
+    C_OBJECT_ABSTRACT(MonitorWidget);
 
 public:
+    static ErrorOr<NonnullRefPtr<MonitorWidget>> try_create();
     bool set_wallpaper(DeprecatedString path);
     StringView wallpaper() const;
 
@@ -32,7 +33,7 @@ public:
     Gfx::Color background_color();
 
 private:
-    MonitorWidget();
+    MonitorWidget() = default;
 
     void redraw_desktop_if_needed();
 

--- a/Userland/Applications/DisplaySettings/ThemePreviewWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemePreviewWidget.cpp
@@ -18,10 +18,10 @@ ThemePreviewWidget::ThemePreviewWidget(Gfx::Palette const& palette)
     set_fixed_size(304, 201);
 }
 
-ErrorOr<void> ThemePreviewWidget::set_theme(DeprecatedString path)
+ErrorOr<void> ThemePreviewWidget::set_theme(String path)
 {
-    auto config_file = TRY(Core::File::open(path, Core::File::OpenMode::Read));
-    TRY(set_theme_from_file(path, move(config_file)));
+    auto config_file = TRY(Core::File::open(path.to_deprecated_string(), Core::File::OpenMode::Read));
+    TRY(set_theme_from_file(path.to_deprecated_string(), move(config_file)));
     return {};
 }
 

--- a/Userland/Applications/DisplaySettings/ThemePreviewWidget.h
+++ b/Userland/Applications/DisplaySettings/ThemePreviewWidget.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <LibGUI/AbstractThemePreview.h>
 #include <LibGUI/Widget.h>
 #include <LibGfx/Bitmap.h>
@@ -18,7 +19,7 @@ class ThemePreviewWidget final : public GUI::AbstractThemePreview {
     C_OBJECT(ThemePreviewWidget);
 
 public:
-    ErrorOr<void> set_theme(DeprecatedString path);
+    ErrorOr<void> set_theme(String path);
 
 private:
     explicit ThemePreviewWidget(Gfx::Palette const& palette);

--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
@@ -89,6 +89,10 @@ ErrorOr<void> ThemesSettingsWidget::setup_interface()
     else {
         color_scheme_combo.set_text("Custom");
         m_color_scheme_is_file_based = false;
+    }
+
+    auto theme_config = TRY(Core::ConfigFile::open(m_selected_theme->path));
+    if (!selected_color_scheme_index.has_value() || GUI::Widget::palette().color_scheme_path() != theme_config->read_entry("Paths", "ColorScheme")) {
         if (m_color_scheme_names.size() > 1) {
             color_scheme_combo.set_enabled(true);
             find_descendant_of_type_named<GUI::CheckBox>("custom_color_scheme_checkbox")->set_checked(true);

--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibGUI/ComboBox.h>
 #include <LibGUI/SettingsWindow.h>
@@ -26,13 +26,13 @@ public:
 private:
     ErrorOr<void> setup_interface();
     Vector<Gfx::SystemThemeMetaData> m_themes;
-    Vector<DeprecatedString> m_theme_names;
-    Vector<DeprecatedString> m_color_scheme_names;
+    Vector<String> m_theme_names;
+    Vector<String> m_color_scheme_names;
 
     RefPtr<GUI::ComboBox> m_themes_combo;
     RefPtr<ThemePreviewWidget> m_theme_preview;
     Gfx::SystemThemeMetaData const* m_selected_theme { nullptr };
-    DeprecatedString m_selected_color_scheme_name = "";
+    String m_selected_color_scheme_name {};
 
     RefPtr<GUI::Button> m_cursor_themes_button;
 

--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.h
@@ -17,12 +17,14 @@
 namespace DisplaySettings {
 
 class ThemesSettingsWidget final : public GUI::SettingsWindow::Tab {
-    C_OBJECT(ThemesSettingsWidget);
+    C_OBJECT_ABSTRACT(ThemesSettingsWidget);
 
 public:
+    static ErrorOr<NonnullRefPtr<ThemesSettingsWidget>> try_create(bool& background_settings_changed);
     virtual void apply_settings() override;
 
 private:
+    ErrorOr<void> setup_interface();
     Vector<Gfx::SystemThemeMetaData> m_themes;
     Vector<DeprecatedString> m_theme_names;
     Vector<DeprecatedString> m_color_scheme_names;

--- a/Userland/Libraries/LibGUI/Desktop.cpp
+++ b/Userland/Libraries/LibGUI/Desktop.cpp
@@ -59,7 +59,7 @@ RefPtr<Gfx::Bitmap> Desktop::wallpaper_bitmap() const
     return ConnectionToWindowServer::the().get_wallpaper().bitmap();
 }
 
-bool Desktop::set_wallpaper(RefPtr<Gfx::Bitmap const> wallpaper_bitmap, Optional<DeprecatedString> path)
+bool Desktop::set_wallpaper(RefPtr<Gfx::Bitmap const> wallpaper_bitmap, Optional<StringView> path)
 {
     if (m_is_setting_desktop_wallpaper)
         return false;

--- a/Userland/Libraries/LibGUI/Desktop.h
+++ b/Userland/Libraries/LibGUI/Desktop.h
@@ -33,7 +33,7 @@ public:
 
     DeprecatedString wallpaper_path() const;
     RefPtr<Gfx::Bitmap> wallpaper_bitmap() const;
-    bool set_wallpaper(RefPtr<Gfx::Bitmap const> wallpaper_bitmap, Optional<DeprecatedString> path);
+    bool set_wallpaper(RefPtr<Gfx::Bitmap const> wallpaper_bitmap, Optional<StringView> path);
 
     void set_system_effects(Vector<bool> effects) { m_system_effects = { effects }; };
     SystemEffects const& system_effects() const { return m_system_effects; }


### PR DESCRIPTION
This improves error propagation across ```DisplaySettings```, converts all instances of ```DeprecatedString``` to ```String``` and activates the color scheme combobox by default if a non-default color scheme is currently in use.