### PR TITLE
LibWeb+AK: Get Google Street View working, along with SVG viewboxes, transforms, scaling, and hit testing!

### DIFF
--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -47,20 +47,32 @@ URL URL::complete_url(StringView relative_url) const
     return URLParser::parse(relative_url, *this);
 }
 
+// NOTE: This only exists for compatibility with the existing URL tests which check for both .is_null() and .is_empty().
+static DeprecatedString deprecated_string_percent_encode(DeprecatedString const& input, URL::PercentEncodeSet set = URL::PercentEncodeSet::Userinfo, URL::SpaceAsPlus space_as_plus = URL::SpaceAsPlus::No)
+{
+    if (input.is_null() || input.is_empty())
+        return input;
+    return URL::percent_encode(input.view(), set, space_as_plus);
+}
+
 void URL::set_scheme(DeprecatedString scheme)
 {
     m_scheme = move(scheme);
     m_valid = compute_validity();
 }
 
-void URL::set_username(DeprecatedString username)
+void URL::set_username(DeprecatedString username, ApplyPercentEncoding apply_percent_encoding)
 {
+    if (apply_percent_encoding == ApplyPercentEncoding::Yes)
+        username = deprecated_string_percent_encode(username, PercentEncodeSet::Userinfo);
     m_username = move(username);
     m_valid = compute_validity();
 }
 
-void URL::set_password(DeprecatedString password)
+void URL::set_password(DeprecatedString password, ApplyPercentEncoding apply_percent_encoding)
 {
+    if (apply_percent_encoding == ApplyPercentEncoding::Yes)
+        password = deprecated_string_percent_encode(password, PercentEncodeSet::Userinfo);
     m_password = move(password);
     m_valid = compute_validity();
 }
@@ -81,19 +93,38 @@ void URL::set_port(Optional<u16> port)
     m_valid = compute_validity();
 }
 
-void URL::set_paths(Vector<DeprecatedString> paths)
+void URL::set_paths(Vector<DeprecatedString> paths, ApplyPercentEncoding apply_percent_encoding)
 {
-    m_paths = move(paths);
+    if (apply_percent_encoding == ApplyPercentEncoding::Yes) {
+        Vector<DeprecatedString> encoded_paths;
+        encoded_paths.ensure_capacity(paths.size());
+        for (auto& segment : paths)
+            encoded_paths.unchecked_append(deprecated_string_percent_encode(segment, PercentEncodeSet::Path));
+        m_paths = move(encoded_paths);
+    } else {
+        m_paths = move(paths);
+    }
     m_valid = compute_validity();
 }
 
-void URL::set_query(DeprecatedString query)
+void URL::append_path(DeprecatedString path, ApplyPercentEncoding apply_percent_encoding)
 {
+    if (apply_percent_encoding == ApplyPercentEncoding::Yes)
+        path = deprecated_string_percent_encode(path, PercentEncodeSet::Path);
+    m_paths.append(path);
+}
+
+void URL::set_query(DeprecatedString query, ApplyPercentEncoding apply_percent_encoding)
+{
+    if (apply_percent_encoding == ApplyPercentEncoding::Yes)
+        query = deprecated_string_percent_encode(query, is_special() ? PercentEncodeSet::SpecialQuery : PercentEncodeSet::Query);
     m_query = move(query);
 }
 
-void URL::set_fragment(DeprecatedString fragment)
+void URL::set_fragment(DeprecatedString fragment, ApplyPercentEncoding apply_percent_encoding)
 {
+    if (apply_percent_encoding == ApplyPercentEncoding::Yes)
+        fragment = deprecated_string_percent_encode(fragment, PercentEncodeSet::Fragment);
     m_fragment = move(fragment);
 }
 
@@ -171,9 +202,8 @@ URL URL::create_with_file_scheme(DeprecatedString const& path, DeprecatedString 
     //       This is because a file URL always needs a non-null hostname.
     url.set_host(hostname.is_null() || hostname == "localhost" ? DeprecatedString::empty() : hostname);
     url.set_paths(lexical_path.parts());
-    // NOTE: To indicate that we want to end the path with a slash, we have to append an empty path segment.
     if (path.ends_with('/'))
-        url.append_path("");
+        url.append_slash();
     url.set_fragment(fragment);
     return url;
 }
@@ -188,9 +218,8 @@ URL URL::create_with_help_scheme(DeprecatedString const& path, DeprecatedString 
     //       This is because a file URL always needs a non-null hostname.
     url.set_host(hostname.is_null() || hostname == "localhost" ? DeprecatedString::empty() : hostname);
     url.set_paths(lexical_path.parts());
-    // NOTE: To indicate that we want to end the path with a slash, we have to append an empty path segment.
     if (path.ends_with('/'))
-        url.append_path("");
+        url.append_slash();
     url.set_fragment(fragment);
     return url;
 }
@@ -242,10 +271,10 @@ DeprecatedString URL::serialize(ExcludeFragment exclude_fragment) const
         builder.append("//"sv);
 
         if (includes_credentials()) {
-            builder.append(percent_encode(m_username, PercentEncodeSet::Userinfo));
+            builder.append(m_username);
             if (!m_password.is_empty()) {
                 builder.append(':');
-                builder.append(percent_encode(m_password, PercentEncodeSet::Userinfo));
+                builder.append(m_password);
             }
             builder.append('@');
         }
@@ -256,24 +285,24 @@ DeprecatedString URL::serialize(ExcludeFragment exclude_fragment) const
     }
 
     if (cannot_be_a_base_url()) {
-        builder.append(percent_encode(m_paths[0], PercentEncodeSet::Path));
+        builder.append(m_paths[0]);
     } else {
         if (m_host.is_null() && m_paths.size() > 1 && m_paths[0].is_empty())
             builder.append("/."sv);
         for (auto& segment : m_paths) {
             builder.append('/');
-            builder.append(percent_encode(segment, PercentEncodeSet::Path));
+            builder.append(segment);
         }
     }
 
     if (!m_query.is_null()) {
         builder.append('?');
-        builder.append(percent_encode(m_query, is_special() ? URL::PercentEncodeSet::SpecialQuery : URL::PercentEncodeSet::Query));
+        builder.append(m_query);
     }
 
     if (exclude_fragment == ExcludeFragment::No && !m_fragment.is_null()) {
         builder.append('#');
-        builder.append(percent_encode(m_fragment, PercentEncodeSet::Fragment));
+        builder.append(m_fragment);
     }
 
     return builder.to_deprecated_string();
