### PR TITLE
AK+LibCompress+LibWasm: Remove the AK::Endian bytes accessor

### DIFF
--- a/AK/Endian.h
+++ b/AK/Endian.h
@@ -88,10 +88,6 @@ public:
 
     constexpr operator T() const { return convert_between_host_and_little_endian(m_value); }
 
-    // This returns the internal representation. In this case, that is the value stored in little endian format.
-    constexpr Bytes bytes() { return Bytes { &m_value, sizeof(m_value) }; }
-    constexpr ReadonlyBytes bytes() const { return ReadonlyBytes { &m_value, sizeof(m_value) }; }
-
 private:
     T m_value { 0 };
 };
@@ -107,10 +103,6 @@ public:
     }
 
     constexpr operator T() const { return convert_between_host_and_big_endian(m_value); }
-
-    // This returns the internal representation. In this case, that is the value stored in big endian format.
-    constexpr Bytes bytes() { return Bytes { &m_value, sizeof(m_value) }; }
-    constexpr ReadonlyBytes bytes() const { return ReadonlyBytes { &m_value, sizeof(m_value) }; }
 
 private:
     T m_value { 0 };

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -968,10 +968,8 @@ ErrorOr<void> DeflateCompressor::flush()
     auto write_uncompressed = [&]() -> ErrorOr<void> {
         TRY(m_output_stream->write_bits(0b00u, 2)); // no compression
         TRY(m_output_stream->align_to_byte_boundary());
-        LittleEndian<u16> len = m_pending_block_size;
-        TRY(m_output_stream->write_until_depleted(len.bytes()));
-        LittleEndian<u16> nlen = ~m_pending_block_size;
-        TRY(m_output_stream->write_until_depleted(nlen.bytes()));
+        TRY(m_output_stream->write_value<LittleEndian<u16>>(m_pending_block_size));
+        TRY(m_output_stream->write_value<LittleEndian<u16>>(~m_pending_block_size));
         TRY(m_output_stream->write_until_depleted(pending_block().slice(0, m_pending_block_size)));
         return {};
     };

--- a/Userland/Libraries/LibCompress/Gzip.cpp
+++ b/Userland/Libraries/LibCompress/Gzip.cpp
@@ -231,10 +231,8 @@ ErrorOr<size_t> GzipCompressor::write_some(ReadonlyBytes bytes)
     TRY(compressed_stream->final_flush());
     Crypto::Checksum::CRC32 crc32;
     crc32.update(bytes);
-    LittleEndian<u32> digest = crc32.digest();
-    LittleEndian<u32> size = bytes.size();
-    TRY(m_output_stream->write_until_depleted(digest.bytes()));
-    TRY(m_output_stream->write_until_depleted(size.bytes()));
+    TRY(m_output_stream->write_value<LittleEndian<u32>>(crc32.digest()));
+    TRY(m_output_stream->write_value<LittleEndian<u32>>(bytes.size()));
     return bytes.size();
 }
 

--- a/Userland/Libraries/LibCompress/Zlib.cpp
+++ b/Userland/Libraries/LibCompress/Zlib.cpp
@@ -113,7 +113,7 @@ ErrorOr<void> ZlibCompressor::write_header(ZlibCompressionMethod compression_met
 
     // FIXME: Support pre-defined dictionaries.
 
-    TRY(m_output_stream->write_until_depleted(header.as_u16.bytes()));
+    TRY(m_output_stream->write_value(header.as_u16));
 
     return {};
 }

--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -486,9 +486,10 @@ ParseResult<Vector<Instruction>> Instruction::parse(Stream& stream, InstructionP
         }
         case Instructions::f32_const.value(): {
             // op literal
-            LittleEndian<u32> value;
-            if (stream.read_until_filled(value.bytes()).is_error())
+            auto value_or_error = stream.read_value<LittleEndian<u32>>();
+            if (value_or_error.is_error())
                 return with_eof_check(stream, ParseError::ExpectedFloatingImmediate);
+            auto value = value_or_error.release_value();
 
             auto floating = bit_cast<float>(static_cast<u32>(value));
             resulting_instructions.append(Instruction { opcode, floating });
@@ -496,9 +497,10 @@ ParseResult<Vector<Instruction>> Instruction::parse(Stream& stream, InstructionP
         }
         case Instructions::f64_const.value(): {
             // op literal
-            LittleEndian<u64> value;
-            if (stream.read_until_filled(value.bytes()).is_error())
+            auto value_or_error = stream.read_value<LittleEndian<u64>>();
+            if (value_or_error.is_error())
                 return with_eof_check(stream, ParseError::ExpectedFloatingImmediate);
+            auto value = value_or_error.release_value();
 
             auto floating = bit_cast<double>(static_cast<u64>(value));
             resulting_instructions.append(Instruction { opcode, floating });


### PR DESCRIPTION
This is a remnant from when we didn't have a `read_value` and `write_value` implementation for `AK::Endian` and instead used the generic functions for reading a span of bytes. Now that we have a more ergonomic alternative, remove the helper that is no longer needed.