### PR TITLE
FileManager+LibGUI: Cache the FileSystem::can_delete_or_move value

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -547,7 +547,7 @@ bool DirectoryView::can_modify_current_selection()
     // FIXME: remove once Clang formats this properly.
     // clang-format off
     return selections.first_matching([&](auto& index) {
-        return FileSystem::can_delete_or_move(node(index).full_path());
+        return node(index).can_delete_or_move();
     }).has_value();
     // clang-format on
 }

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -159,6 +159,13 @@ void FileSystemModel::Node::traverse_if_needed()
     }
 }
 
+bool FileSystemModel::Node::can_delete_or_move() const
+{
+    if (!m_can_delete_or_move.has_value())
+        m_can_delete_or_move = FileSystem::can_delete_or_move(full_path());
+    return m_can_delete_or_move.value();
+}
+
 OwnPtr<FileSystemModel::Node> FileSystemModel::Node::create_child(DeprecatedString const& child_name)
 {
     DeprecatedString child_path = LexicalPath::join(full_path(), child_name).string();

--- a/Userland/Libraries/LibGUI/FileSystemModel.h
+++ b/Userland/Libraries/LibGUI/FileSystemModel.h
@@ -69,6 +69,8 @@ public:
         int error() const { return m_error; }
         char const* error_string() const { return strerror(m_error); }
 
+        bool can_delete_or_move() const;
+
         DeprecatedString full_path() const;
 
     private:
@@ -83,6 +85,7 @@ public:
 
         Node* m_parent { nullptr };
         Vector<NonnullOwnPtr<Node>> m_children;
+        mutable Optional<bool> m_can_delete_or_move;
         bool m_has_traversed { false };
 
         bool m_selected { false };


### PR DESCRIPTION
Add the function FileSystemModel::Node::can_delete_or_move which will cache the result of FileSystem::can_delete_or_move for a node. This prevents having to make system calls repeatedly to obtain this information.

Fixes #18399

Before:
[iconview_rubberbanding_high_cpu.webm](https://user-images.githubusercontent.com/10320822/232340090-a8192848-d479-4dab-9723-f4483a668f62.webm)

After:
[iconview_rubberbanding_high_cpu_after.webm](https://user-images.githubusercontent.com/10320822/232340098-81683999-1d57-4e75-99a8-5f091d6532bf.webm)
