### PR TITLE
LibWeb: Port rest of event system-related in LibWeb to new {Fly}String

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -40,6 +40,7 @@
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/TagNames.h>
 #include <LibWeb/UIEvents/EventNames.h>
+#include <LibWeb/WebGL/EventNames.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 #include <LibWeb/XHR/EventNames.h>
 
@@ -89,6 +90,7 @@ ErrorOr<void> initialize_main_thread_vm()
     TRY(SVG::AttributeNames::initialize_strings());
     TRY(SVG::TagNames::initialize_strings());
     TRY(UIEvents::EventNames::initialize_strings());
+    TRY(WebGL::EventNames::initialize_strings());
     TRY(XHR::EventNames::initialize_strings());
 
     static_cast<WebEngineCustomData*>(s_main_thread_vm->custom_data())->event_loop.set_vm(*s_main_thread_vm);

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -517,6 +517,7 @@ set(SOURCES
     WebDriver/Response.cpp
     WebDriver/Screenshot.cpp
     WebDriver/TimeoutsConfiguration.cpp
+    WebGL/EventNames.cpp
     WebGL/WebGLContextAttributes.cpp
     WebGL/WebGLContextEvent.cpp
     WebGL/WebGLRenderingContext.cpp

--- a/Userland/Libraries/LibWeb/CSS/MediaQueryList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryList.cpp
@@ -79,7 +79,7 @@ void MediaQueryList::add_listener(DOM::IDLEventListener* listener)
     //    callback set to listener, and capture set to false, unless there already is an event listener
     //    in that list with the same type, callback, and capture.
     //    (NOTE: capture is set to false by default)
-    add_event_listener_without_options(HTML::EventNames::change.to_deprecated_fly_string(), *listener);
+    add_event_listener_without_options(HTML::EventNames::change, *listener);
 }
 
 // https://www.w3.org/TR/cssom-view/#dom-mediaquerylist-removelistener
@@ -88,7 +88,7 @@ void MediaQueryList::remove_listener(DOM::IDLEventListener* listener)
     // 1. Remove an event listener from the associated list of event listeners, whose type is change, callback is listener, and capture is false.
     // NOTE: While the spec doesn't technically use remove_event_listener and instead manipulates the list directly, every major engine uses remove_event_listener.
     //       This means if an event listener removes another event listener that comes after it, the removed event listener will not be invoked.
-    remove_event_listener_without_options(HTML::EventNames::change.to_deprecated_fly_string(), *listener);
+    remove_event_listener_without_options(HTML::EventNames::change, *listener);
 }
 
 void MediaQueryList::set_onchange(WebIDL::CallbackType* event_handler)

--- a/Userland/Libraries/LibWeb/DOM/DOMEventListener.h
+++ b/Userland/Libraries/LibWeb/DOM/DOMEventListener.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
+#include <AK/FlyString.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibWeb/Forward.h>
@@ -21,7 +21,7 @@ public:
     ~DOMEventListener();
 
     // type (a string)
