### PR TITLE
Applications+Libraries: Move to `LibFileSystem`

### DIFF
--- a/Userland/Applications/3DFileViewer/WavefrontOBJLoader.cpp
+++ b/Userland/Applications/3DFileViewer/WavefrontOBJLoader.cpp
@@ -9,7 +9,6 @@
 #include "WavefrontOBJLoader.h"
 #include <AK/FixedArray.h>
 #include <AK/String.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/File.h>
 #include <stdlib.h>
 

--- a/Userland/Applications/Escalator/CMakeLists.txt
+++ b/Userland/Applications/Escalator/CMakeLists.txt
@@ -16,4 +16,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_app(Escalator ICON app-escalator)
-target_link_libraries(Escalator PRIVATE LibCore LibDesktop LibGfx LibGUI LibMain)
+target_link_libraries(Escalator PRIVATE LibCore LibFileSystem LibDesktop LibGfx LibGUI LibMain)

--- a/Userland/Applications/Escalator/main.cpp
+++ b/Userland/Applications/Escalator/main.cpp
@@ -9,8 +9,8 @@
 #include <AK/DeprecatedString.h>
 #include <LibCore/Account.h>
 #include <LibCore/ArgsParser.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Desktop.h>
 #include <LibGUI/MessageBox.h>
@@ -33,8 +33,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    auto executable_path = Core::DeprecatedFile::resolve_executable_from_environment(command[0]);
-    if (!executable_path.has_value()) {
+    auto executable_path = FileSystem::resolve_executable_from_environment(command[0]);
+    if (executable_path.is_error()) {
         GUI::MessageBox::show_error(nullptr, DeprecatedString::formatted("Could not execute command {}: Command not found.", command[0]));
         return 127;
     }

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -10,7 +10,6 @@
 #include <AK/NumberFormat.h>
 #include <Applications/FileManager/DirectoryView.h>
 #include <Applications/FileManager/PropertiesWindowGeneralTabGML.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/Directory.h>
 #include <LibCore/System.h>
 #include <LibDesktop/Launcher.h>
@@ -102,11 +101,11 @@ ErrorOr<void> PropertiesWindow::create_widgets(bool disable_rename)
     type->set_text(get_description(m_mode));
 
     if (S_ISLNK(m_mode)) {
-        auto link_destination_or_error = Core::DeprecatedFile::read_link(m_path);
+        auto link_destination_or_error = FileSystem::read_link(m_path);
         if (link_destination_or_error.is_error()) {
             perror("readlink");
         } else {
-            auto link_destination = link_destination_or_error.release_value();
+            auto link_destination = link_destination_or_error.release_value().to_deprecated_string();
             auto* link_location = general_tab->find_descendant_of_type_named<GUI::LinkLabel>("link_location");
             link_location->set_text(link_destination);
             link_location->on_click = [link_destination] {

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -12,7 +12,6 @@
 #include "ViewWidget.h"
 #include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/Directory.h>
 #include <LibCore/MappedFile.h>
 #include <LibCore/MimeData.h>

--- a/Userland/Applications/Run/CMakeLists.txt
+++ b/Userland/Applications/Run/CMakeLists.txt
@@ -16,4 +16,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_app(Run ICON app-run)
-target_link_libraries(Run PRIVATE LibCore LibDesktop LibGfx LibGUI LibMain)
+target_link_libraries(Run PRIVATE LibCore LibFileSystem LibDesktop LibGfx LibGUI LibMain)

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -147,7 +147,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 if (tree_map_widget.viewpoint() == 0)
                     window->set_title("/ - SpaceAnalyzer");
 
-                breadcrumbbar.append_segment("/", GUI::FileIconProvider::icon_for_path("/").bitmap_for_size(16), "/", "/");
+                breadcrumbbar.append_segment("/", GUI::FileIconProvider::icon_for_path("/"sv).bitmap_for_size(16), "/", "/");
                 continue;
             }
 

--- a/Userland/Applications/Terminal/CMakeLists.txt
+++ b/Userland/Applications/Terminal/CMakeLists.txt
@@ -9,4 +9,4 @@ set(SOURCES
 )
 
 serenity_app(Terminal ICON app-terminal)
-target_link_libraries(Terminal PRIVATE LibConfig LibCore LibDesktop LibGfx LibGUI LibVT LibMain)
+target_link_libraries(Terminal PRIVATE LibConfig LibCore LibFileSystem LibDesktop LibGfx LibGUI LibVT LibMain)

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -10,10 +10,10 @@
 #include <LibConfig/Client.h>
 #include <LibConfig/Listener.h>
 #include <LibCore/ArgsParser.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/System.h>
 #include <LibDesktop/Launcher.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -9,7 +9,7 @@
 #include <AK/ScopedValueRollback.h>
 #include <AK/Vector.h>
 #include <Kernel/API/Unveil.h>
-#include <LibCore/DeprecatedFile.h>
+#include <LibFileSystem/FileSystem.h>
 #include <alloca.h>
 #include <assert.h>
 #include <bits/pthread_cancel.h>
@@ -189,7 +189,7 @@ int execvpe(char const* filename, char* const argv[], char* const envp[])
 
     ScopedValueRollback errno_rollback(errno);
 
-    // TODO: Make this use the PATH search implementation from Core::DeprecatedFile.
+    // TODO: Make this use the PATH search implementation from LibFileSystem.
     DeprecatedString path = getenv("PATH");
     if (path.is_empty())
         path = DEFAULT_PATH;

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <AK/LexicalPath.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibFileSystem/FileSystem.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/ConnectionToWindowServer.h>
@@ -42,7 +41,7 @@ Result Client::request_file_read_only_approved(GUI::Window* parent_window, Depre
     if (path.starts_with('/')) {
         async_request_file_read_only_approved(id, parent_window_server_client_id, parent_window_id, path);
     } else {
-        auto full_path = LexicalPath::join(Core::DeprecatedFile::current_working_directory(), path).string();
+        auto full_path = LexicalPath::join(TRY(FileSystem::current_working_directory()), path).string();
         async_request_file_read_only_approved(id, parent_window_server_client_id, parent_window_id, full_path);
     }
 
@@ -67,7 +66,7 @@ Result Client::request_file(GUI::Window* parent_window, DeprecatedString const& 
     if (path.starts_with('/')) {
         async_request_file(id, parent_window_server_client_id, parent_window_id, path, mode);
     } else {
-        auto full_path = LexicalPath::join(Core::DeprecatedFile::current_working_directory(), path).string();
+        auto full_path = LexicalPath::join(TRY(FileSystem::current_working_directory()), path).string();
         async_request_file(id, parent_window_server_client_id, parent_window_id, full_path, mode);
     }
 

--- a/Userland/Libraries/LibGUI/FileIconProvider.h
+++ b/Userland/Libraries/LibGUI/FileIconProvider.h
@@ -14,8 +14,8 @@ namespace GUI {
 
 class FileIconProvider {
 public:
-    static Icon icon_for_path(DeprecatedString const&, mode_t);
-    static Icon icon_for_path(DeprecatedString const&);
+    static Icon icon_for_path(StringView, mode_t);
+    static Icon icon_for_path(StringView);
     static Icon icon_for_executable(DeprecatedString const&);
 
     static Icon filetype_image_icon();

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -11,9 +11,9 @@
 #include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>
 #include <AK/Types.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/StandardPaths.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibGUI/AbstractView.h>
 #include <LibGUI/FileIconProvider.h>
 #include <LibGUI/FileSystemModel.h>
@@ -63,11 +63,11 @@ bool FileSystemModel::Node::fetch_data(DeprecatedString const& full_path, bool i
     mtime = st.st_mtime;
 
     if (S_ISLNK(mode)) {
-        auto sym_link_target_or_error = Core::DeprecatedFile::read_link(full_path);
+        auto sym_link_target_or_error = FileSystem::read_link(full_path);
         if (sym_link_target_or_error.is_error())
             perror("readlink");
         else {
-            symlink_target = sym_link_target_or_error.release_value();
+            symlink_target = sym_link_target_or_error.release_value().to_deprecated_string();
             if (symlink_target.is_null())
                 perror("readlink");
         }
@@ -613,7 +613,7 @@ Variant FileSystemModel::data(ModelIndex const& index, ModelRole role) const
 Icon FileSystemModel::icon_for(Node const& node) const
 {
     if (node.full_path() == "/")
-        return FileIconProvider::icon_for_path("/");
+        return FileIconProvider::icon_for_path("/"sv);
 
     if (Gfx::Bitmap::is_path_a_supported_image_format(node.name)) {
         if (!node.thumbnail) {

--- a/Userland/Libraries/LibGUI/PathBreadcrumbbar.cpp
+++ b/Userland/Libraries/LibGUI/PathBreadcrumbbar.cpp
@@ -110,7 +110,7 @@ void PathBreadcrumbbar::set_current_path(DeprecatedString const& new_path)
     } else {
         m_breadcrumbbar->clear_segments();
 
-        m_breadcrumbbar->append_segment("/", GUI::FileIconProvider::icon_for_path("/").bitmap_for_size(16), "/", "/");
+        m_breadcrumbbar->append_segment("/", GUI::FileIconProvider::icon_for_path("/"sv).bitmap_for_size(16), "/", "/");
         StringBuilder builder;
 
         for (auto& part : lexical_path.parts()) {

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -12,7 +12,6 @@
 #include <AK/ScopeGuard.h>
 #include <AK/StringBuilder.h>
 #include <AK/TemporaryChange.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/Timer.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/AutocompleteProvider.h>

--- a/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <LibCore/ArgsParser.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibFileSystem/FileSystem.h>
 #include <LibTest/JavaScriptTestRunner.h>
 #include <signal.h>
@@ -177,8 +176,19 @@ int main(int argc, char** argv)
 #endif
     }
 
-    test_root = Core::DeprecatedFile::real_path_for(test_root);
-    common_path = Core::DeprecatedFile::real_path_for(common_path);
+    auto test_root_or_error = FileSystem::real_path(test_root);
+    if (test_root_or_error.is_error()) {
+        warnln("Failed to resolve test root: {}", test_root_or_error.error());
+        return 1;
+    }
+    test_root = test_root_or_error.release_value().to_deprecated_string();
+
+    auto common_path_or_error = FileSystem::real_path(common_path);
+    if (common_path_or_error.is_error()) {
+        warnln("Failed to resolve common path: {}", common_path_or_error.error());
+        return 1;
+    }
+    common_path = common_path_or_error.release_value().to_deprecated_string();
 
     if (chdir(test_root.characters()) < 0) {
         auto saved_errno = errno;


### PR DESCRIPTION
Part one of many in the process of moving to `LibFileSystem`. The only remaining usages of `DeprecatedFile` is either using the `open/construct` functions, or inside `LibCore` as it creates a Cyclic import.