### PR TITLE
SoundPlayer: Check if loader is null

### DIFF
--- a/Userland/Applications/SoundPlayer/Player.cpp
+++ b/Userland/Applications/SoundPlayer/Player.cpp
@@ -155,7 +155,11 @@ void Player::toggle_mute()
 
 void Player::seek(int sample)
 {
-    sample *= (m_playback_manager.device_sample_rate() / static_cast<float>(m_playback_manager.loader()->sample_rate()));
+    auto loader = m_playback_manager.loader();
+    if (loader.is_null()) {
+        return;
+    }
+    sample *= (m_playback_manager.device_sample_rate() / static_cast<float>(loader->sample_rate()));
     m_playback_manager.seek(sample);
 }
 


### PR DESCRIPTION
This patch prevents SoundPlayer from crashing when attempting to "seek" when no file has been loaded