### PR TITLE
LibWeb: Small bugfixes and improvements for SVG's 

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
@@ -93,8 +93,7 @@ void SVGGeometryPaintable::paint(PaintContext& context, PaintPhase phase) const
 
         path = new_path;
     }
-
-    if (auto fill_color = geometry_element.fill_color().value_or(svg_context.fill_color()); fill_color.alpha() > 0) {
+    if (auto fill_color = geometry_element.fill_color().value_or(svg_context.fill_color()); fill_color.alpha() > 0 && path.segments().size() > 2) {
         // We need to fill the path before applying the stroke, however the filled
         // path must be closed, whereas the stroke path may not necessary be closed.
         // Copy the path and close it for filling, but use the previous path for stroke

--- a/Userland/Libraries/LibWeb/SVG/AttributeParser.cpp
+++ b/Userland/Libraries/LibWeb/SVG/AttributeParser.cpp
@@ -122,12 +122,19 @@ void AttributeParser::parse_drawto()
     }
 }
 
+// https://www.w3.org/TR/SVG2/paths.html#PathDataMovetoCommands
 void AttributeParser::parse_moveto()
 {
     bool absolute = consume() == 'M';
     parse_whitespace();
-    for (auto& pair : parse_coordinate_pair_sequence())
-        m_instructions.append({ PathInstructionType::Move, absolute, pair });
+    auto coordinate_pairs = parse_coordinate_pair_sequence();
+    for (size_t i = 0; i < coordinate_pairs.size(); i++) {
+        if (i == 0) {
+            m_instructions.append({ PathInstructionType::Move, absolute, coordinate_pairs[i] });
+        } else {
+            m_instructions.append({ PathInstructionType::Line, absolute, coordinate_pairs[i] });
+        }
+    }
 }
 
 void AttributeParser::parse_closepath()

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -83,7 +83,7 @@ Optional<float> SVGGraphicsElement::stroke_width() const
                 viewport_height = svg_svg_layout_node->computed_values().height().resolved(*svg_svg_layout_node, CSS::Length::make_px(0)).to_px(*svg_svg_layout_node);
             }
         }
-        auto scaled_viewport_size = CSS::Length::make_px((viewport_width + viewport_height) * 0.5f);
+        auto scaled_viewport_size = CSS::Length::make_px(sqrtf((viewport_width * viewport_height).value()));
         return width->resolved(*layout_node(), scaled_viewport_size).to_px(*layout_node()).value();
     }
     return {};


### PR DESCRIPTION
This PR contains a few small fixes and improvements for SVG's in the browser. 

- This PR adds scaling for stroke width in SVG's in the case that the viewbox is not the same size as the svg size. 

In this example you can see that increasing the size now increases the stroke width when the viewBox is kept the same. 
![image](https://user-images.githubusercontent.com/10757347/226473571-ec593743-84e3-457d-b827-d3b574b290f2.png)

- The SVG fill painting step now no longer draws lines. (segments of size 2)

- Fixes a bug where line instructions were mistakenly interpreted as move intructions in SVG's. This would result in the close_path to close to the wrong position. This results in the following visual improvement. Since we can't zoom into SVG's yet I have pre-scaled the svg to illustrate the difference. 


![image](https://user-images.githubusercontent.com/10757347/226474861-69d94521-d923-4e2a-810b-1b55e34a480e.png)


<details>
  <summary>Github Arrows SVG</summary>
  
  ```html
<html>
<div>
    <svg aria-hidden="true" height="256" viewBox="0 0 16 16" version="1.1" width="256" data-view-component="true"
        class="octicon octicon-code UnderlineNav-octicon d-none d-sm-inline">
        <path d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 
            4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749
             0 0 1 .326-1.275.749.749 0 0 1 .734.215Z m-6.56 0a.751.751 0 0 1 1.042.018.751.751
              0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0
               1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z">
        </path>
    </svg>
</div>

</html>
  ```
  
</details>


<details>
  <summary>Lines SVG </summary>
  
  ```html
<html>

<?xml version="1.0" standalone="no"?>
<svg width="300" height="100" viewBox="0 0 1200 400" xmlns="http://www.w3.org/2000/svg" version="1.1">
    <desc>Example line01 - lines expressed in user coordinates</desc>
    <!-- Show outline of viewport using 'rect' element -->
    <rect x="1" y="1" width="1198" height="398" fill="none" stroke="blue" stroke-width="2" />

    <g stroke="green">
        <line x1="100" y1="300" x2="300" y2="100" stroke-width="5" />
        <line x1="300" y1="300" x2="500" y2="100" stroke-width="10" />
        <line x1="500" y1="300" x2="700" y2="100" stroke-width="15" />
        <line x1="700" y1="300" x2="900" y2="100" stroke-width="20" />
        <line x1="900" y1="300" x2="1100" y2="100" stroke-width="25" />
    </g>
</svg>
<svg width="800" height="200" viewBox="0 0 1200 400" xmlns="http://www.w3.org/2000/svg" version="1.1">
    <desc>Example line01 - lines expressed in user coordinates</desc>

    <!-- Show outline of viewport using 'rect' element -->
    <rect x="1" y="1" width="1198" height="398" fill="none" stroke="blue" stroke-width="2" />

    <g stroke="green">
        <line x1="100" y1="300" x2="300" y2="100" stroke-width="5" />
        <line x1="300" y1="300" x2="500" y2="100" stroke-width="10" />
        <line x1="500" y1="300" x2="700" y2="100" stroke-width="15" />
        <line x1="700" y1="300" x2="900" y2="100" stroke-width="20" />
        <line x1="900" y1="300" x2="1100" y2="100" stroke-width="25" />
    </g>
</svg>

</html>
  ```
  
</details>
