### PR TITLE
LibWeb: Port {Custom,Mouse,UI,Wheel,}Event to new String

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.cpp
@@ -16,7 +16,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<MediaQueryListEvent>> MediaQueryListEvent::
 }
 
 MediaQueryListEvent::MediaQueryListEvent(JS::Realm& realm, FlyString const& event_name, MediaQueryListEventInit const& event_init)
-    : DOM::Event(realm, event_name.to_deprecated_fly_string(), event_init)
+    : DOM::Event(realm, event_name, event_init)
     , m_media(event_init.media)
     , m_matches(event_init.matches)
 {

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
@@ -62,7 +62,7 @@ void AbortSignal::signal_abort(JS::Value reason)
     m_abort_algorithms.clear();
 
     // 5. Fire an event named abort at signal.
-    dispatch_event(Event::create(realm(), HTML::EventNames::abort.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+    dispatch_event(Event::create(realm(), HTML::EventNames::abort).release_value_but_fixme_should_propagate_errors());
 }
 
 void AbortSignal::set_onabort(WebIDL::CallbackType* event_handler)

--- a/Userland/Libraries/LibWeb/DOM/CustomEvent.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CustomEvent.cpp
@@ -22,7 +22,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomEvent>> CustomEvent::construct_impl(J
 }
 
 CustomEvent::CustomEvent(JS::Realm& realm, FlyString const& event_name, CustomEventInit const& event_init)
-    : Event(realm, event_name.to_deprecated_fly_string(), event_init)
+    : Event(realm, event_name, event_init)
     , m_detail(event_init.detail)
 {
 }
@@ -51,7 +51,7 @@ void CustomEvent::init_custom_event(String const& type, bool bubbles, bool cance
         return;
 
     // 2. Initialize this with type, bubbles, and cancelable.
-    initialize_event(type.to_deprecated_string(), bubbles, cancelable);
+    initialize_event(type, bubbles, cancelable);
 
     // 3. Set this’s detail attribute to detail.
     m_detail = detail;

--- a/Userland/Libraries/LibWeb/DOM/CustomEvent.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CustomEvent.cpp
@@ -11,18 +11,18 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomEvent>> CustomEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, CustomEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomEvent>> CustomEvent::create(JS::Realm& realm, FlyString const& event_name, CustomEventInit const& event_init)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<CustomEvent>(realm, realm, event_name, event_init));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomEvent>> CustomEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, CustomEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomEvent>> CustomEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, CustomEventInit const& event_init)
 {
     return create(realm, event_name, event_init);
 }
 
-CustomEvent::CustomEvent(JS::Realm& realm, DeprecatedFlyString const& event_name, CustomEventInit const& event_init)
-    : Event(realm, event_name, event_init)
+CustomEvent::CustomEvent(JS::Realm& realm, FlyString const& event_name, CustomEventInit const& event_init)
+    : Event(realm, event_name.to_deprecated_fly_string(), event_init)
     , m_detail(event_init.detail)
 {
 }
@@ -44,14 +44,14 @@ void CustomEvent::visit_edges(JS::Cell::Visitor& visitor)
 }
 
 // https://dom.spec.whatwg.org/#dom-customevent-initcustomevent
-void CustomEvent::init_custom_event(DeprecatedString const& type, bool bubbles, bool cancelable, JS::Value detail)
+void CustomEvent::init_custom_event(String const& type, bool bubbles, bool cancelable, JS::Value detail)
 {
     // 1. If this’s dispatch flag is set, then return.
     if (dispatched())
         return;
 
     // 2. Initialize this with type, bubbles, and cancelable.
-    initialize_event(type, bubbles, cancelable);
+    initialize_event(type.to_deprecated_string(), bubbles, cancelable);
 
     // 3. Set this’s detail attribute to detail.
     m_detail = detail;

--- a/Userland/Libraries/LibWeb/DOM/CustomEvent.h
+++ b/Userland/Libraries/LibWeb/DOM/CustomEvent.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <LibWeb/DOM/Event.h>
 
 namespace Web::DOM {
@@ -20,8 +21,8 @@ class CustomEvent : public Event {
     WEB_PLATFORM_OBJECT(CustomEvent, Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomEvent>> create(JS::Realm&, DeprecatedFlyString const& event_name, CustomEventInit const& event_init = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomEvent>> construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, CustomEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomEvent>> create(JS::Realm&, FlyString const& event_name, CustomEventInit const& event_init = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomEvent>> construct_impl(JS::Realm&, FlyString const& event_name, CustomEventInit const& event_init);
 
     virtual ~CustomEvent() override;
 
@@ -31,10 +32,10 @@ public:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
-    void init_custom_event(DeprecatedString const& type, bool bubbles, bool cancelable, JS::Value detail);
+    void init_custom_event(String const& type, bool bubbles, bool cancelable, JS::Value detail);
 
 private:
-    CustomEvent(JS::Realm&, DeprecatedFlyString const& event_name, CustomEventInit const& event_init);
+    CustomEvent(JS::Realm&, FlyString const& event_name, CustomEventInit const& event_init);
 
     // https://dom.spec.whatwg.org/#dom-customevent-initcustomevent-type-bubbles-cancelable-detail-detail
     JS::Value m_detail { JS::js_null() };

--- a/Userland/Libraries/LibWeb/DOM/CustomEvent.idl
+++ b/Userland/Libraries/LibWeb/DOM/CustomEvent.idl
@@ -1,6 +1,6 @@
 #import <DOM/Event.idl>
 
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), UseNewAKString]
 interface CustomEvent : Event {
     constructor(DOMString type, optional CustomEventInit eventInitDict = {});
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1010,7 +1010,7 @@ void Document::set_hovered_node(Node* node)
         // FIXME: Check if we need to dispatch these events in a specific order.
         for (auto target = old_hovered_node; target && target.ptr() != common_ancestor; target = target->parent()) {
             // FIXME: Populate the event with mouse coordinates, etc.
-            target->dispatch_event(UIEvents::MouseEvent::create(realm(), UIEvents::EventNames::mouseleave.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+            target->dispatch_event(UIEvents::MouseEvent::create(realm(), UIEvents::EventNames::mouseleave).release_value_but_fixme_should_propagate_errors());
         }
     }
 
@@ -1019,7 +1019,7 @@ void Document::set_hovered_node(Node* node)
         // FIXME: Check if we need to dispatch these events in a specific order.
         for (auto target = m_hovered_node; target && target.ptr() != common_ancestor; target = target->parent()) {
             // FIXME: Populate the event with mouse coordinates, etc.
-            target->dispatch_event(UIEvents::MouseEvent::create(realm(), UIEvents::EventNames::mouseenter.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+            target->dispatch_event(UIEvents::MouseEvent::create(realm(), UIEvents::EventNames::mouseenter).release_value_but_fixme_should_propagate_errors());
         }
     }
 }
@@ -1292,44 +1292,44 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Document::create_event(DeprecatedSt
     // 2. If interface is an ASCII case-insensitive match for any of the strings in the first column in the following table,
     //      then set constructor to the interface in the second column on the same row as the matching string:
     if (Infra::is_ascii_case_insensitive_match(interface, "beforeunloadevent"sv)) {
-        event = TRY(Event::create(realm, "")); // FIXME: Create BeforeUnloadEvent
+        event = TRY(Event::create(realm, FlyString {})); // FIXME: Create BeforeUnloadEvent
     } else if (Infra::is_ascii_case_insensitive_match(interface, "compositionevent"sv)) {
-        event = TRY(Event::create(realm, "")); // FIXME: Create CompositionEvent
+        event = TRY(Event::create(realm, FlyString {})); // FIXME: Create CompositionEvent
     } else if (Infra::is_ascii_case_insensitive_match(interface, "customevent"sv)) {
         event = TRY(CustomEvent::create(realm, FlyString {}));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "devicemotionevent"sv)) {
-        event = TRY(Event::create(realm, "")); // FIXME: Create DeviceMotionEvent
+        event = TRY(Event::create(realm, FlyString {})); // FIXME: Create DeviceMotionEvent
     } else if (Infra::is_ascii_case_insensitive_match(interface, "deviceorientationevent"sv)) {
-        event = TRY(Event::create(realm, "")); // FIXME: Create DeviceOrientationEvent
+        event = TRY(Event::create(realm, FlyString {})); // FIXME: Create DeviceOrientationEvent
     } else if (Infra::is_ascii_case_insensitive_match(interface, "dragevent"sv)) {
-        event = TRY(Event::create(realm, "")); // FIXME: Create DragEvent
+        event = TRY(Event::create(realm, FlyString {})); // FIXME: Create DragEvent
     } else if (Infra::is_ascii_case_insensitive_match(interface, "event"sv)
         || Infra::is_ascii_case_insensitive_match(interface, "events"sv)) {
-        event = TRY(Event::create(realm, ""));
+        event = TRY(Event::create(realm, FlyString {}));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "focusevent"sv)) {
-        event = TRY(UIEvents::FocusEvent::create(realm, ""));
+        event = TRY(UIEvents::FocusEvent::create(realm, FlyString {}));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "hashchangeevent"sv)) {
-        event = TRY(Event::create(realm, "")); // FIXME: Create HashChangeEvent
+        event = TRY(Event::create(realm, FlyString {})); // FIXME: Create HashChangeEvent
     } else if (Infra::is_ascii_case_insensitive_match(interface, "htmlevents"sv)) {
-        event = TRY(Event::create(realm, ""));
+        event = TRY(Event::create(realm, FlyString {}));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "keyboardevent"sv)) {
         event = TRY(UIEvents::KeyboardEvent::create(realm, String {}));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "messageevent"sv)) {
         event = TRY(HTML::MessageEvent::create(realm, String {}));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "mouseevent"sv)
         || Infra::is_ascii_case_insensitive_match(interface, "mouseevents"sv)) {
-        event = TRY(UIEvents::MouseEvent::create(realm, ""));
+        event = TRY(UIEvents::MouseEvent::create(realm, FlyString {}));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "storageevent"sv)) {
-        event = TRY(Event::create(realm, "")); // FIXME: Create StorageEvent
+        event = TRY(Event::create(realm, FlyString {})); // FIXME: Create StorageEvent
     } else if (Infra::is_ascii_case_insensitive_match(interface, "svgevents"sv)) {
-        event = TRY(Event::create(realm, ""));
+        event = TRY(Event::create(realm, FlyString {}));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "textevent"sv)) {
-        event = TRY(Event::create(realm, "")); // FIXME: Create CompositionEvent
+        event = TRY(Event::create(realm, FlyString {})); // FIXME: Create CompositionEvent
     } else if (Infra::is_ascii_case_insensitive_match(interface, "touchevent"sv)) {
-        event = TRY(Event::create(realm, "")); // FIXME: Create TouchEvent
+        event = TRY(Event::create(realm, FlyString {})); // FIXME: Create TouchEvent
     } else if (Infra::is_ascii_case_insensitive_match(interface, "uievent"sv)
         || Infra::is_ascii_case_insensitive_match(interface, "uievents"sv)) {
-        event = TRY(UIEvents::UIEvent::create(realm, ""));
+        event = TRY(UIEvents::UIEvent::create(realm, FlyString {}));
     }
 
     // 3. If constructor is null, then throw a "NotSupportedError" DOMException.
