### PR TITLE
LibWeb: Fix crash in `apply_clip_overflow_rect`

### DIFF
--- a/Tests/LibWeb/Layout/expected/overflow-x-hidden-with-border-radius.txt
+++ b/Tests/LibWeb/Layout/expected/overflow-x-hidden-with-border-radius.txt
@@ -1,0 +1,6 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x118 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x102 children: not-inline
+      BlockContainer <div.box> at (9,9) content-size 100x100 positioned children: not-inline
+      BlockContainer <(anonymous)> at (8,110) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/overflow-x-hidden-with-border-radius.html
+++ b/Tests/LibWeb/Layout/input/overflow-x-hidden-with-border-radius.html
@@ -1,0 +1,10 @@
+<style>
+    .box {
+        border: 1px solid black;
+        width: 100px;
+        height: 100px;
+        border-radius: 9999px;
+        overflow-x: hidden;
+        position: relative;
+    }
+</style><div class="box"></div>

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -363,7 +363,7 @@ void PaintableBox::apply_clip_overflow_rect(PaintContext& context, PaintPhase ph
         clip_overflow();
     }
 
-    if (overflow_y == CSS::Overflow::Hidden || overflow_x == CSS::Overflow::Hidden) {
+    if (overflow_y == CSS::Overflow::Hidden && overflow_x == CSS::Overflow::Hidden) {
         auto border_radii_data = normalized_border_radii_data(ShrinkRadiiForBorders::Yes);
         if (border_radii_data.has_any_radius()) {
             auto corner_clipper = BorderRadiusCornerClipper::create(context, context.rounded_device_rect(*clip_rect), border_radii_data, CornerClip::Outside, BorderRadiusCornerClipper::UseCachedBitmap::No);

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -314,7 +314,7 @@ BorderRadiiData PaintableBox::normalized_border_radii_data(ShrinkRadiiForBorders
     return border_radius_data;
 }
 
-Optional<CSSPixelRect> PaintableBox::clip_rect() const
+Optional<CSSPixelRect> PaintableBox::calculate_overflow_clipped_rect() const
 {
     if (!m_clip_rect.has_value()) {
         // NOTE: stacking context should not be crossed while aggregating rectangle to
@@ -323,7 +323,7 @@ Optional<CSSPixelRect> PaintableBox::clip_rect() const
         // TODO: figure out if there are cases when stacking context should be
         // crossed to calculate correct clip rect
         if (!stacking_context() && containing_block() && containing_block()->paint_box()) {
-            m_clip_rect = containing_block()->paint_box()->clip_rect();
+            m_clip_rect = containing_block()->paint_box()->calculate_overflow_clipped_rect();
         }
 
         auto overflow_x = computed_values().overflow_x();
@@ -347,7 +347,7 @@ void PaintableBox::apply_clip_overflow_rect(PaintContext& context, PaintPhase ph
         return;
 
     // FIXME: Support more overflow variations.
-    auto clip_rect = this->clip_rect();
+    auto clip_rect = this->calculate_overflow_clipped_rect();
     auto overflow_x = computed_values().overflow_x();
     auto overflow_y = computed_values().overflow_y();
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -98,7 +98,7 @@ public:
         return m_overflow_data->scrollable_overflow_rect;
     }
 
-    Optional<CSSPixelRect> clip_rect() const;
+    Optional<CSSPixelRect> calculate_overflow_clipped_rect() const;
 
     void set_overflow_data(Optional<OverflowData> data) { m_overflow_data = move(data); }
     void set_containing_line_box_fragment(Optional<Layout::LineBoxFragmentCoordinate>);


### PR DESCRIPTION
Example page that crashes without this change:
```html
<style>
    .box {
        border: 1px solid black;
        width: 100px;
        height: 100px;
        border-radius: 9999px;
        overflow-x: hidden;
        position: relative;
    }
</style><div class="box"></div>
```