### PR TITLE
Browser: Support selections from the accessibility tab

### DIFF
--- a/Userland/Applications/Browser/InspectorWidget.cpp
+++ b/Userland/Applications/Browser/InspectorWidget.cpp
@@ -93,6 +93,10 @@ InspectorWidget::InspectorWidget()
     auto& accessibility_tree_container = top_tab_widget.add_tab<GUI::Widget>("Accessibility"_string.release_value_but_fixme_should_propagate_errors());
     accessibility_tree_container.set_layout<GUI::VerticalBoxLayout>(4);
     m_accessibility_tree_view = accessibility_tree_container.add<GUI::TreeView>();
+    m_accessibility_tree_view->on_selection_change = [this] {
+        const auto& index = m_accessibility_tree_view->selection().first();
+        set_selection(index);
+    };
 
     auto& bottom_tab_widget = splitter.add<GUI::TabWidget>();
 
@@ -214,8 +218,6 @@ void InspectorWidget::clear_style_json()
 void InspectorWidget::set_accessibility_json(StringView json)
 {
     m_accessibility_tree_view->set_model(WebView::AccessibilityTreeModel::create(json, *m_accessibility_tree_view));
-
-    // TODO: Support selections from accessibility tab
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
@@ -41,6 +41,7 @@ void AccessibilityTreeNode::serialize_tree_as_json(JsonObjectSerializer<StringBu
             MUST(object.add("name"sv, name));
             auto description = MUST(element->accessible_description(document));
             MUST(object.add("description"sv, description));
+            MUST(object.add("id"sv, element->id()));
 
             if (has_role)
                 MUST(object.add("role"sv, ARIA::role_name(*role)));


### PR DESCRIPTION
This adds the ability to select elements from the accessibility tree tab of the DOM inspector like you can from the DOM tab.