### PR TITLE
LibGfx: Allow OpenType glyphs to extend beyond the em square

### DIFF
--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -59,6 +59,7 @@ public:
     Glyph glyph(u32 code_point, GlyphSubpixelOffset) const override { return glyph(code_point); }
 
     float glyph_left_bearing(u32) const override { return 0; }
+    float glyph_ascender(u32) const override { return 0; }
 
     Glyph raw_glyph(u32 code_point) const;
     bool contains_glyph(u32 code_point) const override;

--- a/Userland/Libraries/LibGfx/Font/Font.h
+++ b/Userland/Libraries/LibGfx/Font/Font.h
@@ -178,6 +178,7 @@ public:
     virtual bool contains_glyph(u32 code_point) const = 0;
 
     virtual float glyph_left_bearing(u32 code_point) const = 0;
+    virtual float glyph_ascender(u32 code_point) const = 0;
     virtual float glyph_width(u32 code_point) const = 0;
     virtual float glyph_or_emoji_width(Utf8CodePointIterator&) const = 0;
     virtual float glyph_or_emoji_width(Utf32CodePointIterator&) const = 0;

--- a/Userland/Libraries/LibGfx/Font/OpenType/Glyf.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Glyf.cpp
@@ -353,15 +353,15 @@ void Glyf::Glyph::rasterize_impl(Gfx::PathRasterizer& rasterizer, Gfx::AffineTra
     rasterizer.draw_path(path);
 }
 
-RefPtr<Gfx::Bitmap> Glyf::Glyph::rasterize_simple(i16 font_ascender, i16 font_descender, float x_scale, float y_scale, Gfx::GlyphSubpixelOffset subpixel_offset) const
+RefPtr<Gfx::Bitmap> Glyf::Glyph::rasterize_simple(float x_scale, float y_scale, Gfx::GlyphSubpixelOffset subpixel_offset) const
 {
     u32 width = (u32)(ceilf((m_xmax - m_xmin) * x_scale)) + 2;
-    u32 height = (u32)(ceilf((font_ascender - font_descender) * y_scale)) + 2;
+    u32 height = (u32)(ceilf((m_ymax - m_ymin) * y_scale)) + 2;
     Gfx::PathRasterizer rasterizer(Gfx::IntSize(width, height));
     auto affine = Gfx::AffineTransform()
                       .translate(subpixel_offset.to_float_point())
                       .scale(x_scale, -y_scale)
-                      .translate(-m_xmin, -font_ascender);
+                      .translate(-m_xmin, -m_ymax);
     rasterize_impl(rasterizer, affine);
     return rasterizer.accumulate();
 }

--- a/Userland/Libraries/LibGfx/Font/OpenType/Glyf.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Glyf.h
@@ -57,13 +57,13 @@ public:
             }
         }
         template<typename GlyphCb>
-        RefPtr<Gfx::Bitmap> rasterize(i16 font_ascender, i16 font_descender, float x_scale, float y_scale, Gfx::GlyphSubpixelOffset subpixel_offset, GlyphCb glyph_callback) const
+        RefPtr<Gfx::Bitmap> rasterize(float x_scale, float y_scale, Gfx::GlyphSubpixelOffset subpixel_offset, GlyphCb glyph_callback) const
         {
             switch (m_type) {
             case Type::Simple:
-                return rasterize_simple(font_ascender, font_descender, x_scale, y_scale, subpixel_offset);
+                return rasterize_simple(x_scale, y_scale, subpixel_offset);
             case Type::Composite:
-                return rasterize_composite(font_ascender, font_descender, x_scale, y_scale, subpixel_offset, glyph_callback);
+                return rasterize_composite(x_scale, y_scale, subpixel_offset, glyph_callback);
             }
             VERIFY_NOT_REACHED();
         }
@@ -98,7 +98,7 @@ public:
         };
 
         void rasterize_impl(Gfx::PathRasterizer&, Gfx::AffineTransform const&) const;
