### PR TITLE
LibWeb: Fix condition to early return in intrinsic sizing for TFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/table-in-auto-height-flex-item.txt
+++ b/Tests/LibWeb/Layout/expected/table-in-auto-height-flex-item.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x39.46875 children: not-inline
+    Box <body> at (10,10) content-size 764x21.46875 flex-container(row) children: not-inline
+      BlockContainer <div.upper> at (11,11) content-size 41.78125x19.46875 flex-item children: not-inline
+        TableWrapper <(anonymous)> at (11,11) content-size 41.78125x19.46875 children: not-inline
+          TableBox <(anonymous)> at (11,11) content-size 41.78125x19.46875 children: not-inline
+            TableRowBox <(anonymous)> at (11,11) content-size 41.78125x19.46875 children: not-inline
+              TableCellBox <div.cell> at (12,12) content-size 39.78125x17.46875 children: inline
+                line 0 width: 39.78125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 5, rect: [12,12 39.78125x17.46875]
+                    "Hello"
+                TextNode <#text>

--- a/Tests/LibWeb/Layout/input/table-in-auto-height-flex-item.html
+++ b/Tests/LibWeb/Layout/input/table-in-auto-height-flex-item.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html><html><head><style>
+    * {
+      border: 1px solid black;
+      font-family: 'SerenitySans';
+    }
+    body {
+      display: flex;
+    }
+    .cell {
+      display: table-cell;
+    }
+    .upper {
+      background: pink;
+    }
+</style></head><body><div class="upper"><div class="cell">Hello</div>

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -521,7 +521,7 @@ void TableFormattingContext::run(Box const& box, LayoutMode layout_mode, Availab
     // Compute the minimum width of each column.
     compute_table_measures();
 
-    if (available_space.width.is_intrinsic_sizing_constraint()) {
+    if (available_space.width.is_intrinsic_sizing_constraint() && !available_space.height.is_intrinsic_sizing_constraint()) {
         determine_intrisic_size_of_table_container(available_space);
         return;
     }


### PR DESCRIPTION
Early return before running full TFC algorithm is only possible when just table width need to be calculated.

Fix https://github.com/SerenityOS/serenity/issues/17944