### PR TITLE
Meta: Allow overriding the calculated disk image inode count

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -125,7 +125,7 @@ if [ $USE_EXISTING -ne 1 ]; then
     if [ "$(uname -s)" = "OpenBSD" ]; then
         VND=$(vnconfig _disk_image)
         (echo "e 0"; echo 83; echo n; echo 0; echo "*"; echo "quit") | fdisk -e "$VND"
-        newfs_ext2fs -D $INODE_SIZE -n $INODE_COUNT "/dev/r${VND}i" || die "could not create filesystem"
+        newfs_ext2fs -D "${INODE_SIZE}" -n "${INODE_COUNT}" "/dev/r${VND}i" || die "could not create filesystem"
     else
         "${MKE2FS_PATH}" -q -I "${INODE_SIZE}" -N "${INODE_COUNT}" _disk_image || die "could not create filesystem"
     fi
@@ -191,7 +191,7 @@ if [ $use_genext2fs = 1 ]; then
     # genext2fs is very slow in generating big images, so I use a smaller image here. size can be updated
     # if it's not enough.
     # not using "-I $INODE_SIZE" since it hangs. Serenity handles whatever default this uses instead.
-    genext2fs -B 4096 -b $((DISK_SIZE_BYTES / 4096)) -N $INODE_COUNT -d mnt _disk_image || die "try increasing image size (genext2fs -b)"
+    genext2fs -B 4096 -b $((DISK_SIZE_BYTES / 4096)) -N "${INODE_COUNT}" -d mnt _disk_image || die "try increasing image size (genext2fs -b)"
     # if using docker with shared mount, file is created as root, so make it writable for users
     chmod 0666 _disk_image
 fi

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -71,6 +71,13 @@ else
     DISK_SIZE_BYTES="$SERENITY_DISK_SIZE_BYTES"
 fi
 
+if [ -n "$SERENITY_INODE_COUNT" ]; then
+    if [ "$INODE_COUNT" -gt "$SERENITY_INODE_COUNT" ]; then
+        die "SERENITY_INODE_COUNT is set to $SERENITY_INODE_COUNT but required inode count is roughly $INODE_COUNT"
+    fi
+    INODE_COUNT="$SERENITY_INODE_COUNT"
+fi
+
 nearest_power_of_2() {
     local n=$1
     local p=1


### PR DESCRIPTION
If we can override the disk image size to make room for more files, we should also be able to override the inode count to make room for more files.