### PR TITLE
LibGUI+FileSystemAccessServer: Add option to specify allowed file types

### DIFF
--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -73,7 +73,7 @@ Result Client::request_file(GUI::Window* parent_window, DeprecatedString const& 
     return handle_promise(id);
 }
 
-Result Client::open_file(GUI::Window* parent_window, DeprecatedString const& window_title, StringView path, Core::File::OpenMode requested_access)
+Result Client::open_file(GUI::Window* parent_window, DeprecatedString const& window_title, StringView path, Core::File::OpenMode requested_access, Optional<Vector<GUI::FileTypeFilter>> const& allowed_file_types)
 {
     auto const id = get_new_id();
     m_promises.set(id, PromiseAndWindow { { Core::Promise<Result>::construct() }, parent_window });
@@ -88,7 +88,7 @@ Result Client::open_file(GUI::Window* parent_window, DeprecatedString const& win
         GUI::ConnectionToWindowServer::the().remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
     });
 
-    async_prompt_open_file(id, parent_window_server_client_id, parent_window_id, window_title, path, requested_access);
+    async_prompt_open_file(id, parent_window_server_client_id, parent_window_id, window_title, path, requested_access, allowed_file_types);
 
     return handle_promise(id);
 }

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -14,6 +14,7 @@
 #include <LibCore/File.h>
 #include <LibCore/Promise.h>
 #include <LibCore/StandardPaths.h>
+#include <LibGUI/FileTypeFilter.h>
 #include <LibGUI/Window.h>
 #include <LibIPC/ConnectionToServer.h>
 
@@ -47,7 +48,7 @@ class Client final
 public:
     Result request_file_read_only_approved(GUI::Window* parent_window, DeprecatedString const& path);
     Result request_file(GUI::Window* parent_window, DeprecatedString const& path, Core::File::OpenMode requested_access);
-    Result open_file(GUI::Window* parent_window, DeprecatedString const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::File::OpenMode requested_access = Core::File::OpenMode::Read);
+    Result open_file(GUI::Window* parent_window, DeprecatedString const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::File::OpenMode requested_access = Core::File::OpenMode::Read, Optional<Vector<GUI::FileTypeFilter>> const& = {});
     Result save_file(GUI::Window* parent_window, DeprecatedString const& name, DeprecatedString const ext, Core::File::OpenMode requested_access = Core::File::OpenMode::Write | Core::File::OpenMode::Truncate);
 
     static Client& the();

--- a/Userland/Libraries/LibGUI/FileTypeFilter.h
+++ b/Userland/Libraries/LibGUI/FileTypeFilter.h
@@ -9,6 +9,8 @@
 #include <AK/DeprecatedString.h>
 #include <AK/Optional.h>
 #include <AK/Vector.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 
 namespace GUI {
 
@@ -26,5 +28,26 @@ struct FileTypeFilter {
         return FileTypeFilter { "Image Files", Vector<DeprecatedString> { "png", "gif", "bmp", "dip", "pbm", "pgm", "ppm", "ico", "jpeg", "jpg", "dds", "qoi" } };
     }
 };
+
+}
+
+namespace IPC {
+
+template<>
+inline ErrorOr<void> encode(Encoder& encoder, GUI::FileTypeFilter const& response)
+{
+    TRY(encoder.encode(response.name));
+    TRY(encoder.encode(response.extensions));
+    return {};
+}
+
+template<>
+inline ErrorOr<GUI::FileTypeFilter> decode(Decoder& decoder)
+{
+    auto name = TRY(decoder.decode<DeprecatedString>());
+    auto extensions = TRY(decoder.decode<Optional<Vector<AK::DeprecatedString>>>());
+
+    return GUI::FileTypeFilter { move(name), move(extensions) };
+}
 
 }

--- a/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
+++ b/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
@@ -112,14 +112,14 @@ void ConnectionFromClient::request_file(i32 request_id, i32 window_server_client
     request_file_handler(request_id, window_server_client_id, parent_window_id, path, requested_access, ShouldPrompt::Yes);
 }
 
