### PR TITLE
Browser+Ladybird: Show current zoom level in the view menu

### DIFF
--- a/Ladybird/BrowserWindow.cpp
+++ b/Ladybird/BrowserWindow.cpp
@@ -83,23 +83,23 @@ BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdrive
 
     view_menu->addSeparator();
 
-    auto* zoom_menu = view_menu->addMenu("&Zoom");
+    m_zoom_menu = view_menu->addMenu("&Zoom");
 
     auto* zoom_in_action = new QAction("Zoom &In", this);
     auto zoom_in_shortcuts = QKeySequence::keyBindings(QKeySequence::StandardKey::ZoomIn);
     zoom_in_shortcuts.append(QKeySequence(Qt::CTRL | Qt::Key_Equal));
     zoom_in_action->setShortcuts(zoom_in_shortcuts);
-    zoom_menu->addAction(zoom_in_action);
+    m_zoom_menu->addAction(zoom_in_action);
     QObject::connect(zoom_in_action, &QAction::triggered, this, &BrowserWindow::zoom_in);
 
     auto* zoom_out_action = new QAction("Zoom &Out", this);
     zoom_out_action->setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::ZoomOut));
-    zoom_menu->addAction(zoom_out_action);
+    m_zoom_menu->addAction(zoom_out_action);
     QObject::connect(zoom_out_action, &QAction::triggered, this, &BrowserWindow::zoom_out);
 
     auto* reset_zoom_action = new QAction("&Reset Zoom", this);
     reset_zoom_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_0));
-    zoom_menu->addAction(reset_zoom_action);
+    m_zoom_menu->addAction(reset_zoom_action);
     QObject::connect(reset_zoom_action, &QAction::triggered, this, &BrowserWindow::reset_zoom);
 
     view_menu->addSeparator();
@@ -322,7 +322,7 @@ BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdrive
     QObject::connect(m_tabs_container, &QTabWidget::currentChanged, [this](int index) {
         setWindowTitle(QString("%1 - Ladybird").arg(m_tabs_container->tabText(index)));
         setWindowIcon(m_tabs_container->tabIcon(index));
-        m_current_tab = verify_cast<Tab>(m_tabs_container->widget(index));
+        set_current_tab(verify_cast<Tab>(m_tabs_container->widget(index)));
     });
     QObject::connect(m_tabs_container, &QTabWidget::tabCloseRequested, this, &BrowserWindow::close_tab);
     QObject::connect(close_current_tab_action, &QAction::triggered, this, &BrowserWindow::close_current_tab);
@@ -330,6 +330,12 @@ BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdrive
     new_tab(s_settings->new_tab_page(), Web::HTML::ActivateTab::Yes);
 
     setCentralWidget(m_tabs_container);
+}
+
+void BrowserWindow::set_current_tab(Tab* tab)
+{
+    m_current_tab = tab;
+    update_zoom_menu_text();
 }
 
 void BrowserWindow::debug_request(DeprecatedString const& request, DeprecatedString const& argument)
@@ -346,7 +352,7 @@ Tab& BrowserWindow::new_tab(QString const& url, Web::HTML::ActivateTab activate_
     m_tabs.append(std::move(tab));
 
     if (m_current_tab == nullptr) {
-        m_current_tab = tab_ptr;
+        set_current_tab(tab_ptr);
     }
 
     m_tabs_container->addTab(tab_ptr, "New Tab");
@@ -494,26 +500,39 @@ void BrowserWindow::enable_dark_color_scheme()
 
 void BrowserWindow::zoom_in()
 {
-    if (m_current_tab)
-        m_current_tab->view().zoom_in();
+    if (!m_current_tab)
+        return;
+    m_current_tab->view().zoom_in();
+    update_zoom_menu_text();
 }
 
 void BrowserWindow::zoom_out()
 {
-    if (m_current_tab)
-        m_current_tab->view().zoom_out();
+    if (!m_current_tab)
+        return;
+    m_current_tab->view().zoom_out();
+    update_zoom_menu_text();
 }
 
 void BrowserWindow::reset_zoom()
 {
-    if (m_current_tab)
-        m_current_tab->view().reset_zoom();
+    if (!m_current_tab)
+        return;
+    m_current_tab->view().reset_zoom();
+    update_zoom_menu_text();
 }
 
 void BrowserWindow::select_all()
 {
     if (auto* tab = m_current_tab)
         tab->view().select_all();
+}
+
+void BrowserWindow::update_zoom_menu_text()
+{
+    VERIFY(m_zoom_menu && m_current_tab);
+    auto zoom_level_text = MUST(String::formatted("&Zoom ({}%)", round_to<int>(m_current_tab->view().zoom_level() * 100)));
+    m_zoom_menu->setTitle(qstring_from_ak_string(zoom_level_text));
 }
 
 void BrowserWindow::copy_selected_text()

--- a/Ladybird/BrowserWindow.h
+++ b/Ladybird/BrowserWindow.h
@@ -59,9 +59,13 @@ private:
 
     void debug_request(DeprecatedString const& request, DeprecatedString const& argument = "");
 
+    void set_current_tab(Tab* tab);
+    void update_zoom_menu_text();
+
     QTabWidget* m_tabs_container { nullptr };
     Vector<NonnullOwnPtr<Tab>> m_tabs;
     Tab* m_current_tab { nullptr };
+    QMenu* m_zoom_menu { nullptr };
 
     Browser::CookieJar& m_cookie_jar;
 

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -84,6 +84,7 @@ BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url)
         auto& tab = static_cast<Browser::Tab&>(active_widget);
         set_window_title_for_tab(tab);
         tab.did_become_active();
