### PR TITLE
LibWeb: Fix broken handling of `flex: <flex-grow>` shorthand

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex-grow-2.txt
+++ b/Tests/LibWeb/Layout/expected/flex-grow-2.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.container> at (9,9) content-size 500x102 flex-container(row) children: not-inline
         BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 132.333343x100 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 82.333335x100 flex-item children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (144.333343,10) content-size 164.666671x100 flex-item children: inline
+        BlockContainer <div.box> at (94.333335,10) content-size 164.666671x100 flex-item children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [144.333343,10 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [94.333335,10 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (311,10) content-size 197x100 flex-item children: inline
+        BlockContainer <div.box> at (261,10) content-size 247x100 flex-item children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [311,10 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [261,10 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline


### PR DESCRIPTION
This is a tiny bit messy because:

- The spec says we should expand this to `flex: <flex-grow> 1 0`
- All major engines expand it to `flex: <flex-grow> 1 0%`

Spec bug: https://github.com/w3c/csswg-drafts/issues/5742

As it turns out, we already had a test that covers this case, and now it renders the same in Ladybird as in other browsers :^)

Before:
![image](https://user-images.githubusercontent.com/5954907/233012026-cbbad0b4-8d11-4671-aabb-dde39f0b92e0.png)

After:
![Screenshot at 2023-04-19 10-12-34](https://user-images.githubusercontent.com/5954907/233012072-a80c5269-ddae-4007-8c3f-d3f53312eb48.png)
