### PR TITLE
LibWeb: Add scalable radio buttons (with theme/accent-color support) 

### DIFF
--- a/Base/res/html/misc/accent-color.html
+++ b/Base/res/html/misc/accent-color.html
@@ -13,53 +13,89 @@
 
 <div>
   <b>System color</b><br>
-  <input type="checkbox" checked></input>
-  <input type="checkbox" ></input>
-  <input class="indeterminate" type="checkbox"></input>
-  <input type="checkbox" checked disabled></input>
-  <input type="checkbox" disabled></input>
-  <input class="indeterminate" type="checkbox" disabled></input>
+  <form>
+    <input type="checkbox" checked></input>
+    <input type="checkbox" ></input>
+    <input class="indeterminate" type="checkbox"></input>
+    <input type="checkbox" checked disabled></input>
+    <input type="checkbox" disabled></input>
+    <input class="indeterminate" type="checkbox" disabled></input>
 
-  <input class="big" type="checkbox" checked></input>
-  <input class="big" type="checkbox" ></input>
-  <input class="big indeterminate" type="checkbox"></input>
-  <input class="big" type="checkbox" checked disabled></input>
-  <input class="big" type="checkbox" disabled></input>
-  <input class="big indeterminate" type="checkbox" disabled></input>
+    <input class="big" type="checkbox" checked></input>
+    <input class="big" type="checkbox" ></input>
+    <input class="big indeterminate" type="checkbox"></input>
+    <input class="big" type="checkbox" checked disabled></input>
+    <input class="big" type="checkbox" disabled></input>
+    <input class="big indeterminate" type="checkbox" disabled></input>
+  </form>
+  <form>
+    <input type="radio" checked></input>
+    <input type="radio"></input>
+    <input type="radio" checked disabled></input>
+    <input type="radio" disabled></input>
+    <input class="big" type="radio" checked></input>
+    <input class="big" type="radio"></input>
+    <input class="big" type="radio" checked disabled></input>
+    <input class="big" type="radio" disabled></input>
+  </form>
 </div>
 <br>
 <div class="color-dark">
   <b>Dark accent color</b><br>
-  <input type="checkbox" checked></input>
-  <input type="checkbox" ></input>
-  <input class="indeterminate" type="checkbox"></input>
-  <input type="checkbox" checked disabled></input>
-  <input type="checkbox" disabled></input>
-  <input class="indeterminate" type="checkbox" disabled></input>
+  <form>
+    <input type="checkbox" checked></input>
+    <input type="checkbox" ></input>
+    <input class="indeterminate" type="checkbox"></input>
+    <input type="checkbox" checked disabled></input>
+    <input type="checkbox" disabled></input>
+    <input class="indeterminate" type="checkbox" disabled></input>
 
-  <input class="big" type="checkbox" checked></input>
-  <input class="big" type="checkbox" ></input>
-  <input class="big indeterminate" type="checkbox"></input>
-  <input class="big" type="checkbox" checked disabled></input>
-  <input class="big" type="checkbox" disabled></input>
-  <input class="big indeterminate" type="checkbox" disabled></input>
+    <input class="big" type="checkbox" checked></input>
+    <input class="big" type="checkbox" ></input>
+    <input class="big indeterminate" type="checkbox"></input>
+    <input class="big" type="checkbox" checked disabled></input>
+    <input class="big" type="checkbox" disabled></input>
+    <input class="big indeterminate" type="checkbox" disabled></input>
+  </form>
+  <form>
+    <input type="radio" checked></input>
+    <input type="radio"></input>
+    <input type="radio" checked disabled></input>
+    <input type="radio" disabled></input>
+    <input class="big" type="radio" checked></input>
+    <input class="big" type="radio"></input>
+    <input class="big" type="radio" checked disabled></input>
+    <input class="big" type="radio" disabled></input>
+  </form>
 </div>
 <br>
 <div class="color-light">
   <b>Light accent color</b><br>
-  <input type="checkbox" checked></input>
-  <input type="checkbox" ></input>
-  <input class="indeterminate" type="checkbox"></input>
-  <input type="checkbox" checked disabled></input>
-  <input type="checkbox" disabled></input>
-  <input class="indeterminate" type="checkbox" disabled></input>
+  <form>
+    <input type="checkbox" checked></input>
+    <input type="checkbox" ></input>
+    <input class="indeterminate" type="checkbox"></input>
+    <input type="checkbox" checked disabled></input>
+    <input type="checkbox" disabled></input>
+    <input class="indeterminate" type="checkbox" disabled></input>
 
