### PR TITLE
LibJS+LibWeb: Ensure all GC-allocated fields are visited

### DIFF
--- a/Userland/Libraries/LibJS/CyclicModule.cpp
+++ b/Userland/Libraries/LibJS/CyclicModule.cpp
@@ -25,7 +25,8 @@ void CyclicModule::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_cycle_root);
-    for (auto module : m_async_parent_modules)
+    visitor.visit(m_top_level_capability);
+    for (auto const& module : m_async_parent_modules)
         visitor.visit(module);
 }
 

--- a/Userland/Libraries/LibJS/Heap/Cell.h
+++ b/Userland/Libraries/LibJS/Heap/Cell.h
@@ -80,6 +80,13 @@ public:
                 visit_impl(value.as_cell());
         }
 
+        // Allow explicitly ignoring a GC-allocated member in a visit_edges implementation instead
+        // of just not using it.
+        template<typename T>
+        void ignore(T const&)
+        {
+        }
+
     protected:
         virtual void visit_impl(Cell&) = 0;
         virtual ~Visitor() = default;

--- a/Userland/Libraries/LibJS/Runtime/Accessor.h
+++ b/Userland/Libraries/LibJS/Runtime/Accessor.h
@@ -30,6 +30,7 @@ public:
 
     void visit_edges(Cell::Visitor& visitor) override
     {
+        Base::visit_edges(visitor);
         visitor.visit(m_getter);
         visitor.visit(m_setter);
     }

--- a/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIterator.cpp
@@ -30,7 +30,7 @@ ThrowCompletionOr<void> AsyncFromSyncIterator::initialize(Realm& realm)
 
 void AsyncFromSyncIterator::visit_edges(Cell::Visitor& visitor)
 {
-    Object::visit_edges(visitor);
+    Base::visit_edges(visitor);
     visitor.visit(m_sync_iterator_record.iterator);
     visitor.visit(m_sync_iterator_record.next_method);
 }

