### PR TITLE
Kernel: Get rid of *LockRefPtr in SysFS filesystem code

### DIFF
--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -21,7 +21,9 @@ ErrorOr<NonnullLockRefPtr<Device>> Device::try_create(USBController const& contr
     auto pipe = TRY(ControlPipe::create(controller, 0, 8, 0));
     auto device = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) Device(controller, port, speed, move(pipe))));
     auto sysfs_node = TRY(SysFSUSBDeviceInformation::create(*device));
-    device->m_sysfs_device_info_node = move(sysfs_node);
+    device->m_sysfs_device_info_node.with([&](auto& node) {
+        node = move(sysfs_node);
+    });
     TRY(device->enumerate_device());
     return device;
 }

--- a/Kernel/Bus/USB/USBDevice.h
+++ b/Kernel/Bus/USB/USBDevice.h
@@ -12,6 +12,7 @@
 #include <AK/Vector.h>
 #include <Kernel/Bus/USB/USBConfiguration.h>
 #include <Kernel/Bus/USB/USBPipe.h>
+#include <Kernel/Locking/SpinlockProtected.h>
 
 namespace Kernel {
 class SysFSUSBDeviceInformation;
@@ -57,7 +58,7 @@ public:
 
     Vector<USBConfiguration> const& configurations() const { return m_configurations; }
 
-    SysFSUSBDeviceInformation& sysfs_device_info_node(Badge<USB::Hub>) { return *m_sysfs_device_info_node; }
+    SpinlockProtected<RefPtr<SysFSUSBDeviceInformation>, LockRank::None>& sysfs_device_info_node(Badge<USB::Hub>) { return m_sysfs_device_info_node; }
 
 protected:
     Device(NonnullLockRefPtr<USBController> controller, u8 address, u8 port, DeviceSpeed speed, NonnullOwnPtr<ControlPipe> default_pipe);
@@ -79,7 +80,7 @@ private:
     IntrusiveListNode<Device, NonnullLockRefPtr<Device>> m_hub_child_node;
 
 protected:
-    LockRefPtr<SysFSUSBDeviceInformation> m_sysfs_device_info_node;
+    SpinlockProtected<RefPtr<SysFSUSBDeviceInformation>, LockRank::None> m_sysfs_device_info_node;
 
 public:
     using List = IntrusiveList<&Device::m_hub_child_node>;

--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -34,19 +34,19 @@ void Device::after_inserting_add_to_device_management()
 
 ErrorOr<void> Device::after_inserting()
 {
-    after_inserting_add_to_device_management();
     VERIFY(!m_sysfs_component);
     auto sys_fs_component = SysFSDeviceComponent::must_create(*this);
     m_sysfs_component = sys_fs_component;
     after_inserting_add_to_device_identifier_directory();
+    after_inserting_add_to_device_management();
     return {};
 }
 
 void Device::will_be_destroyed()
 {
     VERIFY(m_sysfs_component);
-    before_will_be_destroyed_remove_from_device_identifier_directory();
     before_will_be_destroyed_remove_from_device_management();
+    before_will_be_destroyed_remove_from_device_identifier_directory();
 }
 
 Device::~Device()

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -96,10 +96,10 @@ private:
 protected:
     // FIXME: This pointer will be eventually removed after all nodes in /sys/dev/block/ and
     // /sys/dev/char/ are symlinks.
-    LockRefPtr<SysFSDeviceComponent> m_sysfs_component;
+    RefPtr<SysFSDeviceComponent> m_sysfs_component;
 
-    LockRefPtr<SysFSSymbolicLinkDeviceComponent> m_symlink_sysfs_component;
-    LockRefPtr<SysFSDirectory> m_sysfs_device_directory;
+    RefPtr<SysFSSymbolicLinkDeviceComponent> m_symlink_sysfs_component;
+    RefPtr<SysFSDirectory> m_sysfs_device_directory;
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Component.cpp
+++ b/Kernel/FileSystem/SysFS/Component.cpp
@@ -74,8 +74,6 @@ ErrorOr<size_t> SysFSSymbolicLink::read_bytes(off_t offset, size_t count, UserOr
 ErrorOr<NonnullOwnPtr<KBuffer>> SysFSSymbolicLink::try_to_generate_buffer() const
 {
     auto return_path_to_mount_point = TRY(try_generate_return_path_to_mount_point());
-    if (!m_pointed_component)
-        return Error::from_errno(EIO);
     auto pointed_component_base_name = MUST(KString::try_create(m_pointed_component->name()));
     auto pointed_component_relative_path = MUST(m_pointed_component->relative_path(move(pointed_component_base_name), 0));
     auto full_return_and_target_path = TRY(KString::formatted("{}{}", return_path_to_mount_point->view(), pointed_component_relative_path->view()));
@@ -126,9 +124,9 @@ ErrorOr<void> SysFSDirectory::traverse_as_directory(FileSystemID fsid, Function<
     });
 }
 
-LockRefPtr<SysFSComponent> SysFSDirectory::lookup(StringView name)
+RefPtr<SysFSComponent> SysFSDirectory::lookup(StringView name)
 {
-    return m_child_components.with([&](auto& list) -> LockRefPtr<SysFSComponent> {
+    return m_child_components.with([&](auto& list) -> RefPtr<SysFSComponent> {
         for (auto& child_component : list) {
             if (child_component.name() == name) {
                 return child_component;

--- a/Kernel/FileSystem/SysFS/Component.h
+++ b/Kernel/FileSystem/SysFS/Component.h
@@ -9,13 +9,13 @@
 #include <AK/AtomicRefCounted.h>
 #include <AK/Error.h>
 #include <AK/Function.h>
+#include <AK/RefPtr.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/File.h>
 #include <Kernel/FileSystem/FileSystem.h>
 #include <Kernel/FileSystem/OpenFileDescription.h>
 #include <Kernel/Forward.h>
-#include <Kernel/Library/LockRefPtr.h>
 
 namespace Kernel {
 
@@ -31,7 +31,7 @@ public:
     virtual StringView name() const = 0;
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const { return Error::from_errno(ENOTIMPL); }
     virtual ErrorOr<void> traverse_as_directory(FileSystemID, Function<ErrorOr<void>(FileSystem::DirectoryEntryView const&)>) const { VERIFY_NOT_REACHED(); }
-    virtual LockRefPtr<SysFSComponent> lookup(StringView) { VERIFY_NOT_REACHED(); };
+    virtual RefPtr<SysFSComponent> lookup(StringView) { VERIFY_NOT_REACHED(); };
     virtual mode_t permissions() const;
     virtual ErrorOr<void> truncate(u64) { return EPERM; }
     virtual size_t size() const { return 0; }
@@ -51,9 +51,9 @@ protected:
     explicit SysFSComponent(SysFSDirectory const& parent_directory);
     SysFSComponent();
 
-    LockRefPtr<SysFSDirectory> m_parent_directory;
+    RefPtr<SysFSDirectory> const m_parent_directory;
 
-    IntrusiveListNode<SysFSComponent, NonnullLockRefPtr<SysFSComponent>> m_list_node;
+    IntrusiveListNode<SysFSComponent, NonnullRefPtr<SysFSComponent>> m_list_node;
 
 private:
     InodeIndex m_component_index {};
@@ -70,13 +70,13 @@ protected:
 
     explicit SysFSSymbolicLink(SysFSDirectory const& parent_directory, SysFSComponent const& pointed_component);
 
-    LockRefPtr<SysFSComponent> m_pointed_component;
+    NonnullRefPtr<SysFSComponent> const m_pointed_component;
 };
 
 class SysFSDirectory : public SysFSComponent {
 public:
     virtual ErrorOr<void> traverse_as_directory(FileSystemID, Function<ErrorOr<void>(FileSystem::DirectoryEntryView const&)>) const override final;
-    virtual LockRefPtr<SysFSComponent> lookup(StringView name) override final;
+    virtual RefPtr<SysFSComponent> lookup(StringView name) override final;
 
     virtual ErrorOr<NonnullRefPtr<SysFSInode>> to_inode(SysFS const& sysfs_instance) const override final;
 

--- a/Kernel/FileSystem/SysFS/Inode.h
+++ b/Kernel/FileSystem/SysFS/Inode.h
@@ -40,7 +40,7 @@ protected:
     virtual ErrorOr<void> attach(OpenFileDescription& description) override final;
     virtual void did_seek(OpenFileDescription&, off_t) override final;
 
-    NonnullLockRefPtr<SysFSComponent> m_associated_component;
+    NonnullRefPtr<SysFSComponent> const m_associated_component;
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Registry.cpp
+++ b/Kernel/FileSystem/SysFS/Registry.cpp
@@ -45,7 +45,6 @@ SysFSBusDirectory& SysFSComponentRegistry::buses_directory()
 
 void SysFSComponentRegistry::register_new_bus_directory(SysFSDirectory& new_bus_directory)
 {
-    VERIFY(!m_root_directory->m_buses_directory.is_null());
     MUST(m_root_directory->m_buses_directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
         list.append(new_bus_directory);
         return {};

--- a/Kernel/FileSystem/SysFS/Registry.h
+++ b/Kernel/FileSystem/SysFS/Registry.h
@@ -31,7 +31,7 @@ public:
     SysFSBusDirectory& buses_directory();
 
 private:
-    NonnullLockRefPtr<SysFSRootDirectory> m_root_directory;
+    NonnullRefPtr<SysFSRootDirectory> const m_root_directory;
     Spinlock<LockRank::None> m_root_directory_lock {};
 };
 

--- a/Kernel/FileSystem/SysFS/RootDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/RootDirectory.cpp
@@ -14,25 +14,24 @@
 
 namespace Kernel {
 
-NonnullLockRefPtr<SysFSRootDirectory> SysFSRootDirectory::create()
+NonnullRefPtr<SysFSRootDirectory> SysFSRootDirectory::create()
 {
-    return adopt_lock_ref(*new (nothrow) SysFSRootDirectory);
+    return adopt_ref(*new (nothrow) SysFSRootDirectory);
 }
 
 SysFSRootDirectory::SysFSRootDirectory()
+    : m_buses_directory(SysFSBusDirectory::must_create(*this))
 {
-    auto buses_directory = SysFSBusDirectory::must_create(*this);
     auto device_identifiers_directory = SysFSDeviceIdentifiersDirectory::must_create(*this);
     auto devices_directory = SysFSDevicesDirectory::must_create(*this);
     auto global_kernel_stats_directory = SysFSGlobalKernelStatsDirectory::must_create(*this);
     MUST(m_child_components.with([&](auto& list) -> ErrorOr<void> {
-        list.append(buses_directory);
+        list.append(m_buses_directory);
         list.append(device_identifiers_directory);
         list.append(devices_directory);
         list.append(global_kernel_stats_directory);
         return {};
     }));
-    m_buses_directory = buses_directory;
 }
 
 }

--- a/Kernel/FileSystem/SysFS/RootDirectory.h
+++ b/Kernel/FileSystem/SysFS/RootDirectory.h
@@ -16,12 +16,12 @@ class SysFSRootDirectory final : public SysFSDirectory {
 
 public:
     virtual StringView name() const override { return "."sv; }
-    static NonnullLockRefPtr<SysFSRootDirectory> create();
+    static NonnullRefPtr<SysFSRootDirectory> create();
 
 private:
     virtual bool is_root_directory() const override final { return true; }
     SysFSRootDirectory();
-    LockRefPtr<SysFSBusDirectory> m_buses_directory;
+    NonnullRefPtr<SysFSBusDirectory> const m_buses_directory;
 };
 
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/Directory.cpp
@@ -10,9 +10,9 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSBusDirectory> SysFSBusDirectory::must_create(SysFSRootDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSBusDirectory> SysFSBusDirectory::must_create(SysFSRootDirectory const& parent_directory)
 {
-    auto directory = adopt_lock_ref(*new (nothrow) SysFSBusDirectory(parent_directory));
+    auto directory = adopt_ref(*new (nothrow) SysFSBusDirectory(parent_directory));
     return directory;
 }
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/Directory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/Directory.h
@@ -16,7 +16,7 @@ class SysFSBusDirectory : public SysFSDirectory {
 
 public:
     virtual StringView name() const override { return "bus"sv; }
-    static NonnullLockRefPtr<SysFSBusDirectory> must_create(SysFSRootDirectory const&);
+    static NonnullRefPtr<SysFSBusDirectory> must_create(SysFSRootDirectory const&);
 
 private:
     explicit SysFSBusDirectory(SysFSRootDirectory const&);

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.cpp
@@ -15,7 +15,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT void PCIBusSysFSDirectory::initialize()
 {
-    auto pci_directory = adopt_lock_ref(*new (nothrow) PCIBusSysFSDirectory());
+    auto pci_directory = adopt_ref(*new (nothrow) PCIBusSysFSDirectory());
     SysFSComponentRegistry::the().register_new_bus_directory(pci_directory);
 }
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceAttribute.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceAttribute.cpp
@@ -47,9 +47,9 @@ StringView PCIDeviceAttributeSysFSComponent::name() const
     }
 }
 
-NonnullLockRefPtr<PCIDeviceAttributeSysFSComponent> PCIDeviceAttributeSysFSComponent::create(PCIDeviceSysFSDirectory const& device, PCI::RegisterOffset offset, size_t field_bytes_width)
+NonnullRefPtr<PCIDeviceAttributeSysFSComponent> PCIDeviceAttributeSysFSComponent::create(PCIDeviceSysFSDirectory const& device, PCI::RegisterOffset offset, size_t field_bytes_width)
 {
-    return adopt_lock_ref(*new (nothrow) PCIDeviceAttributeSysFSComponent(device, offset, field_bytes_width));
+    return adopt_ref(*new (nothrow) PCIDeviceAttributeSysFSComponent(device, offset, field_bytes_width));
 }
 
 PCIDeviceAttributeSysFSComponent::PCIDeviceAttributeSysFSComponent(PCIDeviceSysFSDirectory const& device, PCI::RegisterOffset offset, size_t field_bytes_width)

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceAttribute.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceAttribute.h
@@ -15,7 +15,7 @@ namespace Kernel {
 
 class PCIDeviceAttributeSysFSComponent : public SysFSComponent {
 public:
-    static NonnullLockRefPtr<PCIDeviceAttributeSysFSComponent> create(PCIDeviceSysFSDirectory const& device, PCI::RegisterOffset offset, size_t field_bytes_width);
+    static NonnullRefPtr<PCIDeviceAttributeSysFSComponent> create(PCIDeviceSysFSDirectory const& device, PCI::RegisterOffset offset, size_t field_bytes_width);
 
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const override;
     virtual ~PCIDeviceAttributeSysFSComponent() {};
@@ -25,7 +25,7 @@ public:
 protected:
     ErrorOr<NonnullOwnPtr<KBuffer>> try_to_generate_buffer() const;
     PCIDeviceAttributeSysFSComponent(PCIDeviceSysFSDirectory const& device, PCI::RegisterOffset offset, size_t field_bytes_width);
-    NonnullLockRefPtr<PCIDeviceSysFSDirectory> m_device;
+    NonnullRefPtr<PCIDeviceSysFSDirectory> m_device;
     PCI::RegisterOffset m_offset;
     size_t m_field_bytes_width;
 };

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.cpp
@@ -13,12 +13,12 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<PCIDeviceSysFSDirectory> PCIDeviceSysFSDirectory::create(SysFSDirectory const& parent_directory, PCI::DeviceIdentifier const& device_identifier)
+UNMAP_AFTER_INIT NonnullRefPtr<PCIDeviceSysFSDirectory> PCIDeviceSysFSDirectory::create(SysFSDirectory const& parent_directory, PCI::DeviceIdentifier const& device_identifier)
 {
     // FIXME: Handle allocation failure gracefully
     auto& address = device_identifier.address();
     auto device_name = MUST(KString::formatted("{:04x}:{:02x}:{:02x}.{}", address.domain(), address.bus(), address.device(), address.function()));
-    auto directory = adopt_lock_ref(*new (nothrow) PCIDeviceSysFSDirectory(move(device_name), parent_directory, device_identifier));
+    auto directory = adopt_ref(*new (nothrow) PCIDeviceSysFSDirectory(move(device_name), parent_directory, device_identifier));
     MUST(directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
         list.append(PCIDeviceAttributeSysFSComponent::create(*directory, PCI::RegisterOffset::VENDOR_ID, 2));
         list.append(PCIDeviceAttributeSysFSComponent::create(*directory, PCI::RegisterOffset::DEVICE_ID, 2));

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.h
@@ -15,7 +15,7 @@ namespace Kernel {
 
 class PCIDeviceSysFSDirectory final : public SysFSDirectory {
 public:
-    static NonnullLockRefPtr<PCIDeviceSysFSDirectory> create(SysFSDirectory const&, PCI::DeviceIdentifier const&);
+    static NonnullRefPtr<PCIDeviceSysFSDirectory> create(SysFSDirectory const&, PCI::DeviceIdentifier const&);
     PCI::DeviceIdentifier const& device_identifier() const { return *m_device_identifier; }
 
     virtual StringView name() const override { return m_device_directory_name->view(); }

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceExpansionROM.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceExpansionROM.cpp
@@ -12,10 +12,10 @@
 
 namespace Kernel {
 
-NonnullLockRefPtr<PCIDeviceExpansionROMSysFSComponent> PCIDeviceExpansionROMSysFSComponent::create(PCIDeviceSysFSDirectory const& device)
+NonnullRefPtr<PCIDeviceExpansionROMSysFSComponent> PCIDeviceExpansionROMSysFSComponent::create(PCIDeviceSysFSDirectory const& device)
 {
     auto option_rom_size = PCI::get_expansion_rom_space_size(device.device_identifier());
-    return adopt_lock_ref(*new (nothrow) PCIDeviceExpansionROMSysFSComponent(device, option_rom_size));
+    return adopt_ref(*new (nothrow) PCIDeviceExpansionROMSysFSComponent(device, option_rom_size));
 }
 
 PCIDeviceExpansionROMSysFSComponent::PCIDeviceExpansionROMSysFSComponent(PCIDeviceSysFSDirectory const& device, size_t option_rom_size)

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceExpansionROM.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceExpansionROM.h
@@ -15,7 +15,7 @@ namespace Kernel {
 
 class PCIDeviceExpansionROMSysFSComponent : public SysFSComponent {
 public:
-    static NonnullLockRefPtr<PCIDeviceExpansionROMSysFSComponent> create(PCIDeviceSysFSDirectory const& device);
+    static NonnullRefPtr<PCIDeviceExpansionROMSysFSComponent> create(PCIDeviceSysFSDirectory const& device);
 
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const override;
     virtual ~PCIDeviceExpansionROMSysFSComponent() {};
@@ -25,7 +25,7 @@ public:
 protected:
     ErrorOr<NonnullOwnPtr<KBuffer>> try_to_generate_buffer(size_t offset_in_rom, size_t count) const;
     PCIDeviceExpansionROMSysFSComponent(PCIDeviceSysFSDirectory const& device, size_t option_rom_size);
-    NonnullLockRefPtr<PCIDeviceSysFSDirectory> m_device;
+    NonnullRefPtr<PCIDeviceSysFSDirectory> m_device;
     size_t const m_option_rom_size { 0 };
 };
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/USB/BusDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/USB/BusDirectory.cpp
@@ -40,7 +40,7 @@ UNMAP_AFTER_INIT SysFSUSBBusDirectory::SysFSUSBBusDirectory(SysFSBusDirectory& b
 
 UNMAP_AFTER_INIT void SysFSUSBBusDirectory::initialize()
 {
-    auto directory = adopt_lock_ref(*new SysFSUSBBusDirectory(SysFSComponentRegistry::the().buses_directory()));
+    auto directory = adopt_ref(*new SysFSUSBBusDirectory(SysFSComponentRegistry::the().buses_directory()));
     SysFSComponentRegistry::the().register_new_bus_directory(directory);
     s_sysfs_usb_bus_directory = directory;
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/USB/DeviceInformation.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/USB/DeviceInformation.cpp
@@ -11,10 +11,10 @@
 
 namespace Kernel {
 
-ErrorOr<NonnullLockRefPtr<SysFSUSBDeviceInformation>> SysFSUSBDeviceInformation::create(USB::Device& device)
+ErrorOr<NonnullRefPtr<SysFSUSBDeviceInformation>> SysFSUSBDeviceInformation::create(USB::Device& device)
 {
     auto device_name = TRY(KString::number(device.address()));
-    return adopt_nonnull_lock_ref_or_enomem(new (nothrow) SysFSUSBDeviceInformation(move(device_name), device));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) SysFSUSBDeviceInformation(move(device_name), device));
 }
 
 SysFSUSBDeviceInformation::SysFSUSBDeviceInformation(NonnullOwnPtr<KString> device_name, USB::Device& device)

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/USB/DeviceInformation.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/USB/DeviceInformation.h
@@ -20,7 +20,7 @@ class SysFSUSBDeviceInformation : public SysFSComponent {
 public:
     virtual ~SysFSUSBDeviceInformation() override;
 
-    static ErrorOr<NonnullLockRefPtr<SysFSUSBDeviceInformation>> create(USB::Device&);
+    static ErrorOr<NonnullRefPtr<SysFSUSBDeviceInformation>> create(USB::Device&);
     virtual StringView name() const override { return m_device_name->view(); }
 
 protected:
@@ -28,7 +28,7 @@ protected:
 
     virtual ErrorOr<size_t> read_bytes(off_t offset, size_t count, UserOrKernelBuffer& buffer, OpenFileDescription*) const override;
 
-    NonnullLockRefPtr<USB::Device> m_device;
+    NonnullRefPtr<USB::Device> m_device;
 
 private:
     ErrorOr<void> try_generate(KBufferBuilder&);

--- a/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/BlockDevicesDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/BlockDevicesDirectory.cpp
@@ -12,9 +12,9 @@ namespace Kernel {
 
 static SysFSBlockDevicesDirectory* s_the { nullptr };
 
-NonnullLockRefPtr<SysFSBlockDevicesDirectory> SysFSBlockDevicesDirectory::must_create(SysFSDeviceIdentifiersDirectory const& devices_directory)
+NonnullRefPtr<SysFSBlockDevicesDirectory> SysFSBlockDevicesDirectory::must_create(SysFSDeviceIdentifiersDirectory const& devices_directory)
 {
-    return adopt_lock_ref_if_nonnull(new SysFSBlockDevicesDirectory(devices_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new SysFSBlockDevicesDirectory(devices_directory)).release_nonnull();
 }
 SysFSBlockDevicesDirectory::SysFSBlockDevicesDirectory(SysFSDeviceIdentifiersDirectory const& devices_directory)
     : SysFSDirectory(devices_directory)

--- a/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/BlockDevicesDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/BlockDevicesDirectory.h
@@ -17,7 +17,7 @@ class SysFSBlockDevicesDirectory final : public SysFSDirectory {
 
 public:
     virtual StringView name() const override { return "block"sv; }
-    static NonnullLockRefPtr<SysFSBlockDevicesDirectory> must_create(SysFSDeviceIdentifiersDirectory const&);
+    static NonnullRefPtr<SysFSBlockDevicesDirectory> must_create(SysFSDeviceIdentifiersDirectory const&);
 
     static SysFSBlockDevicesDirectory& the();
 

--- a/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/CharacterDevicesDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/CharacterDevicesDirectory.cpp
@@ -12,9 +12,9 @@ namespace Kernel {
 
 static SysFSCharacterDevicesDirectory* s_the { nullptr };
 
-NonnullLockRefPtr<SysFSCharacterDevicesDirectory> SysFSCharacterDevicesDirectory::must_create(SysFSDeviceIdentifiersDirectory const& devices_directory)
+NonnullRefPtr<SysFSCharacterDevicesDirectory> SysFSCharacterDevicesDirectory::must_create(SysFSDeviceIdentifiersDirectory const& devices_directory)
 {
-    return adopt_lock_ref_if_nonnull(new SysFSCharacterDevicesDirectory(devices_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new SysFSCharacterDevicesDirectory(devices_directory)).release_nonnull();
 }
 SysFSCharacterDevicesDirectory::SysFSCharacterDevicesDirectory(SysFSDeviceIdentifiersDirectory const& devices_directory)
     : SysFSDirectory(devices_directory)

--- a/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/CharacterDevicesDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/CharacterDevicesDirectory.h
@@ -17,7 +17,7 @@ class SysFSCharacterDevicesDirectory final : public SysFSDirectory {
 
 public:
     virtual StringView name() const override { return "char"sv; }
-    static NonnullLockRefPtr<SysFSCharacterDevicesDirectory> must_create(SysFSDeviceIdentifiersDirectory const&);
+    static NonnullRefPtr<SysFSCharacterDevicesDirectory> must_create(SysFSDeviceIdentifiersDirectory const&);
 
     static SysFSCharacterDevicesDirectory& the();
 

--- a/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/DeviceComponent.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/DeviceComponent.cpp
@@ -10,11 +10,11 @@
 
 namespace Kernel {
 
-NonnullLockRefPtr<SysFSDeviceComponent> SysFSDeviceComponent::must_create(Device const& device)
+NonnullRefPtr<SysFSDeviceComponent> SysFSDeviceComponent::must_create(Device const& device)
 {
     // FIXME: Handle allocation failure gracefully
     auto device_name = MUST(KString::formatted("{}:{}", device.major(), device.minor()));
-    return adopt_lock_ref_if_nonnull(new SysFSDeviceComponent(move(device_name), device)).release_nonnull();
+    return adopt_ref_if_nonnull(new SysFSDeviceComponent(move(device_name), device)).release_nonnull();
 }
 SysFSDeviceComponent::SysFSDeviceComponent(NonnullOwnPtr<KString> major_minor_formatted_device_name, Device const& device)
     : SysFSComponent()

--- a/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/DeviceComponent.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/DeviceComponent.h
@@ -19,7 +19,7 @@ class SysFSDeviceComponent final
     friend class SysFSCharacterDevicesDirectory;
 
 public:
-    static NonnullLockRefPtr<SysFSDeviceComponent> must_create(Device const&);
+    static NonnullRefPtr<SysFSDeviceComponent> must_create(Device const&);
     virtual StringView name() const override { return m_major_minor_formatted_device_name->view(); }
     bool is_block_device() const { return m_block_device; }
 

--- a/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/Directory.cpp
@@ -20,9 +20,9 @@ SysFSDeviceIdentifiersDirectory& SysFSDeviceIdentifiersDirectory::the()
     return *s_the;
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSDeviceIdentifiersDirectory> SysFSDeviceIdentifiersDirectory::must_create(SysFSRootDirectory const& root_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSDeviceIdentifiersDirectory> SysFSDeviceIdentifiersDirectory::must_create(SysFSRootDirectory const& root_directory)
 {
-    auto devices_directory = adopt_lock_ref_if_nonnull(new SysFSDeviceIdentifiersDirectory(root_directory)).release_nonnull();
+    auto devices_directory = adopt_ref_if_nonnull(new SysFSDeviceIdentifiersDirectory(root_directory)).release_nonnull();
     MUST(devices_directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
         list.append(SysFSBlockDevicesDirectory::must_create(*devices_directory));
         list.append(SysFSCharacterDevicesDirectory::must_create(*devices_directory));

--- a/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/Directory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/Directory.h
@@ -14,7 +14,7 @@ namespace Kernel {
 class SysFSDeviceIdentifiersDirectory final : public SysFSDirectory {
 public:
     virtual StringView name() const override { return "dev"sv; }
-    static NonnullLockRefPtr<SysFSDeviceIdentifiersDirectory> must_create(SysFSRootDirectory const&);
+    static NonnullRefPtr<SysFSDeviceIdentifiersDirectory> must_create(SysFSRootDirectory const&);
 
     static SysFSDeviceIdentifiersDirectory& the();
 

--- a/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/SymbolicLinkDeviceComponent.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/SymbolicLinkDeviceComponent.cpp
@@ -11,16 +11,16 @@
 
 namespace Kernel {
 
-ErrorOr<NonnullLockRefPtr<SysFSSymbolicLinkDeviceComponent>> SysFSSymbolicLinkDeviceComponent::try_create(SysFSCharacterDevicesDirectory const& parent_directory, Device const& device, SysFSComponent const& pointed_component)
+ErrorOr<NonnullRefPtr<SysFSSymbolicLinkDeviceComponent>> SysFSSymbolicLinkDeviceComponent::try_create(SysFSCharacterDevicesDirectory const& parent_directory, Device const& device, SysFSComponent const& pointed_component)
 {
     auto device_name = TRY(KString::formatted("{}:{}", device.major(), device.minor()));
-    return adopt_nonnull_lock_ref_or_enomem(new (nothrow) SysFSSymbolicLinkDeviceComponent(parent_directory, move(device_name), device, pointed_component));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) SysFSSymbolicLinkDeviceComponent(parent_directory, move(device_name), device, pointed_component));
 }
 
-ErrorOr<NonnullLockRefPtr<SysFSSymbolicLinkDeviceComponent>> SysFSSymbolicLinkDeviceComponent::try_create(SysFSBlockDevicesDirectory const& parent_directory, Device const& device, SysFSComponent const& pointed_component)
+ErrorOr<NonnullRefPtr<SysFSSymbolicLinkDeviceComponent>> SysFSSymbolicLinkDeviceComponent::try_create(SysFSBlockDevicesDirectory const& parent_directory, Device const& device, SysFSComponent const& pointed_component)
 {
     auto device_name = TRY(KString::formatted("{}:{}", device.major(), device.minor()));
-    return adopt_nonnull_lock_ref_or_enomem(new (nothrow) SysFSSymbolicLinkDeviceComponent(parent_directory, move(device_name), device, pointed_component));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) SysFSSymbolicLinkDeviceComponent(parent_directory, move(device_name), device, pointed_component));
 }
 
 SysFSSymbolicLinkDeviceComponent::SysFSSymbolicLinkDeviceComponent(SysFSCharacterDevicesDirectory const& parent_directory, NonnullOwnPtr<KString> major_minor_formatted_device_name, Device const& device, SysFSComponent const& pointed_component)

--- a/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/SymbolicLinkDeviceComponent.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/DeviceIdentifiers/SymbolicLinkDeviceComponent.h
@@ -21,8 +21,8 @@ class SysFSSymbolicLinkDeviceComponent final
     friend class SysFSComponentRegistry;
 
 public:
-    static ErrorOr<NonnullLockRefPtr<SysFSSymbolicLinkDeviceComponent>> try_create(SysFSCharacterDevicesDirectory const& parent_directory, Device const& device, SysFSComponent const& pointed_component);
-    static ErrorOr<NonnullLockRefPtr<SysFSSymbolicLinkDeviceComponent>> try_create(SysFSBlockDevicesDirectory const& parent_directory, Device const& device, SysFSComponent const& pointed_component);
+    static ErrorOr<NonnullRefPtr<SysFSSymbolicLinkDeviceComponent>> try_create(SysFSCharacterDevicesDirectory const& parent_directory, Device const& device, SysFSComponent const& pointed_component);
+    static ErrorOr<NonnullRefPtr<SysFSSymbolicLinkDeviceComponent>> try_create(SysFSBlockDevicesDirectory const& parent_directory, Device const& device, SysFSComponent const& pointed_component);
 
     virtual StringView name() const override { return m_major_minor_formatted_device_name->view(); }
     bool is_block_device() const { return m_block_device; }
@@ -31,7 +31,7 @@ private:
     SysFSSymbolicLinkDeviceComponent(SysFSCharacterDevicesDirectory const& parent_directory, NonnullOwnPtr<KString> major_minor_formatted_device_name, Device const&, SysFSComponent const& pointed_component);
     SysFSSymbolicLinkDeviceComponent(SysFSBlockDevicesDirectory const& parent_directory, NonnullOwnPtr<KString> major_minor_formatted_device_name, Device const&, SysFSComponent const& pointed_component);
 
-    IntrusiveListNode<SysFSSymbolicLinkDeviceComponent, NonnullLockRefPtr<SysFSSymbolicLinkDeviceComponent>> m_list_node;
+    IntrusiveListNode<SysFSSymbolicLinkDeviceComponent, NonnullRefPtr<SysFSSymbolicLinkDeviceComponent>> m_list_node;
     bool const m_block_device { false };
     NonnullOwnPtr<KString> m_major_minor_formatted_device_name;
 };

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Directory.cpp
@@ -12,9 +12,9 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSDevicesDirectory> SysFSDevicesDirectory::must_create(SysFSRootDirectory const& root_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSDevicesDirectory> SysFSDevicesDirectory::must_create(SysFSRootDirectory const& root_directory)
 {
-    auto devices_directory = adopt_lock_ref_if_nonnull(new (nothrow) SysFSDevicesDirectory(root_directory)).release_nonnull();
+    auto devices_directory = adopt_ref_if_nonnull(new (nothrow) SysFSDevicesDirectory(root_directory)).release_nonnull();
     MUST(devices_directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
         list.append(SysFSStorageDirectory::must_create(*devices_directory));
         list.append(SysFSGraphicsDirectory::must_create(*devices_directory));

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Directory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Directory.h
@@ -14,7 +14,7 @@ namespace Kernel {
 class SysFSDevicesDirectory final : public SysFSDirectory {
 public:
     virtual StringView name() const override { return "devices"sv; }
-    static NonnullLockRefPtr<SysFSDevicesDirectory> must_create(SysFSRootDirectory const&);
+    static NonnullRefPtr<SysFSDevicesDirectory> must_create(SysFSRootDirectory const&);
 
 private:
     explicit SysFSDevicesDirectory(SysFSRootDirectory const&);

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Directory.cpp
@@ -10,9 +10,9 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSGraphicsDirectory> SysFSGraphicsDirectory::must_create(SysFSDevicesDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSGraphicsDirectory> SysFSGraphicsDirectory::must_create(SysFSDevicesDirectory const& parent_directory)
 {
-    auto directory = adopt_lock_ref(*new (nothrow) SysFSGraphicsDirectory(parent_directory));
+    auto directory = adopt_ref(*new (nothrow) SysFSGraphicsDirectory(parent_directory));
     MUST(directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
         list.append(SysFSDisplayConnectorsDirectory::must_create(*directory));
         return {};

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Directory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/Directory.h
@@ -17,7 +17,7 @@ class SysFSGraphicsDirectory : public SysFSDirectory {
 
 public:
     virtual StringView name() const override { return "graphics"sv; }
-    static NonnullLockRefPtr<SysFSGraphicsDirectory> must_create(SysFSDevicesDirectory const&);
+    static NonnullRefPtr<SysFSGraphicsDirectory> must_create(SysFSDevicesDirectory const&);
 
 private:
     explicit SysFSGraphicsDirectory(SysFSDevicesDirectory const&);

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceAttribute.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceAttribute.cpp
@@ -31,9 +31,9 @@ StringView DisplayConnectorAttributeSysFSComponent::name() const
     }
 }
 
-NonnullLockRefPtr<DisplayConnectorAttributeSysFSComponent> DisplayConnectorAttributeSysFSComponent::must_create(DisplayConnectorSysFSDirectory const& device_directory, Type type)
+NonnullRefPtr<DisplayConnectorAttributeSysFSComponent> DisplayConnectorAttributeSysFSComponent::must_create(DisplayConnectorSysFSDirectory const& device_directory, Type type)
 {
-    return adopt_lock_ref(*new (nothrow) DisplayConnectorAttributeSysFSComponent(device_directory, type));
+    return adopt_ref(*new (nothrow) DisplayConnectorAttributeSysFSComponent(device_directory, type));
 }
 
 DisplayConnectorAttributeSysFSComponent::DisplayConnectorAttributeSysFSComponent(DisplayConnectorSysFSDirectory const& device_directory, Type type)

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceAttribute.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceAttribute.h
@@ -25,7 +25,7 @@ public:
     };
 
 public:
-    static NonnullLockRefPtr<DisplayConnectorAttributeSysFSComponent> must_create(DisplayConnectorSysFSDirectory const& device_directory, Type);
+    static NonnullRefPtr<DisplayConnectorAttributeSysFSComponent> must_create(DisplayConnectorSysFSDirectory const& device_directory, Type);
 
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const override;
     virtual ~DisplayConnectorAttributeSysFSComponent() {};
@@ -35,7 +35,7 @@ public:
 protected:
     ErrorOr<NonnullOwnPtr<KBuffer>> try_to_generate_buffer() const;
     DisplayConnectorAttributeSysFSComponent(DisplayConnectorSysFSDirectory const& device, Type);
-    NonnullLockRefPtr<DisplayConnector> m_device;
+    NonnullRefPtr<DisplayConnector> m_device;
     Type const m_type { Type::MutableModeSettingCapable };
 };
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceDirectory.cpp
@@ -18,11 +18,11 @@ DisplayConnector const& DisplayConnectorSysFSDirectory::device(Badge<DisplayConn
     return *m_device;
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<DisplayConnectorSysFSDirectory> DisplayConnectorSysFSDirectory::create(SysFSDirectory const& parent_directory, DisplayConnector const& device)
+UNMAP_AFTER_INIT NonnullRefPtr<DisplayConnectorSysFSDirectory> DisplayConnectorSysFSDirectory::create(SysFSDirectory const& parent_directory, DisplayConnector const& device)
 {
     // FIXME: Handle allocation failure gracefully
     auto device_name = MUST(KString::formatted("{}", device.minor()));
-    auto directory = adopt_lock_ref(*new (nothrow) DisplayConnectorSysFSDirectory(move(device_name), parent_directory, device));
+    auto directory = adopt_ref(*new (nothrow) DisplayConnectorSysFSDirectory(move(device_name), parent_directory, device));
     MUST(directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
         list.append(DisplayConnectorAttributeSysFSComponent::must_create(*directory, DisplayConnectorAttributeSysFSComponent::Type::MutableModeSettingCapable));
         list.append(DisplayConnectorAttributeSysFSComponent::must_create(*directory, DisplayConnectorAttributeSysFSComponent::Type::DoubleFrameBufferingCapable));

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceDirectory.h
@@ -15,7 +15,7 @@ namespace Kernel {
 class DisplayConnectorAttributeSysFSComponent;
 class DisplayConnectorSysFSDirectory final : public SysFSDirectory {
 public:
-    static NonnullLockRefPtr<DisplayConnectorSysFSDirectory> create(SysFSDirectory const&, DisplayConnector const&);
+    static NonnullRefPtr<DisplayConnectorSysFSDirectory> create(SysFSDirectory const&, DisplayConnector const&);
 
     virtual StringView name() const override { return m_device_directory_name->view(); }
 
@@ -23,7 +23,7 @@ public:
 
 private:
     DisplayConnectorSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, SysFSDirectory const&, DisplayConnector const&);
-    LockRefPtr<DisplayConnector> m_device;
+    NonnullRefPtr<DisplayConnector> const m_device;
     NonnullOwnPtr<KString> m_device_directory_name;
 };
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/Directory.cpp
@@ -16,9 +16,9 @@ namespace Kernel {
 
 static SysFSDisplayConnectorsDirectory* s_the { nullptr };
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSDisplayConnectorsDirectory> SysFSDisplayConnectorsDirectory::must_create(SysFSGraphicsDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSDisplayConnectorsDirectory> SysFSDisplayConnectorsDirectory::must_create(SysFSGraphicsDirectory const& parent_directory)
 {
-    auto directory = adopt_lock_ref(*new (nothrow) SysFSDisplayConnectorsDirectory(parent_directory));
+    auto directory = adopt_ref(*new (nothrow) SysFSDisplayConnectorsDirectory(parent_directory));
     s_the = directory;
     return directory;
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/Directory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/Directory.h
@@ -20,7 +20,7 @@ class SysFSDisplayConnectorsDirectory : public SysFSDirectory {
 public:
     virtual StringView name() const override { return "connectors"sv; }
     static SysFSDisplayConnectorsDirectory& the();
-    static NonnullLockRefPtr<SysFSDisplayConnectorsDirectory> must_create(SysFSGraphicsDirectory const&);
+    static NonnullRefPtr<SysFSDisplayConnectorsDirectory> must_create(SysFSGraphicsDirectory const&);
 
     void plug(Badge<DisplayConnector>, DisplayConnectorSysFSDirectory&);
     void unplug(Badge<DisplayConnector>, SysFSDirectory&);

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceAttribute.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceAttribute.cpp
@@ -25,9 +25,9 @@ StringView StorageDeviceAttributeSysFSComponent::name() const
     }
 }
 
-NonnullLockRefPtr<StorageDeviceAttributeSysFSComponent> StorageDeviceAttributeSysFSComponent::must_create(StorageDeviceSysFSDirectory const& device_directory, Type type)
+NonnullRefPtr<StorageDeviceAttributeSysFSComponent> StorageDeviceAttributeSysFSComponent::must_create(StorageDeviceSysFSDirectory const& device_directory, Type type)
 {
-    return adopt_lock_ref(*new (nothrow) StorageDeviceAttributeSysFSComponent(device_directory, type));
+    return adopt_ref(*new (nothrow) StorageDeviceAttributeSysFSComponent(device_directory, type));
 }
 
 StorageDeviceAttributeSysFSComponent::StorageDeviceAttributeSysFSComponent(StorageDeviceSysFSDirectory const& device_directory, Type type)

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceAttribute.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceAttribute.h
@@ -21,7 +21,7 @@ public:
     };
 
 public:
-    static NonnullLockRefPtr<StorageDeviceAttributeSysFSComponent> must_create(StorageDeviceSysFSDirectory const& device_directory, Type);
+    static NonnullRefPtr<StorageDeviceAttributeSysFSComponent> must_create(StorageDeviceSysFSDirectory const& device_directory, Type);
 
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const override;
     virtual ~StorageDeviceAttributeSysFSComponent() {};
@@ -31,7 +31,7 @@ public:
 protected:
     ErrorOr<NonnullOwnPtr<KBuffer>> try_to_generate_buffer() const;
     StorageDeviceAttributeSysFSComponent(StorageDeviceSysFSDirectory const& device, Type);
-    NonnullLockRefPtr<StorageDevice> m_device;
+    NonnullRefPtr<StorageDevice> m_device;
     Type const m_type { Type::EndLBA };
 };
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceDirectory.cpp
@@ -18,12 +18,12 @@ StorageDevice const& StorageDeviceSysFSDirectory::device(Badge<StorageDeviceAttr
     return *m_device;
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<StorageDeviceSysFSDirectory> StorageDeviceSysFSDirectory::create(SysFSDirectory const& parent_directory, StorageDevice const& device)
+UNMAP_AFTER_INIT NonnullRefPtr<StorageDeviceSysFSDirectory> StorageDeviceSysFSDirectory::create(SysFSDirectory const& parent_directory, StorageDevice const& device)
 {
     // FIXME: Handle allocation failure gracefully
     auto lun_address = device.logical_unit_number_address();
     auto device_name = MUST(KString::formatted("{:02x}:{:02x}.{}", lun_address.controller_id, lun_address.target_id, lun_address.disk_id));
-    auto directory = adopt_lock_ref(*new (nothrow) StorageDeviceSysFSDirectory(move(device_name), parent_directory, device));
+    auto directory = adopt_ref(*new (nothrow) StorageDeviceSysFSDirectory(move(device_name), parent_directory, device));
     MUST(directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
         list.append(StorageDeviceAttributeSysFSComponent::must_create(*directory, StorageDeviceAttributeSysFSComponent::Type::EndLBA));
         list.append(StorageDeviceAttributeSysFSComponent::must_create(*directory, StorageDeviceAttributeSysFSComponent::Type::SectorSize));

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceDirectory.h
@@ -15,7 +15,7 @@ namespace Kernel {
 class StorageDeviceAttributeSysFSComponent;
 class StorageDeviceSysFSDirectory final : public SysFSDirectory {
 public:
-    static NonnullLockRefPtr<StorageDeviceSysFSDirectory> create(SysFSDirectory const&, StorageDevice const&);
+    static NonnullRefPtr<StorageDeviceSysFSDirectory> create(SysFSDirectory const&, StorageDevice const&);
 
     virtual StringView name() const override { return m_device_directory_name->view(); }
 
@@ -23,7 +23,7 @@ public:
 
 private:
     StorageDeviceSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, SysFSDirectory const&, StorageDevice const&);
-    LockRefPtr<StorageDevice> m_device;
+    RefPtr<StorageDevice> m_device;
     NonnullOwnPtr<KString> m_device_directory_name;
 };
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/Directory.cpp
@@ -15,9 +15,9 @@ namespace Kernel {
 
 static SysFSStorageDirectory* s_the { nullptr };
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSStorageDirectory> SysFSStorageDirectory::must_create(SysFSDevicesDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSStorageDirectory> SysFSStorageDirectory::must_create(SysFSDevicesDirectory const& parent_directory)
 {
-    auto directory = adopt_lock_ref(*new (nothrow) SysFSStorageDirectory(parent_directory));
+    auto directory = adopt_ref(*new (nothrow) SysFSStorageDirectory(parent_directory));
     s_the = directory;
     return directory;
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/Directory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/Directory.h
@@ -19,7 +19,7 @@ class SysFSStorageDirectory : public SysFSDirectory {
 public:
     virtual StringView name() const override { return "storage"sv; }
     static SysFSStorageDirectory& the();
-    static NonnullLockRefPtr<SysFSStorageDirectory> must_create(SysFSDevicesDirectory const&);
+    static NonnullRefPtr<SysFSStorageDirectory> must_create(SysFSDevicesDirectory const&);
 
     void plug(Badge<StorageDevice>, StorageDeviceSysFSDirectory&);
     void unplug(Badge<StorageDevice>, SysFSDirectory&);

--- a/Kernel/FileSystem/SysFS/Subsystems/Firmware/BIOS/Component.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Firmware/BIOS/Component.cpp
@@ -15,9 +15,9 @@
 
 namespace Kernel {
 
-NonnullLockRefPtr<BIOSSysFSComponent> BIOSSysFSComponent::must_create(Type type, PhysicalAddress blob_paddr, size_t blob_size)
+NonnullRefPtr<BIOSSysFSComponent> BIOSSysFSComponent::must_create(Type type, PhysicalAddress blob_paddr, size_t blob_size)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) BIOSSysFSComponent(type, blob_paddr, blob_size)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) BIOSSysFSComponent(type, blob_paddr, blob_size)).release_nonnull();
 }
 
 UNMAP_AFTER_INIT BIOSSysFSComponent::BIOSSysFSComponent(Type type, PhysicalAddress blob_paddr, size_t blob_size)

--- a/Kernel/FileSystem/SysFS/Subsystems/Firmware/BIOS/Component.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Firmware/BIOS/Component.h
@@ -6,11 +6,11 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Firmware/Directory.h>
 #include <Kernel/KBuffer.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/PhysicalAddress.h>
 
 namespace Kernel {
@@ -23,7 +23,7 @@ public:
     };
 
 public:
-    static NonnullLockRefPtr<BIOSSysFSComponent> must_create(Type, PhysicalAddress, size_t blob_size);
+    static NonnullRefPtr<BIOSSysFSComponent> must_create(Type, PhysicalAddress, size_t blob_size);
     virtual StringView name() const override;
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const override;
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Firmware/BIOS/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Firmware/BIOS/Directory.cpp
@@ -39,9 +39,9 @@ UNMAP_AFTER_INIT void BIOSSysFSDirectory::set_dmi_32_bit_entry_initialization_va
     m_smbios_structure_table_length = smbios_entry.ptr()->legacy_structure.smbios_table_length;
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<BIOSSysFSDirectory> BIOSSysFSDirectory::must_create(FirmwareSysFSDirectory& firmware_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<BIOSSysFSDirectory> BIOSSysFSDirectory::must_create(FirmwareSysFSDirectory& firmware_directory)
 {
-    auto bios_directory = MUST(adopt_nonnull_lock_ref_or_enomem(new (nothrow) BIOSSysFSDirectory(firmware_directory)));
+    auto bios_directory = MUST(adopt_nonnull_ref_or_enomem(new (nothrow) BIOSSysFSDirectory(firmware_directory)));
     bios_directory->create_components();
     return bios_directory;
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Firmware/BIOS/Directory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Firmware/BIOS/Directory.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Firmware/Directory.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/PhysicalAddress.h>
 
 namespace Kernel {
@@ -17,7 +17,7 @@ namespace Kernel {
 class BIOSSysFSDirectory : public SysFSDirectory {
 public:
     virtual StringView name() const override { return "bios"sv; }
-    static NonnullLockRefPtr<BIOSSysFSDirectory> must_create(FirmwareSysFSDirectory&);
+    static NonnullRefPtr<BIOSSysFSDirectory> must_create(FirmwareSysFSDirectory&);
 
     void create_components();
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Firmware/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Firmware/Directory.cpp
@@ -14,7 +14,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT void FirmwareSysFSDirectory::initialize()
 {
-    auto firmware_directory = adopt_lock_ref_if_nonnull(new (nothrow) FirmwareSysFSDirectory()).release_nonnull();
+    auto firmware_directory = adopt_ref_if_nonnull(new (nothrow) FirmwareSysFSDirectory()).release_nonnull();
     SysFSComponentRegistry::the().register_new_component(firmware_directory);
     firmware_directory->create_components();
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/CPUInfo.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/CPUInfo.cpp
@@ -18,9 +18,9 @@ UNMAP_AFTER_INIT SysFSCPUInformation::SysFSCPUInformation(SysFSDirectory const& 
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSCPUInformation> SysFSCPUInformation::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSCPUInformation> SysFSCPUInformation::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSCPUInformation(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSCPUInformation(parent_directory)).release_nonnull();
 }
 
 ErrorOr<void> SysFSCPUInformation::try_generate(KBufferBuilder& builder)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/CPUInfo.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/CPUInfo.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -18,7 +18,7 @@ class SysFSCPUInformation final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "cpuinfo"sv; }
 
-    static NonnullLockRefPtr<SysFSCPUInformation> must_create(SysFSDirectory const& parent_directory);
+    static NonnullRefPtr<SysFSCPUInformation> must_create(SysFSDirectory const& parent_directory);
 
 private:
     SysFSCPUInformation(SysFSDirectory const& parent_directory);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Constants/ConstantInformation.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Constants/ConstantInformation.cpp
@@ -24,9 +24,9 @@ StringView SysFSSystemConstantInformation::name() const
     }
 }
 
-NonnullLockRefPtr<SysFSSystemConstantInformation> SysFSSystemConstantInformation::must_create(SysFSDirectory const& parent_directory, NonnullOwnPtr<KBuffer> constant_data_buffer, mode_t mode, ReadableByJailedProcesses readable_by_jailed_processes, NodeName name)
+NonnullRefPtr<SysFSSystemConstantInformation> SysFSSystemConstantInformation::must_create(SysFSDirectory const& parent_directory, NonnullOwnPtr<KBuffer> constant_data_buffer, mode_t mode, ReadableByJailedProcesses readable_by_jailed_processes, NodeName name)
 {
-    auto node = adopt_lock_ref_if_nonnull(new (nothrow) SysFSSystemConstantInformation(parent_directory, move(constant_data_buffer), mode, readable_by_jailed_processes, name)).release_nonnull();
+    auto node = adopt_ref_if_nonnull(new (nothrow) SysFSSystemConstantInformation(parent_directory, move(constant_data_buffer), mode, readable_by_jailed_processes, name)).release_nonnull();
     return node;
 }
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Constants/ConstantInformation.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Constants/ConstantInformation.h
@@ -28,7 +28,7 @@ public:
     };
 
     virtual StringView name() const override;
-    static NonnullLockRefPtr<SysFSSystemConstantInformation> must_create(SysFSDirectory const& parent_directory, NonnullOwnPtr<KBuffer> constant_data_buffer, mode_t mode, ReadableByJailedProcesses readable_by_jailed_processes, NodeName name);
+    static NonnullRefPtr<SysFSSystemConstantInformation> must_create(SysFSDirectory const& parent_directory, NonnullOwnPtr<KBuffer> constant_data_buffer, mode_t mode, ReadableByJailedProcesses readable_by_jailed_processes, NodeName name);
 
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const override;
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Constants/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Constants/Directory.cpp
@@ -14,9 +14,9 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSGlobalKernelConstantsDirectory> SysFSGlobalKernelConstantsDirectory::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSGlobalKernelConstantsDirectory> SysFSGlobalKernelConstantsDirectory::must_create(SysFSDirectory const& parent_directory)
 {
-    auto global_constants_directory = adopt_lock_ref_if_nonnull(new (nothrow) SysFSGlobalKernelConstantsDirectory(parent_directory)).release_nonnull();
+    auto global_constants_directory = adopt_ref_if_nonnull(new (nothrow) SysFSGlobalKernelConstantsDirectory(parent_directory)).release_nonnull();
     MUST(global_constants_directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
         {
             auto builder = TRY(KBufferBuilder::try_create());

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Constants/Directory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Constants/Directory.h
@@ -14,7 +14,7 @@ namespace Kernel {
 
 class SysFSGlobalKernelConstantsDirectory : public SysFSDirectory {
 public:
-    static NonnullLockRefPtr<SysFSGlobalKernelConstantsDirectory> must_create(SysFSDirectory const&);
+    static NonnullRefPtr<SysFSGlobalKernelConstantsDirectory> must_create(SysFSDirectory const&);
     virtual StringView name() const override { return "constants"sv; }
 
 private:

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Directory.cpp
@@ -27,9 +27,9 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSGlobalKernelStatsDirectory> SysFSGlobalKernelStatsDirectory::must_create(SysFSRootDirectory const& root_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSGlobalKernelStatsDirectory> SysFSGlobalKernelStatsDirectory::must_create(SysFSRootDirectory const& root_directory)
 {
-    auto global_kernel_stats_directory = adopt_lock_ref_if_nonnull(new (nothrow) SysFSGlobalKernelStatsDirectory(root_directory)).release_nonnull();
+    auto global_kernel_stats_directory = adopt_ref_if_nonnull(new (nothrow) SysFSGlobalKernelStatsDirectory(root_directory)).release_nonnull();
     auto global_constants_directory = SysFSGlobalKernelConstantsDirectory::must_create(*global_kernel_stats_directory);
     MUST(global_kernel_stats_directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
         list.append(global_constants_directory);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Directory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Directory.h
@@ -14,7 +14,7 @@ namespace Kernel {
 
 class SysFSGlobalKernelStatsDirectory : public SysFSDirectory {
 public:
-    static NonnullLockRefPtr<SysFSGlobalKernelStatsDirectory> must_create(SysFSRootDirectory const&);
+    static NonnullRefPtr<SysFSGlobalKernelStatsDirectory> must_create(SysFSRootDirectory const&);
     virtual StringView name() const override { return "kernel"sv; }
 
 private:

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/DiskUsage.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/DiskUsage.cpp
@@ -12,9 +12,9 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSDiskUsage> SysFSDiskUsage::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSDiskUsage> SysFSDiskUsage::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSDiskUsage(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSDiskUsage(parent_directory)).release_nonnull();
 }
 
 UNMAP_AFTER_INIT SysFSDiskUsage::SysFSDiskUsage(SysFSDirectory const& parent_directory)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/DiskUsage.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/DiskUsage.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -18,7 +18,7 @@ class SysFSDiskUsage final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "df"sv; }
 
-    static NonnullLockRefPtr<SysFSDiskUsage> must_create(SysFSDirectory const& parent_directory);
+    static NonnullRefPtr<SysFSDiskUsage> must_create(SysFSDirectory const& parent_directory);
 
 private:
     SysFSDiskUsage(SysFSDirectory const& parent_directory);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h
@@ -7,13 +7,13 @@
 #pragma once
 
 #include <AK/Error.h>
+#include <AK/RefPtr.h>
 #include <AK/Try.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/FileSystem.h>
 #include <Kernel/FileSystem/OpenFileDescription.h>
 #include <Kernel/FileSystem/SysFS/Component.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/Locking/Mutex.h>
 #include <Kernel/UserOrKernelBuffer.h>
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Interrupts.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Interrupts.cpp
@@ -18,9 +18,9 @@ UNMAP_AFTER_INIT SysFSInterrupts::SysFSInterrupts(SysFSDirectory const& parent_d
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSInterrupts> SysFSInterrupts::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSInterrupts> SysFSInterrupts::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSInterrupts(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSInterrupts(parent_directory)).release_nonnull();
 }
 
 ErrorOr<void> SysFSInterrupts::try_generate(KBufferBuilder& builder)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Interrupts.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Interrupts.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -18,7 +18,7 @@ class SysFSInterrupts final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "interrupts"sv; }
 
-    static NonnullLockRefPtr<SysFSInterrupts> must_create(SysFSDirectory const& parent_directory);
+    static NonnullRefPtr<SysFSInterrupts> must_create(SysFSDirectory const& parent_directory);
 
 private:
     explicit SysFSInterrupts(SysFSDirectory const& parent_directory);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Jails.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Jails.cpp
@@ -16,9 +16,9 @@ UNMAP_AFTER_INIT SysFSJails::SysFSJails(SysFSDirectory const& parent_directory)
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSJails> SysFSJails::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSJails> SysFSJails::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSJails(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSJails(parent_directory)).release_nonnull();
 }
 
 ErrorOr<void> SysFSJails::try_generate(KBufferBuilder& builder)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Jails.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Jails.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -18,7 +18,7 @@ class SysFSJails final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "jails"sv; }
 
-    static NonnullLockRefPtr<SysFSJails> must_create(SysFSDirectory const& parent_directory);
+    static NonnullRefPtr<SysFSJails> must_create(SysFSDirectory const& parent_directory);
 
 private:
     explicit SysFSJails(SysFSDirectory const& parent_directory);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Keymap.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Keymap.cpp
@@ -16,9 +16,9 @@ UNMAP_AFTER_INIT SysFSKeymap::SysFSKeymap(SysFSDirectory const& parent_directory
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSKeymap> SysFSKeymap::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSKeymap> SysFSKeymap::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSKeymap(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSKeymap(parent_directory)).release_nonnull();
 }
 
 ErrorOr<void> SysFSKeymap::try_generate(KBufferBuilder& builder)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Keymap.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Keymap.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -18,7 +18,7 @@ class SysFSKeymap final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "keymap"sv; }
 
-    static NonnullLockRefPtr<SysFSKeymap> must_create(SysFSDirectory const& parent_directory);
+    static NonnullRefPtr<SysFSKeymap> must_create(SysFSDirectory const& parent_directory);
 
 private:
     explicit SysFSKeymap(SysFSDirectory const& parent_directory);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Log.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Log.cpp
@@ -16,9 +16,9 @@ UNMAP_AFTER_INIT SysFSKernelLog::SysFSKernelLog(SysFSDirectory const& parent_dir
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSKernelLog> SysFSKernelLog::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSKernelLog> SysFSKernelLog::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSKernelLog(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSKernelLog(parent_directory)).release_nonnull();
 }
 
 mode_t SysFSKernelLog::permissions() const

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Log.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Log.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -17,7 +17,7 @@ namespace Kernel {
 class SysFSKernelLog final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "dmesg"sv; }
-    static NonnullLockRefPtr<SysFSKernelLog> must_create(SysFSDirectory const& parent_directory);
+    static NonnullRefPtr<SysFSKernelLog> must_create(SysFSDirectory const& parent_directory);
 
     virtual mode_t permissions() const override;
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/MemoryStatus.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/MemoryStatus.cpp
@@ -16,9 +16,9 @@ UNMAP_AFTER_INIT SysFSMemoryStatus::SysFSMemoryStatus(SysFSDirectory const& pare
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSMemoryStatus> SysFSMemoryStatus::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSMemoryStatus> SysFSMemoryStatus::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSMemoryStatus(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSMemoryStatus(parent_directory)).release_nonnull();
 }
 
 ErrorOr<void> SysFSMemoryStatus::try_generate(KBufferBuilder& builder)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/MemoryStatus.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/MemoryStatus.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -18,7 +18,7 @@ class SysFSMemoryStatus final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "memstat"sv; }
 
-    static NonnullLockRefPtr<SysFSMemoryStatus> must_create(SysFSDirectory const& parent_directory);
+    static NonnullRefPtr<SysFSMemoryStatus> must_create(SysFSDirectory const& parent_directory);
 
 private:
     explicit SysFSMemoryStatus(SysFSDirectory const& parent_directory);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/ARP.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/ARP.cpp
@@ -17,9 +17,9 @@ UNMAP_AFTER_INIT SysFSNetworkARPStats::SysFSNetworkARPStats(SysFSDirectory const
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSNetworkARPStats> SysFSNetworkARPStats::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSNetworkARPStats> SysFSNetworkARPStats::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSNetworkARPStats(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSNetworkARPStats(parent_directory)).release_nonnull();
 }
 
 ErrorOr<void> SysFSNetworkARPStats::try_generate(KBufferBuilder& builder)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/ARP.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/ARP.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -17,7 +17,7 @@ namespace Kernel {
 class SysFSNetworkARPStats final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "arp"sv; }
-    static NonnullLockRefPtr<SysFSNetworkARPStats> must_create(SysFSDirectory const&);
+    static NonnullRefPtr<SysFSNetworkARPStats> must_create(SysFSDirectory const&);
 
 private:
     explicit SysFSNetworkARPStats(SysFSDirectory const&);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Adapters.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Adapters.cpp
@@ -16,9 +16,9 @@ UNMAP_AFTER_INIT SysFSNetworkAdaptersStats::SysFSNetworkAdaptersStats(SysFSDirec
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSNetworkAdaptersStats> SysFSNetworkAdaptersStats::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSNetworkAdaptersStats> SysFSNetworkAdaptersStats::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSNetworkAdaptersStats(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSNetworkAdaptersStats(parent_directory)).release_nonnull();
 }
 
 ErrorOr<void> SysFSNetworkAdaptersStats::try_generate(KBufferBuilder& builder)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Adapters.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Adapters.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -17,7 +17,7 @@ namespace Kernel {
 class SysFSNetworkAdaptersStats final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "adapters"sv; }
-    static NonnullLockRefPtr<SysFSNetworkAdaptersStats> must_create(SysFSDirectory const&);
+    static NonnullRefPtr<SysFSNetworkAdaptersStats> must_create(SysFSDirectory const&);
 
 private:
     explicit SysFSNetworkAdaptersStats(SysFSDirectory const&);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Directory.cpp
@@ -17,9 +17,9 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSGlobalNetworkStatsDirectory> SysFSGlobalNetworkStatsDirectory::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSGlobalNetworkStatsDirectory> SysFSGlobalNetworkStatsDirectory::must_create(SysFSDirectory const& parent_directory)
 {
-    auto global_network_stats_directory = adopt_lock_ref_if_nonnull(new (nothrow) SysFSGlobalNetworkStatsDirectory(parent_directory)).release_nonnull();
+    auto global_network_stats_directory = adopt_ref_if_nonnull(new (nothrow) SysFSGlobalNetworkStatsDirectory(parent_directory)).release_nonnull();
     MUST(global_network_stats_directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
         list.append(SysFSNetworkAdaptersStats::must_create(*global_network_stats_directory));
         list.append(SysFSNetworkARPStats::must_create(*global_network_stats_directory));

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Directory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Directory.h
@@ -14,7 +14,7 @@ namespace Kernel {
 
 class SysFSGlobalNetworkStatsDirectory : public SysFSDirectory {
 public:
-    static NonnullLockRefPtr<SysFSGlobalNetworkStatsDirectory> must_create(SysFSDirectory const&);
+    static NonnullRefPtr<SysFSGlobalNetworkStatsDirectory> must_create(SysFSDirectory const&);
     virtual StringView name() const override { return "net"sv; }
 
 private:

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Local.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Local.cpp
@@ -16,9 +16,9 @@ UNMAP_AFTER_INIT SysFSLocalNetStats::SysFSLocalNetStats(SysFSDirectory const& pa
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSLocalNetStats> SysFSLocalNetStats::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSLocalNetStats> SysFSLocalNetStats::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSLocalNetStats(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSLocalNetStats(parent_directory)).release_nonnull();
 }
 
 ErrorOr<void> SysFSLocalNetStats::try_generate(KBufferBuilder& builder)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Local.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Local.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -17,7 +17,7 @@ namespace Kernel {
 class SysFSLocalNetStats final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "local"sv; }
-    static NonnullLockRefPtr<SysFSLocalNetStats> must_create(SysFSDirectory const&);
+    static NonnullRefPtr<SysFSLocalNetStats> must_create(SysFSDirectory const&);
 
 private:
     explicit SysFSLocalNetStats(SysFSDirectory const&);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Route.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Route.cpp
@@ -16,9 +16,9 @@ UNMAP_AFTER_INIT SysFSNetworkRouteStats::SysFSNetworkRouteStats(SysFSDirectory c
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSNetworkRouteStats> SysFSNetworkRouteStats::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSNetworkRouteStats> SysFSNetworkRouteStats::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSNetworkRouteStats(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSNetworkRouteStats(parent_directory)).release_nonnull();
 }
 
 ErrorOr<void> SysFSNetworkRouteStats::try_generate(KBufferBuilder& builder)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Route.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/Route.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -17,7 +17,7 @@ namespace Kernel {
 class SysFSNetworkRouteStats final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "route"sv; }
-    static NonnullLockRefPtr<SysFSNetworkRouteStats> must_create(SysFSDirectory const&);
+    static NonnullRefPtr<SysFSNetworkRouteStats> must_create(SysFSDirectory const&);
 
 private:
     explicit SysFSNetworkRouteStats(SysFSDirectory const&);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/TCP.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/TCP.cpp
@@ -18,9 +18,9 @@ UNMAP_AFTER_INIT SysFSNetworkTCPStats::SysFSNetworkTCPStats(SysFSDirectory const
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSNetworkTCPStats> SysFSNetworkTCPStats::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSNetworkTCPStats> SysFSNetworkTCPStats::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSNetworkTCPStats(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSNetworkTCPStats(parent_directory)).release_nonnull();
 }
 
 ErrorOr<void> SysFSNetworkTCPStats::try_generate(KBufferBuilder& builder)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/TCP.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/TCP.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -17,7 +17,7 @@ namespace Kernel {
 class SysFSNetworkTCPStats final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "tcp"sv; }
-    static NonnullLockRefPtr<SysFSNetworkTCPStats> must_create(SysFSDirectory const&);
+    static NonnullRefPtr<SysFSNetworkTCPStats> must_create(SysFSDirectory const&);
 
 private:
     explicit SysFSNetworkTCPStats(SysFSDirectory const&);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/UDP.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/UDP.cpp
@@ -17,9 +17,9 @@ UNMAP_AFTER_INIT SysFSNetworkUDPStats::SysFSNetworkUDPStats(SysFSDirectory const
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSNetworkUDPStats> SysFSNetworkUDPStats::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSNetworkUDPStats> SysFSNetworkUDPStats::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSNetworkUDPStats(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSNetworkUDPStats(parent_directory)).release_nonnull();
 }
 
 ErrorOr<void> SysFSNetworkUDPStats::try_generate(KBufferBuilder& builder)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/UDP.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Network/UDP.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -17,7 +17,7 @@ namespace Kernel {
 class SysFSNetworkUDPStats final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "udp"sv; }
-    static NonnullLockRefPtr<SysFSNetworkUDPStats> must_create(SysFSDirectory const&);
+    static NonnullRefPtr<SysFSNetworkUDPStats> must_create(SysFSDirectory const&);
 
 private:
     explicit SysFSNetworkUDPStats(SysFSDirectory const&);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/PowerStateSwitch.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/PowerStateSwitch.cpp
@@ -24,9 +24,9 @@ mode_t SysFSPowerStateSwitchNode::permissions() const
     return S_IRUSR | S_IRGRP | S_IWUSR | S_IWGRP;
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSPowerStateSwitchNode> SysFSPowerStateSwitchNode::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSPowerStateSwitchNode> SysFSPowerStateSwitchNode::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSPowerStateSwitchNode(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSPowerStateSwitchNode(parent_directory)).release_nonnull();
 }
 
 UNMAP_AFTER_INIT SysFSPowerStateSwitchNode::SysFSPowerStateSwitchNode(SysFSDirectory const& parent_directory)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/PowerStateSwitch.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/PowerStateSwitch.h
@@ -7,11 +7,11 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Directory.h>
 #include <Kernel/KBuffer.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/Memory/MappedROM.h>
 #include <Kernel/Memory/Region.h>
 #include <Kernel/PhysicalAddress.h>
@@ -22,7 +22,7 @@ namespace Kernel {
 class SysFSPowerStateSwitchNode final : public SysFSComponent {
 public:
     virtual StringView name() const override { return "power_state"sv; }
-    static NonnullLockRefPtr<SysFSPowerStateSwitchNode> must_create(SysFSDirectory const&);
+    static NonnullRefPtr<SysFSPowerStateSwitchNode> must_create(SysFSDirectory const&);
     virtual mode_t permissions() const override;
     virtual ErrorOr<size_t> write_bytes(off_t, size_t, UserOrKernelBuffer const&, OpenFileDescription*) override;
     virtual ErrorOr<void> truncate(u64) override;

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Processes.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Processes.cpp
@@ -19,9 +19,9 @@ UNMAP_AFTER_INIT SysFSOverallProcesses::SysFSOverallProcesses(SysFSDirectory con
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSOverallProcesses> SysFSOverallProcesses::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSOverallProcesses> SysFSOverallProcesses::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSOverallProcesses(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSOverallProcesses(parent_directory)).release_nonnull();
 }
 
 ErrorOr<void> SysFSOverallProcesses::try_generate(KBufferBuilder& builder)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Processes.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Processes.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -18,7 +18,7 @@ class SysFSOverallProcesses final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "processes"sv; }
 
-    static NonnullLockRefPtr<SysFSOverallProcesses> must_create(SysFSDirectory const& parent_directory);
+    static NonnullRefPtr<SysFSOverallProcesses> must_create(SysFSDirectory const& parent_directory);
 
 private:
     explicit SysFSOverallProcesses(SysFSDirectory const& parent_directory);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Profile.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Profile.cpp
@@ -15,9 +15,9 @@ UNMAP_AFTER_INIT SysFSProfile::SysFSProfile(SysFSDirectory const& parent_directo
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSProfile> SysFSProfile::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSProfile> SysFSProfile::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSProfile(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSProfile(parent_directory)).release_nonnull();
 }
 
 ErrorOr<void> SysFSProfile::try_generate(KBufferBuilder& builder)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Profile.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Profile.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -18,7 +18,7 @@ class SysFSProfile final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "profile"sv; }
 
-    static NonnullLockRefPtr<SysFSProfile> must_create(SysFSDirectory const& parent_directory);
+    static NonnullRefPtr<SysFSProfile> must_create(SysFSDirectory const& parent_directory);
 
 private:
     virtual mode_t permissions() const override;

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/SystemStatistics.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/SystemStatistics.cpp
@@ -17,9 +17,9 @@ UNMAP_AFTER_INIT SysFSSystemStatistics::SysFSSystemStatistics(SysFSDirectory con
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSSystemStatistics> SysFSSystemStatistics::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSSystemStatistics> SysFSSystemStatistics::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSSystemStatistics(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSSystemStatistics(parent_directory)).release_nonnull();
 }
 
 ErrorOr<void> SysFSSystemStatistics::try_generate(KBufferBuilder& builder)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/SystemStatistics.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/SystemStatistics.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -18,7 +18,7 @@ class SysFSSystemStatistics final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "stats"sv; }
 
-    static NonnullLockRefPtr<SysFSSystemStatistics> must_create(SysFSDirectory const& parent_directory);
+    static NonnullRefPtr<SysFSSystemStatistics> must_create(SysFSDirectory const& parent_directory);
 
 private:
     explicit SysFSSystemStatistics(SysFSDirectory const& parent_directory);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Uptime.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Uptime.cpp
@@ -15,9 +15,9 @@ UNMAP_AFTER_INIT SysFSUptime::SysFSUptime(SysFSDirectory const& parent_directory
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSUptime> SysFSUptime::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSUptime> SysFSUptime::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSUptime(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSUptime(parent_directory)).release_nonnull();
 }
 
 ErrorOr<void> SysFSUptime::try_generate(KBufferBuilder& builder)

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Uptime.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Uptime.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -17,7 +17,7 @@ namespace Kernel {
 class SysFSUptime final : public SysFSGlobalInformation {
 public:
     virtual StringView name() const override { return "uptime"sv; }
-    static NonnullLockRefPtr<SysFSUptime> must_create(SysFSDirectory const& parent_directory);
+    static NonnullRefPtr<SysFSUptime> must_create(SysFSDirectory const& parent_directory);
 
 private:
     explicit SysFSUptime(SysFSDirectory const& parent_directory);

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/BooleanVariable.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/BooleanVariable.h
@@ -9,13 +9,13 @@
 #include <AK/AtomicRefCounted.h>
 #include <AK/Error.h>
 #include <AK/Function.h>
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/File.h>
 #include <Kernel/FileSystem/FileSystem.h>
 #include <Kernel/FileSystem/OpenFileDescription.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/Locking/Mutex.h>
 #include <Kernel/Time/TimeManagement.h>
 #include <Kernel/UserOrKernelBuffer.h>

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/CapsLockRemap.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/CapsLockRemap.cpp
@@ -15,9 +15,9 @@ UNMAP_AFTER_INIT SysFSCapsLockRemap::SysFSCapsLockRemap(SysFSDirectory const& pa
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSCapsLockRemap> SysFSCapsLockRemap::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSCapsLockRemap> SysFSCapsLockRemap::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSCapsLockRemap(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSCapsLockRemap(parent_directory)).release_nonnull();
 }
 
 bool SysFSCapsLockRemap::value() const

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/CapsLockRemap.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/CapsLockRemap.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/BooleanVariable.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
@@ -17,7 +17,7 @@ namespace Kernel {
 class SysFSCapsLockRemap final : public SysFSSystemBooleanVariable {
 public:
     virtual StringView name() const override { return "caps_lock_to_ctrl"sv; }
-    static NonnullLockRefPtr<SysFSCapsLockRemap> must_create(SysFSDirectory const&);
+    static NonnullRefPtr<SysFSCapsLockRemap> must_create(SysFSDirectory const&);
 
 private:
     virtual bool value() const override;

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/CoredumpDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/CoredumpDirectory.cpp
@@ -15,9 +15,9 @@ UNMAP_AFTER_INIT SysFSCoredumpDirectory::SysFSCoredumpDirectory(SysFSDirectory c
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSCoredumpDirectory> SysFSCoredumpDirectory::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSCoredumpDirectory> SysFSCoredumpDirectory::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSCoredumpDirectory(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSCoredumpDirectory(parent_directory)).release_nonnull();
 }
 
 ErrorOr<NonnullOwnPtr<KString>> SysFSCoredumpDirectory::value() const

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/CoredumpDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/CoredumpDirectory.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/StringVariable.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -16,7 +16,7 @@ namespace Kernel {
 class SysFSCoredumpDirectory final : public SysFSSystemStringVariable {
 public:
     virtual StringView name() const override { return "coredump_directory"sv; }
-    static NonnullLockRefPtr<SysFSCoredumpDirectory> must_create(SysFSDirectory const&);
+    static NonnullRefPtr<SysFSCoredumpDirectory> must_create(SysFSDirectory const&);
 
 private:
     virtual ErrorOr<NonnullOwnPtr<KString>> value() const override;

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/Directory.cpp
@@ -15,9 +15,9 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSGlobalKernelVariablesDirectory> SysFSGlobalKernelVariablesDirectory::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSGlobalKernelVariablesDirectory> SysFSGlobalKernelVariablesDirectory::must_create(SysFSDirectory const& parent_directory)
 {
-    auto global_variables_directory = adopt_lock_ref_if_nonnull(new (nothrow) SysFSGlobalKernelVariablesDirectory(parent_directory)).release_nonnull();
+    auto global_variables_directory = adopt_ref_if_nonnull(new (nothrow) SysFSGlobalKernelVariablesDirectory(parent_directory)).release_nonnull();
     MUST(global_variables_directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
         list.append(SysFSCapsLockRemap::must_create(*global_variables_directory));
         list.append(SysFSDumpKmallocStacks::must_create(*global_variables_directory));

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/Directory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/Directory.h
@@ -14,7 +14,7 @@ namespace Kernel {
 
 class SysFSGlobalKernelVariablesDirectory : public SysFSDirectory {
 public:
-    static NonnullLockRefPtr<SysFSGlobalKernelVariablesDirectory> must_create(SysFSDirectory const&);
+    static NonnullRefPtr<SysFSGlobalKernelVariablesDirectory> must_create(SysFSDirectory const&);
     virtual StringView name() const override { return "variables"sv; }
 
 private:

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/DumpKmallocStack.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/DumpKmallocStack.cpp
@@ -15,9 +15,9 @@ UNMAP_AFTER_INIT SysFSDumpKmallocStacks::SysFSDumpKmallocStacks(SysFSDirectory c
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSDumpKmallocStacks> SysFSDumpKmallocStacks::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSDumpKmallocStacks> SysFSDumpKmallocStacks::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSDumpKmallocStacks(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSDumpKmallocStacks(parent_directory)).release_nonnull();
 }
 
 bool SysFSDumpKmallocStacks::value() const

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/DumpKmallocStack.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/DumpKmallocStack.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/BooleanVariable.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
@@ -17,7 +17,7 @@ namespace Kernel {
 class SysFSDumpKmallocStacks final : public SysFSSystemBooleanVariable {
 public:
     virtual StringView name() const override { return "kmalloc_stacks"sv; }
-    static NonnullLockRefPtr<SysFSDumpKmallocStacks> must_create(SysFSDirectory const&);
+    static NonnullRefPtr<SysFSDumpKmallocStacks> must_create(SysFSDirectory const&);
 
 private:
     virtual bool value() const override;

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/StringVariable.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/StringVariable.h
@@ -10,6 +10,7 @@
 #include <AK/Error.h>
 #include <AK/Function.h>
 #include <AK/OwnPtr.h>
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/File.h>
 #include <Kernel/FileSystem/FileSystem.h>
@@ -17,7 +18,6 @@
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
 #include <Kernel/KBufferBuilder.h>
 #include <Kernel/KString.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/Locking/Mutex.h>
 #include <Kernel/Time/TimeManagement.h>
 #include <Kernel/UserOrKernelBuffer.h>

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/UBSANDeadly.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/UBSANDeadly.cpp
@@ -15,9 +15,9 @@ UNMAP_AFTER_INIT SysFSUBSANDeadly::SysFSUBSANDeadly(SysFSDirectory const& parent
 {
 }
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<SysFSUBSANDeadly> SysFSUBSANDeadly::must_create(SysFSDirectory const& parent_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSUBSANDeadly> SysFSUBSANDeadly::must_create(SysFSDirectory const& parent_directory)
 {
-    return adopt_lock_ref_if_nonnull(new (nothrow) SysFSUBSANDeadly(parent_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSUBSANDeadly(parent_directory)).release_nonnull();
 }
 
 bool SysFSUBSANDeadly::value() const

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/UBSANDeadly.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/UBSANDeadly.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/BooleanVariable.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -16,7 +16,7 @@ namespace Kernel {
 class SysFSUBSANDeadly final : public SysFSSystemBooleanVariable {
 public:
     virtual StringView name() const override { return "ubsan_is_deadly"sv; }
-    static NonnullLockRefPtr<SysFSUBSANDeadly> must_create(SysFSDirectory const&);
+    static NonnullRefPtr<SysFSUBSANDeadly> must_create(SysFSDirectory const&);
 
 private:
     virtual bool value() const override;

--- a/Kernel/Graphics/DisplayConnector.cpp
+++ b/Kernel/Graphics/DisplayConnector.cpp
@@ -93,7 +93,6 @@ ErrorOr<void> DisplayConnector::allocate_framebuffer_resources(size_t rounded_si
 
 ErrorOr<void> DisplayConnector::after_inserting()
 {
-    after_inserting_add_to_device_management();
     ArmedScopeGuard clean_from_device_management([&] {
         before_will_be_destroyed_remove_from_device_management();
     });
@@ -110,6 +109,7 @@ ErrorOr<void> DisplayConnector::after_inserting()
     auto sys_fs_component = TRY(SysFSSymbolicLinkDeviceComponent::try_create(SysFSCharacterDevicesDirectory::the(), *this, *m_sysfs_device_directory));
     m_symlink_sysfs_component = sys_fs_component;
     after_inserting_add_symlink_to_device_identifier_directory();
+
     ArmedScopeGuard clean_symlink_to_device_identifier_directory([&] {
         VERIFY(m_symlink_sysfs_component);
         before_will_be_destroyed_remove_symlink_from_device_identifier_directory();
@@ -136,6 +136,7 @@ ErrorOr<void> DisplayConnector::after_inserting()
     if (m_enable_write_combine_optimization) {
         [[maybe_unused]] auto result = m_framebuffer_region->set_write_combine(true);
     }
+    after_inserting_add_to_device_management();
     return {};
 }
 

--- a/Kernel/Storage/StorageDevice.cpp
+++ b/Kernel/Storage/StorageDevice.cpp
@@ -38,7 +38,6 @@ StorageDevice::StorageDevice(Badge<RamdiskDevice>, LUNAddress logical_unit_numbe
 
 ErrorOr<void> StorageDevice::after_inserting()
 {
-    after_inserting_add_to_device_management();
     auto sysfs_storage_device_directory = StorageDeviceSysFSDirectory::create(SysFSStorageDirectory::the(), *this);
     m_sysfs_device_directory = sysfs_storage_device_directory;
     SysFSStorageDirectory::the().plug({}, *sysfs_storage_device_directory);
@@ -46,6 +45,7 @@ ErrorOr<void> StorageDevice::after_inserting()
     auto sys_fs_component = TRY(SysFSSymbolicLinkDeviceComponent::try_create(SysFSBlockDevicesDirectory::the(), *this, *m_sysfs_device_directory));
     m_symlink_sysfs_component = sys_fs_component;
     after_inserting_add_symlink_to_device_identifier_directory();
+    after_inserting_add_to_device_management();
     return {};
 }
 


### PR DESCRIPTION
To do this we also need to get rid of LockRefPtrs in the USB code as well.
Most of the SysFS nodes are statically generated during boot and are not mutated afterwards.

The same goes for general device code - once we generate the appropriate SysFS nodes, we almost never mutate the pointer afterwards, making locking unnecessary.