### PR TITLE
PixelPaint: Include possible errno description in error messages

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -753,7 +753,7 @@ void ImageEditor::save_project()
         return;
     auto result = save_project_to_file(response.value().release_stream());
     if (result.is_error()) {
-        GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Could not save {}: {}", path(), result.error()));
+        GUI::MessageBox::show_error(window(), MUST(String::formatted("Could not save {}: {}", path(), result.release_error())));
         return;
     }
     set_unmodified();
@@ -767,7 +767,7 @@ void ImageEditor::save_project_as()
     auto file = response.release_value();
     auto result = save_project_to_file(file.release_stream());
     if (result.is_error()) {
-        GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Could not save {}: {}", file.filename(), result.error()));
+        GUI::MessageBox::show_error(window(), MUST(String::formatted("Could not save {}: {}", file.filename(), result.release_error())));
         return;
     }
     set_path(file.filename().to_deprecated_string());

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -156,13 +156,13 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             if (dialog->exec() == GUI::Dialog::ExecResult::OK) {
                 auto image_result = PixelPaint::Image::create_with_size(dialog->image_size());
                 if (image_result.is_error()) {
-                    GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to create image with size {}, error: {}", dialog->image_size(), image_result.error()));
+                    GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to create image with size {}, error: {}", dialog->image_size(), image_result.release_error())));
                     return;
                 }
                 auto image = image_result.release_value();
                 auto bg_layer_result = PixelPaint::Layer::create_with_size(*image, image->size(), "Background");
                 if (bg_layer_result.is_error()) {
-                    GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to create layer with size {}, error: {}", image->size(), bg_layer_result.error()));
+                    GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to create layer with size {}, error: {}", image->size(), bg_layer_result.release_error())));
                     return;
                 }
                 auto bg_layer = bg_layer_result.release_value();
@@ -187,7 +187,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         "&New Image from Clipboard", { Mod_Ctrl | Mod_Shift, Key_V }, g_icon_bag.new_clipboard, [&](auto&) {
             auto result = create_image_from_clipboard();
             if (result.is_error()) {
-                GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to create image from clipboard: {}", result.error()));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to create image from clipboard: {}", result.release_error())));
             }
         });
 
@@ -229,7 +229,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                 auto preserve_alpha_channel = GUI::MessageBox::show(&window, "Do you wish to preserve transparency?"sv, "Preserve transparency?"sv, GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
                 auto result = editor->image().export_bmp_to_file(response.value().release_stream(), preserve_alpha_channel == GUI::MessageBox::ExecResult::Yes);
                 if (result.is_error())
-                    GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Export to BMP failed: {}", result.error()));
+                    GUI::MessageBox::show_error(&window, MUST(String::formatted("Export to BMP failed: {}", result.release_error())));
             })));
 
     TRY(m_export_submenu->try_add_action(
@@ -244,7 +244,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                 auto preserve_alpha_channel = GUI::MessageBox::show(&window, "Do you wish to preserve transparency?"sv, "Preserve transparency?"sv, GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
                 auto result = editor->image().export_png_to_file(response.value().release_stream(), preserve_alpha_channel == GUI::MessageBox::ExecResult::Yes);
                 if (result.is_error())
-                    GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Export to PNG failed: {}", result.error()));
+                    GUI::MessageBox::show_error(&window, MUST(String::formatted("Export to PNG failed: {}", result.release_error())));
             })));
 
     TRY(m_export_submenu->try_add_action(
@@ -257,7 +257,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                     return;
                 auto result = editor->image().export_qoi_to_file(response.value().release_stream());
                 if (result.is_error())
-                    GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Export to QOI failed: {}", result.error()));
+                    GUI::MessageBox::show_error(&window, MUST(String::formatted("Export to QOI failed: {}", result.release_error())));
             })));
 
     m_export_submenu->set_icon(g_icon_bag.file_export);
@@ -343,7 +343,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         if (!editor) {
             auto result = create_image_from_clipboard();
             if (result.is_error()) {
-                GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to create image from clipboard: {}", result.error()));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to create image from clipboard: {}", result.release_error())));
             }
             return;
         }
@@ -355,7 +355,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
 
         auto layer_result = PixelPaint::Layer::create_with_bitmap(editor->image(), *bitmap, "Pasted layer");
         if (layer_result.is_error()) {
-            GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Could not create bitmap when pasting: {}", layer_result.error()));
+            GUI::MessageBox::show_error(&window, MUST(String::formatted("Could not create bitmap when pasting: {}", layer_result.release_error())));
             return;
         }
         auto layer = layer_result.release_value();
