### PR TITLE
WebDriver: Don't activate new tabs until the Switch To Window command is executed

### DIFF
--- a/Ladybird/BrowserWindow.cpp
+++ b/Ladybird/BrowserWindow.cpp
@@ -313,7 +313,7 @@ BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdrive
     });
 
     QObject::connect(new_tab_action, &QAction::triggered, this, [this] {
-        new_tab(s_settings->new_tab_page(), Activate::Yes);
+        new_tab(s_settings->new_tab_page(), Web::HTML::ActivateTab::Yes);
     });
     QObject::connect(settings_action, &QAction::triggered, this, [this] {
         new SettingsDialog(this);
@@ -327,7 +327,7 @@ BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdrive
     QObject::connect(m_tabs_container, &QTabWidget::tabCloseRequested, this, &BrowserWindow::close_tab);
     QObject::connect(close_current_tab_action, &QAction::triggered, this, &BrowserWindow::close_current_tab);
 
-    new_tab(s_settings->new_tab_page(), Activate::Yes);
+    new_tab(s_settings->new_tab_page(), Web::HTML::ActivateTab::Yes);
 
     setCentralWidget(m_tabs_container);
 }
@@ -339,7 +339,7 @@ void BrowserWindow::debug_request(DeprecatedString const& request, DeprecatedStr
     m_current_tab->debug_request(request, argument);
 }
 
-Tab& BrowserWindow::new_tab(QString const& url, Activate activate)
+Tab& BrowserWindow::new_tab(QString const& url, Web::HTML::ActivateTab activate_tab)
 {
     auto tab = make<Tab>(this, m_webdriver_content_ipc_path);
     auto tab_ptr = tab.ptr();
@@ -350,7 +350,7 @@ Tab& BrowserWindow::new_tab(QString const& url, Activate activate)
     }
 
     m_tabs_container->addTab(tab_ptr, "New Tab");
-    if (activate == Activate::Yes)
+    if (activate_tab == Web::HTML::ActivateTab::Yes)
         m_tabs_container->setCurrentWidget(tab_ptr);
 
     QObject::connect(tab_ptr, &Tab::title_changed, this, &BrowserWindow::tab_title_changed);
@@ -361,11 +361,11 @@ Tab& BrowserWindow::new_tab(QString const& url, Activate activate)
         m_current_tab->navigate(urls[0].toString());
 
         for (qsizetype i = 1; i < urls.size(); ++i)
-            new_tab(urls[i].toString(), Activate::No);
+            new_tab(urls[i].toString(), Web::HTML::ActivateTab::No);
     });
 
-    tab_ptr->view().on_new_tab = [this]() {
-        auto& tab = new_tab("about:blank", Activate::Yes);
+    tab_ptr->view().on_new_tab = [this](auto activate_tab) {
+        auto& tab = new_tab("about:blank", activate_tab);
         return tab.view().handle();
     };
 

--- a/Ladybird/BrowserWindow.cpp
+++ b/Ladybird/BrowserWindow.cpp
@@ -401,6 +401,11 @@ Tab& BrowserWindow::new_tab(QString const& url, Web::HTML::ActivateTab activate_
     return *tab_ptr;
 }
 
+void BrowserWindow::activate_tab(int index)
+{
+    m_tabs_container->setCurrentIndex(index);
+}
+
 void BrowserWindow::close_tab(int index)
 {
     auto* tab = m_tabs_container->widget(index);

--- a/Ladybird/BrowserWindow.h
+++ b/Ladybird/BrowserWindow.h
@@ -9,6 +9,7 @@
 
 #include "Tab.h"
 #include <LibCore/Forward.h>
+#include <LibWeb/HTML/ActivateTab.h>
 #include <QIcon>
 #include <QLineEdit>
 #include <QMainWindow>
@@ -31,15 +32,10 @@ public:
 
     int tab_index(Tab*);
 
-    enum class Activate {
-        Yes,
-        No,
-    };
-
 public slots:
     void tab_title_changed(int index, QString const&);
     void tab_favicon_changed(int index, QIcon icon);
-    Tab& new_tab(QString const&, Activate);
+    Tab& new_tab(QString const&, Web::HTML::ActivateTab);
     void close_tab(int index);
     void close_current_tab();
     void open_next_tab();

--- a/Ladybird/BrowserWindow.h
+++ b/Ladybird/BrowserWindow.h
@@ -36,6 +36,7 @@ public slots:
     void tab_title_changed(int index, QString const&);
     void tab_favicon_changed(int index, QIcon icon);
     Tab& new_tab(QString const&, Web::HTML::ActivateTab);
+    void activate_tab(int index);
     void close_tab(int index);
     void close_current_tab();
     void open_next_tab();

--- a/Ladybird/Tab.cpp
+++ b/Ladybird/Tab.cpp
@@ -64,6 +64,10 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path)
     m_toolbar->addAction(m_home_action);
     m_toolbar->addWidget(m_location_edit);
 
+    QObject::connect(m_view, &WebContentView::activate_tab, [this] {
+        m_window->activate_tab(tab_index());
+    });
+
     QObject::connect(m_view, &WebContentView::close, [this] {
         m_window->close_tab(tab_index());
     });

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -970,23 +970,22 @@ void WebContentView::notify_server_did_set_cookie(Badge<WebContentClient>, AK::U
         on_set_cookie(url, cookie, source);
 }
 
+void WebContentView::notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie)
+{
+    if (on_update_cookie)
+        on_update_cookie(cookie);
+}
+
 void WebContentView::notify_server_did_close_browsing_context(Badge<WebContentClient>)
 {
     emit close();
 }
 
