### PR TITLE
LibPDF: Another round of bug fixes

### DIFF
--- a/Userland/Libraries/LibPDF/Document.cpp
+++ b/Userland/Libraries/LibPDF/Document.cpp
@@ -116,7 +116,9 @@ PDFErrorOr<Page> Document::get_page(u32 index)
     else
         resources = adopt_ref(*new DictObject({}));
 
-    auto contents = TRY(raw_page_object->get_object(this, CommonNames::Contents));
+    RefPtr<Object> contents;
+    if (raw_page_object->contains(CommonNames::Contents))
+        contents = TRY(raw_page_object->get_object(this, CommonNames::Contents));
 
     Rectangle media_box;
     auto maybe_media_box_object = TRY(get_inheritable_object(CommonNames::MediaBox, raw_page_object));

--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -143,7 +143,7 @@ private:
     PDFErrorOr<Destination> create_destination_from_parameters(NonnullRefPtr<ArrayObject>, HashMap<u32, u32> const&);
     PDFErrorOr<Destination> create_destination_from_dictionary_entry(NonnullRefPtr<Object> const& entry, HashMap<u32, u32> const& page_number_by_index_ref);
 
-    PDFErrorOr<NonnullRefPtr<Object>> get_inheritable_object(DeprecatedFlyString const& name, NonnullRefPtr<DictObject>);
+    PDFErrorOr<Optional<NonnullRefPtr<Object>>> get_inheritable_object(DeprecatedFlyString const& name, NonnullRefPtr<DictObject>);
 
     PDFErrorOr<NonnullRefPtr<Object>> find_in_name_tree(NonnullRefPtr<DictObject> root, DeprecatedFlyString name);
     PDFErrorOr<NonnullRefPtr<Object>> find_in_name_tree_nodes(NonnullRefPtr<ArrayObject> siblings, DeprecatedFlyString name);

--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -144,6 +144,7 @@ private:
     PDFErrorOr<Destination> create_destination_from_dictionary_entry(NonnullRefPtr<Object> const& entry, HashMap<u32, u32> const& page_number_by_index_ref);
 
     PDFErrorOr<Optional<NonnullRefPtr<Object>>> get_inheritable_object(DeprecatedFlyString const& name, NonnullRefPtr<DictObject>);
+    PDFErrorOr<Optional<Value>> get_inheritable_value(DeprecatedFlyString const& name, NonnullRefPtr<DictObject>);
 
     PDFErrorOr<NonnullRefPtr<Object>> find_in_name_tree(NonnullRefPtr<DictObject> root, DeprecatedFlyString name);
     PDFErrorOr<NonnullRefPtr<Object>> find_in_name_tree_nodes(NonnullRefPtr<ArrayObject> siblings, DeprecatedFlyString name);

