### PR TITLE
LibWeb: Fix grid size when intrinsically sized

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-column.txt
+++ b/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-column.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x35.46875 children: inline
+    TextNode <#text>
+    BlockContainer <body> at (8,8) content-size 0x19.46875 floating children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        TextNode <#text>
+      Box <div.grid> at (8,8) content-size 0x19.46875 children: not-inline
+        BlockContainer <(anonymous)>  children: inline
+          TextNode <#text>
+        BlockContainer <div.whee> at (9,9) content-size 18x17.46875 children: inline
+          line 0 width: 37.953125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 4, rect: [9,9 37.953125x17.46875]
+              "whee"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid.txt
+++ b/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x39.46875 children: not-inline
+    BlockContainer <body> at (10,10) content-size 2x21.46875 floating children: not-inline
+      Box <div.grid> at (11,11) content-size 0x19.46875 children: not-inline
+        BlockContainer <div.whee> at (12,12) content-size 35.953125x17.46875 children: inline
+          line 0 width: 37.953125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 4, rect: [12,12 37.953125x17.46875]
+              "whee"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/grid/intrinsic-sized-column.html
+++ b/Tests/LibWeb/Layout/input/grid/intrinsic-sized-column.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <style>
+    body {
+      float: left;
+      font-family: 'SerenitySans';
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: 20px;
+    }
+
+    .whee {
+      background: pink;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="grid">
+    <div class="whee" style="border: 1px solid black;">whee

--- a/Tests/LibWeb/Layout/input/grid/intrinsic-sized-grid.html
+++ b/Tests/LibWeb/Layout/input/grid/intrinsic-sized-grid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html><html><head><style>
+  * {
+    border: 1px solid black !important;
+  }
+  body {
+    float: left;
+    font-family: 'SerenitySans';
+  }
+  .grid {
+    display: grid;
+    grid-template-areas: "foo whee";
+    grid-template-columns: min-content minmax(0, auto) min-content;
+  }
+  .whee {
+    grid-area: whee;
+    background: pink;
+  }
+</style></head><body><div class="grid"><div class="whee">whee

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -753,7 +753,7 @@ void GridFormattingContext::calculate_sizes_of_columns(Box const& box, Available
             }
         }
 
-        if (!grid_column.min_track_sizing_function.is_intrinsic_track_sizing()) {
+        if (!grid_column.min_track_sizing_function.is_intrinsic_track_sizing() && !grid_column.max_track_sizing_function.is_intrinsic_track_sizing()) {
             ++index;
             continue;
         }
@@ -1257,7 +1257,7 @@ void GridFormattingContext::calculate_sizes_of_rows(Box const& box)
             }
         }
 
-        if (!grid_row.min_track_sizing_function.is_intrinsic_track_sizing()) {
+        if (!grid_row.min_track_sizing_function.is_intrinsic_track_sizing() && !grid_row.max_track_sizing_function.is_intrinsic_track_sizing()) {
             ++index;
             continue;
         }


### PR DESCRIPTION
This fixes a bug that was seen when a combination of the grid having been floated with `float: left` and a `minmax()` column size were used.

The issue was that a grid track size should be considered intrinsically sized if both the min and max sizes are intrinsic, not just one of them.

Fixes #18387