-String WebContentView::notify_request_open_new_tab(Badge<WebContentClient>)
+String WebContentView::notify_server_did_request_new_tab(Badge<WebContentClient>, Web::HTML::ActivateTab activate_tab)
 {
     if (on_new_tab)
-        return on_new_tab();
-
+        return on_new_tab(activate_tab);
     return {};
-}
-
-void WebContentView::notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie)
-{
-    if (on_update_cookie)
-        on_update_cookie(cookie);
 }
 
 void WebContentView::notify_server_did_update_resource_count(i32 count_waiting)

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -988,6 +988,11 @@ String WebContentView::notify_server_did_request_new_tab(Badge<WebContentClient>
     return {};
 }
 
+void WebContentView::notify_server_did_request_activate_tab(Badge<WebContentClient>)
+{
+    emit activate_tab();
+}
+
 void WebContentView::notify_server_did_update_resource_count(i32 count_waiting)
 {
     // FIXME

--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -20,6 +20,7 @@
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/ActivateTab.h>
 #include <LibWebView/ViewImplementation.h>
 #include <QAbstractScrollArea>
 #include <QPointer>
@@ -49,7 +50,7 @@ public:
     explicit WebContentView(StringView webdriver_content_ipc_path);
     virtual ~WebContentView() override;
 
-    Function<String()> on_new_tab;
+    Function<String(Web::HTML::ActivateTab)> on_new_tab;
     Function<void()> on_close;
     Function<void(Gfx::IntPoint screen_position)> on_context_menu_request;
     Function<void(const AK::URL&, DeprecatedString const& target, unsigned modifiers)> on_link_click;
@@ -146,7 +147,7 @@ public:
     virtual DeprecatedString notify_server_did_request_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::Source source) override;
     virtual void notify_server_did_set_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source) override;
     virtual void notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie) override;
-    virtual String notify_request_open_new_tab(Badge<WebContentClient>) override;
+    virtual String notify_server_did_request_new_tab(Badge<WebContentClient>, Web::HTML::ActivateTab activate_tab) override;
     virtual void notify_server_did_close_browsing_context(Badge<WebContentClient>) override;
     virtual void notify_server_did_update_resource_count(i32 count_waiting) override;
     virtual void notify_server_did_request_restore_window() override;

--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -148,6 +148,7 @@ public:
     virtual void notify_server_did_set_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source) override;
     virtual void notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie) override;
     virtual String notify_server_did_request_new_tab(Badge<WebContentClient>, Web::HTML::ActivateTab activate_tab) override;
+    virtual void notify_server_did_request_activate_tab(Badge<WebContentClient>) override;
     virtual void notify_server_did_close_browsing_context(Badge<WebContentClient>) override;
     virtual void notify_server_did_update_resource_count(i32 count_waiting) override;
     virtual void notify_server_did_request_restore_window() override;
@@ -160,6 +161,7 @@ public:
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
 
 signals:
