### PR TITLE
Meta: Run the QEMU ISA-PC machine with a 64-bit capable CPU

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -366,7 +366,7 @@ fi
 [ -z "$SERENITY_COMMON_QEMU_ISA_PC_ARGS" ] && SERENITY_COMMON_QEMU_ISA_PC_ARGS="
 $SERENITY_EXTRA_QEMU_ARGS
 -m $SERENITY_RAM_SIZE
--cpu pentium3
+-cpu qemu64
 -machine isapc
 -d guest_errors
 -device isa-vga


### PR DESCRIPTION
When we had 32 bit support in the OS kernel and userland, the very bare minimum CPU we supported was Pentium 3, but now the CPU is just required to support x86-64 long mode to be supported, so the exact model is not very important.

I chose the QEMU64 virtual CPU model, because the whole concept of the QEMU ISA-PC machine is that it checks how the kernel handles arbitrarily old hardware setup.