### PR TITLE
LibCore+FileManager: Extract .zip files to a temporary folder when opened 

### DIFF
--- a/Base/res/apps/FileManager.af
+++ b/Base/res/apps/FileManager.af
@@ -2,3 +2,6 @@
 Name=File Manager
 Executable=/bin/FileManager
 Category=Utilities
+
+[Launcher]
+FileTypes=zip

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -11,6 +11,7 @@
 #include <AK/FixedArray.h>
 #include <AK/ScopedValueRollback.h>
 #include <AK/StdLibExtras.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibCore/DeprecatedFile.h>
 #include <LibCore/SessionManagement.h>
@@ -995,6 +996,16 @@ ErrorOr<int> mkstemp(Span<char> pattern)
     if (fd < 0)
         return Error::from_syscall("mkstemp"sv, -errno);
     return fd;
+}
+
+ErrorOr<String> mkdtemp(Span<char> pattern)
+{
+    auto* path = ::mkdtemp(pattern.data());
+    if (path == nullptr) {
+        return Error::from_errno(errno);
+    }
+
+    return String::from_utf8({ path, strlen(path) });
 }
 
 ErrorOr<void> rename(StringView old_path, StringView new_path)

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -166,6 +166,7 @@ ErrorOr<void> chdir(StringView path);
 ErrorOr<void> rmdir(StringView path);
 ErrorOr<pid_t> fork();
 ErrorOr<int> mkstemp(Span<char> pattern);
+ErrorOr<String> mkdtemp(Span<char> pattern);
 ErrorOr<void> fchmod(int fd, mode_t mode);
 ErrorOr<void> fchown(int fd, uid_t, gid_t);
 ErrorOr<void> rename(StringView old_path, StringView new_path);

--- a/Userland/Libraries/LibCore/TempFile.h
+++ b/Userland/Libraries/LibCore/TempFile.h
@@ -1,37 +1,41 @@
 /*
- * Copyright (c) 2020-2021, the SerenityOS developers.
+ * Copyright (c) 2020-2023, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
-#include <AK/Noncopyable.h>
+#include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/String.h>
 
 namespace Core {
 
 class TempFile {
-    AK_MAKE_NONCOPYABLE(TempFile);
-    AK_MAKE_NONMOVABLE(TempFile);
 
 public:
-    enum class Type {
-        File,
-        Directory
-    };
+    static ErrorOr<NonnullOwnPtr<TempFile>> create_temp_directory();
+    static ErrorOr<NonnullOwnPtr<TempFile>> create_temp_file();
 
-    static NonnullOwnPtr<TempFile> create(Type = Type::File);
     ~TempFile();
 
-    DeprecatedString path() const { return m_path; }
+    String const& path() const { return m_path; }
 
 private:
-    TempFile(Type);
-    static DeprecatedString create_temp(Type);
+    enum class Type {
+        Directory,
+        File
+    };
 
-    Type m_type { Type::File };
-    DeprecatedString m_path;
+    TempFile(Type type, String path)
+        : m_type(type)
+        , m_path(move(path))
+    {
+    }
+
+    Type m_type;
+    String m_path;
 };
 
 }


### PR DESCRIPTION
Now, when FileManager is invoked with a `.zip` file as the first argument, a temporary directory will be created and the `.zip` will be extracted into it. Once the FileManager window is closed, `Core::TempFile` will discard the temporary directory.

This adds something like what we see in other operating systems' file explorers, except for the fact that most other operating systems will treat the `.zip` file as its own independent read-only filesystem. It would be nice to do that in the future, but I feel like this is sufficient for now.


https://user-images.githubusercontent.com/71222289/226073493-be2454f3-9df6-45f0-932d-ba7856e44fe6.mp4