+    void activate_tab();
     void close();
     void link_hovered(QString, int timeout = 0);
     void link_unhovered();

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -590,6 +590,10 @@ Tab& BrowserWindow::create_new_tab(URL url, Web::HTML::ActivateTab activate)
         create_new_tab(url, Web::HTML::ActivateTab::Yes);
     };
 
+    new_tab.on_activate_tab_request = [this](auto& tab) {
+        m_tab_widget->set_active_widget(&tab);
+    };
+
     new_tab.on_tab_close_request = [this](auto& tab) {
         m_tab_widget->deferred_invoke([this, &tab] {
             m_tab_widget->remove_tab(tab);

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -102,7 +102,7 @@ BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url)
     };
 
     m_window_actions.on_create_new_tab = [this] {
-        create_new_tab(Browser::url_from_user_input(Browser::g_new_tab_url), true);
+        create_new_tab(Browser::url_from_user_input(Browser::g_new_tab_url), Web::HTML::ActivateTab::Yes);
     };
 
     m_window_actions.on_create_new_window = [this] {
@@ -148,7 +148,7 @@ BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url)
 
     build_menus();
 
-    create_new_tab(move(url), true);
+    create_new_tab(move(url), Web::HTML::ActivateTab::Yes);
 }
 
 void BrowserWindow::build_menus()
@@ -570,7 +570,7 @@ void BrowserWindow::set_window_title_for_tab(Tab const& tab)
     set_title(DeprecatedString::formatted("{} - Browser", title.is_empty() ? url.to_deprecated_string() : title));
 }
 
-Tab& BrowserWindow::create_new_tab(URL url, bool activate)
+Tab& BrowserWindow::create_new_tab(URL url, Web::HTML::ActivateTab activate)
 {
     auto& new_tab = m_tab_widget->add_tab<Browser::Tab>("New tab"_short_string, *this);
 
@@ -587,7 +587,7 @@ Tab& BrowserWindow::create_new_tab(URL url, bool activate)
     };
 
     new_tab.on_tab_open_request = [this](auto& url) {
-        create_new_tab(url, true);
+        create_new_tab(url, Web::HTML::ActivateTab::Yes);
     };
 
     new_tab.on_tab_close_request = [this](auto& tab) {
@@ -655,7 +655,7 @@ Tab& BrowserWindow::create_new_tab(URL url, bool activate)
 
     dbgln_if(SPAM_DEBUG, "Added new tab {:p}, loading {}", &new_tab, url);
 
-    if (activate)
+    if (activate == Web::HTML::ActivateTab::Yes)
         m_tab_widget->set_active_widget(&new_tab);
 
     return new_tab;

--- a/Userland/Applications/Browser/BrowserWindow.h
+++ b/Userland/Applications/Browser/BrowserWindow.h
@@ -13,6 +13,7 @@
 #include <LibConfig/Listener.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Window.h>
+#include <LibWeb/HTML/ActivateTab.h>
 
 namespace Browser {
 
@@ -28,7 +29,7 @@ public:
 
     GUI::TabWidget& tab_widget();
     Tab& active_tab();
-    Tab& create_new_tab(URL, bool activate);
+    Tab& create_new_tab(URL, Web::HTML::ActivateTab activate);
     void create_new_window(URL);
 
     GUI::Action& go_back_action() { return *m_go_back_action; }

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -473,6 +473,10 @@ Tab::Tab(BrowserWindow& window)
         return tab.view().handle();
     };
 
+    view().on_activate_tab = [this]() {
+        on_activate_tab_request(*this);
+    };
+
     view().on_close = [this] {
         on_tab_close_request(*this);
     };

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -468,8 +468,8 @@ Tab::Tab(BrowserWindow& window)
             go_forward();
     };
 