-    DeprecatedFlyString type;
+    FlyString type;
 
     // callback (null or an EventListener object)
     JS::GCPtr<IDLEventListener> callback;

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2327,7 +2327,7 @@ void Document::unload(bool recursive_flag, Optional<DocumentUnloadTimingInfo> un
         m_page_showing = false;
 
         // 2. Fire a page transition event named pagehide at document's relevant global object with document's salvageable state.
-        global_object().fire_a_page_transition_event(HTML::EventNames::pagehide.to_deprecated_fly_string(), m_salvageable);
+        global_object().fire_a_page_transition_event(HTML::EventNames::pagehide, m_salvageable);
 
         // 3. Update the visibility state of newDocument to "hidden".
         update_the_visibility_state(HTML::VisibilityState::Hidden);

--- a/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
@@ -63,7 +63,7 @@ bool EventDispatcher::inner_invoke(Event& event, Vector<JS::Handle<DOM::DOMEvent
             continue;
 
         // 1. If event’s type attribute value is not listener’s type, then continue.
-        if (event.type().to_deprecated_fly_string() != listener->type)
+        if (event.type() != listener->type)
             continue;
 
         // 2. Set found to true.

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -129,7 +129,7 @@ void EventTarget::add_event_listener(FlyString const& type, IDLEventListener* ca
     //    once is once, and signal is signal.
 
     auto event_listener = heap().allocate_without_realm<DOMEventListener>();
-    event_listener->type = type.to_deprecated_fly_string();
+    event_listener->type = type;
     event_listener->callback = callback;
     event_listener->signal = move(flattened_options.signal);
     event_listener->capture = flattened_options.capture;
@@ -194,7 +194,7 @@ void EventTarget::remove_event_listener(FlyString const& type, IDLEventListener*
         return entry.callback->callback().callback == callback->callback().callback;
     };
     auto it = m_event_listener_list.find_if([&](auto& entry) {
-        return entry->type == type.to_deprecated_fly_string()
+        return entry->type == type
             && callbacks_match(*entry)
             && entry->capture == capture;
     });
@@ -560,7 +560,7 @@ void EventTarget::activate_event_handler(FlyString const& name, HTML::EventHandl
 
     // 5. Let listener be a new event listener whose type is the event handler event type corresponding to eventHandler and callback is callback.
     auto listener = realm.heap().allocate_without_realm<DOMEventListener>();
-    listener->type = name.to_deprecated_fly_string();
+    listener->type = name;
     listener->callback = IDLEventListener::create(realm, *callback).release_value_but_fixme_should_propagate_errors();
 
     // 6. Add an event listener with eventTarget and listener.
@@ -738,7 +738,7 @@ bool EventTarget::dispatch_event(Event& event)
 bool EventTarget::has_event_listener(FlyString const& type) const
 {
     for (auto& listener : m_event_listener_list) {
-        if (listener->type == type.to_deprecated_fly_string())
+        if (listener->type == type)
             return true;
     }
     return false;

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.h
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.h
@@ -26,12 +26,12 @@ public:
 
     virtual bool is_focusable() const { return false; }
 
-    void add_event_listener(DeprecatedFlyString const& type, IDLEventListener* callback, Variant<AddEventListenerOptions, bool> const& options);
-    void remove_event_listener(DeprecatedFlyString const& type, IDLEventListener* callback, Variant<EventListenerOptions, bool> const& options);
+    void add_event_listener(FlyString const& type, IDLEventListener* callback, Variant<AddEventListenerOptions, bool> const& options);
+    void remove_event_listener(FlyString const& type, IDLEventListener* callback, Variant<EventListenerOptions, bool> const& options);
 
     // NOTE: These are for internal use only. They operate as though addEventListener(type, callback) was called instead of addEventListener(type, callback, options).
-    void add_event_listener_without_options(DeprecatedFlyString const& type, IDLEventListener& callback);
-    void remove_event_listener_without_options(DeprecatedFlyString const& type, IDLEventListener& callback);
+    void add_event_listener_without_options(FlyString const& type, IDLEventListener& callback);
+    void remove_event_listener_without_options(FlyString const& type, IDLEventListener& callback);
 
     virtual bool dispatch_event(Event&);
     WebIDL::ExceptionOr<bool> dispatch_event_binding(Event&);
@@ -54,13 +54,13 @@ public:
     WebIDL::CallbackType* event_handler_attribute(FlyString const& name);
     void set_event_handler_attribute(FlyString const& name, WebIDL::CallbackType*);
 
-    bool has_event_listener(DeprecatedFlyString const& type) const;
+    bool has_event_listener(FlyString const& type) const;
     bool has_event_listeners() const;
 
 protected:
     explicit EventTarget(JS::Realm&);
 
-    void element_event_handler_attribute_changed(FlyString const& local_name, DeprecatedString const& value);
+    void element_event_handler_attribute_changed(FlyString const& local_name, Optional<String> const& value);
 
     virtual void visit_edges(Cell::Visitor&) override;
 
@@ -69,12 +69,12 @@ private:
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-map
     // Spec Note: The order of the entries of event handler map could be arbitrary. It is not observable through any algorithms that operate on the map.
-    HashMap<DeprecatedFlyString, JS::GCPtr<HTML::EventHandler>> m_event_handler_map;
+    HashMap<FlyString, JS::GCPtr<HTML::EventHandler>> m_event_handler_map;
 
-    WebIDL::CallbackType* get_current_value_of_event_handler(DeprecatedFlyString const& name);
-    void activate_event_handler(DeprecatedFlyString const& name, HTML::EventHandler& event_handler);
-    void deactivate_event_handler(DeprecatedFlyString const& name);
-    JS::ThrowCompletionOr<void> process_event_handler_for_event(DeprecatedFlyString const& name, Event& event);
+    WebIDL::CallbackType* get_current_value_of_event_handler(FlyString const& name);
+    void activate_event_handler(FlyString const& name, HTML::EventHandler& event_handler);
+    void deactivate_event_handler(FlyString const& name);
+    JS::ThrowCompletionOr<void> process_event_handler_for_event(FlyString const& name, Event& event);
 };
 
 bool is_window_reflecting_body_element_event_handler(FlyString const& name);

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.idl
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.idl
@@ -1,7 +1,7 @@
 #import <DOM/AbortSignal.idl>
 
 // https://dom.spec.whatwg.org/#eventtarget
-[Exposed=*]
+[Exposed=*, UseNewAKString]
 interface EventTarget {
 
     undefined addEventListener(DOMString type, EventListener? callback, optional (AddEventListenerOptions or boolean) options = {});

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -1125,7 +1125,7 @@ WebIDL::ExceptionOr<void> BrowsingContext::traverse_the_history(size_t entry_ind
 
             // 4. Fire a page transition event named pageshow at newDocument's relevant global object with true.
             auto& window = verify_cast<HTML::Window>(relevant_global_object(*new_document));
-            window.fire_a_page_transition_event(HTML::EventNames::pageshow.to_deprecated_fly_string(), true);
+            window.fire_a_page_transition_event(HTML::EventNames::pageshow, true);
         });
     }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -71,9 +71,9 @@ void HTMLBodyElement::parse_attribute(DeprecatedFlyString const& name, Deprecate
     }
 
 #undef __ENUMERATE
-#define __ENUMERATE(attribute_name, event_name)                     \
-    if (name == HTML::AttributeNames::attribute_name) {             \
-        element_event_handler_attribute_changed(event_name, value); \
+#define __ENUMERATE(attribute_name, event_name)                                                                     \
+    if (name == HTML::AttributeNames::attribute_name) {                                                             \
+        element_event_handler_attribute_changed(event_name, String::from_deprecated_string(value).release_value()); \
     }
     ENUMERATE_WINDOW_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -276,12 +276,12 @@ void HTMLElement::focus()
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-synthetic-pointer-event
-bool HTMLElement::fire_a_synthetic_pointer_event(DeprecatedFlyString const& type, DOM::Element& target, bool not_trusted)
+bool HTMLElement::fire_a_synthetic_pointer_event(FlyString const& type, DOM::Element& target, bool not_trusted)
 {
     // 1. Let event be the result of creating an event using PointerEvent.
     // 2. Initialize event's type attribute to e.
     // FIXME: Actually create a PointerEvent!
-    auto event = UIEvents::MouseEvent::create(realm(), FlyString::from_deprecated_fly_string(type).release_value()).release_value_but_fixme_should_propagate_errors();
+    auto event = UIEvents::MouseEvent::create(realm(), type).release_value_but_fixme_should_propagate_errors();
 
     // 3. Initialize event's bubbles and cancelable attributes to true.
     event->set_bubbles(true);
@@ -319,7 +319,7 @@ void HTMLElement::click()
     m_click_in_progress = true;
 
     // FIXME: 4. Fire a synthetic pointer event named click at this element, with the not trusted flag set.
-    fire_a_synthetic_pointer_event(HTML::EventNames::click.to_deprecated_fly_string(), *this, true);
+    fire_a_synthetic_pointer_event(HTML::EventNames::click, *this, true);
 
     // 5. Unset this element's click in progress flag.
     m_click_in_progress = false;

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -245,9 +245,9 @@ void HTMLElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedStr
     // 1. If namespace is not null, or localName is not the name of an event handler content attribute on element, then return.
     // FIXME: Add the namespace part once we support attribute namespaces.
 #undef __ENUMERATE
-#define __ENUMERATE(attribute_name, event_name)                     \
-    if (name == HTML::AttributeNames::attribute_name) {             \
-        element_event_handler_attribute_changed(event_name, value); \
+#define __ENUMERATE(attribute_name, event_name)                                                                     \
+    if (name == HTML::AttributeNames::attribute_name) {                                                             \
+        element_event_handler_attribute_changed(event_name, String::from_deprecated_string(value).release_value()); \
     }
     ENUMERATE_GLOBAL_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -54,7 +54,7 @@ public:
 
     void blur();
 
-    bool fire_a_synthetic_pointer_event(DeprecatedFlyString const& type, DOM::Element& target, bool not_trusted);
+    bool fire_a_synthetic_pointer_event(FlyString const& type, DOM::Element& target, bool not_trusted);
 
     // https://html.spec.whatwg.org/multipage/forms.html#category-label
     virtual bool is_labelable() const { return false; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
@@ -30,9 +30,9 @@ void HTMLFrameSetElement::parse_attribute(DeprecatedFlyString const& name, Depre
     HTMLElement::parse_attribute(name, value);
 
 #undef __ENUMERATE
-#define __ENUMERATE(attribute_name, event_name)                     \
-    if (name == HTML::AttributeNames::attribute_name) {             \
-        element_event_handler_attribute_changed(event_name, value); \
+#define __ENUMERATE(attribute_name, event_name)                                                                     \
+    if (name == HTML::AttributeNames::attribute_name) {                                                             \
+        element_event_handler_attribute_changed(event_name, String::from_deprecated_string(value).release_value()); \
     }
     ENUMERATE_WINDOW_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -313,7 +313,7 @@ void HTMLParser::the_end()
         document->set_page_showing(true);
 
         // 11. Fire a page transition event named pageshow at window with false.
-        window->fire_a_page_transition_event(HTML::EventNames::pageshow.to_deprecated_fly_string(), false);
+        window->fire_a_page_transition_event(HTML::EventNames::pageshow, false);
 
         // 12. Completely finish loading the Document.
         document->completely_finish_loading();

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -567,14 +567,14 @@ Optional<CSS::MediaFeatureValue> Window::query_media_feature(CSS::MediaFeatureID
 }
 
 // https://html.spec.whatwg.org/#fire-a-page-transition-event
-void Window::fire_a_page_transition_event(DeprecatedFlyString const& event_name, bool persisted)
+void Window::fire_a_page_transition_event(FlyString const& event_name, bool persisted)
 {
     // To fire a page transition event named eventName at a Window window with a boolean persisted,
     // fire an event named eventName at window, using PageTransitionEvent,
     // with the persisted attribute initialized to persisted,
     PageTransitionEventInit event_init {};
     event_init.persisted = persisted;
-    auto event = PageTransitionEvent::create(associated_document().realm(), String::from_deprecated_string(event_name).release_value_but_fixme_should_propagate_errors(), event_init).release_value_but_fixme_should_propagate_errors();
+    auto event = PageTransitionEvent::create(associated_document().realm(), event_name, event_init).release_value_but_fixme_should_propagate_errors();
 
     // ...the cancelable attribute initialized to true,
     event->set_cancelable(true);

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -106,7 +106,7 @@ public:
 
     Optional<CSS::MediaFeatureValue> query_media_feature(CSS::MediaFeatureID) const;
 
-    void fire_a_page_transition_event(DeprecatedFlyString const& event_name, bool persisted);
+    void fire_a_page_transition_event(FlyString const& event_name, bool persisted);
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Storage>> local_storage();
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Storage>> session_storage();

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -671,7 +671,7 @@ constexpr bool should_ignore_keydown_event(u32 code_point)
     return code_point == 0 || code_point == 27;
 }
 
-bool EventHandler::fire_keyboard_event(DeprecatedFlyString const& event_name, HTML::BrowsingContext& browsing_context, KeyCode key, unsigned int modifiers, u32 code_point)
+bool EventHandler::fire_keyboard_event(FlyString const& event_name, HTML::BrowsingContext& browsing_context, KeyCode key, unsigned int modifiers, u32 code_point)
 {
     JS::NonnullGCPtr<DOM::Document> document = *browsing_context.active_document();
     if (!document)
@@ -684,12 +684,12 @@ bool EventHandler::fire_keyboard_event(DeprecatedFlyString const& event_name, HT
                 return fire_keyboard_event(event_name, *browsing_context_container.nested_browsing_context(), key, modifiers, code_point);
         }
 
-        auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), FlyString::from_deprecated_fly_string(event_name).release_value_but_fixme_should_propagate_errors(), key, modifiers, code_point).release_value_but_fixme_should_propagate_errors();
+        auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), event_name, key, modifiers, code_point).release_value_but_fixme_should_propagate_errors();
         return !focused_element->dispatch_event(event);
     }
 
     // FIXME: De-duplicate this. This is just to prevent wasting a KeyboardEvent allocation when recursing into an (i)frame.
-    auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), FlyString::from_deprecated_fly_string(event_name).release_value_but_fixme_should_propagate_errors(), key, modifiers, code_point).release_value_but_fixme_should_propagate_errors();
+    auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), event_name, key, modifiers, code_point).release_value_but_fixme_should_propagate_errors();
 
     if (JS::GCPtr<HTML::HTMLElement> body = document->body())
         return !body->dispatch_event(event);
@@ -783,17 +783,17 @@ bool EventHandler::handle_keydown(KeyCode key, unsigned modifiers, u32 code_poin
         return true;
     }
 
-    bool continue_ = fire_keyboard_event(UIEvents::EventNames::keydown.to_deprecated_fly_string(), m_browsing_context, key, modifiers, code_point);
+    bool continue_ = fire_keyboard_event(UIEvents::EventNames::keydown, m_browsing_context, key, modifiers, code_point);
     if (!continue_)
         return false;
 
     // FIXME: Work out and implement the difference between this and keydown.
-    return fire_keyboard_event(UIEvents::EventNames::keypress.to_deprecated_fly_string(), m_browsing_context, key, modifiers, code_point);
+    return fire_keyboard_event(UIEvents::EventNames::keypress, m_browsing_context, key, modifiers, code_point);
 }
 
 bool EventHandler::handle_keyup(KeyCode key, unsigned modifiers, u32 code_point)
 {
-    return fire_keyboard_event(UIEvents::EventNames::keyup.to_deprecated_fly_string(), m_browsing_context, key, modifiers, code_point);
+    return fire_keyboard_event(UIEvents::EventNames::keyup, m_browsing_context, key, modifiers, code_point);
 }
 
 void EventHandler::set_mouse_event_tracking_layout_node(Layout::Node* layout_node)

