### PR TITLE
AK+LibCompress: Deflate decompression performance improvements

### DIFF
--- a/AK/NumericLimits.h
+++ b/AK/NumericLimits.h
@@ -19,6 +19,7 @@ struct NumericLimits<bool> {
     static constexpr bool min() { return false; }
     static constexpr bool max() { return true; }
     static constexpr bool is_signed() { return false; }
+    static constexpr size_t digits() { return 1; }
 };
 
 template<>
@@ -26,6 +27,7 @@ struct NumericLimits<signed char> {
     static constexpr signed char min() { return -__SCHAR_MAX__ - 1; }
     static constexpr signed char max() { return __SCHAR_MAX__; }
     static constexpr bool is_signed() { return true; }
+    static constexpr size_t digits() { return __CHAR_BIT__ - 1; }
 };
 
 template<>
@@ -33,6 +35,7 @@ struct NumericLimits<char> {
     static constexpr char min() { return -__SCHAR_MAX__ - 1; }
     static constexpr char max() { return __SCHAR_MAX__; }
     static constexpr bool is_signed() { return true; }
+    static constexpr size_t digits() { return __CHAR_BIT__ - 1; }
 };
 
 template<>
@@ -40,6 +43,7 @@ struct NumericLimits<short> {
     static constexpr short min() { return -__SHRT_MAX__ - 1; }
     static constexpr short max() { return __SHRT_MAX__; }
     static constexpr bool is_signed() { return true; }
+    static constexpr size_t digits() { return __CHAR_BIT__ * sizeof(short) - 1; }
 };
 
 template<>
@@ -47,6 +51,7 @@ struct NumericLimits<int> {
     static constexpr int min() { return -__INT_MAX__ - 1; }
     static constexpr int max() { return __INT_MAX__; }
     static constexpr bool is_signed() { return true; }
+    static constexpr size_t digits() { return __CHAR_BIT__ * sizeof(int) - 1; }
 };
 
 template<>
@@ -54,6 +59,7 @@ struct NumericLimits<long> {
     static constexpr long min() { return -__LONG_MAX__ - 1; }
     static constexpr long max() { return __LONG_MAX__; }
     static constexpr bool is_signed() { return true; }
+    static constexpr size_t digits() { return __CHAR_BIT__ * sizeof(long) - 1; }
 };
 
 template<>
@@ -61,6 +67,7 @@ struct NumericLimits<long long> {
     static constexpr long long min() { return -__LONG_LONG_MAX__ - 1; }
     static constexpr long long max() { return __LONG_LONG_MAX__; }
     static constexpr bool is_signed() { return true; }
+    static constexpr size_t digits() { return __CHAR_BIT__ * sizeof(long long) - 1; }
 };
 
 template<>
@@ -68,6 +75,7 @@ struct NumericLimits<unsigned char> {
     static constexpr unsigned char min() { return 0; }
     static constexpr unsigned char max() { return __SCHAR_MAX__ * 2u + 1; }
     static constexpr bool is_signed() { return false; }
+    static constexpr size_t digits() { return __CHAR_BIT__; }
 };
 
 template<>
@@ -75,6 +83,7 @@ struct NumericLimits<unsigned short> {
     static constexpr unsigned short min() { return 0; }
     static constexpr unsigned short max() { return __SHRT_MAX__ * 2u + 1; }
     static constexpr bool is_signed() { return false; }
+    static constexpr size_t digits() { return __CHAR_BIT__ * sizeof(short); }
 };
 
 template<>
@@ -82,6 +91,7 @@ struct NumericLimits<unsigned> {
     static constexpr unsigned min() { return 0; }
     static constexpr unsigned max() { return __INT_MAX__ * 2u + 1; }
     static constexpr bool is_signed() { return false; }
+    static constexpr size_t digits() { return __CHAR_BIT__ * sizeof(int); }
 };
 
 template<>
