### PR TITLE
LibAudio: Extract loader stream creation from the plugins

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
@@ -4,14 +4,16 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/MemoryStream.h>
 #include <LibAudio/FlacLoader.h>
 #include <stddef.h>
 #include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto flac_data = ByteBuffer::copy(data, size).release_value();
-    auto flac_or_error = Audio::FlacLoaderPlugin::create(flac_data.bytes());
+    auto const flac_bytes = ByteBuffer::copy(data, size).release_value();
+    auto flac_data = try_make<FixedMemoryStream>(flac_bytes).release_value();
+    auto flac_or_error = Audio::FlacLoaderPlugin::create(move(flac_data));
 
     if (flac_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzMP3Loader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMP3Loader.cpp
@@ -10,8 +10,9 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto flac_data = ByteBuffer::copy(data, size).release_value();
-    auto mp3_or_error = Audio::MP3LoaderPlugin::create(flac_data.bytes());
+    auto const mp3_bytes = ByteBuffer::copy(data, size).release_value();
+    auto mp3_data = try_make<FixedMemoryStream>(mp3_bytes).release_value();
+    auto mp3_or_error = Audio::MP3LoaderPlugin::create(move(mp3_data));
 
     if (mp3_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzQOALoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzQOALoader.cpp
@@ -4,14 +4,16 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/MemoryStream.h>
 #include <LibAudio/QOALoader.h>
 #include <stddef.h>
 #include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto qoa_data = ByteBuffer::copy(data, size).release_value();
-    auto qoa_or_error = Audio::QOALoaderPlugin::create(qoa_data.bytes());
+    auto const qoa_bytes = ByteBuffer::copy(data, size).release_value();
+    auto qoa_data = try_make<FixedMemoryStream>(qoa_bytes).release_value();
+    auto qoa_or_error = Audio::QOALoaderPlugin::create(move(qoa_data));
 
     if (qoa_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
@@ -4,17 +4,16 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Stream.h>
+#include <AK/MemoryStream.h>
 #include <LibAudio/WavLoader.h>
 #include <stddef.h>
 #include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    if (!data)
-        return 0;
-    auto wav_data = ReadonlyBytes { data, size };
-    auto wav_or_error = Audio::WavLoaderPlugin::create(wav_data);
+    auto const wav_bytes = ByteBuffer::copy(data, size).release_value();
+    auto wav_data = try_make<FixedMemoryStream>(wav_bytes).release_value();
+    auto wav_or_error = Audio::WavLoaderPlugin::create(move(wav_data));
 
     if (wav_or_error.is_error())
         return 0;

--- a/Tests/LibAudio/TestFLACSpec.cpp
+++ b/Tests/LibAudio/TestFLACSpec.cpp
@@ -19,7 +19,17 @@ struct DiscoverFLACTestsHack {
                 Test::add_test_case_to_suite(adopt_ref(*new ::Test::TestCase(
                     DeprecatedString::formatted("flac_spec_test_{}", path.basename()),
                     [path = move(path)]() {
-                        auto result = Audio::FlacLoaderPlugin::create(path.string());
+                        auto file = Core::File::open(path.string(), Core::File::OpenMode::Read);
+                        if (file.is_error()) {
+                            FAIL(DeprecatedString::formatted("{}", file.error()));
+                            return;
+                        }
+                        auto buffered_file = Core::InputBufferedFile::create(file.release_value());
+                        if (buffered_file.is_error()) {
+                            FAIL(DeprecatedString::formatted("{}", buffered_file.error()));
+                            return;
+                        }
+                        auto result = Audio::FlacLoaderPlugin::create(buffered_file.release_value());
                         if (result.is_error()) {
                             FAIL(DeprecatedString::formatted("{}", result.error()));
                             return;

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -40,8 +40,8 @@ public:
     explicit FlacLoaderPlugin(NonnullOwnPtr<SeekableStream> stream);
     virtual ~FlacLoaderPlugin() override = default;
 
-    static Result<NonnullOwnPtr<FlacLoaderPlugin>, LoaderError> create(StringView path);
-    static Result<NonnullOwnPtr<FlacLoaderPlugin>, LoaderError> create(Bytes buffer);
+    static bool sniff(SeekableStream& stream);
+    static ErrorOr<NonnullOwnPtr<LoaderPlugin>, LoaderError> create(NonnullOwnPtr<SeekableStream>);
 
     virtual ErrorOr<Vector<FixedArray<Sample>>, LoaderError> load_chunks(size_t samples_to_read_from_input) override;
 

--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -6,12 +6,12 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/FixedArray.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
-#include <AK/Result.h>
 #include <AK/Span.h>
 #include <AK/Stream.h>
 #include <AK/StringView.h>
@@ -23,8 +23,6 @@
 #include <LibAudio/SampleFormats.h>
 
 namespace Audio {
-
-static constexpr StringView no_plugin_error = "No loader plugin available"sv;
 
 // Experimentally determined to be a decent buffer size on i686:
 // 4K (the default) is slightly worse, and 64K is much worse.
@@ -87,8 +85,8 @@ protected:
 
 class Loader : public RefCounted<Loader> {
 public:
-    static Result<NonnullRefPtr<Loader>, LoaderError> create(StringView path) { return adopt_ref(*new Loader(TRY(create_plugin(path)))); }
-    static Result<NonnullRefPtr<Loader>, LoaderError> create(Bytes buffer) { return adopt_ref(*new Loader(TRY(create_plugin(buffer)))); }
+    static ErrorOr<NonnullRefPtr<Loader>, LoaderError> create(StringView path);
+    static ErrorOr<NonnullRefPtr<Loader>, LoaderError> create(Bytes buffer);
 
     // Will only read less samples if we're at the end of the stream.
     LoaderSamples get_more_samples(size_t samples_to_read_from_input = 128 * KiB);
@@ -111,8 +109,7 @@ public:
     Vector<PictureData> const& pictures() const { return m_plugin->pictures(); };
 
 private:
-    static Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> create_plugin(StringView path);
-    static Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> create_plugin(Bytes buffer);
+    static ErrorOr<NonnullOwnPtr<LoaderPlugin>, LoaderError> create_plugin(NonnullOwnPtr<SeekableStream> stream);
 
     explicit Loader(NonnullOwnPtr<LoaderPlugin>);
 

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -24,8 +24,8 @@ public:
     explicit MP3LoaderPlugin(NonnullOwnPtr<SeekableStream> stream);
     virtual ~MP3LoaderPlugin() = default;
 
-    static Result<NonnullOwnPtr<MP3LoaderPlugin>, LoaderError> create(StringView path);
-    static Result<NonnullOwnPtr<MP3LoaderPlugin>, LoaderError> create(Bytes buffer);
+    static bool sniff(SeekableStream& stream);
+    static ErrorOr<NonnullOwnPtr<LoaderPlugin>, LoaderError> create(NonnullOwnPtr<SeekableStream>);
 
     virtual ErrorOr<Vector<FixedArray<Sample>>, LoaderError> load_chunks(size_t samples_to_read_from_input) override;
 

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -41,6 +41,7 @@ public:
 
 private:
     MaybeLoaderError initialize();
+    static MaybeLoaderError synchronize(BigEndianInputBitStream& stream, size_t sample_index);
     MaybeLoaderError synchronize();
     MaybeLoaderError build_seek_table();
     ErrorOr<MP3::Header, LoaderError> read_header();

--- a/Userland/Libraries/LibAudio/QOALoader.cpp
+++ b/Userland/Libraries/LibAudio/QOALoader.cpp
@@ -24,22 +24,16 @@ QOALoaderPlugin::QOALoaderPlugin(NonnullOwnPtr<AK::SeekableStream> stream)
 {
 }
 
-Result<NonnullOwnPtr<QOALoaderPlugin>, LoaderError> QOALoaderPlugin::create(StringView path)
+bool QOALoaderPlugin::sniff(SeekableStream& stream)
 {
-    auto stream = LOADER_TRY(Core::InputBufferedFile::create(LOADER_TRY(Core::File::open(path, Core::File::OpenMode::Read))));
-    auto loader = make<QOALoaderPlugin>(move(stream));
-
-    LOADER_TRY(loader->initialize());
-
-    return loader;
+    auto maybe_qoa = stream.read_value<BigEndian<u32>>();
+    return !maybe_qoa.is_error() && maybe_qoa.value() == QOA::magic;
 }
 
-Result<NonnullOwnPtr<QOALoaderPlugin>, LoaderError> QOALoaderPlugin::create(Bytes buffer)
+ErrorOr<NonnullOwnPtr<LoaderPlugin>, LoaderError> QOALoaderPlugin::create(NonnullOwnPtr<SeekableStream> stream)
 {
-    auto loader = make<QOALoaderPlugin>(make<FixedMemoryStream>(buffer));
-
+    auto loader = make<QOALoaderPlugin>(move(stream));
     LOADER_TRY(loader->initialize());
-
     return loader;
 }
 

--- a/Userland/Libraries/LibAudio/QOALoader.h
+++ b/Userland/Libraries/LibAudio/QOALoader.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/Span.h>
 #include <AK/Types.h>
 #include <LibAudio/Loader.h>
@@ -24,8 +25,8 @@ public:
     explicit QOALoaderPlugin(NonnullOwnPtr<AK::SeekableStream> stream);
     virtual ~QOALoaderPlugin() override = default;
 
-    static Result<NonnullOwnPtr<QOALoaderPlugin>, LoaderError> create(StringView path);
-    static Result<NonnullOwnPtr<QOALoaderPlugin>, LoaderError> create(Bytes buffer);
+    static bool sniff(SeekableStream& stream);
+    static ErrorOr<NonnullOwnPtr<LoaderPlugin>, LoaderError> create(NonnullOwnPtr<SeekableStream>);
 
     virtual ErrorOr<Vector<FixedArray<Sample>>, LoaderError> load_chunks(size_t samples_to_read_from_input) override;
 

--- a/Userland/Libraries/LibAudio/WavLoader.h
+++ b/Userland/Libraries/LibAudio/WavLoader.h
@@ -25,8 +25,9 @@ namespace Audio {
 class WavLoaderPlugin : public LoaderPlugin {
 public:
     explicit WavLoaderPlugin(NonnullOwnPtr<SeekableStream> stream);
-    static Result<NonnullOwnPtr<WavLoaderPlugin>, LoaderError> create(StringView path);
-    static Result<NonnullOwnPtr<WavLoaderPlugin>, LoaderError> create(Bytes buffer);
+
+    static bool sniff(SeekableStream& stream);
+    static ErrorOr<NonnullOwnPtr<LoaderPlugin>, LoaderError> create(NonnullOwnPtr<SeekableStream>);
 
     virtual ErrorOr<Vector<FixedArray<Sample>>, LoaderError> load_chunks(size_t samples_to_read_from_input) override;
 
@@ -44,8 +45,6 @@ public:
     virtual PcmSampleFormat pcm_format() override { return m_sample_format; }
 
 private:
-    MaybeLoaderError initialize();
-
     MaybeLoaderError parse_header();
     MaybeLoaderError load_wav_info_block(Vector<RIFF::Chunk> info_chunks);
 


### PR DESCRIPTION
This removes a lot of duplicated stream creation code from the plugins, and also simplifies the way that the appropriate plugin is found. This mirrors the ImageDecoderPlugin design and necessitates new sniffing methods on the loaders.