### PR TITLE
LibGfx/JPEG: Replace a FIXME with some explanations

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -1306,8 +1306,9 @@ static ErrorOr<void> handle_color_transform(JPEGLoadingContext const& context, V
         ycbcr_to_rgb(context, macroblocks);
 
     if (context.components.size() == 1) {
-        // FIXME: This is what we used to do for grayscale,
-        //        we should at least document it and maybe change it.
+        // With Cb and Cr being equal to zero, this function assign the Y
+        // value (luminosity) to R, G and B. Providing a proper conversion
+        // from grayscale to RGB.
         ycbcr_to_rgb(context, macroblocks);
     }
 


### PR DESCRIPTION
Calling the `ycbcr_to_rgb` function still looks unsuitable for this usage, but it does the job correctly.