### PR TITLE
LibWeb: Support loading file:// URLs via fetch (through ResourceLoader)

### DIFF
--- a/Tests/LibWeb/Layout/expected/link-sheet.txt
+++ b/Tests/LibWeb/Layout/expected/link-sheet.txt
@@ -1,0 +1,4 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <div#foo> at (0,0) content-size 123x456 positioned children: not-inline

--- a/Tests/LibWeb/Layout/input/link-sheet.css
+++ b/Tests/LibWeb/Layout/input/link-sheet.css
@@ -1,0 +1,7 @@
+#foo {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 123px;
+    height: 456px;
+}

--- a/Tests/LibWeb/Layout/input/link-sheet.html
+++ b/Tests/LibWeb/Layout/input/link-sheet.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><head><link rel="stylesheet" href="link-sheet.css"></head><body><div id="foo">

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
@@ -36,6 +36,6 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> scheme_fetch(JS::Realm&, 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_fetch(JS::Realm&, Infrastructure::FetchParams const&, MakeCORSPreflight make_cors_preflight = MakeCORSPreflight::No);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_redirect_fetch(JS::Realm&, Infrastructure::FetchParams const&, Infrastructure::Response&);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_network_or_cache_fetch(JS::Realm&, Infrastructure::FetchParams const&, IsAuthenticationFetch is_authentication_fetch = IsAuthenticationFetch::No, IsNewConnectionFetch is_new_connection_fetch = IsNewConnectionFetch::No);
-WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_loader_http_network_fetch(JS::Realm&, Infrastructure::FetchParams const&, IncludeCredentials include_credentials = IncludeCredentials::No, IsNewConnectionFetch is_new_connection_fetch = IsNewConnectionFetch::No);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_loader_file_or_http_network_fetch(JS::Realm&, Infrastructure::FetchParams const&, IncludeCredentials include_credentials = IncludeCredentials::No, IsNewConnectionFetch is_new_connection_fetch = IsNewConnectionFetch::No);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> cors_preflight_fetch(JS::Realm&, Infrastructure::Request&);
 }


### PR DESCRIPTION
This builds on the existing ad-hoc ResourceLoader code for HTTP fetches which works for files as well.

Since there is no Content-Type HTTP header for files, we do have to make a guess about the MIME type. This is done using LibCore's MIME type guessing API.

This also includes a test that checks that stylesheets loaded with the "file" URL scheme actually work.