### PR TITLE
LibTLS: Improve TLS_DEBUG output

### DIFF
--- a/Userland/Libraries/LibTLS/CMakeLists.txt
+++ b/Userland/Libraries/LibTLS/CMakeLists.txt
@@ -2,6 +2,7 @@ add_compile_options(-Wvla)
 
 set(SOURCES
     Certificate.cpp
+    Extensions.cpp
     Handshake.cpp
     HandshakeCertificate.cpp
     HandshakeClient.cpp
@@ -9,6 +10,7 @@ set(SOURCES
     Record.cpp
     Socket.cpp
     TLSv12.cpp
+    TLSRecord.cpp
 )
 
 serenity_lib(LibTLS tls)

--- a/Userland/Libraries/LibTLS/CipherSuite.h
+++ b/Userland/Libraries/LibTLS/CipherSuite.h
@@ -17,25 +17,6 @@ struct SignatureAndHashAlgorithm {
     SignatureAlgorithm signature;
 };
 
-enum class KeyExchangeAlgorithm {
-    Invalid,
-    // Defined in RFC 5246 section 7.4.2 / RFC 4279 section 4
-    RSA_PSK,
-    // Defined in RFC 5246 section 7.4.3
-    DHE_DSS,
-    DHE_RSA,
-    DH_anon,
-    RSA,
-    DH_DSS,
-    DH_RSA,
-    // Defined in RFC 4492 section 2
-    ECDHE_RSA,
-    ECDH_ECDSA,
-    ECDH_RSA,
-    ECDHE_ECDSA,
-    ECDH_anon,
-};
-
 // Defined in RFC 5246 section 7.4.1.4.1
 constexpr SignatureAlgorithm signature_for_key_exchange_algorithm(KeyExchangeAlgorithm algorithm)
 {

--- a/Userland/Libraries/LibTLS/Extensions.cpp
+++ b/Userland/Libraries/LibTLS/Extensions.cpp
@@ -1,0 +1,612 @@
+/*
+ * Copyright (c) 2022, stelar7 <dudedbz@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTLS/Extensions.h>
+#include <LibTLS/TLSRecord.h>
+
+namespace TLS {
+
+SupportedGroups::SupportedGroups()
+    : TLSExtension(ExtensionType::SUPPORTED_GROUPS)
+{
+}
+
+u16 SupportedGroups::size()
+{
+    return sizeof(ExtensionType) + sizeof(u16) + sizeof(u16) + (sizeof(SupportedGroup) * groups.size());
+}
+
+ErrorOr<ByteBuffer> SupportedGroups::encode()
+{
+    ByteBuffer buffer = TRY(ByteBuffer::create_zeroed(size()));
+    ByteReader::store(buffer.offset_pointer(0), static_cast<u16>(type));
+    ByteReader::store(buffer.offset_pointer(2), size() - 4);
+
+    ByteReader::store(buffer.offset_pointer(4), (u16)groups.size());
+    for (size_t i = 0; i < groups.size(); i++) {
+        ByteReader::store(buffer.offset_pointer(5 + (i * 2)), static_cast<u16>(groups[i]));
+    }
+
+    return buffer;
+}
+
+ErrorOr<RefPtr<TLSExtension>> SupportedGroups::decode(ReadonlyBytes buffer)
+{
+    size_t offset = 0;
+
+    auto type = static_cast<ExtensionType>(TLSRecord::read_u16(buffer, offset));
+    VERIFY(type == ExtensionType::SUPPORTED_GROUPS);
+    offset += sizeof(ExtensionType);
+
+    u16 length = TLSRecord::read_u16(buffer, offset);
+    offset += sizeof(length);
+    if (buffer.size() < length) {
+        return AK::Error::from_string_view(enum_to_string(GenericError::NeedMoreData));
+    }
+
+    if (length == 0) {
+        return TRY(try_make_ref_counted<SupportedGroups>());
+    }
+
+    u16 list_bytes = TLSRecord::read_u16(buffer, offset);
+    offset += sizeof(list_bytes);
+    if (buffer.size() < list_bytes) {
+        return AK::Error::from_string_view(enum_to_string(GenericError::NeedMoreData));
+    }
+
+    auto curves = TRY(try_make_ref_counted<SupportedGroups>());
+
+    size_t count = list_bytes / sizeof(u16);
+    for (size_t i = 0; i < count; i++) {
+        auto curve = static_cast<SupportedGroup>(TLSRecord::read_u16(buffer, offset));
+        offset += sizeof(SupportedGroup);
+
+        curves->groups.append(curve);
+    }
+
+    return curves;
+}
+
+ErrorOr<String> SupportedGroups::to_string(size_t indent = 0)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("Supported Groups:\n");
+
+    for (auto group : groups) {
+        builder.append(TRY(String::repeated('\t', indent + 1)));
+        builder.appendff("{}\n", enum_to_string(group));
+    }
+
+    return builder.to_string();
+}
+
+ECPointFormats::ECPointFormats()
+    : TLSExtension(ExtensionType::EC_POINT_FORMATS)
+{
+}
+
+ErrorOr<RefPtr<TLSExtension>> ECPointFormats::decode(ReadonlyBytes buffer)
+{
+    auto type = static_cast<ExtensionType>(TLSRecord::read_u16(buffer, 0));
+    VERIFY(type == ExtensionType::EC_POINT_FORMATS);
+
+    size_t length = TLSRecord::read_u16(buffer, sizeof(ExtensionType));
+    if (buffer.size() < length) {
+        return AK::Error::from_string_view(enum_to_string(GenericError::NeedMoreData));
+    }
+
+    size_t offset = { 3 };
+
+    auto points = TRY(try_make_ref_counted<ECPointFormats>());
+    auto format_count = buffer[offset++];
+    for (auto i = 0; i < format_count; i++) {
+        auto format = static_cast<ECPointFormat>(buffer[offset++]);
+        points->formats.append(format);
+    }
+
+    return points;
+}
+u16 ECPointFormats::size()
+{
+    return sizeof(ExtensionType) + sizeof(u16) + sizeof(u8) + (sizeof(ECPointFormat) * formats.size());
+}
+
+ErrorOr<ByteBuffer> ECPointFormats::encode()
+{
+    ByteBuffer buffer = TRY(ByteBuffer::create_zeroed(size()));
+    ByteReader::store(buffer.offset_pointer(0), static_cast<u16>(type));
+    ByteReader::store(buffer.offset_pointer(2), size() - 4);
+
+    ByteReader::store(buffer.offset_pointer(4), (u8)formats.size());
+    for (size_t i = 0; i < formats.size(); i++) {
+        ByteReader::store(buffer.offset_pointer(5 + i), static_cast<u8>(formats[i]));
+    }
+
+    return buffer;
+}
+
+ErrorOr<String> ECPointFormats::to_string(size_t indent = 0)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("EC Point Formats:\n");
+
+    for (auto format : formats) {
+        builder.append(TRY(String::repeated('\t', indent + 1)));
+        builder.appendff("{}\n", enum_to_string(format));
+    }
+
+    return builder.to_string();
+}
+
+SignatureSchemes::SignatureSchemes()
+    : TLSExtension(ExtensionType::SIGNATURE_ALGORITHMS)
+{
+}
+
+u16 SignatureSchemes::size()
+{
+    return sizeof(ExtensionType) + sizeof(u16) + sizeof(u16) + (sizeof(SignatureScheme) * signatures.size());
+}
+
+ErrorOr<ByteBuffer> SignatureSchemes::encode()
+{
+    ByteBuffer buffer = TRY(ByteBuffer::create_zeroed(size()));
+    ByteReader::store(buffer.offset_pointer(0), static_cast<u16>(type));
+    ByteReader::store(buffer.offset_pointer(2), size() - 4);
+
+    ByteReader::store(buffer.offset_pointer(4), (u16)signatures.size());
+    for (size_t i = 0; i < signatures.size(); i++) {
+        ByteReader::store(buffer.offset_pointer(6 + (i * 2)), static_cast<u16>(signatures[i]));
+    }
+
+    return buffer;
+}
+
+ErrorOr<RefPtr<TLSExtension>> SignatureSchemes::decode(ReadonlyBytes buffer)
+{
+    size_t offset = 0;
+
+    auto type = static_cast<ExtensionType>(TLSRecord::read_u16(buffer, offset));
+    VERIFY(type == ExtensionType::SIGNATURE_ALGORITHMS);
+    offset += sizeof(ExtensionType);
+
+    u16 length = TLSRecord::read_u16(buffer, offset);
+    offset += sizeof(length);
+    if (buffer.size() < length) {
+        return AK::Error::from_string_view(enum_to_string(GenericError::NeedMoreData));
+    }
+
+    if (length == 0) {
+        return TRY(try_make_ref_counted<SignatureSchemes>());
+    }
+
+    u16 list_bytes = TLSRecord::read_u16(buffer, offset);
+    offset += sizeof(list_bytes);
+    if (buffer.size() < list_bytes) {
+        return AK::Error::from_string_view(enum_to_string(GenericError::NeedMoreData));
+    }
+
+    auto signature_schemes = TRY(try_make_ref_counted<SignatureSchemes>());
+
+    size_t count = list_bytes / sizeof(u16);
+    for (size_t i = 0; i < count; i++) {
+        auto scheme = static_cast<SignatureScheme>(TLSRecord::read_u16(buffer, offset));
+        offset += sizeof(SignatureScheme);
+
+        signature_schemes->signatures.append(scheme);
+    }
+
+    return signature_schemes;
+}
+
+ErrorOr<String> SignatureSchemes::to_string(size_t indent = 0)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("Signature Schemes:\n");
+
+    for (auto signature : signatures) {
+        builder.append(TRY(String::repeated('\t', indent + 1)));
+        builder.appendff("{}\n", enum_to_string(signature));
+    }
+
+    return builder.to_string();
+}
+
+EncryptThenMac::EncryptThenMac()
+    : TLSExtension(ExtensionType::ENCRYPT_THEN_MAC)
+{
+}
+
+u16 EncryptThenMac::size()
+{
+    return sizeof(ExtensionType) + sizeof(u16);
+}
+
+ErrorOr<ByteBuffer> EncryptThenMac::encode()
+{
+    ByteBuffer buffer = TRY(ByteBuffer::create_zeroed(size()));
+    ByteReader::store(buffer.offset_pointer(0), static_cast<u16>(type));
+    ByteReader::store(buffer.offset_pointer(2), size() - 4);
+    return buffer;
+}
+
+ErrorOr<String> EncryptThenMac::to_string(size_t indent = 0)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("Encrypt Then MAC\n");
+
+    return builder.to_string();
+}
+
+SessionTicket::SessionTicket()
+    : TLSExtension(ExtensionType::SESSION_TICKET)
+{
+}
+
+u16 SessionTicket::size()
+{
+    return sizeof(ExtensionType) + sizeof(u16);
+}
+
+ErrorOr<ByteBuffer> SessionTicket::encode()
+{
+    ByteBuffer buffer = TRY(ByteBuffer::create_zeroed(size()));
+    ByteReader::store(buffer.offset_pointer(0), static_cast<u16>(type));
+    ByteReader::store(buffer.offset_pointer(2), size() - 4);
+    return buffer;
+}
+
+ErrorOr<String> SessionTicket::to_string(size_t indent = 0)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("Session Ticket\n");
+
+    return builder.to_string();
+}
+
+ExtendMasterSecret::ExtendMasterSecret()
+    : TLSExtension(ExtensionType::EXTENDED_MASTER_SECRET)
+{
+}
+
+u16 ExtendMasterSecret::size()
+{
+    return sizeof(ExtensionType) + sizeof(u16);
+}
+
+ErrorOr<ByteBuffer> ExtendMasterSecret::encode()
+{
+    ByteBuffer buffer = TRY(ByteBuffer::create_zeroed(size()));
+    ByteReader::store(buffer.offset_pointer(0), static_cast<u16>(type));
+    ByteReader::store(buffer.offset_pointer(2), size() - 4);
+    return buffer;
+}
+
+ErrorOr<String> ExtendMasterSecret::to_string(size_t indent = 0)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("Extend Master Secret\n");
+
+    return builder.to_string();
+}
+
+u16 KeyShareEntry::size()
+{
+    return sizeof(SupportedGroup) + sizeof(u16) + key.size();
+}
+
+ErrorOr<String> KeyShareEntry::to_string()
+{
+    return String::formatted("{}: {:hex-dump}", enum_to_string(group), key.bytes());
+}
+
+KeyShares::KeyShares()
+    : TLSExtension(ExtensionType::KEY_SHARE)
+{
+}
+
+u16 KeyShares::size()
+{
+    auto content_size = 0;
+    for (auto& key : keys) {
+        content_size += key.size();
+    }
+
+    return sizeof(ExtensionType) + sizeof(u16) + content_size;
+}
+
+ErrorOr<ByteBuffer> KeyShares::encode()
+{
+    ByteBuffer buffer = TRY(ByteBuffer::create_zeroed(size()));
+    ByteReader::store(buffer.offset_pointer(0), static_cast<u16>(type));
+    ByteReader::store(buffer.offset_pointer(2), size() - 4);
+
+    ByteReader::store(buffer.offset_pointer(4), (u16)size() - 4);
+    size_t offset = 6;
+    for (size_t i = 0; i < keys.size(); i++) {
+        KeyShareEntry entry = keys[i];
+        ByteReader::store(buffer.offset_pointer(offset), static_cast<u16>(entry.group));
+        ByteReader::store(buffer.offset_pointer(offset + 2), (u16)entry.key.size());
+        ByteReader::store(buffer.offset_pointer(offset + 4), entry.key.span());
+        offset += entry.size();
+    }
+
+    return buffer;
+}
+
+ErrorOr<String> KeyShares::to_string(size_t indent = 0)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("Key Shares:\n");
+
+    for (auto key : keys) {
+        builder.append(TRY(String::repeated('\t', indent + 1)));
+        builder.appendff("{}\n", TRY(key.to_string()));
+    }
+
+    return builder.to_string();
+}
+
+SupportedVersions::SupportedVersions()
+    : TLSExtension(ExtensionType::SUPPORTED_VERSIONS)
+{
+}
+
+u16 SupportedVersions::size()
+{
+    return sizeof(ExtensionType) + sizeof(u16) + (sizeof(ProtocolVersion) * versions.size());
+}
+
+ErrorOr<ByteBuffer> SupportedVersions::encode()
+{
+    ByteBuffer buffer = TRY(ByteBuffer::create_zeroed(size()));
+    ByteReader::store(buffer.offset_pointer(0), static_cast<u16>(type));
+    ByteReader::store(buffer.offset_pointer(2), size() - 4);
+
+    ByteReader::store(buffer.offset_pointer(4), (u16)versions.size());
+    for (size_t i = 0; i < versions.size(); i++) {
+        ByteReader::store(buffer.offset_pointer(6 + (i * 2)), static_cast<u16>(versions[i]));
+    }
+
+    return buffer;
+}
+
+ErrorOr<String> SupportedVersions::to_string(size_t indent = 0)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("Supported Versions:\n");
+
+    for (auto version : versions) {
+        builder.append(TRY(String::repeated('\t', indent + 1)));
+        builder.appendff("{}\n", enum_to_string(version));
+    }
+
+    return builder.to_string();
+}
+
+RenegotiationInfo::RenegotiationInfo()
+    : TLSExtension(ExtensionType::RENEGOTIATION_INFO)
+{
+}
+
+u16 RenegotiationInfo::size()
+{
+    return sizeof(ExtensionType) + sizeof(u16) + sizeof(u8) + data.size();
+}
+
+ErrorOr<ByteBuffer> RenegotiationInfo::encode()
+{
+    ByteBuffer buffer = TRY(ByteBuffer::create_zeroed(size()));
+    ByteReader::store(buffer.offset_pointer(0), static_cast<u16>(type));
+    ByteReader::store(buffer.offset_pointer(2), size() - 4);
+
+    ByteReader::store(buffer.offset_pointer(4), (u8)data.size());
+    ByteReader::store(buffer.offset_pointer(5), data.span());
+
+    return buffer;
+}
+
+ErrorOr<String> RenegotiationInfo::to_string(size_t indent = 0)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("Renegotiation Info:\n");
+
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("{:hex-dump}\n", data.bytes());
+
+    return builder.to_string();
+}
+
+PSKKeyExchangeModes::PSKKeyExchangeModes()
+    : TLSExtension(ExtensionType::PSK_KEY_EXCHANGE_MODES)
+{
+}
+
+u16 PSKKeyExchangeModes::size()
+{
+    return sizeof(ExtensionType) + sizeof(u16) + sizeof(u8) + (sizeof(PSKKeyExchangeMode) * modes.size());
+}
+
+ErrorOr<ByteBuffer> PSKKeyExchangeModes::encode()
+{
+    ByteBuffer buffer = TRY(ByteBuffer::create_zeroed(size()));
+    ByteReader::store(buffer.offset_pointer(0), static_cast<u16>(type));
+    ByteReader::store(buffer.offset_pointer(2), size() - 4);
+
+    ByteReader::store(buffer.offset_pointer(4), (u8)modes.size());
+    for (size_t i = 0; i < modes.size(); i++) {
+        ByteReader::store(buffer.offset_pointer(5 + i), static_cast<u8>(modes[i]));
+    }
+
+    return buffer;
+}
+
+ErrorOr<String> PSKKeyExchangeModes::to_string(size_t indent = 0)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("PSK Key Exchange Modes:\n");
+
+    for (auto mode : modes) {
+        builder.append(TRY(String::repeated('\t', indent + 1)));
+        builder.appendff("{}\n", enum_to_string(mode));
+    }
+
+    return builder.to_string();
+}
+
+RecordSizeLimit::RecordSizeLimit()
+    : TLSExtension(ExtensionType::RECORD_SIZE_LIMIT)
+{
+}
+
+u16 RecordSizeLimit::size()
+{
+    return sizeof(ExtensionType) + sizeof(u16) + sizeof(u16);
+}
+
+ErrorOr<ByteBuffer> RecordSizeLimit::encode()
+{
+    ByteBuffer buffer = TRY(ByteBuffer::create_zeroed(size()));
+    ByteReader::store(buffer.offset_pointer(0), static_cast<u16>(type));
+    ByteReader::store(buffer.offset_pointer(2), size() - 4);
+
+    ByteReader::store(buffer.offset_pointer(4), 2);
+    ByteReader::store(buffer.offset_pointer(6), limit);
+
+    return buffer;
+}
+
+ErrorOr<String> RecordSizeLimit::to_string(size_t indent = 0)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("Record Size Limit: {}\n", limit);
+
+    return builder.to_string();
+}
+
+u16 ServerNameEntry::size()
+{
+    return sizeof(NameType) + 2 + name.bytes().size();
+}
+
+ErrorOr<String> ServerNameEntry::to_string()
+{
+    return String::formatted("{}: {}", enum_to_string(type), name);
+}
+
+ServerNameList::ServerNameList()
+    : TLSExtension(ExtensionType::SERVER_NAME)
+{
+}
+
+ErrorOr<RefPtr<TLSExtension>> ServerNameList::decode(ReadonlyBytes buffer)
+{
+    size_t offset = 0;
+
+    auto type = static_cast<ExtensionType>(TLSRecord::read_u16(buffer, offset));
+    VERIFY(type == ExtensionType::SERVER_NAME);
+    offset += sizeof(ExtensionType);
+
+    u16 length = TLSRecord::read_u16(buffer, offset);
+    offset += sizeof(length);
+    if (buffer.size() < length) {
+        return AK::Error::from_string_view(enum_to_string(GenericError::NeedMoreData));
+    }
+
+    if (length == 0) {
+        return TRY(try_make_ref_counted<ServerNameList>());
+    }
+
+    auto name_list_size = TLSRecord::read_u16(buffer, offset);
+    offset += sizeof(u16);
+    auto name_type = static_cast<NameType>(buffer[offset++]);
+    auto name_length = TLSRecord::read_u16(buffer, offset);
+    offset += sizeof(u16);
+
+    if (name_type != NameType::HOST_NAME)
+        return AK::Error::from_string_view(enum_to_string(GenericError::NotUnderstood));
+
+    // Version 1.2 only allows for a single entry in this list,
+    // but earlier versions did not have this limitation.
+    auto current_extension_offset = sizeof(name_type) + 2 + name_length;
+    if (current_extension_offset != name_list_size)
+        return AK::Error::from_string_view(enum_to_string(GenericError::BrokenPacket));
+
+    auto name_view = StringView((char const*)buffer.offset_pointer(offset), (size_t)name_length);
+    auto name = TRY(String::from_utf8(name_view));
+
+    auto name_list = TRY(try_make_ref_counted<ServerNameList>());
+    name_list->names.append(ServerNameEntry { name_type, name });
+
+    return name_list;
+}
+
+u16 ServerNameList::size()
+{
+    auto content_size = 0;
+    for (auto& name : names) {
+        content_size += name.size();
+    }
+
+    return sizeof(ExtensionType) + sizeof(u16) + content_size;
+}
+
+ErrorOr<ByteBuffer> ServerNameList::encode()
+{
+    ByteBuffer buffer = TRY(ByteBuffer::create_zeroed(size()));
+    ByteReader::store(buffer.offset_pointer(0), static_cast<u16>(type));
+    ByteReader::store(buffer.offset_pointer(2), size() - 4);
+
+    ByteReader::store(buffer.offset_pointer(4), (u16)names.size());
+    auto offset = 6;
+    for (size_t i = 0; i < names.size(); i++) {
+        ServerNameEntry entry = names[i];
+        ByteReader::store(buffer.offset_pointer(offset), static_cast<u8>(entry.type));
+        ByteReader::store(buffer.offset_pointer(offset + 1), (u16)entry.name.bytes().size());
+        ByteReader::store(buffer.offset_pointer(offset + 3), entry.name.bytes());
+        offset += entry.size();
+    }
+
+    return buffer;
+}
+
+ErrorOr<String> ServerNameList::to_string(size_t indent = 0)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("Server Name List:\n");
+
+    for (auto entry : names) {
+        builder.append(TRY(String::repeated('\t', indent + 1)));
+        builder.appendff("{}: {}\n", enum_to_string(entry.type), entry.name);
+    }
+
+    return builder.to_string();
+}
+}

--- a/Userland/Libraries/LibTLS/Extensions.h
+++ b/Userland/Libraries/LibTLS/Extensions.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <AK/Types.h>
 
 namespace TLS {
@@ -701,6 +702,142 @@ enum class AlertDescription : u8 {
     __ENUM_ALERT_DESCRIPTIONS
 };
 
+// https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-signaturescheme
+#define __ENUM_SIGNATURE_SCHEMES                               \
+    _ENUM_KEY_VALUE(RSA_PKCS1_SHA1, 0x0201)                    \
+    _ENUM_KEY_VALUE(ECDSA_SHA1, 0x0203)                        \
+    _ENUM_KEY_VALUE(RSA_PKCS1_SHA256, 0x0401)                  \
+    _ENUM_KEY_VALUE(ECDSA_SECP256R1_SHA256, 0x0403)            \
+    _ENUM_KEY_VALUE(RSA_PKCS1_SHA256_LEGACY, 0x0420)           \
+    _ENUM_KEY_VALUE(RSA_PKCS1_SHA384, 0x0501)                  \
+    _ENUM_KEY_VALUE(ECDSA_SECP384R1_SHA384, 0x0503)            \
+    _ENUM_KEY_VALUE(RSA_PKCS1_SHA384_LEGACY, 0x0520)           \
+    _ENUM_KEY_VALUE(RSA_PKCS1_SHA512, 0x0601)                  \
+    _ENUM_KEY_VALUE(ECDSA_SECP521R1_SHA512, 0x0603)            \
+    _ENUM_KEY_VALUE(RSA_PKCS1_SHA512_LEGACY, 0x0620)           \
+    _ENUM_KEY_VALUE(ECCSI_SHA256, 0x0704)                      \
+    _ENUM_KEY_VALUE(ISO_IBS1, 0x0705)                          \
+    _ENUM_KEY_VALUE(ISO_IBS2, 0x0706)                          \
+    _ENUM_KEY_VALUE(ISO_CHINESE_IBS, 0x0707)                   \
+    _ENUM_KEY_VALUE(SM2SIG_SM3, 0x0708)                        \
+    _ENUM_KEY_VALUE(GOSTR34102012_256A, 0x0709)                \
+    _ENUM_KEY_VALUE(GOSTR34102012_256B, 0x070A)                \
+    _ENUM_KEY_VALUE(GOSTR34102012_256C, 0x070B)                \
+    _ENUM_KEY_VALUE(GOSTR34102012_256D, 0x070C)                \
+    _ENUM_KEY_VALUE(GOSTR34102012_512A, 0x070D)                \
+    _ENUM_KEY_VALUE(GOSTR34102012_512B, 0x070E)                \
+    _ENUM_KEY_VALUE(GOSTR34102012_512C, 0x070F)                \
+    _ENUM_KEY_VALUE(RSA_PSS_RSAE_SHA256, 0x0804)               \
+    _ENUM_KEY_VALUE(RSA_PSS_RSAE_SHA384, 0x0805)               \
+    _ENUM_KEY_VALUE(RSA_PSS_RSAE_SHA512, 0x0806)               \
+    _ENUM_KEY_VALUE(ED25519, 0x0807)                           \
+    _ENUM_KEY_VALUE(ED448, 0x0808)                             \
+    _ENUM_KEY_VALUE(RSA_PSS_PSS_SHA256, 0x0809)                \
+    _ENUM_KEY_VALUE(RSA_PSS_PSS_SHA384, 0x080A)                \
+    _ENUM_KEY_VALUE(RSA_PSS_PSS_SHA512, 0x080B)                \
+    _ENUM_KEY_VALUE(ECDSA_BRAINPOOLP256R1TLS13_SHA256, 0x081A) \
+    _ENUM_KEY_VALUE(ECDSA_BRAINPOOLP384R1TLS13_SHA384, 0x081B) \
+    _ENUM_KEY_VALUE(ECDSA_BRAINPOOLP512R1TLS13_SHA512, 0x081C) \
+    _ENUM_KEY_VALUE(GREASE_0, 0x0A0A)                          \
+    _ENUM_KEY_VALUE(GREASE_1, 0x1A1A)                          \
+    _ENUM_KEY_VALUE(GREASE_2, 0x2A2A)                          \
+    _ENUM_KEY_VALUE(GREASE_3, 0x3A3A)                          \
+    _ENUM_KEY_VALUE(GREASE_4, 0x4A4A)                          \
+    _ENUM_KEY_VALUE(GREASE_5, 0x5A5A)                          \
+    _ENUM_KEY_VALUE(GREASE_6, 0x6A6A)                          \
+    _ENUM_KEY_VALUE(GREASE_7, 0x7A7A)                          \
+    _ENUM_KEY_VALUE(GREASE_8, 0x8A8A)                          \
+    _ENUM_KEY_VALUE(GREASE_9, 0x9A9A)                          \
+    _ENUM_KEY_VALUE(GREASE_A, 0xAAAA)                          \
+    _ENUM_KEY_VALUE(GREASE_B, 0xBABA)                          \
+    _ENUM_KEY_VALUE(GREASE_C, 0xCACA)                          \
+    _ENUM_KEY_VALUE(GREASE_D, 0xDADA)                          \
+    _ENUM_KEY_VALUE(GREASE_E, 0xEAEA)                          \
+    _ENUM_KEY_VALUE(GREASE_F, 0xFAFA)
+
+enum class SignatureScheme : u16 {
+    __ENUM_SIGNATURE_SCHEMES
+};
+
+// https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-pskkeyexchangemode
+#define __ENUM_PSK_KEY_EXCHANGE_MODES \
+    _ENUM_KEY_VALUE(PSK_KE, 0)        \
+    _ENUM_KEY_VALUE(PSK_DHE_KE, 1)    \
+    _ENUM_KEY_VALUE(GREASE_0, 0x0B)   \
+    _ENUM_KEY_VALUE(GREASE_1, 0x2A)   \
+    _ENUM_KEY_VALUE(GREASE_2, 0x49)   \
+    _ENUM_KEY_VALUE(GREASE_3, 0x68)   \
+    _ENUM_KEY_VALUE(GREASE_4, 0x87)   \
+    _ENUM_KEY_VALUE(GREASE_5, 0xA6)   \
+    _ENUM_KEY_VALUE(GREASE_6, 0xC5)   \
+    _ENUM_KEY_VALUE(GREASE_7, 0xE4)
+
+enum class PSKKeyExchangeMode : u8 {
+    __ENUM_PSK_KEY_EXCHANGE_MODES
+};
+
+#define __ENUM_COMPRESSION_METHODS \
+    _ENUM_KEY_VALUE(NONE, 0)       \
+    _ENUM_KEY_VALUE(DEFLATE, 1)
+
+enum class CompressionMethod : u8 {
+    __ENUM_COMPRESSION_METHODS
+};
+
+#define __ENUM_KEY_EXCHANGE_ALGORITHMS \
+    _ENUM_KEY(Invalid)                 \
+    _ENUM_KEY(RSA_PSK)                 \
+    _ENUM_KEY(DHE_DSS)                 \
+    _ENUM_KEY(DHE_RSA)                 \
+    _ENUM_KEY(DH_anon)                 \
+    _ENUM_KEY(RSA)                     \
+    _ENUM_KEY(DH_DSS)                  \
+    _ENUM_KEY(DH_RSA)                  \
+    _ENUM_KEY(ECDHE_RSA)               \
+    _ENUM_KEY(ECDH_ECDSA)              \
+    _ENUM_KEY(ECDH_RSA)                \
+    _ENUM_KEY(ECDHE_ECDSA)             \
+    _ENUM_KEY(ECDH_anon)
+
+enum class KeyExchangeAlgorithm {
+    __ENUM_KEY_EXCHANGE_ALGORITHMS
+};
+
+#define __ENUM_GENERIC_ERRORS          \
+    _ENUM_KEY(NoError)                 \
+    _ENUM_KEY(UnknownError)            \
+    _ENUM_KEY(BrokenPacket)            \
+    _ENUM_KEY(NotUnderstood)           \
+    _ENUM_KEY(NoCommonCipher)          \
+    _ENUM_KEY(UnexpectedMessage)       \
+    _ENUM_KEY(CloseConnection)         \
+    _ENUM_KEY(CompressionNotSupported) \
+    _ENUM_KEY(NotVerified)             \
+    _ENUM_KEY(NotSafe)                 \
+    _ENUM_KEY(IntegrityCheckFailed)    \
+    _ENUM_KEY(ErrorAlert)              \
+    _ENUM_KEY(BrokenConnection)        \
+    _ENUM_KEY(BadCertificate)          \
+    _ENUM_KEY(UnsupportedCertificate)  \
+    _ENUM_KEY(NoRenegotiation)         \
+    _ENUM_KEY(FeatureNotSupported)     \
+    _ENUM_KEY(DecryptionFailed)        \
+    _ENUM_KEY(NeedMoreData)            \
+    _ENUM_KEY(TimedOut)                \
+    _ENUM_KEY(OutOfMemory)
+
+enum class GenericError : i8 {
+    __ENUM_GENERIC_ERRORS
+};
+
+#define __ENUM_EC_BASIS_TYPES               \
+    _ENUM_KEY_VALUE(EC_BASIS_TRINOMINAL, 1) \
+    _ENUM_KEY_VALUE(EC_BASIS_PENTANOMINAL, 2)
+
+enum class ECBasisType : u8 {
+    __ENUM_EC_BASIS_TYPES
+};
+
 #undef _ENUM_KEY
 #undef _ENUM_KEY_VALUE
 
@@ -795,6 +932,146 @@ constexpr static StringView enum_to_string(AlertDescription descriptor)
 
     switch (descriptor) {
         __ENUM_ALERT_DESCRIPTIONS
+    }
+
+    return "Unknown"sv;
+#undef _ENUM_KEY_VALUE
+}
+
+constexpr static const StringView enum_to_string(AlertLevel descriptor)
+{
+#define _ENUM_KEY_VALUE(name, value) \
+    case AlertLevel::name:           \
+        return #name##sv;
+
+    switch (descriptor) {
+        __ENUM_ALERT_LEVELS
+    }
+
+    return "Unknown"sv;
+#undef _ENUM_KEY_VALUE
+}
+
+constexpr static StringView enum_to_string(GenericError descriptor)
+{
+#define _ENUM_KEY(name)      \
+    case GenericError::name: \
+        return #name##sv;
+
+    switch (descriptor) {
+        __ENUM_GENERIC_ERRORS
+    }
+
+    return "Unknown"sv;
+#undef _ENUM_KEY
+}
+
+constexpr static StringView enum_to_string(CompressionMethod descriptor)
+{
+#define _ENUM_KEY_VALUE(name, value) \
+    case CompressionMethod::name:    \
+        return #name##sv;
+
+    switch (descriptor) {
+        __ENUM_COMPRESSION_METHODS
+    }
+
+    return "Unknown"sv;
+#undef _ENUM_KEY_VALUE
+}
+
+constexpr static StringView enum_to_string(KeyExchangeAlgorithm descriptor)
+{
+#define _ENUM_KEY(name)              \
+    case KeyExchangeAlgorithm::name: \
+        return #name##sv;
+
+    switch (descriptor) {
+        __ENUM_KEY_EXCHANGE_ALGORITHMS
+    }
+
+    return "Unknown"sv;
+#undef _ENUM_KEY
+}
+
+constexpr static StringView enum_to_string(ECCurveType descriptor)
+{
+#define _ENUM_KEY_VALUE(name, value) \
+    case ECCurveType::name:          \
+        return #name##sv;
+
+    switch (descriptor) {
+        __ENUM_EC_CURVE_TYPES
+    }
+
+    return "Unknown"sv;
+#undef _ENUM_KEY_VALUE
+}
+
+constexpr static StringView enum_to_string(SignatureScheme descriptor)
+{
+#define _ENUM_KEY_VALUE(name, value) \
+    case SignatureScheme::name:      \
+        return #name##sv;
+
+    switch (descriptor) {
+        __ENUM_SIGNATURE_SCHEMES
+    }
+
+    return "Unknown"sv;
+#undef _ENUM_KEY_VALUE
+}
+
+constexpr static StringView enum_to_string(SupportedGroup descriptor)
+{
+#define _ENUM_KEY_VALUE(name, value) \
+    case SupportedGroup::name:       \
+        return #name##sv;
+
+    switch (descriptor) {
+        __ENUM_SUPPORTED_GROUPS
+    }
+
+    return "Unknown"sv;
+#undef _ENUM_KEY_VALUE
+}
+
+constexpr static StringView enum_to_string(ECPointFormat descriptor)
+{
+#define _ENUM_KEY_VALUE(name, value) \
+    case ECPointFormat::name:        \
+        return #name##sv;
+
+    switch (descriptor) {
+        __ENUM_EC_POINT_FORMATS
+    }
+
+    return "Unknown"sv;
+#undef _ENUM_KEY_VALUE
+}
+
+constexpr static StringView enum_to_string(NameType descriptor)
+{
+#define _ENUM_KEY_VALUE(name, value) \
+    case NameType::name:             \
+        return #name##sv;
+
+    switch (descriptor) {
+        __ENUM_NAME_TYPES
+    }
+
+    return "Unknown"sv;
+#undef _ENUM_KEY_VALUE
+}
+
+constexpr static StringView enum_to_string(PSKKeyExchangeMode descriptor)
+{
+#define _ENUM_KEY_VALUE(name, value) \
+    case PSKKeyExchangeMode::name:   \
+        return #name##sv;
+
+    switch (descriptor) {
+        __ENUM_PSK_KEY_EXCHANGE_MODES
     }
 
     return "Unknown"sv;
@@ -977,5 +1254,164 @@ constexpr static const StringView enum_to_value(AlertDescription descriptor)
 
     return "Unknown alert"sv;
 }
+
+class TLSExtension : public RefCounted<TLSExtension> {
+public:
+    TLSExtension(ExtensionType type)
+        : type(type)
+    {
+    }
+
+    ExtensionType type;
+
+    virtual ~TLSExtension() {};
+    virtual u16 size() = 0;
+    virtual ErrorOr<String> to_string(size_t) = 0;
+    virtual ErrorOr<ByteBuffer> encode() = 0;
+};
+
+class SupportedGroups : public TLSExtension {
+public:
+    Vector<SupportedGroup> groups;
+
+    SupportedGroups();
+    u16 size() override;
+    ErrorOr<String> to_string(size_t) override;
+    ErrorOr<ByteBuffer> encode() override;
+    static ErrorOr<RefPtr<TLSExtension>> decode(ReadonlyBytes);
+};
+
+class ECPointFormats : public TLSExtension {
+public:
+    Vector<ECPointFormat> formats;
+
+    ECPointFormats();
+    u16 size() override;
+    ErrorOr<String> to_string(size_t) override;
+    ErrorOr<ByteBuffer> encode() override;
+    static ErrorOr<RefPtr<TLSExtension>> decode(ReadonlyBytes);
+};
+
+class SignatureSchemes : public TLSExtension {
+public:
+    Vector<SignatureScheme> signatures;
+
+    SignatureSchemes();
+    u16 size() override;
+    ErrorOr<String> to_string(size_t) override;
+    ErrorOr<ByteBuffer> encode() override;
+    static ErrorOr<RefPtr<TLSExtension>> decode(ReadonlyBytes);
+};
+
+class EncryptThenMac : public TLSExtension {
+public:
+    EncryptThenMac();
+    u16 size() override;
+    ErrorOr<String> to_string(size_t) override;
+    ErrorOr<ByteBuffer> encode() override;
+    static ErrorOr<RefPtr<TLSExtension>> decode(ReadonlyBytes);
+};
+
+class SessionTicket : public TLSExtension {
+public:
+    SessionTicket();
+    u16 size() override;
+    ErrorOr<String> to_string(size_t) override;
+    ErrorOr<ByteBuffer> encode() override;
+    static ErrorOr<RefPtr<TLSExtension>> decode(ReadonlyBytes);
+};
+
+class ExtendMasterSecret : public TLSExtension {
+public:
+    ExtendMasterSecret();
+    u16 size() override;
+    ErrorOr<String> to_string(size_t) override;
+    ErrorOr<ByteBuffer> encode() override;
+    static ErrorOr<RefPtr<TLSExtension>> decode(ReadonlyBytes);
+};
+
+class KeyShareEntry {
+public:
+    SupportedGroup group;
+    ByteBuffer key;
+
+    u16 size();
+    ErrorOr<String> to_string();
+};
+
+class KeyShares : public TLSExtension {
+public:
+    Vector<KeyShareEntry> keys;
+
+    KeyShares();
+    u16 size() override;
+    ErrorOr<String> to_string(size_t) override;
+    ErrorOr<ByteBuffer> encode() override;
+    static ErrorOr<RefPtr<TLSExtension>> decode(ReadonlyBytes);
+};
+
+class SupportedVersions : public TLSExtension {
+public:
+    Vector<ProtocolVersion> versions;
+
+    SupportedVersions();
+    u16 size() override;
+    ErrorOr<String> to_string(size_t) override;
+    ErrorOr<ByteBuffer> encode() override;
+    static ErrorOr<RefPtr<TLSExtension>> decode(ReadonlyBytes);
+};
+
+class RenegotiationInfo : public TLSExtension {
+public:
+    ByteBuffer data;
+
+    RenegotiationInfo();
+    u16 size() override;
+    ErrorOr<String> to_string(size_t) override;
+    ErrorOr<ByteBuffer> encode() override;
+    static ErrorOr<RefPtr<TLSExtension>> decode(ReadonlyBytes);
+};
+
+class PSKKeyExchangeModes : public TLSExtension {
+public:
+    Vector<PSKKeyExchangeMode> modes;
+
+    PSKKeyExchangeModes();
+    u16 size() override;
+    ErrorOr<String> to_string(size_t) override;
+    ErrorOr<ByteBuffer> encode() override;
+    static ErrorOr<RefPtr<TLSExtension>> decode(ReadonlyBytes);
+};
+
+class RecordSizeLimit : public TLSExtension {
+public:
+    u16 limit;
+
+    RecordSizeLimit();
+    u16 size() override;
+    ErrorOr<String> to_string(size_t) override;
+    ErrorOr<ByteBuffer> encode() override;
+    static ErrorOr<RefPtr<TLSExtension>> decode(ReadonlyBytes);
+};
+
+class ServerNameEntry {
+public:
+    NameType type;
+    String name;
+
+    u16 size();
+    ErrorOr<String> to_string();
+};
+
+class ServerNameList : public TLSExtension {
+public:
+    Vector<ServerNameEntry> names;
+
+    ServerNameList();
+    u16 size() override;
+    ErrorOr<String> to_string(size_t) override;
+    ErrorOr<ByteBuffer> encode() override;
+    static ErrorOr<RefPtr<TLSExtension>> decode(ReadonlyBytes);
+};
 
 }

--- a/Userland/Libraries/LibTLS/Record.cpp
+++ b/Userland/Libraries/LibTLS/Record.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/EventLoop.h>
 #include <LibCore/Timer.h>
 #include <LibCrypto/PK/Code/EMSA_PSS.h>
+#include <LibTLS/TLSRecord.h>
 #include <LibTLS/TLSv12.h>
 
 namespace TLS {
@@ -317,6 +318,16 @@ ssize_t TLSv12::handle_message(ReadonlyBytes buffer)
 
     if (buffer.size() < 5) {
         return (i8)Error::NeedMoreData;
+    }
+
+    if constexpr (TLS_DEBUG) {
+        auto maybe_record = TLSRecord::decode(buffer);
+        if (!maybe_record.is_error()) {
+            auto maybe_string = maybe_record.value()->to_string(0);
+            if (!maybe_string.is_error()) {
+                dbgln("{}", maybe_string.value());
+            }
+        }
     }
 
     auto type = (ContentType)buffer[0];

--- a/Userland/Libraries/LibTLS/TLSRecord.cpp
+++ b/Userland/Libraries/LibTLS/TLSRecord.cpp
@@ -1,0 +1,734 @@
+/*
+ * Copyright (c) 2023, stelar7 <dudedbz@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Debug.h>
+#include <AK/Endian.h>
+#include <AK/MemoryStream.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/Timer.h>
+#include <LibCrypto/PK/Code/EMSA_PSS.h>
+#include <LibTLS/Extensions.h>
+#include <LibTLS/TLSRecord.h>
+#include <LibTLS/TLSv12.h>
+
+namespace TLS {
+
+u16 TLSRecord::read_u16(ReadonlyBytes buffer, size_t offset)
+{
+    return AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(offset)));
+}
+
+Result<ByteBuffer, GenericError> TLSRecord::read_sized_buffer(size_t size, size_t offset, ReadonlyBytes buffer)
+{
+    if (offset + size > buffer.size()) {
+        return GenericError::NeedMoreData;
+    }
+
+    auto maybe_buffer = ByteBuffer::create_uninitialized(size);
+    if (maybe_buffer.is_error()) {
+        return GenericError::OutOfMemory;
+    }
+
+    auto output = maybe_buffer.release_value();
+    output.overwrite(0, buffer.slice(offset, size).data(), size);
+
+    return output;
+}
+
+ErrorOr<String> TLSAlert::to_string(size_t indent)
+{
+    StringBuilder builder;
+
+    builder.appendff("Alert:\n");
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Level: {}\n", enum_to_string(level));
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Description: {}\n", enum_to_string(description));
+    builder.append(TRY(String::repeated('\t', indent + 2)));
+    builder.appendff("{}\n", enum_to_value(description));
+
+    return builder.to_string();
+}
+
+ErrorOr<NonnullRefPtr<TLSAlert>> TLSAlert::decode(ReadonlyBytes buffer)
+{
+    auto alert = TRY(try_make_ref_counted<TLSAlert>());
+    alert->level = static_cast<AlertLevel>(AK::convert_between_host_and_network_endian(buffer[0]));
+    alert->description = static_cast<AlertDescription>(AK::convert_between_host_and_network_endian(buffer[1]));
+    return alert;
+}
+
+ErrorOr<ByteBuffer> TLSAlert::encode() { TODO(); }
+
+ErrorOr<NonnullOwnPtr<TLSRecord>> TLSRecord::decode(ReadonlyBytes payload)
+{
+    size_t offset { 0 };
+
+    // FIXME: Client message boundaries are not preserved in the record layer
+    // (i.e.,multiple client messages of the same ContentType MAY be coalesced into a single TLSPlaintext record,
+    // or a single message MAY be fragmented across several records).
+    NonnullOwnPtr<TLSRecord> record = TRY(AK::try_make<TLSRecord>());
+    record->content_type = static_cast<ContentType>(AK::convert_between_host_and_network_endian(payload[offset++]));
+    record->protocol_version = static_cast<ProtocolVersion>(AK::convert_between_host_and_network_endian(ByteReader::load16(payload.offset_pointer(offset))));
+    offset += 2;
+
+    auto length = AK::convert_between_host_and_network_endian(ByteReader::load16(payload.offset_pointer(offset)));
+    (void)length;
+    offset += 2;
+
+    ReadonlyBytes plain = payload;
+    ByteBuffer decrypted;
+
+    switch (record->content_type) {
+    case ContentType::HANDSHAKE: {
+        auto type = static_cast<HandshakeType>(AK::convert_between_host_and_network_endian(plain[offset]));
+
+        switch (type) {
+        case HandshakeType::HELLO_REQUEST_RESERVED: {
+            auto content = TRY(HelloRequest::decode(plain.slice(offset, plain.size() - offset)));
+            record->contents.append(content);
+            break;
+        }
+
+        case HandshakeType::CLIENT_HELLO: {
+            auto content = TRY(ClientHello::decode(plain.slice(offset, plain.size() - offset)));
+            record->contents.append(content);
+            break;
+        }
+
+        case HandshakeType::SERVER_HELLO: {
+            auto content = TRY(ServerHello::decode(plain.slice(offset, plain.size() - offset)));
+            record->contents.append(content);
+            break;
+        }
+
+        case HandshakeType::CERTIFICATE: {
+            auto content = TRY(HandshakeCertificate::decode(plain.slice(offset, plain.size() - offset)));
+            record->contents.append(content);
+            break;
+        }
+
+        case HandshakeType::SERVER_KEY_EXCHANGE_RESERVED: {
+            /*
+            auto algo = get_key_exchange_algorithm(cipher_suite);
+            auto content = TRY(ServerKeyExchange::decode(plain.slice(offset, plain.size() - offset), algo));
+            record->contents.append(content);
+            */
+            break;
+        }
+
+        case HandshakeType::SERVER_HELLO_DONE_RESERVED: {
+            auto content = TRY(ServerHelloDone::decode(plain.slice(offset, plain.size() - offset)));
+            record->contents.append(content);
+            break;
+        }
+
+        default: {
+            dbgln("Unable to handle handshake of type {}", enum_to_string(type));
+            // TODO();
+            break;
+        }
+        }
+        break;
+    }
+
+    case ContentType::CHANGE_CIPHER_SPEC: {
+        // We ignore this packet, since its not used.
+        // TODO: Toggle on encryption
+        break;
+    }
+
+    case ContentType::ALERT: {
+        record->alert = TRY(TLSAlert::decode(plain.slice(offset, plain.size() - offset)));
+        break;
+    }
+
+    default: {
+        dbgln("Unable to handle TLSRecord of type {}", enum_to_string(record->content_type));
+        // TODO();
+        break;
+    }
+    }
+
+    return record;
+}
+
+ErrorOr<ByteBuffer> TLSRecord::encode() { TODO(); }
+
+ErrorOr<String> TLSRecord::to_string(size_t indent)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("TLSRecord:\n");
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Content Type: {}\n", enum_to_string(content_type));
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Protocol Version: {}\n", enum_to_string(protocol_version));
+
+    if (alert) {
+        builder.append(TRY(String::repeated('\t', indent + 1)));
+        builder.appendff("{}", TRY(alert->to_string(indent + 1)));
+    }
+
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Content:\n");
+
+    for (auto& content : contents) {
+        builder.append(TRY(content->to_string(indent + 2)));
+    }
+
+    return builder.to_string();
+}
+
+ErrorOr<NonnullRefPtr<HelloRequest>> HelloRequest::decode(ReadonlyBytes) { return AK::try_make_ref_counted<HelloRequest>(); }
+
+ErrorOr<ByteBuffer> HelloRequest::encode()
+{
+    auto buffer = TRY(ByteBuffer::create_zeroed(4));
+    buffer.append(static_cast<u8>(handshake_type));
+    buffer.append(0);
+    buffer.append(0);
+    buffer.append(0);
+    return buffer;
+}
+
+ErrorOr<String> HelloRequest::to_string(size_t indent)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("HelloRequest\n");
+
+    return builder.to_string();
+}
+
+static ErrorOr<Vector<RefPtr<TLSExtension>>> parse_extensions(ReadonlyBytes buffer, size_t& offset)
+{
+    Vector<RefPtr<TLSExtension>> extensions;
+
+    u16 extensions_length = TLSRecord::read_u16(buffer, offset);
+    offset += sizeof(extensions_length);
+
+    auto end_index = offset + extensions_length;
+
+    while ((buffer.size() - offset) >= 4 && offset < end_index) {
+        auto extension_type = static_cast<ExtensionType>(TLSRecord::read_u16(buffer, offset));
+        u16 extension_length = TLSRecord::read_u16(buffer, offset + sizeof(ExtensionType));
+
+        dbgln_if(TLS_DEBUG, "parsing extension: {}, expected bytes: {}, remaining bytes after parse: {}",
+            enum_to_string(extension_type), extension_length, (i32)buffer.size() - offset - 4 - extension_length);
+
+        switch (extension_type) {
+        case ExtensionType::SERVER_NAME: {
+            auto name_list = TRY(ServerNameList::decode(buffer.slice(offset, buffer.size() - offset)));
+            extensions.append(name_list.release_nonnull());
+            break;
+        }
+        case ExtensionType::EC_POINT_FORMATS: {
+            auto points = TRY(ECPointFormats::decode(buffer.slice(offset, buffer.size() - offset)));
+            extensions.append(points.release_nonnull());
+            break;
+        }
+        case ExtensionType::SIGNATURE_ALGORITHMS: {
+            auto points = TRY(SignatureSchemes::decode(buffer.slice(offset, buffer.size() - offset)));
+            extensions.append(points.release_nonnull());
+            break;
+        }
+        case ExtensionType::SUPPORTED_GROUPS: {
+            auto points = TRY(SupportedGroups::decode(buffer.slice(offset, buffer.size() - offset)));
+            extensions.append(points.release_nonnull());
+            break;
+        }
+
+        default: {
+            dbgln_if(TLS_DEBUG, "Encountered unknown extension {} with length {}", enum_to_string(extension_type), extension_length);
+        }
+        }
+        offset += sizeof(extension_type) + sizeof(extension_length) + extension_length;
+    }
+
+    dbgln_if(TLS_DEBUG, "Handshake Extensions: parsing over, remaining bytes after parse: {}", (i32)buffer.size() - offset);
+
+    return extensions;
+}
+
+ErrorOr<NonnullRefPtr<ClientHello>> ClientHello::decode(ReadonlyBytes buffer)
+{
+    auto type = static_cast<HandshakeType>(buffer[0]);
+    VERIFY(type == HandshakeType::CLIENT_HELLO);
+
+    size_t length = buffer[1] * 0x10000 + buffer[2] * 0x100 + buffer[3];
+    if (buffer.size() < length) {
+        return AK::Error::from_string_view(enum_to_string(GenericError::NeedMoreData));
+    }
+
+    size_t offset { 4 };
+    auto client_hello = TRY(try_make_ref_counted<ClientHello>());
+
+    client_hello->client_version = static_cast<ProtocolVersion>(TLSRecord::read_u16(buffer, offset));
+    offset += sizeof(ProtocolVersion);
+
+    memcpy(client_hello->client_random, buffer.offset_pointer(offset), sizeof(client_hello->client_random));
+    offset += sizeof(client_hello->client_random);
+
+    auto session_length = buffer[offset++];
+    memcpy(client_hello->session_id, buffer.offset_pointer(offset), session_length);
+    offset += session_length;
+
+    u16 cipher_suite_length = TLSRecord::read_u16(buffer, offset);
+    offset += sizeof(cipher_suite_length);
+
+    auto cipher_suite_count = cipher_suite_length / 2;
+
+    u16 cipher_index = 0;
+    while (buffer.size() - offset >= 2 && cipher_index++ < cipher_suite_count) {
+        client_hello->cipher_suites.append(static_cast<CipherSuite>(TLSRecord::read_u16(buffer, offset)));
+        offset += sizeof(CipherSuite);
+    }
+
+    auto compression_method_length = buffer[offset++];
+    u16 compression_method_index = 0;
+    while (buffer.size() - offset >= 1 && compression_method_index++ < compression_method_length) {
+        client_hello->compression_methods.append(static_cast<CompressionMethod>(buffer[offset++]));
+    }
+
+    client_hello->extensions = TRY(parse_extensions(buffer, offset));
+
+    return client_hello;
+}
+
+ErrorOr<ByteBuffer> ClientHello::encode() { TODO(); }
+
+ErrorOr<String> ClientHello::to_string(size_t indent)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("Server Hello:\n");
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Server version: {}\n", enum_to_string(client_version));
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Server random: {:hex-dump}\n", client_random);
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Session ID: {:hex-dump}\n", session_id);
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Cipher suits: {}\n", cipher_suites.size());
+    for (auto& cipher : cipher_suites) {
+        builder.append(TRY(String::repeated('\t', indent + 2)));
+        builder.appendff("{}\n", enum_to_string(cipher));
+    }
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Compression methods: {}\n", compression_methods.size());
+    for (auto& compression : compression_methods) {
+        builder.append(TRY(String::repeated('\t', indent + 2)));
+        builder.appendff("{}\n", enum_to_string(compression));
+    }
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Extensions: {}\n", extensions.size());
+    for (auto& extension : extensions) {
+        builder.append(TRY(extension->to_string(indent + 2)));
+    }
+
+    return builder.to_string();
+}
+
+ErrorOr<NonnullRefPtr<ServerHello>> ServerHello::decode(ReadonlyBytes buffer)
+{
+    auto type = static_cast<HandshakeType>(buffer[0]);
+    VERIFY(type == HandshakeType::SERVER_HELLO);
+
+    size_t length = buffer[1] * 0x10000 + buffer[2] * 0x100 + buffer[3];
+    if (buffer.size() < length) {
+        return AK::Error::from_string_view(enum_to_string(GenericError::NeedMoreData));
+    }
+
+    size_t offset { 4 };
+    auto server_hello = TRY(try_make_ref_counted<ServerHello>());
+
+    server_hello->server_version = static_cast<ProtocolVersion>(TLSRecord::read_u16(buffer, offset));
+    offset += sizeof(ProtocolVersion);
+
+    memcpy(server_hello->server_random, buffer.offset_pointer(offset), sizeof(server_hello->server_random));
+    offset += sizeof(server_hello->server_random);
+
+    auto session_length = buffer[offset++];
+    memcpy(server_hello->session_id, buffer.offset_pointer(offset), session_length);
+    offset += session_length;
+
+    server_hello->cipher_suite = static_cast<CipherSuite>(TLSRecord::read_u16(buffer, offset));
+    offset += sizeof(CipherSuite);
+
+    if (!TLSv12::supports_cipher(server_hello->cipher_suite)) {
+        dbgln_if(TLS_DEBUG, "No supported cipher could be agreed upon");
+        return AK::Error::from_string_view(enum_to_string(GenericError::NoCommonCipher));
+    }
+
+    server_hello->compression_method = static_cast<CompressionMethod>(buffer[offset++]);
+    if (server_hello->compression_method != CompressionMethod::NONE)
+        return AK::Error::from_string_view(enum_to_string(GenericError::CompressionNotSupported));
+
+    server_hello->extensions = TRY(parse_extensions(buffer, offset));
+
+    return server_hello;
+}
+
+ErrorOr<ByteBuffer> ServerHello::encode() { TODO(); }
+
+ErrorOr<String> ServerHello::to_string(size_t indent)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("Server Hello:\n");
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Server version: {}\n", enum_to_string(server_version));
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Server random: {:hex-dump}\n", server_random);
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Session ID: {:hex-dump}\n", session_id);
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Cipher suite: {}\n", enum_to_string(cipher_suite));
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Compression method: {}\n", enum_to_string(compression_method));
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Extensions: {}\n", extensions.size());
+    for (auto& extension : extensions) {
+        builder.append(TRY(extension->to_string(indent + 2)));
+    }
+
+    return builder.to_string();
+}
+
+ErrorOr<NonnullRefPtr<HandshakeCertificate>> HandshakeCertificate::decode(ReadonlyBytes buffer)
+{
+    size_t offset = { 0 };
+    auto type = static_cast<HandshakeType>(buffer[offset++]);
+    VERIFY(type == HandshakeType::CERTIFICATE);
+
+    size_t extension_length = buffer[offset] * 0x10000 + buffer[offset + 1] * 0x100 + buffer[offset + 2];
+    offset += 3;
+    if (buffer.size() < extension_length) {
+        return AK::Error::from_string_view(enum_to_string(GenericError::NeedMoreData));
+    }
+
+    size_t certificates_length = buffer[offset] * 0x10000 + buffer[offset + 1] * 0x100 + buffer[offset + 2];
+    offset += 3;
+
+    auto handshake_certificates = TRY(try_make_ref_counted<HandshakeCertificate>());
+    while (offset < certificates_length - 7) {
+        size_t certificate_size = buffer[offset] * 0x10000 + buffer[offset + 1] * 0x100 + buffer[offset + 2];
+        offset += 3;
+
+        auto certificate = TRY(Certificate::parse_certificate(buffer.slice(offset, certificate_size), false));
+        handshake_certificates->certificates.append(certificate);
+        offset += certificate_size;
+    }
+
+    return handshake_certificates;
+}
+
+ErrorOr<ByteBuffer> HandshakeCertificate::encode() { TODO(); }
+
+ErrorOr<String> HandshakeCertificate::to_string(size_t indent)
+{
+    StringBuilder builder;
+
+    for (auto& certificate : certificates) {
+        builder.append(TRY(String::repeated('\t', indent)));
+        builder.appendff("Handshake Certificate:\n");
+        builder.append(TRY(String::repeated('\t', indent + 1)));
+        builder.appendff("Version: {}\n", certificate.version);
+        builder.append(TRY(String::repeated('\t', indent + 1)));
+        builder.appendff("Serial Number: {}\n", TRY(certificate.serial_number.to_base(16)));
+        builder.append(TRY(String::repeated('\t', indent + 1)));
+        builder.appendff("Signature Algorithm: {}\n", to_underlying(certificate.algorithm));
+
+        builder.append(TRY(String::repeated('\t', indent + 1)));
+        builder.appendff("Validity:\n");
+        builder.append(TRY(String::repeated('\t', indent + 2)));
+        builder.appendff("Not Before: {}\n", TRY(certificate.validity.not_before.to_string()));
+        builder.append(TRY(String::repeated('\t', indent + 2)));
+        builder.appendff("Not After: {}\n", TRY(certificate.validity.not_after.to_string()));
+
+        builder.append(TRY(String::repeated('\t', indent + 1)));
+        builder.appendff("Issuer: {}\n", TRY(certificate.issuer.to_string()));
+        builder.append(TRY(String::repeated('\t', indent + 1)));
+        builder.appendff("Subject: {}\n", TRY(certificate.subject.to_string()));
+
+        builder.append(TRY(String::repeated('\t', indent + 1)));
+        builder.appendff("Subject Public Key Info:\n");
+        builder.append(TRY(String::repeated('\t', indent + 2)));
+        builder.appendff("Algorithm: {}\n", to_underlying(certificate.public_key.algorithm));
+        switch (certificate.public_key.algorithm) {
+        default:
+            builder.append(TRY(String::repeated('\t', indent + 3)));
+            builder.appendff("Public-Key: {:hex-dump}\n", certificate.public_key.raw_key.bytes());
+            break;
+        }
+    }
+
+    return builder.to_string();
+}
+
+ErrorOr<NonnullRefPtr<HandshakeCertificateVerify>> HandshakeCertificateVerify::decode(ReadonlyBytes) { TODO(); }
+ErrorOr<ByteBuffer> HandshakeCertificateVerify::encode() { TODO(); }
+ErrorOr<String> HandshakeCertificateVerify::to_string(size_t) { TODO(); }
+
+static ErrorOr<ByteBuffer> decode_u8_buffer(ReadonlyBytes bytes, size_t& offset)
+{
+    u8 buffer_size = bytes[offset];
+    offset += sizeof(u8);
+
+    auto maybe_buffer = TLSRecord::read_sized_buffer(buffer_size, offset, bytes);
+    if (maybe_buffer.is_error()) {
+        return AK::Error::from_errno((i8)maybe_buffer.release_error());
+    }
+
+    offset += buffer_size;
+    return maybe_buffer.release_value();
+}
+
+static ErrorOr<ByteBuffer> decode_u16_buffer(ReadonlyBytes bytes, size_t& offset)
+{
+    u16 buffer_size = AK::convert_between_host_and_network_endian(ByteReader::load16(bytes.offset_pointer(offset)));
+    offset += sizeof(u16);
+
+    auto maybe_buffer = TLSRecord::read_sized_buffer(buffer_size, offset, bytes);
+    if (maybe_buffer.is_error()) {
+        return AK::Error::from_string_view(enum_to_string(maybe_buffer.error()));
+    }
+
+    offset += buffer_size;
+    return maybe_buffer.release_value();
+}
+
+static ErrorOr<CurveExchange> decode_curve_exchange(ReadonlyBytes buffer, size_t& offset)
+{
+    CurveExchange exchange;
+    exchange.p = TRY(decode_u16_buffer(buffer, offset));
+    exchange.g = TRY(decode_u16_buffer(buffer, offset));
+    exchange.Ys = TRY(decode_u16_buffer(buffer, offset));
+    return exchange;
+}
+
+static ErrorOr<ExplicitPrime> decode_explicit_prime(ReadonlyBytes buffer, size_t& offset)
+{
+    ExplicitPrime parameter;
+    parameter.prime = TRY(decode_u8_buffer(buffer, offset));
+    return parameter;
+}
+
+static ErrorOr<ExplicitChar> decode_explicit_char(ReadonlyBytes buffer, size_t& offset)
+{
+    ExplicitChar parameter;
+
+    parameter.m = TLSRecord::TLSRecord::read_u16(buffer, offset);
+    offset += sizeof(u16);
+
+    auto basis = static_cast<ECBasisType>(AK::convert_between_host_and_network_endian(buffer[offset++]));
+    if (basis == ECBasisType::EC_BASIS_TRINOMINAL) {
+        ECTrinominal trinominal;
+        trinominal.k = TRY(decode_u8_buffer(buffer, offset));
+        parameter.basis = trinominal;
+    } else if (basis == ECBasisType::EC_BASIS_PENTANOMINAL) {
+        ECPentanominal pentanominal;
+        pentanominal.k1 = TRY(decode_u8_buffer(buffer, offset));
+        pentanominal.k2 = TRY(decode_u8_buffer(buffer, offset));
+        pentanominal.k3 = TRY(decode_u8_buffer(buffer, offset));
+        parameter.basis = pentanominal;
+    } else {
+        VERIFY_NOT_REACHED();
+    }
+
+    return parameter;
+}
+
+static ErrorOr<ECCurveExchange> decode_ec_curve_exchange(ReadonlyBytes buffer, size_t& offset)
+{
+    ECCurveExchange exchange;
+    exchange.curve_type = static_cast<ECCurveType>(AK::convert_between_host_and_network_endian(buffer[offset]));
+    offset += sizeof(ECCurveType);
+
+    if (exchange.curve_type == ECCurveType::NAMED_CURVE) {
+        exchange.curve_params = static_cast<SupportedGroup>(TLSRecord::read_u16(buffer, offset));
+        offset += sizeof(SupportedGroup);
+    } else {
+        ECCurveParameters params;
+
+        if (exchange.curve_type == ECCurveType::EXPLICIT_PRIME) {
+            params.data = TRY(decode_explicit_prime(buffer, offset));
+        } else if (exchange.curve_type == ECCurveType::EXPLICIT_CHAR2) {
+            params.data = TRY(decode_explicit_char(buffer, offset));
+        } else {
+            VERIFY_NOT_REACHED();
+        }
+
+        params.curve.a = TRY(decode_u8_buffer(buffer, offset));
+        params.curve.b = TRY(decode_u8_buffer(buffer, offset));
+        params.base = TRY(decode_u8_buffer(buffer, offset));
+        params.order = TRY(decode_u8_buffer(buffer, offset));
+        params.cofactor = TRY(decode_u8_buffer(buffer, offset));
+
+        exchange.curve_params = params;
+    }
+
+    return exchange;
+}
+
+static ErrorOr<void> decode_key_exchange_signature(ReadonlyBytes buffer, size_t& offset, ServerKeyExchange& server_key_exchange)
+{
+    server_key_exchange.signature_scheme = static_cast<SignatureScheme>(TLSRecord::read_u16(buffer, offset));
+    offset += sizeof(SignatureScheme);
+
+    server_key_exchange.signature = TRY(decode_u16_buffer(buffer, offset));
+    return {};
+}
+
+ErrorOr<NonnullRefPtr<ServerKeyExchange>> ServerKeyExchange::decode(ReadonlyBytes buffer, KeyExchangeAlgorithm exchange_algorithm)
+{
+    auto type = static_cast<HandshakeType>(buffer[0]);
+    VERIFY(type == HandshakeType::SERVER_KEY_EXCHANGE_RESERVED);
+
+    size_t length = buffer[1] * 0x10000 + buffer[2] * 0x100 + buffer[3];
+    if (buffer.size() < length) {
+        return AK::Error::from_string_view(enum_to_string(GenericError::NeedMoreData));
+    }
+
+    size_t offset { 4 };
+    auto server_key_exchange = TRY(try_make_ref_counted<ServerKeyExchange>());
+
+    switch (exchange_algorithm) {
+    // https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.3
+    case KeyExchangeAlgorithm::RSA:
+    case KeyExchangeAlgorithm::DH_DSS:
+    case KeyExchangeAlgorithm::DH_RSA: {
+        break;
+    }
+    case KeyExchangeAlgorithm::DH_anon: {
+        CurveExchange exchange = TRY(decode_curve_exchange(buffer, offset));
+        server_key_exchange->public_key = exchange.Ys;
+        server_key_exchange->exchange_parameters = exchange;
+        break;
+    }
+
+    case KeyExchangeAlgorithm::DHE_DSS:
+    case KeyExchangeAlgorithm::DHE_RSA: {
+        CurveExchange exchange = TRY(decode_curve_exchange(buffer, offset));
+        server_key_exchange->public_key = exchange.Ys;
+        server_key_exchange->exchange_parameters = exchange;
+        TRY(decode_key_exchange_signature(buffer, offset, server_key_exchange));
+        break;
+    }
+
+    case KeyExchangeAlgorithm::ECDHE_RSA: {
+        ECCurveExchange exchange = TRY(decode_ec_curve_exchange(buffer, offset));
+        server_key_exchange->public_key = TRY(decode_u8_buffer(buffer, offset));
+        server_key_exchange->exchange_parameters = exchange;
+        TRY(decode_key_exchange_signature(buffer, offset, server_key_exchange));
+        break;
+    }
+
+    default: {
+        dbgln("Unhandled server key exchange algorithm, {}", enum_to_string(exchange_algorithm));
+        VERIFY_NOT_REACHED();
+        break;
+    }
+    }
+
+    return server_key_exchange;
+}
+
+ErrorOr<ByteBuffer> ServerKeyExchange::encode() { TODO(); }
+
+ErrorOr<String> ServerKeyExchange::to_string(size_t indent)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("Server Key Exchange:\n");
+
+    TRY(exchange_parameters.visit(
+        [](Empty) -> ErrorOr<void> {
+            VERIFY_NOT_REACHED();
+            return AK::Error::from_string_view("Empty exchange params"sv);
+        },
+        [&](CurveExchange exchange) -> ErrorOr<void> {
+            builder.append(TRY(String::repeated('\t', indent + 1)));
+            builder.appendff("Curve Exchange:\n");
+            builder.append(TRY(String::repeated('\t', indent + 2)));
+            builder.appendff("P: {:hex-dump}\n", exchange.p.bytes());
+            builder.append(TRY(String::repeated('\t', indent + 2)));
+            builder.appendff("G: {:hex-dump}\n", exchange.g.bytes());
+            return {};
+        },
+        [&](ECCurveExchange exchange) -> ErrorOr<void> {
+            builder.append(TRY(String::repeated('\t', indent + 1)));
+            builder.appendff("EC Curve Exchange:\n");
+            builder.append(TRY(String::repeated('\t', indent + 2)));
+            builder.appendff("Curve Type: {}\n", enum_to_string(exchange.curve_type));
+            TRY(exchange.curve_params.visit(
+                [](Empty) -> ErrorOr<void> {
+                    VERIFY_NOT_REACHED();
+                    return AK::Error::from_string_view("Empty curve params"sv);
+                },
+                [&](SupportedGroup group) -> ErrorOr<void> {
+                    builder.append(TRY(String::repeated('\t', indent + 2)));
+                    builder.appendff("Curve Name: {}\n", enum_to_string(group));
+                    return {};
+                },
+                [&](ECCurveParameters params) -> ErrorOr<void> {
+                    (void)params;
+                    builder.append(TRY(String::repeated('\t', indent + 2)));
+                    builder.appendff("DUMP FOR ECCurveParameters not configured");
+                    return {};
+                }));
+            return {};
+        }));
+
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Public Key: {:hex-dump}\n", public_key.bytes());
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Signature Scheme: {}\n", enum_to_string(signature_scheme));
+    builder.append(TRY(String::repeated('\t', indent + 1)));
+    builder.appendff("Signature: {:hex-dump}\n", signature.bytes());
+
+    return builder.to_string();
+}
+
+ErrorOr<NonnullRefPtr<ServerHelloDone>> ServerHelloDone::decode(ReadonlyBytes buffer)
+{
+    auto type = static_cast<HandshakeType>(buffer[0]);
+    VERIFY(type == HandshakeType::SERVER_HELLO_DONE_RESERVED);
+
+    size_t length = buffer[1] * 0x10000 + buffer[2] * 0x100 + buffer[3];
+    if (buffer.size() < length) {
+        return AK::Error::from_string_view(enum_to_string(GenericError::NeedMoreData));
+    }
+
+    return TRY(try_make_ref_counted<ServerHelloDone>());
+}
+
+ErrorOr<ByteBuffer> ServerHelloDone::encode()
+{
+    auto buffer = TRY(ByteBuffer::create_zeroed(4));
+    buffer.append(static_cast<u8>(handshake_type));
+    buffer.append(0);
+    buffer.append(0);
+    buffer.append(0);
+    return buffer;
+}
+
+ErrorOr<String> ServerHelloDone::to_string(size_t indent)
+{
+    StringBuilder builder;
+
+    builder.append(TRY(String::repeated('\t', indent)));
+    builder.appendff("Server Hello Done");
+
+    return builder.to_string();
+}
+}

