### PR TITLE
LibTimeZone: Update to TZDB version 2023c

### DIFF
--- a/Meta/CMake/time_zone_data.cmake
+++ b/Meta/CMake/time_zone_data.cmake
@@ -2,7 +2,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/utils.cmake)
 
 set(TZDB_PATH "${SERENITY_CACHE_DIR}/TZDB" CACHE PATH "Download location for TZDB files")
 
-set(TZDB_VERSION 2023b)
+set(TZDB_VERSION 2023c)
 set(TZDB_VERSION_FILE "${TZDB_PATH}/version.txt")
 
 set(TZDB_ZIP_URL "https://data.iana.org/time-zones/releases/tzdata${TZDB_VERSION}.tar.gz")


### PR DESCRIPTION
https://mm.icann.org/pipermail/tz-announce/2023-March/000079.html