### PR TITLE
LibHTTP: Tolerate extra \r\n in chunked-encoding last block size

### DIFF
--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -416,6 +416,9 @@ void Job::on_socket_connected()
                     auto size_data = maybe_size_data.release_value();
 
                     if (m_should_read_chunk_ending_line) {
+                        // NOTE: Some servers seem to send an extra \r\n here despite there being no size.
+                        //       This makes us tolerate that.
+                        size_data = size_data.trim("\r\n"sv, TrimMode::Right);
                         VERIFY(size_data.is_empty());
                         m_should_read_chunk_ending_line = false;
                         continue;

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -204,8 +204,10 @@ ErrorOr<Vector<Answer>> LookupServer::lookup(Name const& name, RecordType record
                 break;
         } while (--retries);
         if (!upstream_answers.is_empty()) {
-            for (auto& answer : upstream_answers)
+            for (auto& answer : upstream_answers) {
                 add_answer(answer);
+                put_in_cache(answer);
+            }
             break;
         } else {
             if (!did_get_response)


### PR DESCRIPTION
Some servers put CR/LF there, so let's tolerate that behaviour.
Fixes #18151.