### PR TITLE
LibWeb: Parse Element.style url functions relative to the document

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -93,7 +93,9 @@ WebIDL::ExceptionOr<void> PropertyOwningCSSStyleDeclaration::set_property(Proper
         return {};
 
     // 5. Let component value list be the result of parsing value for property property.
-    auto component_value_list = parse_css_value(CSS::Parser::ParsingContext { realm() }, value, property_id);
+    auto component_value_list = is<ElementInlineCSSStyleDeclaration>(this)
+        ? parse_css_value(CSS::Parser::ParsingContext { static_cast<ElementInlineCSSStyleDeclaration&>(*this).element()->document() }, value, property_id)
+        : parse_css_value(CSS::Parser::ParsingContext { realm() }, value, property_id);
 
     // 6. If component value list is null, then return.
     if (!component_value_list)


### PR DESCRIPTION
Previously we used a parsing context with no access to the document, so any URLs in url() functions would become invalid.

Fixes the images on Steam's store carousel, which sets Element.style.backgroundImage to url() functions.

Before:
![Screenshot from 2023-03-29 01-05-26](https://user-images.githubusercontent.com/25595356/228395125-95711ee0-2af4-4376-8148-e393fecb49f3.png)

After:
![Screenshot from 2023-03-29 01-04-25](https://user-images.githubusercontent.com/25595356/228395140-1ed1bf2c-b012-4ba7-baf6-d4105b0ce619.png)
