### PR TITLE
LibWeb: Use device pixels to translate NestedBrowsingContextPaintable

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
@@ -51,7 +51,9 @@ void NestedBrowsingContextPaintable::paint(PaintContext& context, PaintPhase pha
         auto old_viewport_rect = context.device_viewport_rect();
 
         context.painter().add_clip_rect(clip_rect.to_type<int>());
-        context.painter().translate(absolute_rect.x().value(), absolute_rect.y().value());
+
+        auto absolute_device_rect = context.enclosing_device_rect(absolute_rect);
+        context.painter().translate(absolute_device_rect.x().value(), absolute_device_rect.y().value());
 
         context.set_device_viewport_rect({ {}, context.enclosing_device_size(layout_box().dom_node().nested_browsing_context()->size()) });
         const_cast<Layout::Viewport*>(hosted_layout_tree)->paint_all_phases(context);


### PR DESCRIPTION
Fix translation of iframes on devices where pixel size is not 1.0
For example iframe on https://www.jochentopf.com/