@@ -1589,7 +1589,7 @@ void Document::update_readiness(HTML::DocumentReadyState readiness_value)
     }
 
     // 4. Fire an event named readystatechange at document.
-    dispatch_event(Event::create(realm(), HTML::EventNames::readystatechange.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+    dispatch_event(Event::create(realm(), HTML::EventNames::readystatechange).release_value_but_fixme_should_propagate_errors());
 }
 
 Page* Document::page()
@@ -1604,7 +1604,7 @@ Page const* Document::page() const
 
 EventTarget* Document::get_parent(Event const& event)
 {
-    if (event.type() == HTML::EventNames::load.to_deprecated_fly_string())
+    if (event.type() == HTML::EventNames::load)
         return nullptr;
 
     return m_window;
@@ -1637,7 +1637,7 @@ void Document::completely_finish_loading()
     // 5. Otherwise, if container is non-null, then queue an element task on the DOM manipulation task source given container to fire an event named load at container.
     else if (container) {
         container->queue_an_element_task(HTML::Task::Source::DOMManipulation, [container] {
-            container->dispatch_event(DOM::Event::create(container->realm(), HTML::EventNames::load.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+            container->dispatch_event(DOM::Event::create(container->realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
         });
     }
 }
@@ -1767,7 +1767,7 @@ void Document::update_the_visibility_state(HTML::VisibilityState visibility_stat
     // FIXME: 3. Run any page visibility change steps which may be defined in other specifications, with visibility state and document.
 
     // 4. Fire an event named visibilitychange at document, with its bubbles attribute initialized to true.
-    auto event = DOM::Event::create(realm(), HTML::EventNames::visibilitychange.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors();
+    auto event = DOM::Event::create(realm(), HTML::EventNames::visibilitychange).release_value_but_fixme_should_propagate_errors();
     event->set_bubbles(true);
     dispatch_event(event);
 }
@@ -1788,7 +1788,7 @@ void Document::run_the_resize_steps()
         return;
     m_last_viewport_size = viewport_size;
 
-    window().dispatch_event(DOM::Event::create(realm(), UIEvents::EventNames::resize.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+    window().dispatch_event(DOM::Event::create(realm(), UIEvents::EventNames::resize).release_value_but_fixme_should_propagate_errors());
 
     schedule_layout_update();
 }
@@ -1800,14 +1800,14 @@ void Document::run_the_scroll_steps()
     for (auto& target : m_pending_scroll_event_targets) {
         // 1. If target is a Document, fire an event named scroll that bubbles at target and fire an event named scroll at the VisualViewport that is associated with target.
         if (is<Document>(*target)) {
-            auto event = DOM::Event::create(realm(), HTML::EventNames::scroll.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors();
+            auto event = DOM::Event::create(realm(), HTML::EventNames::scroll).release_value_but_fixme_should_propagate_errors();
             event->set_bubbles(true);
             target->dispatch_event(event);
             // FIXME: Fire at the associated VisualViewport
         }
         // 2. Otherwise, fire an event named scroll at target.
         else {
-            auto event = DOM::Event::create(realm(), HTML::EventNames::scroll.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors();
+            auto event = DOM::Event::create(realm(), HTML::EventNames::scroll).release_value_but_fixme_should_propagate_errors();
             target->dispatch_event(event);
         }
     }
@@ -1847,7 +1847,7 @@ void Document::evaluate_media_queries_and_report_changes()
             CSS::MediaQueryListEventInit init;
             init.media = String::from_deprecated_string(media_query_list->media()).release_value_but_fixme_should_propagate_errors();
             init.matches = now_matches;
-            auto event = CSS::MediaQueryListEvent::create(realm(), HTML::EventNames::change.to_deprecated_fly_string(), init).release_value_but_fixme_should_propagate_errors();
+            auto event = CSS::MediaQueryListEvent::create(realm(), HTML::EventNames::change, init).release_value_but_fixme_should_propagate_errors();
             event->set_is_trusted(true);
             media_query_list->dispatch_event(*event);
         }
@@ -2347,7 +2347,7 @@ void Document::unload(bool recursive_flag, Optional<DocumentUnloadTimingInfo> un
         // then fire an event named unload at document's relevant global object, with legacy target override flag set.
         // FIXME: The legacy target override flag is currently set by a virtual override of dispatch_event()
         //        We should reorganize this so that the flag appears explicitly here instead.
-        auto event = DOM::Event::create(realm(), HTML::EventNames::unload.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors();
+        auto event = DOM::Event::create(realm(), HTML::EventNames::unload).release_value_but_fixme_should_propagate_errors();
         global_object().dispatch_event(event);
     }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1296,7 +1296,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Document::create_event(DeprecatedSt
     } else if (Infra::is_ascii_case_insensitive_match(interface, "compositionevent"sv)) {
         event = TRY(Event::create(realm, "")); // FIXME: Create CompositionEvent
     } else if (Infra::is_ascii_case_insensitive_match(interface, "customevent"sv)) {
-        event = TRY(CustomEvent::create(realm, ""));
+        event = TRY(CustomEvent::create(realm, FlyString {}));
     } else if (Infra::is_ascii_case_insensitive_match(interface, "devicemotionevent"sv)) {
         event = TRY(Event::create(realm, "")); // FIXME: Create DeviceMotionEvent
     } else if (Infra::is_ascii_case_insensitive_match(interface, "deviceorientationevent"sv)) {

--- a/Userland/Libraries/LibWeb/DOM/Event.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Event.cpp
@@ -14,24 +14,24 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Event::create(JS::Realm& realm, DeprecatedFlyString const& event_name, EventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Event::create(JS::Realm& realm, FlyString const& event_name, EventInit const& event_init)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<Event>(realm, realm, event_name, event_init));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Event::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, EventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Event::construct_impl(JS::Realm& realm, FlyString const& event_name, EventInit const& event_init)
 {
     return create(realm, event_name, event_init);
 }
 
-Event::Event(JS::Realm& realm, DeprecatedFlyString const& type)
+Event::Event(JS::Realm& realm, FlyString const& type)
     : PlatformObject(realm)
     , m_type(type)
     , m_initialized(true)
 {
 }
 
-Event::Event(JS::Realm& realm, DeprecatedFlyString const& type, EventInit const& event_init)
+Event::Event(JS::Realm& realm, FlyString const& type, EventInit const& event_init)
     : PlatformObject(realm)
     , m_type(type)
     , m_bubbles(event_init.bubbles)
@@ -100,7 +100,7 @@ void Event::set_cancelled_flag()
 }
 
 // https://dom.spec.whatwg.org/#concept-event-initialize
-void Event::initialize_event(DeprecatedString const& type, bool bubbles, bool cancelable)
+void Event::initialize_event(String const& type, bool bubbles, bool cancelable)
 {
     // 1. Set event’s initialized flag.
     m_initialized = true;
@@ -127,7 +127,7 @@ void Event::initialize_event(DeprecatedString const& type, bool bubbles, bool ca
 }
 
 // https://dom.spec.whatwg.org/#dom-event-initevent
-void Event::init_event(DeprecatedString const& type, bool bubbles, bool cancelable)
+void Event::init_event(String const& type, bool bubbles, bool cancelable)
 {
     // 1. If this’s dispatch flag is set, then return.
     if (m_dispatch)

--- a/Userland/Libraries/LibWeb/DOM/Event.h
+++ b/Userland/Libraries/LibWeb/DOM/Event.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
+#include <AK/FlyString.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/DOM/EventTarget.h>
 
@@ -45,18 +45,18 @@ public:
 
     using Path = Vector<PathEntry>;
 
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> create(JS::Realm&, DeprecatedFlyString const& event_name, EventInit const& event_init = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, EventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> create(JS::Realm&, FlyString const& event_name, EventInit const& event_init = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> construct_impl(JS::Realm&, FlyString const& event_name, EventInit const& event_init);
 
-    Event(JS::Realm&, DeprecatedFlyString const& type);
-    Event(JS::Realm&, DeprecatedFlyString const& type, EventInit const& event_init);
+    Event(JS::Realm&, FlyString const& type);
+    Event(JS::Realm&, FlyString const& type, EventInit const& event_init);
 
     virtual ~Event() = default;
 
     double time_stamp() const;
 
-    DeprecatedFlyString const& type() const { return m_type; }
-    void set_type(StringView type) { m_type = type; }
+    FlyString const& type() const { return m_type; }
+    void set_type(FlyString const& type) { m_type = type; }
 
     JS::GCPtr<EventTarget> target() const { return m_target; }
     void set_target(EventTarget* target) { m_target = target; }
@@ -137,20 +137,20 @@ public:
         m_stop_immediate_propagation = true;
     }
 
-    void init_event(DeprecatedString const&, bool, bool);
+    void init_event(String const&, bool, bool);
 
     void set_time_stamp(double time_stamp) { m_time_stamp = time_stamp; }
 
     Vector<JS::Handle<EventTarget>> composed_path() const;
 
 protected:
-    void initialize_event(DeprecatedString const&, bool, bool);
+    void initialize_event(String const&, bool, bool);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Visitor&) override;
 
 private:
-    DeprecatedFlyString m_type;
+    FlyString m_type;
     JS::GCPtr<EventTarget> m_target;
     JS::GCPtr<EventTarget> m_related_target;
     JS::GCPtr<EventTarget> m_current_target;

--- a/Userland/Libraries/LibWeb/DOM/Event.idl
+++ b/Userland/Libraries/LibWeb/DOM/Event.idl
@@ -1,7 +1,7 @@
 #import <DOM/EventTarget.idl>
 
 // https://dom.spec.whatwg.org/#event
-[Exposed=*]
+[Exposed=*, UseNewAKString]
 interface Event {
 
     constructor(DOMString type, optional EventInit eventInitDict = {});

--- a/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
@@ -63,7 +63,7 @@ bool EventDispatcher::inner_invoke(Event& event, Vector<JS::Handle<DOM::DOMEvent
             continue;
 
         // 1. If event’s type attribute value is not listener’s type, then continue.
-        if (event.type() != listener->type)
+        if (event.type().to_deprecated_fly_string() != listener->type)
             continue;
 
         // 2. Set found to true.
@@ -180,14 +180,14 @@ void EventDispatcher::invoke(Event::PathEntry& struct_, Event& event, Event::Pha
 
         // 2. If event’s type attribute value is a match for any of the strings in the first column in the following table,
         //    set event’s type attribute value to the string in the second column on the same row as the matching string, and return otherwise.
-        if (event.type() == "animationend")
-            event.set_type("webkitAnimationEnd"sv);
-        else if (event.type() == "animationiteration")
-            event.set_type("webkitAnimationIteration"sv);
-        else if (event.type() == "animationstart")
-            event.set_type("webkitAnimationStart"sv);
-        else if (event.type() == "transitionend")
-            event.set_type("webkitTransitionEnd"sv);
+        if (event.type() == HTML::EventNames::animationend)
+            event.set_type(HTML::EventNames::webkitAnimationEnd);
+        else if (event.type() == HTML::EventNames::animationiteration)
+            event.set_type(HTML::EventNames::webkitAnimationIteration);
+        else if (event.type() == HTML::EventNames::animationstart)
+            event.set_type(HTML::EventNames::webkitAnimationStart);
+        else if (event.type() == HTML::EventNames::transitionend)
+            event.set_type(HTML::EventNames::webkitTransitionEnd);
         else
             return;
 
@@ -235,7 +235,7 @@ bool EventDispatcher::dispatch(JS::NonnullGCPtr<EventTarget> target, Event& even
         event.append_to_path(*target, target_override, related_target, touch_targets, false);
 
         // 4. Let isActivationEvent be true, if event is a MouseEvent object and event’s type attribute is "click"; otherwise false.
-        bool is_activation_event = is<UIEvents::MouseEvent>(event) && FlyString::from_deprecated_fly_string(event.type()).release_value() == HTML::EventNames::click;
+        bool is_activation_event = is<UIEvents::MouseEvent>(event) && event.type() == HTML::EventNames::click;
 
         // 5. If isActivationEvent is true and target has activation behavior, then set activationTarget to target.
         if (is_activation_event && target->activation_behavior)

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -616,7 +616,7 @@ JS::ThrowCompletionOr<void> EventTarget::process_event_handler_for_event(Depreca
     // 3. Let special error event handling be true if event is an ErrorEvent object, event's type is error, and event's currentTarget implements the WindowOrWorkerGlobalScope mixin.
     //    Otherwise, let special error event handling be false.
     // FIXME: This doesn't check for WorkerGlobalScape as we don't currently have it.
-    bool special_error_event_handling = is<HTML::ErrorEvent>(event) && event.type() == HTML::EventNames::error.to_deprecated_fly_string() && is<HTML::Window>(event.current_target().ptr());
+    bool special_error_event_handling = is<HTML::ErrorEvent>(event) && event.type() == HTML::EventNames::error && is<HTML::Window>(event.current_target().ptr());
 
     // 4. Process the Event object event as follows:
     JS::Completion return_value_or_error;

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -1187,7 +1187,7 @@ WebIDL::ExceptionOr<void> BrowsingContext::traverse_the_history(size_t entry_ind
             // and the newURL attribute initialized to newURL.
 
             // FIXME: Implement a proper HashChangeEvent class.
-            auto event = DOM::Event::create(verify_cast<HTML::Window>(relevant_global_object(*new_document)).realm(), HTML::EventNames::hashchange.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors();
+            auto event = DOM::Event::create(verify_cast<HTML::Window>(relevant_global_object(*new_document)).realm(), HTML::EventNames::hashchange).release_value_but_fixme_should_propagate_errors();
             new_document->dispatch_event(event);
         });
     }

--- a/Userland/Libraries/LibWeb/HTML/CloseEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CloseEvent.cpp
@@ -20,7 +20,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CloseEvent>> CloseEvent::construct_impl(JS:
 }
 
 CloseEvent::CloseEvent(JS::Realm& realm, FlyString const& event_name, CloseEventInit const& event_init)
-    : DOM::Event(realm, event_name.to_deprecated_fly_string(), event_init)
+    : DOM::Event(realm, event_name, event_init)
     , m_was_clean(event_init.was_clean)
     , m_code(event_init.code)
     , m_reason(event_init.reason)

--- a/Userland/Libraries/LibWeb/HTML/ErrorEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ErrorEvent.cpp
@@ -20,7 +20,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ErrorEvent>> ErrorEvent::construct_impl(JS:
 }
 
 ErrorEvent::ErrorEvent(JS::Realm& realm, FlyString const& event_name, ErrorEventInit const& event_init)
-    : DOM::Event(realm, event_name.to_deprecated_fly_string())
+    : DOM::Event(realm, event_name)
     , m_message(event_init.message)
     , m_filename(event_init.filename)
     , m_lineno(event_init.lineno)

--- a/Userland/Libraries/LibWeb/HTML/EventNames.h
+++ b/Userland/Libraries/LibWeb/HTML/EventNames.h
@@ -91,10 +91,10 @@ namespace Web::HTML::EventNames {
     __ENUMERATE_HTML_EVENT(visibilitychange)         \
     __ENUMERATE_HTML_EVENT(volumechange)             \
     __ENUMERATE_HTML_EVENT(waiting)                  \
-    __ENUMERATE_HTML_EVENT(webkitanimationend)       \
-    __ENUMERATE_HTML_EVENT(webkitanimationiteration) \
-    __ENUMERATE_HTML_EVENT(webkitanimationstart)     \
-    __ENUMERATE_HTML_EVENT(webkittransitionend)
+    __ENUMERATE_HTML_EVENT(webkitAnimationEnd)       \
+    __ENUMERATE_HTML_EVENT(webkitAnimationIteration) \
+    __ENUMERATE_HTML_EVENT(webkitAnimationStart)     \
+    __ENUMERATE_HTML_EVENT(webkitTransitionEnd)
 
 #define __ENUMERATE_HTML_EVENT(name) extern FlyString name;
 ENUMERATE_HTML_EVENTS

--- a/Userland/Libraries/LibWeb/HTML/EventNames.h
+++ b/Userland/Libraries/LibWeb/HTML/EventNames.h
@@ -17,6 +17,9 @@ namespace Web::HTML::EventNames {
 #define ENUMERATE_HTML_EVENTS                        \
     __ENUMERATE_HTML_EVENT(abort)                    \
     __ENUMERATE_HTML_EVENT(addtrack)                 \
+    __ENUMERATE_HTML_EVENT(animationend)             \
+    __ENUMERATE_HTML_EVENT(animationiteration)       \
+    __ENUMERATE_HTML_EVENT(animationstart)           \
     __ENUMERATE_HTML_EVENT(afterprint)               \
     __ENUMERATE_HTML_EVENT(beforeprint)              \
     __ENUMERATE_HTML_EVENT(beforeunload)             \
@@ -86,6 +89,7 @@ namespace Web::HTML::EventNames {
     __ENUMERATE_HTML_EVENT(suspend)                  \
     __ENUMERATE_HTML_EVENT(timeupdate)               \
     __ENUMERATE_HTML_EVENT(toggle)                   \
+    __ENUMERATE_HTML_EVENT(transitionend)            \
     __ENUMERATE_HTML_EVENT(unhandledrejection)       \
     __ENUMERATE_HTML_EVENT(unload)                   \
     __ENUMERATE_HTML_EVENT(visibilitychange)         \

--- a/Userland/Libraries/LibWeb/HTML/Focus.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Focus.cpp
@@ -65,7 +65,7 @@ static void run_focus_update_steps(Vector<JS::Handle<DOM::Node>> old_chain, Vect
         //    with related blur target as the related target.
         if (blur_event_target) {
             // FIXME: Implement the "fire a focus event" spec operation.
-            auto blur_event = UIEvents::FocusEvent::create(blur_event_target->realm(), HTML::EventNames::blur.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors();
+            auto blur_event = UIEvents::FocusEvent::create(blur_event_target->realm(), HTML::EventNames::blur).release_value_but_fixme_should_propagate_errors();
             blur_event->set_related_target(related_blur_target);
             blur_event_target->dispatch_event(blur_event);
         }
@@ -108,7 +108,7 @@ static void run_focus_update_steps(Vector<JS::Handle<DOM::Node>> old_chain, Vect
         //    with related focus target as the related target.
         if (focus_event_target) {
             // FIXME: Implement the "fire a focus event" spec operation.
-            auto focus_event = UIEvents::FocusEvent::create(focus_event_target->realm(), HTML::EventNames::focus.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors();
+            auto focus_event = UIEvents::FocusEvent::create(focus_event_target->realm(), HTML::EventNames::focus).release_value_but_fixme_should_propagate_errors();
             focus_event->set_related_target(related_focus_target);
             focus_event_target->dispatch_event(focus_event);
         }

--- a/Userland/Libraries/LibWeb/HTML/FormDataEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormDataEvent.cpp
@@ -16,7 +16,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<FormDataEvent>> FormDataEvent::construct_im
 }
 
 FormDataEvent::FormDataEvent(JS::Realm& realm, FlyString const& event_name, FormDataEventInit const& event_init)
-    : DOM::Event(realm, event_name.to_deprecated_fly_string(), event_init)
+    : DOM::Event(realm, event_name, event_init)
     , m_form_data(event_init.form_data)
 {
 }

--- a/Userland/Libraries/LibWeb/HTML/GlobalEventHandlers.h
+++ b/Userland/Libraries/LibWeb/HTML/GlobalEventHandlers.h
@@ -71,10 +71,10 @@
     E(ontoggle, HTML::EventNames::toggle)                                     \
     E(onvolumechange, HTML::EventNames::volumechange)                         \
     E(onwaiting, HTML::EventNames::waiting)                                   \
-    E(onwebkitanimationend, HTML::EventNames::webkitanimationend)             \
-    E(onwebkitanimationiteration, HTML::EventNames::webkitanimationiteration) \
-    E(onwebkitanimationstart, HTML::EventNames::webkitanimationstart)         \
-    E(onwebkittransitionend, HTML::EventNames::webkittransitionend)           \
+    E(onwebkitanimationend, HTML::EventNames::webkitAnimationEnd)             \
+    E(onwebkitanimationiteration, HTML::EventNames::webkitAnimationIteration) \
+    E(onwebkitanimationstart, HTML::EventNames::webkitAnimationStart)         \
+    E(onwebkittransitionend, HTML::EventNames::webkitTransitionEnd)           \
     E(onwheel, UIEvents::EventNames::wheel)
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -281,7 +281,7 @@ bool HTMLElement::fire_a_synthetic_pointer_event(DeprecatedFlyString const& type
     // 1. Let event be the result of creating an event using PointerEvent.
     // 2. Initialize event's type attribute to e.
     // FIXME: Actually create a PointerEvent!
-    auto event = UIEvents::MouseEvent::create(realm(), type).release_value_but_fixme_should_propagate_errors();
+    auto event = UIEvents::MouseEvent::create(realm(), FlyString::from_deprecated_fly_string(type).release_value()).release_value_but_fixme_should_propagate_errors();
 
     // 3. Initialize event's bubbles and cancelable attributes to true.
     event->set_bubbles(true);

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -156,7 +156,7 @@ ErrorOr<void> HTMLFormElement::submit_form(JS::GCPtr<HTMLElement> submitter, boo
 void HTMLFormElement::reset_form()
 {
     // 1. Let reset be the result of firing an event named reset at form, with the bubbles and cancelable attributes initialized to true.
-    auto reset_event = DOM::Event::create(realm(), HTML::EventNames::reset.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors();
+    auto reset_event = DOM::Event::create(realm(), HTML::EventNames::reset).release_value_but_fixme_should_propagate_errors();
     reset_event->set_bubbles(true);
     reset_event->set_cancelable(true);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -165,7 +165,7 @@ void run_iframe_load_event_steps(HTML::HTMLIFrameElement& element)
     // FIXME: 4. Set childDocument's iframe load in progress flag.
 
     // 5. Fire an event named load at element.
-    element.dispatch_event(DOM::Event::create(element.realm(), HTML::EventNames::load.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+    element.dispatch_event(DOM::Event::create(element.realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
 
     // FIXME: 6. Unset childDocument's iframe load in progress flag.
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -27,7 +27,7 @@ HTMLImageElement::HTMLImageElement(DOM::Document& document, DOM::QualifiedName q
         set_needs_style_update(true);
         this->document().set_needs_layout();
         queue_an_element_task(HTML::Task::Source::DOMManipulation, [this] {
-            dispatch_event(DOM::Event::create(this->realm(), EventNames::load.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+            dispatch_event(DOM::Event::create(this->realm(), EventNames::load).release_value_but_fixme_should_propagate_errors());
             m_load_event_delayer.clear();
         });
     };
@@ -37,7 +37,7 @@ HTMLImageElement::HTMLImageElement(DOM::Document& document, DOM::QualifiedName q
         set_needs_style_update(true);
         this->document().set_needs_layout();
         queue_an_element_task(HTML::Task::Source::DOMManipulation, [this] {
-            dispatch_event(DOM::Event::create(this->realm(), EventNames::error.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+            dispatch_event(DOM::Event::create(this->realm(), EventNames::error).release_value_but_fixme_should_propagate_errors());
             m_load_event_delayer.clear();
         });
     };

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -156,11 +156,11 @@ void HTMLInputElement::update_the_file_selection(JS::NonnullGCPtr<FileAPI::FileL
         this->set_files(files.ptr());
 
         // 2. Fire an event named input at the input element, with the bubbles and composed attributes initialized to true.
-        auto input_event = DOM::Event::create(this->realm(), EventNames::input.to_deprecated_fly_string(), { .bubbles = true, .composed = true }).release_value_but_fixme_should_propagate_errors();
+        auto input_event = DOM::Event::create(this->realm(), EventNames::input, { .bubbles = true, .composed = true }).release_value_but_fixme_should_propagate_errors();
         this->dispatch_event(input_event);
 
         // 3. Fire an event named change at the input element, with the bubbles attribute initialized to true.
-        auto change_event = DOM::Event::create(this->realm(), EventNames::change.to_deprecated_fly_string(), { .bubbles = true }).release_value_but_fixme_should_propagate_errors();
+        auto change_event = DOM::Event::create(this->realm(), EventNames::change, { .bubbles = true }).release_value_but_fixme_should_propagate_errors();
         this->dispatch_event(change_event);
     });
 }
@@ -247,13 +247,13 @@ ErrorOr<void> HTMLInputElement::run_input_activation_behavior()
             return {};
 
         // 2. Fire an event named input at the element with the bubbles and composed attributes initialized to true.
-        auto input_event = DOM::Event::create(realm(), HTML::EventNames::input.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors();
+        auto input_event = DOM::Event::create(realm(), HTML::EventNames::input).release_value_but_fixme_should_propagate_errors();
         input_event->set_bubbles(true);
         input_event->set_composed(true);
         dispatch_event(input_event);
 
         // 3. Fire an event named change at the element with the bubbles attribute initialized to true.
-        auto change_event = DOM::Event::create(realm(), HTML::EventNames::change.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors();
+        auto change_event = DOM::Event::create(realm(), HTML::EventNames::change).release_value_but_fixme_should_propagate_errors();
         change_event->set_bubbles(true);
         dispatch_event(*change_event);
     } else if (type_state() == TypeAttributeState::SubmitButton) {
@@ -271,7 +271,7 @@ ErrorOr<void> HTMLInputElement::run_input_activation_behavior()
     } else if (type_state() == TypeAttributeState::FileUpload) {
         show_the_picker_if_applicable(*this);
     } else {
-        dispatch_event(DOM::Event::create(realm(), EventNames::change.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+        dispatch_event(DOM::Event::create(realm(), EventNames::change).release_value_but_fixme_should_propagate_errors());
     }
 
     return {};
@@ -286,13 +286,13 @@ void HTMLInputElement::did_edit_text_node(Badge<BrowsingContext>)
     // NOTE: This is a bit ad-hoc, but basically implements part of "4.10.5.5 Common event behaviors"
     //       https://html.spec.whatwg.org/multipage/input.html#common-input-element-events
     queue_an_element_task(HTML::Task::Source::UserInteraction, [this] {
-        auto input_event = DOM::Event::create(realm(), HTML::EventNames::input.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors();
+        auto input_event = DOM::Event::create(realm(), HTML::EventNames::input).release_value_but_fixme_should_propagate_errors();
         input_event->set_bubbles(true);
         input_event->set_composed(true);
         dispatch_event(*input_event);
 
         // FIXME: This should only fire when the input is "committed", whatever that means.
-        auto change_event = DOM::Event::create(realm(), HTML::EventNames::change.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors();
+        auto change_event = DOM::Event::create(realm(), HTML::EventNames::change).release_value_but_fixme_should_propagate_errors();
         change_event->set_bubbles(true);
         dispatch_event(change_event);
     });

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -403,11 +403,11 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
         }
 
         // 2. Fire an event named load at el.
-        dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::load.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+        dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
     }
     // 5. Otherwise, fire an event named error at el.
     else {
-        dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+        dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
     }
 
     // FIXME: 6. If el contributes a script-blocking style sheet, then:

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -117,7 +117,7 @@ void HTMLMediaElement::set_duration(double duration)
     if (!isnan(duration)) {
         // FIXME: Handle seeking to the end of the media resource when needed.
         queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::durationchange.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::durationchange).release_value_but_fixme_should_propagate_errors());
         });
     }
 
@@ -154,7 +154,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::load_element()
     //    fire an event named abort at the media element.
     if (m_network_state == NetworkState::Loading || m_network_state == NetworkState::Idle) {
         queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::abort.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::abort).release_value_but_fixme_should_propagate_errors());
         });
     }
 
@@ -162,7 +162,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::load_element()
     if (m_network_state != NetworkState::Empty) {
         // 1. Queue a media element task given the media element to fire an event named emptied at the media element.
         queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::emptied.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::emptied).release_value_but_fixme_should_propagate_errors());
         });
 
         // 2. If a fetching process is in progress for the media element, the user agent should stop it.
@@ -247,7 +247,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::select_resource()
 
     // 8. ⌛ Queue a media element task given the media element to fire an event named loadstart at the media element.
     queue_a_media_element_task([this] {
-        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::loadstart.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::loadstart).release_value_but_fixme_should_propagate_errors());
     });
 
     // 9. Run the appropriate steps from the following list:
@@ -584,7 +584,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::process_media_data(Function<void()> 
         TrackEventInit event_init {};
         event_init.track = video_track;
 
-        auto event = TRY(TrackEvent::create(realm, TRY_OR_THROW_OOM(vm, FlyString::from_deprecated_fly_string(HTML::EventNames::addtrack.to_deprecated_fly_string())), event_init));
+        auto event = TRY(TrackEvent::create(realm, HTML::EventNames::addtrack, event_init));
         m_video_tracks->dispatch_event(event);
     }
 
@@ -608,7 +608,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::process_media_data(Function<void()> 
             video_element.set_video_height(video_track->pixel_height());
 
             queue_a_media_element_task([this] {
-                dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::resize.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+                dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::resize).release_value_but_fixme_should_propagate_errors());
             });
         }
 
@@ -634,11 +634,11 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::process_media_data(Function<void()> 
     // -> Once the entire media resource has been fetched (but potentially before any of it has been decoded)
     if (video_track != nullptr) {
         // Fire an event named progress at the media element.
-        dispatch_event(TRY(DOM::Event::create(this->realm(), HTML::EventNames::progress.to_deprecated_fly_string())));
+        dispatch_event(TRY(DOM::Event::create(this->realm(), HTML::EventNames::progress)));
 
         // Set the networkState to NETWORK_IDLE and fire an event named suspend at the media element.
         m_network_state = NetworkState::Idle;
-        dispatch_event(TRY(DOM::Event::create(this->realm(), HTML::EventNames::suspend.to_deprecated_fly_string())));
+        dispatch_event(TRY(DOM::Event::create(this->realm(), HTML::EventNames::suspend)));
 
         // If the user agent ever discards any media data and then needs to resume the network activity to obtain it again, then it must queue a media
         // element task given the media element to set the networkState to NETWORK_LOADING.
@@ -668,7 +668,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::handle_media_source_failure()
     // FIXME: 4. Set the element's show poster flag to true.
 
     // 5. Fire an event named error at the media element.
-    dispatch_event(TRY(DOM::Event::create(realm(), HTML::EventNames::error.to_deprecated_fly_string())));
+    dispatch_event(TRY(DOM::Event::create(realm(), HTML::EventNames::error)));
 
     // FIXME: 6. Reject pending play promises with promises and a "NotSupportedError" DOMException.
     // FIXME: 7. Set the element's delaying-the-load-event flag to false. This stops delaying the load event.
@@ -695,7 +695,7 @@ void HTMLMediaElement::set_ready_state(ReadyState ready_state)
     if (m_ready_state == ReadyState::HaveNothing && ready_state == ReadyState::HaveMetadata) {
         // Queue a media element task given the media element to fire an event named loadedmetadata at the element.
         queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::loadedmetadata.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+            dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::loadedmetadata).release_value_but_fixme_should_propagate_errors());
         });
 
         return;
@@ -709,7 +709,7 @@ void HTMLMediaElement::set_ready_state(ReadyState ready_state)
             m_first_data_load_event_since_load_start = false;
 
             queue_a_media_element_task([this] {
-                dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::loadeddata.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+                dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::loadeddata).release_value_but_fixme_should_propagate_errors());
             });
         }
 
@@ -731,7 +731,7 @@ void HTMLMediaElement::set_ready_state(ReadyState ready_state)
     if (m_ready_state <= ReadyState::HaveCurrentData && ready_state == ReadyState::HaveFutureData) {
         // The user agent must queue a media element task given the media element to fire an event named canplay at the element.
         queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::canplay.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+            dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::canplay).release_value_but_fixme_should_propagate_errors());
         });
 
         // FIXME: If the element's paused attribute is false, the user agent must notify about playing for the element.
@@ -745,13 +745,13 @@ void HTMLMediaElement::set_ready_state(ReadyState ready_state)
         if (m_ready_state <= ReadyState::HaveCurrentData) {
             // FIXME: Handle the paused attribute.
             queue_a_media_element_task([this] {
-                dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::canplay.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+                dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::canplay).release_value_but_fixme_should_propagate_errors());
             });
         }
 
         // The user agent must queue a media element task given the media element to fire an event named canplaythrough at the element.
         queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::canplaythrough.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+            dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::canplaythrough).release_value_but_fixme_should_propagate_errors());
         });
 
         // FIXME: If the element is not eligible for autoplay, then the user agent must abort these substeps.

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -124,7 +124,7 @@ void HTMLObjectElement::queue_element_task_to_run_object_representation_steps()
 
             // 3. If that failed, fire an event named error at the element, then jump to the step below labeled fallback.
             if (!url.is_valid()) {
-                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
                 return run_object_representation_fallback_steps();
             }
 
@@ -151,7 +151,7 @@ void HTMLObjectElement::queue_element_task_to_run_object_representation_steps()
 void HTMLObjectElement::resource_did_fail()
 {
     // 4.7. If the load failed (e.g. there was an HTTP 404 error, there was a DNS error), fire an event named error at the element, then jump to the step below labeled fallback.
-    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
     run_object_representation_fallback_steps();
 }
 
@@ -289,7 +289,7 @@ void HTMLObjectElement::run_object_representation_completed_steps(Representation
     // 4.11. If the object element does not represent its nested browsing context, then once the resource is completely loaded, queue an element task on the DOM manipulation task source given the object element to fire an event named load at the element.
     if (representation != Representation::NestedBrowsingContext) {
         queue_an_element_task(HTML::Task::Source::DOMManipulation, [&]() {
-            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
         });
     }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -72,7 +72,7 @@ void HTMLScriptElement::execute_script()
     // 3. If el's result is null, then fire an event named error at el, and return.
     if (m_result.has<ResultState::Null>()) {
         dbgln("HTMLScriptElement: Refusing to run script because the element's result is null.");
-        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
         return;
     }
 
@@ -123,7 +123,7 @@ void HTMLScriptElement::execute_script()
 
     // 8. If el's from an external file is true, then fire an event named load at el.
     if (m_from_an_external_file)
-        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
 }
 
 // https://html.spec.whatwg.org/multipage/scripting.html#prepare-a-script
@@ -294,7 +294,7 @@ void HTMLScriptElement::prepare_script()
         if (m_script_type == ScriptType::ImportMap) {
             // then queue an element task on the DOM manipulation task source given el to fire an event named error at el, and return.
             queue_an_element_task(HTML::Task::Source::DOMManipulation, [this] {
-                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
             });
             return;
         }
@@ -306,7 +306,7 @@ void HTMLScriptElement::prepare_script()
         if (src.is_empty()) {
             dbgln("HTMLScriptElement: Refusing to run script because the src attribute is empty.");
             queue_an_element_task(HTML::Task::Source::DOMManipulation, [this] {
-                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
             });
             return;
         }
@@ -321,7 +321,7 @@ void HTMLScriptElement::prepare_script()
         if (!url.is_valid()) {
             dbgln("HTMLScriptElement: Refusing to run script because the src URL '{}' is invalid.", url);
             queue_an_element_task(HTML::Task::Source::DOMManipulation, [this] {
-                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
             });
             return;
         }

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
@@ -20,7 +20,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<MessageEvent>> MessageEvent::construct_impl
 }
 
 MessageEvent::MessageEvent(JS::Realm& realm, FlyString const& event_name, MessageEventInit const& event_init)
-    : DOM::Event(realm, event_name.to_deprecated_fly_string(), event_init)
+    : DOM::Event(realm, event_name, event_init)
     , m_data(event_init.data)
     , m_origin(event_init.origin)
     , m_last_event_id(event_init.last_event_id)

--- a/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.cpp
@@ -20,7 +20,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PageTransitionEvent>> PageTransitionEvent::
 }
 
 PageTransitionEvent::PageTransitionEvent(JS::Realm& realm, FlyString const& event_name, PageTransitionEventInit const& event_init)
-    : DOM::Event(realm, event_name.to_deprecated_fly_string(), event_init)
+    : DOM::Event(realm, event_name, event_init)
     , m_persisted(event_init.persisted)
 {
 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -256,7 +256,7 @@ void HTMLParser::the_end()
         document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::unsafe_shared_current_time();
 
         // 2. Fire an event named DOMContentLoaded at the Document object, with its bubbles attribute initialized to true.
-        auto content_loaded_event = DOM::Event::create(document->realm(), HTML::EventNames::DOMContentLoaded.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors();
+        auto content_loaded_event = DOM::Event::create(document->realm(), HTML::EventNames::DOMContentLoaded).release_value_but_fixme_should_propagate_errors();
         content_loaded_event->set_bubbles(true);
         document->dispatch_event(content_loaded_event);
 
@@ -297,7 +297,7 @@ void HTMLParser::the_end()
         // 5. Fire an event named load at window, with legacy target override flag set.
         // FIXME: The legacy target override flag is currently set by a virtual override of dispatch_event()
         //        We should reorganize this so that the flag appears explicitly here instead.
-        window->dispatch_event(DOM::Event::create(document->realm(), HTML::EventNames::load.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+        window->dispatch_event(DOM::Event::create(document->realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
 
         // FIXME: 6. Invoke WebDriver BiDi load complete with the Document's browsing context, and a new WebDriver BiDi navigation status whose id is the Document object's navigation id, status is "complete", and url is the Document object's URL.
 

--- a/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.cpp
@@ -20,7 +20,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PromiseRejectionEvent>> PromiseRejectionEve
 }
 
 PromiseRejectionEvent::PromiseRejectionEvent(JS::Realm& realm, FlyString const& event_name, PromiseRejectionEventInit const& event_init)
-    : DOM::Event(realm, event_name.to_deprecated_fly_string(), event_init)
+    : DOM::Event(realm, event_name, event_init)
     , m_promise(const_cast<JS::Promise*>(event_init.promise.cell()))
     , m_reason(event_init.reason)
 {

--- a/Userland/Libraries/LibWeb/HTML/SubmitEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SubmitEvent.cpp
@@ -20,7 +20,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<SubmitEvent>> SubmitEvent::construct_impl(J
 }
 
 SubmitEvent::SubmitEvent(JS::Realm& realm, FlyString const& event_name, SubmitEventInit const& event_init)
-    : DOM::Event(realm, event_name.to_deprecated_fly_string(), event_init)
+    : DOM::Event(realm, event_name, event_init)
     , m_submitter(event_init.submitter)
 {
 }

--- a/Userland/Libraries/LibWeb/HTML/TrackEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TrackEvent.cpp
@@ -21,7 +21,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<TrackEvent>> TrackEvent::construct_impl(JS:
 }
 
 TrackEvent::TrackEvent(JS::Realm& realm, FlyString const& event_name, TrackEventInit const& event_init)
-    : DOM::Event(realm, event_name.to_deprecated_fly_string(), event_init)
+    : DOM::Event(realm, event_name, event_init)
     , m_track(event_init.track)
 {
 }

--- a/Userland/Libraries/LibWeb/HTML/VideoTrack.cpp
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrack.cpp
@@ -138,7 +138,7 @@ void VideoTrack::set_selected(bool selected)
 
         if (previously_unselected_track_is_selected || selected_track_was_unselected_without_another_selection) {
             m_media_element->queue_a_media_element_task([this]() {
-                m_video_track_list->dispatch_event(DOM::Event::create(realm(), HTML::EventNames::change.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+                m_video_track_list->dispatch_event(DOM::Event::create(realm(), HTML::EventNames::change).release_value_but_fixme_should_propagate_errors());
             });
         }
     }

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -185,7 +185,7 @@ bool EventHandler::handle_mousewheel(CSSPixelPoint position, unsigned button, un
                 return false;
 
             auto offset = compute_mouse_event_offset(position, *layout_node);
-            if (node->dispatch_event(UIEvents::WheelEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::wheel.to_deprecated_fly_string(), offset.x(), offset.y(), position.x(), position.y(), wheel_delta_x, wheel_delta_y, buttons, button).release_value_but_fixme_should_propagate_errors())) {
+            if (node->dispatch_event(UIEvents::WheelEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::wheel, offset.x(), offset.y(), position.x(), position.y(), wheel_delta_x, wheel_delta_y, buttons, button).release_value_but_fixme_should_propagate_errors())) {
                 if (auto* page = m_browsing_context->page()) {
                     page->client().page_did_request_scroll(wheel_delta_x * 20, wheel_delta_y * 20);
                 }
@@ -249,12 +249,12 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, unsigned button, unsig
             auto offset = compute_mouse_event_offset(position, *layout_node);
             auto client_offset = compute_mouse_event_client_offset(position);
             auto page_offset = compute_mouse_event_page_offset(client_offset);
-            node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mouseup.to_deprecated_fly_string(), offset, client_offset, page_offset, buttons, button).release_value_but_fixme_should_propagate_errors());
+            node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mouseup, offset, client_offset, page_offset, buttons, button).release_value_but_fixme_should_propagate_errors());
             handled_event = true;
 
             bool run_activation_behavior = true;
             if (node.ptr() == m_mousedown_target && button == GUI::MouseButton::Primary) {
-                run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::click.to_deprecated_fly_string(), offset, client_offset, page_offset, button).release_value_but_fixme_should_propagate_errors());
+                run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::click, offset, client_offset, page_offset, button).release_value_but_fixme_should_propagate_errors());
             }
 
             if (run_activation_behavior) {
@@ -372,7 +372,7 @@ bool EventHandler::handle_mousedown(CSSPixelPoint position, unsigned button, uns
         auto offset = compute_mouse_event_offset(position, *layout_node);
         auto client_offset = compute_mouse_event_client_offset(position);
         auto page_offset = compute_mouse_event_page_offset(client_offset);
-        node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mousedown.to_deprecated_fly_string(), offset, client_offset, page_offset, buttons, button).release_value_but_fixme_should_propagate_errors());
+        node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mousedown, offset, client_offset, page_offset, buttons, button).release_value_but_fixme_should_propagate_errors());
     }
 
     // NOTE: Dispatching an event may have disturbed the world.
@@ -488,7 +488,7 @@ bool EventHandler::handle_mousemove(CSSPixelPoint position, unsigned buttons, un
             auto offset = compute_mouse_event_offset(position, *layout_node);
             auto client_offset = compute_mouse_event_client_offset(position);
             auto page_offset = compute_mouse_event_page_offset(client_offset);
-            node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mousemove.to_deprecated_fly_string(), offset, client_offset, page_offset, buttons).release_value_but_fixme_should_propagate_errors());
+            node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mousemove, offset, client_offset, page_offset, buttons).release_value_but_fixme_should_propagate_errors());
             // NOTE: Dispatching an event may have disturbed the world.
             if (!paint_root() || paint_root() != node->document().paint_box())
                 return true;
