### PR TITLE
Teach icc to print if a curve looks like the sRGB curve

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.cpp
+++ b/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.cpp
@@ -38,6 +38,13 @@ static ErrorOr<NonnullRefPtr<XYZTagData>> XYZ_data(XYZ xyz)
     return try_make_ref_counted<XYZTagData>(0, 0, move(xyzs));
 }
 
+ErrorOr<NonnullRefPtr<TagData>> sRGB_curve()
+{
+    // Numbers from https://en.wikipedia.org/wiki/SRGB#From_sRGB_to_CIE_XYZ
+    Array<S15Fixed16, 7> curve_parameters = { 2.4, 1 / 1.055, 0.055 / 1.055, 1 / 12.92, 0.04045 };
+    return try_make_ref_counted<ParametricCurveTagData>(0, 0, ParametricCurveTagData::FunctionType::sRGB, curve_parameters);
+}
+
 ErrorOr<NonnullRefPtr<Profile>> sRGB()
 {
     // Returns an sRGB profile.
@@ -54,9 +61,7 @@ ErrorOr<NonnullRefPtr<Profile>> sRGB()
     TRY(tag_table.try_set(copyrightTag, TRY(en_US("Public Domain"sv))));
 
     // Transfer function.
-    // Numbers from https://en.wikipedia.org/wiki/SRGB#From_sRGB_to_CIE_XYZ
-    Array<S15Fixed16, 7> curve_parameters = { 2.4, 1 / 1.055, 0.055 / 1.055, 1 / 12.92, 0.04045 };
-    auto curve = TRY(try_make_ref_counted<ParametricCurveTagData>(0, 0, ParametricCurveTagData::FunctionType::sRGB, curve_parameters));
+    auto curve = TRY(sRGB_curve());
     TRY(tag_table.try_set(redTRCTag, curve));
     TRY(tag_table.try_set(greenTRCTag, curve));
     TRY(tag_table.try_set(blueTRCTag, curve));

--- a/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.h
+++ b/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.h
@@ -15,4 +15,6 @@ class Profile;
 
 ErrorOr<NonnullRefPtr<Profile>> sRGB();
 
+ErrorOr<NonnullRefPtr<TagData>> sRGB_curve();
+
 }

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -76,15 +76,21 @@ static void out_parametric_curve(Gfx::ICC::ParametricCurveTagData const& paramet
     }
 }
 
+static void out_curve_tag(Gfx::ICC::TagData const& tag, int indent_amount)
+{
+    VERIFY(tag.type() == Gfx::ICC::CurveTagData::Type || tag.type() == Gfx::ICC::ParametricCurveTagData::Type);
+    if (tag.type() == Gfx::ICC::CurveTagData::Type)
+        out_curve(static_cast<Gfx::ICC::CurveTagData const&>(tag), indent_amount);
+    if (tag.type() == Gfx::ICC::ParametricCurveTagData::Type)
+        out_parametric_curve(static_cast<Gfx::ICC::ParametricCurveTagData const&>(tag), indent_amount);
+}
+
 static void out_curves(Vector<Gfx::ICC::LutCurveType> const& curves)
 {
     for (auto const& curve : curves) {
         VERIFY(curve->type() == Gfx::ICC::CurveTagData::Type || curve->type() == Gfx::ICC::ParametricCurveTagData::Type);
         outln("        type {}, relative offset {}, size {}", curve->type(), curve->offset(), curve->size());
-        if (curve->type() == Gfx::ICC::CurveTagData::Type)
-            out_curve(static_cast<Gfx::ICC::CurveTagData&>(*curve), /*indent=*/12);
-        if (curve->type() == Gfx::ICC::ParametricCurveTagData::Type)
-            out_parametric_curve(static_cast<Gfx::ICC::ParametricCurveTagData&>(*curve), /*indent=*/12);
+        out_curve_tag(*curve, /*indent=*/12);
     }
 }
 
