### PR TITLE
LibJS: Support the yy{/,-}mm{/,-}dd hh:mm format for Date

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -147,10 +147,12 @@ static double parse_simplified_iso8601(DeprecatedString const& iso_8601)
     return time_clip(time_ms);
 }
 
-static constexpr AK::Array<StringView, 3> extra_formats = {
+static constexpr AK::Array<StringView, 5> extra_formats = {
     "%a %b %e %T %z %Y"sv,
     "%m/%e/%Y"sv,
     "%m/%e/%Y %R %z"sv,
+    "%Y/%m/%e %R"sv,
+    "%Y-%m-%e %R"sv,
 };
 
 static double parse_date_string(DeprecatedString const& date_string)
@@ -163,6 +165,7 @@ static double parse_date_string(DeprecatedString const& date_string)
     // Parse formats of this type: "Wed Apr 17 23:08:53 +0000 2019"
     // And: "4/17/2019"
     // And: "12/05/2022 10:00 -0800"
+    // And: "2014/11/14 13:05" or "2014-11-14 13:05"
     // FIXME: Exactly what timezone and which additional formats we should support is unclear.
     //        Both Chrome and Firefox seem to support "4/17/2019 11:08 PM +0000" with most parts
     //        being optional, however this is not clearly documented anywhere.

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -84,3 +84,9 @@ test("mm/dd/yy hh:mm timezone-offset extension", () => {
     expect(Date.parse("12/05/2022 10:00 -0800")).toBe(1670263200000);
     expect(Date.parse("01/03/2023 10:00 -0800")).toBe(1672768800000);
 });
+
+test("yy{/,-}mm{/,-}dd hh:mm extension", () => {
+    // Example from a UK news website.
+    expect(Date.parse("2014/11/14 13:05")).toBe(1415970300000);
+    expect(Date.parse("2014-11-14 13:05")).toBe(1415970300000);
+});


### PR DESCRIPTION
Required by a UK news website for loading a Piano configuration. This is presumably configuration for piano.io Analytics.