+        update_zoom_menu_text();
     };
 
     m_tab_widget->on_middle_click = [](auto& clicked_widget) {
@@ -172,22 +173,26 @@ void BrowserWindow::build_menus()
     view_menu.add_action(WindowActions::the().show_bookmarks_bar_action());
     view_menu.add_action(WindowActions::the().vertical_tabs_action());
     view_menu.add_separator();
-    view_menu.add_action(GUI::CommonActions::make_zoom_in_action(
+    m_zoom_menu = view_menu.add_submenu("&Zoom");
+    m_zoom_menu->add_action(GUI::CommonActions::make_zoom_in_action(
         [this](auto&) {
             auto& tab = active_tab();
             tab.view().zoom_in();
+            update_zoom_menu_text();
         },
         this));
-    view_menu.add_action(GUI::CommonActions::make_zoom_out_action(
+    m_zoom_menu->add_action(GUI::CommonActions::make_zoom_out_action(
         [this](auto&) {
             auto& tab = active_tab();
             tab.view().zoom_out();
+            update_zoom_menu_text();
         },
         this));
-    view_menu.add_action(GUI::CommonActions::make_reset_zoom_action(
+    m_zoom_menu->add_action(GUI::CommonActions::make_reset_zoom_action(
         [this](auto&) {
             auto& tab = active_tab();
             tab.view().reset_zoom();
+            update_zoom_menu_text();
         },
         this));
     view_menu.add_separator();
@@ -789,6 +794,13 @@ ErrorOr<void> BrowserWindow::take_screenshot(ScreenshotType type)
     TRY(screenshot_file->write_until_depleted(encoded));
 
     return {};
+}
+
+void BrowserWindow::update_zoom_menu_text()
+{
+    VERIFY(m_zoom_menu);
+    auto zoom_level_text = DeprecatedString::formatted("&Zoom ({}%)", round_to<int>(active_tab().view().zoom_level() * 100));
+    m_zoom_menu->set_name(zoom_level_text);
 }
 
 }

--- a/Userland/Applications/Browser/BrowserWindow.h
+++ b/Userland/Applications/Browser/BrowserWindow.h
@@ -62,6 +62,8 @@ private:
 
     virtual void event(Core::Event&) override;
 
+    void update_zoom_menu_text();
+
     enum class ScreenshotType {
         Visible,
         Full,
@@ -79,6 +81,8 @@ private:
     RefPtr<GUI::Action> m_inspect_dom_node_action;
     RefPtr<GUI::Action> m_take_visible_screenshot_action;
     RefPtr<GUI::Action> m_take_full_screenshot_action;
+
+    RefPtr<GUI::Menu> m_zoom_menu;
 
     CookieJar& m_cookie_jar;
     WindowActions m_window_actions;

--- a/Userland/Libraries/LibGUI/Menu.h
+++ b/Userland/Libraries/LibGUI/Menu.h
@@ -33,6 +33,8 @@ public:
     int menu_id() const { return m_menu_id; }
 
     DeprecatedString const& name() const { return m_name; }
+    void set_name(DeprecatedString);
+
     Gfx::Bitmap const* icon() const { return m_icon.ptr(); }
     void set_icon(Gfx::Bitmap const*);
 
@@ -73,12 +75,17 @@ private:
 
     void realize_menu_item(MenuItem&, int item_id);
 
+    void set_parent(Menu& menu, int submenu_index);
+    void update_parent_menu_item();
+
     int m_menu_id { -1 };
     DeprecatedString m_name;
     RefPtr<Gfx::Bitmap const> m_icon;
     Vector<NonnullOwnPtr<MenuItem>> m_items;
     WeakPtr<Action> m_current_default_action;
     bool m_visible { false };
+    WeakPtr<Menu> m_parent_menu;
+    int m_index_in_parent_menu { -1 };
 
     Function<void(Action&)> m_recent_files_callback;
 };

--- a/Userland/Libraries/LibGUI/MenuItem.cpp
+++ b/Userland/Libraries/LibGUI/MenuItem.cpp
@@ -80,10 +80,23 @@ void MenuItem::update_window_server()
 {
     if (m_menu_id < 0)
         return;
-    auto& action = *m_action;
-    auto shortcut_text = action.shortcut().is_valid() ? action.shortcut().to_deprecated_string() : DeprecatedString();
-    auto icon = action.icon() ? action.icon()->to_shareable_bitmap() : Gfx::ShareableBitmap();
-    ConnectionToWindowServer::the().async_update_menu_item(m_menu_id, m_identifier, -1, action.text(), action.is_enabled(), action.is_visible(), action.is_checkable(), action.is_checkable() ? action.is_checked() : false, m_default, shortcut_text, icon);
+    switch (m_type) {
+    case MenuItem::Type::Action: {
+        auto& action = *m_action;
+        auto shortcut_text = action.shortcut().is_valid() ? action.shortcut().to_deprecated_string() : DeprecatedString();
+        auto icon = action.icon() ? action.icon()->to_shareable_bitmap() : Gfx::ShareableBitmap();
+        ConnectionToWindowServer::the().async_update_menu_item(m_menu_id, m_identifier, -1, action.text(), action.is_enabled(), action.is_visible(), action.is_checkable(), action.is_checkable() ? action.is_checked() : false, m_default, shortcut_text, icon);
+        break;
+    }
+    case MenuItem::Type::Submenu: {
+        auto& submenu = *m_submenu;
+        auto icon = submenu.icon() ? submenu.icon()->to_shareable_bitmap() : Gfx::ShareableBitmap();
+        ConnectionToWindowServer::the().async_update_menu_item(m_menu_id, m_identifier, submenu.menu_id(), submenu.name(), m_enabled, m_visible, false, false, m_default, "", icon);
+        break;
+    }
+    default:
+        VERIFY_NOT_REACHED();
+    }
 }
 
 void MenuItem::set_menu_id(Badge<Menu>, unsigned int menu_id)

--- a/Userland/Libraries/LibGUI/MenuItem.h
+++ b/Userland/Libraries/LibGUI/MenuItem.h
@@ -56,6 +56,7 @@ public:
     void set_identifier(Badge<Menu>, unsigned identifier);
 
     void update_from_action(Badge<Action>) { update_window_server(); }
+    void update_from_menu(Badge<Menu>) { update_window_server(); }
 
 private:
     void update_window_server();

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -794,6 +794,9 @@ void HTMLInputElement::form_associated_element_was_inserted()
 // https://html.spec.whatwg.org/multipage/input.html#radio-button-group
 static bool is_in_same_radio_button_group(HTML::HTMLInputElement const& a, HTML::HTMLInputElement const& b)
 {
+    auto non_empty_equals = [](auto const& value_a, auto const& value_b) {
+        return !value_a.is_empty() && value_a == value_b;
+    };
     // The radio button group that contains an input element a also contains all the
     // other input elements b that fulfill all of the following conditions:
     return (
@@ -807,7 +810,7 @@ static bool is_in_same_radio_button_group(HTML::HTMLInputElement const& a, HTML:
         // value of a's name attribute equals the value of b's name attribute.
         && a.has_attribute(HTML::AttributeNames::name)
         && b.has_attribute(HTML::AttributeNames::name)
-        && a.name() == b.name());
+        && non_empty_equals(a.name(), b.name()));
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -40,6 +40,7 @@ public:
     void zoom_in();
     void zoom_out();
     void reset_zoom();
+    float zoom_level() const { return m_zoom_level; }
 
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
 

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -96,6 +96,27 @@ void ConnectionFromClient::create_menu(i32 menu_id, DeprecatedString const& name
     m_menus.set(menu_id, move(menu));
 }
 
+void ConnectionFromClient::set_menu_name(i32 menu_id, DeprecatedString const& name)
+{
+    auto it = m_menus.find(menu_id);
+    if (it == m_menus.end()) {
+        did_misbehave("DestroyMenu: Bad menu ID");
+        return;
+    }
+    auto& menu = *it->value;
+    menu.set_name(name);
+    for (auto& it : m_windows) {
+        auto& window = *it.value;
+        window.menubar().for_each_menu([&](Menu& other_menu) {
+            if (&menu == &other_menu) {
+                window.invalidate_menubar();
+                return IterationDecision::Break;
+            }
+            return IterationDecision::Continue;
+        });
+    }
+}
+
 void ConnectionFromClient::destroy_menu(i32 menu_id)
 {
     auto it = m_menus.find(menu_id);

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -90,9 +90,9 @@ void ConnectionFromClient::notify_about_new_screen_rects()
     async_screen_rects_changed(Screen::rects(), Screen::main().index(), wm.window_stack_rows(), wm.window_stack_columns());
 }
 
-void ConnectionFromClient::create_menu(i32 menu_id, DeprecatedString const& menu_title)
+void ConnectionFromClient::create_menu(i32 menu_id, DeprecatedString const& name)
 {
-    auto menu = Menu::construct(this, menu_id, menu_title);
+    auto menu = Menu::construct(this, menu_id, name);
     m_menus.set(menu_id, move(menu));
 }
 

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -94,6 +94,7 @@ private:
     void destroy_window(Window&, Vector<i32>& destroyed_window_ids);
 
     virtual void create_menu(i32, DeprecatedString const&) override;
+    virtual void set_menu_name(i32, DeprecatedString const&) override;
     virtual void destroy_menu(i32) override;
     virtual void add_menu(i32, i32) override;
     virtual void add_menu_item(i32, i32, i32, DeprecatedString const&, bool, bool, bool, bool, bool, DeprecatedString const&, Gfx::ShareableBitmap const&, bool) override;

--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -752,6 +752,11 @@ void Menu::set_hovered_index(int index, bool make_input)
         redraw(*old_hovered_item);
 }
 
+void Menu::set_name(DeprecatedString name)
+{
+    m_name = move(name);
+}
+
 bool Menu::is_open() const
 {
     return MenuManager::the().is_open(*this);

--- a/Userland/Services/WindowServer/Menu.h
+++ b/Userland/Services/WindowServer/Menu.h
@@ -59,6 +59,7 @@ public:
     void add_item(NonnullOwnPtr<MenuItem>);
 
     DeprecatedString const& name() const { return m_name; }
+    void set_name(DeprecatedString);
 
     template<typename Callback>
     IterationDecision for_each_item(Callback callback)

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -5,6 +5,7 @@
 endpoint WindowServer
 {
     create_menu(i32 menu_id, [UTF8] DeprecatedString name) =|
+    set_menu_name(i32 menu_id, DeprecatedString name) =|
     destroy_menu(i32 menu_id) =|
 
     add_menu(i32 window_id, i32 menu_id) =|

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -4,7 +4,7 @@
 
 endpoint WindowServer
 {
-    create_menu(i32 menu_id, [UTF8] DeprecatedString menu_title) =|
+    create_menu(i32 menu_id, [UTF8] DeprecatedString name) =|
     destroy_menu(i32 menu_id) =|
 
     add_menu(i32 window_id, i32 menu_id) =|


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11597044/227797522-365f87f9-ae86-4855-9889-708c35acdd76.png)
![image](https://user-images.githubusercontent.com/11597044/227797586-0968f9e8-fca0-4013-ae78-495a4256ea95.png)

This PR now shows the current zoom level in both Ladybird and Browser. 
This is a minor QoL feature that I've been missing, since it's not easy to guess the zoom level :^) 

---
_P.s. First commit is a unrelated fix-up for #18046 (though it did not seem worthy of a new PR)_ 