### PR TITLE
LibGfx/JPEG: Support up to 4 quantization tables 

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2022-2023, Lucas Chollet <lucas.chollet@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -135,10 +135,10 @@ struct MacroblockMeta {
 
 struct Component {
     // B.2.2 - Frame header syntax
-    u8 id { 0 };             // Ci, Component identifier
-    u8 hsample_factor { 1 }; // Hi, Horizontal sampling factor
-    u8 vsample_factor { 1 }; // Vi, Vertical sampling factor
-    u8 qtable_id { 0 };      // Tqi, Quantization table destination selector
+    u8 id { 0 };                    // Ci, Component identifier
+    u8 hsample_factor { 1 };        // Hi, Horizontal sampling factor
+    u8 vsample_factor { 1 };        // Vi, Vertical sampling factor
+    u8 quantization_table_id { 0 }; // Tqi, Quantization table destination selector
 
     // The JPEG specification does not specify which component corresponds to
     // Y, Cb or Cr. This field (actually the index in the parent Vector) will
@@ -1063,7 +1063,7 @@ static ErrorOr<void> read_start_of_frame(Stream& stream, JPEGLoadingContext& con
             }
         }
 
-        component.qtable_id = TRY(stream.read_value<u8>());
+        component.quantization_table_id = TRY(stream.read_value<u8>());
 
         context.components.append(move(component));
     }
@@ -1128,12 +1128,12 @@ static ErrorOr<void> dequantize(JPEGLoadingContext& context, Vector<Macroblock>&
             for (u32 i = 0; i < context.components.size(); i++) {
                 auto const& component = context.components[i];
 
-                if (!context.quantization_tables[component.qtable_id].has_value()) {
-                    dbgln_if(JPEG_DEBUG, "Unknown quantization table id: {}!", component.qtable_id);
+                if (!context.quantization_tables[component.quantization_table_id].has_value()) {
+                    dbgln_if(JPEG_DEBUG, "Unknown quantization table id: {}!", component.quantization_table_id);
                     return Error::from_string_literal("Unknown quantization table id");
                 }
 
-                auto const& table = context.quantization_tables[component.qtable_id].value();
+                auto const& table = context.quantization_tables[component.quantization_table_id].value();
 
                 for (u32 vfactor_i = 0; vfactor_i < component.vsample_factor; vfactor_i++) {
                     for (u32 hfactor_i = 0; hfactor_i < component.hsample_factor; hfactor_i++) {

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2022-2023, Lucas Chollet <lucas.chollet@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */


### PR DESCRIPTION
Images are from [w3.org/MarkUp/Test/xhtml-print/20050519/tests/A_2_1-BF-01.htm](https://www.w3.org/MarkUp/Test/xhtml-print/20050519/tests/A_2_1-BF-01.htm)

![WHF](https://user-images.githubusercontent.com/26030965/233754503-67c94f06-910b-46b4-9a3b-11f22ee961b5.png)

Fixes both #18455 and #18456