### PR TITLE
LibWeb: Support implicit lineto commands after moveto in SVG paths

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/svg-path-with-implicit-lineto.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-path-with-implicit-lineto.txt
@@ -1,0 +1,7 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: inline
+      line 0 width: 100, height: 100, bottom: 100, baseline: 60
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100]
+      SVGSVGBox <svg> at (8,8) content-size 100x100 children: not-inline
+        SVGGeometryBox <path> at (28,28) content-size 60x60 children: not-inline

--- a/Tests/LibWeb/Layout/input/svg/svg-path-with-implicit-lineto.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-path-with-implicit-lineto.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html><html><body><svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="100"
+          height="100"
+          viewBox="0 0 10 10"
+        ><path d="M 2 2 5 8 8 2 z"></path></svg>

--- a/Userland/Libraries/LibWeb/SVG/AttributeParser.cpp
+++ b/Userland/Libraries/LibWeb/SVG/AttributeParser.cpp
@@ -130,12 +130,19 @@ void AttributeParser::parse_drawto()
     }
 }
 
+// https://www.w3.org/TR/SVG2/paths.html#PathDataMovetoCommands
 void AttributeParser::parse_moveto()
 {
     bool absolute = consume() == 'M';
     parse_whitespace();
-    for (auto& pair : parse_coordinate_pair_sequence())
-        m_instructions.append({ PathInstructionType::Move, absolute, pair });
+
+    bool is_first = true;
+    for (auto& pair : parse_coordinate_pair_sequence()) {
+        // NOTE: "M 1 2 3 4" is equivalent to "M 1 2 L 3 4".
+        auto type = is_first ? PathInstructionType::Move : PathInstructionType::Line;
+        m_instructions.append({ type, absolute, pair });
+        is_first = false;
+    }
 }
 
 void AttributeParser::parse_closepath()


### PR DESCRIPTION
Per SVG2, any coordinate pairs following a moveto command should be treated as implicit lineto commands with the same absoluteness as the moveto command.

Example:
```svg
<path d="M 2 2 5 8 8 2 z">
```

Before:
![image](https://user-images.githubusercontent.com/5954907/232460699-30e6f213-d033-4efb-9840-98e124dca1e0.png)

After:
![image](https://user-images.githubusercontent.com/5954907/232460660-d792a5bd-5734-4b77-bcfc-69595752e820.png)
