### PR TITLE
LibWeb: Implement SVG `preserveAspectRatio` attribute 

### DIFF
--- a/Base/res/html/misc/svg-preserve-aspect-ratio.html
+++ b/Base/res/html/misc/svg-preserve-aspect-ratio.html
@@ -1,0 +1,185 @@
+<!-- Based on the hit MDN example! -->
+<style>
+  svg {
+    border: 1px solid black;
+  }
+  div {
+    display: inline-block;
+    margin: 20px;
+  }
+</style>
+
+<!-- (width>height) meet -->
+<div>
+<b>xMidYMid meet</b><br>
+<svg
+  viewBox="0 0 100 100"
+  width="100"
+  height="50"
+  preserveAspectRatio="xMidYMid meet"
+  x="0"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+</div>
+
+<div>
+<b>xMinYMid meet</b><br>
+<svg
+  viewBox="0 0 100 100"
+  width="100"
+  height="50"
+  preserveAspectRatio="xMinYMid meet"
+  x="25"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+</div>
+
+<div>
+<b>xMaxYMid meet</b><br>
+<svg
+  viewBox="0 0 100 100"
+  width="100"
+  height="50"
+  preserveAspectRatio="xMaxYMid meet"
+  x="50"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+</div>
+
+<!-- (width>height) slice -->
+<div>
+<b>xMidYMin slice</b><br>
+<svg
+  viewBox="0 0 100 100"
+  width="100"
+  height="50"
+  preserveAspectRatio="xMidYMin slice"
+  x="0"
+  y="15">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+</div>
+
+<div>
+<b>xMidYMid slice</b><br>
+<svg
+  viewBox="0 0 100 100"
+  width="100"
+  height="50"
+  preserveAspectRatio="xMidYMid slice"
+  x="25"
+  y="15">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+</div>
+
+<div>
+<b>xMidYMax slice</b><br>
+<svg
+  viewBox="0 0 100 100"
+  width="100"
+  height="50"
+  preserveAspectRatio="xMidYMax slice"
+  x="50"
+  y="15">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+</div>
+
+<!-- (width<height) meet -->
+<div>
+  <b>xMidYMin meet</b><br>
+<svg
+  viewBox="0 0 100 100"
+  width="50"
+  height="125"
+  preserveAspectRatio="xMidYMin meet"
+  x="75"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+</div>
+
+<div>
+  <b>xMidYMid meet</b><br>
+</rect>
+<svg
+  viewBox="0 0 100 100"
+  width="50"
+  height="125"
+  preserveAspectRatio="xMidYMid meet"
+  x="90"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+</div>
+
+<div>
+  <b>xMidYMax meet</b><br>
+<svg
+  viewBox="0 0 100 100"
+  width="50"
+  height="125"
+  preserveAspectRatio="xMidYMax meet"
+  x="105"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+</div>
+
+<!-- (width<height) slice -->
+<div>
+  <b>xMinYMid slice</b><br>
+<svg
+  viewBox="0 0 100 100"
+  width="50"
+  height="125"
+  preserveAspectRatio="xMinYMid slice"
+  x="120"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+</div>
+
+<div>
+  <b>xMidYMid slice</b><br>
+<svg
+  viewBox="0 0 100 100"
+  width="50"
+  height="125"
+  preserveAspectRatio="xMidYMid slice"
+  x="135"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+</div>
+
+<div>
+  <b>xMaxYMid slice</b><br>
+<svg
+  viewBox="0 0 100 100"
+  width="50"
+  height="125"
+  preserveAspectRatio="xMaxYMid slice"
+  x="150"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+</div>
+
+<!-- none -->
+<div>
+  <b>none</b><br>
+<svg
+  viewBox="0 0 100 100"
+  width="160"
+  height="60"
+  preserveAspectRatio="none"
+  x="0"
+  y="30">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+</div>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -71,6 +71,7 @@
             <li><a href="pre.html">pre</a></li>
             <li><a href="svg.html">svg</a></li>
             <li><a href="svg-transforms.html">svg transforms</a></li>
+            <li><a href="svg-preserve-aspect-ratio.html">svg preserveAspectRatio</a></li>
             <li><a href="small.html">small</a></li>
             <li><a href="link.html">link</a></li>
             <li><a href="afrag.html">links with fragments</a></li>

