### PR TITLE
LibWeb: Fix a few font scaling issues 

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -14,6 +14,7 @@
 #include <LibJS/Heap/Handle.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/StyleProperties.h>
+#include <LibWeb/FontCache.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Layout/BoxModelMetrics.h>
 #include <LibWeb/Painting/PaintContext.h>
@@ -117,6 +118,8 @@ public:
     bool can_contain_boxes_with_position_absolute() const;
 
     Gfx::Font const& font() const;
+    Gfx::Font const& scaled_font(PaintContext&) const;
+
     CSS::ImmutableComputedValues const& computed_values() const;
     CSSPixels line_height() const;
 
@@ -235,6 +238,11 @@ inline Gfx::Font const& Node::font() const
     if (m_has_style)
         return static_cast<NodeWithStyle const*>(this)->font();
     return parent()->font();
+}
+
+inline Gfx::Font const& Node::scaled_font(PaintContext& context) const
+{
+    return *FontCache::the().scaled_font(font(), context.device_pixels_per_css_pixel());
 }
 
 inline const CSS::ImmutableComputedValues& Node::computed_values() const

--- a/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -79,7 +79,9 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
     case CSS::ListStyleType::UpperRoman:
         if (layout_box().text().is_null())
             break;
-        context.painter().draw_text(device_enclosing.to_type<int>(), layout_box().text(), Gfx::TextAlignment::Center);
+        // FIXME: This should use proper text layout logic!
+        // This does not line up with the text in the <li> element which looks very sad :(
+        context.painter().draw_text(device_enclosing.to_type<int>(), layout_box().text(), layout_box().scaled_font(context), Gfx::TextAlignment::Center);
         break;
     case CSS::ListStyleType::None:
         return;

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -8,7 +8,6 @@
 #include <AK/GenericShorthands.h>
 #include <LibUnicode/CharacterTypes.h>
 #include <LibWeb/DOM/Document.h>
-#include <LibWeb/FontCache.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/Viewport.h>
@@ -525,16 +524,16 @@ static void paint_text_fragment(PaintContext& context, Layout::TextNode const& t
         DevicePixelPoint baseline_start { fragment_absolute_device_rect.x(), fragment_absolute_device_rect.y() + context.rounded_device_pixels(fragment.baseline()) };
         Utf8View view { text.substring_view(fragment.start(), fragment.length()) };
 
-        auto scaled_font = FontCache::the().scaled_font(fragment.layout_node().font(), context.device_pixels_per_css_pixel());
+        auto& scaled_font = fragment.layout_node().scaled_font(context);
 
-        painter.draw_text_run(baseline_start.to_type<int>(), view, *scaled_font, text_node.computed_values().color());
+        painter.draw_text_run(baseline_start.to_type<int>(), view, scaled_font, text_node.computed_values().color());
 
         auto selection_rect = context.enclosing_device_rect(fragment.selection_rect(text_node.font())).to_type<int>();
         if (!selection_rect.is_empty()) {
             painter.fill_rect(selection_rect, context.palette().selection());
             Gfx::PainterStateSaver saver(painter);
             painter.add_clip_rect(selection_rect);
-            painter.draw_text_run(baseline_start.to_type<int>(), view, *scaled_font, context.palette().selection_text());
+            painter.draw_text_run(baseline_start.to_type<int>(), view, scaled_font, context.palette().selection_text());
         }
 
         paint_text_decoration(context, painter, text_node, fragment);

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -11,6 +11,7 @@
 #include <LibGfx/Filters/StackBlurFilter.h>
 #include <LibGfx/Painter.h>
 #include <LibWeb/Layout/LineBoxFragment.h>
+#include <LibWeb/Layout/Node.h>
 #include <LibWeb/Painting/BorderPainting.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/PaintContext.h>
@@ -369,10 +370,9 @@ void paint_text_shadow(PaintContext& context, Layout::LineBoxFragment const& fra
         auto shadow_bitmap = maybe_shadow_bitmap.release_value();
 
         Gfx::Painter shadow_painter { *shadow_bitmap };
-        shadow_painter.set_font(context.painter().font());
         // FIXME: "Spread" the shadow somehow.
         DevicePixelPoint baseline_start(text_rect.x(), text_rect.y() + context.rounded_device_pixels(fragment.baseline()));
-        shadow_painter.draw_text_run(baseline_start.to_type<int>(), Utf8View(fragment.text()), context.painter().font(), layer.color);
+        shadow_painter.draw_text_run(baseline_start.to_type<int>(), Utf8View(fragment.text()), fragment.layout_node().scaled_font(context), layer.color);
 
         // Blur
         Gfx::StackBlurFilter filter(*shadow_bitmap);


### PR DESCRIPTION
This now correctly uses the current font and scales it for text shadows and (ordered) list item markers. 