### PR TITLE
LibSQL: Implement variable heap storage

### DIFF
--- a/Base/res/html/misc/cookie.html
+++ b/Base/res/html/misc/cookie.html
@@ -6,6 +6,7 @@
     <br /><input type=button onclick="setCookie(this.value)" value="cookie4=value4;SameSite=Lax" />
     <br /><input type=button onclick="setCookie(this.value)" value="cookie5=value5;SameSite=Strict" />
     <br /><input type=button onclick="setCookie(this.value)" value="cookie6=value6;SameSite=None" />
+    <br /><input type=button onclick="setPrettyLargeCookie()" value="cookie7=xxxxx..[2048 x's]" />
     <br />
 
     <h3>Invalid cookies (the browser should reject these):</h3>
@@ -34,6 +35,10 @@
         function setCookie(cookie) {
             document.cookie = cookie;
             document.getElementById('cookies').innerHTML = document.cookie;
+        }
+
+        function setPrettyLargeCookie() {
+            setCookie('cookie7=' + 'x'.repeat(2048));
         }
 
         function setTooLargeCookie() {

--- a/Tests/LibSQL/TestSqlBtreeIndex.cpp
+++ b/Tests/LibSQL/TestSqlBtreeIndex.cpp
@@ -153,7 +153,7 @@ void insert_and_get_to_and_from_btree(int num_keys)
         for (auto ix = 0; ix < num_keys; ix++) {
             SQL::Key k(btree->descriptor());
             k[0] = keys[ix];
-            k.set_pointer(pointers[ix]);
+            k.set_block_index(pointers[ix]);
             btree->insert(k);
         }
 #ifdef LIST_TREE
@@ -189,7 +189,7 @@ void insert_into_and_scan_btree(int num_keys)
         for (auto ix = 0; ix < num_keys; ix++) {
             SQL::Key k(btree->descriptor());
             k[0] = keys[ix];
-            k.set_pointer(pointers[ix]);
+            k.set_block_index(pointers[ix]);
             btree->insert(k);
         }
 
@@ -213,7 +213,7 @@ void insert_into_and_scan_btree(int num_keys)
             auto key_value = key[0].to_int<i32>();
             for (auto ix = 0; ix < num_keys; ix++) {
                 if (keys[ix] == key_value) {
-                    EXPECT_EQ(key.pointer(), pointers[ix]);
+                    EXPECT_EQ(key.block_index(), pointers[ix]);
                     break;
                 }
             }

--- a/Tests/LibSQL/TestSqlBtreeIndex.cpp
+++ b/Tests/LibSQL/TestSqlBtreeIndex.cpp
@@ -131,7 +131,7 @@ NonnullRefPtr<SQL::BTree> setup_btree(SQL::Serializer& serializer)
 
     auto root_pointer = serializer.heap().user_value(0);
     if (!root_pointer) {
-        root_pointer = serializer.heap().new_record_pointer();
+        root_pointer = serializer.heap().request_new_block_index();
         serializer.heap().set_user_value(0, root_pointer);
     }
     auto btree = SQL::BTree::construct(serializer, tuple_descriptor, true, root_pointer);

--- a/Tests/LibSQL/TestSqlBtreeIndex.cpp
+++ b/Tests/LibSQL/TestSqlBtreeIndex.cpp
@@ -208,9 +208,8 @@ void insert_into_and_scan_btree(int num_keys)
         SQL::Tuple prev;
         for (auto iter = btree->begin(); !iter.is_end(); iter++, count++) {
             auto key = (*iter);
-            if (prev.size()) {
+            if (prev.size())
                 EXPECT(prev < key);
-            }
             auto key_value = key[0].to_int<i32>();
             for (auto ix = 0; ix < num_keys; ix++) {
                 if (keys[ix] == key_value) {

--- a/Tests/LibSQL/TestSqlDatabase.cpp
+++ b/Tests/LibSQL/TestSqlDatabase.cpp
@@ -110,7 +110,7 @@ TEST_CASE(create_heap)
     ScopeGuard guard([]() { unlink("/tmp/test.db"); });
     auto heap = SQL::Heap::construct("/tmp/test.db");
     EXPECT(!heap->open().is_error());
-    EXPECT_EQ(heap->version(), SQL::Heap::current_version);
+    EXPECT_EQ(heap->version(), SQL::Heap::VERSION);
 }
 
 TEST_CASE(create_from_dev_random)

--- a/Tests/LibSQL/TestSqlHashIndex.cpp
+++ b/Tests/LibSQL/TestSqlHashIndex.cpp
@@ -129,7 +129,7 @@ NonnullRefPtr<SQL::HashIndex> setup_hash_index(SQL::Serializer& serializer)
 
     auto directory_pointer = serializer.heap().user_value(0);
     if (!directory_pointer) {
-        directory_pointer = serializer.heap().new_record_pointer();
+        directory_pointer = serializer.heap().request_new_block_index();
         serializer.heap().set_user_value(0, directory_pointer);
     }
     auto hash_index = SQL::HashIndex::construct(serializer, tuple_descriptor, directory_pointer);

--- a/Tests/LibSQL/TestSqlHashIndex.cpp
+++ b/Tests/LibSQL/TestSqlHashIndex.cpp
@@ -127,12 +127,12 @@ NonnullRefPtr<SQL::HashIndex> setup_hash_index(SQL::Serializer& serializer)
     tuple_descriptor->append({ "schema", "table", "key_value", SQL::SQLType::Integer, SQL::Order::Ascending });
     tuple_descriptor->append({ "schema", "table", "text_value", SQL::SQLType::Text, SQL::Order::Ascending });
 
-    auto directory_pointer = serializer.heap().user_value(0);
-    if (!directory_pointer) {
-        directory_pointer = serializer.heap().request_new_block_index();
-        serializer.heap().set_user_value(0, directory_pointer);
+    auto directory_block_index = serializer.heap().user_value(0);
+    if (!directory_block_index) {
+        directory_block_index = serializer.heap().request_new_block_index();
+        serializer.heap().set_user_value(0, directory_block_index);
     }
-    auto hash_index = SQL::HashIndex::construct(serializer, tuple_descriptor, directory_pointer);
+    auto hash_index = SQL::HashIndex::construct(serializer, tuple_descriptor, directory_block_index);
     return hash_index;
 }
 
@@ -149,7 +149,7 @@ void insert_and_get_to_and_from_hash_index(int num_keys)
             SQL::Key k(hash_index->descriptor());
             k[0] = keys[ix];
             k[1] = DeprecatedString::formatted("The key value is {} and the pointer is {}", keys[ix], pointers[ix]);
-            k.set_pointer(pointers[ix]);
+            k.set_block_index(pointers[ix]);
             hash_index->insert(k);
         }
 #ifdef LIST_HASH_INDEX
@@ -247,7 +247,7 @@ void insert_into_and_scan_hash_index(int num_keys)
             SQL::Key k(hash_index->descriptor());
             k[0] = keys[ix];
             k[1] = DeprecatedString::formatted("The key value is {} and the pointer is {}", keys[ix], pointers[ix]);
-            k.set_pointer(pointers[ix]);
+            k.set_block_index(pointers[ix]);
             hash_index->insert(k);
         }
 #ifdef LIST_HASH_INDEX
@@ -273,7 +273,7 @@ void insert_into_and_scan_hash_index(int num_keys)
 
             for (auto ix = 0; ix < num_keys; ix++) {
                 if (keys[ix] == key_value) {
-                    EXPECT_EQ(key.pointer(), pointers[ix]);
+                    EXPECT_EQ(key.block_index(), pointers[ix]);
                     if (found[ix])
                         FAIL(DeprecatedString::formatted("Key {}, index {} already found previously", *key_value, ix));
                     found[ix] = true;

--- a/Userland/Libraries/LibSQL/BTree.cpp
+++ b/Userland/Libraries/LibSQL/BTree.cpp
@@ -9,14 +9,14 @@
 
 namespace SQL {
 
-BTree::BTree(Serializer& serializer, NonnullRefPtr<TupleDescriptor> const& descriptor, bool unique, u32 pointer)
-    : Index(serializer, descriptor, unique, pointer)
+BTree::BTree(Serializer& serializer, NonnullRefPtr<TupleDescriptor> const& descriptor, bool unique, Block::Index block_index)
+    : Index(serializer, descriptor, unique, block_index)
     , m_root(nullptr)
 {
 }
 
-BTree::BTree(Serializer& serializer, NonnullRefPtr<TupleDescriptor> const& descriptor, u32 pointer)
-    : BTree(serializer, descriptor, true, pointer)
+BTree::BTree(Serializer& serializer, NonnullRefPtr<TupleDescriptor> const& descriptor, Block::Index block_index)
+    : BTree(serializer, descriptor, true, block_index)
 {
 }
 
@@ -35,16 +35,16 @@ BTreeIterator BTree::end()
 
 void BTree::initialize_root()
 {
-    if (pointer()) {
-        if (serializer().has_block(pointer())) {
-            serializer().read_storage(pointer());
-            m_root = serializer().make_and_deserialize<TreeNode>(*this, pointer());
+    if (block_index()) {
+        if (serializer().has_block(block_index())) {
+            serializer().read_storage(block_index());
+            m_root = serializer().make_and_deserialize<TreeNode>(*this, block_index());
         } else {
-            m_root = make<TreeNode>(*this, nullptr, pointer());
+            m_root = make<TreeNode>(*this, nullptr, block_index());
         }
     } else {
-        set_pointer(request_new_block_index());
-        m_root = make<TreeNode>(*this, nullptr, pointer());
+        set_block_index(request_new_block_index());
+        m_root = make<TreeNode>(*this, nullptr, block_index());
         if (on_new_root)
             on_new_root();
     }
@@ -53,8 +53,8 @@ void BTree::initialize_root()
 
 TreeNode* BTree::new_root()
 {
-    set_pointer(request_new_block_index());
-    m_root = make<TreeNode>(*this, nullptr, m_root.leak_ptr(), pointer());
+    set_block_index(request_new_block_index());
+    m_root = make<TreeNode>(*this, nullptr, m_root.leak_ptr(), block_index());
     serializer().serialize_and_write(*m_root.ptr());
     if (on_new_root)
         on_new_root();

--- a/Userland/Libraries/LibSQL/BTree.cpp
+++ b/Userland/Libraries/LibSQL/BTree.cpp
@@ -65,7 +65,6 @@ bool BTree::insert(Key const& key)
 {
     if (!m_root)
         initialize_root();
-    VERIFY(m_root);
     return m_root->insert(key);
 }
 
@@ -73,7 +72,6 @@ bool BTree::update_key_pointer(Key const& key)
 {
     if (!m_root)
         initialize_root();
-    VERIFY(m_root);
     return m_root->update_key_pointer(key);
 }
 
@@ -81,7 +79,6 @@ Optional<u32> BTree::get(Key& key)
 {
     if (!m_root)
         initialize_root();
-    VERIFY(m_root);
     return m_root->get(key);
 }
 
@@ -89,7 +86,6 @@ BTreeIterator BTree::find(Key const& key)
 {
     if (!m_root)
         initialize_root();
-    VERIFY(m_root);
     for (auto node = m_root->node_for(key); node; node = node->up()) {
         for (auto ix = 0u; ix < node->size(); ix++) {
             auto match = (*node)[ix].match(key);

--- a/Userland/Libraries/LibSQL/BTree.cpp
+++ b/Userland/Libraries/LibSQL/BTree.cpp
@@ -37,13 +37,13 @@ void BTree::initialize_root()
 {
     if (pointer()) {
         if (serializer().has_block(pointer())) {
-            serializer().get_block(pointer());
+            serializer().read_storage(pointer());
             m_root = serializer().make_and_deserialize<TreeNode>(*this, pointer());
         } else {
             m_root = make<TreeNode>(*this, nullptr, pointer());
         }
     } else {
-        set_pointer(new_record_pointer());
+        set_pointer(request_new_block_index());
         m_root = make<TreeNode>(*this, nullptr, pointer());
         if (on_new_root)
             on_new_root();
@@ -53,7 +53,7 @@ void BTree::initialize_root()
 
 TreeNode* BTree::new_root()
 {
-    set_pointer(new_record_pointer());
+    set_pointer(request_new_block_index());
     m_root = make<TreeNode>(*this, nullptr, m_root.leak_ptr(), pointer());
     serializer().serialize_and_write(*m_root.ptr());
     if (on_new_root)

--- a/Userland/Libraries/LibSQL/BTree.h
+++ b/Userland/Libraries/LibSQL/BTree.h
@@ -32,28 +32,28 @@ namespace SQL {
  */
 class DownPointer {
 public:
-    explicit DownPointer(TreeNode*, u32 = 0);
+    explicit DownPointer(TreeNode*, Block::Index = 0);
     DownPointer(TreeNode*, TreeNode*);
     DownPointer(DownPointer&&);
     DownPointer(TreeNode*, DownPointer&);
     ~DownPointer() = default;
-    [[nodiscard]] u32 pointer() const { return m_pointer; }
+    [[nodiscard]] Block::Index block_index() const { return m_block_index; }
     TreeNode* node();
 
 private:
     void deserialize(Serializer&);
 
     TreeNode* m_owner;
-    u32 m_pointer { 0 };
+    Block::Index m_block_index { 0 };
     OwnPtr<TreeNode> m_node { nullptr };
     friend TreeNode;
 };
 
 class TreeNode : public IndexNode {
 public:
-    TreeNode(BTree&, u32 = 0);
-    TreeNode(BTree&, TreeNode*, u32 = 0);
-    TreeNode(BTree&, TreeNode*, TreeNode*, u32 = 0);
+    TreeNode(BTree&, Block::Index = 0);
+    TreeNode(BTree&, TreeNode*, Block::Index = 0);
+    TreeNode(BTree&, TreeNode*, TreeNode*, Block::Index = 0);
     ~TreeNode() override = default;
 
     [[nodiscard]] BTree& tree() const { return m_tree; }
@@ -61,7 +61,7 @@ public:
     [[nodiscard]] size_t size() const { return m_entries.size(); }
     [[nodiscard]] size_t length() const;
     [[nodiscard]] Vector<Key> entries() const { return m_entries; }
-    [[nodiscard]] u32 down_pointer(size_t) const;
+    [[nodiscard]] Block::Index down_pointer(size_t) const;
     [[nodiscard]] TreeNode* down_node(size_t);
     [[nodiscard]] bool is_leaf() const { return m_is_leaf; }
 
@@ -97,7 +97,7 @@ class BTree : public Index {
 public:
     ~BTree() override = default;
 
-    u32 root() const { return (m_root) ? m_root->pointer() : 0; }
+    Block::Index root() const { return m_root ? m_root->block_index() : 0; }
     bool insert(Key const&);
     bool update_key_pointer(Key const&);
     Optional<u32> get(Key&);
@@ -109,8 +109,8 @@ public:
     Function<void(void)> on_new_root;
 
 private:
-    BTree(Serializer&, NonnullRefPtr<TupleDescriptor> const&, bool unique, u32 pointer);
-    BTree(Serializer&, NonnullRefPtr<TupleDescriptor> const&, u32 pointer);
+    BTree(Serializer&, NonnullRefPtr<TupleDescriptor> const&, bool unique, Block::Index);
+    BTree(Serializer&, NonnullRefPtr<TupleDescriptor> const&, Block::Index);
     void initialize_root();
     TreeNode* new_root();
     OwnPtr<TreeNode> m_root { nullptr };

--- a/Userland/Libraries/LibSQL/BTreeIterator.cpp
+++ b/Userland/Libraries/LibSQL/BTreeIterator.cpp
@@ -133,9 +133,8 @@ BTreeIterator BTreeIterator::next() const
 // end (which is really the beginning) of the tree.
 BTreeIterator BTreeIterator::previous() const
 {
-    if (is_end()) {
+    if (is_end())
         return end();
-    }
 
     auto node = m_current;
     auto ix = m_index;

--- a/Userland/Libraries/LibSQL/BTreeIterator.cpp
+++ b/Userland/Libraries/LibSQL/BTreeIterator.cpp
@@ -107,7 +107,7 @@ BTreeIterator BTreeIterator::next() const
             for (size_t i = 0; i < up->size(); i++) {
                 // One level up, try to find the entry with the current
                 // node's pointer as the left pointer:
-                if (up->down_pointer(i) == node->pointer())
+                if (up->down_pointer(i) == node->block_index())
                     // Found it. This is the iterator's next value:
                     return BTreeIterator(up, (int)i);
             }
@@ -182,7 +182,7 @@ BTreeIterator BTreeIterator::previous() const
             for (size_t i = up->size(); i > 0; i--) {
                 // One level up, try to find the entry with the current
                 // node's pointer as the right pointer:
-                if (up->down_pointer(i) == node->pointer()) {
+                if (up->down_pointer(i) == node->block_index()) {
                     // Found it. This is the iterator's next value:
                     node = up;
                     ix = (int)i - 1;
@@ -218,7 +218,7 @@ bool BTreeIterator::update(Key const& new_value)
 {
     if (is_end())
         return false;
-    if ((cmp(new_value) == 0) && (key().pointer() == new_value.pointer()))
+    if ((cmp(new_value) == 0) && (key().block_index() == new_value.block_index()))
         return true;
     auto previous_iter = previous();
     auto next_iter = next();

--- a/Userland/Libraries/LibSQL/Database.cpp
+++ b/Userland/Libraries/LibSQL/Database.cpp
@@ -6,8 +6,7 @@
  */
 
 #include <AK/DeprecatedString.h>
-#include <AK/RefPtr.h>
-
+#include <AK/NonnullRefPtr.h>
 #include <LibSQL/BTree.h>
 #include <LibSQL/Database.h>
 #include <LibSQL/Heap.h>
@@ -174,9 +173,8 @@ ErrorOr<Vector<Row>> Database::select_all(TableDef& table)
 {
     VERIFY(m_table_cache.get(table.key().hash()).has_value());
     Vector<Row> ret;
-    for (auto pointer = table.pointer(); pointer; pointer = ret.last().next_pointer()) {
+    for (auto pointer = table.pointer(); pointer; pointer = ret.last().next_pointer())
         ret.append(m_serializer.deserialize_block<Row>(pointer, table, pointer));
-    }
     return ret;
 }
 

--- a/Userland/Libraries/LibSQL/Database.cpp
+++ b/Userland/Libraries/LibSQL/Database.cpp
@@ -197,9 +197,9 @@ ErrorOr<Vector<Row>> Database::match(TableDef& table, Key const& key)
 ErrorOr<void> Database::insert(Row& row)
 {
     VERIFY(m_table_cache.get(row.table().key().hash()).has_value());
-    // TODO Check constraints
+    // TODO: implement table constraints such as unique, foreign key, etc.
 
-    row.set_pointer(m_heap->new_record_pointer());
+    row.set_pointer(m_heap->request_new_block_index());
     row.set_next_pointer(row.table().pointer());
     TRY(update(row));
 
@@ -244,7 +244,8 @@ ErrorOr<void> Database::remove(Row& row)
 ErrorOr<void> Database::update(Row& tuple)
 {
     VERIFY(m_table_cache.get(tuple.table().key().hash()).has_value());
-    // TODO Check constraints
+    // TODO: implement table constraints such as unique, foreign key, etc.
+
     m_serializer.reset();
     m_serializer.serialize_and_write<Tuple>(tuple);
 

--- a/Userland/Libraries/LibSQL/HashIndex.cpp
+++ b/Userland/Libraries/LibSQL/HashIndex.cpp
@@ -187,13 +187,11 @@ Key const& HashBucket::operator[](size_t ix)
 {
     if (!m_inflated)
         m_hash_index.serializer().deserialize_block_to(pointer(), *this);
-    VERIFY(ix < size());
     return m_entries[ix];
 }
 
 Key const& HashBucket::operator[](size_t ix) const
 {
-    VERIFY(ix < m_entries.size());
     return m_entries[ix];
 }
 

--- a/Userland/Libraries/LibSQL/HashIndex.cpp
+++ b/Userland/Libraries/LibSQL/HashIndex.cpp
@@ -86,9 +86,8 @@ void HashBucket::serialize(Serializer& serializer) const
         pointer(), index(), local_depth(), size());
     serializer.serialize<u32>(local_depth());
     serializer.serialize<u32>(size());
-    for (auto& key : m_entries) {
+    for (auto& key : m_entries)
         serializer.serialize<Key>(key);
-    }
 }
 
 void HashBucket::deserialize(Serializer& serializer)
@@ -111,9 +110,8 @@ void HashBucket::deserialize(Serializer& serializer)
 size_t HashBucket::length() const
 {
     size_t len = 2 * sizeof(u32);
-    for (auto& key : m_entries) {
+    for (auto& key : m_entries)
         len += key.length();
-    }
     return len;
 }
 
@@ -132,9 +130,8 @@ bool HashBucket::insert(Key const& key)
 {
     if (!m_inflated)
         m_hash_index.serializer().deserialize_block_to(pointer(), *this);
-    if (find_key_in_bucket(key).has_value()) {
+    if (find_key_in_bucket(key).has_value())
         return false;
-    }
     if ((length() + key.length()) > BLOCKSIZE) {
         dbgln_if(SQL_DEBUG, "Adding key {} would make length exceed block size", key.to_deprecated_string());
         return false;
@@ -148,9 +145,8 @@ Optional<size_t> HashBucket::find_key_in_bucket(Key const& key)
 {
     for (auto ix = 0u; ix < size(); ix++) {
         auto& k = entries()[ix];
-        if (k == key) {
+        if (k == key)
             return ix;
-        }
     }
     return {};
 }
@@ -199,9 +195,8 @@ void HashBucket::list_bucket()
 {
     warnln("Bucket #{} size {} local depth {} pointer {}{}",
         index(), size(), local_depth(), pointer(), (pointer() ? "" : " (VIRTUAL)"));
-    for (auto& key : entries()) {
+    for (auto& key : entries())
         warnln("  {} hash {}", key.to_deprecated_string(), key.hash());
-    }
 }
 
 HashIndex::HashIndex(Serializer& serializer, NonnullRefPtr<TupleDescriptor> const& descriptor, u32 first_node)
@@ -209,9 +204,8 @@ HashIndex::HashIndex(Serializer& serializer, NonnullRefPtr<TupleDescriptor> cons
     , m_nodes()
     , m_buckets()
 {
-    if (!first_node) {
+    if (!first_node)
         set_pointer(new_record_pointer());
-    }
     if (serializer.has_block(first_node)) {
         u32 pointer = first_node;
         do {
@@ -272,9 +266,8 @@ HashBucket* HashIndex::get_bucket_for_insert(Key const& key)
                 auto moved = 0;
                 for (auto entry_index = (int)bucket->m_entries.size() - 1; entry_index >= 0; entry_index--) {
                     if (bucket->m_entries[entry_index].hash() % size() == ix) {
-                        if (!sub_bucket->pointer()) {
+                        if (!sub_bucket->pointer())
                             sub_bucket->set_pointer(new_record_pointer());
-                        }
                         sub_bucket->insert(bucket->m_entries.take(entry_index));
                         moved++;
                     }
@@ -389,18 +382,12 @@ void HashIndex::list_hash()
 {
     warnln("Number of buckets: {} (Global depth {})", size(), global_depth());
     warn("Directory pointer(s): ");
-    for (auto ptr : m_nodes) {
+    for (auto ptr : m_nodes)
         warn("{}, ", ptr);
-    }
     warnln();
 
-    bool first_bucket = true;
-    for (auto& bucket : m_buckets) {
-        if (first_bucket) {
-            first_bucket = false;
-        }
+    for (auto& bucket : m_buckets)
         bucket->list_bucket();
-    }
 }
 
 HashIndexIterator::HashIndexIterator(HashBucket const* bucket, size_t index)

--- a/Userland/Libraries/LibSQL/HashIndex.cpp
+++ b/Userland/Libraries/LibSQL/HashIndex.cpp
@@ -132,7 +132,7 @@ bool HashBucket::insert(Key const& key)
         m_hash_index.serializer().deserialize_block_to(pointer(), *this);
     if (find_key_in_bucket(key).has_value())
         return false;
-    if ((length() + key.length()) > BLOCKSIZE) {
+    if ((length() + key.length()) > Heap::BLOCK_SIZE) {
         dbgln_if(SQL_DEBUG, "Adding key {} would make length exceed block size", key.to_deprecated_string());
         return false;
     }
@@ -247,9 +247,8 @@ HashBucket* HashIndex::get_bucket_for_insert(Key const& key)
     do {
         dbgln_if(SQL_DEBUG, "HashIndex::get_bucket_for_insert({}) bucket {} of {}", key.to_deprecated_string(), key_hash % size(), size());
         auto bucket = get_bucket(key_hash % size());
-        if (bucket->length() + key.length() < BLOCKSIZE) {
+        if (bucket->length() + key.length() < Heap::BLOCK_SIZE)
             return bucket;
-        }
         dbgln_if(SQL_DEBUG, "Bucket is full (bucket size {}/length {} key length {}). Expanding directory", bucket->size(), bucket->length(), key.length());
 
         // We previously doubled the directory but the target bucket is
@@ -287,7 +286,7 @@ HashBucket* HashIndex::get_bucket_for_insert(Key const& key)
             write_directory_to_write_ahead_log();
 
             auto bucket_after_redistribution = get_bucket(key_hash % size());
-            if (bucket_after_redistribution->length() + key.length() < BLOCKSIZE)
+            if (bucket_after_redistribution->length() + key.length() < Heap::BLOCK_SIZE)
                 return bucket_after_redistribution;
         }
         expand();

--- a/Userland/Libraries/LibSQL/HashIndex.h
+++ b/Userland/Libraries/LibSQL/HashIndex.h
@@ -82,7 +82,7 @@ private:
     HashIndex(Serializer&, NonnullRefPtr<TupleDescriptor> const&, u32);
 
     void expand();
-    void write_directory_to_write_ahead_log();
+    void write_directory();
     HashBucket* append_bucket(u32 index, u32 local_depth, u32 pointer);
     HashBucket* get_bucket_for_insert(Key const&);
     [[nodiscard]] HashBucket* get_bucket_by_index(u32 index);
@@ -104,7 +104,7 @@ public:
     void serialize(Serializer&) const;
     [[nodiscard]] u32 number_of_pointers() const { return min(max_pointers_in_node(), m_hash_index.size() - m_offset); }
     [[nodiscard]] bool is_last() const { return m_is_last; }
-    static constexpr size_t max_pointers_in_node() { return (Heap::BLOCK_SIZE - 3 * sizeof(u32)) / (2 * sizeof(u32)); }
+    static constexpr size_t max_pointers_in_node() { return (Block::DATA_SIZE - 3 * sizeof(u32)) / (2 * sizeof(u32)); }
 
 private:
     HashIndex& m_hash_index;

--- a/Userland/Libraries/LibSQL/HashIndex.h
+++ b/Userland/Libraries/LibSQL/HashIndex.h
@@ -104,7 +104,7 @@ public:
     void serialize(Serializer&) const;
     [[nodiscard]] u32 number_of_pointers() const { return min(max_pointers_in_node(), m_hash_index.size() - m_offset); }
     [[nodiscard]] bool is_last() const { return m_is_last; }
-    static constexpr size_t max_pointers_in_node() { return (BLOCKSIZE - 3 * sizeof(u32)) / (2 * sizeof(u32)); }
+    static constexpr size_t max_pointers_in_node() { return (Heap::BLOCK_SIZE - 3 * sizeof(u32)) / (2 * sizeof(u32)); }
 
 private:
     HashIndex& m_hash_index;

--- a/Userland/Libraries/LibSQL/HashIndex.h
+++ b/Userland/Libraries/LibSQL/HashIndex.h
@@ -24,7 +24,7 @@ namespace SQL {
 class HashBucket : public IndexNode
     , public Weakable<HashBucket> {
 public:
-    HashBucket(HashIndex&, u32 index, u32 local_depth, u32 pointer);
+    HashBucket(HashIndex&, Block::Index index, u32 local_depth, Block::Index pointer);
     ~HashBucket() override = default;
     Optional<u32> get(Key&);
     bool insert(Key const&);
@@ -35,7 +35,7 @@ public:
     [[nodiscard]] u32 size() { return entries().size(); }
     [[nodiscard]] size_t length() const;
     [[nodiscard]] u32 size() const { return m_entries.size(); }
-    [[nodiscard]] u32 index() const { return m_index; }
+    [[nodiscard]] Block::Index index() const { return m_index; }
     void serialize(Serializer&) const;
     void deserialize(Serializer&);
     [[nodiscard]] HashIndex const& hash_index() const { return m_hash_index; }
@@ -45,12 +45,12 @@ public:
 
 private:
     Optional<size_t> find_key_in_bucket(Key const&);
-    void set_index(u32 index) { m_index = index; }
+    void set_index(Block::Index index) { m_index = index; }
     void set_local_depth(u32 depth) { m_local_depth = depth; }
 
     HashIndex& m_hash_index;
     u32 m_local_depth { 1 };
-    u32 m_index { 0 };
+    Block::Index m_index { 0 };
     Vector<Key> m_entries;
     bool m_inflated { false };
 
@@ -79,7 +79,7 @@ public:
     void list_hash();
 
 private:
-    HashIndex(Serializer&, NonnullRefPtr<TupleDescriptor> const&, u32);
+    HashIndex(Serializer&, NonnullRefPtr<TupleDescriptor> const&, Block::Index);
 
     void expand();
     void write_directory();

--- a/Userland/Libraries/LibSQL/Heap.cpp
+++ b/Userland/Libraries/LibSQL/Heap.cpp
@@ -10,9 +10,7 @@
 #include <LibCore/IODevice.h>
 #include <LibCore/System.h>
 #include <LibSQL/Heap.h>
-#include <LibSQL/Serializer.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 
 namespace SQL {
 
@@ -169,9 +167,8 @@ ErrorOr<void> Heap::flush()
 {
     VERIFY(m_file);
     Vector<u32> blocks;
-    for (auto& wal_entry : m_write_ahead_log) {
+    for (auto& wal_entry : m_write_ahead_log)
         blocks.append(wal_entry.key);
-    }
     quick_sort(blocks);
     for (auto& block : blocks) {
         auto buffer_it = m_write_ahead_log.find(block);
@@ -221,9 +218,8 @@ ErrorOr<void> Heap::read_zero_block()
 
     memcpy(m_user_values.data(), buffer.offset_pointer(USER_VALUES_OFFSET), m_user_values.size() * sizeof(u32));
     for (auto ix = 0u; ix < m_user_values.size(); ix++) {
-        if (m_user_values[ix]) {
+        if (m_user_values[ix])
             dbgln_if(SQL_DEBUG, "User value {}: {}", ix, m_user_values[ix]);
-        }
     }
     return {};
 }
@@ -237,9 +233,8 @@ void Heap::update_zero_block()
     dbgln_if(SQL_DEBUG, "Table Columns root node: {}", m_table_columns_root);
     dbgln_if(SQL_DEBUG, "Free list: {}", m_free_list);
     for (auto ix = 0u; ix < m_user_values.size(); ix++) {
-        if (m_user_values[ix]) {
+        if (m_user_values[ix])
             dbgln_if(SQL_DEBUG, "User value {}: {}", ix, m_user_values[ix]);
-        }
     }
 
     // FIXME: Handle an OOM failure here.
@@ -263,9 +258,8 @@ void Heap::initialize_zero_block()
     m_table_columns_root = 0;
     m_next_block = 1;
     m_free_list = 0;
-    for (auto& user : m_user_values) {
+    for (auto& user : m_user_values)
         user = 0u;
-    }
     update_zero_block();
 }
 

--- a/Userland/Libraries/LibSQL/Heap.cpp
+++ b/Userland/Libraries/LibSQL/Heap.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ * Copyright (c) 2023, Jelle Raaijmakers <jelle@gmta.nl>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -42,8 +43,10 @@ ErrorOr<void> Heap::open()
     } else {
         file_size = stat_buffer.st_size;
     }
-    if (file_size > 0)
-        m_next_block = m_end_of_file = file_size / BLOCK_SIZE;
+    if (file_size > 0) {
+        m_next_block = file_size / Block::SIZE;
+        m_highest_block_written = m_next_block - 1;
+    }
 
     auto file = TRY(Core::File::open(name(), Core::File::OpenMode::ReadWrite));
     m_file = TRY(Core::BufferedFile::create(move(file)));
@@ -54,7 +57,7 @@ ErrorOr<void> Heap::open()
             return error_maybe.release_error();
         }
     } else {
-        initialize_zero_block();
+        TRY(initialize_zero_block());
     }
 
     // FIXME: We should more gracefully handle version incompatibilities. For now, we drop the database.
@@ -66,118 +69,137 @@ ErrorOr<void> Heap::open()
         return open();
     }
 
-    dbgln_if(SQL_DEBUG, "Heap file {} opened. Size = {}", name(), size());
+    dbgln_if(SQL_DEBUG, "Heap file {} opened; number of blocks = {}", name(), m_highest_block_written);
     return {};
 }
 
-ErrorOr<ByteBuffer> Heap::read_block(u32 block)
+bool Heap::has_block(Block::Index index) const
 {
-    if (!m_file) {
-        warnln("Heap({})::read_block({}): Heap file not opened"sv, name(), block);
-        return Error::from_string_literal("Heap()::read_block(): Heap file not opened");
+    return index <= m_highest_block_written || m_write_ahead_log.contains(index);
+}
+
+ErrorOr<ByteBuffer> Heap::read_storage(Block::Index index)
+{
+    dbgln_if(SQL_DEBUG, "{}({})", __FUNCTION__, index);
+
+    // Reconstruct the data storage from a potential chain of blocks
+    ByteBuffer data;
+    while (index > 0) {
+        auto block = TRY(read_block(index));
+        dbgln_if(SQL_DEBUG, "  -> {} bytes", block.size_in_bytes());
+        TRY(data.try_append(block.data().bytes().slice(0, block.size_in_bytes())));
+        index = block.next_block();
     }
+    return data;
+}
 
-    if (auto buffer = m_write_ahead_log.get(block); buffer.has_value())
-        return TRY(ByteBuffer::copy(*buffer));
+ErrorOr<void> Heap::write_storage(Block::Index index, ReadonlyBytes data)
+{
+    dbgln_if(SQL_DEBUG, "{}({}, {} bytes)", __FUNCTION__, index, data.size());
+    VERIFY(data.size() > 0);
 
-    if (block >= m_next_block) {
-        warnln("Heap({})::read_block({}): block # out of range (>= {})"sv, name(), block, m_next_block);
-        return Error::from_string_literal("Heap()::read_block(): block # out of range");
+    // Split up the storage across multiple blocks if necessary, creating a chain
+    u32 remaining_size = static_cast<u32>(data.size());
+    u32 offset_in_data = 0;
+    while (remaining_size > 0) {
+        auto block_data_size = AK::min(remaining_size, Block::DATA_SIZE);
+        remaining_size -= block_data_size;
+        auto next_block_index = (remaining_size > 0) ? request_new_block_index() : 0;
+
+        auto block_data = TRY(ByteBuffer::create_uninitialized(block_data_size));
+        block_data.bytes().overwrite(0, data.offset(offset_in_data), block_data_size);
+
+        TRY(write_block({ index, block_data_size, next_block_index, move(block_data) }));
+
+        index = next_block_index;
+        offset_in_data += block_data_size;
     }
+    return {};
+}
 
-    dbgln_if(SQL_DEBUG, "Read heap block {}", block);
-    TRY(seek_block(block));
+ErrorOr<ByteBuffer> Heap::read_raw_block(Block::Index index)
+{
+    VERIFY(m_file);
+    VERIFY(index < m_next_block);
 
-    auto buffer = TRY(ByteBuffer::create_uninitialized(BLOCK_SIZE));
+    if (auto data = m_write_ahead_log.get(index); data.has_value())
+        return data.value();
+
+    TRY(m_file->seek(index * Block::SIZE, SeekMode::SetPosition));
+    auto buffer = TRY(ByteBuffer::create_uninitialized(Block::SIZE));
     TRY(m_file->read_until_filled(buffer));
-
-    dbgln_if(SQL_DEBUG, "{:hex-dump}", buffer.bytes().trim(8));
-
     return buffer;
 }
 
-ErrorOr<void> Heap::write_block(u32 block, ByteBuffer& buffer)
+ErrorOr<Block> Heap::read_block(Block::Index index)
 {
-    if (!m_file) {
-        warnln("Heap({})::write_block({}): Heap file not opened"sv, name(), block);
-        return Error::from_string_literal("Heap()::write_block(): Heap file not opened");
-    }
-    if (block > m_next_block) {
-        warnln("Heap({})::write_block({}): block # out of range (> {})"sv, name(), block, m_next_block);
-        return Error::from_string_literal("Heap()::write_block(): block # out of range");
-    }
-    if (buffer.size() > BLOCK_SIZE) {
-        warnln("Heap({})::write_block({}): Oversized block ({} > {})"sv, name(), block, buffer.size(), BLOCK_SIZE);
-        return Error::from_string_literal("Heap()::write_block(): Oversized block");
-    }
+    dbgln_if(SQL_DEBUG, "Read heap block {}", index);
 
-    dbgln_if(SQL_DEBUG, "Write heap block {} size {}", block, buffer.size());
-    TRY(seek_block(block));
+    auto buffer = TRY(read_raw_block(index));
+    auto size_in_bytes = *reinterpret_cast<u32*>(buffer.offset_pointer(0));
+    auto next_block = *reinterpret_cast<Block::Index*>(buffer.offset_pointer(sizeof(u32)));
+    auto data = TRY(buffer.slice(Block::HEADER_SIZE, Block::DATA_SIZE));
 
-    if (auto current_size = buffer.size(); current_size < BLOCK_SIZE) {
-        TRY(buffer.try_resize(BLOCK_SIZE));
-        memset(buffer.offset_pointer(current_size), 0, BLOCK_SIZE - current_size);
-    }
-
-    dbgln_if(SQL_DEBUG, "{:hex-dump}", buffer.bytes().trim(8));
-    TRY(m_file->write_until_depleted(buffer));
-
-    if (block == m_end_of_file)
-        m_end_of_file++;
-    return {};
+    return Block { index, size_in_bytes, next_block, move(data) };
 }
 
-ErrorOr<void> Heap::seek_block(u32 block)
+ErrorOr<void> Heap::write_raw_block(Block::Index index, ReadonlyBytes data)
 {
-    if (!m_file) {
-        warnln("Heap({})::seek_block({}): Heap file not opened"sv, name(), block);
-        return Error::from_string_literal("Heap()::seek_block(): Heap file not opened");
-    }
-    if (block > m_end_of_file) {
-        warnln("Heap({})::seek_block({}): Cannot seek beyond end of file at block {}"sv, name(), block, m_end_of_file);
-        return Error::from_string_literal("Heap()::seek_block(): Cannot seek beyond end of file");
-    }
+    dbgln_if(SQL_DEBUG, "Write raw block {}", index);
 
-    if (block == m_end_of_file)
-        TRY(m_file->seek(0, SeekMode::FromEndPosition));
-    else
-        TRY(m_file->seek(block * BLOCK_SIZE, SeekMode::SetPosition));
-
-    return {};
-}
-
-u32 Heap::new_record_pointer()
-{
     VERIFY(m_file);
-    if (m_free_list) {
-        auto block_or_error = read_block(m_free_list);
-        if (block_or_error.is_error()) {
-            warnln("FREE LIST CORRUPTION");
-            VERIFY_NOT_REACHED();
-        }
-        auto new_pointer = m_free_list;
-        memcpy(&m_free_list, block_or_error.value().offset_pointer(0), sizeof(u32));
-        update_zero_block();
-        return new_pointer;
-    }
-    return m_next_block++;
+    VERIFY(data.size() == Block::SIZE);
+
+    TRY(m_file->seek(index * Block::SIZE, SeekMode::SetPosition));
+    TRY(m_file->write_until_depleted(data));
+
+    if (index > m_highest_block_written)
+        m_highest_block_written = index;
+
+    return {};
+}
+
+ErrorOr<void> Heap::write_raw_block_to_wal(Block::Index index, ByteBuffer&& data)
+{
+    dbgln_if(SQL_DEBUG, "{}(): adding raw block {} to WAL", __FUNCTION__, index);
+    VERIFY(index < m_next_block);
+    VERIFY(data.size() == Block::SIZE);
+
+    TRY(m_write_ahead_log.try_set(index, move(data)));
+
+    return {};
+}
+
+ErrorOr<void> Heap::write_block(Block const& block)
+{
+    VERIFY(block.index() < m_next_block);
+    VERIFY(block.next_block() < m_next_block);
+    VERIFY(block.data().size() <= Block::DATA_SIZE);
+
+    auto size_in_bytes = block.size_in_bytes();
+    auto next_block = block.next_block();
+
+    auto heap_data = TRY(ByteBuffer::create_zeroed(Block::SIZE));
+    heap_data.overwrite(0, &size_in_bytes, sizeof(size_in_bytes));
+    heap_data.overwrite(sizeof(size_in_bytes), &next_block, sizeof(next_block));
+
+    block.data().bytes().copy_to(heap_data.bytes().slice(Block::HEADER_SIZE));
+
+    return write_raw_block_to_wal(block.index(), move(heap_data));
 }
 
 ErrorOr<void> Heap::flush()
 {
     VERIFY(m_file);
-    Vector<u32> blocks;
-    for (auto& wal_entry : m_write_ahead_log)
-        blocks.append(wal_entry.key);
-    quick_sort(blocks);
-    for (auto& block : blocks) {
-        auto buffer_it = m_write_ahead_log.find(block);
-        VERIFY(buffer_it != m_write_ahead_log.end());
-        dbgln_if(SQL_DEBUG, "Flushing block {} to {}", block, name());
-        TRY(write_block(block, buffer_it->value));
+    auto indices = m_write_ahead_log.keys();
+    quick_sort(indices);
+    for (auto index : indices) {
+        dbgln_if(SQL_DEBUG, "Flushing block {} to {}", index, name());
+        auto& data = m_write_ahead_log.get(index).value();
+        TRY(write_raw_block(index, data));
     }
     m_write_ahead_log.clear();
-    dbgln_if(SQL_DEBUG, "WAL flushed. Heap size = {}", size());
+    dbgln_if(SQL_DEBUG, "WAL flushed; new number of blocks = {}", m_highest_block_written);
     return {};
 }
 
@@ -186,37 +208,33 @@ constexpr static auto VERSION_OFFSET = FILE_ID.length();
 constexpr static auto SCHEMAS_ROOT_OFFSET = VERSION_OFFSET + sizeof(u32);
 constexpr static auto TABLES_ROOT_OFFSET = SCHEMAS_ROOT_OFFSET + sizeof(u32);
 constexpr static auto TABLE_COLUMNS_ROOT_OFFSET = TABLES_ROOT_OFFSET + sizeof(u32);
-constexpr static auto FREE_LIST_OFFSET = TABLE_COLUMNS_ROOT_OFFSET + sizeof(u32);
-constexpr static auto USER_VALUES_OFFSET = FREE_LIST_OFFSET + sizeof(u32);
+constexpr static auto USER_VALUES_OFFSET = TABLE_COLUMNS_ROOT_OFFSET + sizeof(u32);
 
 ErrorOr<void> Heap::read_zero_block()
 {
-    auto buffer = TRY(read_block(0));
-    auto file_id_buffer = TRY(buffer.slice(0, FILE_ID.length()));
+    dbgln_if(SQL_DEBUG, "Read zero block from {}", name());
+
+    auto block = TRY(read_raw_block(0));
+    auto file_id_buffer = TRY(block.slice(0, FILE_ID.length()));
     auto file_id = StringView(file_id_buffer);
     if (file_id != FILE_ID) {
         warnln("{}: Zero page corrupt. This is probably not a {} heap file"sv, name(), FILE_ID);
         return Error::from_string_literal("Heap()::read_zero_block(): Zero page corrupt. This is probably not a SerenitySQL heap file");
     }
 
-    dbgln_if(SQL_DEBUG, "Read zero block from {}", name());
-
-    memcpy(&m_version, buffer.offset_pointer(VERSION_OFFSET), sizeof(u32));
+    memcpy(&m_version, block.offset_pointer(VERSION_OFFSET), sizeof(u32));
     dbgln_if(SQL_DEBUG, "Version: {}.{}", (m_version & 0xFFFF0000) >> 16, (m_version & 0x0000FFFF));
 
-    memcpy(&m_schemas_root, buffer.offset_pointer(SCHEMAS_ROOT_OFFSET), sizeof(u32));
+    memcpy(&m_schemas_root, block.offset_pointer(SCHEMAS_ROOT_OFFSET), sizeof(u32));
     dbgln_if(SQL_DEBUG, "Schemas root node: {}", m_schemas_root);
 
-    memcpy(&m_tables_root, buffer.offset_pointer(TABLES_ROOT_OFFSET), sizeof(u32));
+    memcpy(&m_tables_root, block.offset_pointer(TABLES_ROOT_OFFSET), sizeof(u32));
     dbgln_if(SQL_DEBUG, "Tables root node: {}", m_tables_root);
 
-    memcpy(&m_table_columns_root, buffer.offset_pointer(TABLE_COLUMNS_ROOT_OFFSET), sizeof(u32));
+    memcpy(&m_table_columns_root, block.offset_pointer(TABLE_COLUMNS_ROOT_OFFSET), sizeof(u32));
     dbgln_if(SQL_DEBUG, "Table columns root node: {}", m_table_columns_root);
 
-    memcpy(&m_free_list, buffer.offset_pointer(FREE_LIST_OFFSET), sizeof(u32));
-    dbgln_if(SQL_DEBUG, "Free list: {}", m_free_list);
-
-    memcpy(m_user_values.data(), buffer.offset_pointer(USER_VALUES_OFFSET), m_user_values.size() * sizeof(u32));
+    memcpy(m_user_values.data(), block.offset_pointer(USER_VALUES_OFFSET), m_user_values.size() * sizeof(u32));
     for (auto ix = 0u; ix < m_user_values.size(); ix++) {
         if (m_user_values[ix])
             dbgln_if(SQL_DEBUG, "User value {}: {}", ix, m_user_values[ix]);
@@ -224,43 +242,40 @@ ErrorOr<void> Heap::read_zero_block()
     return {};
 }
 
-void Heap::update_zero_block()
+ErrorOr<void> Heap::update_zero_block()
 {
     dbgln_if(SQL_DEBUG, "Write zero block to {}", name());
     dbgln_if(SQL_DEBUG, "Version: {}.{}", (m_version & 0xFFFF0000) >> 16, (m_version & 0x0000FFFF));
     dbgln_if(SQL_DEBUG, "Schemas root node: {}", m_schemas_root);
     dbgln_if(SQL_DEBUG, "Tables root node: {}", m_tables_root);
     dbgln_if(SQL_DEBUG, "Table Columns root node: {}", m_table_columns_root);
-    dbgln_if(SQL_DEBUG, "Free list: {}", m_free_list);
     for (auto ix = 0u; ix < m_user_values.size(); ix++) {
-        if (m_user_values[ix])
+        if (m_user_values[ix] > 0)
             dbgln_if(SQL_DEBUG, "User value {}: {}", ix, m_user_values[ix]);
     }
 
-    // FIXME: Handle an OOM failure here.
-    auto buffer = ByteBuffer::create_zeroed(BLOCK_SIZE).release_value_but_fixme_should_propagate_errors();
-    buffer.overwrite(0, FILE_ID.characters_without_null_termination(), FILE_ID.length());
-    buffer.overwrite(VERSION_OFFSET, &m_version, sizeof(u32));
-    buffer.overwrite(SCHEMAS_ROOT_OFFSET, &m_schemas_root, sizeof(u32));
-    buffer.overwrite(TABLES_ROOT_OFFSET, &m_tables_root, sizeof(u32));
-    buffer.overwrite(TABLE_COLUMNS_ROOT_OFFSET, &m_table_columns_root, sizeof(u32));
-    buffer.overwrite(FREE_LIST_OFFSET, &m_free_list, sizeof(u32));
-    buffer.overwrite(USER_VALUES_OFFSET, m_user_values.data(), m_user_values.size() * sizeof(u32));
+    auto buffer = TRY(ByteBuffer::create_zeroed(Block::SIZE));
+    auto buffer_bytes = buffer.bytes();
+    buffer_bytes.overwrite(0, FILE_ID.characters_without_null_termination(), FILE_ID.length());
+    buffer_bytes.overwrite(VERSION_OFFSET, &m_version, sizeof(u32));
+    buffer_bytes.overwrite(SCHEMAS_ROOT_OFFSET, &m_schemas_root, sizeof(u32));
+    buffer_bytes.overwrite(TABLES_ROOT_OFFSET, &m_tables_root, sizeof(u32));
+    buffer_bytes.overwrite(TABLE_COLUMNS_ROOT_OFFSET, &m_table_columns_root, sizeof(u32));
+    buffer_bytes.overwrite(USER_VALUES_OFFSET, m_user_values.data(), m_user_values.size() * sizeof(u32));
 
-    add_to_wal(0, buffer);
+    return write_raw_block_to_wal(0, move(buffer));
 }
 
-void Heap::initialize_zero_block()
+ErrorOr<void> Heap::initialize_zero_block()
 {
     m_version = VERSION;
     m_schemas_root = 0;
     m_tables_root = 0;
     m_table_columns_root = 0;
     m_next_block = 1;
-    m_free_list = 0;
     for (auto& user : m_user_values)
         user = 0u;
-    update_zero_block();
+    return update_zero_block();
 }
 
 }

--- a/Userland/Libraries/LibSQL/Heap.h
+++ b/Userland/Libraries/LibSQL/Heap.h
@@ -10,7 +10,6 @@
 #include <AK/Debug.h>
 #include <AK/DeprecatedString.h>
 #include <AK/HashMap.h>
-#include <AK/Vector.h>
 #include <LibCore/File.h>
 #include <LibCore/Object.h>
 

--- a/Userland/Libraries/LibSQL/Heap.h
+++ b/Userland/Libraries/LibSQL/Heap.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ * Copyright (c) 2023, Jelle Raaijmakers <jelle@gmta.nl>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -16,6 +17,43 @@
 namespace SQL {
 
 /**
+ * A Block represents a single discrete chunk of 1024 bytes inside the Heap, and
+ * acts as the container format for the actual data we are storing. This structure
+ * is used for everything except block 0, the zero / super block.
+ *
+ * If data needs to be stored that is larger than 1016 bytes, Blocks are chained
+ * together by setting the next block index and the data is reconstructed by
+ * repeatedly reading blocks until the next block index is 0.
+ */
+class Block {
+public:
+    typedef u32 Index;
+
+    static constexpr u32 SIZE = 1024;
+    static constexpr u32 HEADER_SIZE = sizeof(u32) + sizeof(Index);
+    static constexpr u32 DATA_SIZE = SIZE - HEADER_SIZE;
+
+    Block(Index index, u32 size_in_bytes, Index next_block, ByteBuffer data)
+        : m_index(index)
+        , m_size_in_bytes(size_in_bytes)
+        , m_next_block(next_block)
+        , m_data(move(data))
+    {
+    }
+
+    Index index() const { return m_index; }
+    u32 size_in_bytes() const { return m_size_in_bytes; }
+    Index next_block() const { return m_next_block; }
+    ByteBuffer const& data() const { return m_data; }
+
+private:
+    Index m_index;
+    u32 m_size_in_bytes;
+    Index m_next_block;
+    ByteBuffer m_data;
+};
+
+/**
  * A Heap is a logical container for database (SQL) data. Conceptually a
  * Heap can be a database file, or a memory block, or another storage medium.
  * It contains datastructures, like B-Trees, hash_index tables, or tuple stores
@@ -23,30 +61,25 @@ namespace SQL {
  *
  * A Heap can be thought of the backing storage of a single database. It's
  * assumed that a single SQL database is backed by a single Heap.
- *
- * Currently only B-Trees and tuple stores are implemented.
  */
 class Heap : public Core::Object {
     C_OBJECT(Heap);
 
 public:
-    static constexpr u32 VERSION = 3;
-    static constexpr u32 BLOCK_SIZE = 1024;
+    static constexpr u32 VERSION = 4;
 
     virtual ~Heap() override;
 
     ErrorOr<void> open();
-    u32 size() const { return m_end_of_file; }
-    ErrorOr<ByteBuffer> read_block(u32);
-    [[nodiscard]] u32 new_record_pointer();
-    [[nodiscard]] bool valid() const { return static_cast<bool>(m_file); }
+    bool has_block(Block::Index) const;
+    [[nodiscard]] Block::Index request_new_block_index() { return m_next_block++; }
 
     u32 schemas_root() const { return m_schemas_root; }
 
     void set_schemas_root(u32 root)
     {
         m_schemas_root = root;
-        update_zero_block();
+        update_zero_block().release_value_but_fixme_should_propagate_errors();
     }
 
     u32 tables_root() const { return m_tables_root; }
@@ -54,7 +87,7 @@ public:
     void set_tables_root(u32 root)
     {
         m_tables_root = root;
-        update_zero_block();
+        update_zero_block().release_value_but_fixme_should_propagate_errors();
     }
 
     u32 table_columns_root() const { return m_table_columns_root; }
@@ -62,7 +95,7 @@ public:
     void set_table_columns_root(u32 root)
     {
         m_table_columns_root = root;
-        update_zero_block();
+        update_zero_block().release_value_but_fixme_should_propagate_errors();
     }
     u32 version() const { return m_version; }
 
@@ -74,31 +107,30 @@ public:
     void set_user_value(size_t index, u32 value)
     {
         m_user_values[index] = value;
-        update_zero_block();
+        update_zero_block().release_value_but_fixme_should_propagate_errors();
     }
 
-    void add_to_wal(u32 block, ByteBuffer& buffer)
-    {
-        dbgln_if(SQL_DEBUG, "Adding to WAL: block #{}, size {}", block, buffer.size());
-        dbgln_if(SQL_DEBUG, "{:hex-dump}", buffer.bytes().trim(8));
-        m_write_ahead_log.set(block, buffer);
-    }
+    ErrorOr<ByteBuffer> read_storage(Block::Index);
+    ErrorOr<void> write_storage(Block::Index, ReadonlyBytes);
 
     ErrorOr<void> flush();
 
 private:
     explicit Heap(DeprecatedString);
 
-    ErrorOr<void> write_block(u32, ByteBuffer&);
-    ErrorOr<void> seek_block(u32);
+    ErrorOr<ByteBuffer> read_raw_block(Block::Index);
+    ErrorOr<void> write_raw_block(Block::Index, ReadonlyBytes);
+    ErrorOr<void> write_raw_block_to_wal(Block::Index, ByteBuffer&&);
+
+    ErrorOr<Block> read_block(Block::Index);
+    ErrorOr<void> write_block(Block const&);
     ErrorOr<void> read_zero_block();
-    void initialize_zero_block();
-    void update_zero_block();
+    ErrorOr<void> initialize_zero_block();
+    ErrorOr<void> update_zero_block();
 
     OwnPtr<Core::BufferedFile> m_file;
-    u32 m_free_list { 0 };
+    Block::Index m_highest_block_written { 0 };
     u32 m_next_block { 1 };
-    u32 m_end_of_file { 1 };
     u32 m_schemas_root { 0 };
     u32 m_tables_root { 0 };
     u32 m_table_columns_root { 0 };

--- a/Userland/Libraries/LibSQL/Heap.h
+++ b/Userland/Libraries/LibSQL/Heap.h
@@ -15,8 +15,6 @@
 
 namespace SQL {
 
-constexpr static u32 BLOCKSIZE = 1024;
-
 /**
  * A Heap is a logical container for database (SQL) data. Conceptually a
  * Heap can be a database file, or a memory block, or another storage medium.
@@ -32,7 +30,8 @@ class Heap : public Core::Object {
     C_OBJECT(Heap);
 
 public:
-    static constexpr inline u32 current_version = 3;
+    static constexpr u32 VERSION = 3;
+    static constexpr u32 BLOCK_SIZE = 1024;
 
     virtual ~Heap() override;
 
@@ -103,7 +102,7 @@ private:
     u32 m_schemas_root { 0 };
     u32 m_tables_root { 0 };
     u32 m_table_columns_root { 0 };
-    u32 m_version { current_version };
+    u32 m_version { VERSION };
     Array<u32, 16> m_user_values { 0 };
     HashMap<u32, ByteBuffer> m_write_ahead_log;
 };

--- a/Userland/Libraries/LibSQL/Heap.h
+++ b/Userland/Libraries/LibSQL/Heap.h
@@ -70,13 +70,11 @@ public:
 
     u32 user_value(size_t index) const
     {
-        VERIFY(index < m_user_values.size());
         return m_user_values[index];
     }
 
     void set_user_value(size_t index, u32 value)
     {
-        VERIFY(index < m_user_values.size());
         m_user_values[index] = value;
         update_zero_block();
     }

--- a/Userland/Libraries/LibSQL/Heap.h
+++ b/Userland/Libraries/LibSQL/Heap.h
@@ -74,25 +74,25 @@ public:
     bool has_block(Block::Index) const;
     [[nodiscard]] Block::Index request_new_block_index() { return m_next_block++; }
 
-    u32 schemas_root() const { return m_schemas_root; }
+    Block::Index schemas_root() const { return m_schemas_root; }
 
-    void set_schemas_root(u32 root)
+    void set_schemas_root(Block::Index root)
     {
         m_schemas_root = root;
         update_zero_block().release_value_but_fixme_should_propagate_errors();
     }
 
-    u32 tables_root() const { return m_tables_root; }
+    Block::Index tables_root() const { return m_tables_root; }
 
-    void set_tables_root(u32 root)
+    void set_tables_root(Block::Index root)
     {
         m_tables_root = root;
         update_zero_block().release_value_but_fixme_should_propagate_errors();
     }
 
-    u32 table_columns_root() const { return m_table_columns_root; }
+    Block::Index table_columns_root() const { return m_table_columns_root; }
 
-    void set_table_columns_root(u32 root)
+    void set_table_columns_root(Block::Index root)
     {
         m_table_columns_root = root;
         update_zero_block().release_value_but_fixme_should_propagate_errors();
@@ -130,13 +130,13 @@ private:
 
     OwnPtr<Core::BufferedFile> m_file;
     Block::Index m_highest_block_written { 0 };
-    u32 m_next_block { 1 };
-    u32 m_schemas_root { 0 };
-    u32 m_tables_root { 0 };
-    u32 m_table_columns_root { 0 };
+    Block::Index m_next_block { 1 };
+    Block::Index m_schemas_root { 0 };
+    Block::Index m_tables_root { 0 };
+    Block::Index m_table_columns_root { 0 };
     u32 m_version { VERSION };
     Array<u32, 16> m_user_values { 0 };
-    HashMap<u32, ByteBuffer> m_write_ahead_log;
+    HashMap<Block::Index, ByteBuffer> m_write_ahead_log;
 };
 
 }

--- a/Userland/Libraries/LibSQL/Index.cpp
+++ b/Userland/Libraries/LibSQL/Index.cpp
@@ -6,7 +6,6 @@
 
 #include <LibSQL/Heap.h>
 #include <LibSQL/Index.h>
-#include <LibSQL/Meta.h>
 #include <LibSQL/TupleDescriptor.h>
 
 namespace SQL {

--- a/Userland/Libraries/LibSQL/Index.cpp
+++ b/Userland/Libraries/LibSQL/Index.cpp
@@ -10,18 +10,18 @@
 
 namespace SQL {
 
-Index::Index(Serializer& serializer, NonnullRefPtr<TupleDescriptor> const& descriptor, bool unique, u32 pointer)
+Index::Index(Serializer& serializer, NonnullRefPtr<TupleDescriptor> const& descriptor, bool unique, Block::Index block_index)
     : m_serializer(serializer)
     , m_descriptor(descriptor)
     , m_unique(unique)
-    , m_pointer(pointer)
+    , m_block_index(block_index)
 {
 }
 
-Index::Index(Serializer& serializer, NonnullRefPtr<TupleDescriptor> const& descriptor, u32 pointer)
+Index::Index(Serializer& serializer, NonnullRefPtr<TupleDescriptor> const& descriptor, Block::Index block_index)
     : m_serializer(serializer)
     , m_descriptor(descriptor)
-    , m_pointer(pointer)
+    , m_block_index(block_index)
 {
 }
 

--- a/Userland/Libraries/LibSQL/Index.h
+++ b/Userland/Libraries/LibSQL/Index.h
@@ -48,8 +48,7 @@ protected:
 
     [[nodiscard]] Serializer& serializer() { return m_serializer; }
     void set_pointer(u32 pointer) { m_pointer = pointer; }
-    u32 new_record_pointer() { return m_serializer.new_record_pointer(); }
-    //    ByteBuffer read_block(u32);
+    u32 request_new_block_index() { return m_serializer.request_new_block_index(); }
 
 private:
     Serializer m_serializer;

--- a/Userland/Libraries/LibSQL/Index.h
+++ b/Userland/Libraries/LibSQL/Index.h
@@ -16,19 +16,19 @@ namespace SQL {
 class IndexNode {
 public:
     virtual ~IndexNode() = default;
-    [[nodiscard]] u32 pointer() const { return m_pointer; }
+    [[nodiscard]] Block::Index block_index() const { return m_block_index; }
     IndexNode* as_index_node() { return dynamic_cast<IndexNode*>(this); }
 
 protected:
-    explicit IndexNode(u32 pointer)
-        : m_pointer(pointer)
+    explicit IndexNode(Block::Index block_index)
+        : m_block_index(block_index)
     {
     }
 
-    void set_pointer(u32 pointer) { m_pointer = pointer; }
+    void set_block_index(Block::Index block_index) { m_block_index = block_index; }
 
 private:
-    u32 m_pointer;
+    Block::Index m_block_index;
 };
 
 class Index : public Core::Object {
@@ -40,21 +40,21 @@ public:
     NonnullRefPtr<TupleDescriptor> descriptor() const { return m_descriptor; }
     [[nodiscard]] bool duplicates_allowed() const { return !m_unique; }
     [[nodiscard]] bool unique() const { return m_unique; }
-    [[nodiscard]] u32 pointer() const { return m_pointer; }
+    [[nodiscard]] Block::Index block_index() const { return m_block_index; }
 
 protected:
-    Index(Serializer&, NonnullRefPtr<TupleDescriptor> const&, bool unique, u32 pointer);
-    Index(Serializer&, NonnullRefPtr<TupleDescriptor> const&, u32 pointer);
+    Index(Serializer&, NonnullRefPtr<TupleDescriptor> const&, bool unique, Block::Index block_index);
+    Index(Serializer&, NonnullRefPtr<TupleDescriptor> const&, Block::Index block_index);
 
     [[nodiscard]] Serializer& serializer() { return m_serializer; }
-    void set_pointer(u32 pointer) { m_pointer = pointer; }
+    void set_block_index(Block::Index block_index) { m_block_index = block_index; }
     u32 request_new_block_index() { return m_serializer.request_new_block_index(); }
 
 private:
     Serializer m_serializer;
     NonnullRefPtr<TupleDescriptor> m_descriptor;
     bool m_unique { false };
-    u32 m_pointer { 0 };
+    Block::Index m_block_index { 0 };
 };
 
 }

--- a/Userland/Libraries/LibSQL/Meta.cpp
+++ b/Userland/Libraries/LibSQL/Meta.cpp
@@ -29,7 +29,7 @@ Key SchemaDef::key() const
 {
     auto key = Key(index_def()->to_tuple_descriptor());
     key["schema_name"] = name();
-    key.set_pointer(pointer());
+    key.set_block_index(block_index());
     return key;
 }
 
@@ -171,7 +171,7 @@ Key TableDef::key() const
     auto key = Key(index_def()->to_tuple_descriptor());
     key["schema_hash"] = parent_relation()->key().hash();
     key["table_name"] = name();
-    key.set_pointer(pointer());
+    key.set_block_index(block_index());
     return key;
 }
 

--- a/Userland/Libraries/LibSQL/Meta.h
+++ b/Userland/Libraries/LibSQL/Meta.h
@@ -12,6 +12,7 @@
 #include <AK/Vector.h>
 #include <LibCore/Object.h>
 #include <LibSQL/Forward.h>
+#include <LibSQL/Heap.h>
 #include <LibSQL/Type.h>
 #include <LibSQL/Value.h>
 
@@ -27,29 +28,29 @@ class Relation : public Core::Object {
 
 public:
     u32 hash() const;
-    u32 pointer() const { return m_pointer; }
-    void set_pointer(u32 pointer) { m_pointer = pointer; }
+    Block::Index block_index() const { return m_block_index; }
+    void set_block_index(Block::Index block_index) { m_block_index = block_index; }
     ~Relation() override = default;
     virtual Key key() const = 0;
     Relation const* parent_relation() const { return dynamic_cast<Relation const*>(parent()); }
 
 protected:
-    Relation(DeprecatedString name, u32 pointer, Relation* parent = nullptr)
+    Relation(DeprecatedString name, Block::Index block_index, Relation* parent = nullptr)
         : Core::Object(parent)
-        , m_pointer(pointer)
+        , m_block_index(block_index)
     {
         set_name(move(name));
     }
 
     explicit Relation(DeprecatedString name, Relation* parent = nullptr)
         : Core::Object(parent)
-        , m_pointer(0)
+        , m_block_index(0)
     {
         set_name(move(name));
     }
 
 private:
-    u32 m_pointer { 0 };
+    Block::Index m_block_index { 0 };
 };
 
 class SchemaDef : public Relation {

--- a/Userland/Libraries/LibSQL/Meta.h
+++ b/Userland/Libraries/LibSQL/Meta.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
-#include <AK/NonnullOwnPtr.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Result.h>
 #include <AK/Vector.h>

--- a/Userland/Libraries/LibSQL/Row.cpp
+++ b/Userland/Libraries/LibSQL/Row.cpp
@@ -9,23 +9,23 @@
 
 namespace SQL {
 
-Row::Row(NonnullRefPtr<TableDef> table, u32 pointer)
+Row::Row(NonnullRefPtr<TableDef> table, Block::Index block_index)
     : Tuple(table->to_tuple_descriptor())
     , m_table(move(table))
 {
-    set_pointer(pointer);
+    set_block_index(block_index);
 }
 
 void Row::deserialize(Serializer& serializer)
 {
     Tuple::deserialize(serializer);
-    m_next_pointer = serializer.deserialize<u32>();
+    m_next_block_index = serializer.deserialize<Block::Index>();
 }
 
 void Row::serialize(Serializer& serializer) const
 {
     Tuple::serialize(serializer);
-    serializer.serialize<u32>(next_pointer());
+    serializer.serialize<Block::Index>(next_block_index());
 }
 
 }

--- a/Userland/Libraries/LibSQL/Row.h
+++ b/Userland/Libraries/LibSQL/Row.h
@@ -25,22 +25,22 @@ namespace SQL {
  */
 class Row : public Tuple {
 public:
-    explicit Row(NonnullRefPtr<TableDef>, u32 pointer = 0);
+    explicit Row(NonnullRefPtr<TableDef>, Block::Index block_index = 0);
     virtual ~Row() override = default;
 
-    [[nodiscard]] u32 next_pointer() const { return m_next_pointer; }
-    void set_next_pointer(u32 ptr) { m_next_pointer = ptr; }
+    [[nodiscard]] Block::Index next_block_index() const { return m_next_block_index; }
+    void set_next_block_index(Block::Index index) { m_next_block_index = index; }
 
     TableDef const& table() const { return *m_table; }
     TableDef& table() { return *m_table; }
 
-    [[nodiscard]] virtual size_t length() const override { return Tuple::length() + sizeof(u32); }
+    [[nodiscard]] virtual size_t length() const override { return Tuple::length() + sizeof(Block::Index); }
     virtual void serialize(Serializer&) const override;
     virtual void deserialize(Serializer&) override;
 
 private:
     NonnullRefPtr<TableDef> m_table;
-    u32 m_next_pointer { 0 };
+    Block::Index m_next_block_index { 0 };
 };
 
 }

--- a/Userland/Libraries/LibSQL/Serializer.cpp
+++ b/Userland/Libraries/LibSQL/Serializer.cpp
@@ -10,7 +10,7 @@ namespace SQL {
 
 void Serializer::serialize(DeprecatedString const& text)
 {
-    serialize<u32>((u32)text.length());
+    serialize<u32>(text.length());
     if (!text.is_empty())
         write((u8 const*)text.characters(), text.length());
 }

--- a/Userland/Libraries/LibSQL/Serializer.h
+++ b/Userland/Libraries/LibSQL/Serializer.h
@@ -160,6 +160,7 @@ private:
 
     ByteBuffer m_buffer {};
     size_t m_current_offset { 0 };
+    // FIXME: make this a NonnullRefPtr<Heap> so we can get rid of the null checks
     RefPtr<Heap> m_heap { nullptr };
 };
 

--- a/Userland/Libraries/LibSQL/Serializer.h
+++ b/Userland/Libraries/LibSQL/Serializer.h
@@ -10,7 +10,6 @@
 #include <AK/Debug.h>
 #include <AK/DeprecatedString.h>
 #include <AK/Format.h>
-#include <AK/ScopeGuard.h>
 #include <LibSQL/Forward.h>
 #include <LibSQL/Heap.h>
 #include <string.h>
@@ -155,9 +154,8 @@ private:
         StringBuilder builder;
         builder.appendff("{0} {1:04x} | ", prefix, sz);
         Vector<DeprecatedString> bytes;
-        for (auto ix = 0u; ix < sz; ++ix) {
+        for (auto ix = 0u; ix < sz; ++ix)
             bytes.append(DeprecatedString::formatted("{0:02x}", *(ptr + ix)));
-        }
         StringBuilder bytes_builder;
         bytes_builder.join(' ', bytes);
         builder.append(bytes_builder.to_deprecated_string());

--- a/Userland/Libraries/LibSQL/Serializer.h
+++ b/Userland/Libraries/LibSQL/Serializer.h
@@ -28,7 +28,6 @@ public:
 
     void get_block(u32 pointer)
     {
-        VERIFY(m_heap.ptr() != nullptr);
         auto buffer_or_error = m_heap->read_block(pointer);
         if (buffer_or_error.is_error())
             VERIFY_NOT_REACHED();
@@ -110,7 +109,7 @@ public:
     template<typename T>
     bool serialize_and_write(T const& t)
     {
-        VERIFY(m_heap.ptr() != nullptr);
+        VERIFY(!m_heap.is_null());
         reset();
         serialize<T>(t);
         m_heap->add_to_wal(t.pointer(), m_buffer);
@@ -120,20 +119,17 @@ public:
     [[nodiscard]] size_t offset() const { return m_current_offset; }
     u32 new_record_pointer()
     {
-        VERIFY(m_heap.ptr() != nullptr);
         return m_heap->new_record_pointer();
     }
 
     bool has_block(u32 pointer) const
     {
-        VERIFY(m_heap.ptr() != nullptr);
         return pointer < m_heap->size();
     }
 
     Heap& heap()
     {
-        VERIFY(m_heap.ptr() != nullptr);
-        return *(m_heap.ptr());
+        return *m_heap;
     }
 
 private:

--- a/Userland/Libraries/LibSQL/Serializer.h
+++ b/Userland/Libraries/LibSQL/Serializer.h
@@ -42,16 +42,16 @@ public:
     }
 
     template<typename T, typename... Args>
-    T deserialize_block(u32 pointer, Args&&... args)
+    T deserialize_block(Block::Index block_index, Args&&... args)
     {
-        read_storage(pointer);
+        read_storage(block_index);
         return deserialize<T>(forward<Args>(args)...);
     }
 
     template<typename T>
-    void deserialize_block_to(u32 pointer, T& t)
+    void deserialize_block_to(Block::Index block_index, T& t)
     {
-        read_storage(pointer);
+        read_storage(block_index);
         return deserialize_to<T>(t);
     }
 
@@ -107,7 +107,7 @@ public:
         VERIFY(!m_heap.is_null());
         reset();
         serialize<T>(t);
-        m_heap->write_storage(t.pointer(), m_buffer).release_value_but_fixme_should_propagate_errors();
+        m_heap->write_storage(t.block_index(), m_buffer).release_value_but_fixme_should_propagate_errors();
         return true;
     }
 

--- a/Userland/Libraries/LibSQL/TreeNode.cpp
+++ b/Userland/Libraries/LibSQL/TreeNode.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/Debug.h>
 #include <AK/Format.h>
-#include <AK/NonnullOwnPtr.h>
 #include <AK/StringBuilder.h>
 #include <LibSQL/BTree.h>
 #include <LibSQL/Serializer.h>
@@ -145,9 +144,8 @@ size_t TreeNode::length() const
     if (!size())
         return 0;
     size_t len = sizeof(u32);
-    for (auto& key : m_entries) {
+    for (auto& key : m_entries)
         len += sizeof(u32) + key.length();
-    }
     return len;
 }
 
@@ -315,9 +313,8 @@ void TreeNode::split()
         auto down = m_down.take(median_index);
 
         // Reparent to new right node:
-        if (down.m_node != nullptr) {
+        if (down.m_node != nullptr)
             down.m_node->m_up = new_node;
-        }
         new_node->m_entries.append(entry);
         new_node->m_down.append(move(down));
     }
@@ -354,15 +351,13 @@ void TreeNode::dump_if(int flag, DeprecatedString&& msg)
             VERIFY(m_down[ix].pointer() == 0);
         builder.appendff("'{}' ", (DeprecatedString)m_entries[ix]);
     }
-    if (!is_leaf()) {
+    if (!is_leaf())
         builder.appendff("[v{}]", m_down[size()].pointer());
-    } else {
+    else
         VERIFY(m_down[size()].pointer() == 0);
-    }
     builder.appendff(" (size {}", (int)size());
-    if (is_leaf()) {
+    if (is_leaf())
         builder.append(", leaf"sv);
-    }
     builder.append(')');
     dbgln(builder.to_deprecated_string());
 }
@@ -370,22 +365,19 @@ void TreeNode::dump_if(int flag, DeprecatedString&& msg)
 void TreeNode::list_node(int indent)
 {
     auto do_indent = [&]() {
-        for (int i = 0; i < indent; ++i) {
+        for (int i = 0; i < indent; ++i)
             warn(" ");
-        }
     };
     do_indent();
     warnln("--> #{}", pointer());
     for (auto ix = 0u; ix < size(); ix++) {
-        if (!is_leaf()) {
+        if (!is_leaf())
             down_node(ix)->list_node(indent + 2);
-        }
         do_indent();
         warnln("{}", m_entries[ix].to_deprecated_string());
     }
-    if (!is_leaf()) {
+    if (!is_leaf())
         down_node(size())->list_node(indent + 2);
-    }
 }
 
 }

--- a/Userland/Libraries/LibSQL/TreeNode.cpp
+++ b/Userland/Libraries/LibSQL/TreeNode.cpp
@@ -12,30 +12,30 @@
 
 namespace SQL {
 
-DownPointer::DownPointer(TreeNode* owner, u32 pointer)
+DownPointer::DownPointer(TreeNode* owner, Block::Index block_index)
     : m_owner(owner)
-    , m_pointer(pointer)
+    , m_block_index(block_index)
     , m_node(nullptr)
 {
 }
 
 DownPointer::DownPointer(TreeNode* owner, TreeNode* node)
     : m_owner(owner)
-    , m_pointer((node) ? node->pointer() : 0)
+    , m_block_index((node) ? node->block_index() : 0)
     , m_node(adopt_own_if_nonnull(node))
 {
 }
 
 DownPointer::DownPointer(TreeNode* owner, DownPointer& down)
     : m_owner(owner)
-    , m_pointer(down.m_pointer)
+    , m_block_index(down.m_block_index)
     , m_node(move(down.m_node))
 {
 }
 
 DownPointer::DownPointer(DownPointer&& other)
     : m_owner(other.m_owner)
-    , m_pointer(other.pointer())
+    , m_block_index(other.block_index())
     , m_node(other.m_node ? move(other.m_node) : nullptr)
 {
 }
@@ -49,14 +49,14 @@ TreeNode* DownPointer::node()
 
 void DownPointer::deserialize(Serializer& serializer)
 {
-    if (m_node || !m_pointer)
+    if (m_node || !m_block_index)
         return;
-    serializer.read_storage(m_pointer);
-    m_node = serializer.make_and_deserialize<TreeNode>(m_owner->tree(), m_owner, m_pointer);
+    serializer.read_storage(m_block_index);
+    m_node = serializer.make_and_deserialize<TreeNode>(m_owner->tree(), m_owner, m_block_index);
 }
 
-TreeNode::TreeNode(BTree& tree, u32 pointer)
-    : IndexNode(pointer)
+TreeNode::TreeNode(BTree& tree, Block::Index block_index)
+    : IndexNode(block_index)
     , m_tree(tree)
     , m_up(nullptr)
     , m_entries()
@@ -64,8 +64,8 @@ TreeNode::TreeNode(BTree& tree, u32 pointer)
 {
 }
 
-TreeNode::TreeNode(BTree& tree, TreeNode* up, u32 pointer)
-    : IndexNode(pointer)
+TreeNode::TreeNode(BTree& tree, TreeNode* up, Block::Index block_index)
+    : IndexNode(block_index)
     , m_tree(tree)
     , m_up(up)
     , m_entries()
@@ -75,8 +75,8 @@ TreeNode::TreeNode(BTree& tree, TreeNode* up, u32 pointer)
     m_is_leaf = true;
 }
 
-TreeNode::TreeNode(BTree& tree, TreeNode* up, DownPointer& left, u32 pointer)
-    : IndexNode(pointer)
+TreeNode::TreeNode(BTree& tree, TreeNode* up, DownPointer& left, Block::Index block_index)
+    : IndexNode(block_index)
     , m_tree(tree)
     , m_up(up)
     , m_entries()
@@ -85,20 +85,20 @@ TreeNode::TreeNode(BTree& tree, TreeNode* up, DownPointer& left, u32 pointer)
     if (left.m_node != nullptr)
         left.m_node->m_up = this;
     m_down.append(DownPointer(this, left));
-    m_is_leaf = left.pointer() == 0;
-    if (!pointer)
-        set_pointer(m_tree.request_new_block_index());
+    m_is_leaf = left.block_index() == 0;
+    if (!block_index)
+        set_block_index(m_tree.request_new_block_index());
 }
 
-TreeNode::TreeNode(BTree& tree, TreeNode* up, TreeNode* left, u32 pointer)
-    : IndexNode(pointer)
+TreeNode::TreeNode(BTree& tree, TreeNode* up, TreeNode* left, Block::Index block_index)
+    : IndexNode(block_index)
     , m_tree(tree)
     , m_up(up)
     , m_entries()
     , m_down()
 {
     m_down.append(DownPointer(this, left));
-    m_is_leaf = left->pointer() == 0;
+    m_is_leaf = left->block_index() == 0;
 }
 
 void TreeNode::deserialize(Serializer& serializer)
@@ -130,12 +130,12 @@ void TreeNode::serialize(Serializer& serializer) const
     if (sz > 0) {
         for (auto ix = 0u; ix < size(); ix++) {
             auto& entry = m_entries[ix];
-            dbgln_if(SQL_DEBUG, "Serializing Left[{}] = {}", ix, m_down[ix].pointer());
-            serializer.serialize<u32>(is_leaf() ? 0u : m_down[ix].pointer());
+            dbgln_if(SQL_DEBUG, "Serializing Left[{}] = {}", ix, m_down[ix].block_index());
+            serializer.serialize<u32>(is_leaf() ? 0u : m_down[ix].block_index());
             serializer.serialize<Key>(entry);
         }
-        dbgln_if(SQL_DEBUG, "Serializing Right = {}", m_down[size()].pointer());
-        serializer.serialize<u32>(is_leaf() ? 0u : m_down[size()].pointer());
+        dbgln_if(SQL_DEBUG, "Serializing Right = {}", m_down[size()].block_index());
+        serializer.serialize<u32>(is_leaf() ? 0u : m_down[size()].block_index());
     }
 }
 
@@ -151,7 +151,7 @@ size_t TreeNode::length() const
 
 bool TreeNode::insert(Key const& key)
 {
-    dbgln_if(SQL_DEBUG, "[#{}] INSERT({})", pointer(), key.to_deprecated_string());
+    dbgln_if(SQL_DEBUG, "[#{}] INSERT({})", block_index(), key.to_deprecated_string());
     if (!is_leaf())
         return node_for(key)->insert_in_leaf(key);
     return insert_in_leaf(key);
@@ -159,16 +159,16 @@ bool TreeNode::insert(Key const& key)
 
 bool TreeNode::update_key_pointer(Key const& key)
 {
-    dbgln_if(SQL_DEBUG, "[#{}] UPDATE({}, {})", pointer(), key.to_deprecated_string(), key.pointer());
+    dbgln_if(SQL_DEBUG, "[#{}] UPDATE({}, {})", block_index(), key.to_deprecated_string(), key.block_index());
     if (!is_leaf())
         return node_for(key)->update_key_pointer(key);
 
     for (auto ix = 0u; ix < size(); ix++) {
         if (key == m_entries[ix]) {
             dbgln_if(SQL_DEBUG, "[#{}] {} == {}",
-                pointer(), key.to_deprecated_string(), m_entries[ix].to_deprecated_string());
-            if (m_entries[ix].pointer() != key.pointer()) {
-                m_entries[ix].set_pointer(key.pointer());
+                block_index(), key.to_deprecated_string(), m_entries[ix].to_deprecated_string());
+            if (m_entries[ix].block_index() != key.block_index()) {
+                m_entries[ix].set_block_index(key.block_index());
                 dump_if(SQL_DEBUG, "To WAL");
                 tree().serializer().serialize_and_write<TreeNode>(*this);
             }
@@ -184,20 +184,20 @@ bool TreeNode::insert_in_leaf(Key const& key)
     if (!m_tree.duplicates_allowed()) {
         for (auto& entry : m_entries) {
             if (key == entry) {
-                dbgln_if(SQL_DEBUG, "[#{}] duplicate key {}", pointer(), key.to_deprecated_string());
+                dbgln_if(SQL_DEBUG, "[#{}] duplicate key {}", block_index(), key.to_deprecated_string());
                 return false;
             }
         }
     }
 
-    dbgln_if(SQL_DEBUG, "[#{}] insert_in_leaf({})", pointer(), key.to_deprecated_string());
+    dbgln_if(SQL_DEBUG, "[#{}] insert_in_leaf({})", block_index(), key.to_deprecated_string());
     just_insert(key, nullptr);
     return true;
 }
 
-u32 TreeNode::down_pointer(size_t ix) const
+Block::Index TreeNode::down_pointer(size_t ix) const
 {
-    return m_down[ix].pointer();
+    return m_down[ix].block_index();
 }
 
 TreeNode* TreeNode::down_node(size_t ix)
@@ -213,12 +213,12 @@ TreeNode* TreeNode::node_for(Key const& key)
     for (size_t ix = 0; ix < size(); ix++) {
         if (key < m_entries[ix]) {
             dbgln_if(SQL_DEBUG, "[{}] {} < {} v{}",
-                pointer(), (DeprecatedString)key, (DeprecatedString)m_entries[ix], m_down[ix].pointer());
+                block_index(), (DeprecatedString)key, (DeprecatedString)m_entries[ix], m_down[ix].block_index());
             return down_node(ix)->node_for(key);
         }
     }
     dbgln_if(SQL_DEBUG, "[#{}] {} >= {} v{}",
-        pointer(), key.to_deprecated_string(), (DeprecatedString)m_entries[size() - 1], m_down[size()].pointer());
+        block_index(), key.to_deprecated_string(), (DeprecatedString)m_entries[size() - 1], m_down[size()].block_index());
     return down_node(size())->node_for(key);
 }
 
@@ -229,42 +229,42 @@ Optional<u32> TreeNode::get(Key& key)
         if (key < m_entries[ix]) {
             if (is_leaf()) {
                 dbgln_if(SQL_DEBUG, "[#{}] {} < {} -> 0",
-                    pointer(), key.to_deprecated_string(), (DeprecatedString)m_entries[ix]);
+                    block_index(), key.to_deprecated_string(), (DeprecatedString)m_entries[ix]);
                 return {};
             } else {
                 dbgln_if(SQL_DEBUG, "[{}] {} < {} ({} -> {})",
-                    pointer(), key.to_deprecated_string(), (DeprecatedString)m_entries[ix],
-                    ix, m_down[ix].pointer());
+                    block_index(), key.to_deprecated_string(), (DeprecatedString)m_entries[ix],
+                    ix, m_down[ix].block_index());
                 return down_node(ix)->get(key);
             }
         }
         if (key == m_entries[ix]) {
             dbgln_if(SQL_DEBUG, "[#{}] {} == {} -> {}",
-                pointer(), key.to_deprecated_string(), (DeprecatedString)m_entries[ix],
-                m_entries[ix].pointer());
-            key.set_pointer(m_entries[ix].pointer());
-            return m_entries[ix].pointer();
+                block_index(), key.to_deprecated_string(), (DeprecatedString)m_entries[ix],
+                m_entries[ix].block_index());
+            key.set_block_index(m_entries[ix].block_index());
+            return m_entries[ix].block_index();
         }
     }
     if (m_entries.is_empty()) {
-        dbgln_if(SQL_DEBUG, "[#{}] {} Empty node??", pointer(), key.to_deprecated_string());
+        dbgln_if(SQL_DEBUG, "[#{}] {} Empty node??", block_index(), key.to_deprecated_string());
         VERIFY_NOT_REACHED();
     }
     if (is_leaf()) {
         dbgln_if(SQL_DEBUG, "[#{}] {} > {} -> 0",
-            pointer(), key.to_deprecated_string(), (DeprecatedString)m_entries[size() - 1]);
+            block_index(), key.to_deprecated_string(), (DeprecatedString)m_entries[size() - 1]);
         return {};
     }
     dbgln_if(SQL_DEBUG, "[#{}] {} > {} ({} -> {})",
-        pointer(), key.to_deprecated_string(), (DeprecatedString)m_entries[size() - 1],
-        size(), m_down[size()].pointer());
+        block_index(), key.to_deprecated_string(), (DeprecatedString)m_entries[size() - 1],
+        size(), m_down[size()].block_index());
     return down_node(size())->get(key);
 }
 
 void TreeNode::just_insert(Key const& key, TreeNode* right)
 {
     dbgln_if(SQL_DEBUG, "[#{}] just_insert({}, right = {})",
-        pointer(), (DeprecatedString)key, (right) ? right->pointer() : 0);
+        block_index(), (DeprecatedString)key, (right) ? right->block_index() : 0);
     dump_if(SQL_DEBUG, "Before");
     for (auto ix = 0u; ix < size(); ix++) {
         if (key < m_entries[ix]) {
@@ -336,25 +336,25 @@ void TreeNode::dump_if(int flag, DeprecatedString&& msg)
     if (!flag)
         return;
     StringBuilder builder;
-    builder.appendff("[#{}] ", pointer());
+    builder.appendff("[#{}] ", block_index());
     if (!msg.is_empty())
         builder.appendff("{}", msg);
     builder.append(": "sv);
     if (m_up)
-        builder.appendff("[^{}] -> ", m_up->pointer());
+        builder.appendff("[^{}] -> ", m_up->block_index());
     else
         builder.append("* -> "sv);
     for (size_t ix = 0; ix < m_entries.size(); ix++) {
         if (!is_leaf())
-            builder.appendff("[v{}] ", m_down[ix].pointer());
+            builder.appendff("[v{}] ", m_down[ix].block_index());
         else
-            VERIFY(m_down[ix].pointer() == 0);
+            VERIFY(m_down[ix].block_index() == 0);
         builder.appendff("'{}' ", (DeprecatedString)m_entries[ix]);
     }
     if (!is_leaf())
-        builder.appendff("[v{}]", m_down[size()].pointer());
+        builder.appendff("[v{}]", m_down[size()].block_index());
     else
-        VERIFY(m_down[size()].pointer() == 0);
+        VERIFY(m_down[size()].block_index() == 0);
     builder.appendff(" (size {}", (int)size());
     if (is_leaf())
         builder.append(", leaf"sv);
@@ -369,7 +369,7 @@ void TreeNode::list_node(int indent)
             warn(" ");
     };
     do_indent();
-    warnln("--> #{}", pointer());
+    warnln("--> #{}", block_index());
     for (auto ix = 0u; ix < size(); ix++) {
         if (!is_leaf())
             down_node(ix)->list_node(indent + 2);

--- a/Userland/Libraries/LibSQL/TreeNode.cpp
+++ b/Userland/Libraries/LibSQL/TreeNode.cpp
@@ -271,7 +271,7 @@ void TreeNode::just_insert(Key const& key, TreeNode* right)
             m_entries.insert(ix, key);
             VERIFY(is_leaf() == (right == nullptr));
             m_down.insert(ix + 1, DownPointer(this, right));
-            if (length() > BLOCKSIZE) {
+            if (length() > Heap::BLOCK_SIZE) {
                 split();
             } else {
                 dump_if(SQL_DEBUG, "To WAL");
@@ -283,7 +283,7 @@ void TreeNode::just_insert(Key const& key, TreeNode* right)
     m_entries.append(key);
     m_down.empend(this, right);
 
-    if (length() > BLOCKSIZE) {
+    if (length() > Heap::BLOCK_SIZE) {
         split();
     } else {
         dump_if(SQL_DEBUG, "To WAL");

--- a/Userland/Libraries/LibSQL/Tuple.cpp
+++ b/Userland/Libraries/LibSQL/Tuple.cpp
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <cstring>
-
 #include <AK/DeprecatedString.h>
 #include <AK/StringBuilder.h>
 #include <LibSQL/Serializer.h>
@@ -26,9 +24,8 @@ Tuple::Tuple(NonnullRefPtr<TupleDescriptor> const& descriptor, u32 pointer)
     , m_data()
     , m_pointer(pointer)
 {
-    for (auto& element : *descriptor) {
+    for (auto& element : *descriptor)
         m_data.empend(element.type);
-    }
 }
 
 Tuple::Tuple(NonnullRefPtr<TupleDescriptor> const& descriptor, Serializer& serializer)
@@ -42,10 +39,10 @@ void Tuple::deserialize(Serializer& serializer)
     dbgln_if(SQL_DEBUG, "deserialize tuple at offset {}", serializer.offset());
     serializer.deserialize_to<u32>(m_pointer);
     dbgln_if(SQL_DEBUG, "pointer: {}", m_pointer);
-    auto sz = serializer.deserialize<u32>();
+    auto number_of_elements = serializer.deserialize<u32>();
     m_data.clear();
     m_descriptor->clear();
-    for (auto ix = 0u; ix < sz; ++ix) {
+    for (auto ix = 0u; ix < number_of_elements; ++ix) {
         m_descriptor->append(serializer.deserialize<TupleElementDescriptor>());
         m_data.append(serializer.deserialize<Value>());
     }
@@ -56,11 +53,10 @@ void Tuple::serialize(Serializer& serializer) const
     VERIFY(m_descriptor->size() == m_data.size());
     dbgln_if(SQL_DEBUG, "Serializing tuple pointer {}", pointer());
     serializer.serialize<u32>(pointer());
-    serializer.serialize<u32>((u32)m_descriptor->size());
+    serializer.serialize<u32>(m_descriptor->size());
     for (auto ix = 0u; ix < m_descriptor->size(); ix++) {
-        auto& key_part = m_data[ix];
         serializer.serialize<TupleElementDescriptor>((*m_descriptor)[ix]);
-        serializer.serialize<Value>(key_part);
+        serializer.serialize<Value>(m_data[ix]);
     }
 }
 
@@ -73,9 +69,8 @@ Tuple::Tuple(Tuple const& other)
 
 Tuple& Tuple::operator=(Tuple const& other)
 {
-    if (this != &other) {
+    if (this != &other)
         copy_from(other);
-    }
     return *this;
 }
 
@@ -83,9 +78,8 @@ Optional<size_t> Tuple::index_of(StringView name) const
 {
     for (auto ix = 0u; ix < m_descriptor->size(); ix++) {
         auto& part = (*m_descriptor)[ix];
-        if (part.name == name) {
+        if (part.name == name)
             return ix;
-        }
     }
     return {};
 }
@@ -107,9 +101,8 @@ Value& Tuple::operator[](DeprecatedString const& name)
 void Tuple::append(Value const& value)
 {
     VERIFY(descriptor()->size() >= size());
-    if (descriptor()->size() == size()) {
+    if (descriptor()->size() == size())
         descriptor()->append(value.descriptor());
-    }
     m_data.append(value);
 }
 
@@ -122,9 +115,8 @@ Tuple& Tuple::operator+=(Value const& value)
 void Tuple::extend(Tuple const& other)
 {
     VERIFY((descriptor()->size() == size()) || (descriptor()->size() >= size() + other.size()));
-    if (descriptor()->size() == size()) {
+    if (descriptor()->size() == size())
         descriptor()->extend(other.descriptor());
-    }
     m_data.extend(other.m_data);
 }
 
@@ -165,14 +157,12 @@ DeprecatedString Tuple::to_deprecated_string() const
 {
     StringBuilder builder;
     for (auto& part : m_data) {
-        if (!builder.is_empty()) {
+        if (!builder.is_empty())
             builder.append('|');
-        }
         builder.append(part.to_deprecated_string());
     }
-    if (pointer() != 0) {
+    if (pointer() != 0)
         builder.appendff(":{}", pointer());
-    }
     return builder.to_deprecated_string();
 }
 
@@ -180,14 +170,12 @@ void Tuple::copy_from(Tuple const& other)
 {
     if (*m_descriptor != *other.m_descriptor) {
         m_descriptor->clear();
-        for (TupleElementDescriptor const& part : *other.m_descriptor) {
+        for (TupleElementDescriptor const& part : *other.m_descriptor)
             m_descriptor->append(part);
-        }
     }
     m_data.clear();
-    for (auto& part : other.m_data) {
+    for (auto& part : other.m_data)
         m_data.append(part);
-    }
     m_pointer = other.pointer();
 }
 

--- a/Userland/Libraries/LibSQL/Tuple.cpp
+++ b/Userland/Libraries/LibSQL/Tuple.cpp
@@ -120,27 +120,6 @@ void Tuple::extend(Tuple const& other)
     m_data.extend(other.m_data);
 }
 
-bool Tuple::is_compatible(Tuple const& other) const
-{
-    if ((m_descriptor->size() == 0) && (other.m_descriptor->size() == 0)) {
-        return true;
-    }
-    if (m_descriptor->size() != other.m_descriptor->size()) {
-        return false;
-    }
-    for (auto ix = 0u; ix < m_descriptor->size(); ix++) {
-        auto& my_part = (*m_descriptor)[ix];
-        auto& other_part = (*other.m_descriptor)[ix];
-        if (my_part.type != other_part.type) {
-            return false;
-        }
-        if (my_part.order != other_part.order) {
-            return false;
-        }
-    }
-    return true;
-}
-
 size_t Tuple::length() const
 {
     size_t len = 2 * sizeof(u32);

--- a/Userland/Libraries/LibSQL/Tuple.h
+++ b/Userland/Libraries/LibSQL/Tuple.h
@@ -54,7 +54,6 @@ public:
     void append(Value const&);
     Tuple& operator+=(Value const&);
     void extend(Tuple const&);
-    [[nodiscard]] bool is_compatible(Tuple const&) const;
 
     [[nodiscard]] u32 pointer() const { return m_pointer; }
     void set_pointer(u32 ptr) { m_pointer = ptr; }

--- a/Userland/Libraries/LibSQL/Tuple.h
+++ b/Userland/Libraries/LibSQL/Tuple.h
@@ -27,7 +27,7 @@ namespace SQL {
 class Tuple {
 public:
     Tuple();
-    explicit Tuple(NonnullRefPtr<TupleDescriptor> const&, u32 pointer = 0);
+    explicit Tuple(NonnullRefPtr<TupleDescriptor> const&, Block::Index = 0);
     Tuple(NonnullRefPtr<TupleDescriptor> const&, Serializer&);
     Tuple(Tuple const&);
     virtual ~Tuple() = default;
@@ -55,8 +55,8 @@ public:
     Tuple& operator+=(Value const&);
     void extend(Tuple const&);
 
-    [[nodiscard]] u32 pointer() const { return m_pointer; }
-    void set_pointer(u32 ptr) { m_pointer = ptr; }
+    [[nodiscard]] Block::Index block_index() const { return m_block_index; }
+    void set_block_index(Block::Index index) { m_block_index = index; }
 
     [[nodiscard]] size_t size() const { return m_data.size(); }
     [[nodiscard]] virtual size_t length() const;
@@ -77,7 +77,7 @@ protected:
 private:
     NonnullRefPtr<TupleDescriptor> m_descriptor;
     Vector<Value> m_data;
-    u32 m_pointer { 2 * sizeof(u32) };
+    Block::Index m_block_index { 0 };
 
     friend Serializer;
 };

--- a/Userland/Libraries/LibSQL/TupleDescriptor.h
+++ b/Userland/Libraries/LibSQL/TupleDescriptor.h
@@ -36,7 +36,7 @@ struct TupleElementDescriptor {
 
     size_t length() const
     {
-        return (sizeof(u32) + name.length()) + 2 * sizeof(u8);
+        return sizeof(u32) + name.length() + 2 * sizeof(u8);
     }
 
     DeprecatedString to_deprecated_string() const
@@ -85,18 +85,16 @@ public:
     size_t length() const
     {
         size_t len = sizeof(u32);
-        for (auto& element : *this) {
+        for (auto& element : *this)
             len += element.length();
-        }
         return len;
     }
 
     DeprecatedString to_deprecated_string() const
     {
         Vector<DeprecatedString> elements;
-        for (auto& element : *this) {
+        for (auto& element : *this)
             elements.append(element.to_deprecated_string());
-        }
         return DeprecatedString::formatted("[\n{}\n]", DeprecatedString::join('\n', elements));
     }
 

--- a/Userland/Libraries/LibSQL/Type.h
+++ b/Userland/Libraries/LibSQL/Type.h
@@ -13,7 +13,7 @@ namespace SQL {
 
 // Adding to this list is fine, but changing the order of any value here will result in LibSQL
 // becoming unable to read existing .db files. If the order must absolutely be changed, be sure
-// to bump Heap::current_version.
+// to bump Heap::VERSION.
 #define ENUMERATE_SQL_TYPES(S) \
     S("null", Null)            \
     S("text", Text)            \

--- a/Userland/Libraries/LibSQL/Value.cpp
+++ b/Userland/Libraries/LibSQL/Value.cpp
@@ -12,7 +12,6 @@
 #include <LibSQL/Serializer.h>
 #include <LibSQL/TupleDescriptor.h>
 #include <LibSQL/Value.h>
-#include <string.h>
 
 namespace SQL {
 
@@ -738,7 +737,6 @@ void Value::deserialize(Serializer& serializer)
     switch (m_type) {
     case SQLType::Null:
         VERIFY_NOT_REACHED();
-        break;
     case SQLType::Text:
         m_value = serializer.deserialize<DeprecatedString>();
         break;
@@ -770,7 +768,6 @@ void Value::deserialize(Serializer& serializer)
             break;
         default:
             VERIFY_NOT_REACHED();
-            break;
         }
         break;
     case SQLType::Float:

--- a/Userland/Libraries/LibSQL/Value.cpp
+++ b/Userland/Libraries/LibSQL/Value.cpp
@@ -30,7 +30,7 @@ static_assert(to_underlying(SQLTypeWithCount::Count) <= 0x0f, "Too many SQL type
 
 // Adding to this list is fine, but changing the order of any value here will result in LibSQL
 // becoming unable to read existing .db files. If the order must absolutely be changed, be sure
-// to bump Heap::current_version.
+// to bump Heap::VERSION.
 enum class TypeData : u8 {
     Null = 1 << 4,
     Int8 = 2 << 4,

--- a/Userland/Libraries/LibSQL/Value.h
+++ b/Userland/Libraries/LibSQL/Value.h
@@ -68,7 +68,6 @@ public:
 
     [[nodiscard]] auto const& value() const
     {
-        VERIFY(m_value.has_value());
         return *m_value;
     }
 


### PR DESCRIPTION
Our previous heap storage implementation silently truncated data whenever the data to store inside a block was larger than 1024 bytes, effectively corrupting the database. These changes allow for arbitrarily large data storage in the heap, which the other LibSQL components now transparently use.

:sparkle: Browser/Ladybird people review motivation: thicc cookies go brrrr