### PR TITLE
3DFileViewer+Tubes: Use `map_fixed` pledge to prevent crash

### DIFF
--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -350,7 +350,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath unix prot_exec"));
+    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath unix prot_exec map_fixed"));
 
     TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/res", "r"));

--- a/Userland/Demos/Tubes/Tubes.cpp
+++ b/Userland/Demos/Tubes/Tubes.cpp
@@ -12,7 +12,6 @@
 #include <LibGUI/Application.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/Painter.h>
-#include <LibGUI/Widget.h>
 #include <LibGfx/Bitmap.h>
 
 constexpr size_t grid_resolution = 15;

--- a/Userland/Demos/Tubes/main.cpp
+++ b/Userland/Demos/Tubes/main.cpp
@@ -14,7 +14,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix prot_exec"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix prot_exec map_fixed"));
 
     unsigned refresh_rate = 12;
 
@@ -25,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath prot_exec"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath prot_exec map_fixed"));
 
     auto window = TRY(Desktop::Screensaver::create_window("Tubes"sv, "app-tubes"sv));
     window->update();

--- a/Userland/Demos/Tubes/main.cpp
+++ b/Userland/Demos/Tubes/main.cpp
@@ -8,7 +8,6 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
-#include <LibGUI/Icon.h>
 #include <LibGUI/Window.h>
 #include <LibMain/Main.h>
 


### PR DESCRIPTION
Commit 01318d8f9b fixed that we were not actually checking the `map_fixed` pledge, so now applications started to crash. This fixes both 3DFileViewer and Tubes, and additionally removes two unused includes.