### PR TITLE
LibCompress: Increase buffer sizes, remove an intermediate buffer

### DIFF
--- a/AK/CircularBuffer.cpp
+++ b/AK/CircularBuffer.cpp
@@ -206,4 +206,20 @@ ErrorOr<size_t> CircularBuffer::fill_from_stream(Stream& stream)
     return bytes.size();
 }
 
+ErrorOr<void> CircularBuffer::copy_from_seekback(size_t distance, size_t length)
+{
+    if (distance > m_seekback_limit)
+        return Error::from_string_literal("Tried a seekback copy beyond the seekback limit");
+
+    while (length > 0) {
+        auto next_span = next_read_span_with_seekback(distance);
+        if (next_span.size() == 0)
+            break;
+
+        length -= write(next_span.trim(length));
+    }
+
+    return {};
+}
+
 }

--- a/AK/CircularBuffer.h
+++ b/AK/CircularBuffer.h
@@ -33,6 +33,8 @@ public:
     /// before the current write pointer and allows for reading already-read data.
     ErrorOr<Bytes> read_with_seekback(Bytes bytes, size_t distance);
 
+    ErrorOr<void> copy_from_seekback(size_t distance, size_t length);
+
     [[nodiscard]] size_t empty_space() const;
     [[nodiscard]] size_t used_space() const;
     [[nodiscard]] size_t capacity() const;

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -207,9 +207,7 @@ ErrorOr<bool> DeflateDecompressor::CompressedBlock::try_read_more()
                 m_decompressor.m_output_buffer.write({ &byte, sizeof(byte) });
             }
         } else {
-            Array<u8, DeflateDecompressor::max_back_reference_length> buffer;
-            auto bytes = TRY(m_decompressor.m_output_buffer.read_with_seekback({ buffer.data(), length }, distance));
-            m_decompressor.m_output_buffer.write(bytes);
+            TRY(m_decompressor.m_output_buffer.copy_from_seekback(distance, length));
         }
 
         return true;

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -436,7 +436,7 @@ ErrorOr<void> DeflateDecompressor::decode_codes(CanonicalCode& literal_code, Opt
 
     // Next we extract the code lengths of the code that was used to encode the block.
 
-    Vector<u8> code_lengths;
+    Vector<u8, 286> code_lengths;
     while (code_lengths.size() < literal_code_count + distance_code_count) {
         auto symbol = TRY(code_length_code.read_symbol(*m_input_stream));
 

--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -38,8 +38,8 @@ private:
     };
 
     // Decompression - indexed by code
-    Vector<u16> m_symbol_codes;
-    Vector<u16> m_symbol_values;
+    Vector<u16, 286> m_symbol_codes;
+    Vector<u16, 286> m_symbol_values;
 
     Array<PrefixTableEntry, 1 << max_allowed_prefixed_code_length> m_prefix_table {};
     size_t m_max_prefixed_code_length { 0 };

--- a/Userland/Utilities/gunzip.cpp
+++ b/Userland/Utilities/gunzip.cpp
@@ -15,7 +15,7 @@ static ErrorOr<void> decompress_file(NonnullOwnPtr<Stream> input_stream, Stream&
 {
     auto gzip_stream = Compress::GzipDecompressor { move(input_stream) };
 
-    auto buffer = TRY(ByteBuffer::create_uninitialized(4096));
+    auto buffer = TRY(ByteBuffer::create_uninitialized(256 * KiB));
     while (!gzip_stream.is_eof()) {
         auto span = TRY(gzip_stream.read_some(buffer));
         TRY(output_stream.write_until_depleted(span));
@@ -52,7 +52,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         }
 
         auto input_file = TRY(Core::File::open(input_filename, Core::File::OpenMode::Read));
-        auto buffered_input_file = TRY(Core::BufferedFile::create(move(input_file)));
+        auto buffered_input_file = TRY(Core::BufferedFile::create(move(input_file), 256 * KiB));
 
         auto output_stream = write_to_stdout ? TRY(Core::File::standard_output()) : TRY(Core::File::open(output_filename, Core::File::OpenMode::Write));
 


### PR DESCRIPTION
These changes, combined with the CRC32 PR #18103, bring a warm decompression of enwik8 down to 1.05s on Serenity.