--- a/Userland/Libraries/LibWeb/Page/EventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.h
@@ -40,7 +40,7 @@ private:
     bool focus_next_element();
     bool focus_previous_element();
 
-    bool fire_keyboard_event(DeprecatedFlyString const& event_name, HTML::BrowsingContext& browsing_context, KeyCode key, unsigned modifiers, u32 code_point);
+    bool fire_keyboard_event(FlyString const& event_name, HTML::BrowsingContext& browsing_context, KeyCode key, unsigned modifiers, u32 code_point);
     CSSPixelPoint compute_mouse_event_client_offset(CSSPixelPoint event_page_position) const;
     CSSPixelPoint compute_mouse_event_page_offset(CSSPixelPoint event_client_offset) const;
 

--- a/Userland/Libraries/LibWeb/WebGL/EventNames.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/EventNames.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, Kenneth Myhra <kennethmyhra@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/WebGL/EventNames.h>
+
+namespace Web::WebGL::EventNames {
+
+#define __ENUMERATE_GL_EVENT(name) FlyString name;
+ENUMERATE_GL_EVENTS
+#undef __ENUMERATE_GL_EVENT
+
+ErrorOr<void> initialize_strings()
+{
+    static bool s_initialized = false;
+    VERIFY(!s_initialized);
+
+#define __ENUMERATE_GL_EVENT(name) \
+    name = TRY(#name##_fly_string);
+    ENUMERATE_GL_EVENTS
+#undef __ENUMERATE_GL_EVENT
+
+    s_initialized = true;
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibWeb/WebGL/EventNames.h
+++ b/Userland/Libraries/LibWeb/WebGL/EventNames.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023, Kenneth Myhra <kennethmyhra@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/FlyString.h>
+
+namespace Web::WebGL::EventNames {
+
+#define ENUMERATE_GL_EVENTS                         \
+    __ENUMERATE_GL_EVENT(webglcontextcreationerror) \
+    __ENUMERATE_GL_EVENT(webglcontextlost)          \
+    __ENUMERATE_GL_EVENT(webglcontextrestored)
+
+#define __ENUMERATE_GL_EVENT(name) extern FlyString name;
+ENUMERATE_GL_EVENTS
+#undef __ENUMERATE_GL_EVENT
+
+ErrorOr<void> initialize_strings();
+
+}

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
@@ -7,17 +7,18 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLCanvasElement.h>
+#include <LibWeb/WebGL/EventNames.h>
 #include <LibWeb/WebGL/WebGLContextEvent.h>
 #include <LibWeb/WebGL/WebGLRenderingContext.h>
 
 namespace Web::WebGL {
 
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/#fire-a-webgl-context-event
-static void fire_webgl_context_event(HTML::HTMLCanvasElement& canvas_element, DeprecatedFlyString const& type)
+static void fire_webgl_context_event(HTML::HTMLCanvasElement& canvas_element, FlyString const& type)
 {
     // To fire a WebGL context event named e means that an event using the WebGLContextEvent interface, with its type attribute [DOM4] initialized to e, its cancelable attribute initialized to true, and its isTrusted attribute [DOM4] initialized to true, is to be dispatched at the given object.
     // FIXME: Consider setting a status message.
-    auto event = WebGLContextEvent::create(canvas_element.realm(), String::from_deprecated_string(type).release_value_but_fixme_should_propagate_errors(), WebGLContextEventInit {}).release_value_but_fixme_should_propagate_errors();
+    auto event = WebGLContextEvent::create(canvas_element.realm(), type, WebGLContextEventInit {}).release_value_but_fixme_should_propagate_errors();
     event->set_is_trusted(true);
     event->set_cancelable(true);
     canvas_element.dispatch_event(*event);
@@ -27,7 +28,7 @@ static void fire_webgl_context_event(HTML::HTMLCanvasElement& canvas_element, De
 static void fire_webgl_context_creation_error(HTML::HTMLCanvasElement& canvas_element)
 {
     // 1. Fire a WebGL context event named "webglcontextcreationerror" at canvas, optionally with its statusMessage attribute set to a platform dependent string about the nature of the failure.
-    fire_webgl_context_event(canvas_element, "webglcontextcreationerror"sv);
+    fire_webgl_context_event(canvas_element, EventNames::webglcontextcreationerror);
 }
 
 JS::ThrowCompletionOr<JS::GCPtr<WebGLRenderingContext>> WebGLRenderingContext::create(JS::Realm& realm, HTML::HTMLCanvasElement& canvas_element, JS::Value options)

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -983,19 +983,19 @@ bool XMLHttpRequest::must_survive_garbage_collection() const
     if ((m_state == State::Opened && m_send)
         || m_state == State::HeadersReceived
         || m_state == State::Loading) {
-        if (has_event_listener(EventNames::readystatechange.to_deprecated_fly_string()))
+        if (has_event_listener(EventNames::readystatechange))
             return true;
-        if (has_event_listener(EventNames::progress.to_deprecated_fly_string()))
+        if (has_event_listener(EventNames::progress))
             return true;
-        if (has_event_listener(EventNames::abort.to_deprecated_fly_string()))
+        if (has_event_listener(EventNames::abort))
             return true;
-        if (has_event_listener(EventNames::error.to_deprecated_fly_string()))
+        if (has_event_listener(EventNames::error))
             return true;
-        if (has_event_listener(EventNames::load.to_deprecated_fly_string()))
+        if (has_event_listener(EventNames::load))
             return true;
-        if (has_event_listener(EventNames::timeout.to_deprecated_fly_string()))
+        if (has_event_listener(EventNames::timeout))
             return true;
-        if (has_event_listener(EventNames::loadend.to_deprecated_fly_string()))
+        if (has_event_listener(EventNames::loadend))
             return true;
     }
 

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -92,7 +92,7 @@ void XMLHttpRequest::visit_edges(Cell::Visitor& visitor)
 }
 
 // https://xhr.spec.whatwg.org/#concept-event-fire-progress
-static void fire_progress_event(XMLHttpRequestEventTarget& target, DeprecatedString const& event_name, u64 transmitted, u64 length)
+static void fire_progress_event(XMLHttpRequestEventTarget& target, FlyString const& event_name, u64 transmitted, u64 length)
 {
     // To fire a progress event named e at target, given transmitted and length, means to fire an event named e at target, using ProgressEvent,
     // with the loaded attribute initialized to transmitted, and if length is not 0, with the lengthComputable attribute initialized to true
@@ -102,7 +102,7 @@ static void fire_progress_event(XMLHttpRequestEventTarget& target, DeprecatedStr
     event_init.loaded = transmitted;
     event_init.total = length;
     // FIXME: If we're in an async context, this will propagate to a callback context which can't propagate it anywhere else and does not expect this to fail.
-    target.dispatch_event(*ProgressEvent::create(target.realm(), String::from_deprecated_string(event_name).release_value_but_fixme_should_propagate_errors(), event_init).release_value_but_fixme_should_propagate_errors());
+    target.dispatch_event(*ProgressEvent::create(target.realm(), event_name, event_init).release_value_but_fixme_should_propagate_errors());
 }
 
 // https://xhr.spec.whatwg.org/#dom-xmlhttprequest-responsetext
@@ -277,7 +277,7 @@ ErrorOr<MimeSniff::MimeType> XMLHttpRequest::get_response_mime_type() const
 ErrorOr<Optional<StringView>> XMLHttpRequest::get_final_encoding() const
 {
     // 1. Let label be null.
-    Optional<DeprecatedString> label;
+    Optional<String> label;
 
     // 2. Let responseMIME be the result of get a response MIME type for xhr.
     auto response_mime = TRY(get_response_mime_type());
@@ -285,13 +285,13 @@ ErrorOr<Optional<StringView>> XMLHttpRequest::get_final_encoding() const
     // 3. If responseMIME’s parameters["charset"] exists, then set label to it.
     auto response_mime_charset_it = response_mime.parameters().find("charset"sv);
     if (response_mime_charset_it != response_mime.parameters().end())
-        label = response_mime_charset_it->value.to_deprecated_string();
+        label = response_mime_charset_it->value;
 
     // 4. If xhr’s override MIME type’s parameters["charset"] exists, then set label to it.
     if (m_override_mime_type.has_value()) {
         auto override_mime_charset_it = m_override_mime_type->parameters().find("charset"sv);
         if (override_mime_charset_it != m_override_mime_type->parameters().end())
-            label = override_mime_charset_it->value.to_deprecated_string();
+            label = override_mime_charset_it->value;
     }
 
     // 5. If label is null, then return null.
@@ -607,7 +607,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
     // 11. If this’s synchronous flag is unset, then:
     if (!m_synchronous) {
         // 1. Fire a progress event named loadstart at this with 0 and 0.
-        fire_progress_event(*this, EventNames::loadstart.to_deprecated_fly_string(), 0, 0);
+        fire_progress_event(*this, EventNames::loadstart, 0, 0);
 
         // 2. Let requestBodyTransmitted be 0.
         // NOTE: This is kept on the XHR object itself instead of the stack, as we cannot capture references to stack variables in an async context.
@@ -625,7 +625,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
 
         // 5. If this’s upload complete flag is unset and this’s upload listener flag is set, then fire a progress event named loadstart at this’s upload object with requestBodyTransmitted and requestBodyLength.
         if (!m_upload_complete && m_upload_listener)
-            fire_progress_event(m_upload_object, EventNames::loadstart.to_deprecated_fly_string(), m_request_body_transmitted, request_body_length);
+            fire_progress_event(m_upload_object, EventNames::loadstart, m_request_body_transmitted, request_body_length);
 
         // 6. If this’s state is not opened or this’s send() flag is unset, then return.
         if (m_state != State::Opened || !m_send)
@@ -642,7 +642,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
 
             // 3. If this’s upload listener flag is set, then fire a progress event named progress at this’s upload object with requestBodyTransmitted and requestBodyLength.
             if (m_upload_listener)
-                fire_progress_event(m_upload_object, EventNames::progress.to_deprecated_fly_string(), m_request_body_transmitted, request_body_length);
+                fire_progress_event(m_upload_object, EventNames::progress, m_request_body_transmitted, request_body_length);
         };
 
         // 8. Let processRequestEndOfBody be these steps:
@@ -657,13 +657,13 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
                 return;
 
             // 3. Fire a progress event named progress at this’s upload object with requestBodyTransmitted and requestBodyLength.
-            fire_progress_event(m_upload_object, EventNames::progress.to_deprecated_fly_string(), m_request_body_transmitted, request_body_length);
+            fire_progress_event(m_upload_object, EventNames::progress, m_request_body_transmitted, request_body_length);
 
             // 4. Fire a progress event named load at this’s upload object with requestBodyTransmitted and requestBodyLength.
-            fire_progress_event(m_upload_object, EventNames::load.to_deprecated_fly_string(), m_request_body_transmitted, request_body_length);
+            fire_progress_event(m_upload_object, EventNames::load, m_request_body_transmitted, request_body_length);
 
             // 5. Fire a progress event named loadend at this’s upload object with requestBodyTransmitted and requestBodyLength.
-            fire_progress_event(m_upload_object, EventNames::loadend.to_deprecated_fly_string(), m_request_body_transmitted, request_body_length);
+            fire_progress_event(m_upload_object, EventNames::loadend, m_request_body_transmitted, request_body_length);
         };
 
         // 9. Let processResponse, given a response, be these steps:
@@ -1017,7 +1017,7 @@ void XMLHttpRequest::abort()
         // NOTE: This cannot throw as we don't pass in an exception. XHR::abort cannot be reached in a synchronous context where the state matches above.
         //       This is because it pauses inside XHR::send until the request is done or times out and then immediately calls `handle_response_end_of_body`
         //       which will always set `m_state` to `Done`.
-        MUST(request_error_steps(EventNames::abort.to_deprecated_fly_string()));
+        MUST(request_error_steps(EventNames::abort));
     }
 
     // 3. If this’s state is done, then set this’s state to unsent and this’s response to a network error.
@@ -1078,7 +1078,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::handle_response_end_of_body()
 
     // 6. If xhr’s synchronous flag is unset, then fire a progress event named progress at xhr with transmitted and length.
     if (!m_synchronous)
-        fire_progress_event(*this, EventNames::progress.to_deprecated_fly_string(), transmitted, length);
+        fire_progress_event(*this, EventNames::progress, transmitted, length);
 
     // 7. Set xhr’s state to done.
     m_state = State::Done;
@@ -1091,10 +1091,10 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::handle_response_end_of_body()
     dispatch_event(*DOM::Event::create(realm, EventNames::readystatechange).release_value_but_fixme_should_propagate_errors());
 
     // 10. Fire a progress event named load at xhr with transmitted and length.
-    fire_progress_event(*this, EventNames::load.to_deprecated_fly_string(), transmitted, length);
+    fire_progress_event(*this, EventNames::load, transmitted, length);
 
     // 11. Fire a progress event named loadend at xhr with transmitted and length.
-    fire_progress_event(*this, EventNames::loadend.to_deprecated_fly_string(), transmitted, length);
+    fire_progress_event(*this, EventNames::loadend, transmitted, length);
 
     return {};
 }
@@ -1108,20 +1108,20 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::handle_errors()
 
     // 2. If xhr’s timed out flag is set, then run the request error steps for xhr, timeout, and "TimeoutError" DOMException.
     if (m_timed_out)
-        return TRY(request_error_steps(EventNames::timeout.to_deprecated_fly_string(), WebIDL::TimeoutError::create(realm(), "Timed out"sv)));
+        return TRY(request_error_steps(EventNames::timeout, WebIDL::TimeoutError::create(realm(), "Timed out"sv)));
 
     // 3. Otherwise, if xhr’s response’s aborted flag is set, run the request error steps for xhr, abort, and "AbortError" DOMException.
     if (m_response->aborted())
-        return TRY(request_error_steps(EventNames::abort.to_deprecated_fly_string(), WebIDL::AbortError::create(realm(), "Aborted"sv)));
+        return TRY(request_error_steps(EventNames::abort, WebIDL::AbortError::create(realm(), "Aborted"sv)));
 
     // 4. Otherwise, if xhr’s response is a network error, then run the request error steps for xhr, error, and "NetworkError" DOMException.
     if (m_response->is_network_error())
-        return TRY(request_error_steps(EventNames::error.to_deprecated_fly_string(), WebIDL::NetworkError::create(realm(), "Network error"sv)));
+        return TRY(request_error_steps(EventNames::error, WebIDL::NetworkError::create(realm(), "Network error"sv)));
 
     return {};
 }
 
-JS::ThrowCompletionOr<void> XMLHttpRequest::request_error_steps(DeprecatedFlyString const& event_name, JS::GCPtr<WebIDL::DOMException> exception)
+JS::ThrowCompletionOr<void> XMLHttpRequest::request_error_steps(FlyString const& event_name, JS::GCPtr<WebIDL::DOMException> exception)
 {
     // 1. Set xhr’s state to done.
     m_state = State::Done;
@@ -1153,7 +1153,7 @@ JS::ThrowCompletionOr<void> XMLHttpRequest::request_error_steps(DeprecatedFlyStr
             fire_progress_event(m_upload_object, event_name, 0, 0);
 
             // 2. Fire a progress event named loadend at xhr’s upload object with 0 and 0.
-            fire_progress_event(m_upload_object, EventNames::loadend.to_deprecated_fly_string(), 0, 0);
+            fire_progress_event(m_upload_object, EventNames::loadend, 0, 0);
         }
     }
 
@@ -1161,7 +1161,7 @@ JS::ThrowCompletionOr<void> XMLHttpRequest::request_error_steps(DeprecatedFlyStr
     fire_progress_event(*this, event_name, 0, 0);
 
     // 8. Fire a progress event named loadend at xhr with 0 and 0.
-    fire_progress_event(*this, EventNames::loadend.to_deprecated_fly_string(), 0, 0);
+    fire_progress_event(*this, EventNames::loadend, 0, 0);
 
     return {};
 }

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -89,7 +89,7 @@ private:
 
     WebIDL::ExceptionOr<void> handle_response_end_of_body();
     WebIDL::ExceptionOr<void> handle_errors();
-    JS::ThrowCompletionOr<void> request_error_steps(DeprecatedFlyString const& event_name, JS::GCPtr<WebIDL::DOMException> exception = nullptr);
+    JS::ThrowCompletionOr<void> request_error_steps(FlyString const& event_name, JS::GCPtr<WebIDL::DOMException> exception = nullptr);
 
     XMLHttpRequest(JS::Realm&, XMLHttpRequestUpload&, Fetch::Infrastructure::HeaderList&, Fetch::Infrastructure::Response&, Fetch::Infrastructure::FetchController&);
 

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -245,7 +245,7 @@ void XMLDocumentBuilder::document_end()
         document->set_page_showing(true);
 
         // Fire a page transition event named pageshow at window with false.
-        window->fire_a_page_transition_event(HTML::EventNames::pageshow.to_deprecated_fly_string(), false);
+        window->fire_a_page_transition_event(HTML::EventNames::pageshow, false);
 
         // Completely finish loading the Document.
         document->completely_finish_loading();


### PR DESCRIPTION
Includes WebGL::EventNames for WebGL event types.