### PR TITLE
ImageViewer: Use `LibFileSystemAccessClient`

### DIFF
--- a/Userland/Applications/ImageViewer/CMakeLists.txt
+++ b/Userland/Applications/ImageViewer/CMakeLists.txt
@@ -12,4 +12,4 @@ set(SOURCES
 )
 
 serenity_app(ImageViewer ICON filetype-image)
-target_link_libraries(ImageViewer PRIVATE LibCore LibDesktop LibGUI LibGfx LibConfig LibImageDecoderClient LibMain)
+target_link_libraries(ImageViewer PRIVATE LibCore LibDesktop LibFileSystemAccessClient LibGUI LibGfx LibConfig LibImageDecoderClient LibMain)

--- a/Userland/Applications/ImageViewer/ViewWidget.h
+++ b/Userland/Applications/ImageViewer/ViewWidget.h
@@ -4,6 +4,7 @@
  * Copyright (c) 2021, Mohsan Ali <mohsan0073@gmail.com>
  * Copyright (c) 2022, Mustafa Quraish <mustafa@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2023, Caoimhe Byrne <caoimhebyrne06@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -30,12 +31,12 @@ public:
     virtual ~ViewWidget() override = default;
 
     Gfx::Bitmap const* bitmap() const { return m_bitmap.ptr(); }
-    DeprecatedString const& path() const { return m_path; }
+    String const& path() const { return m_path; }
     void set_toolbar_height(int height) { m_toolbar_height = height; }
     int toolbar_height() { return m_toolbar_height; }
     bool scaled_for_first_image() { return m_scaled_for_first_image; }
     void set_scaled_for_first_image(bool val) { m_scaled_for_first_image = val; }
-    void set_path(DeprecatedString const& path);
+    void set_path(String const& path);
     void resize_window();
     void scale_image_for_window();
     void set_scaling_mode(Gfx::Painter::ScalingMode);
@@ -47,7 +48,7 @@ public:
     void flip(Gfx::Orientation);
     void rotate(Gfx::RotationDirection);
     void navigate(Directions);
-    void load_from_file(DeprecatedString const&);
+    void open_file(String const&, Core::File&);
 
     Function<void()> on_doubleclick;
     Function<void(const GUI::DropEvent&)> on_drop;
@@ -66,8 +67,9 @@ private:
     void set_bitmap(Gfx::Bitmap const* bitmap);
     void animate();
     Vector<DeprecatedString> load_files_from_directory(DeprecatedString const& path) const;
+    ErrorOr<void> try_open_file(String const&, Core::File&);
 
-    DeprecatedString m_path;
+    String m_path;
     RefPtr<Gfx::Bitmap const> m_bitmap;
     Optional<ImageDecoderClient::DecodedImage> m_decoded_image;
 


### PR DESCRIPTION
This PR improves ImageViewer by making it use `LibFileSystemAccessClient`, and also starts using `String` wherever possible.

These two changes are both tightly related, so everything is bundled in one commit, as it was hard for me to separate them without the first commit seeming weirdly unnecessary without the second commit's context. Either that, or the second commit would make changes to things added in the first commit - it just didn't make sense, so I bundled them as one.

I will explain any changes that may seem 'un-needed' below, as they do seem a bit weird on first glance:
- **Moving where we call `on_image_change()`:**
  Making `try_open_file` call `set_path` means that we must call `on_image_change` after `set_path` is called. It didn't make sense for a callee of `open_file` to call `set_path` beforehand, since in all the cases we were calling `set_path`, we were also calling `open_file`.
- **Not using `real_path_for` anymore:**
  It wasn't needed, calling `set_path` instead of `m_path = Core::DeprecatedFile::real_path_for(..)` works perfectly, unsure why it was used in the first place, since opening `./image.png` doesn't have any negative effects when not using `real_path_for`. 
  The navigation actions and everything else still work as expected. If there was a reason for that being used, let me know and it can be added back in.
  
As a final note, there's a FIXME left in ViewWidget.cpp about this, but I'll discuss it here too. We do not `unveil(nullptr, nullptr)` in ImageViewer at the moment:
- `ViewWidget::load_files_from_directory` attempts to get the path of every file in the directory of the file that was just opened, but this is not possible as we don't have access to anything after ``Core::System::unveil(nullptr, nullptr)``, hence why `LibFileSystemAccessClient` exists. And since LibFSAC doesn't expose an API to get a list of files in a certain directory, I decided to leave that out for now, as it may not be a wanted addition to LibFSAC.
- This functionality is required for the navigate forward, backward, to start, and to end actions.
- If, in the future, the functionality is added to LibFSAC, or there is another way we could do it, we can then use `unveil(nullptr, nullptr);`

Either way, I think this PR is a nice step forward in modernizing ImageViewer and it also solves a crash that ImageViewer had when opening files, as before trying to use the "Open File" action would result in a crash! :^)
  