### PR TITLE
Kernel: Disable interrupt signaling for the SD driver

### DIFF
--- a/Kernel/Storage/SD/SDHostController.cpp
+++ b/Kernel/Storage/SD/SDHostController.cpp
@@ -81,7 +81,6 @@ ErrorOr<void> SDHostController::initialize()
     TRY(reset_host_controller());
 
     m_registers->interrupt_status_enable = 0xffffffff;
-    m_registers->interrupt_signal_enable = 0xffffffff;
 
     auto card_or_error = try_initialize_inserted_card();
     if (card_or_error.is_error() && card_or_error.error().code() != ENODEV) {


### PR DESCRIPTION
Currently we do not use interrupts for the SD driver, yet we had enabled the signaling of all of them.
Since we were never acknowledging them, we were getting spammed by unnecessary interrupts, causing the system to slow down to a crawl.

This commit makes the system boot in less than 1 minute with PIO, compared to the old 30+ minute boot.

(It boots even faster with the DMA from #18161 ) 