### PR TITLE
LibWeb: Add an initial implementation of CRC2D.clip()

### DIFF
--- a/Base/res/html/misc/canvas-clip-path.html
+++ b/Base/res/html/misc/canvas-clip-path.html
@@ -1,0 +1,44 @@
+<style>
+  canvas {
+    border: 1px solid black;
+  }
+</style>
+<!-- Examples taken from MDN -->
+<b>(nonzero) path clipping:</b><br>
+<canvas id="canvas1" width="200" height="160"></canvas>
+<br>
+<b>evenodd path clipping:</b><br>
+<canvas id="canvas2" width="200" height="160"></canvas>
+<script>
+{
+  const canvas = document.getElementById("canvas1");
+  const ctx = canvas.getContext("2d");
+
+  // Create circular clipping region
+  ctx.beginPath();
+  ctx.arc(0/*FIMXE: Should be 100, but ctx.arc() is currently broken*/, 75, 50, 0, Math.PI * 2);
+  ctx.clip();
+
+  // Draw stuff that gets clipped
+  ctx.fillStyle = "blue";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = "orange";
+  ctx.fillRect(0, 0, 100, 100);
+}
+</script>
+<script>
+{
+  const canvas = document.getElementById("canvas2");
+  const ctx = canvas.getContext("2d");
+
+  // Create clipping path
+  let region = new Path2D();
+  region.rect(80, 10, 20, 130);
+  region.rect(40, 50, 100, 50);
+  ctx.clip(region, "evenodd");
+
+  // Draw stuff that gets clipped
+  ctx.fillStyle = "blue";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+</script>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -194,6 +194,7 @@
             <li><a href="canvas-path-quadratic-curve.html">canvas path quadratic curve test</a></li>
             <li><a href="img-canvas.html">canvas drawImage() test</a></li>
             <li><a href="canvas-path.html">canvas path house!</a></li>
+            <li><a href="canvas-clip-path.html">canvas clip paths</a></li>
             <li><a href="trigonometry.html">canvas + trigonometry functions</a></li>
             <li><a href="canvas-path2d.html">Path2D</a></li>
             <li><a href="webgl-clear-color-and-multiple-contexts.html">WebGL Demo - Multiple Contexts and glClear(Color)</a></li>

--- a/Userland/Libraries/LibGfx/FillPathImplementation.cpp
+++ b/Userland/Libraries/LibGfx/FillPathImplementation.cpp
@@ -117,7 +117,8 @@ void Painter::fill_path_impl(Path const& path, ColorOrFunction color, Gfx::Paint
 
     auto draw_scanline = [&](int y, GridCoordinateType x1, GridCoordinateType x2) {
         const auto draw_offset = offset.value_or({ 0, 0 });
-        const auto draw_origin = (path.bounding_box().top_left() + draw_offset).to_type<int>();
+        // Note: .to_floored() is used here to be consistent with enclosing_int_rect()
+        const auto draw_origin = (path.bounding_box().top_left() + draw_offset).to_floored<int>();
         // FIMXE: Offset is added here to handle floating point translations in the AA painter,
         // really this should be done there but this function is a bit too specialised.
         y = floorf(y + draw_offset.y());

--- a/Userland/Libraries/LibGfx/PaintStyle.h
+++ b/Userland/Libraries/LibGfx/PaintStyle.h
@@ -12,6 +12,7 @@
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/Vector.h>
+#include <LibGfx/Bitmap.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Gradients.h>
@@ -57,6 +58,32 @@ private:
     }
 
     Color m_color;
+};
+
+class BitmapPaintStyle : public PaintStyle {
+public:
+    static ErrorOr<NonnullRefPtr<BitmapPaintStyle>> create(Bitmap const& bitmap, IntPoint offset = {})
+    {
+        return adopt_nonnull_ref_or_enomem(new (nothrow) BitmapPaintStyle(bitmap, offset));
+    }
+
+    virtual Color sample_color(IntPoint point) const override
+    {
+        point += m_offset;
+        if (m_bitmap->rect().contains(point))
+            return m_bitmap->get_pixel(point);
+        return Color();
+    }
+
+private:
+    BitmapPaintStyle(Bitmap const& bitmap, IntPoint offset)
+        : m_bitmap(bitmap)
+        , m_offset(offset)
+    {
+    }
+
+    NonnullRefPtr<Bitmap const> m_bitmap;
+    IntPoint m_offset;
 };
 
 class GradientPaintStyle : public PaintStyle {

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -144,8 +144,10 @@ void Path::close_all_subpaths()
     Optional<FloatPoint> cursor, start_of_subpath;
     bool is_first_point_in_subpath { false };
 
-    for (auto& segment : m_segments) {
-        switch (segment->type()) {
+    auto segment_count = m_segments.size();
+    for (size_t i = 0; i < segment_count; i++) {
+        // Note: We need to use m_segments[i] as append_segment() may invalidate any references.
+        switch (m_segments[i]->type()) {
         case Segment::Type::MoveTo: {
             if (cursor.has_value() && !is_first_point_in_subpath) {
                 // This is a move from a subpath to another
@@ -157,7 +159,7 @@ void Path::close_all_subpaths()
                 append_segment<LineSegment>(start_of_subpath.value());
             }
             is_first_point_in_subpath = true;
-            cursor = segment->point();
+            cursor = m_segments[i]->point();
             break;
         }
         case Segment::Type::LineTo:
@@ -168,7 +170,7 @@ void Path::close_all_subpaths()
                 start_of_subpath = cursor;
                 is_first_point_in_subpath = false;
             }
-            cursor = segment->point();
+            cursor = m_segments[i]->point();
             break;
         case Segment::Type::Invalid:
             VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -247,6 +247,13 @@ public:
         return Point<U>(ceil(x()), ceil(y()));
     }
 
+    template<typename U>
+    requires FloatingPoint<T>
+    [[nodiscard]] Point<U> to_floored() const
+    {
+        return Point<U>(AK::floor(x()), AK::floor(y()));
+    }
+
     [[nodiscard]] DeprecatedString to_deprecated_string() const;
 
 private:

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -206,6 +206,7 @@ set(SOURCES
     HTML/BrowsingContextGroup.cpp
     HTML/Canvas/CanvasDrawImage.cpp
     HTML/Canvas/CanvasPath.cpp
+    HTML/Canvas/CanvasPathClipper.cpp
     HTML/Canvas/CanvasState.cpp
     HTML/CanvasGradient.cpp
     HTML/CanvasPattern.cpp

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasDrawPath.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasDrawPath.h
@@ -24,7 +24,8 @@ public:
     virtual void stroke() = 0;
     virtual void stroke(Path2D const& path) = 0;
 
-    virtual void clip() = 0;
+    virtual void clip(DeprecatedString const& fill_rule) = 0;
+    virtual void clip(Path2D& path, DeprecatedString const& fill_rule) = 0;
 
 protected:
     CanvasDrawPath() = default;

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasDrawPath.idl
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasDrawPath.idl
@@ -13,10 +13,10 @@ interface mixin CanvasDrawPath {
     undefined stroke();
     undefined stroke(Path2D path);
 
-    // FIXME: Replace this with these two definitions:
-    // undefined clip(optional CanvasFillRule fillRule = "nonzero");
-    // undefined clip(Path2D path, optional CanvasFillRule fillRule = "nonzero");
-    undefined clip();
+    // FIXME: `DOMString` should be `CanvasFillRule`
+    undefined clip(optional DOMString fillRule = "nonzero");
+    // FIXME: `DOMString` should be `CanvasFillRule`
+    undefined clip(Path2D path, optional DOMString fillRule = "nonzero");
 
     // FIXME: boolean isPointInPath(unrestricted double x, unrestricted double y, optional CanvasFillRule fillRule = "nonzero");
     // FIXME: boolean isPointInPath(Path2D path, unrestricted double x, unrestricted double y, optional CanvasFillRule fillRule = "nonzero");

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPathClipper.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPathClipper.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/AntiAliasingPainter.h>
+#include <LibWeb/HTML/Canvas/CanvasPathClipper.h>
+
+namespace Web::HTML {
+
+// FIXME: This pretty naive, we should be able to cut down the allocations here
+// (especially for the paint style which is a bit sad).
+
+ErrorOr<CanvasPathClipper> CanvasPathClipper::create(Gfx::Painter& painter, CanvasClip const& canvas_clip)
+{
+    auto bounding_box = enclosing_int_rect(canvas_clip.path.bounding_box());
+    Gfx::IntRect actual_save_rect {};
+    auto maybe_bitmap = painter.get_region_bitmap(bounding_box, Gfx::BitmapFormat::BGRA8888, actual_save_rect);
+    RefPtr<Gfx::Bitmap> saved_clip_region;
+    if (!maybe_bitmap.is_error()) {
+        saved_clip_region = maybe_bitmap.release_value();
+    } else if (actual_save_rect.is_empty()) {
+        // This is okay, no need to report an error.
+    } else {
+        return maybe_bitmap.release_error();
+    }
+    painter.save();
+    painter.add_clip_rect(bounding_box);
+    return CanvasPathClipper(move(saved_clip_region), bounding_box, canvas_clip);
+}
+
+ErrorOr<void> CanvasPathClipper::apply_clip(Gfx::Painter& painter)
+{
+    painter.restore();
+    if (!m_saved_clip_region)
+        return {};
+    Gfx::IntRect actual_save_rect {};
+    auto clip_area = TRY(painter.get_region_bitmap(m_bounding_box, Gfx::BitmapFormat::BGRA8888, actual_save_rect));
+    painter.blit(actual_save_rect.location(), *m_saved_clip_region, m_saved_clip_region->rect(), 1.0f, false);
+    Gfx::AntiAliasingPainter aa_painter { painter };
+    auto fill_offset = m_bounding_box.location() - actual_save_rect.location();
+    aa_painter.fill_path(m_canvas_clip.path, TRY(Gfx::BitmapPaintStyle::create(clip_area, fill_offset)), m_canvas_clip.winding_rule);
+    return {};
+}
+}

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPathClipper.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPathClipper.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/Painter.h>
+#include <LibGfx/Path.h>
+
+namespace Web::HTML {
+
+struct CanvasClip {
+    Gfx::Path path;
+    Gfx::Painter::WindingRule winding_rule;
+};
+
+class CanvasPathClipper {
+public:
+    static ErrorOr<CanvasPathClipper> create(Gfx::Painter&, CanvasClip const& canvas_clip);
+    ErrorOr<void> apply_clip(Gfx::Painter& painter);
+
+private:
+    CanvasPathClipper(RefPtr<Gfx::Bitmap const> saved_clip_region, Gfx::IntRect bounding_box, CanvasClip const& canvas_clip)
+        : m_saved_clip_region(saved_clip_region)
+        , m_bounding_box(bounding_box)
+        , m_canvas_clip(canvas_clip)
+    {
+    }
+
+    RefPtr<Gfx::Bitmap const> m_saved_clip_region;
+    Gfx::IntRect m_bounding_box;
+    CanvasClip const& m_canvas_clip;
+};
+
+class ScopedCanvasPathClip {
+    AK_MAKE_NONMOVABLE(ScopedCanvasPathClip);
+    AK_MAKE_NONCOPYABLE(ScopedCanvasPathClip);
+
+public:
+    ScopedCanvasPathClip(Gfx::Painter& painter, Optional<CanvasClip> const& canvas_clip)
+        : m_painter(painter)
+    {
+        if (canvas_clip.has_value()) {
+            auto clipper = CanvasPathClipper::create(painter, *canvas_clip);
+            if (!clipper.is_error())
+                m_canvas_clipper = clipper.release_value();
+            else
+                dbgln("CRC2D Error: Failed to apply canvas clip path: {}", clipper.error());
+        }
+    }
+
+    ~ScopedCanvasPathClip()
+    {
+        if (m_canvas_clipper.has_value())
+            m_canvas_clipper->apply_clip(m_painter).release_value_but_fixme_should_propagate_errors();
+    }
+
+private:
+    Gfx::Painter& m_painter;
+    Optional<CanvasPathClipper> m_canvas_clipper;
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
@@ -13,6 +13,7 @@
 #include <LibGfx/Color.h>
 #include <LibGfx/PaintStyle.h>
 #include <LibWeb/Bindings/CanvasRenderingContext2DPrototype.h>
+#include <LibWeb/HTML/Canvas/CanvasPathClipper.h>
 #include <LibWeb/HTML/CanvasGradient.h>
 #include <LibWeb/HTML/CanvasPattern.h>
 
@@ -77,6 +78,7 @@ public:
         float line_width { 1 };
         bool image_smoothing_enabled { true };
         Bindings::ImageSmoothingQuality image_smoothing_quality { Bindings::ImageSmoothingQuality::Low };
+        Optional<CanvasClip> clip;
     };
     DrawingState& drawing_state() { return m_drawing_state; }
     DrawingState const& drawing_state() const { return m_drawing_state; }

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -71,58 +71,51 @@ JS::NonnullGCPtr<HTMLCanvasElement> CanvasRenderingContext2D::canvas_for_binding
 
 void CanvasRenderingContext2D::fill_rect(float x, float y, float width, float height)
 {
-    auto painter = this->antialiased_painter();
-    if (!painter.has_value())
-        return;
-
-    auto& drawing_state = this->drawing_state();
-
-    auto rect = drawing_state.transform.map(Gfx::FloatRect(x, y, width, height));
-    auto color_fill = drawing_state.fill_style.as_color();
-    if (color_fill.has_value()) {
-        painter->fill_rect(rect, *color_fill);
-    } else {
-        // FIXME: This should use AntiAliasingPainter::fill_rect() too but that does not support FillPath yet.
-        painter->underlying_painter().fill_rect(rect.to_rounded<int>(), *drawing_state.fill_style.to_gfx_paint_style());
-    }
-    did_draw(rect);
+    draw_clipped([&](auto& painter) {
+        auto& drawing_state = this->drawing_state();
+        auto rect = drawing_state.transform.map(Gfx::FloatRect(x, y, width, height));
+        auto color_fill = drawing_state.fill_style.as_color();
+        if (color_fill.has_value()) {
+            painter.fill_rect(rect, *color_fill);
+        } else {
+            // FIXME: This should use AntiAliasingPainter::fill_rect() too but that does not support FillPath yet.
+            painter.underlying_painter().fill_rect(rect.to_rounded<int>(), *drawing_state.fill_style.to_gfx_paint_style());
+        }
+        return rect;
+    });
 }
 
 void CanvasRenderingContext2D::clear_rect(float x, float y, float width, float height)
 {
-    auto painter = this->painter();
-    if (!painter)
-        return;
-
-    auto rect = drawing_state().transform.map(Gfx::FloatRect(x, y, width, height));
-    painter->clear_rect(enclosing_int_rect(rect), Color());
-    did_draw(rect);
+    draw_clipped([&](auto& painter) {
+        auto rect = drawing_state().transform.map(Gfx::FloatRect(x, y, width, height));
+        painter.underlying_painter().clear_rect(enclosing_int_rect(rect), Color());
+        return rect;
+    });
 }
 
 void CanvasRenderingContext2D::stroke_rect(float x, float y, float width, float height)
 {
-    auto painter = this->antialiased_painter();
-    if (!painter.has_value())
-        return;
+    draw_clipped([&](auto& painter) {
+        auto& drawing_state = this->drawing_state();
 
-    auto& drawing_state = this->drawing_state();
+        auto rect = drawing_state.transform.map(Gfx::FloatRect(x, y, width, height));
+        // We could remove the rounding here, but the lines look better when they have whole number pixel endpoints.
+        auto top_left = drawing_state.transform.map(Gfx::FloatPoint(x, y)).to_rounded<float>();
+        auto top_right = drawing_state.transform.map(Gfx::FloatPoint(x + width - 1, y)).to_rounded<float>();
+        auto bottom_left = drawing_state.transform.map(Gfx::FloatPoint(x, y + height - 1)).to_rounded<float>();
+        auto bottom_right = drawing_state.transform.map(Gfx::FloatPoint(x + width - 1, y + height - 1)).to_rounded<float>();
 
-    auto rect = drawing_state.transform.map(Gfx::FloatRect(x, y, width, height));
-    // We could remove the rounding here, but the lines look better when they have whole number pixel endpoints.
-    auto top_left = drawing_state.transform.map(Gfx::FloatPoint(x, y)).to_rounded<float>();
-    auto top_right = drawing_state.transform.map(Gfx::FloatPoint(x + width - 1, y)).to_rounded<float>();
-    auto bottom_left = drawing_state.transform.map(Gfx::FloatPoint(x, y + height - 1)).to_rounded<float>();
-    auto bottom_right = drawing_state.transform.map(Gfx::FloatPoint(x + width - 1, y + height - 1)).to_rounded<float>();
+        Gfx::Path path;
+        path.move_to(top_left);
+        path.line_to(top_right);
+        path.line_to(bottom_right);
+        path.line_to(bottom_left);
+        path.line_to(top_left);
+        painter.stroke_path(path, drawing_state.stroke_style.to_color_but_fixme_should_accept_any_paint_style(), drawing_state.line_width);
 
-    Gfx::Path path;
-    path.move_to(top_left);
-    path.line_to(top_right);
-    path.line_to(bottom_right);
-    path.line_to(bottom_left);
-    path.line_to(top_left);
-    painter->stroke_path(path, drawing_state.stroke_style.to_color_but_fixme_should_accept_any_paint_style(), drawing_state.line_width);
-
-    did_draw(rect);
+        return rect;
+    });
 }
 
 // 4.12.5.1.14 Drawing images, https://html.spec.whatwg.org/multipage/canvas.html#drawing-images
@@ -170,20 +163,21 @@ WebIDL::ExceptionOr<void> CanvasRenderingContext2D::draw_image_internal(CanvasIm
         return {};
 
     // 6. Paint the region of the image argument specified by the source rectangle on the region of the rendering context's output bitmap specified by the destination rectangle, after applying the current transformation matrix to the destination rectangle.
-    auto painter = this->painter();
-    if (!painter)
-        return {};
+    draw_clipped([&](auto& painter) {
+        auto scaling_mode = Gfx::Painter::ScalingMode::NearestNeighbor;
+        if (drawing_state().image_smoothing_enabled) {
+            // FIXME: Honor drawing_state().image_smoothing_quality
+            scaling_mode = Gfx::Painter::ScalingMode::BilinearBlend;
+        }
 
-    auto scaling_mode = Gfx::Painter::ScalingMode::NearestNeighbor;
-    if (drawing_state().image_smoothing_enabled) {
-        // FIXME: Honor drawing_state().image_smoothing_quality
-        scaling_mode = Gfx::Painter::ScalingMode::BilinearBlend;
-    }
-    painter->draw_scaled_bitmap_with_transform(destination_rect.to_rounded<int>(), *bitmap, source_rect, drawing_state().transform, 1.0f, scaling_mode);
+        painter.underlying_painter().draw_scaled_bitmap_with_transform(destination_rect.to_rounded<int>(), *bitmap, source_rect, drawing_state().transform, 1.0f, scaling_mode);
 
-    // 7. If image is not origin-clean, then set the CanvasRenderingContext2D's origin-clean flag to false.
-    if (image_is_not_origin_clean(image))
-        m_origin_clean = false;
+        // 7. If image is not origin-clean, then set the CanvasRenderingContext2D's origin-clean flag to false.
+        if (image_is_not_origin_clean(image))
+            m_origin_clean = false;
+
+        return destination_rect;
+    });
 
     return {};
 }
@@ -219,16 +213,14 @@ void CanvasRenderingContext2D::fill_text(DeprecatedString const& text, float x, 
     if (max_width.has_value() && max_width.value() <= 0)
         return;
 
-    auto painter = this->painter();
-    if (!painter)
-        return;
-
-    auto& drawing_state = this->drawing_state();
-
-    auto text_rect = Gfx::FloatRect(x, y, max_width.has_value() ? static_cast<float>(max_width.value()) : painter->font().width(text), painter->font().pixel_size());
-    auto transformed_rect = drawing_state.transform.map(text_rect);
-    painter->draw_text(transformed_rect, text, Gfx::TextAlignment::TopLeft, drawing_state.fill_style.to_color_but_fixme_should_accept_any_paint_style());
-    did_draw(transformed_rect);
+    draw_clipped([&](auto& painter) {
+        auto& drawing_state = this->drawing_state();
+        auto& base_painter = painter.underlying_painter();
+        auto text_rect = Gfx::FloatRect(x, y, max_width.has_value() ? static_cast<float>(max_width.value()) : base_painter.font().width(text), base_painter.font().pixel_size());
+        auto transformed_rect = drawing_state.transform.map(text_rect);
+        base_painter.draw_text(transformed_rect, text, Gfx::TextAlignment::TopLeft, drawing_state.fill_style.to_color_but_fixme_should_accept_any_paint_style());
+        return transformed_rect;
+    });
 }
 
 void CanvasRenderingContext2D::stroke_text(DeprecatedString const& text, float x, float y, Optional<double> max_width)
@@ -244,14 +236,12 @@ void CanvasRenderingContext2D::begin_path()
 
 void CanvasRenderingContext2D::stroke_internal(Gfx::Path const& path)
 {
-    auto painter = this->antialiased_painter();
-    if (!painter.has_value())
-        return;
+    draw_clipped([&](auto& painter) {
+        auto& drawing_state = this->drawing_state();
 
-    auto& drawing_state = this->drawing_state();
-
-    painter->stroke_path(path, drawing_state.stroke_style.to_color_but_fixme_should_accept_any_paint_style(), drawing_state.line_width);
-    did_draw(path.bounding_box());
+        painter.stroke_path(path, drawing_state.stroke_style.to_color_but_fixme_should_accept_any_paint_style(), drawing_state.line_width);
+        return path.bounding_box();
+    });
 }
 
 void CanvasRenderingContext2D::stroke()
@@ -266,24 +256,23 @@ void CanvasRenderingContext2D::stroke(Path2D const& path)
     stroke_internal(transformed_path);
 }
 
-void CanvasRenderingContext2D::fill_internal(Gfx::Path& path, DeprecatedString const& fill_rule)
+static Gfx::Painter::WindingRule parse_fill_rule(StringView fill_rule)
 {
-    auto painter = this->antialiased_painter();
-    if (!painter.has_value())
-        return;
+    if (fill_rule == "evenodd"sv)
+        return Gfx::Painter::WindingRule::EvenOdd;
+    if (fill_rule == "nonzero"sv)
+        return Gfx::Painter::WindingRule::Nonzero;
+    dbgln("Unrecognized fillRule for CRC2D.fill() - this problem goes away once we pass an enum instead of a string");
+    return Gfx::Painter::WindingRule::Nonzero;
+}
 
-    path.close_all_subpaths();
-
-    auto winding = Gfx::Painter::WindingRule::Nonzero;
-    if (fill_rule == "evenodd")
-        winding = Gfx::Painter::WindingRule::EvenOdd;
-    else if (fill_rule == "nonzero")
-        winding = Gfx::Painter::WindingRule::Nonzero;
-    else
-        dbgln("Unrecognized fillRule for CRC2D.fill() - this problem goes away once we pass an enum instead of a string");
-
-    painter->fill_path(path, *drawing_state().fill_style.to_gfx_paint_style(), winding);
-    did_draw(path.bounding_box());
+void CanvasRenderingContext2D::fill_internal(Gfx::Path& path, StringView fill_rule)
+{
+    draw_clipped([&](auto& painter) {
+        path.close_all_subpaths();
+        painter.fill_path(path, *drawing_state().fill_style.to_gfx_paint_style(), parse_fill_rule(fill_rule));
+        return path.bounding_box();
+    });
 }
 
 void CanvasRenderingContext2D::fill(DeprecatedString const& fill_rule)
@@ -345,13 +334,10 @@ WebIDL::ExceptionOr<JS::GCPtr<ImageData>> CanvasRenderingContext2D::get_image_da
 
 void CanvasRenderingContext2D::put_image_data(ImageData const& image_data, float x, float y)
 {
-    auto painter = this->painter();
-    if (!painter)
-        return;
-
-    painter->blit(Gfx::IntPoint(x, y), image_data.bitmap(), image_data.bitmap().rect());
-
-    did_draw(Gfx::FloatRect(x, y, image_data.width(), image_data.height()));
+    draw_clipped([&](auto& painter) {
+        painter.underlying_painter().blit(Gfx::IntPoint(x, y), image_data.bitmap(), image_data.bitmap().rect());
+        return Gfx::FloatRect(x, y, image_data.width(), image_data.height());
+    });
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#reset-the-rendering-context-to-its-default-state
@@ -503,9 +489,27 @@ CanvasRenderingContext2D::PreparedText CanvasRenderingContext2D::prepare_text(De
     return prepared_text;
 }
 
-void CanvasRenderingContext2D::clip()
+void CanvasRenderingContext2D::clip_internal(Gfx::Path& path, StringView fill_rule)
 {
-    // FIXME: Implement.
+    // FIXME: This should calculate the new clip path by intersecting the given path with the current one.
+    // See: https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-clip-dev
+    path.close_all_subpaths();
+    if (drawing_state().clip.has_value()) {
+        dbgln("FIXME: CRC2D: Calculate the new clip path by intersecting the given path with the current one.");
+    }
+    drawing_state().clip = CanvasClip { path, parse_fill_rule(fill_rule) };
+}
+
+void CanvasRenderingContext2D::clip(DeprecatedString const& fill_rule)
+{
+    auto transformed_path = path().copy_transformed(drawing_state().transform);
+    return clip_internal(transformed_path, fill_rule);
+}
+
+void CanvasRenderingContext2D::clip(Path2D& path, DeprecatedString const& fill_rule)
+{
+    auto transformed_path = path.path().copy_transformed(drawing_state().transform);
+    return clip_internal(transformed_path, fill_rule);
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#check-the-usability-of-the-image-argument


### PR DESCRIPTION
With this PR Google street view, starts to kinda work (though laggy):
 
[screen-capture - 2023-04-07T142817.674.webm](https://user-images.githubusercontent.com/11597044/230617038-5cbe6fc9-7f10-423c-aac2-1155d4543155.webm)



**Boring demo:**
![image](https://user-images.githubusercontent.com/11597044/230485776-6506f40b-bf6e-4c3d-9449-dc062619b57c.png)

With this PR you can clip the canvas to any path you like! 
The implementation probably could be better, but this is a start :^)
