### PR TITLE
LibWeb: Stub out a few form validation and selection methods

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -258,6 +258,20 @@ unsigned HTMLFormElement::length() const
     return elements()->length();
 }
 
+// https://html.spec.whatwg.org/multipage/forms.html#dom-form-checkvalidity
+WebIDL::ExceptionOr<bool> HTMLFormElement::check_validity()
+{
+    dbgln("(STUBBED) HTMLFormElement::check_validity(). Called on: {}", debug_description());
+    return true;
+}
+
+// https://html.spec.whatwg.org/multipage/forms.html#dom-form-reportvalidity
+WebIDL::ExceptionOr<bool> HTMLFormElement::report_validity()
+{
+    dbgln("(STUBBED) HTMLFormElement::report_validity(). Called on: {}", debug_description());
+    return true;
+}
+
 // https://html.spec.whatwg.org/multipage/forms.html#category-submit
 ErrorOr<Vector<JS::NonnullGCPtr<DOM::Element>>> HTMLFormElement::get_submittable_elements()
 {

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -40,6 +40,9 @@ public:
     JS::NonnullGCPtr<DOM::HTMLCollection> elements() const;
     unsigned length() const;
 
+    WebIDL::ExceptionOr<bool> check_validity();
+    WebIDL::ExceptionOr<bool> report_validity();
+
     // https://www.w3.org/TR/html-aria/#el-form
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::form; }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
@@ -12,6 +12,8 @@ interface HTMLFormElement : HTMLElement {
 
     undefined submit();
     [CEReactions] undefined reset();
+    boolean checkValidity();
+    boolean reportValidity();
 
     // FIXME: Should be a HTMLFormControlsCollection
     [SameObject] readonly attribute HTMLCollection elements;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -874,6 +874,34 @@ i32 HTMLInputElement::default_tab_index_value() const
     return 0;
 }
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity
+WebIDL::ExceptionOr<bool> HTMLInputElement::check_validity()
+{
+    dbgln("(STUBBED) HTMLInputElement::check_validity(). Called on: {}", debug_description());
+    return true;
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity
+WebIDL::ExceptionOr<bool> HTMLInputElement::report_validity()
+{
+    dbgln("(STUBBED) HTMLInputElement::report_validity(). Called on: {}", debug_description());
+    return true;
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity
+void HTMLInputElement::set_custom_validity(DeprecatedString const& error)
+{
+    dbgln("(STUBBED) HTMLInputElement::set_custom_validity(error={}). Called on: {}", error, debug_description());
+    return;
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-select
+WebIDL::ExceptionOr<void> HTMLInputElement::select()
+{
+    dbgln("(STUBBED) HTMLInputElement::select(). Called on: {}", debug_description());
+    return {};
+}
+
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-setselectionrange
 WebIDL::ExceptionOr<void> HTMLInputElement::set_selection_range(u32 start, u32 end, DeprecatedString const& direction)
 {

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -87,6 +87,11 @@ public:
     // https://html.spec.whatwg.org/multipage/input.html#update-the-file-selection
     void update_the_file_selection(JS::NonnullGCPtr<FileAPI::FileList>);
 
+    WebIDL::ExceptionOr<bool> check_validity();
+    WebIDL::ExceptionOr<bool> report_validity();
+    void set_custom_validity(DeprecatedString const&);
+
+    WebIDL::ExceptionOr<void> select();
     WebIDL::ExceptionOr<void> set_selection_range(u32 start, u32 end, DeprecatedString const& direction);
 
     WebIDL::ExceptionOr<void> show_picker();

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -38,6 +38,11 @@ interface HTMLInputElement : HTMLElement {
     [Reflect] attribute DOMString align;
     [Reflect=usemap] attribute DOMString useMap;
 
+    boolean checkValidity();
+    boolean reportValidity();
+    undefined setCustomValidity(DOMString error);
+
+    undefined select();
     undefined setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 
     undefined showPicker();


### PR DESCRIPTION
Hi! This PR stubs out a few methods on `<input>` and `<form>` elements, making Ladybird more useful when encountering forms that try to validate their input.