### PR TITLE
AK: Increase LittleEndianOutputBitStream's buffer size and remove loops

### DIFF
--- a/Tests/AK/TestBitStream.cpp
+++ b/Tests/AK/TestBitStream.cpp
@@ -22,6 +22,8 @@ TEST_CASE(little_endian_bit_stream_input_output_match)
     {
         MUST(bit_write_stream.write_bits(0b1111u, 4));
         MUST(bit_write_stream.write_bits(0b1111u, 4));
+        MUST(bit_write_stream.flush_buffer_to_stream());
+
         auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1111u, result);
         result = MUST(bit_read_stream.read_bits(4));
@@ -30,6 +32,8 @@ TEST_CASE(little_endian_bit_stream_input_output_match)
     {
         MUST(bit_write_stream.write_bits(0b0000u, 4));
         MUST(bit_write_stream.write_bits(0b0000u, 4));
+        MUST(bit_write_stream.flush_buffer_to_stream());
+
         auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b0000u, result);
         result = MUST(bit_read_stream.read_bits(4));
@@ -40,6 +44,8 @@ TEST_CASE(little_endian_bit_stream_input_output_match)
     {
         MUST(bit_write_stream.write_bits(0b1000u, 4));
         MUST(bit_write_stream.write_bits(0b1000u, 4));
+        MUST(bit_write_stream.flush_buffer_to_stream());
+
         auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1000u, result);
         result = MUST(bit_read_stream.read_bits(4));
@@ -50,6 +56,8 @@ TEST_CASE(little_endian_bit_stream_input_output_match)
     {
         MUST(bit_write_stream.write_bits(0b1000u, 4));
         MUST(bit_write_stream.write_bits(0b0100u, 4));
+        MUST(bit_write_stream.flush_buffer_to_stream());
+
         auto result = MUST(bit_read_stream.read_bits(4));
         EXPECT_EQ(0b1000u, result);
         result = MUST(bit_read_stream.read_bits(4));
@@ -59,6 +67,8 @@ TEST_CASE(little_endian_bit_stream_input_output_match)
     // Test a pattern that spans multiple bytes.
     {
         MUST(bit_write_stream.write_bits(0b1101001000100001u, 16));
+        MUST(bit_write_stream.flush_buffer_to_stream());
+
         auto result = MUST(bit_read_stream.read_bits(16));
         EXPECT_EQ(0b1101001000100001u, result);
     }

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -1061,6 +1061,7 @@ ErrorOr<void> DeflateCompressor::final_flush()
     VERIFY(!m_finished);
     m_finished = true;
     TRY(flush());
+    TRY(m_output_stream->flush_buffer_to_stream());
     return {};
 }
 


### PR DESCRIPTION
This is very similar to the LittleEndianInputBitStream bit buffer change from 8e834d4bb2f8a217013142658fe7203c5a5c3170.

We currently buffer one byte of data for the underlying stream. And when we put bits onto that buffer, we do so 1 bit at a time.

This replaces the u8 buffer with a u64. And instead of looping at all, we perform bitwise operations to write the desired number of bits.

Using the "enwik8" file as a test (100MB uncompressed, commonly used in benchmarks: https://www.mattmahoney.net/dc/enwik8.zip), compression time decreases from:

    13.62s to 10.9s on Serenity (cold)
    13.62s to 9.22s on Serenity (warm)
    2.93s to 2.32s on Linux

One caveat is that this requires explicitly flushing any leftover bits when the caller is done with the stream. The byte buffer implementation implicitly flushed its data every time the buffer was byte-aligned, as doing so would always fill the byte. This is no longer the case. But for now, this should be fine as the one user of this class, DEFLATE, already has a "flush everything now that we're done" finalizer.