@@ -300,24 +329,24 @@ DeprecatedString URL::serialize_for_display() const
     }
 
     if (cannot_be_a_base_url()) {
-        builder.append(percent_encode(m_paths[0], PercentEncodeSet::Path));
+        builder.append(m_paths[0]);
     } else {
         if (m_host.is_null() && m_paths.size() > 1 && m_paths[0].is_empty())
             builder.append("/."sv);
         for (auto& segment : m_paths) {
             builder.append('/');
-            builder.append(percent_encode(segment, PercentEncodeSet::Path));
+            builder.append(segment);
         }
     }
 
     if (!m_query.is_null()) {
         builder.append('?');
-        builder.append(percent_encode(m_query, is_special() ? URL::PercentEncodeSet::SpecialQuery : URL::PercentEncodeSet::Query));
+        builder.append(m_query);
     }
 
     if (!m_fragment.is_null()) {
         builder.append('#');
-        builder.append(percent_encode(m_fragment, PercentEncodeSet::Fragment));
+        builder.append(m_fragment);
     }
 
     return builder.to_deprecated_string();

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -19,8 +19,6 @@
 
 namespace AK {
 
-// NOTE: The member variables cannot contain any percent encoded sequences.
-//       The URL parser automatically decodes those sequences and the serialize() method will re-encode them as necessary.
 class URL {
     friend class URLParser;
 
@@ -70,16 +68,25 @@ public:
     bool includes_credentials() const { return !m_username.is_empty() || !m_password.is_empty(); }
     bool is_special() const { return is_special_scheme(m_scheme); }
 
+    enum class ApplyPercentEncoding {
+        Yes,
+        No
+    };
     void set_scheme(DeprecatedString);
-    void set_username(DeprecatedString);
-    void set_password(DeprecatedString);
+    void set_username(DeprecatedString username, ApplyPercentEncoding apply_percent_encoding = ApplyPercentEncoding::Yes);
+    void set_password(DeprecatedString password, ApplyPercentEncoding apply_percent_encoding = ApplyPercentEncoding::Yes);
     void set_host(DeprecatedString);
     void set_port(Optional<u16>);
-    void set_paths(Vector<DeprecatedString>);
-    void set_query(DeprecatedString);
-    void set_fragment(DeprecatedString);
+    void set_paths(Vector<DeprecatedString> password, ApplyPercentEncoding apply_percent_encoding = ApplyPercentEncoding::Yes);
+    void set_query(DeprecatedString query, ApplyPercentEncoding apply_percent_encoding = ApplyPercentEncoding::Yes);
+    void set_fragment(DeprecatedString fragment, ApplyPercentEncoding apply_percent_encoding = ApplyPercentEncoding::Yes);
     void set_cannot_be_a_base_url(bool value) { m_cannot_be_a_base_url = value; }
-    void append_path(DeprecatedString path) { m_paths.append(move(path)); }
+    void append_path(DeprecatedString path, ApplyPercentEncoding apply_percent_encoding = ApplyPercentEncoding::Yes);
+    void append_slash()
+    {
+        // NOTE: To indicate that we want to end the path with a slash, we have to append an empty path segment.
+        append_path("", ApplyPercentEncoding::No);
+    }
 
     DeprecatedString path() const;
     DeprecatedString basename() const;

--- a/Base/res/html/misc/svg-transforms.html
+++ b/Base/res/html/misc/svg-transforms.html
@@ -1,0 +1,108 @@
+<style>
+  body {
+    margin: 50px;
+  }
+</style>
+<!-- SVG transforms test page, based on MDN examples -->
+<svg
+  width="200px" height="100px"
+  viewBox="0 0 150 100"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <g
+    fill="grey"
+    transform="rotate(-10 50 100)
+               translate(-36 45.5)
+               skewX(40)
+               scale(1 0.5)">
+    <path
+      d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z"
+     />
+  </g>
+  <g
+    fill="none"
+    stroke="red"
+    >
+    <path
+      d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z" />
+  </g>
+</svg>
+<svg width="200px" height="200px" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="10" width="30" height="20" fill="green" />
+  <rect
+    x="10"
+    y="10"
+    width="30"
+    height="20"
+    fill="red"
+    transform="matrix(3 1 -1 3 30 40)" />
+</svg>
+<svg width="200px" height="200px"  viewBox="-5 -5 10 10" xmlns="http://www.w3.org/2000/svg">
+  <rect x="-3" y="-3" width="6" height="6" />
+
+  <rect x="-3" y="-3" width="6" height="6" fill="red" transform="skewX(30)" />
+</svg>
+<svg width="200px" height="200px" viewBox="-12 -2 34 14" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="10" height="10" />
+
+  <!-- rotation is done around the point 0,0 -->
+  <rect x="0" y="0" width="10" height="10" fill="red" transform="rotate(100)" />
+
+  <!-- rotation is done around the point 10,10 -->
+  <rect
+    x="0"
+    y="0"
+    width="10"
+    height="10"
+    fill="green"
+    transform="rotate(100 10 10)" />
+</svg>
+<svg  width="200px" height="200px" viewBox="-50 -50 100 100" xmlns="http://www.w3.org/2000/svg">
+  <!-- uniform scale -->
+  <circle cx="0" cy="0" r="10" fill="red" transform="scale(4)" />
+
+  <!-- vertical scale -->
+  <circle cx="0" cy="0" r="10" fill="yellow" transform="scale(1 4)" />
+
+  <!-- horizontal scale -->
+  <circle cx="0" cy="0" r="10" fill="pink" transform="scale(4 1)" />
+
+  <!-- No scale -->
+  <circle cx="0" cy="0" r="10" fill="black" />
+</svg>
+<svg width="200px" height="200px" viewBox="-5 -5 10 10" xmlns="http://www.w3.org/2000/svg">
+  <rect x="-3" y="-3" width="6" height="6" />
+
+  <rect x="-3" y="-3" width="6" height="6" fill="red" transform="skewY(30)" />
+</svg>
+<svg width="200px" height="200px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <!-- No translation -->
+  <rect x="5" y="5" width="40" height="40" fill="green" />
+
+  <!-- Horizontal translation -->
+  <rect
+    x="5"
+    y="5"
+    width="40"
+    height="40"
+    fill="blue"
+    transform="translate(50)" />
+
+  <!-- Vertical translation -->
+  <rect
+    x="5"
+    y="5"
+    width="40"
+    height="40"
+    fill="red"
+    transform="translate(0 50)" />
+
+  <!-- Both horizontal and vertical translation -->
+  <rect
+    x="5"
+    y="5"
+    width="40"
+    height="40"
+    fill="yellow"
+    transform="translate(50 50)" />
+</svg>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -70,6 +70,7 @@
             <li><a href="images.html">images</a></li>
             <li><a href="pre.html">pre</a></li>
             <li><a href="svg.html">svg</a></li>
+            <li><a href="svg-transforms.html">svg transforms</a></li>
             <li><a href="small.html">small</a></li>
             <li><a href="link.html">link</a></li>
             <li><a href="afrag.html">links with fragments</a></li>

--- a/Tests/AK/TestURL.cpp
+++ b/Tests/AK/TestURL.cpp
@@ -151,7 +151,7 @@ TEST_CASE(file_url_with_encoded_characters)
     URL url("file:///my/file/test%23file.txt"sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "file");
-    EXPECT_EQ(url.path(), "/my/file/test#file.txt");
+    EXPECT_EQ(url.path(), "/my/file/test%23file.txt");
     EXPECT(url.query().is_null());
     EXPECT(url.fragment().is_null());
 }
@@ -389,7 +389,7 @@ TEST_CASE(unicode)
 {
     URL url { "http://example.com/_ünicöde_téxt_©"sv };
     EXPECT(url.is_valid());
-    EXPECT_EQ(url.path(), "/_ünicöde_téxt_©");
+    EXPECT_EQ(url.path(), "/_%C3%BCnic%C3%B6de_t%C3%A9xt_%C2%A9");
     EXPECT(url.query().is_null());
     EXPECT(url.fragment().is_null());
 }
@@ -414,4 +414,11 @@ TEST_CASE(empty_url_with_base_url)
     URL parsed_url = URLParser::parse(""sv, base_url);
     EXPECT_EQ(parsed_url.is_valid(), true);
     EXPECT(base_url.equals(parsed_url));
+}
+
+TEST_CASE(google_street_view)
+{
+    constexpr auto streetview_url = "https://www.google.co.uk/maps/@53.3354159,-1.9573545,3a,75y,121.1h,75.67t/data=!3m7!1e1!3m5!1sSY8xCv17jAX4S7SRdV38hg!2e0!6shttps:%2F%2Fstreetviewpixels-pa.googleapis.com%2Fv1%2Fthumbnail%3Fpanoid%3DSY8xCv17jAX4S7SRdV38hg%26cb_client%3Dmaps_sv.tactile.gps%26w%3D203%26h%3D100%26yaw%3D188.13148%26pitch%3D0%26thumbfov%3D100!7i13312!8i6656";
+    URL url(streetview_url);
+    EXPECT_EQ(url.serialize(), streetview_url);
 }

