### PR TITLE
LibWeb: Don't re-sort StyleSheetList on every new sheet insertion

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -927,16 +927,6 @@ void Node::remove_all_children(bool suppress_observers)
 // https://dom.spec.whatwg.org/#dom-node-comparedocumentposition
 u16 Node::compare_document_position(JS::GCPtr<Node> other)
 {
-    enum Position : u16 {
-        DOCUMENT_POSITION_EQUAL = 0,
-        DOCUMENT_POSITION_DISCONNECTED = 1,
-        DOCUMENT_POSITION_PRECEDING = 2,
-        DOCUMENT_POSITION_FOLLOWING = 4,
-        DOCUMENT_POSITION_CONTAINS = 8,
-        DOCUMENT_POSITION_CONTAINED_BY = 16,
-        DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 32,
-    };
-
     // 1. If this is other, then return zero.
     if (this == other.ptr())
         return DOCUMENT_POSITION_EQUAL;

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -101,6 +101,17 @@ public:
     void insert_before(JS::NonnullGCPtr<Node> node, JS::GCPtr<Node> child, bool suppress_observers = false);
     void remove(bool suppress_observers = false);
     void remove_all_children(bool suppress_observers = false);
+
+    enum DocumentPosition : u16 {
+        DOCUMENT_POSITION_EQUAL = 0,
+        DOCUMENT_POSITION_DISCONNECTED = 1,
+        DOCUMENT_POSITION_PRECEDING = 2,
+        DOCUMENT_POSITION_FOLLOWING = 4,
+        DOCUMENT_POSITION_CONTAINS = 8,
+        DOCUMENT_POSITION_CONTAINED_BY = 16,
+        DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 32,
+    };
+
     u16 compare_document_position(JS::GCPtr<Node> other);
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> replace_child(JS::NonnullGCPtr<Node> node, JS::NonnullGCPtr<Node> child);


### PR DESCRIPTION
This was causing a huge slowdown when loading some pages with weirdly
huge number of style sheets. For example, amazon.com has over 200 style
elements, which meant we had to resort the StyleSheetList 200 times.
(And sorting itself was slow because it has to compare DOM positions.)
    
Instead of sorting, we now look for the correct insertion point when
adding new style sheets, and we start the search from the end, which is
where style sheets are typically added in the vast majority of cases.
    
This removes a 600ms time sink when loading Amazon on my machine! :^)