### PR TITLE
Kernel+LibC: Add the futimens syscall, properly implement the LibC futimens function

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -84,6 +84,7 @@ enum class NeedsBigProcessLock {
     S(fsync, NeedsBigProcessLock::No)                      \
     S(ftruncate, NeedsBigProcessLock::No)                  \
     S(futex, NeedsBigProcessLock::Yes)                     \
+    S(futimens, NeedsBigProcessLock::No)                   \
     S(get_dir_entries, NeedsBigProcessLock::Yes)           \
     S(get_root_session_id, NeedsBigProcessLock::No)        \
     S(get_stack_bounds, NeedsBigProcessLock::No)           \
@@ -455,6 +456,11 @@ struct SC_utimensat_params {
     StringArgument path;
     struct timespec const* times;
     int flag;
+};
+
+struct SC_futimens_params {
+    int fd;
+    struct timespec const* times;
 };
 
 struct SC_waitid_params {

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -313,10 +313,15 @@ ErrorOr<void> VirtualFileSystem::utime(Credentials const& credentials, StringVie
 ErrorOr<void> VirtualFileSystem::utimensat(Credentials const& credentials, StringView path, Custody& base, timespec const& atime, timespec const& mtime, int options)
 {
     auto custody = TRY(resolve_path(credentials, path, base, nullptr, options));
-    auto& inode = custody->inode();
+    return do_utimens(credentials, custody, atime, mtime);
+}
+
+ErrorOr<void> VirtualFileSystem::do_utimens(Credentials const& credentials, Custody& custody, timespec const& atime, timespec const& mtime)
+{
+    auto& inode = custody.inode();
     if (!credentials.is_superuser() && inode.metadata().uid != credentials.euid())
         return EACCES;
-    if (custody->is_readonly())
+    if (custody.is_readonly())
         return EROFS;
 
     // NOTE: A standard ext2 inode cannot store nanosecond timestamps.

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -75,6 +75,7 @@ public:
     ErrorOr<InodeMetadata> lookup_metadata(Credentials const&, StringView path, Custody& base, int options = 0);
     ErrorOr<void> utime(Credentials const&, StringView path, Custody& base, time_t atime, time_t mtime);
     ErrorOr<void> utimensat(Credentials const&, StringView path, Custody& base, timespec const& atime, timespec const& mtime, int options = 0);
+    ErrorOr<void> do_utimens(Credentials const& credentials, Custody& custody, timespec const& atime, timespec const& mtime);
     ErrorOr<void> rename(Credentials const&, Custody& old_base, StringView oldpath, Custody& new_base, StringView newpath);
     ErrorOr<void> mknod(Credentials const&, StringView path, mode_t, dev_t, Custody& base);
     ErrorOr<NonnullRefPtr<Custody>> open_directory(Credentials const&, StringView path, Custody& base);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -334,6 +334,7 @@ public:
     ErrorOr<FlatPtr> sys$annotate_mapping(Userspace<void*>, int flags);
     ErrorOr<FlatPtr> sys$lseek(int fd, Userspace<off_t*>, int whence);
     ErrorOr<FlatPtr> sys$ftruncate(int fd, Userspace<off_t const*>);
+    ErrorOr<FlatPtr> sys$futimens(Userspace<Syscall::SC_futimens_params const*>);
     ErrorOr<FlatPtr> sys$posix_fallocate(int fd, Userspace<off_t const*>, Userspace<off_t const*>);
     ErrorOr<FlatPtr> sys$kill(pid_t pid_or_pgid, int sig);
     [[noreturn]] void sys$exit(int status);

--- a/Kernel/Syscalls/utimensat.cpp
+++ b/Kernel/Syscalls/utimensat.cpp
@@ -12,6 +12,40 @@
 
 namespace Kernel {
 
+ErrorOr<FlatPtr> Process::sys$futimens(Userspace<Syscall::SC_futimens_params const*> user_params)
+{
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
+    TRY(require_promise(Pledge::fattr));
+
+    auto params = TRY(copy_typed_from_user(user_params));
+    auto now = kgettimeofday().to_timespec();
+
+    timespec times[2];
+    if (params.times) {
+        TRY(copy_from_user(times, params.times, sizeof(times)));
+        if (times[0].tv_nsec == UTIME_NOW)
+            times[0] = now;
+        if (times[1].tv_nsec == UTIME_NOW)
+            times[1] = now;
+    } else {
+        // According to POSIX, both access and modification times are set to
+        // the current time given a nullptr.
+        times[0] = now;
+        times[1] = now;
+    }
+
+    auto description = TRY(open_file_description(params.fd));
+    if (!description->inode())
+        return EBADF;
+    if (!description->custody())
+        return EBADF;
+
+    auto& atime = times[0];
+    auto& mtime = times[1];
+    TRY(VirtualFileSystem::the().do_utimens(credentials(), *description->custody(), atime, mtime));
+    return 0;
+}
+
 ErrorOr<FlatPtr> Process::sys$utimensat(Userspace<Syscall::SC_utimensat_params const*> user_params)
 {
     VERIFY_NO_PROCESS_BIG_LOCK(this);

--- a/Userland/Libraries/LibC/bits/utimens.h
+++ b/Userland/Libraries/LibC/bits/utimens.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, sin-ack <sin-ack@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/API/POSIX/fcntl.h>
+#include <Kernel/API/POSIX/sys/stat.h>
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS
+
+int __utimens(int fd, char const* path, struct timespec const times[2], int flag);
+
+__END_DECLS

--- a/Userland/Libraries/LibC/stat.cpp
+++ b/Userland/Libraries/LibC/stat.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <assert.h>
+#include <bits/utimens.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -119,6 +120,6 @@ int fstatat(int fd, char const* path, struct stat* statbuf, int flags)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/futimens.html
 int futimens(int fd, struct timespec const times[2])
 {
-    return utimensat(fd, "", times, 0);
+    return __utimens(fd, nullptr, times, 0);
 }
 }


### PR DESCRIPTION
This fixes an issue with the LibC futimens function, which was very easy to trigger - simply run "touch new-file-which-not-existing" and you could see that even though the file is created, you will get an error in `stderr`.