--- a/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
+++ b/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
@@ -1,0 +1,96 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x700 children: not-inline
+    BlockContainer <body> at (50,50) content-size 700x600 children: inline
+      line 0 width: 616, height: 203.46875, bottom: 203.46875, baseline: 200
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [50,150 200x100]
+        frag 1 from TextNode start: 0, length: 1, rect: [250,236 8x17.46875]
+          " "
+        frag 2 from SVGSVGBox start: 0, length: 0, rect: [258,50 200x200]
+        frag 3 from TextNode start: 0, length: 1, rect: [458,236 8x17.46875]
+          " "
+        frag 4 from SVGSVGBox start: 0, length: 0, rect: [466,50 200x200]
+      line 1 width: 616, height: 203.46875, bottom: 403.46875, baseline: 200
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [50,250 200x200]
+        frag 1 from TextNode start: 0, length: 1, rect: [250,436 8x17.46875]
+          " "
+        frag 2 from SVGSVGBox start: 0, length: 0, rect: [258,250 200x200]
+        frag 3 from TextNode start: 0, length: 1, rect: [458,436 8x17.46875]
+          " "
+        frag 4 from SVGSVGBox start: 0, length: 0, rect: [466,250 200x200]
+      line 2 width: 200, height: 200, bottom: 600, baseline: 200
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [50,450 200x200]
+      SVGSVGBox <svg> at (50,150) content-size 200x100 children: inline
+        TextNode <#text>
+        SVGGraphicsBox <g>  children: inline
+          TextNode <#text>
+          SVGGeometryBox <path> at (45.193222,199.330932) content-size 119.782173x48.453796 children: not-inline
+          TextNode <#text>
+        TextNode <#text>
+        SVGGraphicsBox <g>  children: inline
+          TextNode <#text>
+          SVGGeometryBox <path> at (84.5,159.504882) content-size 81x80.995117 children: not-inline
+          TextNode <#text>
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (258,50) content-size 200x200 children: inline
+        TextNode <#text>
+        SVGGeometryBox <rect> at (267.5,59.5) content-size 31x21 children: not-inline
+        TextNode <#text>
+        SVGGeometryBox <rect> at (287.5,129.5) content-size 111x91 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (466,50) content-size 200x200 children: inline
+        TextNode <#text>
+        SVGGeometryBox <rect> at (505.5,89.5) content-size 121x121 children: not-inline
+        TextNode <#text>
+        SVGGeometryBox <rect> at (470.858978,89.5) content-size 190.282043x121 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (50,250) content-size 200x200 children: inline
+        TextNode <#text>
+        SVGGeometryBox <rect> at (120.088233,320.088256) content-size 59.823524x59.823528 children: not-inline
+        TextNode <#text>
+        TextNode <#text>
+        SVGGeometryBox <rect> at (51.943771,309.873626) content-size 69.144462x69.144454 children: not-inline
+        TextNode <#text>
+        TextNode <#text>
+        SVGGeometryBox <rect> at (178.911773,320.981903) content-size 69.14447x69.144462 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (258,250) content-size 200x200 children: inline
+        TextNode <#text>
+        TextNode <#text>
+        SVGGeometryBox <circle> at (277.5,269.5) content-size 161x161 children: not-inline
+        TextNode <#text>
+        TextNode <#text>
+        SVGGeometryBox <circle> at (337.5,269.5) content-size 41x161 children: not-inline
+        TextNode <#text>
+        TextNode <#text>
+        SVGGeometryBox <circle> at (277.5,329.5) content-size 161x41 children: not-inline
+        TextNode <#text>
+        TextNode <#text>
+        SVGGeometryBox <circle> at (337.5,329.5) content-size 41x41 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (466,250) content-size 200x200 children: inline
+        TextNode <#text>
+        SVGGeometryBox <rect> at (505.5,289.5) content-size 121x121 children: not-inline
+        TextNode <#text>
+        SVGGeometryBox <rect> at (505.5,254.858978) content-size 121x190.282043 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (50,450) content-size 200x200 children: inline
+        TextNode <#text>
+        TextNode <#text>
+        SVGGeometryBox <rect> at (59.5,459.5) content-size 81x81 children: not-inline
+        TextNode <#text>
+        TextNode <#text>
+        SVGGeometryBox <rect> at (159.5,459.5) content-size 81x81 children: not-inline
+        TextNode <#text>
+        TextNode <#text>
+        SVGGeometryBox <rect> at (59.5,559.5) content-size 81x81 children: not-inline
+        TextNode <#text>
+        TextNode <#text>
+        SVGGeometryBox <rect> at (159.5,559.5) content-size 81x81 children: not-inline
+        TextNode <#text>
+      TextNode <#text>

