### PR TITLE
Update/general convolution parameters

### DIFF
--- a/Userland/Applications/PixelPaint/BaseConvolutionParamsWidget.cpp
+++ b/Userland/Applications/PixelPaint/BaseConvolutionParamsWidget.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "BaseConvolutionParamsWidget.h"
+#include "LibGUI/Label.h"
+#include <AK/Format.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/CheckBox.h>
+
+REGISTER_WIDGET(PixelPaint, BaseConvolutionParamsWidget);
+
+namespace PixelPaint {
+
+void BaseConvolutionParamsWidget::set_name_label(StringView name)
+{
+    if (!name.is_empty()) {
+        m_name_label->set_text(name.to_deprecated_string());
+        m_name_label->set_visible(true);
+    } else {
+        m_name_label->set_visible(false);
+    }
+}
+
+BaseConvolutionParamsWidget::BaseConvolutionParamsWidget()
+{
+    set_layout<GUI::VerticalBoxLayout>(0, 0);
+    set_frame_thickness(0);
+
+    m_name_label = &add<GUI::Label>();
+    m_name_label->set_visible(false);
+    m_name_label->set_font_weight(Gfx::FontWeight::Bold);
+    m_name_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    m_name_label->set_fixed_height(20);
+
+    m_should_wrap_checkbox = &add<GUI::CheckBox>(String::from_utf8("Wrap Around"sv).release_value_but_fixme_should_propagate_errors());
+    m_should_wrap_checkbox->set_checked(m_should_wrap);
+
+    m_should_wrap_checkbox->on_checked = [&](bool checked) {
+        if (on_wrap_around_checked) {
+            on_wrap_around_checked(checked);
+        }
+    };
+}
+
+void BaseConvolutionParamsWidget::set_should_wrap(bool should_wrap)
+{
+    m_should_wrap_checkbox->set_checked(should_wrap);
+}
+
+}

--- a/Userland/Applications/PixelPaint/BaseConvolutionParamsWidget.h
+++ b/Userland/Applications/PixelPaint/BaseConvolutionParamsWidget.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <AK/RefPtr.h>
+#include <AK/StringView.h>
+#include <Applications/PixelPaint/Image.h>
+#include <LibGUI/CheckBox.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/Widget.h>
+
+namespace PixelPaint {
+
+class BaseConvolutionParamsWidget final : public GUI::Frame {
+    C_OBJECT(BaseConvolutionParamsWidget);
+
+public:
+    virtual ~BaseConvolutionParamsWidget() = default;
+    Function<void(bool)> on_wrap_around_checked;
+
+    void set_name_label(StringView name);
+    void set_should_wrap(bool should_wrap);
+
+private:
+    explicit BaseConvolutionParamsWidget();
+
+    bool m_should_wrap { false };
+
+    GUI::CheckBox* m_should_wrap_checkbox;
+    GUI::Label* m_name_label;
+
+    RefPtr<GUI::Widget> m_options_widget { nullptr };
+};
+
+}

--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SOURCES
     FilterGallery.cpp
     FilterTreeModel.cpp
     FilterPreviewWidget.cpp
+    BaseConvolutionParamsWidget.cpp
     Filters/Bloom.cpp
     Filters/BoxBlur3.cpp
     Filters/BoxBlur5.cpp
@@ -34,6 +35,7 @@ set(SOURCES
     Filters/Median.cpp
     Filters/Sepia.cpp
     Filters/Sharpen.cpp
+    Filters/ConvolutionFilter.cpp
     HistogramWidget.cpp
     IconBag.cpp
     Image.cpp

--- a/Userland/Applications/PixelPaint/Filters/BoxBlur3.cpp
+++ b/Userland/Applications/PixelPaint/Filters/BoxBlur3.cpp
@@ -1,19 +1,19 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "BoxBlur3.h"
-#include "../FilterParams.h"
+#include <Applications/PixelPaint/FilterParams.h>
 
 namespace PixelPaint::Filters {
 
 void BoxBlur3::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
     Gfx::BoxBlurFilter<3> filter;
-    if (auto parameters = PixelPaint::FilterParameters<Gfx::BoxBlurFilter<3>>::get())
+    if (auto parameters = PixelPaint::FilterParameters<Gfx::BoxBlurFilter<3>>::get(get_filter_options()))
         filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect(), *parameters);
 }
-
 }

