### PR TITLE
Userland/disk_benchmark: Remove the call to umask

### DIFF
--- a/Userland/Utilities/disk_benchmark.cpp
+++ b/Userland/Utilities/disk_benchmark.cpp
@@ -68,8 +68,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         block_sizes = { 8192, 32768, 65536 };
     }
 
-    umask(0644);
-
     auto filename = DeprecatedString::formatted("{}/disk_benchmark.tmp", directory);
 
     for (auto file_size : file_sizes) {


### PR DESCRIPTION
Calling umask and open with the same permission value will result in a file with no permissions bits if the program is stopped while it is doing an IO. This will result in an error with EACCES when we try to run the benchmark with the same file name. The file needs to be manually removed before continuing the benchmark.

There is no use in calling umask here, so just remove it so that interrupting the program while it is doing an IO will not result in the file with no permissions error the next time we run the program.

Before the patch:

![before_umask_patch](https://user-images.githubusercontent.com/33182938/228837262-6ab965c1-db80-4862-8ca3-3d85ccd74f6e.png)
After  the patch:

![after_umask_patch](https://user-images.githubusercontent.com/33182938/228837365-ac650745-8b84-4013-9be7-13923accae03.png)
