### PR TITLE
GMLPlayground: Fix crash when previewing `@GUI::Calendar`

### DIFF
--- a/Userland/DevTools/GMLPlayground/main.cpp
+++ b/Userland/DevTools/GMLPlayground/main.cpp
@@ -68,7 +68,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio thread recvfd sendfd cpath rpath wpath unix"));
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    Config::pledge_domain("GMLPlayground");
+    Config::pledge_domains({ "GMLPlayground", "Calendar" });
     app->set_config_domain(TRY("GMLPlayground"_string));
 
     TRY(Core::System::unveil("/res", "r"));


### PR DESCRIPTION
This now allows for the preview of `@GUI::Calendar` without crashing the whole program.