### PR TITLE
Spreadsheet: Add blank sheet when import dialog is cancelled

### DIFF
--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -511,6 +511,9 @@ void SpreadsheetWidget::load_file(String const& filename, Core::File& file)
     auto result = m_workbook->open_file(filename, file);
     if (result.is_error()) {
         GUI::MessageBox::show_error(window(), result.error());
+        if (!m_workbook->has_sheets()) {
+            add_sheet();
+        }
         return;
     }
 


### PR DESCRIPTION
If you launch the Spreadsheet app by clicking on a CSV (or other supported formats) the import dialog is immediately launched. If you cancel out of the import the application ends up in an empty state where there are no sheets added. When you launch the app normally it defaults to having a blank sheet, so we should have the same behaviour in this scenario to prevent users from having to manually add the new/blank sheet before being able to use the app.

Example of behaviour before the fix:

https://user-images.githubusercontent.com/11325341/233714789-259c290d-216d-41b0-a17b-01120be7552f.mp4

Example of behaviour after the fix:

https://user-images.githubusercontent.com/11325341/233714869-2a6cb919-8326-48a5-81cb-d32c4dbfff80.mp4


