### PR TITLE
LibFileSystemAccessClient: Don't make illegal operation on files

### DIFF
--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -129,13 +129,13 @@ void Client::handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> co
         return;
     }
 
-    if (FileSystem::is_device(*chosen_file)) {
+    if (FileSystem::is_device(ipc_file->fd())) {
         GUI::MessageBox::show_error(request_data.parent_window, DeprecatedString::formatted("Opening \"{}\" failed: Cannot open device files", *chosen_file));
         request_data.promise->resolve(Error::from_string_literal("Cannot open device files")).release_value_but_fixme_should_propagate_errors();
         return;
     }
 
-    if (FileSystem::is_directory(*chosen_file)) {
+    if (FileSystem::is_directory(ipc_file->fd())) {
         GUI::MessageBox::show_error(request_data.parent_window, DeprecatedString::formatted("Opening \"{}\" failed: Cannot open directory", *chosen_file));
         request_data.promise->resolve(Error::from_errno(EISDIR)).release_value_but_fixme_should_propagate_errors();
         return;


### PR DESCRIPTION
`handle_prompt_end` is calling `is_device` and `is_directory` on the path chosen by the user. However, this path is not necessarily unveiled. Meaning that it the both functions results in an illegal operation.

This is a regression introduced with the usage of LibFileSystem in 1d24f394. This patch, revert the behavior at its previous state, i.e. calling both functions with the fd provided by the FSAS.

Result of `pp unicorn.jpg`:

![Capture d’écran du 2023-03-21 22-49-24](https://user-images.githubusercontent.com/26030965/226789469-4c111f27-a3f3-48cd-891b-0f55d0f55f70.png)

Result of `te Documents` (it used to gracefully show an error dialog):
![Capture d’écran du 2023-03-21 22-50-07](https://user-images.githubusercontent.com/26030965/226789559-e11b12e4-7651-4934-993e-9d9cdd899fc2.png)
