### PR TITLE
WebDriver: Unlink server socket before binding to it

### DIFF
--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -57,6 +57,8 @@ ErrorOr<NonnullRefPtr<Core::LocalServer>> Session::create_server(NonnullRefPtr<S
 {
     dbgln("Listening for WebDriver connection on {}", *m_web_content_socket_path);
 
+    (void)Core::System::unlink(*m_web_content_socket_path);
+
     auto server = TRY(Core::LocalServer::try_create());
     server->listen(*m_web_content_socket_path);
 


### PR DESCRIPTION
Previously, the create_server function would fail with an "Address already in use" error if a file that used for socket address is already exists.