### PR TITLE
LibWeb+LibGfx: Add support for scalable and theme-able checkboxes using SDFs     

### DIFF
--- a/Base/res/html/misc/accent-color.html
+++ b/Base/res/html/misc/accent-color.html
@@ -1,0 +1,70 @@
+<style>
+  .big {
+    width: 64px;
+    height: 64px;
+  }
+  .color-light {
+    accent-color: wheat;
+  }
+  .color-dark {
+    accent-color: rebeccapurple
+  }
+</style>
+
+<div>
+  <b>System color</b><br>
+  <input type="checkbox" checked></input>
+  <input type="checkbox" ></input>
+  <input class="indeterminate" type="checkbox"></input>
+  <input type="checkbox" checked disabled></input>
+  <input type="checkbox" disabled></input>
+  <input class="indeterminate" type="checkbox" disabled></input>
+
+  <input class="big" type="checkbox" checked></input>
+  <input class="big" type="checkbox" ></input>
+  <input class="big indeterminate" type="checkbox"></input>
+  <input class="big" type="checkbox" checked disabled></input>
+  <input class="big" type="checkbox" disabled></input>
+  <input class="big indeterminate" type="checkbox" disabled></input>
+</div>
+<br>
+<div class="color-dark">
+  <b>Dark accent color</b><br>
+  <input type="checkbox" checked></input>
+  <input type="checkbox" ></input>
+  <input class="indeterminate" type="checkbox"></input>
+  <input type="checkbox" checked disabled></input>
+  <input type="checkbox" disabled></input>
+  <input class="indeterminate" type="checkbox" disabled></input>
+
+  <input class="big" type="checkbox" checked></input>
+  <input class="big" type="checkbox" ></input>
+  <input class="big indeterminate" type="checkbox"></input>
+  <input class="big" type="checkbox" checked disabled></input>
+  <input class="big" type="checkbox" disabled></input>
+  <input class="big indeterminate" type="checkbox" disabled></input>
+</div>
+<br>
+<div class="color-light">
+  <b>Light accent color</b><br>
+  <input type="checkbox" checked></input>
+  <input type="checkbox" ></input>
+  <input class="indeterminate" type="checkbox"></input>
+  <input type="checkbox" checked disabled></input>
+  <input type="checkbox" disabled></input>
+  <input class="indeterminate" type="checkbox" disabled></input>
+
+  <input class="big" type="checkbox" checked></input>
+  <input class="big" type="checkbox" ></input>
+  <input class="big indeterminate" type="checkbox"></input>
+  <input class="big" type="checkbox" checked disabled></input>
+  <input class="big" type="checkbox" disabled></input>
+  <input class="big indeterminate" type="checkbox" disabled></input>
+</div>
+<br>
+<script>
+document.querySelectorAll(".indeterminate").forEach(checkbox => {
+  checkbox.indeterminate = true;
+});
+
+</script>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -140,6 +140,7 @@
             <li><a href="transform.html">Transforms</a></li>
             <li><a href="clip.html">Clip</a></li>
             <li><a href="cursor.html">Cursor</a></li>
+            <li><a href="accent-color.html">accent-color</a></li>
             <li><h3>Features</h3></li>
             <li><a href="css.html">Basic functionality</a></li>
             <li><a href="colors.html">css colors</a></li>

--- a/Userland/Libraries/LibGfx/GrayscaleBitmap.h
+++ b/Userland/Libraries/LibGfx/GrayscaleBitmap.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Size.h"
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
+#include <AK/StringView.h>
+
+namespace Gfx {
+
+class GrayscaleBitmap {
+public:
+    GrayscaleBitmap() = delete;
+    constexpr GrayscaleBitmap(ReadonlyBytes data, unsigned width, unsigned height)
+        : m_data(data)
+        , m_size(width, height)
+    {
+        VERIFY(width * height == data.size());
+    }
+
+    constexpr u8 pixel_at(unsigned x, unsigned y) const { return m_data[y * width() + x]; }
+    constexpr ReadonlyBytes data() const { return m_data; }
+
+    constexpr IntSize size() const { return m_size; }
+    constexpr unsigned width() const { return m_size.width(); }
+    constexpr unsigned height() const { return m_size.height(); }
+
+private:
+    ReadonlyBytes m_data {};
+    IntSize m_size {};
+};
+
+}

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -15,6 +15,7 @@
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Gradients.h>
+#include <LibGfx/GrayscaleBitmap.h>
 #include <LibGfx/PaintStyle.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
@@ -113,6 +114,7 @@ public:
     void draw_glyph_or_emoji(FloatPoint, u32, Font const&, Color);
     void draw_glyph_or_emoji(FloatPoint, Utf8CodePointIterator&, Font const&, Color);
     void draw_circle_arc_intersecting(IntRect const&, IntPoint, int radius, Color, int thickness);
