### PR TITLE
LibWeb: Load alternative font urls if others fail

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5435,6 +5435,10 @@ Vector<FontFace::Source> Parser::parse_font_face_src(TokenStream<ComponentValue>
         // FIXME: Implement optional tech() function from CSS-Fonts-4.
         if (auto maybe_url = parse_url_function(first, AllowedDataUrlType::Font); maybe_url.has_value()) {
             auto url = maybe_url.release_value();
+            if (!url.is_valid()) {
+                continue;
+            }
+
             Optional<FlyString> format;
 
             source_tokens.skip_whitespace();

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -102,7 +102,7 @@ private:
         auto mime_type = resource()->mime_type();
         if (mime_type == "font/ttf"sv || mime_type == "application/x-font-ttf"sv)
             return TRY(OpenType::Font::try_load_from_externally_owned_memory(resource()->encoded_data()));
-        if (mime_type == "font/woff"sv)
+        if (mime_type == "font/woff"sv || mime_type == "application/font-woff"sv)
             return TRY(WOFF::Font::try_load_from_externally_owned_memory(resource()->encoded_data()));
         auto ttf = OpenType::Font::try_load_from_externally_owned_memory(resource()->encoded_data());
         if (!ttf.is_error())


### PR DESCRIPTION
We don't support all parts of the font formats we assume as "supported" in the CSS parser completely. For example, if an open type font has a CFF table, we reject loading it. This meant that until now, when such an unsupported-supported font URL was first in the list of URLs, we couldn't load it at all, even when we would support a later URL.

To resolve that, try loading all font URLs one after each other, in case we are not able to load the higher priority one.

This also resolves a `FIXME` related to spec compliant URL prioritization. Our CSS parser already filters and prioritizes font src URLs in compliance with the spec. However, we still had to resort to brittle file extension matching, because some websites don't set the `format` and if the first URL in a src list happened to be one we don't support, the font wouldn't be loaded at all. This now is unnecessary because we can try and discard those URLs instead.