--- a/Userland/Applications/PixelPaint/Filters/BoxBlur3.h
+++ b/Userland/Applications/PixelPaint/Filters/BoxBlur3.h
@@ -1,22 +1,23 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include "Filter.h"
+#include <Applications/PixelPaint/Filters/ConvolutionFilter.h>
 
 namespace PixelPaint::Filters {
 
-class BoxBlur3 final : public Filter {
+class BoxBlur3 final : public ConvolutionFilter {
 public:
     virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() const override { return "Box Blur (3x3)"sv; }
 
     BoxBlur3(ImageEditor* editor)
-        : Filter(editor) {};
+        : ConvolutionFilter(editor) {};
 };
 
 }

--- a/Userland/Applications/PixelPaint/Filters/BoxBlur5.cpp
+++ b/Userland/Applications/PixelPaint/Filters/BoxBlur5.cpp
@@ -1,18 +1,19 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "BoxBlur5.h"
-#include "../FilterParams.h"
+#include <Applications/PixelPaint/FilterParams.h>
 
 namespace PixelPaint::Filters {
 
 void BoxBlur5::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
     Gfx::BoxBlurFilter<5> filter;
-    if (auto parameters = PixelPaint::FilterParameters<Gfx::BoxBlurFilter<5>>::get())
+    if (auto parameters = PixelPaint::FilterParameters<Gfx::BoxBlurFilter<5>>::get(get_filter_options()))
         filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect(), *parameters);
 }
 

--- a/Userland/Applications/PixelPaint/Filters/BoxBlur5.h
+++ b/Userland/Applications/PixelPaint/Filters/BoxBlur5.h
@@ -1,22 +1,23 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include "Filter.h"
+#include <Applications/PixelPaint/Filters/ConvolutionFilter.h>
 
 namespace PixelPaint::Filters {
 
-class BoxBlur5 final : public Filter {
+class BoxBlur5 final : public ConvolutionFilter {
 public:
     virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() const override { return "Box Blur (5x5)"sv; }
 
     BoxBlur5(ImageEditor* editor)
-        : Filter(editor) {};
+        : ConvolutionFilter(editor) {};
 };
 
 }

--- a/Userland/Applications/PixelPaint/Filters/ConvolutionFilter.cpp
+++ b/Userland/Applications/PixelPaint/Filters/ConvolutionFilter.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ConvolutionFilter.h"
+#include <Applications/PixelPaint/BaseConvolutionParamsWidget.h>
+#include <Applications/PixelPaint/FilterParams.h>
+
+namespace PixelPaint::Filters {
+ErrorOr<RefPtr<GUI::Widget>> ConvolutionFilter::get_settings_widget()
+{
+    if (!m_settings_widget) {
+        auto base_params_widget = BaseConvolutionParamsWidget::construct();
+        base_params_widget->on_wrap_around_checked = [&](bool checked) {
+            m_filter_options.should_wrap = checked;
+            update_preview();
+        };
+        base_params_widget->set_name_label(filter_name());
+        base_params_widget->set_should_wrap(m_filter_options.should_wrap);
+
+        m_settings_widget = GUI::Widget::construct();
+        m_settings_widget->set_layout<GUI::VerticalBoxLayout>();
+        m_settings_widget->add_child(base_params_widget);
+
+        update_preview();
+    }
+
+    return m_settings_widget;
+}
+}

--- a/Userland/Applications/PixelPaint/Filters/ConvolutionFilter.h
+++ b/Userland/Applications/PixelPaint/Filters/ConvolutionFilter.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "LibGfx/Filters/GenericConvolutionFilter.h"
+#include <Applications/PixelPaint/Filters/Filter.h>
+
+namespace PixelPaint::Filters {
+
+class ConvolutionFilter : public Filter {
+public:
+    virtual ErrorOr<RefPtr<GUI::Widget>> get_settings_widget() override;
+
+    ConvolutionFilter(ImageEditor* editor)
+        : Filter(editor) {};
+
+protected:
+    Gfx::ConvolutionFilterOptions m_filter_options = Gfx::ConvolutionFilterOptions { true };
+    inline Gfx::ConvolutionFilterOptions get_filter_options() const { return m_filter_options; };
+};
+
+}

--- a/Userland/Applications/PixelPaint/Filters/GaussBlur3.cpp
+++ b/Userland/Applications/PixelPaint/Filters/GaussBlur3.cpp
@@ -1,18 +1,19 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "GaussBlur3.h"
-#include "../FilterParams.h"
+#include <Applications/PixelPaint/FilterParams.h>
 
 namespace PixelPaint::Filters {
 
 void GaussBlur3::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
     Gfx::SpatialGaussianBlurFilter<3> filter;
-    if (auto parameters = PixelPaint::FilterParameters<Gfx::SpatialGaussianBlurFilter<3>>::get())
+    if (auto parameters = PixelPaint::FilterParameters<Gfx::SpatialGaussianBlurFilter<3>>::get(get_filter_options()))
         filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect(), *parameters);
 }
 

