### PR TITLE
Kernel: Ensure jailed processes can be reaped by a jailed parent process

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -760,13 +760,6 @@ void Process::finalize()
     m_fds.with_exclusive([](auto& fds) { fds.clear(); });
     m_tty = nullptr;
     m_executable.with([](auto& executable) { executable = nullptr; });
-    m_jail_process_list.with([this](auto& list_ptr) {
-        if (list_ptr) {
-            list_ptr->attached_processes().with([&](auto& list) {
-                list.remove(*this);
-            });
-        }
-    });
     m_attached_jail.with([](auto& jail) {
         if (jail)
             jail->detach({});
@@ -818,6 +811,17 @@ void Process::unblock_waiters(Thread::WaitBlocker::UnblockFlags flags, u8 signal
 
     if (waiter_process)
         waiter_process->m_wait_blocker_set.unblock(*this, flags, signal);
+}
+
+void Process::remove_from_secondary_lists()
+{
+    m_jail_process_list.with([this](auto& list_ptr) {
+        if (list_ptr) {
+            list_ptr->attached_processes().with([&](auto& list) {
+                list.remove(*this);
+            });
+        }
+    });
 }
 
 void Process::die()

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -203,6 +203,8 @@ public:
 
     ~Process();
 
+    virtual void remove_from_secondary_lists();
+
     ErrorOr<NonnullRefPtr<Thread>> create_kernel_thread(void (*entry)(void*), void* entry_data, u32 priority, NonnullOwnPtr<KString> name, u32 affinity = THREAD_AFFINITY_DEFAULT, bool joinable = true);
 
     bool is_profiling() const { return m_profiling; }


### PR DESCRIPTION
We were detaching from the jail process list too early. To ensure we detach properly, leverage the remove_from_secondary_lists method so the possibly jailed parent process can still see the dying process and therefore clean it properly.

Partially fixes #17810 (really we have 2 problems, so this will sufficiently close the first problem where we had zombie processes after they were jailed).