### PR TITLE
LibWeb: Give generated constructor functions a name

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2990,7 +2990,7 @@ using namespace Web::WebIDL;
 namespace Web::Bindings {
 
 @constructor_class@::@constructor_class@(JS::Realm& realm)
-    : NativeFunction(*realm.intrinsics().function_prototype())
+    : NativeFunction("@name@"sv, *realm.intrinsics().function_prototype())
 {
 }
 


### PR DESCRIPTION
Required by code that brand checks native constructors.

For example, Wistia brand checks XMLHttpRequest by doing:
```
XMLHttpRequest.prototype.constructor.toString()
```

It then checks if it matches either one of:
```
function XMLHttpRequest() { [native code] }
```
```
[object XMLHttpRequestConstructor]
```

If neither matches, it disables HLS playback and prints: "The XMLHttpRequest constructor has been tampered with. Because this affects CORS/Range XHR requests, HLS playback has been disabled. To enable HLS playback and other important features, please remove code that changes the definition of window.XMLHttpRequest."

We hit this path due to not giving generated constructors a name, as we would provide `function () { [native code] }`.