### PR TITLE
LibWeb: Implement integrity-metadata part of fetch algorithm

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Iterator.h>
+#include <AK/Optional.h>
 #include <AK/Span.h>
 #include <AK/StdLibExtras.h>
 #include <AK/TypedTransfer.h>
@@ -117,6 +118,20 @@ struct Array {
         for (size_t i = 1; i < Size; ++i)
             value = AK::min(__data[i], value);
         return value;
+    }
+
+    bool contains_slow(T const& value) const
+    {
+        return first_index_of(value).has_value();
+    }
+
+    Optional<size_t> first_index_of(T const& value) const
+    {
+        for (size_t i = 0; i < Size; ++i) {
+            if (__data[i] == value)
+                return i;
+        }
+        return {};
     }
 
     Conditional<Size == 0, Detail::EmptyArrayStorage<T>, T[Size]> __data;

--- a/Ladybird/EventLoopPluginQt.cpp
+++ b/Ladybird/EventLoopPluginQt.cpp
@@ -18,13 +18,13 @@ namespace Ladybird {
 EventLoopPluginQt::EventLoopPluginQt() = default;
 EventLoopPluginQt::~EventLoopPluginQt() = default;
 
-void EventLoopPluginQt::spin_until(Function<bool()> goal_condition)
+void EventLoopPluginQt::spin_until(JS::SafeFunction<bool()> goal_condition)
 {
     while (!goal_condition())
         QCoreApplication::processEvents(QEventLoop::ProcessEventsFlag::AllEvents | QEventLoop::ProcessEventsFlag::WaitForMoreEvents);
 }
 
-void EventLoopPluginQt::deferred_invoke(Function<void()> function)
+void EventLoopPluginQt::deferred_invoke(JS::SafeFunction<void()> function)
 {
     VERIFY(function);
     QTimer::singleShot(0, [function = move(function)] {

--- a/Ladybird/EventLoopPluginQt.h
+++ b/Ladybird/EventLoopPluginQt.h
@@ -15,8 +15,8 @@ public:
     EventLoopPluginQt();
     virtual ~EventLoopPluginQt() override;
 
-    virtual void spin_until(Function<bool()> goal_condition) override;
-    virtual void deferred_invoke(Function<void()>) override;
+    virtual void spin_until(JS::SafeFunction<bool()> goal_condition) override;
+    virtual void deferred_invoke(JS::SafeFunction<void()>) override;
     virtual NonnullRefPtr<Web::Platform::Timer> create_timer() override;
     virtual void quit() override;
 };

--- a/Tests/AK/TestArray.cpp
+++ b/Tests/AK/TestArray.cpp
@@ -28,3 +28,21 @@ TEST_CASE(compile_time_iterable)
     constexpr Array<int, 8> array = { 0, 1, 2, 3, 4, 5, 6, 7 };
     static_assert(constexpr_sum(array) == 28);
 }
+
+TEST_CASE(contains_slow)
+{
+    constexpr Array<int, 8> array = { 0, 1, 2, 3, 4, 5, 6, 7 };
+    EXPECT(array.contains_slow(0));
+    EXPECT(array.contains_slow(4));
+    EXPECT(array.contains_slow(7));
+    EXPECT(!array.contains_slow(42));
+}
+
+TEST_CASE(first_index_of)
+{
+    constexpr Array<int, 8> array = { 0, 1, 2, 3, 4, 5, 6, 7 };
+    EXPECT(array.first_index_of(0) == 0u);
+    EXPECT(array.first_index_of(4) == 4u);
+    EXPECT(array.first_index_of(7) == 7u);
+    EXPECT(!array.first_index_of(42).has_value());
+}

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -35,7 +35,7 @@ public:
     struct CustomData {
         virtual ~CustomData() = default;
 
-        virtual void spin_event_loop_until(Function<bool()> goal_condition) = 0;
+        virtual void spin_event_loop_until(JS::SafeFunction<bool()> goal_condition) = 0;
     };
 
     static ErrorOr<NonnullRefPtr<VM>> create(OwnPtr<CustomData> = {});

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -499,7 +499,7 @@ NonnullOwnPtr<JS::ExecutionContext> create_a_new_javascript_realm(JS::VM& vm, Fu
     return realm_execution_context;
 }
 
-void WebEngineCustomData::spin_event_loop_until(Function<bool()> goal_condition)
+void WebEngineCustomData::spin_event_loop_until(JS::SafeFunction<bool()> goal_condition)
 {
     Platform::EventLoopPlugin::the().spin_until(move(goal_condition));
 }

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.h
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.h
@@ -38,7 +38,7 @@ struct CustomElementReactionsStack {
 struct WebEngineCustomData final : public JS::VM::CustomData {
     virtual ~WebEngineCustomData() override = default;
 
-    virtual void spin_event_loop_until(Function<bool()> goal_condition) override;
+    virtual void spin_event_loop_until(JS::SafeFunction<bool()> goal_condition) override;
 
     HTML::EventLoop event_loop;
 

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -470,6 +470,7 @@ set(SOURCES
     RequestIdleCallback/IdleDeadline.cpp
     ResizeObserver/ResizeObserver.cpp
     SecureContexts/AbstractOperations.cpp
+    SRI/SRI.cpp
     Streams/AbstractOperations.cpp
     Streams/ReadableByteStreamController.cpp
     Streams/ReadableStream.cpp

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/PendingResponse.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/PendingResponse.cpp
@@ -56,9 +56,9 @@ void PendingResponse::run_callback()
 {
     VERIFY(m_callback);
     VERIFY(m_response);
-    Platform::EventLoopPlugin::the().deferred_invoke([strong_this = JS::make_handle(*this)] {
-        strong_this->m_callback(*strong_this->m_response);
-        strong_this->m_request->remove_pending_response({}, *strong_this.ptr());
+    Platform::EventLoopPlugin::the().deferred_invoke([this] {
+        m_callback(*m_response);
+        m_request->remove_pending_response({}, *this);
     });
 }
 

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -51,7 +51,7 @@ EventLoop& main_thread_event_loop()
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop
-void EventLoop::spin_until(Function<bool()> goal_condition)
+void EventLoop::spin_until(JS::SafeFunction<bool()> goal_condition)
 {
     // FIXME: 1. Let task be the event loop's currently running task.
 

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -37,7 +37,7 @@ public:
     TaskQueue& microtask_queue() { return m_microtask_queue; }
     TaskQueue const& microtask_queue() const { return m_microtask_queue; }
 
-    void spin_until(Function<bool()> goal_condition);
+    void spin_until(JS::SafeFunction<bool()> goal_condition);
     void process();
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#termination-nesting-level

--- a/Userland/Libraries/LibWeb/Platform/EventLoopPlugin.h
+++ b/Userland/Libraries/LibWeb/Platform/EventLoopPlugin.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <LibJS/SafeFunction.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::Platform {
@@ -18,8 +19,8 @@ public:
 
     virtual ~EventLoopPlugin();
 
-    virtual void spin_until(Function<bool()> goal_condition) = 0;
-    virtual void deferred_invoke(Function<void()>) = 0;
+    virtual void spin_until(JS::SafeFunction<bool()> goal_condition) = 0;
+    virtual void deferred_invoke(JS::SafeFunction<void()>) = 0;
     virtual NonnullRefPtr<Timer> create_timer() = 0;
     virtual void quit() = 0;
 };

--- a/Userland/Libraries/LibWeb/Platform/EventLoopPluginSerenity.cpp
+++ b/Userland/Libraries/LibWeb/Platform/EventLoopPluginSerenity.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "EventLoopPluginSerenity.h"
-#include <AK/Function.h>
 #include <AK/NonnullRefPtr.h>
 #include <LibCore/EventLoop.h>
 #include <LibWeb/Platform/TimerSerenity.h>
@@ -15,12 +14,12 @@ namespace Web::Platform {
 EventLoopPluginSerenity::EventLoopPluginSerenity() = default;
 EventLoopPluginSerenity::~EventLoopPluginSerenity() = default;
 
-void EventLoopPluginSerenity::spin_until(Function<bool()> goal_condition)
+void EventLoopPluginSerenity::spin_until(JS::SafeFunction<bool()> goal_condition)
 {
     Core::EventLoop::current().spin_until(move(goal_condition));
 }
 
-void EventLoopPluginSerenity::deferred_invoke(Function<void()> function)
+void EventLoopPluginSerenity::deferred_invoke(JS::SafeFunction<void()> function)
 {
     VERIFY(function);
     Core::deferred_invoke(move(function));

--- a/Userland/Libraries/LibWeb/Platform/EventLoopPluginSerenity.h
+++ b/Userland/Libraries/LibWeb/Platform/EventLoopPluginSerenity.h
@@ -15,8 +15,8 @@ public:
     EventLoopPluginSerenity();
     virtual ~EventLoopPluginSerenity() override;
 
-    virtual void spin_until(Function<bool()> goal_condition) override;
-    virtual void deferred_invoke(Function<void()>) override;
+    virtual void spin_until(JS::SafeFunction<bool()> goal_condition) override;
+    virtual void deferred_invoke(JS::SafeFunction<void()>) override;
     virtual NonnullRefPtr<Timer> create_timer() override;
     virtual void quit() override;
 };

--- a/Userland/Libraries/LibWeb/SRI/SRI.cpp
+++ b/Userland/Libraries/LibWeb/SRI/SRI.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Array.h>
+#include <AK/Base64.h>
+#include <AK/Vector.h>
+#include <LibCrypto/Hash/SHA2.h>
+#include <LibWeb/SRI/SRI.h>
+
+namespace Web::SRI {
+
+constexpr Array supported_hash_functions {
+    // These are sorted by strength, low to high.
+    // NOTE: We are specifically told to refuse MD5 and SHA1.
+    //       https://w3c.github.io/webappsec-subresource-integrity/#hash-functions
+    "sha256"sv,
+    "sha384"sv,
+    "sha512"sv,
+};
+
+// https://w3c.github.io/webappsec-subresource-integrity/#getprioritizedhashfunction
+static StringView get_prioritized_hash_function(StringView a, StringView b)
+{
+    if (a == b)
+        return ""sv;
+
+    auto a_priority = supported_hash_functions.first_index_of(a).value();
+    auto b_priority = supported_hash_functions.first_index_of(b).value();
+    if (a_priority > b_priority)
+        return a;
+    return b;
+}
+
+// https://w3c.github.io/webappsec-subresource-integrity/#apply-algorithm-to-response
+ErrorOr<String> apply_algorithm_to_bytes(StringView algorithm, ByteBuffer const& bytes)
+{
+    // NOTE: The steps are duplicated here because each hash algorithm returns a different result type.
+
+    if (algorithm == "sha256"sv) {
+        // 1. Let result be the result of applying algorithm to bytes.
+        auto result = Crypto::Hash::SHA256::hash(bytes);
+
+        // 2. Return the result of base64 encoding result.
+        return encode_base64(result.bytes());
+    }
+
+    if (algorithm == "sha384"sv) {
+        // 1. Let result be the result of applying algorithm to bytes.
+        auto result = Crypto::Hash::SHA384::hash(bytes);
+
+        // 2. Return the result of base64 encoding result.
+        return encode_base64(result.bytes());
+    }
+
+    if (algorithm == "sha512"sv) {
+        // 1. Let result be the result of applying algorithm to bytes.
+        auto result = Crypto::Hash::SHA512::hash(bytes);
+
+        // 2. Return the result of base64 encoding result.
+        return encode_base64(result.bytes());
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
+// https://w3c.github.io/webappsec-subresource-integrity/#parse-metadata
+ErrorOr<Vector<Metadata>> parse_metadata(StringView metadata)
+{
+    // 1. Let result be the empty set.
+    Vector<Metadata> result;
+
+    // 2. For each item returned by splitting metadata on spaces:
+    TRY(metadata.for_each_split_view(' ', SplitBehavior::Nothing, [&](StringView item) -> ErrorOr<void> {
+        // 1. Let hash-with-opt-token-list be the result of splitting item on U+003F (?).
+        auto hash_with_opt_token_list = item.split_view('?');
+
+        // 2. Let hash-expression be hash-with-opt-token-list[0].
+        auto hash_expression = hash_with_opt_token_list[0];
+
+        // 3. Let base64-value be the empty string.
+        StringView base64_value;
+
+        // 4. Let hash-expr-token-list be the result of splitting hash-expression on U+002D (-).
+        auto hash_expr_token_list = hash_expression.split_view('-');
+
+        // 5. Let algorithm be hash-expr-token-list[0].
+        auto algorithm = hash_expr_token_list[0];
+
+        // 6. If hash-expr-token-list[1] exists, set base64-value to hash-expr-token-list[1].
+        if (hash_expr_token_list.size() >= 1)
+            base64_value = hash_expr_token_list[1];
+
+        // 7. If algorithm is not a hash function recognized by the user agent, continue.
+        if (!supported_hash_functions.contains_slow(algorithm))
+            return {};
+
+        // 8. Let metadata be the ordered map «["alg" → algorithm, "val" → base64-value]».
+        //    Note: Since no options are defined (see the §3.1 Integrity metadata), a corresponding entry is not set in metadata.
+        //    If options are defined in a future version, hash-with-opt-token-list[1] can be utilized as options.
+        auto metadata = Metadata {
+            .algorithm = TRY(String::from_utf8(algorithm)),
+            .base64_value = TRY(String::from_utf8(base64_value)),
+            .options = {},
+        };
+
+        // 9. Append metadata to result.
+        TRY(result.try_append(move(metadata)));
+
+        return {};
+    }));
+
+    // 3. Return result.
+    return result;
+}
+
+// https://w3c.github.io/webappsec-subresource-integrity/#get-the-strongest-metadata
+ErrorOr<Vector<Metadata>> get_strongest_metadata_from_set(Vector<Metadata> const& set)
+{
+    // 1. Let result be the empty set and strongest be the empty string.
+    Vector<Metadata> result;
+    Optional<Metadata> strongest;
+
+    // 2. For each item in set:
+    for (auto const& item : set) {
+        // 1. If result is the empty set, add item to result and set strongest to item, skip to the next item.
+        if (result.is_empty()) {
+            TRY(result.try_append(item));
+            strongest = item;
+            continue;
+        }
+
+        // 2. Let currentAlgorithm be the alg component of strongest.
+        auto& current_algorithm = strongest->algorithm;
+
+        // 3. Let newAlgorithm be the alg component of item.
+        auto& new_algorithm = item.algorithm;
+
+        // 4. If the result of getPrioritizedHashFunction(currentAlgorithm, newAlgorithm) is the empty string, add item to result.
+        auto prioritized_hash_function = get_prioritized_hash_function(current_algorithm, new_algorithm);
+        if (prioritized_hash_function.is_empty()) {
+            TRY(result.try_append(item));
+        }
+        //    If the result is newAlgorithm, set strongest to item, set result to the empty set, and add item to result.
+        else if (prioritized_hash_function == new_algorithm) {
+            strongest = item;
+            result.clear_with_capacity();
+            TRY(result.try_append(item));
+        }
+    }
+
+    // 3. Return result.
+    return result;
+}
+
+// https://w3c.github.io/webappsec-subresource-integrity/#does-response-match-metadatalist
+ErrorOr<bool> do_bytes_match_metadata_list(ByteBuffer const& bytes, StringView metadata_list)
+{
+    // 1. Let parsedMetadata be the result of parsing metadataList.
+    auto parsed_metadata = TRY(parse_metadata(metadata_list));
+
+    // 2. If parsedMetadata is empty set, return true.
+    if (parsed_metadata.is_empty())
+        return true;
+
+    // 3. Let metadata be the result of getting the strongest metadata from parsedMetadata.
+    auto metadata = TRY(get_strongest_metadata_from_set(parsed_metadata));
+
+    // 4. For each item in metadata:
+    for (auto const& item : metadata) {
+        // 1. Let algorithm be the item["alg"].
+        auto& algorithm = item.algorithm;
+
+        // 2. Let expectedValue be the item["val"].
+        auto& expected_value = item.base64_value;
+
+        // 3. Let actualValue be the result of applying algorithm to bytes.
+        auto actual_value = TRY(apply_algorithm_to_bytes(algorithm, bytes));
+
+        // 4. If actualValue is a case-sensitive match for expectedValue, return true.
+        if (actual_value == expected_value)
+            return true;
+    }
+
+    // 5. Return false.
+    return false;
+}
+
+}

--- a/Userland/Libraries/LibWeb/SRI/SRI.h
+++ b/Userland/Libraries/LibWeb/SRI/SRI.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+
+namespace Web::SRI {
+
+// https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata
+struct Metadata {
+    String algorithm;    // "alg"
+    String base64_value; // "val"
+    String options {};   // "opt"
+};
+
+ErrorOr<String> apply_algorithm_to_bytes(StringView algorithm, ByteBuffer const& bytes);
+ErrorOr<Vector<Metadata>> parse_metadata(StringView metadata);
+ErrorOr<Vector<Metadata>> get_strongest_metadata_from_set(Vector<Metadata> const& set);
+ErrorOr<bool> do_bytes_match_metadata_list(ByteBuffer const& bytes, StringView metadata_list);
+
+}


### PR DESCRIPTION
On `getboostrap.com`, this now makes this `<link>` work:
```html
<link href="/docs/5.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-KK94CHFLLe+nY2dmCWGMq91rCGa5gtU4mk92HdvYe+M/SXH301p5ILy+dN9+nJOZ" crossorigin="anonymous">
```

Before:
![image](https://user-images.githubusercontent.com/222642/233421139-dd6e7a47-9d11-484c-983e-ddcf19b2db29.png)

After: 
![image](https://user-images.githubusercontent.com/222642/233420767-48a3572a-484c-471c-85f8-74792821fbde.png)
