### PR TITLE
SoundPlayer: Keep track of the selected visualization in the config

### DIFF
--- a/Userland/Applications/SoundPlayer/CMakeLists.txt
+++ b/Userland/Applications/SoundPlayer/CMakeLists.txt
@@ -19,4 +19,4 @@ set(SOURCES
 )
 
 serenity_app(SoundPlayer ICON app-sound-player)
-target_link_libraries(SoundPlayer PRIVATE LibAudio LibCore LibDSP LibGfx LibGUI LibIPC LibMain LibThreading LibImageDecoderClient)
+target_link_libraries(SoundPlayer PRIVATE LibAudio LibConfig LibCore LibDSP LibGfx LibGUI LibIPC LibMain LibThreading LibImageDecoderClient)

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -14,6 +14,7 @@
 #include <AK/DeprecatedString.h>
 #include <AK/LexicalPath.h>
 #include <AK/SIMD.h>
+#include <LibConfig/Client.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -53,7 +54,16 @@ SoundPlayerWidgetAdvancedView::SoundPlayerWidgetAdvancedView(GUI::Window& window
     m_volume_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/audio-volume-medium.png"sv).release_value_but_fixme_should_propagate_errors();
     m_muted_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/audio-volume-muted.png"sv).release_value_but_fixme_should_propagate_errors();
 
-    m_visualization = m_player_view->add<BarsVisualizationWidget>();
+    auto visualization = Config::read_string("SoundPlayer"sv, "Preferences"sv, "Visualization"sv, "bars"sv);
+    if (visualization == "samples") {
+        m_visualization = m_player_view->add<SampleWidget>();
+    } else if (visualization == "album_cover") {
+        m_visualization = m_player_view->add<AlbumCoverVisualizationWidget>([this]() {
+            return get_image_from_music_file();
+        });
+    } else {
+        m_visualization = m_player_view->add<BarsVisualizationWidget>();
+    }
 
     m_playback_progress_slider = m_player_view->add<GUI::HorizontalSlider>();
     m_playback_progress_slider->set_fixed_height(20);

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
@@ -16,6 +16,7 @@
 #include <LibGUI/Slider.h>
 #include <LibGUI/Splitter.h>
 #include <LibGUI/Widget.h>
+#include <LibImageDecoderClient/Client.h>
 
 class SoundPlayerWidgetAdvancedView final : public GUI::Widget
     , public Player {
@@ -24,6 +25,7 @@ class SoundPlayerWidgetAdvancedView final : public GUI::Widget
 public:
     void set_nonlinear_volume_slider(bool nonlinear);
     void set_playlist_visible(bool visible);
+    RefPtr<Gfx::Bitmap> get_image_from_music_file();
 
     template<typename T, typename... Args>
     void set_visualization(Args... args)
@@ -53,13 +55,14 @@ protected:
     void keydown_event(GUI::KeyEvent&) override;
 
 private:
-    SoundPlayerWidgetAdvancedView(GUI::Window&, Audio::ConnectionToServer&);
+    SoundPlayerWidgetAdvancedView(GUI::Window&, Audio::ConnectionToServer&, ImageDecoderClient::Client&);
 
     void sync_previous_next_actions();
 
     void drag_enter_event(GUI::DragEvent& event) override;
     void drop_event(GUI::DropEvent& event) override;
     GUI::Window& m_window;
+    ImageDecoderClient::Client& m_image_decoder_client;
 
     RefPtr<GUI::HorizontalSplitter> m_splitter;
     RefPtr<GUI::Widget> m_player_view;


### PR DESCRIPTION
Before, the SoundPlayer would not keep track of what visualization the user had selected. So, if the user selected a certain visualization (e.g. album cover), and restarted SoundPlayer, it would return to the default (which is bars).

Now, we use `LibConfig` to keep track of the selected visualization, which is a nice UX improvement in my opinion :^)

https://user-images.githubusercontent.com/71222289/226192589-9a962957-2108-45fd-ac49-61e666808cfb.mp4

