### PR TITLE
Ladybird+Browser: Add (reset) zoom level button to toolbar

### DIFF
--- a/Ladybird/BrowserWindow.cpp
+++ b/Ladybird/BrowserWindow.cpp
@@ -336,7 +336,7 @@ void BrowserWindow::set_current_tab(Tab* tab)
 {
     m_current_tab = tab;
     if (tab)
-        update_zoom_menu_text();
+        update_displayed_zoom_level();
 }
 
 void BrowserWindow::debug_request(DeprecatedString const& request, DeprecatedString const& argument)
@@ -523,7 +523,7 @@ void BrowserWindow::zoom_in()
     if (!m_current_tab)
         return;
     m_current_tab->view().zoom_in();
-    update_zoom_menu_text();
+    update_displayed_zoom_level();
 }
 
 void BrowserWindow::zoom_out()
@@ -531,7 +531,7 @@ void BrowserWindow::zoom_out()
     if (!m_current_tab)
         return;
     m_current_tab->view().zoom_out();
-    update_zoom_menu_text();
+    update_displayed_zoom_level();
 }
 
 void BrowserWindow::reset_zoom()
@@ -539,7 +539,7 @@ void BrowserWindow::reset_zoom()
     if (!m_current_tab)
         return;
     m_current_tab->view().reset_zoom();
-    update_zoom_menu_text();
+    update_displayed_zoom_level();
 }
 
 void BrowserWindow::select_all()
@@ -548,11 +548,12 @@ void BrowserWindow::select_all()
         tab->view().select_all();
 }
 
-void BrowserWindow::update_zoom_menu_text()
+void BrowserWindow::update_displayed_zoom_level()
 {
     VERIFY(m_zoom_menu && m_current_tab);
     auto zoom_level_text = MUST(String::formatted("&Zoom ({}%)", round_to<int>(m_current_tab->view().zoom_level() * 100)));
     m_zoom_menu->setTitle(qstring_from_ak_string(zoom_level_text));
+    m_current_tab->update_reset_zoom_button();
 }
 
 void BrowserWindow::copy_selected_text()

--- a/Ladybird/BrowserWindow.h
+++ b/Ladybird/BrowserWindow.h
@@ -60,7 +60,7 @@ private:
     void debug_request(DeprecatedString const& request, DeprecatedString const& argument = "");
 
     void set_current_tab(Tab* tab);
-    void update_zoom_menu_text();
+    void update_displayed_zoom_level();
 
     QTabWidget* m_tabs_container { nullptr };
     Vector<NonnullOwnPtr<Tab>> m_tabs;

--- a/Ladybird/Tab.h
+++ b/Ladybird/Tab.h
@@ -16,6 +16,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QToolBar>
+#include <QToolButton>
 #include <QWidget>
 
 class BrowserWindow;
@@ -34,6 +35,8 @@ public:
     void navigate(QString, LoadType = LoadType::Normal);
 
     void debug_request(DeprecatedString const& request, DeprecatedString const& argument);
+
+    void update_reset_zoom_button();
 
 public slots:
     void focus_location_editor();
@@ -56,6 +59,8 @@ private:
 
     QBoxLayout* m_layout;
     QToolBar* m_toolbar { nullptr };
+    QToolButton* m_reset_zoom_button { nullptr };
+    QAction* m_reset_zoom_button_action { nullptr };
     LocationEdit* m_location_edit { nullptr };
     WebContentView* m_view { nullptr };
     BrowserWindow* m_window { nullptr };

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -84,7 +84,7 @@ BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url)
         auto& tab = static_cast<Browser::Tab&>(active_widget);
         set_window_title_for_tab(tab);
         tab.did_become_active();
