### PR TITLE
LibWeb: Clamp fit-content widths in flex layout to min/max-width

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-auto-width-with-max-width-constraint.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-auto-width-with-max-width-constraint.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x331.570312 children: not-inline
+    Box <body.hero> at (2,2) content-size 600x329.570312 flex-container(column) children: not-inline
+      BlockContainer <div.header> at (102,3) content-size 400x327.570312 flex-item children: inline
+        line 0 width: 340.488281, height: 65.507812, bottom: 65.507812, baseline: 50.742187
+          frag 0 from TextNode start: 0, length: 11, rect: [102,3 340.488281x65.507812]
+            "This entire"
+        line 1 width: 341.25, height: 66.015625, bottom: 131.523437, baseline: 50.742187
+          frag 0 from TextNode start: 12, length: 11, rect: [102,68 341.25x65.507812]
+            "text should"
+        line 2 width: 274.160156, height: 65.523437, bottom: 196.539062, baseline: 50.742187
+          frag 0 from TextNode start: 24, length: 8, rect: [102,134 274.160156x65.507812]
+            "be on an"
+        line 3 width: 204.082031, height: 66.03125, bottom: 262.554687, baseline: 50.742187
+          frag 0 from TextNode start: 33, length: 6, rect: [102,199 204.082031x65.507812]
+            "orange"
+        line 4 width: 351.5625, height: 65.539062, bottom: 327.570312, baseline: 50.742187
+          frag 0 from TextNode start: 40, length: 11, rect: [102,265 351.5625x65.507812]
+            "background."
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/flex-column-item-with-auto-height-depending-auto-width-with-max-width-constraint.html
+++ b/Tests/LibWeb/Layout/input/flex-column-item-with-auto-height-depending-auto-width-with-max-width-constraint.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html><html><head><style>
+    * {
+        border: 1px solid black;
+        margin: 0;
+        padding: 0;
+        font: 60px SerenitySans;
+    }
+    html {
+        background: white;
+    }
+    .hero {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        width: 600px;
+        background: pink;
+    }
+    .header {
+        max-width: 400px;
+        background: orange;
+    }
+</style></head><body class="hero"><div class="header">This entire text should be on an orange background.</div></body></html>

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1840,6 +1840,16 @@ CSSPixels FlexFormattingContext::calculate_cross_max_content_contribution(FlexIt
     return item.add_cross_margin_box_sizes(clamped_inner_size);
 }
 
+CSSPixels FlexFormattingContext::calculate_clamped_fit_content_width(Box const& box, AvailableSpace const& available_space) const
+{
+    auto const& computed_min_size = box.computed_values().min_width();
+    auto const& computed_max_size = box.computed_values().max_width();
+    auto clamp_min = (!computed_min_size.is_auto() && (!computed_min_size.contains_percentage())) ? specified_cross_min_size(box) : 0;
+    auto clamp_max = (!computed_max_size.is_none() && (!computed_max_size.contains_percentage())) ? specified_cross_max_size(box) : NumericLimits<float>::max();
+    auto size = FormattingContext::calculate_fit_content_width(box, available_space);
+    return css_clamp(size, clamp_min, clamp_max);
+}
+
 CSSPixels FlexFormattingContext::calculate_min_content_main_size(FlexItem const& item) const
 {
     if (is_row_layout()) {
@@ -1847,7 +1857,7 @@ CSSPixels FlexFormattingContext::calculate_min_content_main_size(FlexItem const&
     }
     auto available_space = m_state.get(item.box).available_inner_space_or_constraints_from(m_available_space_for_items->space);
     if (available_space.width.is_indefinite()) {
-        available_space.width = AvailableSize::make_definite(calculate_fit_content_width(item.box, m_available_space_for_items->space));
+        available_space.width = AvailableSize::make_definite(calculate_clamped_fit_content_width(item.box, m_available_space_for_items->space));
     }
     return calculate_min_content_height(item.box, available_space.width);
 }
@@ -1859,7 +1869,7 @@ CSSPixels FlexFormattingContext::calculate_max_content_main_size(FlexItem const&
     }
     auto available_space = m_state.get(item.box).available_inner_space_or_constraints_from(m_available_space_for_items->space);
     if (available_space.width.is_indefinite()) {
-        available_space.width = AvailableSize::make_definite(calculate_fit_content_width(item.box, m_available_space_for_items->space));
+        available_space.width = AvailableSize::make_definite(calculate_clamped_fit_content_width(item.box, m_available_space_for_items->space));
     }
     return calculate_max_content_height(item.box, available_space.width);
 }
@@ -1883,7 +1893,7 @@ CSSPixels FlexFormattingContext::calculate_min_content_cross_size(FlexItem const
     if (is_row_layout()) {
         auto available_space = m_state.get(item.box).available_inner_space_or_constraints_from(m_available_space_for_flex_container->space);
         if (available_space.width.is_indefinite()) {
-            available_space.width = AvailableSize::make_definite(calculate_fit_content_width(item.box, m_available_space_for_items->space));
+            available_space.width = AvailableSize::make_definite(calculate_clamped_fit_content_width(item.box, m_available_space_for_items->space));
         }
         return calculate_min_content_height(item.box, available_space.width);
     }
@@ -1895,7 +1905,7 @@ CSSPixels FlexFormattingContext::calculate_max_content_cross_size(FlexItem const
     if (is_row_layout()) {
         auto available_space = m_state.get(item.box).available_inner_space_or_constraints_from(m_available_space_for_flex_container->space);
         if (available_space.width.is_indefinite()) {
-            available_space.width = AvailableSize::make_definite(calculate_fit_content_width(item.box, m_available_space_for_items->space));
+            available_space.width = AvailableSize::make_definite(calculate_clamped_fit_content_width(item.box, m_available_space_for_items->space));
         }
         return calculate_max_content_height(item.box, available_space.width);
     }

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -207,6 +207,8 @@ private:
     [[nodiscard]] CSSPixels calculate_fit_content_main_size(FlexItem const&) const;
     [[nodiscard]] CSSPixels calculate_fit_content_cross_size(FlexItem const&) const;
 
+    CSSPixels calculate_clamped_fit_content_width(Box const&, AvailableSpace const&) const;
+
     virtual void parent_context_did_dimension_child_root_box() override;
 
     CSS::FlexBasisData used_flex_basis_for_item(FlexItem const&) const;


### PR DESCRIPTION
In situations where we need a width to calculate the intrinsic height of a flex item, we use the fit-content width as a stand-in. However, we also need to clamp it to any min-width and max-width properties present.