### PR TITLE
Everywhere: Remove unused DeprecatedString includes

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzCyrillicDecoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzCyrillicDecoder.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <LibTextCodec/Decoder.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/Meta/Lagom/Fuzzers/FuzzGIFLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGIFLoader.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Debug.h>
-#include <AK/DeprecatedString.h>
 #include <AK/Format.h>
 #include <LibGfx/ImageFormats/GIFLoader.h>
 #include <stddef.h>

--- a/Meta/Lagom/Fuzzers/FuzzHebrewDecoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzHebrewDecoder.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <LibTextCodec/Decoder.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/Meta/Lagom/Fuzzers/FuzzLatin1Decoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzLatin1Decoder.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <LibTextCodec/Decoder.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/Meta/Lagom/Fuzzers/FuzzLatin2Decoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzLatin2Decoder.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <LibTextCodec/Decoder.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/Meta/Lagom/Fuzzers/FuzzQuotedPrintableParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzQuotedPrintableParser.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <AK/StringView.h>
 #include <LibIMAP/QuotedPrintable.h>
 

--- a/Meta/Lagom/Fuzzers/FuzzUTF16BEDecoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzUTF16BEDecoder.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <LibTextCodec/Decoder.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <AK/Format.h>
 #include <AK/Function.h>
 #include <AK/StringView.h>

--- a/Userland/Applications/3DFileViewer/MeshLoader.h
+++ b/Userland/Applications/3DFileViewer/MeshLoader.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <LibCore/Forward.h>
 
 #include "Common.h"

