### PR TITLE
Ladybird+Browser: Support running without SQLServer for easier GDB usage

### DIFF
--- a/Userland/Applications/Browser/Forward.h
+++ b/Userland/Applications/Browser/Forward.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Traits.h>
+
+namespace Browser {
+
+class CookieJar;
+class Database;
+
+struct CookieStorageKey;
+
+}
+
+namespace AK {
+
+template<>
+struct Traits<Browser::CookieStorageKey>;
+
+}


### PR DESCRIPTION
I've had variants of these changes sitting around in `git stash` for when I need to gdb Ladybird / test cookie storage, figured its probably useful for others.