### PR TITLE
Kernel: Add support for SD host controllers on the PCI bus

### DIFF
--- a/Kernel/Bus/PCI/Definitions.h
+++ b/Kernel/Bus/PCI/Definitions.h
@@ -84,6 +84,7 @@ enum class ClassID {
     MassStorage = 0x1,
     Multimedia = 0x4,
     Bridge = 0x6,
+    Base = 0x8,
 };
 
 namespace MassStorage {
@@ -112,6 +113,14 @@ namespace Bridge {
 
 enum class SubclassID {
     PCI_TO_PCI = 0x4,
+};
+
+}
+
+namespace Base {
+
+enum class SubclassID {
+    SDHostController = 0x5,
 };
 
 }

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -112,6 +112,7 @@ set(KERNEL_SOURCES
     Storage/NVMe/NVMeInterruptQueue.cpp
     Storage/NVMe/NVMePollQueue.cpp
     Storage/NVMe/NVMeQueue.cpp
+    Storage/SD/PCISDHostController.cpp
     Storage/SD/SDHostController.cpp
     Storage/SD/SDMemoryCard.cpp
     Storage/DiskPartition.cpp

--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -101,11 +101,14 @@ public:
 
 private:
     mutable NonnullRefPtr<BlockBasedFileSystem> m_fs;
+    NonnullOwnPtr<KBuffer> m_cached_block_data;
+
+    // NOTE: m_entries must be declared before m_dirty_list and m_clean_list because their entries are allocated from it.
+    // We need to ensure that the destructors of m_dirty_list and m_clean_list are called before m_entries is destroyed.
+    NonnullOwnPtr<KBuffer> m_entries;
     mutable IntrusiveList<&CacheEntry::list_node> m_dirty_list;
     mutable IntrusiveList<&CacheEntry::list_node> m_clean_list;
     mutable HashMap<BlockBasedFileSystem::BlockIndex, CacheEntry*> m_hash;
-    NonnullOwnPtr<KBuffer> m_cached_block_data;
-    NonnullOwnPtr<KBuffer> m_entries;
 };
 
 BlockBasedFileSystem::BlockBasedFileSystem(OpenFileDescription& file_description)

--- a/Kernel/Storage/SD/PCISDHostController.cpp
+++ b/Kernel/Storage/SD/PCISDHostController.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Bus/PCI/API.h>
+#include <Kernel/Storage/SD/PCISDHostController.h>
+
+namespace Kernel {
+
+ErrorOr<NonnullRefPtr<PCISDHostController>> PCISDHostController::try_initialize(PCI::DeviceIdentifier const& device_identifier)
+{
+    auto sdhc = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) PCISDHostController(device_identifier)));
+    TRY(sdhc->initialize());
+
+    return sdhc;
+}
+
+PCISDHostController::PCISDHostController(PCI::DeviceIdentifier const& device_identifier)
+    : PCI::Device(device_identifier)
+    , SDHostController()
+{
+    auto slot_information_register = read_slot_information();
+
+    if (slot_information_register.slots_available() != 1) {
+        // TODO: Support multiple slots
+        dmesgln("SD Host Controller has {} slots, but we currently only support using only one", slot_information_register.slots_available());
+    }
+
+    auto physical_address_of_sdhc_registers = PhysicalAddress {
+        PCI::get_BAR(device_identifier, static_cast<PCI::HeaderType0BaseRegister>(slot_information_register.first_bar_number))
+    };
+    m_registers = Memory::map_typed_writable<SD::HostControlRegisterMap volatile>(physical_address_of_sdhc_registers).release_value_but_fixme_should_propagate_errors();
+}
+
+}

--- a/Kernel/Storage/SD/PCISDHostController.h
+++ b/Kernel/Storage/SD/PCISDHostController.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Bus/PCI/API.h>
+#include <Kernel/Bus/PCI/Device.h>
+#include <Kernel/Memory/TypedMapping.h>
+#include <Kernel/Storage/SD/SDHostController.h>
+
+namespace Kernel {
+
+class PCISDHostController : public PCI::Device
+    , public SDHostController {
+public:
+    static ErrorOr<NonnullRefPtr<PCISDHostController>> try_initialize(PCI::DeviceIdentifier const& device_identifier);
+
+    // ^PCI::Device
+    virtual StringView device_name() const override { return "SD Host Controller"sv; }
+
+protected:
+    // ^SDHostController
+    virtual SD::HostControlRegisterMap volatile* get_register_map_base_address() override { return m_registers.ptr(); }
+
+private:
+    PCISDHostController(PCI::DeviceIdentifier const& device_identifier);
+
+    struct [[gnu::packed]] SlotInformationRegister {
+        u8 first_bar_number : 3;
+        u8 : 1;
+        u8 number_of_slots : 3;
+        u8 : 1;
+
+        u8 slots_available() const { return number_of_slots + 1; }
+    };
+    static_assert(AssertSize<SlotInformationRegister, 1>());
+
+    SlotInformationRegister read_slot_information() const
+    {
+        SpinlockLocker locker(device_identifier().operation_lock());
+        return bit_cast<SlotInformationRegister>(PCI::Access::the().read8_field(device_identifier(), 0x40));
+    }
+
+    Memory::TypedMapping<SD::HostControlRegisterMap volatile> m_registers;
+};
+
+}

