### PR TITLE
BrickGame: Optionally show brick shadow hints

### DIFF
--- a/Userland/Games/BrickGame/BrickGame.cpp
+++ b/Userland/Games/BrickGame/BrickGame.cpp
@@ -535,7 +535,7 @@ void BrickGame::paint_cell(GUI::Painter& painter, Gfx::IntRect rect, bool is_on)
     painter.fill_rect(rect, is_on ? m_front_color : m_shadow_color);
 }
 
-void BrickGame::paint_sidebar_text(GUI::Painter& painter, int row, DeprecatedString const& text)
+void BrickGame::paint_sidebar_text(GUI::Painter& painter, int row, StringView text)
 {
     auto const text_width = static_cast<int>(ceilf(font().width(text)));
     auto const entire_area_rect { frame_inner_rect() };
@@ -596,10 +596,10 @@ void BrickGame::paint_game(GUI::Painter& painter, Gfx::IntRect const& rect)
                 paint_cell(painter, cell_rect(position), (*m_brick_game)[board_position]);
             }
 
-        paint_sidebar_text(painter, 0, DeprecatedString::formatted("Score: {}", m_brick_game->score()));
-        paint_sidebar_text(painter, 1, DeprecatedString::formatted("Level: {}", m_brick_game->level()));
-        paint_sidebar_text(painter, 4, DeprecatedString::formatted("Hi-Score: {}", m_high_score));
-        paint_sidebar_text(painter, 12, "Next:");
+        paint_sidebar_text(painter, 0, String::formatted("Score: {}", m_brick_game->score()).release_value_but_fixme_should_propagate_errors());
+        paint_sidebar_text(painter, 1, String::formatted("Level: {}", m_brick_game->level()).release_value_but_fixme_should_propagate_errors());
+        paint_sidebar_text(painter, 4, String::formatted("Hi-Score: {}", m_high_score).release_value_but_fixme_should_propagate_errors());
+        paint_sidebar_text(painter, 12, "Next:"sv);
 
         auto const hint_rect = Gfx::IntRect {
             frame_inner_rect().x() + frame_inner_rect().width() - 105,
@@ -640,7 +640,7 @@ void BrickGame::game_over()
         Config::write_i32(m_app_name, m_app_name, "HighScore"sv, int(m_high_score = current_score));
     }
     GUI::MessageBox::show(window(),
-        text.to_deprecated_string(),
+        text.string_view(),
         "Game Over"sv,
         GUI::MessageBox::Type::Information);
 

--- a/Userland/Games/BrickGame/BrickGame.cpp
+++ b/Userland/Games/BrickGame/BrickGame.cpp
@@ -477,6 +477,11 @@ void BrickGame::set_show_shadow_hint(bool should_show)
     repaint();
 }
 
