### PR TITLE
LibWeb: Stop parsing `auto` as a LengthStyleValue, fixing some bugs

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3382,10 +3382,6 @@ Optional<Length> Parser::parse_length(ComponentValue const& component_value)
     if (dimension->is_length())
         return dimension->length();
 
-    // FIXME: auto isn't a length!
-    if (component_value.is(Token::Type::Ident) && component_value.token().ident().equals_ignoring_ascii_case("auto"sv))
-        return Length::make_auto();
-
     return {};
 }
 
@@ -3677,9 +3673,6 @@ RefPtr<StyleValue> Parser::parse_dimension_value(ComponentValue const& component
 
     if (component_value.is(Token::Type::Number) && !(m_context.in_quirks_mode() && property_has_quirk(m_context.current_property_id(), Quirk::UnitlessLength)))
         return {};
-
-    if (component_value.is(Token::Type::Ident) && component_value.token().ident().equals_ignoring_ascii_case("auto"sv))
-        return LengthStyleValue::create(Length::make_auto());
 
     auto dimension = parse_dimension(component_value);
     if (!dimension.has_value())

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4388,7 +4388,7 @@ RefPtr<StyleValue> Parser::parse_single_background_position_value(TokenStream<Co
             return zero_offset;
         };
 
-        if (value->has_identifier()) {
+        if (value->is_identifier()) {
             auto identifier = value->to_identifier();
             if (is_horizontal(identifier)) {
                 bool offset_provided = false;
@@ -4474,7 +4474,7 @@ RefPtr<StyleValue> Parser::parse_single_background_position_x_or_y_value(TokenSt
     };
 
     auto value = parse_value(tokens.next_token());
-    if (value->has_identifier()) {
+    if (value->is_identifier()) {
         auto identifier = value->to_identifier();
         if (identifier == ValueID::Center) {
             transaction.commit();

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5128,17 +5128,6 @@ RefPtr<StyleValue> Parser::parse_flex_value(Vector<ComponentValue> const& compon
         if (!value)
             return nullptr;
 
-        if (value->is_identifier() && property_accepts_value(PropertyID::Flex, *value)) {
-            switch (value->to_identifier()) {
-            case ValueID::None: {
-                auto zero = NumericStyleValue::create_integer(0);
-                return FlexStyleValue::create(zero, zero, IdentifierStyleValue::create(ValueID::Auto));
-            }
-            default:
-                return value;
-            }
-        }
-
         if (property_accepts_value(PropertyID::FlexGrow, *value)) {
             // NOTE: The spec says that flex-basis should be 0 here, but other engines currently use 0%.
             // https://github.com/w3c/csswg-drafts/issues/5742
@@ -5150,6 +5139,17 @@ RefPtr<StyleValue> Parser::parse_flex_value(Vector<ComponentValue> const& compon
         if (property_accepts_value(PropertyID::FlexBasis, *value)) {
             auto one = NumericStyleValue::create_integer(1);
             return FlexStyleValue::create(one, one, *value);
+        }
+
+        if (value->is_identifier() && property_accepts_value(PropertyID::Flex, *value)) {
+            switch (value->to_identifier()) {
+            case ValueID::None: {
+                auto zero = NumericStyleValue::create_integer(0);
+                return FlexStyleValue::create(zero, zero, IdentifierStyleValue::create(ValueID::Auto));
+            }
+            default:
+                return value;
+            }
         }
 
         return nullptr;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4579,6 +4579,8 @@ RefPtr<StyleValue> Parser::parse_single_background_size_value(TokenStream<Compon
     auto transaction = tokens.begin_transaction();
 
     auto get_length_percentage = [](StyleValue& style_value) -> Optional<LengthPercentage> {
+        if (style_value.has_auto())
+            return LengthPercentage { Length::make_auto() };
         if (style_value.is_percentage())
             return LengthPercentage { style_value.as_percentage().percentage() };
         if (style_value.has_length())

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -166,6 +166,8 @@ static NonnullRefPtr<StyleValue const> value_or_default(Optional<StyleProperty> 
 
 static NonnullRefPtr<StyleValue const> style_value_for_length_percentage(LengthPercentage const& length_percentage)
 {
+    if (length_percentage.is_auto())
+        return IdentifierStyleValue::create(ValueID::Auto);
     if (length_percentage.is_percentage())
         return PercentageStyleValue::create(length_percentage.percentage());
     if (length_percentage.is_length())
@@ -595,11 +597,7 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
     }
     case CSS::PropertyID::VerticalAlign:
         if (auto const* length_percentage = layout_node.computed_values().vertical_align().get_pointer<CSS::LengthPercentage>()) {
-            if (length_percentage->is_length())
-                return LengthStyleValue::create(length_percentage->length());
-            if (length_percentage->is_percentage())
-                return PercentageStyleValue::create(length_percentage->percentage());
-            VERIFY_NOT_REACHED();
+            return style_value_for_length_percentage(*length_percentage);
         }
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().vertical_align().get<CSS::VerticalAlign>()));
     case CSS::PropertyID::WhiteSpace:

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -114,6 +114,9 @@ Optional<LengthPercentage> StyleProperties::length_percentage(CSS::PropertyID id
     if (value->has_length())
         return value->to_length();
 
+    if (value->has_auto())
+        return LengthPercentage { Length::make_auto() };
+
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -336,4 +336,16 @@ ValueComparingNonnullRefPtr<StyleValue const> StyleValue::absolutized(CSSPixelRe
     return *this;
 }
 
+bool StyleValue::has_auto() const
+{
+    return is_identifier() && as_identifier().id() == ValueID::Auto;
+}
+
+ValueID StyleValue::to_identifier() const
+{
+    if (is_identifier())
+        return as_identifier().id();
+    return ValueID::Invalid;
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -276,9 +276,8 @@ public:
     UnsetStyleValue& as_unset() { return const_cast<UnsetStyleValue&>(const_cast<StyleValue const&>(*this).as_unset()); }
     StyleValueList& as_value_list() { return const_cast<StyleValueList&>(const_cast<StyleValue const&>(*this).as_value_list()); }
 
-    virtual bool has_auto() const { return false; }
+    bool has_auto() const;
     virtual bool has_color() const { return false; }
-    virtual bool has_identifier() const { return false; }
     virtual bool has_length() const { return false; }
     virtual bool has_rect() const { return false; }
     virtual bool has_number() const { return false; }
@@ -287,7 +286,7 @@ public:
     virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const;
 
     virtual Color to_color(Layout::NodeWithStyle const&) const { return {}; }
-    virtual CSS::ValueID to_identifier() const { return ValueID::Invalid; }
+    ValueID to_identifier() const;
     virtual Length to_length() const { VERIFY_NOT_REACHED(); }
     virtual float to_number() const { return 0; }
     virtual float to_integer() const { return 0; }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/IdentifierStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/IdentifierStyleValue.h
@@ -24,9 +24,6 @@ public:
 
     ValueID id() const { return m_id; }
 
-    virtual bool has_auto() const override { return m_id == ValueID::Auto; }
-    virtual bool has_identifier() const override { return true; }
-    virtual ValueID to_identifier() const override { return m_id; }
     virtual bool has_color() const override;
     virtual Color to_color(Layout::NodeWithStyle const& node) const override;
     virtual ErrorOr<String> to_string() const override;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.cpp
@@ -13,10 +13,7 @@ namespace Web::CSS {
 
 ValueComparingNonnullRefPtr<LengthStyleValue> LengthStyleValue::create(Length const& length)
 {
-    if (length.is_auto()) {
-        static auto value = adopt_ref(*new LengthStyleValue(CSS::Length::make_auto()));
-        return value;
-    }
+    VERIFY(!length.is_auto());
     if (length.is_px()) {
         if (length.raw_value() == 0) {
             static auto value = adopt_ref(*new LengthStyleValue(CSS::Length::make_px(0)));

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
@@ -20,12 +20,9 @@ public:
 
     Length const& length() const { return m_length; }
 
-    virtual bool has_auto() const override { return m_length.is_auto(); }
     virtual bool has_length() const override { return true; }
-    virtual bool has_identifier() const override { return has_auto(); }
     virtual ErrorOr<String> to_string() const override { return m_length.to_string(); }
     virtual Length to_length() const override { return m_length; }
-    virtual ValueID to_identifier() const override { return has_auto() ? ValueID::Auto : ValueID::Invalid; }
     virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const override;
 
     bool properties_equal(LengthStyleValue const& other) const { return m_length == other.m_length; }

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -334,7 +334,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
                 }
             }
 
-            if (auto attachment_value = value_for_layer(attachments, layer_index); attachment_value && attachment_value->has_identifier()) {
+            if (auto attachment_value = value_for_layer(attachments, layer_index); attachment_value && attachment_value->is_identifier()) {
                 switch (attachment_value->to_identifier()) {
                 case CSS::ValueID::Fixed:
                     layer.attachment = CSS::BackgroundAttachment::Fixed;
@@ -363,11 +363,11 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
                 }
             };
 
-            if (auto origin_value = value_for_layer(origins, layer_index); origin_value && origin_value->has_identifier()) {
+            if (auto origin_value = value_for_layer(origins, layer_index); origin_value && origin_value->is_identifier()) {
                 layer.origin = as_box(origin_value->to_identifier());
             }
 
-            if (auto clip_value = value_for_layer(clips, layer_index); clip_value && clip_value->has_identifier()) {
+            if (auto clip_value = value_for_layer(clips, layer_index); clip_value && clip_value->is_identifier()) {
                 layer.clip = as_box(clip_value->to_identifier());
             }
 
@@ -389,7 +389,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
                     layer.size_type = CSS::BackgroundSize::LengthPercentage;
                     layer.size_x = size.size_x();
                     layer.size_y = size.size_y();
-                } else if (size_value->has_identifier()) {
+                } else if (size_value->is_identifier()) {
                     switch (size_value->to_identifier()) {
                     case CSS::ValueID::Contain:
                         layer.size_type = CSS::BackgroundSize::Contain;


### PR DESCRIPTION
The fact that either a `LengthStyleValue` or `IdentifierStyleValue` could hold `auto` was causing bugs, as well as confusion. As noted, the "can this property accept this value?" check was broken if the property accepted `<length>`, since it would automatically accept `auto` too whether you wanted it to or not.

This PR fixes that issue by ensuring that `auto` is always an `IdentifierStyleValue`. (And there's a `VERIFY()` to make sure we don't create a `LengthStyleValue` by accident.) This also lets us clean up some of the extra complexity that was required to make the old way work.

`Length::make_auto()` still exists for now, but at least as far as StyleValues are concerned the typing is a bit clearer.