### PR TITLE
Browser: Remove unused variables in `BookmarksBarWidget`

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -275,7 +275,6 @@ bool BookmarksBarWidget::contains_bookmark(DeprecatedString const& url)
 {
     for (int item_index = 0; item_index < model()->row_count(); ++item_index) {
 
-        auto item_title = model()->index(item_index, 0).data().to_deprecated_string();
         auto item_url = model()->index(item_index, 1).data().to_deprecated_string();
         if (item_url == url) {
             return true;
@@ -288,7 +287,6 @@ bool BookmarksBarWidget::remove_bookmark(DeprecatedString const& url)
 {
     for (int item_index = 0; item_index < model()->row_count(); ++item_index) {
 
-        auto item_title = model()->index(item_index, 0).data().to_deprecated_string();
         auto item_url = model()->index(item_index, 1).data().to_deprecated_string();
         if (item_url == url) {
             auto& json_model = *static_cast<GUI::JsonArrayModel*>(model());


### PR DESCRIPTION
The `item_title` variables are initialized and thereafter never used in `contains_bookmark()` and `remove_bookmark()`.