### PR TITLE
ImageViewer: Fix crash when opening ImageViewer without an image

### DIFF
--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -221,6 +221,9 @@ void ViewWidget::resize_event(GUI::ResizeEvent& event)
 
 void ViewWidget::scale_image_for_window()
 {
+    if (!m_bitmap)
+        return;
+
     set_original_rect(m_bitmap->rect());
     fit_content_to_view(GUI::AbstractZoomPanWidget::FitType::Both);
 }


### PR DESCRIPTION
This seems like a thing that slipped through the cracks during PR review... 
We shouldn't try to scale the image to the window's size if the bitmap doesn't exist.