### PR TITLE
Shell: Implement enough _stuff_ to get config.sub running

### DIFF
--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -3691,6 +3691,17 @@ ErrorOr<Vector<String>> ListValue::resolve_as_list(RefPtr<Shell> shell)
     return resolve_slices(shell, move(values), m_slices);
 }
 
+ErrorOr<String> ListValue::resolve_as_string(RefPtr<Shell> shell)
+{
+    if (!shell || !shell->posix_mode())
+        return Value::resolve_as_string(shell);
+
+    if (m_contained_values.is_empty())
+        return resolve_slices(shell, String {}, m_slices);
+
+    return resolve_slices(shell, TRY(m_contained_values[0]->resolve_as_string(shell)), m_slices);
+}
+
 ErrorOr<NonnullRefPtr<Value>> ListValue::resolve_without_cast(RefPtr<Shell> shell)
 {
     Vector<NonnullRefPtr<Value>> values;

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -3842,7 +3842,7 @@ ErrorOr<NonnullRefPtr<Value>> SimpleVariableValue::resolve_without_cast(RefPtr<S
 {
     VERIFY(shell);
 
-    if (auto value = TRY(shell->lookup_local_variable(m_name))) {
+    if (auto value = TRY(shell->look_up_local_variable(m_name))) {
         auto result = value.release_nonnull();
         // If a slice is applied, add it.
         if (!m_slices.is_empty())
@@ -3884,11 +3884,11 @@ ErrorOr<Vector<String>> SpecialVariableValue::resolve_as_list(RefPtr<Shell> shel
     case '$':
         return { resolve_slices(shell, Vector { TRY(String::number(getpid())) }, m_slices) };
     case '*':
-        if (auto argv = TRY(shell->lookup_local_variable("ARGV"sv)))
+        if (auto argv = TRY(shell->look_up_local_variable("ARGV"sv)))
             return resolve_slices(shell, TRY(const_cast<Value&>(*argv).resolve_as_list(shell)), m_slices);
         return resolve_slices(shell, Vector<String> {}, m_slices);
     case '#':
-        if (auto argv = TRY(shell->lookup_local_variable("ARGV"sv))) {
+        if (auto argv = TRY(shell->look_up_local_variable("ARGV"sv))) {
             if (argv->is_list()) {
                 auto list_argv = static_cast<AST::ListValue const*>(argv.ptr());
                 return { resolve_slices(shell, Vector { TRY(String::number(list_argv->values().size())) }, m_slices) };

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -2363,7 +2363,9 @@ ErrorOr<RefPtr<Value>> MatchExpr::run(RefPtr<Shell> shell)
             return move(result).get<RefPtr<Value>>();
     }
 
-    shell->raise_error(Shell::ShellError::EvaluatedSyntaxError, "Non-exhaustive match rules!", position());
+    // Non-exhaustive 'case' statements are valid in POSIX.
+    if (!shell || !shell->posix_mode())
+        shell->raise_error(Shell::ShellError::EvaluatedSyntaxError, "Non-exhaustive match rules!", position());
     return make_ref_counted<AST::ListValue>({});
 }
 

--- a/Userland/Shell/AST.h
+++ b/Userland/Shell/AST.h
@@ -310,6 +310,7 @@ private:
 class ListValue final : public Value {
 public:
     virtual ErrorOr<Vector<String>> resolve_as_list(RefPtr<Shell>) override;
+    virtual ErrorOr<String> resolve_as_string(RefPtr<Shell>) override;
     virtual ErrorOr<NonnullRefPtr<Value>> resolve_without_cast(RefPtr<Shell>) override;
     virtual ErrorOr<NonnullRefPtr<Value>> clone() const override { return TRY(try_make_ref_counted<ListValue>(m_contained_values))->set_slices(m_slices); }
     virtual ~ListValue();

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -1198,9 +1198,12 @@ ErrorOr<int> Shell::builtin_wait(Main::Arguments arguments)
 ErrorOr<int> Shell::builtin_unset(Main::Arguments arguments)
 {
     Vector<DeprecatedString> vars;
+    bool unset_only_variables = false; // POSIX only.
 
     Core::ArgsParser parser;
     parser.add_positional_argument(vars, "List of variables", "variables", Core::ArgsParser::Required::Yes);
+    if (m_in_posix_mode)
+        parser.add_option(unset_only_variables, "Unset only variables", "variables", 'v');
 
     if (!parser.parse(arguments, Core::ArgsParser::FailureBehavior::PrintUsage))
         return 1;
@@ -1212,7 +1215,7 @@ ErrorOr<int> Shell::builtin_unset(Main::Arguments arguments)
 
         if (TRY(lookup_local_variable(value)) != nullptr) {
             unset_local_variable(value);
-        } else {
+        } else if (!unset_only_variables) {
             unsetenv(value.characters());
         }
     }

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -215,6 +215,56 @@ ErrorOr<int> Shell::builtin_unalias(Main::Arguments arguments)
     return failed ? 1 : 0;
 }
 
+ErrorOr<int> Shell::builtin_break(Main::Arguments arguments)
+{
+    if (!m_in_posix_mode) {
+        raise_error(ShellError::EvaluatedSyntaxError, "break: Invalid use of builtin break in non-POSIX mode");
+        return 1;
+    }
+
+    unsigned count = 1;
+
+    Core::ArgsParser parser;
+    parser.add_positional_argument(count, "Number of loops to 'break' out of", "count", Core::ArgsParser::Required::No);
+
+    if (!parser.parse(arguments, Core::ArgsParser::FailureBehavior::PrintUsage))
+        return 1;
+
+    if (count != 1) {
+        raise_error(ShellError::EvaluatedSyntaxError, "break: count must be equal to 1 (NYI)");
+        return 1;
+    }
+
+    raise_error(ShellError::InternalControlFlowBreak, "POSIX break");
+
+    return 0;
+}
+
+ErrorOr<int> Shell::builtin_continue(Main::Arguments arguments)
+{
+    if (!m_in_posix_mode) {
+        raise_error(ShellError::EvaluatedSyntaxError, "break: Invalid use of builtin continue in non-POSIX mode");
+        return 1;
+    }
+
+    unsigned count = 1;
+
+    Core::ArgsParser parser;
+    parser.add_positional_argument(count, "Number of loops to 'continue' out of", "count", Core::ArgsParser::Required::No);
+
+    if (!parser.parse(arguments, Core::ArgsParser::FailureBehavior::PrintUsage))
+        return 1;
+
+    if (count != 0) {
+        raise_error(ShellError::EvaluatedSyntaxError, "continue: count must be equal to 1 (NYI)");
+        return 1;
+    }
+
+    raise_error(ShellError::InternalControlFlowContinue, "POSIX continue");
+
+    return 0;
+}
+
 ErrorOr<int> Shell::builtin_bg(Main::Arguments arguments)
 {
     int job_id = -1;

--- a/Userland/Shell/ImmediateFunctions.cpp
+++ b/Userland/Shell/ImmediateFunctions.cpp
@@ -515,9 +515,14 @@ ErrorOr<RefPtr<AST::Node>> Shell::immediate_null_or_alternative(AST::ImmediateEx
         return nullptr;
     }
 
-    auto value = TRY(TRY(const_cast<AST::Node&>(*arguments.first()).run(*this))->resolve_without_cast(*this));
+    auto name = TRY(TRY(const_cast<AST::Node&>(*arguments.first()).run(*this))->resolve_as_string(*this));
+    auto frame = find_frame_containing_local_variable(name);
+    if (!frame)
+        return make_ref_counted<AST::StringLiteral>(invoking_node.position(), ""_short_string, AST::StringLiteral::EnclosureType::None);
+
+    auto value = frame->local_variables.get(name.bytes_as_string_view()).value();
     if ((value->is_string() && TRY(value->resolve_as_string(*this)).is_empty()) || (value->is_list() && TRY(value->resolve_as_list(*this)).is_empty()))
-        return make_ref_counted<AST::SyntheticNode>(invoking_node.position(), value);
+        return make_ref_counted<AST::SyntheticNode>(invoking_node.position(), *value);
 
     return arguments.last();
 }

--- a/Userland/Shell/ImmediateFunctions.cpp
+++ b/Userland/Shell/ImmediateFunctions.cpp
@@ -1245,7 +1245,7 @@ ErrorOr<RefPtr<AST::Node>> Shell::immediate_math(AST::ImmediateExpression& invok
             [&](String const& name) -> ErrorOr<i64> {
                 size_t resolution_attempts_remaining = 100;
                 for (auto resolved_name = name; resolution_attempts_remaining > 0; --resolution_attempts_remaining) {
-                    auto value = TRY(lookup_local_variable(resolved_name.bytes_as_string_view()));
+                    auto value = TRY(look_up_local_variable(resolved_name.bytes_as_string_view()));
                     if (!value)
                         break;
 

--- a/Userland/Shell/PosixLexer.cpp
+++ b/Userland/Shell/PosixLexer.cpp
@@ -581,9 +581,13 @@ ErrorOr<Lexer::ReductionResult> Lexer::reduce_start()
         m_state.on_new_line = true;
 
         m_state.buffer.clear();
+        m_state.position.start_offset = m_state.position.end_offset;
+        m_state.position.start_line = m_state.position.end_line;
+
+        Vector<Token> tokens { move(token), Token::newline() };
 
         return ReductionResult {
-            .tokens = { move(token) },
+            .tokens = move(tokens),
             .next_reduction = Reduction::Start,
         };
     }

--- a/Userland/Shell/PosixLexer.cpp
+++ b/Userland/Shell/PosixLexer.cpp
@@ -41,7 +41,7 @@ ErrorOr<Vector<Token>> Lexer::batch_next(Optional<Reduction> starting_reduction)
 ExpansionRange Lexer::range(ssize_t offset) const
 {
     return {
-        m_state.position.end_offset - m_state.position.start_offset + offset - 1,
+        m_state.position.end_offset - m_state.position.start_offset + offset,
         0,
     };
 }
@@ -358,15 +358,15 @@ ErrorOr<Lexer::ReductionResult> Lexer::reduce_double_quoted_string()
         };
     case '$':
         if (m_lexer.next_is("("))
-            m_state.expansions.empend(CommandExpansion { .command = StringBuilder {}, .range = range() });
+            m_state.expansions.empend(CommandExpansion { .command = StringBuilder {}, .range = range(-1) });
         else
-            m_state.expansions.empend(ParameterExpansion { .parameter = StringBuilder {}, .range = range() });
+            m_state.expansions.empend(ParameterExpansion { .parameter = StringBuilder {}, .range = range(-1) });
         return ReductionResult {
             .tokens = {},
             .next_reduction = Reduction::Expansion,
         };
     case '`':
-        m_state.expansions.empend(CommandExpansion { .command = StringBuilder {}, .range = range() });
+        m_state.expansions.empend(CommandExpansion { .command = StringBuilder {}, .range = range(-1) });
         return ReductionResult {
             .tokens = {},
             .next_reduction = Reduction::CommandExpansion,
@@ -498,9 +498,9 @@ ErrorOr<Lexer::ReductionResult> Lexer::reduce_heredoc_contents()
     if (!m_state.escaping && consume_specific('$')) {
         m_state.buffer.append('$');
         if (m_lexer.next_is("("))
-            m_state.expansions.empend(CommandExpansion { .command = StringBuilder {}, .range = range() });
+            m_state.expansions.empend(CommandExpansion { .command = StringBuilder {}, .range = range(-1) });
         else
-            m_state.expansions.empend(ParameterExpansion { .parameter = StringBuilder {}, .range = range() });
+            m_state.expansions.empend(ParameterExpansion { .parameter = StringBuilder {}, .range = range(-1) });
 
         return ReductionResult {
             .tokens = {},
@@ -510,7 +510,7 @@ ErrorOr<Lexer::ReductionResult> Lexer::reduce_heredoc_contents()
 
     if (!m_state.escaping && consume_specific('`')) {
         m_state.buffer.append('`');
-        m_state.expansions.empend(CommandExpansion { .command = StringBuilder {}, .range = range() });
+        m_state.expansions.empend(CommandExpansion { .command = StringBuilder {}, .range = range(-1) });
         return ReductionResult {
             .tokens = {},
             .next_reduction = Reduction::CommandExpansion,
@@ -682,9 +682,9 @@ ErrorOr<Lexer::ReductionResult> Lexer::reduce_start()
     if (!m_state.escaping && consume_specific('$')) {
         m_state.buffer.append('$');
         if (m_lexer.next_is("("))
-            m_state.expansions.empend(CommandExpansion { .command = StringBuilder {}, .range = range() });
+            m_state.expansions.empend(CommandExpansion { .command = StringBuilder {}, .range = range(-1) });
         else
-            m_state.expansions.empend(ParameterExpansion { .parameter = StringBuilder {}, .range = range() });
+            m_state.expansions.empend(ParameterExpansion { .parameter = StringBuilder {}, .range = range(-1) });
 
         return ReductionResult {
             .tokens = {},
@@ -694,7 +694,7 @@ ErrorOr<Lexer::ReductionResult> Lexer::reduce_start()
 
     if (!m_state.escaping && consume_specific('`')) {
         m_state.buffer.append('`');
-        m_state.expansions.empend(CommandExpansion { .command = StringBuilder {}, .range = range() });
+        m_state.expansions.empend(CommandExpansion { .command = StringBuilder {}, .range = range(-1) });
         return ReductionResult {
             .tokens = {},
             .next_reduction = Reduction::CommandExpansion,
@@ -749,7 +749,7 @@ ErrorOr<Lexer::ReductionResult> Lexer::reduce_special_parameter_expansion()
     m_state.buffer.append(ch);
     m_state.expansions.last() = ParameterExpansion {
         .parameter = StringBuilder {},
-        .range = range(-1),
+        .range = range(-2),
     };
     auto& expansion = m_state.expansions.last().get<ParameterExpansion>();
     expansion.parameter.append(ch);

--- a/Userland/Shell/PosixLexer.h
+++ b/Userland/Shell/PosixLexer.h
@@ -321,6 +321,8 @@ struct Token {
             return Token::Type::Great;
         if (name == "<"sv)
             return Token::Type::Less;
+        if (name == "\n"sv)
+            return Token::Type::Newline;
 
         return {};
     }

--- a/Userland/Shell/PosixParser.cpp
+++ b/Userland/Shell/PosixParser.cpp
@@ -1685,6 +1685,10 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_word()
             switch (ch) {
             case '\\':
                 if (!escape && i + 1 < string.length()) {
+                    if (run_start.has_value())
+                        TRY(append_string_literal(string.substring_view(*run_start, i - *run_start)));
+                    run_start = i + 1;
+
                     if (is_one_of(string[i + 1], '"', '\'', '$', '`', '\\')) {
                         escape = in_quote != Quote::Single;
                         continue;

--- a/Userland/Shell/PosixParser.cpp
+++ b/Userland/Shell/PosixParser.cpp
@@ -417,7 +417,7 @@ Vector<Token> Parser::perform_expansions(Vector<Token> tokens)
                         }
 
                         return ResolvedParameterExpansion {
-                            .parameter = {},
+                            .parameter = String::from_code_point(text[0]),
                             .argument = {},
                             .range = expansion.range,
                             .op = op,

--- a/Userland/Shell/PosixParser.cpp
+++ b/Userland/Shell/PosixParser.cpp
@@ -1365,11 +1365,14 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_for_clause()
         iterated_expression = parse_word_list();
 
     if (saw_in) {
-        if (peek().type == Token::Type::Semicolon)
+        if (peek().type == Token::Type::Semicolon || peek().type == Token::Type::Newline)
             skip();
         else
             error(peek(), "Expected a semicolon, not {}", peek().type_name());
     }
+
+    while (peek().type == Token::Type::Newline)
+        skip();
 
     auto body = TRY(parse_do_group());
     return AST::make_ref_counted<AST::ForLoop>(

--- a/Userland/Shell/PosixParser.cpp
+++ b/Userland/Shell/PosixParser.cpp
@@ -698,6 +698,9 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_list()
 
 ErrorOr<RefPtr<AST::Node>> Parser::parse_and_or()
 {
+    while (peek().type == Token::Type::Newline)
+        skip();
+
     auto node = TRY(parse_pipeline());
     if (!node)
         return RefPtr<AST::Node> {};

--- a/Userland/Shell/PosixParser.h
+++ b/Userland/Shell/PosixParser.h
@@ -54,6 +54,7 @@ private:
     {
         if (eof())
             return;
+        handle_heredoc_contents();
         m_token_index++;
     }
     bool eof() const

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -352,7 +352,7 @@ Shell::LocalFrame* Shell::find_frame_containing_local_variable(StringView name)
     return nullptr;
 }
 
-ErrorOr<RefPtr<AST::Value const>> Shell::lookup_local_variable(StringView name) const
+ErrorOr<RefPtr<AST::Value const>> Shell::look_up_local_variable(StringView name) const
 {
     if (auto* frame = find_frame_containing_local_variable(name))
         return frame->local_variables.get(name).value();
@@ -369,7 +369,7 @@ ErrorOr<RefPtr<AST::Value const>> Shell::get_argument(size_t index) const
         return adopt_ref(*new AST::StringValue(TRY(String::from_deprecated_string(current_script))));
 
     --index;
-    if (auto argv = TRY(lookup_local_variable("ARGV"sv))) {
+    if (auto argv = TRY(look_up_local_variable("ARGV"sv))) {
         if (argv->is_list_without_resolution()) {
             AST::ListValue const* list = static_cast<AST::ListValue const*>(argv.ptr());
             if (list->values().size() <= index)
@@ -389,7 +389,7 @@ ErrorOr<RefPtr<AST::Value const>> Shell::get_argument(size_t index) const
 
 ErrorOr<DeprecatedString> Shell::local_variable_or(StringView name, DeprecatedString const& replacement) const
 {
-    auto value = TRY(lookup_local_variable(name));
+    auto value = TRY(look_up_local_variable(name));
     if (value) {
         StringBuilder builder;
         builder.join(' ', TRY(const_cast<AST::Value&>(*value).resolve_as_list(const_cast<Shell&>(*this))));
@@ -1095,7 +1095,7 @@ bool Shell::is_allowed_to_modify_termios(const AST::Command& command) const
     if (command.argv.is_empty())
         return false;
 
-    auto value = lookup_local_variable("PROGRAMS_ALLOWED_TO_MODIFY_DEFAULT_TERMIOS"sv);
+    auto value = look_up_local_variable("PROGRAMS_ALLOWED_TO_MODIFY_DEFAULT_TERMIOS"sv);
     if (value.is_error())
         return false;
 

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -308,6 +308,8 @@ public:
 
     void notify_child_event();
 
+    bool posix_mode() const { return m_in_posix_mode; }
+
     struct termios termios;
     struct termios default_termios;
     bool was_interrupted { false };

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -23,40 +23,41 @@
 #include <LibMain/Main.h>
 #include <termios.h>
 
-#define ENUMERATE_SHELL_BUILTINS()      \
-    __ENUMERATE_SHELL_BUILTIN(alias)    \
-    __ENUMERATE_SHELL_BUILTIN(where)    \
-    __ENUMERATE_SHELL_BUILTIN(cd)       \
-    __ENUMERATE_SHELL_BUILTIN(cdh)      \
-    __ENUMERATE_SHELL_BUILTIN(pwd)      \
-    __ENUMERATE_SHELL_BUILTIN(type)     \
-    __ENUMERATE_SHELL_BUILTIN(exec)     \
-    __ENUMERATE_SHELL_BUILTIN(exit)     \
-    __ENUMERATE_SHELL_BUILTIN(export)   \
-    __ENUMERATE_SHELL_BUILTIN(glob)     \
-    __ENUMERATE_SHELL_BUILTIN(unalias)  \
-    __ENUMERATE_SHELL_BUILTIN(unset)    \
-    __ENUMERATE_SHELL_BUILTIN(history)  \
-    __ENUMERATE_SHELL_BUILTIN(umask)    \
-    __ENUMERATE_SHELL_BUILTIN(not )     \
-    __ENUMERATE_SHELL_BUILTIN(dirs)     \
-    __ENUMERATE_SHELL_BUILTIN(pushd)    \
-    __ENUMERATE_SHELL_BUILTIN(popd)     \
-    __ENUMERATE_SHELL_BUILTIN(setopt)   \
-    __ENUMERATE_SHELL_BUILTIN(shift)    \
-    __ENUMERATE_SHELL_BUILTIN(source)   \
-    __ENUMERATE_SHELL_BUILTIN(time)     \
-    __ENUMERATE_SHELL_BUILTIN(jobs)     \
-    __ENUMERATE_SHELL_BUILTIN(disown)   \
-    __ENUMERATE_SHELL_BUILTIN(fg)       \
-    __ENUMERATE_SHELL_BUILTIN(bg)       \
-    __ENUMERATE_SHELL_BUILTIN(wait)     \
-    __ENUMERATE_SHELL_BUILTIN(dump)     \
-    __ENUMERATE_SHELL_BUILTIN(kill)     \
-    __ENUMERATE_SHELL_BUILTIN(noop)     \
-    __ENUMERATE_SHELL_BUILTIN(break)    \
-    __ENUMERATE_SHELL_BUILTIN(continue) \
-    __ENUMERATE_SHELL_BUILTIN(read)     \
+#define ENUMERATE_SHELL_BUILTINS()          \
+    __ENUMERATE_SHELL_BUILTIN(alias)        \
+    __ENUMERATE_SHELL_BUILTIN(where)        \
+    __ENUMERATE_SHELL_BUILTIN(cd)           \
+    __ENUMERATE_SHELL_BUILTIN(cdh)          \
+    __ENUMERATE_SHELL_BUILTIN(pwd)          \
+    __ENUMERATE_SHELL_BUILTIN(type)         \
+    __ENUMERATE_SHELL_BUILTIN(exec)         \
+    __ENUMERATE_SHELL_BUILTIN(exit)         \
+    __ENUMERATE_SHELL_BUILTIN(export)       \
+    __ENUMERATE_SHELL_BUILTIN(glob)         \
+    __ENUMERATE_SHELL_BUILTIN(unalias)      \
+    __ENUMERATE_SHELL_BUILTIN(unset)        \
+    __ENUMERATE_SHELL_BUILTIN(history)      \
+    __ENUMERATE_SHELL_BUILTIN(umask)        \
+    __ENUMERATE_SHELL_BUILTIN(not )         \
+    __ENUMERATE_SHELL_BUILTIN(dirs)         \
+    __ENUMERATE_SHELL_BUILTIN(pushd)        \
+    __ENUMERATE_SHELL_BUILTIN(popd)         \
+    __ENUMERATE_SHELL_BUILTIN(setopt)       \
+    __ENUMERATE_SHELL_BUILTIN(shift)        \
+    __ENUMERATE_SHELL_BUILTIN(source)       \
+    __ENUMERATE_SHELL_BUILTIN(time)         \
+    __ENUMERATE_SHELL_BUILTIN(jobs)         \
+    __ENUMERATE_SHELL_BUILTIN(disown)       \
+    __ENUMERATE_SHELL_BUILTIN(fg)           \
+    __ENUMERATE_SHELL_BUILTIN(bg)           \
+    __ENUMERATE_SHELL_BUILTIN(wait)         \
+    __ENUMERATE_SHELL_BUILTIN(dump)         \
+    __ENUMERATE_SHELL_BUILTIN(kill)         \
+    __ENUMERATE_SHELL_BUILTIN(noop)         \
+    __ENUMERATE_SHELL_BUILTIN(break)        \
+    __ENUMERATE_SHELL_BUILTIN(continue)     \
+    __ENUMERATE_SHELL_BUILTIN(read)         \
+    __ENUMERATE_SHELL_BUILTIN(run_with_env) \
     __ENUMERATE_SHELL_BUILTIN(argsparser_parse)
 
 #define ENUMERATE_SHELL_OPTIONS()                                                                                    \

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -183,7 +183,7 @@ public:
     static bool has_history_event(StringView);
 
     ErrorOr<RefPtr<AST::Value const>> get_argument(size_t) const;
-    ErrorOr<RefPtr<AST::Value const>> lookup_local_variable(StringView) const;
+    ErrorOr<RefPtr<AST::Value const>> look_up_local_variable(StringView) const;
     ErrorOr<DeprecatedString> local_variable_or(StringView, DeprecatedString const&) const;
     void set_local_variable(DeprecatedString const&, RefPtr<AST::Value>, bool only_in_current_frame = false);
     void unset_local_variable(StringView, bool only_in_current_frame = false);

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -23,42 +23,42 @@
 #include <LibMain/Main.h>
 #include <termios.h>
 
-#define ENUMERATE_SHELL_BUILTINS()          \
-    __ENUMERATE_SHELL_BUILTIN(alias)        \
-    __ENUMERATE_SHELL_BUILTIN(where)        \
-    __ENUMERATE_SHELL_BUILTIN(cd)           \
-    __ENUMERATE_SHELL_BUILTIN(cdh)          \
-    __ENUMERATE_SHELL_BUILTIN(pwd)          \
-    __ENUMERATE_SHELL_BUILTIN(type)         \
-    __ENUMERATE_SHELL_BUILTIN(exec)         \
-    __ENUMERATE_SHELL_BUILTIN(exit)         \
-    __ENUMERATE_SHELL_BUILTIN(export)       \
-    __ENUMERATE_SHELL_BUILTIN(glob)         \
-    __ENUMERATE_SHELL_BUILTIN(unalias)      \
-    __ENUMERATE_SHELL_BUILTIN(unset)        \
-    __ENUMERATE_SHELL_BUILTIN(history)      \
-    __ENUMERATE_SHELL_BUILTIN(umask)        \
-    __ENUMERATE_SHELL_BUILTIN(not )         \
-    __ENUMERATE_SHELL_BUILTIN(dirs)         \
-    __ENUMERATE_SHELL_BUILTIN(pushd)        \
-    __ENUMERATE_SHELL_BUILTIN(popd)         \
-    __ENUMERATE_SHELL_BUILTIN(setopt)       \
-    __ENUMERATE_SHELL_BUILTIN(shift)        \
-    __ENUMERATE_SHELL_BUILTIN(source)       \
-    __ENUMERATE_SHELL_BUILTIN(time)         \
-    __ENUMERATE_SHELL_BUILTIN(jobs)         \
-    __ENUMERATE_SHELL_BUILTIN(disown)       \
-    __ENUMERATE_SHELL_BUILTIN(fg)           \
-    __ENUMERATE_SHELL_BUILTIN(bg)           \
-    __ENUMERATE_SHELL_BUILTIN(wait)         \
-    __ENUMERATE_SHELL_BUILTIN(dump)         \
-    __ENUMERATE_SHELL_BUILTIN(kill)         \
-    __ENUMERATE_SHELL_BUILTIN(noop)         \
-    __ENUMERATE_SHELL_BUILTIN(break)        \
-    __ENUMERATE_SHELL_BUILTIN(continue)     \
-    __ENUMERATE_SHELL_BUILTIN(read)         \
-    __ENUMERATE_SHELL_BUILTIN(run_with_env) \
-    __ENUMERATE_SHELL_BUILTIN(argsparser_parse)
+#define ENUMERATE_SHELL_BUILTINS()                           \
+    __ENUMERATE_SHELL_BUILTIN(alias, InAllModes)             \
+    __ENUMERATE_SHELL_BUILTIN(where, InAllModes)             \
+    __ENUMERATE_SHELL_BUILTIN(cd, InAllModes)                \
+    __ENUMERATE_SHELL_BUILTIN(cdh, InAllModes)               \
+    __ENUMERATE_SHELL_BUILTIN(pwd, InAllModes)               \
+    __ENUMERATE_SHELL_BUILTIN(type, InAllModes)              \
+    __ENUMERATE_SHELL_BUILTIN(exec, InAllModes)              \
+    __ENUMERATE_SHELL_BUILTIN(exit, InAllModes)              \
+    __ENUMERATE_SHELL_BUILTIN(export, InAllModes)            \
+    __ENUMERATE_SHELL_BUILTIN(glob, InAllModes)              \
+    __ENUMERATE_SHELL_BUILTIN(unalias, InAllModes)           \
+    __ENUMERATE_SHELL_BUILTIN(unset, InAllModes)             \
+    __ENUMERATE_SHELL_BUILTIN(history, InAllModes)           \
+    __ENUMERATE_SHELL_BUILTIN(umask, InAllModes)             \
+    __ENUMERATE_SHELL_BUILTIN(not, InAllModes)               \
+    __ENUMERATE_SHELL_BUILTIN(dirs, InAllModes)              \
+    __ENUMERATE_SHELL_BUILTIN(pushd, InAllModes)             \
+    __ENUMERATE_SHELL_BUILTIN(popd, InAllModes)              \
+    __ENUMERATE_SHELL_BUILTIN(setopt, InAllModes)            \
+    __ENUMERATE_SHELL_BUILTIN(shift, InAllModes)             \
+    __ENUMERATE_SHELL_BUILTIN(source, InAllModes)            \
+    __ENUMERATE_SHELL_BUILTIN(time, InAllModes)              \
+    __ENUMERATE_SHELL_BUILTIN(jobs, InAllModes)              \
+    __ENUMERATE_SHELL_BUILTIN(disown, InAllModes)            \
+    __ENUMERATE_SHELL_BUILTIN(fg, InAllModes)                \
+    __ENUMERATE_SHELL_BUILTIN(bg, InAllModes)                \
+    __ENUMERATE_SHELL_BUILTIN(wait, InAllModes)              \
+    __ENUMERATE_SHELL_BUILTIN(dump, InAllModes)              \
+    __ENUMERATE_SHELL_BUILTIN(kill, InAllModes)              \
+    __ENUMERATE_SHELL_BUILTIN(noop, InAllModes)              \
+    __ENUMERATE_SHELL_BUILTIN(break, OnlyInPOSIXMode)        \
+    __ENUMERATE_SHELL_BUILTIN(continue, OnlyInPOSIXMode)     \
+    __ENUMERATE_SHELL_BUILTIN(read, OnlyInPOSIXMode)         \
+    __ENUMERATE_SHELL_BUILTIN(run_with_env, OnlyInPOSIXMode) \
+    __ENUMERATE_SHELL_BUILTIN(argsparser_parse, InAllModes)
 
 #define ENUMERATE_SHELL_OPTIONS()                                                                                    \
     __ENUMERATE_SHELL_OPTION(inline_exec_keep_empty_segments, false, "Keep empty segments in inline execute $(...)") \
@@ -90,6 +90,11 @@
 namespace Shell {
 
 class Shell;
+
+enum class POSIXModeRequirement {
+    OnlyInPOSIXMode,
+    InAllModes,
+};
 
 class Shell : public Core::Object {
     C_OBJECT(Shell);
@@ -443,7 +448,7 @@ private:
 
     ErrorOr<RefPtr<AST::Node>> immediate_length_impl(AST::ImmediateExpression& invoking_node, Vector<NonnullRefPtr<AST::Node>> const&, bool across);
 
-#define __ENUMERATE_SHELL_BUILTIN(builtin) \
+#define __ENUMERATE_SHELL_BUILTIN(builtin, _mode) \
     ErrorOr<int> builtin_##builtin(Main::Arguments);
 
     ENUMERATE_SHELL_BUILTINS();
@@ -451,7 +456,7 @@ private:
 #undef __ENUMERATE_SHELL_BUILTIN
 
     static constexpr Array builtin_names = {
-#define __ENUMERATE_SHELL_BUILTIN(builtin) #builtin##sv,
+#define __ENUMERATE_SHELL_BUILTIN(builtin, _mode) #builtin##sv,
 
         ENUMERATE_SHELL_BUILTINS()
 

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -191,15 +191,21 @@ public:
 
     RefPtr<Line::Editor> editor() const { return m_editor; }
 
+    enum class LocalFrameKind {
+        FunctionOrGlobal,
+        Block,
+    };
     struct LocalFrame {
-        LocalFrame(DeprecatedString name, HashMap<DeprecatedString, RefPtr<AST::Value>> variables)
+        LocalFrame(DeprecatedString name, HashMap<DeprecatedString, RefPtr<AST::Value>> variables, LocalFrameKind kind = LocalFrameKind::Block)
             : name(move(name))
             , local_variables(move(variables))
+            , is_function_frame(kind == LocalFrameKind::FunctionOrGlobal)
         {
         }
 
         DeprecatedString name;
         HashMap<DeprecatedString, RefPtr<AST::Value>> local_variables;
+        bool is_function_frame;
     };
 
     struct Frame {
@@ -218,7 +224,7 @@ public:
         bool should_destroy_frame { true };
     };
 
-    [[nodiscard]] Frame push_frame(DeprecatedString name);
+    [[nodiscard]] Frame push_frame(DeprecatedString name, LocalFrameKind = LocalFrameKind::Block);
     void pop_frame();
 
     struct Promise {

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -23,37 +23,39 @@
 #include <LibMain/Main.h>
 #include <termios.h>
 
-#define ENUMERATE_SHELL_BUILTINS()     \
-    __ENUMERATE_SHELL_BUILTIN(alias)   \
-    __ENUMERATE_SHELL_BUILTIN(where)   \
-    __ENUMERATE_SHELL_BUILTIN(cd)      \
-    __ENUMERATE_SHELL_BUILTIN(cdh)     \
-    __ENUMERATE_SHELL_BUILTIN(pwd)     \
-    __ENUMERATE_SHELL_BUILTIN(type)    \
-    __ENUMERATE_SHELL_BUILTIN(exec)    \
-    __ENUMERATE_SHELL_BUILTIN(exit)    \
-    __ENUMERATE_SHELL_BUILTIN(export)  \
-    __ENUMERATE_SHELL_BUILTIN(glob)    \
-    __ENUMERATE_SHELL_BUILTIN(unalias) \
-    __ENUMERATE_SHELL_BUILTIN(unset)   \
-    __ENUMERATE_SHELL_BUILTIN(history) \
-    __ENUMERATE_SHELL_BUILTIN(umask)   \
-    __ENUMERATE_SHELL_BUILTIN(not )    \
-    __ENUMERATE_SHELL_BUILTIN(dirs)    \
-    __ENUMERATE_SHELL_BUILTIN(pushd)   \
-    __ENUMERATE_SHELL_BUILTIN(popd)    \
-    __ENUMERATE_SHELL_BUILTIN(setopt)  \
-    __ENUMERATE_SHELL_BUILTIN(shift)   \
-    __ENUMERATE_SHELL_BUILTIN(source)  \
-    __ENUMERATE_SHELL_BUILTIN(time)    \
-    __ENUMERATE_SHELL_BUILTIN(jobs)    \
-    __ENUMERATE_SHELL_BUILTIN(disown)  \
-    __ENUMERATE_SHELL_BUILTIN(fg)      \
-    __ENUMERATE_SHELL_BUILTIN(bg)      \
-    __ENUMERATE_SHELL_BUILTIN(wait)    \
-    __ENUMERATE_SHELL_BUILTIN(dump)    \
-    __ENUMERATE_SHELL_BUILTIN(kill)    \
-    __ENUMERATE_SHELL_BUILTIN(noop)    \
+#define ENUMERATE_SHELL_BUILTINS()      \
+    __ENUMERATE_SHELL_BUILTIN(alias)    \
+    __ENUMERATE_SHELL_BUILTIN(where)    \
+    __ENUMERATE_SHELL_BUILTIN(cd)       \
+    __ENUMERATE_SHELL_BUILTIN(cdh)      \
+    __ENUMERATE_SHELL_BUILTIN(pwd)      \
+    __ENUMERATE_SHELL_BUILTIN(type)     \
+    __ENUMERATE_SHELL_BUILTIN(exec)     \
+    __ENUMERATE_SHELL_BUILTIN(exit)     \
+    __ENUMERATE_SHELL_BUILTIN(export)   \
+    __ENUMERATE_SHELL_BUILTIN(glob)     \
+    __ENUMERATE_SHELL_BUILTIN(unalias)  \
+    __ENUMERATE_SHELL_BUILTIN(unset)    \
+    __ENUMERATE_SHELL_BUILTIN(history)  \
+    __ENUMERATE_SHELL_BUILTIN(umask)    \
+    __ENUMERATE_SHELL_BUILTIN(not )     \
+    __ENUMERATE_SHELL_BUILTIN(dirs)     \
+    __ENUMERATE_SHELL_BUILTIN(pushd)    \
+    __ENUMERATE_SHELL_BUILTIN(popd)     \
+    __ENUMERATE_SHELL_BUILTIN(setopt)   \
+    __ENUMERATE_SHELL_BUILTIN(shift)    \
+    __ENUMERATE_SHELL_BUILTIN(source)   \
+    __ENUMERATE_SHELL_BUILTIN(time)     \
+    __ENUMERATE_SHELL_BUILTIN(jobs)     \
+    __ENUMERATE_SHELL_BUILTIN(disown)   \
+    __ENUMERATE_SHELL_BUILTIN(fg)       \
+    __ENUMERATE_SHELL_BUILTIN(bg)       \
+    __ENUMERATE_SHELL_BUILTIN(wait)     \
+    __ENUMERATE_SHELL_BUILTIN(dump)     \
+    __ENUMERATE_SHELL_BUILTIN(kill)     \
+    __ENUMERATE_SHELL_BUILTIN(noop)     \
+    __ENUMERATE_SHELL_BUILTIN(break)    \
+    __ENUMERATE_SHELL_BUILTIN(continue) \
     __ENUMERATE_SHELL_BUILTIN(argsparser_parse)
 
 #define ENUMERATE_SHELL_OPTIONS()                                                                                    \

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -56,6 +56,7 @@
     __ENUMERATE_SHELL_BUILTIN(noop)     \
     __ENUMERATE_SHELL_BUILTIN(break)    \
     __ENUMERATE_SHELL_BUILTIN(continue) \
+    __ENUMERATE_SHELL_BUILTIN(read)     \
     __ENUMERATE_SHELL_BUILTIN(argsparser_parse)
 
 #define ENUMERATE_SHELL_OPTIONS()                                                                                    \


### PR DESCRIPTION
```console
❯ Build/lagom/Userland/Shell/Shell --posix config.sub x86_64-serenity
x86_64-pc-serenity

❯ Build/lagom/Userland/Shell/Shell --posix config.sub x86_64-cray
x86_64-cray-none

❯ Build/lagom/Userland/Shell/Shell --posix config.sub tpf
s390x-ibm-tpf
```

~~Note: The repeated `-`s are a bug, but I ran out of time, so will be debugging those later.~~