### PR TITLE
Kernel: Revert execve page fault crash regression

### DIFF
--- a/Kernel/Arch/aarch64/PageDirectory.cpp
+++ b/Kernel/Arch/aarch64/PageDirectory.cpp
@@ -64,11 +64,9 @@ UNMAP_AFTER_INIT NonnullLockRefPtr<PageDirectory> PageDirectory::must_create_ker
     return adopt_lock_ref_if_nonnull(new (nothrow) PageDirectory).release_nonnull();
 }
 
-ErrorOr<NonnullLockRefPtr<PageDirectory>> PageDirectory::try_create_for_userspace(Process& process)
+ErrorOr<NonnullLockRefPtr<PageDirectory>> PageDirectory::try_create_for_userspace()
 {
     auto directory = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) PageDirectory));
-
-    directory->m_process = &process;
 
     directory->m_root_table = TRY(MM.allocate_physical_page());
 

--- a/Kernel/Arch/aarch64/PageDirectory.h
+++ b/Kernel/Arch/aarch64/PageDirectory.h
@@ -179,7 +179,7 @@ class PageDirectory final : public AtomicRefCounted<PageDirectory> {
     friend class MemoryManager;
 
 public:
-    static ErrorOr<NonnullLockRefPtr<PageDirectory>> try_create_for_userspace(Process&);
+    static ErrorOr<NonnullLockRefPtr<PageDirectory>> try_create_for_userspace();
     static NonnullLockRefPtr<PageDirectory> must_create_kernel_page_directory();
     static LockRefPtr<PageDirectory> find_current();
 
@@ -197,7 +197,10 @@ public:
         return m_root_table;
     }
 
-    Process* process() { return m_process; }
+    AddressSpace* address_space() { return m_space; }
+    AddressSpace const* address_space() const { return m_space; }
+
+    void set_space(Badge<AddressSpace>, AddressSpace& space) { m_space = &space; }
 
     RecursiveSpinlock<LockRank::None>& get_lock() { return m_lock; }
 
@@ -209,7 +212,7 @@ private:
     static void register_page_directory(PageDirectory* directory);
     static void deregister_page_directory(PageDirectory* directory);
 
-    Process* m_process { nullptr };
+    AddressSpace* m_space { nullptr };
     RefPtr<PhysicalPage> m_root_table;
     RefPtr<PhysicalPage> m_directory_table;
     RefPtr<PhysicalPage> m_directory_pages[512];

--- a/Kernel/Arch/x86_64/PageDirectory.cpp
+++ b/Kernel/Arch/x86_64/PageDirectory.cpp
@@ -61,11 +61,9 @@ UNMAP_AFTER_INIT NonnullLockRefPtr<PageDirectory> PageDirectory::must_create_ker
     return adopt_lock_ref_if_nonnull(new (nothrow) PageDirectory).release_nonnull();
 }
 
-ErrorOr<NonnullLockRefPtr<PageDirectory>> PageDirectory::try_create_for_userspace(Process& process)
+ErrorOr<NonnullLockRefPtr<PageDirectory>> PageDirectory::try_create_for_userspace()
 {
     auto directory = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) PageDirectory));
-
-    directory->m_process = &process;
 
     directory->m_pml4t = TRY(MM.allocate_physical_page());
 

--- a/Kernel/Arch/x86_64/PageDirectory.h
+++ b/Kernel/Arch/x86_64/PageDirectory.h
@@ -162,7 +162,7 @@ class PageDirectory final : public AtomicRefCounted<PageDirectory> {
     friend class MemoryManager;
 
 public:
-    static ErrorOr<NonnullLockRefPtr<PageDirectory>> try_create_for_userspace(Process& process);
+    static ErrorOr<NonnullLockRefPtr<PageDirectory>> try_create_for_userspace();
     static NonnullLockRefPtr<PageDirectory> must_create_kernel_page_directory();
     static LockRefPtr<PageDirectory> find_current();
 
@@ -180,7 +180,10 @@ public:
         return m_pml4t;
     }
 
-    Process* process() { return m_process; }
+    AddressSpace* address_space() { return m_space; }
+    AddressSpace const* address_space() const { return m_space; }
+
+    void set_space(Badge<AddressSpace>, AddressSpace& space) { m_space = &space; }
 
     RecursiveSpinlock<LockRank::None>& get_lock() { return m_lock; }
 
