### PR TITLE
FontEditor: Pledge "FileManager" config domain

### DIFF
--- a/Userland/Applications/FontEditor/main.cpp
+++ b/Userland/Applications/FontEditor/main.cpp
@@ -25,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme("/usr/share/man/man1/FontEditor.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    Config::pledge_domain("FontEditor");
+    Config::pledge_domains({ "FontEditor", "FileManager" });
     TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath"));
 
     StringView path;


### PR DESCRIPTION
This stops FontEditor from crashing when attempting to open a new file from inside the GUI