### PR TITLE
LibTLS: Check that all certificates in cacert.pem are self signed

### DIFF
--- a/Tests/LibTLS/TestTLSHandshake.cpp
+++ b/Tests/LibTLS/TestTLSHandshake.cpp
@@ -72,8 +72,11 @@ Vector<Certificate> load_certificates()
             continue;
         }
         auto certificate = certificate_result.release_value();
-        if (certificate.is_certificate_authority)
+        if (certificate.is_certificate_authority && certificate.is_self_signed()) {
             certificates.append(move(certificate));
+        } else {
+            dbgln("Skipped '{}' because it is not a valid root CA", certificate.subject_identifier_string());
+        }
     }
 
     return certificates;

--- a/Userland/Libraries/LibTLS/Certificate.cpp
+++ b/Userland/Libraries/LibTLS/Certificate.cpp
@@ -349,6 +349,11 @@ Optional<Certificate> Certificate::parse_asn1(ReadonlyBytes buffer, bool)
             return {};
     }
 
+    // self issued
+    {
+        certificate.is_self_issued = certificate.issuer_identifier_string() == certificate.subject_identifier_string();
+    }
+
     // extensions
     {
         if (certificate.version == 2) {

--- a/Userland/Libraries/LibTLS/Certificate.h
+++ b/Userland/Libraries/LibTLS/Certificate.h
@@ -60,9 +60,11 @@ public:
     bool is_allowed_to_sign_certificate { false };
     bool is_certificate_authority { false };
     Optional<size_t> path_length_constraint {};
+    bool is_self_issued { false };
 
     static Optional<Certificate> parse_asn1(ReadonlyBytes, bool client_cert = false);
 
+    bool is_self_signed();
     bool is_valid() const;
 
     DeprecatedString subject_identifier_string() const
@@ -124,6 +126,9 @@ public:
         }
         return cert_name.to_deprecated_string();
     }
+
+private:
+    Optional<bool> m_is_self_signed;
 };
 
 class DefaultRootCACertificates {

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -522,12 +522,11 @@ void DefaultRootCACertificates::reload_certificates(ByteBuffer& data)
             continue;
         }
         auto certificate = certificate_result.release_value();
-        // FIXME: We might want to check additional things here to make sure we only load root CAs:
-        //        - Root certificates are self-signed
-        //        - Either it has matched Authority Key Identifier with Subject Key Identifier,
-        //        - in some cases there is no Authority Key identifier, then Issuer string should match with Subject string
-        if (certificate.is_certificate_authority)
+        if (certificate.is_certificate_authority && certificate.is_self_signed()) {
             m_ca_certificates.append(move(certificate));
+        } else {
+            dbgln("Skipped '{}' because it is not a valid root CA", certificate.subject_identifier_string());
+        }
     }
 
     dbgln("Loaded {} of {} ({:.2}%) provided CA Certificates", m_ca_certificates.size(), certs.size(), (m_ca_certificates.size() * 100.0) / certs.size());

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -115,6 +115,23 @@ bool Certificate::is_valid() const
     return true;
 }
 
+// https://www.ietf.org/rfc/rfc5280.html#page-12
+bool Certificate::is_self_signed()
+{
+    if (m_is_self_signed.has_value())
+        return *m_is_self_signed;
+
+    // Self-signed certificates are self-issued certificates where the digital
+    // signature may be verified by the public key bound into the certificate.
+    if (!this->is_self_issued)
+        m_is_self_signed.emplace(false);
+
+    // FIXME: Actually check if we sign ourself
+
+    m_is_self_signed.emplace(true);
+    return *m_is_self_signed;
+}
+
 void TLSv12::try_disambiguate_error() const
 {
     dbgln("Possible failure cause(s): ");


### PR DESCRIPTION
To be a root CA a CA needs to be self signed.

This PR adds the very basics of this check as the more advanced methods are currently not supported by our parser.