### PR TITLE
LibWeb: Convert `calc()` to spec's internal representation, fixing nested `calc()` in the process

### DIFF
--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -796,6 +796,15 @@ public:
         return {};
     }
 
+    template<typename TUnaryPredicate>
+    Optional<size_t> find_first_index_if(TUnaryPredicate&& finder) const
+    {
+        auto maybe_result = AK::find_if(begin(), end(), finder);
+        if (maybe_result == end())
+            return {};
+        return maybe_result.index();
+    }
+
     void reverse()
     {
         for (size_t i = 0; i < size() / 2; ++i)

--- a/Base/res/html/misc/calc.html
+++ b/Base/res/html/misc/calc.html
@@ -34,6 +34,11 @@
         <div class="box" style="width: calc(100px + 30% - (120px / (2*4 + 3 )));"></div>
     </div>
 
+    <p>calc(100px + 30% - calc(120px / calc(2*4 + 3 )))</p>
+    <div class="container">
+        <div class="box" style="width: calc(100px + 30% - calc(120px / calc(2*4 + 3 )));"></div>
+    </div>
+
     <p>calc(50% + 60px)</p>
     <div class="container">
         <div class="box" style="width: calc(50% + 60px);"></div>

--- a/Tests/AK/TestVector.cpp
+++ b/Tests/AK/TestVector.cpp
@@ -423,6 +423,14 @@ TEST_CASE(should_find_index)
     EXPECT(!v.find_first_index(42).has_value());
 }
 