--- a/Tests/LibWeb/Layout/input/svg-transforms-and-viewboxes.html
+++ b/Tests/LibWeb/Layout/input/svg-transforms-and-viewboxes.html
@@ -1,0 +1,111 @@
+<style>
+  body {
+    margin: 50px;
+  }
+  * {
+    font-family: 'SerenitySans';
+  }
+</style>
+<!-- SVG transforms test page, based on MDN examples -->
+<svg
+  width="200px" height="100px"
+  viewBox="0 0 150 100"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <g
+    fill="grey"
+    transform="rotate(-10 50 100)
+               translate(-36 45.5)
+               skewX(40)
+               scale(1 0.5)">
+    <path
+      d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z"
+     />
+  </g>
+  <g
+    fill="none"
+    stroke="red"
+    >
+    <path
+      d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z" />
+  </g>
+</svg>
+<svg width="200px" height="200px" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="10" width="30" height="20" fill="green" />
+  <rect
+    x="10"
+    y="10"
+    width="30"
+    height="20"
+    fill="red"
+    transform="matrix(3 1 -1 3 30 40)" />
+</svg>
+<svg width="200px" height="200px"  viewBox="-5 -5 10 10" xmlns="http://www.w3.org/2000/svg">
+  <rect x="-3" y="-3" width="6" height="6" />
+
+  <rect x="-3" y="-3" width="6" height="6" fill="red" transform="skewX(30)" />
+</svg>
+<svg width="200px" height="200px" viewBox="-12 -2 34 14" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="10" height="10" />
+
+  <!-- rotation is done around the point 0,0 -->
+  <rect x="0" y="0" width="10" height="10" fill="red" transform="rotate(100)" />
+
+  <!-- rotation is done around the point 10,10 -->
+  <rect
+    x="0"
+    y="0"
+    width="10"
+    height="10"
+    fill="green"
+    transform="rotate(100 10 10)" />
+</svg>
+<svg  width="200px" height="200px" viewBox="-50 -50 100 100" xmlns="http://www.w3.org/2000/svg">
+  <!-- uniform scale -->
+  <circle cx="0" cy="0" r="10" fill="red" transform="scale(4)" />
+
+  <!-- vertical scale -->
+  <circle cx="0" cy="0" r="10" fill="yellow" transform="scale(1 4)" />
+
+  <!-- horizontal scale -->
+  <circle cx="0" cy="0" r="10" fill="pink" transform="scale(4 1)" />
+
+  <!-- No scale -->
+  <circle cx="0" cy="0" r="10" fill="black" />
+</svg>
+<svg width="200px" height="200px" viewBox="-5 -5 10 10" xmlns="http://www.w3.org/2000/svg">
+  <rect x="-3" y="-3" width="6" height="6" />
+
+  <rect x="-3" y="-3" width="6" height="6" fill="red" transform="skewY(30)" />
+</svg>
+<svg width="200px" height="200px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <!-- No translation -->
+  <rect x="5" y="5" width="40" height="40" fill="green" />
+
+  <!-- Horizontal translation -->
+  <rect
+    x="5"
+    y="5"
+    width="40"
+    height="40"
+    fill="blue"
+    transform="translate(50)" />
+
+  <!-- Vertical translation -->
+  <rect
+    x="5"
+    y="5"
+    width="40"
+    height="40"
+    fill="red"
+    transform="translate(0 50)" />
+
+  <!-- Both horizontal and vertical translation -->
+  <rect
+    x="5"
+    y="5"
+    width="40"
+    height="40"
+    fill="yellow"
+    transform="translate(50 50)" />
+</svg>

--- a/Userland/Libraries/LibGfx/AffineTransform.cpp
+++ b/Userland/Libraries/LibGfx/AffineTransform.cpp
@@ -79,6 +79,13 @@ AffineTransform& AffineTransform::set_scale(FloatPoint s)
     return set_scale(s.x(), s.y());
 }
 
+AffineTransform& AffineTransform::skew_radians(float x_radians, float y_radians)
+{
+    AffineTransform skew_transform(1, AK::tan(y_radians), AK::tan(x_radians), 1, 0, 0);
+    multiply(skew_transform);
+    return *this;
+}
+
 AffineTransform& AffineTransform::translate(float tx, float ty)
 {
     m_values[4] += tx * m_values[0] + ty * m_values[2];

--- a/Userland/Libraries/LibGfx/AffineTransform.h
+++ b/Userland/Libraries/LibGfx/AffineTransform.h
@@ -64,6 +64,7 @@ public:
     AffineTransform& set_translation(float tx, float ty);
     AffineTransform& set_translation(FloatPoint t);
     AffineTransform& rotate_radians(float);
+    AffineTransform& skew_radians(float x_radians, float y_radians);
     AffineTransform& multiply(AffineTransform const&);
 
     Optional<AffineTransform> inverse() const;

--- a/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
@@ -25,7 +25,7 @@ CSSPixelPoint SVGGeometryBox::viewbox_origin() const
     return { svg_box->view_box().value().min_x, svg_box->view_box().value().min_y };
 }
 