--- a/Kernel/Storage/SD/SDHostController.h
+++ b/Kernel/Storage/SD/SDHostController.h
@@ -57,6 +57,8 @@ private:
     }
     bool currently_active_command_uses_transfer_complete_interrupt();
 
+    ErrorOr<u32> calculate_sd_clock_divisor(u32 sd_clock_frequency, u32 frequency);
+    bool is_sd_clock_enabled();
     ErrorOr<void> sd_clock_supply(u32 frequency);
     void sd_clock_stop();
     ErrorOr<void> sd_clock_frequency_change(u32 frequency);

--- a/Kernel/Storage/StorageManagement.cpp
+++ b/Kernel/Storage/StorageManagement.cpp
@@ -54,6 +54,7 @@ static constexpr StringView block_device_prefix = "block"sv;
 static constexpr StringView ata_device_prefix = "ata"sv;
 static constexpr StringView nvme_device_prefix = "nvme"sv;
 static constexpr StringView logical_unit_number_device_prefix = "lun"sv;
+static constexpr StringView sd_device_prefix = "sd"sv;
 
 UNMAP_AFTER_INIT StorageManagement::StorageManagement()
 {
@@ -324,6 +325,13 @@ UNMAP_AFTER_INIT void StorageManagement::determine_nvme_boot_device()
     });
 }
 
+UNMAP_AFTER_INIT void StorageManagement::determine_sd_boot_device()
+{
+    determine_hardware_relative_boot_device(sd_device_prefix, [](StorageDevice const& device) -> bool {
+        return device.command_set() == StorageDevice::CommandSet::SD;
+    });
+}
+
 UNMAP_AFTER_INIT void StorageManagement::determine_block_boot_device()
 {
     VERIFY(m_boot_argument.starts_with(block_device_prefix));
@@ -385,6 +393,11 @@ UNMAP_AFTER_INIT void StorageManagement::determine_boot_device()
 
     if (m_boot_argument.starts_with(nvme_device_prefix)) {
         determine_nvme_boot_device();
+        return;
+    }
+
+    if (m_boot_argument.starts_with(sd_device_prefix)) {
+        determine_sd_boot_device();
         return;
     }
     PANIC("StorageManagement: Invalid root boot parameter.");

--- a/Kernel/Storage/StorageManagement.h
+++ b/Kernel/Storage/StorageManagement.h
@@ -54,6 +54,7 @@ private:
     void determine_boot_device_with_logical_unit_number();
     void determine_block_boot_device();
     void determine_nvme_boot_device();
+    void determine_sd_boot_device();
     void determine_ata_boot_device();
     void determine_hardware_relative_boot_device(StringView relative_hardware_prefix, Function<bool(StorageDevice const&)> filter_device_callback);
     Array<unsigned, 3> extract_boot_device_address_parameters(StringView device_prefix);

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -79,8 +79,8 @@ nearest_power_of_2() {
     done
     echo $p
 }
-if [ "$SERENITY_ARCH" = "aarch64" ]; then
-    # The Aarch64 port loads from an SD card, which must have a size that is a power of 2 
+if [ "$SERENITY_ARCH" = "aarch64" ] || { [ -n "$SERENITY_USE_SDCARD" ] && [ "$SERENITY_USE_SDCARD" -eq 1 ]; }; then
+    # SD cards must have a size that is a power of 2. The Aarch64 port loads from an SD card. 
     DISK_SIZE_BYTES=$(nearest_power_of_2 "$DISK_SIZE_BYTES")
 fi
 

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -254,6 +254,11 @@ else
     fi
 fi
 
+if [ "$SERENITY_USE_SDCARD" -eq 1 ]; then
+    SERENITY_BOOT_DRIVE="-device sdhci-pci -device sd-card,drive=sd-boot-drive -drive id=sd-boot-drive,if=none,format=raw,file=${SERENITY_DISK_IMAGE}"
+    SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE root=sd2:0:0"
+fi
+
 if [ -z "$SERENITY_HOST_IP" ]; then
     SERENITY_HOST_IP="127.0.0.1"
 fi


### PR DESCRIPTION
These commits allow using SD cards on x86 too + a fix for a kernel page fault when unmounting a disk.

Note that there's still no support for hot-plugging cards: only cards connected since boot will work.

To test this:

**Create an image for the SD card**
```
touch sd-card.img
qemu-img resize sd-card.img 2G
mkfs.ext2 sd-card.img
mkdir mountpoint
sudo mount sd-card.img mountpoint
sudo sh -c 'echo Hello world from the SD card > mountpoint/Hello.txt'
sudo umount mountpoint
```

**Run with the SD card inserted**
```
SERENITY_EXTRA_QEMU_ARGS="-device sdhci-pci -device sd-card,drive=mydrive -drive id=mydrive,if=none,format=raw,file=$(pwd)/sd-card.img" Meta/serenity.sh run
```

**Inside Serenity**
```
su
mkdir sd-card
mount /dev/hdb sd-card
ls sd-card
```