-  <input class="big" type="checkbox" checked></input>
-  <input class="big" type="checkbox" ></input>
-  <input class="big indeterminate" type="checkbox"></input>
-  <input class="big" type="checkbox" checked disabled></input>
-  <input class="big" type="checkbox" disabled></input>
-  <input class="big indeterminate" type="checkbox" disabled></input>
+    <input class="big" type="checkbox" checked></input>
+    <input class="big" type="checkbox" ></input>
+    <input class="big indeterminate" type="checkbox"></input>
+    <input class="big" type="checkbox" checked disabled></input>
+    <input class="big" type="checkbox" disabled></input>
+    <input class="big indeterminate" type="checkbox" disabled></input>
+  </form>
+  <form>
+    <input type="radio" checked></input>
+    <input type="radio"></input>
+    <input type="radio" checked disabled></input>
+    <input type="radio" disabled></input>
+    <input class="big" type="radio" checked></input>
+    <input class="big" type="radio"></input>
+    <input class="big" type="radio" checked disabled></input>
+    <input class="big" type="radio" disabled></input>
+  </form>
 </div>
 <br>
 <script>

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2583,6 +2583,13 @@ void Painter::draw_signed_distance_field(IntRect const& dst_rect, Color color, G
         return x * x * (3 - 2 * x);
     };
 
