### PR TITLE
LibWeb: Improve size of empty text inputs using the lh unit

### DIFF
--- a/Tests/LibWeb/Layout/expected/lh-1.txt
+++ b/Tests/LibWeb/Layout/expected/lh-1.txt
@@ -1,0 +1,6 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
+      BlockContainer <div#a> at (8,8) content-size 100x100 children: not-inline
+        BlockContainer <div#b> at (8,8) content-size 100x100 children: inline
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/lh-2.txt
+++ b/Tests/LibWeb/Layout/expected/lh-2.txt
@@ -1,0 +1,6 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
+      BlockContainer <div#a> at (8,8) content-size 100x100 children: not-inline
+        BlockContainer <div#b> at (8,8) content-size 100x100 children: inline
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/lh-1.html
+++ b/Tests/LibWeb/Layout/input/lh-1.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<head><style>
+* {
+    font-family: SerenitySans;
+}
+:root {
+    font-size: 20px;
+    line-height: 2;
+}
+#a {
+    background-color: red;
+    width: 100px;
+    height: 100px;
+}
+#b {
+    background-color: green;
+    font-size: 50px;
+    line-height: 100%;
+    width: 2lh;
+    height: 2.5rlh;
+}
+</style>
+<body><div id="a"><div id="b">

--- a/Tests/LibWeb/Layout/input/lh-2.html
+++ b/Tests/LibWeb/Layout/input/lh-2.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<head><style>
+* {
+    font-family: SerenitySans;
+}
+:root {
+    font-size: 20px;
+    line-height: 2;
+}
+#a {
+    background-color: red;
+    width: 100px;
+    height: 100px;
+}
+#b {
+    background-color: green;
+    line-height: 50px;
+    width: 2lh;
+    height: 2.5rlh;
+}
+</style>
+<body><div id="a"><div id="b">

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -70,7 +70,7 @@ Length Length::resolved(Layout::Node const& layout_node) const
     return *this;
 }
 
-CSSPixels Length::relative_length_to_px(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
+CSSPixels Length::relative_length_to_px(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const
 {
     switch (m_type) {
     case Type::Ex:
@@ -90,6 +90,10 @@ CSSPixels Length::relative_length_to_px(CSSPixelRect const& viewport_rect, Gfx::
         return min(viewport_rect.width(), viewport_rect.height()) * (m_value / 100);
     case Type::Vmax:
         return max(viewport_rect.width(), viewport_rect.height()) * (m_value / 100);
+    case Type::Lh:
+        return m_value * line_height;
+    case Type::Rlh:
+        return m_value * root_line_height;
     default:
         VERIFY_NOT_REACHED();
     }
@@ -109,7 +113,7 @@ CSSPixels Length::to_px(Layout::Node const& layout_node) const
     auto* root_element = layout_node.document().document_element();
     if (!root_element || !root_element->layout_node())
         return 0;
-    return to_px(viewport_rect, layout_node.font().pixel_metrics(), layout_node.computed_values().font_size(), root_element->layout_node()->computed_values().font_size());
+    return to_px(viewport_rect, layout_node.font().pixel_metrics(), layout_node.computed_values().font_size(), root_element->layout_node()->computed_values().font_size(), layout_node.line_height(), root_element->layout_node()->line_height());
 }
 
 ErrorOr<String> Length::to_string() const
@@ -156,6 +160,10 @@ char const* Length::unit_name() const
         return "vmax";
     case Type::Vmin:
         return "vmin";
+    case Type::Lh:
+        return "lh";
+    case Type::Rlh:
+        return "rlh";
     case Type::Calculated:
         return "calculated";
     }
@@ -194,6 +202,10 @@ Optional<Length::Type> Length::unit_from_name(StringView name)
         return Length::Type::In;
     } else if (name.equals_ignoring_ascii_case("Q"sv)) {
         return Length::Type::Q;
+    } else if (name.equals_ignoring_ascii_case("lh"sv)) {
+        return Length::Type::Lh;
+    } else if (name.equals_ignoring_ascii_case("rlh"sv)) {
+        return Length::Type::Rlh;
     }
 
     return {};

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -35,6 +35,8 @@ public:
         Vw,
         Vmax,
         Vmin,
+        Lh,
+        Rlh,
     };
 
     static Optional<Type> unit_from_name(StringView);
