### PR TITLE
Fuzzers: Stop loading audio frames once the end is reached

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
@@ -22,7 +22,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
         auto samples = flac->load_chunks(10 * KiB);
         if (samples.is_error())
             return 0;
-        if (samples.value().size() > 0)
+        if (samples.value().size() == 0)
             break;
     }
 

--- a/Meta/Lagom/Fuzzers/FuzzMP3Loader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMP3Loader.cpp
@@ -22,7 +22,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
         auto samples = mp3->load_chunks(1 * KiB);
         if (samples.is_error())
             return 0;
-        if (samples.value().size() > 0)
+        if (samples.value().size() == 0)
             break;
     }
 

--- a/Meta/Lagom/Fuzzers/FuzzQOALoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzQOALoader.cpp
@@ -22,7 +22,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
         auto samples = qoa->load_chunks(5 * KiB);
         if (samples.is_error())
             return 0;
-        if (samples.value().size() > 0)
+        if (samples.value().size() == 0)
             break;
     }
 

--- a/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
@@ -25,7 +25,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
         auto samples = wav->load_chunks(4 * KiB);
         if (samples.is_error())
             return 0;
-        if (samples.value().size() > 0)
+        if (samples.value().size() == 0)
             break;
     }
 


### PR DESCRIPTION
Previously, the condition was reversed, so we would stop immediately on a file that has at least one working chunk, and we would infinitely loop on a file with no chunks.

Fixes #18313.
Fixes #18314.