### PR TITLE
AK: Fix crash during teardown of self-owning ref-counted objects

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -129,10 +129,8 @@ public:
 private:
     void clear()
     {
-        if (!m_ptr)
-            return;
-        delete m_ptr;
-        m_ptr = nullptr;
+        auto* ptr = exchange(m_ptr, nullptr);
+        delete ptr;
     }
 
     T* m_ptr = nullptr;

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -94,8 +94,8 @@ public:
 
     ALWAYS_INLINE ~NonnullRefPtr()
     {
-        unref_if_not_null(m_ptr);
-        m_ptr = nullptr;
+        auto* ptr = exchange(m_ptr, nullptr);
+        unref_if_not_null(ptr);
 #ifdef SANITIZE_PTRS
         m_ptr = reinterpret_cast<T*>(explode_byte(NONNULLREFPTR_SCRUB_BYTE));
 #endif

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -106,8 +106,8 @@ public:
 
     void clear()
     {
-        TDeleter {}(m_ptr);
-        m_ptr = nullptr;
+        auto* ptr = exchange(m_ptr, nullptr);
+        TDeleter {}(ptr);
     }
 
     bool operator!() const { return !m_ptr; }

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -220,8 +220,8 @@ public:
 
     ALWAYS_INLINE void clear()
     {
-        unref_if_not_null(m_ptr);
-        m_ptr = nullptr;
+        auto* ptr = exchange(m_ptr, nullptr);
+        unref_if_not_null(ptr);
     }
 
     bool operator!() const { return !m_ptr; }

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -51,6 +51,7 @@ set(AK_TEST_SOURCES
     TestMemory.cpp
     TestMemoryStream.cpp
     TestNeverDestroyed.cpp
+    TestNonnullOwnPtr.cpp
     TestNonnullRefPtr.cpp
     TestNumberFormat.cpp
     TestOptional.cpp

--- a/Tests/AK/TestIntrusiveList.cpp
+++ b/Tests/AK/TestIntrusiveList.cpp
@@ -155,3 +155,9 @@ TEST_CASE(intrusive_nonnull_ref_ptr_intrusive)
 
     EXPECT(nonnull_ref_list.is_empty());
 }
+
+TEST_CASE(destroy_nonempty_intrusive_list)
+{
+    IntrusiveNonnullRefPtrList nonnull_ref_list;
+    nonnull_ref_list.append(adopt_ref(*new IntrusiveNonnullRefPtrItem));
+}

--- a/Tests/AK/TestNonnullOwnPtr.cpp
+++ b/Tests/AK/TestNonnullOwnPtr.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/DeprecatedString.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/OwnPtr.h>
+
+TEST_CASE(destroy_self_owning_object)
+{
+    // This test is a little convoluted because SelfOwning can't own itself
+    // through a NonnullOwnPtr directly. We have to use an intermediate object ("Inner").
+    struct SelfOwning {
+        SelfOwning()
+        {
+        }
+        struct Inner {
+            explicit Inner(NonnullOwnPtr<SelfOwning> self)
+                : self(move(self))
+            {
+            }
+            NonnullOwnPtr<SelfOwning> self;
+        };
+        OwnPtr<Inner> inner;
+    };
+    OwnPtr<SelfOwning> object = make<SelfOwning>();
+    auto* object_ptr = object.ptr();
+    object_ptr->inner = make<SelfOwning::Inner>(object.release_nonnull());
+    object_ptr->inner = nullptr;
+}

--- a/Tests/AK/TestNonnullRefPtr.cpp
+++ b/Tests/AK/TestNonnullRefPtr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +8,7 @@
 
 #include <AK/DeprecatedString.h>
 #include <AK/NonnullRefPtr.h>
+#include <AK/OwnPtr.h>
 
 struct Object : public RefCounted<Object> {
     int x;
@@ -57,4 +58,28 @@ TEST_CASE(swap_with_self)
     auto object = adopt_ref(*new Object);
     swap(object, object);
     EXPECT_EQ(object->ref_count(), 1u);
+}
+
+TEST_CASE(destroy_self_owning_refcounted_object)
+{
+    // This test is a little convoluted because SelfOwningRefCounted can't own itself
+    // through a NonnullRefPtr directly. We have to use an intermediate object ("Inner").
+    struct SelfOwningRefCounted : public RefCounted<SelfOwningRefCounted> {
+        SelfOwningRefCounted()
+            : inner(make<Inner>(*this))
+        {
+        }
+        struct Inner {
+            explicit Inner(SelfOwningRefCounted& self)
+                : self(self)
+            {
+            }
+            NonnullRefPtr<SelfOwningRefCounted> self;
+        };
+        OwnPtr<Inner> inner;
+    };
+    RefPtr object = make_ref_counted<SelfOwningRefCounted>();
+    auto* object_ptr = object.ptr();
+    object = nullptr;
+    object_ptr->inner = nullptr;
 }

--- a/Tests/AK/TestOwnPtr.cpp
+++ b/Tests/AK/TestOwnPtr.cpp
@@ -21,3 +21,15 @@ TEST_CASE(should_call_custom_deleter)
     ptr.clear();
     EXPECT_EQ(1u, deleter_call_count);
 }
+
+TEST_CASE(destroy_self_owning_object)
+{
+    struct SelfOwning {
+        OwnPtr<SelfOwning> self;
+    };
+    OwnPtr<SelfOwning> object = make<SelfOwning>();
+    auto* object_ptr = object.ptr();
+    object->self = move(object);
+    object = nullptr;
+    object_ptr->self = nullptr;
+}

--- a/Tests/AK/TestRefPtr.cpp
+++ b/Tests/AK/TestRefPtr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -152,4 +152,16 @@ TEST_CASE(adopt_ref_if_nonnull)
     SelfAwareObject* null_object = nullptr;
     RefPtr<SelfAwareObject> failed_allocation = adopt_ref_if_nonnull(null_object);
     EXPECT_EQ(failed_allocation.is_null(), true);
+}
+
+TEST_CASE(destroy_self_owning_refcounted_object)
+{
+    struct SelfOwningRefCounted : public RefCounted<SelfOwningRefCounted> {
+        RefPtr<SelfOwningRefCounted> self;
+    };
+    RefPtr object = make_ref_counted<SelfOwningRefCounted>();
+    auto* object_ptr = object.ptr();
+    object->self = object;
+    object = nullptr;
+    object_ptr->self = nullptr;
 }


### PR DESCRIPTION
Null out the smart pointer *before* calling unref on the pointee. This ensures that the same smart pointer can't be used to acquire a new reference to the pointee after its destruction has begun.

I ran into this when destroying a non-empty IntrusiveList of RefPtrs, but the problem was more general so this fixes it for both RefPtr and NonnullRefPtr.