### PR TITLE
LibGfx: Prevent out-of-bounds accumulation in PathRasterizer

### DIFF
--- a/Userland/Libraries/LibGfx/Font/PathRasterizer.cpp
+++ b/Userland/Libraries/LibGfx/Font/PathRasterizer.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Srimanta Barua <srimanta.barua1@gmail.com>
+ * Copyright (c) 2023, Jelle Raaijmakers <jelle@gmta.nl>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,10 +12,9 @@ namespace Gfx {
 PathRasterizer::PathRasterizer(Gfx::IntSize size)
     : m_size(size)
 {
-    m_data.resize(m_size.width() * m_size.height());
-    for (int i = 0; i < m_size.width() * m_size.height(); i++) {
-        m_data[i] = 0.0f;
-    }
+    m_data.resize(m_size.area());
+    for (int i = 0; i < m_size.area(); i++)
+        m_data[i] = 0.f;
 }
 
 void PathRasterizer::draw_path(Gfx::Path& path)
@@ -31,17 +31,11 @@ RefPtr<Gfx::Bitmap> PathRasterizer::accumulate()
     auto bitmap = bitmap_or_error.release_value_but_fixme_should_propagate_errors();
     Color base_color = Color::from_rgb(0xffffff);
     for (int y = 0; y < m_size.height(); y++) {
-        float accumulator = 0.0;
+        float accumulator = 0.f;
         for (int x = 0; x < m_size.width(); x++) {
             accumulator += m_data[y * m_size.width() + x];
-            float value = accumulator;
-            if (value < 0.0f) {
-                value = -value;
-            }
-            if (value > 1.0f) {
-                value = 1.0;
-            }
-            u8 alpha = value * 255.0f;
+            float value = AK::min(AK::abs(accumulator), 1.f);
+            u8 alpha = value * 255.f;
             bitmap->set_pixel(x, y, base_color.with_alpha(alpha));
         }
     }
@@ -51,46 +45,38 @@ RefPtr<Gfx::Bitmap> PathRasterizer::accumulate()
 void PathRasterizer::draw_line(Gfx::FloatPoint p0, Gfx::FloatPoint p1)
 {
     // FIXME: Shift x and y according to dy/dx
-    if (p0.x() < 0.0f) {
+    if (p0.x() < 0.f)
         p0.set_x(roundf(p0.x()));
-    }
-    if (p0.y() < 0.0f) {
+    if (p0.y() < 0.f)
         p0.set_y(roundf(p0.y()));
-    }
-    if (p1.x() < 0.0f) {
+    if (p1.x() < 0.f)
         p1.set_x(roundf(p1.x()));
-    }
-    if (p1.y() < 0.0f) {
+    if (p1.y() < 0.f)
         p1.set_y(roundf(p1.y()));
-    }
 
-    if (!(p0.x() >= 0.0f && p0.y() >= 0.0f && p0.x() <= m_size.width() && p0.y() <= m_size.height())) {
+    if (p0.x() < 0.f || p0.y() < 0.f || p0.x() > m_size.width() || p0.y() > m_size.height()) {
         dbgln("!P0({},{})", p0.x(), p0.y());
         return;
     }
 
-    if (!(p1.x() >= 0.0f && p1.y() >= 0.0f && p1.x() <= m_size.width() && p1.y() <= m_size.height())) {
+    if (p1.x() < 0.f || p1.y() < 0.f || p1.x() > m_size.width() || p1.y() > m_size.height()) {
         dbgln("!P1({},{})", p1.x(), p1.y());
         return;
     }
 
-    VERIFY(p0.x() >= 0.0f && p0.y() >= 0.0f && p0.x() <= m_size.width() && p0.y() <= m_size.height());
-    VERIFY(p1.x() >= 0.0f && p1.y() >= 0.0f && p1.x() <= m_size.width() && p1.y() <= m_size.height());
-
     // If we're on the same Y, there's no need to draw
-    if (p0.y() == p1.y()) {
+    if (p0.y() == p1.y())
         return;
-    }
 
-    float direction = -1.0;
+    float direction = -1.f;
     if (p1.y() < p0.y()) {
-        direction = 1.0;
-        auto tmp = p0;
-        p0 = p1;
-        p1 = tmp;
+        direction = 1.f;
+        AK::swap(p0, p1);
     }
 
-    float dxdy = (p1.x() - p0.x()) / (p1.y() - p0.y());
+    float const dxdy = (p1.x() - p0.x()) / (p1.y() - p0.y());
+    float const dydx = AK::abs(1.f / dxdy);
+
     u32 y0 = floorf(p0.y());
     u32 y1 = ceilf(p1.y());
     float x_cur = p0.x();
@@ -98,12 +84,10 @@ void PathRasterizer::draw_line(Gfx::FloatPoint p0, Gfx::FloatPoint p1)
     for (u32 y = y0; y < y1; y++) {
         u32 line_offset = m_size.width() * y;
 
-        float dy = min(y + 1.0f, p1.y()) - max((float)y, p0.y());
+        float dy = AK::min(y + 1.f, p1.y()) - AK::max(static_cast<float>(y), p0.y());
         float directed_dy = dy * direction;
         float x_next = x_cur + dy * dxdy;
-        if (x_next < 0.0f) {
-            x_next = 0.0f;
-        }
+        x_next = AK::max(x_next, 0.f);
         float x0 = x_cur;
         float x1 = x_next;
         if (x1 < x0) {
@@ -112,27 +96,23 @@ void PathRasterizer::draw_line(Gfx::FloatPoint p0, Gfx::FloatPoint p1)
         }
         float x0_floor = floorf(x0);
         float x1_ceil = ceilf(x1);
-        u32 x0i = x0_floor;
+        u32 x0_floor_i = x0_floor;
 
-        if (x1_ceil <= x0_floor + 1.0f) {
+        if (x1_ceil <= x0_floor + 1.f) {
             // If x0 and x1 are within the same pixel, then area to the right is (1 - (mid(x0, x1) - x0_floor)) * dy
-            float area = ((x0 + x1) * 0.5f) - x0_floor;
-            m_data[line_offset + x0i] += directed_dy * (1.0f - area);
-            m_data[line_offset + x0i + 1] += directed_dy * area;
+            float area = .5f * (x0 + x1) - x0_floor;
+            m_data[line_offset + x0_floor_i] += directed_dy * (1.f - area);
+            m_data[line_offset + x0_floor_i + 1] += directed_dy * area;
         } else {
-            float dydx = 1.0f / dxdy;
-            if (dydx < 0)
-                dydx = -dydx;
-
-            float x0_right = 1.0f - (x0 - x0_floor);
+            float x0_right = 1.f - (x0 - x0_floor);
             u32 x1_floor_i = floorf(x1);
-            float area_upto_here = 0.5f * x0_right * x0_right * dydx;
-            m_data[line_offset + x0i] += direction * area_upto_here;
-            for (u32 x = x0i + 1; x < x1_floor_i; x++) {
+            float area_upto_here = .5f * x0_right * x0_right * dydx;
+            m_data[line_offset + x0_floor_i] += direction * area_upto_here;
+            for (u32 x = x0_floor_i + 1; x < x1_floor_i; x++) {
                 m_data[line_offset + x] += direction * dydx;
                 area_upto_here += dydx;
             }
-            float remaining_area = (dy - area_upto_here);
+            float remaining_area = dy - area_upto_here;
             m_data[line_offset + x1_floor_i] += direction * remaining_area;
         }
 

--- a/Userland/Libraries/LibGfx/Font/PathRasterizer.cpp
+++ b/Userland/Libraries/LibGfx/Font/PathRasterizer.cpp
@@ -102,7 +102,8 @@ void PathRasterizer::draw_line(Gfx::FloatPoint p0, Gfx::FloatPoint p1)
             // If x0 and x1 are within the same pixel, then area to the right is (1 - (mid(x0, x1) - x0_floor)) * dy
             float area = .5f * (x0 + x1) - x0_floor;
             m_data[line_offset + x0_floor_i] += directed_dy * (1.f - area);
-            m_data[line_offset + x0_floor_i + 1] += directed_dy * area;
+            if (x0_floor_i + 1 < static_cast<u32>(m_size.width()))
+                m_data[line_offset + x0_floor_i + 1] += directed_dy * area;
         } else {
             float x0_right = 1.f - (x0 - x0_floor);
             u32 x1_floor_i = floorf(x1);

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2116,7 +2116,7 @@ void Painter::draw_triangle_wave(IntPoint a_p1, IntPoint a_p2, Color color, int 
 
 static bool can_approximate_bezier_curve(FloatPoint p1, FloatPoint p2, FloatPoint control)
 {
-    constexpr float tolerance = 0.0015f;
+    constexpr float tolerance = 0.015f;
 
     auto p1x = 3 * control.x() - 2 * p1.x() - p2.x();
     auto p1y = 3 * control.y() - 2 * p1.y() - p2.y();
@@ -2190,7 +2190,7 @@ void Painter::for_each_line_segment_on_cubic_bezier_curve(FloatPoint control_poi
 
 static bool can_approximate_cubic_bezier_curve(FloatPoint p1, FloatPoint p2, FloatPoint control_0, FloatPoint control_1)
 {
-    constexpr float tolerance = 0.0015f;
+    constexpr float tolerance = 0.015f;
 
     auto ax = 3 * control_0.x() - 2 * p1.x() - p2.x();
     auto ay = 3 * control_0.y() - 2 * p1.y() - p2.y();


### PR DESCRIPTION
Fixes #18394.

![image](https://user-images.githubusercontent.com/3210731/232915658-ad7351b4-fe7e-4093-8f2a-44769c97cff9.png)