-    view().on_new_tab = [this] {
-        auto& tab = this->window().create_new_tab(URL("about:blank"), true);
+    view().on_new_tab = [this](auto activate_tab) {
+        auto& tab = this->window().create_new_tab(URL("about:blank"), activate_tab);
         return tab.view().handle();
     };
 

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -62,6 +62,7 @@ public:
 
     Function<void(DeprecatedString const&)> on_title_change;
     Function<void(const URL&)> on_tab_open_request;
+    Function<void(Tab&)> on_activate_tab_request;
     Function<void(Tab&)> on_tab_close_request;
     Function<void(Tab&)> on_tab_close_other_request;
     Function<void(const URL&)> on_window_open_request;

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -175,7 +175,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     for (size_t i = 1; i < specified_urls.size(); ++i)
-        window->create_new_tab(url_from_argument_string(specified_urls[i]), false);
+        window->create_new_tab(url_from_argument_string(specified_urls[i]), Web::HTML::ActivateTab::No);
 
     window->show();
 

--- a/Userland/Libraries/LibWeb/HTML/ActivateTab.h
+++ b/Userland/Libraries/LibWeb/HTML/ActivateTab.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Web::HTML {
+
+enum class ActivateTab {
+    Yes,
+    No,
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -615,7 +615,7 @@ JS::GCPtr<DOM::Node> BrowsingContext::currently_focused_area()
 }
 
 // https://html.spec.whatwg.org/#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
-BrowsingContext::ChosenBrowsingContext BrowsingContext::choose_a_browsing_context(StringView name, bool no_opener)
+BrowsingContext::ChosenBrowsingContext BrowsingContext::choose_a_browsing_context(StringView name, bool no_opener, ActivateTab activate_tab)
 {
     // The rules for choosing a browsing context, given a browsing context name name, a browsing context current, and
     // a boolean noopener are as follows:
@@ -699,7 +699,7 @@ BrowsingContext::ChosenBrowsingContext BrowsingContext::choose_a_browsing_contex
 
             // 3. If noopener is true, then set chosen to the result of creating a new top-level browsing context.
             if (no_opener) {
-                auto handle = m_page->client().page_did_request_new_tab();
+                auto handle = m_page->client().page_did_request_new_tab(activate_tab);
                 chosen = RemoteBrowsingContext::create_a_new_remote_browsing_context(handle);
             }
 

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -17,6 +17,7 @@
 #include <LibJS/Heap/Cell.h>
 #include <LibWeb/DOM/Position.h>
 #include <LibWeb/HTML/AbstractBrowsingContext.h>
+#include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/BrowsingContextContainer.h>
 #include <LibWeb/HTML/HistoryHandlingBehavior.h>
 #include <LibWeb/HTML/Origin.h>
@@ -171,7 +172,7 @@ public:
         WindowType window_type;
     };
 
-    ChosenBrowsingContext choose_a_browsing_context(StringView name, bool no_opener);
+    ChosenBrowsingContext choose_a_browsing_context(StringView name, bool no_opener, ActivateTab = ActivateTab::Yes);
 
     size_t document_tree_child_browsing_context_count() const;
 

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -203,6 +203,7 @@ public:
     virtual void page_did_update_cookie(Web::Cookie::Cookie) { }
     virtual void page_did_update_resource_count(i32) { }
     virtual String page_did_request_new_tab(HTML::ActivateTab) { return {}; }
+    virtual void page_did_request_activate_tab() { }
     virtual void page_did_close_browsing_context(HTML::BrowsingContext const&) { }
 
     virtual void request_file(FileRequest) = 0;

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -25,6 +25,7 @@
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/Loader/FileRequest.h>
 #include <LibWeb/PixelUnits.h>
 
@@ -201,7 +202,7 @@ public:
     virtual void page_did_set_cookie(const AK::URL&, Cookie::ParsedCookie const&, Cookie::Source) { }
     virtual void page_did_update_cookie(Web::Cookie::Cookie) { }
     virtual void page_did_update_resource_count(i32) { }
-    virtual String page_did_request_new_tab() { return {}; }
+    virtual String page_did_request_new_tab(HTML::ActivateTab) { return {}; }
     virtual void page_did_close_browsing_context(HTML::BrowsingContext const&) { }
 
     virtual void request_file(FileRequest) = 0;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -59,14 +59,6 @@ void OutOfProcessWebView::handle_web_content_process_crash()
     load_html(builder.to_deprecated_string(), m_url);
 }
 
-String OutOfProcessWebView::notify_request_open_new_tab(Badge<WebContentClient>)
-{
-    if (on_new_tab)
-        return on_new_tab();
-
-    return {};
-}
-
 void OutOfProcessWebView::create_client()
 {
     m_client_state = {};
@@ -475,16 +467,23 @@ void OutOfProcessWebView::notify_server_did_set_cookie(Badge<WebContentClient>, 
         on_set_cookie(url, cookie, source);
 }
 
-void OutOfProcessWebView::notify_server_did_close_browsing_context(Badge<WebContentClient>)
-{
-    if (on_close)
-        on_close();
-}
-
 void OutOfProcessWebView::notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie)
 {
     if (on_update_cookie)
         on_update_cookie(cookie);
+}
+
+String OutOfProcessWebView::notify_server_did_request_new_tab(Badge<WebContentClient>, Web::HTML::ActivateTab activate_tab)
+{
+    if (on_new_tab)
+        return on_new_tab(activate_tab);
+    return {};
+}
+
+void OutOfProcessWebView::notify_server_did_close_browsing_context(Badge<WebContentClient>)
+{
+    if (on_close)
+        on_close();
 }
 
 void OutOfProcessWebView::notify_server_did_update_resource_count(i32 count_waiting)

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -480,6 +480,12 @@ String OutOfProcessWebView::notify_server_did_request_new_tab(Badge<WebContentCl
     return {};
 }
 
+void OutOfProcessWebView::notify_server_did_request_activate_tab(Badge<WebContentClient>)
+{
+    if (on_activate_tab)
+        on_activate_tab();
+}
+
 void OutOfProcessWebView::notify_server_did_close_browsing_context(Badge<WebContentClient>)
 {
     if (on_close)

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -12,6 +12,7 @@
 #include <LibGUI/AbstractScrollableWidget.h>
 #include <LibGUI/Widget.h>
 #include <LibWeb/CSS/Selector.h>
+#include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWebView/ViewImplementation.h>
 
@@ -57,7 +58,7 @@ public:
     // In practice, this means that OOPWV may render scaled stale versions of the content while resizing.
     void set_content_scales_to_viewport(bool);
 
-    Function<String()> on_new_tab;
+    Function<String(Web::HTML::ActivateTab)> on_new_tab;
     Function<void()> on_close;
     Function<void(Gfx::IntPoint screen_position)> on_context_menu_request;
     Function<void(const AK::URL&, DeprecatedString const& target, unsigned modifiers)> on_link_click;
@@ -162,7 +163,7 @@ private:
     virtual DeprecatedString notify_server_did_request_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::Source source) override;
     virtual void notify_server_did_set_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source) override;
     virtual void notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie) override;
