### PR TITLE
LibArchive+Utilities: Add a helper to `Archive::ZipOutputStream` for adding files (and use it in `zip`)

### DIFF
--- a/Userland/Libraries/LibArchive/CMakeLists.txt
+++ b/Userland/Libraries/LibArchive/CMakeLists.txt
@@ -5,4 +5,4 @@ set(SOURCES
         )
 
 serenity_lib(LibArchive archive)
-target_link_libraries(LibArchive PRIVATE LibCore)
+target_link_libraries(LibArchive PRIVATE LibCore LibCompress LibCrypto LibFileSystem)

--- a/Userland/Libraries/LibArchive/Zip.h
+++ b/Userland/Libraries/LibArchive/Zip.h
@@ -250,6 +250,16 @@ struct ZipMember {
     DOSPackedDate modification_date;
 };
 
+struct ZipMemberFromFileResult {
+    String canonicalized_path;
+    int deflated_amount;
+};
+
+enum class RecurseThroughDirectories {
+    Yes,
+    No
+};
+
 class Zip {
 public:
     static Optional<Zip> try_create(ReadonlyBytes buffer);
@@ -271,9 +281,16 @@ private:
 
 class ZipOutputStream {
 public:
-    ZipOutputStream(NonnullOwnPtr<Stream>);
+    using AddMemberCallback = Function<void(ZipMemberFromFileResult const&)>;
 
-    ErrorOr<void> add_member(ZipMember const&);
+    ZipOutputStream(NonnullOwnPtr<Stream> stream);
+
+    ErrorOr<void> add_member(ZipMember const& member);
+
+    ErrorOr<void> add_member_from_path(StringView path, RecurseThroughDirectories recurse_through_directories, AddMemberCallback const& callback);
+    ErrorOr<void> add_directory_from_path(StringView path, RecurseThroughDirectories recurse_through_directories, AddMemberCallback const& callback);
+    ErrorOr<ZipMemberFromFileResult> add_file_from_path(StringView path);
+
     ErrorOr<void> finish();
 
 private:

--- a/Userland/Utilities/zip.cpp
+++ b/Userland/Utilities/zip.cpp
@@ -53,84 +53,19 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto file_stream = TRY(Core::File::open(zip_file_path, Core::File::OpenMode::Write));
     Archive::ZipOutputStream zip_stream(move(file_stream));
 
-    auto add_file = [&](DeprecatedString path) -> ErrorOr<void> {
-        auto canonicalized_path = LexicalPath::canonicalized_path(path);
-        auto file = TRY(Core::File::open(path, Core::File::OpenMode::Read));
-        auto file_buffer = TRY(file->read_until_eof());
-        Archive::ZipMember member {};
-        member.name = TRY(String::from_deprecated_string(canonicalized_path));
-
-        auto stat = TRY(Core::System::fstat(file->fd()));
-        auto date = Core::DateTime::from_timestamp(stat.st_mtim.tv_sec);
-        member.modification_date = to_packed_dos_date(date.year(), date.month(), date.day());
-        member.modification_time = to_packed_dos_time(date.hour(), date.minute(), date.second());
-
-        auto deflate_buffer = Compress::DeflateCompressor::compress_all(file_buffer);
-        if (!deflate_buffer.is_error() && deflate_buffer.value().size() < file_buffer.size()) {
-            member.compressed_data = deflate_buffer.value().bytes();
-            member.compression_method = Archive::ZipCompressionMethod::Deflate;
-            auto compression_ratio = (double)deflate_buffer.value().size() / file_buffer.size();
-            outln("  adding: {} (deflated {}%)", canonicalized_path, (int)(compression_ratio * 100));
-        } else {
-            member.compressed_data = file_buffer.bytes();
-            member.compression_method = Archive::ZipCompressionMethod::Store;
-            outln("  adding: {} (stored 0%)", canonicalized_path);
-        }
-        member.uncompressed_size = file_buffer.size();
-        Crypto::Checksum::CRC32 checksum { file_buffer.bytes() };
-        member.crc32 = checksum.digest();
-        member.is_directory = false;
-        return zip_stream.add_member(member);
-    };
-
-    auto add_directory = [&](DeprecatedString path, auto handle_directory) -> ErrorOr<void> {
-        auto canonicalized_path = DeprecatedString::formatted("{}/", LexicalPath::canonicalized_path(path));
-        Archive::ZipMember member {};
-        member.name = TRY(String::from_deprecated_string(canonicalized_path));
-        member.compressed_data = {};
-        member.compression_method = Archive::ZipCompressionMethod::Store;
-        member.uncompressed_size = 0;
-        member.crc32 = 0;
-        member.is_directory = true;
-
-        auto stat = TRY(Core::System::stat(canonicalized_path));
-        auto date = Core::DateTime::from_timestamp(stat.st_mtim.tv_sec);
-        member.modification_date = to_packed_dos_date(date.year(), date.month(), date.day());
-        member.modification_time = to_packed_dos_time(date.hour(), date.minute(), date.second());
-
-        TRY(zip_stream.add_member(member));
-        outln("  adding: {} (stored 0%)", canonicalized_path);
-
-        if (!recurse)
-            return {};
-
-        Core::DirIterator it(path, Core::DirIterator::Flags::SkipParentAndBaseDir);
-        while (it.has_next()) {
-            auto child_path = it.next_full_path();
-            if (FileSystem::is_link(child_path))
-                return {};
-            if (!FileSystem::is_directory(child_path)) {
-                auto result = add_file(child_path);
-                if (result.is_error())
-                    warnln("Couldn't add file '{}': {}", child_path, result.error());
-            } else {
-                auto result = handle_directory(child_path, handle_directory);
-                if (result.is_error())
-                    warnln("Couldn't add directory '{}': {}", child_path, result.error());
-            }
-        }
-        return {};
-    };
-
     for (auto const& source_path : source_paths) {
-        if (FileSystem::is_directory(source_path)) {
-            auto result = add_directory(source_path, add_directory);
-            if (result.is_error())
-                warnln("Couldn't add directory '{}': {}", source_path, result.error());
-        } else {
-            auto result = add_file(source_path);
-            if (result.is_error())
-                warnln("Couldn't add file '{}': {}", source_path, result.error());
+        auto should_recurse = recurse ? Archive::RecurseThroughDirectories::Yes : Archive::RecurseThroughDirectories::No;
+        auto result = zip_stream.add_member_from_path(source_path, should_recurse, [](auto const& member) {
+            if (member.deflated_amount != 0) {
+                outln("   adding: {} (deflated {}%)", member.canonicalized_path, member.deflated_amount);
+            } else {
+                outln("   adding: {} (stored 0%)", member.canonicalized_path);
+            }
+        });
+
+        if (result.is_error()) {
+            auto type = FileSystem::is_directory(source_path) ? "directory"sv : "file"sv;
+            outln("Couldn't add {} '{}': {}", type, source_path, result.error());
         }
     }
 


### PR DESCRIPTION
Prior to this PR, you'd need to do a bit of manual work (as seen in the `zip` utility) to add a file to a zip via ZipOutputStream. 
**Now, you can just call `add_member_from_path` and let it handle directories and files for you! Amazing, right?**

You also can pass a callback function, which will get called with the file's canonical path, and the deflated amount as a percentage. This is useful for utilities like zip which provide the user with progress updates.

*This is the first PR in a series of a few which aims to improve the experience of ZIP files in Serenity. My next one will be making `FileOperation` support the extraction and creation of zip files so we can do it asynchronously without blocking FileManager.*