-Gfx::AffineTransform SVGGeometryBox::layout_transform() const
+Optional<Gfx::AffineTransform> SVGGeometryBox::layout_transform() const
 {
     auto& geometry_element = dom_node();
     auto transform = geometry_element.get_transform();
@@ -37,9 +37,12 @@ Gfx::AffineTransform SVGGeometryBox::layout_transform() const
         // Note: SVGFormattingContext has already done the scaling based on the viewbox,
         // we now have to derive what it was from the original bounding box size.
         // FIXME: It would be nice if we could store the transform from layout somewhere, so we don't have to solve for it here.
+        auto original_bounding_box = Gfx::AffineTransform {}.translate(-origin).multiply(transform).map(const_cast<SVG::SVGGeometryElement&>(geometry_element).get_path().bounding_box());
+        // If the transform (or path) results in a empty box we can't display this.
+        if (original_bounding_box.is_empty())
+            return {};
         auto scaled_width = paint_box()->content_width().value();
         auto scaled_height = paint_box()->content_height().value();
-        auto original_bounding_box = Gfx::AffineTransform {}.translate(-origin).multiply(transform).map(const_cast<SVG::SVGGeometryElement&>(geometry_element).get_path().bounding_box());
         scaling = min(scaled_width / original_bounding_box.width(), scaled_height / original_bounding_box.height());
         auto scaled_bounding_box = original_bounding_box.scaled(scaling, scaling);
         paint_offset = (paint_box()->absolute_rect().location() - svg_box->paint_box()->absolute_rect().location()).to_type<float>() - scaled_bounding_box.location();

--- a/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
@@ -17,33 +17,34 @@ SVGGeometryBox::SVGGeometryBox(DOM::Document& document, SVG::SVGGeometryElement&
 {
 }
 
-float SVGGeometryBox::viewbox_scaling() const
-{
-    auto* svg_box = dom_node().first_ancestor_of_type<SVG::SVGSVGElement>();
-
-    if (!svg_box || !svg_box->view_box().has_value())
-        return 1;
-
-    auto view_box = svg_box->view_box().value();
-
-    bool has_specified_width = svg_box->has_attribute(HTML::AttributeNames::width);
-    auto specified_width = paint_box()->content_width().value();
-
-    bool has_specified_height = svg_box->has_attribute(HTML::AttributeNames::height);
-    auto specified_height = paint_box()->content_height().value();
-
-    auto scale_width = has_specified_width ? specified_width / view_box.width : 1;
-    auto scale_height = has_specified_height ? specified_height / view_box.height : 1;
-
-    return min(scale_width, scale_height);
-}
-
 CSSPixelPoint SVGGeometryBox::viewbox_origin() const
 {
     auto* svg_box = dom_node().first_ancestor_of_type<SVG::SVGSVGElement>();
     if (!svg_box || !svg_box->view_box().has_value())
         return { 0, 0 };
     return { svg_box->view_box().value().min_x, svg_box->view_box().value().min_y };
+}
+
+Gfx::AffineTransform SVGGeometryBox::layout_transform() const
+{
+    auto& geometry_element = dom_node();
+    auto transform = geometry_element.get_transform();
+    auto* svg_box = geometry_element.first_ancestor_of_type<SVG::SVGSVGElement>();
+    float scaling = 1;
+    auto origin = viewbox_origin().to_type<float>();
+    Gfx::FloatPoint paint_offset = {};
+    if (svg_box && svg_box->view_box().has_value()) {
+        // Note: SVGFormattingContext has already done the scaling based on the viewbox,
+        // we now have to derive what it was from the original bounding box size.
+        // FIXME: It would be nice if we could store the transform from layout somewhere, so we don't have to solve for it here.
+        auto scaled_width = paint_box()->content_width().value();
+        auto scaled_height = paint_box()->content_height().value();
+        auto original_bounding_box = Gfx::AffineTransform {}.translate(-origin).multiply(transform).map(const_cast<SVG::SVGGeometryElement&>(geometry_element).get_path().bounding_box());
+        scaling = min(scaled_width / original_bounding_box.width(), scaled_height / original_bounding_box.height());
+        auto scaled_bounding_box = original_bounding_box.scaled(scaling, scaling);
+        paint_offset = (paint_box()->absolute_rect().location() - svg_box->paint_box()->absolute_rect().location()).to_type<float>() - scaled_bounding_box.location();
+    }
+    return Gfx::AffineTransform {}.translate(paint_offset).scale(scaling, scaling).translate(-origin).multiply(transform);
 }
 
 JS::GCPtr<Painting::Paintable> SVGGeometryBox::create_paintable() const

--- a/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <LibWeb/Layout/SVGGraphicsBox.h>
 #include <LibWeb/SVG/SVGGeometryElement.h>
 
@@ -21,7 +22,7 @@ public:
     SVG::SVGGeometryElement& dom_node() { return static_cast<SVG::SVGGeometryElement&>(SVGGraphicsBox::dom_node()); }
     SVG::SVGGeometryElement const& dom_node() const { return static_cast<SVG::SVGGeometryElement const&>(SVGGraphicsBox::dom_node()); }
 
-    Gfx::AffineTransform layout_transform() const;
+    Optional<Gfx::AffineTransform> layout_transform() const;
 
     virtual JS::GCPtr<Painting::Paintable> create_paintable() const override;
 

--- a/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.h
@@ -21,12 +21,13 @@ public:
     SVG::SVGGeometryElement& dom_node() { return static_cast<SVG::SVGGeometryElement&>(SVGGraphicsBox::dom_node()); }
     SVG::SVGGeometryElement const& dom_node() const { return static_cast<SVG::SVGGeometryElement const&>(SVGGraphicsBox::dom_node()); }
 
-    float viewbox_scaling() const;
-    CSSPixelPoint viewbox_origin() const;
+    Gfx::AffineTransform layout_transform() const;
 
     virtual JS::GCPtr<Painting::Paintable> create_paintable() const override;
 
 private:
+    CSSPixelPoint viewbox_origin() const;
+
     virtual bool is_svg_geometry_box() const final { return true; }
 };
 

--- a/Userland/Libraries/LibWeb/Painting/PaintContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintContext.cpp
@@ -67,6 +67,14 @@ DevicePixelPoint PaintContext::rounded_device_point(CSSPixelPoint point) const
     };
 }
 
