### PR TITLE
Kernel: Use purpose-sized buffers for reading symlinks from inodes

### DIFF
--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -118,6 +118,21 @@ ErrorOr<size_t> Inode::read_bytes(off_t offset, size_t length, UserOrKernelBuffe
     return read_bytes_locked(offset, length, buffer, open_description);
 }
 
+ErrorOr<size_t> Inode::read_until_filled_or_end(off_t offset, size_t length, UserOrKernelBuffer buffer, OpenFileDescription* open_description) const
+{
+    auto remaining_length = length;
+
+    while (remaining_length > 0) {
+        auto filled_bytes = TRY(read_bytes(offset, remaining_length, buffer, open_description));
+        if (filled_bytes == 0)
+            break;
+        offset += filled_bytes;
+        remaining_length -= filled_bytes;
+    }
+
+    return length - remaining_length;
+}
+
 ErrorOr<void> Inode::update_timestamps([[maybe_unused]] Optional<Time> atime, [[maybe_unused]] Optional<Time> ctime, [[maybe_unused]] Optional<Time> mtime)
 {
     return ENOTIMPL;

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -80,8 +80,14 @@ ErrorOr<NonnullRefPtr<Custody>> Inode::resolve_as_link(Credentials const& creden
     // The default implementation simply treats the stored
     // contents as a path and resolves that. That is, it
     // behaves exactly how you would expect a symlink to work.
-    auto contents = TRY(read_entire());
-    return VirtualFileSystem::the().resolve_path(credentials, StringView { contents->bytes() }, base, out_parent, options, symlink_recursion_level);
+
+    // Make sure that our assumptions about the path length hold up.
+    // Note that this doesn't mean that the reported size can be trusted, some inodes just report zero.
+    VERIFY(size() <= MAXPATHLEN);
+
+    Array<u8, MAXPATHLEN> contents;
+    auto read_bytes = TRY(read_until_filled_or_end(0, contents.size(), UserOrKernelBuffer::for_kernel_buffer(contents.data()), nullptr));
+    return VirtualFileSystem::the().resolve_path(credentials, StringView { contents.span().trim(read_bytes) }, base, out_parent, options, symlink_recursion_level);
 }
 
 Inode::Inode(FileSystem& fs, InodeIndex index)

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -51,30 +51,6 @@ void Inode::sync()
     fs().flush_writes();
 }
 
-ErrorOr<NonnullOwnPtr<KBuffer>> Inode::read_entire(OpenFileDescription* description) const
-{
-    auto builder = TRY(KBufferBuilder::try_create());
-
-    u8 buffer[4096];
-    off_t offset = 0;
-    for (;;) {
-        auto buf = UserOrKernelBuffer::for_kernel_buffer(buffer);
-        auto nread = TRY(read_bytes(offset, sizeof(buffer), buf, description));
-        VERIFY(nread <= sizeof(buffer));
-        if (nread == 0)
-            break;
-        TRY(builder.append((char const*)buffer, nread));
-        offset += nread;
-        if (nread < sizeof(buffer))
-            break;
-    }
-
-    auto entire_file = builder.build();
-    if (!entire_file)
-        return ENOMEM;
-    return entire_file.release_nonnull();
-}
-
 ErrorOr<NonnullRefPtr<Custody>> Inode::resolve_as_link(Credentials const& credentials, Custody& base, RefPtr<Custody>* out_parent, int options, int symlink_recursion_level) const
 {
     // The default implementation simply treats the stored

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -53,8 +53,6 @@ public:
     InodeIdentifier identifier() const { return { fsid(), index() }; }
     virtual InodeMetadata metadata() const = 0;
 
-    ErrorOr<NonnullOwnPtr<KBuffer>> read_entire(OpenFileDescription* = nullptr) const;
-
     ErrorOr<size_t> write_bytes(off_t, size_t, UserOrKernelBuffer const& data, OpenFileDescription*);
     ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer& buffer, OpenFileDescription*) const;
     ErrorOr<size_t> read_until_filled_or_end(off_t, size_t, UserOrKernelBuffer buffer, OpenFileDescription*) const;

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -57,6 +57,7 @@ public:
 
     ErrorOr<size_t> write_bytes(off_t, size_t, UserOrKernelBuffer const& data, OpenFileDescription*);
     ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer& buffer, OpenFileDescription*) const;
