### PR TITLE
LibGUI: Update progress of thumbnail generations on failure 

### DIFF
--- a/Userland/Libraries/LibThreading/BackgroundAction.h
+++ b/Userland/Libraries/LibThreading/BackgroundAction.h
@@ -98,8 +98,12 @@ private:
                     error = result.release_error();
 
                 m_promise->cancel(Error::from_errno(ECANCELED));
-                if (m_on_error)
-                    m_on_error(move(error));
+                if (m_on_error) {
+                    origin_event_loop->deferred_invoke([this, error = move(error)]() mutable {
+                        m_on_error(move(error));
+                    });
+                    origin_event_loop->wake();
+                }
 
                 remove_from_parent();
             }


### PR DESCRIPTION
If you have some images which can't be decoded, the progress bar will hang in an unfinished state.
With this patch, even if we fail to generate a thumbnail, we update the progress to notify that we are done with the file.

![WHF](https://user-images.githubusercontent.com/26030965/226136462-25f7d9ff-b1a1-49a3-9f1c-f0cc916f45dc.png)
