### PR TITLE
nc: Fix bugs and improve QoL

### DIFF
--- a/Base/usr/share/man/man1/nc.md
+++ b/Base/usr/share/man/man1/nc.md
@@ -5,7 +5,7 @@ nc
 ## Synopsis
 
 ```sh
-$ nc [--length ] [--listen] [-N] [--udp] [--verbose] <target> <port>
+$ nc [--length ] [--listen] [-N] [--udp] [-p port] [--verbose] [target] [port]
 ```
 
 ## Description
@@ -18,6 +18,7 @@ Network cat: Connect to network sockets as if it were a file.
 * `-l`, `--listen`: Listen instead of connecting
 * `-N`: Close connection after reading stdin to the end
 * `-u`, `--udp`: UDP mode
+* `-p port`: Local port for remote connections
 * `-v`, `--verbose`: Log everything that's happening
 
 ## Arguments

--- a/Base/usr/share/man/man1/nc.md
+++ b/Base/usr/share/man/man1/nc.md
@@ -5,7 +5,7 @@ nc
 ## Synopsis
 
 ```sh
-$ nc [--length ] [--listen] [-N] [--udp] [-p port] [--verbose] [target] [port]
+$ nc [--length ] [--listen] [-N] [-n] [--udp] [-p port] [--verbose] [target] [port]
 ```
 
 ## Description
@@ -17,6 +17,7 @@ Network cat: Connect to network sockets as if it were a file.
 * `-I`, `--length`: Set maximum tcp receive buffer size
 * `-l`, `--listen`: Listen instead of connecting
 * `-N`: Close connection after reading stdin to the end
+* `-n`: Suppress name resolution
 * `-u`, `--udp`: UDP mode
 * `-p port`: Local port for remote connections
 * `-v`, `--verbose`: Log everything that's happening

--- a/Base/usr/share/man/man1/nc.md
+++ b/Base/usr/share/man/man1/nc.md
@@ -5,7 +5,7 @@ nc
 ## Synopsis
 
 ```sh
-$ nc [--listen] [--verbose] [--udp] [-N] [--length ] <target> <port>
+$ nc [--length ] [--listen] [-N] [--udp] [--verbose] <target> <port>
 ```
 
 ## Description
@@ -14,11 +14,11 @@ Network cat: Connect to network sockets as if it were a file.
 
 ## Options
 
-* `-l`, `--listen`: Listen instead of connecting
-* `-v`, `--verbose`: Log everything that's happening
-* `-u`, `--udp`: UDP mode
-* `-N`: Close connection after reading stdin to the end
 * `-I`, `--length`: Set maximum tcp receive buffer size
+* `-l`, `--listen`: Listen instead of connecting
+* `-N`: Close connection after reading stdin to the end
+* `-u`, `--udp`: UDP mode
+* `-v`, `--verbose`: Log everything that's happening
 
 ## Arguments
 

--- a/Userland/Utilities/nc.cpp
+++ b/Userland/Utilities/nc.cpp
@@ -114,7 +114,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         TRY(Core::System::getsockname(listen_fd, (struct sockaddr*)&sin, &len));
 
         if (verbose)
-            warnln("waiting for a connection on {}:{}", inet_ntop(sin.sin_family, &sin.sin_addr, addr_str, sizeof(addr_str) - 1), ntohs(sin.sin_port));
+            warnln("waiting for a connection on {}:{}", inet_ntop(sin.sin_family, &sin.sin_addr, addr_str, sizeof(addr_str)), ntohs(sin.sin_port));
 
     } else {
         fd = TRY(Core::System::socket(AF_INET, SOCK_STREAM, 0));
@@ -138,7 +138,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         if (verbose) {
             char addr_str[INET_ADDRSTRLEN];
-            warnln("connecting to {}:{}", inet_ntop(dst_addr.sin_family, &dst_addr.sin_addr, addr_str, sizeof(addr_str) - 1), ntohs(dst_addr.sin_port));
+            warnln("connecting to {}:{}", inet_ntop(dst_addr.sin_family, &dst_addr.sin_addr, addr_str, sizeof(addr_str)), ntohs(dst_addr.sin_port));
         }
 
         TRY(Core::System::connect(fd, (struct sockaddr*)&dst_addr, sizeof(dst_addr)));
@@ -258,7 +258,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             connected_clients.set(new_client);
 
             if (verbose)
-                warnln("got connection from {}:{}", inet_ntop(client.sin_family, &client.sin_addr, client_str, sizeof(client_str) - 1), ntohs(client.sin_port));
+                warnln("got connection from {}:{}", inet_ntop(client.sin_family, &client.sin_addr, client_str, sizeof(client_str)), ntohs(client.sin_port));
         }
 
         if (has_clients) {

--- a/Userland/Utilities/nc.cpp
+++ b/Userland/Utilities/nc.cpp
@@ -55,11 +55,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Network cat: Connect to network sockets as if it were a file.");
-    args_parser.add_option(should_listen, "Listen instead of connecting", "listen", 'l');
-    args_parser.add_option(verbose, "Log everything that's happening", "verbose", 'v');
-    args_parser.add_option(udp_mode, "UDP mode", "udp", 'u');
-    args_parser.add_option(should_close, "Close connection after reading stdin to the end", nullptr, 'N');
     args_parser.add_option(maximum_tcp_receive_buffer_size_input, "Set maximum tcp receive buffer size", "length", 'I', nullptr);
+    args_parser.add_option(should_listen, "Listen instead of connecting", "listen", 'l');
+    args_parser.add_option(should_close, "Close connection after reading stdin to the end", nullptr, 'N');
+    args_parser.add_option(udp_mode, "UDP mode", "udp", 'u');
+    args_parser.add_option(verbose, "Log everything that's happening", "verbose", 'v');
     args_parser.add_positional_argument(target, "Address to listen on, or the address or hostname to connect to", "target");
     args_parser.add_positional_argument(port, "Port to connect to or listen on", "port");
     args_parser.parse(arguments);


### PR DESCRIPTION
This PR reorders the command line arguments to be alphabetically sorted, fixed some off-by-one-errors and adds two new command line options: `-n` and `-p`.

~~It also enables our TCP stack to support `bind and connect` connections where we set a local port with `bind` ourself instead of letting the kernel choose one once we call `connect`.~~

We decided to drop this part of the PR for now: https://discord.com/channels/830522505605283862/830525093905170492/1100487777939882136 ff