### PR TITLE
Presenter: Change how full-screening works, and add a "Resize to Fit Content" action

### DIFF
--- a/Userland/Applications/Presenter/PresenterWidget.cpp
+++ b/Userland/Applications/Presenter/PresenterWidget.cpp
@@ -83,8 +83,9 @@ ErrorOr<void> PresenterWidget::initialize_menubar()
             update_slides_actions();
         }
     });
-    m_full_screen_action = GUI::Action::create("&Full Screen", { KeyModifier::Mod_Shift, KeyCode::Key_F5 }, { KeyCode::Key_F11 }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/fullscreen.png"sv)), [this](auto&) {
-        this->window()->set_fullscreen(true);
+    m_full_screen_action = GUI::Action::create("Toggle &Full Screen", { KeyModifier::Mod_Shift, KeyCode::Key_F5 }, { KeyCode::Key_F11 }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/fullscreen.png"sv)), [this](auto&) {
+        auto* window = this->window();
+        window->set_fullscreen(!window->is_fullscreen());
     });
     m_present_from_first_slide_action = GUI::Action::create("Present From First &Slide", { KeyCode::Key_F5 }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/play.png"sv)), [this](auto&) {
         if (m_current_presentation) {

--- a/Userland/Applications/Presenter/PresenterWidget.cpp
+++ b/Userland/Applications/Presenter/PresenterWidget.cpp
@@ -100,8 +100,17 @@ ErrorOr<void> PresenterWidget::initialize_menubar()
         auto* window = this->window();
         window->set_fullscreen(!window->is_fullscreen());
     });
+    m_resize_to_fit_content_action = GUI::Action::create("Resize to Fit &Content", { KeyModifier::Mod_Alt, KeyCode::Key_C }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/scale.png"sv)), [this](auto&) {
+        if (m_current_presentation) {
+            auto presentation_size = m_current_presentation->normative_size();
+            auto* window = this->window();
+
+            window->resize(window->size().match_aspect_ratio(presentation_size.aspect_ratio(), Orientation::Horizontal));
+        }
+    });
 
     TRY(view_menu->try_add_action(*m_full_screen_action));
+    TRY(view_menu->try_add_action(*m_resize_to_fit_content_action));
 
     update_slides_actions();
 

--- a/Userland/Applications/Presenter/PresenterWidget.cpp
+++ b/Userland/Applications/Presenter/PresenterWidget.cpp
@@ -83,10 +83,6 @@ ErrorOr<void> PresenterWidget::initialize_menubar()
             update_slides_actions();
         }
     });
-    m_full_screen_action = GUI::Action::create("Toggle &Full Screen", { KeyModifier::Mod_Shift, KeyCode::Key_F5 }, { KeyCode::Key_F11 }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/fullscreen.png"sv)), [this](auto&) {
-        auto* window = this->window();
-        window->set_fullscreen(!window->is_fullscreen());
-    });
     m_present_from_first_slide_action = GUI::Action::create("Present From First &Slide", { KeyCode::Key_F5 }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/play.png"sv)), [this](auto&) {
         if (m_current_presentation) {
             m_current_presentation->go_to_first_slide();
@@ -97,8 +93,15 @@ ErrorOr<void> PresenterWidget::initialize_menubar()
 
     TRY(presentation_menu->try_add_action(*m_next_slide_action));
     TRY(presentation_menu->try_add_action(*m_previous_slide_action));
-    TRY(presentation_menu->try_add_action(*m_full_screen_action));
     TRY(presentation_menu->try_add_action(*m_present_from_first_slide_action));
+
+    auto view_menu = TRY(window->try_add_menu("&View"));
+    m_full_screen_action = GUI::Action::create("Toggle &Full Screen", { KeyModifier::Mod_Shift, KeyCode::Key_F5 }, { KeyCode::Key_F11 }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/fullscreen.png"sv)), [this](auto&) {
+        auto* window = this->window();
+        window->set_fullscreen(!window->is_fullscreen());
+    });
+
+    TRY(view_menu->try_add_action(*m_full_screen_action));
 
     update_slides_actions();
 

--- a/Userland/Applications/Presenter/PresenterWidget.h
+++ b/Userland/Applications/Presenter/PresenterWidget.h
@@ -49,4 +49,5 @@ private:
     RefPtr<GUI::Action> m_present_from_first_slide_action;
 
     RefPtr<GUI::Action> m_full_screen_action;
+    RefPtr<GUI::Action> m_resize_to_fit_content_action;
 };

--- a/Userland/Applications/Presenter/PresenterWidget.h
+++ b/Userland/Applications/Presenter/PresenterWidget.h
@@ -46,6 +46,7 @@ private:
     OwnPtr<Presentation> m_current_presentation;
     RefPtr<GUI::Action> m_next_slide_action;
     RefPtr<GUI::Action> m_previous_slide_action;
-    RefPtr<GUI::Action> m_full_screen_action;
     RefPtr<GUI::Action> m_present_from_first_slide_action;
+
+    RefPtr<GUI::Action> m_full_screen_action;
 };


### PR DESCRIPTION
I found one or two nit-picky issues with the Presenter application whilst I was looking for some yaks in Serenity:
- Pressing Shift+F5 in Presenter (the full-screen key bind) did not un-fullscreen the window.
- Trying to get the content to fit perfectly when resizing the window can be quite annoying.

This PR addresses both of those:
- The "Full Screen" action has been changed to "Toggle Full Screen" and its behavior has been updated accordingly.
- A showcase of the new "Resize to Fit Content" action is shown below. 
  With this new action, it is possible to automatically adjust the window's size to match the content's aspect ratio. When it is resizing, it will maintain the width of the window, but adjust the height to match the aspect ratio of the content.

https://user-images.githubusercontent.com/71222289/226206113-a03a7fdf-d0d6-49dd-a1ef-b79bfadd1732.mp4

