### PR TITLE
LibWeb: Don't match the root node of HTMLCollection

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -44,7 +44,7 @@ void HTMLCollection::visit_edges(Cell::Visitor& visitor)
 JS::MarkedVector<Element*> HTMLCollection::collect_matching_elements() const
 {
     JS::MarkedVector<Element*> elements(m_root->heap());
-    m_root->for_each_in_inclusive_subtree_of_type<Element>([&](auto& element) {
+    m_root->for_each_in_subtree_of_type<Element>([&](auto& element) {
         if (m_filter(element))
             elements.append(const_cast<Element*>(&element));
         return IterationDecision::Continue;


### PR DESCRIPTION
Every user of HTMLCollection does not expect the root node to be a potential match, so let's avoid it by using non-inclusive sub-tree traversal. This avoids matching the element that getElementsByTagName was called on for example, which is required by Ruffle: https://github.com/ruffle-rs/ruffle/blob/da689b7687d6bb23f37251e902ccddabdfcc5f48/web/packages/core/src/ruffle-object.ts#L321-L329