### PR TITLE
Kernel: Mark address-space related syscalls as not needing the big lock

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -128,7 +128,7 @@ enum class NeedsBigProcessLock {
     S(mmap, NeedsBigProcessLock::No)                       \
     S(mount, NeedsBigProcessLock::Yes)                     \
     S(mprotect, NeedsBigProcessLock::No)                   \
-    S(mremap, NeedsBigProcessLock::Yes)                    \
+    S(mremap, NeedsBigProcessLock::No)                     \
     S(msync, NeedsBigProcessLock::Yes)                     \
     S(munmap, NeedsBigProcessLock::No)                     \
     S(open, NeedsBigProcessLock::No)                       \

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -121,7 +121,7 @@ enum class NeedsBigProcessLock {
     S(link, NeedsBigProcessLock::No)                       \
     S(listen, NeedsBigProcessLock::No)                     \
     S(lseek, NeedsBigProcessLock::No)                      \
-    S(madvise, NeedsBigProcessLock::Yes)                   \
+    S(madvise, NeedsBigProcessLock::No)                    \
     S(map_time_page, NeedsBigProcessLock::Yes)             \
     S(mkdir, NeedsBigProcessLock::No)                      \
     S(mknod, NeedsBigProcessLock::No)                      \

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -125,7 +125,7 @@ enum class NeedsBigProcessLock {
     S(map_time_page, NeedsBigProcessLock::No)              \
     S(mkdir, NeedsBigProcessLock::No)                      \
     S(mknod, NeedsBigProcessLock::No)                      \
-    S(mmap, NeedsBigProcessLock::Yes)                      \
+    S(mmap, NeedsBigProcessLock::No)                       \
     S(mount, NeedsBigProcessLock::Yes)                     \
     S(mprotect, NeedsBigProcessLock::Yes)                  \
     S(mremap, NeedsBigProcessLock::Yes)                    \

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -127,7 +127,7 @@ enum class NeedsBigProcessLock {
     S(mknod, NeedsBigProcessLock::No)                      \
     S(mmap, NeedsBigProcessLock::No)                       \
     S(mount, NeedsBigProcessLock::Yes)                     \
-    S(mprotect, NeedsBigProcessLock::Yes)                  \
+    S(mprotect, NeedsBigProcessLock::No)                   \
     S(mremap, NeedsBigProcessLock::Yes)                    \
     S(msync, NeedsBigProcessLock::Yes)                     \
     S(munmap, NeedsBigProcessLock::Yes)                    \

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -122,7 +122,7 @@ enum class NeedsBigProcessLock {
     S(listen, NeedsBigProcessLock::No)                     \
     S(lseek, NeedsBigProcessLock::No)                      \
     S(madvise, NeedsBigProcessLock::No)                    \
-    S(map_time_page, NeedsBigProcessLock::Yes)             \
+    S(map_time_page, NeedsBigProcessLock::No)              \
     S(mkdir, NeedsBigProcessLock::No)                      \
     S(mknod, NeedsBigProcessLock::No)                      \
     S(mmap, NeedsBigProcessLock::Yes)                      \

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -157,7 +157,7 @@ enum class NeedsBigProcessLock {
     S(scheduler_set_parameters, NeedsBigProcessLock::No)   \
     S(sendfd, NeedsBigProcessLock::No)                     \
     S(sendmsg, NeedsBigProcessLock::Yes)                   \
-    S(set_mmap_name, NeedsBigProcessLock::Yes)             \
+    S(set_mmap_name, NeedsBigProcessLock::No)              \
     S(set_thread_name, NeedsBigProcessLock::No)            \
     S(setegid, NeedsBigProcessLock::No)                    \
     S(seteuid, NeedsBigProcessLock::No)                    \

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -129,7 +129,7 @@ enum class NeedsBigProcessLock {
     S(mount, NeedsBigProcessLock::Yes)                     \
     S(mprotect, NeedsBigProcessLock::No)                   \
     S(mremap, NeedsBigProcessLock::No)                     \
-    S(msync, NeedsBigProcessLock::Yes)                     \
+    S(msync, NeedsBigProcessLock::No)                      \
     S(munmap, NeedsBigProcessLock::No)                     \
     S(open, NeedsBigProcessLock::No)                       \
     S(perf_event, NeedsBigProcessLock::Yes)                \

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -130,7 +130,7 @@ enum class NeedsBigProcessLock {
     S(mprotect, NeedsBigProcessLock::No)                   \
     S(mremap, NeedsBigProcessLock::Yes)                    \
     S(msync, NeedsBigProcessLock::Yes)                     \
-    S(munmap, NeedsBigProcessLock::Yes)                    \
+    S(munmap, NeedsBigProcessLock::No)                     \
     S(open, NeedsBigProcessLock::No)                       \
     S(perf_event, NeedsBigProcessLock::Yes)                \
     S(perf_register_string, NeedsBigProcessLock::Yes)      \

--- a/Kernel/Arch/aarch64/PageDirectory.cpp
+++ b/Kernel/Arch/aarch64/PageDirectory.cpp
@@ -62,9 +62,11 @@ UNMAP_AFTER_INIT NonnullLockRefPtr<PageDirectory> PageDirectory::must_create_ker
     return adopt_lock_ref_if_nonnull(new (nothrow) PageDirectory).release_nonnull();
 }
 
-ErrorOr<NonnullLockRefPtr<PageDirectory>> PageDirectory::try_create_for_userspace()
+ErrorOr<NonnullLockRefPtr<PageDirectory>> PageDirectory::try_create_for_userspace(Process& process)
 {
     auto directory = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) PageDirectory));
+
+    directory->m_process = &process;
 
     directory->m_root_table = TRY(MM.allocate_physical_page());
 

--- a/Kernel/Arch/aarch64/PageDirectory.h
+++ b/Kernel/Arch/aarch64/PageDirectory.h
@@ -179,7 +179,7 @@ class PageDirectory final : public AtomicRefCounted<PageDirectory> {
     friend class MemoryManager;
 
 public:
-    static ErrorOr<NonnullLockRefPtr<PageDirectory>> try_create_for_userspace();
+    static ErrorOr<NonnullLockRefPtr<PageDirectory>> try_create_for_userspace(Process&);
     static NonnullLockRefPtr<PageDirectory> must_create_kernel_page_directory();
     static LockRefPtr<PageDirectory> find_current();
 
@@ -197,10 +197,7 @@ public:
         return m_root_table;
     }
 
-    AddressSpace* address_space() { return m_space; }
-    AddressSpace const* address_space() const { return m_space; }
-
-    void set_space(Badge<AddressSpace>, AddressSpace& space) { m_space = &space; }
+    Process* process() { return m_process; }
 
     RecursiveSpinlock<LockRank::None>& get_lock() { return m_lock; }
 
@@ -212,7 +209,7 @@ private:
     static void register_page_directory(PageDirectory* directory);
     static void deregister_page_directory(PageDirectory* directory);
 
-    AddressSpace* m_space { nullptr };
+    Process* m_process { nullptr };
     RefPtr<PhysicalPage> m_root_table;
     RefPtr<PhysicalPage> m_directory_table;
     RefPtr<PhysicalPage> m_directory_pages[512];

--- a/Kernel/Arch/x86_64/PageDirectory.cpp
+++ b/Kernel/Arch/x86_64/PageDirectory.cpp
@@ -61,9 +61,11 @@ UNMAP_AFTER_INIT NonnullLockRefPtr<PageDirectory> PageDirectory::must_create_ker
     return adopt_lock_ref_if_nonnull(new (nothrow) PageDirectory).release_nonnull();
 }
 
-ErrorOr<NonnullLockRefPtr<PageDirectory>> PageDirectory::try_create_for_userspace()
+ErrorOr<NonnullLockRefPtr<PageDirectory>> PageDirectory::try_create_for_userspace(Process& process)
 {
     auto directory = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) PageDirectory));
+
+    directory->m_process = &process;
 
     directory->m_pml4t = TRY(MM.allocate_physical_page());
 

--- a/Kernel/Arch/x86_64/PageDirectory.h
+++ b/Kernel/Arch/x86_64/PageDirectory.h
@@ -162,7 +162,7 @@ class PageDirectory final : public AtomicRefCounted<PageDirectory> {
     friend class MemoryManager;
 
 public:
-    static ErrorOr<NonnullLockRefPtr<PageDirectory>> try_create_for_userspace();
+    static ErrorOr<NonnullLockRefPtr<PageDirectory>> try_create_for_userspace(Process& process);
     static NonnullLockRefPtr<PageDirectory> must_create_kernel_page_directory();
     static LockRefPtr<PageDirectory> find_current();
 
@@ -180,10 +180,7 @@ public:
         return m_pml4t;
     }
 
-    AddressSpace* address_space() { return m_space; }
-    AddressSpace const* address_space() const { return m_space; }
-
-    void set_space(Badge<AddressSpace>, AddressSpace& space) { m_space = &space; }
+    Process* process() { return m_process; }
 
     RecursiveSpinlock<LockRank::None>& get_lock() { return m_lock; }
 
@@ -195,7 +192,7 @@ private:
     static void register_page_directory(PageDirectory* directory);
     static void deregister_page_directory(PageDirectory* directory);
 
-    AddressSpace* m_space { nullptr };
+    Process* m_process { nullptr };
     RefPtr<PhysicalPage> m_pml4t;
     RefPtr<PhysicalPage> m_directory_table;
     RefPtr<PhysicalPage> m_directory_pages[512];

--- a/Kernel/Memory/AddressSpace.cpp
+++ b/Kernel/Memory/AddressSpace.cpp
@@ -19,9 +19,9 @@
 
 namespace Kernel::Memory {
 
-ErrorOr<NonnullOwnPtr<AddressSpace>> AddressSpace::try_create(AddressSpace const* parent)
+ErrorOr<NonnullOwnPtr<AddressSpace>> AddressSpace::try_create(Process& process, AddressSpace const* parent)
 {
-    auto page_directory = TRY(PageDirectory::try_create_for_userspace());
+    auto page_directory = TRY(PageDirectory::try_create_for_userspace(process));
 
     VirtualRange total_range = [&]() -> VirtualRange {
         if (parent)
@@ -33,9 +33,7 @@ ErrorOr<NonnullOwnPtr<AddressSpace>> AddressSpace::try_create(AddressSpace const
         return VirtualRange(VirtualAddress { base }, userspace_range_ceiling - base);
     }();
 
-    auto space = TRY(adopt_nonnull_own_or_enomem(new (nothrow) AddressSpace(move(page_directory), total_range)));
-    space->page_directory().set_space({}, *space);
-    return space;
+    return adopt_nonnull_own_or_enomem(new (nothrow) AddressSpace(move(page_directory), total_range));
 }
 
 AddressSpace::AddressSpace(NonnullLockRefPtr<PageDirectory> page_directory, VirtualRange total_range)

--- a/Kernel/Memory/AddressSpace.h
+++ b/Kernel/Memory/AddressSpace.h
@@ -21,7 +21,7 @@ namespace Kernel::Memory {
 
 class AddressSpace {
 public:
-    static ErrorOr<NonnullOwnPtr<AddressSpace>> try_create(AddressSpace const* parent);
+    static ErrorOr<NonnullOwnPtr<AddressSpace>> try_create(Process&, AddressSpace const* parent);
     ~AddressSpace();
 
     PageDirectory& page_directory() { return *m_page_directory; }

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -658,16 +658,6 @@ UNMAP_AFTER_INIT void MemoryManager::initialize(u32 cpu)
     }
 }
 
-Region* MemoryManager::kernel_region_from_vaddr(VirtualAddress address)
-{
-    if (is_user_address(address))
-        return nullptr;
-
-    return MM.m_global_data.with([&](auto& global_data) {
-        return global_data.region_tree.find_region_containing(address);
-    });
-}
-
 Region* MemoryManager::find_user_region_from_vaddr(AddressSpace& space, VirtualAddress vaddr)
 {
     return space.find_region_containing({ vaddr, 1 });
@@ -715,20 +705,6 @@ void MemoryManager::validate_syscall_preconditions(Process& process, RegisterSta
     }
 }
 
-Region* MemoryManager::find_region_from_vaddr(VirtualAddress vaddr)
-{
-    if (auto* region = kernel_region_from_vaddr(vaddr))
-        return region;
-    auto page_directory = PageDirectory::find_current();
-    if (!page_directory)
-        return nullptr;
-    auto* process = page_directory->process();
-    VERIFY(process);
-    return process->address_space().with([&](auto& space) {
-        return find_user_region_from_vaddr(*space, vaddr);
-    });
-}
-
 PageFaultResponse MemoryManager::handle_page_fault(PageFault const& fault)
 {
     auto faulted_in_range = [&fault](auto const* start, auto const* end) {
@@ -753,11 +729,44 @@ PageFaultResponse MemoryManager::handle_page_fault(PageFault const& fault)
         return PageFaultResponse::ShouldCrash;
     }
     dbgln_if(PAGE_FAULT_DEBUG, "MM: CPU[{}] handle_page_fault({:#04x}) at {}", Processor::current_id(), fault.code(), fault.vaddr());
-    auto* region = find_region_from_vaddr(fault.vaddr());
-    if (!region) {
-        return PageFaultResponse::ShouldCrash;
+
+    // The faulting region may be unmapped concurrently to handling this page fault, and since
+    // regions are singly-owned it would usually result in the region being immediately
+    // de-allocated. To ensure the region is not de-allocated while we're still handling the
+    // fault we increase a page fault counter on the region, and the region will refrain from
+    // de-allocating itself until the counter reaches zero. (Since unmapping the region also
+    // includes removing it from the region tree while holding the address space spinlock, and
+    // because we increment the counter while still holding the spinlock it is guaranteed that
+    // we always increment the counter before it gets a chance to be deleted)
+    Region* region = nullptr;
+    if (is_user_address(fault.vaddr())) {
+        auto page_directory = PageDirectory::find_current();
+        if (!page_directory)
+            return PageFaultResponse::ShouldCrash;
+        auto* process = page_directory->process();
+        VERIFY(process);
+        region = process->address_space().with([&](auto& space) -> Region* {
+            auto* region = find_user_region_from_vaddr(*space, fault.vaddr());
+            if (!region)
+                return nullptr;
+            region->start_handling_page_fault({});
+            return region;
+        });
+    } else {
+        region = MM.m_global_data.with([&](auto& global_data) -> Region* {
+            auto* region = global_data.region_tree.find_region_containing(fault.vaddr());
+            if (!region)
+                return nullptr;
+            region->start_handling_page_fault({});
+            return region;
+        });
     }
-    return region->handle_fault(fault);
+    if (!region)
+        return PageFaultResponse::ShouldCrash;
+
+    auto response = region->handle_fault(fault);
+    region->finish_handling_page_fault({});
+    return response;
 }
 
 ErrorOr<NonnullOwnPtr<Region>> MemoryManager::allocate_contiguous_kernel_region(size_t size, StringView name, Region::Access access, Region::Cacheable cacheable)

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -722,8 +722,11 @@ Region* MemoryManager::find_region_from_vaddr(VirtualAddress vaddr)
     auto page_directory = PageDirectory::find_current();
     if (!page_directory)
         return nullptr;
-    VERIFY(page_directory->address_space());
-    return find_user_region_from_vaddr(*page_directory->address_space(), vaddr);
+    auto* process = page_directory->process();
+    VERIFY(process);
+    return process->address_space().with([&](auto& space) {
+        return find_user_region_from_vaddr(*space, vaddr);
+    });
 }
 
 PageFaultResponse MemoryManager::handle_page_fault(PageFault const& fault)

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -249,10 +249,6 @@ private:
     static void flush_tlb_local(VirtualAddress, size_t page_count = 1);
     static void flush_tlb(PageDirectory const*, VirtualAddress, size_t page_count = 1);
 
-    static Region* kernel_region_from_vaddr(VirtualAddress);
-
-    static Region* find_region_from_vaddr(VirtualAddress);
-
     RefPtr<PhysicalPage> find_free_physical_page(bool);
 
     ALWAYS_INLINE u8* quickmap_page(PhysicalPage& page)

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -207,6 +207,9 @@ public:
     [[nodiscard]] bool mmapped_from_readable() const { return m_mmapped_from_readable; }
     [[nodiscard]] bool mmapped_from_writable() const { return m_mmapped_from_writable; }
 
+    void start_handling_page_fault(Badge<MemoryManager>) { m_in_progress_page_faults++; };
+    void finish_handling_page_fault(Badge<MemoryManager>) { m_in_progress_page_faults--; };
+
 private:
     Region();
     Region(NonnullLockRefPtr<VMObject>, size_t offset_in_vmobject, OwnPtr<KString>, Region::Access access, Cacheable, bool shared);
@@ -234,6 +237,7 @@ private:
     size_t m_offset_in_vmobject { 0 };
     LockRefPtr<VMObject> m_vmobject;
     OwnPtr<KString> m_name;
+    Atomic<u32> m_in_progress_page_faults;
     u8 m_access { Region::None };
     bool m_shared : 1 { false };
     bool m_cacheable : 1 { false };

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -485,7 +485,7 @@ public:
 
     ErrorOr<void> exec(NonnullOwnPtr<KString> path, Vector<NonnullOwnPtr<KString>> arguments, Vector<NonnullOwnPtr<KString>> environment, Thread*& new_main_thread, InterruptsState& previous_interrupts_state, int recursion_depth = 0);
 
-    ErrorOr<LoadResult> load(NonnullRefPtr<OpenFileDescription> main_program_description, RefPtr<OpenFileDescription> interpreter_description, const ElfW(Ehdr) & main_program_header);
+    ErrorOr<LoadResult> load(Memory::AddressSpace& new_space, NonnullRefPtr<OpenFileDescription> main_program_description, RefPtr<OpenFileDescription> interpreter_description, const ElfW(Ehdr) & main_program_header);
 
     void terminate_due_to_signal(u8 signal);
     ErrorOr<void> send_signal(u8 signal, Process* sender);

--- a/Kernel/Syscalls/clock.cpp
+++ b/Kernel/Syscalls/clock.cpp
@@ -12,7 +12,7 @@ namespace Kernel {
 
 ErrorOr<FlatPtr> Process::sys$map_time_page()
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
     TRY(require_promise(Pledge::stdio));
 
     auto& vmobject = TimeManagement::the().time_page_vmobject();

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -488,7 +488,7 @@ ErrorOr<void> Process::do_exec(NonnullRefPtr<OpenFileDescription> main_program_d
     auto new_process_name = TRY(KString::try_create(last_part));
     auto new_main_thread_name = TRY(new_process_name->try_clone());
 
-    auto allocated_space = TRY(Memory::AddressSpace::try_create(nullptr));
+    auto allocated_space = TRY(Memory::AddressSpace::try_create(*this, nullptr));
     OwnPtr<Memory::AddressSpace> old_space;
     auto& new_space = m_space.with([&](auto& space) -> Memory::AddressSpace& {
         old_space = move(space);

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -470,7 +470,7 @@ ErrorOr<FlatPtr> Process::sys$set_mmap_name(Userspace<Syscall::SC_set_mmap_name_
 
 ErrorOr<FlatPtr> Process::sys$munmap(Userspace<void*> addr, size_t size)
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
     TRY(require_promise(Pledge::stdio));
     TRY(address_space().with([&](auto& space) {
         return space->unmap_mmap_range(addr.vaddr(), size);

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -480,7 +480,7 @@ ErrorOr<FlatPtr> Process::sys$munmap(Userspace<void*> addr, size_t size)
 
 ErrorOr<FlatPtr> Process::sys$mremap(Userspace<Syscall::SC_mremap_params const*> user_params)
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
     TRY(require_promise(Pledge::stdio));
     auto params = TRY(copy_typed_from_user(user_params));
 

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -268,7 +268,7 @@ ErrorOr<FlatPtr> Process::sys$mmap(Userspace<Syscall::SC_mmap_params const*> use
 
 ErrorOr<FlatPtr> Process::sys$mprotect(Userspace<void*> addr, size_t size, int prot)
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
     TRY(require_promise(Pledge::stdio));
 
     if (prot & PROT_EXEC) {

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -606,6 +606,7 @@ ErrorOr<FlatPtr> Process::sys$annotate_mapping(Userspace<void*> address, int fla
 
 ErrorOr<FlatPtr> Process::sys$msync(Userspace<void*> address, size_t size, int flags)
 {
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
     if ((flags & (MS_SYNC | MS_ASYNC | MS_INVALIDATE)) != flags)
         return EINVAL;
 

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -125,7 +125,7 @@ ErrorOr<void> Process::validate_inode_mmap_prot(int prot, bool readable_descript
 
 ErrorOr<FlatPtr> Process::sys$mmap(Userspace<Syscall::SC_mmap_params const*> user_params)
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
     TRY(require_promise(Pledge::stdio));
     auto params = TRY(copy_typed_from_user(user_params));
 

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -110,7 +110,6 @@ ErrorOr<void> Process::validate_mmap_prot(int prot, bool map_stack, bool map_ano
 
 ErrorOr<void> Process::validate_inode_mmap_prot(int prot, bool readable_description, bool description_writable, bool map_shared) const
 {
-    auto credentials = this->credentials();
     if ((prot & PROT_READ) && !readable_description)
         return EACCES;
 

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -441,7 +441,7 @@ ErrorOr<FlatPtr> Process::sys$madvise(Userspace<void*> address, size_t size, int
 
 ErrorOr<FlatPtr> Process::sys$set_mmap_name(Userspace<Syscall::SC_set_mmap_name_params const*> user_params)
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
     TRY(require_promise(Pledge::stdio));
     auto params = TRY(copy_typed_from_user(user_params));
 

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -407,7 +407,7 @@ ErrorOr<FlatPtr> Process::sys$mprotect(Userspace<void*> addr, size_t size, int p
 
 ErrorOr<FlatPtr> Process::sys$madvise(Userspace<void*> address, size_t size, int advice)
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
     TRY(require_promise(Pledge::stdio));
 
     auto range_to_madvise = TRY(Memory::expand_range_to_page_boundaries(address.ptr(), size));


### PR DESCRIPTION
All of these are already serialized using the process address space spinlock.