-void ConnectionFromClient::prompt_open_file(i32 request_id, i32 window_server_client_id, i32 parent_window_id, DeprecatedString const& window_title, DeprecatedString const& path_to_view, Core::File::OpenMode requested_access)
+void ConnectionFromClient::prompt_open_file(i32 request_id, i32 window_server_client_id, i32 parent_window_id, DeprecatedString const& window_title, DeprecatedString const& path_to_view, Core::File::OpenMode requested_access, Optional<Vector<GUI::FileTypeFilter>> const& allowed_file_types)
 {
     auto relevant_permissions = requested_access & (Core::File::OpenMode::Read | Core::File::OpenMode::Write);
     VERIFY(relevant_permissions != Core::File::OpenMode::NotOpen);
 
     auto main_window = create_dummy_child_window(window_server_client_id, parent_window_id);
 
-    auto user_picked_file = GUI::FilePicker::get_open_filepath(main_window, window_title, path_to_view);
+    auto user_picked_file = GUI::FilePicker::get_open_filepath(main_window, window_title, path_to_view, false, GUI::Dialog::ScreenPosition::CenterWithinParent, allowed_file_types);
 
     prompt_helper(request_id, user_picked_file, requested_access);
 }

--- a/Userland/Services/FileSystemAccessServer/ConnectionFromClient.h
+++ b/Userland/Services/FileSystemAccessServer/ConnectionFromClient.h
@@ -10,6 +10,7 @@
 #include <FileSystemAccessServer/FileSystemAccessClientEndpoint.h>
 #include <FileSystemAccessServer/FileSystemAccessServerEndpoint.h>
 #include <LibCore/Forward.h>
+#include <LibGUI/FileTypeFilter.h>
 #include <LibGUI/Forward.h>
 #include <LibIPC/ConnectionFromClient.h>
 
@@ -29,7 +30,7 @@ private:
 
     virtual void request_file_read_only_approved(i32, i32, i32, DeprecatedString const&) override;
     virtual void request_file(i32, i32, i32, DeprecatedString const&, Core::File::OpenMode) override;
-    virtual void prompt_open_file(i32, i32, i32, DeprecatedString const&, DeprecatedString const&, Core::File::OpenMode) override;
+    virtual void prompt_open_file(i32, i32, i32, DeprecatedString const&, DeprecatedString const&, Core::File::OpenMode, Optional<Vector<GUI::FileTypeFilter>> const&) override;
     virtual void prompt_save_file(i32, i32, i32, DeprecatedString const&, DeprecatedString const&, DeprecatedString const&, Core::File::OpenMode) override;
 
     void prompt_helper(i32, Optional<DeprecatedString> const&, Core::File::OpenMode);

--- a/Userland/Services/FileSystemAccessServer/FileSystemAccessServer.ipc
+++ b/Userland/Services/FileSystemAccessServer/FileSystemAccessServer.ipc
@@ -1,10 +1,11 @@
 #include <AK/URL.h>
+#include <LibGUI/FileTypeFilter.h>
 
 endpoint FileSystemAccessServer
 {
     request_file_read_only_approved(i32 request_id, i32 window_server_client_id, i32 window_id, DeprecatedString path) =|
     request_file(i32 request_id, i32 window_server_client_id, i32 window_id, DeprecatedString path, Core::File::OpenMode requested_access) =|
-    prompt_open_file(i32 request_id, i32 window_server_client_id, i32 window_id, DeprecatedString window_title, DeprecatedString path_to_view, Core::File::OpenMode requested_access) =|
+    prompt_open_file(i32 request_id, i32 window_server_client_id, i32 window_id, DeprecatedString window_title, DeprecatedString path_to_view, Core::File::OpenMode requested_access, Optional<Vector<GUI::FileTypeFilter>> allowed_file_types) =|
     prompt_save_file(i32 request_id, i32 window_server_client_id, i32 window_id, DeprecatedString title, DeprecatedString ext, DeprecatedString path_to_view, Core::File::OpenMode requested_access) =|
 
     expose_window_server_client_id() => (i32 client_id)


### PR DESCRIPTION
Like in FilePicker, this gives the ability to specify the types of files that `FileSystemAccessServer` is allowed to access.