+    void draw_signed_distance_field(IntRect const& dst_rect, Color, Gfx::GrayscaleBitmap const&, float smoothing);
 
     // Streamlined text drawing routine that does no wrapping/elision/alignment.
     void draw_text_run(IntPoint baseline_start, Utf8View const&, Font const&, Color);

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -168,6 +168,7 @@ public:
     float flex_grow() const { return m_noninherited.flex_grow; }
     float flex_shrink() const { return m_noninherited.flex_shrink; }
     int order() const { return m_noninherited.order; }
+    Optional<Color> accent_color() const { return m_inherited.accent_color; }
     CSS::AlignContent align_content() const { return m_noninherited.align_content; }
     CSS::AlignItems align_items() const { return m_noninherited.align_items; }
     CSS::AlignSelf align_self() const { return m_noninherited.align_self; }
@@ -244,6 +245,7 @@ protected:
         int font_weight { InitialValues::font_weight() };
         CSS::FontVariant font_variant { InitialValues::font_variant() };
         Color color { InitialValues::color() };
+        Optional<Color> accent_color {};
         CSS::Cursor cursor { InitialValues::cursor() };
         CSS::ImageRendering image_rendering { InitialValues::image_rendering() };
         CSS::PointerEvents pointer_events { InitialValues::pointer_events() };
@@ -382,6 +384,7 @@ public:
     void set_flex_grow(float value) { m_noninherited.flex_grow = value; }
     void set_flex_shrink(float value) { m_noninherited.flex_shrink = value; }
     void set_order(int value) { m_noninherited.order = value; }
+    void set_accent_color(Color value) { m_inherited.accent_color = value; }
     void set_align_content(CSS::AlignContent value) { m_noninherited.align_content = value; }
     void set_align_items(CSS::AlignItems value) { m_noninherited.align_items = value; }
     void set_align_self(CSS::AlignSelf value) { m_noninherited.align_self = value; }

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -64,33 +64,6 @@ button:hover, input[type=submit]:hover, input[type=button]:hover, input[type=res
     background-color: -libweb-palette-hover-highlight;
 }
 
