### PR TITLE
Kernel/Syscalls: use copy_n_to_user when applicable

### DIFF
--- a/Kernel/StdLib.h
+++ b/Kernel/StdLib.h
@@ -156,7 +156,7 @@ template<typename T>
 }
 
 template<typename T>
-[[nodiscard]] inline ErrorOr<void> try_copy_n_to_user(Userspace<T*> dest, T const* src, size_t count)
+[[nodiscard]] inline ErrorOr<void> copy_n_to_user(Userspace<T*> dest, T const* src, size_t count)
 {
     static_assert(IsTriviallyCopyable<T>);
     Checked<size_t> size = sizeof(T);

--- a/Kernel/Syscalls/getuid.cpp
+++ b/Kernel/Syscalls/getuid.cpp
@@ -83,7 +83,7 @@ ErrorOr<FlatPtr> Process::sys$getgroups(size_t count, Userspace<GroupID*> user_g
         return credentials->extra_gids().size();
     if (count != credentials->extra_gids().size())
         return EINVAL;
-    TRY(copy_to_user(user_gids, credentials->extra_gids().data(), sizeof(GroupID) * count));
+    TRY(copy_n_to_user(user_gids, credentials->extra_gids().data(), count));
     return 0;
 }
 

--- a/Kernel/Syscalls/keymap.cpp
+++ b/Kernel/Syscalls/keymap.cpp
@@ -50,11 +50,11 @@ ErrorOr<FlatPtr> Process::sys$getkeymap(Userspace<Syscall::SC_getkeymap_params c
         TRY(copy_to_user(params.map_name.data, keymap_data.character_map_name->characters(), keymap_data.character_map_name->length()));
 
         auto const& character_maps = keymap_data.character_map;
-        TRY(copy_to_user(params.map, character_maps.map, CHAR_MAP_SIZE * sizeof(u32)));
-        TRY(copy_to_user(params.shift_map, character_maps.shift_map, CHAR_MAP_SIZE * sizeof(u32)));
-        TRY(copy_to_user(params.alt_map, character_maps.alt_map, CHAR_MAP_SIZE * sizeof(u32)));
-        TRY(copy_to_user(params.altgr_map, character_maps.altgr_map, CHAR_MAP_SIZE * sizeof(u32)));
-        TRY(copy_to_user(params.shift_altgr_map, character_maps.shift_altgr_map, CHAR_MAP_SIZE * sizeof(u32)));
+        TRY(copy_n_to_user(params.map, character_maps.map, CHAR_MAP_SIZE));
+        TRY(copy_n_to_user(params.shift_map, character_maps.shift_map, CHAR_MAP_SIZE));
+        TRY(copy_n_to_user(params.alt_map, character_maps.alt_map, CHAR_MAP_SIZE));
+        TRY(copy_n_to_user(params.altgr_map, character_maps.altgr_map, CHAR_MAP_SIZE));
+        TRY(copy_n_to_user(params.shift_altgr_map, character_maps.shift_altgr_map, CHAR_MAP_SIZE));
         return 0;
     });
 }

--- a/Kernel/Syscalls/pipe.cpp
+++ b/Kernel/Syscalls/pipe.cpp
@@ -43,7 +43,8 @@ ErrorOr<FlatPtr> Process::sys$pipe(Userspace<int*> pipefd, int flags)
             reader_fd_allocation.fd,
             writer_fd_allocation.fd,
         };
-        if (copy_to_user(pipefd, fds_for_userspace, sizeof(fds_for_userspace)).is_error()) {
+        if (copy_n_to_user(pipefd, fds_for_userspace, 2).is_error()) {
+            // Avoid leaking both file descriptors on error.
             fds[reader_fd_allocation.fd] = {};
             fds[writer_fd_allocation.fd] = {};
             return EFAULT;

--- a/Kernel/Syscalls/poll.cpp
+++ b/Kernel/Syscalls/poll.cpp
@@ -131,7 +131,7 @@ ErrorOr<FlatPtr> Process::sys$poll(Userspace<Syscall::SC_poll_params const*> use
     }
 
     if (params.nfds > 0)
-        TRY(copy_to_user(&params.fds[0], fds_copy.data(), params.nfds * sizeof(pollfd)));
+        TRY(copy_n_to_user(&params.fds[0], fds_copy.data(), params.nfds));
 
     return fds_with_revents;
 }

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -428,7 +428,7 @@ ErrorOr<FlatPtr> Process::sys$socketpair(Userspace<Syscall::SC_socketpair_params
         setup_socket_fd(fds, allocated_fds[0], pair.description0, params.type);
         setup_socket_fd(fds, allocated_fds[1], pair.description1, params.type);
 
-        if (copy_to_user(params.sv, allocated_fds, sizeof(allocated_fds)).is_error()) {
+        if (copy_n_to_user(params.sv, allocated_fds, 2).is_error()) {
             // Avoid leaking both file descriptors on error.
             fds[allocated_fds[0]] = {};
             fds[allocated_fds[1]] = {};


### PR DESCRIPTION
`copy_n_to_user` was not used anywhere in Syscalls even though it makes sense to use them in many places. This simplifies the caller code by passing just the count.

PS: I noticed this could be done when watching one of Andreas's [video](https://www.youtube.com/watch?v=ffRNM8vEITI)