### PR TITLE
LibAudio: Make FLAC seeking actually work

### DIFF
--- a/Userland/Libraries/LibAudio/CMakeLists.txt
+++ b/Userland/Libraries/LibAudio/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    GenericTypes.cpp
     SampleFormats.cpp
     Loader.cpp
     WavLoader.cpp

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -87,6 +87,8 @@ private:
     ALWAYS_INLINE ErrorOr<u32, LoaderError> convert_sample_rate_code(u8 sample_rate_code);
     ALWAYS_INLINE ErrorOr<PcmSampleFormat, LoaderError> convert_bit_depth_code(u8 bit_depth_code);
 
+    bool should_insert_seekpoint_at(u64 sample_index) const;
+
     // Data obtained directly from the FLAC metadata: many values have specific bit counts
     u32 m_sample_rate { 0 };         // 20 bit
     u8 m_num_channels { 0 };         // 3 bit
@@ -105,7 +107,7 @@ private:
     u64 m_data_start_location { 0 };
     Optional<FlacFrameHeader> m_current_frame;
     u64 m_current_sample_or_frame { 0 };
-    Vector<FlacSeekPoint> m_seektable;
+    SeekTable m_seektable;
 };
 
 }

--- a/Userland/Libraries/LibAudio/FlacTypes.h
+++ b/Userland/Libraries/LibAudio/FlacTypes.h
@@ -91,11 +91,4 @@ struct FlacSubframeHeader {
     u8 bits_per_sample;
 };
 
-// 11.14. SEEKPOINT
-struct FlacSeekPoint {
-    u64 sample_index;
-    u64 byte_offset;
-    u16 num_samples;
-};
-
 }

--- a/Userland/Libraries/LibAudio/GenericTypes.cpp
+++ b/Userland/Libraries/LibAudio/GenericTypes.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GenericTypes.h"
+#include <AK/BinarySearch.h>
+#include <AK/Error.h>
+#include <AK/Optional.h>
+
+namespace Audio {
+
+size_t SeekTable::size() const
+{
+    return m_seek_points.size();
+}
+
+ReadonlySpan<SeekPoint> SeekTable::seek_points() const
+{
+    return m_seek_points.span();
+}
+
+Optional<SeekPoint const&> SeekTable::seek_point_before(u64 sample_index) const
+{
+    if (m_seek_points.is_empty())
+        return {};
+    size_t nearby_seek_point_index = 0;
+    AK::binary_search(m_seek_points, sample_index, &nearby_seek_point_index, [](auto const& sample_index, auto const& seekpoint_candidate) {
+        return static_cast<i64>(sample_index) - static_cast<i64>(seekpoint_candidate.sample_index);
+    });
+    // Binary search will always give us a close index, but it may be too large or too small.
+    // By doing the index adjustment in this order, we will always find a seek point before the given sample.
+    while (nearby_seek_point_index < m_seek_points.size() - 1 && m_seek_points[nearby_seek_point_index].sample_index < sample_index)
+        ++nearby_seek_point_index;
+    while (nearby_seek_point_index > 0 && m_seek_points[nearby_seek_point_index].sample_index > sample_index)
+        --nearby_seek_point_index;
+    return m_seek_points[nearby_seek_point_index];
+}
+
+Optional<u64> SeekTable::seek_point_sample_distance_around(u64 sample_index) const
+{
+    if (m_seek_points.is_empty())
+        return {};
+    size_t nearby_seek_point_index = 0;
+    AK::binary_search(m_seek_points, sample_index, &nearby_seek_point_index, [](auto const& sample_index, auto const& seekpoint_candidate) {
+        return static_cast<i64>(sample_index) - static_cast<i64>(seekpoint_candidate.sample_index);
+    });
+
+    while (nearby_seek_point_index < m_seek_points.size() && m_seek_points[nearby_seek_point_index].sample_index <= sample_index)
+        ++nearby_seek_point_index;
+    // There is no seek point beyond the sample index.
+    if (nearby_seek_point_index >= m_seek_points.size())
+        return {};
+    auto upper_seek_point_index = nearby_seek_point_index;
+
+    while (nearby_seek_point_index > 0 && m_seek_points[nearby_seek_point_index].sample_index > sample_index)
+        --nearby_seek_point_index;
+    auto lower_seek_point_index = nearby_seek_point_index;
+
+    VERIFY(upper_seek_point_index >= lower_seek_point_index);
+    return m_seek_points[upper_seek_point_index].sample_index - m_seek_points[lower_seek_point_index].sample_index;
+}
+
+ErrorOr<void> SeekTable::insert_seek_point(SeekPoint seek_point)
+{
+    if (auto previous_seek_point = seek_point_before(seek_point.sample_index); previous_seek_point.has_value() && previous_seek_point->sample_index == seek_point.sample_index) {
+        // Do not insert a duplicate seek point.
+        return {};
+    }
+
+    // FIXME: This could be even faster if we used binary search while finding the insertion point.
+    return m_seek_points.try_insert_before_matching(seek_point, [&](auto const& other_seek_point) {
+        return seek_point.sample_index < other_seek_point.sample_index;
+    });
+}
+
+}

