### PR TITLE
ImageViewer: Fix crash when setting wallpaper

### DIFF
--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -43,7 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    Config::pledge_domain("ImageViewer");
+    Config::pledge_domains({ "ImageViewer", "WindowManager" });
 
     app->set_config_domain(TRY("ImageViewer"_string));
 


### PR DESCRIPTION
When trying to set the wallpaper from the menu, ImageViewer would crash because setting the wallpaper requires the program to pledge to the WindowManager domain. This patch adds that pledge.