### PR TITLE
LibWeb: Implement `background-position-x` and `background-position-y` longhand longhands

### DIFF
--- a/Base/res/html/misc/background-position-xy.html
+++ b/Base/res/html/misc/background-position-xy.html
@@ -1,0 +1,25 @@
+<style>
+.example {
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  border: 1px solid black;
+  background-repeat: no-repeat;
+  background-size: 30px 30px;
+  background-image: linear-gradient(red, red);
+}
+</style>
+<b>background-position-x</b><br>
+<div class="example" style="background-position-x: left"></div>
+<div class="example" style="background-position-x: center"></div>
+<div class="example" style="background-position-x: 25%"></div>
+<div class="example" style="background-position-x: 2rem"></div>
+<div class="example" style="background-position-x: right 32px"></div>
+<br>
+<br>
+<b>background-position-y</b><br>
+<div class="example" style="background-position-y: top"></div>
+<div class="example" style="background-position-y: center"></div>
+<div class="example" style="background-position-y: 25%"></div>
+<div class="example" style="background-position-y: 2rem"></div>
+<div class="example" style="background-position-y: bottom 32px"></div>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -114,6 +114,7 @@
             <li><a href="backdrop-filter.html">backdrop-filter</a></li>
             <li><a href="backgrounds.html">Backgrounds</a></li>
             <li><a href="background-repeat-test.html">Background-repeat</a></li>
+            <li><a href="background-position-xy.html">Background-position-x/y</a></li>
             <li><a href="box-shadow.html">Box-shadow</a></li>
             <li><a href="text-shadow.html">Text-shadow</a></li>
             <li><a href="opacity.html">Opacity</a></li>

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -78,6 +78,7 @@ set(SOURCES
     CSS/StyleValues/ColorStyleValue.cpp
     CSS/StyleValues/ConicGradientStyleValue.cpp
     CSS/StyleValues/ContentStyleValue.cpp
+    CSS/StyleValues/EdgeStyleValue.cpp
     CSS/StyleValues/FilterValueListStyleValue.cpp
     CSS/StyleValues/FlexFlowStyleValue.cpp
     CSS/StyleValues/FlexStyleValue.cpp

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -294,6 +294,7 @@ private:
     RefPtr<StyleValue> parse_filter_value_list_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_background_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_single_background_position_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_single_background_position_x_or_y_value(TokenStream<ComponentValue>&, PropertyID);
     RefPtr<StyleValue> parse_single_background_repeat_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_single_background_size_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_border_value(Vector<ComponentValue> const&);

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -128,6 +128,44 @@
     ],
     "quirks": [
       "unitless-length"
+    ],
+    "longhands": [
+      "background-position-x",
+      "background-position-y"
+    ]
+  },
+  "background-position-x": {
+    "inherited": false,
+    "affects-layout": false,
+    "initial": "0%",
+    "valid-types": [
+      "length",
+      "percentage"
+    ],
+    "valid-identifiers": [
+      "center",
+      "left",
+      "right"
+    ],
+    "quirks": [
+      "unitless-length"
+    ]
+  },
+  "background-position-y": {
+    "inherited": false,
+    "affects-layout": false,
+    "initial": "0%",
+    "valid-types": [
+      "length",
+      "percentage"
+    ],
+    "valid-identifiers": [
+      "center",
+      "bottom",
+      "top"
+    ],
+    "quirks": [
+      "unitless-length"
     ]
   },
   "background-repeat": {

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -19,6 +19,7 @@
 #include <LibWeb/CSS/StyleValues/BorderStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CalculatedStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
+#include <LibWeb/CSS/StyleValues/EdgeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridAreaShorthandStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackPlacementShorthandStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h>
@@ -195,7 +196,7 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
         return BackgroundStyleValue::create(
             value_or_default(maybe_background_color, InitialStyleValue::the()),
             value_or_default(maybe_background_image, IdentifierStyleValue::create(CSS::ValueID::None)),
-            value_or_default(maybe_background_position, PositionStyleValue::create(PositionEdge::Left, Length::make_px(0), PositionEdge::Top, Length::make_px(0))),
+            value_or_default(maybe_background_position, PositionStyleValue::create(EdgeStyleValue::create(PositionEdge::Left, Length::make_px(0)), EdgeStyleValue::create(PositionEdge::Top, Length::make_px(0)))),
             value_or_default(maybe_background_size, IdentifierStyleValue::create(CSS::ValueID::Auto)),
             value_or_default(maybe_background_repeat, BackgroundRepeatStyleValue::create(CSS::Repeat::Repeat, CSS::Repeat::Repeat)),
             value_or_default(maybe_background_attachment, IdentifierStyleValue::create(CSS::ValueID::Scroll)),

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -43,6 +43,7 @@
 #include <LibWeb/CSS/StyleValues/NumericStyleValue.h>
 #include <LibWeb/CSS/StyleValues/OverflowStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
+#include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
 #include <LibWeb/CSS/StyleValues/TextDecorationStyleValue.h>
 #include <LibWeb/CSS/StyleValues/UnresolvedStyleValue.h>
@@ -451,6 +452,19 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundAttachment, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundOrigin, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundClip, value, document);
+        return;
+    }
+
+    if (property_id == CSS::PropertyID::BackgroundPosition) {
+        if (value.is_position()) {
+            auto const& position = value.as_position();
+            style.set_property(CSS::PropertyID::BackgroundPositionX, position.edge_x());
+            style.set_property(CSS::PropertyID::BackgroundPositionY, position.edge_y());
+            return;
+        }
+
+        style.set_property(CSS::PropertyID::BackgroundPositionX, value);
+        style.set_property(CSS::PropertyID::BackgroundPositionY, value);
         return;
     }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ConicGradientStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ContentStyleValue.h>
