### PR TITLE
HackStudio: Add configuration domain pledge for FileManager

### DIFF
--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -42,7 +42,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd tty rpath cpath wpath proc exec unix fattr thread ptrace"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
-    Config::pledge_domains({ "HackStudio", "Terminal" });
+    Config::pledge_domains({ "HackStudio", "Terminal", "FileManager" });
 
     auto window = GUI::Window::construct();
     window->resize(840, 600);


### PR DESCRIPTION
This fixes a bug where clicking the "Save" button would crash the application because 'FileManager' was a pledged domain.

The bug can be replicated by opening HackStudio and immediate clicking the save button.