@@ -577,7 +577,7 @@ bool EventHandler::handle_doubleclick(CSSPixelPoint position, unsigned button, u
     auto offset = compute_mouse_event_offset(position, *layout_node);
     auto client_offset = compute_mouse_event_client_offset(position);
     auto page_offset = compute_mouse_event_page_offset(client_offset);
-    node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::dblclick.to_deprecated_fly_string(), offset, client_offset, page_offset, buttons, button).release_value_but_fixme_should_propagate_errors());
+    node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::dblclick, offset, client_offset, page_offset, buttons, button).release_value_but_fixme_should_propagate_errors());
 
     // NOTE: Dispatching an event may have disturbed the world.
     if (!paint_root() || paint_root() != node->document().paint_box())

--- a/Userland/Libraries/LibWeb/UIEvents/FocusEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/FocusEvent.cpp
@@ -15,7 +15,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<FocusEvent>> FocusEvent::construct_impl(JS:
 }
 
 FocusEvent::FocusEvent(JS::Realm& realm, FlyString const& event_name, FocusEventInit const& event_init)
-    : UIEvent(realm, event_name.to_deprecated_fly_string())
+    : UIEvent(realm, event_name)
 {
     set_related_target(const_cast<DOM::EventTarget*>(event_init.related_target.ptr()));
 }

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
@@ -117,7 +117,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyboardEvent>> KeyboardEvent::construct_im
 }
 
 KeyboardEvent::KeyboardEvent(JS::Realm& realm, FlyString const& event_name, KeyboardEventInit const& event_init)
