### PR TITLE
LibWeb: Handle null values when making args for attributeChangedCallback

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Attr.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Attr.cpp
@@ -99,9 +99,9 @@ void Attr::handle_attribute_changes(Element& element, DeprecatedString const& ol
 
         JS::MarkedVector<JS::Value> arguments { vm.heap() };
         arguments.append(JS::PrimitiveString::create(vm, local_name()));
-        arguments.append(JS::PrimitiveString::create(vm, old_value));
-        arguments.append(JS::PrimitiveString::create(vm, new_value));
-        arguments.append(JS::PrimitiveString::create(vm, namespace_uri()));
+        arguments.append(old_value.is_null() ? JS::js_null() : JS::PrimitiveString::create(vm, old_value));
+        arguments.append(new_value.is_null() ? JS::js_null() : JS::PrimitiveString::create(vm, new_value));
+        arguments.append(namespace_uri().is_null() ? JS::js_null() : JS::PrimitiveString::create(vm, namespace_uri()));
 
         element.enqueue_a_custom_element_callback_reaction(HTML::CustomElementReactionNames::attributeChangedCallback, move(arguments));
     }


### PR DESCRIPTION
JS::PrimitiveString::create uses `is_empty()` on DeprecatedString to use the empty string cache on the VM. However, this also considers the DeprecatedString null state to be empty, giving an empty string instead of `null` for null DeprecatedStrings.

Before:
![Screenshot from 2023-04-11 22-29-57](https://user-images.githubusercontent.com/25595356/231292779-24b211a5-e0c7-4c20-bc0d-1de6edeb1ab8.png)

After:
![Screenshot from 2023-04-11 22-28-08](https://user-images.githubusercontent.com/25595356/231292812-5eb3dde0-a2cc-454a-ba0d-e565f3a34132.png)
