### PR TITLE
LibVideo/VP9: Optimizations Part 2: The Funny Number

### DIFF
--- a/Userland/Libraries/LibVideo/Color/ColorConverter.cpp
+++ b/Userland/Libraries/LibVideo/Color/ColorConverter.cpp
@@ -201,7 +201,7 @@ ALWAYS_INLINE FloatVector4 max_zero(FloatVector4 vector)
 }
 
 // Referencing https://en.wikipedia.org/wiki/YCbCr
-Gfx::Color ColorConverter::convert_yuv_to_full_range_rgb(u16 y, u16 u, u16 v)
+Gfx::Color ColorConverter::convert_yuv_to_full_range_rgb(u16 y, u16 u, u16 v) const
 {
     FloatVector4 color_vector = { static_cast<float>(y), static_cast<float>(u), static_cast<float>(v), 1.0f };
     color_vector = m_input_conversion_matrix * color_vector;

--- a/Userland/Libraries/LibVideo/Color/ColorConverter.h
+++ b/Userland/Libraries/LibVideo/Color/ColorConverter.h
@@ -31,7 +31,7 @@ public:
         return lookup_table;
     }
 
-    float do_lookup(float value) const
+    ALWAYS_INLINE float do_lookup(float value) const
     {
         float float_index = value * (maximum_value / static_cast<float>(Scale));
         if (float_index > maximum_value) [[unlikely]]
@@ -42,7 +42,7 @@ public:
         return value;
     }
 