@@ -192,7 +195,7 @@ private:
     static void register_page_directory(PageDirectory* directory);
     static void deregister_page_directory(PageDirectory* directory);
 
-    Process* m_process { nullptr };
+    AddressSpace* m_space { nullptr };
     RefPtr<PhysicalPage> m_pml4t;
     RefPtr<PhysicalPage> m_directory_table;
     RefPtr<PhysicalPage> m_directory_pages[512];

--- a/Kernel/Memory/AddressSpace.h
+++ b/Kernel/Memory/AddressSpace.h
@@ -21,7 +21,7 @@ namespace Kernel::Memory {
 
 class AddressSpace {
 public:
-    static ErrorOr<NonnullOwnPtr<AddressSpace>> try_create(Process&, AddressSpace const* parent);
+    static ErrorOr<NonnullOwnPtr<AddressSpace>> try_create(AddressSpace const* parent);
     ~AddressSpace();
 
     PageDirectory& page_directory() { return *m_page_directory; }

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -722,11 +722,8 @@ Region* MemoryManager::find_region_from_vaddr(VirtualAddress vaddr)
     auto page_directory = PageDirectory::find_current();
     if (!page_directory)
         return nullptr;
-    auto* process = page_directory->process();
-    VERIFY(process);
-    return process->address_space().with([&](auto& space) {
-        return find_user_region_from_vaddr(*space, vaddr);
-    });
+    VERIFY(page_directory->address_space());
+    return find_user_region_from_vaddr(*page_directory->address_space(), vaddr);
 }
 
 PageFaultResponse MemoryManager::handle_page_fault(PageFault const& fault)

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -658,6 +658,16 @@ UNMAP_AFTER_INIT void MemoryManager::initialize(u32 cpu)
     }
 }
 
+Region* MemoryManager::kernel_region_from_vaddr(VirtualAddress address)
+{
+    if (is_user_address(address))
+        return nullptr;
+
+    return MM.m_global_data.with([&](auto& global_data) {
+        return global_data.region_tree.find_region_containing(address);
+    });
+}
+
 Region* MemoryManager::find_user_region_from_vaddr(AddressSpace& space, VirtualAddress vaddr)
 {
     return space.find_region_containing({ vaddr, 1 });
@@ -705,6 +715,20 @@ void MemoryManager::validate_syscall_preconditions(Process& process, RegisterSta
     }
 }
 
+Region* MemoryManager::find_region_from_vaddr(VirtualAddress vaddr)
+{
+    if (auto* region = kernel_region_from_vaddr(vaddr))
+        return region;
+    auto page_directory = PageDirectory::find_current();
+    if (!page_directory)
+        return nullptr;
+    auto* process = page_directory->process();
+    VERIFY(process);
+    return process->address_space().with([&](auto& space) {
+        return find_user_region_from_vaddr(*space, vaddr);
+    });
+}
+
 PageFaultResponse MemoryManager::handle_page_fault(PageFault const& fault)
 {
     auto faulted_in_range = [&fault](auto const* start, auto const* end) {
@@ -729,44 +753,11 @@ PageFaultResponse MemoryManager::handle_page_fault(PageFault const& fault)
         return PageFaultResponse::ShouldCrash;
     }
     dbgln_if(PAGE_FAULT_DEBUG, "MM: CPU[{}] handle_page_fault({:#04x}) at {}", Processor::current_id(), fault.code(), fault.vaddr());
-
-    // The faulting region may be unmapped concurrently to handling this page fault, and since
-    // regions are singly-owned it would usually result in the region being immediately
-    // de-allocated. To ensure the region is not de-allocated while we're still handling the
-    // fault we increase a page fault counter on the region, and the region will refrain from
-    // de-allocating itself until the counter reaches zero. (Since unmapping the region also
-    // includes removing it from the region tree while holding the address space spinlock, and
-    // because we increment the counter while still holding the spinlock it is guaranteed that
-    // we always increment the counter before it gets a chance to be deleted)
-    Region* region = nullptr;
-    if (is_user_address(fault.vaddr())) {
-        auto page_directory = PageDirectory::find_current();
-        if (!page_directory)
-            return PageFaultResponse::ShouldCrash;
-        auto* process = page_directory->process();
-        VERIFY(process);
-        region = process->address_space().with([&](auto& space) -> Region* {
-            auto* region = find_user_region_from_vaddr(*space, fault.vaddr());
-            if (!region)
-                return nullptr;
-            region->start_handling_page_fault({});
-            return region;
-        });
-    } else {
-        region = MM.m_global_data.with([&](auto& global_data) -> Region* {
-            auto* region = global_data.region_tree.find_region_containing(fault.vaddr());
-            if (!region)
-                return nullptr;
-            region->start_handling_page_fault({});
-            return region;
-        });
-    }
-    if (!region)
+    auto* region = find_region_from_vaddr(fault.vaddr());
+    if (!region) {
         return PageFaultResponse::ShouldCrash;
-
-    auto response = region->handle_fault(fault);
-    region->finish_handling_page_fault({});
-    return response;
+    }
+    return region->handle_fault(fault);
 }
 
 ErrorOr<NonnullOwnPtr<Region>> MemoryManager::allocate_contiguous_kernel_region(size_t size, StringView name, Region::Access access, Region::Cacheable cacheable)

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -249,6 +249,10 @@ private:
     static void flush_tlb_local(VirtualAddress, size_t page_count = 1);
     static void flush_tlb(PageDirectory const*, VirtualAddress, size_t page_count = 1);
 
