### PR TITLE
LibWeb: Convert video control dimensions from CSSPixels to DevicePixels

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/VideoPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/VideoPaintable.cpp
@@ -86,9 +86,9 @@ void VideoPaintable::paint(PaintContext& context, PaintPhase phase) const
 
 void VideoPaintable::paint_loaded_video_controls(PaintContext& context, HTML::HTMLVideoElement const& video_element, DevicePixelRect video_rect, Optional<DevicePixelPoint> const& mouse_position) const
 {
-    static constexpr DevicePixels maximum_control_box_size = 60;
-    static constexpr DevicePixels maximum_playback_button_size = 30;
-    static constexpr DevicePixels maximum_playback_button_offset_x = 30;
+    auto maximum_control_box_size = context.rounded_device_pixels(30);
+    auto maximum_playback_button_size = context.rounded_device_pixels(15);
+    auto maximum_playback_button_offset_x = context.rounded_device_pixels(15);
 
     auto is_hovered = document().hovered_node() == &video_element;
     auto is_paused = video_element.paused();
@@ -141,8 +141,8 @@ void VideoPaintable::paint_loaded_video_controls(PaintContext& context, HTML::HT
 
 void VideoPaintable::paint_placeholder_video_controls(PaintContext& context, DevicePixelRect video_rect, Optional<DevicePixelPoint> const& mouse_position) const
 {
-    static constexpr DevicePixels maximum_control_box_size = 200;
-    static constexpr DevicePixels maximum_playback_button_size = 80;
+    auto maximum_control_box_size = context.rounded_device_pixels(100);
+    auto maximum_playback_button_size = context.rounded_device_pixels(40);
 
     auto center = video_rect.center();
 


### PR DESCRIPTION
Rather than storing static DevicePixels dimensions, treat the desired pixel sizes as CSSPixels and convert them to DevicePixels.

This was originally developed on a mac with a device-to-CSS-pixel ratio of 2. Running it on another machine with a ratio of 1 made the controls appear huge.