### PR TITLE
LibCrypto/LibTLS: Store the TBS ASN.1 data on the certificate

### DIFF
--- a/Userland/Libraries/LibCrypto/ASN1/DER.cpp
+++ b/Userland/Libraries/LibCrypto/ASN1/DER.cpp
@@ -67,6 +67,16 @@ ErrorOr<u8> Decoder::read_byte()
     return byte;
 }
 
+ErrorOr<ReadonlyBytes> Decoder::peek_entry_bytes()
+{
+    if (m_stack.is_empty())
+        return Error::from_string_literal("ASN1::Decoder: Reading bytes from an empty stack");
+
+    auto entry = m_stack.last();
+
+    return entry;
+}
+
 ErrorOr<ReadonlyBytes> Decoder::read_bytes(size_t length)
 {
     if (m_stack.is_empty())

--- a/Userland/Libraries/LibCrypto/ASN1/DER.h
+++ b/Userland/Libraries/LibCrypto/ASN1/DER.h
@@ -151,6 +151,8 @@ public:
     ErrorOr<void> enter();
     ErrorOr<void> leave();
 
+    ErrorOr<ReadonlyBytes> peek_entry_bytes();
+
 private:
     template<typename ValueType, typename DecodedType>
     ErrorOr<ValueType> with_type_check(DecodedType&& value)

--- a/Userland/Libraries/LibTLS/Certificate.cpp
+++ b/Userland/Libraries/LibTLS/Certificate.cpp
@@ -745,9 +745,21 @@ static ErrorOr<Certificate> parse_tbs_certificate(Crypto::ASN1::Decoder& decoder
     //     -- If present, version shall be v3]]
     // }
 
+    // Note: Parse out the ASN.1 of this object, since its used for TLS verification.
+    // To do this, we get the bytes of our parent, the size of ourself, and slice the parent buffer.
+    auto pre_cert_buffer = TRY(decoder.peek_entry_bytes());
+
+    // FIXME: Dont assume this value.
+    // Note: we assume this to be 4. 1 for the tag, and 3 for the length.
+    auto entry_length_byte_count = 4;
+
     ENTER_TYPED_SCOPE(Sequence, "TBSCertificate"sv);
 
+    auto post_cert_buffer = TRY(decoder.peek_entry_bytes());
+    auto asn1_data = TRY(ByteBuffer::copy(pre_cert_buffer.slice(0, post_cert_buffer.size() + entry_length_byte_count)));
+
     Certificate certificate;
+    certificate.tbs_asn1 = asn1_data;
     certificate.version = TRY(parse_version(decoder, current_scope)).to_u64();
     certificate.serial_number = TRY(parse_serial_number(decoder, current_scope));
     certificate.algorithm = TRY(parse_algorithm_identifier(decoder, current_scope));

--- a/Userland/Libraries/LibTLS/Certificate.h
+++ b/Userland/Libraries/LibTLS/Certificate.h
@@ -240,6 +240,7 @@ public:
     CertificateKeyAlgorithm signature_algorithm { CertificateKeyAlgorithm::Unsupported };
     ByteBuffer signature_value {};
     ByteBuffer original_asn1 {};
+    ByteBuffer tbs_asn1 {};
     bool is_allowed_to_sign_certificate { false };
     bool is_certificate_authority { false };
     Optional<size_t> path_length_constraint {};

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -373,9 +373,7 @@ bool Context::verify_certificate_pair(Certificate const& subject, Certificate co
     auto verification_buffer_bytes = verification_buffer.bytes();
     rsa.verify(subject.signature_value, verification_buffer_bytes);
 
-    // FIXME: This slice is subject hack, this will work for most certificates, but you actually have to parse
-    //        the ASN.1 data to correctly extract the signed part of the certificate.
-    ReadonlyBytes message = subject.original_asn1.bytes().slice(4, subject.original_asn1.size() - 4 - (5 + subject.signature_value.size()) - 15);
+    ReadonlyBytes message = subject.tbs_asn1.bytes();
     auto pkcs1 = Crypto::PK::EMSA_PKCS1_V1_5<Crypto::Hash::Manager>(kind);
     auto verification = pkcs1.verify(message, verification_buffer_bytes, subject.signature_value.size() * 8);
     return verification == Crypto::VerificationConsistency::Consistent;


### PR DESCRIPTION
This way we dont need to guess the offsets in LibTLS when using it.

Moves one FIXME from LibTLS to LibCrypto :^)