+bool BrickGame::show_shadow_hint()
+{
+    return m_show_shadow_hint;
+}
+
 void BrickGame::timer_event(Core::TimerEvent&)
 {
     switch (m_brick_game->state()) {

--- a/Userland/Games/BrickGame/BrickGame.cpp
+++ b/Userland/Games/BrickGame/BrickGame.cpp
@@ -303,7 +303,7 @@ public:
         return RenderRequest::RequestUpdate;
     }
 
-    RenderRequest move_down_fast()
+    [[nodiscard]] RenderRequest move_down_fast()
     {
         for (auto block = m_block;; block.move_down()) {
             if (block.has_collision(m_well)) {

--- a/Userland/Games/BrickGame/BrickGame.cpp
+++ b/Userland/Games/BrickGame/BrickGame.cpp
@@ -471,6 +471,12 @@ void BrickGame::toggle_pause()
     update();
 }
 
+void BrickGame::set_show_shadow_hint(bool should_show)
+{
+    m_show_shadow_hint = should_show;
+    repaint();
+}
+
 void BrickGame::timer_event(Core::TimerEvent&)
 {
     switch (m_brick_game->state()) {
@@ -547,7 +553,7 @@ void BrickGame::paint_cell(GUI::Painter& painter, Gfx::IntRect rect, BrickGame::
         break;
     case BrickGame::BoardSpace::ShadowHint:
         inside_color = m_shadow_color;
-        outside_color = m_hint_block_color;
+        outside_color = m_show_shadow_hint ? m_hint_block_color : m_shadow_color;
         break;
     case BrickGame::BoardSpace::Off:
         inside_color = m_shadow_color;

--- a/Userland/Games/BrickGame/BrickGame.h
+++ b/Userland/Games/BrickGame/BrickGame.h
@@ -27,6 +27,7 @@ public:
     void reset();
     void toggle_pause();
     void set_show_shadow_hint(bool);
+    bool show_shadow_hint();
 
 private:
     BrickGame(StringView app_name);

--- a/Userland/Games/BrickGame/BrickGame.h
+++ b/Userland/Games/BrickGame/BrickGame.h
@@ -26,6 +26,7 @@ public:
 
     void reset();
     void toggle_pause();
+    void set_show_shadow_hint(bool);
 
 private:
     BrickGame(StringView app_name);
@@ -48,6 +49,7 @@ private:
     GameState m_state {};
     NonnullOwnPtr<Bricks> m_brick_game;
     unsigned m_high_score {};
+    bool m_show_shadow_hint { true };
 
     Color m_back_color { Color::from_rgb(0x8fbc8f) };
     Color m_front_color { Color::Black };

--- a/Userland/Games/BrickGame/BrickGame.h
+++ b/Userland/Games/BrickGame/BrickGame.h
@@ -26,7 +26,7 @@ private:
     virtual void keydown_event(GUI::KeyEvent&) override;
     virtual void timer_event(Core::TimerEvent&) override;
 
-    void paint_sidebar_text(GUI::Painter&, int row, DeprecatedString const&);
+    void paint_sidebar_text(GUI::Painter&, int row, StringView);
     void paint_paused_text(GUI::Painter&);
     void paint_cell(GUI::Painter&, Gfx::IntRect, bool);
     void paint_game(GUI::Painter&, Gfx::IntRect const&);

--- a/Userland/Games/BrickGame/BrickGame.h
+++ b/Userland/Games/BrickGame/BrickGame.h
@@ -15,6 +15,13 @@ class BrickGame : public GUI::Frame {
     C_OBJECT(BrickGame);
 
 public:
+    // How should a particular space on the board be presented to the user
+    enum class BoardSpace {
+        FullyOn,
+        ShadowHint,
+        Off
+    };
+
     virtual ~BrickGame() override = default;
 
     void reset();
@@ -28,7 +35,7 @@ private:
 
     void paint_sidebar_text(GUI::Painter&, int row, StringView);
     void paint_paused_text(GUI::Painter&);
-    void paint_cell(GUI::Painter&, Gfx::IntRect, bool);
+    void paint_cell(GUI::Painter&, Gfx::IntRect, BoardSpace);
     void paint_game(GUI::Painter&, Gfx::IntRect const&);
     void game_over();
 
@@ -45,4 +52,5 @@ private:
     Color m_back_color { Color::from_rgb(0x8fbc8f) };
     Color m_front_color { Color::Black };
     Color m_shadow_color { Color::from_rgb(0x729672) };
+    Color m_hint_block_color { Color::from_rgb(0x485e48) };
 };

--- a/Userland/Games/BrickGame/main.cpp
+++ b/Userland/Games/BrickGame/main.cpp
@@ -59,6 +59,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(game_menu->try_add_action(GUI::Action::create("Toggle &Pause", { Mod_None, Key_P }, [&](auto&) {
         game->toggle_pause();
     })));
+    auto show_shadow_piece_action = TRY(GUI::Action::try_create_checkable("&Show Shadow Piece", GUI::Shortcut {}, [&](auto& action) {
+        game->set_show_shadow_hint(action.is_checked());
+    }));
+    show_shadow_piece_action->set_checked(true);
+    TRY(game_menu->try_add_action(show_shadow_piece_action));
     TRY(game_menu->try_add_separator());
     TRY(game_menu->try_add_action(GUI::CommonActions::make_quit_action([](auto&) {
         GUI::Application::the()->quit();

--- a/Userland/Games/BrickGame/main.cpp
+++ b/Userland/Games/BrickGame/main.cpp
@@ -56,7 +56,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(game_menu->try_add_action(GUI::Action::create("&New Game", { Mod_None, Key_F2 }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/reload.png"sv)), [&](auto&) {
         game->reset();
     })));
-    TRY(game_menu->try_add_action(GUI::Action::create("Toggle &pause", { Mod_None, Key_P }, [&](auto&) {
+    TRY(game_menu->try_add_action(GUI::Action::create("Toggle &Pause", { Mod_None, Key_P }, [&](auto&) {
         game->toggle_pause();
     })));
     TRY(game_menu->try_add_separator());

--- a/Userland/Games/BrickGame/main.cpp
+++ b/Userland/Games/BrickGame/main.cpp
@@ -59,10 +59,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(game_menu->try_add_action(GUI::Action::create("Toggle &Pause", { Mod_None, Key_P }, [&](auto&) {
         game->toggle_pause();
     })));
-    auto show_shadow_piece_action = TRY(GUI::Action::try_create_checkable("&Show Shadow Piece", GUI::Shortcut {}, [&](auto& action) {
+
+    auto show_shadow_piece_action = TRY(GUI::Action::try_create_checkable("Show Shadow Piece", GUI::Shortcut {}, [&](auto& action) {
         game->set_show_shadow_hint(action.is_checked());
+        Config::write_bool(app_name, app_name, "ShowShadowPiece"sv, action.is_checked());
     }));
-    show_shadow_piece_action->set_checked(true);
+    game->set_show_shadow_hint(Config::read_bool(app_name, app_name, "ShowShadowPiece"sv, true));
+    show_shadow_piece_action->set_checked(game->show_shadow_hint());
+
     TRY(game_menu->try_add_action(show_shadow_piece_action));
     TRY(game_menu->try_add_separator());
     TRY(game_menu->try_add_action(GUI::CommonActions::make_quit_action([](auto&) {


### PR DESCRIPTION
## BrickGame drop hints

This feature makes it easier to avoid misdrops :^)

<table><thead><tr><th colspan=2>Design</th></tr></thead>
<tbody>
<tr>
<td>A standard brick:<br/><img src="https://user-images.githubusercontent.com/6043048/230728712-ec05cfeb-fab5-459b-98c4-bb752ce00a8d.png"></td>
<td>The new shadow hint:<br/><img src="https://user-images.githubusercontent.com/6043048/230728704-e409fc89-1a15-49e6-8959-3748f4d5bb32.png"></td>
</tr>
</tbody></table>

**Gameplay example:**  
<video src='https://user-images.githubusercontent.com/6043048/230728165-7a380970-2431-4d73-a280-6cbeefb2497a.mov' alt="Part of a playthrough with hints enabled">

The hints have been made enabled by default, but can be disabled in the menu. The setting persists across `BrickGame` invocations:  
![menu options](https://user-images.githubusercontent.com/6043048/230728651-80bb49c1-3466-46b4-9cd4-a93ca1a8e1ff.png)

Additionally, this gets rid of `DeprecatedStrings` from BrickGame.
