### PR TITLE
Assistant: Improve query performance and reduce memory usage

### DIFF
--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -174,6 +174,9 @@ void FileProvider::query(DeprecatedString const& query, Function<void(Vector<Non
                 on_complete(move(results.value()));
 
             return {};
+        },
+        [](auto) {
+            // Ignore cancellation errors.
         });
 }
 

--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -117,7 +117,7 @@ void CalculatorProvider::query(DeprecatedString const& query, Function<void(Vect
     }
 
     Vector<NonnullRefPtr<Result>> results;
-    results.append(adopt_ref(*new CalculatorResult(calculation)));
+    results.append(make_ref_counted<CalculatorResult>(calculation));
     on_complete(move(results));
 }
 
@@ -235,7 +235,7 @@ void TerminalProvider::query(DeprecatedString const& query, Function<void(Vector
     auto command = query.substring(1).trim_whitespace();
 
     Vector<NonnullRefPtr<Result>> results;
-    results.append(adopt_ref(*new TerminalResult(move(command))));
+    results.append(make_ref_counted<TerminalResult>(move(command)));
     on_complete(move(results));
 }
 
@@ -257,7 +257,7 @@ void URLProvider::query(DeprecatedString const& query, Function<void(Vector<Nonn
         return;
 
     Vector<NonnullRefPtr<Result>> results;
-    results.append(adopt_ref(*new URLResult(url)));
+    results.append(make_ref_counted<URLResult>(url));
     on_complete(results);
 }
 

--- a/Userland/Applications/Assistant/Providers.h
+++ b/Userland/Applications/Assistant/Providers.h
@@ -18,6 +18,8 @@
 
 namespace Assistant {
 
+static constexpr size_t MAX_SEARCH_RESULTS = 6;
+
 class Result : public RefCounted<Result> {
 public:
     virtual ~Result() = default;

--- a/Userland/Applications/Assistant/Providers.h
+++ b/Userland/Applications/Assistant/Providers.h
@@ -141,7 +141,12 @@ public:
 
 class AppProvider final : public Provider {
 public:
+    AppProvider();
+
     void query(DeprecatedString const& query, Function<void(Vector<NonnullRefPtr<Result>>)> on_complete) override;
+
+private:
+    Vector<NonnullRefPtr<Desktop::AppFile>> m_app_file_cache;
 };
 
 class CalculatorProvider final : public Provider {

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -144,8 +144,6 @@ private:
 
 }
 
-static constexpr size_t MAX_SEARCH_RESULTS = 6;
-
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd rpath cpath unix proc exec thread"));
@@ -270,7 +268,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         else
             app_state.selected_index = 0;
         app_state.results = results;
-        app_state.visible_result_count = min(results.size(), MAX_SEARCH_RESULTS);
+        app_state.visible_result_count = min(results.size(), Assistant::MAX_SEARCH_RESULTS);
 
         update_ui_timer->restart();
     };


### PR DESCRIPTION
This PR improves Assistant query performance and significantly reduces memory usage.

I have also included a commit which prevents cancellation error messages being logged to the console.

These changes were tested by issuing 26 1 letter queries from 'a' to 'z', which I believe gives the worst case in terms of potential memory usage.

The following results were obtained on a system containing approximately 21,000 files. The performance increase is more noticable when more files are indexed.

This allows Assistant to run without crashing, when booting with as little as 384MB.

Memory usage:

|          | Virtual | Private |
|--------|--------|--------|
| Before | 102.7M | 48.7M |
| After | 46.7M | 7.5M |

CPU usage:

Before:
![assistant_profile_before](https://user-images.githubusercontent.com/2817754/231525739-ac457dd8-bb4b-41c7-8983-e00e66fbab52.png)

After:
![assistant_profile_after](https://user-images.githubusercontent.com/2817754/231525775-df5ee1e7-f567-401d-8cfc-be940ccb9df2.png)
