### PR TITLE
Meta: Remove SonarCloud cache and threads setup as it is now offered by default

### DIFF
--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 11
 
       - name: Download and set up sonar-scanner
@@ -42,8 +43,6 @@ jobs:
           echo "sonar.projectVersion=${{ github.sha }}" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.organization=serenityos" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.cfamily.compile-commands=${{ github.workspace }}/Build/${{ env.SONAR_ANALYSIS_ARCH }}/compile_commands.json" >> ${{ github.workspace }}/sonar-project.properties
-          echo "sonar.cfamily.threads=2" >> ${{ github.workspace }}/sonar-project.properties
-          echo "sonar.cfamily.cache.enabled=false" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.exclusions=Userland/Libraries/LibWasm/Parser/Parser.cpp" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.host.url=${{ env.SONAR_SERVER_URL }}" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.sources=AK,Build,Userland,Kernel,Meta" >> ${{ github.workspace }}/sonar-project.properties


### PR DESCRIPTION
No need to configure the cache and threads anymore, SonarCloud now has an automatic analysis caching and threads detection. See https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache.