### PR TITLE
LibCompress: Implement proper handling of LZMA end-of-stream markers

### DIFF
--- a/Tests/LibCompress/TestLzma.cpp
+++ b/Tests/LibCompress/TestLzma.cpp
@@ -166,7 +166,6 @@ TEST_CASE(specification_bad_incorrect_size_lzma_decompress)
 
     auto stream = MUST(try_make<FixedMemoryStream>(compressed));
     auto decompressor = MUST(Compress::LzmaDecompressor::create_from_container(move(stream)));
-    // FIXME: This should detect that there is still remaining (non-'end of stream') data after the expected data and reject the last read.
-    //        As of now, this test accepts any result, except for crashes.
-    (void)decompressor->read_until_eof(PAGE_SIZE);
+    auto buffer_or_error = decompressor->read_until_eof(PAGE_SIZE);
+    EXPECT(buffer_or_error.is_error());
 }

--- a/Userland/Libraries/LibCompress/Lzma.h
+++ b/Userland/Libraries/LibCompress/Lzma.h
@@ -81,6 +81,8 @@ private:
     MaybeOwned<CircularBuffer> m_dictionary;
     u64 m_total_decoded_bytes { 0 };
     bool m_found_end_of_stream_marker { false };
+    bool is_range_decoder_in_clean_state() const;
+    bool has_reached_expected_data_size() const;
     Optional<u16> m_leftover_match_length;
 
     // Range decoder state (initialized with stream data in LzmaDecompressor::create).

--- a/Userland/Libraries/LibCompress/Lzma.h
+++ b/Userland/Libraries/LibCompress/Lzma.h
@@ -29,6 +29,7 @@ struct LzmaDecompressorOptions {
     u8 position_bits { 0 };
     u32 dictionary_size { 0 };
     Optional<u64> uncompressed_size;
+    bool reject_end_of_stream_marker { false };
 };
 
 // Described in section "lzma file format".

--- a/Userland/Libraries/LibCompress/Lzma2.cpp
+++ b/Userland/Libraries/LibCompress/Lzma2.cpp
@@ -106,6 +106,9 @@ ErrorOr<Bytes> Lzma2Decompressor::read_some(Bytes bytes)
                     .position_bits = properties.position_bits,
                     .dictionary_size = static_cast<u32>(dictionary_size),
                     .uncompressed_size = uncompressed_size,
+
+                    // Note: This is not specified anywhere. However, it is apparently tested by bad-1-lzma2-7.xz from the XZ utils test files.
+                    .reject_end_of_stream_marker = true,
                 };
                 [[fallthrough]];
             }


### PR DESCRIPTION
Now we correctly reject all bad files from the LZMA examples. :^)