### PR TITLE
HackStudio: Move around execution order to prevent crashing after command is executed

### DIFF
--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -542,7 +542,7 @@ void Editor::LanguageServerAidedAutocompleteProvider::provide_completions(Functi
         data.value().position.column());
 }
 
-void Editor::will_execute(GUI::TextDocumentUndoCommand const& command)
+void Editor::after_execute(GUI::TextDocumentUndoCommand const& command)
 {
     if (!m_language_client)
         return;
@@ -568,7 +568,7 @@ void Editor::will_execute(GUI::TextDocumentUndoCommand const& command)
         return;
     }
 
-    VERIFY_NOT_REACHED();
+    flush_file_content_to_langauge_server();
 }
 
 void Editor::undo()

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -50,7 +50,7 @@ public:
     CodeDocument& code_document();
 
     virtual void set_document(GUI::TextDocument&) override;
-    virtual void will_execute(GUI::TextDocumentUndoCommand const&) override;
+    virtual void after_execute(GUI::TextDocumentUndoCommand const&) override;
 
     virtual void undo() override;
     virtual void redo() override;

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -381,12 +381,12 @@ private:
     {
         auto command = make<T>(*m_document, forward<Args>(args)...);
         command->perform_formatting(*this);
-        will_execute(*command);
         command->execute_from(*this);
+        after_execute(*command);
         m_document->add_to_undo_stack(move(command));
     }
 
-    virtual void will_execute(TextDocumentUndoCommand const&) { }
+    virtual void after_execute(TextDocumentUndoCommand const&) { }
     void on_search_results(GUI::TextRange current, Vector<GUI::TextRange> all_results);
 
     static constexpr auto search_results_span_collection_index = 1;


### PR DESCRIPTION
Previously hackstudio tried to synchronize the language server before executing the command inside the editor.  If sync-command for the server (for example the CommentLineCommand) is not implemented inside the function responsible for syncing the language server, the IDE would crash.

This patch makes it such that the synchronization happens only after IDE executes the command locally.  If such command is not implemented (as was the case earlier), it would simply reupdate the content inside the language server. Even though the reupdate might be expensive, it is better than crashing hackstudio altogether.

Because of reordering, the relevant function names have been changed to better reflect the code flow.