+    ErrorOr<size_t> read_until_filled_or_end(off_t, size_t, UserOrKernelBuffer buffer, OpenFileDescription*) const;
 
     virtual ErrorOr<void> attach(OpenFileDescription&) { return {}; }
     virtual void detach(OpenFileDescription&) { }

--- a/Kernel/FileSystem/OpenFileDescription.cpp
+++ b/Kernel/FileSystem/OpenFileDescription.cpp
@@ -202,14 +202,6 @@ bool OpenFileDescription::can_read() const
     return m_file->can_read(*this, offset());
 }
 
-ErrorOr<NonnullOwnPtr<KBuffer>> OpenFileDescription::read_entire_file()
-{
-    // HACK ALERT: (This entire function)
-    VERIFY(m_file->is_inode());
-    VERIFY(m_inode);
-    return m_inode->read_entire(this);
-}
-
 ErrorOr<size_t> OpenFileDescription::get_dir_entries(UserOrKernelBuffer& output_buffer, size_t size)
 {
     if (!is_directory())

--- a/Kernel/FileSystem/OpenFileDescription.h
+++ b/Kernel/FileSystem/OpenFileDescription.h
@@ -58,8 +58,6 @@ public:
 
     ErrorOr<size_t> get_dir_entries(UserOrKernelBuffer& buffer, size_t);
 
-    ErrorOr<NonnullOwnPtr<KBuffer>> read_entire_file();
-
     ErrorOr<NonnullOwnPtr<KString>> original_absolute_path() const;
     ErrorOr<NonnullOwnPtr<KString>> pseudo_path() const;
 

--- a/Kernel/Syscalls/readlink.cpp
+++ b/Kernel/Syscalls/readlink.cpp
@@ -22,11 +22,16 @@ ErrorOr<FlatPtr> Process::sys$readlink(Userspace<Syscall::SC_readlink_params con
     if (!description->metadata().is_symlink())
         return EINVAL;
 
-    auto link_target = TRY(description->read_entire_file());
-    auto size_to_copy = min(link_target->size(), params.buffer.size);
-    TRY(copy_to_user(params.buffer.data, link_target->data(), size_to_copy));
+    // Make sure that our assumptions about the path length hold up.
+    // Note that this doesn't mean that the reported size can be trusted, some inodes just report zero.
+    VERIFY(description->inode()->size() <= MAXPATHLEN);
+
+    Array<u8, MAXPATHLEN> link_target;
+    auto read_bytes = TRY(description->inode()->read_until_filled_or_end(0, link_target.size(), UserOrKernelBuffer::for_kernel_buffer(link_target.data()), description));
+    auto size_to_copy = min(read_bytes, params.buffer.size);
+    TRY(copy_to_user(params.buffer.data, link_target.data(), size_to_copy));
     // Note: we return the whole size here, not the copied size.
-    return link_target->size();
+    return read_bytes;
 }
 
 }


### PR DESCRIPTION
Previously, we would allocate a `KBufferBuilder`, read the inode contents into that in chunks, allocate and copy everything into a consecutive `KBuffer`, and then (if applicable) copy that into the user-provided buffer.

Since paths have an upper limit for the size, we can just allocate a statically sized array on the stack beforehand and read directly into that, skipping allocating and filling the `KBufferBuilder` and its chunks.

This improves `readlink` speed to roughly one tenth of the time, resulting in the LLVM build time being around 30 minutes faster (with 6 hours now being the total time).