### PR TITLE
Kernel: Remove problematic file description number allocation method

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -827,11 +827,6 @@ public:
         return m_fds.with_shared([fd](auto& fds) { return fds.open_file_description(fd); });
     }
 
-    ErrorOr<ScopedDescriptionAllocation> allocate_fd()
-    {
-        return m_fds.with_exclusive([](auto& fds) { return fds.allocate(); });
-    }
-
 private:
     ErrorOr<NonnullRefPtr<Custody>> custody_for_dirfd(int dirfd);
 

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -511,7 +511,7 @@ ErrorOr<void> Process::do_exec(NonnullRefPtr<OpenFileDescription> main_program_d
     // (For dynamically linked executable) Allocate an FD for passing the main executable to the dynamic loader.
     Optional<ScopedDescriptionAllocation> main_program_fd_allocation;
     if (has_interpreter)
-        main_program_fd_allocation = TRY(allocate_fd());
+        main_program_fd_allocation = TRY(m_fds.with_exclusive([](auto& fds) { return fds.allocate(); }));
 
     auto old_credentials = this->credentials();
     auto new_credentials = old_credentials;


### PR DESCRIPTION
This method was used in the past in a faulty manner, because this method was called before other conditions could failed, and if we failed we never returned the fd allocation, therefore opening files extensively could lead in theory to exhaustion of the fd number allocation pool just by failing on other conditions, leaving the fd table mostly empty and exhausted.

Therefore, let's ensure the open syscall allocates a fd number in the end of the sequence, where we already hold the m_fds mutex and there are no other conditions that could fail after the allocation.