### PR TITLE
Teach webp lossless decoder to read Tests/LibGfx/test-inputs/simple-vp8l.webp

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -302,6 +302,18 @@ TEST_CASE(test_webp_simple_lossless)
     EXPECT(!plugin_decoder->loop_count());
 
     EXPECT_EQ(plugin_decoder->size(), Gfx::IntSize(386, 395));
+
+    // Ironically, simple-vp8l.webp is a much more complex file than extended-lossless.webp tested below.
+    // extended-lossless.webp tests the decoding basics.
+    // This here tests the predictor, color, and subtract green transforms,
+    // as well as meta prefix images, one-element canonical code handling,
+    // and handling of canonical codes with more than 288 elements.
+    // This image uses all 13 predictor modes of the predictor transform.
+    auto frame = MUST(plugin_decoder->frame(0));
+    EXPECT_EQ(frame.image->size(), Gfx::IntSize(386, 395));
+
+    // This pixel tests all predictor modes except 5, 7, 8, 9, and 13.
+    EXPECT_EQ(frame.image->get_pixel(289, 332), Gfx::Color(0xf2, 0xee, 0xd3, 255));
 }
 
 TEST_CASE(test_webp_extended_lossy)

--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -45,8 +45,10 @@ private:
     size_t m_max_prefixed_code_length { 0 };
 
     // Compression - indexed by symbol
-    Array<u16, 288> m_bit_codes {}; // deflate uses a maximum of 288 symbols (maximum of 32 for distances)
-    Array<u16, 288> m_bit_code_lengths {};
+    // Deflate uses a maximum of 288 symbols (maximum of 32 for distances),
+    // but this is also used by webp, which can use up to 256 + 24 + (1 << 11) == 2328 symbols.
+    Vector<u16, 288> m_bit_codes {};
+    Vector<u16, 288> m_bit_code_lengths {};
 };
 
 class DeflateDecompressor final : public Stream {

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -923,6 +923,85 @@ ARGB32 PredictorTransform::inverse_transform(ARGB32 pixel, ARGB32 prediction)
         .value();
 }
 
+// https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#42_color_transform
+class ColorTransform : public Transform {
+public:
+    static ErrorOr<NonnullOwnPtr<ColorTransform>> read(WebPLoadingContext&, LittleEndianInputBitStream&, IntSize const& image_size);
+    virtual ErrorOr<void> transform(Bitmap&) override;
+
+private:
+    ColorTransform(int size_bits, NonnullRefPtr<Bitmap> color_bitmap)
+        : m_size_bits(size_bits)
+        , m_color_bitmap(move(color_bitmap))
+    {
+    }
+
+    static i8 ColorTransformDelta(i8 transform, i8 color)
+    {
+        return (transform * color) >> 5;
+    }
+
+    static ARGB32 inverse_transform(ARGB32 pixel, ARGB32 transform);
+
+    int m_size_bits;
+    NonnullRefPtr<Bitmap> m_color_bitmap;
+};
+
+ErrorOr<NonnullOwnPtr<ColorTransform>> ColorTransform::read(WebPLoadingContext& context, LittleEndianInputBitStream& bit_stream, IntSize const& image_size)
+{
+    // color-image          =  3BIT ; sub-pixel code
+    //                         entropy-coded-image
+    int size_bits = TRY(bit_stream.read_bits(3)) + 2;
+    int block_size = 1 << size_bits;
+    IntSize color_image_size { ceil_div(image_size.width(), block_size), ceil_div(image_size.height(), block_size) };
+
+    auto color_bitmap = TRY(decode_webp_chunk_VP8L_image(context, ImageKind::EntropyCoded, BitmapFormat::BGRx8888, color_image_size, bit_stream));
+
+    return adopt_nonnull_own_or_enomem(new (nothrow) ColorTransform(size_bits, move(color_bitmap)));
+}
+
+ErrorOr<void> ColorTransform::transform(Bitmap& bitmap)
+{
+    for (int y = 0; y < bitmap.height(); ++y) {
+        ARGB32* bitmap_scanline = bitmap.scanline(y);
+
+        int color_y = y >> m_size_bits;
+        ARGB32* color_scanline = m_color_bitmap->scanline(color_y);
+
+        for (int x = 0; x < bitmap.width(); ++x) {
+            int color_x = x >> m_size_bits;
+            bitmap_scanline[x] = inverse_transform(bitmap_scanline[x], color_scanline[color_x]);
+        }
+    }
+    return {};
+}
+
+ARGB32 ColorTransform::inverse_transform(ARGB32 pixel, ARGB32 transform)
+{
+    // https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#51_roles_of_image_data
+    // "Each ColorTransformElement 'cte' is treated as a pixel whose alpha component is 255,
+    // red component is cte.red_to_blue, green component is cte.green_to_blue
+    // and blue component is cte.green_to_red."
+    auto transform_color = Color::from_argb(transform);
+    i8 red_to_blue = static_cast<i8>(transform_color.red());
+    i8 green_to_blue = static_cast<i8>(transform_color.green());
+    i8 green_to_red = static_cast<i8>(transform_color.blue());
+
+    auto pixel_color = Color::from_argb(pixel);
+
+    // "Transformed values of red and blue components"
+    int tmp_red = pixel_color.red();
+    int green = pixel_color.green();
+    int tmp_blue = pixel_color.blue();
+
+    // "Applying the inverse transform is just adding the color transform deltas"
+    tmp_red += ColorTransformDelta(green_to_red, green);
+    tmp_blue += ColorTransformDelta(green_to_blue, green);
+    tmp_blue += ColorTransformDelta(red_to_blue, tmp_red & 0xff);
+
+    return Color(tmp_red & 0xff, green, tmp_blue & 0xff, pixel_color.alpha()).value();
+}
+
 // https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#43_subtract_green_transform
 class SubtractGreenTransform : public Transform {
 public:
@@ -1005,7 +1084,8 @@ static ErrorOr<void> decode_webp_chunk_VP8L(WebPLoadingContext& context, Chunk c
             TRY(transforms.try_append(TRY(PredictorTransform::read(context, bit_stream, context.size.value()))));
             break;
         case COLOR_TRANSFORM:
-            return context.error("WebPImageDecoderPlugin: VP8L COLOR_TRANSFORM handling not yet implemented");
+            TRY(transforms.try_append(TRY(ColorTransform::read(context, bit_stream, context.size.value()))));
+            break;
         case SUBTRACT_GREEN_TRANSFORM:
             TRY(transforms.try_append(TRY(try_make<SubtractGreenTransform>())));
             break;


### PR DESCRIPTION
This requires implementing most of the rest of the spec.

This adds decoding of the subimages for the predictor and color transforms and for the meta prefix image, and adds code to use them.

It also adds two tweaks to the bitstream decoding for two cases where webp's bitstream is ever so slightly different from deflate's.

Finally, it adds a test.

With this, we can decode not just Tests/LibGfx/test-inputs/simple-vp8l.webp but many other webp files I tried (…well, 5 – namely, the lossless webp files at https://developers.google.com/speed/webp/gallery2).

The only thing still missing after this is the color index transform (plus random bugfixes).