### PR TITLE
PixelPaint: Correctly set default layer name

### DIFF
--- a/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
@@ -28,7 +28,7 @@ CreateNewLayerDialog::CreateNewLayerDialog(Gfx::IntSize suggested_size, GUI::Win
     name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
     m_name_textbox = main_widget->add<GUI::TextBox>();
-    m_name_textbox->set_text("Layer"sv);
+    m_name_textbox->set_text(default_layer_name);
     m_name_textbox->select_all();
     m_name_textbox->on_change = [this] {
         m_layer_name = m_name_textbox->text();

--- a/Userland/Applications/PixelPaint/CreateNewLayerDialog.h
+++ b/Userland/Applications/PixelPaint/CreateNewLayerDialog.h
@@ -18,10 +18,12 @@ public:
     DeprecatedString const& layer_name() const { return m_layer_name; }
 
 private:
+    static constexpr StringView default_layer_name = "Layer"sv;
+
     CreateNewLayerDialog(Gfx::IntSize suggested_size, GUI::Window* parent_window);
 
     Gfx::IntSize m_layer_size;
-    DeprecatedString m_layer_name;
+    DeprecatedString m_layer_name { default_layer_name };
 
     RefPtr<GUI::TextBox> m_name_textbox;
 };


### PR DESCRIPTION
Previously, if you confirmed the "new layer" dialog without any change to the layer name, the layer would end up with an empty string for its name.