### PR TITLE
LibGfx+LibGUI: Improve error and font handling for MessageBox

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -201,7 +201,7 @@ void BookmarksBarWidget::model_did_update(unsigned)
         auto title = model()->index(item_index, 0).data().to_deprecated_string();
         auto url = model()->index(item_index, 1).data().to_deprecated_string();
 
-        Gfx::IntRect rect { width, 0, static_cast<int>(ceilf(font().width(title))) + 32, height() };
+        Gfx::IntRect rect { width, 0, font().width_rounded_up(title) + 32, height() };
 
         auto& button = add<GUI::Button>();
         m_bookmarks.append(button);

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -265,8 +265,9 @@ void MonitorSettingsWidget::apply_settings()
                 return;
             auto current_box_text = current_box_text_or_error.release_value();
 
-            auto box = GUI::MessageBox::construct(window(), current_box_text, "Apply new screen layout"sv,
-                GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
+            auto box = GUI::MessageBox::create(window(), current_box_text, "Apply new screen layout"sv,
+                GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo)
+                           .release_value_but_fixme_should_propagate_errors();
             box->set_icon(window()->icon());
 
             // If after 10 seconds the user doesn't close the message box, just close it.
@@ -279,7 +280,7 @@ void MonitorSettingsWidget::apply_settings()
                     return;
                 }
                 auto current_box_text = current_box_text_or_error.release_value();
-                box->set_text(current_box_text.to_deprecated_string());
+                box->set_text(current_box_text);
                 if (seconds_until_revert <= 0) {
                     box->close();
                 }

--- a/Userland/Applications/KeyboardMapper/KeyButton.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyButton.cpp
@@ -41,7 +41,7 @@ void KeyButton::paint_event(GUI::PaintEvent& event)
     if (text().is_empty() || text().bytes_as_string_view().starts_with('\0'))
         return;
 
-    Gfx::IntRect text_rect { 0, 0, static_cast<int>(ceilf(font.width(text()))), font.pixel_size_rounded_up() };
+    Gfx::IntRect text_rect { 0, 0, font.width_rounded_up(text()), font.pixel_size_rounded_up() };
     text_rect.align_within(key_cap_face_rect, Gfx::TextAlignment::Center);
 
     painter.draw_text(text_rect, text(), font, Gfx::TextAlignment::Center, Color::Black, Gfx::TextElision::Right);

