### PR TITLE
AK+LibJS: Implement Stream::format and use it

### DIFF
--- a/AK/Stream.cpp
+++ b/AK/Stream.cpp
@@ -8,6 +8,7 @@
 #include <AK/ByteBuffer.h>
 #include <AK/Format.h>
 #include <AK/Stream.h>
+#include <AK/StringBuilder.h>
 
 namespace AK {
 
@@ -94,6 +95,16 @@ ErrorOr<void> Stream::write_until_depleted(ReadonlyBytes buffer)
         nwritten += result.value();
     }
 
+    return {};
+}
+
+ErrorOr<void> Stream::format_impl(StringView fmtstr, TypeErasedFormatParams& parameters)
+{
+    StringBuilder builder;
+    TRY(vformat(builder, fmtstr, parameters));
+
+    auto const string = builder.string_view();
+    TRY(write_until_depleted(string.bytes()));
     return {};
 }
 

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Error.h>
+#include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/Traits.h>
 
@@ -74,6 +75,16 @@ public:
     ErrorOr<void> write_value(T const& value)
     {
         return write_until_depleted({ &value, sizeof(value) });
+    }
+
+    virtual ErrorOr<void> format_impl(StringView, TypeErasedFormatParams&);
+
+    template<typename... Parameters>
+    ErrorOr<void> format(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
+    {
+        VariadicFormatParams<AllowDebugOnlyFormatters::No, Parameters...> variadic_format_params { parameters... };
+        TRY(format_impl(fmtstr.view(), variadic_format_params));
+        return {};
     }
 
     /// Returns whether the stream has reached the end of file. For sockets,

--- a/Userland/Libraries/LibJS/Print.cpp
+++ b/Userland/Libraries/LibJS/Print.cpp
@@ -140,15 +140,10 @@ DeprecatedString strip_ansi(StringView format_string)
 template<typename... Args>
 ErrorOr<void> js_out(JS::PrintContext& print_context, CheckedFormatString<Args...> format_string, Args const&... args)
 {
-    DeprecatedString formatted;
     if (print_context.strip_ansi)
-        formatted = DeprecatedString::formatted(strip_ansi(format_string.view()), args...);
+        TRY(print_context.stream.format(strip_ansi(format_string.view()), args...));
     else
-        formatted = DeprecatedString::formatted(format_string.view(), args...);
-
-    auto bytes = formatted.bytes();
-    while (!bytes.is_empty())
-        bytes = bytes.slice(TRY(print_context.stream.write_some(bytes)));
+        TRY(print_context.stream.format(format_string.view(), args...));
 
     return {};
 }


### PR DESCRIPTION
Hi! I think it would be useful to have some kind of formatted printing for `Core::File`, and `AK::Stream` seems like the most suitable place in the class hierarchy, so I implemented it there.

The second commit is an example of its use in `LibJS/Print.cpp`, which together with the third commit gets rid of a `DeprecatedString`-import :) 

Very open for suggestions of alternative names of `Steam::format`! And I don't have any experience with C++, so feel very free to nitpick.

(I'm Lambda on discord, so just reach out to me there, if you want to discuss as well.)