### PR TITLE
LibVideo/PlaybackManager: Decode frames off the main thread

### DIFF
--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -105,7 +105,7 @@ public:
 
     static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_data(ReadonlyBytes data);
 
-    PlaybackManager(NonnullOwnPtr<Demuxer>& demuxer, Track video_track, NonnullOwnPtr<VideoDecoder>&& decoder);
+    PlaybackManager(NonnullOwnPtr<Demuxer>& demuxer, Track video_track, NonnullOwnPtr<VideoDecoder>&& decoder, NonnullOwnPtr<VideoFrameQueue>&& frame_queue);
     ~PlaybackManager();
 
     void resume_playback();
@@ -143,7 +143,7 @@ private:
     class SeekingStateHandler;
     class StoppedStateHandler;
 
-    static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> create_with_demuxer(NonnullOwnPtr<Demuxer> demuxer);
+    static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> create(NonnullOwnPtr<Demuxer> demuxer);
 
     void start_timer(int milliseconds);
     void timer_callback();
@@ -172,7 +172,7 @@ private:
 
     RefPtr<Core::Timer> m_decode_timer;
 
-    NonnullOwnPtr<PlaybackStateHandler> m_playback_handler;
+    OwnPtr<PlaybackStateHandler> m_playback_handler;
     Optional<FrameQueueItem> m_next_frame;
 
     u64 m_skipped_frames { 0 };

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -161,6 +161,7 @@ private:
     Optional<Time> seek_demuxer_to_most_recent_keyframe(Time timestamp, Optional<Time> earliest_available_sample = OptionalNone());
 
     Optional<FrameQueueItem> dequeue_one_frame();
+    void set_state_update_timer(int delay_ms);
 
     void decode_and_queue_one_sample();
 
@@ -179,7 +180,7 @@ private:
 
     VideoFrameQueue m_frame_queue;
 
-    RefPtr<Core::Timer> m_present_timer;
+    RefPtr<Core::Timer> m_state_update_timer;
     unsigned m_decoding_buffer_time_ms = 16;
 
     RefPtr<Threading::Thread> m_decode_thread;
@@ -216,7 +217,7 @@ private:
 
         virtual Time current_time() const;
 
-        virtual ErrorOr<void> on_timer_callback() { return {}; };
+        virtual ErrorOr<void> do_timed_state_update() { return {}; };
 
     protected:
         template<class T, class... Args>


### PR DESCRIPTION
Running decoding on the main thread can cause frames to be delayed due to the presentation timer waiting for a decode to finish. If a frame takes too long to decode, this delay can be quite visible. This PR moves decoding in `PlaybackManager` to a separate thread, with frames sent to the main thread through a thread-safe queue.

The improves frame timing delay in a 720p60 video to a very consistent ~1-2ms, where previously it would often go up to 16ms.