### PR TITLE
LibWeb: Properly reject abrupt completions in WebIDL::clean_up_on_return

### DIFF
--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -672,7 +672,7 @@ WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller(ReadableStre
     auto start_result = TRY(start_algorithm());
 
     // 10. Let startPromise be a promise resolved with startResult.
-    auto start_promise = WebIDL::create_resolved_promise(realm, start_result ? start_result->promise() : JS::js_undefined());
+    auto start_promise = WebIDL::create_resolved_promise(realm, start_result);
 
     // 11. Upon fulfillment of startPromise,
     WebIDL::upon_fulfillment(start_promise, [&](auto const&) -> WebIDL::ExceptionOr<JS::Value> {
@@ -711,7 +711,7 @@ WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller_from_underly
     auto controller = MUST_OR_THROW_OOM(stream.heap().allocate<ReadableStreamDefaultController>(realm, realm));
 
     // 2. Let startAlgorithm be an algorithm that returns undefined.
-    StartAlgorithm start_algorithm = [] { return JS::GCPtr<WebIDL::Promise> {}; };
+    StartAlgorithm start_algorithm = [] { return JS::js_undefined(); };
 
     // 3. Let pullAlgorithm be an algorithm that returns a promise resolved with undefined.
     PullAlgorithm pull_algorithm = [&realm]() {
@@ -725,10 +725,9 @@ WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller_from_underly
 
     // 5. If underlyingSourceDict["start"] exists, then set startAlgorithm to an algorithm which returns the result of invoking underlyingSourceDict["start"] with argument list « controller » and callback this value underlyingSource.
     if (underlying_source.start) {
-        start_algorithm = [&, callback = underlying_source.start]() -> WebIDL::ExceptionOr<JS::GCPtr<WebIDL::Promise>> {
-            // Note: callback return a promise, so invoke_callback will never return an abrupt completion
-            auto result = MUST_OR_THROW_OOM(WebIDL::invoke_callback(*callback, underlying_source_value, controller)).release_value();
-            return WebIDL::create_resolved_promise(realm, result);
+        start_algorithm = [&, callback = underlying_source.start]() -> WebIDL::ExceptionOr<JS::Value> {
+            // Note: callback does not return a promise, so invoke_callback may return an abrupt completion
+            return WebIDL::invoke_callback(*callback, underlying_source_value, controller);
         };
     }
 
@@ -1668,7 +1667,7 @@ WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller(WritableStre
     auto start_result = TRY(start_algorithm());
 
     // 16. Let startPromise be a promise resolved with startResult.
-    auto start_promise = WebIDL::create_resolved_promise(realm, start_result ? start_result->promise() : JS::js_undefined());
+    auto start_promise = WebIDL::create_resolved_promise(realm, start_result);
 
     // 17. Upon fulfillment of startPromise,
     WebIDL::upon_fulfillment(*start_promise, [&](auto const&) -> WebIDL::ExceptionOr<JS::Value> {
@@ -1712,7 +1711,7 @@ WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller_from_underly
     auto controller = MUST_OR_THROW_OOM(realm.heap().allocate<WritableStreamDefaultController>(realm, realm));
 
     // 2. Let startAlgorithm be an algorithm that returns undefined.
-    StartAlgorithm start_algorithm = [] { return JS::GCPtr<WebIDL::Promise> {}; };
+    StartAlgorithm start_algorithm = [] { return JS::js_undefined(); };
 
     // 3. Let writeAlgorithm be an algorithm that returns a promise resolved with undefined.
     WriteAlgorithm write_algorithm = [&realm](auto const&) {
@@ -1731,10 +1730,9 @@ WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller_from_underly
 
     // 6. If underlyingSinkDict["start"] exists, then set startAlgorithm to an algorithm which returns the result of invoking underlyingSinkDict["start"] with argument list « controller » and callback this value underlyingSink.
     if (underlying_sink.start) {
-        start_algorithm = [&, callback = underlying_sink.start]() -> WebIDL::ExceptionOr<JS::GCPtr<WebIDL::Promise>> {
-            // Note: callback return a promise, so invoke_callback will never return an abrupt completion
-            auto result = MUST_OR_THROW_OOM(WebIDL::invoke_callback(*callback, underlying_sink_value, controller)).release_value();
-            return WebIDL::create_resolved_promise(realm, result);
+        start_algorithm = [&, callback = underlying_sink.start]() -> WebIDL::ExceptionOr<JS::Value> {
+            // Note: callback does not return a promise, so invoke_callback may return an abrupt completion
+            return WebIDL::invoke_callback(*callback, underlying_sink_value, controller);
         };
     }
 

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -2077,7 +2077,7 @@ bool is_close_sentinel(JS::Value value)
 
 // Non-standard function to aid in converting a user-provided function into a WebIDL::Callback. This is essentially
 // what the Bindings generator would do at compile time, but at runtime instead.
-JS::ThrowCompletionOr<JS::Handle<WebIDL::CallbackType>> property_to_callback(JS::VM& vm, JS::Value value, JS::PropertyKey const& property_key)
+JS::ThrowCompletionOr<JS::Handle<WebIDL::CallbackType>> property_to_callback(JS::VM& vm, JS::Value value, JS::PropertyKey const& property_key, WebIDL::OperationReturnsPromise operation_returns_promise)
 {
     auto property = TRY(value.get(vm, property_key));
 
@@ -2087,7 +2087,7 @@ JS::ThrowCompletionOr<JS::Handle<WebIDL::CallbackType>> property_to_callback(JS:
     if (!property.is_function())
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAFunction, TRY_OR_THROW_OOM(vm, property.to_string_without_side_effects()));
 
-    return vm.heap().allocate_without_realm<WebIDL::CallbackType>(property.as_object(), HTML::incumbent_settings_object());
+    return vm.heap().allocate_without_realm<WebIDL::CallbackType>(property.as_object(), HTML::incumbent_settings_object(), operation_returns_promise);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -725,27 +725,27 @@ WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller_from_underly
 
     // 5. If underlyingSourceDict["start"] exists, then set startAlgorithm to an algorithm which returns the result of invoking underlyingSourceDict["start"] with argument list « controller » and callback this value underlyingSource.
     if (underlying_source.start) {
-        start_algorithm = [&, start = underlying_source.start]() -> WebIDL::ExceptionOr<JS::GCPtr<WebIDL::Promise>> {
-            // FIXME: This needs to create a rejected Promise for throw completions, which invoke_callback() currently doesn't do.
-            auto result = TRY(WebIDL::invoke_callback(*start, underlying_source_value, controller)).release_value();
+        start_algorithm = [&, callback = underlying_source.start]() -> WebIDL::ExceptionOr<JS::GCPtr<WebIDL::Promise>> {
+            // Note: callback return a promise, so invoke_callback will never return an abrupt completion
+            auto result = MUST_OR_THROW_OOM(WebIDL::invoke_callback(*callback, underlying_source_value, controller)).release_value();
             return WebIDL::create_resolved_promise(realm, result);
         };
     }
 
     // 6. If underlyingSourceDict["pull"] exists, then set pullAlgorithm to an algorithm which returns the result of invoking underlyingSourceDict["pull"] with argument list « controller » and callback this value underlyingSource.
     if (underlying_source.pull) {
-        pull_algorithm = [&, pull = underlying_source.pull]() -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
-            // FIXME: This needs to create a rejected Promise for throw completions, which invoke_callback() currently doesn't do.
-            auto result = TRY(WebIDL::invoke_callback(*pull, underlying_source_value, controller)).release_value();
+        pull_algorithm = [&, callback = underlying_source.pull]() -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
+            // Note: callback return a promise, so invoke_callback will never return an abrupt completion
+            auto result = MUST_OR_THROW_OOM(WebIDL::invoke_callback(*callback, underlying_source_value, controller)).release_value();
             return WebIDL::create_resolved_promise(realm, result);
         };
     }
 
     // 7. If underlyingSourceDict["cancel"] exists, then set cancelAlgorithm to an algorithm which takes an argument reason and returns the result of invoking underlyingSourceDict["cancel"] with argument list « reason » and callback this value underlyingSource.
     if (underlying_source.cancel) {
-        cancel_algorithm = [&, cancel = underlying_source.cancel](auto const& reason) -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
-            // FIXME: This needs to create a rejected Promise for throw completions, which invoke_callback() currently doesn't do.
-            auto result = TRY(WebIDL::invoke_callback(*cancel, underlying_source_value, reason)).release_value();
+        cancel_algorithm = [&, callback = underlying_source.cancel](auto const& reason) -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
+            // Note: callback return a promise, so invoke_callback will never return an abrupt completion
+            auto result = MUST_OR_THROW_OOM(WebIDL::invoke_callback(*callback, underlying_source_value, reason)).release_value();
             return WebIDL::create_resolved_promise(realm, result);
         };
     }
@@ -1732,8 +1732,8 @@ WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller_from_underly
     // 6. If underlyingSinkDict["start"] exists, then set startAlgorithm to an algorithm which returns the result of invoking underlyingSinkDict["start"] with argument list « controller » and callback this value underlyingSink.
     if (underlying_sink.start) {
         start_algorithm = [&, callback = underlying_sink.start]() -> WebIDL::ExceptionOr<JS::GCPtr<WebIDL::Promise>> {
-            // FIXME: This needs to create a rejected Promise for throw completions, which invoke_callback() currently doesn't do.
-            auto result = TRY(WebIDL::invoke_callback(*callback, underlying_sink_value, controller)).release_value();
+            // Note: callback return a promise, so invoke_callback will never return an abrupt completion
+            auto result = MUST_OR_THROW_OOM(WebIDL::invoke_callback(*callback, underlying_sink_value, controller)).release_value();
             return WebIDL::create_resolved_promise(realm, result);
         };
     }
@@ -1741,8 +1741,8 @@ WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller_from_underly
     // 7. If underlyingSinkDict["write"] exists, then set writeAlgorithm to an algorithm which takes an argument chunk and returns the result of invoking underlyingSinkDict["write"] with argument list « chunk, controller » and callback this value underlyingSink.
     if (underlying_sink.write) {
         write_algorithm = [&, callback = underlying_sink.write](JS::Value chunk) -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
-            // FIXME: This needs to create a rejected Promise for throw completions, which invoke_callback() currently doesn't do.
-            auto result = TRY(WebIDL::invoke_callback(*callback, underlying_sink_value, chunk, controller)).release_value();
+            // Note: callback return a promise, so invoke_callback will never return an abrupt completion
+            auto result = MUST_OR_THROW_OOM(WebIDL::invoke_callback(*callback, underlying_sink_value, chunk, controller)).release_value();
             return WebIDL::create_resolved_promise(realm, result);
         };
     }
@@ -1750,8 +1750,8 @@ WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller_from_underly
     // 8. If underlyingSinkDict["close"] exists, then set closeAlgorithm to an algorithm which returns the result of invoking underlyingSinkDict["close"] with argument list «» and callback this value underlyingSink.
     if (underlying_sink.close) {
         close_algorithm = [&, callback = underlying_sink.close]() -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
-            // FIXME: This needs to create a rejected Promise for throw completions, which invoke_callback() currently doesn't do.
-            auto result = TRY(WebIDL::invoke_callback(*callback, underlying_sink_value)).release_value();
+            // Note: callback return a promise, so invoke_callback will never return an abrupt completion
+            auto result = MUST_OR_THROW_OOM(WebIDL::invoke_callback(*callback, underlying_sink_value)).release_value();
             return WebIDL::create_resolved_promise(realm, result);
         };
     }
@@ -1759,8 +1759,8 @@ WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller_from_underly
     // 9. If underlyingSinkDict["abort"] exists, then set abortAlgorithm to an algorithm which takes an argument reason and returns the result of invoking underlyingSinkDict["abort"] with argument list « reason » and callback this value underlyingSink.
     if (underlying_sink.abort) {
         abort_algorithm = [&, callback = underlying_sink.abort](JS::Value reason) -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
-            // FIXME: This needs to create a rejected Promise for throw completions, which invoke_callback() currently doesn't do.
-            auto result = TRY(WebIDL::invoke_callback(*callback, underlying_sink_value, reason)).release_value();
+            // Note: callback return a promise, so invoke_callback will never return an abrupt completion
+            auto result = MUST_OR_THROW_OOM(WebIDL::invoke_callback(*callback, underlying_sink_value, reason)).release_value();
             return WebIDL::create_resolved_promise(realm, result);
         };
     }

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -18,7 +18,7 @@ namespace Web::Streams {
 using SizeAlgorithm = JS::SafeFunction<JS::Completion(JS::Value)>;
 using PullAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>()>;
 using CancelAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>(JS::Value)>;
-using StartAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::GCPtr<WebIDL::Promise>>()>;
+using StartAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::Value>()>;
 using AbortAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>(JS::Value)>;
 using CloseAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>()>;
 using WriteAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>>(JS::Value)>;

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -9,6 +9,7 @@
 
 #include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/WebIDL/CallbackType.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 #include <LibWeb/WebIDL/Promise.h>
 
@@ -107,7 +108,7 @@ bool is_non_negative_number(JS::Value);
 
 JS::Value create_close_sentinel();
 bool is_close_sentinel(JS::Value);
-JS::ThrowCompletionOr<JS::Handle<WebIDL::CallbackType>> property_to_callback(JS::VM& vm, JS::Value value, JS::PropertyKey const& property_key);
+JS::ThrowCompletionOr<JS::Handle<WebIDL::CallbackType>> property_to_callback(JS::VM& vm, JS::Value value, JS::PropertyKey const& property_key, WebIDL::OperationReturnsPromise);
 
 // https://streams.spec.whatwg.org/#value-with-size
 struct ValueWithSize {

--- a/Userland/Libraries/LibWeb/Streams/UnderlyingSink.cpp
+++ b/Userland/Libraries/LibWeb/Streams/UnderlyingSink.cpp
@@ -19,10 +19,10 @@ JS::ThrowCompletionOr<UnderlyingSink> UnderlyingSink::from_value(JS::VM& vm, JS:
     auto& object = value.as_object();
 
     UnderlyingSink underlying_sink {
-        .start = TRY(property_to_callback(vm, value, "start")),
-        .write = TRY(property_to_callback(vm, value, "write")),
-        .close = TRY(property_to_callback(vm, value, "close")),
-        .abort = TRY(property_to_callback(vm, value, "abort")),
+        .start = TRY(property_to_callback(vm, value, "start", WebIDL::OperationReturnsPromise::No)),
+        .write = TRY(property_to_callback(vm, value, "write", WebIDL::OperationReturnsPromise::Yes)),
+        .close = TRY(property_to_callback(vm, value, "close", WebIDL::OperationReturnsPromise::Yes)),
+        .abort = TRY(property_to_callback(vm, value, "abort", WebIDL::OperationReturnsPromise::Yes)),
         .type = {},
     };
 

--- a/Userland/Libraries/LibWeb/Streams/UnderlyingSource.cpp
+++ b/Userland/Libraries/LibWeb/Streams/UnderlyingSource.cpp
@@ -19,9 +19,9 @@ JS::ThrowCompletionOr<UnderlyingSource> UnderlyingSource::from_value(JS::VM& vm,
     auto& object = value.as_object();
 
     UnderlyingSource underlying_source {
-        .start = TRY(property_to_callback(vm, value, "start")),
-        .pull = TRY(property_to_callback(vm, value, "pull")),
-        .cancel = TRY(property_to_callback(vm, value, "cancel")),
+        .start = TRY(property_to_callback(vm, value, "start", WebIDL::OperationReturnsPromise::No)),
+        .pull = TRY(property_to_callback(vm, value, "pull", WebIDL::OperationReturnsPromise::Yes)),
+        .cancel = TRY(property_to_callback(vm, value, "cancel", WebIDL::OperationReturnsPromise::Yes)),
         .type = {},
         .auto_allocate_chunk_size = {},
     };

--- a/Userland/Libraries/LibWeb/Streams/WritableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/WritableStream.cpp
@@ -30,7 +30,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStream>> WritableStream::construct_
     auto underlying_sink_dict = TRY(UnderlyingSink::from_value(vm, underlying_sink));
 
     // 3. If underlyingSinkDict["type"] exists, throw a RangeError exception.
-    if (!underlying_sink_dict.type.has_value())
+    if (underlying_sink_dict.type.has_value())
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::RangeError, "Invalid use of reserved key 'type'"sv };
 
     // 4. Perform ! InitializeWritableStream(this).

--- a/Userland/Libraries/LibWeb/WebIDL/CallbackType.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/CallbackType.cpp
@@ -10,9 +10,10 @@
 
 namespace Web::WebIDL {
 
-CallbackType::CallbackType(JS::Object& callback, HTML::EnvironmentSettingsObject& callback_context)
+CallbackType::CallbackType(JS::Object& callback, HTML::EnvironmentSettingsObject& callback_context, OperationReturnsPromise operation_returns_promise)
     : callback(callback)
     , callback_context(callback_context)
+    , operation_returns_promise(operation_returns_promise)
 {
 }
 

--- a/Userland/Libraries/LibWeb/WebIDL/CallbackType.h
+++ b/Userland/Libraries/LibWeb/WebIDL/CallbackType.h
@@ -12,15 +12,23 @@
 
 namespace Web::WebIDL {
 
+enum class OperationReturnsPromise {
+    Yes,
+    No,
+};
+
 // https://webidl.spec.whatwg.org/#idl-callback-interface
 class CallbackType final : public JS::Cell {
 public:
-    CallbackType(JS::Object& callback, HTML::EnvironmentSettingsObject& callback_context);
+    CallbackType(JS::Object& callback, HTML::EnvironmentSettingsObject& callback_context, OperationReturnsPromise = OperationReturnsPromise::No);
 
     JS::NonnullGCPtr<JS::Object> callback;
 
     // https://webidl.spec.whatwg.org/#dfn-callback-context
     JS::NonnullGCPtr<HTML::EnvironmentSettingsObject> callback_context;
+
+    // Non-standard property used to distinguish Promise-returning callbacks in callback-related AOs
+    OperationReturnsPromise operation_returns_promise;
 
 private:
     virtual StringView class_name() const override;


### PR DESCRIPTION
This fixes the issue mentioned in [#18370](https://github.com/SerenityOS/serenity/pull/18370#discussion_r1166874947) where an error in `WebIDL::invoke_callback` would not be properly wrapped in a `Promise` if the callback in question returns a `Promise`. This PR adds an enum to `WebIDL::CallbackType` to indicate whether or not the callback returns a promise and uses it to properly implement the AO steps. I'm not sure if this is the best way to solve the problem, as it feels clunky, but I'm not sure how else it would be handled. If anyone else has a better suggestion I am all ears.

Also fixes the usages in `Streams/AbstractAlgorithms.cpp`, as well as a typo I found while getting the images below. I also realized that `StartAlgorithm` is not supposed to return a promise, so I've changed that to return `JS::Value`, which of course makes the implementation line up a bit closer with the spec (should have been a :triangular_flag_on_post:!).

Before: 
![before image](https://i.imgur.com/lgYJBTY.png)

After:
![after image](https://i.imgur.com/ryouBDw.png)