+    auto pixel_at = [&](unsigned x, unsigned y) -> u8 {
+        // Returning 255 means this pixel is outside the shape.
+        if (x >= sdf.width() || y >= sdf.height())
+            return 255;
+        return sdf.pixel_at(x, y);
+    };
+
     for (int i = 0; i < clipped_rect.height(); ++i) {
         for (int j = 0; j < clipped_rect.width(); ++j) {
             auto point = IntPoint { j, i };
@@ -2592,12 +2599,10 @@ void Painter::draw_signed_distance_field(IntRect const& dst_rect, Color color, G
             auto target_fraction_x = (x_ratio * sample_point.x()) - target_x;
             auto target_fraction_y = (y_ratio * sample_point.y()) - target_y;
 
-            auto x2 = min(target_x + 1, sdf.width() - 1);
-            auto y2 = min(target_y + 1, sdf.height() - 1);
-            auto a = sdf.pixel_at(target_x, target_y);
-            auto b = sdf.pixel_at(x2, target_y);
-            auto c = sdf.pixel_at(target_x, y2);
-            auto d = sdf.pixel_at(x2, y2);
+            auto a = pixel_at(target_x, target_y);
+            auto b = pixel_at(target_x + 1, target_y);
+            auto c = pixel_at(target_x, target_y + 1);
+            auto d = pixel_at(target_x + 1, target_y + 1);
 
             float distance = (a * (1 - target_fraction_x) * (1 - target_fraction_y)
                                  + b * target_fraction_x * (1 - target_fraction_y)

--- a/Userland/Libraries/LibWeb/Painting/InputColors.h
+++ b/Userland/Libraries/LibWeb/Painting/InputColors.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <LibGfx/Color.h>
+#include <LibGfx/Palette.h>
+
+namespace Web::Painting {
+
+// Note: the color names reflect what the colors would be for a light theme,
+// not necessary the actual colors.
+struct InputColors {
+    Color accent;
+    Color base;
+    Color dark_gray;
+    Color gray;
+    Color mid_gray;
+    Color light_gray;
+
+    Color background_color(bool enabled) { return enabled ? base : light_gray; }
+    Color border_color(bool enabled) { return enabled ? gray : mid_gray; }
+
+    static Color get_shade(Color color, float amount, bool is_dark_theme)
+    {
+        return color.mixed_with(is_dark_theme ? Color::Black : Color::White, amount);
+    }
+};
+
+static InputColors compute_input_colors(Palette const& palette, Optional<Color> accent_color)
+{
+    // These shades have been picked to work well for all themes and have enough variation to paint
+    // all input states (disabled, enabled, checked, etc).
+    bool dark_theme = palette.is_dark();
+    auto base_text_color = palette.color(ColorRole::BaseText);
+    auto accent = accent_color.value_or(palette.color(ColorRole::Accent));
+    auto base = InputColors::get_shade(base_text_color.inverted(), 0.8f, dark_theme);
+    auto dark_gray = InputColors::get_shade(base_text_color, 0.3f, dark_theme);
+    auto gray = InputColors::get_shade(dark_gray, 0.4f, dark_theme);
+    auto mid_gray = InputColors::get_shade(gray, 0.3f, dark_theme);
+    auto light_gray = InputColors::get_shade(mid_gray, 0.3f, dark_theme);
+    return InputColors {
+        .accent = accent,
+        .base = base,
+        .dark_gray = dark_gray,
+        .gray = gray,
+        .mid_gray = mid_gray,
+        .light_gray = light_gray
+    };
+}
+
+}

--- a/Userland/Libraries/LibWeb/Painting/RadioButtonPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RadioButtonPaintable.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,6 +12,7 @@
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/Layout/Label.h>
 #include <LibWeb/Layout/RadioButton.h>
+#include <LibWeb/Painting/InputColors.h>
 #include <LibWeb/Painting/RadioButtonPaintable.h>
 
 namespace Web::Painting {
@@ -32,9 +34,58 @@ void RadioButtonPaintable::paint(PaintContext& context, PaintPhase phase) const
 
     PaintableBox::paint(context, phase);
 
-    auto const& radio_box = static_cast<HTML::HTMLInputElement const&>(layout_box().dom_node());
-    if (phase == PaintPhase::Foreground)
-        Gfx::StylePainter::paint_radio_button(context.painter(), context.enclosing_device_rect(absolute_rect()).to_type<int>(), context.palette(), radio_box.checked(), being_pressed());
+    if (phase != PaintPhase::Foreground)
+        return;
+
+    Gfx::AntiAliasingPainter painter { context.painter() };
+
+    auto draw_circle = [&](auto const& rect, Color color) {
+        // Note: Doing this is a bit more forgiving than draw_circle() which will round to the nearset even radius.
+        // This will fudge it (which works better here).
+        painter.fill_rect_with_rounded_corners(rect, color, rect.width() / 2);
+    };
+
+    auto shrink_all = [&](auto const& rect, int amount) {
+        return rect.shrunken(amount, amount, amount, amount);
+    };
+
+    auto const& radio_button = static_cast<HTML::HTMLInputElement const&>(layout_box().dom_node());
+
+    auto& palette = context.palette();
+    bool enabled = layout_box().dom_node().enabled();
+    auto input_colors = compute_input_colors(palette, computed_values().accent_color());
+
+    auto background_color = input_colors.background_color(enabled);
+    auto accent = input_colors.accent;
+
+    auto radio_color = [&] {
+        if (radio_button.checked()) {
+            // Handle the awkward case where a light color has been used for the accent color.
+            if (accent.contrast_ratio(background_color) < 2 && accent.contrast_ratio(input_colors.dark_gray) > 2)
+                background_color = input_colors.dark_gray;
+            return accent;
+        }
+        return input_colors.gray;
+    };
+
+    auto fill_color = [&] {
+        if (!enabled)
+            return input_colors.mid_gray;
+        auto color = radio_color();
+        if (being_pressed())
+            color = InputColors::get_shade(color, 0.3f, palette.is_dark());
+        return color;
+    }();
+
+    // This is based on a 1px outer border and 2px inner border when drawn at 13x13.
+    auto radio_button_rect = context.enclosing_device_rect(absolute_rect()).to_type<int>();
+    auto outer_border_width = max(1, static_cast<int>(ceilf(radio_button_rect.width() / 13.0f)));
+    auto inner_border_width = max(2, static_cast<int>(ceilf(radio_button_rect.width() / 4.0f)));
+
+    draw_circle(radio_button_rect, fill_color);
+    draw_circle(shrink_all(radio_button_rect, outer_border_width), background_color);
+    if (radio_button.checked())
+        draw_circle(shrink_all(radio_button_rect, inner_border_width), fill_color);
 }
 
 }


### PR DESCRIPTION
Part 2 of making inputs more scalable in LibWeb (no signed distance fields this time :stuck_out_tongue:)  

I noticed that currently radio buttons in LibWeb don't scale at all, and they don't show the `disabled` input state:

**Before:**
![image](https://user-images.githubusercontent.com/11597044/227383315-69abc8bf-28b1-4221-afed-d3b4bf946e42.png)
(Some of these radio buttons are meant to be scaled, and some disabled, but you can't tell)

**After:**

These now work similar to the checkboxes, they follow the system theme or the `accent-color` CSS property, and work pretty well for all scales (including fractional scales).

![image](https://user-images.githubusercontent.com/11597044/227382893-8230bd02-99b4-4104-b335-57c5d2429ab6.png)
