### PR TITLE
LibVideo+LibWeb: Generalize PlaybackManage for use within LibWeb...and use it

### DIFF
--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
@@ -51,8 +51,6 @@ private:
 
     void toggle_fullscreen();
 
-    void event(Core::Event&) override;
-
     virtual void drop_event(GUI::DropEvent&) override;
 
     DeprecatedString m_path;

--- a/Userland/Libraries/LibVideo/DecoderError.h
+++ b/Userland/Libraries/LibVideo/DecoderError.h
@@ -10,11 +10,10 @@
 #include <AK/Error.h>
 #include <AK/Format.h>
 #include <AK/SourceLocation.h>
+#include <LibVideo/Forward.h>
 #include <errno.h>
 
 namespace Video {
-
-struct DecoderError;
 
 template<typename T>
 using DecoderErrorOr = ErrorOr<T, DecoderError>;
@@ -33,7 +32,7 @@ enum class DecoderErrorCategory : u32 {
     NotImplemented,
 };
 
-struct DecoderError {
+class DecoderError {
 public:
     static DecoderError with_description(DecoderErrorCategory category, StringView description)
     {

--- a/Userland/Libraries/LibVideo/Forward.h
+++ b/Userland/Libraries/LibVideo/Forward.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Video {
+
+class DecoderError;
+class FrameQueueItem;
+class PlaybackManager;
+class Sample;
+class Track;
+class VideoDecoder;
+class VideoFrame;
+
+}

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -314,7 +314,7 @@ protected:
         return {};
     }
 
-    bool m_playing;
+    bool m_playing { false };
 };
 
 class PlaybackManager::StartingStateHandler : public PlaybackManager::ResumingStateHandler {
@@ -362,7 +362,7 @@ class PlaybackManager::StartingStateHandler : public PlaybackManager::ResumingSt
         return {};
     }
 
-    bool m_playing;
+    bool m_playing { false };
 };
 
 class PlaybackManager::PlayingStateHandler : public PlaybackManager::PlaybackStateHandler {

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -47,7 +47,18 @@ private:
 
 DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> PlaybackManager::from_file(StringView filename, PlaybackTimerCreator playback_timer_creator)
 {
-    NonnullOwnPtr<Demuxer> demuxer = TRY(Matroska::MatroskaDemuxer::from_file(filename));
+    auto demuxer = TRY(Matroska::MatroskaDemuxer::from_file(filename));
+    return create_with_demuxer(move(demuxer), move(playback_timer_creator));
+}
+
+DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> PlaybackManager::from_data(ReadonlyBytes data, PlaybackTimerCreator playback_timer_creator)
+{
+    auto demuxer = TRY(Matroska::MatroskaDemuxer::from_data(data));
+    return create_with_demuxer(move(demuxer), move(playback_timer_creator));
+}
+
+DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> PlaybackManager::create_with_demuxer(NonnullOwnPtr<Demuxer> demuxer, PlaybackTimerCreator playback_timer_creator)
+{
     auto video_tracks = TRY(demuxer->get_tracks_for_type(TrackType::Video));
     if (video_tracks.is_empty())
         return DecoderError::with_description(DecoderErrorCategory::Invalid, "No video track is present"sv);

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -25,7 +25,27 @@ namespace Video {
         _fatal_expression.release_value();                                                           \
     })
 
-DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> PlaybackManager::from_file(Core::Object& event_handler, StringView filename)
+class DefaultPlaybackTimer final : public PlaybackTimer {
+public:
+    static ErrorOr<NonnullOwnPtr<DefaultPlaybackTimer>> create(int interval_ms, Function<void()>&& timeout_handler)
+    {
+        auto timer = TRY(Core::Timer::create_single_shot(interval_ms, move(timeout_handler)));
+        return adopt_nonnull_own_or_enomem(new (nothrow) DefaultPlaybackTimer(move(timer)));
+    }
+
+    virtual void start() override { m_timer->start(); }
+    virtual void start(int interval_ms) override { m_timer->start(interval_ms); }
+
+private:
+    explicit DefaultPlaybackTimer(NonnullRefPtr<Core::Timer> timer)
+        : m_timer(move(timer))
+    {
+    }
+
+    NonnullRefPtr<Core::Timer> m_timer;
+};
+
+DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> PlaybackManager::from_file(StringView filename, PlaybackTimerCreator playback_timer_creator)
 {
     NonnullOwnPtr<Demuxer> demuxer = TRY(Matroska::MatroskaDemuxer::from_file(filename));
     auto video_tracks = TRY(demuxer->get_tracks_for_type(TrackType::Video));
@@ -35,20 +55,24 @@ DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> PlaybackManager::from_file(Core::
 
     dbgln_if(PLAYBACK_MANAGER_DEBUG, "Selecting video track number {}", track.identifier());
 
-    return make<PlaybackManager>(event_handler, demuxer, track, make<VP9::Decoder>());
+    return make<PlaybackManager>(demuxer, track, make<VP9::Decoder>(), move(playback_timer_creator));
 }
 
-PlaybackManager::PlaybackManager(Core::Object& event_handler, NonnullOwnPtr<Demuxer>& demuxer, Track video_track, NonnullOwnPtr<VideoDecoder>&& decoder)
-    : m_event_handler(event_handler)
-    , m_main_loop(Core::EventLoop::current())
-    , m_demuxer(move(demuxer))
+PlaybackManager::PlaybackManager(NonnullOwnPtr<Demuxer>& demuxer, Track video_track, NonnullOwnPtr<VideoDecoder>&& decoder, PlaybackTimerCreator playback_timer_creator)
+    : m_demuxer(move(demuxer))
     , m_selected_video_track(video_track)
     , m_decoder(move(decoder))
     , m_frame_queue(make<VideoFrameQueue>())
     , m_playback_handler(make<StartingStateHandler>(*this, false))
 {
-    m_present_timer = Core::Timer::create_single_shot(0, [&] { timer_callback(); }).release_value_but_fixme_should_propagate_errors();
-    m_decode_timer = Core::Timer::create_single_shot(0, [&] { on_decode_timer(); }).release_value_but_fixme_should_propagate_errors();
+    if (playback_timer_creator) {
+        m_present_timer = playback_timer_creator(0, [&] { timer_callback(); }).release_value_but_fixme_should_propagate_errors();
+        m_decode_timer = playback_timer_creator(0, [&] { on_decode_timer(); }).release_value_but_fixme_should_propagate_errors();
+    } else {
+        m_present_timer = DefaultPlaybackTimer::create(0, [&] { timer_callback(); }).release_value_but_fixme_should_propagate_errors();
+        m_decode_timer = DefaultPlaybackTimer::create(0, [&] { on_decode_timer(); }).release_value_but_fixme_should_propagate_errors();
+    }
+
     TRY_OR_FATAL_ERROR(m_playback_handler->on_enter());
 }
 
@@ -84,9 +108,8 @@ void PlaybackManager::dispatch_fatal_error(Error error)
     dbgln_if(PLAYBACK_MANAGER_DEBUG, "Encountered fatal error: {}", error.string_literal());
     // FIXME: For threading, this will have to use a pre-allocated event to send to the main loop
     //        to be able to gracefully handle OOM.
-    VERIFY(&m_main_loop == &Core::EventLoop::current());
-    FatalPlaybackErrorEvent event { move(error) };
-    m_event_handler.dispatch_event(event);
+    if (on_fatal_playback_error)
+        on_fatal_playback_error(move(error));
 }
 
 void PlaybackManager::dispatch_decoder_error(DecoderError error)
@@ -99,14 +122,18 @@ void PlaybackManager::dispatch_decoder_error(DecoderError error)
     default:
         dbgln("Playback error encountered: {}", error.string_literal());
         TRY_OR_FATAL_ERROR(m_playback_handler->stop());
-        m_main_loop.post_event(m_event_handler, make<DecoderErrorEvent>(move(error)));
+
+        if (on_decoder_error)
+            on_decoder_error(move(error));
+
         break;
     }
 }
 
 void PlaybackManager::dispatch_new_frame(RefPtr<Gfx::Bitmap> frame)
 {
-    m_main_loop.post_event(m_event_handler, make<VideoFramePresentEvent>(frame));
+    if (on_video_frame)
+        on_video_frame(move(frame));
 }
 
 bool PlaybackManager::dispatch_frame_queue_item(FrameQueueItem&& item)