--- a/Userland/Applications/PixelPaint/Filters/GaussBlur3.h
+++ b/Userland/Applications/PixelPaint/Filters/GaussBlur3.h
@@ -1,23 +1,24 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include "Filter.h"
+#include <Applications/PixelPaint/Filters/ConvolutionFilter.h>
 
 namespace PixelPaint::Filters {
 
 // FIXME: Make a generic gaussian blur that does not need the templated radius
-class GaussBlur3 final : public Filter {
+class GaussBlur3 final : public ConvolutionFilter {
 public:
     virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() const override { return "Gaussian Blur (3x3)"sv; }
 
     GaussBlur3(ImageEditor* editor)
-        : Filter(editor) {};
+        : ConvolutionFilter(editor) {};
 };
 
 }

--- a/Userland/Applications/PixelPaint/Filters/GaussBlur5.cpp
+++ b/Userland/Applications/PixelPaint/Filters/GaussBlur5.cpp
@@ -1,18 +1,19 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "GaussBlur5.h"
-#include "../FilterParams.h"
+#include <Applications/PixelPaint/FilterParams.h>
 
 namespace PixelPaint::Filters {
 
 void GaussBlur5::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
     Gfx::SpatialGaussianBlurFilter<5> filter;
-    if (auto parameters = PixelPaint::FilterParameters<Gfx::SpatialGaussianBlurFilter<5>>::get())
+    if (auto parameters = PixelPaint::FilterParameters<Gfx::SpatialGaussianBlurFilter<5>>::get(get_filter_options()))
         filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect(), *parameters);
 }
 

--- a/Userland/Applications/PixelPaint/Filters/GaussBlur5.h
+++ b/Userland/Applications/PixelPaint/Filters/GaussBlur5.h
@@ -1,22 +1,23 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include "Filter.h"
+#include <Applications/PixelPaint/Filters/ConvolutionFilter.h>
 
 namespace PixelPaint::Filters {
 
-class GaussBlur5 final : public Filter {
+class GaussBlur5 final : public ConvolutionFilter {
 public:
     virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() const override { return "Gaussian Blur (5x5)"sv; }
 
     GaussBlur5(ImageEditor* editor)
-        : Filter(editor) {};
+        : ConvolutionFilter(editor) {};
 };
 
 }

--- a/Userland/Applications/PixelPaint/Filters/LaplaceCardinal.cpp
+++ b/Userland/Applications/PixelPaint/Filters/LaplaceCardinal.cpp
@@ -1,18 +1,19 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "LaplaceCardinal.h"
-#include "../FilterParams.h"
+#include <Applications/PixelPaint/FilterParams.h>
 
 namespace PixelPaint::Filters {
 
 void LaplaceCardinal::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
     Gfx::LaplacianFilter filter;
-    if (auto parameters = PixelPaint::FilterParameters<Gfx::LaplacianFilter>::get(false))
+    if (auto parameters = PixelPaint::FilterParameters<Gfx::LaplacianFilter>::get(false, get_filter_options()))
         filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect(), *parameters);
 }
 

--- a/Userland/Applications/PixelPaint/Filters/LaplaceCardinal.h
+++ b/Userland/Applications/PixelPaint/Filters/LaplaceCardinal.h
@@ -1,22 +1,23 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include "Filter.h"
+#include <Applications/PixelPaint/Filters/ConvolutionFilter.h>
 
 namespace PixelPaint::Filters {
 
-class LaplaceCardinal final : public Filter {
+class LaplaceCardinal final : public ConvolutionFilter {
 public:
     virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() const override { return "Laplacian Cardinal"sv; }
 
     LaplaceCardinal(ImageEditor* editor)
-        : Filter(editor) {};
+        : ConvolutionFilter(editor) {};
 };
 
 }

--- a/Userland/Applications/PixelPaint/Filters/LaplaceDiagonal.cpp
+++ b/Userland/Applications/PixelPaint/Filters/LaplaceDiagonal.cpp
@@ -1,18 +1,19 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "LaplaceDiagonal.h"
-#include "../FilterParams.h"
+#include <Applications/PixelPaint/FilterParams.h>
 
 namespace PixelPaint::Filters {
 
 void LaplaceDiagonal::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
     Gfx::LaplacianFilter filter;
-    if (auto parameters = PixelPaint::FilterParameters<Gfx::LaplacianFilter>::get(true))
+    if (auto parameters = PixelPaint::FilterParameters<Gfx::LaplacianFilter>::get(true, get_filter_options()))
         filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect(), *parameters);
 }
 

