### PR TITLE
LibGfx: Correct the type of Lookup.subtable_offsets

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
@@ -559,7 +559,7 @@ struct Lookup {
     BigEndian<u16> lookup_type;
     BigEndian<u16> lookup_flag;
     BigEndian<u16> subtable_count;
-    BigEndian<u16> subtable_offsets[];
+    Offset16 subtable_offsets[];
 };
 
 // https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-list-table


### PR DESCRIPTION
According to the spec (and the variable name), it should be an array of offsets, not u16s. Noticed this while watching Andreas' [most recent video](https://youtu.be/xULCsNvseC8)