### PR TITLE
PDFViewer: Fix crash in OutlineModel

### DIFF
--- a/Userland/Applications/PDFViewer/OutlineModel.cpp
+++ b/Userland/Applications/PDFViewer/OutlineModel.cpp
@@ -130,8 +130,8 @@ GUI::ModelIndex OutlineModel::parent_index(const GUI::ModelIndex& index) const
 GUI::ModelIndex OutlineModel::index(int row, int column, const GUI::ModelIndex& parent) const
 {
     if (!parent.is_valid())
-        return create_index(row, column, &m_outline->children[row]);
+        return create_index(row, column, m_outline->children[row].ptr());
 
     auto parent_outline_item = static_cast<PDF::OutlineItem*>(parent.internal_data());
-    return create_index(row, column, &parent_outline_item->children[row]);
+    return create_index(row, column, parent_outline_item->children[row].ptr());
 }


### PR DESCRIPTION
This was a nasty crash that was allowed to happen because `GUI::ModelIndex::internal_data()` doesn't remember type information. We simply cast this pointer to the wrong type here.