### PR TITLE
LibGUI: Resolve use-after-free error

### DIFF
--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -729,7 +729,7 @@ bool FileSystemModel::fetch_thumbnail_for(Node const& node)
     auto const on_error = [path, update_progress](Error error) -> void {
         // Note: We need to defer that to avoid the function removing its last reference
         //       i.e. trying to destroy itself, which is prohibited.
-        Core::EventLoop::current().deferred_invoke([&] {
+        Core::EventLoop::current().deferred_invoke([path, error = Error::copy(error)]() mutable {
             s_thumbnail_cache.with_locked([path, error = move(error)](auto& cache) {
                 if (error != Error::from_errno(ECANCELED)) {
                     cache.thumbnail_cache.set(path, nullptr);


### PR DESCRIPTION
Objects taken by reference are no longer valid when used in `deferred_invoke`. Explicitly copying them solve the issue.