+TEST_CASE(should_find_predicate_index)
+{
+    Vector<int> v { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
+
+    EXPECT_EQ(4u, v.find_first_index_if([](auto const v) { return v == 0; }).value());
+    EXPECT(!v.find_first_index_if([](auto const v) { return v == 123; }).has_value());
+}
+
 TEST_CASE(should_contain_start)
 {
     // Tests whether value is found if at the start of the range.

--- a/Tests/LibWeb/Layout/expected/grid/borders.txt
+++ b/Tests/LibWeb/Layout/expected/grid/borders.txt
@@ -103,14 +103,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,275.34375) content-size 784x90.9375 children: not-inline
         BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (445.434356,285.34375) content-size 337.800018x17.46875 children: inline
+        BlockContainer <div.grid-item> at (445.934356,285.34375) content-size 337.300018x17.46875 children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [445.434356,285.34375 6.34375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [445.934356,285.34375 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (18,338.8125) content-size 339.034362x17.46875 children: inline
+        BlockContainer <div.grid-item> at (18,338.8125) content-size 338.534362x17.46875 children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [18,338.8125 8.8125x17.46875]
               "2"

--- a/Tests/LibWeb/Layout/expected/grid/gap.txt
+++ b/Tests/LibWeb/Layout/expected/grid/gap.txt
@@ -38,14 +38,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,52.9375) content-size 784x50.9375 children: not-inline
         BlockContainer <(anonymous)> at (8,52.9375) content-size 0x0 children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (435.434356,52.9375) content-size 357.800018x17.46875 children: inline
+        BlockContainer <div.grid-item> at (435.934356,52.9375) content-size 357.300018x17.46875 children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [435.434356,52.9375 6.34375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [435.934356,52.9375 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> at (8,52.9375) content-size 0x0 children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,86.40625) content-size 359.034362x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,86.40625) content-size 358.534362x17.46875 children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,86.40625 8.8125x17.46875]
               "2"

--- a/Userland/Libraries/LibWeb/CSS/Angle.h
+++ b/Userland/Libraries/LibWeb/CSS/Angle.h
@@ -30,6 +30,9 @@ public:
     ErrorOr<String> to_string() const;
     float to_degrees() const;
 
+    Type type() const { return m_type; }
+    float raw_value() const { return m_value; }
+
     bool operator==(Angle const& other) const
     {
         return m_type == other.m_type && m_value == other.m_value;

--- a/Userland/Libraries/LibWeb/CSS/Frequency.h
+++ b/Userland/Libraries/LibWeb/CSS/Frequency.h
@@ -27,6 +27,9 @@ public:
     ErrorOr<String> to_string() const;
     float to_hertz() const;
 
+    Type type() const { return m_type; }
+    float raw_value() const { return m_value; }
+
     bool operator==(Frequency const& other) const
     {
         return m_type == other.m_type && m_value == other.m_value;

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -79,6 +79,7 @@ public:
             || m_type == Type::Rlh;
     }
 
+    Type type() const { return m_type; }
     float raw_value() const { return m_value; }
 
     CSSPixels to_px(Layout::Node const&) const;

--- a/Userland/Libraries/LibWeb/CSS/Number.h
+++ b/Userland/Libraries/LibWeb/CSS/Number.h
@@ -31,6 +31,7 @@ public:
     {
     }
 
+    Type type() const { return m_type; }
     float value() const { return m_value; }
     i64 integer_value() const
     {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -323,13 +323,7 @@ private:
     RefPtr<StyleValue> parse_grid_template_areas_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_area_shorthand_value(Vector<ComponentValue> const&);
 
-    // calc() parsing, according to https://www.w3.org/TR/css-values-3/#calc-syntax
-    OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_sum(TokenStream<ComponentValue>&);
-    OwnPtr<CalculatedStyleValue::CalcProduct> parse_calc_product(TokenStream<ComponentValue>&);
-    Optional<CalculatedStyleValue::CalcValue> parse_calc_value(TokenStream<ComponentValue>&);
-    OwnPtr<CalculatedStyleValue::CalcProductPartWithOperator> parse_calc_product_part_with_operator(TokenStream<ComponentValue>&);
-    OwnPtr<CalculatedStyleValue::CalcSumPartWithOperator> parse_calc_sum_part_with_operator(TokenStream<ComponentValue>&);
-    OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_expression(Vector<ComponentValue> const&);
+    ErrorOr<OwnPtr<CalculationNode>> parse_a_calculation(Vector<ComponentValue> const&);
 
     ParseErrorOr<NonnullRefPtr<Selector>> parse_complex_selector(TokenStream<ComponentValue>&, SelectorType);
     ParseErrorOr<Optional<Selector::CompoundSelector>> parse_compound_selector(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -327,13 +327,8 @@ private:
     OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_sum(TokenStream<ComponentValue>&);
     OwnPtr<CalculatedStyleValue::CalcProduct> parse_calc_product(TokenStream<ComponentValue>&);
     Optional<CalculatedStyleValue::CalcValue> parse_calc_value(TokenStream<ComponentValue>&);
-    OwnPtr<CalculatedStyleValue::CalcNumberSum> parse_calc_number_sum(TokenStream<ComponentValue>&);
-    OwnPtr<CalculatedStyleValue::CalcNumberProduct> parse_calc_number_product(TokenStream<ComponentValue>&);
-    Optional<CalculatedStyleValue::CalcNumberValue> parse_calc_number_value(TokenStream<ComponentValue>&);
     OwnPtr<CalculatedStyleValue::CalcProductPartWithOperator> parse_calc_product_part_with_operator(TokenStream<ComponentValue>&);
     OwnPtr<CalculatedStyleValue::CalcSumPartWithOperator> parse_calc_sum_part_with_operator(TokenStream<ComponentValue>&);
-    OwnPtr<CalculatedStyleValue::CalcNumberProductPartWithOperator> parse_calc_number_product_part_with_operator(TokenStream<ComponentValue>& tokens);
-    OwnPtr<CalculatedStyleValue::CalcNumberSumPartWithOperator> parse_calc_number_sum_part_with_operator(TokenStream<ComponentValue>&);
     OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_expression(Vector<ComponentValue> const&);
 
     ParseErrorOr<NonnullRefPtr<Selector>> parse_complex_selector(TokenStream<ComponentValue>&, SelectorType);

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -331,4 +331,9 @@ StyleValueList const& StyleValue::as_value_list() const
     return static_cast<StyleValueList const&>(*this);
 }
 
+ValueComparingNonnullRefPtr<StyleValue const> StyleValue::absolutized(CSSPixelRect const&, Gfx::FontPixelMetrics const&, CSSPixels, CSSPixels, CSSPixels, CSSPixels) const
+{
+    return *this;
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -710,11 +710,6 @@ CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberSumPartW
     return value->resolve(layout_node, percentage_basis);
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> StyleValue::absolutized(CSSPixelRect const&, Gfx::FontPixelMetrics const&, CSSPixels, CSSPixels, CSSPixels, CSSPixels) const
-{
-    return *this;
-}
-
 bool CalculatedStyleValue::contains_percentage() const
 {
     return m_expression->contains_percentage();

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -64,17 +64,6 @@ public:
     struct CalcSumPartWithOperator;
     struct CalcProduct;
     struct CalcProductPartWithOperator;
-    struct CalcNumberSum;
-    struct CalcNumberSumPartWithOperator;
-    struct CalcNumberProduct;
-    struct CalcNumberProductPartWithOperator;
-
-    struct CalcNumberValue {
-        Variant<Number, NonnullOwnPtr<CalcNumberSum>> value;
-        ErrorOr<String> to_string() const;
-        Optional<ResolvedType> resolved_type() const;
-        CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
-    };
 
     struct CalcValue {
         Variant<Number, Angle, Frequency, Length, Percentage, Time, NonnullOwnPtr<CalcSum>> value;
@@ -98,19 +87,6 @@ public:
         CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
 
         bool contains_percentage() const;
-    };
-
-    struct CalcNumberSum {
-        CalcNumberSum(NonnullOwnPtr<CalcNumberProduct> first_calc_number_product, Vector<NonnullOwnPtr<CalcNumberSumPartWithOperator>> additional)
-            : first_calc_number_product(move(first_calc_number_product))
-            , zero_or_more_additional_calc_number_products(move(additional)) {};
-
-        NonnullOwnPtr<CalcNumberProduct> first_calc_number_product;
-        Vector<NonnullOwnPtr<CalcNumberSumPartWithOperator>> zero_or_more_additional_calc_number_products;
-
-        ErrorOr<String> to_string() const;
-        Optional<ResolvedType> resolved_type() const;
-        CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
 
     struct CalcProduct {
@@ -139,44 +115,13 @@ public:
 
     struct CalcProductPartWithOperator {
         ProductOperation op;
-        Variant<CalcValue, CalcNumberValue> value;
+        CalcValue value;
 
         ErrorOr<String> to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
 
         bool contains_percentage() const;
-    };
-
-    struct CalcNumberProduct {
-        CalcNumberValue first_calc_number_value;
-        Vector<NonnullOwnPtr<CalcNumberProductPartWithOperator>> zero_or_more_additional_calc_number_values;
-
-        ErrorOr<String> to_string() const;
-        Optional<ResolvedType> resolved_type() const;
-        CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
-    };
-
-    struct CalcNumberProductPartWithOperator {
-        ProductOperation op;
-        CalcNumberValue value;
-
-        ErrorOr<String> to_string() const;
-        Optional<ResolvedType> resolved_type() const;
-        CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
-    };
-
-    struct CalcNumberSumPartWithOperator {
-        CalcNumberSumPartWithOperator(SumOperation op, NonnullOwnPtr<CalcNumberProduct> calc_number_product)
-            : op(op)
-            , value(move(calc_number_product)) {};
-
-        SumOperation op;
-        NonnullOwnPtr<CalcNumberProduct> value;
-
-        ErrorOr<String> to_string() const;
-        Optional<ResolvedType> resolved_type() const;
-        CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
 
     static ValueComparingNonnullRefPtr<CalculatedStyleValue> create(NonnullOwnPtr<CalcSum> calc_sum, ResolvedType resolved_type)

--- a/Userland/Libraries/LibWeb/CSS/Time.h
+++ b/Userland/Libraries/LibWeb/CSS/Time.h
@@ -28,6 +28,9 @@ public:
     ErrorOr<String> to_string() const;
     float to_seconds() const;
 
+    Type type() const { return m_type; }
+    float raw_value() const { return m_value; }
+
     bool operator==(Time const& other) const
     {
         return m_type == other.m_type && m_value == other.m_value;


### PR DESCRIPTION
[VALUES-4](https://www.w3.org/TR/css-values-4/) specifies how we should parse `calc()` and how its internal representation should look like, along with a bunch of new mathematical functions. This is step 1, converting our ad-hoc tree to a new tree of CalculationNode classes. There are no real functional changes, except that we do now parse `calc()` inside `calc()` like we were supposed to, but which never worked before.

There's still a lot to do, but this is already quite a big change so it seems sensible to pause here. That does mean we don't get to the juicy new features just yet, but they're coming! :^)