### PR TITLE
LibMarkdown: Avoid catastrophic backtracking in thematic break regex

### DIFF
--- a/Userland/Libraries/LibMarkdown/HorizontalRule.cpp
+++ b/Userland/Libraries/LibMarkdown/HorizontalRule.cpp
@@ -35,7 +35,7 @@ RecursionDecision HorizontalRule::walk(Visitor& visitor) const
     return RecursionDecision::Continue;
 }
 
-static Regex<ECMA262> thematic_break_re("^ {0,3}([\\*\\-_])(\\s*\\1\\s*){2,}$");
+static Regex<ECMA262> thematic_break_re("^ {0,3}([\\*\\-_])\\s*(\\1\\s*){2,}$");
 
 OwnPtr<HorizontalRule> HorizontalRule::parse(LineIterator& lines)
 {


### PR DESCRIPTION
Tested with the following (base64 encoded) input from the linked issue:

```
JyogKiBsaXQyCi0tLS0tLS0tLS0tLSAgICAgICAgICAgLS0tLSAgICAgICAgICAgICAgICAgICAg
ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgLS0tLSAgICAtLSAgICAgICAgICAgLS0t
LSAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHIAAAAgICAgIAAg
IC0t
```

This PR causes no change in `TestCommonmark` output.

Fixes #17937