### PR TITLE
webp lossless: Some preparations for handling transforms and entropy image

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -448,7 +448,7 @@ enum class ImageKind {
     EntropyCoded,
 };
 
-static ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L_image(WebPLoadingContext& context, ImageKind image_kind, VP8LHeader const& vp8l_header, LittleEndianInputBitStream& bit_stream)
+static ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L_image(WebPLoadingContext& context, ImageKind image_kind, BitmapFormat format, IntSize const& size, LittleEndianInputBitStream& bit_stream)
 {
     // https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#623_decoding_entropy-coded_image_data
     // https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#523_color_cache_coding
@@ -495,7 +495,7 @@ static ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L_image(WebPLoadingCo
 
     PrefixCodeGroup group = TRY(decode_webp_chunk_VP8L_prefix_code_group(context, color_cache_size, bit_stream));
 
-    auto bitmap = TRY(Bitmap::create(vp8l_header.is_alpha_used ? BitmapFormat::BGRA8888 : BitmapFormat::BGRx8888, context.size.value()));
+    auto bitmap = TRY(Bitmap::create(format, size));
 
     // https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#522_lz77_backward_reference
     struct Offset {
@@ -681,7 +681,8 @@ static ErrorOr<void> decode_webp_chunk_VP8L(WebPLoadingContext& context, Chunk c
         }
     }
 
-    context.bitmap = TRY(decode_webp_chunk_VP8L_image(context, ImageKind::SpatiallyCoded, vp8l_header, bit_stream));
+    auto format = vp8l_header.is_alpha_used ? BitmapFormat::BGRA8888 : BitmapFormat::BGRx8888;
+    context.bitmap = TRY(decode_webp_chunk_VP8L_image(context, ImageKind::SpatiallyCoded, format, context.size.value(), bit_stream));
     return {};
 }
 

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -463,8 +463,38 @@ static ErrorOr<void> decode_webp_chunk_VP8L(WebPLoadingContext& context, Chunk c
     // https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#72_structure_of_transforms
 
     // optional-transform   =  (%b1 transform optional-transform) / %b0
-    if (TRY(bit_stream.read_bits(1)))
-        return context.error("WebPImageDecoderPlugin: VP8L transform handling not yet implemented");
+    while (TRY(bit_stream.read_bits(1))) {
+        // transform            =  predictor-tx / color-tx / subtract-green-tx
+        // transform            =/ color-indexing-tx
+
+        enum TransformType {
+            // predictor-tx         =  %b00 predictor-image
+            PREDICTOR_TRANSFORM = 0,
+
+            // color-tx             =  %b01 color-image
+            COLOR_TRANSFORM = 1,
+
+            // subtract-green-tx    =  %b10
+            SUBTRACT_GREEN_TRANSFORM = 2,
+
+            // color-indexing-tx    =  %b11 color-indexing-image
+            COLOR_INDEXING_TRANSFORM = 3,
+        };
+
+        TransformType transform_type = static_cast<TransformType>(TRY(bit_stream.read_bits(2)));
+        dbgln_if(WEBP_DEBUG, "transform type {}", (int)transform_type);
+
+        switch (transform_type) {
+        case PREDICTOR_TRANSFORM:
+            return context.error("WebPImageDecoderPlugin: VP8L PREDICTOR_TRANSFORM handling not yet implemented");
+        case COLOR_TRANSFORM:
+            return context.error("WebPImageDecoderPlugin: VP8L COLOR_TRANSFORM handling not yet implemented");
+        case SUBTRACT_GREEN_TRANSFORM:
+            return context.error("WebPImageDecoderPlugin: VP8L SUBTRACT_GREEN_TRANSFORM handling not yet implemented");
+        case COLOR_INDEXING_TRANSFORM:
+            return context.error("WebPImageDecoderPlugin: VP8L COLOR_INDEXING_TRANSFORM handling not yet implemented");
+        }
+    }
 
     // https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#623_decoding_entropy-coded_image_data
     // https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#523_color_cache_coding

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -550,7 +550,6 @@ static ErrorOr<void> decode_webp_chunk_VP8L(WebPLoadingContext& context, Chunk c
 
     while (pixel < end) {
         auto symbol = TRY(group[0].read_symbol(bit_stream));
-        dbgln_if(WEBP_DEBUG, "  pixel sym {}", symbol);
         if (symbol >= 256u + 24u + color_cache_size)
             return context.error("WebPImageDecoderPlugin: Symbol out of bounds");
 
@@ -600,8 +599,6 @@ static ErrorOr<void> decode_webp_chunk_VP8L(WebPLoadingContext& context, Chunk c
             // https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#522_lz77_backward_reference
             // "Distance codes larger than 120 denote the pixel-distance in scan-line order, offset by 120."
             // "The smallest distance codes [1..120] are special, and are reserved for a close neighborhood of the current pixel."
-            dbgln_if(WEBP_DEBUG, "  backref L {} D {}", length, distance);
-
             if (distance <= 120) {
                 auto offset = distance_map[distance - 1];
                 distance = offset.x + offset.y * context.size->width();
@@ -610,7 +607,6 @@ static ErrorOr<void> decode_webp_chunk_VP8L(WebPLoadingContext& context, Chunk c
             } else {
                 distance = distance - 120;
             }
-            dbgln_if(WEBP_DEBUG, "    effective distance {}", distance);
 
             if (pixel - context.bitmap->begin() < distance)
                 return context.error("WebPImageDecoderPlugin: Backward reference distance out of bounds");
@@ -626,7 +622,6 @@ static ErrorOr<void> decode_webp_chunk_VP8L(WebPLoadingContext& context, Chunk c
         else {
             // "a. Use S - (256 + 24) as the index into the color cache."
             unsigned index = symbol - (256 + 24);
-            dbgln_if(WEBP_DEBUG, "  use color cache {}", index);
 
             // "b. Get ARGB color from the color cache at that index."
             if (index >= color_cache_size)


### PR DESCRIPTION
Also fix a tricky FIXME about `max_symbols`.

Doesn't really change behavior yet.