--- a/Userland/Applications/PixelPaint/Filters/LaplaceDiagonal.h
+++ b/Userland/Applications/PixelPaint/Filters/LaplaceDiagonal.h
@@ -1,22 +1,23 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include "Filter.h"
+#include <Applications/PixelPaint/Filters/ConvolutionFilter.h>
 
 namespace PixelPaint::Filters {
 
-class LaplaceDiagonal final : public Filter {
+class LaplaceDiagonal final : public ConvolutionFilter {
 public:
     virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() const override { return "Laplacian Diagonal"sv; }
 
     LaplaceDiagonal(ImageEditor* editor)
-        : Filter(editor) {};
+        : ConvolutionFilter(editor) {};
 };
 
 }

--- a/Userland/Applications/PixelPaint/Filters/Sharpen.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Sharpen.cpp
@@ -1,18 +1,19 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "Sharpen.h"
-#include "../FilterParams.h"
+#include <Applications/PixelPaint/FilterParams.h>
 
 namespace PixelPaint::Filters {
 
 void Sharpen::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
     Gfx::SharpenFilter filter;
-    if (auto parameters = PixelPaint::FilterParameters<Gfx::SharpenFilter>::get())
+    if (auto parameters = PixelPaint::FilterParameters<Gfx::SharpenFilter>::get(get_filter_options()))
         filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect(), *parameters);
 }
 

--- a/Userland/Applications/PixelPaint/Filters/Sharpen.h
+++ b/Userland/Applications/PixelPaint/Filters/Sharpen.h
@@ -1,22 +1,23 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2023, Luiz Gustavo de França Chaves
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include "Filter.h"
+#include <Applications/PixelPaint/Filters/ConvolutionFilter.h>
 
 namespace PixelPaint::Filters {
 
-class Sharpen final : public Filter {
+class Sharpen final : public ConvolutionFilter {
 public:
     virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() const override { return "Sharpen"sv; }
 
     Sharpen(ImageEditor* editor)
-        : Filter(editor) {};
+        : ConvolutionFilter(editor) {};
 };
 
 }

--- a/Userland/Libraries/LibGfx/Filters/GenericConvolutionFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/GenericConvolutionFilter.h
@@ -29,14 +29,20 @@ static constexpr void normalize(Matrix<N, T>& matrix)
     }
 }
 
+struct ConvolutionFilterOptions {
+    bool should_wrap = true;
+};
+
+static constexpr struct ConvolutionFilterOptions default_convolution_filter_options = ConvolutionFilterOptions { true };
+
 template<size_t N>
 class GenericConvolutionFilter : public Filter {
 public:
     class Parameters : public Filter::Parameters {
     public:
-        Parameters(Gfx::Matrix<N, float> const& kernel, bool should_wrap = true)
+        Parameters(Gfx::Matrix<N, float> const& kernel, struct ConvolutionFilterOptions options = default_convolution_filter_options)
             : m_kernel(kernel)
-            , m_should_wrap(should_wrap)
+            , m_should_wrap(options.should_wrap)
 
         {
         }


### PR DESCRIPTION
Following up with the issue https://github.com/SerenityOS/serenity/issues/9175 

In the previous PR ([#15351](https://github.com/SerenityOS/serenity/pull/15351)), I changed the default behavior of the borders to a more sensible option and indicated my intention to implement a UI selector for all general convolution settings. In this PR, I have created the BaseConvolutionParamsWidget class that contains the UI selector for all general convolution filter settings. This widget replaces the existing Wrap Around option in the GenericConvolutionFilter.

In addition, I created a new class called ConvolutionFilter, which serves as a base class for all convolution filters in the project. This class contains all the common convolution options that are relevant for all filters. The intention behind these changes is to provide a consistent and unified user experience across all convolution filters in the project, reducing the risk of errors and confusion, like the current behavior where the `GenericConvolutionFilter`'s screen has a Wrap Around option and other convolution filters do not have, even though of them use the same convolution implementation

Its my first change not fixing a simple bug in the project, and I'm still learning C++, so I'm open to any feedback or tips of how to implement this in a better way.