### PR TITLE
Ports: Resolve some patch-related footguns

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -836,7 +836,7 @@ do_dev() {
                     else
                         # The patch didn't apply, oh no!
                         # Ask the user to figure it out :shrug:
-                        git am "$patch" || true
+                        git am --keep-cr --keep-non-patch --3way "$patch" || true
                         >&2 echo "- This patch does not apply, you'll be dropped into a shell to investigate and fix this, quit the shell when the problem is resolved."
                         >&2 echo "Note that the patch needs to be committed into the current repository!"
                         launch_user_shell


### PR DESCRIPTION
Namely, mangling patches when having to apply them manually, and then also loosing those manual changes when the script doesn't notice that the patches should be updated.