### PR TITLE
AK: Efficiently resize CircularBuffer seekback copy distance

### DIFF
--- a/Tests/AK/TestCircularBuffer.cpp
+++ b/Tests/AK/TestCircularBuffer.cpp
@@ -348,3 +348,18 @@ TEST_CASE(offset_of_with_until_and_after_wrapping_around)
     result = circular_buffer.offset_of("Well "sv, 14, 19);
     EXPECT_EQ(result.value_or(42), 14ul);
 }
+
+BENCHMARK_CASE(looping_copy_from_seekback)
+{
+    auto circular_buffer = MUST(CircularBuffer::create_empty(16 * MiB));
+
+    {
+        auto written_bytes = circular_buffer.write("\0"sv.bytes());
+        EXPECT_EQ(written_bytes, 1ul);
+    }
+
+    {
+        auto copied_bytes = TRY_OR_FAIL(circular_buffer.copy_from_seekback(1, 15 * MiB));
+        EXPECT_EQ(copied_bytes, 15 * MiB);
+    }
+}


### PR DESCRIPTION
Previously, if we copied the last byte for a length of 100, we'd recalculate the read span 100 times and memmove one byte 100 times, which resulted in a lot of overhead.

Now, if we know that we have two consecutive copies of the data, we just extend the distance to cover both copies, which halves the number of times that we recalculate the span and actually call memmove.

This takes the running time of the attached benchmark case from 150ms down to 15ms.

This should also fix [this](https://crbug.com/oss-fuzz/57348) oss-fuzz bug, which was previously timing out due to taking too long to decompress. Running the reproducer testcase now takes 0.9 seconds on my local machine, whereas it would take 18 seconds previously.