### PR TITLE
Ports: Repair qt6-qtbase by disabling QDnsLookup

### DIFF
--- a/Ports/qt6-qtbase/patches/0001-Add-a-SerenityOS-platform-definition.patch
+++ b/Ports/qt6-qtbase/patches/0001-Add-a-SerenityOS-platform-definition.patch
@@ -60,7 +60,7 @@ index 0000000000000000000000000000000000000000..3808b5a269788a32d4aa74aa629b519d
 +load(qt_config)
 diff --git a/mkspecs/serenity-g++/qplatformdefs.h b/mkspecs/serenity-g++/qplatformdefs.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..1f0dd9819abb1f8dac52250d24aa8d0763f05445
+index 0000000000000000000000000000000000000000..ff6bd088c99a77689733af03858950fab1cf6284
 --- /dev/null
 +++ b/mkspecs/serenity-g++/qplatformdefs.h
 @@ -0,0 +1,87 @@
@@ -148,7 +148,7 @@ index 0000000000000000000000000000000000000000..1f0dd9819abb1f8dac52250d24aa8d07
 +#endif
 +
 +#include <langinfo.h>
-+#include <sys/ioctl_numbers.h>
++#include <sys/ioctl.h>
 +
 +#endif // QPLATFORMDEFS_H
 diff --git a/src/corelib/global/qsystemdetection.h b/src/corelib/global/qsystemdetection.h

--- a/Ports/qt6-qtbase/patches/0002-Disable-shared-memory-and-semaphores.patch
+++ b/Ports/qt6-qtbase/patches/0002-Disable-shared-memory-and-semaphores.patch
@@ -11,7 +11,7 @@ It's probably not done in the cleanest way but it works
  3 files changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/mkspecs/serenity-g++/qplatformdefs.h b/mkspecs/serenity-g++/qplatformdefs.h
-index 1f0dd9819abb1f8dac52250d24aa8d0763f05445..65b641e283a42cdc2bd6c63c1750b46e0b33ab02 100644
+index ff6bd088c99a77689733af03858950fab1cf6284..c39b40670b45aa853b6678835ef2d46564ba9506 100644
 --- a/mkspecs/serenity-g++/qplatformdefs.h
 +++ b/mkspecs/serenity-g++/qplatformdefs.h
 @@ -43,6 +43,9 @@

--- a/Ports/qt6-qtbase/patches/0007-Disable-QDnsLookup-entirely.patch
+++ b/Ports/qt6-qtbase/patches/0007-Disable-QDnsLookup-entirely.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+Date: Sat, 8 Apr 2023 20:53:52 +0200
+Subject: [PATCH] Disable QDnsLookup entirely
+
+It seems that we used to include the host's system headers, which we no
+longer do. Now this feature breaks the package, which is why we have to
+disable it in order to build Qt6.
+---
+ src/network/kernel/qdnslookup_unix.cpp | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/src/network/kernel/qdnslookup_unix.cpp b/src/network/kernel/qdnslookup_unix.cpp
+index 75f7c6c440e880b93530d2c38fed34a0c143f885..42aaba2699b3feb8e1624db633a792c3168a087f 100644
+--- a/src/network/kernel/qdnslookup_unix.cpp
++++ b/src/network/kernel/qdnslookup_unix.cpp
+@@ -13,6 +13,11 @@
+ 
+ #include <sys/types.h>
+ #include <netinet/in.h>
++
++#if 0
++// FIXME: arpa/nameser.h is not part of Serenity. So either we just disable the feature wholesale,
++// or use the host headers (e.g. libc6-dev), but these often don't work either.
++
+ #include <arpa/nameser.h>
+ #if !defined(Q_OS_OPENBSD)
+ #  include <arpa/nameser_compat.h>
+@@ -385,3 +390,21 @@ void QDnsLookupRunnable::query(const int requestType, const QByteArray &requestN
+ #endif /* QT_CONFIG(library) */
+ 
+ QT_END_NAMESPACE
++
++#endif
++
++QT_BEGIN_NAMESPACE
++
++using namespace Qt::StringLiterals;
++
++void QDnsLookupRunnable::query(const int requestType, const QByteArray &requestName, const QHostAddress &nameserver, QDnsLookupReply *reply)
++{
++    Q_UNUSED(requestType);
++    Q_UNUSED(requestName);
++    Q_UNUSED(nameserver);
++    reply->error = QDnsLookup::ResolverError;
++    reply->errorString = tr("Resolver library can't be loaded: No runtime library loading support");
++    return;
++}
++
++QT_END_NAMESPACE

--- a/Ports/qt6-qtbase/patches/ReadMe.md
+++ b/Ports/qt6-qtbase/patches/ReadMe.md
@@ -38,3 +38,11 @@ Serenity: Disable local domain name lookup via resolv
 Serenity doesn't support /etc/resolv.conf or the structures in
 <resolv.h> to do Unix-like domain name resolution.
 
+## `0007-Disable-QDnsLookup-entirely.patch`
+
+Disable QDnsLookup entirely
+
+It seems that we used to include the host's system headers, which we no
+longer do. Now this feature breaks the package, which is why we have to
+disable it in order to build Qt6.
+


### PR DESCRIPTION
This fixes the qt6-qtbase port, and indirectly also qt6-qt5compat.

Specifically:
- We don't have any header called `sys/ioctl_numbers.h` anymore, so update it to the new location `Kernel/API/Ioctl.h`.
- We don't have any header called `arpa/nameser.h`, and we no longer use the host's headers for that, so we shouldn't try to use it.

See also https://github.com/SerenityOS/serenity/issues/18238