@@ -456,7 +456,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
 
             auto result = PixelPaint::PaletteWidget::load_palette_file(response.release_value().release_stream());
             if (result.is_error()) {
-                GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Loading color palette failed: {}", result.error()));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Loading color palette failed: {}", result.release_error())));
                 return;
             }
 
@@ -470,7 +470,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
 
             auto result = PixelPaint::PaletteWidget::save_palette_file(m_palette_widget->colors(), response.release_value().release_stream());
             if (result.is_error())
-                GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Writing color palette failed: {}", result.error()));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Writing color palette failed: {}", result.release_error())));
         })));
 
     m_view_menu = TRY(window.try_add_menu("&View"));
@@ -714,7 +714,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             if (dialog->exec() == GUI::Dialog::ExecResult::OK) {
                 auto layer_or_error = PixelPaint::Layer::create_with_size(editor->image(), dialog->layer_size(), dialog->layer_name());
                 if (layer_or_error.is_error()) {
-                    GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Unable to create layer with size {}", dialog->size()));
+                    GUI::MessageBox::show_error(&window, MUST(String::formatted("Unable to create layer with size {}", dialog->size())));
                     return;
                 }
                 editor->image().add_layer(layer_or_error.release_value());
@@ -772,7 +772,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         "Add M&ask", { Mod_Ctrl | Mod_Shift, Key_M }, g_icon_bag.add_mask, create_layer_mask_callback("Add Mask", [&](Layer* active_layer) {
             VERIFY(!active_layer->is_masked());
             if (auto maybe_error = active_layer->create_mask(); maybe_error.is_error())
-                GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to create layer mask: {}", maybe_error.release_error()));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to create layer mask: {}", maybe_error.release_error())));
         }));
     TRY(m_layer_menu->try_add_action(*m_add_mask_action));
 
@@ -866,7 +866,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             } else {
                 auto layer_result = PixelPaint::Layer::create_with_size(editor->image(), editor->image().size(), "Background");
                 if (layer_result.is_error()) {
-                    GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to create layer with size {}, error: {}", editor->image().size(), layer_result.error())));
+                    GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to create layer with size {}, error: {}", editor->image().size(), layer_result.release_error())));
                     return;
                 }
                 auto layer = layer_result.release_value();
@@ -885,7 +885,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             auto* editor = current_image_editor();
             VERIFY(editor);
             if (auto maybe_error = editor->image().flatten_all_layers(); maybe_error.is_error()) {
-                GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to flatten all layers: {}", maybe_error.release_error()));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to flatten all layers: {}", maybe_error.release_error())));
                 return;
             }
             editor->did_complete_action("Flatten Image"sv);
@@ -896,7 +896,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             auto* editor = current_image_editor();
             VERIFY(editor);
             if (auto maybe_error = editor->image().merge_visible_layers(); maybe_error.is_error()) {
-                GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to merge visible layers: {}", maybe_error.release_error()));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to merge visible layers: {}", maybe_error.release_error())));
                 return;
             }
             editor->did_complete_action("Merge Visible"sv);
@@ -911,7 +911,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                 return;
 
             if (auto maybe_error = editor->image().merge_active_layer_up(*active_layer); maybe_error.is_error()) {
-                GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to merge active layer up: {}", maybe_error.release_error()));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to merge active layer up: {}", maybe_error.release_error())));
                 return;
             }
             editor->did_complete_action("Merge Active Layer Up"sv);
@@ -926,7 +926,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                 return;
 
             if (auto maybe_error = editor->image().merge_active_layer_down(*active_layer); maybe_error.is_error()) {
-                GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to merge active layer down: {}", maybe_error.release_error()));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to merge active layer down: {}", maybe_error.release_error())));
                 return;
             }
             editor->did_complete_action("Merge Active Layer Down"sv);
@@ -1172,7 +1172,7 @@ void MainWidget::open_image(FileSystemAccessClient::File file)
 {
     auto try_load = m_loader.load_from_file(file.release_stream());
     if (try_load.is_error()) {
-        GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Unable to open file: {}, {}", file.filename(), try_load.error()));
+        GUI::MessageBox::show_error(window(), MUST(String::formatted("Unable to open file: {}, {}", file.filename(), try_load.release_error())));
         return;
     }
 

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -603,7 +603,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             VERIFY(editor);
             auto image_flip_or_error = editor->image().flip(Gfx::Orientation::Vertical);
             if (image_flip_or_error.is_error()) {
-                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to flip image: {}", image_flip_or_error.error().string_literal())));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to flip image: {}", image_flip_or_error.release_error())));
                 return;
             }
             editor->did_complete_action("Flip Image Vertically"sv);
