### PR TITLE
LibWeb: Add borders functionality to CSS Grid

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/borders.txt
+++ b/Tests/LibWeb/Layout/expected/grid/borders.txt
@@ -1,0 +1,164 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x444.28125 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x428.28125 children: not-inline
+      Box <div.grid-container> at (8,8) content-size 784x74.9375 children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (18,18) content-size 372.140625x17.46875 children: inline
+          line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [18,18 6.34375x17.46875]
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (410.140625,18) content-size 372x17.46875 children: inline
+          line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [410.140625,18 8.8125x17.46875]
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (18,55.46875) content-size 372.140625x17.46875 children: inline
+          line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [18,55.46875 9.09375x17.46875]
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (410.140625,55.46875) content-size 372x17.46875 children: inline
+          line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [410.140625,55.46875 7.75x17.46875]
+              "4"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,82.9375) content-size 784x0 children: inline
+        TextNode <#text>
+      Box <div.grid-container> at (8,82.9375) content-size 784x107.46875 children: not-inline
+        BlockContainer <(anonymous)> at (8,82.9375) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (18,92.9375) content-size 372.140625x50 children: inline
+          line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [18,92.9375 6.34375x17.46875]
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,82.9375) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (410.140625,92.9375) content-size 372x50 children: inline
+          line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [410.140625,92.9375 8.8125x17.46875]
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,82.9375) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (18,162.9375) content-size 372.140625x17.46875 children: inline
+          line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [18,162.9375 9.09375x17.46875]
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,82.9375) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (410.140625,162.9375) content-size 372x17.46875 children: inline
+          line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [410.140625,162.9375 7.75x17.46875]
+              "4"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,82.9375) content-size 0x0 children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,190.40625) content-size 784x0 children: inline
+        TextNode <#text>
+      Box <div.grid-container> at (8,190.40625) content-size 784x84.9375 children: not-inline
+        BlockContainer <(anonymous)> at (8,190.40625) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (18,200.40625) content-size 347.140625x17.46875 children: inline
+          line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [18,200.40625 6.34375x17.46875]
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,190.40625) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (435.140625,200.40625) content-size 347x17.46875 children: inline
+          line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [435.140625,200.40625 8.8125x17.46875]
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,190.40625) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (18,247.875) content-size 347.140625x17.46875 children: inline
+          line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [18,247.875 9.09375x17.46875]
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,190.40625) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (435.140625,247.875) content-size 347x17.46875 children: inline
+          line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [435.140625,247.875 7.75x17.46875]
+              "4"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,190.40625) content-size 0x0 children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,275.34375) content-size 784x0 children: inline
+        TextNode <#text>
+      Box <div.grid-container> at (8,275.34375) content-size 784x90.9375 children: not-inline
+        BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (445.434356,285.34375) content-size 337.800018x17.46875 children: inline
+          line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [445.434356,285.34375 6.34375x17.46875]
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (18,338.8125) content-size 339.034362x17.46875 children: inline
+          line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [18,338.8125 8.8125x17.46875]
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,366.28125) content-size 784x0 children: inline
+        TextNode <#text>
+      Box <div.grid-container> at (8,366.28125) content-size 784x50 children: not-inline
+        BlockContainer <(anonymous)> at (8,366.28125) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (18,376.28125) content-size 280x5 children: inline
+          line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [18,376.28125 6.34375x17.46875]
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,366.28125) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (318,376.28125) content-size 280x5 children: inline
+          line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [318,376.28125 8.8125x17.46875]
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,366.28125) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (18,401.28125) content-size 280x5 children: inline
+          line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [18,401.28125 8.8125x17.46875]
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,366.28125) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (318,401.28125) content-size 280x5 children: inline
+          line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [318,401.28125 8.8125x17.46875]
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,366.28125) content-size 0x0 children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,416.28125) content-size 784x0 children: inline
+        TextNode <#text>
+      Box <div.grid-container> at (8,416.28125) content-size 784x20 children: not-inline
+        BlockContainer <(anonymous)> at (8,416.28125) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (18,426.28125) content-size 764x0 children: inline
+          line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [18,426.28125 6.34375x17.46875]
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,416.28125) content-size 0x0 children: inline
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/row-height.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-height.txt
@@ -1,0 +1,34 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x83.46875 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x67.46875 children: not-inline
+      Box <div.grid-container> at (8,8) content-size 784x67.46875 children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (8,8) content-size 392.140625x50 children: inline
+          line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (400.140625,8) content-size 392x50 children: inline
+          line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [400.140625,8 8.8125x17.46875]
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (8,58) content-size 392.140625x17.46875 children: inline
+          line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [8,58 9.09375x17.46875]
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (400.140625,58) content-size 392x17.46875 children: inline
+          line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [400.140625,58 7.75x17.46875]
+              "4"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/grid/borders.html
+++ b/Tests/LibWeb/Layout/input/grid/borders.html
@@ -1,0 +1,62 @@
+<style>
+  body {
+    font-family: 'SerenitySans';
+  }
+
+  .grid-container {
+    display: grid;
+    background-color: lightsalmon;
+  }
+
+  .grid-item {
+    background-color: lightblue;
+    border: 10px solid black;
+  }
+</style>
+
+<div class="grid-container" style="grid-template-columns: auto auto;">
+  <div class="grid-item">1</div>
+  <div class="grid-item">2</div>
+  <div class="grid-item">3</div>
+  <div class="grid-item">4</div>
+</div>
+
+<div class="grid-container" style="grid-template-columns: auto auto;">
+  <div class="grid-item" style="height: 50px;">1</div>
+  <div class="grid-item">2</div>
+  <div class="grid-item">3</div>
+  <div class="grid-item">4</div>
+</div>
+
+<div class="grid-container" style="
+    grid-template-columns: auto auto;
+    gap: 10px 50px;
+  ">
+  <div class="grid-item">1</div>
+  <div class="grid-item">2</div>
+  <div class="grid-item">3</div>
+  <div class="grid-item">4</div>
+</div>
+
+<div class="grid-container" style="
+    grid-template-columns: auto auto;
+    gap: calc(1vh + 10px) calc(10% - 10px);
+  ">
+  <div class="grid-item" style="grid-column: 2 / span 1">1</div>
+  <div class="grid-item">2</div>
+</div>
+
+<div class="grid-container" style="
+    height: 50px;
+    grid-template-columns: minmax(150px, 300px) minmax(150px, 300px);
+    grid-template-rows: minmax(25px, 50px) minmax(25px, 50px);
+  ">
+  <div class="grid-item">1</div>
+  <div class="grid-item">2</div>
+  <div class="grid-item">2</div>
+  <div class="grid-item">2</div>
+</div>
+
+<div class="grid-container" style="grid-template-rows: 20px;">
+  <div class="grid-item">1</div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid/row-height.html
+++ b/Tests/LibWeb/Layout/input/grid/row-height.html
@@ -1,0 +1,22 @@
+<style>
+  body {
+    font-family: 'SerenitySans';
+  }
+
+  .grid-container {
+    display: grid;
+    background-color: lightsalmon;
+  }
+
+  .grid-item {
+    background-color: lightblue;
+  }
+</style>
+
+<!-- Should render a 2x2 grid with the first row having a height of 50px -->
+<div class="grid-container" style="grid-template-columns: auto auto;">
+  <div class="grid-item" style="height: 50px;">1</div>
+  <div class="grid-item">2</div>
+  <div class="grid-item">3</div>
+  <div class="grid-item">4</div>
+</div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -145,6 +145,8 @@ private:
     void initialize_grid_tracks(Box const&, AvailableSpace const&, int column_count, int row_count);
     void calculate_sizes_of_columns(Box const&, AvailableSpace const&);
     void calculate_sizes_of_rows(Box const&);
