### PR TITLE
LibVideo/etc: Fix seeking to the start of a video with a non-zero first timestamp

### DIFF
--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/NumberFormat.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/BoxLayout.h>
@@ -249,8 +250,8 @@ void VideoPlayerWidget::set_time_label(Time timestamp)
 {
     StringBuilder string_builder;
     auto append_time = [&](Time time) {
-        auto seconds = time.to_seconds();
-        string_builder.appendff("{:02}:{:02}:{:02}", seconds / 3600, seconds / 60, seconds % 60);
+        auto seconds = (time.to_milliseconds() + 500) / 1000;
+        string_builder.append(human_readable_digital_time(seconds));
     };
 
     append_time(timestamp);
@@ -259,7 +260,7 @@ void VideoPlayerWidget::set_time_label(Time timestamp)
         string_builder.append(" / "sv);
         append_time(m_playback_manager->duration());
     } else {
-        string_builder.append(" / --:--:--.---"sv);
+        string_builder.append(" / --:--:--"sv);
     }
 
     m_timestamp_label->set_text(string_builder.string_view());

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -135,6 +135,10 @@ void VideoPlayerWidget::open_file(StringView filename)
 
     m_playback_manager->on_playback_state_change = [this]() {
         update_play_pause_icon();
+        // If we are seeking, do not set the timestamp, as that will override the seek position.
+        if (!m_was_playing_before_seek && m_playback_manager->get_state() != Video::PlaybackState::Seeking) {
+            set_current_timestamp(m_playback_manager->current_playback_time());
+        }
     };
 
     m_playback_manager->on_decoder_error = [this](auto error) {

--- a/Userland/Libraries/LibGUI/AbstractSlider.cpp
+++ b/Userland/Libraries/LibGUI/AbstractSlider.cpp
@@ -57,10 +57,9 @@ void AbstractSlider::set_value(int value, AllowCallback allow_callback, DoClamp 
     if (m_value == value)
         return;
     m_value = value;
-    update();
-
     if (on_change && allow_callback == AllowCallback::Yes)
         on_change(m_value);
+    update();
 }
 
 }

--- a/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
@@ -855,7 +855,7 @@ DecoderErrorOr<SampleIterator> Reader::seek_to_random_access_point(SampleIterato
 {
     if (TRY(has_cues_for_track(iterator.m_track.track_number()))) {
         TRY(seek_to_cue_for_timestamp(iterator, timestamp));
-        VERIFY(iterator.last_timestamp().has_value() && iterator.last_timestamp().value() <= timestamp);
+        VERIFY(iterator.last_timestamp().has_value());
         return iterator;
     }
 

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -349,7 +349,7 @@ protected:
         manager().dispatch_state_change();
         return {};
     }
-    bool is_playing() override { return m_playing; }
+    bool is_playing() const override { return m_playing; }
     ErrorOr<void> pause() override
     {
         m_playing = false;
@@ -369,6 +369,8 @@ class PlaybackManager::StartingStateHandler : public PlaybackManager::ResumingSt
     }
 
     StringView name() override { return "Starting"sv; }
+
+    PlaybackState get_state() const override { return PlaybackState::Starting; }
 
     ErrorOr<void> on_timer_callback() override
     {
@@ -409,7 +411,8 @@ private:
 
     StringView name() override { return "Playing"sv; }
 
-    bool is_playing() override { return true; };
+    bool is_playing() const override { return true; };
+    PlaybackState get_state() const override { return PlaybackState::Playing; }
     ErrorOr<void> pause() override
     {
         manager().m_last_present_in_media_time = current_time();
@@ -531,7 +534,8 @@ private:
     {
         return replace_handler_and_delete_this<PlayingStateHandler>();
     }
-    bool is_playing() override { return false; };
+    bool is_playing() const override { return false; };
+    PlaybackState get_state() const override { return PlaybackState::Paused; }
 };
 
 class PlaybackManager::BufferingStateHandler : public PlaybackManager::ResumingStateHandler {
@@ -549,6 +553,8 @@ class PlaybackManager::BufferingStateHandler : public PlaybackManager::ResumingS
     {
         return assume_next_state();
     }
+
+    PlaybackState get_state() const override { return PlaybackState::Buffering; }
 };
 
 class PlaybackManager::SeekingStateHandler : public PlaybackManager::ResumingStateHandler {
@@ -649,6 +655,8 @@ private:
         return skip_samples_until_timestamp();
     }
 
+    PlaybackState get_state() const override { return PlaybackState::Seeking; }
+
     Time m_target_timestamp { Time::zero() };
     SeekMode m_seek_mode { SeekMode::Accurate };
 };
@@ -678,7 +686,8 @@ private:
         manager().m_last_present_in_media_time = start_timestamp.release_value();
         return replace_handler_and_delete_this<StartingStateHandler>(true);
     }
