### PR TITLE
Ladybird: Don't update the zoom menu text for null tabs

### DIFF
--- a/Ladybird/BrowserWindow.cpp
+++ b/Ladybird/BrowserWindow.cpp
@@ -335,7 +335,8 @@ BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdrive
 void BrowserWindow::set_current_tab(Tab* tab)
 {
     m_current_tab = tab;
-    update_zoom_menu_text();
+    if (tab)
+        update_zoom_menu_text();
 }
 
 void BrowserWindow::debug_request(DeprecatedString const& request, DeprecatedString const& argument)


### PR DESCRIPTION
This fixes an "Assertion `m_zoom_menu && m_current_tab' failed." error when closing a window.