+    static Region* kernel_region_from_vaddr(VirtualAddress);
+
+    static Region* find_region_from_vaddr(VirtualAddress);
+
     RefPtr<PhysicalPage> find_free_physical_page(bool);
 
     ALWAYS_INLINE u8* quickmap_page(PhysicalPage& page)

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -75,16 +75,6 @@ Region::~Region()
 
     if (is_kernel())
         MM.unregister_kernel_region(*this);
-
-    // Extend the lifetime of the region if there are any page faults in progress for this region's pages.
-    // Both the removal of regions from the region trees and the fetching of the regions from the tree
-    // during the start of page fault handling are serialized under the address space spinlock. This means
-    // that once the region is removed no more page faults on this region can start, so this counter will
-    // eventually reach 0. And similarly since we can only reach the region destructor once the region was
-    // removed from the appropriate region tree, it is guaranteed that any page faults that are still being
-    // handled have already increased this counter, and will be allowed to finish before deallocation.
-    while (m_in_progress_page_faults)
-        Processor::wait_check();
 }
 
 ErrorOr<NonnullOwnPtr<Region>> Region::create_unbacked()

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -207,9 +207,6 @@ public:
     [[nodiscard]] bool mmapped_from_readable() const { return m_mmapped_from_readable; }
     [[nodiscard]] bool mmapped_from_writable() const { return m_mmapped_from_writable; }
 
-    void start_handling_page_fault(Badge<MemoryManager>) { m_in_progress_page_faults++; };
-    void finish_handling_page_fault(Badge<MemoryManager>) { m_in_progress_page_faults--; };
-
 private:
     Region();
     Region(NonnullLockRefPtr<VMObject>, size_t offset_in_vmobject, OwnPtr<KString>, Region::Access access, Cacheable, bool shared);
@@ -237,7 +234,6 @@ private:
     size_t m_offset_in_vmobject { 0 };
     LockRefPtr<VMObject> m_vmobject;
     OwnPtr<KString> m_name;
-    Atomic<u32> m_in_progress_page_faults;
     u8 m_access { Region::None };
     bool m_shared : 1 { false };
     bool m_cacheable : 1 { false };

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -287,22 +287,20 @@ void Process::unprotect_data()
 
 ErrorOr<Process::ProcessAndFirstThread> Process::create(NonnullOwnPtr<KString> name, UserID uid, GroupID gid, ProcessID ppid, bool is_kernel_process, RefPtr<Custody> current_directory, RefPtr<Custody> executable, RefPtr<TTY> tty, Process* fork_parent)
 {
+    OwnPtr<Memory::AddressSpace> new_address_space;
+    if (fork_parent) {
+        TRY(fork_parent->address_space().with([&](auto& parent_address_space) -> ErrorOr<void> {
+            new_address_space = TRY(Memory::AddressSpace::try_create(parent_address_space.ptr()));
+            return {};
+        }));
+    } else {
+        new_address_space = TRY(Memory::AddressSpace::try_create(nullptr));
+    }
     auto unveil_tree = UnveilNode { TRY(KString::try_create("/"sv)), UnveilMetadata(TRY(KString::try_create("/"sv))) };
     auto exec_unveil_tree = UnveilNode { TRY(KString::try_create("/"sv)), UnveilMetadata(TRY(KString::try_create("/"sv))) };
     auto credentials = TRY(Credentials::create(uid, gid, uid, gid, uid, gid, {}, fork_parent ? fork_parent->sid() : 0, fork_parent ? fork_parent->pgid() : 0));
 
     auto process = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) Process(move(name), move(credentials), ppid, is_kernel_process, move(current_directory), move(executable), tty, move(unveil_tree), move(exec_unveil_tree))));