-        RefPtr<Gfx::Bitmap> rasterize_simple(i16 ascender, i16 descender, float x_scale, float y_scale, Gfx::GlyphSubpixelOffset) const;
+        RefPtr<Gfx::Bitmap> rasterize_simple(float x_scale, float y_scale, Gfx::GlyphSubpixelOffset) const;
 
         template<typename GlyphCb>
         void rasterize_composite_loop(Gfx::PathRasterizer& rasterizer, Gfx::AffineTransform const& transform, GlyphCb glyph_callback) const
@@ -124,15 +124,15 @@ public:
         }
 
         template<typename GlyphCb>
-        RefPtr<Gfx::Bitmap> rasterize_composite(i16 font_ascender, i16 font_descender, float x_scale, float y_scale, Gfx::GlyphSubpixelOffset subpixel_offset, GlyphCb glyph_callback) const
+        RefPtr<Gfx::Bitmap> rasterize_composite(float x_scale, float y_scale, Gfx::GlyphSubpixelOffset subpixel_offset, GlyphCb glyph_callback) const
         {
-            u32 width = (u32)(ceilf((m_xmax - m_xmin) * x_scale)) + 1;
-            u32 height = (u32)(ceilf((font_ascender - font_descender) * y_scale)) + 1;
+            u32 width = (u32)(ceilf((m_xmax - m_xmin) * x_scale)) + 2;
+            u32 height = (u32)(ceilf((m_ymax - m_ymin) * y_scale)) + 2;
             Gfx::PathRasterizer rasterizer(Gfx::IntSize(width, height));
             auto affine = Gfx::AffineTransform()
                               .translate(subpixel_offset.to_float_point())
                               .scale(x_scale, -y_scale)
-                              .translate(-m_xmin, -font_ascender);
+                              .translate(-m_xmin, -m_ymax);
 
             rasterize_composite_loop(rasterizer, affine, glyph_callback);
 

--- a/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
@@ -97,6 +97,12 @@ float ScaledFont::glyph_left_bearing(u32 code_point) const
     return glyph_metrics(id).left_side_bearing;
 }
 
+float ScaledFont::glyph_ascender(u32 code_point) const
+{
+    auto id = glyph_id_for_code_point(code_point);
+    return glyph_metrics(id).ascender;
+}
+
 float ScaledFont::glyph_width(u32 code_point) const
 {
     auto id = glyph_id_for_code_point(code_point);

--- a/Userland/Libraries/LibGfx/Font/ScaledFont.h
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.h
@@ -45,6 +45,7 @@ public:
     virtual u16 weight() const override { return m_font->weight(); }
     virtual Gfx::Glyph glyph(u32 code_point) const override;
     virtual float glyph_left_bearing(u32 code_point) const override;
+    virtual float glyph_ascender(u32 code_point) const override;
     virtual Glyph glyph(u32 code_point, GlyphSubpixelOffset) const override;
     virtual bool contains_glyph(u32 code_point) const override { return m_font->glyph_id_for_code_point(code_point) > 0; }
     virtual float glyph_width(u32 code_point) const override;

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1362,7 +1362,7 @@ FLATTEN void Painter::draw_glyph(FloatPoint point, u32 code_point, Color color)
 
 FLATTEN void Painter::draw_glyph(FloatPoint point, u32 code_point, Font const& font, Color color)
 {
-    auto top_left = point + FloatPoint(font.glyph_left_bearing(code_point), 0);
+    auto top_left = point + FloatPoint(font.glyph_left_bearing(code_point), font.glyph_ascender(code_point));
     auto glyph_position = Gfx::GlyphRasterPosition::get_nearest_fit_for(top_left);
     auto glyph = font.glyph(code_point, glyph_position.subpixel_offset);
 


### PR DESCRIPTION
Basically, this aims to fix the problem pictured down below.

Before:
![before](https://user-images.githubusercontent.com/25061393/226220358-9a1c6bf8-c717-43f3-8839-5c072fa53620.png)

And after:
![after](https://user-images.githubusercontent.com/25061393/226220373-f8bc849c-d08c-4776-8198-14f8f991a6b0.png)
