### PR TITLE
LibGfx/WebP: Don't assert when size in header is smaller than header

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -162,6 +162,8 @@ static ErrorOr<void> decode_webp_header(WebPLoadingContext& context)
     //  Readers MAY parse such files, ignoring the trailing data."
     if (context.data.size() - 8 < header.file_size)
         return context.error("WebP data too small for size in header");
+    if (header.file_size < 4) // Need at least 4 bytes for 'WEBP', else we'll trim to less than the header size below.
+        return context.error("WebP stored file size too small for header it's stored in");
     if (context.data.size() - 8 > header.file_size) {
         dbgln_if(WEBP_DEBUG, "WebP has {} bytes of data, but header needs only {}. Trimming.", context.data.size(), header.file_size + 8);
         context.data = context.data.trim(header.file_size + 8);


### PR DESCRIPTION
read_webp_first_chunk() sensibly assumes that if decode_webp_header() succeeds, there are at least sizeof(WebPFileHeader) bytes available.

But if the file size in the header was less than the size of the header, decode_webp_header() would truncate the data to less than that and happily report success. Now it no longer does that.

Found by clusterfuzz:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57843&sort=-opened&can=1&q=proj%3Aserenity