### PR TITLE
LibWeb: Support the :scope pseudo class

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -479,6 +479,8 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Root);
         if (pseudo_name.equals_ignoring_ascii_case("visited"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Visited);
+        if (pseudo_name.equals_ignoring_ascii_case("scope"sv))
+            return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Scope);
 
         // Single-colon syntax allowed for ::after, ::before, ::first-letter and ::first-line for compatibility.
         // https://www.w3.org/TR/selectors/#pseudo-element-syntax

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -227,6 +227,7 @@ ErrorOr<String> Selector::SimpleSelector::serialize() const
         case Selector::SimpleSelector::PseudoClass::Type::Enabled:
         case Selector::SimpleSelector::PseudoClass::Type::Checked:
         case Selector::SimpleSelector::PseudoClass::Type::Active:
+        case Selector::SimpleSelector::PseudoClass::Type::Scope:
             // If the pseudo-class does not accept arguments append ":" (U+003A), followed by the name of the pseudo-class, to s.
             TRY(s.try_append(':'));
             TRY(s.try_append(pseudo_class_name(pseudo_class.type)));

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -111,6 +111,7 @@ public:
                 Where,
                 Active,
                 Lang,
+                Scope,
             };
             Type type;
 
@@ -292,6 +293,8 @@ constexpr StringView pseudo_class_name(Selector::SimpleSelector::PseudoClass::Ty
         return "where"sv;
     case Selector::SimpleSelector::PseudoClass::Type::Lang:
         return "lang"sv;
+    case Selector::SimpleSelector::PseudoClass::Type::Scope:
+        return "scope"sv;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.h
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.h
@@ -11,6 +11,6 @@
 
 namespace Web::SelectorEngine {
 
-bool matches(CSS::Selector const&, DOM::Element const&, Optional<CSS::Selector::PseudoElement> = {});
+bool matches(CSS::Selector const&, DOM::Element const&, Optional<CSS::Selector::PseudoElement> = {}, JS::GCPtr<DOM::ParentNode const> scope = {});
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -532,13 +532,17 @@ JS::GCPtr<ShadowRoot> Element::shadow_root() const
 // https://dom.spec.whatwg.org/#dom-element-matches
 WebIDL::ExceptionOr<bool> Element::matches(StringView selectors) const
 {
+    // 1. Let s be the result of parse a selector from selectors.
     auto maybe_selectors = parse_selector(CSS::Parser::ParsingContext(static_cast<ParentNode&>(const_cast<Element&>(*this))), selectors);
+
+    // 2. If s is failure, then throw a "SyntaxError" DOMException.
     if (!maybe_selectors.has_value())
         return WebIDL::SyntaxError::create(realm(), "Failed to parse selector");
 
+    // 3. If the result of match a selector against an element, using s, this, and scoping root this, returns success, then return true; otherwise, return false.
     auto sel = maybe_selectors.value();
     for (auto& s : sel) {
-        if (SelectorEngine::matches(s, *this))
+        if (SelectorEngine::matches(s, *this, {}, static_cast<ParentNode const*>(this)))
             return true;
     }
     return false;

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -50,19 +50,28 @@ WebIDL::ExceptionOr<JS::GCPtr<Element>> ParentNode::query_selector(StringView se
     return result;
 }
 
+// https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall
 WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeList>> ParentNode::query_selector_all(StringView selector_text)
 {
+    // The querySelectorAll(selectors) method steps are to return the static result of running scope-match a selectors string selectors against this.
+
+    // https://dom.spec.whatwg.org/#scope-match-a-selectors-string
+    // To scope-match a selectors string selectors against a node, run these steps:
+    // 1. Let s be the result of parse a selector selectors.
     auto maybe_selectors = parse_selector(CSS::Parser::ParsingContext(*this), selector_text);
+
+    // 2. If s is failure, then throw a "SyntaxError" DOMException.
     if (!maybe_selectors.has_value())
         return WebIDL::SyntaxError::create(realm(), "Failed to parse selector");
 
     auto selectors = maybe_selectors.value();
 
+    // 3. Return the result of match a selector against a tree with s and node’s root using scoping root node.
     Vector<JS::Handle<Node>> elements;
     // FIXME: This should be shadow-including. https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree
     for_each_in_subtree_of_type<Element>([&](auto& element) {
         for (auto& selector : selectors) {
-            if (SelectorEngine::matches(selector, element)) {
+            if (SelectorEngine::matches(selector, element, {}, this)) {
                 elements.append(&element);
             }
         }

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -456,6 +456,9 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::Lang:
                     pseudo_class_description = "Lang";
                     break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Scope:
+                    pseudo_class_description = "Scope";
+                    break;
                 }
 
                 builder.appendff(" pseudo_class={}", pseudo_class_description);


### PR DESCRIPTION
This PR adds support for the `:scope` CSS pseudo class selector, which matches the element on which `matches()`, `closest()`, `querySelector()` or `querySelectorAll()` is called.