--- a/Userland/Libraries/LibTLS/TLSRecord.h
+++ b/Userland/Libraries/LibTLS/TLSRecord.h
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2022, stelar7 <dudedbz@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/Error.h>
+#include <AK/OwnPtr.h>
+#include <AK/RefPtr.h>
+#include <AK/Result.h>
+#include <AK/Types.h>
+#include <AK/Vector.h>
+#include <LibCrypto/Cipher/AES.h>
+#include <LibTLS/Certificate.h>
+#include <LibTLS/Extensions.h>
+
+namespace TLS {
+
+using CipherVariant = Variant<
+    Empty,
+    Crypto::Cipher::AESCipher::CBCMode,
+    Crypto::Cipher::AESCipher::GCMMode>;
+
+class TLSHandshake : public RefCounted<TLSHandshake> {
+public:
+    HandshakeType handshake_type;
+
+    virtual ErrorOr<String> to_string(size_t) { TODO(); }
+    virtual ~TLSHandshake() {};
+};
+
+class TLSAlert : public RefCounted<TLSAlert> {
+public:
+    AlertLevel level;
+    AlertDescription description;
+
+    ErrorOr<String> to_string(size_t);
+    static ErrorOr<NonnullRefPtr<TLSAlert>> decode(ReadonlyBytes);
+    ErrorOr<ByteBuffer> encode();
+};
+
+class TLSRecord {
+public:
+    ContentType content_type;
+    ProtocolVersion protocol_version;
+    Vector<RefPtr<TLSHandshake>> contents;
+    RefPtr<TLSAlert> alert;
+
+    ErrorOr<String> to_string(size_t);
+    static ErrorOr<NonnullOwnPtr<TLSRecord>> decode(ReadonlyBytes);
+    ErrorOr<ByteBuffer> encode();
+
+    static Result<ByteBuffer, GenericError> read_sized_buffer(size_t, size_t, ReadonlyBytes);
+    static u16 read_u16(ReadonlyBytes, size_t);
+};
+
+class HelloRequest : public TLSHandshake {
+public:
+    ErrorOr<String> to_string(size_t) override;
+    static ErrorOr<NonnullRefPtr<HelloRequest>> decode(ReadonlyBytes);
+    ErrorOr<ByteBuffer> encode();
+};
+
+class ClientHello : public TLSHandshake {
+public:
+    ProtocolVersion client_version;
+    u8 client_random[32] {};
+    u8 session_id[32] {};
+    Vector<CipherSuite> cipher_suites;
+    Vector<CompressionMethod> compression_methods;
+    Vector<RefPtr<TLSExtension>> extensions;
+
+    ErrorOr<String> to_string(size_t) override;
+    static ErrorOr<NonnullRefPtr<ClientHello>> decode(ReadonlyBytes);
+    ErrorOr<ByteBuffer> encode();
+};
+
+class ServerHello : public TLSHandshake {
+public:
+    ProtocolVersion server_version;
+    u8 server_random[32] {};
+    u8 session_id[32] {};
+    CipherSuite cipher_suite;
+    CompressionMethod compression_method;
+    Vector<RefPtr<TLSExtension>> extensions;
+
+    ErrorOr<String> to_string(size_t) override;
+    static ErrorOr<NonnullRefPtr<ServerHello>> decode(ReadonlyBytes);
+    ErrorOr<ByteBuffer> encode();
+};
+
+class HandshakeCertificate : public TLSHandshake {
+public:
+    Vector<Certificate> certificates;
+
+    ErrorOr<String> to_string(size_t) override;
+    static ErrorOr<NonnullRefPtr<HandshakeCertificate>> decode(ReadonlyBytes);
+    ErrorOr<ByteBuffer> encode();
+};
+
+class HandshakeCertificateVerify : public TLSHandshake {
+public:
+    SignatureAlgorithm algorithm;
+    ByteBuffer signature;
+
+    ErrorOr<String> to_string(size_t) override;
+    static ErrorOr<NonnullRefPtr<HandshakeCertificateVerify>> decode(ReadonlyBytes);
+    ErrorOr<ByteBuffer> encode();
+};
+
+struct ECCurve {
+    ByteBuffer a;
+    ByteBuffer b;
+};
+
+struct ExplicitPrime {
+    ByteBuffer prime;
+};
+
+struct ECTrinominal {
+    ByteBuffer k;
+};
+
+struct ECPentanominal {
+    ByteBuffer k1;
+    ByteBuffer k2;
+    ByteBuffer k3;
+};
+
+struct ExplicitChar {
+    u16 m;
+    Variant<Empty, ECTrinominal, ECPentanominal> basis;
+};
+
+struct ECCurveParameters {
+    Variant<Empty, ExplicitPrime, ExplicitChar> data;
+    ECCurve curve;
+    ByteBuffer base;
+    ByteBuffer order;
+    ByteBuffer cofactor;
+};
+
+struct ECCurveExchange {
+    ECCurveType curve_type;
+    Variant<Empty, SupportedGroup, ECCurveParameters> curve_params;
+};
+
+struct CurveExchange {
+    ByteBuffer p;
+    ByteBuffer g;
+    ByteBuffer Ys;
+};
+
+class ServerKeyExchange : public TLSHandshake {
+public:
+    Variant<Empty, CurveExchange, ECCurveExchange> exchange_parameters;
+    ByteBuffer public_key;
+    SignatureScheme signature_scheme;
+    ByteBuffer signature;
+
+    ErrorOr<String> to_string(size_t) override;
+    static ErrorOr<NonnullRefPtr<ServerKeyExchange>> decode(ReadonlyBytes, KeyExchangeAlgorithm);
+    ErrorOr<ByteBuffer> encode();
+};
+
+class ServerHelloDone : public TLSHandshake {
+public:
+    ErrorOr<String> to_string(size_t) override;
+    static ErrorOr<NonnullRefPtr<ServerHelloDone>> decode(ReadonlyBytes);
+    ErrorOr<ByteBuffer> encode();
+};
+
+}

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -322,7 +322,7 @@ public:
 
     StringView alpn() const { return m_context.negotiated_alpn; }
 
