### PR TITLE
LibWeb: Implement HTMLAnchorElement.text and .referrerPolicy properties

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -446,6 +446,7 @@ set(SOURCES
     Platform/Timer.cpp
     Platform/TimerSerenity.cpp
     ReferrerPolicy/AbstractOperations.cpp
+    ReferrerPolicy/ReferrerPolicy.cpp
     RequestIdleCallback/IdleDeadline.cpp
     ResizeObserver/ResizeObserver.cpp
     SecureContexts/AbstractOperations.cpp

--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.h
@@ -195,6 +195,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(poster)                     \
     __ENUMERATE_HTML_ATTRIBUTE(preload)                    \
     __ENUMERATE_HTML_ATTRIBUTE(readonly)                   \
+    __ENUMERATE_HTML_ATTRIBUTE(referrerpolicy)             \
     __ENUMERATE_HTML_ATTRIBUTE(rel)                        \
     __ENUMERATE_HTML_ATTRIBUTE(required)                   \
     __ENUMERATE_HTML_ATTRIBUTE(rev)                        \

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -100,4 +100,18 @@ Optional<ARIA::Role> HTMLAnchorElement::default_role() const
     return ARIA::Role::generic;
 }
 
+// https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-text
+DeprecatedString HTMLAnchorElement::text() const
+{
+    // The text attribute's getter must return this element's descendant text content.
+    return descendant_text_content();
+}
+
+// https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-text
+void HTMLAnchorElement::set_text(DeprecatedString const& text)
+{
+    // The text attribute's setter must string replace all with the given value within this element.
+    string_replace_all(text);
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -7,6 +7,7 @@
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/HTML/HTMLAnchorElement.h>
 #include <LibWeb/HTML/Window.h>
+#include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
 
 namespace Web::HTML {
 
@@ -112,6 +113,24 @@ void HTMLAnchorElement::set_text(DeprecatedString const& text)
 {
     // The text attribute's setter must string replace all with the given value within this element.
     string_replace_all(text);
+}
+
+// https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-referrerpolicy
+DeprecatedString HTMLAnchorElement::referrer_policy() const
+{
+    // The IDL attribute referrerPolicy must reflect the referrerpolicy content attribute, limited to only known values.
+    auto policy_string = attribute(HTML::AttributeNames::referrerpolicy);
+    auto maybe_policy = ReferrerPolicy::from_string(policy_string);
+    if (maybe_policy.has_value())
+        return ReferrerPolicy::to_string(maybe_policy.value());
+    return "";
+}
+
+// https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-referrerpolicy
+WebIDL::ExceptionOr<void> HTMLAnchorElement::set_referrer_policy(DeprecatedString const& referrer_policy)
+{
+    // The IDL attribute referrerPolicy must reflect the referrerpolicy content attribute, limited to only known values.
+    return set_attribute(HTML::AttributeNames::referrerpolicy, referrer_policy);
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -23,6 +23,9 @@ public:
     DeprecatedString target() const { return attribute(HTML::AttributeNames::target); }
     DeprecatedString download() const { return attribute(HTML::AttributeNames::download); }
 
+    DeprecatedString text() const;
+    void set_text(DeprecatedString const&);
+
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-a-element
     virtual bool is_focusable() const override { return has_attribute(HTML::AttributeNames::href); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -26,6 +26,9 @@ public:
     DeprecatedString text() const;
     void set_text(DeprecatedString const&);
 
+    DeprecatedString referrer_policy() const;
+    WebIDL::ExceptionOr<void> set_referrer_policy(DeprecatedString const&);
+
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-a-element
     virtual bool is_focusable() const override { return has_attribute(HTML::AttributeNames::href); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.idl
@@ -15,6 +15,8 @@ interface HTMLAnchorElement : HTMLElement {
     [CEReactions, Reflect] attribute DOMString hreflang;
     [CEReactions, Reflect] attribute DOMString type;
 
+    [CEReactions] attribute DOMString text;
+
     // Obsolete
     [CEReactions, Reflect] attribute DOMString coords;
     [CEReactions, Reflect] attribute DOMString charset;

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.idl
@@ -17,6 +17,8 @@ interface HTMLAnchorElement : HTMLElement {
 
     [CEReactions] attribute DOMString text;
 
+    [CEReactions] attribute DOMString referrerPolicy;
+
     // Obsolete
     [CEReactions, Reflect] attribute DOMString coords;
     [CEReactions, Reflect] attribute DOMString charset;

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.idl
@@ -7,20 +7,20 @@ interface HTMLAnchorElement : HTMLElement {
 
     [HTMLConstructor] constructor();
 
-    [Reflect] attribute DOMString target;
-    [Reflect] attribute DOMString download;
-    [Reflect] attribute DOMString ping;
-    [Reflect] attribute DOMString rel;
+    [CEReactions, Reflect] attribute DOMString target;
+    [CEReactions, Reflect] attribute DOMString download;
+    [CEReactions, Reflect] attribute DOMString ping;
+    [CEReactions, Reflect] attribute DOMString rel;
     // FIXME: [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
-    [Reflect] attribute DOMString hreflang;
-    [Reflect] attribute DOMString type;
+    [CEReactions, Reflect] attribute DOMString hreflang;
+    [CEReactions, Reflect] attribute DOMString type;
 
     // Obsolete
-    [Reflect] attribute DOMString coords;
-    [Reflect] attribute DOMString charset;
-    [Reflect] attribute DOMString name;
-    [Reflect] attribute DOMString rev;
-    [Reflect] attribute DOMString shape;
+    [CEReactions, Reflect] attribute DOMString coords;
+    [CEReactions, Reflect] attribute DOMString charset;
+    [CEReactions, Reflect] attribute DOMString name;
+    [CEReactions, Reflect] attribute DOMString rev;
+    [CEReactions, Reflect] attribute DOMString shape;
 
 };
 

--- a/Userland/Libraries/LibWeb/ReferrerPolicy/ReferrerPolicy.cpp
+++ b/Userland/Libraries/LibWeb/ReferrerPolicy/ReferrerPolicy.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
+
+namespace Web::ReferrerPolicy {
+
+StringView to_string(ReferrerPolicy referrer_policy)
+{
+    switch (referrer_policy) {
+    case ReferrerPolicy::NoReferrer:
+        return "no-referrer"sv;
+    case ReferrerPolicy::NoReferrerWhenDowngrade:
+        return "no-referrer-when-downgrade"sv;
+    case ReferrerPolicy::SameOrigin:
+        return "same-origin"sv;
+    case ReferrerPolicy::Origin:
+        return "origin"sv;
+    case ReferrerPolicy::StrictOrigin:
+        return "strict-origin"sv;
+    case ReferrerPolicy::OriginWhenCrossOrigin:
+        return "origin-when-cross-origin"sv;
+    case ReferrerPolicy::StrictOriginWhenCrossOrigin:
+        return "strict-origin-when-cross-origin"sv;
+    case ReferrerPolicy::UnsafeURL:
+        return "unsafe-url"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+Optional<ReferrerPolicy> from_string(StringView string)
+{
+    if (string.equals_ignoring_ascii_case("no-referrer"sv))
+        return ReferrerPolicy::NoReferrer;
+    if (string.equals_ignoring_ascii_case("no-referrer-when-downgrade"sv))
+        return ReferrerPolicy::NoReferrerWhenDowngrade;
+    if (string.equals_ignoring_ascii_case("same-origin"sv))
+        return ReferrerPolicy::SameOrigin;
+    if (string.equals_ignoring_ascii_case("origin"sv))
+        return ReferrerPolicy::Origin;
+    if (string.equals_ignoring_ascii_case("strict-origin"sv))
+        return ReferrerPolicy::StrictOrigin;
+    if (string.equals_ignoring_ascii_case("origin-when-cross-origin"sv))
+        return ReferrerPolicy::OriginWhenCrossOrigin;
+    if (string.equals_ignoring_ascii_case("strict-origin-when-cross-origin"sv))
+        return ReferrerPolicy::StrictOriginWhenCrossOrigin;
+    if (string.equals_ignoring_ascii_case("unsafe-url"sv))
+        return ReferrerPolicy::UnsafeURL;
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibWeb/ReferrerPolicy/ReferrerPolicy.h
+++ b/Userland/Libraries/LibWeb/ReferrerPolicy/ReferrerPolicy.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <AK/Optional.h>
+#include <AK/StringView.h>
+
 namespace Web::ReferrerPolicy {
 
 // https://w3c.github.io/webappsec-referrer-policy/#enumdef-referrerpolicy
@@ -23,5 +26,8 @@ enum class ReferrerPolicy {
 // https://w3c.github.io/webappsec-referrer-policy/#default-referrer-policy
 // The default referrer policy is "strict-origin-when-cross-origin".
 constexpr auto DEFAULT_REFERRER_POLICY = ReferrerPolicy::StrictOriginWhenCrossOrigin;
+
+StringView to_string(ReferrerPolicy);
+Optional<ReferrerPolicy> from_string(StringView);
 
 }


### PR DESCRIPTION
The `referrerPolicy` isn't yet used when following the link, (so it's useless :upside_down_face:) but it otherwise behaves correctly.