-    virtual String notify_request_open_new_tab(Badge<WebContentClient>) override;
+    virtual String notify_server_did_request_new_tab(Badge<WebContentClient>, Web::HTML::ActivateTab activate_tab) override;
     virtual void notify_server_did_close_browsing_context(Badge<WebContentClient>) override;
     virtual void notify_server_did_update_resource_count(i32 count_waiting) override;
     virtual void notify_server_did_request_restore_window() override;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -59,6 +59,7 @@ public:
     void set_content_scales_to_viewport(bool);
 
     Function<String(Web::HTML::ActivateTab)> on_new_tab;
+    Function<void()> on_activate_tab;
     Function<void()> on_close;
     Function<void(Gfx::IntPoint screen_position)> on_context_menu_request;
     Function<void(const AK::URL&, DeprecatedString const& target, unsigned modifiers)> on_link_click;
@@ -164,6 +165,7 @@ private:
     virtual void notify_server_did_set_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source) override;
     virtual void notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie) override;
     virtual String notify_server_did_request_new_tab(Badge<WebContentClient>, Web::HTML::ActivateTab activate_tab) override;
+    virtual void notify_server_did_request_activate_tab(Badge<WebContentClient>) override;
     virtual void notify_server_did_close_browsing_context(Badge<WebContentClient>) override;
     virtual void notify_server_did_update_resource_count(i32 count_waiting) override;
     virtual void notify_server_did_request_restore_window() override;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -12,6 +12,7 @@
 #include <LibGfx/Forward.h>
 #include <LibGfx/StandardCursor.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/ActivateTab.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/WebContentClient.h>
 
@@ -98,7 +99,7 @@ public:
     virtual DeprecatedString notify_server_did_request_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::Source source) = 0;
     virtual void notify_server_did_set_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source) = 0;
     virtual void notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie) = 0;
-    virtual String notify_request_open_new_tab(Badge<WebContentClient>) = 0;
+    virtual String notify_server_did_request_new_tab(Badge<WebContentClient>, Web::HTML::ActivateTab activate_tab) = 0;
     virtual void notify_server_did_close_browsing_context(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_update_resource_count(i32 count_waiting) = 0;
     virtual void notify_server_did_request_restore_window() = 0;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -100,6 +100,7 @@ public:
     virtual void notify_server_did_set_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source) = 0;
     virtual void notify_server_did_update_cookie(Badge<WebContentClient>, Web::Cookie::Cookie const& cookie) = 0;
     virtual String notify_server_did_request_new_tab(Badge<WebContentClient>, Web::HTML::ActivateTab activate_tab) = 0;