@@ -614,7 +614,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             VERIFY(editor);
             auto image_flip_or_error = editor->image().flip(Gfx::Orientation::Horizontal);
             if (image_flip_or_error.is_error()) {
-                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to flip image: {}", image_flip_or_error.error().string_literal())));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to flip image: {}", image_flip_or_error.release_error())));
                 return;
             }
             editor->did_complete_action("Flip Image Horizontally"sv);
@@ -627,7 +627,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             VERIFY(editor);
             auto image_rotate_or_error = editor->image().rotate(Gfx::RotationDirection::CounterClockwise);
             if (image_rotate_or_error.is_error()) {
-                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to rotate image: {}", image_rotate_or_error.error().string_literal())));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to rotate image: {}", image_rotate_or_error.release_error())));
                 return;
             }
             editor->did_complete_action("Rotate Image Counterclockwise"sv);
@@ -639,7 +639,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             VERIFY(editor);
             auto image_rotate_or_error = editor->image().rotate(Gfx::RotationDirection::Clockwise);
             if (image_rotate_or_error.is_error()) {
-                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to rotate image: {}", image_rotate_or_error.error().string_literal())));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to rotate image: {}", image_rotate_or_error.release_error())));
                 return;
             }
             editor->did_complete_action("Rotate Image Clockwise"sv);
@@ -653,7 +653,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             if (dialog->exec() == GUI::Dialog::ExecResult::OK) {
                 auto image_resize_or_error = editor->image().resize(dialog->desired_size(), dialog->scaling_mode());
                 if (image_resize_or_error.is_error()) {
-                    GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to resize image: {}", image_resize_or_error.error().string_literal())));
+                    GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to resize image: {}", image_resize_or_error.release_error())));
                     return;
                 }
                 editor->did_complete_action("Resize Image"sv);
@@ -669,7 +669,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             auto crop_rect = editor->image().rect().intersected(editor->image().selection().bounding_rect());
             auto image_crop_or_error = editor->image().crop(crop_rect);
             if (image_crop_or_error.is_error()) {
-                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to crop image: {}", image_crop_or_error.error().string_literal())));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to crop image: {}", image_crop_or_error.release_error())));
                 return;
             }
             editor->image().selection().clear();
@@ -687,7 +687,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
 
             auto image_crop_or_error = editor->image().crop(content_bounding_rect.value());
             if (image_crop_or_error.is_error()) {
-                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to crop image: {}", image_crop_or_error.error().string_literal())));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to crop image: {}", image_crop_or_error.release_error())));
                 return;
             }
             editor->did_complete_action("Crop Image to Content"sv);
@@ -728,7 +728,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         "Layer via Copy", { Mod_Ctrl | Mod_Shift, Key_C }, g_icon_bag.new_layer, [&](auto&) {
             auto add_layer_success = current_image_editor()->add_new_layer_from_selection();
             if (add_layer_success.is_error()) {
-                GUI::MessageBox::show_error(&window, add_layer_success.release_error().string_literal());
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("{}", add_layer_success.release_error())));
                 return;
             }
             current_image_editor()->did_complete_action("New Layer via Copy"sv);
@@ -740,7 +740,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         "Layer via Cut", { Mod_Ctrl | Mod_Shift, Key_X }, g_icon_bag.new_layer, [&](auto&) {
             auto add_layer_success = current_image_editor()->add_new_layer_from_selection();
             if (add_layer_success.is_error()) {
-                GUI::MessageBox::show_error(&window, add_layer_success.release_error().string_literal());
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("{}", add_layer_success.release_error())));
                 return;
             }
             current_image_editor()->active_layer()->erase_selection(current_image_editor()->image().selection());