-
-    OwnPtr<Memory::AddressSpace> new_address_space;
-    if (fork_parent) {
-        TRY(fork_parent->address_space().with([&](auto& parent_address_space) -> ErrorOr<void> {
-            new_address_space = TRY(Memory::AddressSpace::try_create(*process, parent_address_space.ptr()));
-            return {};
-        }));
-    } else {
-        new_address_space = TRY(Memory::AddressSpace::try_create(*process, nullptr));
-    }
-
     auto first_thread = TRY(process->attach_resources(new_address_space.release_nonnull(), fork_parent));
 
     return ProcessAndFirstThread { move(process), move(first_thread) };

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -485,7 +485,7 @@ public:
 
     ErrorOr<void> exec(NonnullOwnPtr<KString> path, Vector<NonnullOwnPtr<KString>> arguments, Vector<NonnullOwnPtr<KString>> environment, Thread*& new_main_thread, InterruptsState& previous_interrupts_state, int recursion_depth = 0);
 
-    ErrorOr<LoadResult> load(Memory::AddressSpace& new_space, NonnullRefPtr<OpenFileDescription> main_program_description, RefPtr<OpenFileDescription> interpreter_description, const ElfW(Ehdr) & main_program_header);
+    ErrorOr<LoadResult> load(NonnullRefPtr<OpenFileDescription> main_program_description, RefPtr<OpenFileDescription> interpreter_description, const ElfW(Ehdr) & main_program_header);
 
     void terminate_due_to_signal(u8 signal);
     ErrorOr<void> send_signal(u8 signal, Process* sender);

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -488,7 +488,7 @@ ErrorOr<void> Process::do_exec(NonnullRefPtr<OpenFileDescription> main_program_d
     auto new_process_name = TRY(KString::try_create(last_part));
     auto new_main_thread_name = TRY(new_process_name->try_clone());
 
-    auto allocated_space = TRY(Memory::AddressSpace::try_create(*this, nullptr));
+    auto allocated_space = TRY(Memory::AddressSpace::try_create(nullptr));
     OwnPtr<Memory::AddressSpace> old_space;
     auto& new_space = m_space.with([&](auto& space) -> Memory::AddressSpace& {
         old_space = move(space);

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -30,6 +30,7 @@ namespace Kernel {
 extern Memory::Region* g_signal_trampoline_region;
 
 struct LoadResult {
+    OwnPtr<Memory::AddressSpace> space;
     FlatPtr load_base { 0 };
     FlatPtr entry_eip { 0 };
     size_t size { 0 };
@@ -260,7 +261,7 @@ enum class ShouldAllowSyscalls {
     Yes,
 };
 
-static ErrorOr<LoadResult> load_elf_object(Memory::AddressSpace& new_space, OpenFileDescription& object_description,
+static ErrorOr<LoadResult> load_elf_object(NonnullOwnPtr<Memory::AddressSpace> new_space, OpenFileDescription& object_description,
     FlatPtr load_offset, ShouldAllocateTls should_allocate_tls, ShouldAllowSyscalls should_allow_syscalls)
 {
     auto& inode = *(object_description.inode());
@@ -289,7 +290,7 @@ static ErrorOr<LoadResult> load_elf_object(Memory::AddressSpace& new_space, Open
     auto elf_name = TRY(object_description.pseudo_path());
     VERIFY(!Processor::in_critical());
 
-    Memory::MemoryManager::enter_address_space(new_space);
+    Memory::MemoryManager::enter_address_space(*new_space);
 
     auto load_tls_section = [&](auto& program_header) -> ErrorOr<void> {
         VERIFY(should_allocate_tls == ShouldAllocateTls::Yes);
@@ -301,7 +302,7 @@ static ErrorOr<LoadResult> load_elf_object(Memory::AddressSpace& new_space, Open
         }
 
         auto region_name = TRY(KString::formatted("{} (master-tls)", elf_name));
-        master_tls_region = TRY(new_space.allocate_region(Memory::RandomizeVirtualAddress::Yes, {}, program_header.size_in_memory(), PAGE_SIZE, region_name->view(), PROT_READ | PROT_WRITE, AllocationStrategy::Reserve));
+        master_tls_region = TRY(new_space->allocate_region(Memory::RandomizeVirtualAddress::Yes, {}, program_header.size_in_memory(), PAGE_SIZE, region_name->view(), PROT_READ | PROT_WRITE, AllocationStrategy::Reserve));
         master_tls_size = program_header.size_in_memory();
         master_tls_alignment = program_header.alignment();
 
@@ -329,7 +330,7 @@ static ErrorOr<LoadResult> load_elf_object(Memory::AddressSpace& new_space, Open
         size_t rounded_range_end = TRY(Memory::page_round_up(program_header.vaddr().offset(load_offset).offset(program_header.size_in_memory()).get()));
         auto range_end = VirtualAddress { rounded_range_end };
 
-        auto region = TRY(new_space.allocate_region(Memory::RandomizeVirtualAddress::Yes, range_base, range_end.get() - range_base.get(), PAGE_SIZE, region_name->view(), prot, AllocationStrategy::Reserve));
+        auto region = TRY(new_space->allocate_region(Memory::RandomizeVirtualAddress::Yes, range_base, range_end.get() - range_base.get(), PAGE_SIZE, region_name->view(), prot, AllocationStrategy::Reserve));
 
         // It's not always the case with PIE executables (and very well shouldn't be) that the
         // virtual address in the program header matches the one we end up giving the process.
@@ -364,7 +365,7 @@ static ErrorOr<LoadResult> load_elf_object(Memory::AddressSpace& new_space, Open
         auto range_base = VirtualAddress { Memory::page_round_down(program_header.vaddr().offset(load_offset).get()) };
         size_t rounded_range_end = TRY(Memory::page_round_up(program_header.vaddr().offset(load_offset).offset(program_header.size_in_memory()).get()));
         auto range_end = VirtualAddress { rounded_range_end };
-        auto region = TRY(new_space.allocate_region_with_vmobject(Memory::RandomizeVirtualAddress::Yes, range_base, range_end.get() - range_base.get(), program_header.alignment(), *vmobject, program_header.offset(), elf_name->view(), prot, true));
+        auto region = TRY(new_space->allocate_region_with_vmobject(Memory::RandomizeVirtualAddress::Yes, range_base, range_end.get() - range_base.get(), program_header.alignment(), *vmobject, program_header.offset(), elf_name->view(), prot, true));
 
         if (should_allow_syscalls == ShouldAllowSyscalls::Yes)
             region->set_syscall_region(true);
@@ -406,10 +407,11 @@ static ErrorOr<LoadResult> load_elf_object(Memory::AddressSpace& new_space, Open
         return ENOEXEC;
     }
 
-    auto* stack_region = TRY(new_space.allocate_region(Memory::RandomizeVirtualAddress::Yes, {}, stack_size, PAGE_SIZE, "Stack (Main thread)"sv, PROT_READ | PROT_WRITE, AllocationStrategy::Reserve));
+    auto* stack_region = TRY(new_space->allocate_region(Memory::RandomizeVirtualAddress::Yes, {}, stack_size, PAGE_SIZE, "Stack (Main thread)"sv, PROT_READ | PROT_WRITE, AllocationStrategy::Reserve));
     stack_region->set_stack(true);
 
     return LoadResult {
+        move(new_space),
         load_base_address,
         elf_image.entry().offset(load_offset).get(),
         executable_size,
@@ -421,20 +423,26 @@ static ErrorOr<LoadResult> load_elf_object(Memory::AddressSpace& new_space, Open
 }
 
 ErrorOr<LoadResult>
-Process::load(Memory::AddressSpace& new_space, NonnullRefPtr<OpenFileDescription> main_program_description,
+Process::load(NonnullRefPtr<OpenFileDescription> main_program_description,
     RefPtr<OpenFileDescription> interpreter_description, const ElfW(Ehdr) & main_program_header)
 {
+    auto new_space = TRY(Memory::AddressSpace::try_create(nullptr));
+
+    ScopeGuard space_guard([&]() {
+        Memory::MemoryManager::enter_process_address_space(*this);
+    });
+
     auto load_offset = TRY(get_load_offset(main_program_header, main_program_description, interpreter_description));
 
     if (interpreter_description.is_null()) {
-        auto load_result = TRY(load_elf_object(new_space, main_program_description, load_offset, ShouldAllocateTls::Yes, ShouldAllowSyscalls::No));
+        auto load_result = TRY(load_elf_object(move(new_space), main_program_description, load_offset, ShouldAllocateTls::Yes, ShouldAllowSyscalls::No));
         m_master_tls_region = load_result.tls_region;
         m_master_tls_size = load_result.tls_size;
         m_master_tls_alignment = load_result.tls_alignment;
         return load_result;
     }
 
-    auto interpreter_load_result = TRY(load_elf_object(new_space, *interpreter_description, load_offset, ShouldAllocateTls::No, ShouldAllowSyscalls::Yes));
+    auto interpreter_load_result = TRY(load_elf_object(move(new_space), *interpreter_description, load_offset, ShouldAllocateTls::No, ShouldAllowSyscalls::Yes));
 
     // TLS allocation will be done in userspace by the loader
     VERIFY(!interpreter_load_result.tls_region);
@@ -488,22 +496,7 @@ ErrorOr<void> Process::do_exec(NonnullRefPtr<OpenFileDescription> main_program_d
     auto new_process_name = TRY(KString::try_create(last_part));
     auto new_main_thread_name = TRY(new_process_name->try_clone());
 
-    auto allocated_space = TRY(Memory::AddressSpace::try_create(nullptr));
-    OwnPtr<Memory::AddressSpace> old_space;
-    auto& new_space = m_space.with([&](auto& space) -> Memory::AddressSpace& {
-        old_space = move(space);
-        space = move(allocated_space);
-        return *space;
-    });
-    ArmedScopeGuard space_guard([&]() {
-        // If we failed at any point from now on we have to revert back to the old address space
-        m_space.with([&](auto& space) {
-            space = old_space.release_nonnull();
-        });
-        Memory::MemoryManager::enter_process_address_space(*this);
-    });
-
-    auto load_result = TRY(load(new_space, main_program_description, interpreter_description, main_program_header));
+    auto load_result = TRY(load(main_program_description, interpreter_description, main_program_header));
 
     // NOTE: We don't need the interpreter executable description after this point.
     //       We destroy it here to prevent it from getting destroyed when we return from this function.
@@ -512,7 +505,7 @@ ErrorOr<void> Process::do_exec(NonnullRefPtr<OpenFileDescription> main_program_d
     bool has_interpreter = interpreter_description;
     interpreter_description = nullptr;
 
-    auto* signal_trampoline_region = TRY(new_space.allocate_region_with_vmobject(Memory::RandomizeVirtualAddress::Yes, {}, PAGE_SIZE, PAGE_SIZE, g_signal_trampoline_region->vmobject(), 0, "Signal trampoline"sv, PROT_READ | PROT_EXEC, true));
+    auto* signal_trampoline_region = TRY(load_result.space->allocate_region_with_vmobject(Memory::RandomizeVirtualAddress::Yes, {}, PAGE_SIZE, PAGE_SIZE, g_signal_trampoline_region->vmobject(), 0, "Signal trampoline"sv, PROT_READ | PROT_EXEC, true));
     signal_trampoline_region->set_syscall_region(true);
 
     // (For dynamically linked executable) Allocate an FD for passing the main executable to the dynamic loader.
@@ -559,7 +552,6 @@ ErrorOr<void> Process::do_exec(NonnullRefPtr<OpenFileDescription> main_program_d
     }
 
     // We commit to the new executable at this point. There is no turning back!
-    space_guard.disarm();
 
     // Prevent other processes from attaching to us with ptrace while we're doing this.
     MutexLocker ptrace_locker(ptrace_lock());
@@ -575,6 +567,12 @@ ErrorOr<void> Process::do_exec(NonnullRefPtr<OpenFileDescription> main_program_d
         protected_data.dumpable = !executable_is_setid;
         protected_data.executable_is_setid = executable_is_setid;
     });
+
+    // We make sure to enter the new address space before destroying the old one.
+    // This ensures that the process always has a valid page directory.
+    Memory::MemoryManager::enter_address_space(*load_result.space);
+
+    m_space.with([&](auto& space) { space = load_result.space.release_nonnull(); });
 
     m_executable.with([&](auto& executable) { executable = main_program_description->custody(); });
     m_arguments = move(arguments);


### PR DESCRIPTION
PR #18178 introduced a bug, in which if we run `su`, the kernel will simply page-fault and crash.
Until we can figure out why it crashed, let's revert those changes :)