### PR TITLE
LibWeb: Make <svg> inside <svg> not crash

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
@@ -1,0 +1,10 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x40 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x24 children: inline
+      line 0 width: 24, height: 24, bottom: 24, baseline: 24
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 24x24]
+      SVGSVGBox <svg> at (8,8) content-size 24x24 children: inline
+        SVGGraphicsBox <g>  children: inline
+          SVGSVGBox <svg> at (8,8) content-size 24x24 children: not-inline
+            SVGGeometryBox <rect> at (8,8) content-size 24x24 children: not-inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/svg/svg-inside-svg.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-inside-svg.html
@@ -1,0 +1,12 @@
+<!doctype html><body><svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    ><g><svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+        ><rect x="0" y="0" width="24" height="24"></svg></g>
+</svg>

--- a/Userland/Libraries/LibWeb/Layout/SVGGraphicsBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGGraphicsBox.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Layout/SVGGraphicsBox.h>
+#include <LibWeb/Painting/SVGGraphicsPaintable.h>
 #include <LibWeb/Painting/StackingContext.h>
 
 namespace Web::Layout {
@@ -12,6 +13,11 @@ namespace Web::Layout {
 SVGGraphicsBox::SVGGraphicsBox(DOM::Document& document, SVG::SVGGraphicsElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
     : SVGBox(document, element, properties)
 {
+}
+
+JS::GCPtr<Painting::Paintable> SVGGraphicsBox::create_paintable() const
+{
+    return Painting::SVGGraphicsPaintable::create(*this);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/SVGGraphicsBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGGraphicsBox.h
@@ -21,6 +21,8 @@ public:
 
     SVG::SVGGraphicsElement& dom_node() { return verify_cast<SVG::SVGGraphicsElement>(SVGBox::dom_node()); }
     SVG::SVGGraphicsElement const& dom_node() const { return verify_cast<SVG::SVGGraphicsElement>(SVGBox::dom_node()); }
+
+    virtual JS::GCPtr<Painting::Paintable> create_paintable() const override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/SVGGraphicsPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGGraphicsPaintable.cpp
@@ -9,6 +9,11 @@
 
 namespace Web::Painting {
 
+JS::NonnullGCPtr<SVGGraphicsPaintable> SVGGraphicsPaintable::create(Layout::SVGGraphicsBox const& layout_box)
+{
+    return layout_box.heap().allocate_without_realm<SVGGraphicsPaintable>(layout_box);
+}
+
 SVGGraphicsPaintable::SVGGraphicsPaintable(Layout::SVGGraphicsBox const& layout_box)
     : SVGPaintable(layout_box)
 {

--- a/Userland/Libraries/LibWeb/Painting/SVGGraphicsPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/SVGGraphicsPaintable.h
@@ -15,6 +15,8 @@ class SVGGraphicsPaintable : public SVGPaintable {
     JS_CELL(SVGGraphicsPaintable, SVGPaintable);
 
 public:
+    static JS::NonnullGCPtr<SVGGraphicsPaintable> create(Layout::SVGGraphicsBox const&);
+
     virtual void before_children_paint(PaintContext&, PaintPhase) const override;
 
     Layout::SVGGraphicsBox const& layout_box() const;


### PR DESCRIPTION
Also let's make a `SVGGraphicsPaintable` for `<g>` boxes. Together these two commits make it possible to load https://awesomekling.substack.com 