### PR TITLE
LibVideo/VP9: Optimize inter-frame prediction

### DIFF
--- a/Userland/Libraries/LibVideo/VP9/ContextStorage.h
+++ b/Userland/Libraries/LibVideo/VP9/ContextStorage.h
@@ -265,7 +265,13 @@ struct ReferenceFrame {
     u8 bit_depth { 0 };
     Array<Vector<u16>, 3> frame_planes {};
 
-    bool is_valid() { return bit_depth > 0; }
+    bool is_valid() const { return bit_depth > 0; }
+
+    // These values are set at the start of each inter frame to be used during prediction.
+    i32 x_scale { 0 };
+    i32 y_scale { 0 };
+    i32 scaled_step_x { 0 };
+    i32 scaled_step_y { 0 };
 };
 
 }

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -59,6 +59,8 @@ private:
     // (8.5.1) Intra prediction process
     DecoderErrorOr<void> predict_intra(u8 plane, BlockContext const& block_context, u32 x, u32 y, bool have_left, bool have_above, bool not_on_right, TransformSize transform_size, u32 block_index);
 
+    DecoderErrorOr<void> prepare_referenced_frame(Gfx::Size<u32> frame_size, u8 reference_frame_index);
+
     // (8.5.1) Inter prediction process
     DecoderErrorOr<void> predict_inter(u8 plane, BlockContext const& block_context, u32 x, u32 y, u32 width, u32 height, u32 block_index);
     // (8.5.2.1) Motion vector selection process

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -220,6 +220,9 @@ DecoderErrorOr<void> Parser::uncompressed_header(FrameContext& frame_context)
             render_size = TRY(parse_render_size(frame_context.bit_stream, frame_size));
             frame_context.high_precision_motion_vectors_allowed = TRY_READ(frame_context.bit_stream.read_bit());
             frame_context.interpolation_filter = TRY(read_interpolation_filter(frame_context.bit_stream));
+            for (auto i = 0; i < REFS_PER_FRAME; i++) {
+                TRY(m_decoder.prepare_referenced_frame(frame_size, frame_context.reference_frame_indices[i]));
+            }
         }
     }
 


### PR DESCRIPTION
Mainly by reducing branches in some of hot loops (especially in `predict_inter_block()`), these changes achieve approximately a 64% improvement in benchmarked decoding time for a 26-second 720p video downloaded from YouTube. Specifically, the benchmark runtime started at ~43.5s total, and was reduced to ~15.6s.