### PR TITLE
LibWeb: Invalidate sibling styles on input element checked state change

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -85,7 +85,12 @@ void HTMLInputElement::set_checked(bool checked, ChangeSource change_source)
         m_dirty_checkedness = true;
 
     m_checked = checked;
-    set_needs_style_update(true);
+
+    // This element's :checked pseudo-class could be used in a sibling's sibling-selector,
+    // so we need to invalidate the style of all siblings.
+    parent()->for_each_child([&](auto& child) {
+        child.invalidate_style();
+    });
 }
 
 void HTMLInputElement::set_checked_binding(bool checked)


### PR DESCRIPTION
Checkedness of an input element can influence sibling style, as well as style of their children, when they use the `:checked` pseudo-class in combination with a kind of sibling selector. That means, it is not sufficient to just invalidate the input elements on style.

This is actually more commonly observable than one might expect, because this pattern is often used as a JS-free toggle solution for things like menus.
