### PR TITLE
LibTLS: Dont also include the OID when printing the RDN short name

### DIFF
--- a/Userland/Libraries/LibTLS/Certificate.cpp
+++ b/Userland/Libraries/LibTLS/Certificate.cpp
@@ -850,13 +850,11 @@ ErrorOr<Certificate> Certificate::parse_certificate(ReadonlyBytes buffer, bool)
 
 ErrorOr<String> RelativeDistinguishedName::to_string()
 {
-#define ADD_IF_RECOGNIZED(identifier, shorthand_code)                 \
-    do {                                                              \
-        if (it->key == identifier) {                                  \
-            cert_name.appendff("\\{}={}", shorthand_code, it->value); \
-            continue;                                                 \
-        }                                                             \
-    } while (0);
+#define ADD_IF_RECOGNIZED(identifier, shorthand_code)             \
+    if (it->key == identifier) {                                  \
+        cert_name.appendff("\\{}={}", shorthand_code, it->value); \
+        continue;                                                 \
+    }
 
     StringBuilder cert_name;
 


### PR DESCRIPTION
Remove the while-loop from the macro, so the `continue` works as expected.

Before:
`\OU=Root CA\2.5.4.11=Root CA\O=GlobalSign nv-sa\2.5.4.10=GlobalSign nv-sa\CN=GlobalSign Root CA\2.5.4.3=GlobalSign Root CA\C=BE\2.5.4.6=BE`

After:
`\OU=Root CA\O=GlobalSign nv-sa\CN=GlobalSign Root CA\C=BE`
