### PR TITLE
Kernel: Stop using LockRefPtrs in the Jail code

### DIFF
--- a/Kernel/Jail.cpp
+++ b/Kernel/Jail.cpp
@@ -24,11 +24,11 @@ NonnullRefPtr<ProcessList> Jail::process_list()
     return m_process_list;
 }
 
-ErrorOr<NonnullLockRefPtr<Jail>> Jail::create(NonnullOwnPtr<KString> name)
+ErrorOr<NonnullRefPtr<Jail>> Jail::create(NonnullOwnPtr<KString> name)
 {
-    return s_all_instances->with([&](auto& list) -> ErrorOr<NonnullLockRefPtr<Jail>> {
+    return s_all_instances->with([&](auto& list) -> ErrorOr<NonnullRefPtr<Jail>> {
         auto process_list = TRY(ProcessList::create());
-        auto jail = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) Jail(move(name), generate_jail_id(), move(process_list))));
+        auto jail = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) Jail(move(name), generate_jail_id(), move(process_list))));
         list.append(jail);
         return jail;
     });
@@ -50,9 +50,9 @@ ErrorOr<void> Jail::for_each_when_process_is_not_jailed(Function<ErrorOr<void>(J
     });
 }
 
-LockRefPtr<Jail> Jail::find_by_index(JailIndex index)
+RefPtr<Jail> Jail::find_by_index(JailIndex index)
 {
-    return s_all_instances->with([&](auto& list) -> LockRefPtr<Jail> {
+    return s_all_instances->with([&](auto& list) -> RefPtr<Jail> {
         for (auto& jail : list) {
             if (jail.index() == index)
                 return jail;

--- a/Kernel/Jail.h
+++ b/Kernel/Jail.h
@@ -16,7 +16,6 @@
 #include <AK/Try.h>
 #include <AK/Types.h>
 #include <Kernel/KString.h>
-#include <Kernel/Library/LockRefPtr.h>
 #include <Kernel/Locking/SpinlockProtected.h>
 #include <Kernel/Process.h>
 
@@ -31,8 +30,8 @@ class Jail : public AtomicRefCounted<Jail> {
 public:
     NonnullRefPtr<ProcessList> process_list();
 
-    static LockRefPtr<Jail> find_by_index(JailIndex);
-    static ErrorOr<NonnullLockRefPtr<Jail>> create(NonnullOwnPtr<KString> name);
+    static RefPtr<Jail> find_by_index(JailIndex);
+    static ErrorOr<NonnullRefPtr<Jail>> create(NonnullOwnPtr<KString> name);
     static ErrorOr<void> for_each_when_process_is_not_jailed(Function<ErrorOr<void>(Jail const&)> callback);
 
     StringView name() const { return m_name->view(); }
@@ -47,7 +46,7 @@ private:
     NonnullOwnPtr<KString> m_name;
     JailIndex const m_index;
 
-    IntrusiveListNode<Jail, NonnullLockRefPtr<Jail>> m_list_node;
+    IntrusiveListNode<Jail, NonnullRefPtr<Jail>> m_list_node;
 
 public:
     using List = IntrusiveListRelaxedConst<&Jail::m_list_node>;

--- a/Kernel/Jail.h
+++ b/Kernel/Jail.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/AtomicRefCounted.h>
 #include <AK/DistinctNumeric.h>
 #include <AK/Error.h>
 #include <AK/IntrusiveList.h>
@@ -25,7 +26,7 @@ class ProcessList;
 
 AK_TYPEDEF_DISTINCT_ORDERED_ID(u64, JailIndex);
 
-class Jail : public RefCounted<Jail> {
+class Jail : public AtomicRefCounted<Jail> {
 
 public:
     NonnullRefPtr<ProcessList> process_list();


### PR DESCRIPTION
Each Jail object within the list is already protected by the global list
spinlock, therefore there's no need for using LockRefPtrs at all.

Also, each Jail object is atomically ref-counted, to prevent possible race conditions when changing the ref-count counter.