-    : UIEvent(realm, event_name.to_deprecated_fly_string(), event_init)
+    : UIEvent(realm, event_name, event_init)
     , m_key(event_init.key)
     , m_code(event_init.code)
     , m_location(event_init.location)

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -13,7 +13,7 @@
 
 namespace Web::UIEvents {
 
-MouseEvent::MouseEvent(JS::Realm& realm, DeprecatedFlyString const& event_name, MouseEventInit const& event_init)
+MouseEvent::MouseEvent(JS::Realm& realm, FlyString const& event_name, MouseEventInit const& event_init)
     : UIEvent(realm, event_name, event_init)
     , m_offset_x(event_init.offset_x)
     , m_offset_y(event_init.offset_y)
@@ -56,12 +56,12 @@ static i16 determine_button(unsigned mouse_button)
     }
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> MouseEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, MouseEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> MouseEvent::create(JS::Realm& realm, FlyString const& event_name, MouseEventInit const& event_init)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<MouseEvent>(realm, realm, event_name, event_init));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> MouseEvent::create_from_platform_event(JS::Realm& realm, DeprecatedFlyString const& event_name, CSSPixelPoint offset, CSSPixelPoint client_offset, CSSPixelPoint page_offset, unsigned buttons, unsigned mouse_button)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> MouseEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixelPoint offset, CSSPixelPoint client_offset, CSSPixelPoint page_offset, unsigned buttons, unsigned mouse_button)
 {
     MouseEventInit event_init {};
     event_init.offset_x = static_cast<double>(offset.x().value());
@@ -77,8 +77,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> MouseEvent::create_from_platfo
 
 void MouseEvent::set_event_characteristics()
 {
-    auto type = String::from_deprecated_string(this->type()).release_value();
-    if (type.is_one_of(EventNames::mousedown, EventNames::mousemove, EventNames::mouseout, EventNames::mouseover, EventNames::mouseup, HTML::EventNames::click)) {
+    if (type().is_one_of(EventNames::mousedown, EventNames::mousemove, EventNames::mouseout, EventNames::mouseover, EventNames::mouseup, HTML::EventNames::click)) {
         set_bubbles(true);
         set_cancelable(true);
         set_composed(true);

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
@@ -29,8 +29,8 @@ class MouseEvent : public UIEvent {
     WEB_PLATFORM_OBJECT(MouseEvent, UIEvent);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> create(JS::Realm&, DeprecatedFlyString const& event_name, MouseEventInit const& event_init = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> create_from_platform_event(JS::Realm&, DeprecatedFlyString const& event_name, CSSPixelPoint offset, CSSPixelPoint client_offset, CSSPixelPoint page_offset, unsigned buttons, unsigned mouse_button = 1);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> create(JS::Realm&, FlyString const& event_name, MouseEventInit const& event_init = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint offset, CSSPixelPoint client_offset, CSSPixelPoint page_offset, unsigned buttons, unsigned mouse_button = 1);
 
     virtual ~MouseEvent() override;
 
@@ -56,7 +56,7 @@ public:
     virtual u32 which() const override { return m_button + 1; }
 
 protected:
-    MouseEvent(JS::Realm&, DeprecatedFlyString const& event_name, MouseEventInit const& event_init);
+    MouseEvent(JS::Realm&, FlyString const& event_name, MouseEventInit const& event_init);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.idl
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.idl
@@ -1,5 +1,5 @@
 // https://w3c.github.io/uievents/#mouseevent
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface MouseEvent : UIEvent {
 
     readonly attribute double offsetX;

--- a/Userland/Libraries/LibWeb/UIEvents/UIEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/UIEvent.cpp
@@ -9,22 +9,22 @@
 
 namespace Web::UIEvents {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> UIEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> UIEvent::create(JS::Realm& realm, FlyString const& event_name)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<UIEvent>(realm, realm, event_name));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> UIEvent::construct_impl(JS::Realm& realm, DeprecatedFlyString const& event_name, UIEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> UIEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, UIEventInit const& event_init)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<UIEvent>(realm, realm, event_name, event_init));
 }
 
-UIEvent::UIEvent(JS::Realm& realm, DeprecatedFlyString const& event_name)
+UIEvent::UIEvent(JS::Realm& realm, FlyString const& event_name)
     : Event(realm, event_name)
 {
 }
 
-UIEvent::UIEvent(JS::Realm& realm, DeprecatedFlyString const& event_name, UIEventInit const& event_init)
+UIEvent::UIEvent(JS::Realm& realm, FlyString const& event_name, UIEventInit const& event_init)
     : Event(realm, event_name, event_init)
     , m_view(event_init.view)
     , m_detail(event_init.detail)

--- a/Userland/Libraries/LibWeb/UIEvents/UIEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/UIEvent.h
@@ -21,8 +21,8 @@ class UIEvent : public DOM::Event {
     WEB_PLATFORM_OBJECT(UIEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> create(JS::Realm&, DeprecatedFlyString const& type);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> construct_impl(JS::Realm&, DeprecatedFlyString const& event_name, UIEventInit const& event_init);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> create(JS::Realm&, FlyString const& type);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> construct_impl(JS::Realm&, FlyString const& event_name, UIEventInit const& event_init);
 
     virtual ~UIEvent() override;
 
@@ -30,7 +30,7 @@ public:
     int detail() const { return m_detail; }
     virtual u32 which() const { return 0; }
 
-    void init_ui_event(DeprecatedString const& type, bool bubbles, bool cancelable, HTML::Window* view, int detail)
+    void init_ui_event(String const& type, bool bubbles, bool cancelable, HTML::Window* view, int detail)
     {
         init_event(type, bubbles, cancelable);
         m_view = view;
@@ -38,8 +38,8 @@ public:
     }
 
 protected:
-    UIEvent(JS::Realm&, DeprecatedFlyString const& event_name);
-    UIEvent(JS::Realm&, DeprecatedFlyString const& event_name, UIEventInit const& event_init);
+    UIEvent(JS::Realm&, FlyString const& event_name);
+    UIEvent(JS::Realm&, FlyString const& event_name, UIEventInit const& event_init);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/UIEvents/UIEvent.idl
+++ b/Userland/Libraries/LibWeb/UIEvents/UIEvent.idl
@@ -1,7 +1,7 @@
 #import <DOM/Event.idl>
 
 // https://w3c.github.io/uievents/#uievent
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface UIEvent : Event {
     constructor(DOMString type, optional UIEventInit eventInitDict = {});
     readonly attribute Window? view;

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
@@ -12,7 +12,7 @@
 
 namespace Web::UIEvents {
 
-WheelEvent::WheelEvent(JS::Realm& realm, DeprecatedFlyString const& event_name, WheelEventInit const& event_init)
+WheelEvent::WheelEvent(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init)
     : MouseEvent(realm, event_name, event_init)
     , m_delta_x(event_init.delta_x)
     , m_delta_y(event_init.delta_y)
@@ -31,12 +31,12 @@ JS::ThrowCompletionOr<void> WheelEvent::initialize(JS::Realm& realm)
     return {};
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create(JS::Realm& realm, DeprecatedFlyString const& event_name, WheelEventInit const& event_init)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<WheelEvent>(realm, realm, event_name, event_init));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create_from_platform_event(JS::Realm& realm, DeprecatedFlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, double delta_x, double delta_y, unsigned buttons, unsigned button)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, double delta_x, double delta_y, unsigned buttons, unsigned button)
 {
     WheelEventInit event_init {};
     event_init.offset_x = static_cast<double>(offset_x.value());

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
@@ -29,8 +29,8 @@ class WheelEvent final : public MouseEvent {
     WEB_PLATFORM_OBJECT(WheelEvent, MouseEvent);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> create(JS::Realm&, DeprecatedFlyString const& event_name, WheelEventInit const& event_init = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> create_from_platform_event(JS::Realm&, DeprecatedFlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, double delta_x, double delta_y, unsigned buttons, unsigned button);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> create(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, double delta_x, double delta_y, unsigned buttons, unsigned button);
 
     virtual ~WheelEvent() override;
 
@@ -40,7 +40,7 @@ public:
     unsigned long delta_mode() const { return to_underlying(m_delta_mode); }
 
 private:
-    WheelEvent(JS::Realm&, DeprecatedFlyString const& event_name, WheelEventInit const& event_init);
+    WheelEvent(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.idl
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.idl
@@ -1,7 +1,7 @@
 #import <UIEvents/MouseEvent.idl>
 
 // https://www.w3.org/TR/uievents/#idl-wheelevent
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface WheelEvent : MouseEvent {
     // DeltaModeCode
     const unsigned long DOM_DELTA_PIXEL = 0x00;

--- a/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.cpp
@@ -20,7 +20,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> WebGLContextEvent::cons
 }
 
 WebGLContextEvent::WebGLContextEvent(JS::Realm& realm, FlyString const& type, WebGLContextEventInit const& event_init)
-    : DOM::Event(realm, type.to_deprecated_fly_string(), event_init)
+    : DOM::Event(realm, type, event_init)
     , m_status_message(event_init.status_message)
 {
 }

--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -204,13 +204,13 @@ void WebSocket::on_open()
     // 1. Change the readyState attribute's value to OPEN (1).
     // 2. Change the extensions attribute's value to the extensions in use, if it is not the null value. [WSP]
     // 3. Change the protocol attribute's value to the subprotocol in use, if it is not the null value. [WSP]
-    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::open.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::open).release_value_but_fixme_should_propagate_errors());
 }
 
 // https://websockets.spec.whatwg.org/#feedback-from-the-protocol
 void WebSocket::on_error()
 {
-    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
 }
 
 // https://websockets.spec.whatwg.org/#feedback-from-the-protocol

--- a/Userland/Libraries/LibWeb/XHR/ProgressEvent.cpp
+++ b/Userland/Libraries/LibWeb/XHR/ProgressEvent.cpp
@@ -20,7 +20,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ProgressEvent>> ProgressEvent::construct_im
 }
 
 ProgressEvent::ProgressEvent(JS::Realm& realm, FlyString const& event_name, ProgressEventInit const& event_init)
-    : Event(realm, event_name.to_deprecated_fly_string(), event_init)
+    : Event(realm, event_name, event_init)
     , m_length_computable(event_init.length_computable)
     , m_loaded(event_init.loaded)
     , m_total(event_init.total)

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -436,7 +436,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::open(String const& method_string, Stri
         m_state = State::Opened;
 
         // 2. Fire an event named readystatechange at this.
-        dispatch_event(TRY(DOM::Event::create(realm(), EventNames::readystatechange.to_deprecated_fly_string())));
+        dispatch_event(TRY(DOM::Event::create(realm(), EventNames::readystatechange)));
     }
 
     return {};
@@ -686,7 +686,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
 
             // 5. Fire an event named readystatechange at this.
             // FIXME: We're in an async context, so we can't propagate the error anywhere.
-            dispatch_event(*DOM::Event::create(this->realm(), EventNames::readystatechange.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+            dispatch_event(*DOM::Event::create(this->realm(), EventNames::readystatechange).release_value_but_fixme_should_propagate_errors());
 
             // 6. If this’s state is not headers received, then return.
             if (m_state != State::HeadersReceived)
@@ -1088,7 +1088,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::handle_response_end_of_body()
 
     // 9. Fire an event named readystatechange at xhr.
     // FIXME: If we're in an async context, this will propagate to a callback context which can't propagate it anywhere else and does not expect this to fail.
-    dispatch_event(*DOM::Event::create(realm, EventNames::readystatechange.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+    dispatch_event(*DOM::Event::create(realm, EventNames::readystatechange).release_value_but_fixme_should_propagate_errors());
 
     // 10. Fire a progress event named load at xhr with transmitted and length.
     fire_progress_event(*this, EventNames::load.to_deprecated_fly_string(), transmitted, length);
@@ -1140,7 +1140,7 @@ JS::ThrowCompletionOr<void> XMLHttpRequest::request_error_steps(DeprecatedFlyStr
 
     // 5. Fire an event named readystatechange at xhr.
     // FIXME: Since we're in an async context, this will propagate to a callback context which can't propagate it anywhere else and does not expect this to fail.
-    dispatch_event(*DOM::Event::create(realm(), EventNames::readystatechange.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+    dispatch_event(*DOM::Event::create(realm(), EventNames::readystatechange).release_value_but_fixme_should_propagate_errors());
 
     // 6. If xhr’s upload complete flag is unset, then:
     if (!m_upload_complete) {

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -189,7 +189,7 @@ void XMLDocumentBuilder::document_end()
         document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::unsafe_shared_current_time();
 
         // Fire an event named DOMContentLoaded at the Document object, with its bubbles attribute initialized to true.
-        auto content_loaded_event = DOM::Event::create(document->realm(), HTML::EventNames::DOMContentLoaded.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors();
+        auto content_loaded_event = DOM::Event::create(document->realm(), HTML::EventNames::DOMContentLoaded).release_value_but_fixme_should_propagate_errors();
         content_loaded_event->set_bubbles(true);
         document->dispatch_event(content_loaded_event);
 
@@ -229,7 +229,7 @@ void XMLDocumentBuilder::document_end()
         // Fire an event named load at window, with legacy target override flag set.
         // FIXME: The legacy target override flag is currently set by a virtual override of dispatch_event()
         // We should reorganize this so that the flag appears explicitly here instead.
-        window->dispatch_event(DOM::Event::create(document->realm(), HTML::EventNames::load.to_deprecated_fly_string()).release_value_but_fixme_should_propagate_errors());
+        window->dispatch_event(DOM::Event::create(document->realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
 
         // FIXME: Invoke WebDriver BiDi load complete with the Document's browsing context, and a new WebDriver BiDi navigation status whose id is the Document object's navigation id, status is "complete", and url is the Document object's URL.
 

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -38,6 +38,7 @@
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Platform/Timer.h>
+#include <LibWeb/UIEvents/EventNames.h>
 #include <LibWeb/UIEvents/MouseEvent.h>
 #include <LibWeb/WebDriver/ExecuteScript.h>
 #include <LibWeb/WebDriver/Screenshot.h>
@@ -307,7 +308,7 @@ static Optional<Web::DOM::Element&> container_for_element(Web::DOM::Element& ele
 }
 
 template<typename T>
-static bool fire_an_event(DeprecatedString name, Optional<Web::DOM::Element&> target)
+static bool fire_an_event(FlyString name, Optional<Web::DOM::Element&> target)
 {
     // FIXME: This is supposed to call the https://dom.spec.whatwg.org/#concept-event-fire DOM algorithm,
     //        but that doesn't seem to be implemented elsewhere. So, we'll ad-hack it for now. :^)
@@ -1322,13 +1323,13 @@ Messages::WebDriverClient::ElementClickResponse WebDriverConnection::element_cli
         auto parent_node = element_container;
 
         // 2. Fire a mouseOver event at parent node.
-        fire_an_event<Web::UIEvents::MouseEvent>("mouseOver", parent_node);
+        fire_an_event<Web::UIEvents::MouseEvent>(Web::UIEvents::EventNames::mouseover, parent_node);
 
         // 3. Fire a mouseMove event at parent node.
-        fire_an_event<Web::UIEvents::MouseEvent>("mouseMove", parent_node);
+        fire_an_event<Web::UIEvents::MouseEvent>(Web::UIEvents::EventNames::mousemove, parent_node);
 
         // 4. Fire a mouseDown event at parent node.
-        fire_an_event<Web::UIEvents::MouseEvent>("mouseDown", parent_node);
+        fire_an_event<Web::UIEvents::MouseEvent>(Web::UIEvents::EventNames::mousedown, parent_node);
 
         // 5. Run the focusing steps on parent node.
         Web::HTML::run_focusing_steps(parent_node.has_value() ? &*parent_node : nullptr);
@@ -1336,7 +1337,7 @@ Messages::WebDriverClient::ElementClickResponse WebDriverConnection::element_cli
         // 6. If element is not disabled:
         if (!option_element.is_actually_disabled()) {
             // 1. Fire an input event at parent node.
-            fire_an_event<Web::DOM::Event>("input", parent_node);
+            fire_an_event<Web::DOM::Event>(Web::HTML::EventNames::input, parent_node);
 
             // 2. Let previous selectedness be equal to element selectedness.
             auto previous_selectedness = option_element.selected();
@@ -1353,14 +1354,14 @@ Messages::WebDriverClient::ElementClickResponse WebDriverConnection::element_cli
 
             // 4. If previous selectedness is false, fire a change event at parent node.
             if (!previous_selectedness) {
-                fire_an_event<Web::DOM::Event>("change", parent_node);
+                fire_an_event<Web::DOM::Event>(Web::HTML::EventNames::change, parent_node);
             }
         }
         // 7. Fire a mouseUp event at parent node.
-        fire_an_event<Web::UIEvents::MouseEvent>("mouseUp", parent_node);
+        fire_an_event<Web::UIEvents::MouseEvent>(Web::UIEvents::EventNames::mouseup, parent_node);
 
         // 8. Fire a click event at parent node.
-        fire_an_event<Web::UIEvents::MouseEvent>("click", parent_node);
+        fire_an_event<Web::UIEvents::MouseEvent>(Web::UIEvents::EventNames::click, parent_node);
     }
     // -> Otherwise
     else {


### PR DESCRIPTION
All IDL implementations in the LibWeb event system is now ported to new String. There are still a few areas of the event system, not directly related to the IDL implementations, that is still using Deprecated{Fly}String.