### PR TITLE
Meta: Small improvements to man.serenityos.org

### DIFF
--- a/Base/usr/share/man/man7/Help-index.md
+++ b/Base/usr/share/man/man7/Help-index.md
@@ -1,21 +1,24 @@
 ![Help Icon](/res/icons/32x32/app-help.png)
 
-## Welcome to the SerenityOS on-line help system!
+### Welcome to the SerenityOS on-line help system!
 
-This is **Help**, the built-in documentation viewer for the SerenityOS desktop environment. If you prefer a command-line interface, the [`man`(1)](help://man/1/man) command offers a text-only view of the same library.
+This is the system documentation for SerenityOS, in the form of [man pages](https://en.wikipedia.org/wiki/Man_page), divided into traditional Unix-style sections. For more details, see [`man`(7)](help://man/7/man). Developer documentation is available on [GitHub](https://github.com/SerenityOS/serenity/tree/master/Documentation).
+
+Use the [Help](help://man/1/Applications/Help) application to access the man pages within SerenityOS. If you prefer a command-line interface, the [`man`(1)](help://man/1/man) command offers a text-only view of the same library. A website version is also available at [man.serenityos.org](https://man.serenityos.org/).
 
 ---
 
-Documentation is divided into traditional Unix-style manual categories. Use the **Browse** tab on the left-hand side to navigate by category.
+Use the **Browse** tab on the left-hand side to navigate by section.
 
 There's also a full-text search option under the **Search** tab.
 
-If you want more information on the structure of the manual system, take a look at [`man(7)`](help://man/7/man).
-
-### Getting Started
-* [Keyboard Shortcuts](help://man/7/KeyboardShortcuts)
-* [Tips and Tricks](help://man/7/Tips-and-Tricks)
-
 ---
 
-Thank you for using ***SerenityOS Help!***
+### Getting Started
+
+- [Keyboard Shortcuts](help://man/7/KeyboardShortcuts)
+- [Tips and Tricks](help://man/7/Tips-and-Tricks)
+
+<!---
+The 'Sections' list seen on man.serenityos.org can be edited in Meta/Websites/man.serenityos.org/sections.md
+--->

--- a/Meta/Websites/man.serenityos.org/banner-preamble.inc
+++ b/Meta/Websites/man.serenityos.org/banner-preamble.inc
@@ -1,1 +1,0 @@
-<img src="/banner.png" style="display: block; margin-left: auto; margin-right: auto; margin-bottom: 2em;">

--- a/Meta/Websites/man.serenityos.org/cant-run-application.md
+++ b/Meta/Websites/man.serenityos.org/cant-run-application.md
@@ -1,4 +1,6 @@
-# Sorry :^(
+![Warning Icon](icons/32x32/msgbox-warning.png)
+
+## Sorry :^(
 
 This is a link to open the application directly, but that only works in SerenityOS.
 

--- a/Meta/Websites/man.serenityos.org/index-template.html
+++ b/Meta/Websites/man.serenityos.org/index-template.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$lang$" xml:lang="$lang$"$if(dir)$ dir="$dir$"$endif$>
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+$for(author-meta)$
+  <meta name="author" content="$author-meta$" />
+$endfor$
+$if(date-meta)$
+  <meta name="dcterms.date" content="$date-meta$" />
+$endif$
+$if(keywords)$
+  <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$" />
+$endif$
+$if(description-meta)$
+  <meta name="description" content="$description-meta$" />
+$endif$
+  <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
+  <style>
+  /* ORIGINAL CSS */
+  
+  html {
+    line-height: 1.5;
+    font-family: Georgia, serif;
+    font-size: 20px;
+    color: #1a1a1a;
+    background-color: #fdfdfd;
+  }
+  body {
+    margin: 0 auto;
+    max-width: 36em;
+    padding-left: 50px;
+    padding-right: 50px;
+    padding-top: 50px;
+    padding-bottom: 50px;
+    hyphens: auto;
+    word-wrap: break-word;
+    text-rendering: optimizeLegibility;
+    font-kerning: normal;
+  }
+  @media (max-width: 600px) {
+    body {
+      font-size: 0.9em;
+      padding: 1em;
+    }
+  }
+  @media print {
+    body {
+      background-color: transparent;
+      color: black;
+      font-size: 12pt;
+    }
+    p, h2, h3 {
+      orphans: 3;
+      widows: 3;
+    }
+    h2, h3, h4 {
+      page-break-after: avoid;
+    }
+  }
+  p {
+    margin: 1em 0;
+  }
+  a {
+    color: #1a1a1a;
+  }
+  a:visited {
+    color: #1a1a1a;
+  }
+  img {
+    max-width: 100%;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    margin-top: 1.4em;
+  }
+  h5, h6 {
+    font-size: 1em;
+    font-style: italic;
+  }
+  h6 {
+    font-weight: normal;
+  }
+  ol, ul {
+    padding-left: 1.7em;
+    margin-top: 1em;
+  }
+  li > ol, li > ul {
+    margin-top: 0;
+  }
+  blockquote {
+    margin: 1em 0 1em 1.7em;
+    padding-left: 1em;
+    border-left: 2px solid #e6e6e6;
+    color: #606060;
+  }
+  code {
+    font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
+    font-size: 85%;
+    margin: 0;
+  }
+  pre {
+    margin: 1em 0;
+    overflow: auto;
+  }
+  pre code {
+    padding: 0;
+    overflow: visible;
+  }
+  .sourceCode {
+    background-color: transparent;
+    overflow: visible;
+  }
+  hr {
+    background-color: #1a1a1a;
+    border: none;
+    height: 1px;
+    margin: 1em 0;
+  }
+  table {
+    margin: 1em 0;
+    border-collapse: collapse;
+    width: 100%;
+    overflow-x: auto;
+    display: block;
+    font-variant-numeric: lining-nums tabular-nums;
+  }
+  table caption {
+    margin-bottom: 0.75em;
+  }
+  tbody {
+    margin-top: 0.5em;
+    border-top: 1px solid #1a1a1a;
+    border-bottom: 1px solid #1a1a1a;
+  }
+  th {
+    border-top: 1px solid #1a1a1a;
+    padding: 0.25em 0.5em 0.25em 0.5em;
+  }
+  td {
+    padding: 0.125em 0.5em 0.25em 0.5em;
+  }
+  header {
+    margin-bottom: 4em;
+    text-align: center;
+  }
+  #TOC li {
+    list-style: none;
+  }
+  #TOC a:not(:hover) {
+    text-decoration: none;
+  }
+  code{white-space: pre-wrap;}
+  span.smallcaps{font-variant: small-caps;}
+  span.underline{text-decoration: underline;}
+  div.column{display: inline-block; vertical-align: top; width: 50%;}
+  div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+  ul.task-list{list-style: none;}
+  .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+
+  /* CUSTOM CSS */
+
+  img {
+    image-rendering: pixelated;
+    image-rendering: -moz-crisp-edges;
+    image-rendering: crisp-edges;
+  }
+  #banner {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 2em;
+    text-align: center;
+    image-rendering: smooth;
+  }
+
+  /* For removing the help application instructions in the index */
+  
+  p:nth-of-type(4), p:nth-of-type(5), hr:nth-of-type(1) {
+    visibility: hidden;
+    font-size: 0;
+  }
+  </style>
+$for(css)$
+  <link rel="stylesheet" href="$css$" />
+$endfor$
+$for(header-includes)$
+  $header-includes$
+$endfor$
+$if(math)$
+$if(mathjax)$
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+$endif$
+  $math$
+$endif$
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
+</head>
+<body>
+$for(include-before)$
+$include-before$
+$endfor$
+$if(title)$
+<header id="title-block-header">
+  <a href="/index.html" title="Go to main page">
+    <img src="/banner.png" id="banner" alt="SerenityOS Banner">
+  </a>
+  <h1 class="title">$title$</h1>
+  $if(subtitle)$
+  <p class="subtitle">$subtitle$</p>
+  $endif$
+  $for(author)$
+  <p class="author">$author$</p>
+  $endfor$
+  $if(date)$
+  <p class="date">$date$</p>
+  $endif$
+  $if(abstract)$
+  <div class="abstract">
+  <div class="abstract-title">$abstract-title$</div>
+  $abstract$
+  </div>
+  $endif$
+</header>
+$endif$
+$if(toc)$
+<nav id="$idprefix$TOC" role="doc-toc">
+$if(toc-title)$
+<h2 id="$idprefix$toc-title">$toc-title$</h2>
+$endif$
+$table-of-contents$
+</nav>
+$endif$
+$body$
+$for(include-after)$
+$include-after$
+$endfor$
+</body>
+</html>

--- a/Meta/Websites/man.serenityos.org/sections.md
+++ b/Meta/Websites/man.serenityos.org/sections.md
@@ -1,3 +1,5 @@
+### Sections
+
 - [Section 1: User Programs (applets, applications, utilities, etc.)](man1/index.html)
 - [Section 2: System Calls (getuid, mount, pledge, sendfd, etc.)](man2/index.html)
 - [Section 3: Library Functions (basename, isatty, POSIX functions, etc.)](man3/index.html)

--- a/Meta/Websites/man.serenityos.org/template.html
+++ b/Meta/Websites/man.serenityos.org/template.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$lang$" xml:lang="$lang$"$if(dir)$ dir="$dir$"$endif$>
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+$for(author-meta)$
+  <meta name="author" content="$author-meta$" />
+$endfor$
+$if(date-meta)$
+  <meta name="dcterms.date" content="$date-meta$" />
+$endif$
+$if(keywords)$
+  <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$" />
+$endif$
+$if(description-meta)$
+  <meta name="description" content="$description-meta$" />
+$endif$
+  <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
+  <style>
+  /* ORIGINAL CSS */
+  
+  html {
+    line-height: 1.5;
+    font-family: Georgia, serif;
+    font-size: 20px;
+    color: #1a1a1a;
+    background-color: #fdfdfd;
+  }
+  body {
+    margin: 0 auto;
+    max-width: 36em;
+    padding-left: 50px;
+    padding-right: 50px;
+    padding-top: 50px;
+    padding-bottom: 50px;
+    hyphens: auto;
+    word-wrap: break-word;
+    text-rendering: optimizeLegibility;
+    font-kerning: normal;
+  }
+  @media (max-width: 600px) {
+    body {
+      font-size: 0.9em;
+      padding: 1em;
+    }
+  }
+  @media print {
+    body {
+      background-color: transparent;
+      color: black;
+      font-size: 12pt;
+    }
+    p, h2, h3 {
+      orphans: 3;
+      widows: 3;
+    }
+    h2, h3, h4 {
+      page-break-after: avoid;
+    }
+  }
+  p {
+    margin: 1em 0;
+  }
+  a {
+    color: #1a1a1a;
+  }
+  a:visited {
+    color: #1a1a1a;
+  }
+  img {
+    max-width: 100%;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    margin-top: 1.4em;
+  }
+  h5, h6 {
+    font-size: 1em;
+    font-style: italic;
+  }
+  h6 {
+    font-weight: normal;
+  }
+  ol, ul {
+    padding-left: 1.7em;
+    margin-top: 1em;
+  }
+  li > ol, li > ul {
+    margin-top: 0;
+  }
+  blockquote {
+    margin: 1em 0 1em 1.7em;
+    padding-left: 1em;
+    border-left: 2px solid #e6e6e6;
+    color: #606060;
+  }
+  code {
+    font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
+    font-size: 85%;
+    margin: 0;
+  }
+  pre {
+    margin: 1em 0;
+    overflow: auto;
+  }
+  pre code {
+    padding: 0;
+    overflow: visible;
+  }
+  .sourceCode {
+    background-color: transparent;
+    overflow: visible;
+  }
+  hr {
+    background-color: #1a1a1a;
+    border: none;
+    height: 1px;
+    margin: 1em 0;
+  }
+  table {
+    margin: 1em 0;
+    border-collapse: collapse;
+    width: 100%;
+    overflow-x: auto;
+    display: block;
+    font-variant-numeric: lining-nums tabular-nums;
+  }
+  table caption {
+    margin-bottom: 0.75em;
+  }
+  tbody {
+    margin-top: 0.5em;
+    border-top: 1px solid #1a1a1a;
+    border-bottom: 1px solid #1a1a1a;
+  }
+  th {
+    border-top: 1px solid #1a1a1a;
+    padding: 0.25em 0.5em 0.25em 0.5em;
+  }
+  td {
+    padding: 0.125em 0.5em 0.25em 0.5em;
+  }
+  header {
+    margin-bottom: 4em;
+    text-align: center;
+  }
+  #TOC li {
+    list-style: none;
+  }
+  #TOC a:not(:hover) {
+    text-decoration: none;
+  }
+  code{white-space: pre-wrap;}
+  span.smallcaps{font-variant: small-caps;}
+  span.underline{text-decoration: underline;}
+  div.column{display: inline-block; vertical-align: top; width: 50%;}
+  div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+  ul.task-list{list-style: none;}
+  .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+
+  /* CUSTOM CSS */
+
+  img {
+    image-rendering: pixelated;
+    image-rendering: -moz-crisp-edges;
+    image-rendering: crisp-edges;
+  }
+  #banner {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 2em;
+    text-align: center;
+    image-rendering: smooth;
+  }
+  </style>
+$for(css)$
+  <link rel="stylesheet" href="$css$" />
+$endfor$
+$for(header-includes)$
+  $header-includes$
+$endfor$
+$if(math)$
+$if(mathjax)$
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+$endif$
+  $math$
+$endif$
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
+</head>
+<body>
+$for(include-before)$
+$include-before$
+$endfor$
+$if(title)$
+<header id="title-block-header">
+  <a href="/index.html" title="Go to main page">
+    <img src="/banner.png" id="banner" alt="SerenityOS Banner">
+  </a>
+  <h1 class="title">$title$</h1>
+  $if(subtitle)$
+  <p class="subtitle">$subtitle$</p>
+  $endif$
+  $for(author)$
+  <p class="author">$author$</p>
+  $endfor$
+  $if(date)$
+  <p class="date">$date$</p>
+  $endif$
+  $if(abstract)$
+  <div class="abstract">
+  <div class="abstract-title">$abstract-title$</div>
+  $abstract$
+  </div>
+  $endif$
+</header>
+$endif$
+$if(toc)$
+<nav id="$idprefix$TOC" role="doc-toc">
+$if(toc-title)$
+<h2 id="$idprefix$toc-title">$toc-title$</h2>
+$endif$
+$table-of-contents$
+</nav>
+$endif$
+$body$
+$for(include-after)$
+$include-after$
+$endfor$
+</body>
+</html>

--- a/Meta/build-manpages-website.sh
+++ b/Meta/build-manpages-website.sh
@@ -25,6 +25,8 @@ for d in "${MAN_DIR}"*/; do
 done
 
 # Convert markdown to html
+custom_template="Meta/Websites/man.serenityos.org/template.html"
+index_template="Meta/Websites/man.serenityos.org/index-template.html"
 
 # If you're here because your local results are different from the website:
 # Check that your pandoc version matches the pandoc-version specified in manpages.yaml.
@@ -39,8 +41,7 @@ for md_file in $(find "${MAN_DIR}" -iname '*.md' | ${SORT}); do
 
     echo "Generating $md_file -> $output_file"
     mkdir -p "$(dirname "${output_file}")"
-    pandoc -f gfm -t html5 -s \
-        -B Meta/Websites/man.serenityos.org/banner-preamble.inc \
+    pandoc -f gfm -t html5 -s --template $custom_template \
         --lua-filter=Meta/convert-markdown-links.lua \
         --metadata title="${name}(${section_number}) - SerenityOS man pages" \
         -o "${output_file}" \
@@ -69,8 +70,7 @@ for section_directory in output/*/; do
     output="output/${section}/index.html"
 
     echo "Generating section ${section_number} index -> ${output}"
-    pandoc -f gfm -t html5 -s \
-        -B Meta/Websites/man.serenityos.org/banner-preamble.inc \
+    pandoc -f gfm -t html5 -s --template $custom_template \
         --metadata title="Section ${section_number} - ${section_title}" \
         -o "${output}" \
         <(
@@ -91,15 +91,13 @@ done
 
 # Generate main landing page listings through pandoc
 echo 'Generating main pages'
-pandoc -f gfm -t html5 -s \
-    -B Meta/Websites/man.serenityos.org/banner-preamble.inc \
+pandoc -f gfm -t html5 -s --template $index_template \
     --metadata title="SerenityOS man pages" \
     --lua-filter=Meta/convert-markdown-links.lua \
     -o output/index.html \
     Base/usr/share/man/man7/Help-index.md \
     Meta/Websites/man.serenityos.org/sections.md &
-pandoc -f gfm -t html5 -s \
-    -B Meta/Websites/man.serenityos.org/banner-preamble.inc \
+pandoc -f gfm -t html5 -s --template $custom_template \
     --metadata title="Can't run applications" \
     -o output/cant-run-application.html \
     Meta/Websites/man.serenityos.org/cant-run-application.md &

--- a/Meta/build-manpages-website.sh
+++ b/Meta/build-manpages-website.sh
@@ -108,6 +108,7 @@ pandoc -f gfm -t html5 -s \
 echo 'Copying images'
 rsync -a Meta/Websites/man.serenityos.org/banner.png output/ &
 rsync -a Base/usr/share/man/man7/LibDSP_classes.svg output/ &
+rsync -a Base/res/icons/32x32/msgbox-warning.png output/icons/32x32/ &
 find Base/usr/share/man/ -iname '*.png' -exec rsync -a {} output/ \; &
 
 # Copy icons

--- a/Meta/build-manpages-website.sh
+++ b/Meta/build-manpages-website.sh
@@ -94,8 +94,10 @@ echo 'Generating main pages'
 pandoc -f gfm -t html5 -s \
     -B Meta/Websites/man.serenityos.org/banner-preamble.inc \
     --metadata title="SerenityOS man pages" \
+    --lua-filter=Meta/convert-markdown-links.lua \
     -o output/index.html \
-    Meta/Websites/man.serenityos.org/index.md &
+    Base/usr/share/man/man7/Help-index.md \
+    Meta/Websites/man.serenityos.org/sections.md &
 pandoc -f gfm -t html5 -s \
     -B Meta/Websites/man.serenityos.org/banner-preamble.inc \
     --metadata title="Can't run applications" \


### PR DESCRIPTION
I decided the man page website needed a little love and attention:

- Adapt and make `Help-index(7)` the index for both the Help application and man.serenityos.org
- Add a warning icon to the _Can't run applications_ page
- Use a custom HTML template, allowing custom CSS, and also:
  - Merge `banner-preamble.inc` (the original banner image html) into the HTML template and put its styling into `<style>`.
  - Clicking the banner image on the man page website should take you to the index/main page.
  - Use [image-rendering](https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering) so icons are displayed pixelated/crisp-edges so they are no longer blurry (though display the banner normally).
  - Hide the instructions specific to the Help application (not relevant to the website) by having a template specifically for index (all other methods of adding CSS have been a nightmare).

### Image rendering before vs. after:
<img width="734" alt="Image rendering before & after" src="https://user-images.githubusercontent.com/7754483/229634840-bd2c26d5-b3e8-4db0-8066-08d0d6e45f64.png">

### The new index in the Help application:
<img width="734" alt="New Index (Help)" src="https://user-images.githubusercontent.com/7754483/229634539-96b2f5cd-9516-461d-98ee-78fc4cda4e13.png">

### The new index on the man page website:
<img width="1071" alt="New Index (Website)" src="https://user-images.githubusercontent.com/7754483/229634656-dcee8cf6-c178-4145-b758-756f010843fa.png">