@@ -76,7 +78,9 @@ public:
             || m_type == Type::Vh
             || m_type == Type::Vw
             || m_type == Type::Vmax
-            || m_type == Type::Vmin;
+            || m_type == Type::Vmin
+            || m_type == Type::Lh
+            || m_type == Type::Rlh;
     }
 
     float raw_value() const { return m_value; }
@@ -84,12 +88,12 @@ public:
 
     CSSPixels to_px(Layout::Node const&) const;
 
-    ALWAYS_INLINE CSSPixels to_px(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
+    ALWAYS_INLINE CSSPixels to_px(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const
     {
         if (is_auto())
             return 0;
         if (is_relative())
-            return relative_length_to_px(viewport_rect, font_metrics, font_size, root_font_size);
+            return relative_length_to_px(viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height);
         if (is_calculated())
             VERIFY_NOT_REACHED(); // We can't resolve a calculated length from here. :^(
         return absolute_length_to_px();
@@ -125,7 +129,7 @@ public:
     // this file already. To break the cyclic dependency, we must move all method definitions out.
     bool operator==(Length const& other) const;
 
-    CSSPixels relative_length_to_px(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const;
+    CSSPixels relative_length_to_px(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const;
 
 private:
     char const* unit_name() const;

--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -168,9 +168,10 @@ bool MediaFeature::compare(HTML::Window const& window, MediaFeatureValue left, C
             auto const& initial_font = window.associated_document().style_computer().initial_font();
             Gfx::FontPixelMetrics const& initial_font_metrics = initial_font.pixel_metrics();
             float initial_font_size = initial_font.presentation_size();
+            float initial_line_height = initial_font_metrics.line_spacing();
 
-            left_px = left.length().to_px(viewport_rect, initial_font_metrics, initial_font_size, initial_font_size);
-            right_px = right.length().to_px(viewport_rect, initial_font_metrics, initial_font_size, initial_font_size);
+            left_px = left.length().to_px(viewport_rect, initial_font_metrics, initial_font_size, initial_font_size, initial_line_height, initial_line_height);
+            right_px = right.length().to_px(viewport_rect, initial_font_metrics, initial_font_size, initial_font_size, initial_line_height, initial_line_height);
         }
 
         switch (comparison) {

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -103,6 +103,8 @@ private:
 
     CSSPixelRect viewport_rect() const;
     CSSPixels root_element_font_size() const;
+    CSSPixels root_element_line_height() const;
+    CSSPixels parent_or_root_element_line_height(DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const;
 
     struct MatchingRuleSet {
         Vector<MatchingRule> user_agent_rules;

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -138,6 +138,35 @@ NonnullRefPtr<Gfx::Font const> StyleProperties::font_fallback(bool monospace, bo
     return Platform::FontPlugin::the().default_font();
 }
 
+// FIXME: This implementation is almost identical to line_height(Layout::Node) below. Maybe they can be combined somehow.
+CSSPixels StyleProperties::line_height(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels parent_line_height, CSSPixels root_line_height) const
+{
+    auto line_height = property(CSS::PropertyID::LineHeight);
+
+    if (line_height->is_identifier() && line_height->to_identifier() == ValueID::Normal)
+        return font_metrics.line_spacing();
+
+    if (line_height->is_length()) {
+        auto line_height_length = line_height->to_length();
+        if (!line_height_length.is_auto())
+            return line_height_length.to_px(viewport_rect, font_metrics, font_size, root_font_size, parent_line_height, root_line_height);
+    }
+
+    if (line_height->is_numeric())
+        return Length(line_height->to_number(), Length::Type::Em).to_px(viewport_rect, font_metrics, font_size, root_font_size, parent_line_height, root_line_height);
+
+    if (line_height->is_percentage()) {
+        // Percentages are relative to 1em. https://www.w3.org/TR/css-inline-3/#valdef-line-height-percentage
+        auto& percentage = line_height->as_percentage().percentage();
+        return Length(percentage.as_fraction(), Length::Type::Em).to_px(viewport_rect, font_metrics, font_size, root_font_size, parent_line_height, root_line_height);
+    }
+
+    if (line_height->is_calculated())
+        return CSS::Length::make_calculated(const_cast<CalculatedStyleValue&>(line_height->as_calculated())).to_px(viewport_rect, font_metrics, font_size, root_font_size, parent_line_height, root_line_height);
+
+    return font_metrics.line_spacing();
+}
+
 CSSPixels StyleProperties::line_height(Layout::Node const& layout_node) const
 {
     auto line_height = property(CSS::PropertyID::LineHeight);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -108,6 +108,7 @@ public:
         m_font = move(font);
     }
 
+    CSSPixels line_height(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const&, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const;
     CSSPixels line_height(Layout::Node const&) const;
 
     bool operator==(StyleProperties const&) const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -2235,48 +2235,48 @@ ValueComparingNonnullRefPtr<LengthStyleValue> LengthStyleValue::create(Length co
     return adopt_ref(*new LengthStyleValue(length));
 }
 
-static Optional<CSS::Length> absolutized_length(CSS::Length const& length, CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size)
+static Optional<CSS::Length> absolutized_length(CSS::Length const& length, CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height)
 {
     if (length.is_px())
         return {};
     if (length.is_absolute() || length.is_relative()) {
-        auto px = length.to_px(viewport_rect, font_metrics, font_size, root_font_size);
+        auto px = length.to_px(viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height);
         return CSS::Length::make_px(px);
     }
     return {};
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> StyleValue::absolutized(CSSPixelRect const&, Gfx::FontPixelMetrics const&, CSSPixels, CSSPixels) const
+ValueComparingNonnullRefPtr<StyleValue const> StyleValue::absolutized(CSSPixelRect const&, Gfx::FontPixelMetrics const&, CSSPixels, CSSPixels, CSSPixels, CSSPixels) const
 {
     return *this;
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> LengthStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
+ValueComparingNonnullRefPtr<StyleValue const> LengthStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const
 {
-    if (auto length = absolutized_length(m_length, viewport_rect, font_metrics, font_size, root_font_size); length.has_value())
+    if (auto length = absolutized_length(m_length, viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height); length.has_value())
         return LengthStyleValue::create(length.release_value());
     return *this;
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> ShadowStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
+ValueComparingNonnullRefPtr<StyleValue const> ShadowStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const
 {
-    auto absolutized_offset_x = absolutized_length(m_properties.offset_x, viewport_rect, font_metrics, font_size, root_font_size).value_or(m_properties.offset_x);
-    auto absolutized_offset_y = absolutized_length(m_properties.offset_y, viewport_rect, font_metrics, font_size, root_font_size).value_or(m_properties.offset_y);
-    auto absolutized_blur_radius = absolutized_length(m_properties.blur_radius, viewport_rect, font_metrics, font_size, root_font_size).value_or(m_properties.blur_radius);
-    auto absolutized_spread_distance = absolutized_length(m_properties.spread_distance, viewport_rect, font_metrics, font_size, root_font_size).value_or(m_properties.spread_distance);
+    auto absolutized_offset_x = absolutized_length(m_properties.offset_x, viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height).value_or(m_properties.offset_x);
+    auto absolutized_offset_y = absolutized_length(m_properties.offset_y, viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height).value_or(m_properties.offset_y);
+    auto absolutized_blur_radius = absolutized_length(m_properties.blur_radius, viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height).value_or(m_properties.blur_radius);
+    auto absolutized_spread_distance = absolutized_length(m_properties.spread_distance, viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height).value_or(m_properties.spread_distance);
     return ShadowStyleValue::create(m_properties.color, absolutized_offset_x, absolutized_offset_y, absolutized_blur_radius, absolutized_spread_distance, m_properties.placement);
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> BorderRadiusStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const
+ValueComparingNonnullRefPtr<StyleValue const> BorderRadiusStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const
 {
     if (m_properties.horizontal_radius.is_percentage() && m_properties.vertical_radius.is_percentage())
         return *this;
     auto absolutized_horizontal_radius = m_properties.horizontal_radius;
     auto absolutized_vertical_radius = m_properties.vertical_radius;
     if (!m_properties.horizontal_radius.is_percentage())
-        absolutized_horizontal_radius = absolutized_length(m_properties.horizontal_radius.length(), viewport_rect, font_metrics, font_size, root_font_size).value_or(m_properties.horizontal_radius.length());
+        absolutized_horizontal_radius = absolutized_length(m_properties.horizontal_radius.length(), viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height).value_or(m_properties.horizontal_radius.length());
     if (!m_properties.vertical_radius.is_percentage())
-        absolutized_vertical_radius = absolutized_length(m_properties.vertical_radius.length(), viewport_rect, font_metrics, font_size, root_font_size).value_or(m_properties.vertical_radius.length());
+        absolutized_vertical_radius = absolutized_length(m_properties.vertical_radius.length(), viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height).value_or(m_properties.vertical_radius.length());
     return BorderRadiusStyleValue::create(absolutized_horizontal_radius, absolutized_vertical_radius);
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -465,7 +465,7 @@ public:
     virtual bool has_number() const { return false; }
     virtual bool has_integer() const { return false; }
 
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const;
 
     virtual Color to_color(Layout::NodeWithStyle const&) const { return {}; }
     virtual EdgeRect to_rect() const { VERIFY_NOT_REACHED(); }
@@ -701,7 +701,7 @@ private:
     {
     }
 
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const override;
 
     struct Properties {
         bool is_elliptical;
@@ -1631,7 +1631,7 @@ public:
     virtual ErrorOr<String> to_string() const override { return m_length.to_string(); }
     virtual Length to_length() const override { return m_length; }
     virtual ValueID to_identifier() const override { return has_auto() ? ValueID::Auto : ValueID::Invalid; }
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const override;
 
     bool properties_equal(LengthStyleValue const& other) const { return m_length == other.m_length; }
 
@@ -1860,7 +1860,7 @@ private:
     {
     }
 
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const override;
 
     struct Properties {
         Color color;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -394,7 +394,7 @@ void HTMLInputElement::create_shadow_tree_if_needed()
     if (initial_value.is_null())
         initial_value = DeprecatedString::empty();
     auto element = document().create_element(HTML::TagNames::div).release_value();
-    MUST(element->set_attribute(HTML::AttributeNames::style, "white-space: pre; padding-top: 1px; padding-bottom: 1px; padding-left: 2px; padding-right: 2px"));
+    MUST(element->set_attribute(HTML::AttributeNames::style, "white-space: pre; padding-top: 1px; padding-bottom: 1px; padding-left: 2px; padding-right: 2px; height: 1lh;"));
     m_text_node = heap().allocate<DOM::Text>(realm(), document(), initial_value).release_allocated_value_but_fixme_should_propagate_errors();
     m_text_node->set_always_editable(m_type != TypeAttributeState::FileUpload);
     m_text_node->set_owner_input_element({}, *this);

--- a/Userland/Libraries/LibWebView/DOMTreeModel.cpp
+++ b/Userland/Libraries/LibWebView/DOMTreeModel.cpp
@@ -127,7 +127,7 @@ GUI::Variant DOMTreeModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
     if (role == GUI::ModelRole::ForegroundColor) {
         // FIXME: Allow models to return a foreground color *role*.
         //        Then we won't need to have a GUI::TreeView& member anymore.
-        if (type == "comment"sv)
+        if (type == "comment"sv || type == "shadow-root"sv)
             return m_tree_view->palette().syntax_comment();
         if (type == "pseudo-element"sv)
             return m_tree_view->palette().syntax_type();
@@ -154,6 +154,8 @@ GUI::Variant DOMTreeModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
             return with_whitespace_collapsed(node.get_deprecated_string("text"sv).value());
         if (type == "comment"sv)
             return DeprecatedString::formatted("<!--{}-->", node.get_deprecated_string("data"sv).value());
+        if (type == "shadow-root"sv)
+            return DeprecatedString::formatted("{} ({})", node_name, node.get_deprecated_string("mode"sv).value());
         if (type != "element")
             return node_name;
 


### PR DESCRIPTION
This PR add the `lh` and `rlh` CSS units and uses them to make the height of empty text inputs match the height of text inputs containing text.

It also adds shadow roots to the DOM inspector, which makes investigating the style of their inner elements more convenient.