### PR TITLE
LibWeb: A couple of error handling improvements

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1668,7 +1668,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_load
             if (status_code.value_or(0) == 0) {
                 response = Infrastructure::Response::network_error(vm, TRY_OR_IGNORE("HTTP request failed"_string));
             } else {
-                response->set_status(status_code.value_or(200));
+                response->set_type(Infrastructure::Response::Type::Error);
+                response->set_status(status_code.value_or(400));
                 // FIXME: Set response status message and body
             }
             pending_response->resolve(response);

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -244,8 +244,10 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, Has
 
             if (file_or_error.is_error()) {
                 log_failure(request, file_or_error.error());
-                if (error_callback)
-                    error_callback(DeprecatedString::formatted("{}", file_or_error.error()), file_or_error.error().code());
+                if (error_callback) {
+                    auto status = file_or_error.error().code() == ENOENT ? 404u : 500u;
+                    error_callback(DeprecatedString::formatted("{}", file_or_error.error()), status);
+                }
                 return;
             }
 
@@ -255,7 +257,7 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, Has
             if (maybe_file.is_error()) {
                 log_failure(request, maybe_file.error());
                 if (error_callback)
-                    error_callback(DeprecatedString::formatted("{}", maybe_file.error()), maybe_file.error().code());
+                    error_callback(DeprecatedString::formatted("{}", maybe_file.error()), 500u);
                 return;
             }
 
@@ -264,7 +266,7 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, Has
             if (maybe_data.is_error()) {
                 log_failure(request, maybe_data.error());
                 if (error_callback)
-                    error_callback(DeprecatedString::formatted("{}", maybe_data.error()), maybe_data.error().code());
+                    error_callback(DeprecatedString::formatted("{}", maybe_data.error()), 500u);
                 return;
             }
             auto data = maybe_data.release_value();


### PR DESCRIPTION
Things that will trip up a certain media-related element when it (fails to) fetch some super cool media resources