### PR TITLE
readelf: Pledge `map_fixed` for loading ELFs

### DIFF
--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -207,7 +207,7 @@ static char const* object_relocation_type_to_string(ElfW(Word) type)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    TRY(Core::System::pledge("stdio rpath map_fixed"));
 
     DeprecatedString path {};
     static bool display_all = false;


### PR DESCRIPTION
I'm starting to think that we should maybe just remove the `map_fixed` pledge, considering that the initial reason for adding it seems to have been "nothing apart from `DynamicLoader` needs this anyways, so lock it down"...