### PR TITLE
PixelPaint: Add a Duplicate Layer action

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -200,17 +200,28 @@ ErrorOr<void> Image::export_qoi_to_file(NonnullOwnPtr<Stream> stream) const
     return {};
 }
 
-void Image::add_layer(NonnullRefPtr<Layer> layer)
+void Image::insert_layer(NonnullRefPtr<Layer> layer, size_t index)
 {
+    VERIFY(index <= m_layers.size());
+
     for (auto& existing_layer : m_layers) {
         VERIFY(existing_layer != layer);
     }
-    m_layers.append(move(layer));
+
+    if (index == m_layers.size())
+        m_layers.append(move(layer));
+    else
+        m_layers.insert(index, move(layer));
 
     for (auto* client : m_clients)
-        client->image_did_add_layer(m_layers.size() - 1);
+        client->image_did_add_layer(index);
 
     did_modify_layer_stack();
+}
+
+void Image::add_layer(NonnullRefPtr<Layer> layer)
+{
+    insert_layer(move(layer), m_layers.size());
 }
 
 ErrorOr<NonnullRefPtr<Image>> Image::take_snapshot() const

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -65,6 +65,7 @@ public:
     Gfx::IntRect rect() const { return { {}, m_size }; }
 
     void add_layer(NonnullRefPtr<Layer>);
+    void insert_layer(NonnullRefPtr<Layer>, size_t index);
     ErrorOr<NonnullRefPtr<Image>> take_snapshot() const;
     ErrorOr<void> restore_snapshot(Image const&);
 
@@ -123,6 +124,8 @@ private:
 
     ErrorOr<void> merge_layers(LayerMergeMode);
     ErrorOr<void> merge_active_layer(NonnullRefPtr<Layer> const&, LayerMergeDirection);
+
+    DeprecatedString generate_unique_layer_name(DeprecatedString const& original_name);
 
     Gfx::IntSize m_size;
     Vector<NonnullRefPtr<Layer>> m_layers;

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -127,6 +127,7 @@ public:
     Function<void(DeprecatedString)> on_appended_status_info_change;
     DeprecatedString appended_status_info() { return m_appended_status_info; };
     void set_appended_status_info(DeprecatedString);
+    DeprecatedString generate_unique_layer_name(DeprecatedString const& original_layer_name);
 
 private:
     explicit ImageEditor(NonnullRefPtr<Image>);

--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -405,4 +405,12 @@ Optional<Gfx::IntRect> Layer::nonempty_content_bounding_rect() const
     };
 }
 
+ErrorOr<NonnullRefPtr<Layer>> Layer::duplicate(DeprecatedString name)
+{
+    auto duplicated_layer = TRY(Layer::create_snapshot(m_image, *this));
+    duplicated_layer->m_name = move(name);
+    duplicated_layer->m_selected = false;
+    return duplicated_layer;
+}
+
 }

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -102,6 +102,8 @@ public:
 
     Gfx::Bitmap& currently_edited_bitmap();
 
+    ErrorOr<NonnullRefPtr<Layer>> duplicate(DeprecatedString name);
+
 private:
     Layer(Image&, NonnullRefPtr<Gfx::Bitmap>, DeprecatedString name);
 


### PR DESCRIPTION
The "Duplicate Layer" action inserts a copy of the selected layer into the layer stack. The new layer is placed above the selected layer.

The new layer is named "(original layer name) copy" with additional copies being sequentially numbered. This matches the behavior of Photoshop.

I chose Ctrl+Shift+D as the shortcut for this feature. This combination matches GIMP and fits in with other layer copying functions we already have.

Video:

https://user-images.githubusercontent.com/2817754/227605103-17b32837-79a2-410a-8bd5-9e7ab5605951.mp4