--- a/Userland/Libraries/LibAudio/GenericTypes.h
+++ b/Userland/Libraries/LibAudio/GenericTypes.h
@@ -51,4 +51,28 @@ struct PictureData {
     Vector<u8> data;
 };
 
+// A generic sample seek point within a file.
+struct SeekPoint {
+    u64 sample_index;
+    u64 byte_offset;
+};
+
+class SeekTable {
+public:
+    Optional<SeekPoint const&> seek_point_before(u64 sample_index) const;
+    // Returns the distance between the closest two seek points around the sample index.
+    // The lower seek point may be exactly at the sample index, but the upper seek point must be after the sample index.
+    Optional<u64> seek_point_sample_distance_around(u64 sample_index) const;
+
+    size_t size() const;
+    ReadonlySpan<SeekPoint> seek_points() const;
+
+    ErrorOr<void> insert_seek_point(SeekPoint);
+
+private:
+    // Invariant: The list of seek points is always sorted.
+    // This makes all operations, such as inserting and searching, faster.
+    Vector<SeekPoint> m_seek_points;
+};
+
 }

--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -32,6 +32,13 @@ static constexpr StringView no_plugin_error = "No loader plugin available"sv;
 // There was no intensive fine-tuning done to determine this value, so improvements may definitely be possible.
 constexpr size_t const loader_buffer_size = 8 * KiB;
 
+// Two seek points should ideally not be farther apart than this.
+// This variable is a heuristic for seek table-constructing loaders.
+constexpr u64 const maximum_seekpoint_distance_ms = 1000;
+// Seeking should be at least as precise as this.
+// That means: The actual achieved seek position must not be more than this amount of time before the requested seek position.
+constexpr u64 const seek_tolerance_ms = 5000;
+
 using LoaderSamples = ErrorOr<FixedArray<Sample>, LoaderError>;
 using MaybeLoaderError = ErrorOr<void, LoaderError>;
 

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -57,7 +57,7 @@ private:
     static void synthesis(Array<float, 1024>& V, Array<float, 32>& samples, Array<float, 32>& result);
     static ReadonlySpan<MP3::Tables::ScaleFactorBand> get_scalefactor_bands(MP3::Granule const&, int samplerate);
 
-    AK::Vector<AK::Tuple<size_t, int>> m_seek_table;
+    SeekTable m_seek_table;
     AK::Array<AK::Array<AK::Array<float, 18>, 32>, 2> m_last_values {};
     AK::Array<AK::Array<float, 1024>, 2> m_synthesis_buffer {};
     static DSP::MDCT<36> s_mdct_36;


### PR DESCRIPTION
This PR fixes 90% of issues with FLAC seeking (it should at least not error out anymore in any case).

The PR also introduces a generic seek table data structure, which is used by MP3 via the second commit. This seek table is designed to be very performant so that no matter how many seek points you insert, seeking will continue to be fast.