### PR TITLE
VideoPlayer: Add drag and drop support

### DIFF
--- a/Userland/Applications/VideoPlayer/CMakeLists.txt
+++ b/Userland/Applications/VideoPlayer/CMakeLists.txt
@@ -17,4 +17,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_app(VideoPlayer ICON app-video-player)
-target_link_libraries(VideoPlayer PRIVATE LibVideo LibAudio LibCore LibGfx LibGUI LibMain)
+target_link_libraries(VideoPlayer PRIVATE LibVideo LibAudio LibCore LibGfx LibGUI LibMain LibFileSystemAccessClient)

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/FilePicker.h>
@@ -263,6 +264,26 @@ void VideoPlayerWidget::event(Core::Event& event)
     }
 
     Widget::event(event);
+}
+
+void VideoPlayerWidget::drop_event(GUI::DropEvent& event)
+{
+    event.accept();
+    window()->move_to_front();
+
+    if (event.mime_data().has_urls()) {
+        auto urls = event.mime_data().urls();
+        if (urls.is_empty())
+            return;
+        if (urls.size() > 1) {
+            GUI::MessageBox::show_error(window(), "VideoPlayer can only view one clip at a time!"sv);
+            return;
+        }
+        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window(), urls.first().path());
+        if (response.is_error())
+            return;
+        open_file(response.value().filename());
+    }
 }
 
 void VideoPlayerWidget::cycle_sizing_modes()

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
@@ -53,6 +53,8 @@ private:
 
     void event(Core::Event&) override;
 
+    virtual void drop_event(GUI::DropEvent&) override;
+
     DeprecatedString m_path;
 
     RefPtr<VideoFrameWidget> m_video_display;


### PR DESCRIPTION
This patch makes it so that we view clips by dropping them on an open VideoPlayer window.