### PR TITLE
WebDriver: Handle incomplete HTTP request parsing error

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzHttpRequest.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzHttpRequest.cpp
@@ -11,7 +11,7 @@
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     auto request_wrapper = HTTP::HttpRequest::from_raw_request(ReadonlyBytes { data, size });
-    if (!request_wrapper.has_value())
+    if (!request_wrapper.is_error())
         return 0;
 
     auto& request = request_wrapper.value();

--- a/Userland/Libraries/LibHTTP/HttpRequest.h
+++ b/Userland/Libraries/LibHTTP/HttpRequest.h
@@ -20,6 +20,7 @@ class HttpRequest {
 public:
     enum class ParseError {
         RequestTooLarge,
+        RequestIncomplete,
         OutOfMemory,
         UnsupportedMethod
     };
@@ -29,6 +30,8 @@ public:
         switch (error) {
         case ParseError::RequestTooLarge:
             return "Request too large"sv;
+        case ParseError::RequestIncomplete:
+            return "Request is incomplete"sv;
         case ParseError::OutOfMemory:
             return "Out of memory"sv;
         case ParseError::UnsupportedMethod:

--- a/Userland/Libraries/LibHTTP/HttpRequest.h
+++ b/Userland/Libraries/LibHTTP/HttpRequest.h
@@ -18,6 +18,26 @@ namespace HTTP {
 
 class HttpRequest {
 public:
+    enum class ParseError {
+        RequestTooLarge,
+        OutOfMemory,
+        UnsupportedMethod
+    };
+
+    static StringView parse_error_to_string(ParseError error)
+    {
+        switch (error) {
+        case ParseError::RequestTooLarge:
+            return "Request too large"sv;
+        case ParseError::OutOfMemory:
+            return "Out of memory"sv;
+        case ParseError::UnsupportedMethod:
+            return "Unsupported method"sv;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+
     enum Method {
         Invalid,
         HEAD,
@@ -61,7 +81,7 @@ public:
 
     void set_headers(HashMap<DeprecatedString, DeprecatedString> const&);
 
-    static Optional<HttpRequest> from_raw_request(ReadonlyBytes);
+    static ErrorOr<HttpRequest, HttpRequest::ParseError> from_raw_request(ReadonlyBytes);
     static Optional<Header> get_http_basic_authentication_header(URL const&);
     static Optional<BasicAuthenticationCredentials> parse_http_basic_authentication_header(DeprecatedString const&);
 

--- a/Userland/Libraries/LibWeb/WebDriver/Client.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.h
@@ -109,7 +109,7 @@ protected:
     Client(NonnullOwnPtr<Core::BufferedTCPSocket>, Core::Object* parent);
 
 private:
-    using WrappedError = Variant<AK::Error, WebDriver::Error>;
+    using WrappedError = Variant<AK::Error, HTTP::HttpRequest::ParseError, WebDriver::Error>;
 
     void die();
     ErrorOr<void, WrappedError> on_ready_to_read();

--- a/Userland/Libraries/LibWeb/WebDriver/Client.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.h
@@ -121,6 +121,7 @@ private:
 
     NonnullOwnPtr<Core::BufferedTCPSocket> m_socket;
     Optional<HTTP::HttpRequest> m_request;
+    StringBuilder m_remaining_request;
 };
 
 }

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -97,7 +97,7 @@ void Client::start()
 ErrorOr<bool> Client::handle_request(ReadonlyBytes raw_request)
 {
     auto request_or_error = HTTP::HttpRequest::from_raw_request(raw_request);
-    if (!request_or_error.has_value())
+    if (request_or_error.is_error())
         return false;
     auto& request = request_or_error.value();
     auto resource_decoded = URL::percent_decode(request.resource());


### PR DESCRIPTION
Currently significant portion of requests coming to WebDriver server fails with error while parsing json body because it is incomplete (especially noticeable if you run WPT).

This change solves this by waiting for more data to arrive if HTTP request parser found that there is not enough data yet to parse the whole request.
