### PR TITLE
Kernel: Fix compilation of aarch64/RPi/Framebuffer.cpp

### DIFF
--- a/Kernel/Arch/aarch64/RPi/Framebuffer.cpp
+++ b/Kernel/Arch/aarch64/RPi/Framebuffer.cpp
@@ -8,13 +8,9 @@
 #include <Kernel/Arch/aarch64/BootPPMParser.h>
 #include <Kernel/Arch/aarch64/RPi/Framebuffer.h>
 #include <Kernel/Arch/aarch64/RPi/FramebufferMailboxMessages.h>
+#include <Kernel/BootInfo.h>
 #include <Kernel/Sections.h>
 
-extern READONLY_AFTER_INIT PhysicalAddress multiboot_framebuffer_addr;
-extern READONLY_AFTER_INIT u32 multiboot_framebuffer_pitch;
-extern READONLY_AFTER_INIT u32 multiboot_framebuffer_width;
-extern READONLY_AFTER_INIT u32 multiboot_framebuffer_height;
-extern READONLY_AFTER_INIT u8 multiboot_framebuffer_type;
 extern const u32 serenity_boot_logo_start;
 extern const u32 serenity_boot_logo_size;
 


### PR DESCRIPTION
The definitions were being defined already by `BootInfo.h` and that was being included here via transitive includes. The extern definitions of the variables do not have the `READONLY_AFTER_INIT` attribute in `BootInfo.h`. This causes conflicting definitions of the same variable.

The `READONLY_AFTER_INIT` specifier is not needed for extern variables as it only effects their linkage, not their actual use, so just use the versions in `BootInfo.h` instead of re-declaring.