### PR TITLE
LibWeb: Transform the default path in CRC2D#fill(CanvasFillRule)

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -288,7 +288,8 @@ void CanvasRenderingContext2D::fill_internal(Gfx::Path& path, DeprecatedString c
 
 void CanvasRenderingContext2D::fill(DeprecatedString const& fill_rule)
 {
-    return fill_internal(path(), fill_rule);
+    auto transformed_path = path().copy_transformed(drawing_state().transform);
+    return fill_internal(transformed_path, fill_rule);
 }
 
 void CanvasRenderingContext2D::fill(Path2D& path, DeprecatedString const& fill_rule)


### PR DESCRIPTION
Required by Factory Balls Forever to position anything that isn't an image.

Before:
![image](https://user-images.githubusercontent.com/25595356/230428646-b0a7d5b4-8c41-49c7-b5b7-e8ca6b973d4d.png)

After:
![image](https://user-images.githubusercontent.com/25595356/230428694-a446fc8e-4f86-4f50-9e36-a0990c920814.png)
