### PR TITLE
HackStudio: set_cursor even if the file is already open

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -321,6 +321,7 @@ bool HackStudioWidget::open_file(DeprecatedString const& full_filename, size_t l
 
     if (editor_wrapper_or_none.has_value()) {
         set_current_editor_wrapper(editor_wrapper_or_none.release_value());
+        current_editor().set_cursor(line, column);
         return true;
     } else if (active_file().is_empty() && !current_editor().document().is_modified() && !full_filename.is_empty()) {
         // Replace "Untitled" blank file since it hasn't been modified


### PR DESCRIPTION
Upon opening already opened file, the cursor was previously not set to the correct line and column. With this patch, it should be correctly set.

Fixes a bug where ctrl+clicking a function declaration would not jump to the line if the file containing the function is already open.