### PR TITLE
Progress towards decoding Tests/LibGfx/test-inputs/simple-vp8l.webp

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -435,7 +435,7 @@ static ErrorOr<PrefixCodeGroup> decode_webp_chunk_VP8L_prefix_code_group(WebPLoa
     //  * G channel: 256 + 24 + color_cache_size
     //  * other literals (A,R,B): 256
     //  * distance code: 40"
-    static Array<size_t, 5> const alphabet_sizes { 256 + 24 + static_cast<size_t>(color_cache_size), 256, 256, 256, 40 };
+    Array<size_t, 5> const alphabet_sizes { 256 + 24 + static_cast<size_t>(color_cache_size), 256, 256, 256, 40 };
 
     PrefixCodeGroup group;
     for (size_t i = 0; i < alphabet_sizes.size(); ++i)


### PR DESCRIPTION
Includes a bugfix for a bug that's only observable once we decode some of the helper bitmaps (not yet in this PR, will be in a future PR), and starts fleshing out transform handling by putting scaffolding into place and implementing `SUBTRACT_GREEN_TRANSFORM`, the simplest of the 4 transforms.

Before these changes:

```
% Build/lagom/image Tests/LibGfx/test-inputs/simple-vp8l.webp -o tmp.png
Runtime error: WebPImageDecoderPlugin: VP8L SUBTRACT_GREEN_TRANSFORM handling not yet implemented
```

With these changes:

```
% Build/lagom/image Tests/LibGfx/test-inputs/simple-vp8l.webp -o tmp.png
Runtime error: WebPImageDecoderPlugin: VP8L PREDICTOR_TRANSFORM handling not yet implemented
```
its-something.gif