### PR TITLE
Ports/llvm: Increase the default stack size for LLVM executables

### DIFF
--- a/Toolchain/Patches/llvm/0012-cmake-Increase-the-default-stack-size-when-running-o.patch
+++ b/Toolchain/Patches/llvm/0012-cmake-Increase-the-default-stack-size-when-running-o.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Mon, 10 Apr 2023 12:17:32 +0200
+Subject: [PATCH] cmake: Increase the default stack size when running on
+ SerenityOS
+
+---
+ llvm/cmake/modules/HandleLLVMOptions.cmake | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/llvm/cmake/modules/HandleLLVMOptions.cmake b/llvm/cmake/modules/HandleLLVMOptions.cmake
+index 8597d80d3afd3e70e1306fdb7c36963f8e6aede4..2b1609ad43fe65d3f0492cc9a590e38c62e99c22 100644
+--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
++++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
+@@ -444,6 +444,9 @@ elseif(MINGW) # FIXME: Also cygwin?
+   if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+     append("-Wa,-mbig-obj" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+   endif()
++elseif(SERENITYOS)
++  # SerenityOS sets a very low default stack size value, so increase it to 4MB manually.
++  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,stack-size=4194304")
+ endif()
+ 
+ option(LLVM_ENABLE_WARNINGS "Enable compiler warnings." ON)

--- a/Toolchain/Patches/llvm/ReadMe.md
+++ b/Toolchain/Patches/llvm/ReadMe.md
@@ -93,3 +93,8 @@ Prevent the use of POSIX shm on SerenityOS
 POSIX shm is not supported by SerenityOS yet, so this causes a
 compilation error.
 
+## `0012-cmake-Increase-the-default-stack-size-when-running-o.patch`
+
+cmake: Increase the default stack size when running on SerenityOS
+
+


### PR DESCRIPTION
LLVM absolutely destroys our stack size limit when processing heavy source files, so let's add ourselves to the list of operating systems where we should give a hint on how much stack space we need.