@@ -247,7 +253,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             outln("    video full range flag: {} - {}", cicp.video_full_range_flag(),
                 Video::video_full_range_flag_to_string((Video::VideoFullRangeFlag)cicp.video_full_range_flag()));
         } else if (tag_data->type() == Gfx::ICC::CurveTagData::Type) {
-            out_curve(static_cast<Gfx::ICC::CurveTagData&>(*tag_data), /*indent=*/4);
+            out_curve_tag(*tag_data, /*indent=*/4);
         } else if (tag_data->type() == Gfx::ICC::Lut16TagData::Type) {
             auto& lut16 = static_cast<Gfx::ICC::Lut16TagData&>(*tag_data);
             outln("    input table: {} channels x {} entries", lut16.number_of_input_channels(), lut16.number_of_input_table_entries());
@@ -384,7 +390,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (named_colors.size() > 5u)
                 outln("        ...");
         } else if (tag_data->type() == Gfx::ICC::ParametricCurveTagData::Type) {
-            out_parametric_curve(static_cast<Gfx::ICC::ParametricCurveTagData&>(*tag_data), /*indent=*/4);
+            out_curve_tag(*tag_data, /*indent=*/4);
         } else if (tag_data->type() == Gfx::ICC::S15Fixed16ArrayTagData::Type) {
             // This tag can contain arbitrarily many fixed-point numbers, but in practice it's
             // exclusively used for the 'chad' tag, where it always contains 9 values that

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -35,43 +35,41 @@ static void out_optional(char const* label, Optional<T> const& optional)
 
 static void out_curve(Gfx::ICC::CurveTagData const& curve, int indent_amount)
 {
-    auto indent = MUST(String::repeated(' ', indent_amount));
     if (curve.values().is_empty()) {
-        outln("{}identity curve", indent);
+        outln("{: >{}}identity curve", "", indent_amount);
     } else if (curve.values().size() == 1) {
-        outln("{}gamma: {}", indent, FixedPoint<8, u16>::create_raw(curve.values()[0]));
+        outln("{: >{}}gamma: {}", "", indent_amount, FixedPoint<8, u16>::create_raw(curve.values()[0]));
     } else {
         // FIXME: Maybe print the actual points if -v is passed?
-        outln("{}curve with {} points", indent, curve.values().size());
+        outln("{: >{}}curve with {} points", "", indent_amount, curve.values().size());
     }
 }
 
 static void out_parametric_curve(Gfx::ICC::ParametricCurveTagData const& parametric_curve, int indent_amount)
 {
-    auto indent = MUST(String::repeated(' ', indent_amount));
     switch (parametric_curve.function_type()) {
     case Gfx::ICC::ParametricCurveTagData::FunctionType::Type0:
-        outln("{}Y = X**{}", indent, parametric_curve.g());
+        outln("{: >{}}Y = X**{}", "", indent_amount, parametric_curve.g());
         break;
     case Gfx::ICC::ParametricCurveTagData::FunctionType::Type1:
-        outln("{}Y = ({}*X + {})**{}   if X >= -{}/{}", indent,
+        outln("{: >{}}Y = ({}*X + {})**{}   if X >= -{}/{}", "", indent_amount,
             parametric_curve.a(), parametric_curve.b(), parametric_curve.g(), parametric_curve.b(), parametric_curve.a());
-        outln("{}Y = 0                                else", indent);
+        outln("{: >{}}Y = 0                                else", "", indent_amount);
         break;
     case Gfx::ICC::ParametricCurveTagData::FunctionType::Type2:
-        outln("{}Y = ({}*X + {})**{} + {}   if X >= -{}/{}", indent,
+        outln("{: >{}}Y = ({}*X + {})**{} + {}   if X >= -{}/{}", "", indent_amount,
             parametric_curve.a(), parametric_curve.b(), parametric_curve.g(), parametric_curve.c(), parametric_curve.b(), parametric_curve.a());
-        outln("{}Y =  {}                                    else", indent, parametric_curve.c());
+        outln("{: >{}}Y =  {}                                    else", "", indent_amount, parametric_curve.c());
         break;
     case Gfx::ICC::ParametricCurveTagData::FunctionType::Type3:
-        outln("{}Y = ({}*X + {})**{}   if X >= {}", indent,
+        outln("{: >{}}Y = ({}*X + {})**{}   if X >= {}", "", indent_amount,
             parametric_curve.a(), parametric_curve.b(), parametric_curve.g(), parametric_curve.d());
-        outln("{}Y =  {}*X                         else", indent, parametric_curve.c());
+        outln("{: >{}}Y =  {}*X                         else", "", indent_amount, parametric_curve.c());
         break;
     case Gfx::ICC::ParametricCurveTagData::FunctionType::Type4:
-        outln("{}Y = ({}*X + {})**{} + {}   if X >= {}", indent,
+        outln("{: >{}}Y = ({}*X + {})**{} + {}   if X >= {}", "", indent_amount,
             parametric_curve.a(), parametric_curve.b(), parametric_curve.g(), parametric_curve.e(), parametric_curve.d());
-        outln("{}Y =  {}*X + {}                             else", indent, parametric_curve.c(), parametric_curve.f());
+        outln("{: >{}}Y =  {}*X + {}                             else", "", indent_amount, parametric_curve.c(), parametric_curve.f());
         break;
     }
 }


### PR DESCRIPTION
The motivation here is mainly to find an excuse to incrementally add `evaluate()` to the two curve tags.

Screenshot:

```
% Build/lagom/icc Tests/LibGfx/test-inputs/icc-v4.jpg
...
redTRCTag ('rTRC'): type 'para', offset 524, size 32
    Y = (0.94786*X + 0.052139)**2.399993   if X >= 0.040451
    Y =  0.077392*X                         else
    Looks like sRGB's curve (distance 0)

% Build/lagom/icc ~/src/Compact-ICC-Profiles/profiles/Rec709-v4.icc 
...
redTRCTag ('rTRC'): type 'para', offset 448, size 32
    Y = (0.909912*X + 0.090087)**2.222244   if X >= 0.081008
    Y =  0.222229*X                         else
    Does not look like sRGB's curve (distance: 7.783267)
```