+#include <LibWeb/CSS/StyleValues/EdgeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FilterValueListStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FlexFlowStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FlexStyleValue.h>
@@ -136,6 +137,12 @@ ContentStyleValue const& StyleValue::as_content() const
 {
     VERIFY(is_content());
     return static_cast<ContentStyleValue const&>(*this);
+}
+
+EdgeStyleValue const& StyleValue::as_edge() const
+{
+    VERIFY(is_edge());
+    return static_cast<EdgeStyleValue const&>(*this);
 }
 
 FilterValueListStyleValue const& StyleValue::as_filter_value_list() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -99,6 +99,7 @@ public:
         Color,
         ConicGradient,
         Content,
+        Edge,
         FilterValueList,
         Flex,
         FlexFlow,
@@ -148,6 +149,7 @@ public:
     bool is_color() const { return type() == Type::Color; }
     bool is_conic_gradient() const { return type() == Type::ConicGradient; }
     bool is_content() const { return type() == Type::Content; }
+    bool is_edge() const { return type() == Type::Edge; }
     bool is_filter_value_list() const { return type() == Type::FilterValueList; }
     bool is_flex() const { return type() == Type::Flex; }
     bool is_flex_flow() const { return type() == Type::FlexFlow; }
@@ -195,6 +197,7 @@ public:
     ColorStyleValue const& as_color() const;
     ConicGradientStyleValue const& as_conic_gradient() const;
     ContentStyleValue const& as_content() const;
+    EdgeStyleValue const& as_edge() const;
     FilterValueListStyleValue const& as_filter_value_list() const;
     FlexFlowStyleValue const& as_flex_flow() const;
     FlexStyleValue const& as_flex() const;
@@ -240,6 +243,7 @@ public:
     ColorStyleValue& as_color() { return const_cast<ColorStyleValue&>(const_cast<StyleValue const&>(*this).as_color()); }
     ConicGradientStyleValue& as_conic_gradient() { return const_cast<ConicGradientStyleValue&>(const_cast<StyleValue const&>(*this).as_conic_gradient()); }
     ContentStyleValue& as_content() { return const_cast<ContentStyleValue&>(const_cast<StyleValue const&>(*this).as_content()); }
+    EdgeStyleValue& as_edge() { return const_cast<EdgeStyleValue&>(const_cast<StyleValue const&>(*this).as_edge()); }
     FilterValueListStyleValue& as_filter_value_list() { return const_cast<FilterValueListStyleValue&>(const_cast<StyleValue const&>(*this).as_filter_value_list()); }
     FlexFlowStyleValue& as_flex_flow() { return const_cast<FlexFlowStyleValue&>(const_cast<StyleValue const&>(*this).as_flex_flow()); }
     FlexStyleValue& as_flex() { return const_cast<FlexStyleValue&>(const_cast<StyleValue const&>(*this).as_flex()); }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "EdgeStyleValue.h"
