### PR TITLE
LibWeb: Fix multi-line flex column layouts with auto height on container

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/multi-line-column-container-with-automatic-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/multi-line-column-container-with-automatic-height.txt
@@ -1,0 +1,7 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x176 children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x158 children: not-inline
+      Box <div.flexbox> at (11,11) content-size 200x156 flex-container(column) children: not-inline
+        BlockContainer <div> at (12,12) content-size 50x50 flex-item children: not-inline
+        BlockContainer <div> at (12,64) content-size 50x50 flex-item children: not-inline
+        BlockContainer <div> at (12,116) content-size 50x50 flex-item children: not-inline

--- a/Tests/LibWeb/Layout/input/flex/multi-line-column-container-with-automatic-height.html
+++ b/Tests/LibWeb/Layout/input/flex/multi-line-column-container-with-automatic-height.html
@@ -1,0 +1,15 @@
+<!doctype html><style>
+* {
+    border: 1px solid black;
+}
+.flexbox {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    width: 200px;
+}
+.flexbox > div {
+    width: 50px;
+    height: 50px;
+}
+</style><div class="flexbox"><div></div><div></div><div></div>

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -845,7 +845,7 @@ void FlexFormattingContext::collect_flex_items_into_flex_lines()
     CSSPixels line_main_size = 0;
     for (auto& item : m_flex_items) {
         auto const outer_hypothetical_main_size = item.outer_hypothetical_main_size();
-        if (!line.items.is_empty() && (line_main_size + outer_hypothetical_main_size) > m_available_space_for_items->main.to_px_or_zero()) {
+        if (!line.items.is_empty() && (line_main_size + outer_hypothetical_main_size) > m_available_space_for_items->main.to_px()) {
             m_flex_lines.append(move(line));
             line = {};
             line_main_size = 0;


### PR DESCRIPTION
When sizing a flex container with flex-direction:column under a max-content height constraint, we were incorrectly truncating the infinite available height to 0 when collecting flex items into lines.

This caused us to put every flex item in its own flex line, which is the complete opposite of what we want during max-content intrinsic sizing, as the layout would grow wide but not tall.