### PR TITLE
Ports: Repair the launcher icons of 'stpuzzles'

### DIFF
--- a/Ports/stpuzzles/package.sh
+++ b/Ports/stpuzzles/package.sh
@@ -14,7 +14,7 @@ install() {
     run make install
 
     for puzzle in bridges cube dominosa fifteen filling flip flood galaxies guess inertia keen lightup loopy magnets map mines mosaic net netslide palisade pattern pearl pegs range rect samegame signpost singles sixteen slant solo tents towers tracks twiddle undead unequal unruly untangle; do
-        install_launcher "$puzzle" "Games/Puzzles" "/usr/local/bin/$puzzle"
+        install_launcher "$puzzle" "Games/Puzzles" "/usr/local/bin/$puzzle" ""
         install_icon "static-icons/${puzzle}.ico" "/usr/local/bin/$puzzle"
     done
 }


### PR DESCRIPTION
Now that https://github.com/SerenityPorts/stpuzzles/pull/7 is merged, we can repair the launcher icons.

Root cause of the bug is that `install_launcher` was changed to take a new required argument, and stpuzzles did not provide that argument. That is easily fixed, because stpuzzles never actually cares about the working directory.

![Bildschirmfoto_2023-04-09_13-44-59](https://user-images.githubusercontent.com/2690845/230770872-f8ef526c-d0d3-4837-b554-704d73fd122a.png)

See also https://github.com/SerenityOS/serenity/issues/18238
