### PR TITLE
AK: Bake CLion IDE check into AK_COMPILER_CLANG

### DIFF
--- a/AK/CheckedFormatString.h
+++ b/AK/CheckedFormatString.h
@@ -14,7 +14,7 @@
 #ifdef ENABLE_COMPILETIME_FORMAT_CHECK
 // FIXME: Seems like clang doesn't like calling 'consteval' functions inside 'consteval' functions quite the same way as GCC does,
 //        it seems to entirely forget that it accepted that parameters to a 'consteval' function to begin with.
-#    if defined(AK_COMPILER_CLANG) || defined(__CLION_IDE__) || defined(__CLION_IDE_)
+#    if defined(AK_COMPILER_CLANG)
 #        undef ENABLE_COMPILETIME_FORMAT_CHECK
 #    endif
 #endif

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -38,7 +38,7 @@
 #    define AK_ARCH_32_BIT
 #endif
 
-#if defined(__clang__)
+#if defined(__clang__) || defined(__CLION_IDE__) || defined(__CLION_IDE_)
 #    define AK_COMPILER_CLANG
 #elif defined(__GNUC__)
 #    define AK_COMPILER_GCC
@@ -116,7 +116,7 @@
 #    define VALIDATE_IS_AARCH64() static_assert(false, "Trying to include aarch64 only header on non aarch64 platform");
 #endif
 
-#if !defined(AK_COMPILER_CLANG) && !defined(__CLION_IDE_) && !defined(__CLION_IDE__)
+#if !defined(AK_COMPILER_CLANG)
 #    define AK_HAS_CONDITIONALLY_TRIVIAL
 #endif
 

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -8,7 +8,7 @@
 
 #include <AK/Platform.h>
 
-#if defined(AK_COMPILER_CLANG) || defined(__CLION_IDE__)
+#if defined(AK_COMPILER_CLANG)
 #    pragma clang diagnostic ignored "-Wunqualified-std-cast-call"
 #endif
 


### PR DESCRIPTION
For whatever reason, when CLion does its code indexing thing, it doesn't define __clang__ despite using Clang. This causes it to run into various problems that we've solved by checking for Clang.

Since CLion does define __CLION_IDE__ (or sometimes __CLION_IDE_, no idea why but I have seen this issue locally), let's make that part of the AK_COMPILER_CLANG check.

This makes CLion stop highlighting various things as errors.