### PR TITLE
LibGfx/OpenType: Dynamically parse GPOS::ValueRecord depending on the valueFormat in the PairPosFormat1 table

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -1122,7 +1122,7 @@ Optional<i16> GPOS::glyph_kerning(u16 left_glyph_id, u16 right_glyph_id) const
 
                 if (!coverage_index.has_value()) {
                     dbgln_if(OPENTYPE_GPOS_DEBUG, "Glyph ID not covered by table");
-                    return {};
+                    continue;
                 }
 
                 size_t value1_size = popcount(static_cast<u32>(pair_pos_format1.value_format1 & 0xff)) * sizeof(u16);
@@ -1202,7 +1202,7 @@ Optional<i16> GPOS::glyph_kerning(u16 left_glyph_id, u16 right_glyph_id) const
 
                 if (!left_class.has_value() || !right_class.has_value()) {
                     dbgln_if(OPENTYPE_GPOS_DEBUG, "Need glyph class for both sides");
-                    return {};
+                    continue;
                 }
 
                 dbgln_if(OPENTYPE_GPOS_DEBUG, "Classes: {}, {}", left_class.value(), right_class.value());

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, Srimanta Barua <srimanta.barua1@gmail.com>
  * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
+ * Copyright (c) 2023, Lukas Affolter <git@lukasach.dev>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -635,19 +636,6 @@ public:
         Offset16 y_placement_device_offset;
         Offset16 x_advance_device_offset;
         Offset16 y_advance_device_offset;
-    };
-
-    // https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-1-adjustments-for-glyph-pairs
-    struct PairValueRecord {
-        BigEndian<u16> second_glyph;
-        ValueRecord value_record1;
-        ValueRecord value_record2;
-    };
-
-    // https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-1-adjustments-for-glyph-pairs
-    struct PairSet {
-        BigEndian<u16> pair_value_count;
-        PairValueRecord pair_value_records[];
     };
 
     // https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-2-class-pair-adjustment


### PR DESCRIPTION
In https://github.com/SerenityOS/serenity/pull/17951 while implementing the [`PairPosFormat1` subtable](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-1-adjustments-for-glyph-pairs), I made an error by `bit_cast`ing the contents of the `PairValueRecord` to a ValueRecord. Instead, the field `valueFormat(1/2)` specifies which fields of the `ValueRecord` are actually stored.

Here, I take a similar approach to the implementation in `PairPosFormat2`, and extracted the helper function `read_value_record`. I am not sure if this is the correct way to do this. I did not want to include it in `Table.h` due to the reference to `FixedMemoryStream` and the additional header include.

Comparison table of a Font using PairPosFormat1:
(See the section 'Other links')
no kerning | only kerning using GPOS
:------:|:-----:
<img width="912" alt="without kerning" src="https://user-images.githubusercontent.com/16141905/226667408-e1a4d133-441f-4ba3-8676-0343e9212db9.png"> | <img width="912" alt="with kerning" src="https://user-images.githubusercontent.com/16141905/226667441-e27bddef-986e-4bb3-8d5b-2431ee79b54d.png">