### PR TITLE
Chess: Make sure to kill ChessEngine process on exit

### DIFF
--- a/Userland/Services/ChessEngine/main.cpp
+++ b/Userland/Services/ChessEngine/main.cpp
@@ -10,12 +10,26 @@
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 
+#include <unistd.h>
+
+namespace {
+
+bool is_parent_dead()
+{
+    pid_t ppid = getppid();
+    return kill(ppid, 0) < 0;
+}
+
+}
+
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd unix"));
+    TRY(Core::System::pledge("stdio recvfd sendfd unix proc"));
     Core::EventLoop loop;
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto engine = TRY(ChessEngine::try_create(Core::DeprecatedFile::standard_input(), Core::DeprecatedFile::standard_output()));
-    return loop.exec();
+
+    loop.spin_until(is_parent_dead);
+    return 0;
 }


### PR DESCRIPTION
This is a fix for #17427 

ChessEngine doesn't quit after Chess app is closed. Mainly due to the fact ChessEngine is run in a forked process. To fix this problem, the program should make sure the forked process(ChessEngine) is aware of its parent's termination status. The changes to fix this problem are as follows (ChessEngines->main.cpp):

1. add a function to check whether the parent process is dead using `kill` syscall
2. change the `loop.exec` logic to `spin_until` using the above as predicate

During the process, I referred to this previous PR (#17564). 