### PR TITLE
Kernel/aarch64: Add support for signal handling

### DIFF
--- a/Kernel/Arch/aarch64/PageDirectory.cpp
+++ b/Kernel/Arch/aarch64/PageDirectory.cpp
@@ -49,12 +49,14 @@ LockRefPtr<PageDirectory> PageDirectory::find_current()
 void activate_kernel_page_directory(PageDirectory const& page_directory)
 {
     Aarch64::Asm::set_ttbr0_el1(page_directory.ttbr0());
+    Processor::flush_entire_tlb_local();
 }
 
 void activate_page_directory(PageDirectory const& page_directory, Thread* current_thread)
 {
     current_thread->regs().ttbr0_el1 = page_directory.ttbr0();
     Aarch64::Asm::set_ttbr0_el1(page_directory.ttbr0());
+    Processor::flush_entire_tlb_local();
 }
 
 UNMAP_AFTER_INIT NonnullLockRefPtr<PageDirectory> PageDirectory::must_create_kernel_page_directory()

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -273,6 +273,8 @@ public:
 
     static void set_thread_specific_data(VirtualAddress thread_specific_data);
 
+    static void flush_entire_tlb_local();
+
 private:
     Processor(Processor const&) = delete;
 

--- a/Kernel/Arch/aarch64/RegisterState.h
+++ b/Kernel/Arch/aarch64/RegisterState.h
@@ -24,14 +24,12 @@ struct RegisterState {
     FlatPtr userspace_sp() const { return sp_el0; }
     void set_userspace_sp(FlatPtr value)
     {
-        (void)value;
-        TODO_AARCH64();
+        sp_el0 = value;
     }
     FlatPtr ip() const { return elr_el1; }
     void set_ip(FlatPtr value)
     {
-        (void)value;
-        TODO_AARCH64();
+        elr_el1 = value;
     }
     FlatPtr bp() const { return x[29]; }
 

--- a/Kernel/Arch/aarch64/RegisterState.h
+++ b/Kernel/Arch/aarch64/RegisterState.h
@@ -56,16 +56,20 @@ static_assert(AssertSize<RegisterState, REGISTER_STATE_SIZE>());
 
 inline void copy_kernel_registers_into_ptrace_registers(PtraceRegisters& ptrace_regs, RegisterState const& kernel_regs)
 {
-    (void)ptrace_regs;
-    (void)kernel_regs;
-    TODO_AARCH64();
+    for (auto i = 0; i < 31; i++)
+        ptrace_regs.x[i] = kernel_regs.x[i];
+
+    ptrace_regs.sp = kernel_regs.userspace_sp();
+    ptrace_regs.pc = kernel_regs.ip();
 }
 
 inline void copy_ptrace_registers_into_kernel_registers(RegisterState& kernel_regs, PtraceRegisters const& ptrace_regs)
 {
-    (void)kernel_regs;
-    (void)ptrace_regs;
-    TODO_AARCH64();
+    for (auto i = 0; i < 31; i++)
+        kernel_regs.x[i] = ptrace_regs.x[i];
+
+    kernel_regs.set_userspace_sp(ptrace_regs.sp);
+    kernel_regs.set_ip(ptrace_regs.pc);
 }
 
 struct DebugRegisterState {

--- a/Kernel/Arch/aarch64/ThreadRegisters.h
+++ b/Kernel/Arch/aarch64/ThreadRegisters.h
@@ -22,6 +22,7 @@ struct ThreadRegisters {
     FlatPtr ip() const { return elr_el1; }
     void set_ip(FlatPtr value) { elr_el1 = value; }
 
+    FlatPtr sp() const { return sp_el0; }
     void set_sp(FlatPtr value) { sp_el0 = value; }
 
     void set_initial_state(bool is_kernel_process, Memory::AddressSpace& space, FlatPtr kernel_stack_top)

--- a/Kernel/Arch/aarch64/mcontext.h
+++ b/Kernel/Arch/aarch64/mcontext.h
@@ -13,37 +13,7 @@ extern "C" {
 #endif
 
 struct __attribute__((packed)) __mcontext {
-    uint64_t r0;
-    uint64_t r1;
-    uint64_t r2;
-    uint64_t r3;
-    uint64_t r4;
-    uint64_t r5;
-    uint64_t r6;
-    uint64_t r7;
-    uint64_t r8;
-    uint64_t r9;
-    uint64_t r10;
-    uint64_t r11;
-    uint64_t r12;
-    uint64_t r13;
-    uint64_t r14;
-    uint64_t r15;
-    uint64_t r16;
-    uint64_t r17;
-    uint64_t r18;
-    uint64_t r19;
-    uint64_t r20;
-    uint64_t r21;
-    uint64_t r22;
-    uint64_t r23;
-    uint64_t r24;
-    uint64_t r25;
-    uint64_t r26;
-    uint64_t r27;
-    uint64_t r28;
-    uint64_t r29;
-    uint64_t r30;
+    uint64_t x[31];
     uint64_t sp;
     uint64_t pc;
 };

--- a/Kernel/Memory/ScopedAddressSpaceSwitcher.cpp
+++ b/Kernel/Memory/ScopedAddressSpaceSwitcher.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, Timon Kruiper <timonkruiper@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,23 +14,14 @@ namespace Kernel {
 ScopedAddressSpaceSwitcher::ScopedAddressSpaceSwitcher(Process& process)
 {
     VERIFY(Thread::current() != nullptr);
-#if ARCH(X86_64)
-    m_previous_cr3 = read_cr3();
-#elif ARCH(AARCH64)
-    TODO_AARCH64();
-#endif
+    m_previous_page_directory = Memory::PageDirectory::find_current();
     Memory::MemoryManager::enter_process_address_space(process);
 }
 
 ScopedAddressSpaceSwitcher::~ScopedAddressSpaceSwitcher()
 {
     InterruptDisabler disabler;
-#if ARCH(X86_64)
-    Thread::current()->regs().cr3 = m_previous_cr3;
-    write_cr3(m_previous_cr3);
-#elif ARCH(AARCH64)
-    TODO_AARCH64();
-#endif
+    Memory::activate_page_directory(*m_previous_page_directory, Thread::current());
 }
 
 }

--- a/Kernel/Memory/ScopedAddressSpaceSwitcher.h
+++ b/Kernel/Memory/ScopedAddressSpaceSwitcher.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, Timon Kruiper <timonkruiper@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,6 +8,7 @@
 #pragma once
 
 #include <AK/Types.h>
+#include <Kernel/Arch/PageDirectory.h>
 #include <Kernel/Forward.h>
 
 namespace Kernel {
@@ -17,7 +19,7 @@ public:
     ~ScopedAddressSpaceSwitcher();
 
 private:
-    u32 m_previous_cr3 { 0 };
+    LockRefPtr<Memory::PageDirectory> m_previous_page_directory;
 };
 
 }

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, Timon Kruiper <timonkruiper@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -409,14 +410,36 @@ void signal_trampoline_dummy()
         : "i"(Syscall::SC_sigreturn),
         "i"(offset_to_first_register_slot));
 #elif ARCH(AARCH64)
+    constexpr static auto offset_to_first_register_slot = align_up_to(sizeof(__ucontext) + sizeof(siginfo) + sizeof(FPUState) + 3 * sizeof(FlatPtr), 16);
     asm(
         ".global asm_signal_trampoline\n"
         "asm_signal_trampoline:\n"
-        // TODO: Implement this when we support userspace for aarch64
-        "wfi\n"
+        // stack state: 0, ucontext, signal_info (alignment = 16), fpu_state (alignment = 16), ucontext*, siginfo*, signal, handler
+
+        // Load the handler address into x3.
+        "ldr x3, [sp, #0]\n"
+        // Store x0 (return value from a syscall) into the register slot, such that we can return the correct value in sys$sigreturn.
+        "str x0, [sp, %[offset_to_first_register_slot]]\n"
+        // Load the signal number into the first argument.
+        "ldr x0, [sp, #8]\n"
+        // Load a pointer to the signal_info structure into the second argument.
+        "ldr x1, [sp, #16]\n"
+        // Load a pointer to the ucontext into the third argument.
+        "ldr x2, [sp, #24]\n"
+        // Pop the values off the stack.
+        "add sp, sp, 32\n"
+        // Call the signal handler.
+        "blr x3\n"
+
+        // Call sys$sigreturn.
+        "mov x8, %[sigreturn_syscall_number]\n"
+        "svc #0\n"
+        // We should never return, so trap if we do return.
+        "brk #0\n"
         "\n"
         ".global asm_signal_trampoline_end\n"
-        "asm_signal_trampoline_end: \n");
+        "asm_signal_trampoline_end: \n" ::[sigreturn_syscall_number] "i"(Syscall::SC_sigreturn),
+        [offset_to_first_register_slot] "i"(offset_to_first_register_slot));
 #else
 #    error Unknown architecture
 #endif

--- a/Kernel/Syscalls/sigaction.cpp
+++ b/Kernel/Syscalls/sigaction.cpp
@@ -87,14 +87,12 @@ ErrorOr<FlatPtr> Process::sys$sigreturn(RegisterState& registers)
     // Stack state (created by the signal trampoline):
     // saved_ax, ucontext, signal_info, fpu_state?.
 
-#if ARCH(X86_64)
     // The FPU state is at the top here, pop it off and restore it.
     // FIXME: The stack alignment is off by 8 bytes here, figure this out and remove this excessively aligned object.
     alignas(alignof(FPUState) * 2) FPUState data {};
     TRY(copy_from_user(&data, bit_cast<FPUState const*>(stack_ptr)));
     Thread::current()->fpu_state() = data;
     stack_ptr += sizeof(FPUState);
-#endif
 
     stack_ptr += sizeof(siginfo); // We don't need this here.
 

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -1150,10 +1150,8 @@ DispatchSignalResult Thread::dispatch_signal(u8 signal)
 
         VERIFY(stack % 16 == 0);
 
-#if ARCH(X86_64)
         // Save the FPU/SSE state
         TRY(copy_value_on_user_stack(stack, fpu_state()));
-#endif
 
         TRY(push_value_on_user_stack(stack, pointer_to_ucontext));
         TRY(push_value_on_user_stack(stack, pointer_to_signal_info));

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -231,7 +231,8 @@ Time TimeManagement::boot_time()
 #if ARCH(X86_64)
     return RTC::boot_time();
 #elif ARCH(AARCH64)
-    TODO_AARCH64();
+    // FIXME: Return correct boot time
+    return Time::from_seconds(0);
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Libraries/LibC/sys/arch/aarch64/regs.h
+++ b/Userland/Libraries/LibC/sys/arch/aarch64/regs.h
@@ -21,46 +21,22 @@ struct [[gnu::packed]] PtraceRegisters : public __mcontext {
 #    if defined(__cplusplus) && defined(__cpp_concepts)
     FlatPtr ip() const
     {
-#        if ARCH(X86_64)
-        return rip;
-#        elif ARCH(AARCH64)
         return pc;
-#        else
-#            error Unknown architecture
-#        endif
     }
 
     void set_ip(FlatPtr ip)
     {
-#        if ARCH(X86_64)
-        rip = ip;
-#        elif ARCH(AARCH64)
         pc = ip;
-#        else
-#            error Unknown architecture
-#        endif
     }
 
     FlatPtr bp() const
     {
-#        if ARCH(X86_64)
-        return rbp;
-#        elif ARCH(AARCH64)
-        return r29;
-#        else
-#            error Unknown architecture
-#        endif
+        return x[29];
     }
 
     void set_bp(FlatPtr bp)
     {
-#        if ARCH(X86_64)
-        rbp = bp;
-#        elif ARCH(AARCH64)
-        r29 = bp;
-#        else
-#            error Unknown architecture
-#        endif
+        x[29] = bp;
     }
 #    endif
 };


### PR DESCRIPTION
~~This is a draft as it is dependent on #18143 and #18131. It also doesn't work yet, there is some bug in the last commit, that actually adds the assembly code for handling the signals. I'm still trying to debug it.~~

~~I thought I might as well create a draft PR, such that other people don't duplicate the work :)~~

With this PR, we are now able to successfully boot to the text mode! See the demo at the end of the PR.

The following patch is applied to boot to text mode, and also to print some information to the Shell:
<details>
<summary>Patch</summary>
<br>

```patch
diff --git a/Base/etc/shellrc b/Base/etc/shellrc
index 0e5229b10a..451c3bab1b 100644
--- a/Base/etc/shellrc
+++ b/Base/etc/shellrc
@@ -42,3 +42,10 @@ export TMPDIR=/tmp
 PROGRAMS_ALLOWED_TO_MODIFY_DEFAULT_TERMIOS=(stty)

 for /usr/share/shell/completion/*.sh { source $it }
+
+echo "pwd"
+pwd
+echo "ls"
+ls
+echo "uname -a"
+uname -a
diff --git a/Kernel/Arch/init.cpp b/Kernel/Arch/init.cpp
index 4eb0b02048..c3c723d438 100644
--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -192,7 +192,7 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init([[maybe_unused]] BootInfo con
     multiboot_module_entry_t modules[] = {};
     multiboot_modules = modules;
     multiboot_modules_count = 0;
-    kernel_cmdline = "";
+    kernel_cmdline = "system_mode=text";
 #endif

     setup_serial_debug();

```
</details>

~~Still a draft as it depends on #18131.~~

https://user-images.githubusercontent.com/18349222/229527128-6f3c3a23-a05c-44a5-9a3b-41015a880c59.mov

