### PR TITLE
Meta: Move more common flags to common_compile_options.cmake

### DIFF
--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -17,3 +17,15 @@ if (NOT CMAKE_HOST_SYSTEM_NAME MATCHES SerenityOS)
     #        Disable -Werror for now.
     add_compile_options(-Werror)
 endif()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+    # Clang's default constexpr-steps limit is 1048576(2^20), GCC doesn't have one
+    add_compile_options(-fconstexpr-steps=16777216)
+
+    add_compile_options(-Wno-implicit-const-int-float-conversion)
+    add_compile_options(-Wno-user-defined-literals)
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # Only ignore expansion-to-defined for g++, clang's implementation doesn't complain about function-like macros
+    add_compile_options(-Wno-expansion-to-defined)
+    add_compile_options(-Wno-literal-suffix)
+endif()

--- a/Meta/CMake/lagom_compile_options.cmake
+++ b/Meta/CMake/lagom_compile_options.cmake
@@ -1,7 +1,5 @@
 include(${CMAKE_CURRENT_LIST_DIR}/common_compile_options.cmake)
 
-add_compile_options(-Wno-implicit-const-int-float-conversion)
-add_compile_options(-Wno-literal-suffix)
 add_compile_options(-Wno-maybe-uninitialized)
 add_compile_options(-Wno-shorten-64-to-32)
 add_compile_options(-fsigned-char)

--- a/Meta/CMake/serenity_compile_options.cmake
+++ b/Meta/CMake/serenity_compile_options.cmake
@@ -31,19 +31,13 @@ add_compile_options(-gdwarf-4)
 add_compile_options(-g1)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(-Wno-literal-suffix)
     add_compile_options(-Wno-maybe-uninitialized)
-    # Only ignore expansion-to-defined for g++, clang's implementation doesn't complain about function-like macros
-    add_compile_options(-Wno-expansion-to-defined)
     add_compile_options(-Wcast-align)
     add_compile_options(-Wdouble-promotion)
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
-    add_compile_options(-Wno-user-defined-literals)
     add_compile_options(-Wno-atomic-alignment)
-    add_compile_options(-Wno-implicit-const-int-float-conversion)
     add_compile_options(-Wno-unused-const-variable)
     add_compile_options(-Wno-unused-private-field)
-    add_compile_options(-fconstexpr-steps=16777216)
 
     # Clang doesn't add compiler_rt to the search path when compiling with -nostdlib.
     link_directories(${TOOLCHAIN_ROOT}/lib/clang/${CMAKE_CXX_COMPILER_VERSION}/lib/${SERENITY_ARCH}-pc-serenity/)

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -131,8 +131,7 @@ if (ENABLE_LAGOM_LADYBIRD AND (ENABLE_FUZZERS OR ENABLE_COMPILER_EXPLORER_BUILD)
 endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
-    # Clang's default constexpr-steps limit is 1048576(2^20), GCC doesn't have one
-    add_compile_options(-Wno-overloaded-virtual -Wno-user-defined-literals -fconstexpr-steps=16777216)
+    add_compile_options(-Wno-overloaded-virtual)
     # FIXME: Re-enable this check when the warning stops triggering, or document why we can't stop it from triggering.
     # For now, there is a lot of unused private fields in LibWeb that trigger this that could be removed.
     # See issue #14137 for details
@@ -144,7 +143,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     endif()
 
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(-Wno-expansion-to-defined)
     if (ENABLE_FUZZERS_LIBFUZZER)
         message(FATAL_ERROR
             "Fuzzer Sanitizer (-fsanitize=fuzzer) is only supported for Fuzzer targets with LLVM. "


### PR DESCRIPTION
For the most part no behavior change, except that we now pass -Wno-implicit-const-int-float-conversion and -Wno-literal-suffix only to clang and gcc each in both lagom and serenity builds, while we previously passed them to both in lagom builds (and passed them to one each in serenity builds). The former is a clang flag, the latter a gcc flag, but since we also use -Wno-unknown-warning-option it doesn't really matter.