### PR TITLE
LibVT: Fix integer overflow when parsing long OSC sequences

### DIFF
--- a/Userland/Libraries/LibVT/EscapeSequenceParser.h
+++ b/Userland/Libraries/LibVT/EscapeSequenceParser.h
@@ -69,7 +69,7 @@ private:
     Vector<unsigned, 4> m_param_vector;
     unsigned m_param { 0 };
 
-    Vector<u8> m_osc_parameter_indexes;
+    Vector<size_t> m_osc_parameter_indexes;
     Vector<u8, 16> m_osc_raw;
 
     bool m_ignoring { false };


### PR DESCRIPTION
We were storing indices into OSC escape sequences as `u8`s, which overflow at a length of just 256 characters. This caused a crash when parsing OSC 8 hyperlinks pointing to long filenames.