--- a/Tests/LibWeb/Layout/expected/svg-preserve-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/svg-preserve-aspect-ratio.txt
@@ -1,0 +1,105 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x273.46875 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x257.46875 children: inline
+      line 0 width: 772, height: 130.46875, bottom: 130.46875, baseline: 127
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,84 100x50]
+        frag 1 from TextNode start: 0, length: 1, rect: [110,121 8x17.46875]
+          " "
+        frag 2 from SVGSVGBox start: 0, length: 0, rect: [119,84 100x50]
+        frag 3 from TextNode start: 0, length: 1, rect: [220,121 8x17.46875]
+          " "
+        frag 4 from SVGSVGBox start: 0, length: 0, rect: [229,84 100x50]
+        frag 5 from TextNode start: 0, length: 1, rect: [330,121 8x17.46875]
+          " "
+        frag 6 from SVGSVGBox start: 0, length: 0, rect: [339,84 100x50]
+        frag 7 from TextNode start: 0, length: 1, rect: [440,121 8x17.46875]
+          " "
+        frag 8 from SVGSVGBox start: 0, length: 0, rect: [449,84 100x50]
+        frag 9 from TextNode start: 0, length: 1, rect: [550,121 8x17.46875]
+          " "
+        frag 10 from SVGSVGBox start: 0, length: 0, rect: [559,84 100x50]
+        frag 11 from TextNode start: 0, length: 1, rect: [660,121 8x17.46875]
+          " "
+        frag 12 from SVGSVGBox start: 0, length: 0, rect: [669,9 50x125]
+        frag 13 from TextNode start: 0, length: 1, rect: [720,121 8x17.46875]
+          " "
+        frag 14 from SVGSVGBox start: 0, length: 0, rect: [729,9 50x125]
+      line 1 width: 402, height: 130.46875, bottom: 257.46875, baseline: 127
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,136 50x125]
+        frag 1 from TextNode start: 0, length: 1, rect: [60,248 8x17.46875]
+          " "
+        frag 2 from SVGSVGBox start: 0, length: 0, rect: [69,136 50x125]
+        frag 3 from TextNode start: 0, length: 1, rect: [120,248 8x17.46875]
+          " "
+        frag 4 from SVGSVGBox start: 0, length: 0, rect: [129,136 50x125]
+        frag 5 from TextNode start: 0, length: 1, rect: [180,248 8x17.46875]
+          " "
+        frag 6 from SVGSVGBox start: 0, length: 0, rect: [189,136 50x125]
+        frag 7 from TextNode start: 0, length: 1, rect: [240,248 8x17.46875]
+          " "
+        frag 8 from SVGSVGBox start: 0, length: 0, rect: [249,201 160x60]
+      SVGSVGBox <svg> at (9,84) content-size 100x50 children: inline
+        TextNode <#text>
+        SVGGeometryBox <circle> at (34,84) content-size 50x50 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (119,84) content-size 100x50 children: inline
+        TextNode <#text>
+        SVGGeometryBox <circle> at (119,84) content-size 50x50 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (229,84) content-size 100x50 children: inline
+        TextNode <#text>
+        SVGGeometryBox <circle> at (279,84) content-size 50x50 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (339,84) content-size 100x50 children: inline
+        TextNode <#text>
+        SVGGeometryBox <circle> at (339,84) content-size 100x100 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (449,84) content-size 100x50 children: inline
+        TextNode <#text>
+        SVGGeometryBox <circle> at (449,59) content-size 100x100 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (559,84) content-size 100x50 children: inline
+        TextNode <#text>
+        SVGGeometryBox <circle> at (559,34) content-size 100x100 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (669,9) content-size 50x125 children: inline
+        TextNode <#text>
+        SVGGeometryBox <circle> at (669,9) content-size 50x50 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (729,9) content-size 50x125 children: inline
+        TextNode <#text>
+        SVGGeometryBox <circle> at (729,46.5) content-size 50x50 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (9,136) content-size 50x125 children: inline
+        TextNode <#text>
+        SVGGeometryBox <circle> at (9,211) content-size 50x50 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (69,136) content-size 50x125 children: inline
+        TextNode <#text>
+        SVGGeometryBox <circle> at (69,136) content-size 125x125 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (129,136) content-size 50x125 children: inline
+        TextNode <#text>
+        SVGGeometryBox <circle> at (91.5,136) content-size 125x125 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (189,136) content-size 50x125 children: inline
+        TextNode <#text>
+        SVGGeometryBox <circle> at (114,136) content-size 125x125 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+      SVGSVGBox <svg> at (249,201) content-size 160x60 children: inline
+        TextNode <#text>
+        SVGGeometryBox <circle> at (299,201) content-size 60x60 children: not-inline
+        TextNode <#text>
+      TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
+++ b/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
@@ -48,13 +48,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
       SVGSVGBox <svg> at (50,250) content-size 200x200 children: inline
         TextNode <#text>
