### PR TITLE
Fuzzers: Skip trying to parse invalid UTF-8 in LibJS Fuzzers

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzJs.cpp
@@ -15,6 +15,9 @@
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     auto js = StringView(static_cast<unsigned char const*>(data), size);
+    // FIXME: https://github.com/SerenityOS/serenity/issues/17899
+    if (!Utf8View(js).validate())
+        return 0;
     auto vm = MUST(JS::VM::create());
     auto interpreter = JS::Interpreter::create<JS::GlobalObject>(*vm);
     auto parse_result = JS::Script::parse(js, interpreter->realm());

--- a/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
@@ -210,16 +210,20 @@ int main(int, char**)
 
         auto js = StringView(static_cast<unsigned char const*>(data_buffer.data()), script_size);
 
-        auto parse_result = JS::Script::parse(js, interpreter->realm());
-        if (parse_result.is_error()) {
+        // FIXME: https://github.com/SerenityOS/serenity/issues/17899
+        if (!UTF8View(js).validate()) {
             result = 1;
         } else {
-            auto completion = interpreter->run(parse_result.value());
-            if (completion.is_error()) {
+            auto parse_result = JS::Script::parse(js, interpreter->realm());
+            if (parse_result.is_error()) {
                 result = 1;
+            } else {
+                auto completion = interpreter->run(parse_result.value());
+                if (completion.is_error()) {
+                    result = 1;
+                }
             }
         }
-
         fflush(stdout);
         fflush(stderr);
 


### PR DESCRIPTION
Invalid UTF-8 crashes JS::Script::Parse.

This should work around #17899 and restore some stability to our fuzzers.