### PR TITLE
Meta: Make the gdb kernel debug script work for AArch64

### DIFF
--- a/Meta/debug-kernel.sh
+++ b/Meta/debug-kernel.sh
@@ -57,6 +57,7 @@ exec $SERENITY_KERNEL_DEBUGGER \
     -ex "set confirm on" \
     -ex "set arch $gdb_arch" \
     -ex "set print frame-arguments none" \
+    -ex "set print asm-demangle on" \
     -ex "target remote ${gdb_host}:1234" \
     -ex "source $SCRIPT_DIR/serenity_gdb.py" \
     -ex "layout asm" \

--- a/Meta/debug-kernel.sh
+++ b/Meta/debug-kernel.sh
@@ -38,7 +38,7 @@ if [ "$SERENITY_ARCH" = "x86_64" ]; then
 elif [ "$SERENITY_ARCH" = "aarch64" ]; then
     gdb_arch=aarch64:armv8-r
     prekernel_image=Prekernel
-    kernel_base=0xc0000000 # FIXME
+    kernel_base=0x0
 fi
 
 # FIXME: This doesn't work when running QEMU inside the WSL2 VM


### PR DESCRIPTION
I've no clue how you've been bringing up the kernel without working GDB :slightly_smiling_face: 