@@ -89,6 +99,7 @@ struct NumericLimits<unsigned long> {
     static constexpr unsigned long min() { return 0; }
     static constexpr unsigned long max() { return __LONG_MAX__ * 2ul + 1; }
     static constexpr bool is_signed() { return false; }
+    static constexpr size_t digits() { return __CHAR_BIT__ * sizeof(long); }
 };
 
 template<>
@@ -96,6 +107,7 @@ struct NumericLimits<unsigned long long> {
     static constexpr unsigned long long min() { return 0; }
     static constexpr unsigned long long max() { return __LONG_LONG_MAX__ * 2ull + 1; }
     static constexpr bool is_signed() { return false; }
+    static constexpr size_t digits() { return __CHAR_BIT__ * sizeof(long long); }
 };
 
 #ifndef KERNEL
@@ -106,6 +118,7 @@ struct NumericLimits<float> {
     static constexpr float max() { return __FLT_MAX__; }
     static constexpr float epsilon() { return __FLT_EPSILON__; }
     static constexpr bool is_signed() { return true; }
+    static constexpr size_t digits() { return __FLT_MANT_DIG__; }
 };
 
 template<>
@@ -115,6 +128,7 @@ struct NumericLimits<double> {
     static constexpr double max() { return __DBL_MAX__; }
     static constexpr double epsilon() { return __DBL_EPSILON__; }
     static constexpr bool is_signed() { return true; }
+    static constexpr size_t digits() { return __DBL_MANT_DIG__; }
 };
 
 template<>
@@ -124,6 +138,7 @@ struct NumericLimits<long double> {
     static constexpr long double max() { return __LDBL_MAX__; }
     static constexpr long double epsilon() { return __LDBL_EPSILON__; }
     static constexpr bool is_signed() { return true; }
+    static constexpr size_t digits() { return __LDBL_MANT_DIG__; }
 };
 #endif
 

--- a/Meta/Azure/Setup.yml
+++ b/Meta/Azure/Setup.yml
@@ -17,14 +17,14 @@ steps:
   - ${{ if eq(parameters.os, 'Linux') }}:
     - script: |
         set -e
-        sudo apt-get purge -y clang-12 gcc-10
+        sudo apt-get purge -y clang-12 clang-13 clang-14 gcc-10
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-13 main'
+        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main'
         sudo apt-get update
-        sudo apt-get install ccache gcc-12 g++-12 clang-13 libstdc++-12-dev ninja-build unzip qt6-base-dev qt6-tools-dev-tools libgl1-mesa-dev
+        sudo apt-get install ccache gcc-12 g++-12 clang-15 libstdc++-12-dev ninja-build unzip qt6-base-dev qt6-tools-dev-tools libgl1-mesa-dev
 
-        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-13 100
-        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-13 100
+        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100
+        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 100
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100
 

--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -76,7 +76,7 @@ public:
     friend CompressedBlock;
     friend UncompressedBlock;
 
-    static ErrorOr<NonnullOwnPtr<DeflateDecompressor>> construct(MaybeOwned<Stream> stream);
+    static ErrorOr<NonnullOwnPtr<DeflateDecompressor>> construct(MaybeOwned<LittleEndianInputBitStream> stream);
     ~DeflateDecompressor();
 
     virtual ErrorOr<Bytes> read_some(Bytes) override;
@@ -88,7 +88,7 @@ public:
     static ErrorOr<ByteBuffer> decompress_all(ReadonlyBytes);
 
 private:
-    DeflateDecompressor(MaybeOwned<Stream> stream, CircularBuffer buffer);
+    DeflateDecompressor(MaybeOwned<LittleEndianInputBitStream> stream, CircularBuffer buffer);
 
     ErrorOr<u32> decode_length(u32);
     ErrorOr<u32> decode_distance(u32);

--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -30,9 +30,19 @@ public:
     static Optional<CanonicalCode> from_bytes(ReadonlyBytes);
 
 private:
