### PR TITLE
LibGfx: Don't render OpenType glyphs that have no outline

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -699,8 +699,15 @@ RefPtr<Gfx::Bitmap> Font::rasterize_glyph(u32 glyph_id, float x_scale, float y_s
     if (glyph_id >= glyph_count()) {
         glyph_id = 0;
     }
-    auto glyph_offset = m_loca->get_glyph_offset(glyph_id);
-    auto glyph = m_glyf->glyph(glyph_offset);
+
+    auto glyph_offset0 = m_loca->get_glyph_offset(glyph_id);
+    auto glyph_offset1 = m_loca->get_glyph_offset(glyph_id + 1);
+
+    // If a glyph has no outline, then loca[n] = loca [n+1].
+    if (glyph_offset0 == glyph_offset1)
+        return nullptr;
+
+    auto glyph = m_glyf->glyph(glyph_offset0);
 
     i16 ascender = 0;
     i16 descender = 0;

--- a/Userland/Libraries/LibGfx/Font/OpenType/Glyf.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Glyf.cpp
@@ -208,7 +208,8 @@ Optional<Loca> Loca::from_slice(ReadonlyBytes slice, u32 num_glyphs, IndexToLocF
 
 u32 Loca::get_glyph_offset(u32 glyph_id) const
 {
-    VERIFY(glyph_id < m_num_glyphs);
+    // NOTE: The value of n is numGlyphs + 1.
+    VERIFY(glyph_id <= m_num_glyphs);
     switch (m_index_to_loc_format) {
     case IndexToLocFormat::Offset16:
         return ((u32)be_u16(m_slice.offset_pointer(glyph_id * 2))) * 2;


### PR DESCRIPTION
With this fix, our test PDFs look much better again.
![spaces](https://user-images.githubusercontent.com/25061393/228256062-dfd60a7e-b2f5-42c2-85d3-ca27464e5caa.png)
