### PR TITLE
LibLine: Unify the is-empty flag in Style::unify_with() as well

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -1709,6 +1709,8 @@ void Style::unify_with(Style const& other, bool prefer_other)
     // Unify links.
     if (prefer_other || m_hyperlink.is_empty())
         m_hyperlink = other.hyperlink();
+
+    m_is_empty &= other.m_is_empty;
 }
 
 DeprecatedString Style::to_deprecated_string() const


### PR DESCRIPTION
Not doing so can make the final unified state incorrectly marked as empty, and will make LibLine ignore the style.