### PR TITLE
gzip+gunzip+LibCompress: Consolidate buffered GZIP file handling

### DIFF
--- a/Userland/Libraries/LibCompress/Gzip.h
+++ b/Userland/Libraries/LibCompress/Gzip.h
@@ -93,6 +93,7 @@ public:
     virtual void close() override;
 
     static ErrorOr<ByteBuffer> compress_all(ReadonlyBytes bytes);
+    static ErrorOr<void> compress_file(StringView input_file, NonnullOwnPtr<Stream> output_stream);
 
 private:
     MaybeOwned<Stream> m_output_stream;

--- a/Userland/Libraries/LibCompress/Gzip.h
+++ b/Userland/Libraries/LibCompress/Gzip.h
@@ -52,6 +52,8 @@ public:
     virtual void close() override {};
 
     static ErrorOr<ByteBuffer> decompress_all(ReadonlyBytes);
+    static ErrorOr<void> decompress_file(StringView input_file, NonnullOwnPtr<Stream> output_stream);
+
     static Optional<DeprecatedString> describe_header(ReadonlyBytes);
     static bool is_likely_compressed(ReadonlyBytes bytes);
 


### PR DESCRIPTION
`gzip -d` being 3x slower than `gunzip` was sad.

![Screenshot_20230331_191034](https://user-images.githubusercontent.com/5600524/229249613-9b70edf6-da57-412f-a76d-9fa4f237027d.png)