+DevicePixelPoint PaintContext::floored_device_point(CSSPixelPoint point) const
+{
+    return {
+        floorf(point.x().value() * m_device_pixels_per_css_pixel),
+        floorf(point.y().value() * m_device_pixels_per_css_pixel)
+    };
+}
+
 DevicePixelRect PaintContext::enclosing_device_rect(CSSPixelRect rect) const
 {
     return {

--- a/Userland/Libraries/LibWeb/Painting/PaintContext.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintContext.h
@@ -42,6 +42,7 @@ public:
     DevicePixels floored_device_pixels(CSSPixels css_pixels) const;
     DevicePixels rounded_device_pixels(CSSPixels css_pixels) const;
     DevicePixelPoint rounded_device_point(CSSPixelPoint) const;
+    DevicePixelPoint floored_device_point(CSSPixelPoint) const;
     DevicePixelRect enclosing_device_rect(CSSPixelRect) const;
     DevicePixelRect rounded_device_rect(CSSPixelRect) const;
     DevicePixelSize enclosing_device_size(CSSPixelSize) const;

--- a/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -49,50 +50,7 @@ void SVGGeometryPaintable::paint(PaintContext& context, PaintPhase phase) const
 
     context.painter().add_clip_rect(context.enclosing_device_rect(absolute_rect()).to_type<int>());
 
-    Gfx::Path path = const_cast<SVG::SVGGeometryElement&>(geometry_element).get_path();
-
-    if (maybe_view_box.has_value()) {
-        Gfx::Path new_path;
-        auto scaling = layout_box().viewbox_scaling();
-        auto origin = layout_box().viewbox_origin();
-
-        auto transform_point = [&scaling, &origin](Gfx::FloatPoint point) -> Gfx::FloatPoint {
-            auto new_point = point;
-            new_point.translate_by({ -origin.x(), -origin.y() });
-            new_point.scale_by(scaling);
-            return new_point;
-        };
-
-        for (auto& segment : path.segments()) {
-            switch (segment->type()) {
-            case Gfx::Segment::Type::Invalid:
-                break;
-            case Gfx::Segment::Type::MoveTo:
-                new_path.move_to(transform_point(segment->point()));
-                break;
-            case Gfx::Segment::Type::LineTo:
-                new_path.line_to(transform_point(segment->point()));
-                break;
-            case Gfx::Segment::Type::QuadraticBezierCurveTo: {
-                auto& quadratic_bezier_segment = static_cast<Gfx::QuadraticBezierCurveSegment const&>(*segment);
-                new_path.quadratic_bezier_curve_to(transform_point(quadratic_bezier_segment.through()), transform_point(quadratic_bezier_segment.point()));
-                break;
-            }
-            case Gfx::Segment::Type::CubicBezierCurveTo: {
-                auto& cubic_bezier_segment = static_cast<Gfx::CubicBezierCurveSegment const&>(*segment);
-                new_path.cubic_bezier_curve_to(transform_point(cubic_bezier_segment.through_0()), transform_point(cubic_bezier_segment.through_1()), transform_point(cubic_bezier_segment.point()));
-                break;
-            }
-            case Gfx::Segment::Type::EllipticalArcTo: {
-                auto& elliptical_arc_segment = static_cast<Gfx::EllipticalArcSegment const&>(*segment);
-                new_path.elliptical_arc_to(transform_point(elliptical_arc_segment.point()), elliptical_arc_segment.radii().scaled_by(scaling, scaling), elliptical_arc_segment.x_axis_rotation(), elliptical_arc_segment.large_arc(), elliptical_arc_segment.sweep());
-                break;
-            }
-            }
-        }
-
-        path = new_path;
-    }
+    Gfx::Path path = const_cast<SVG::SVGGeometryElement&>(geometry_element).get_path().copy_transformed(Gfx::AffineTransform {}.multiply(layout_box().layout_transform()));
 
     if (auto fill_color = geometry_element.fill_color().value_or(svg_context.fill_color()); fill_color.alpha() > 0) {
         // We need to fill the path before applying the stroke, however the filled

--- a/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
@@ -27,6 +27,19 @@ Layout::SVGGeometryBox const& SVGGeometryPaintable::layout_box() const
     return static_cast<Layout::SVGGeometryBox const&>(layout_node());
 }
 
+Optional<HitTestResult> SVGGeometryPaintable::hit_test(CSSPixelPoint position, HitTestType type) const
+{
+    auto result = SVGGraphicsPaintable::hit_test(position, type);
+    if (!result.has_value())
+        return {};
+    auto& geometry_element = layout_box().dom_node();
+    auto transformed_bounding_box = layout_box().layout_transform().map_to_quad(
+        const_cast<SVG::SVGGeometryElement&>(geometry_element).get_path().bounding_box());
+    if (!transformed_bounding_box.contains(position.to_type<float>()))
+        return {};
+    return result;
+}
+
 void SVGGeometryPaintable::paint(PaintContext& context, PaintPhase phase) const
 {
     if (!is_visible())

--- a/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.h
@@ -17,6 +17,8 @@ class SVGGeometryPaintable final : public SVGGraphicsPaintable {
 public:
     static JS::NonnullGCPtr<SVGGeometryPaintable> create(Layout::SVGGeometryBox const&);
 
+    virtual Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const override;
+
     virtual void paint(PaintContext&, PaintPhase) const override;
 
     Layout::SVGGeometryBox const& layout_box() const;

--- a/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -30,7 +30,7 @@ void SVGSVGPaintable::before_children_paint(PaintContext& context, PaintPhase ph
         return;
 
     if (!context.has_svg_context())
-        context.set_svg_context(SVGContext(absolute_rect().to_type<float>()));
+        context.set_svg_context(SVGContext(absolute_rect()));
 
     PaintableBox::before_children_paint(context, phase);
 }

--- a/Userland/Libraries/LibWeb/SVG/AttributeParser.cpp
+++ b/Userland/Libraries/LibWeb/SVG/AttributeParser.cpp
@@ -1,20 +1,28 @@
 /*
  * Copyright (c) 2020, Matthew Olsson <mattco@serenityos.org>
  * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "AttributeParser.h"
 #include <AK/FloatingPointStringConversions.h>
+#include <AK/GenericShorthands.h>
 #include <AK/StringBuilder.h>
 #include <ctype.h>
 
 namespace Web::SVG {
 
 AttributeParser::AttributeParser(StringView source)
-    : m_source(move(source))
+    : m_lexer(source)
 {
+}
+
+Optional<Vector<Transform>> AttributeParser::parse_transform(StringView input)
+{
+    AttributeParser parser { input };
+    return parser.parse_transform();
 }
 
 Vector<PathInstruction> AttributeParser::parse_path_data(StringView input)
@@ -361,12 +369,12 @@ float AttributeParser::parse_nonnegative_number()
     //       at the start. That condition should have been checked by the caller.
     VERIFY(!match('+') && !match('-'));
 
-    auto remaining_source_text = m_source.substring_view(m_cursor);
+    auto remaining_source_text = m_lexer.remaining();
     char const* start = remaining_source_text.characters_without_null_termination();
 
     auto maybe_float = parse_first_floating_point<float>(start, start + remaining_source_text.length());
     VERIFY(maybe_float.parsed_value());
-    m_cursor += maybe_float.end_ptr - start;
+    m_lexer.ignore(maybe_float.end_ptr - start);
 
     return maybe_float.value;
 }
@@ -387,6 +395,109 @@ int AttributeParser::parse_sign()
     if (match('+'))
         consume();
     return 1;
+}
+
+// https://drafts.csswg.org/css-transforms/#svg-syntax
+Optional<Vector<Transform>> AttributeParser::parse_transform()
+{
+    // wsp:
+    // Either a U+000A LINE FEED, U+000D CARRIAGE RETURN, U+0009 CHARACTER TABULATION, or U+0020 SPACE.
+    auto wsp = [](char c) {
+        return AK::first_is_one_of(c, '\n', '\r', '\t', '\f', ' ');
+    };
+    auto consume_whitespace = [&] {
+        m_lexer.consume_while(wsp);
+    };
+
+    auto consume_comma_whitespace = [&] {
+        consume_whitespace();
+        m_lexer.consume_specific(',');
+        consume_whitespace();
+    };
+
+    // FIXME: AttributeParser currently does not handle invalid parses in most cases (e.g. parse_number()) and just crashes.
+    auto parse_optional_number = [&](float default_value = 0.0f) {
+        consume_comma_whitespace();
+        if (m_lexer.next_is(isdigit))
+            return parse_number();
+        return default_value;
+    };
+
+    auto parse_function = [&](auto body) -> Optional<Transform> {
+        consume_whitespace();
+        if (!m_lexer.consume_specific('('))
+            return {};
+        consume_whitespace();
+        Transform transform { .operation = Transform::Operation { body() } };
+        consume_whitespace();
+        if (m_lexer.consume_specific(')'))
+            return transform;
+        return {};
+    };
+
+    // NOTE: This looks very similar to the CSS transform but the syntax is not compatible.
+    Vector<Transform> transform_list;
+    consume_whitespace();
+    while (!done()) {
+        Optional<Transform> maybe_transform;
+        if (m_lexer.consume_specific("translate"sv)) {
+            maybe_transform = parse_function([&] {
+                Transform::Translate translate {};
+                translate.x = parse_number();
+                translate.y = parse_optional_number();
+                return translate;
+            });
+        } else if (m_lexer.consume_specific("scale"sv)) {
+            maybe_transform = parse_function([&] {
+                Transform::Scale scale {};
+                scale.x = parse_number();
+                scale.y = parse_optional_number(scale.x);
+                return scale;
+            });
+        } else if (m_lexer.consume_specific("rotate"sv)) {
+            maybe_transform = parse_function([&] {
+                Transform::Rotate rotate {};
+                rotate.a = parse_number();
+                rotate.x = parse_optional_number();
+                rotate.y = parse_optional_number();
+                return rotate;
+            });
+        } else if (m_lexer.consume_specific("skewX"sv)) {
+            maybe_transform = parse_function([&] {
+                Transform::SkewX skew_x {};
+                skew_x.a = parse_number();
+                return skew_x;
+            });
+        } else if (m_lexer.consume_specific("skewY"sv)) {
+            maybe_transform = parse_function([&] {
+                Transform::SkewY skew_y {};
+                skew_y.a = parse_number();
+                return skew_y;
+            });
+        } else if (m_lexer.consume_specific("matrix"sv)) {
+            maybe_transform = parse_function([&] {
+                Transform::Matrix matrix;
+                matrix.a = parse_number();
+                consume_comma_whitespace();
+                matrix.b = parse_number();
+                consume_comma_whitespace();
+                matrix.c = parse_number();
+                consume_comma_whitespace();
+                matrix.d = parse_number();
+                consume_comma_whitespace();
+                matrix.e = parse_number();
+                consume_comma_whitespace();
+                matrix.f = parse_number();
+                return matrix;
+            });
+        }
+        if (maybe_transform.has_value())
+            transform_list.append(*maybe_transform);
+        else
+            return {};
+        consume_comma_whitespace();
+    }
+    return transform_list;
 }
 
 bool AttributeParser::match_whitespace() const

--- a/Userland/Libraries/LibWeb/SVG/SVGContext.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGContext.h
@@ -14,7 +14,7 @@ namespace Web {
 
 class SVGContext {
 public:
-    SVGContext(Gfx::FloatRect svg_element_bounds)
+    SVGContext(CSSPixelRect svg_element_bounds)
         : m_svg_element_bounds(svg_element_bounds)
     {
         m_states.append(State());
@@ -28,7 +28,7 @@ public:
     void set_stroke_color(Gfx::Color color) { state().stroke_color = color; }
     void set_stroke_width(float width) { state().stroke_width = width; }
 
-    Gfx::FloatPoint svg_element_position() const { return m_svg_element_bounds.top_left(); }
+    CSSPixelPoint svg_element_position() const { return m_svg_element_bounds.top_left(); }
 
     void save() { m_states.append(m_states.last()); }
     void restore() { m_states.take_last(); }
@@ -43,7 +43,7 @@ private:
     State const& state() const { return m_states.last(); }
     State& state() { return m_states.last(); }
 
-    Gfx::FloatRect m_svg_element_bounds;
+    CSSPixelRect m_svg_element_bounds;
     Vector<State> m_states;
 };
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -20,7 +20,10 @@ class SVGGraphicsElement : public SVGElement {
 public:
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
+    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+
     Optional<Gfx::Color> fill_color() const;
+    Gfx::Painter::WindingRule fill_rule() const;
     Optional<Gfx::Color> stroke_color() const;
     Optional<float> stroke_width() const;
 
@@ -28,6 +31,8 @@ protected:
     SVGGraphicsElement(DOM::Document&, DOM::QualifiedName);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
+
+    Optional<float> m_fill_opacity = {};
 };
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -9,6 +9,7 @@
 
 #include <LibGfx/Path.h>
 #include <LibWeb/DOM/Node.h>
+#include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGElement.h>
 #include <LibWeb/SVG/TagNames.h>
 
@@ -27,12 +28,17 @@ public:
     Optional<Gfx::Color> stroke_color() const;
     Optional<float> stroke_width() const;
 
+    Gfx::AffineTransform get_transform() const;
+
 protected:
     SVGGraphicsElement(DOM::Document&, DOM::QualifiedName);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
     Optional<float> m_fill_opacity = {};
+    Gfx::AffineTransform m_transform = {};
 };
+
+Gfx::AffineTransform transform_from_transform_list(ReadonlySpan<Transform> tranform_list);
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -37,6 +37,13 @@ JS::GCPtr<Layout::Node> SVGSVGElement::create_layout_node(NonnullRefPtr<CSS::Sty
 
 void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) const
 {
+    // NOTE: Hack to ensure SVG unitless widths/heights are parsed even with <!DOCTYPE html>
+    auto previous_quirks_mode = document().mode();
+    const_cast<DOM::Document&>(document()).set_quirks_mode(DOM::QuirksMode::Yes);
+    ScopeGuard reset_quirks_mode = [&] {
+        const_cast<DOM::Document&>(document()).set_quirks_mode(previous_quirks_mode);
+    };
+
     auto width_attribute = attribute(SVG::AttributeNames::width);
     auto parsing_context = CSS::Parser::ParsingContext { document() };
     if (auto width_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::width), CSS::PropertyID::Width)) {

--- a/Userland/Libraries/LibWeb/SVG/ViewBox.cpp
+++ b/Userland/Libraries/LibWeb/SVG/ViewBox.cpp
@@ -30,7 +30,7 @@ Optional<ViewBox> try_parse_view_box(StringView string)
     while (!lexer.is_eof()) {
         lexer.consume_while([](auto ch) { return is_ascii_space(ch); });
         auto token = lexer.consume_until([](auto ch) { return is_ascii_space(ch) && ch != ','; });
-        auto maybe_number = token.to_int();
+        auto maybe_number = token.to_float();
         if (!maybe_number.has_value())
             return {};
         switch (state) {

--- a/Userland/Libraries/LibWeb/URL/URL.h
+++ b/Userland/Libraries/LibWeb/URL/URL.h
@@ -62,7 +62,7 @@ public:
 
     WebIDL::ExceptionOr<String> to_json() const;
 
-    void set_query(Badge<URLSearchParams>, String query) { m_url.set_query(query.to_deprecated_string()); }
+    void set_query(Badge<URLSearchParams>, String query) { m_url.set_query(query.to_deprecated_string(), AK::URL::ApplyPercentEncoding::Yes); }
 
 private:
     URL(JS::Realm&, AK::URL, JS::NonnullGCPtr<URLSearchParams> query);


### PR DESCRIPTION
This was a much bigger yak hole than I expected, all the changes made in this PR are done to get Google Street View functioning. I've tried to order commits best I can, but it's a little tricky (since I create the commits as a final step from a pile of `git commit -m "WIP"` :yakkie:)

Rough order: 
 - Commits 1 & 2 fix two stacking context hit-testing cases, that previously failed. 
	- Both are needed to interact with street view and move the camera around.
 - Commit 3 fixes the parsing and then re-serialization of URLs that contain percent encoded data, that does not use the default percent encoding sets.
    - The previous percent decoding during parsing was non spec-compliant and broke street view URLS.
		- (streetview URLs contain a percent encoded URL within their path... its weird)
 - Commit 5 parses and applies the `fill-opacity` attribute for SVG paths/elements
	- This is needed to correctly paint some UI elements
 - Commit 9 allows SVGs to scale on zoom... Kinda akward this did not work before, given they're scalable :P
 - Commit 11 fixes parsing `width/height="<unitless length>` on documents with `<!DOCTYPE html>`
 - All other commits implement SVG transforms and fix SVG viewboxes (for a bunch of cases)
	- This is needed UI elements (such as the streetview cursor) to show up and be rendered in the correct place.
	- The layout and hit testing changes are needed both to render things correctly, and to stop SVGs blocking all hit testing.

**Demos**

**Using looking around on Google Street View** (as you can tell it's a little laggy :^)).


[screen-capture - 2023-04-10T230557.488.webm](https://user-images.githubusercontent.com/11597044/231008057-82e584ba-5402-43e7-b8ab-77791e20036b.webm)


**Moving around on Google Street View**


[screen-capture - 2023-04-10T215856.132.webm](https://user-images.githubusercontent.com/11597044/231007277-4c6a0994-ab07-4996-a233-459dc960f89a.webm)

**Transformed SVGs, all with each of which have a `viewbox`, with working hit testing:**
![image](https://user-images.githubusercontent.com/11597044/230900029-67019eec-7036-433c-87f5-f4244eb2d768.png)

**Scaling SVGs:**

[screen-capture - 2023-04-10T131827.400.webm](https://user-images.githubusercontent.com/11597044/230900278-169acf70-5680-4209-9f07-33e2883a7edb.webm)



