### PR TITLE
LibWeb: Make the Element.style setter work

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2571,7 +2571,6 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.setter_callback@)
 }
 )~~~");
         } else if (auto put_forwards_identifier = attribute.extended_attributes.get("PutForwards"sv); put_forwards_identifier.has_value()) {
-            attribute_generator.set("attribute.name", attribute.name.to_snakecase());
             attribute_generator.set("put_forwards_identifier"sv, *put_forwards_identifier);
 
             attribute_generator.append(R"~~~(
@@ -2580,7 +2579,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.setter_callback@)
     auto* impl = TRY(impl_from(vm));
     auto value = vm.argument(0);
 
-    auto receiver = TRY(throw_dom_exception_if_needed(vm, [&]() { return impl->@attribute.name@(); }));
+    auto receiver = TRY(throw_dom_exception_if_needed(vm, [&]() { return impl->@attribute.cpp_name@(); }));
     TRY(receiver->set(JS::PropertyKey { "@put_forwards_identifier@" }, value, JS::Object::ShouldThrowExceptions::Yes));
 
     return JS::js_undefined();

--- a/Userland/Libraries/LibWeb/CSS/ElementCSSInlineStyle.idl
+++ b/Userland/Libraries/LibWeb/CSS/ElementCSSInlineStyle.idl
@@ -1,0 +1,6 @@
+#import <CSS/CSSStyleDeclaration.idl>
+
+// https://w3c.github.io/csswg-drafts/cssom/#elementcssinlinestyle
+interface mixin ElementCSSInlineStyle {
+    [SameObject, PutForwards=cssText, ImplementedAs=style_for_bindings] readonly attribute CSSStyleDeclaration style;
+};

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -1,5 +1,4 @@
 #import <ARIA/ARIAMixin.idl>
-#import <CSS/CSSStyleDeclaration.idl>
 #import <DOM/Attr.idl>
 #import <DOM/ChildNode.idl>
 #import <DOM/DOMTokenList.idl>
@@ -61,8 +60,6 @@ interface Element : Node {
 
     readonly attribute Element? nextElementSibling;
     readonly attribute Element? previousElementSibling;
-
-    [ImplementedAs=style_for_bindings] readonly attribute CSSStyleDeclaration style;
 
     DOMRect getBoundingClientRect();
     DOMRectList getClientRects();

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
@@ -1,3 +1,4 @@
+#import <CSS/ElementCSSInlineStyle.idl>
 #import <HTML/DOMStringMap.idl>
 #import <DOM/EventHandler.idl>
 
@@ -37,3 +38,5 @@ interface mixin HTMLOrSVGElement {
     [CEReactions, Reflect] attribute boolean autofocus;
     [CEReactions] attribute long tabIndex;
 };
+
+HTMLElement includes ElementCSSInlineStyle;

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.idl
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.idl
@@ -1,3 +1,4 @@
+#import <CSS/ElementCSSInlineStyle.idl>
 #import <DOM/Element.idl>
 #import <HTML/HTMLElement.idl>
 #import <HTML/DOMStringMap.idl>
@@ -8,3 +9,4 @@ interface SVGElement : Element {
 };
 
 SVGElement includes HTMLOrSVGElement;
+SVGElement includes ElementCSSInlineStyle;


### PR DESCRIPTION
This attribute was missing a `PutForwards` and the CSSOM spec defines it via a mixin.

Additionally this PR contains a bug fix where the method name supplied by `ImplementedAs` was not used for `PutForwards`.