--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -30,7 +30,7 @@ struct Rectangle {
 
 struct Page {
     NonnullRefPtr<DictObject> resources;
-    NonnullRefPtr<Object> contents;
+    RefPtr<Object> contents;
     Rectangle media_box;
     Rectangle crop_box;
     float user_unit;

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
@@ -85,7 +85,7 @@ PDFErrorOr<NonnullRefPtr<Gfx::Font>> PDFFont::replacement_for(StringView name, f
     float point_size = (font_size * POINTS_PER_INCH) / DEFAULT_DPI;
     auto font = Gfx::FontDatabase::the().get(font_family, font_variant, point_size);
     if (!font)
-        Error::internal_error("Failed to load {} {} at {}pt", font_family, font_variant, point_size);
+        return Error::internal_error("Failed to load {} {} at {}pt", font_family, font_variant, point_size);
     return font.release_nonnull();
 }
 

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
@@ -108,7 +108,7 @@ PDFErrorOr<Vector<ByteBuffer>> PS1FontProgram::parse_subroutines(Reader& reader)
         return error("Expected array length");
 
     auto length = TRY(parse_int(reader));
-    VERIFY(length <= 1024);
+    VERIFY(length > 0);
 
     Vector<ByteBuffer> array;
     TRY(array.try_resize(length));

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
@@ -17,13 +17,12 @@ public:
 
 protected:
     PDFErrorOr<void> initialize(Document* document, NonnullRefPtr<DictObject> const& dict, float font_size) override;
+    virtual float get_glyph_width(u8 char_code) const = 0;
     virtual void draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color) = 0;
     RefPtr<Encoding>& encoding() { return m_encoding; }
     RefPtr<Encoding> const& encoding() const { return m_encoding; }
 
 private:
-    float get_char_width(u8 char_code) const;
-
     RefPtr<Encoding> m_encoding;
     RefPtr<StreamObject> m_to_unicode;
     HashMap<u8, u16> m_widths;

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -17,6 +17,7 @@ PDFErrorOr<void> TrueTypeFont::initialize(Document* document, NonnullRefPtr<Dict
 {
     TRY(SimpleFont::initialize(document, dict, font_size));
 
+    // If there's an embedded font program we use that; otherwise we try to find a replacement font
     if (dict->contains(CommonNames::FontDescriptor)) {
         auto descriptor = MUST(dict->get_dict(document, CommonNames::FontDescriptor));
         if (descriptor->contains(CommonNames::FontFile2)) {
@@ -26,7 +27,11 @@ PDFErrorOr<void> TrueTypeFont::initialize(Document* document, NonnullRefPtr<Dict
             m_font = adopt_ref(*new Gfx::ScaledFont(*ttf_font, point_size, point_size));
         }
     }
+    if (!m_font) {
+        m_font = TRY(replacement_for(base_font_name().to_lowercase(), font_size));
+    }
 
+    VERIFY(m_font);
     return {};
 }
 

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -30,11 +30,13 @@ PDFErrorOr<void> TrueTypeFont::initialize(Document* document, NonnullRefPtr<Dict
     return {};
 }
 
+float TrueTypeFont::get_glyph_width(u8 char_code) const
+{
+    return m_font->glyph_width(char_code);
+}
+
 void TrueTypeFont::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float, u8 char_code, Color color)
 {
-    if (!m_font)
-        return;
-
     // Account for the reversed font baseline
     auto position = point.translated(0, -m_font->baseline());
     painter.draw_glyph(position, char_code, *m_font, color);

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -14,6 +14,7 @@ namespace PDF {
 
 class TrueTypeFont : public SimpleFont {
 public:
+    float get_glyph_width(u8 char_code) const override;
     void draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8, Color) override;
     Type type() const override { return PDFFont::Type::TrueType; }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -49,6 +49,11 @@ PDFErrorOr<void> Type1Font::initialize(Document* document, NonnullRefPtr<DictObj
     return {};
 }
 
+float Type1Font::get_glyph_width(u8 char_code) const
+{
+    return m_font->glyph_width(char_code);
+}
+
 void Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color)
 {
     if (!m_font_program) {

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -14,6 +14,7 @@ namespace PDF {
 
 class Type1Font : public SimpleFont {
 public:
+    float get_glyph_width(u8 char_code) const override;
     void draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color) override;
     Type type() const override { return PDFFont::Type::Type1; }
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -299,7 +299,7 @@ void Renderer::end_path_paint()
 RENDERER_HANDLER(path_stroke)
 {
     begin_path_paint();
-    m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_color, state().line_width);
+    m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_color, state().ctm.x_scale() * state().line_width);
     end_path_paint();
     return {};
 }
@@ -334,13 +334,13 @@ RENDERER_HANDLER(path_fill_evenodd)
 
 RENDERER_HANDLER(path_fill_stroke_nonzero)
 {
-    m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_color, state().line_width);
+    m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_color, state().ctm.x_scale() * state().line_width);
     return handle_path_fill_nonzero(args);
 }
 
 RENDERER_HANDLER(path_fill_stroke_evenodd)
 {
-    m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_color, state().line_width);
+    m_anti_aliasing_painter.stroke_path(m_current_path, state().stroke_color, state().ctm.x_scale() * state().line_width);
     return handle_path_fill_evenodd(args);
 }
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -85,6 +85,9 @@ Renderer::Renderer(RefPtr<Document> document, Page const& page, RefPtr<Gfx::Bitm
 
 PDFErrorsOr<void> Renderer::render()
 {
+    if (m_page.contents.is_null())
+        return {};
+
     // Use our own vector, as the /Content can be an array with multiple
     // streams which gets concatenated
     // FIXME: Text operators are supposed to only have effects on the current

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -197,7 +197,7 @@ RENDERER_HANDLER(set_dash_pattern)
     Vector<int> pattern;
     for (auto& element : *dash_array)
         pattern.append(element.to_int());
-    state().line_dash_pattern = LineDashPattern { pattern, args[1].get<int>() };
+    state().line_dash_pattern = LineDashPattern { pattern, args[1].to_int() };
     return {};
 }
 


### PR DESCRIPTION
In this PR, I'm tackling another bunch of bugs I've encountered so far.
The big ones were, in summary:

- Wrong behaviour of ASCII hex filters
- Requiring page attributes that should be optional or are trivially replaceable
- Two small renderer bugs
- Overlapping OpenType glyphs
- Not loading replacements for non-embedded TrueTypeFonts

<img width="440" height="573" alt="t2-handbook.pdf_p66_before" src="https://github.com/user-attachments/assets/db575165-dc3b-4cf4-b1c5-f32666658612" />
<img width="441" height="573" alt="t2-handbook.pdf_p66_after" src="https://github.com/user-attachments/assets/5c4bd411-1941-484f-b619-2452266b17ce" />