-    FloatVector4 do_lookup(FloatVector4 vector) const
+    ALWAYS_INLINE FloatVector4 do_lookup(FloatVector4 vector) const
     {
         return {
             do_lookup(vector.x()),
@@ -58,12 +58,97 @@ private:
     Array<float, N> m_lookup_table;
 };
 
+static auto hlg_ootf_lookup_table = InterpolatedLookupTable<32, 1000>::create(
+    [](float value) {
+        return AK::pow(value, 1.2f - 1.0f);
+    });
+
 class ColorConverter final {
+
+private:
+    // Tonemapping methods are outlined here:
+    // https://64.github.io/tonemapping/
+
+    template<typename T>
+    static ALWAYS_INLINE constexpr T scalar_to_color_vector(float value)
+    {
+        if constexpr (IsSame<T, Gfx::VectorN<4, float>>) {
+            return Gfx::VectorN<4, float>(value, value, value, 1.0f);
+        } else if constexpr (IsSame<T, Gfx::VectorN<3, float>>) {
+            return Gfx::VectorN<3, float>(value, value, value);
+        } else {
+            static_assert(IsFloatingPoint<T>);
+            return static_cast<T>(value);
+        }
+    }
+
+    template<typename T>
+    static ALWAYS_INLINE constexpr T hable_tonemapping_partial(T value)
+    {
+        constexpr auto a = scalar_to_color_vector<T>(0.15f);
+        constexpr auto b = scalar_to_color_vector<T>(0.5f);
+        constexpr auto c = scalar_to_color_vector<T>(0.1f);
+        constexpr auto d = scalar_to_color_vector<T>(0.2f);
+        constexpr auto e = scalar_to_color_vector<T>(0.02f);
+        constexpr auto f = scalar_to_color_vector<T>(0.3f);
+        return ((value * (a * value + c * b) + d * e) / (value * (a * value + b) + d * f)) - e / f;
+    }
+
+    template<typename T>
+    static ALWAYS_INLINE constexpr T hable_tonemapping(T value)
+    {
+        constexpr auto exposure_bias = scalar_to_color_vector<T>(2.0f);
+        value = hable_tonemapping_partial<T>(value * exposure_bias);
+        constexpr auto scale = scalar_to_color_vector<T>(1.0f) / scalar_to_color_vector<T>(hable_tonemapping_partial(11.2f));
+        return value * scale;
+    }
 
 public:
     static DecoderErrorOr<ColorConverter> create(u8 bit_depth, CodingIndependentCodePoints cicp);
 
-    Gfx::Color convert_yuv_to_full_range_rgb(u16 y, u16 u, u16 v) const;
+    // Referencing https://en.wikipedia.org/wiki/YCbCr
+    ALWAYS_INLINE Gfx::Color convert_yuv_to_full_range_rgb(u16 y, u16 u, u16 v) const
+    {
+        auto max_zero = [](FloatVector4 vector) {
+            return FloatVector4(max(0.0f, vector.x()), max(0.0f, vector.y()), max(0.0f, vector.z()), vector.w());
+        };
+
+        FloatVector4 color_vector = { static_cast<float>(y), static_cast<float>(u), static_cast<float>(v), 1.0f };
+        color_vector = m_input_conversion_matrix * color_vector;
+
+        if (m_should_skip_color_remapping) {
+            color_vector.clamp(0.0f, 1.0f);
+        } else {
+            color_vector = max_zero(color_vector);
+            color_vector = m_to_linear_lookup.do_lookup(color_vector);
+
+            if (m_cicp.transfer_characteristics() == TransferCharacteristics::HLG) {
+                // See: https://en.wikipedia.org/wiki/Hybrid_log-gamma under a bolded section "HLG reference OOTF"
+                float luminance = (0.2627f * color_vector.x() + 0.6780f * color_vector.y() + 0.0593f * color_vector.z()) * 1000.0f;
+                float coefficient = hlg_ootf_lookup_table.do_lookup(luminance);
+                color_vector = { color_vector.x() * coefficient, color_vector.y() * coefficient, color_vector.z() * coefficient, 1.0f };
+            }
+
+            // FIXME: We could implement gamut compression here:
+            //        https://github.com/jedypod/gamut-compress/blob/master/docs/gamut-compress-algorithm.md
+            //        This would allow the color values outside the output gamut to be
+            //        preserved relative to values within the gamut instead of clipping. The
+            //        downside is that this requires a pass over the image before conversion
+            //        back into gamut is done to find the maximum color values to compress.
+            //        The compression would have to be somewhat temporally consistent as well.
+            color_vector = m_color_space_conversion_matrix * color_vector;
+            color_vector = max_zero(color_vector);
+            if (m_should_tonemap)
+                color_vector = hable_tonemapping(color_vector);
+            color_vector = m_to_non_linear_lookup.do_lookup(color_vector);
+            color_vector = max_zero(color_vector);
+        }
+
+        u8 r = static_cast<u8>(color_vector.x() * 255.0f);
+        u8 g = static_cast<u8>(color_vector.y() * 255.0f);
+        u8 b = static_cast<u8>(color_vector.z() * 255.0f);
+        return Gfx::Color(r, g, b);
+    }
 
 private:
     static constexpr size_t to_linear_size = 64;
@@ -80,6 +165,7 @@ private:
         , m_to_non_linear_lookup(move(to_non_linear_lookup))
     {
     }
+
     u8 m_bit_depth;
     CodingIndependentCodePoints m_cicp;
     bool m_should_skip_color_remapping;

--- a/Userland/Libraries/LibVideo/Color/ColorConverter.h
+++ b/Userland/Libraries/LibVideo/Color/ColorConverter.h
@@ -63,7 +63,7 @@ class ColorConverter final {
 public:
     static DecoderErrorOr<ColorConverter> create(u8 bit_depth, CodingIndependentCodePoints cicp);
 
-    Gfx::Color convert_yuv_to_full_range_rgb(u16 y, u16 u, u16 v);
+    Gfx::Color convert_yuv_to_full_range_rgb(u16 y, u16 u, u16 v) const;
 
 private:
     static constexpr size_t to_linear_size = 64;

--- a/Userland/Libraries/LibVideo/VP9/Context.h
+++ b/Userland/Libraries/LibVideo/VP9/Context.h
@@ -143,7 +143,11 @@ public:
     bool use_predicted_segment_id_tree { false };
     Array<u8, 3> predicted_segment_id_tree_probabilities;
     bool should_use_absolute_segment_base_quantizer { false };
-    Array<Array<SegmentFeature, SEG_LVL_MAX>, MAX_SEGMENTS> segmentation_features;
+    SegmentationFeatures segmentation_features;
+    SegmentFeatureStatus get_segment_feature(u8 segment_id, SegmentFeature feature) const
+    {
+        return segmentation_features[segment_id][to_underlying(feature)];
+    }
 
     u16 header_size_in_bytes { 0 };
 
@@ -334,6 +338,11 @@ struct BlockContext {
     SegmentationPredictionContextView above_segmentation_ids;
     NonZeroTokensView left_non_zero_tokens;
     SegmentationPredictionContextView left_segmentation_ids;
+
+    SegmentFeatureStatus get_segment_feature(SegmentFeature feature) const
+    {
+        return frame_context.get_segment_feature(segment_id, feature);
+    }
 };
 
 struct BlockMotionVectorCandidateSet {

--- a/Userland/Libraries/LibVideo/VP9/Context.h
+++ b/Userland/Libraries/LibVideo/VP9/Context.h
@@ -32,6 +32,14 @@ enum class FrameShowMode {
     DoNotShowFrame,
 };
 
+struct Quantizers {
+    u16 y_ac_quantizer { 0 };
+    u16 uv_ac_quantizer { 0 };
+
+    u16 y_dc_quantizer { 0 };
+    u16 uv_dc_quantizer { 0 };
+};
+
 struct FrameContext {
 public:
     static ErrorOr<FrameContext> create(ReadonlyBytes data,
@@ -126,15 +134,9 @@ public:
     Array<i8, MAX_REF_FRAMES> loop_filter_reference_deltas;
     Array<i8, 2> loop_filter_mode_deltas;
 
-    u8 base_quantizer_index { 0 };
-    i8 y_dc_quantizer_index_delta { 0 };
-    i8 uv_dc_quantizer_index_delta { 0 };
-    i8 uv_ac_quantizer_index_delta { 0 };
-    bool is_lossless() const
-    {
-        // From quantization_params( ) in the spec.
-        return base_quantizer_index == 0 && y_dc_quantizer_index_delta == 0 && uv_dc_quantizer_index_delta == 0 && uv_ac_quantizer_index_delta == 0;
-    }
+    // Set based on quantization_params( ) in the spec.
+    bool lossless { false };
+    Array<Quantizers, MAX_SEGMENTS> segment_quantizers;
 
     bool segmentation_enabled { false };
     // Note: We can use Optional<Array<...>> for these tree probabilities, but unfortunately it seems to have measurable performance overhead.

--- a/Userland/Libraries/LibVideo/VP9/Context.h
+++ b/Userland/Libraries/LibVideo/VP9/Context.h
@@ -94,6 +94,20 @@ public:
     u32 columns() const { return m_columns; }
     u32 superblock_rows() const { return blocks_ceiled_to_superblocks(rows()); }
     u32 superblock_columns() const { return blocks_ceiled_to_superblocks(columns()); }
+    // Calculates the output size for each plane in the frame.
+    Gfx::Size<u32> decoded_size(bool uv) const
+    {
+        // NOTE: According to the spec, this would be `y_size_to_uv_size(subsampling, blocks_to_pixels(blocks_size))`.
+        // We are deviating from that by creating smaller buffers to fit just the data we will store in an output
+        // frame or reference frame buffer.
+        if (uv) {
+            return {
+                y_size_to_uv_size(color_config.subsampling_y, size().width()),
+                y_size_to_uv_size(color_config.subsampling_y, size().height()),
+            };
+        }
+        return size();
+    }
 
     Vector2D<FrameBlockContext> const& block_contexts() const { return m_block_contexts; }
 

--- a/Userland/Libraries/LibVideo/VP9/ContextStorage.h
+++ b/Userland/Libraries/LibVideo/VP9/ContextStorage.h
@@ -243,10 +243,13 @@ struct PersistentBlockContext {
     u8 segment_id { 0 };
 };
 
-struct SegmentFeature {
+struct SegmentFeatureStatus {
     bool enabled { false };
     u8 value { 0 };
 };
+
+using SegmentFeatures = Array<SegmentFeatureStatus, to_underlying(SegmentFeature::Sentinel)>;
+using SegmentationFeatures = Array<SegmentFeatures, MAX_SEGMENTS>;
 
 struct ColorConfig {
     u8 bit_depth { 8 };

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -793,6 +793,7 @@ DecoderErrorOr<void> Decoder::prepare_referenced_frame(Gfx::Size<u32> frame_size
     // A variable yScale is set equal to (RefFrameHeight[ refIdx ] << REF_SCALE_SHIFT) / FrameHeight.
     // (xScale and yScale specify the size of the reference frame relative to the current frame in units where 16 is
     // equivalent to the reference frame having the same size.)
+    // NOTE: This spec note above seems to be incorrect. The 1:1 scale value would be 16,384.
     i32 x_scale = (reference_frame.size.width() << REF_SCALE_SHIFT) / frame_size.width();
     i32 y_scale = (reference_frame.size.height() << REF_SCALE_SHIFT) / frame_size.height();
 
@@ -857,8 +858,11 @@ DecoderErrorOr<void> Decoder::predict_inter_block(u8 plane, BlockContext const& 
     auto reference_frame_index = block_context.frame_context.reference_frame_indices[block_context.reference_frame_types[reference_index] - ReferenceFrameType::LastFrame];
     auto const& reference_frame = m_parser->m_reference_frames[reference_frame_index];
 
+    // Scale values range from 8192 to 262144.
+    // 16384 = 1:1, higher values indicate the reference frame is larger than the current frame.
     auto x_scale = reference_frame.x_scale;
-    auto y_scale = reference_frame.x_scale;
+    auto y_scale = reference_frame.y_scale;
+
     auto scaled_step_x = reference_frame.scaled_step_x;
     auto scaled_step_y = reference_frame.scaled_step_y;
 

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -1399,7 +1399,7 @@ inline DecoderErrorOr<void> Decoder::inverse_discrete_cosine_transform_array_per
 }
 
 template<u8 log2_of_block_size>
-inline DecoderErrorOr<void> Decoder::inverse_discrete_cosine_transform(Span<Intermediate> data)
+ALWAYS_INLINE DecoderErrorOr<void> Decoder::inverse_discrete_cosine_transform(Span<Intermediate> data)
 {
     static_assert(log2_of_block_size >= 2 && log2_of_block_size <= 5, "Block size out of range.");
 
@@ -1790,7 +1790,7 @@ inline DecoderErrorOr<void> Decoder::inverse_asymmetric_discrete_sine_transform(
 }
 
 template<u8 log2_of_block_size>
-DecoderErrorOr<void> Decoder::inverse_transform_2d(BlockContext const& block_context, Span<Intermediate> dequantized, TransformSet transform_set)
+ALWAYS_INLINE DecoderErrorOr<void> Decoder::inverse_transform_2d(BlockContext const& block_context, Span<Intermediate> dequantized, TransformSet transform_set)
 {
     static_assert(log2_of_block_size >= 2 && log2_of_block_size <= 5);
 

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -1173,9 +1173,10 @@ u8 Decoder::get_base_quantizer_index(BlockContext const& block_context)
 {
     // The function get_qindex( ) returns the quantizer index for the current block and is specified by the following:
     // − If seg_feature_active( SEG_LVL_ALT_Q ) is equal to 1 the following ordered steps apply:
-    if (Parser::seg_feature_active(block_context, SEG_LVL_ALT_Q)) {
+    auto alternative_quantizer_feature = block_context.get_segment_feature(SegmentFeature::UseAlternativeQuantizerBase);
+    if (alternative_quantizer_feature.enabled) {
         // 1. Set the variable data equal to FeatureData[ segment_id ][ SEG_LVL_ALT_Q ].
-        auto data = block_context.frame_context.segmentation_features[block_context.segment_id][SEG_LVL_ALT_Q].value;
+        auto data = alternative_quantizer_feature.value;
 
         // 2. If segmentation_abs_or_delta_update is equal to 0, set data equal to base_q_idx + data
         if (!block_context.frame_context.should_use_absolute_segment_base_quantizer) {

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -693,15 +693,15 @@ MotionVector Decoder::select_motion_vector(u8 plane, BlockContext const& block_c
     auto round_mv_comp_q2 = [&](MotionVector in) {
         // return (value < 0 ? value - 1 : value + 1) / 2
         return MotionVector {
-            (in.row() < 0 ? in.row() - 1 : in.row() + 1) >> 1,
-            (in.column() < 0 ? in.column() - 1 : in.column() + 1) >> 1
+            (in.row() < 0 ? in.row() - 1 : in.row() + 1) / 2,
+            (in.column() < 0 ? in.column() - 1 : in.column() + 1) / 2
         };
     };
     auto round_mv_comp_q4 = [&](MotionVector in) {
         // return (value < 0 ? value - 2 : value + 2) / 4
         return MotionVector {
-            (in.row() < 0 ? in.row() - 2 : in.row() + 2) >> 2,
-            (in.column() < 0 ? in.column() - 2 : in.column() + 2) >> 2
+            (in.row() < 0 ? in.row() - 2 : in.row() + 2) / 4,
+            (in.column() < 0 ? in.column() - 2 : in.column() + 2) / 4
         };
     };
 

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -1400,7 +1400,7 @@ inline DecoderErrorOr<void> Decoder::inverse_discrete_cosine_transform_array_per
 
     // 1.2. T[ i ] is set equal to copyT[ brev( n, i ) ] for i = 0..((1<<n) - 1).
     for (auto i = 0u; i < block_size; i++)
-        data[i] = data_copy[brev(log2_of_block_size, i)];
+        data[i] = data_copy[brev<log2_of_block_size>(i)];
 
     return {};
 }
@@ -1432,7 +1432,7 @@ inline DecoderErrorOr<void> Decoder::inverse_discrete_cosine_transform(Span<Inte
     // 2.6 Invoke B( n1+i, n0-1-i, 32-brev( 5, n1+i), 0 ) for i = 0..(n2-1).
     for (auto i = 0u; i < quarter_block_size; i++) {
         auto index = half_block_size + i;
-        butterfly_rotation_in_place(data, index, block_size - 1 - i, 32 - brev(5, index), false);
+        butterfly_rotation_in_place(data, index, block_size - 1 - i, 32 - brev<5>(index), false);
     }
 
     // 2.7 If n is greater than or equal to 3:

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -81,9 +81,12 @@ private:
 
     // (8.6.2) Reconstruct process
     DecoderErrorOr<void> reconstruct(u8 plane, BlockContext const&, u32 transform_block_x, u32 transform_block_y, TransformSize transform_block_size, TransformSet);
+    template<u8 log2_of_block_size>
+    DecoderErrorOr<void> reconstruct_templated(u8 plane, BlockContext const&, u32 transform_block_x, u32 transform_block_y, TransformSet);
 
     // (8.7) Inverse transform process
-    DecoderErrorOr<void> inverse_transform_2d(BlockContext const&, Span<Intermediate> dequantized, u8 log2_of_block_size, TransformSet);
+    template<u8 log2_of_block_size>
+    DecoderErrorOr<void> inverse_transform_2d(BlockContext const&, Span<Intermediate> dequantized, TransformSet);
 
     // (8.7.1) 1D Transforms
     // (8.7.1.1) Butterfly functions
@@ -107,16 +110,20 @@ private:
     inline DecoderErrorOr<void> inverse_walsh_hadamard_transform(Span<Intermediate> data, u8 log2_of_block_size, u8 shift);
 
     // (8.7.1.2) Inverse DCT array permutation process
-    inline DecoderErrorOr<void> inverse_discrete_cosine_transform_array_permutation(Span<Intermediate> data, u8 log2_of_block_size);
+    template<u8 log2_of_block_size>
+    inline DecoderErrorOr<void> inverse_discrete_cosine_transform_array_permutation(Span<Intermediate> data);
     // (8.7.1.3) Inverse DCT process
-    inline DecoderErrorOr<void> inverse_discrete_cosine_transform(Span<Intermediate> data, u8 log2_of_block_size);
+    template<u8 log2_of_block_size>
+    inline DecoderErrorOr<void> inverse_discrete_cosine_transform(Span<Intermediate> data);
 
     // (8.7.1.4) This process performs the in-place permutation of the array T of length 2 n which is required as the first step of
     // the inverse ADST.
-    inline void inverse_asymmetric_discrete_sine_transform_input_array_permutation(Span<Intermediate> data, u8 log2_of_block_size);
+    template<u8 log2_of_block_size>
+    inline void inverse_asymmetric_discrete_sine_transform_input_array_permutation(Span<Intermediate> data);
     // (8.7.1.5) This process performs the in-place permutation of the array T of length 2 n which is required before the final
     // step of the inverse ADST.
-    inline void inverse_asymmetric_discrete_sine_transform_output_array_permutation(Span<Intermediate> data, u8 log2_of_block_size);
+    template<u8 log2_of_block_size>
+    inline void inverse_asymmetric_discrete_sine_transform_output_array_permutation(Span<Intermediate> data);
 
     // (8.7.1.6) This process does an in-place transform of the array T to perform an inverse ADST.
     inline void inverse_asymmetric_discrete_sine_transform_4(Span<Intermediate> data);
@@ -127,7 +134,8 @@ private:
     // results.
     inline DecoderErrorOr<void> inverse_asymmetric_discrete_sine_transform_16(Span<Intermediate> data);
     // (8.7.1.9) This process performs an in-place inverse ADST process on the array T of size 2 n for 2 ≤ n ≤ 4.
-    inline DecoderErrorOr<void> inverse_asymmetric_discrete_sine_transform(Span<Intermediate> data, u8 log2_of_block_size);
+    template<u8 log2_of_block_size>
+    inline DecoderErrorOr<void> inverse_asymmetric_discrete_sine_transform(Span<Intermediate> data);
 
     /* (8.10) Reference Frame Update Process */
     DecoderErrorOr<void> update_reference_frames(FrameContext const&);

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -73,11 +73,11 @@ private:
     /* (8.6) Reconstruction and Dequantization */
 
     // Returns the quantizer index for the current block
-    static u8 get_base_quantizer_index(BlockContext const&);
+    static u8 get_base_quantizer_index(SegmentFeatureStatus alternative_quantizer_feature, bool should_use_absolute_segment_base_quantizer, u8 base_quantizer_index);
     // Returns the quantizer value for the dc coefficient for a particular plane
-    static u16 get_dc_quantizer(BlockContext const&, u8 plane);
+    static u16 get_dc_quantizer(u8 bit_depth, u8 base, i8 delta);
     // Returns the quantizer value for the ac coefficient for a particular plane
-    static u16 get_ac_quantizer(BlockContext const&, u8 plane);
+    static u16 get_ac_quantizer(u8 bit_depth, u8 base, i8 delta);
 
     // (8.6.2) Reconstruct process
     DecoderErrorOr<void> reconstruct(u8 plane, BlockContext const&, u32 transform_block_x, u32 transform_block_y, TransformSize transform_block_size, TransformSet);

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -103,9 +103,6 @@ private:
     template<typename S, typename D>
     inline void hadamard_rotation(Span<S> source, Span<D> destination, size_t index_a, size_t index_b);
 
-    template<typename T>
-    inline i32 rounded_right_shift(T value, u8 bits);
-
     // (8.7.1.10) This process does an in-place Walsh-Hadamard transform of the array T (of length 4).
     inline DecoderErrorOr<void> inverse_walsh_hadamard_transform(Span<Intermediate> data, u8 log2_of_block_size, u8 shift);
 

--- a/Userland/Libraries/LibVideo/VP9/Enums.h
+++ b/Userland/Libraries/LibVideo/VP9/Enums.h
@@ -163,9 +163,9 @@ enum Token : u8 {
 
 enum class SegmentFeature : u8 {
     // SEG_LVL_ALT_Q
-    UseAlternativeQuantizerBase,
+    AlternativeQuantizerBase,
     // SEG_LVL_ALT_L
-    UseAlternativeLoopFilterBase,
+    AlternativeLoopFilterBase,
     // SEG_LVL_REF_FRAME
     ReferenceFrameOverride,
     // SEG_LVL_SKIP

--- a/Userland/Libraries/LibVideo/VP9/Enums.h
+++ b/Userland/Libraries/LibVideo/VP9/Enums.h
@@ -161,4 +161,17 @@ enum Token : u8 {
     DctValCat6 = 10,
 };
 
+enum class SegmentFeature : u8 {
+    // SEG_LVL_ALT_Q
+    UseAlternativeQuantizerBase,
+    // SEG_LVL_ALT_L
+    UseAlternativeLoopFilterBase,
+    // SEG_LVL_REF_FRAME
+    ReferenceFrameOverride,
+    // SEG_LVL_SKIP
+    SkipResidualsOverride,
+    // SEG_LVL_MAX
+    Sentinel,
+};
+
 }

--- a/Userland/Libraries/LibVideo/VP9/LookupTables.h
+++ b/Userland/Libraries/LibVideo/VP9/LookupTables.h
@@ -15,8 +15,8 @@ namespace Video::VP9 {
 
 static constexpr InterpolationFilter literal_to_type[4] = { EightTapSmooth, EightTap, EightTapSharp, Bilinear };
 static constexpr TransformSize tx_mode_to_biggest_tx_size[TX_MODES] = { Transform_4x4, Transform_8x8, Transform_16x16, Transform_32x32, Transform_32x32 };
-static constexpr u8 segmentation_feature_bits[SEG_LVL_MAX] = { 8, 6, 2, 0 };
-static constexpr bool segmentation_feature_signed[SEG_LVL_MAX] = { true, true, false, false };
+static constexpr u8 segmentation_feature_bits[to_underlying(SegmentFeature::Sentinel)] = { 8, 6, 2, 0 };
+static constexpr bool segmentation_feature_signed[to_underlying(SegmentFeature::Sentinel)] = { true, true, false, false };
 static constexpr u8 inv_map_table[MAX_PROB] = {
     7, 20, 33, 46, 59, 72, 85, 98, 111, 124, 137, 150, 163, 176, 189, 202, 215, 228, 241, 254,
     1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 27,

--- a/Userland/Libraries/LibVideo/VP9/LookupTables.h
+++ b/Userland/Libraries/LibVideo/VP9/LookupTables.h
@@ -336,7 +336,7 @@ static constexpr u8 counter_to_context[19] = {
 };
 
 // Coefficients used by predict_inter
-static constexpr i32 subpel_filters[4][16][8] = {
+static constexpr i16 subpel_filters[4][16][8] = {
     { { 0, 0, 0, 128, 0, 0, 0, 0 },
         { 0, 1, -5, 126, 8, -3, 1, 0 },
         { -1, 3, -10, 122, 18, -6, 2, 0 },

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -1366,20 +1366,6 @@ DecoderErrorOr<i32> Parser::read_single_motion_vector_component(BooleanDecoder& 
     return (mv_sign ? -1 : 1) * static_cast<i32>(magnitude);
 }
 
-Gfx::Point<size_t> Parser::get_decoded_point_for_plane(FrameContext const& frame_context, u32 column, u32 row, u8 plane)
-{
-    (void)frame_context;
-    if (plane == 0)
-        return { column * 8, row * 8 };
-    return { (column * 8) >> frame_context.color_config.subsampling_x, (row * 8) >> frame_context.color_config.subsampling_y };
-}
-
-Gfx::Size<size_t> Parser::get_decoded_size_for_plane(FrameContext const& frame_context, u8 plane)
-{
-    auto point = get_decoded_point_for_plane(frame_context, frame_context.columns(), frame_context.rows(), plane);
-    return { point.x(), point.y() };
-}
-
 static TransformSize get_uv_transform_size(TransformSize transform_size, BlockSubsize size_for_plane)
 {
     return min(transform_size, max_txsize_lookup[size_for_plane]);

--- a/Userland/Libraries/LibVideo/VP9/Parser.h
+++ b/Userland/Libraries/LibVideo/VP9/Parser.h
@@ -30,6 +30,7 @@ struct FrameContext;
 struct TileContext;
 struct BlockContext;
 struct MotionVectorCandidate;
+struct QuantizationParameters;
 
 class Parser {
     friend class TreeParser;
@@ -61,10 +62,10 @@ private:
     DecoderErrorOr<void> compute_image_size(FrameContext&);
     DecoderErrorOr<InterpolationFilter> read_interpolation_filter(BigEndianInputBitStream&);
     DecoderErrorOr<void> loop_filter_params(FrameContext&);
-    DecoderErrorOr<void> quantization_params(FrameContext&);
     DecoderErrorOr<i8> read_delta_q(BigEndianInputBitStream&);
     DecoderErrorOr<void> segmentation_params(FrameContext&);
     DecoderErrorOr<u8> read_prob(BigEndianInputBitStream&);
+    static void precalculate_quantizers(FrameContext& frame_context, QuantizationParameters quantization_parameters);
     DecoderErrorOr<void> parse_tile_counts(FrameContext&);
     void setup_past_independence();
 

--- a/Userland/Libraries/LibVideo/VP9/Parser.h
+++ b/Userland/Libraries/LibVideo/VP9/Parser.h
@@ -98,7 +98,6 @@ private:
     DecoderErrorOr<void> intra_frame_mode_info(BlockContext&, FrameBlockContext above_context, FrameBlockContext left_context);
     DecoderErrorOr<void> set_intra_segment_id(BlockContext&);
     DecoderErrorOr<bool> read_should_skip_residuals(BlockContext&, FrameBlockContext above_context, FrameBlockContext left_context);
-    static bool seg_feature_active(BlockContext const&, u8 feature);
     DecoderErrorOr<TransformSize> read_tx_size(BlockContext&, FrameBlockContext above_context, FrameBlockContext left_context, bool allow_select);
     DecoderErrorOr<void> inter_frame_mode_info(BlockContext&, FrameBlockContext above_context, FrameBlockContext left_context);
     DecoderErrorOr<void> set_inter_segment_id(BlockContext&);
@@ -130,7 +129,7 @@ private:
     Array<i8, MAX_REF_FRAMES> m_previous_loop_filter_ref_deltas;
     Array<i8, 2> m_previous_loop_filter_mode_deltas;
     bool m_previous_should_use_absolute_segment_base_quantizer;
-    Array<Array<SegmentFeature, SEG_LVL_MAX>, MAX_SEGMENTS> m_previous_segmentation_features;
+    SegmentationFeatures m_previous_segmentation_features;
 
     ReferenceFrame m_reference_frames[NUM_REF_FRAMES];
 

--- a/Userland/Libraries/LibVideo/VP9/Parser.h
+++ b/Userland/Libraries/LibVideo/VP9/Parser.h
@@ -122,9 +122,6 @@ private:
     void add_motion_vector_if_reference_frame_type_is_same(BlockContext const&, MotionVector candidate_vector, ReferenceFrameType ref_frame, Vector<MotionVector, 2>& list, bool use_prev);
     void add_motion_vector_if_reference_frame_type_is_different(BlockContext const&, MotionVector candidate_vector, ReferenceFrameType ref_frame, Vector<MotionVector, 2>& list, bool use_prev);
 
-    Gfx::Point<size_t> get_decoded_point_for_plane(FrameContext const&, u32 row, u32 column, u8 plane);
-    Gfx::Size<size_t> get_decoded_size_for_plane(FrameContext const&, u8 plane);
-
     bool m_is_first_compute_image_size_invoke { true };
     Gfx::Size<u32> m_previous_frame_size { 0, 0 };
     bool m_previous_show_frame { false };

--- a/Userland/Libraries/LibVideo/VP9/Symbols.h
+++ b/Userland/Libraries/LibVideo/VP9/Symbols.h
@@ -33,11 +33,6 @@ namespace Video::VP9 {
 #define COMP_MODE_CONTEXTS 5
 #define REF_CONTEXTS 5
 #define MAX_SEGMENTS 8
-#define SEG_LVL_ALT_Q 0
-#define SEG_LVL_ALT_L 1
-#define SEG_LVL_REF_FRAME 2
-#define SEG_LVL_SKIP 3
-#define SEG_LVL_MAX 4
 #define BLOCK_TYPES 2
 #define REF_TYPES 2
 #define COEF_BANDS 6

--- a/Userland/Libraries/LibVideo/VP9/Utilities.h
+++ b/Userland/Libraries/LibVideo/VP9/Utilities.h
@@ -119,4 +119,9 @@ inline u8 transform_size_to_sub_blocks(TransformSize transform_size)
     return 1 << transform_size;
 }
 
+inline u32 y_size_to_uv_size(bool subsampled, u32 size)
+{
+    return (size + subsampled) >> subsampled;
+}
+
 }

--- a/Userland/Libraries/LibVideo/VP9/Utilities.h
+++ b/Userland/Libraries/LibVideo/VP9/Utilities.h
@@ -34,15 +34,26 @@ u16 clip_1(u8 bit_depth, T x)
     return x;
 }
 
-template<typename T, typename C>
-inline T brev(C bit_count, T value)
+template<u8 bits>
+inline u8 brev(u8 value)
 {
-    T result = 0;
-    for (C i = 0; i < bit_count; i++) {
-        auto bit = (value >> i) & 1;
-        result |= bit << (bit_count - 1 - i);
-    }
-    return result;
+    static_assert(bits <= 8, "brev() expects an 8-bit value.");
+
+    static constexpr auto lookup_table = [] {
+        constexpr size_t value_count = 1 << bits;
+        Array<u8, value_count> the_table;
+        for (u8 lookup_value = 0; lookup_value < value_count; lookup_value++) {
+            u8 reversed = 0;
+            for (u8 bit_index = 0; bit_index < bits; bit_index++) {
+                auto bit = (lookup_value >> bit_index) & 1;
+                reversed |= bit << (bits - 1 - bit_index);
+            }
+            the_table[lookup_value] = reversed;
+        }
+        return the_table;
+    }();
+
+    return lookup_table[value];
 }
 
 inline BlockSubsize get_subsampled_block_size(BlockSubsize size, bool subsampling_x, bool subsampling_y)

--- a/Userland/Libraries/LibVideo/VideoFrame.h
+++ b/Userland/Libraries/LibVideo/VideoFrame.h
@@ -23,20 +23,20 @@ public:
     virtual DecoderErrorOr<void> output_to_bitmap(Gfx::Bitmap& bitmap) = 0;
     virtual DecoderErrorOr<NonnullRefPtr<Gfx::Bitmap>> to_bitmap()
     {
-        auto bitmap = DECODER_TRY_ALLOC(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, m_size));
+        auto bitmap = DECODER_TRY_ALLOC(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, { width(), height() }));
         TRY(output_to_bitmap(bitmap));
         return bitmap;
     }
 
-    inline Gfx::IntSize size() { return m_size; }
-    inline size_t width() { return size().width(); }
-    inline size_t height() { return size().height(); }
+    inline Gfx::Size<u32> size() const { return m_size; }
+    inline u32 width() const { return size().width(); }
+    inline u32 height() const { return size().height(); }
 
-    inline u8 bit_depth() { return m_bit_depth; }
+    inline u8 bit_depth() const { return m_bit_depth; }
     inline CodingIndependentCodePoints& cicp() { return m_cicp; }
 
 protected:
-    VideoFrame(Gfx::IntSize size,
+    VideoFrame(Gfx::Size<u32> size,
         u8 bit_depth, CodingIndependentCodePoints cicp)
         : m_size(size)
         , m_bit_depth(bit_depth)
@@ -44,7 +44,7 @@ protected:
     {
     }
 
-    Gfx::IntSize m_size;
+    Gfx::Size<u32> m_size;
     u8 m_bit_depth;
     CodingIndependentCodePoints m_cicp;
 };
@@ -53,13 +53,13 @@ class SubsampledYUVFrame : public VideoFrame {
 
 public:
     static ErrorOr<NonnullOwnPtr<SubsampledYUVFrame>> try_create(
-        Gfx::IntSize size,
+        Gfx::Size<u32> size,
         u8 bit_depth, CodingIndependentCodePoints cicp,
         bool subsampling_horizontal, bool subsampling_vertical,
         Span<u16> plane_y, Span<u16> plane_u, Span<u16> plane_v);
 
     SubsampledYUVFrame(
-        Gfx::IntSize size,
+        Gfx::Size<u32> size,
         u8 bit_depth, CodingIndependentCodePoints cicp,
         bool subsampling_horizontal, bool subsampling_vertical,
         FixedArray<u16>& plane_y, FixedArray<u16>& plane_u, FixedArray<u16>& plane_v)


### PR DESCRIPTION
In this PR, you will receive a 69% improvement in 1080p video decoding performance!

Inter-prediction has been reworked to have some fast paths for when one or both convolutions are not needed, as well as when scaling isn't present. This will result in a massive speedup in videos with predictable movement.

Residuals also get a pretty big improvement here too, by making transformations specialize on the block size so that they can be inlined more aggressively and run without many branches.

There are also a few bug fixes included.

Here is the obligatory screencap, now with ∞% more Linus!

https://user-images.githubusercontent.com/3149592/233362799-3a6ba698-4ae8-4e67-971c-c9c5e87e47b8.mp4