+
+    CSSPixels content_based_minimum_height(GridItem const&, Box const& parent_box);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -80,6 +80,21 @@ private:
         CSSPixels planned_increase { 0 };
         bool is_gap { false };
 
+        CSSPixels border_left { 0 };
+        CSSPixels border_right { 0 };
+        CSSPixels border_top { 0 };
+        CSSPixels border_bottom { 0 };
+
+        CSSPixels full_horizontal_size() const
+        {
+            return base_size + border_left + border_right;
+        }
+
+        CSSPixels full_vertical_size() const
+        {
+            return base_size + border_top + border_bottom;
+        }
+
         TemporaryTrack(CSS::GridSize min_track_sizing_function, CSS::GridSize max_track_sizing_function)
             : min_track_sizing_function(min_track_sizing_function)
             , max_track_sizing_function(max_track_sizing_function)

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -29,9 +29,9 @@ private:
     Vector<Vector<bool>> m_occupation_grid;
 };
 
-class PositionedBox {
+class GridItem {
 public:
-    PositionedBox(Box const& box, int row, int row_span, int column, int column_span)
+    GridItem(Box const& box, int row, int row_span, int column, int column_span)
         : m_box(box)
         , m_row(row)
         , m_row_span(row_span)
@@ -40,13 +40,13 @@ public:
     {
     }
 
-    Box const& box() { return m_box; }
+    Box const& box() const { return m_box; }
 
     int raw_row_span() { return m_row_span; }
     int raw_column_span() { return m_column_span; }
 
-    int gap_adjusted_row(Box const& parent_box);
-    int gap_adjusted_column(Box const& parent_box);
+    int gap_adjusted_row(Box const& parent_box) const;
+    int gap_adjusted_column(Box const& parent_box) const;
 
 private:
     JS::NonnullGCPtr<Box const> m_box;
@@ -120,7 +120,7 @@ private:
     Vector<TemporaryTrack> m_grid_columns;
 
     OccupationGrid m_occupation_grid;
-    Vector<PositionedBox> m_positioned_boxes;
+    Vector<GridItem> m_grid_items;
     Vector<JS::NonnullGCPtr<Box const>> m_boxes_to_place;
 
     CSSPixels get_free_space_x(AvailableSpace const& available_space);


### PR DESCRIPTION
Adds borders to the CSS Grid. 

![image](https://user-images.githubusercontent.com/45781926/229359962-91af56f0-b9d5-49f6-af35-5da01c76a910.png)


