### PR TITLE
LibWeb: Honor gap between flex lines when using align-content: stretch

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/stretch-alignment-with-cross-gap.txt
+++ b/Tests/LibWeb/Layout/expected/flex/stretch-alignment-with-cross-gap.txt
@@ -1,0 +1,10 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x220 children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x202 children: not-inline
+      Box <div.flex> at (11,11) content-size 300x200 flex-container(row) children: not-inline
+        BlockContainer <div> at (12,12) content-size 100x20 flex-item children: not-inline
+        BlockContainer <div> at (114,12) content-size 100x20 flex-item children: not-inline
+        BlockContainer <div> at (12,95.333328) content-size 100x20 flex-item children: not-inline
+        BlockContainer <div> at (114,95.333328) content-size 100x20 flex-item children: not-inline
+        BlockContainer <div> at (12,178.666656) content-size 100x20 flex-item children: not-inline
+        BlockContainer <div> at (114,178.666656) content-size 100x20 flex-item children: not-inline

--- a/Tests/LibWeb/Layout/input/flex/stretch-alignment-with-cross-gap.html
+++ b/Tests/LibWeb/Layout/input/flex/stretch-alignment-with-cross-gap.html
@@ -1,0 +1,17 @@
+<!doctype html><style>
+* {
+    border: 1px solid black;
+}
+.flex {
+    display: flex;
+    align-content: stretch;
+    width: 300px;
+    height: 200px;
+    flex-wrap: wrap;
+    row-gap: 50px;
+}
+.flex > div {
+    width: 100px;
+    height: 20px;
+}
+</style><div class="flex"><div></div><div></div><div></div><div></div><div></div><div></div>

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -2022,6 +2022,9 @@ void FlexFormattingContext::handle_align_content_stretch()
     for (auto& line : m_flex_lines)
         sum_of_flex_line_cross_sizes += line.cross_size;
 
+    // CSS-FLEXBOX-2: Account for gap between flex lines.
+    sum_of_flex_line_cross_sizes += cross_gap() * (m_flex_lines.size() - 1);
+
     if (sum_of_flex_line_cross_sizes >= inner_cross_size(flex_container()))
         return;
 


### PR DESCRIPTION
We have to take the cross gap into account when calculating the "sum of flex line cross sizes" in "Handle 'align-content: stretch'".