### PR TITLE
LibWeb: Correct bugs in parsing of CSS unicode-ranges

### DIFF
--- a/AK/Utf8View.h
+++ b/AK/Utf8View.h
@@ -38,6 +38,8 @@ public:
         return m_ptr - other.m_ptr;
     }
 
+    u8 const* ptr() const { return m_ptr; }
+
     // Note : These methods return the information about the underlying UTF-8 bytes.
     // If the UTF-8 string encoding is not valid at the iterator's position, then the underlying bytes might be different from the
     // decoded character's re-encoded bytes (which will be an `0xFFFD REPLACEMENT CHARACTER` with an UTF-8 length of three bytes).

--- a/Userland/Libraries/LibWeb/CSS/Parser/Token.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Token.h
@@ -147,6 +147,7 @@ public:
     ErrorOr<String> to_string() const;
     ErrorOr<String> to_debug_string() const;
 
+    String const& representation() const { return m_representation; }
     Position const& start_position() const { return m_start_position; }
     Position const& end_position() const { return m_end_position; }
 
@@ -181,6 +182,7 @@ private:
     Number m_number_value;
     HashType m_hash_type { HashType::Unrestricted };
 
+    String m_representation;
     Position m_start_position;
     Position m_end_position;
 };

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -534,10 +534,11 @@ Number Tokenizer::consume_a_number()
     // U+0065 LATIN SMALL LETTER E (e), optionally followed by U+002D HYPHEN-MINUS (-)
     // or U+002B PLUS SIGN (+), followed by a digit, then:
     auto maybe_exp = peek_triplet();
-    if (is_E(maybe_exp.first) || is_e(maybe_exp.first)) {
+    if ((is_E(maybe_exp.first) || is_e(maybe_exp.first))
+        && (((is_plus_sign(maybe_exp.second) || is_hyphen_minus(maybe_exp.second)) && is_ascii_digit(maybe_exp.third))
+            || (is_ascii_digit(maybe_exp.second)))) {
         // 1. Consume them.
         // 2. Append them to repr.
-        // FIXME: These conditions should be part of step 5 above.
         if (is_plus_sign(maybe_exp.second) || is_hyphen_minus(maybe_exp.second)) {
             if (is_ascii_digit(maybe_exp.third)) {
                 repr.append_code_point(next_code_point());

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
@@ -68,6 +68,9 @@ private:
 
     [[nodiscard]] ErrorOr<Vector<Token>> tokenize();
 
+    size_t current_byte_offset() const;
+    ErrorOr<String> input_since(size_t offset) const;
+
     [[nodiscard]] u32 next_code_point();
     [[nodiscard]] u32 peek_code_point(size_t offset = 0) const;
     [[nodiscard]] U32Twin peek_twin() const;
@@ -77,8 +80,8 @@ private:
     [[nodiscard]] U32Triplet start_of_input_stream_triplet();
 
     [[nodiscard]] static Token create_new_token(Token::Type);
-    [[nodiscard]] static Token create_value_token(Token::Type, FlyString&& value);
-    [[nodiscard]] static Token create_value_token(Token::Type, u32 value);
+    [[nodiscard]] static Token create_value_token(Token::Type, FlyString&& value, String&& representation);
+    [[nodiscard]] static Token create_value_token(Token::Type, u32 value, String&& representation);
     [[nodiscard]] ErrorOr<Token> consume_a_token();
     [[nodiscard]] ErrorOr<Token> consume_string_token(u32 ending_code_point);
     [[nodiscard]] ErrorOr<Token> consume_a_numeric_token();


### PR DESCRIPTION
This relies on the "representation" of the CSS tokens, AKA the original source text. Previously we didn't have that, and did some nasty hacks to generate it incorrectly on demand, which caused bugs. Let's actually record the representation of each token instead. :^)

Also fixed a different bug I noticed when parsing numbers.

cc: @awesomekling 