### PR TITLE
ImageViewer: Various improvements

### DIFF
--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -226,8 +226,6 @@ void ViewWidget::resize_window()
 
     auto absolute_bitmap_rect = content_rect();
     absolute_bitmap_rect.translate_by(window()->rect().top_left());
-    if (window()->rect().contains(absolute_bitmap_rect))
-        return;
 
     if (!m_bitmap)
         return;
@@ -239,8 +237,14 @@ void ViewWidget::resize_window()
     if (new_size.height() < 200)
         new_size.set_height(200);
 
+    if (new_size.width() > 500)
+        new_size = { 500, 500 * absolute_bitmap_rect.height() / absolute_bitmap_rect.width() };
+    if (new_size.height() > 500)
+        new_size = { 500 * absolute_bitmap_rect.width() / absolute_bitmap_rect.height(), 500 };
+
     new_size.set_height(new_size.height() + m_toolbar_height);
     window()->resize(new_size);
+    scale_image_for_window();
 }
 
 void ViewWidget::set_bitmap(Gfx::Bitmap const* bitmap)

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -192,7 +192,11 @@ void ViewWidget::load_from_file(DeprecatedString const& path)
 
     m_path = Core::DeprecatedFile::real_path_for(path);
     GUI::Application::the()->set_most_recently_open_file(String::from_utf8(path).release_value_but_fixme_should_propagate_errors());
-    reset_view();
+
+    if (scaled_for_first_image())
+        scale_image_for_window();
+    else
+        reset_view();
 }
 
 void ViewWidget::drag_enter_event(GUI::DragEvent& event)

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -48,19 +48,13 @@ void ViewWidget::clear()
 void ViewWidget::flip(Gfx::Orientation orientation)
 {
     m_bitmap = m_bitmap->flipped(orientation).release_value_but_fixme_should_propagate_errors();
-    set_original_rect(m_bitmap->rect());
-    set_scale(scale());
-
-    resize_window();
+    scale_image_for_window();
 }
 
 void ViewWidget::rotate(Gfx::RotationDirection rotation_direction)
 {
     m_bitmap = m_bitmap->rotated(rotation_direction).release_value_but_fixme_should_propagate_errors();
-    set_original_rect(m_bitmap->rect());
-    set_scale(scale());
-
-    resize_window();
+    scale_image_for_window();
 }
 
 bool ViewWidget::is_next_available() const
@@ -213,6 +207,12 @@ void ViewWidget::drop_event(GUI::DropEvent& event)
     event.accept();
     if (on_drop)
         on_drop(event);
+}
+
+void ViewWidget::scale_image_for_window()
+{
+    set_original_rect(m_bitmap->rect());
+    fit_content_to_view(GUI::AbstractZoomPanWidget::FitType::Both);
 }
 
 void ViewWidget::resize_window()

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -213,6 +213,12 @@ void ViewWidget::drop_event(GUI::DropEvent& event)
         on_drop(event);
 }
 
+void ViewWidget::resize_event(GUI::ResizeEvent& event)
+{
+    event.accept();
+    scale_image_for_window();
+}
+
 void ViewWidget::scale_image_for_window()
 {
     set_original_rect(m_bitmap->rect());

--- a/Userland/Applications/ImageViewer/ViewWidget.h
+++ b/Userland/Applications/ImageViewer/ViewWidget.h
@@ -37,6 +37,7 @@ public:
     void set_scaled_for_first_image(bool val) { m_scaled_for_first_image = val; }
     void set_path(DeprecatedString const& path);
     void resize_window();
+    void scale_image_for_window();
     void set_scaling_mode(Gfx::Painter::ScalingMode);
 
     bool is_next_available() const;

--- a/Userland/Applications/ImageViewer/ViewWidget.h
+++ b/Userland/Applications/ImageViewer/ViewWidget.h
@@ -61,6 +61,7 @@ private:
     virtual void mouseup_event(GUI::MouseEvent&) override;
     virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
+    virtual void resize_event(GUI::ResizeEvent&) override;
 
     void set_bitmap(Gfx::Bitmap const* bitmap);
     void animate();


### PR DESCRIPTION

[ImageViewer: Don't resize window on image rotation or flip](https://github.com/SerenityOS/serenity/commit/587051dee09e0fa858c46c8a21b6ab711d13b399):

Before:

[1.webm](https://user-images.githubusercontent.com/26030965/227000123-9080b648-316e-404e-97b7-74057462a301.webm)

After:

[1_after.webm](https://user-images.githubusercontent.com/26030965/227000564-3f5a3000-1eef-45aa-8b93-7428fbd14aa8.webm)

------

[ImageViewer: Scale image to window size on image change](https://github.com/SerenityOS/serenity/commit/568e4bff496bb7dedcbe9ae8845d24b649da2cc4):

Before:

[2.webm](https://user-images.githubusercontent.com/26030965/227001060-917d7787-76f6-4a63-8c8c-b2c93ba7aea8.webm)

After:

[2_after.webm](https://user-images.githubusercontent.com/26030965/227001324-ecdb07f6-6139-4f59-aa54-4984db47f57e.webm)

------

[ImageViewer: Scale image to window on startup](https://github.com/SerenityOS/serenity/commit/6c2461dbc73bf7265689cd60fc393e9ca83514e6)

Before:

[3.webm](https://user-images.githubusercontent.com/26030965/227001743-56cf761c-1416-4a5d-a0aa-88b5f44b6949.webm)

After:

[after_3.webm](https://user-images.githubusercontent.com/26030965/227001881-e922d386-91e0-4cbb-9764-a1eb08963436.webm)


------

[ImageViewer: Scale image to window on resize](https://github.com/SerenityOS/serenity/commit/c1a60a312362f03287b0d35a4dfb056f0ce4a36c)

Before:

[4.webm](https://user-images.githubusercontent.com/26030965/227002019-5ee1c234-8b0c-4d16-b287-6ec2feea994b.webm)

After:

[4_after.webm](https://user-images.githubusercontent.com/26030965/227002790-378209d4-ae13-445f-9414-badf4d3b4887.webm)

