### PR TITLE
Everywhere: Make all headers compile again

### DIFF
--- a/AK/RecursionDecision.h
+++ b/AK/RecursionDecision.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Platform.h>
+
 namespace AK {
 
 enum class RecursionDecision {

--- a/AK/RefCountForwarder.h
+++ b/AK/RefCountForwarder.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Platform.h>
+
 namespace AK {
 
 template<typename T>

--- a/AK/ScopedValueRollback.h
+++ b/AK/ScopedValueRollback.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Platform.h>
+
 namespace AK {
 
 template<typename T>

--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -11,6 +11,12 @@
 #include <AK/StdLibExtras.h>
 #include <AK/TypeList.h>
 
+#if defined(KERNEL)
+#    include <Kernel/Heap/kmalloc.h>
+#else
+#    include <new>
+#endif
+
 namespace AK::Detail {
 
 template<typename T, typename IndexType, IndexType InitialIndex, typename... InTypes>

--- a/Meta/HeaderCheck/CMakeLists.txt
+++ b/Meta/HeaderCheck/CMakeLists.txt
@@ -1,5 +1,5 @@
 execute_process(COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/generate_all.py" "${SERENITY_ARCH}" OUTPUT_VARIABLE SOURCES_STRING)
-string(REPLACE "\n" ";" SOURCES_LIST ${SOURCES_STRING})
+string(REPLACE "\n" ";" SOURCES_LIST "${SOURCES_STRING}")
 
 # TODO: LibSoftGPU does not compile with this warning enabled, so we disable it here.
 # Once LibSoftGPU drops this disable, HeaderCheck should remove it, too. In particular, the following error would be generated:

--- a/Meta/HeaderCheck/generate_all.py
+++ b/Meta/HeaderCheck/generate_all.py
@@ -46,9 +46,17 @@ def generate_part(header):
     verbosely_write(as_filename(header), content)
 
 
+def is_foreign_to(header_name, arch):
+    # FIXME: This is more involved than it seems, since sys/arch/regs.h should never count as "foreign".
+    # Since HeaderCheck needs to be manually enabled anyway, simply assume x86_64.
+    assert arch == "x86_64", "The hardcoded hack broke"
+    return header_name.startswith("Userland/Libraries/LibC/sys/arch/aarch64")
+
+
 def run(root_path, arch):
     os.chdir(root_path)
     headers_list = get_headers_here()
+    headers_list = [h for h in headers_list if not is_foreign_to(h, arch)]
 
     generated_files_path = os.path.join(root_path, 'Build', arch, 'Meta', 'HeaderCheck')
     if not os.path.exists(generated_files_path):

--- a/Userland/Libraries/LibCMake/CMakeCache/Token.h
+++ b/Userland/Libraries/LibCMake/CMakeCache/Token.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibCMake/Position.h>
 
 namespace CMake::Cache {

--- a/Userland/Libraries/LibCore/Process.h
+++ b/Userland/Libraries/LibCore/Process.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AK/DeprecatedString.h>
 #include <AK/Forward.h>
 #include <AK/Span.h>
 

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
@@ -8,11 +8,11 @@
 
 #pragma once
 
-#include "AK/Endian.h"
-#include "AK/Forward.h"
 #include <AK/DeprecatedString.h>
+#include <AK/Endian.h>
 #include <AK/Error.h>
 #include <AK/FixedArray.h>
+#include <AK/Forward.h>
 #include <AK/Span.h>
 
 namespace OpenType {

--- a/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
@@ -10,6 +10,7 @@
 #include <AK/Debug.h>
 #include <AK/Endian.h>
 #include <AK/ScopeGuard.h>
+#include <AK/Stream.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/Types.h>

--- a/Userland/Libraries/LibIPC/Message.h
+++ b/Userland/Libraries/LibIPC/Message.h
@@ -10,6 +10,7 @@
 #include <AK/Error.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
+#include <AK/Vector.h>
 #include <unistd.h>
 
 namespace IPC {

--- a/Userland/Libraries/LibManual/PageNode.h
+++ b/Userland/Libraries/LibManual/PageNode.h
@@ -8,10 +8,9 @@
 
 #include <AK/NonnullRefPtr.h>
 #include <LibManual/Node.h>
+#include <LibManual/SectionNode.h>
 
 namespace Manual {
-
-class SectionNode;
 
 class PageNode : public Node {
 public:

--- a/Userland/Libraries/LibPDF/XRefTable.h
+++ b/Userland/Libraries/LibPDF/XRefTable.h
@@ -11,6 +11,7 @@
 #include <AK/RefCounted.h>
 #include <AK/Vector.h>
 #include <LibPDF/Error.h>
+#include <LibPDF/ObjectDerivatives.h>
 
 namespace PDF {
 

--- a/Userland/Libraries/LibSQL/Index.h
+++ b/Userland/Libraries/LibSQL/Index.h
@@ -10,6 +10,7 @@
 #include <LibSQL/Forward.h>
 #include <LibSQL/Meta.h>
 #include <LibSQL/Serializer.h>
+#include <LibSQL/TupleDescriptor.h>
 
 namespace SQL {
 

--- a/Userland/Libraries/LibSoftGPU/ShaderProcessor.h
+++ b/Userland/Libraries/LibSoftGPU/ShaderProcessor.h
@@ -10,6 +10,7 @@
 #include <AK/SIMD.h>
 #include <AK/Vector.h>
 #include <LibGPU/Config.h>
+#include <LibSoftGPU/ISA.h>
 #include <LibSoftGPU/PixelQuad.h>
 #include <LibSoftGPU/Sampler.h>
 

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AK/Noncopyable.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/Vector.h>
 #include <Kernel/API/KeyCode.h>
 #include <LibVT/CharacterSet.h>

--- a/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.cpp
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "MatroskaDemuxer.h"
-#include "AK/Debug.h"
+#include <AK/Debug.h>
 
 namespace Video::Matroska {
 

--- a/Userland/Libraries/LibVirtGPU/CommandBufferBuilder.cpp
+++ b/Userland/Libraries/LibVirtGPU/CommandBufferBuilder.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <AK/StringView.h>
-#include <Kernel/API/VirGL.h>
 #include <sys/ioctl.h>
 
 #include <LibVirtGPU/CommandBufferBuilder.h>

--- a/Userland/Libraries/LibVirtGPU/CommandBufferBuilder.h
+++ b/Userland/Libraries/LibVirtGPU/CommandBufferBuilder.h
@@ -10,6 +10,7 @@
 
 #include <AK/StringView.h>
 #include <AK/Vector.h>
+#include <Kernel/API/VirGL.h>
 #include <LibGfx/Size.h>
 #include <LibVirtGPU/Commands.h>
 #include <LibVirtGPU/VirGLProtocol.h>

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -12,6 +12,7 @@
 #include <AK/LEB128.h>
 #include <AK/Result.h>
 #include <AK/Variant.h>
+#include <AK/Vector.h>
 #include <LibWasm/Constants.h>
 #include <LibWasm/Forward.h>
 #include <LibWasm/Opcode.h>

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -435,6 +435,7 @@ set(SOURCES
     Painting/FilterPainting.cpp
     Painting/ImagePaintable.cpp
     Painting/InlinePaintable.cpp
+    Painting/InputColors.cpp
     Painting/LabelablePaintable.cpp
     Painting/MarkerPaintable.cpp
     Painting/NestedBrowsingContextPaintable.cpp

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ContentStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ContentStyleValue.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <LibWeb/CSS/StyleValue.h>
+#include <LibWeb/CSS/StyleValues/StyleValueList.h>
 
 namespace Web::CSS {
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/GridAreaShorthandStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/GridAreaShorthandStyleValue.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <LibWeb/CSS/StyleValue.h>
+#include <LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h>
 
 namespace Web::CSS {
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementShorthandStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementShorthandStyleValue.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <LibWeb/CSS/StyleValue.h>
+#include <LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h>
 
 namespace Web::CSS {
 

--- a/Userland/Libraries/LibWeb/Fetch/Body.h
+++ b/Userland/Libraries/LibWeb/Fetch/Body.h
@@ -9,6 +9,7 @@
 #include <AK/Forward.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/GCPtr.h>
+#include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::Fetch {

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <AK/String.h>
 
 namespace Web::MimeSniff {
 

--- a/Userland/Libraries/LibWeb/Page/EditEventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EditEventHandler.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Types.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 
 namespace Web {

--- a/Userland/Libraries/LibWeb/Painting/InputColors.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InputColors.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Painting/InputColors.h>
+
+namespace Web::Painting {
+
+InputColors compute_input_colors(Palette const& palette, Optional<Color> accent_color)
+{
+    // These shades have been picked to work well for all themes and have enough variation to paint
+    // all input states (disabled, enabled, checked, etc).
+    bool dark_theme = palette.is_dark();
+    auto base_text_color = palette.color(ColorRole::BaseText);
+    auto accent = accent_color.value_or(palette.color(ColorRole::Accent));
+    auto base = InputColors::get_shade(base_text_color.inverted(), 0.8f, dark_theme);
+    auto dark_gray = InputColors::get_shade(base_text_color, 0.3f, dark_theme);
+    auto gray = InputColors::get_shade(dark_gray, 0.4f, dark_theme);
+    auto mid_gray = InputColors::get_shade(gray, 0.3f, dark_theme);
+    auto light_gray = InputColors::get_shade(mid_gray, 0.3f, dark_theme);
+    return InputColors {
+        .accent = accent,
+        .base = base,
+        .dark_gray = dark_gray,
+        .gray = gray,
+        .mid_gray = mid_gray,
+        .light_gray = light_gray
+    };
+}
+
+}

--- a/Userland/Libraries/LibWeb/Painting/InputColors.h
+++ b/Userland/Libraries/LibWeb/Painting/InputColors.h
@@ -31,26 +31,6 @@ struct InputColors {
     }
 };
 
-static InputColors compute_input_colors(Palette const& palette, Optional<Color> accent_color)
-{
-    // These shades have been picked to work well for all themes and have enough variation to paint
-    // all input states (disabled, enabled, checked, etc).
-    bool dark_theme = palette.is_dark();
-    auto base_text_color = palette.color(ColorRole::BaseText);
-    auto accent = accent_color.value_or(palette.color(ColorRole::Accent));
-    auto base = InputColors::get_shade(base_text_color.inverted(), 0.8f, dark_theme);
-    auto dark_gray = InputColors::get_shade(base_text_color, 0.3f, dark_theme);
-    auto gray = InputColors::get_shade(dark_gray, 0.4f, dark_theme);
-    auto mid_gray = InputColors::get_shade(gray, 0.3f, dark_theme);
-    auto light_gray = InputColors::get_shade(mid_gray, 0.3f, dark_theme);
-    return InputColors {
-        .accent = accent,
-        .base = base,
-        .dark_gray = dark_gray,
-        .gray = gray,
-        .mid_gray = mid_gray,
-        .light_gray = light_gray
-    };
-}
+InputColors compute_input_colors(Palette const& palette, Optional<Color> accent_color);
 
 }

--- a/Userland/Libraries/LibWeb/RequestIdleCallback/IdleRequest.h
+++ b/Userland/Libraries/LibWeb/RequestIdleCallback/IdleRequest.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/Forward.h>
+#include <AK/Optional.h>
 #include <AK/Types.h>
 
 namespace Web::RequestIdleCallback {

--- a/Userland/Libraries/LibWeb/Streams/UnderlyingSink.h
+++ b/Userland/Libraries/LibWeb/Streams/UnderlyingSink.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Heap/Handle.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::Streams {


### PR DESCRIPTION
Did you know that the following does not compile?

```c++
#include <AK/RecursionDecision.h>
```

But it should! With this PR, all the library headers compile again.

This PR:
- Cleans up badly-formatted includes
- Cleans up an overly strict rule in HeaderCheck (foreign-arch headers cannot be always compiled)
- Adds in missing headers
- Moves an overly-inline function out of line
- Adds in even more missing headers

I handled LibWeb separately because LibWeb has some funky inter-header dependencies. This should make it easier to bisect if something did indeed go wrong.