### PR TITLE
Base: Fix a typo in the uniq manpage

### DIFF
--- a/Base/usr/share/man/man1/uniq.md
+++ b/Base/usr/share/man/man1/uniq.md
@@ -18,7 +18,7 @@ Filter out repeated adjacent lines from INPUT (or standard input) and write to O
 * `-d`, `--repeated`: Only print repeated lines.
 * `-u`, `--unique`: Only print unique lines (default).
 * `-f N`, `--skip-fields N`: Skip first N fields of each line before comparing.
-* `-c N`, `--skip-chars N`: Skip first N chars of each line before comparing.
+* `-s N`, `--skip-chars N`: Skip first N chars of each line before comparing.
 * `--help`: Display help message and exit.
 * `--version`: Print version.
 


### PR DESCRIPTION
The `uniq` manpage incorrectly says `-c` is used for both "count" and "skip chars". The actual implementation uses `-s` to skip chars, not `-c`. 