-        SVGGeometryBox <rect> at (120.588233,320.588256) content-size 58.823524x58.823528 children: not-inline
+        SVGGeometryBox <rect> at (120.588233,320.588256) content-size 58.823524x58.823532 children: not-inline
         TextNode <#text>
         TextNode <#text>
-        SVGGeometryBox <rect> at (52.443771,310.373626) content-size 68.144462x68.144454 children: not-inline
+        SVGGeometryBox <rect> at (52.443771,310.373657) content-size 68.144462x68.144454 children: not-inline
         TextNode <#text>
         TextNode <#text>
-        SVGGeometryBox <rect> at (179.411773,321.481903) content-size 68.14447x68.144462 children: not-inline
+        SVGGeometryBox <rect> at (179.411773,321.481903) content-size 68.14447x68.14447 children: not-inline
         TextNode <#text>
       TextNode <#text>
       SVGSVGBox <svg> at (258,250) content-size 200x200 children: inline

--- a/Tests/LibWeb/Layout/input/svg-preserve-aspect-ratio.html
+++ b/Tests/LibWeb/Layout/input/svg-preserve-aspect-ratio.html
@@ -1,0 +1,125 @@
+<style>
+  * {
+    font-family: 'SerenitySans';
+  }
+  svg {
+    border: 1px solid black;
+  }
+</style>
+<svg
+  viewBox="0 0 100 100"
+  width="100"
+  height="50"
+  preserveAspectRatio="xMidYMid meet"
+  x="0"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+<svg
+  viewBox="0 0 100 100"
+  width="100"
+  height="50"
+  preserveAspectRatio="xMinYMid meet"
+  x="25"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+<svg
+  viewBox="0 0 100 100"
+  width="100"
+  height="50"
+  preserveAspectRatio="xMaxYMid meet"
+  x="50"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+<svg
+  viewBox="0 0 100 100"
+  width="100"
+  height="50"
+  preserveAspectRatio="xMidYMin slice"
+  x="0"
+  y="15">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+<svg
+  viewBox="0 0 100 100"
+  width="100"
+  height="50"
+  preserveAspectRatio="xMidYMid slice"
+  x="25"
+  y="15">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+<svg
+  viewBox="0 0 100 100"
+  width="100"
+  height="50"
+  preserveAspectRatio="xMidYMax slice"
+  x="50"
+  y="15">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+<svg
+  viewBox="0 0 100 100"
+  width="50"
+  height="125"
+  preserveAspectRatio="xMidYMin meet"
+  x="75"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+<svg
+  viewBox="0 0 100 100"
+  width="50"
+  height="125"
+  preserveAspectRatio="xMidYMid meet"
+  x="90"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+<svg
+  viewBox="0 0 100 100"
+  width="50"
+  height="125"
+  preserveAspectRatio="xMidYMax meet"
+  x="105"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+<svg
+  viewBox="0 0 100 100"
+  width="50"
+  height="125"
+  preserveAspectRatio="xMinYMid slice"
+  x="120"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+<svg
+  viewBox="0 0 100 100"
+  width="50"
+  height="125"
+  preserveAspectRatio="xMidYMid slice"
+  x="135"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+<svg
+  viewBox="0 0 100 100"
+  width="50"
+  height="125"
+  preserveAspectRatio="xMaxYMid slice"
+  x="150"
+  y="0">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>
+<svg
+  viewBox="0 0 100 100"
+  width="160"
+  height="60"
+  preserveAspectRatio="none"
+  x="0"
+  y="30">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>

--- a/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -32,9 +32,105 @@ CSSPixels SVGFormattingContext::automatic_content_height() const
     return 0;
 }
 