-    bool supports_cipher(CipherSuite suite) const
+    static bool supports_cipher(CipherSuite suite)
     {
         switch (suite) {
 #define C(is_supported, suite, key_exchange, cipher, hash, iv_size, is_aead) \


### PR DESCRIPTION
Improves the output of TLS_DEBUG by parsing the buffers into classes that can be printed more pretty.
(Also includes a `encode()` method that can take over for the packetbuilder in the future)

This also starts the work of making everything TLS more object oriented, where this can be extended in the future to handle all the parsing.

Single commit with the remaining changes from my "tls-objects!!" idea, since im not too sure where to split it.

```
TLSRecord:
        Content Type: HANDSHAKE
        Protocol Version: VERSION_1_2
        Content:
                Server Hello:
                        Server version: VERSION_1_2
                        Server random: 6439c5d441d5909c33a7a13b3fd14f11ff7fdcda157f67fa444f574e47524401
                        Session ID: e720fcfdb8770c3e1e10d732bc513bb1aaaa641ddd64cd54565195cc33940a51
                        Cipher suite: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
                        Compression method: NONE
                        Extensions: 1
                                EC Point Formats:
                                        ANSIX962_COMPRESSED_PRIME
                                        UNCOMPRESSED
```
```
 TLSRecord:
        Content Type: HANDSHAKE
        Protocol Version: VERSION_1_2
        Content:
                Handshake Certificate:
                        Version: 2
                        Serial Number: 3b136b60ddc257d70a0c11234e9e28ca
                        Signature Algorithm: 11
                        Validity:
                                Not Before: 2023-03-28 16:54:02
                                Not After: 2023-06-20 16:54:01
                        Issuer: \O=Google Trust Services LLC\CN=GTS CA 1C3\C=US
                        Subject: \CN=*.gstatic.com
                        Subject Public Key Info:
                                Algorithm: 1
                                        Public-Key: 3082010a0282010100efa8e035fc8dccc122d87c739b0fb59cea0a8a80eeca7f0c21bc620b34dd11c365b792a116115a2019cdbfa0565e89eae7b5012182fa81ae356120497273f6017313e8ec3ade1c676a5a6ee8c1986a8b7dac9bcfa05d97e672eca1f79f8411c8fa875fd1536f83374b34604c70cb0243472938e16dc550bfd79aa42a07fe6a41a087d6966debee3326eced8d696bcbb4d6e7ab8828e04cccbef4eca0278f15d85724abb2260f9527bebe4f126564482232f838f17f695c2d75ca64bd51a11da025a47e5c418be3789deaec1d67f425b274eb81eb2de043bcccbb044f65d2ab35751c72e61274588a63a31fcb0747d9c2fded8506572eb8a99db3140eb6ddf8cd0203010001
```
