### PR TITLE
Tests: Add benchmarks for JPEGLoader

### DIFF
--- a/Tests/LibGfx/BenchmarkJPEGLoader.cpp
+++ b/Tests/LibGfx/BenchmarkJPEGLoader.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, Lucas Chollet <lucas.chollet@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/File.h>
+#include <LibGfx/ImageFormats/JPEGLoader.h>
+#include <LibTest/TestCase.h>
+
+#ifdef AK_OS_SERENITY
+#    define TEST_INPUT(x) ("/usr/Tests/LibGfx/test-inputs/" x)
+#else
+#    define TEST_INPUT(x) ("test-inputs/" x)
+#endif
+
+// FIXME: Enable formatting when the patch will be mainstream
+//        https://github.com/llvm/llvm-project/commit/fd86789962964a98157e8159c3d95cdc241942e3
+// clang-format off
+auto small_image = Core::File::open(TEST_INPUT("rgb24.jpg"sv), Core::File::OpenMode::Read).release_value()->read_until_eof().release_value();
+auto big_image = Core::File::open(TEST_INPUT("big_image.jpg"sv), Core::File::OpenMode::Read).release_value()->read_until_eof().release_value();
+auto rgb_image = Core::File::open(TEST_INPUT("rgb_components.jpg"sv), Core::File::OpenMode::Read).release_value()->read_until_eof().release_value();
+auto several_scans = Core::File::open(TEST_INPUT("several_scans.jpg"sv), Core::File::OpenMode::Read).release_value()->read_until_eof().release_value();
+// clang-format on
+
+BENCHMARK_CASE(small_image)
+{
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(small_image));
+    MUST(plugin_decoder->frame(0));
+}
+
+BENCHMARK_CASE(big_image)
+{
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(big_image));
+    MUST(plugin_decoder->frame(0));
+}
+
+BENCHMARK_CASE(rgb_image)
+{
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(rgb_image));
+    MUST(plugin_decoder->frame(0));
+}
+
+BENCHMARK_CASE(several_scans)
+{
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(several_scans));
+    MUST(plugin_decoder->frame(0));
+}

--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     BenchmarkGfxPainter.cpp
+    BenchmarkJPEGLoader.cpp
     TestFontHandling.cpp
     TestICCProfile.cpp
     TestImageDecoder.cpp

--- a/Userland/Libraries/LibTest/TestSuite.cpp
+++ b/Userland/Libraries/LibTest/TestSuite.cpp
@@ -174,7 +174,9 @@ int TestSuite::run(Vector<NonnullRefPtr<TestCase>> const& tests)
         m_testtime,
         m_benchtime,
         global_timer.elapsed_milliseconds() - (m_testtime + m_benchtime));
-    dbgln("Out of {} tests, {} passed and {} failed.", test_count, test_count - test_failed_count, test_failed_count);
+
+    if (test_count != 0)
+        dbgln("Out of {} tests, {} passed and {} failed.", test_count, test_count - test_failed_count, test_failed_count);
 
     return (int)test_failed_count;
 }


### PR DESCRIPTION
Yes, the image is 5Mo, but IMO it's important to test the decoder on big images. I will obviously remove it if it's a big no no.