@@ -123,7 +150,8 @@ bool PlaybackManager::dispatch_frame_queue_item(FrameQueueItem&& item)
 
 void PlaybackManager::dispatch_state_change()
 {
-    m_main_loop.post_event(m_event_handler, TRY_OR_FATAL_ERROR(try_make<PlaybackStateChangeEvent>()));
+    if (on_playback_state_change)
+        on_playback_state_change();
 }
 
 void PlaybackManager::timer_callback()

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -23,7 +23,8 @@
 
 namespace Video {
 
-struct FrameQueueItem {
+class FrameQueueItem {
+public:
     static constexpr Time no_timestamp = Time::min();
 
     enum class Type {

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -156,7 +156,7 @@ private:
     NonnullOwnPtr<PlaybackStateHandler> m_playback_handler;
     Optional<FrameQueueItem> m_next_frame;
 
-    u64 m_skipped_frames;
+    u64 m_skipped_frames { 0 };
 
     // This is a nested class to allow private access.
     class PlaybackStateHandler {

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -11,7 +11,6 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Queue.h>
 #include <AK/Time.h>
-#include <LibCore/EventLoop.h>
 #include <LibCore/SharedCircularQueue.h>
 #include <LibGfx/Bitmap.h>
 #include <LibThreading/ConditionVariable.h>
@@ -83,6 +82,14 @@ private:
 static constexpr size_t FRAME_BUFFER_COUNT = 4;
 using VideoFrameQueue = Queue<FrameQueueItem, FRAME_BUFFER_COUNT>;
 
+class PlaybackTimer {
+public:
+    virtual ~PlaybackTimer() = default;
+
+    virtual void start() = 0;
+    virtual void start(int interval_ms) = 0;
+};
+
 class PlaybackManager {
 public:
     enum class SeekMode {
@@ -92,9 +99,11 @@ public:
 
     static constexpr SeekMode DEFAULT_SEEK_MODE = SeekMode::Accurate;
 
-    static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_file(Core::Object& event_handler, StringView file);
+    using PlaybackTimerCreator = Function<ErrorOr<NonnullOwnPtr<PlaybackTimer>>(int, Function<void()>)>;
 
-    PlaybackManager(Core::Object& event_handler, NonnullOwnPtr<Demuxer>& demuxer, Track video_track, NonnullOwnPtr<VideoDecoder>&& decoder);
+    static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_file(StringView file, PlaybackTimerCreator = nullptr);
+
+    PlaybackManager(NonnullOwnPtr<Demuxer>& demuxer, Track video_track, NonnullOwnPtr<VideoDecoder>&& decoder, PlaybackTimerCreator);
 
     void resume_playback();
     void pause_playback();
@@ -110,7 +119,10 @@ public:
     Time current_playback_time();
     Time duration();
 
-    Function<void(NonnullRefPtr<Gfx::Bitmap>, Time)> on_frame_present;
+    Function<void(RefPtr<Gfx::Bitmap>)> on_video_frame;
+    Function<void()> on_playback_state_change;
+    Function<void(DecoderError)> on_decoder_error;
+    Function<void(Error)> on_fatal_playback_error;
 
 private:
     class PlaybackStateHandler;
@@ -137,9 +149,6 @@ private:
     void dispatch_state_change();
     void dispatch_fatal_error(Error);
 
-    Core::Object& m_event_handler;
-    Core::EventLoop& m_main_loop;
-
     Time m_last_present_in_media_time = Time::zero();
 
     NonnullOwnPtr<Demuxer> m_demuxer;
@@ -148,10 +157,10 @@ private:
 
     NonnullOwnPtr<VideoFrameQueue> m_frame_queue;
 
-    RefPtr<Core::Timer> m_present_timer;
+    OwnPtr<PlaybackTimer> m_present_timer;
     unsigned m_decoding_buffer_time_ms = 16;
 
-    RefPtr<Core::Timer> m_decode_timer;
+    OwnPtr<PlaybackTimer> m_decode_timer;
 
     NonnullOwnPtr<PlaybackStateHandler> m_playback_handler;
     Optional<FrameQueueItem> m_next_frame;
@@ -199,67 +208,6 @@ private:
         bool m_has_exited { false };
 #endif
     };
-};
-
-enum EventType : unsigned {
-    DecoderErrorOccurred = (('v' << 2) | ('i' << 1) | 'd') << 4,
-    VideoFramePresent,
-    PlaybackStateChange,
-    FatalPlaybackError,
-};
-
-class DecoderErrorEvent : public Core::Event {
-public:
-    explicit DecoderErrorEvent(DecoderError error)
-        : Core::Event(DecoderErrorOccurred)
-        , m_error(move(error))
-    {
-    }
-    virtual ~DecoderErrorEvent() = default;
-
-    DecoderError const& error() { return m_error; }
-
-private:
-    DecoderError m_error;
-};
-
-class VideoFramePresentEvent : public Core::Event {
-public:
-    VideoFramePresentEvent() = default;
-    explicit VideoFramePresentEvent(RefPtr<Gfx::Bitmap> frame)
-        : Core::Event(VideoFramePresent)
-        , m_frame(move(frame))
-    {
-    }
-    virtual ~VideoFramePresentEvent() = default;
-
-    RefPtr<Gfx::Bitmap> frame() { return m_frame; }
-
-private:
-    RefPtr<Gfx::Bitmap> m_frame;
-};
-
-class PlaybackStateChangeEvent : public Core::Event {
-public:
-    explicit PlaybackStateChangeEvent()
-        : Core::Event(PlaybackStateChange)
-    {
-    }
-    virtual ~PlaybackStateChangeEvent() = default;
-};
-
-class FatalPlaybackErrorEvent : public Core::Event {
-public:
-    explicit FatalPlaybackErrorEvent(Error error)
-        : Core::Event(FatalPlaybackError)
-        , m_error(move(error))
-    {
-    }
-    virtual ~FatalPlaybackErrorEvent() = default;
-    Error const& error() { return m_error; }
-
-private:
-    Error m_error;
 };
 
 }

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -102,6 +102,7 @@ public:
     using PlaybackTimerCreator = Function<ErrorOr<NonnullOwnPtr<PlaybackTimer>>(int, Function<void()>)>;
 
     static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_file(StringView file, PlaybackTimerCreator = nullptr);
+    static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_data(ReadonlyBytes data, PlaybackTimerCreator = nullptr);
 
     PlaybackManager(NonnullOwnPtr<Demuxer>& demuxer, Track video_track, NonnullOwnPtr<VideoDecoder>&& decoder, PlaybackTimerCreator);
 
@@ -134,6 +135,8 @@ private:
     class BufferingStateHandler;
     class SeekingStateHandler;
     class StoppedStateHandler;
+
+    static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> create_with_demuxer(NonnullOwnPtr<Demuxer> demuxer, PlaybackTimerCreator playback_timer_creator);
 
     void start_timer(int milliseconds);
     void timer_callback();

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -125,6 +125,8 @@ public:
     Function<void(DecoderError)> on_decoder_error;
     Function<void(Error)> on_fatal_playback_error;
 
+    Track const& selected_video_track() const { return m_selected_video_track; }
+
 private:
     class PlaybackStateHandler;
     // Abstract class to allow resuming play/pause after the state is completed.

--- a/Userland/Libraries/LibVideo/Track.h
+++ b/Userland/Libraries/LibVideo/Track.h
@@ -20,7 +20,7 @@ enum class TrackType : u32 {
     Subtitles,
 };
 
-struct Track {
+class Track {
     struct VideoData {
         Time duration {};
         u64 pixel_width { 0 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -28,6 +28,8 @@ public:
     u32 video_height() const;
 
     void set_video_track(JS::GCPtr<VideoTrack>);
+
+    void set_current_frame(Badge<VideoTrack>, RefPtr<Gfx::Bitmap> frame);
     RefPtr<Gfx::Bitmap> const& current_frame() const { return m_current_frame; }
 
 private:
@@ -42,7 +44,6 @@ private:
     virtual void on_paused() override;
 
     JS::GCPtr<HTML::VideoTrack> m_video_track;
-    RefPtr<Platform::Timer> m_video_timer;
     RefPtr<Gfx::Bitmap> m_current_frame;
 
     u32 m_video_width { 0 };

--- a/Userland/Libraries/LibWeb/HTML/VideoTrack.h
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrack.h
@@ -9,9 +9,7 @@
 #include <AK/String.h>
 #include <AK/Time.h>
 #include <LibGfx/Forward.h>
-#include <LibVideo/Containers/Matroska/MatroskaDemuxer.h>
-#include <LibVideo/Track.h>
-#include <LibVideo/VP9/Decoder.h>
+#include <LibVideo/Forward.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 
 namespace Web::HTML {
@@ -24,11 +22,12 @@ public:
 
     void set_video_track_list(Badge<VideoTrackList>, JS::GCPtr<VideoTrackList> video_track_list) { m_video_track_list = video_track_list; }
 
-    RefPtr<Gfx::Bitmap> next_frame();
+    void play_video(Badge<HTMLVideoElement>);
+    void pause_video(Badge<HTMLVideoElement>);
 
-    Time duration() const { return m_track.video_data().duration; }
-    u64 pixel_width() const { return m_track.video_data().pixel_width; }
-    u64 pixel_height() const { return m_track.video_data().pixel_height; }
+    Time duration() const;
+    u64 pixel_width() const;
+    u64 pixel_height() const;
 
     String const& id() const { return m_id; }
     String const& kind() const { return m_kind; }
@@ -39,7 +38,7 @@ public:
     void set_selected(bool selected);
 
 private:
-    explicit VideoTrack(JS::Realm&, JS::NonnullGCPtr<HTMLMediaElement>, NonnullOwnPtr<Video::Matroska::MatroskaDemuxer>, Video::Track);
+    VideoTrack(JS::Realm&, JS::NonnullGCPtr<HTMLMediaElement>, NonnullOwnPtr<Video::PlaybackManager>);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -62,9 +61,7 @@ private:
     JS::NonnullGCPtr<HTMLMediaElement> m_media_element;
     JS::GCPtr<VideoTrackList> m_video_track_list;
 
-    NonnullOwnPtr<Video::Matroska::MatroskaDemuxer> m_demuxer;
-    Video::VP9::Decoder m_decoder;
-    Video::Track m_track;
+    NonnullOwnPtr<Video::PlaybackManager> m_playback_manager;
 };
 
 }


### PR DESCRIPTION
This has several advantages over the current manual demuxing currently
being performed. PlaybackManager hides the specific demuxer being used,
which will allow more codecs to be added transparently to LibWeb. It
also provides buffering and controls playback rate for us.

Further, it will allow us to much more easily implement the "media
timeline" to render a timestamp and implement seeking.