### PR TITLE
LibWeb: Create a video document for `video/` MIME types on navigation

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -184,6 +184,26 @@ static bool build_xml_document(DOM::Document& document, ByteBuffer const& data)
     return !result.is_error() && !builder.has_error();
 }
 
+static bool build_video_document(DOM::Document& document)
+{
+    auto html_element = DOM::create_element(document, HTML::TagNames::html, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
+    MUST(document.append_child(html_element));
+
+    auto head_element = DOM::create_element(document, HTML::TagNames::head, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
+    MUST(html_element->append_child(head_element));
+
+    auto body_element = DOM::create_element(document, HTML::TagNames::body, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
+    MUST(html_element->append_child(body_element));
+
+    auto video_element = DOM::create_element(document, HTML::TagNames::video, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
+    MUST(video_element->set_attribute(HTML::AttributeNames::src, document.url().to_deprecated_string()));
+    MUST(video_element->set_attribute(HTML::AttributeNames::autoplay, DeprecatedString::empty()));
+    MUST(video_element->set_attribute(HTML::AttributeNames::controls, DeprecatedString::empty()));
+    MUST(body_element->append_child(video_element));
+
+    return true;
+}
+
 bool FrameLoader::parse_document(DOM::Document& document, ByteBuffer const& data)
 {
     auto& mime_type = document.content_type();
@@ -196,6 +216,8 @@ bool FrameLoader::parse_document(DOM::Document& document, ByteBuffer const& data
         return build_xml_document(document, data);
     if (mime_type.starts_with("image/"sv))
         return build_image_document(document, data);
+    if (mime_type.starts_with("video/"sv))
+        return build_video_document(document);
     if (mime_type == "text/plain" || mime_type == "application/json")
         return build_text_document(document, data);
     if (mime_type == "text/markdown")


### PR DESCRIPTION
Examples from pulling YouTube's Google Video links:
720p:

https://user-images.githubusercontent.com/25595356/231308051-a05ce0f0-10a1-486d-a175-702e1ca1479e.mp4

144p:

https://user-images.githubusercontent.com/25595356/231310198-848eef77-b13d-4149-9fc0-10f64bd64857.mp4

1080p:
![Screenshot from 2023-04-11 23-54-32](https://user-images.githubusercontent.com/25595356/231310280-c0c372a4-6dc4-4c5b-a726-ece800fea27c.png)