-        update_zoom_menu_text();
+        update_displayed_zoom_level();
     };
 
     m_tab_widget->on_middle_click = [](auto& clicked_widget) {
@@ -178,21 +178,21 @@ void BrowserWindow::build_menus()
         [this](auto&) {
             auto& tab = active_tab();
             tab.view().zoom_in();
-            update_zoom_menu_text();
+            update_displayed_zoom_level();
         },
         this));
     m_zoom_menu->add_action(GUI::CommonActions::make_zoom_out_action(
         [this](auto&) {
             auto& tab = active_tab();
             tab.view().zoom_out();
-            update_zoom_menu_text();
+            update_displayed_zoom_level();
         },
         this));
     m_zoom_menu->add_action(GUI::CommonActions::make_reset_zoom_action(
         [this](auto&) {
             auto& tab = active_tab();
             tab.view().reset_zoom();
-            update_zoom_menu_text();
+            update_displayed_zoom_level();
         },
         this));
     view_menu.add_separator();
@@ -796,11 +796,12 @@ ErrorOr<void> BrowserWindow::take_screenshot(ScreenshotType type)
     return {};
 }
 
-void BrowserWindow::update_zoom_menu_text()
+void BrowserWindow::update_displayed_zoom_level()
 {
     VERIFY(m_zoom_menu);
     auto zoom_level_text = DeprecatedString::formatted("&Zoom ({}%)", round_to<int>(active_tab().view().zoom_level() * 100));
     m_zoom_menu->set_name(zoom_level_text);
+    active_tab().update_reset_zoom_button();
 }
 
 }

--- a/Userland/Applications/Browser/BrowserWindow.h
+++ b/Userland/Applications/Browser/BrowserWindow.h
@@ -62,7 +62,7 @@ private:
 
     virtual void event(Core::Event&) override;
 
-    void update_zoom_menu_text();
+    void update_displayed_zoom_level();
 
     enum class ScreenshotType {
         Visible,

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -201,6 +201,15 @@ Tab::Tab(BrowserWindow& window)
         },
         this);
 
+    m_reset_zoom_button = toolbar.add<GUI::Button>();
+    m_reset_zoom_button->on_click = [&](auto) {
+        view().reset_zoom();
+        update_reset_zoom_button();
+    };
+    m_reset_zoom_button->set_button_style(Gfx::ButtonStyle::Coolbar);
+    m_reset_zoom_button->set_visible(false);
+    m_reset_zoom_button->set_preferred_width(GUI::SpecialDimension::Shrink);
+
     m_bookmark_button = toolbar.add<GUI::Button>();
     m_bookmark_button->set_action(bookmark_action);
     m_bookmark_button->set_button_style(Gfx::ButtonStyle::Coolbar);
@@ -512,6 +521,17 @@ Tab::Tab(BrowserWindow& window)
     view().on_context_menu_request = [&](auto screen_position) {
         m_page_context_menu->popup(screen_position);
     };
+}
+
+void Tab::update_reset_zoom_button()
+{
+    auto zoom_level = view().zoom_level();
+    if (zoom_level != 1.0f) {
+        m_reset_zoom_button->set_text(MUST(String::formatted("{}%", round_to<int>(zoom_level * 100))));
+        m_reset_zoom_button->set_visible(true);
+    } else {
+        m_reset_zoom_button->set_visible(false);
+    }
 }
 
 Optional<URL> Tab::url_from_location_bar(MayAppendTLD may_append_tld)

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -90,6 +90,8 @@ public:
     void show_storage_inspector();
     void show_history_inspector();
 
+    void update_reset_zoom_button();
+
     DeprecatedString const& title() const { return m_title; }
     Gfx::Bitmap const* icon() const { return m_icon; }
 
@@ -124,6 +126,7 @@ private:
     RefPtr<WebView::OutOfProcessWebView> m_web_content_view;
 
     RefPtr<GUI::UrlBox> m_location_box;
+    RefPtr<GUI::Button> m_reset_zoom_button;
     RefPtr<GUI::Button> m_bookmark_button;
     RefPtr<InspectorWidget> m_dom_inspector_widget;
     RefPtr<ConsoleWidget> m_console_widget;


### PR DESCRIPTION
**Demo (works the same way in Browser too)**

[screen-capture - 2023-03-29T002909.153.webm](https://user-images.githubusercontent.com/11597044/228389395-5e1887b9-76e1-4f60-8e53-1676b5625a08.webm)

This is based on @awesomekling's suggestion from #18054 and the behaviour of FireFox.

It adds a button to the toolbar that shows the current zoom level (for non-100% zoom levels), which when clicked resets the zoom back to 100%. 