### PR TITLE
AK: Remove workaround for old macOS SDK

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -181,18 +181,10 @@
 #    ifdef AK_OS_WINDOWS
 // FIXME: No idea where to get this, but it's 4096 anyway :^)
 #        define PAGE_SIZE 4096
-// On macOS (at least Mojave), Apple's version of this header is not wrapped
-// in extern "C".
 #    else
-#        if defined(AK_OS_MACOS)
-extern "C" {
-#        endif
 #        include <unistd.h>
 #        undef PAGE_SIZE
 #        define PAGE_SIZE sysconf(_SC_PAGESIZE)
-#        ifdef AK_OS_MACOS
-}
-#        endif
 #    endif
 #endif
 


### PR DESCRIPTION
https://github.com/SerenityOS/serenity/pull/9716#issuecomment-1508606204 has details.