### PR TITLE
Ports: Make libksba/libassuan/ntbtls use Serenity's gpg-error-config

### DIFF
--- a/Ports/gnupg/patches/0001-Link-against-libiconv.patch
+++ b/Ports/gnupg/patches/0001-Link-against-libiconv.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+Date: Sun, 9 Apr 2023 11:48:19 +0200
+Subject: [PATCH] Link against libiconv
+
+---
+ sm/Makefile.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sm/Makefile.in b/sm/Makefile.in
+index 06c15db5b91d89dba33168436e4e316533a012f5..c1b9f936aee31b4f515bc94ba2819a09180c74af 100644
+--- a/sm/Makefile.in
++++ b/sm/Makefile.in
+@@ -554,7 +554,7 @@ module_tests =
+ module_maint_tests = t-minip12
+ t_common_src = 
+ t_common_ldadd = $(libcommon) $(LIBGCRYPT_LIBS) $(KSBA_LIBS) \
+-                 $(GPG_ERROR_LIBS) $(LIBINTL)
++                 $(GPG_ERROR_LIBS) $(LIBINTL) $(LIBICONV)
+ 
+ t_minip12_CFLAGS = -DWITHOUT_NPTH=1 \
+ 	           $(LIBGCRYPT_CFLAGS) $(GPG_ERROR_CFLAGS)

--- a/Ports/gnupg/patches/ReadMe.md
+++ b/Ports/gnupg/patches/ReadMe.md
@@ -1,0 +1,7 @@
+# Patches for gnupg on SerenityOS
+
+## `0001-Link-against-libiconv.patch`
+
+Link against libiconv
+
+

--- a/Ports/libassuan/package.sh
+++ b/Ports/libassuan/package.sh
@@ -7,6 +7,9 @@ config_sub_paths=("build-aux/config.sub")
 depends=("libgpg-error")
 files="https://gnupg.org/ftp/gcrypt/libassuan/libassuan-${version}.tar.bz2 libassuan-${version}.tar.bz2 8e8c2fcc982f9ca67dcbb1d95e2dc746b1739a4668bc20b3a3c5be632edb34e4"
 auth_type=sha256
+configopts=(
+    "--with-libgpg-error-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
+)
 
 pre_configure() {
     export ac_cv_lib_pthread_pthread_create=no

--- a/Ports/libksba/package.sh
+++ b/Ports/libksba/package.sh
@@ -7,6 +7,9 @@ config_sub_paths=("build-aux/config.sub")
 depends=("libgpg-error")
 files="https://gnupg.org/ftp/gcrypt/libksba/libksba-${version}.tar.bz2 libksba-${version}.tar.bz2 b0f4c65e4e447d9a2349f6b8c0e77a28be9531e4548ba02c545d1f46dc7bf921"
 auth_type=sha256
+configopts=(
+    "--with-libgpg-error-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
+)
 
 pre_configure() {
     export ksba_cv_gcc_has_f_visibility=no

--- a/Ports/ntbtls/package.sh
+++ b/Ports/ntbtls/package.sh
@@ -7,6 +7,14 @@ config_sub_paths=("build-aux/config.sub")
 depends=("libgpg-error" "libksba" "libgcrypt" "zlib")
 files="https://gnupg.org/ftp/gcrypt/ntbtls/ntbtls-${version}.tar.bz2 ntbtls-${version}.tar.bz2 649fe74a311d13e43b16b26ebaa91665ddb632925b73902592eac3ed30519e17"
 auth_type=sha256
+configopts=(
+    "--with-libgcrypt-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
+    "--with-libgpg-error-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
+    # It's documented as "--with-libksba-prefix" (note the "lib"), but if it is set it is
+    # immediately overwritten by whatever is given through "--with-ksba-prefix",
+    # EVEN IF the latter switch is not given, thus overwriting it with the empty string.
+    "--with-ksba-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
+)
 
 pre_configure() {
     export ntbtls_cv_gcc_has_f_visibility=no


### PR DESCRIPTION
This is likely because we usually used the host's version of the file. I happen to use a newer libgpg-error (which is relevant because that particular executable has been renamed, so my system no longer contains a file of the name gpg-error-config), which revealed this latent bug.