### PR TITLE
Add gunzip, gzip to lagom and make deflate decompression a bit faster on arm

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -502,6 +502,12 @@ if (BUILD_LAGOM)
         add_executable(gml-format ../../Userland/Utilities/gml-format.cpp)
         target_link_libraries(gml-format LibCore LibGUI LibMain)
 
+        add_executable(gunzip ../../Userland/Utilities/gunzip.cpp)
+        target_link_libraries(gunzip LibCompress LibCore LibMain)
+
+        add_executable(gzip ../../Userland/Utilities/gzip.cpp)
+        target_link_libraries(gzip LibCompress LibCore LibMain)
+
         if (ENABLE_LAGOM_LADYBIRD)
             add_serenity_subdirectory(Ladybird)
         endif()

--- a/Userland/Libraries/LibCrypto/Checksum/CRC32.cpp
+++ b/Userland/Libraries/LibCrypto/Checksum/CRC32.cpp
@@ -13,14 +13,33 @@ namespace Crypto::Checksum {
 
 #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
 
-void CRC32::update(ReadonlyBytes data)
+void CRC32::update(ReadonlyBytes span)
 {
     // FIXME: Does this require runtime checking on rpi?
     //        (Maybe the instruction is present on the rpi4 but not on the rpi3?)
 
-    // FIXME: Use __builtin_arm_crc32d() for aligned middle part.
-    for (size_t i = 0; i < data.size(); i++)
-        m_state = __builtin_arm_crc32b(m_state, data.at(i));
+    u8 const* data = span.data();
+    size_t size = span.size();
+
+    while (size > 0 && (reinterpret_cast<FlatPtr>(data) & 7) != 0) {
+        m_state = __builtin_arm_crc32b(m_state, *data);
+        ++data;
+        --size;
+    }
+
+    auto* data64 = reinterpret_cast<u64 const*>(data);
+    while (size >= 8) {
+        m_state = __builtin_arm_crc32d(m_state, *data64);
+        ++data64;
+        size -= 8;
+    }
+
+    data = reinterpret_cast<u8 const*>(data64);
+    while (size > 0) {
+        m_state = __builtin_arm_crc32b(m_state, *data);
+        ++data;
+        --size;
+    }
 };
 
     // FIXME: On Intel, use _mm_crc32_u8 / _mm_crc32_u64 if available (SSE 4.2).


### PR DESCRIPTION
This makes it easy to compare the performance of Serenity's
deflate implementation to the host system implementation.

On my M1 Max MBP:

    % time gunzip -c \
        /Users/thakis/Downloads/trace_bug.json.gz > /dev/null

takes between 0.064s and 0.082s.

    % time Build/lagom/gunzip -c \
        /Users/thakis/Downloads/trace_bug.json.gz > /dev/null

on the other hand takes 4 seconds.

---

So we're ~57x slower than macOS gunzip.

But, not to fret, after the dramatic speedups herein we only need 3.87s, merely 55x slower.