+    virtual void notify_server_did_request_activate_tab(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_close_browsing_context(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_update_resource_count(i32 count_waiting) = 0;
     virtual void notify_server_did_request_restore_window() = 0;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -240,9 +240,9 @@ void WebContentClient::did_update_cookie(Web::Cookie::Cookie const& cookie)
     m_view.notify_server_did_update_cookie({}, cookie);
 }
 
-Messages::WebContentClient::DidRequestNewTabResponse WebContentClient::did_request_new_tab()
+Messages::WebContentClient::DidRequestNewTabResponse WebContentClient::did_request_new_tab(Web::HTML::ActivateTab const& activate_tab)
 {
-    return m_view.notify_request_open_new_tab({});
+    return m_view.notify_server_did_request_new_tab({}, activate_tab);
 }
 
 void WebContentClient::did_close_browsing_context()

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -245,6 +245,11 @@ Messages::WebContentClient::DidRequestNewTabResponse WebContentClient::did_reque
     return m_view.notify_server_did_request_new_tab({}, activate_tab);
 }
 
+void WebContentClient::did_request_activate_tab()
+{
+    m_view.notify_server_did_request_activate_tab({});
+}
+
 void WebContentClient::did_close_browsing_context()
 {
     m_view.notify_server_did_close_browsing_context({});

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -8,6 +8,7 @@
 
 #include <AK/HashMap.h>
 #include <LibIPC/ConnectionToServer.h>
+#include <LibWeb/HTML/ActivateTab.h>
 #include <WebContent/WebContentClientEndpoint.h>
 #include <WebContent/WebContentServerEndpoint.h>
 
@@ -69,6 +70,7 @@ private:
     virtual Messages::WebContentClient::DidRequestCookieResponse did_request_cookie(AK::URL const&, u8) override;
     virtual void did_set_cookie(AK::URL const&, Web::Cookie::ParsedCookie const&, u8) override;
     virtual void did_update_cookie(Web::Cookie::Cookie const&) override;
+    virtual Messages::WebContentClient::DidRequestNewTabResponse did_request_new_tab(Web::HTML::ActivateTab const& activate_tab) override;
     virtual void did_close_browsing_context() override;
     virtual void did_update_resource_count(i32 count_waiting) override;
     virtual void did_request_restore_window() override;
@@ -79,7 +81,6 @@ private:
     virtual Messages::WebContentClient::DidRequestFullscreenWindowResponse did_request_fullscreen_window() override;
     virtual void did_request_file(DeprecatedString const& path, i32) override;
     virtual void did_finish_handling_input_event(bool event_was_accepted) override;
-    virtual Messages::WebContentClient::DidRequestNewTabResponse did_request_new_tab() override;
 
     ViewImplementation& m_view;
 };

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -71,6 +71,7 @@ private:
     virtual void did_set_cookie(AK::URL const&, Web::Cookie::ParsedCookie const&, u8) override;
     virtual void did_update_cookie(Web::Cookie::Cookie const&) override;
     virtual Messages::WebContentClient::DidRequestNewTabResponse did_request_new_tab(Web::HTML::ActivateTab const& activate_tab) override;
+    virtual void did_request_activate_tab() override;
     virtual void did_close_browsing_context() override;
     virtual void did_update_resource_count(i32 count_waiting) override;
     virtual void did_request_restore_window() override;

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -382,6 +382,11 @@ String PageHost::page_did_request_new_tab(Web::HTML::ActivateTab activate_tab)
     return m_client.did_request_new_tab(activate_tab);
 }
 
+void PageHost::page_did_request_activate_tab()
+{
+    m_client.async_did_request_activate_tab();
+}
+
 void PageHost::page_did_close_browsing_context(Web::HTML::BrowsingContext const&)
 {
     m_client.async_did_close_browsing_context();

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -377,9 +377,9 @@ void PageHost::page_did_update_resource_count(i32 count_waiting)
     m_client.async_did_update_resource_count(count_waiting);
 }
 
