### PR TITLE
LibSQL: Handle statements with malformed exists expressions correctly

### DIFF
--- a/Userland/Libraries/LibSQL/AST/Parser.h
+++ b/Userland/Libraries/LibSQL/AST/Parser.h
@@ -77,10 +77,10 @@ private:
     RefPtr<Expression> parse_column_name_expression(DeprecatedString with_parsed_identifier = {}, bool with_parsed_period = false);
     RefPtr<Expression> parse_unary_operator_expression();
     RefPtr<Expression> parse_binary_operator_expression(NonnullRefPtr<Expression> lhs);
-    RefPtr<Expression> parse_chained_expression();
+    RefPtr<Expression> parse_chained_expression(bool surrounded_by_parentheses = true);
     RefPtr<Expression> parse_cast_expression();
     RefPtr<Expression> parse_case_expression();
-    RefPtr<Expression> parse_exists_expression(bool invert_expression, TokenType opening_token = TokenType::Exists);
+    RefPtr<Expression> parse_exists_expression(bool invert_expression);
     RefPtr<Expression> parse_collate_expression(NonnullRefPtr<Expression> expression);
     RefPtr<Expression> parse_is_expression(NonnullRefPtr<Expression> expression);
     RefPtr<Expression> parse_match_expression(NonnullRefPtr<Expression> lhs, bool invert_expression);


### PR DESCRIPTION
Previously, using the `SELECT` keyword within a `VALUES` expression would cause a null pointer dereference, crashing the running program.

I was able to reproduce the bug with the following statement, on a blank database in SQL Studio:

`INSERT INTO t(a) VALUES(SELECT);`

I have also tested this fix against the statements in the linked issues:

`INSERT INTO t(a,b)VALUES(0,8),(/**/SELECT;`

and

`INSERT INTO d(a,b)VALUES(2,5),(SELECT+;`

Fixes #18036

Fixes #18302