### PR TITLE
Toolchain+Meta: Only build GDB when the user asks for it + fix #18145

### DIFF
--- a/Meta/debug-kernel.sh
+++ b/Meta/debug-kernel.sh
@@ -9,7 +9,9 @@ fi
 # Set this environment variable to override the default debugger.
 #
 if [ -z "$SERENITY_KERNEL_DEBUGGER" ]; then
-    # Prepend the toolchain bin directory so we pick up GDB from there
+    # Prepend the toolchain's GDB bin directory so we pick up GDB from there
+    PATH="$SCRIPT_DIR/../Toolchain/Local/$SERENITY_ARCH-gdb/bin:$PATH"
+    # GDB used to be installed directly inside the toolchain bin directory
     PATH="$SCRIPT_DIR/../Toolchain/Local/$SERENITY_ARCH/bin:$PATH"
 
     if command -v "$SERENITY_ARCH-pc-serenity-gdb" >/dev/null; then
@@ -20,6 +22,9 @@ if [ -z "$SERENITY_KERNEL_DEBUGGER" ]; then
         SERENITY_KERNEL_DEBUGGER="gdb"
     else
         echo "Error: No suitable GDB installation found." >&2
+        echo "Please install $SERENITY_ARCH-elf-gdb or build it with Toolchain/BuildGDB.sh $SERENITY_ARCH" >&2
+        # Prevent tmux from dying instantly by waiting for user input
+        read -rp "Press Enter to exit"
         exit 1
     fi
 fi

--- a/Toolchain/BuildGDB.sh
+++ b/Toolchain/BuildGDB.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -e
+
+GDB_VERSION="13.1"
+GDB_MD5SUM="4aaad768ff2585464173c091947287ec"
+GDB_NAME="gdb-$GDB_VERSION"
+GDB_PKG="${GDB_NAME}.tar.xz"
+GDB_BASE_URL="https://ftp.gnu.org/gnu/gdb"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+ARCH=${1:-"x86_64"}
+TARGET="$ARCH-pc-serenity"
+PREFIX="$DIR/Local/$ARCH-gdb"
+
+echo "Building GDB $GDB_VERSION for $TARGET"
+
+MD5SUM="md5sum"
+NPROC="nproc"
+
+SYSTEM_NAME="$(uname -s)"
+
+if [ "$SYSTEM_NAME" = "OpenBSD" ]; then
+    MD5SUM="md5 -q"
+    NPROC="sysctl -n hw.ncpuonline"
+    export CC=egcc
+    export CXX=eg++
+    export with_gmp=/usr/local
+    export LDFLAGS=-Wl,-z,notext
+elif [ "$SYSTEM_NAME" = "FreeBSD" ]; then
+    MD5SUM="md5 -q"
+    NPROC="sysctl -n hw.ncpu"
+    export with_gmp=/usr/local
+    export with_mpfr=/usr/local
+elif [ "$SYSTEM_NAME" = "Darwin" ]; then
+    MD5SUM="md5 -q"
+    NPROC="sysctl -n hw.ncpu"
+fi
+
+if [ -z "$MAKEJOBS" ]; then
+    MAKEJOBS=$($NPROC)
+fi
+
+buildstep() {
+    NAME=$1
+    shift
+    "$@" 2>&1 | sed $'s|^|\x1b[34m['"${NAME}"$']\x1b[39m |'
+}
+
+missing_lib() {
+    buildstep dependencies echo "Please make sure to install the $lib library and headers." >&2
+    exit 1
+}
+
+config_args=()
+for lib in gmp isl mpfr mpc; do
+    buildstep dependencies echo "Checking whether the $lib library and headers are available..."
+    if [ "$SYSTEM_NAME" = "Darwin" ]; then
+        [ "$lib" = "mpc" ] && formula_name="libmpc" || formula_name="$lib"
+        config_args+=("--with-$lib=$(brew --prefix --installed "$formula_name")") || missing_lib $lib
+    else
+        if ! ${CC:-cc} -I /usr/local/include -L /usr/local/lib -l$lib -o /dev/null -xc - >/dev/null <<PROGRAM
+#include <$lib.h>
+int main() {}
+PROGRAM
+              then
+                  missing_lib $lib
+              fi
+    fi
+done
+
+if [ "$SYSTEM_NAME" = "Darwin" ]; then
+    config_args+=("--with-libgmp-prefix=$(brew --prefix gmp)")
+fi
+
+mkdir -p "$DIR/Tarballs"
+
+pushd "$DIR/Tarballs"
+    md5=""
+    if [ -e "$GDB_PKG" ]; then
+        md5="$($MD5SUM "$GDB_PKG" | cut -f1 -d' ')"
+    fi
+    if [ "$md5" != "$GDB_MD5SUM" ]; then
+        curl -C - -O "$GDB_BASE_URL/$GDB_PKG"
+    else
+        echo "Skipped downloading $GDB_PKG"
+    fi
+
+    md5="$($MD5SUM "$GDB_PKG" | cut -f1 -d' ')"
+    echo "gdb md5='$md5'"
+    if  [ "$md5" != "$GDB_MD5SUM" ] ; then
+        echo "gdb md5 sum mismatching, please run script again."
+        rm -f "$GDB_PKG"
+        exit 1
+    fi
+
+    # If the source directory exists, re-extract it again in case the patches have changed.
+    if [ -d ${GDB_NAME} ]; then
+        rm -rf "${GDB_NAME}"
+        rm -rf "$DIR/Build/$ARCH-gdb"
+    fi
+    echo "Extracting gdb..."
+    tar -xJf "$GDB_PKG"
+
+    pushd "$GDB_NAME"
+        for patch in "${DIR}"/Patches/gdb/*.patch; do
+            patch -p1 < "${patch}" > /dev/null
+        done
+    popd
+popd
+
+mkdir -p "$DIR/Build"
+
+rm -rf "$DIR/Build/$ARCH-gdb"
+mkdir "$DIR/Build/$ARCH-gdb"
+
+pushd "$DIR/Build/$ARCH-gdb"
+    unset PKG_CONFIG_LIBDIR # Just in case
+
+    buildstep "gdb/configure" "$DIR"/Tarballs/$GDB_NAME/configure --prefix="$PREFIX" \
+                                                                  --target="$TARGET" \
+                                                                  --disable-werror \
+                                                                  --disable-nls \
+                                                                  --with-python \
+                                                                  "${config_args[@]}" || exit 1
+
+    buildstep "gdb/build" make MAKEINFO=true -j "$MAKEJOBS" || exit 1
+    buildstep "gdb/install" make MAKEINFO=true install || exit 1
+popd


### PR DESCRIPTION
I submitted a WIP testing branch with bugs instead of the real deal in #18145. Shame on me :/

This PR actually ensures that GDB is built only when the user requests it.

**Meta: Fix GDB supported architecture check**
The output of the `set architecture` command is printed to `stderr`, so
a redirection is needed if we want to run `grep` on it. This commit also
adds the `-q` flag to `grep`.


**Toolchain: Move GDB build to a separate script**

Target GDB is only used for debugging the kernel, which is not relevant
to most people. Starting with 924758c6f, GDB would always be built
as part of the toolchain if the user didn't have it installed. This is
unnecessary.

This commit adds a separate script for building GDB, which the user
needs to explicitly invoke. A message is added to Meta/debug-kernel.sh
which alerts the user to this fact.