@@ -866,7 +866,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             } else {
                 auto layer_result = PixelPaint::Layer::create_with_size(editor->image(), editor->image().size(), "Background");
                 if (layer_result.is_error()) {
-                    GUI::MessageBox::show_error(&window, DeprecatedString::formatted("Failed to create layer with size {}, error: {}", editor->image().size(), layer_result.error()));
+                    GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to create layer with size {}, error: {}", editor->image().size(), layer_result.error())));
                     return;
                 }
                 auto layer = layer_result.release_value();
@@ -942,7 +942,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                 return;
             auto layer_flip_or_error = active_layer->flip(Gfx::Orientation::Vertical);
             if (layer_flip_or_error.is_error()) {
-                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to flip layer: {}", layer_flip_or_error.error().string_literal())));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to flip layer: {}", layer_flip_or_error.release_error())));
                 return;
             }
             editor->did_complete_action("Flip Layer Vertically"sv);
@@ -956,7 +956,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                 return;
             auto layer_flip_or_error = active_layer->flip(Gfx::Orientation::Horizontal);
             if (layer_flip_or_error.is_error()) {
-                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to flip layer: {}", layer_flip_or_error.error().string_literal())));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to flip layer: {}", layer_flip_or_error.release_error())));
                 return;
             }
             editor->did_complete_action("Flip Layer Horizontally"sv);
@@ -972,7 +972,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                 return;
             auto layer_rotate_or_error = active_layer->rotate(Gfx::RotationDirection::CounterClockwise);
             if (layer_rotate_or_error.is_error()) {
-                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to rotate layer: {}", layer_rotate_or_error.error().string_literal())));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to rotate layer: {}", layer_rotate_or_error.release_error())));
                 return;
             }
             editor->did_complete_action("Rotate Layer Counterclockwise"sv);
@@ -987,7 +987,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                 return;
             auto layer_rotate_or_error = active_layer->rotate(Gfx::RotationDirection::Clockwise);
             if (layer_rotate_or_error.is_error()) {
-                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to rotate layer: {}", layer_rotate_or_error.error().string_literal())));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to rotate layer: {}", layer_rotate_or_error.release_error())));
                 return;
             }
             editor->did_complete_action("Rotate Layer Clockwise"sv);
@@ -1006,7 +1006,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             auto crop_rect = intersection.translated(-active_layer->location());
             auto layer_crop_or_error = active_layer->crop(crop_rect);
             if (layer_crop_or_error.is_error()) {
-                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to crop layer: {}", layer_crop_or_error.error().string_literal())));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to crop layer: {}", layer_crop_or_error.release_error())));
                 return;
             }
             active_layer->set_location(intersection.location());
@@ -1025,7 +1025,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
                 return;
             auto layer_crop_or_error = active_layer->crop(content_bounding_rect.value());
             if (layer_crop_or_error.is_error()) {
-                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to crop layer: {}", layer_crop_or_error.error().string_literal())));
+                GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to crop layer: {}", layer_crop_or_error.release_error())));
                 return;
             }
             active_layer->set_location(content_bounding_rect->location());

--- a/Userland/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Userland/Applications/PixelPaint/PaletteWidget.cpp
@@ -130,7 +130,7 @@ PaletteWidget::PaletteWidget()
 
     auto result = load_palette_path("/res/color-palettes/default.palette");
     if (result.is_error()) {
-        GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Loading default palette failed: {}", result.error()));
+        GUI::MessageBox::show_error(window(), MUST(String::formatted("Loading default palette failed: {}", result.release_error())));
         display_color_list(fallback_colors());
 
         return;

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -126,7 +126,7 @@ void MoveTool::on_mouseup(Layer* layer, MouseEvent& event)
     if (m_scaling) {
         auto scaled_layer_or_error = m_editor->active_layer()->scale(m_new_layer_rect, Gfx::Painter::ScalingMode::BilinearBlend);
         if (scaled_layer_or_error.is_error())
-            GUI::MessageBox::show_error(m_editor->window(), MUST(String::formatted("Failed to resize layer: {}", scaled_layer_or_error.error().string_literal())));
+            GUI::MessageBox::show_error(m_editor->window(), MUST(String::formatted("Failed to resize layer: {}", scaled_layer_or_error.release_error())));
         else
             m_editor->layers_did_change();
     }


### PR DESCRIPTION
In the case where an error is created from an errno, calling `string_literal()` will print nothing. Using Error's formatter instead gives a more descriptive error message.

Before:
![error_message_before](https://user-images.githubusercontent.com/2817754/227656669-01065942-e9d6-46e2-95f4-2a459e7ed729.png)

After:
![descriptive_error_message](https://user-images.githubusercontent.com/2817754/227656651-51b3b4d2-b5ee-4da0-ace9-691a0209aaae.png)


