### PR TITLE
Kernel/HID: Don't update the remapped Ctrl modifier unconditionally

### DIFF
--- a/Kernel/Devices/HID/KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/KeyboardDevice.cpp
@@ -246,11 +246,10 @@ void KeyboardDevice::key_state_changed(u8 scan_code, bool pressed)
     if (!g_caps_lock_remapped_to_ctrl && key == Key_CapsLock && pressed)
         m_caps_lock_on = !m_caps_lock_on;
 
-    if (g_caps_lock_remapped_to_ctrl && key == Key_CapsLock)
+    if (g_caps_lock_remapped_to_ctrl && key == Key_CapsLock) {
         m_caps_lock_to_ctrl_pressed = pressed;
-
-    if (g_caps_lock_remapped_to_ctrl)
         update_modifier(Mod_Ctrl, m_caps_lock_to_ctrl_pressed);
+    }
 
     if (pressed)
         event.flags |= Is_Press;


### PR DESCRIPTION
Instead, only update it when the Caps Lock key event is generated and remapping to the Ctrl key is enabled.

This fixes a bug that when enabling remapping Caps Lock key to the Ctrl key, the original Ctrl key is no longer usable.

cc @trflynn89 