### PR TITLE
LibWeb: Implement indeterminate checkboxes

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -70,6 +70,8 @@ input[type=checkbox] {
     height: 12px;
     margin: 2px;
     border: 1px solid -libweb-palette-threed-shadow1;
+    background-repeat: no-repeat;
+    background-size: cover;
 }
 
 input[type=checkbox]:checked {

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -83,6 +83,12 @@ input[type=checkbox]:checked {
     background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAABHNCSVQICAgIfAhkiAAAAEhJREFUKFNjYBgs4D/MIYxEuAiuGKiWkZAGFMUgw5mQbECWBAljKAYJwmxAl0Tnw81FdhK6DcgGYtWA0xlw1TgY2GzCoZQWwgCU1woFwvnCFQAAAABJRU5ErkJggg==);
 }
 
+input[type=checkbox]:indeterminate {
+    image-rendering: pixelated;
+    /* FIXME: Eventually respect the `accent-color` property here. */
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAAXNSR0IArs4c6QAAACZJREFUKFNjZCARMJKonmGQa/hPwD9g5yP7gWQNRAXYIA8lovwAAHYYAg3vRihbAAAAAElFTkSuQmCC);
+}
+
 option {
     display: none;
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -447,6 +447,8 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Active);
         if (pseudo_name.equals_ignoring_ascii_case("checked"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Checked);
+        if (pseudo_name.equals_ignoring_ascii_case("indeterminate"sv))
+            return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Indeterminate);
         if (pseudo_name.equals_ignoring_ascii_case("disabled"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Disabled);
         if (pseudo_name.equals_ignoring_ascii_case("empty"sv))

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -105,6 +105,7 @@ public:
                 Disabled,
                 Enabled,
                 Checked,
+                Indeterminate,
                 Is,
                 Not,
                 Where,
@@ -275,6 +276,8 @@ constexpr StringView pseudo_class_name(Selector::SimpleSelector::PseudoClass::Ty
         return "enabled"sv;
     case Selector::SimpleSelector::PseudoClass::Type::Checked:
         return "checked"sv;
+    case Selector::SimpleSelector::PseudoClass::Type::Indeterminate:
+        return "indeterminate"sv;
     case Selector::SimpleSelector::PseudoClass::Type::Active:
         return "active"sv;
     case Selector::SimpleSelector::PseudoClass::Type::NthChild:

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -89,8 +89,10 @@ static inline bool matches_checked_pseudo_class(DOM::Element const& element)
         }
     }
 
-    // FIXME: - option elements whose selectedness is true
-
+    // - option elements whose selectedness is true
+    if (is<HTML::HTMLOptionElement>(element)) {
+        return static_cast<HTML::HTMLOptionElement const&>(element).selected();
+    }
     return false;
 }
 

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -441,6 +441,9 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::Checked:
                     pseudo_class_description = "Checked";
                     break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Indeterminate:
+                    pseudo_class_description = "Indeterminate";
+                    break;
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::Not:
                     pseudo_class_description = "Not";
                     break;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -107,6 +107,13 @@ void HTMLInputElement::set_checked_binding(bool checked)
     }
 }
 
+// https://html.spec.whatwg.org/multipage/input.html#dom-input-indeterminate
+void HTMLInputElement::set_indeterminate(bool value)
+{
+    // On setting, it must be set to the new value. It has no effect except for changing the appearance of checkbox controls.
+    m_indeterminate = value;
+}
+
 // https://html.spec.whatwg.org/multipage/input.html#dom-input-files
 JS::GCPtr<FileAPI::FileList> HTMLInputElement::files()
 {
@@ -797,14 +804,15 @@ void HTMLInputElement::set_checked_within_group()
 void HTMLInputElement::legacy_pre_activation_behavior()
 {
     m_before_legacy_pre_activation_behavior_checked = checked();
+    m_before_legacy_pre_activation_behavior_indeterminate = indeterminate();
 
     // 1. If this element's type attribute is in the Checkbox state, then set
     // this element's checkedness to its opposite value (i.e. true if it is
     // false, false if it is true) and set this element's indeterminate IDL
     // attribute to false.
-    // FIXME: Set indeterminate to false when that exists.
     if (type_state() == TypeAttributeState::Checkbox) {
         set_checked(!checked(), ChangeSource::User);
+        set_indeterminate(false);
     }
 
     // 2. If this element's type attribute is in the Radio Button state, then
@@ -834,6 +842,7 @@ void HTMLInputElement::legacy_cancelled_activation_behavior()
     // to the values they had before the legacy-pre-activation behavior was run.
     if (type_state() == TypeAttributeState::Checkbox) {
         set_checked(m_before_legacy_pre_activation_behavior_checked, ChangeSource::Programmatic);
+        set_indeterminate(m_before_legacy_pre_activation_behavior_indeterminate);
     }
 
     // 2. If this element 's type attribute is in the Radio Button state, then

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -78,6 +78,9 @@ public:
     bool checked_binding() const { return checked(); }
     void set_checked_binding(bool);
 
+    bool indeterminate() const { return m_indeterminate; };
+    void set_indeterminate(bool);
+
     void did_edit_text_node(Badge<BrowsingContext>);
 
     JS::GCPtr<FileAPI::FileList> files();
@@ -156,6 +159,9 @@ private:
     JS::GCPtr<DOM::Text> m_text_node;
     bool m_checked { false };
 
+    // https://html.spec.whatwg.org/multipage/input.html#dom-input-indeterminate
+    bool m_indeterminate { false };
+
     // https://html.spec.whatwg.org/multipage/input.html#concept-input-checked-dirty-flag
     bool m_dirty_checkedness { false };
 
@@ -164,6 +170,7 @@ private:
 
     // https://html.spec.whatwg.org/multipage/input.html#the-input-element:legacy-pre-activation-behavior
     bool m_before_legacy_pre_activation_behavior_checked { false };
+    bool m_before_legacy_pre_activation_behavior_indeterminate { false };
     JS::GCPtr<HTMLInputElement> m_legacy_pre_activation_behavior_checked_element_in_group;
 
     // https://html.spec.whatwg.org/multipage/input.html#concept-input-type-file-selected

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -22,6 +22,7 @@ interface HTMLInputElement : HTMLElement {
     [Reflect=value] attribute DOMString defaultValue;
 
     attribute DOMString type;
+    attribute boolean indeterminate;
 
     [LegacyNullToEmptyString] attribute DOMString value;
 


### PR DESCRIPTION
... and fix a FIXME in SelectorEngine.cpp while we're here.

## Results:
```html
<html>
    <body>
        <input type=checkbox id=c1>
        <input type=checkbox id=c2>
        <input type=checkbox id=c3 checked>
        <input type=checkbox id=c4 checked>
        <input type=checkbox id=c5 style='width:36px;height:36px'>
        <input type=checkbox id=c6 style='width:36px;height:36px'>
        <input type=checkbox id=c7 checked style='width:36px;height:36px'>
        <input type=checkbox id=c8 checked style='width:36px;height:36px'>
        <script>
            document.getElementById("c2").indeterminate = true;
            document.getElementById("c3").indeterminate = true;
            document.getElementById("c6").indeterminate = true;
            document.getElementById("c7").indeterminate = true;
        </script>
    </body>
</html>
```

![image](https://user-images.githubusercontent.com/9142257/226290785-c10760c7-4789-445d-b737-7f0a54877a5e.png)