### PR TITLE
Ports/frotz: Add patch to Makefile and fix sha256

### DIFF
--- a/Ports/frotz/package.sh
+++ b/Ports/frotz/package.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port='frotz'
 version='2.54'
-files="https://gitlab.com/DavidGriffith/frotz/-/archive/${version}/frotz-${version}.tar.bz2 frotz-${version}.tar.bz2 bdf9131e6de49108c9f032200cea3cb4011e5ca0c9fbdbf5b0c05f7c56c81395"
+files="https://gitlab.com/DavidGriffith/frotz/-/archive/${version}/frotz-${version}.tar.bz2 frotz-${version}.tar.bz2 756d7e11370c9c8e61573e350e2a5071e77fd2781be74c107bd432f817f3abc7"
 auth_type='sha256'
 depends=("ncurses")
 

--- a/Ports/frotz/patches/0001-Set-UNAME_S-to-SerenityOS-and-LINUX-to-yes.patch
+++ b/Ports/frotz/patches/0001-Set-UNAME_S-to-SerenityOS-and-LINUX-to-yes.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: EWouters <6179932+EWouters@users.noreply.github.com>
+Date: Thu, 13 Apr 2023 00:47:41 +0200
+Subject: [PATCH] Set `UNAME_S` to SerenityOS and `LINUX` to yes
+
+---
+ Makefile | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 18361eea8d90921984d52d53663876064374a3bc..8ec06525c91f694647e4fcf8fa4788519ba7d07e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -129,7 +129,8 @@ RANLIB ?= $(shell which ranlib)
+ AR ?= $(shell which ar)
+ # For now, assume !windows == unix.
+ OS_TYPE ?= unix
+-UNAME_S := $(shell uname -s)
++UNAME_S := SerenityOS
++LINUX = yes
+ 
+ ifeq ($(MAKECMDGOALS),tops20)
+     EXPORT_TYPE = tops20

--- a/Ports/frotz/patches/ReadMe.md
+++ b/Ports/frotz/patches/ReadMe.md
@@ -1,0 +1,7 @@
+# Patches for frotz on SerenityOS
+
+## `0001-Set-UNAME_S-to-SerenityOS-and-LINUX-to-yes.patch`
+
+Set `UNAME_S` to SerenityOS and `LINUX` to yes
+
+


### PR DESCRIPTION
This fixes the frotz port. I'm not sure how the sha256 mismatch came about.

Can be taken off the list: https://github.com/SerenityOS/serenity/issues/18238