### PR TITLE
PixelPaint: Make Bloom use InplaceFilter instead of Filter

### DIFF
--- a/Userland/Applications/PixelPaint/Filters/Bloom.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Bloom.cpp
@@ -16,9 +16,9 @@
 
 namespace PixelPaint::Filters {
 
-void Bloom::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
+void Bloom::apply(Gfx::Bitmap& target_bitmap) const
 {
-    auto intermediate_bitmap_or_error = source_bitmap.clone();
+    auto intermediate_bitmap_or_error = target_bitmap.clone();
     if (intermediate_bitmap_or_error.is_error())
         return;
 

--- a/Userland/Applications/PixelPaint/Filters/Bloom.h
+++ b/Userland/Applications/PixelPaint/Filters/Bloom.h
@@ -6,20 +6,20 @@
 
 #pragma once
 
-#include "Filter.h"
+#include "InplaceFilter.h"
 
 namespace PixelPaint::Filters {
 
-class Bloom final : public Filter {
+class Bloom final : public InplaceFilter {
 public:
-    virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
+    virtual void apply(Gfx::Bitmap& target_bitmap) const override;
 
     virtual ErrorOr<RefPtr<GUI::Widget>> get_settings_widget() override;
 
     virtual StringView filter_name() const override { return "Bloom Filter"sv; }
 
     Bloom(ImageEditor* editor)
-        : Filter(editor) {};
+        : InplaceFilter(editor) {};
 
 private:
     int m_luma_lower { 128 };


### PR DESCRIPTION
Previously the preview image wouldn't update when lowering the blur radius, as it didn't reset the target bitmap to the original image.

Before:
![image](https://user-images.githubusercontent.com/26722564/229356932-3ab0e534-7832-4040-b46d-5e7857a3856f.png)


After:
![image](https://user-images.githubusercontent.com/26722564/229356826-0ca13615-a0f0-49b2-b1e7-518162115ffe.png)
