### PR TITLE
AK: Fix Clang 16 UBSan issue with zero-length `Array`

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -13,6 +13,16 @@
 
 namespace AK {
 
+namespace Detail {
+// This type serves as the storage of 0-sized `AK::Array`s. While zero-length `T[0]`
+// is accepted as a GNU extension, it causes problems with UBSan in Clang 16.
+template<typename T>
+struct EmptyArrayStorage {
+    T& operator[](size_t) const { VERIFY_NOT_REACHED(); }
+    constexpr operator T*() const { return nullptr; }
+};
+}
+
 template<typename T, size_t Size>
 struct Array {
     using ValueType = T;
@@ -109,7 +119,7 @@ struct Array {
         return value;
     }
 
-    T __data[Size];
+    Conditional<Size == 0, Detail::EmptyArrayStorage<T>, T[Size]> __data;
 };
 
 template<typename T, typename... Types>


### PR DESCRIPTION
The current implementation of `Array<T, 0>` has a zero-length C array as its storage type. While this is accepted as a GNU extension, when compiling with Clang 16, an UBSan error is raised every time an object is accessed whose only field is a zero-length array.

This is likely a bug in Clang 16's implementation of UBSan, which has been reported here: https://github.com/llvm/llvm-project/issues/61775

See https://discord.com/channels/830522505605283862/864504515818029087/1087079359808012339 for more context