### PR TITLE
LibWeb: Implement CRC2D.imageSmoothingEnabled

### DIFF
--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -530,6 +530,7 @@ enum class CanPlayTypeResult;
 enum class CanvasFillRule;
 enum class EndingType;
 enum class DOMParserSupportedType;
+enum class ImageSmoothingQuality;
 enum class ReferrerPolicy;
 enum class RequestDestination;
 enum class RequestMode;

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasImageSmoothing.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasImageSmoothing.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/HTML/ImageData.h>
+
+namespace Web::HTML {
+
+// https://html.spec.whatwg.org/multipage/canvas.html#canvasimagesmoothing
+class CanvasImageSmoothing {
+public:
+    virtual ~CanvasImageSmoothing() = default;
+
+    virtual bool image_smoothing_enabled() const = 0;
+    virtual void set_image_smoothing_enabled(bool) = 0;
+    virtual Bindings::ImageSmoothingQuality image_smoothing_quality() const = 0;
+    virtual void set_image_smoothing_quality(Bindings::ImageSmoothingQuality) = 0;
+
+protected:
+    CanvasImageSmoothing() = default;
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasImageSmoothing.idl
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasImageSmoothing.idl
@@ -1,0 +1,6 @@
+// https://html.spec.whatwg.org/multipage/canvas.html#canvasimagesmoothing
+interface mixin CanvasImageSmoothing {
+    // image smoothing
+    attribute boolean imageSmoothingEnabled; // (default true)
+    attribute ImageSmoothingQuality imageSmoothingQuality; // (default low)
+};

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
@@ -12,6 +12,7 @@
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/PaintStyle.h>
+#include <LibWeb/Bindings/CanvasRenderingContext2DPrototype.h>
 #include <LibWeb/HTML/CanvasGradient.h>
 #include <LibWeb/HTML/CanvasPattern.h>
 
@@ -74,6 +75,8 @@ public:
         FillOrStrokeStyle fill_style { Gfx::Color::Black };
         FillOrStrokeStyle stroke_style { Gfx::Color::Black };
         float line_width { 1 };
+        bool image_smoothing_enabled { true };
+        Bindings::ImageSmoothingQuality image_smoothing_quality { Bindings::ImageSmoothingQuality::Low };
     };
     DrawingState& drawing_state() { return m_drawing_state; }
     DrawingState const& drawing_state() const { return m_drawing_state; }

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -20,6 +20,7 @@
 #include <LibWeb/HTML/Canvas/CanvasDrawPath.h>
 #include <LibWeb/HTML/Canvas/CanvasFillStrokeStyles.h>
 #include <LibWeb/HTML/Canvas/CanvasImageData.h>
+#include <LibWeb/HTML/Canvas/CanvasImageSmoothing.h>
 #include <LibWeb/HTML/Canvas/CanvasPath.h>
 #include <LibWeb/HTML/Canvas/CanvasPathDrawingStyles.h>
 #include <LibWeb/HTML/Canvas/CanvasRect.h>
@@ -48,6 +49,7 @@ class CanvasRenderingContext2D
     , public CanvasText
     , public CanvasDrawImage
     , public CanvasImageData
+    , public CanvasImageSmoothing
     , public CanvasPathDrawingStyles<CanvasRenderingContext2D> {
 
     WEB_PLATFORM_OBJECT(CanvasRenderingContext2D, Bindings::PlatformObject);
@@ -83,6 +85,11 @@ public:
     virtual JS::NonnullGCPtr<TextMetrics> measure_text(DeprecatedString const& text) override;
 
     virtual void clip() override;
+
+    virtual bool image_smoothing_enabled() const override;
+    virtual void set_image_smoothing_enabled(bool) override;
+    virtual Bindings::ImageSmoothingQuality image_smoothing_quality() const override;
+    virtual void set_image_smoothing_quality(Bindings::ImageSmoothingQuality) override;
 
 private:
     explicit CanvasRenderingContext2D(JS::Realm&, HTMLCanvasElement&);

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
@@ -3,12 +3,15 @@
 #import <HTML/Canvas/CanvasDrawPath.idl>
 #import <HTML/Canvas/CanvasFillStrokeStyles.idl>
 #import <HTML/Canvas/CanvasImageData.idl>
+#import <HTML/Canvas/CanvasImageSmoothing.idl>
 #import <HTML/Canvas/CanvasPath.idl>
 #import <HTML/Canvas/CanvasPathDrawingStyles.idl>
 #import <HTML/Canvas/CanvasRect.idl>
 #import <HTML/Canvas/CanvasState.idl>
 #import <HTML/Canvas/CanvasText.idl>
 #import <HTML/Canvas/CanvasTransform.idl>
+
+enum ImageSmoothingQuality { "low", "medium", "high" };
 
 // https://html.spec.whatwg.org/multipage/canvas.html#canvasrenderingcontext2d
 [Exposed=Window]
@@ -19,7 +22,7 @@ interface CanvasRenderingContext2D {
 CanvasRenderingContext2D includes CanvasState;
 CanvasRenderingContext2D includes CanvasTransform;
 // FIXME: CanvasRenderingContext2D includes CanvasCompositing;
-// FIXME: CanvasRenderingContext2D includes CanvasImageSmoothing;
+CanvasRenderingContext2D includes CanvasImageSmoothing;
 CanvasRenderingContext2D includes CanvasFillStrokeStyles;
 // FIXME: CanvasRenderingContext2D includes CanvasShadowStyles;
 // FIXME: CanvasRenderingContext2D includes CanvasFilters;


### PR DESCRIPTION
We now select between nearest neighbor and bilinear filtering when scaling images in CRC2D.drawImage().

This patch also adds CRC2D.imageSmoothingQuality but it's ignored for now as we don't have a bunch of different quality levels to map it to.

Work towards #17993 (Ruffle Flash Player)

![image](https://user-images.githubusercontent.com/5954907/228608469-049b6f76-3acd-4908-acda-219ee2c17f70.png)
