### PR TITLE
LibGfx: Make webp lossless decoder 6 times as fast

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -619,7 +619,7 @@ static ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L_image(WebPLoadingCo
     ARGB32* end = bitmap->end();
     ARGB32* pixel = begin;
 
-    auto prefix_group = [prefix_bits, begin, &groups, size, &entropy_image](ARGB32* pixel) {
+    auto prefix_group = [prefix_bits, begin, &groups, size, &entropy_image](ARGB32* pixel) -> PrefixCodeGroup const& {
         if (!prefix_bits)
             return groups[0];
 


### PR DESCRIPTION
Reduces the time to run

    Build/lagom/image ~/src/libwebp/webp_js/test_webp_wasm.webp -o tmp.png

from 0.5s to 0.25s.

Before, 60% of the time was spent decoding webp and 40% writing png. Now, 16% of the time was spent decoding webp and 84% writing png.

That means png writing takes 0.2s, and webp decoding time went from 0.3s to 0.05s.

A template expression without explicit return type deduces its return type as if for a function whose return type is declared auto. That does deduce return-by-value, while `decltype(auto)` would deduce return-by-reference.  Explictly saying `decltype(auto)` would work too, but writing out the type is maybe easier to understand.

No behavior change other than being much faster.