-input[type=checkbox] {
-    display: inline-block;
-    width: 12px;
-    height: 12px;
-    margin: 2px;
-    border: 1px solid -libweb-palette-threed-shadow1;
-    background-repeat: no-repeat;
-    background-size: cover;
-}
-
-input[type=checkbox]:checked {
-    /*
-    This roughly resembles ClassicStylePainter's paint_check_box() while uncoupling the styling from LibGfx, similar to
-    <button> above. This is a simple checkmark that still looks ok at 2x scale.
-    Eventually we should respect the `accent-color` property here, which may require going back to an implementation via
-    CheckBoxPaintable::paint().
-    */
-    image-rendering: pixelated;
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAABHNCSVQICAgIfAhkiAAAAEhJREFUKFNjYBgs4D/MIYxEuAiuGKiWkZAGFMUgw5mQbECWBAljKAYJwmxAl0Tnw81FdhK6DcgGYtWA0xlw1TgY2GzCoZQWwgCU1woFwvnCFQAAAABJRU5ErkJggg==);
-}
-
-input[type=checkbox]:indeterminate {
-    image-rendering: pixelated;
-    /* FIXME: Eventually respect the `accent-color` property here. */
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAAXNSR0IArs4c6QAAACZJREFUKFNjZCARMJKonmGQa/hPwD9g5yP7gWQNRAXYIA8lovwAAHYYAg3vRihbAAAAAElFTkSuQmCC);
-}
-
 option {
     display: none;
 }

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1,4 +1,14 @@
 {
+  "accent-color": {
+    "inherited": true,
+    "initial": "auto",
+    "valid-types": [
+      "color"
+    ],
+    "valid-identifiers": [
+      "auto"
+    ]
+  },
   "align-content": {
     "inherited": false,
     "initial": "stretch",

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -375,6 +375,14 @@ CSS::TransformOrigin StyleProperties::transform_origin() const
     return { x_value.value(), y_value.value() };
 }
 
+Optional<Color> StyleProperties::accent_color(Layout::NodeWithStyle const& node) const
+{
+    auto value = property(CSS::PropertyID::AccentColor);
+    if (value->has_color())
+        return value->to_color(node);
+    return {};
+}
+
 Optional<CSS::AlignContent> StyleProperties::align_content() const
 {
     auto value = property(CSS::PropertyID::AlignContent);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -68,6 +68,7 @@ public:
     float flex_grow() const;
     float flex_shrink() const;
     int order() const;
+    Optional<Color> accent_color(Layout::NodeWithStyle const&) const;
     Optional<CSS::AlignContent> align_content() const;
     Optional<CSS::AlignItems> align_items() const;
     Optional<CSS::AlignSelf> align_self() const;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -462,6 +462,10 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     if (justify_content.has_value())
         computed_values.set_justify_content(justify_content.value());
 
+    auto accent_color = computed_style.accent_color(*this);
+    if (accent_color.has_value())
+        computed_values.set_accent_color(accent_color.value());
+
     auto align_content = computed_style.align_content();
     if (align_content.has_value())
         computed_values.set_align_content(align_content.value());

--- a/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.cpp
@@ -1,10 +1,14 @@
 /*
  * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <LibGUI/Event.h>
+#include <LibGfx/AntiAliasingPainter.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/GrayscaleBitmap.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/Layout/CheckBox.h>
@@ -13,7 +17,60 @@
 
 namespace Web::Painting {
 
-JS::NonnullGCPtr<CheckBoxPaintable> CheckBoxPaintable::create(Layout::CheckBox const& layout_box)
+// A 16x16 signed distance field for the checkbox's tick (slightly rounded):
+static Array<u8, 16 * 16> s_check_mark_sdf {
+    254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 251, 254, 254, 254,
+    254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 231, 194, 189, 218, 254, 254,
+    254, 254, 254, 254, 254, 254, 254, 254, 254, 245, 193, 142, 131, 165, 205, 254,
+    254, 254, 254, 254, 254, 254, 254, 254, 254, 209, 156, 105, 78, 116, 174, 237,
+    254, 254, 254, 254, 254, 254, 254, 254, 226, 173, 120, 69, 79, 132, 185, 243,
+    254, 254, 254, 254, 254, 254, 254, 243, 190, 138, 85, 62, 115, 167, 219, 254,
+    254, 254, 227, 203, 212, 249, 254, 207, 154, 102, 50, 98, 149, 202, 254, 254,
+    254, 225, 180, 141, 159, 204, 224, 171, 119, 67, 81, 134, 186, 238, 254, 254,
+    243, 184, 135, 90, 113, 157, 188, 136, 84, 64, 116, 169, 221, 254, 254, 254,
+    237, 174, 118, 71, 68, 113, 153, 100, 48, 100, 152, 204, 254, 254, 254, 254,
+    254, 208, 162, 116, 71, 67, 107, 65, 83, 135, 187, 240, 254, 254, 254, 254,
+    254, 251, 206, 162, 116, 71, 43, 66, 119, 171, 223, 254, 254, 254, 254, 254,
+    254, 254, 251, 206, 162, 116, 73, 102, 154, 207, 254, 254, 254, 254, 254, 254,
+    254, 254, 254, 251, 206, 162, 124, 139, 190, 242, 254, 254, 254, 254, 254, 254,
+    254, 254, 254, 254, 251, 210, 187, 194, 229, 254, 254, 254, 254, 254, 254, 254,
+    254, 254, 254, 254, 254, 254, 251, 254, 254, 254, 254, 254, 254, 254, 254, 254
+};
+
+// A 16x16 signed distance field for an indeterminate checkbox (rounded line)
+// Note: We could use the AA fill_rect_with_rounded_corners() for this in future,
+// though right now it can't draw at subpixel accuracy (so is misaligned and jitters when scaling).
+static Array<u8, 16 * 16> s_check_indeterminate {
+    254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254,
+    254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254,
+    254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254,
+    254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254,
+    254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254,
+    254, 254, 254, 239, 211, 209, 209, 209, 209, 209, 209, 211, 237, 254, 254, 254,
+    254, 254, 252, 195, 151, 145, 145, 145, 145, 145, 145, 150, 193, 250, 254, 254,
+    254, 254, 243, 179, 115, 81, 81, 81, 81, 81, 81, 113, 177, 241, 254, 254,
+    254, 254, 243, 179, 115, 79, 79, 79, 79, 79, 79, 113, 177, 241, 254, 254,
+    254, 254, 251, 194, 149, 143, 143, 143, 143, 143, 143, 148, 192, 250, 254, 254,
+    254, 254, 254, 237, 210, 207, 207, 207, 207, 207, 207, 209, 236, 254, 254, 254,
+    254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254,
+    254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254,
+    254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254,
+    254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254,
+    254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254
+};
+
+static constexpr Gfx::GrayscaleBitmap check_mark_sdf()
+{
+    return Gfx::GrayscaleBitmap(s_check_mark_sdf, 16, 16);
+}
+
+static constexpr Gfx::GrayscaleBitmap check_indeterminate_sdf()
+{
+    return Gfx::GrayscaleBitmap(s_check_indeterminate, 16, 16);
+}
+
+JS::NonnullGCPtr<CheckBoxPaintable>
+CheckBoxPaintable::create(Layout::CheckBox const& layout_box)
 {
     return layout_box.heap().allocate_without_realm<CheckBoxPaintable>(layout_box);
 }
@@ -31,6 +88,75 @@ Layout::CheckBox const& CheckBoxPaintable::layout_box() const
 Layout::CheckBox& CheckBoxPaintable::layout_box()
 {
     return static_cast<Layout::CheckBox&>(layout_node());
+}
+
+void CheckBoxPaintable::paint(PaintContext& context, PaintPhase phase) const
+{
+    if (!is_visible())
+        return;
+
+    PaintableBox::paint(context, phase);
+
+    if (phase != PaintPhase::Foreground)
+        return;
+
+    auto const& checkbox = static_cast<HTML::HTMLInputElement const&>(layout_box().dom_node());
+    bool enabled = layout_box().dom_node().enabled();
+    Gfx::AntiAliasingPainter painter { context.painter() };
+    auto checkbox_rect = context.enclosing_device_rect(absolute_rect()).to_type<int>();
+    auto checkbox_radius = checkbox_rect.width() / 5;
+
+    auto& palette = context.palette();
+
+    auto shade = [&](Color color, float amount) {
+        return color.mixed_with(palette.is_dark() ? Color::Black : Color::White, amount);
+    };
+
+    auto modify_color = [&](Color color) {
+        if (being_pressed() && enabled)
+            return shade(color, 0.3f);
+        return color;
+    };
+
+    auto base_text_color = palette.color(ColorRole::BaseText);
+    auto accent = computed_values().accent_color().value_or(palette.color(ColorRole::Accent));
+    auto base = shade(base_text_color.inverted(), 0.8f);
+    auto dark_gray = shade(base_text_color, 0.3f);
+    auto gray = shade(dark_gray, 0.4f);
+    auto mid_gray = shade(gray, 0.3f);
+    auto light_gray = shade(mid_gray, 0.3f);
+
+    auto increase_contrast = [&](Color color, Color background) {
+        auto constexpr min_contrast = 2;
+        if (color.contrast_ratio(background) < min_contrast) {
+            color = color.inverted();
+            if (color.contrast_ratio(background) > min_contrast)
+                return color;
+        }
+        return color;
+    };
+
+    // Little heuristic that smaller things look better with more smoothness.
+    float smoothness = 1.0f / (max(checkbox_rect.width(), checkbox_rect.height()) / 2);
+    if (checkbox.checked() && !checkbox.indeterminate()) {
+        auto background_color = enabled ? accent : mid_gray;
+        painter.fill_rect_with_rounded_corners(checkbox_rect, modify_color(background_color), checkbox_radius);
+        auto tick_color = increase_contrast(base, background_color);
+        if (!enabled)
+            tick_color = shade(tick_color, 0.5f);
+        context.painter().draw_signed_distance_field(checkbox_rect, tick_color, check_mark_sdf(), smoothness);
+    } else {
+        auto background_color = enabled ? base : light_gray;
+        auto border_thickness = max(1, checkbox_rect.width() / 10);
+        painter.fill_rect_with_rounded_corners(checkbox_rect, modify_color(enabled ? gray : mid_gray), checkbox_radius);
+        painter.fill_rect_with_rounded_corners(checkbox_rect.shrunken(border_thickness, border_thickness, border_thickness, border_thickness),
+            enabled ? base : light_gray, max(0, checkbox_radius - border_thickness));
+        if (checkbox.indeterminate()) {
+            auto dash_color = increase_contrast(dark_gray, background_color);
+            context.painter().draw_signed_distance_field(checkbox_rect,
+                modify_color(enabled ? dash_color : shade(dash_color, 0.3f)), check_indeterminate_sdf(), smoothness);
+        }
+    }
 }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.h
@@ -20,6 +20,8 @@ public:
     Layout::CheckBox const& layout_box() const;
     Layout::CheckBox& layout_box();
 
+    virtual void paint(PaintContext&, PaintPhase) const override;
+
 private:
     CheckBoxPaintable(Layout::CheckBox const&);
 };


### PR DESCRIPTION
This PR adds new smoothly scaling check boxes (using a simple singed distance field),  that respect the system them and/or the `accent-color` CSS property.


Check boxes are just a start here, I think this method could be used to add more scalable UI in other places too, without too much extra complexity over bitmaps :^)

|                                                                                                                 | Testing all themes                                                                                                               |
|-----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
|![image](https://user-images.githubusercontent.com/11597044/227042378-5ad7f583-1d42-416a-8771-fc0b38284e11.png) | ![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/11597044/226440942-d32fe3a6-f057-47ef-9275-908e1f92d949.gif) |

**Smooth scaling demo:**

[screen-capture - 2023-03-20T001833.748.webm](https://user-images.githubusercontent.com/11597044/226219497-019273b6-b0eb-428a-af08-dc33fe9a2773.webm)