### PR TITLE
Lagom: Add an option for standalone fuzzers to BuildFuzzers.sh

### DIFF
--- a/Meta/Lagom/BuildFuzzers.sh
+++ b/Meta/Lagom/BuildFuzzers.sh
@@ -74,6 +74,13 @@ if [ "$#" -gt "0" ] && [ "--oss-fuzz" = "$1" ] ; then
         -DCMAKE_PREFIX_PATH=Build/tool-install
     ninja -C Build/fuzzers
     cp Build/fuzzers/Fuzzers/Fuzz* "$OUT"/
+elif [ "$#" -gt "0" ] && [ "--standalone" = "$1" ] ; then
+    echo "Building for standalone fuzz configuration..."
+    cmake -GNinja -B Build/lagom-fuzzers-standalone \
+        -DBUILD_LAGOM=ON \
+        -DENABLE_FUZZERS=ON \
+        -DCMAKE_PREFIX_PATH=Build/tool-install
+    ninja -C Build/lagom-fuzzers-standalone
 else
     echo "Building for local fuzz configuration..."
     pick_clang

--- a/Meta/Lagom/ReadMe.md
+++ b/Meta/Lagom/ReadMe.md
@@ -63,6 +63,15 @@ To build with LLVM's libFuzzer, invoke the ``BuildFuzzers.sh`` script with no ar
 
 (Note that we require clang >= 13, see the pick_clang() function in the script for the paths that are searched)
 
+To build fuzzers without any kind of default instrumentation, pass the ``--standalone`` flag to ``BuildFuzzers.sh``:
+
+```sh
+./BuildFuzzers.sh --standalone
+
+# This binary will read a single test input from a given filename (or, if no filename is given, from stdin) and exit.
+./Build/lagom-fuzzers-standalone/Fuzzers/FuzzSomething
+```
+
 The fuzzing build's CMake cache can be manipulated with commands like `cmake -B Build/fuzzers -S . -DENABLE_LAGOM_LIBWEB=OFF`.
 
 Any fuzzing results (particularly slow inputs, crashes, etc.) will be dropped in the current directory.


### PR DESCRIPTION
This builds simple fuzzing binaries without any oss-fuzz specific configuration and without any LibFuzzer instrumentation.