--- a/Userland/Applications/Browser/IconBag.cpp
+++ b/Userland/Applications/Browser/IconBag.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <Applications/Browser/IconBag.h>
 
 namespace Browser {

--- a/Userland/Applications/Escalator/EscalatorWindow.h
+++ b/Userland/Applications/Escalator/EscalatorWindow.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 #include <LibCore/Account.h>

--- a/Userland/Applications/PixelPaint/IconBag.cpp
+++ b/Userland/Applications/PixelPaint/IconBag.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <Applications/PixelPaint/IconBag.h>
 
 namespace PixelPaint {

--- a/Userland/Applications/PixelPaint/ProjectLoader.cpp
+++ b/Userland/Applications/PixelPaint/ProjectLoader.cpp
@@ -7,7 +7,6 @@
 #include "ProjectLoader.h"
 #include "Image.h"
 #include "Layer.h"
-#include <AK/DeprecatedString.h>
 #include <AK/JsonObject.h>
 #include <AK/Result.h>
 #include <LibCore/MappedFile.h>

--- a/Userland/Games/2048/Game.cpp
+++ b/Userland/Games/2048/Game.cpp
@@ -6,7 +6,6 @@
 
 #include "Game.h"
 #include <AK/Array.h>
-#include <AK/DeprecatedString.h>
 #include <AK/NumericLimits.h>
 #include <AK/ScopeGuard.h>
 #include <stdlib.h>

--- a/Userland/Libraries/LibC/grp.cpp
+++ b/Userland/Libraries/LibC/grp.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
+#include <AK/Format.h>
 #include <AK/ScopeGuard.h>
 #include <AK/Vector.h>
 #include <errno.h>

--- a/Userland/Libraries/LibC/pwd.cpp
+++ b/Userland/Libraries/LibC/pwd.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
+#include <AK/Format.h>
 #include <AK/ScopeGuard.h>
 #include <AK/TemporaryChange.h>
 #include <AK/Vector.h>

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/DateConstants.h>
-#include <AK/DeprecatedString.h>
 #include <AK/StringBuilder.h>
 #include <AK/Time.h>
 #include <Kernel/API/TimePage.h>

--- a/Userland/Libraries/LibCore/Event.h
+++ b/Userland/Libraries/LibCore/Event.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/Function.h>
 #include <AK/Types.h>
 #include <AK/WeakPtr.h>

--- a/Userland/Libraries/LibCore/FilePermissionsMask.h
+++ b/Userland/Libraries/LibCore/FilePermissionsMask.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/Error.h>
 #include <AK/OwnPtr.h>
 #include <sys/stat.h>

--- a/Userland/Libraries/LibCore/MappedFile.cpp
+++ b/Userland/Libraries/LibCore/MappedFile.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <AK/ScopeGuard.h>
 #include <LibCore/File.h>
 #include <LibCore/MappedFile.h>

--- a/Userland/Libraries/LibCrypto/Curves/SECP256r1.cpp
+++ b/Userland/Libraries/LibCrypto/Curves/SECP256r1.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/ByteReader.h>
-#include <AK/DeprecatedString.h>
 #include <AK/Endian.h>
 #include <AK/Random.h>
 #include <AK/StringBuilder.h>

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.h
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.h
@@ -9,7 +9,6 @@
 #include "AttributeValue.h"
 #include "DwarfTypes.h"
 #include <AK/ByteBuffer.h>
-#include <AK/DeprecatedString.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/RedBlackTree.h>
 #include <AK/RefCounted.h>

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -6,7 +6,6 @@
 
 #include "LineProgram.h"
 #include <AK/Debug.h>
-#include <AK/DeprecatedString.h>
 #include <AK/Function.h>
 #include <AK/LEB128.h>
 #include <AK/StringBuilder.h>

--- a/Userland/Libraries/LibDeviceTree/Validation.cpp
+++ b/Userland/Libraries/LibDeviceTree/Validation.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/AllOf.h>
 #include <AK/CharacterTypes.h>
-#include <AK/DeprecatedString.h>
 #include <AK/Endian.h>
 #include <AK/Format.h>
 #include <AK/Try.h>

--- a/Userland/Libraries/LibGUI/ModelIndex.cpp
+++ b/Userland/Libraries/LibGUI/ModelIndex.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <LibGUI/Model.h>
 #include <LibGUI/Variant.h>
 

--- a/Userland/Libraries/LibGUI/TextPosition.h
+++ b/Userland/Libraries/LibGUI/TextPosition.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/Format.h>
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Assertions.h>
-#include <AK/DeprecatedString.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/TextEditor.h>
 #include <LibGUI/VimEditingEngine.h>

--- a/Userland/Libraries/LibGemini/GeminiRequest.h
+++ b/Userland/Libraries/LibGemini/GeminiRequest.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/Optional.h>
 #include <AK/URL.h>
 #include <LibCore/Forward.h>

--- a/Userland/Libraries/LibGfx/Font/Emoji.cpp
+++ b/Userland/Libraries/LibGfx/Font/Emoji.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <AK/Debug.h>
-#include <AK/DeprecatedString.h>
 #include <AK/HashMap.h>
 #include <AK/LexicalPath.h>
 #include <AK/Span.h>

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.cpp
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <AK/Endian.h>
 #include <LibGfx/ICC/BinaryFormat.h>
 #include <LibGfx/ICC/TagTypes.h>

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Debug.h>
-#include <AK/DeprecatedString.h>
 #include <AK/Endian.h>
 #include <AK/Error.h>
 #include <AK/MemoryStream.h>

--- a/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <AK/Debug.h>
-#include <AK/DeprecatedString.h>
 #include <AK/Endian.h>
 #include <AK/ScopeGuard.h>
 #include <AK/String.h>

--- a/Userland/Libraries/LibGfx/ImageFormats/QOIWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/QOIWriter.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "QOIWriter.h"
-#include <AK/DeprecatedString.h>
 #include <AK/Endian.h>
 
 namespace Gfx {

--- a/Userland/Libraries/LibJS/Interpreter.h
+++ b/Userland/Libraries/LibJS/Interpreter.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <AK/DeprecatedFlyString.h>
-#include <AK/DeprecatedString.h>
 #include <AK/HashMap.h>
 #include <AK/Weakable.h>
 #include <LibJS/Forward.h>

--- a/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/BigInt.h>
 #include <LibJS/Runtime/BigIntConstructor.h>

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <AK/Badge.h>
-#include <AK/DeprecatedString.h>
 #include <AK/HashMap.h>
 #include <AK/StringView.h>
 #include <LibJS/Forward.h>

--- a/Userland/Libraries/LibJS/Runtime/Reference.h
+++ b/Userland/Libraries/LibJS/Runtime/Reference.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <LibJS/Runtime/Environment.h>
 #include <LibJS/Runtime/EnvironmentCoordinate.h>
 #include <LibJS/Runtime/PropertyKey.h>

--- a/Userland/Libraries/LibJS/Runtime/RegExpLegacyStaticProperties.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpLegacyStaticProperties.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/Optional.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/Utf16String.h>

--- a/Userland/Libraries/LibLine/KeyCallbackMachine.h
+++ b/Userland/Libraries/LibLine/KeyCallbackMachine.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/Vector.h>

--- a/Userland/Libraries/LibLine/SuggestionDisplay.h
+++ b/Userland/Libraries/LibLine/SuggestionDisplay.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/Forward.h>
 #include <LibLine/StringMetrics.h>
 #include <LibLine/SuggestionManager.h>

--- a/Userland/Libraries/LibPDF/Operator.h
+++ b/Userland/Libraries/LibPDF/Operator.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/Format.h>
 #include <AK/StringBuilder.h>
 #include <AK/Vector.h>

--- a/Userland/Libraries/LibRegex/RegexError.h
+++ b/Userland/Libraries/LibRegex/RegexError.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/StringView.h>
 #include <AK/Types.h>
 #ifdef AK_OS_SERENITY
 #    include <bits/regex_defs.h>

--- a/Userland/Libraries/LibSQL/Result.h
+++ b/Userland/Libraries/LibSQL/Result.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/DeprecatedString.h>
 #include <AK/Error.h>
 #include <AK/Noncopyable.h>
 #include <LibSQL/Type.h>

--- a/Userland/Libraries/LibSQL/Type.h
+++ b/Userland/Libraries/LibSQL/Type.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/HashMap.h>
 #include <AK/StringView.h>
 

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <AK/MemoryStream.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Size.h>

--- a/Userland/Libraries/LibWeb/Bindings/Intrinsics.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/Intrinsics.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <AK/HashMap.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/NativeFunction.h>

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include <AK/Concepts.h>
-#include <AK/DeprecatedString.h>
 #include <AK/GenericShorthands.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/RefCounted.h>

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasDrawImage.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasDrawImage.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <LibWeb/HTML/HTMLCanvasElement.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Debug.h>
-#include <AK/DeprecatedString.h>
 #include <LibJS/Runtime/ConsoleObject.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibWeb/Bindings/MainThreadVM.h>

--- a/Userland/Libraries/LibWeb/HTML/WorkerLocation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerLocation.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <LibWeb/HTML/WorkerGlobalScope.h>
 #include <LibWeb/HTML/WorkerLocation.h>
 

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/HashMap.h>
 
 namespace Web::MimeSniff {

--- a/Userland/Libraries/LibWeb/SVG/AttributeParser.h
+++ b/Userland/Libraries/LibWeb/SVG/AttributeParser.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/Vector.h>
 #include <LibGfx/Point.h>
 

--- a/Userland/Libraries/LibWeb/URL/URL.h
+++ b/Userland/Libraries/LibWeb/URL/URL.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/URL.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/URL/URLSearchParams.h>

--- a/Userland/Services/ChessEngine/MCTSTree.cpp
+++ b/Userland/Services/ChessEngine/MCTSTree.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "MCTSTree.h"
-#include <AK/DeprecatedString.h>
 #include <stdlib.h>
 
 MCTSTree::MCTSTree(Chess::Board const& board, MCTSTree* parent)

--- a/Userland/Services/SQLServer/SQLStatement.h
+++ b/Userland/Services/SQLServer/SQLStatement.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Vector.h>
 #include <LibCore/Object.h>

--- a/Userland/Services/TelnetServer/Client.cpp
+++ b/Userland/Services/TelnetServer/Client.cpp
@@ -7,7 +7,6 @@
 #include "Client.h"
 
 #include <AK/ByteBuffer.h>
-#include <AK/DeprecatedString.h>
 #include <AK/MemoryStream.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>

--- a/Userland/Services/TelnetServer/Client.h
+++ b/Userland/Services/TelnetServer/Client.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
 #include <LibCore/Notifier.h>

--- a/Userland/Services/TelnetServer/Parser.cpp
+++ b/Userland/Services/TelnetServer/Parser.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <AK/Types.h>
 
 #include "Parser.h"

--- a/Userland/Services/TelnetServer/Parser.h
+++ b/Userland/Services/TelnetServer/Parser.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/Function.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>

--- a/Userland/Services/WindowServer/VirtualScreenBackend.h
+++ b/Userland/Services/WindowServer/VirtualScreenBackend.h
@@ -8,7 +8,6 @@
 
 #include "ScreenBackend.h"
 #include "ScreenLayout.h"
-#include <AK/DeprecatedString.h>
 #include <AK/Error.h>
 #include <AK/Span.h>
 

--- a/Userland/Shell/Execution.h
+++ b/Userland/Shell/Execution.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "Forward.h"
-#include <AK/DeprecatedString.h>
 #include <AK/Forward.h>
 #include <AK/Vector.h>
 #include <LibCore/ElapsedTimer.h>

--- a/Userland/Utilities/allocate.cpp
+++ b/Userland/Utilities/allocate.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
+#include <AK/Format.h>
 #include <AK/Optional.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibMain/Main.h>

--- a/Userland/Utilities/date.cpp
+++ b/Userland/Utilities/date.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DateTime.h>
 #include <LibCore/System.h>

--- a/Userland/Utilities/kill.cpp
+++ b/Userland/Utilities/kill.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <AK/Optional.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>

--- a/Userland/Utilities/lsusb.cpp
+++ b/Userland/Utilities/lsusb.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/ByteBuffer.h>
-#include <AK/DeprecatedString.h>
 #include <AK/FixedArray.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>

--- a/Userland/Utilities/seq.cpp
+++ b/Userland/Utilities/seq.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <AK/Format.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Vector.h>

--- a/Userland/Utilities/shuf.cpp
+++ b/Userland/Utilities/shuf.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <AK/Random.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>

--- a/Userland/Utilities/stat.cpp
+++ b/Userland/Utilities/stat.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DateTime.h>
 #include <LibCore/System.h>

--- a/Userland/Utilities/test-fuzz.cpp
+++ b/Userland/Utilities/test-fuzz.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <LibMain/Main.h>

--- a/Userland/Utilities/userdel.cpp
+++ b/Userland/Utilities/userdel.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedString.h>
 #include <LibCore/Account.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DeprecatedFile.h>


### PR DESCRIPTION
I was looking for hotspots that need some love, attention, and DeprecatedString-to-String conversion, and found lots of files with exactly one `#include <AK/DeprecatedString.h>` and no other mention or use of DeprecatedString. So let's get rid of these.