### PR TITLE
Tests/LibWeb: Time limit layout tests

### DIFF
--- a/Meta/Azure/Setup.yml
+++ b/Meta/Azure/Setup.yml
@@ -38,7 +38,7 @@ steps:
     - script: |
         set -e
         brew update
-        brew install bash ninja wabt ccache unzip qt llvm@15
+        brew install coreutils bash ninja wabt ccache unzip qt llvm@15
       displayName: 'Install Dependencies'
 
   - ${{ if eq(parameters.os, 'Android') }}:

--- a/Tests/LibWeb/Layout/layout_test.sh
+++ b/Tests/LibWeb/Layout/layout_test.sh
@@ -16,7 +16,7 @@ find "${SCRIPT_DIR}/input/" -type f -name "*.html" -print0 | while IFS= read -r 
     input_html_file=${input_html_path/${SCRIPT_DIR}"/input/"/}
     input_html_file=${input_html_file/".html"/}
 
-    output_layout_dump=$(cd "${LADYBIRD_BUILD_DIR}"; "${BROWSER_BINARY}" -d "${input_html_path}")
+    output_layout_dump=$(cd "${LADYBIRD_BUILD_DIR}"; timeout 300s "${BROWSER_BINARY}" -d "${input_html_path}")
     expected_layout_dump_path="${SCRIPT_DIR}/expected/${input_html_file}.txt"
 
     if cmp <(echo "${output_layout_dump}") "${expected_layout_dump_path}"; then


### PR DESCRIPTION
This change will prevent CI runners from being stuck trying to run layout tests on PR that made browser hang.

(my navigables PR currently makes CI hang https://github.com/SerenityOS/serenity/pull/18219)