### PR TITLE
LibTLS: Streamline certificate loading

### DIFF
--- a/Tests/LibTLS/TestTLSHandshake.cpp
+++ b/Tests/LibTLS/TestTLSHandshake.cpp
@@ -42,7 +42,7 @@ ErrorOr<Vector<Certificate>> load_certificates()
 {
     auto cacert_file = TRY(Core::File::open(locate_ca_certs_file(), Core::File::OpenMode::Read));
     auto data = TRY(cacert_file->read_until_eof());
-    return TRY(DefaultRootCACertificates::the().reload_certificates(data));
+    return TRY(DefaultRootCACertificates::parse_pem_root_certificate_authorities(data));
 }
 
 TEST_CASE(test_TLS_hello_handshake)

--- a/Userland/Libraries/LibTLS/CMakeLists.txt
+++ b/Userland/Libraries/LibTLS/CMakeLists.txt
@@ -12,6 +12,6 @@ set(SOURCES
 )
 
 serenity_lib(LibTLS tls)
-target_link_libraries(LibTLS PRIVATE LibCore LibCrypto)
+target_link_libraries(LibTLS PRIVATE LibCore LibCrypto LibFileSystem)
 
 include(ca_certificates_data)

--- a/Userland/Libraries/LibTLS/Certificate.h
+++ b/Userland/Libraries/LibTLS/Certificate.h
@@ -260,7 +260,8 @@ public:
 
     Vector<Certificate> const& certificates() const { return m_ca_certificates; }
 
-    ErrorOr<Vector<Certificate>> reload_certificates(ByteBuffer&);
+    static ErrorOr<Vector<Certificate>> parse_pem_root_certificate_authorities(ByteBuffer&);
+    static ErrorOr<Vector<Certificate>> load_certificates();
 
     static DefaultRootCACertificates& the() { return s_the; }
 

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -521,8 +521,6 @@ ErrorOr<Vector<Certificate>> DefaultRootCACertificates::parse_pem_root_certifica
 
     for (auto& cert : certs) {
         auto certificate_result = Certificate::parse_certificate(cert.bytes());
-        // If the certificate does not parse it is likely using elliptic curve keys/signatures, which are not
-        // supported right now. It might make sense to cleanup cacert.pem before adding it to the system.
         if (certificate_result.is_error()) {
             // FIXME: It would be nice to have more informations about the certificate we failed to parse.
             //        Like: Issuer, Algorithm, CN, etc


### PR DESCRIPTION
Some refactoring of our root ca loading process:

- Remove duplicate code
- Remove duplicate calls to `parse_root_ca`
- Load user imported certificates in Browser/RequestServer

It will also fix this bug in `TestTLSHandshake` because we no longer take the singleton:

```
Running test 'test_TLS_hello_handshake'.
Failed to load CA Certificates: open: No such file or directory (errno=2)
Loaded 137 of 137 (100%) provided CA Certificates
```