### PR TITLE
AK: Remove arbitrary 1 KB limit when filling a BufferedStream's buffer

### DIFF
--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -234,19 +234,10 @@ private:
         size_t bytes_to_read = bits_to_read / bits_per_byte;
 
         BufferType buffer = 0;
-
-        Bytes bytes { &buffer, bytes_to_read };
-        size_t bytes_read = 0;
-
-        // FIXME: When the underlying stream is buffered, `read_some` seems to stop before EOF.
-        do {
-            auto result = TRY(m_stream->read_some(bytes));
-            bytes = bytes.slice(result.size());
-            bytes_read += result.size();
-        } while (!bytes.is_empty() && !m_stream->is_eof());
+        auto bytes = TRY(m_stream->read_some({ &buffer, bytes_to_read }));
 
         m_bit_buffer = (buffer << m_bit_count) | lsb_aligned_buffer();
-        m_bit_count += bytes_read * bits_per_byte;
+        m_bit_count += bytes.size() * bits_per_byte;
         m_bit_offset = 0;
 
         return {};

--- a/AK/BufferedStream.h
+++ b/AK/BufferedStream.h
@@ -67,7 +67,7 @@ public:
             return buffer;
 
         // Fill the internal buffer if it has run dry.
-        if (m_buffer.used_space() == 0)
+        if (m_buffer.used_space() < buffer.size())
             TRY(populate_read_buffer());
 
         // Let's try to take all we can from the buffer first.

--- a/AK/CircularBuffer.h
+++ b/AK/CircularBuffer.h
@@ -27,6 +27,7 @@ public:
     size_t write(ReadonlyBytes bytes);
     Bytes read(Bytes bytes);
     ErrorOr<void> discard(size_t discarded_bytes);
+    ErrorOr<size_t> fill_from_stream(Stream&);
 
     /// Compared to `read()`, this starts reading from an offset that is `distance` bytes
     /// before the current write pointer and allows for reading already-read data.


### PR DESCRIPTION
No real speed improvement outside of noise on a 100MB file, but in a profile, this reduces `BufferedHelper::populate_read_buffer` from taking 17% of the runtime down to 2%.