### PR TITLE
LibWeb: Whine instead of dying on unexpected box during line layout

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -123,7 +123,11 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     }
 
     // Any box that has simple flow inside should have generated line box fragments already.
-    VERIFY(!box.display().is_flow_inside());
+    if (box.display().is_flow_inside()) {
+        dbgln("FIXME: InlineFormattingContext::dimension_box_on_line got unexpected box in inline context:");
+        dump_tree(box);
+        return;
+    }
 
     auto const& width_value = box.computed_values().width();
     CSSPixels unconstrained_width = 0;


### PR DESCRIPTION
Log a FIXME on the debug log, along with a layout tree dump of the box that we didn't expect to see. This will be annoying (until fixed), but far less so than crashing the browser.

As an example, this makes the GitHub "issues" view stop crashing.