-String PageHost::page_did_request_new_tab()
+String PageHost::page_did_request_new_tab(Web::HTML::ActivateTab activate_tab)
 {
-    return m_client.did_request_new_tab();
+    return m_client.did_request_new_tab(activate_tab);
 }
 
 void PageHost::page_did_close_browsing_context(Web::HTML::BrowsingContext const&)

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -98,7 +98,7 @@ private:
     virtual void page_did_set_cookie(const URL&, Web::Cookie::ParsedCookie const&, Web::Cookie::Source) override;
     virtual void page_did_update_cookie(Web::Cookie::Cookie) override;
     virtual void page_did_update_resource_count(i32) override;
-    virtual String page_did_request_new_tab() override;
+    virtual String page_did_request_new_tab(Web::HTML::ActivateTab activate_tab) override;
     virtual void page_did_close_browsing_context(Web::HTML::BrowsingContext const&) override;
     virtual void request_file(Web::FileRequest) override;
 

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -99,6 +99,7 @@ private:
     virtual void page_did_update_cookie(Web::Cookie::Cookie) override;
     virtual void page_did_update_resource_count(i32) override;
     virtual String page_did_request_new_tab(Web::HTML::ActivateTab activate_tab) override;
+    virtual void page_did_request_activate_tab() override;
     virtual void page_did_close_browsing_context(Web::HTML::BrowsingContext const&) override;
     virtual void request_file(Web::FileRequest) override;
 

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -48,6 +48,7 @@ endpoint WebContentClient
     did_update_cookie(Web::Cookie::Cookie cookie) =|
     did_update_resource_count(i32 count_waiting) =|
     did_request_new_tab(Web::HTML::ActivateTab activate_tab) => (String handle)
