### PR TITLE
LibWeb: Don't apply element inline style & presentational hints to associated pseudo elements

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-inline-style.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-inline-style.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x120 children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x102 children: not-inline
+      BlockContainer <div.outer> at (11,11) content-size 100x100 children: not-inline
+        BlockContainer <(anonymous)> at (12,12) content-size 50x50 children: inline
+          line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+            frag 0 from TextNode start: 0, length: 0, rect: [12,12 0x21.835937]
+              ""
+          TextNode <#text>
+        BlockContainer <div.inner> at (12,64) content-size 98x0 children: inline
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x47.835937 children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x29.835937 children: not-inline
+      TableWrapper <(anonymous)> at (10,10) content-size 104x29.835937 children: not-inline
+        TableBox <table> at (11,11) content-size 104x27.835937 children: not-inline
+          TableRowGroupBox <tbody> at (11,11) content-size 104x27.835937 children: not-inline
+            TableRowBox <tr> at (11,11) content-size 104x27.835937 children: not-inline
+              TableCellBox <td> at (13,13) content-size 100x23.835937 children: not-inline
+                BlockContainer <(anonymous)> at (14,14) content-size 98x21.835937 children: inline
+                  line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+                    frag 0 from TextNode start: 0, length: 0, rect: [14,14 0x21.835937]
+                      ""
+                  TextNode <#text>

--- a/Tests/LibWeb/Layout/input/css-pseudo-element-should-not-be-affected-by-inline-style.html
+++ b/Tests/LibWeb/Layout/input/css-pseudo-element-should-not-be-affected-by-inline-style.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html><html><head><style>
+* {
+    border: 1px solid black;
+    font: 20px SerenitySans;
+}
+.outer::before {
+    display: block;
+    content: "";
+    width: 50px;
+    height: 50px;
+    border: 1px solid red;
+}
+</style><head><body><div class="outer" style="height: 100px; width: 100px;"><div class="inner">

--- a/Tests/LibWeb/Layout/input/css-pseudo-element-should-not-be-affected-by-presentational-hints.html
+++ b/Tests/LibWeb/Layout/input/css-pseudo-element-should-not-be-affected-by-presentational-hints.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html><html><head><style>
+* {
+    border: 1px solid black;
+    font: 20px SerenitySans;
+}
+td::before {
+    display: block;
+    content: "";
+    border: 1px solid red;
+}
+</style><head><body><table><tr><td width="100" height="100">

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -912,7 +912,8 @@ ErrorOr<void> StyleComputer::compute_cascaded_values(StyleProperties& style, DOM
     // FIXME: Normal user declarations
 
     // Author presentational hints (NOTE: The spec doesn't say exactly how to prioritize these.)
-    element.apply_presentational_hints(style);
+    if (!pseudo_element.has_value())
+        element.apply_presentational_hints(style);
 
     // Normal author declarations
     cascade_declarations(style, element, pseudo_element, matching_rule_set.author_rules, CascadeOrigin::Author, Important::No);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -111,7 +111,7 @@ private:
         Vector<MatchingRule> author_rules;
     };
 
-    void cascade_declarations(StyleProperties&, DOM::Element&, Vector<MatchingRule> const&, CascadeOrigin, Important important) const;
+    void cascade_declarations(StyleProperties&, DOM::Element&, Optional<CSS::Selector::PseudoElement>, Vector<MatchingRule> const&, CascadeOrigin, Important) const;
 
     void build_rule_cache();
     void build_rule_cache_if_needed() const;


### PR DESCRIPTION
An element's inline style, if present, should not leak into any pseudo
elements generated by that element.

The same goes for presentational hints from content attributes.