### PR TITLE
Meta: Move global VM creation to fuzzer "global" structure

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzCSSParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzCSSParser.cpp
@@ -9,16 +9,21 @@
 #include <LibWeb/Platform/EventLoopPluginSerenity.h>
 
 namespace {
+
 struct Globals {
     Globals();
 } globals;
-Globals::Globals() { Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPluginSerenity); }
+
+Globals::Globals()
+{
+    Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPluginSerenity);
+    MUST(Web::Bindings::initialize_main_thread_vm());
+}
+
 }
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    MUST(Web::Bindings::initialize_main_thread_vm());
-
     // FIXME: There's got to be a better way to do this "correctly"
     auto& vm = Web::Bindings::main_thread_vm();
     (void)Web::parse_css_stylesheet(Web::CSS::Parser::ParsingContext(*vm.current_realm()), { data, size });


### PR DESCRIPTION
Turns out LLVMFuzzerTestOneInput may be called more than once per process.