### PR TITLE
LibWeb: Don't churn HTML::EventLoop while in microtask checkpoint

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -226,8 +226,8 @@ void EventLoop::process()
 
     // FIXME:     2. If there are no tasks in the event loop's task queues and the WorkerGlobalScope object's closing flag is true, then destroy the event loop, aborting these steps, resuming the run a worker steps described in the Web workers section below.
 
-    // If there are tasks in the queue, schedule a new round of processing. :^)
-    if (m_task_queue.has_runnable_tasks() || !m_microtask_queue.is_empty())
+    // If there are eligible tasks in the queue, schedule a new round of processing. :^)
+    if (m_task_queue.has_runnable_tasks() || (!m_microtask_queue.is_empty() && !m_performing_a_microtask_checkpoint))
         schedule();
 }
 


### PR DESCRIPTION
At the end of HTML::EventLoop::process(), the loop reschedules itself if there are more runnable tasks available.

However, the condition was flawed: we would reschedule if there were any microtasks queued, but those tasks will not be processed if we're currently within the scope of a microtask checkpoint.

To fix this, we now only reschedule the HTML event loop for microtask processing *if* we're not already in a microtask checkpoint.

This fixes the 100% CPU churn seen when looking at PRs on GitHub. :^)