+    did_request_activate_tab() =|
     did_close_browsing_context() =|
     did_request_restore_window() =|
     did_request_reposition_window(Gfx::IntPoint position) => (Gfx::IntPoint window_position)

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -3,6 +3,7 @@
 #include <LibGfx/ShareableBitmap.h>
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
+#include <LibWeb/HTML/ActivateTab.h>
 
 endpoint WebContentClient
 {
@@ -46,6 +47,7 @@ endpoint WebContentClient
     did_set_cookie(URL url, Web::Cookie::ParsedCookie cookie, u8 source) =|
     did_update_cookie(Web::Cookie::Cookie cookie) =|
     did_update_resource_count(i32 count_waiting) =|
+    did_request_new_tab(Web::HTML::ActivateTab activate_tab) => (String handle)
     did_close_browsing_context() =|
     did_request_restore_window() =|
     did_request_reposition_window(Gfx::IntPoint position) => (Gfx::IntPoint window_position)
@@ -55,7 +57,6 @@ endpoint WebContentClient
     did_request_fullscreen_window() => (Gfx::IntRect window_rect)
     did_request_file(DeprecatedString path, i32 request_id) =|
     did_finish_handling_input_event(bool event_was_accepted) =|
-    did_request_new_tab() => (String handle)
 
     did_output_js_console_message(i32 message_index) =|
     did_get_js_console_messages(i32 start_index, Vector<DeprecatedString> message_types, Vector<DeprecatedString> messages) =|

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -17,6 +17,7 @@ endpoint WebDriverClient {
     get_title() => (Web::WebDriver::Response response)
     get_window_handle() => (String handle)
     close_window() => (Web::WebDriver::Response response)
+    switch_to_window() => (Web::WebDriver::Response response)
     new_window(JsonValue payload) => (Web::WebDriver::Response response)
     get_window_rect() => (Web::WebDriver::Response response)
     set_window_rect(JsonValue payload) => (Web::WebDriver::Response response)

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -567,7 +567,7 @@ Messages::WebDriverClient::NewWindowResponse WebDriverConnection::new_window(Jso
     //    created browsing context should be in a new OS window. In all other cases the details of how the browsing
     //    context is presented to the user are implementation defined.
     // FIXME: Reuse code of window.open() instead of calling choose_a_browsing_context
-    auto [browsing_context, window_type] = m_page_client.page().top_level_browsing_context().choose_a_browsing_context("_blank"sv, true);
+    auto [browsing_context, window_type] = m_page_client.page().top_level_browsing_context().choose_a_browsing_context("_blank"sv, true, Web::HTML::ActivateTab::No);
 
     // 6. Let handle be the associated window handle of the newly created window.
     auto handle = browsing_context->window_handle();

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -545,6 +545,16 @@ Messages::WebDriverClient::CloseWindowResponse WebDriverConnection::close_window
     return JsonValue {};
 }
 
+// 11.3 Switch to Window, https://w3c.github.io/webdriver/#dfn-switch-to-window
+Messages::WebDriverClient::SwitchToWindowResponse WebDriverConnection::switch_to_window()
+{
+    // 5. Update any implementation-specific state that would result from the user selecting the current
+    //    browsing context for interaction, without altering OS-level focus.
+    m_page_client.page_did_request_activate_tab();
+
+    return JsonValue {};
+}
+
 // 11.5 New Window, https://w3c.github.io/webdriver/#dfn-new-window
 Messages::WebDriverClient::NewWindowResponse WebDriverConnection::new_window(JsonValue const&)
 {

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -54,6 +54,7 @@ private:
     virtual Messages::WebDriverClient::GetTitleResponse get_title() override;
     virtual Messages::WebDriverClient::GetWindowHandleResponse get_window_handle() override;
     virtual Messages::WebDriverClient::CloseWindowResponse close_window() override;
+    virtual Messages::WebDriverClient::SwitchToWindowResponse switch_to_window() override;
     virtual Messages::WebDriverClient::NewWindowResponse new_window(JsonValue const& payload) override;
     virtual Messages::WebDriverClient::GetWindowRectResponse get_window_rect() override;
     virtual Messages::WebDriverClient::SetWindowRectResponse set_window_rect(JsonValue const& payload) override;

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -144,8 +144,9 @@ Web::WebDriver::Response Session::switch_to_window(StringView handle)
     else
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchWindow, "Window not found");
 
-    // FIXME: 5. Update any implementation-specific state that would result from the user selecting the current
-    //          browsing context for interaction, without altering OS-level focus.
+    // 5. Update any implementation-specific state that would result from the user selecting the current
+    //    browsing context for interaction, without altering OS-level focus.
+    TRY(web_content_connection().switch_to_window());
 
     // 6. Return success with data null.
     return JsonValue {};

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -134,6 +134,7 @@ private:
     void notify_server_did_set_cookie(Badge<WebView::WebContentClient>, const URL&, Web::Cookie::ParsedCookie const&, Web::Cookie::Source) override { }
     void notify_server_did_update_cookie(Badge<WebView::WebContentClient>, Web::Cookie::Cookie const&) override { }
     String notify_server_did_request_new_tab(Badge<WebView::WebContentClient>, Web::HTML::ActivateTab) override { return {}; }
+    void notify_server_did_request_activate_tab(Badge<WebView::WebContentClient>) override { }
     void notify_server_did_close_browsing_context(Badge<WebView::WebContentClient>) override { }
     void notify_server_did_update_resource_count(i32) override { }
     void notify_server_did_request_restore_window() override { }

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -36,6 +36,7 @@
 #include <LibIPC/File.h>
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
+#include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/Loader/FrameLoader.h>
 #include <LibWebView/ViewImplementation.h>
 #include <LibWebView/WebContentClient.h>
@@ -132,7 +133,7 @@ private:
     DeprecatedString notify_server_did_request_cookie(Badge<WebView::WebContentClient>, const URL&, Web::Cookie::Source) override { return {}; }
     void notify_server_did_set_cookie(Badge<WebView::WebContentClient>, const URL&, Web::Cookie::ParsedCookie const&, Web::Cookie::Source) override { }
     void notify_server_did_update_cookie(Badge<WebView::WebContentClient>, Web::Cookie::Cookie const&) override { }
-    String notify_request_open_new_tab(Badge<WebView::WebContentClient>) override { return {}; }
+    String notify_server_did_request_new_tab(Badge<WebView::WebContentClient>, Web::HTML::ActivateTab) override { return {}; }
     void notify_server_did_close_browsing_context(Badge<WebView::WebContentClient>) override { }
     void notify_server_did_update_resource_count(i32) override { }
     void notify_server_did_request_restore_window() override { }


### PR DESCRIPTION
When New Window is executed, we should create but not activate a new tab. We should only activate the tab when Switch To Window is executed.


https://user-images.githubusercontent.com/5600524/226491513-00aecac2-e7f0-4b12-9ee8-3d4f6e8a8875.mp4