--- a/Userland/Games/BrickGame/BrickGame.cpp
+++ b/Userland/Games/BrickGame/BrickGame.cpp
@@ -585,7 +585,7 @@ void BrickGame::paint_cell(GUI::Painter& painter, Gfx::IntRect rect, BrickGame::
 
 void BrickGame::paint_sidebar_text(GUI::Painter& painter, int row, StringView text)
 {
-    auto const text_width = static_cast<int>(ceilf(font().width(text)));
+    auto const text_width = font().width_rounded_up(text);
     auto const entire_area_rect { frame_inner_rect() };
     auto const margin = 4;
     auto const rect { Gfx::IntRect { entire_area_rect.x() + entire_area_rect.width() - 116,
@@ -597,7 +597,7 @@ void BrickGame::paint_sidebar_text(GUI::Painter& painter, int row, StringView te
 void BrickGame::paint_paused_text(GUI::Painter& painter)
 {
     auto const paused_text = "Paused"sv;
-    auto const paused_text_width = static_cast<int>(ceilf(font().width(paused_text)));
+    auto const paused_text_width = font().width_rounded_up(paused_text);
     auto const more_or_less_font_height = static_cast<int>(font().pixel_size_rounded_up());
     auto const entire_area_rect { frame_inner_rect() };
     auto const margin = more_or_less_font_height * 2;

--- a/Userland/Games/Hearts/ScoreCard.cpp
+++ b/Userland/Games/Hearts/ScoreCard.cpp
@@ -71,7 +71,7 @@ void ScoreCard::paint_event(GUI::PaintEvent& event)
         for (int score_index = 0; score_index < (int)player.scores.size(); score_index++) {
             auto text_rect = cell_rect(player_index, 1 + score_index);
             auto score_text = DeprecatedString::formatted("{}", player.scores[score_index]);
-            auto score_text_width = static_cast<int>(ceilf(font.width(score_text)));
+            auto score_text_width = font.width_rounded_up(score_text);
             if (score_index != (int)player.scores.size() - 1) {
                 painter.draw_line(
                     { text_rect.left() + text_rect.width() / 2 - score_text_width / 2 - 3, text_rect.top() + font.pixel_size_rounded_up() / 2 },

--- a/Userland/Libraries/LibCards/CardPainter.cpp
+++ b/Userland/Libraries/LibCards/CardPainter.cpp
@@ -201,7 +201,7 @@ void CardPainter::paint_card_front(Gfx::Bitmap& bitmap, Cards::Suit suit, Cards:
     paint_rect.set_height(paint_rect.height() / 2);
     paint_rect.shrink(10, 6);
 
-    auto text_rect = Gfx::IntRect { 4, 6, static_cast<int>(ceilf(font.width("10"sv))), font.pixel_size_rounded_up() };
+    auto text_rect = Gfx::IntRect { 4, 6, font.width_rounded_up("10"sv), font.pixel_size_rounded_up() };
     painter.draw_text(text_rect, card_rank_label(rank), font, Gfx::TextAlignment::Center, suit_color);
 
     painter.draw_bitmap(

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -23,7 +23,7 @@ namespace GUI {
 Button::Button(String text)
     : AbstractButton(move(text))
 {
-    set_min_size({ 40, SpecialDimension::Shrink });
+    set_min_size({ SpecialDimension::Shrink });
     set_preferred_size({ SpecialDimension::OpportunisticGrow, SpecialDimension::Shrink });
     set_focus_policy(GUI::FocusPolicy::StrongFocus);
 
@@ -275,24 +275,18 @@ void Button::timer_event(Core::TimerEvent&)
 
 Optional<UISize> Button::calculated_min_size() const
 {
-    int width = 0;
-    int height = 0;
-
+    int width = 22;
+    int height = 22;
+    int constexpr padding = 6;
     if (!text().is_empty()) {
-        auto& font = this->font();
-        width = static_cast<int>(ceilf(font.width(text()))) + 2;
-        height = font.pixel_size_rounded_up() + 4; // FIXME: Use actual maximum total height
+        width = max(width, font().width_rounded_up("..."sv) + padding);
+        height = max(height, font().pixel_size_rounded_up() + padding);
     }
-
-    if (m_icon) {
-        height += max(height, m_icon->height());
-        width += m_icon->width() + icon_spacing();
+    if (icon()) {
+        int icon_width = icon()->width() + icon_spacing();
+        width = text().is_empty() ? max(width, icon_width) : width + icon_width;
+        height = max(height, icon()->height() + padding);
     }
-
-    width += 8;
-    height += 4;
-
-    height = max(22, height);
 
     return UISize(width, height);
 }

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -291,4 +291,14 @@ Optional<UISize> Button::calculated_min_size() const
     return UISize(width, height);
 }
 
+Optional<UISize> DialogButton::calculated_min_size() const
+{
+    int constexpr scale = 8;
+    int constexpr padding = 6;
+    int width = max(80, font().presentation_size() * scale);
+    int height = max(22, font().pixel_size_rounded_up() + padding);
+
+    return UISize(width, height);
+}
+
 }

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -105,7 +105,7 @@ void Button::paint_event(PaintEvent& event)
         content_rect.set_width(content_rect.width() - m_icon->width() - icon_spacing());
     }
 
-    Gfx::IntRect text_rect { 0, 0, static_cast<int>(ceilf(font.width(text()))), font.pixel_size_rounded_up() };
+    Gfx::IntRect text_rect { 0, 0, font.width_rounded_up(text()), font.pixel_size_rounded_up() };
     if (text_rect.width() > content_rect.width())
         text_rect.set_width(content_rect.width());
     text_rect.align_within(content_rect, text_alignment());

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -95,8 +95,11 @@ public:
     explicit DialogButton(String text = {})
         : Button(move(text))
     {
-        set_fixed_width(80);
+        set_min_size({ SpecialDimension::Shrink });
+        set_preferred_size({ SpecialDimension::Shrink });
     }
+
+    virtual Optional<UISize> calculated_min_size() const override;
 };
 
 }

--- a/Userland/Libraries/LibGUI/CheckBox.cpp
+++ b/Userland/Libraries/LibGUI/CheckBox.cpp
@@ -65,7 +65,7 @@ void CheckBox::paint_event(PaintEvent& event)
     auto text_rect = rect();
     if (m_checkbox_position == CheckBoxPosition::Left)
         text_rect.set_left(box_rect.right() + 1 + gap_between_box_and_rect());
-    text_rect.set_width(static_cast<int>(ceilf(font().width(text()))));
+    text_rect.set_width(font().width_rounded_up(text()));
     text_rect.set_top(height() / 2 - font().pixel_size_rounded_up() / 2);
     text_rect.set_height(font().pixel_size_rounded_up());
 
@@ -101,7 +101,7 @@ void CheckBox::set_autosize(bool autosize)
 
 void CheckBox::size_to_fit()
 {
-    set_fixed_width(box_rect().width() + gap_between_box_and_rect() + static_cast<int>(ceilf(font().width(text()))) + horizontal_padding() * 2);
+    set_fixed_width(box_rect().width() + gap_between_box_and_rect() + font().width_rounded_up(text()) + horizontal_padding() * 2);
 }
 
 Optional<UISize> CheckBox::calculated_min_size() const

--- a/Userland/Libraries/LibGUI/GroupBox.cpp
+++ b/Userland/Libraries/LibGUI/GroupBox.cpp
@@ -43,7 +43,7 @@ void GroupBox::paint_event(PaintEvent& event)
     Gfx::StylePainter::paint_frame(painter, frame_rect, palette(), Gfx::FrameShape::Box, Gfx::FrameShadow::Sunken, 2);
 
     if (!m_title.is_empty()) {
-        Gfx::IntRect text_rect { 6, 1, static_cast<int>(ceilf(font().width(m_title) + 6)), font().pixel_size_rounded_up() };
+        Gfx::IntRect text_rect { 6, 1, font().width_rounded_up(m_title) + 6, font().pixel_size_rounded_up() };
         painter.fill_rect(text_rect, palette().button());
         painter.draw_text(text_rect, m_title, Gfx::TextAlignment::CenterLeft, palette().button_text());
     }

--- a/Userland/Libraries/LibGUI/HeaderView.cpp
+++ b/Userland/Libraries/LibGUI/HeaderView.cpp
@@ -272,7 +272,7 @@ void HeaderView::paint_horizontal(Painter& painter)
         painter.draw_text(text_rect, text, font(), section_data.alignment, palette().button_text());
 
         if (is_key_column && (m_table_view.sort_order() != SortOrder::None)) {
-            Gfx::IntPoint offset { text_rect.x() + static_cast<int>(ceilf(font().width(text))) + sorting_arrow_offset, sorting_arrow_offset };
+            Gfx::IntPoint offset { text_rect.x() + font().width_rounded_up(text) + sorting_arrow_offset, sorting_arrow_offset };
             auto coordinates = m_table_view.sort_order() == SortOrder::Ascending
                 ? ascending_arrow_coordinates.span()
                 : descending_arrow_coordinates.span();

--- a/Userland/Libraries/LibGUI/IconView.cpp
+++ b/Userland/Libraries/LibGUI/IconView.cpp
@@ -428,7 +428,7 @@ void IconView::get_item_rects(int item_index, ItemData& item_data, Gfx::Font con
     item_data.icon_offset_y = -font.pixel_size_rounded_up() - 6;
     item_data.icon_rect.translate_by(0, item_data.icon_offset_y);
 
-    int unwrapped_text_width = static_cast<int>(ceilf(font.width(item_data.text)));
+    int unwrapped_text_width = font.width_rounded_up(item_data.text);
     int available_width = item_rect.width() - 6;
 
     item_data.text_rect = { 0, item_data.icon_rect.bottom() + 6 + 1, 0, font.pixel_size_rounded_up() };

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -23,7 +23,7 @@ Label::Label(DeprecatedString text)
     REGISTER_TEXT_WRAPPING_PROPERTY("text_wrapping", text_wrapping, set_text_wrapping);
 
     set_preferred_size({ SpecialDimension::OpportunisticGrow });
-    set_min_height(22);
+    set_min_size({ SpecialDimension::Shrink });
 
     set_frame_thickness(0);
     set_frame_shadow(Gfx::FrameShadow::Plain);
@@ -127,6 +127,16 @@ int Label::text_calculated_preferred_height() const
 Optional<UISize> Label::calculated_preferred_size() const
 {
     return GUI::UISize(text_calculated_preferred_width(), text_calculated_preferred_height());
+}
+
+Optional<UISize> Label::calculated_min_size() const
+{
+    int frame = frame_thickness() * 2;
+    int width = font().width_rounded_up("..."sv) + frame;
+    int height = font().pixel_size_rounded_up() + frame;
+    height = max(height, 22);
+
+    return UISize(width, height);
 }
 
 }

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -116,7 +116,7 @@ void Label::size_to_fit()
 
 int Label::text_calculated_preferred_width() const
 {
-    return static_cast<int>(ceilf(font().width(m_text))) + m_autosize_padding * 2;
+    return font().width_rounded_up(m_text) + m_autosize_padding * 2;
 }
 
 int Label::text_calculated_preferred_height() const

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -109,9 +109,16 @@ void Label::paint_event(PaintEvent& event)
     }
 }
 
+void Label::did_change_font()
+{
+    if (m_autosize)
+        size_to_fit();
+}
+
 void Label::size_to_fit()
 {
     set_fixed_width(text_calculated_preferred_width());
+    set_fixed_height(text_calculated_preferred_height());
 }
 
 int Label::text_calculated_preferred_width() const

--- a/Userland/Libraries/LibGUI/Label.h
+++ b/Userland/Libraries/LibGUI/Label.h
@@ -38,6 +38,7 @@ public:
     bool is_autosize() const { return m_autosize; }
     void set_autosize(bool, size_t padding = 0);
 
+    virtual Optional<UISize> calculated_min_size() const override;
     virtual Optional<UISize> calculated_preferred_size() const override;
     int text_calculated_preferred_height() const;
     int text_calculated_preferred_width() const;

--- a/Userland/Libraries/LibGUI/Label.h
+++ b/Userland/Libraries/LibGUI/Label.h
@@ -49,6 +49,7 @@ protected:
     explicit Label(DeprecatedString text = {});
 
     virtual void paint_event(PaintEvent&) override;
+    virtual void did_change_font() override;
     virtual void did_change_text() { }
 
 private:

--- a/Userland/Libraries/LibGUI/LinkLabel.cpp
+++ b/Userland/Libraries/LibGUI/LinkLabel.cpp
@@ -81,7 +81,7 @@ void LinkLabel::paint_event(PaintEvent& event)
     GUI::Painter painter(*this);
 
     if (m_hovered)
-        painter.draw_line({ 0, rect().bottom() }, { static_cast<int>(ceilf(font().width(text()))), rect().bottom() }, palette().link());
+        painter.draw_line({ 0, rect().bottom() }, { font().width_rounded_up(text()), rect().bottom() }, palette().link());
 
     if (is_focused())
         painter.draw_focus_rect(text_rect(), palette().focus_outline());

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -12,13 +12,29 @@
 #include <LibGUI/ImageWidget.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/MessageBox.h>
-#include <LibGfx/Font/Font.h>
 
 namespace GUI {
 
+ErrorOr<NonnullRefPtr<MessageBox>> MessageBox::create(Window* parent_window, StringView text, StringView title, Type type, InputType input_type)
+{
+    auto box = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) MessageBox(parent_window, type, input_type)));
+    TRY(box->build());
+    box->set_title(TRY(String::from_utf8(title)).to_deprecated_string());
+    box->set_text(TRY(String::from_utf8(text)));
+    auto size = box->main_widget()->effective_min_size();
+    box->resize(TRY(size.width().shrink_value()), TRY(size.height().shrink_value()));
+
+    return box;
+}
+
 Dialog::ExecResult MessageBox::show(Window* parent_window, StringView text, StringView title, Type type, InputType input_type)
 {
-    auto box = MessageBox::construct(parent_window, text, title, type, input_type);
+    return MUST(try_show(parent_window, text, title, type, input_type));
+}
+
+ErrorOr<Dialog::ExecResult> MessageBox::try_show(Window* parent_window, StringView text, StringView title, Type type, InputType input_type)
+{
+    auto box = TRY(MessageBox::create(parent_window, text, title, type, input_type));
     if (parent_window)
         box->set_icon(parent_window->icon());
     return box->exec();
@@ -26,31 +42,41 @@ Dialog::ExecResult MessageBox::show(Window* parent_window, StringView text, Stri
 
 Dialog::ExecResult MessageBox::show_error(Window* parent_window, StringView text)
 {
-    return show(parent_window, text, "Error"sv, GUI::MessageBox::Type::Error, GUI::MessageBox::InputType::OK);
+    return MUST(try_show_error(parent_window, text));
+}
+
+ErrorOr<Dialog::ExecResult> MessageBox::try_show_error(Window* parent_window, StringView text)
+{
+    return TRY(try_show(parent_window, text, "Error"sv, GUI::MessageBox::Type::Error, GUI::MessageBox::InputType::OK));
 }
 
 Dialog::ExecResult MessageBox::ask_about_unsaved_changes(Window* parent_window, StringView path, Optional<Time> last_unmodified_timestamp)
 {
+    return MUST(try_ask_about_unsaved_changes(parent_window, path, last_unmodified_timestamp));
+}
+
+ErrorOr<Dialog::ExecResult> MessageBox::try_ask_about_unsaved_changes(Window* parent_window, StringView path, Optional<Time> last_unmodified_timestamp)
+{
     StringBuilder builder;
-    builder.append("Save changes to "sv);
+    TRY(builder.try_append("Save changes to "sv));
     if (path.is_empty())
-        builder.append("untitled document"sv);
+        TRY(builder.try_append("untitled document"sv));
     else
-        builder.appendff("\"{}\"", LexicalPath::basename(path));
-    builder.append(" before closing?"sv);
+        TRY(builder.try_appendff("\"{}\"", LexicalPath::basename(path)));
+    TRY(builder.try_append(" before closing?"sv));
 
     if (!path.is_empty() && last_unmodified_timestamp.has_value()) {
         auto age = (Time::now_monotonic() - *last_unmodified_timestamp).to_seconds();
         auto readable_time = human_readable_time(age);
-        builder.appendff("\nLast saved {} ago.", readable_time);
+        TRY(builder.try_appendff("\nLast saved {} ago.", readable_time));
     }
 
-    auto box = MessageBox::construct(parent_window, builder.string_view(), "Unsaved changes"sv, Type::Warning, InputType::YesNoCancel);
+    auto box = TRY(MessageBox::create(parent_window, builder.string_view(), "Unsaved changes"sv, Type::Warning, InputType::YesNoCancel));
     if (parent_window)
         box->set_icon(parent_window->icon());
 
     if (path.is_empty())
-        box->m_yes_button->set_text("Save As..."_string.release_value_but_fixme_should_propagate_errors());
+        box->m_yes_button->set_text(TRY("Save As..."_string));
     else
         box->m_yes_button->set_text("Save"_short_string);
     box->m_no_button->set_text("Discard"_short_string);
@@ -59,33 +85,31 @@ Dialog::ExecResult MessageBox::ask_about_unsaved_changes(Window* parent_window, 
     return box->exec();
 }
 
-void MessageBox::set_text(DeprecatedString text)
+void MessageBox::set_text(String text)
 {
-    m_text = move(text);
-    build();
+    m_text_label->set_text(move(text).to_deprecated_string());
 }
 
-MessageBox::MessageBox(Window* parent_window, StringView text, StringView title, Type type, InputType input_type)
+MessageBox::MessageBox(Window* parent_window, Type type, InputType input_type)
     : Dialog(parent_window)
-    , m_text(text)
     , m_type(type)
     , m_input_type(input_type)
 {
-    set_title(title);
-    build();
+    set_resizable(false);
+    set_auto_shrink(true);
 }
 
-RefPtr<Gfx::Bitmap> MessageBox::icon() const
+ErrorOr<RefPtr<Gfx::Bitmap>> MessageBox::icon() const
 {
     switch (m_type) {
     case Type::Information:
-        return Gfx::Bitmap::load_from_file("/res/icons/32x32/msgbox-information.png"sv).release_value_but_fixme_should_propagate_errors();
+        return TRY(Gfx::Bitmap::load_from_file("/res/icons/32x32/msgbox-information.png"sv));
     case Type::Warning:
-        return Gfx::Bitmap::load_from_file("/res/icons/32x32/msgbox-warning.png"sv).release_value_but_fixme_should_propagate_errors();
+        return TRY(Gfx::Bitmap::load_from_file("/res/icons/32x32/msgbox-warning.png"sv));
     case Type::Error:
-        return Gfx::Bitmap::load_from_file("/res/icons/32x32/msgbox-error.png"sv).release_value_but_fixme_should_propagate_errors();
+        return TRY(Gfx::Bitmap::load_from_file("/res/icons/32x32/msgbox-error.png"sv));
     case Type::Question:
-        return Gfx::Bitmap::load_from_file("/res/icons/32x32/msgbox-question.png"sv).release_value_but_fixme_should_propagate_errors();
+        return TRY(Gfx::Bitmap::load_from_file("/res/icons/32x32/msgbox-question.png"sv));
     default:
         return nullptr;
     }
@@ -111,72 +135,49 @@ bool MessageBox::should_include_no_button() const
     return should_include_yes_button();
 }
 
-void MessageBox::build()
+ErrorOr<void> MessageBox::build()
 {
-    auto widget = set_main_widget<Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = TRY(set_main_widget<Widget>());
+    main_widget->set_fill_with_background_color(true);
+    TRY(main_widget->try_set_layout<VerticalBoxLayout>(8, 6));
 
-    int text_width = widget->font().width(m_text);
-    auto number_of_lines = m_text.split('\n').size();
-    int padded_text_height = widget->font().pixel_size_rounded_up() * 1.6;
-    int total_text_height = number_of_lines * padded_text_height;
-    int icon_width = 0;
+    auto message_container = TRY(main_widget->try_add<Widget>());
+    auto message_margins = Margins { 8, m_type != Type::None ? 8 : 0 };
+    TRY(message_container->try_set_layout<HorizontalBoxLayout>(message_margins, 8));
 
-    widget->set_layout<VerticalBoxLayout>(8, 6);
-    widget->set_fill_with_background_color(true);
-
-    auto& message_container = widget->add<Widget>();
-    message_container.set_layout<HorizontalBoxLayout>(GUI::Margins {}, 8);
-
-    if (m_type != Type::None) {
-        auto& icon_image = message_container.add<ImageWidget>();
-        icon_image.set_bitmap(icon());
-        if (icon()) {
-            icon_width = icon()->width();
-            if (icon_width > 0)
-                message_container.layout()->set_margins({ 0, 0, 0, 8 });
-        }
+    if (auto icon = TRY(this->icon()); icon && m_type != Type::None) {
+        auto image_widget = TRY(message_container->try_add<ImageWidget>());
+        image_widget->set_bitmap(icon);
     }
 
-    auto& label = message_container.add<Label>(m_text);
-    label.set_fixed_height(total_text_height);
+    m_text_label = TRY(message_container->try_add<Label>());
+    m_text_label->set_text_wrapping(Gfx::TextWrapping::DontWrap);
+    m_text_label->set_autosize(true);
     if (m_type != Type::None)
-        label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        m_text_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
-    auto& button_container = widget->add<Widget>();
-    button_container.set_layout<HorizontalBoxLayout>(GUI::Margins {}, 8);
-    button_container.set_fixed_height(24);
+    auto button_container = TRY(main_widget->try_add<Widget>());
+    TRY(button_container->try_set_layout<HorizontalBoxLayout>(Margins {}, 8));
 
-    constexpr int button_width = 80;
-    int button_count = 0;
-
-    auto add_button = [&](String label, ExecResult result) -> GUI::Button& {
-        auto& button = button_container.add<Button>();
-        button.set_fixed_width(button_width);
-        button.set_text(move(label));
-        button.on_click = [this, result](auto) {
-            done(result);
-        };
-        ++button_count;
+    auto add_button = [&](String text, ExecResult result) -> ErrorOr<NonnullRefPtr<Button>> {
+        auto button = TRY(button_container->try_add<DialogButton>());
+        button->set_text(move(text));
+        button->on_click = [this, result](auto) { done(result); };
         return button;
     };
 
-    button_container.add_spacer().release_value_but_fixme_should_propagate_errors();
+    TRY(button_container->add_spacer());
     if (should_include_ok_button())
-        m_ok_button = add_button("OK"_short_string, ExecResult::OK);
+        m_ok_button = TRY(add_button("OK"_short_string, ExecResult::OK));
     if (should_include_yes_button())
-        m_yes_button = add_button("Yes"_short_string, ExecResult::Yes);
+        m_yes_button = TRY(add_button("Yes"_short_string, ExecResult::Yes));
     if (should_include_no_button())
-        m_no_button = add_button("No"_short_string, ExecResult::No);
+        m_no_button = TRY(add_button("No"_short_string, ExecResult::No));
     if (should_include_cancel_button())
-        m_cancel_button = add_button("Cancel"_short_string, ExecResult::Cancel);
-    button_container.add_spacer().release_value_but_fixme_should_propagate_errors();
+        m_cancel_button = TRY(add_button("Cancel"_short_string, ExecResult::Cancel));
+    TRY(button_container->add_spacer());
 
-    int width = (button_count * button_width) + ((button_count - 1) * button_container.layout()->spacing()) + 32;
-    width = max(width, text_width + icon_width + 56);
-
-    // FIXME: Use shrink from new layout system
-    set_rect(x(), y(), width, 80 + label.text_calculated_preferred_height());
-    set_resizable(false);
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibGUI/MessageBox.h
+++ b/Userland/Libraries/LibGUI/MessageBox.h
@@ -13,7 +13,7 @@
 namespace GUI {
 
 class MessageBox : public Dialog {
-    C_OBJECT(MessageBox)
+    C_OBJECT_ABSTRACT(MessageBox)
 public:
     enum class Type {
         None,
@@ -36,19 +36,25 @@ public:
     static ExecResult show_error(Window* parent_window, StringView text);
     static ExecResult ask_about_unsaved_changes(Window* parent_window, StringView path, Optional<Time> last_unmodified_timestamp = {});
 
-    void set_text(DeprecatedString text);
+    static ErrorOr<ExecResult> try_show(Window* parent_window, StringView text, StringView title, Type type = Type::None, InputType input_type = InputType::OK);
+    static ErrorOr<ExecResult> try_show_error(Window* parent_window, StringView text);
+    static ErrorOr<ExecResult> try_ask_about_unsaved_changes(Window* parent_window, StringView path, Optional<Time> last_unmodified_timestamp = {});
+
+    static ErrorOr<NonnullRefPtr<MessageBox>> create(Window* parent_window, StringView text, StringView title, Type type = Type::None, InputType input_type = InputType::OK);
+
+    void set_text(String);
 
 private:
-    explicit MessageBox(Window* parent_window, StringView text, StringView title, Type type = Type::None, InputType input_type = InputType::OK);
+    MessageBox(Window* parent_window, Type type = Type::None, InputType input_type = InputType::OK);
 
     bool should_include_ok_button() const;
     bool should_include_cancel_button() const;
     bool should_include_yes_button() const;
     bool should_include_no_button() const;
-    void build();
-    RefPtr<Gfx::Bitmap> icon() const;
 
-    DeprecatedString m_text;
+    ErrorOr<void> build();
+    ErrorOr<RefPtr<Gfx::Bitmap>> icon() const;
+
     Type m_type { Type::None };
     InputType m_input_type { InputType::OK };
 
@@ -56,6 +62,7 @@ private:
     RefPtr<GUI::Button> m_yes_button;
     RefPtr<GUI::Button> m_no_button;
     RefPtr<GUI::Button> m_cancel_button;
+    RefPtr<Label> m_text_label;
 };
 
 }

--- a/Userland/Libraries/LibGUI/RadioButton.cpp
+++ b/Userland/Libraries/LibGUI/RadioButton.cpp
@@ -51,7 +51,7 @@ void RadioButton::paint_event(PaintEvent& event)
 
     Gfx::StylePainter::paint_radio_button(painter, circle_rect, palette(), is_checked(), is_being_pressed());
 
-    Gfx::IntRect text_rect { circle_rect.right() + 5 + horizontal_padding(), 0, static_cast<int>(ceilf(font().width(text()))), font().pixel_size_rounded_up() };
+    Gfx::IntRect text_rect { circle_rect.right() + 5 + horizontal_padding(), 0, font().width_rounded_up(text()), font().pixel_size_rounded_up() };
     text_rect.center_vertically_within(rect());
     paint_text(painter, text_rect, font(), Gfx::TextAlignment::TopLeft);
 
@@ -69,7 +69,7 @@ void RadioButton::click(unsigned)
 Optional<UISize> RadioButton::calculated_min_size() const
 {
     auto const& font = this->font();
-    int width = horizontal_padding() * 2 + circle_size().width() + static_cast<int>(ceilf(font.width(text())));
+    int width = horizontal_padding() * 2 + circle_size().width() + font.width_rounded_up(text());
     int height = max(22, max(font.pixel_size_rounded_up() + 8, circle_size().height()));
     return UISize(width, height);
 }

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -452,7 +452,7 @@ Gfx::IntRect TabWidget::close_button_rect(size_t index) const
 
 int TabWidget::TabData::width(Gfx::Font const& font) const
 {
-    auto width = 16 + static_cast<int>(ceilf(font.width(title))) + (icon ? (16 + 4) : 0);
+    auto width = 16 + font.width_rounded_up(title) + (icon ? (16 + 4) : 0);
     // NOTE: This needs to always be an odd number, because the button rect
     //       includes 3px of light and shadow on the left and right edges. If
     //       the button rect width is not an odd number, the area left for the

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -63,6 +63,9 @@ public:
     bool is_obeying_widget_min_size() { return m_obey_widget_min_size; }
     void set_obey_widget_min_size(bool);
 
+    bool is_auto_shrinking() const { return m_auto_shrink; }
+    void set_auto_shrink(bool);
+
     bool is_minimizable() const { return m_minimizable; }
     void set_minimizable(bool minimizable) { m_minimizable = minimizable; }
 
@@ -321,6 +324,7 @@ private:
     bool m_moved_by_client { false };
     bool m_blocks_emoji_input { false };
     bool m_resizing { false };
+    bool m_auto_shrink { false };
 };
 
 }

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
@@ -336,6 +336,11 @@ float BitmapFont::glyph_or_emoji_width(Utf32CodePointIterator& it) const
     return glyph_or_emoji_width_impl(*this, it);
 }
 
+int BitmapFont::width_rounded_up(StringView view) const
+{
+    return static_cast<int>(ceilf(width(view)));
+}
+
 float BitmapFont::width(StringView view) const { return unicode_view_width(Utf8View(view)); }
 float BitmapFont::width(Utf8View const& view) const { return unicode_view_width(view); }
 float BitmapFont::width(Utf32View const& view) const { return unicode_view_width(view); }

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -97,6 +97,8 @@ public:
     virtual float width(Utf8View const&) const override;
     virtual float width(Utf32View const&) const override;
 
+    virtual int width_rounded_up(StringView) const override;
+
     DeprecatedString name() const override { return m_name; }
     void set_name(DeprecatedString name) { m_name = move(name); }
 

--- a/Userland/Libraries/LibGfx/Font/Font.h
+++ b/Userland/Libraries/LibGfx/Font/Font.h
@@ -196,6 +196,8 @@ public:
     virtual float width(Utf8View const&) const = 0;
     virtual float width(Utf32View const&) const = 0;
 
+    virtual int width_rounded_up(StringView) const = 0;
+
     virtual DeprecatedString name() const = 0;
 
     virtual bool is_fixed_width() const = 0;

--- a/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
@@ -36,6 +36,11 @@ ScaledFont::ScaledFont(NonnullRefPtr<VectorFont> font, float point_width, float 
     };
 }
 
+int ScaledFont::width_rounded_up(StringView view) const
+{
+    return static_cast<int>(ceilf(width(view)));
+}
+
 float ScaledFont::width(StringView view) const { return unicode_view_width(Utf8View(view)); }
 float ScaledFont::width(Utf8View const& view) const { return unicode_view_width(view); }
 float ScaledFont::width(Utf32View const& view) const { return unicode_view_width(view); }

--- a/Userland/Libraries/LibGfx/Font/ScaledFont.h
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.h
@@ -61,6 +61,7 @@ public:
     virtual float width(StringView) const override;
     virtual float width(Utf8View const&) const override;
     virtual float width(Utf32View const&) const override;
+    virtual int width_rounded_up(StringView) const override;
     virtual DeprecatedString name() const override { return DeprecatedString::formatted("{} {}", family(), variant()); }
     virtual bool is_fixed_width() const override { return m_font->is_fixed_width(); }
     virtual u8 glyph_spacing() const override { return 0; }

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2453,7 +2453,7 @@ void Gfx::Painter::draw_ui_text(Gfx::IntRect const& rect, StringView text, Gfx::
     Optional<size_t> underline_offset;
     auto name_to_draw = parse_ampersand_string(text, &underline_offset);
 
-    Gfx::IntRect text_rect { 0, 0, static_cast<int>(ceilf(font.width(name_to_draw))), font.pixel_size_rounded_up() };
+    Gfx::IntRect text_rect { 0, 0, font.width_rounded_up(name_to_draw), font.pixel_size_rounded_up() };
     text_rect.align_within(rect, text_alignment);
 
     draw_text(text_rect, name_to_draw, font, text_alignment, color);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -352,7 +352,7 @@ void OutOfProcessWebView::notify_server_did_request_image_context_menu(Badge<Web
 
 void OutOfProcessWebView::notify_server_did_request_alert(Badge<WebContentClient>, String const& message)
 {
-    m_dialog = GUI::MessageBox::construct(window(), message, "Alert"sv, GUI::MessageBox::Type::Information, GUI::MessageBox::InputType::OK);
+    m_dialog = GUI::MessageBox::create(window(), message, "Alert"sv, GUI::MessageBox::Type::Information, GUI::MessageBox::InputType::OK).release_value_but_fixme_should_propagate_errors();
     m_dialog->set_icon(window()->icon());
     m_dialog->exec();
 
@@ -362,7 +362,7 @@ void OutOfProcessWebView::notify_server_did_request_alert(Badge<WebContentClient
 
 void OutOfProcessWebView::notify_server_did_request_confirm(Badge<WebContentClient>, String const& message)
 {
-    m_dialog = GUI::MessageBox::construct(window(), message, "Confirm"sv, GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::OKCancel);
+    m_dialog = GUI::MessageBox::create(window(), message, "Confirm"sv, GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::OKCancel).release_value_but_fixme_should_propagate_errors();
     m_dialog->set_icon(window()->icon());
 
     client().async_confirm_closed(m_dialog->exec() == GUI::Dialog::ExecResult::OK);

--- a/Userland/Services/Taskbar/TaskbarButton.cpp
+++ b/Userland/Services/Taskbar/TaskbarButton.cpp
@@ -106,7 +106,7 @@ void TaskbarButton::paint_event(GUI::PaintEvent& event)
         content_rect.set_width(content_rect.width() - icon.width() - 4);
     }
 
-    Gfx::IntRect text_rect { 0, 0, static_cast<int>(ceilf(font.width(text()))), font.pixel_size_rounded_up() };
+    Gfx::IntRect text_rect { 0, 0, font.width_rounded_up(text()), font.pixel_size_rounded_up() };
     if (text_rect.width() > content_rect.width())
         text_rect.set_width(content_rect.width());
     text_rect.align_within(content_rect, text_alignment());


### PR DESCRIPTION
[box.webm](https://user-images.githubusercontent.com/66646555/232075322-feb044a7-eec8-4a5a-aa33-c41e67d70f16.webm)

slims these little chonks back down in the process:
![btns](https://user-images.githubusercontent.com/66646555/232075410-d158db71-5806-491b-aa39-0119004f304c.png)
