### PR TITLE
LibGfx: Add some support for decoding lossless webp files

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -330,6 +330,22 @@ TEST_CASE(test_webp_extended_lossless)
     EXPECT(!plugin_decoder->loop_count());
 
     EXPECT_EQ(plugin_decoder->size(), Gfx::IntSize(417, 223));
+
+    auto frame = MUST(plugin_decoder->frame(0));
+    EXPECT_EQ(frame.image->size(), Gfx::IntSize(417, 223));
+
+    // Check some basic pixels.
+    EXPECT_EQ(frame.image->get_pixel(0, 0), Gfx::Color(0, 0, 0, 0));
+    EXPECT_EQ(frame.image->get_pixel(43, 75), Gfx::Color(255, 0, 0, 255));
+    EXPECT_EQ(frame.image->get_pixel(141, 75), Gfx::Color(0, 255, 0, 255));
+    EXPECT_EQ(frame.image->get_pixel(235, 75), Gfx::Color(0, 0, 255, 255));
+    EXPECT_EQ(frame.image->get_pixel(341, 75), Gfx::Color(0, 0, 0, 128));
+
+    // Check pixels using the color cache.
+    EXPECT_EQ(frame.image->get_pixel(94, 73), Gfx::Color(255, 0, 0, 255));
+    EXPECT_EQ(frame.image->get_pixel(176, 115), Gfx::Color(0, 255, 0, 255));
+    EXPECT_EQ(frame.image->get_pixel(290, 89), Gfx::Color(0, 0, 255, 255));
+    EXPECT_EQ(frame.image->get_pixel(359, 73), Gfx::Color(0, 0, 0, 128));
 }
 
 TEST_CASE(test_webp_extended_lossless_animated)

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -430,7 +430,6 @@ ErrorOr<void> DeflateDecompressor::decode_codes(CanonicalCode& literal_code, Opt
     auto const code_length_code = TRY(CanonicalCode::from_bytes({ code_lengths_code_lengths, sizeof(code_lengths_code_lengths) }));
 
     // Next we extract the code lengths of the code that was used to encode the block.
-
     Vector<u8, 286> code_lengths;
     while (code_lengths.size() < literal_code_count + distance_code_count) {
         auto symbol = TRY(code_length_code.read_symbol(*m_input_stream));

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -135,6 +135,9 @@ public:
     [[nodiscard]] ARGB32* scanline(int physical_y);
     [[nodiscard]] ARGB32 const* scanline(int physical_y) const;
 
+    [[nodiscard]] ARGB32* begin();
+    [[nodiscard]] ARGB32* end();
+
     [[nodiscard]] IntRect rect() const { return { {}, m_size }; }
     [[nodiscard]] IntSize size() const { return m_size; }
     [[nodiscard]] int width() const { return m_size.width(); }
@@ -291,6 +294,16 @@ ALWAYS_INLINE ARGB32* Bitmap::scanline(int y)
 ALWAYS_INLINE ARGB32 const* Bitmap::scanline(int y) const
 {
     return reinterpret_cast<ARGB32 const*>(scanline_u8(y));
+}
+
+ALWAYS_INLINE ARGB32* Bitmap::begin()
+{
+    return scanline(0);
+}
+
+ALWAYS_INLINE ARGB32* Bitmap::end()
+{
+    return reinterpret_cast<ARGB32*>(reinterpret_cast<u8*>(m_data) + (m_size.height() * m_pitch));
 }
 
 template<>


### PR DESCRIPTION
Missing:
* Transform support (used by virtually all lossless webp files)
* Meta prefix / entropy image support

Working:
* Decoding of regular image streams
* Color cache

This happens to be enough to be able to decode
Tests/LibGfx/test-inputs/extended-lossless.webp

The canonical prefix code is very similar to deflate's, enough so that
this can use Compress::CanonicalCode (and take advantage of all the
recent performance improvements there).