### PR TITLE
DisplaySettings: Add configuration domain pledge for FileManager

### DIFF
--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -25,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio thread recvfd sendfd rpath cpath wpath unix proc exec"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
-    Config::pledge_domain("WindowManager");
+    Config::pledge_domains({ "WindowManager", "FileManager" });
 
     StringView selected_tab;
     Core::ArgsParser args_parser;


### PR DESCRIPTION
This fixes a bug where clicking the "Browse" button would crash the application due to not mentioning 'FileManager' in the pledge call.