-    bool is_playing() override { return false; };
+    bool is_playing() const override { return false; };
+    PlaybackState get_state() const override { return PlaybackState::Stopped; }
 };
 
 }

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -313,8 +313,8 @@ ErrorOr<void> PlaybackManager::PlaybackStateHandler::replace_handler_and_delete_
     m_has_exited = true;
     dbgln("Changing state from {} to {}", temp_handler->name(), m_manager.m_playback_handler->name());
 #endif
-    m_manager.dispatch_state_change();
     TRY(m_manager.m_playback_handler->on_enter());
+    m_manager.dispatch_state_change();
     return {};
 }
 

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -91,6 +91,15 @@ public:
     virtual void start(int interval_ms) = 0;
 };
 
+enum class PlaybackState {
+    Starting,
+    Playing,
+    Paused,
+    Buffering,
+    Seeking,
+    Stopped,
+};
+
 class PlaybackManager {
 public:
     enum class SeekMode {
@@ -114,6 +123,10 @@ public:
     bool is_playing() const
     {
         return m_playback_handler->is_playing();
+    }
+    PlaybackState get_state() const
+    {
+        return m_playback_handler->get_state();
     }
 
     u64 number_of_skipped_frames() const { return m_skipped_frames; }
@@ -187,7 +200,8 @@ private:
         virtual ErrorOr<void> on_enter() { return {}; }
 
         virtual ErrorOr<void> play() { return {}; };
-        virtual bool is_playing() = 0;
+        virtual bool is_playing() const = 0;
+        virtual PlaybackState get_state() const = 0;
         virtual ErrorOr<void> pause() { return {}; };
         virtual ErrorOr<void> buffer() { return {}; };
         virtual ErrorOr<void> seek(Time target_timestamp, SeekMode);

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -92,7 +92,6 @@ public:
 };
 
 enum class PlaybackState {
-    Starting,
     Playing,
     Paused,
     Buffering,
@@ -146,7 +145,6 @@ private:
     class PlaybackStateHandler;
     // Abstract class to allow resuming play/pause after the state is completed.
     class ResumingStateHandler;
-    class StartingStateHandler;
     class PlayingStateHandler;
     class PausedStateHandler;
     class BufferingStateHandler;


### PR DESCRIPTION
Previously, seeking to the start in `test-webm.webm` could cause the player to skip frames until it reached the previous playback position. These commits change it so that seeking will always set the timestamp correctly, and will always present a frame if the current frame doesn't correspond to the seek target.

This should correctly the issue that the first commit of https://github.com/SerenityOS/serenity/pull/18296 attempts to fix.

Other related improvements include:
- The video player will now floor the seconds displayed in the timestamp label, preventing for example a 4ms timestamp from displaying as one second into a video.
- When a seek exits into Paused state, the video player will now update its playback position.
- `PlaybackManager` now allows its clients to determine the current playback state.
- The `StartingStateHandler` is now removed, since the `SeekingStateHandler` now works correctly for its intended purpose of retrieving the first frame and presenting it.
- Jitter in the seek bar when fast seeking is enabled should be completely prevented.