--- a/Userland/Libraries/LibJS/Runtime/Environment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Environment.cpp
@@ -16,7 +16,7 @@ Environment::Environment(Environment* outer_environment)
 
 void Environment::visit_edges(Visitor& visitor)
 {
-    Cell::visit_edges(visitor);
+    Base::visit_edges(visitor);
     visitor.visit(m_outer_environment);
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
@@ -355,6 +355,17 @@ void Intrinsics::visit_edges(Visitor& visitor)
     visitor.visit(m_async_generator_prototype);
     visitor.visit(m_generator_prototype);
     visitor.visit(m_intl_segments_prototype);
+    visitor.visit(m_eval_function);
+    visitor.visit(m_is_finite_function);
+    visitor.visit(m_is_nan_function);
+    visitor.visit(m_parse_float_function);
+    visitor.visit(m_parse_int_function);
+    visitor.visit(m_decode_uri_function);
+    visitor.visit(m_decode_uri_component_function);
+    visitor.visit(m_encode_uri_function);
+    visitor.visit(m_encode_uri_component_function);
+    visitor.visit(m_escape_function);
+    visitor.visit(m_unescape_function);
     visitor.visit(m_array_prototype_values_function);
     visitor.visit(m_date_constructor_now_function);
     visitor.visit(m_eval_function);

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
@@ -345,6 +345,7 @@ JS_ENUMERATE_BUILTIN_NAMESPACE_OBJECTS
 
 void Intrinsics::visit_edges(Visitor& visitor)
 {
+    Base::visit_edges(visitor);
     visitor.visit(m_realm);
     visitor.visit(m_empty_object_shape);
     visitor.visit(m_new_object_shape);

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -1288,7 +1288,7 @@ Optional<Completion> Object::enumerate_object_properties(Function<Optional<Compl
 
 void Object::visit_edges(Cell::Visitor& visitor)
 {
-    Cell::visit_edges(visitor);
+    Base::visit_edges(visitor);
     visitor.visit(m_shape);
 
     for (auto& value : m_storage)

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -51,7 +51,7 @@ PrimitiveString::~PrimitiveString()
 
 void PrimitiveString::visit_edges(Cell::Visitor& visitor)
 {
-    Cell::visit_edges(visitor);
+    Base::visit_edges(visitor);
     if (m_is_rope) {
         visitor.visit(m_lhs);
         visitor.visit(m_rhs);

--- a/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.cpp
@@ -47,7 +47,7 @@ bool PrivateName::operator==(PrivateName const& rhs) const
 
 void PrivateEnvironment::visit_edges(Visitor& visitor)
 {
-    Cell::visit_edges(visitor);
+    Base::visit_edges(visitor);
     visitor.visit(m_outer_environment);
 }
 

--- a/Userland/Libraries/LibJS/Runtime/PromiseCapability.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseCapability.cpp
@@ -25,6 +25,7 @@ PromiseCapability::PromiseCapability(GCPtr<Object> promise, GCPtr<FunctionObject
 
 void PromiseCapability::visit_edges(Cell::Visitor& visitor)
 {
+    Base::visit_edges(visitor);
     visitor.visit(m_promise);
     visitor.visit(m_resolve);
     visitor.visit(m_reject);

--- a/Userland/Libraries/LibJS/Runtime/PromiseReaction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseReaction.cpp
@@ -24,7 +24,7 @@ PromiseReaction::PromiseReaction(Type type, GCPtr<PromiseCapability> capability,
 
 void PromiseReaction::visit_edges(Cell::Visitor& visitor)
 {
-    Cell::visit_edges(visitor);
+    Base::visit_edges(visitor);
     visitor.visit(m_capability);
 }
 

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
@@ -15,7 +15,7 @@ namespace JS {
 
 void PromiseValueList::visit_edges(Visitor& visitor)
 {
-    Cell::visit_edges(visitor);
+    Base::visit_edges(visitor);
     for (auto& val : m_values)
         visitor.visit(val);
 }

--- a/Userland/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Shape.cpp
@@ -123,6 +123,7 @@ void Shape::visit_edges(Cell::Visitor& visitor)
         for (auto& it : *m_property_table)
             it.key.visit_edges(visitor);
     }
+    visitor.ignore(m_prototype_transitions);
 }
 
 Optional<PropertyMetadata> Shape::lookup(StringOrSymbol const& property_key) const

--- a/Userland/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Shape.cpp
@@ -114,7 +114,7 @@ Shape::Shape(Shape& previous_shape, Object* new_prototype)
 
 void Shape::visit_edges(Cell::Visitor& visitor)
 {
-    Cell::visit_edges(visitor);
+    Base::visit_edges(visitor);
     visitor.visit(m_realm);
     visitor.visit(m_prototype);
     visitor.visit(m_previous);

--- a/Userland/Libraries/LibWeb/Bindings/Intrinsics.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/Intrinsics.cpp
@@ -17,10 +17,13 @@ void Intrinsics::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
 
+    for (auto& it : m_namespaces)
+        visitor.visit(it.value);
     for (auto& it : m_prototypes)
         visitor.visit(it.value);
     for (auto& it : m_constructors)
         visitor.visit(it.value);
+    visitor.visit(m_realm);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
@@ -73,9 +73,9 @@ void AccessibilityTreeNode::serialize_tree_as_json(JsonObjectSerializer<StringBu
 void AccessibilityTreeNode::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(value());
-    for (auto child : children())
-        child->visit_edges(visitor);
+    visitor.visit(m_value);
+    for (auto const& child : m_children)
+        visitor.visit(child);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/DOMEventListener.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMEventListener.cpp
@@ -15,7 +15,7 @@ DOMEventListener::~DOMEventListener() = default;
 
 void DOMEventListener::visit_edges(Cell::Visitor& visitor)
 {
-    Cell::visit_edges(visitor);
+    Base::visit_edges(visitor);
     visitor.visit(callback.ptr());
     visitor.visit(signal.ptr());
 }

--- a/Userland/Libraries/LibWeb/DOM/DOMEventListener.h
+++ b/Userland/Libraries/LibWeb/DOM/DOMEventListener.h
@@ -16,6 +16,8 @@ namespace Web::DOM {
 // https://dom.spec.whatwg.org/#concept-event-listener
 // NOTE: The spec calls this "event listener", and it's *importantly* not the same as "EventListener"
 class DOMEventListener : public JS::Cell {
+    JS_CELL(DOMEventListener, JS::Cell);
+
 public:
     DOMEventListener();
     ~DOMEventListener();
@@ -43,7 +45,6 @@ public:
 
 private:
     virtual void visit_edges(Cell::Visitor&) override;
-    virtual StringView class_name() const override { return "DOMEventListener"sv; }
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -328,19 +328,20 @@ JS::ThrowCompletionOr<void> Document::initialize(JS::Realm& realm)
 void Document::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_window.ptr());
-    visitor.visit(m_style_sheets.ptr());
-    visitor.visit(m_hovered_node.ptr());
-    visitor.visit(m_inspected_node.ptr());
-    visitor.visit(m_active_favicon.ptr());
-    visitor.visit(m_focused_element.ptr());
-    visitor.visit(m_active_element.ptr());
-    visitor.visit(m_implementation.ptr());
-    visitor.visit(m_current_script.ptr());
-    visitor.visit(m_associated_inert_template_document.ptr());
+    visitor.visit(m_window);
+    visitor.visit(m_layout_root);
+    visitor.visit(m_style_sheets);
+    visitor.visit(m_hovered_node);
+    visitor.visit(m_inspected_node);
+    visitor.visit(m_active_favicon);
+    visitor.visit(m_focused_element);
+    visitor.visit(m_active_element);
+    visitor.visit(m_implementation);
+    visitor.visit(m_current_script);
+    visitor.visit(m_associated_inert_template_document);
     visitor.visit(m_appropriate_template_contents_owner_document);
-    visitor.visit(m_pending_parsing_blocking_script.ptr());
-    visitor.visit(m_history.ptr());
+    visitor.visit(m_pending_parsing_blocking_script);
+    visitor.visit(m_history);
 
     visitor.visit(m_browsing_context);
 
@@ -357,17 +358,17 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_parser);
 
     for (auto& script : m_scripts_to_execute_when_parsing_has_finished)
-        visitor.visit(script.ptr());
+        visitor.visit(script);
     for (auto& script : m_scripts_to_execute_as_soon_as_possible)
-        visitor.visit(script.ptr());
+        visitor.visit(script);
 
     for (auto& node_iterator : m_node_iterators)
         visitor.visit(node_iterator);
 
     for (auto& target : m_pending_scroll_event_targets)
-        visitor.visit(target.ptr());
+        visitor.visit(target);
     for (auto& target : m_pending_scrollend_event_targets)
-        visitor.visit(target.ptr());
+        visitor.visit(target);
 }
 
 // https://w3c.github.io/selection-api/#dom-document-getselection

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
@@ -22,7 +22,14 @@ void Request::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_header_list);
-    for (auto pending_response : m_pending_responses)
+    visitor.visit(m_client);
+    m_reserved_client.visit(
+        [&](JS::GCPtr<HTML::EnvironmentSettingsObject> const& value) { visitor.visit(value); },
+        [](auto const&) {});
+    m_window.visit(
+        [&](JS::GCPtr<HTML::EnvironmentSettingsObject> const& value) { visitor.visit(value); },
+        [](auto const&) {});
+    for (auto const& pending_response : m_pending_responses)
         visitor.visit(pending_response);
 }
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
@@ -157,7 +157,7 @@ public:
     using OriginType = Variant<Origin, HTML::Origin>;
     using PolicyContainerType = Variant<PolicyContainer, HTML::PolicyContainer>;
     using ReferrerType = Variant<Referrer, AK::URL>;
-    using ReservedClientType = Variant<Empty, JS::GCPtr<HTML::Environment>, JS::GCPtr<HTML::EnvironmentSettingsObject>>;
+    using ReservedClientType = Variant<Empty, HTML::Environment*, JS::GCPtr<HTML::EnvironmentSettingsObject>>;
     using WindowType = Variant<Window, JS::GCPtr<HTML::EnvironmentSettingsObject>>;
 
     [[nodiscard]] static JS::NonnullGCPtr<Request> create(JS::VM&);

--- a/Userland/Libraries/LibWeb/HTML/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventHandler.cpp
@@ -21,7 +21,7 @@ EventHandler::EventHandler(WebIDL::CallbackType& c)
 
 void EventHandler::visit_edges(Cell::Visitor& visitor)
 {
-    Cell::visit_edges(visitor);
+    Base::visit_edges(visitor);
     visitor.visit(listener);
 
     if (auto* callback = value.get_pointer<JS::GCPtr<WebIDL::CallbackType>>())

--- a/Userland/Libraries/LibWeb/HTML/EventHandler.h
+++ b/Userland/Libraries/LibWeb/HTML/EventHandler.h
@@ -14,6 +14,8 @@
 namespace Web::HTML {
 
 class EventHandler final : public JS::Cell {
+    JS_CELL(EventHandler, JS::Cell);
+
 public:
     explicit EventHandler(DeprecatedString);
     explicit EventHandler(WebIDL::CallbackType&);
@@ -29,7 +31,6 @@ public:
     JS::GCPtr<DOM::DOMEventListener> listener;
 
 private:
-    virtual StringView class_name() const override { return "EventHandler"sv; }
     virtual void visit_edges(Cell::Visitor&) override;
 };
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -79,13 +79,13 @@ private:
         HTML::Origin origin;
         // environment
         //      An environment
-        HTML::EnvironmentSettingsObject* environment;
+        JS::GCPtr<HTML::EnvironmentSettingsObject> environment;
         // policy container
         //      A policy container
         HTML::PolicyContainer policy_container;
         // document (default null)
         //      Null or a Document
-        Web::DOM::Document* document { nullptr };
+        JS::GCPtr<Web::DOM::Document> document;
         // FIXME: on document ready (default null)
         //          Null or an algorithm accepting a Document
     };

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -37,6 +37,7 @@ void EnvironmentSettingsObject::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(target_browsing_context);
+    visitor.ignore(m_outstanding_rejected_promises_weak_set);
 }
 
 JS::ExecutionContext& EnvironmentSettingsObject::realm_execution_context()

--- a/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
@@ -22,7 +22,7 @@ WindowEnvironmentSettingsObject::~WindowEnvironmentSettingsObject() = default;
 
 void WindowEnvironmentSettingsObject::visit_edges(JS::Cell::Visitor& visitor)
 {
-    EnvironmentSettingsObject::visit_edges(visitor);
+    Base::visit_edges(visitor);
     visitor.visit(m_window.ptr());
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -45,6 +45,10 @@ void Worker::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_inner_settings);
     visitor.visit(m_implicit_port);
     visitor.visit(m_outside_port);
+
+    // These are in a separate VM and shouldn't be visited
+    visitor.ignore(m_worker_realm);
+    visitor.ignore(m_worker_scope);
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-worker

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -41,9 +41,10 @@ JS::ThrowCompletionOr<void> Worker::initialize(JS::Realm& realm)
 void Worker::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_document.ptr());
-    visitor.visit(m_implicit_port.ptr());
-    visitor.visit(m_outside_port.ptr());
+    visitor.visit(m_document);
+    visitor.visit(m_inner_settings);
+    visitor.visit(m_implicit_port);
+    visitor.visit(m_outside_port);
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-worker

--- a/Userland/Libraries/LibWeb/WebIDL/CallbackType.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/CallbackType.cpp
@@ -16,10 +16,9 @@ CallbackType::CallbackType(JS::Object& callback, HTML::EnvironmentSettingsObject
 {
 }
 
-StringView CallbackType::class_name() const { return "CallbackType"sv; }
 void CallbackType::visit_edges(Cell::Visitor& visitor)
 {
-    Cell::visit_edges(visitor);
+    Base::visit_edges(visitor);
     visitor.visit(callback);
     visitor.visit(callback_context);
 }

--- a/Userland/Libraries/LibWeb/WebIDL/CallbackType.h
+++ b/Userland/Libraries/LibWeb/WebIDL/CallbackType.h
@@ -14,6 +14,8 @@ namespace Web::WebIDL {
 
 // https://webidl.spec.whatwg.org/#idl-callback-interface
 class CallbackType final : public JS::Cell {
+    JS_CELL(CallbackType, JS::Cell);
+
 public:
     CallbackType(JS::Object& callback, HTML::EnvironmentSettingsObject& callback_context);
 
@@ -23,7 +25,6 @@ public:
     JS::NonnullGCPtr<HTML::EnvironmentSettingsObject> callback_context;
 
 private:
-    virtual StringView class_name() const override;
     virtual void visit_edges(Cell::Visitor&) override;
 };
 


### PR DESCRIPTION
This expands the LibJSGCVerifier tool to also check the various `visit_edges` implementations. Specifically, it ensures they all start with a call to `Base::visit_edges(visitor)`, as well as visiting all of their GC-allocated members (well, at least accessing. See the comment in the code for more info).