### PR TITLE
Spider: Fix crash when completing a deck

### DIFF
--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -145,7 +145,7 @@ void Game::detect_full_stacks()
         uint8_t last_value;
         Color color;
         for (size_t i = current_pile.stack().size(); i > 0; i--) {
-            auto& card = current_pile.stack().at(i - 1);
+            auto card = current_pile.stack().at(i - 1);
             if (card->is_upside_down())
                 break;
 


### PR DESCRIPTION
This resolves a regression caused by
8a48246ed1a93983668a25f5b9b0af0e745e3f04.