### PR TITLE
Kernel: Mark a bunch of NonnullRefPtrs also const to ensure immutability

### DIFF
--- a/Kernel/Bus/PCI/Device.h
+++ b/Kernel/Bus/PCI/Device.h
@@ -38,7 +38,7 @@ protected:
     explicit Device(DeviceIdentifier const& pci_identifier);
 
 private:
-    NonnullRefPtr<DeviceIdentifier const> m_pci_identifier;
+    NonnullRefPtr<DeviceIdentifier const> const m_pci_identifier;
 };
 
 template<typename... Parameters>

--- a/Kernel/Coredump.h
+++ b/Kernel/Coredump.h
@@ -80,7 +80,7 @@ private:
     ErrorOr<void> create_notes_metadata_data(auto&) const;
 
     NonnullRefPtr<Process> const m_process;
-    NonnullRefPtr<OpenFileDescription> m_description;
+    NonnullRefPtr<OpenFileDescription> const m_description;
     size_t m_num_program_headers { 0 };
     Vector<FlatRegionData> m_regions;
 };

--- a/Kernel/FileSystem/Custody.h
+++ b/Kernel/FileSystem/Custody.h
@@ -37,7 +37,7 @@ private:
 
     RefPtr<Custody> m_parent;
     NonnullOwnPtr<KString> m_name;
-    NonnullRefPtr<Inode> m_inode;
+    NonnullRefPtr<Inode> const m_inode;
     int m_mount_flags { 0 };
 
     mutable IntrusiveListNode<Custody> m_all_custodies_list_node;

--- a/Kernel/FileSystem/FileBackedFileSystem.h
+++ b/Kernel/FileSystem/FileBackedFileSystem.h
@@ -38,6 +38,6 @@ private:
     virtual bool is_file_backed() const override { return true; }
 
     IntrusiveListNode<FileBackedFileSystem> m_file_backed_file_system_node;
-    NonnullRefPtr<OpenFileDescription> m_file_description;
+    NonnullRefPtr<OpenFileDescription> const m_file_description;
 };
 }

--- a/Kernel/FileSystem/InodeFile.h
+++ b/Kernel/FileSystem/InodeFile.h
@@ -52,7 +52,7 @@ private:
     virtual bool is_regular_file() const override;
 
     explicit InodeFile(NonnullRefPtr<Inode>);
-    NonnullRefPtr<Inode> m_inode;
+    NonnullRefPtr<Inode> const m_inode;
 };
 
 }

--- a/Kernel/FileSystem/OpenFileDescription.h
+++ b/Kernel/FileSystem/OpenFileDescription.h
@@ -141,7 +141,7 @@ private:
     }
 
     RefPtr<Inode> m_inode;
-    NonnullRefPtr<File> m_file;
+    NonnullRefPtr<File> const m_file;
 
     struct State {
         OwnPtr<OpenFileDescriptionData> data;

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.h
@@ -23,7 +23,7 @@ public:
 private:
     PCIDeviceSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, SysFSDirectory const&, PCI::DeviceIdentifier const&);
 
-    NonnullRefPtr<PCI::DeviceIdentifier const> m_device_identifier;
+    NonnullRefPtr<PCI::DeviceIdentifier const> const m_device_identifier;
 
     NonnullOwnPtr<KString> m_device_directory_name;
 };

--- a/Kernel/Jail.h
+++ b/Kernel/Jail.h
@@ -52,7 +52,7 @@ public:
     using List = IntrusiveListRelaxedConst<&Jail::m_list_node>;
 
 private:
-    NonnullRefPtr<ProcessList> m_process_list;
+    NonnullRefPtr<ProcessList> const m_process_list;
 
     SpinlockProtected<size_t, LockRank::None> m_attach_count { 0 };
 };

--- a/Kernel/Memory/InodeVMObject.h
+++ b/Kernel/Memory/InodeVMObject.h
@@ -37,7 +37,7 @@ protected:
 
     virtual bool is_inode() const final { return true; }
 
-    NonnullRefPtr<Inode> m_inode;
+    NonnullRefPtr<Inode> const m_inode;
     Bitmap m_dirty_pages;
 };
 

--- a/Kernel/Storage/ATA/AHCI/Port.h
+++ b/Kernel/Storage/ATA/AHCI/Port.h
@@ -123,7 +123,7 @@ private:
     // it's probably better to just "cache" this here instead.
     AHCI::HBADefinedCapabilities const m_hba_capabilities;
 
-    NonnullRefPtr<Memory::PhysicalPage> m_identify_buffer_page;
+    NonnullRefPtr<Memory::PhysicalPage> const m_identify_buffer_page;
 
     volatile AHCI::PortRegisters& m_port_registers;
     LockWeakPtr<AHCIController> m_parent_controller;

--- a/Kernel/Storage/NVMe/NVMeQueue.h
+++ b/Kernel/Storage/NVMe/NVMeQueue.h
@@ -75,6 +75,6 @@ private:
     Vector<NonnullRefPtr<Memory::PhysicalPage>> m_sq_dma_page;
     Span<NVMeCompletion> m_cqe_array;
     Memory::TypedMapping<DoorbellRegister volatile> m_db_regs;
-    NonnullRefPtr<Memory::PhysicalPage const> m_rw_dma_page;
+    NonnullRefPtr<Memory::PhysicalPage const> const m_rw_dma_page;
 };
 }


### PR DESCRIPTION
These were easy to pick-up as these pointers are assigned during the construction point and are never changed afterwards.

This small change to these pointers will ensure that our code will not accidentally assign these pointers with a new object which is always a kind of bug we will want to prevent.