### PR TITLE
Everywhere: Small changes for launching (and debugging) ports on AArch64

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -370,12 +370,8 @@ struct SC_create_thread_params {
     unsigned int reported_guard_page_size = 0; // The lie we tell callers
     unsigned int stack_size = 1 * MiB;         // Equal to Thread::default_userspace_stack_size
     void* stack_location;                      // nullptr means any, o.w. process virtual address
-#    if ARCH(X86_64)
-    FlatPtr rdi;
-    FlatPtr rsi;
-    FlatPtr rcx;
-    FlatPtr rdx;
-#    endif
+    void* (*entry)(void*);
+    void* entry_argument;
 };
 
 struct SC_realpath_params {

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -131,8 +131,15 @@ static TitleAndText build_cpu_registers(const ELF::Core::ThreadInfo& thread_info
     builder.appendff("r12={:p} r13={:p} r14={:p} r15={:p}\n", regs.r12, regs.r13, regs.r14, regs.r15);
     builder.appendff("rip={:p} rflags={:p}", regs.rip, regs.rflags);
 #elif ARCH(AARCH64)
-    (void)regs;
-    TODO_AARCH64();
+    builder.appendff("Stack pointer   sp={:p}\n", regs.sp);
+    builder.appendff("Program counter pc={:p}\n", regs.pc);
+    builder.appendff(" x0={:p}  x1={:p}  x2={:p}  x3={:p}  x4={:p}\n", regs.x[0], regs.x[1], regs.x[2], regs.x[3], regs.x[4]);
+    builder.appendff(" x5={:p}  x6={:p}  x7={:p}  x8={:p}  x9={:p}\n", regs.x[5], regs.x[6], regs.x[7], regs.x[8], regs.x[9]);
+    builder.appendff("x10={:p} x11={:p} x12={:p} x13={:p} x14={:p}\n", regs.x[10], regs.x[11], regs.x[12], regs.x[13], regs.x[14]);
+    builder.appendff("x15={:p} x16={:p} x17={:p} x18={:p} x19={:p}\n", regs.x[15], regs.x[16], regs.x[17], regs.x[18], regs.x[19]);
+    builder.appendff("x20={:p} x21={:p} x22={:p} x23={:p} x24={:p}\n", regs.x[20], regs.x[21], regs.x[22], regs.x[23], regs.x[24]);
+    builder.appendff("x25={:p} x26={:p} x27={:p} x28={:p} x29={:p}\n", regs.x[25], regs.x[26], regs.x[27], regs.x[28], regs.x[29]);
+    builder.appendff("x30={:p}", regs.x[30]);
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/DynamicLoader/main.cpp
+++ b/Userland/DynamicLoader/main.cpp
@@ -63,7 +63,11 @@ void _entry(int, char**, char**) __attribute__((used));
 NAKED void _start(int, char**, char**)
 {
 #if ARCH(AARCH64)
+    // Make sure backtrace computation stops here by setting FP and LR to 0.
+    // FIXME: The kernel should ensure that registers are zeroed on program start
     asm(
+        "mov x29, 0\n"
+        "mov x30, 0\n"
         "bl _entry\n");
 #else
     asm(

--- a/Userland/Libraries/LibC/pthread.cpp
+++ b/Userland/Libraries/LibC/pthread.cpp
@@ -90,18 +90,9 @@ static int create_thread(pthread_t* thread, void* (*entry)(void*), void* argumen
     while (((uintptr_t)stack - 16) % 16 != 0)
         push_on_stack(nullptr);
 
-#if ARCH(X86_64)
-    thread_params->rdi = (FlatPtr)entry;
-    thread_params->rsi = (FlatPtr)argument;
-    thread_params->rdx = (FlatPtr)thread_params->stack_location;
-    thread_params->rcx = thread_params->stack_size;
-#elif ARCH(AARCH64)
-    (void)entry;
-    (void)argument;
-    TODO_AARCH64();
-#else
-#    error Unknown architecture
-#endif
+    thread_params->entry = entry;
+    thread_params->entry_argument = argument;
+
     VERIFY((uintptr_t)stack % 16 == 0);
 
     // Push a fake return address

--- a/Userland/Libraries/LibCoredump/Backtrace.cpp
+++ b/Userland/Libraries/LibCoredump/Backtrace.cpp
@@ -48,9 +48,8 @@ Backtrace::Backtrace(Reader const& coredump, const ELF::Core::ThreadInfo& thread
     auto start_bp = m_thread_info.regs.rbp;
     auto start_ip = m_thread_info.regs.rip;
 #elif ARCH(AARCH64)
-    auto start_bp = 0;
-    auto start_ip = 0;
-    TODO_AARCH64();
+    auto start_bp = m_thread_info.regs.x[29];
+    auto start_ip = m_thread_info.regs.pc;
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
@@ -161,6 +161,13 @@ ErrorOr<AttributeValue> DwarfInfo::get_attribute_value(AttributeDataForm form, s
         value.m_data.as_unsigned = data + unit->offset();
         break;
     }
+    case AttributeDataForm::RefUData: {
+        auto data = TRY(debug_info_stream.read_value<LEB128<size_t>>());
+        value.m_type = AttributeValue::Type::DieReference;
+        VERIFY(unit);
+        value.m_data.as_unsigned = data + unit->offset();
+        break;
+    }
     case AttributeDataForm::FlagPresent: {
         value.m_type = AttributeValue::Type::Boolean;
         value.m_data.as_bool = true;

--- a/Userland/Libraries/LibELF/Arch/aarch64/plt_trampoline.S
+++ b/Userland/Libraries/LibELF/Arch/aarch64/plt_trampoline.S
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Nico Weber <thakis@chromium.org>
+ * Copyright (c) 2023, Daniel Bertalan <dani@danielbertalan.dev>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +9,63 @@
 .globl _plt_trampoline
 .hidden _plt_trampoline
 .type _plt_trampoline,@function
-_plt_trampoline: # (object, relocation_index)
-    # FIXME: Possibly incomplete.
-    ret
+
+// This function is called by the PLT stub to resolve functions lazily at runtime.
+// It saves off any argument registers that might be clobbered by the symbol
+// resolution code, calls that, and then jumps to the resolved function.
+//
+// See section 9.3 "Procedure Linkage Table" of the AArch64 ELF ABI.
+// https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst
+//
+// The calling convention is:
+//   x16 = &got.plt[2]
+//   x17 = &_plt_trampoline
+//   [sp, #0] = &got.plt[relocation_index + 3]
+//   [sp, #8] = return address
+_plt_trampoline:
+    mov x17, sp
+
+    // Save argument registers: x0-x7, v0-v7.
+    stp x0, x1, [sp, #-16]!
+    stp x2, x3, [sp, #-16]!
+    stp x4, x5, [sp, #-16]!
+    stp x6, x7, [sp, #-16]!
+
+    stp q0, q1, [sp, #-32]!
+    stp q2, q3, [sp, #-32]!
+    stp q4, q5, [sp, #-32]!
+    stp q6, q7, [sp, #-32]!
+
+    // Load DynamicObject* from got.plt[1].
+    ldr x0, [x16, #-8]
+
+    // Calculate the rela.plt relocation offset.
+    ldr x2, [x17]
+    sub x1, x2, x16
+    sub x1, x1, #8
+    // GOT entries are 8 bytes, but sizeof(Elf64_Rela) == 24, so multiply
+    // by 3 to get the relocation offset.
+    add x1, x1, x1, lsl #1
+
+    bl _fixup_plt_entry
+
+    // Save the resolved function's address.
+    mov x16, x0
+
+    // Restore argument registers.
+    ldp q6, q7, [sp], #32
+    ldp q4, q5, [sp], #32
+    ldp q2, q3, [sp], #32
+    ldp q0, q1, [sp], #32
+
+    ldp x6, x7, [sp], #16
+    ldp x4, x5, [sp], #16
+    ldp x2, x3, [sp], #16
+    ldp x0, x1, [sp], #16
+
+    // Restore link register saved by the PLT stub.
+    ldp xzr, x30, [sp], #16
+
+    // Jump to the resolved function.
+    br x16
+


### PR DESCRIPTION
This PR contains all the *stuff* I had to do in order to launch and then debug `sshd` on AArch64.
As I realized after all this, we don't yet have networking support on AArch64, but this might be useful for other ports too.

---
**LibELF: Add AArch64 PLT trampoline**

This is used for lazy symbol binding, which is used by e.g. ports that
are not linked with `-z now`.

**Kernel+LibC: Implement pthread_create for AArch64**

Instead of storing x86_64 register names in `SC_create_thread_params`,
 let the Kernel figure out how to pass the parameters to
 `pthread_create_helper`.


**LibDebug: Support DW_FORM_ref_udata**

This is used alongside/instead of the fixed-length DW_FORM_ref4 form
when compiling for AArch64.

**LibCoredump+CrashReporter: Make CrashReporter work on AArch64**

This commit implements printing out the AArch64 register file and
generating backtraces. Tested to work on the sshd port.

**DynamicLoader: Ensure that backtrace computation stops at _start**

If we don't set FP and LR to 0, the Kernel might not stop generating
backtraces when it reaches `_start`'s stack frame, and might continue by
reading garbage memory instead. This leads to a kernel panic, as SafeMem
access faults aren't handled properly in the AArch64 kernel yet.

We might want to ensure that the kernel zeroes out all registers when a
new process is created.
