### PR TITLE
LibWeb: Set Comment's prototype

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Comment.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Comment.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/CommentPrototype.h>
 #include <LibWeb/DOM/Comment.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/TextNode.h>
@@ -20,6 +21,14 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Comment>> Comment::construct_impl(JS::Realm
 {
     auto& window = verify_cast<HTML::Window>(realm.global_object());
     return MUST_OR_THROW_OOM(realm.heap().allocate<Comment>(realm, window.associated_document(), data));
+}
+
+JS::ThrowCompletionOr<void> Comment::initialize(JS::Realm& realm)
+{
+    MUST_OR_THROW_OOM(Base::initialize(realm));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::CommentPrototype>(realm, "Comment"));
+
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Comment.h
+++ b/Userland/Libraries/LibWeb/DOM/Comment.h
@@ -22,6 +22,8 @@ public:
 
 private:
     Comment(Document&, DeprecatedString const&);
+
+    virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 };
 
 template<>


### PR DESCRIPTION
This makes YouTube's thumbnails start appearing on the homepage. Yes, seriously.

Simply put, this is because this check failed when Comment had the incorrect prototype:
https://github.com/webcomponents/polyfills/blob/90cb97f847ce918289dac0978c50dcda0a0afd72/packages/shadycss/src/style-util.js#L397

This causes it to try and reconvert style sheets that are already in Shady format, which would cause it to spuriously add things such as class selectors on the end of tag selectors. This caused nothing to match the selectors.

When YouTube is generating the thumbnails, it checks if the thumbnail grid container has a non-zero clientWidth. If it's zero, it simply bails generating thumbnails. Since the selectors for this container did not apply, we would not properly create a paint box for it, causing clientWidth to return zero.

Before:
![Screenshot from 2023-04-14 09-36-37](https://user-images.githubusercontent.com/25595356/231991331-8514bb62-7283-40b1-bfc0-b54bc411789d.png)

After:
![Screenshot from 2023-04-14 09-28-08](https://user-images.githubusercontent.com/25595356/231991391-889d3d2a-6e25-463a-b7d6-e290211b98fc.png)
