### PR TITLE
Kernel+Userland: Remove the `nfds` entry from `/sys/kernel/processes`

### DIFF
--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Processes.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Processes.cpp
@@ -81,7 +81,6 @@ ErrorOr<void> SysFSOverallProcesses::try_generate(KBufferBuilder& builder)
         } else {
             TRY(process_object.add("tty"sv, ""));
         }
-        TRY(process_object.add("nfds"sv, process.fds().with_shared([](auto& fds) { return fds.open_count(); })));
         TRY(process.name().with([&](auto& process_name) { return process_object.add("name"sv, process_name->view()); }));
         TRY(process_object.add("executable"sv, process.executable() ? TRY(process.executable()->try_serialize_absolute_path())->view() : ""sv));
 

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -36,7 +36,6 @@ ErrorOr<AllProcessesStatistics> ProcessStatisticsReader::get_all(SeekableStream&
         process.uid = process_object.get_u32("uid"sv).value_or(0);
         process.gid = process_object.get_u32("gid"sv).value_or(0);
         process.ppid = process_object.get_u32("ppid"sv).value_or(0);
-        process.nfds = process_object.get_u32("nfds"sv).value_or(0);
         process.kernel = process_object.get_bool("kernel"sv).value_or(false);
         process.name = process_object.get_deprecated_string("name"sv).value_or("");
         process.executable = process_object.get_deprecated_string("executable"sv).value_or("");

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.h
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.h
@@ -43,7 +43,6 @@ struct ProcessStatistics {
     uid_t uid;
     gid_t gid;
     pid_t ppid;
-    unsigned nfds;
     bool kernel;
     DeprecatedString name;
     DeprecatedString executable;

--- a/Userland/Utilities/top.cpp
+++ b/Userland/Utilities/top.cpp
@@ -46,7 +46,6 @@ struct ThreadData {
     uid_t uid;
     gid_t gid;
     pid_t ppid;
-    unsigned nfds;
     DeprecatedString name;
     DeprecatedString tty;
     size_t amount_virtual;
@@ -105,7 +104,6 @@ static ErrorOr<Snapshot> get_snapshot()
             thread_data.uid = process.uid;
             thread_data.gid = process.gid;
             thread_data.ppid = process.ppid;
-            thread_data.nfds = process.nfds;
             thread_data.name = process.name;
             thread_data.tty = process.tty;
             thread_data.amount_virtual = process.amount_virtual;


### PR DESCRIPTION
`process.fds()` is protected by a Mutex, which causes issues when we try to acquire it while holding a Spinlock. Since nothing seems to use this value, let's just remove it entirely for now.