+
+namespace Web::CSS {
+
+ErrorOr<String> EdgeStyleValue::to_string() const
+{
+    auto to_string = [](PositionEdge edge) {
+        switch (edge) {
+        case PositionEdge::Left:
+            return "left";
+        case PositionEdge::Right:
+            return "right";
+        case PositionEdge::Top:
+            return "top";
+        case PositionEdge::Bottom:
+            return "bottom";
+        }
+        VERIFY_NOT_REACHED();
+    };
+
+    return String::formatted("{} {}", to_string(m_properties.edge), TRY(m_properties.offset.to_string()));
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/Enums.h>
+#include <LibWeb/CSS/PercentageOr.h>
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+class EdgeStyleValue final : public StyleValueWithDefaultOperators<EdgeStyleValue> {
+public:
+    static ValueComparingNonnullRefPtr<EdgeStyleValue> create(PositionEdge edge, LengthPercentage const& offset)
+    {
+        return adopt_ref(*new EdgeStyleValue(edge, offset));
+    }
+    virtual ~EdgeStyleValue() override = default;
+
+    PositionEdge edge() const { return m_properties.edge; }
+    LengthPercentage const& offset() const { return m_properties.offset; }
+
+    virtual ErrorOr<String> to_string() const override;
+
+    bool properties_equal(EdgeStyleValue const& other) const { return m_properties == other.m_properties; }
+
+private:
+    EdgeStyleValue(PositionEdge edge, LengthPercentage const& offset)
+        : StyleValueWithDefaultOperators(Type::Edge)
+        , m_properties { .edge = edge, .offset = offset }
+    {
+    }
+
+    struct Properties {
+        PositionEdge edge;
+        LengthPercentage offset;
+        bool operator==(Properties const&) const = default;
+    } m_properties;
+};
+
+}

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/PositionStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/PositionStyleValue.cpp
@@ -13,21 +13,7 @@ namespace Web::CSS {
 
 ErrorOr<String> PositionStyleValue::to_string() const
 {
-    auto to_string = [](PositionEdge edge) {
-        switch (edge) {
-        case PositionEdge::Left:
-            return "left";
-        case PositionEdge::Right:
-            return "right";
-        case PositionEdge::Top:
-            return "top";
-        case PositionEdge::Bottom:
-            return "bottom";
-        }
-        VERIFY_NOT_REACHED();
-    };
-
-    return String::formatted("{} {} {} {}", to_string(m_properties.edge_x), TRY(m_properties.offset_x.to_string()), to_string(m_properties.edge_y), TRY(m_properties.offset_y.to_string()));
+    return String::formatted("{} {}", TRY(m_properties.edge_x->to_string()), TRY(m_properties.edge_y->to_string()));
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/PositionStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/PositionStyleValue.h
@@ -17,33 +17,29 @@ namespace Web::CSS {
 
 class PositionStyleValue final : public StyleValueWithDefaultOperators<PositionStyleValue> {
 public:
-    static ValueComparingNonnullRefPtr<PositionStyleValue> create(PositionEdge edge_x, LengthPercentage const& offset_x, PositionEdge edge_y, LengthPercentage const& offset_y)
+    static ValueComparingNonnullRefPtr<PositionStyleValue> create(ValueComparingNonnullRefPtr<StyleValue> egde_x, ValueComparingNonnullRefPtr<StyleValue> edge_y)
     {
-        return adopt_ref(*new PositionStyleValue(edge_x, offset_x, edge_y, offset_y));
+        return adopt_ref(*new PositionStyleValue(move(egde_x), move(edge_y)));
     }
     virtual ~PositionStyleValue() override = default;
 
-    PositionEdge edge_x() const { return m_properties.edge_x; }
-    LengthPercentage const& offset_x() const { return m_properties.offset_x; }
-    PositionEdge edge_y() const { return m_properties.edge_y; }
-    LengthPercentage const& offset_y() const { return m_properties.offset_y; }
+    ValueComparingNonnullRefPtr<StyleValue> edge_x() const { return m_properties.edge_x; }
+    ValueComparingNonnullRefPtr<StyleValue> edge_y() const { return m_properties.edge_y; }
 
     virtual ErrorOr<String> to_string() const override;
 
     bool properties_equal(PositionStyleValue const& other) const { return m_properties == other.m_properties; }
 
 private:
-    PositionStyleValue(PositionEdge edge_x, LengthPercentage const& offset_x, PositionEdge edge_y, LengthPercentage const& offset_y)
+    PositionStyleValue(ValueComparingNonnullRefPtr<StyleValue> edge_x, ValueComparingNonnullRefPtr<StyleValue> edge_y)
         : StyleValueWithDefaultOperators(Type::Position)
-        , m_properties { .edge_x = edge_x, .offset_x = offset_x, .edge_y = edge_y, .offset_y = offset_y }
+        , m_properties { .edge_x = edge_x, .edge_y = edge_y }
     {
     }
 
     struct Properties {
-        PositionEdge edge_x;
-        LengthPercentage offset_x;
-        PositionEdge edge_y;
-        LengthPercentage offset_y;
+        ValueComparingNonnullRefPtr<StyleValue> edge_x;
+        ValueComparingNonnullRefPtr<StyleValue> edge_y;
         bool operator==(Properties const&) const = default;
     } m_properties;
 };

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -53,6 +53,7 @@ class CSSStyleRule;
 class CSSStyleSheet;
 class CSSSupportsRule;
 class Display;
+class EdgeStyleValue;
 class ElementInlineCSSStyleDeclaration;
 class ExplicitGridTrack;
 class FilterValueListStyleValue;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -9,7 +9,7 @@
 #include <LibWeb/CSS/StyleValues/BackgroundRepeatStyleValue.h>
 #include <LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h>
-#include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
+#include <LibWeb/CSS/StyleValues/EdgeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Dump.h>
@@ -293,7 +293,8 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
         auto clips = computed_style.property(CSS::PropertyID::BackgroundClip);
         auto images = computed_style.property(CSS::PropertyID::BackgroundImage);
         auto origins = computed_style.property(CSS::PropertyID::BackgroundOrigin);
-        auto positions = computed_style.property(CSS::PropertyID::BackgroundPosition);
+        auto x_positions = computed_style.property(CSS::PropertyID::BackgroundPositionX);
+        auto y_positions = computed_style.property(CSS::PropertyID::BackgroundPositionY);
         auto repeats = computed_style.property(CSS::PropertyID::BackgroundRepeat);
         auto sizes = computed_style.property(CSS::PropertyID::BackgroundSize);
 
@@ -315,7 +316,8 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
         layer_count = max(layer_count, count_layers(clips));
         layer_count = max(layer_count, count_layers(images));
         layer_count = max(layer_count, count_layers(origins));
-        layer_count = max(layer_count, count_layers(positions));
+        layer_count = max(layer_count, count_layers(x_positions));
+        layer_count = max(layer_count, count_layers(y_positions));
         layer_count = max(layer_count, count_layers(repeats));
         layer_count = max(layer_count, count_layers(sizes));
 
@@ -369,13 +371,17 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
                 layer.clip = as_box(clip_value->to_identifier());
             }
 
-            if (auto position_value = value_for_layer(positions, layer_index); position_value && position_value->is_position()) {
-                auto& position = position_value->as_position();
-                layer.position_edge_x = position.edge_x();
-                layer.position_edge_y = position.edge_y();
-                layer.position_offset_x = position.offset_x();
-                layer.position_offset_y = position.offset_y();
+            if (auto position_value = value_for_layer(x_positions, layer_index); position_value && position_value->is_edge()) {
+                auto& position = position_value->as_edge();
+                layer.position_edge_x = position.edge();
+                layer.position_offset_x = position.offset();
             }
+
+            if (auto position_value = value_for_layer(y_positions, layer_index); position_value && position_value->is_edge()) {
+                auto& position = position_value->as_edge();
+                layer.position_edge_y = position.edge();
+                layer.position_offset_y = position.offset();
+            };
 
             if (auto size_value = value_for_layer(sizes, layer_index); size_value) {
                 if (size_value->is_background_size()) {


### PR DESCRIPTION
This is technically from CSS Backgrounds and Borders Module Level 4, which has this neat looking banner at the bottom: 
![New Project (1)](https://user-images.githubusercontent.com/11597044/229381435-2fdb2802-b29e-4e61-85a3-6f908e4848f4.png)

However, these properties are in use on real websites and are needed to fix the left button on https://store.steampowered.com/:

| Before                                                                                                          | After                                                                                                           |
|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![image](https://user-images.githubusercontent.com/11597044/229381669-3e258ac8-6c56-47b9-b269-d18e06d91b1d.png) | ![image](https://user-images.githubusercontent.com/11597044/229381681-9681d8da-c892-4206-8736-9a14f848bb01.png) |
| (Left button faces wrong direction)                                                                             |                                                                                                                 |