+    static constexpr size_t max_allowed_prefixed_code_length = 8;
+
+    struct PrefixTableEntry {
+        u16 symbol_value { 0 };
+        u16 code_length { 0 };
+    };
+
     // Decompression - indexed by code
     Vector<u16> m_symbol_codes;
     Vector<u16> m_symbol_values;
+
+    Array<PrefixTableEntry, 1 << max_allowed_prefixed_code_length> m_prefix_table {};
+    size_t m_max_prefixed_code_length { 0 };
 
     // Compression - indexed by symbol
     Array<u16, 288> m_bit_codes {}; // deflate uses a maximum of 288 symbols (maximum of 32 for distances)

--- a/Userland/Libraries/LibCompress/Gzip.cpp
+++ b/Userland/Libraries/LibCompress/Gzip.cpp
@@ -7,6 +7,7 @@
 
 #include <LibCompress/Gzip.h>
 
+#include <AK/BitStream.h>
 #include <AK/DeprecatedString.h>
 #include <AK/MemoryStream.h>
 #include <LibCore/DateTime.h>
@@ -38,9 +39,9 @@ bool BlockHeader::supported_by_implementation() const
     return true;
 }
 
-ErrorOr<NonnullOwnPtr<GzipDecompressor::Member>> GzipDecompressor::Member::construct(BlockHeader header, Stream& stream)
+ErrorOr<NonnullOwnPtr<GzipDecompressor::Member>> GzipDecompressor::Member::construct(BlockHeader header, LittleEndianInputBitStream& stream)
 {
-    auto deflate_stream = TRY(DeflateDecompressor::construct(MaybeOwned<Stream>(stream)));
+    auto deflate_stream = TRY(DeflateDecompressor::construct(MaybeOwned<LittleEndianInputBitStream>(stream)));
     return TRY(adopt_nonnull_own_or_enomem(new (nothrow) Member(header, move(deflate_stream))));
 }
 
@@ -51,7 +52,7 @@ GzipDecompressor::Member::Member(BlockHeader header, NonnullOwnPtr<DeflateDecomp
 }
 
 GzipDecompressor::GzipDecompressor(NonnullOwnPtr<Stream> stream)
-    : m_input_stream(move(stream))
+    : m_input_stream(make<LittleEndianInputBitStream>(move(stream)))
 {
 }
 

--- a/Userland/Libraries/LibCompress/Gzip.h
+++ b/Userland/Libraries/LibCompress/Gzip.h
@@ -58,7 +58,7 @@ public:
 private:
     class Member {
     public:
-        static ErrorOr<NonnullOwnPtr<Member>> construct(BlockHeader header, Stream&);
+        static ErrorOr<NonnullOwnPtr<Member>> construct(BlockHeader header, LittleEndianInputBitStream&);
 
         BlockHeader m_header;
         NonnullOwnPtr<DeflateDecompressor> m_stream;
@@ -72,7 +72,7 @@ private:
     Member const& current_member() const { return *m_current_member; }
     Member& current_member() { return *m_current_member; }
 
-    NonnullOwnPtr<Stream> m_input_stream;
+    NonnullOwnPtr<LittleEndianInputBitStream> m_input_stream;
     u8 m_partial_header[sizeof(BlockHeader)];
     size_t m_partial_header_offset { 0 };
     OwnPtr<Member> m_current_member {};


### PR DESCRIPTION
This contains two performance improvements for Deflate decompression:
* Increase `LittleEndianInputBitStream` bit buffer size to a u64 and replace loops with bitwise operations
* Use a prefix table to decode Huffman codes up to 8 bits in length

Overall, this decreases decoding of the [enwik8](https://www.mattmahoney.net/dc/enwik8.zip) file (100MB when uncompressed) from:
* 11.1s to 1.6s on my Linux machine
* 242s to 5.8s on Serenity (cold)
* 242s to 2.3s on Serenity (warm)