### PR TITLE
LibCompress: Reorganize and const-correct the XZ decompressor

### DIFF
--- a/Userland/Libraries/LibCompress/Xz.h
+++ b/Userland/Libraries/LibCompress/Xz.h
@@ -112,6 +112,7 @@ private:
     XzDecompressor(NonnullOwnPtr<CountingStream>);
 
     ErrorOr<bool> load_next_stream();
+    ErrorOr<void> load_next_block(u8 encoded_block_header_size);
     ErrorOr<void> finish_current_block();
     ErrorOr<void> finish_current_stream();
 

--- a/Userland/Libraries/LibCompress/Xz.h
+++ b/Userland/Libraries/LibCompress/Xz.h
@@ -61,7 +61,7 @@ struct [[gnu::packed]] XzStreamHeader {
     XzStreamFlags flags;
     LittleEndian<u32> flags_crc32;
 
-    ErrorOr<void> validate();
+    ErrorOr<void> validate() const;
 };
 static_assert(sizeof(XzStreamHeader) == 12);
 
@@ -72,8 +72,8 @@ struct [[gnu::packed]] XzStreamFooter {
     XzStreamFlags flags;
     u8 magic[2];
 
-    ErrorOr<void> validate();
-    u32 backward_size();
+    ErrorOr<void> validate() const;
+    u32 backward_size() const;
 };
 static_assert(sizeof(XzStreamFooter) == 12);
 
@@ -84,7 +84,7 @@ struct [[gnu::packed]] XzBlockFlags {
     bool compressed_size_present : 1;
     bool uncompressed_size_present : 1;
 
-    u8 number_of_filters();
+    u8 number_of_filters() const;
 };
 static_assert(sizeof(XzBlockFlags) == 1);
 
@@ -93,8 +93,8 @@ struct [[gnu::packed]] XzFilterLzma2Properties {
     u8 encoded_dictionary_size : 6;
     u8 reserved : 2;
 
-    ErrorOr<void> validate();
-    u32 dictionary_size();
+    ErrorOr<void> validate() const;
+    u32 dictionary_size() const;
 };
 static_assert(sizeof(XzFilterLzma2Properties) == 1);
 

--- a/Userland/Libraries/LibCompress/Xz.h
+++ b/Userland/Libraries/LibCompress/Xz.h
@@ -111,6 +111,8 @@ public:
 private:
     XzDecompressor(NonnullOwnPtr<CountingStream>);
 
+    ErrorOr<bool> load_next_stream();
+
     NonnullOwnPtr<CountingStream> m_stream;
     Optional<XzStreamFlags> m_stream_flags;
     bool m_found_first_stream_header { false };

--- a/Userland/Libraries/LibCompress/Xz.h
+++ b/Userland/Libraries/LibCompress/Xz.h
@@ -113,6 +113,7 @@ private:
 
     ErrorOr<bool> load_next_stream();
     ErrorOr<void> finish_current_block();
+    ErrorOr<void> finish_current_stream();
 
     NonnullOwnPtr<CountingStream> m_stream;
     Optional<XzStreamFlags> m_stream_flags;

--- a/Userland/Libraries/LibCompress/Xz.h
+++ b/Userland/Libraries/LibCompress/Xz.h
@@ -112,6 +112,7 @@ private:
     XzDecompressor(NonnullOwnPtr<CountingStream>);
 
     ErrorOr<bool> load_next_stream();
+    ErrorOr<void> finish_current_block();
 
     NonnullOwnPtr<CountingStream> m_stream;
     Optional<XzStreamFlags> m_stream_flags;


### PR DESCRIPTION
`XzDecompressor::read_some()` eventually grew into a 330+ lines function, which is a bit unwieldy. Split it up into the four (rather distinct) operations of "load next stream", "load next block", "finish current block" and "finish current stream", which should make those functions easier to look at and to provide a reasonable high-level overview of how we process multistream files.

As usual, feel free to tell me if those first four commits should just be one.