### PR TITLE
LibWeb: Check all conditions of radio button groups

### DIFF
--- a/Base/res/html/misc/accent-color.html
+++ b/Base/res/html/misc/accent-color.html
@@ -29,12 +29,12 @@
     <input class="big indeterminate" type="checkbox" disabled></input>
   </form>
   <form>
-    <input type="radio" checked></input>
-    <input type="radio"></input>
+    <input name="radio-small" type="radio" checked></input>
+    <input name="radio-small" type="radio"></input>
     <input type="radio" checked disabled></input>
     <input type="radio" disabled></input>
-    <input class="big" type="radio" checked></input>
-    <input class="big" type="radio"></input>
+    <input name="radio-big" class="big" type="radio" checked></input>
+    <input name="radio-big" class="big" type="radio"></input>
     <input class="big" type="radio" checked disabled></input>
     <input class="big" type="radio" disabled></input>
   </form>
@@ -58,12 +58,12 @@
     <input class="big indeterminate" type="checkbox" disabled></input>
   </form>
   <form>
-    <input type="radio" checked></input>
-    <input type="radio"></input>
+    <input name="radio-small" type="radio" checked></input>
+    <input name="radio-small" type="radio"></input>
     <input type="radio" checked disabled></input>
     <input type="radio" disabled></input>
-    <input class="big" type="radio" checked></input>
-    <input class="big" type="radio"></input>
+    <input name="radio-big" class="big" type="radio" checked></input>
+    <input name="radio-big" class="big" type="radio"></input>
     <input class="big" type="radio" checked disabled></input>
     <input class="big" type="radio" disabled></input>
   </form>
@@ -87,12 +87,12 @@
     <input class="big indeterminate" type="checkbox" disabled></input>
   </form>
   <form>
-    <input type="radio" checked></input>
-    <input type="radio"></input>
+    <input name="radio-small" type="radio" checked></input>
+    <input name="radio-small" type="radio"></input>
     <input type="radio" checked disabled></input>
     <input type="radio" disabled></input>
-    <input class="big" type="radio" checked></input>
-    <input class="big" type="radio"></input>
+    <input name="radio-big" class="big" name="c" type="radio" checked></input>
+    <input name="radio-big" class="big" name="c" type="radio"></input>
     <input class="big" type="radio" checked disabled></input>
     <input class="big" type="radio" disabled></input>
   </form>

--- a/Base/res/html/misc/input.html
+++ b/Base/res/html/misc/input.html
@@ -32,7 +32,9 @@
     <input type="range" id="range" value="range" /><br />
     <input type="color" id="color" value="color" /><br />
     <input type="checkbox" id="checkbox" value="checkbox" /><br />
-    <input type="radio" id="radio" value="radio" /><br />
+    <input type="radio" id="radio-a" value="a" name="test-radio" /><br />
+    <input type="radio" id="radio-b" value="b" name="test-radio" /><br />
+    <input type="radio" id="radio-c" value="c" name="test-radio" /><br />
     <input type="file" id="file" value="file" /><br />
     <input type="submit" id="submit" value="submit" /><br />
     <input type="image" id="image" value="image" /><br />


### PR DESCRIPTION
This fixes a few issues I noticed when playing around with radio buttons. Previously radio buttons would uncheck checkboxes with the same "name" attribute, uncheck inputs across different forms, and treated no name attribute as a group.

This now implements the radio button group check from the HTML spec.