### PR TITLE
LibPDF: Several small bug fixes

### DIFF
--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -692,19 +692,13 @@ bool DocumentParser::navigate_to_before_eof_marker()
     m_reader.set_reading_backwards();
 
     while (!m_reader.done()) {
+        m_reader.consume_eol();
+        if (m_reader.matches("%%EOF")) {
+            m_reader.move_by(5);
+            return true;
+        }
+
         m_reader.move_until([&](auto) { return m_reader.matches_eol(); });
-        if (m_reader.done())
-            return false;
-
-        m_reader.consume_eol();
-        if (!m_reader.matches("%%EOF"))
-            continue;
-
-        m_reader.move_by(5);
-        if (!m_reader.matches_eol())
-            continue;
-        m_reader.consume_eol();
-        return true;
     }
 
     return false;

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -23,7 +23,7 @@ PDFErrorOr<void> TrueTypeFont::initialize(Document* document, NonnullRefPtr<Dict
             auto font_file_stream = TRY(descriptor->get_stream(document, CommonNames::FontFile2));
             auto ttf_font = TRY(OpenType::Font::try_load_from_externally_owned_memory(font_file_stream->bytes()));
             float point_size = (font_size * POINTS_PER_INCH) / DEFAULT_DPI;
-            m_font = adopt_ref(*new Gfx::ScaledFont(*ttf_font, font_size, point_size));
+            m_font = adopt_ref(*new Gfx::ScaledFont(*ttf_font, point_size, point_size));
         }
     }
 

--- a/Userland/Libraries/LibPDF/Reader.cpp
+++ b/Userland/Libraries/LibPDF/Reader.cpp
@@ -46,8 +46,11 @@ bool Reader::consume_eol()
         consume(2);
         return true;
     }
-    auto consumed = consume();
-    return consumed == 0xd || consumed == 0xa;
+    if (matches_eol()) {
+        consume();
+        return true;
+    }
+    return false;
 }
 
 bool Reader::consume_whitespace()


### PR DESCRIPTION
I resolved these issues:
- TrueTypeFont used different point sizes for x and y
- The end-of-file marker couldn't be found in some documents, even though it exists
- It was assumed that, even for non-linearized files, there had to be a dictionary after the file header

Also, we now accept documents with broken headers, since we don't need that information for anything. If there are other issues with the document, we should throw a related error anyway.