### PR TITLE
LibWeb: Honor box-sizing in flex item "specified size suggestion"

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/specified-size-suggestion-with-box-sizing-border-box.txt
+++ b/Tests/LibWeb/Layout/expected/flex/specified-size-suggestion-with-box-sizing-border-box.txt
@@ -1,0 +1,5 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x100 children: not-inline
+    Box <body> at (0,0) content-size 800x100 flex-container(row) children: not-inline
+      ImageBox <img> at (0,0) content-size 400x100 flex-item children: not-inline
+      ImageBox <img.padded> at (600,0) content-size 200x100 flex-item children: not-inline

--- a/Tests/LibWeb/Layout/input/flex/specified-size-suggestion-with-box-sizing-border-box.html
+++ b/Tests/LibWeb/Layout/input/flex/specified-size-suggestion-with-box-sizing-border-box.html
@@ -1,0 +1,21 @@
+<!doctype html><style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+      font: 16px SerenitySans;
+    }
+    body {
+      width: 800px;
+      display: flex;
+      flex-wrap: wrap;
+    }
+    img {
+      width: 50%;
+      height: 100px;
+      background: pink;
+    }
+    .padded {
+      padding-left: 200px;
+    }
+</style><body><img><img class="padded" alt="hello this text is here to make the img have a wide intrinsic size" />

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -705,8 +705,10 @@ Optional<CSSPixels> FlexFormattingContext::specified_size_suggestion(FlexItem co
 {
     // If the item’s preferred main size is definite and not automatic,
     // then the specified size suggestion is that size. It is otherwise undefined.
-    if (has_definite_main_size(item.box))
-        return inner_main_size(item.box);
+    if (has_definite_main_size(item.box)) {
+        // NOTE: We use get_pixel_{width,height} to ensure that CSS box-sizing is respected.
+        return is_row_layout() ? get_pixel_width(item.box, computed_main_size(item.box)) : get_pixel_height(item.box, computed_main_size(item.box));
+    }
     return {};
 }
 


### PR DESCRIPTION
Although the spec doesn't mention it, if a flex item has box-sizing: border-box, and the specified size suggestion is a definite size, we have to subtract the borders and padding from the size before using it.

This fixes an issue seen in "This Week in Ladybird #4" where the screenshots ended up in one long vertical stack instead of paired up 2 by 2.

Before:
![image](https://user-images.githubusercontent.com/5954907/232537610-cfa31346-f4ad-426d-af46-ff011a9efcb4.png)

After:
![image](https://user-images.githubusercontent.com/5954907/232537725-fed276ae-aa58-469a-9af9-93c149116399.png)
