### PR TITLE
LibWeb: Remove redundant invocation of `children changed` in HTMLParser

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -957,7 +957,6 @@ void HTMLParser::flush_character_insertions()
     if (m_character_insertion_builder.is_empty())
         return;
     m_character_insertion_node->set_data(m_character_insertion_builder.to_deprecated_string());
-    m_character_insertion_node->parent()->children_changed();
     m_character_insertion_builder.clear();
 }
 


### PR DESCRIPTION
Setting the `data` of a text node already triggers `children changed` per spec, so there's no need for an explicit call.

This avoids parsing every HTMLStyleElement sheet twice. :^)