### PR TITLE
LibGfx/JPEG: Make JPEGImageDecoderPlugin's constructor take a Stream

### DIFF
--- a/Userland/Libraries/LibGfx/JPEGLoader.h
+++ b/Userland/Libraries/LibGfx/JPEGLoader.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/MemoryStream.h>
 #include <LibGfx/ImageDecoder.h>
 
 namespace Gfx {
@@ -31,7 +32,7 @@ public:
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
-    JPEGImageDecoderPlugin(u8 const*, size_t);
+    JPEGImageDecoderPlugin(NonnullOwnPtr<FixedMemoryStream>);
 
     OwnPtr<JPEGLoadingContext> m_context;
 };


### PR DESCRIPTION
This allows us to get rid of the raw pointer and size in the JPEG context struct.