+struct ViewBoxTransform {
+    CSSPixelPoint offset;
+    float scale_factor;
+};
+
+// https://svgwg.org/svg2-draft/coords.html#PreserveAspectRatioAttribute
+static ViewBoxTransform scale_and_align_viewbox_content(SVG::PreserveAspectRatio const& preserve_aspect_ratio,
+    SVG::ViewBox const& view_box, Gfx::FloatSize viewbox_scale, auto const& svg_box_state)
+{
+    ViewBoxTransform viewbox_transform {};
+
+    switch (preserve_aspect_ratio.meet_or_slice) {
+    case SVG::PreserveAspectRatio::MeetOrSlice::Meet:
+        // meet (the default) - Scale the graphic such that:
+        // - aspect ratio is preserved
+        // - the entire ‘viewBox’ is visible within the SVG viewport
+        // - the ‘viewBox’ is scaled up as much as possible, while still meeting the other criteria
+        viewbox_transform.scale_factor = min(viewbox_scale.width(), viewbox_scale.height());
+        break;
+    case SVG::PreserveAspectRatio::MeetOrSlice::Slice:
+        // slice - Scale the graphic such that:
+        // aspect ratio is preserved
+        // the entire SVG viewport is covered by the ‘viewBox’
+        // the ‘viewBox’ is scaled down as much as possible, while still meeting the other criteria
+        viewbox_transform.scale_factor = max(viewbox_scale.width(), viewbox_scale.height());
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+    // Handle X alignment:
+    if (svg_box_state.has_definite_width()) {
+        switch (preserve_aspect_ratio.align) {
+        case SVG::PreserveAspectRatio::Align::xMinYMin:
+        case SVG::PreserveAspectRatio::Align::xMinYMid:
+        case SVG::PreserveAspectRatio::Align::xMinYMax:
+            // Align the <min-x> of the element's ‘viewBox’ with the smallest X value of the SVG viewport.
+            viewbox_transform.offset.translate_by(0, 0);
+            break;
+        case SVG::PreserveAspectRatio::Align::None: {
+            // Do not force uniform scaling. Scale the graphic content of the given element non-uniformly
+            // if necessary such that the element's bounding box exactly matches the SVG viewport rectangle.
+            // FIXME: None is unimplemented (treat as xMidYMid)
+            [[fallthrough]];
+        }
+        case SVG::PreserveAspectRatio::Align::xMidYMin:
+        case SVG::PreserveAspectRatio::Align::xMidYMid:
+        case SVG::PreserveAspectRatio::Align::xMidYMax:
+            // Align the midpoint X value of the element's ‘viewBox’ with the midpoint X value of the SVG viewport.
+            viewbox_transform.offset.translate_by((svg_box_state.content_width() - (view_box.width * viewbox_transform.scale_factor)) / 2, 0);
+            break;
+        case SVG::PreserveAspectRatio::Align::xMaxYMin:
+        case SVG::PreserveAspectRatio::Align::xMaxYMid:
+        case SVG::PreserveAspectRatio::Align::xMaxYMax:
+            // Align the <min-x>+<width> of the element's ‘viewBox’ with the maximum X value of the SVG viewport.
+            viewbox_transform.offset.translate_by((svg_box_state.content_width() - (view_box.width * viewbox_transform.scale_factor)), 0);
+            break;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+
+    if (svg_box_state.has_definite_width()) {
+        switch (preserve_aspect_ratio.align) {
+        case SVG::PreserveAspectRatio::Align::xMinYMin:
+        case SVG::PreserveAspectRatio::Align::xMidYMin:
+        case SVG::PreserveAspectRatio::Align::xMaxYMin:
+            // Align the <min-y> of the element's ‘viewBox’ with the smallest Y value of the SVG viewport.
+            viewbox_transform.offset.translate_by(0, 0);
+            break;
+        case SVG::PreserveAspectRatio::Align::None: {
+            // Do not force uniform scaling. Scale the graphic content of the given element non-uniformly
+            // if necessary such that the element's bounding box exactly matches the SVG viewport rectangle.
+            // FIXME: None is unimplemented (treat as xMidYMid)
+            [[fallthrough]];
+        }
+        case SVG::PreserveAspectRatio::Align::xMinYMid:
+        case SVG::PreserveAspectRatio::Align::xMidYMid:
+        case SVG::PreserveAspectRatio::Align::xMaxYMid:
+            // Align the midpoint Y value of the element's ‘viewBox’ with the midpoint Y value of the SVG viewport.
+            viewbox_transform.offset.translate_by(0, (svg_box_state.content_height() - (view_box.height * viewbox_transform.scale_factor)) / 2);
+            break;
+        case SVG::PreserveAspectRatio::Align::xMinYMax:
+        case SVG::PreserveAspectRatio::Align::xMidYMax:
+        case SVG::PreserveAspectRatio::Align::xMaxYMax:
+            // Align the <min-y>+<height> of the element's ‘viewBox’ with the maximum Y value of the SVG viewport.
+            viewbox_transform.offset.translate_by(0, (svg_box_state.content_height() - (view_box.height * viewbox_transform.scale_factor)));
+            break;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+
+    return viewbox_transform;
+}
+
 void SVGFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] AvailableSpace const& available_space)
 {
-    // FIXME: This entire thing is an ad-hoc hack.
+    // FIXME: This a bunch of this thing is an ad-hoc hack.
 
     auto& svg_svg_element = verify_cast<SVG::SVGSVGElement>(*box.dom_node());
 
@@ -59,37 +155,33 @@ void SVGFormattingContext::run(Box const& box, LayoutMode, [[maybe_unused]] Avai
             auto& dom_node = const_cast<SVGGeometryBox&>(geometry_box).dom_node();
 
             auto& path = dom_node.get_path();
-            auto transform = dom_node.get_transform();
+            auto path_transform = dom_node.get_transform();
 
+            float viewbox_scale = 1;
             auto& maybe_view_box = svg_svg_element.view_box();
-            float viewbox_scale = 1.0f;
-
-            CSSPixelPoint offset {};
             if (maybe_view_box.has_value()) {
-                auto view_box = maybe_view_box.value();
                 // FIXME: This should allow just one of width or height to be specified.
                 // E.g. We should be able to layout <svg width="100%"> where height is unspecified/auto.
                 if (!svg_box_state.has_definite_width() || !svg_box_state.has_definite_height()) {
                     dbgln("FIXME: Attempting to layout indefinitely sized SVG with a viewbox -- this likely won't work!");
                 }
+
+                auto view_box = maybe_view_box.value();
                 auto scale_width = svg_box_state.has_definite_width() ? svg_box_state.content_width().value() / view_box.width : 1;
                 auto scale_height = svg_box_state.has_definite_height() ? svg_box_state.content_height().value() / view_box.height : 1;
-                viewbox_scale = min(scale_width, scale_height);
 
-                // Center the viewbox within the SVG element:
-                if (svg_box_state.has_definite_width())
-                    offset.translate_by((svg_box_state.content_width() - (view_box.width * viewbox_scale)) / 2, 0);
-                if (svg_box_state.has_definite_height())
-                    offset.translate_by(0, (svg_box_state.content_height() - (view_box.height * viewbox_scale)) / 2);
-
-                transform = Gfx::AffineTransform {}.scale(viewbox_scale, viewbox_scale).translate({ -view_box.min_x, -view_box.min_y }).multiply(transform);
+                // The initial value for preserveAspectRatio is xMidYMid meet.
+                auto preserve_aspect_ratio = svg_svg_element.preserve_aspect_ratio().value_or(SVG::PreserveAspectRatio {});
+                auto viewbox_transform = scale_and_align_viewbox_content(preserve_aspect_ratio, view_box, { scale_width, scale_height }, svg_box_state);
+                path_transform = Gfx::AffineTransform {}.translate(viewbox_transform.offset.to_type<float>()).scale(viewbox_transform.scale_factor, viewbox_transform.scale_factor).translate({ -view_box.min_x, -view_box.min_y }).multiply(path_transform);
+                viewbox_scale = viewbox_transform.scale_factor;
             }
 
             // Stroke increases the path's size by stroke_width/2 per side.
-            auto path_bounding_box = transform.map(path.bounding_box()).to_type<CSSPixels>();
+            auto path_bounding_box = path_transform.map(path.bounding_box()).to_type<CSSPixels>();
             CSSPixels stroke_width = geometry_box.dom_node().visible_stroke_width() * viewbox_scale;
             path_bounding_box.inflate(stroke_width, stroke_width);
-            geometry_box_state.set_content_offset(path_bounding_box.top_left() + offset);
+            geometry_box_state.set_content_offset(path_bounding_box.top_left());
             geometry_box_state.set_content_width(path_bounding_box.width());
             geometry_box_state.set_content_height(path_bounding_box.height());
         }

--- a/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -26,13 +26,15 @@ Layout::SVGSVGBox const& SVGSVGPaintable::layout_box() const
 
 void SVGSVGPaintable::before_children_paint(PaintContext& context, PaintPhase phase) const
 {
+    PaintableBox::before_children_paint(context, phase);
     if (phase != PaintPhase::Foreground)
         return;
 
     if (!context.has_svg_context())
         context.set_svg_context(SVGContext(absolute_rect()));
 
-    PaintableBox::before_children_paint(context, phase);
+    context.painter().save();
+    context.painter().add_clip_rect(context.enclosing_device_rect(absolute_rect()).to_type<int>());
 }
 
 void SVGSVGPaintable::after_children_paint(PaintContext& context, PaintPhase phase) const
@@ -40,6 +42,8 @@ void SVGSVGPaintable::after_children_paint(PaintContext& context, PaintPhase pha
     PaintableBox::after_children_paint(context, phase);
     if (phase != PaintPhase::Foreground)
         return;
+
+    context.painter().restore();
     context.clear_svg_context();
 }
 

--- a/Userland/Libraries/LibWeb/SVG/AttributeParser.h
+++ b/Userland/Libraries/LibWeb/SVG/AttributeParser.h
@@ -67,6 +67,27 @@ struct Transform {
     Operation operation;
 };
 
+struct PreserveAspectRatio {
+    enum class Align {
+        None,
+        xMinYMin,
+        xMidYMin,
+        xMaxYMin,
+        xMinYMid,
+        xMidYMid,
+        xMaxYMid,
+        xMinYMax,
+        xMidYMax,
+        xMaxYMax
+    };
+    enum class MeetOrSlice {
+        Meet,
+        Slice
+    };
+    Align align { Align::xMidYMid };
+    MeetOrSlice meet_or_slice { MeetOrSlice::Meet };
+};
+
 class AttributeParser final {
 public:
     ~AttributeParser() = default;
@@ -77,6 +98,7 @@ public:
     static Vector<Gfx::FloatPoint> parse_points(StringView input);
     static Vector<PathInstruction> parse_path_data(StringView input);
     static Optional<Vector<Transform>> parse_transform(StringView input);
+    static Optional<PreserveAspectRatio> parse_preserve_aspect_ratio(StringView input);
 
 private:
     AttributeParser(StringView source);

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -73,6 +73,8 @@ void SVGSVGElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedS
 
     if (name.equals_ignoring_ascii_case(SVG::AttributeNames::viewBox))
         m_view_box = try_parse_view_box(value);
+    if (name.equals_ignoring_ascii_case(SVG::AttributeNames::preserveAspectRatio))
+        m_preserve_aspect_ratio = AttributeParser::parse_preserve_aspect_ratio(value);
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibGfx/Bitmap.h>
+#include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGGraphicsElement.h>
 #include <LibWeb/SVG/ViewBox.h>
 
@@ -24,6 +25,7 @@ public:
     virtual bool is_svg_container() const override { return true; }
 
     Optional<ViewBox> const& view_box() const { return m_view_box; }
+    Optional<PreserveAspectRatio> const& preserve_aspect_ratio() const { return m_preserve_aspect_ratio; }
 
 private:
     SVGSVGElement(DOM::Document&, DOM::QualifiedName);
@@ -35,6 +37,7 @@ private:
     virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     Optional<ViewBox> m_view_box;
+    Optional<PreserveAspectRatio> m_preserve_aspect_ratio;
 };
 
 }


### PR DESCRIPTION
This PR implements all values of the SVG viewbox `preserveAspectRatio` attribute (except `none`, which needs a few more tweaks). It also now brings our SVG layout a little closer to the spec -- spec comments and all :^)
![image](https://user-images.githubusercontent.com/11597044/232353018-71ea89c1-2d8b-4bc5-b401-e4f570c28d45.png)

With this the Discord login background, which uses `xMinYMin slice`, is now properly scaled and positioned: 

![image](https://user-images.githubusercontent.com/11597044/232353184-4a0543f9-616a-4414-b50a-614ea39175c0.png)
