### PR TITLE
LibWeb: Paint SVG's correctly when the browser is zoomed in/out

### DIFF
--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -212,12 +212,12 @@ void AntiAliasingPainter::draw_line(FloatPoint actual_from, FloatPoint actual_to
 
 void AntiAliasingPainter::fill_path(Path const& path, Color color, Painter::WindingRule rule)
 {
-    m_underlying_painter.antialiased_fill_path(path, color, rule, m_transform.translation());
+    m_underlying_painter.antialiased_fill_path(path, color, rule, m_transform);
 }
 
 void AntiAliasingPainter::fill_path(Path const& path, PaintStyle const& paint_style, Painter::WindingRule rule)
 {
-    m_underlying_painter.antialiased_fill_path(path, paint_style, rule, m_transform.translation());
+    m_underlying_painter.antialiased_fill_path(path, paint_style, rule, m_transform);
 }
 
 void AntiAliasingPainter::stroke_path(Path const& path, Color color, float thickness)

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -44,6 +44,7 @@ public:
 
     void translate(float dx, float dy) { m_transform.translate(dx, dy); }
     void translate(FloatPoint delta) { m_transform.translate(delta); }
+    void set_transform(AffineTransform transform) { m_transform = transform; }
 
     void draw_ellipse(IntRect const& a_rect, Color, int thickness);
 

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -218,8 +218,8 @@ private:
     template<typename DrawGlyphFunction>
     void do_draw_text(FloatRect const&, Utf8View const& text, Font const&, TextAlignment, TextElision, TextWrapping, DrawGlyphFunction);
 
-    void antialiased_fill_path(Path const&, Color, WindingRule rule, FloatPoint translation);
-    void antialiased_fill_path(Path const&, PaintStyle const& paint_style, WindingRule rule, FloatPoint translation);
+    void antialiased_fill_path(Path const&, Color, WindingRule rule, AffineTransform transform);
+    void antialiased_fill_path(Path const&, PaintStyle const& paint_style, WindingRule rule, AffineTransform transform);
     enum class FillPathMode {
         PlaceOnIntGrid,
         AllowFloatingPoints,
@@ -227,7 +227,7 @@ private:
     template<typename T, typename TColorOrFunction>
     void draw_scanline_for_fill_path(int y, T x_start, T x_end, TColorOrFunction color);
     template<FillPathMode fill_path_mode, typename ColorOrFunction>
-    void fill_path_impl(Path const& path, ColorOrFunction color, Gfx::Painter::WindingRule winding_rule, Optional<FloatPoint> offset = {});
+    void fill_path_impl(Path const& path, ColorOrFunction color, Gfx::Painter::WindingRule winding_rule, Optional<AffineTransform> const& maybe_transform = {});
 };
 
 class PainterStateSaver {

--- a/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
@@ -41,58 +41,21 @@ void SVGGeometryPaintable::paint(PaintContext& context, PaintPhase phase) const
     Gfx::AntiAliasingPainter painter { context.painter() };
     auto& svg_context = context.svg_context();
 
-    auto offset = svg_context.svg_element_position();
-    painter.translate(offset);
-
-    auto const* svg_element = geometry_element.first_ancestor_of_type<SVG::SVGSVGElement>();
-    auto maybe_view_box = svg_element->view_box();
+    auto svg_position = svg_context.svg_element_position() * context.device_pixels_per_css_pixel();
+    auto scaling = layout_box().viewbox_scaling() * context.device_pixels_per_css_pixel();
 
     context.painter().add_clip_rect(context.enclosing_device_rect(absolute_rect()).to_type<int>());
 
     Gfx::Path path = const_cast<SVG::SVGGeometryElement&>(geometry_element).get_path();
 
-    if (maybe_view_box.has_value()) {
-        Gfx::Path new_path;
-        auto scaling = layout_box().viewbox_scaling();
-        auto origin = layout_box().viewbox_origin();
+    auto origin = layout_box().viewbox_origin();
+    auto affine_transform = Gfx::AffineTransform();
+    auto x_translation = -origin.x().value() + svg_position.x();
+    auto y_translation = -origin.y().value() + svg_position.y();
 
-        auto transform_point = [&scaling, &origin](Gfx::FloatPoint point) -> Gfx::FloatPoint {
-            auto new_point = point;
-            new_point.translate_by({ -origin.x(), -origin.y() });
-            new_point.scale_by(scaling);
-            return new_point;
-        };
-
-        for (auto& segment : path.segments()) {
-            switch (segment->type()) {
-            case Gfx::Segment::Type::Invalid:
-                break;
-            case Gfx::Segment::Type::MoveTo:
-                new_path.move_to(transform_point(segment->point()));
-                break;
-            case Gfx::Segment::Type::LineTo:
-                new_path.line_to(transform_point(segment->point()));
-                break;
-            case Gfx::Segment::Type::QuadraticBezierCurveTo: {
-                auto& quadratic_bezier_segment = static_cast<Gfx::QuadraticBezierCurveSegment const&>(*segment);
-                new_path.quadratic_bezier_curve_to(transform_point(quadratic_bezier_segment.through()), transform_point(quadratic_bezier_segment.point()));
-                break;
-            }
-            case Gfx::Segment::Type::CubicBezierCurveTo: {
-                auto& cubic_bezier_segment = static_cast<Gfx::CubicBezierCurveSegment const&>(*segment);
-                new_path.cubic_bezier_curve_to(transform_point(cubic_bezier_segment.through_0()), transform_point(cubic_bezier_segment.through_1()), transform_point(cubic_bezier_segment.point()));
-                break;
-            }
-            case Gfx::Segment::Type::EllipticalArcTo: {
-                auto& elliptical_arc_segment = static_cast<Gfx::EllipticalArcSegment const&>(*segment);
-                new_path.elliptical_arc_to(transform_point(elliptical_arc_segment.point()), elliptical_arc_segment.radii().scaled_by(scaling, scaling), elliptical_arc_segment.x_axis_rotation(), elliptical_arc_segment.large_arc(), elliptical_arc_segment.sweep());
-                break;
-            }
-            }
-        }
-
-        path = new_path;
-    }
+    affine_transform.scale(scaling, scaling);
+    affine_transform.set_translation(x_translation, y_translation);
+    painter.set_transform(affine_transform);
 
     if (auto fill_color = geometry_element.fill_color().value_or(svg_context.fill_color()); fill_color.alpha() > 0) {
         // We need to fill the path before applying the stroke, however the filled
@@ -115,7 +78,6 @@ void SVGGeometryPaintable::paint(PaintContext& context, PaintPhase phase) const
             geometry_element.stroke_width().value_or(svg_context.stroke_width()));
     }
 
-    painter.translate(-offset);
     context.painter().clear_clip_rect();
 }
 


### PR DESCRIPTION
Previously when zooming in/out in the browser SVG's would paint outside of their clip rect and would not show on the screen. This patch scales the SVG and it's origin using the device_pixels_per_css_pixel ratio.

**Note:** This code change looks way bigger than it is, most of it is is indentation. 

With this commit we can display the github page zoomed in like this with the SVG's in the correct place and sized accordingly. Note that this increases the clarity of the SVG as it will be rendered at a higher resolution. (only when zoomed in)
![image](https://user-images.githubusercontent.com/10757347/226492999-fe57eb8e-1f45-4730-99ae-7a208b9885de.png)




