### PR TITLE
LibWeb: Do not dereference empty Optional in ReadableStream::visit_edges

### DIFF
--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -108,7 +108,8 @@ JS::ThrowCompletionOr<void> ReadableStream::initialize(JS::Realm& realm)
 void ReadableStream::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    m_controller->visit([&](auto& controller) { visitor.visit(controller); });
+    if (m_controller.has_value())
+        m_controller->visit([&](auto& controller) { visitor.visit(controller); });
     visitor.visit(m_stored_error);
     visitor.visit(m_reader);
 }


### PR DESCRIPTION
There are quite a few steps between a `ReadableStream` being created and its controller being set. If GC occurs between those points, we will have an empty `Optional` in `ReadableStream::visit_edges`. Seen on YouTube.