### PR TITLE
LibJS: Ensure Date tests can pass in any time zone by testing UTC values

### DIFF
--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -280,7 +280,9 @@ Optional<DateTime> DateTime::parse(StringView format, DeprecatedString const& st
 {
     unsigned format_pos = 0;
     unsigned string_pos = 0;
+
     struct tm tm = {};
+    tm.tm_isdst = -1;
 
     auto parsing_failed = false;
     auto tm_represents_utc_time = false;
@@ -549,4 +551,5 @@ Optional<DateTime> DateTime::parse(StringView format, DeprecatedString const& st
 
     return DateTime::from_timestamp(mktime(&tm));
 }
+
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.js
@@ -14,16 +14,14 @@ test("timestamp constructor", () => {
     // The timestamp constructor takes a timestamp in milliseconds since the start of the epoch, in UTC.
 
     // 50 days and 1234 milliseconds after the start of the epoch.
-    // Most Date methods return values in local time, but since timezone offsets are less than 17 days,
-    // these checks will pass in all timezones.
     let timestamp = 50 * 24 * 60 * 60 * 1000 + 1234;
 
     let date = new Date(timestamp);
     expect(date.getTime()).toBe(timestamp); // getTime() returns the timestamp in UTC.
-    expect(date.getMilliseconds()).toBe(234);
-    expect(date.getSeconds()).toBe(1);
-    expect(date.getFullYear()).toBe(1970);
-    expect(date.getMonth()).toBe(1); // Feb
+    expect(date.getUTCMilliseconds()).toBe(234);
+    expect(date.getUTCSeconds()).toBe(1);
+    expect(date.getUTCFullYear()).toBe(1970);
+    expect(date.getUTCMonth()).toBe(1); // Feb
 
     date = new Date(NaN);
     expect(date.getTime()).toBe(NaN);

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setTime.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setTime.js
@@ -22,9 +22,9 @@ test("Timestamp as argument", () => {
     let date = new Date(2021, 0, 1);
 
     date.setTime(1622993746000);
-    expect(date.getDate()).toBe(6);
-    expect(date.getMonth()).toBe(5);
-    expect(date.getFullYear()).toBe(2021);
+    expect(date.getUTCDate()).toBe(6);
+    expect(date.getUTCMonth()).toBe(5);
+    expect(date.getUTCFullYear()).toBe(2021);
     expect(date.getUTCHours()).toBe(15);
     expect(date.getUTCMinutes()).toBe(35);
     expect(date.getUTCSeconds()).toBe(46);
@@ -37,9 +37,9 @@ test("Make Invalid Date valid again", () => {
     expect(date.getTime()).toBe(NaN);
 
     date.setTime(1622993746000);
-    expect(date.getDate()).toBe(6);
-    expect(date.getMonth()).toBe(5);
-    expect(date.getFullYear()).toBe(2021);
+    expect(date.getUTCDate()).toBe(6);
+    expect(date.getUTCMonth()).toBe(5);
+    expect(date.getUTCFullYear()).toBe(2021);
     expect(date.getUTCHours()).toBe(15);
     expect(date.getUTCMinutes()).toBe(35);
     expect(date.getUTCSeconds()).toBe(46);


### PR DESCRIPTION
Note that not all tests can pass in all time zones yet due to LibTimeZone incompleteness. For example, in `America/Bahia_Banderas`, we fail `Date.parse("10/1/2021")`. We incorrectly think that date is in Standard time because we don't handle rules like "lastSun" yet.