### PR TITLE
FontEditor+LibGUI+LibGfx: Make `FontEditor` use `LibFileSystemAccessClient`

### DIFF
--- a/Userland/Applications/FontEditor/CMakeLists.txt
+++ b/Userland/Applications/FontEditor/CMakeLists.txt
@@ -25,4 +25,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_app(FontEditor ICON app-font-editor)
-target_link_libraries(FontEditor PRIVATE LibConfig LibCore LibGUI LibDesktop LibGfx LibMain LibUnicode)
+target_link_libraries(FontEditor PRIVATE LibConfig LibCore LibFileSystemAccessClient LibGUI LibDesktop LibGfx LibMain LibUnicode)

--- a/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
+++ b/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
@@ -31,6 +31,9 @@ void GlyphEditorWidget::set_glyph(int glyph)
 
 void GlyphEditorWidget::paint_event(GUI::PaintEvent& event)
 {
+    if (!m_font)
+        return;
+
     GUI::Frame::paint_event(event);
 
     GUI::Painter painter(*this);

--- a/Userland/Applications/FontEditor/MainWidget.h
+++ b/Userland/Applications/FontEditor/MainWidget.h
@@ -37,8 +37,8 @@ public:
     ErrorOr<void> initialize(DeprecatedString const& path, RefPtr<Gfx::BitmapFont>&&);
     ErrorOr<void> initialize_menubar(GUI::Window&);
 
-    ErrorOr<void> open_file(DeprecatedString const&);
-    ErrorOr<void> save_file(DeprecatedString const&);
+    ErrorOr<void> open_file(StringView, NonnullOwnPtr<Core::File>);
+    ErrorOr<void> save_file(DeprecatedString const&, NonnullOwnPtr<Core::File>);
     bool request_close();
     void update_title();
 

--- a/Userland/Libraries/LibGUI/GlyphMapWidget.cpp
+++ b/Userland/Libraries/LibGUI/GlyphMapWidget.cpp
@@ -49,6 +49,7 @@ void GlyphMapWidget::Selection::extend_to(int glyph)
 }
 
 GlyphMapWidget::GlyphMapWidget()
+    : AbstractScrollableWidget()
 {
     set_focus_policy(FocusPolicy::StrongFocus);
     horizontal_scrollbar().set_visible(false);
@@ -145,7 +146,7 @@ void GlyphMapWidget::paint_event(PaintEvent& event)
                 painter.draw_emoji(inner_rect.location(), *emoji, font());
         } else if (font().contains_glyph(glyph)) {
             if (m_highlight_modifications && m_modified_glyphs.contains(glyph)) {
-                if (m_original_font->contains_glyph(glyph)) {
+                if (m_original_font && m_original_font->contains_glyph(glyph)) {
                     // Modified
                     if (palette().is_dark())
                         painter.fill_rect(outer_rect, Gfx::Color { 0, 65, 159 });
@@ -165,7 +166,7 @@ void GlyphMapWidget::paint_event(PaintEvent& event)
         } else if (auto* emoji = Gfx::Emoji::emoji_for_code_point(glyph); emoji && m_show_system_emoji) {
             painter.draw_emoji(inner_rect.location(), *emoji, font());
         } else {
-            if (m_highlight_modifications && m_original_font->contains_glyph(glyph)) {
+            if (m_highlight_modifications && m_original_font && m_original_font->contains_glyph(glyph)) {
                 // Deleted
                 if (palette().is_dark())
                     painter.fill_rect(outer_rect, Gfx::Color { 127, 0, 0 });

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
@@ -233,9 +233,14 @@ RefPtr<BitmapFont> BitmapFont::load_from_file(DeprecatedString const& path)
 
 ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::try_load_from_file(DeprecatedString const& path)
 {
-    auto file = TRY(Core::MappedFile::map(path));
-    auto font = TRY(load_from_memory((u8 const*)file->data()));
-    font->m_mapped_file = file;
+    auto mapped_file = TRY(Core::MappedFile::map(path));
+    return try_load_from_mapped_file(move(mapped_file));
+}
+
+ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::try_load_from_mapped_file(RefPtr<Core::MappedFile> const& mapped_file)
+{
+    auto font = TRY(load_from_memory((u8 const*)mapped_file->data()));
+    font->m_mapped_file = mapped_file;
     return font;
 }
 

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -32,6 +32,7 @@ public:
 
     static RefPtr<BitmapFont> load_from_file(DeprecatedString const& path);
     static ErrorOr<NonnullRefPtr<BitmapFont>> try_load_from_file(DeprecatedString const& path);
+    static ErrorOr<NonnullRefPtr<BitmapFont>> try_load_from_mapped_file(RefPtr<Core::MappedFile> const&);
     ErrorOr<void> write_to_file(DeprecatedString const& path);
 
     ~BitmapFont();

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -33,7 +33,9 @@ public:
     static RefPtr<BitmapFont> load_from_file(DeprecatedString const& path);
     static ErrorOr<NonnullRefPtr<BitmapFont>> try_load_from_file(DeprecatedString const& path);
     static ErrorOr<NonnullRefPtr<BitmapFont>> try_load_from_mapped_file(RefPtr<Core::MappedFile> const&);
+
     ErrorOr<void> write_to_file(DeprecatedString const& path);
+    ErrorOr<void> write_to_file(NonnullOwnPtr<Core::File> file);
 
     ~BitmapFont();
 


### PR DESCRIPTION
A few changes were needed to get FontEditor to use LibFSAC nicely, but I feel like it was done in a decent way in this PR.

This resolves a crash that occurs due to `FilePicker` requiring anyone who calls it to pledge the `FileManager` configuration domain.