### PR TITLE
Browser: Have `BookmarksBarWidget` signal bookmark changes for `Tab`

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.h
+++ b/Userland/Applications/Browser/BookmarksBarWidget.h
@@ -34,7 +34,7 @@ public:
 
     Function<void(DeprecatedString const& url, Open)> on_bookmark_click;
     Function<void(DeprecatedString const&, DeprecatedString const&)> on_bookmark_hover;
-    Function<void(DeprecatedString const& url)> on_bookmark_add;
+    Function<void()> on_bookmark_change;
 
     bool contains_bookmark(DeprecatedString const& url);
     bool remove_bookmark(DeprecatedString const& url);

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -605,7 +605,6 @@ void Tab::bookmark_current_url()
     } else {
         BookmarksBarWidget::the().add_bookmark(url, m_title);
     }
-    update_bookmark_button(url);
 }
 
 void Tab::update_bookmark_button(DeprecatedString const& url)
@@ -634,10 +633,8 @@ void Tab::did_become_active()
         m_statusbar->set_text(url);
     };
 
-    BookmarksBarWidget::the().on_bookmark_add = [this](auto& url) {
-        auto current_url = this->url().to_deprecated_string();
-        if (current_url == url)
-            update_bookmark_button(current_url);
+    BookmarksBarWidget::the().on_bookmark_change = [this]() {
+        update_bookmark_button(url().to_deprecated_string());
     };
 
     BookmarksBarWidget::the().remove_from_parent();


### PR DESCRIPTION
This fixes an issue with a tab not updating its bookmark button when we either edit or delete a bookmark and the tab happens to be on the same page associated with the bookmark URL. `BookmarksBarWidget` "signals" a `Tab` object for bookmark changes, where it will update the bookmark button depending on if the current URL is an existing bookmark or not.

A quick demo of the bookmark button updating properly when we add, edit, and delete a bookmark:

![video1726092316](https://user-images.githubusercontent.com/60799661/228717689-6a5b364b-aee3-452b-8017-71c57db20676.gif)