### PR TITLE
LibWeb: Convert navigationId from DeprecatedString to String

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2171,12 +2171,12 @@ void Document::set_domain(DeprecatedString const& domain)
     dbgln("(STUBBED) Document::set_domain(domain='{}')", domain);
 }
 
-void Document::set_navigation_id(Optional<AK::DeprecatedString> navigation_id)
+void Document::set_navigation_id(Optional<String> navigation_id)
 {
     m_navigation_id = move(navigation_id);
 }
 
-Optional<DeprecatedString> Document::navigation_id() const
+Optional<String> Document::navigation_id() const
 {
     return m_navigation_id;
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -426,8 +426,8 @@ public:
     bool is_completely_loaded() const;
 
     // https://html.spec.whatwg.org/multipage/dom.html#concept-document-navigation-id
-    Optional<DeprecatedString> navigation_id() const;
-    void set_navigation_id(Optional<DeprecatedString>);
+    Optional<String> navigation_id() const;
+    void set_navigation_id(Optional<String>);
 
     // https://html.spec.whatwg.org/multipage/origin.html#active-sandboxing-flag-set
     HTML::SandboxingFlagSet active_sandboxing_flag_set() const;
@@ -609,7 +609,7 @@ private:
     Optional<AK::Time> m_completely_loaded_time;
 
     // https://html.spec.whatwg.org/multipage/dom.html#concept-document-navigation-id
-    Optional<DeprecatedString> m_navigation_id;
+    Optional<String> m_navigation_id;
 
     // https://html.spec.whatwg.org/multipage/origin.html#active-sandboxing-flag-set
     HTML::SandboxingFlagSet m_active_sandboxing_flag_set;

--- a/Userland/Libraries/LibWeb/HTML/AbstractBrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/AbstractBrowsingContext.h
@@ -35,7 +35,7 @@ public:
         HistoryHandlingBehavior history_handling = HistoryHandlingBehavior::Default,
         Optional<PolicyContainer> history_policy_container = {},
         DeprecatedString navigation_type = "other",
-        Optional<DeprecatedString> navigation_id = {},
+        Optional<String> navigation_id = {},
         Function<void(JS::NonnullGCPtr<Fetch::Infrastructure::Response>)> process_response_end_of_body = {})
         = 0;
 

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -872,7 +872,7 @@ WebIDL::ExceptionOr<void> BrowsingContext::navigate(
     HistoryHandlingBehavior history_handling,
     Optional<PolicyContainer> history_policy_container,
     DeprecatedString navigation_type,
-    Optional<DeprecatedString> navigation_id,
+    Optional<String> navigation_id,
     Function<void(JS::NonnullGCPtr<Fetch::Infrastructure::Response>)> process_response_end_of_body)
 {
     // 1. If resource is a URL, then set resource to a new request whose URL is resource.
@@ -905,7 +905,7 @@ WebIDL::ExceptionOr<void> BrowsingContext::navigate(
         } else {
             // Otherwise let navigation id be the result of generating a random UUID. [UUID]
             // FIXME: Generate a UUID.
-            navigation_id = "FIXME";
+            navigation_id = String::from_utf8_short_string("FIXME"sv);
         }
     }
 
@@ -989,7 +989,7 @@ WebIDL::ExceptionOr<void> BrowsingContext::navigate(
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid
-WebIDL::ExceptionOr<void> BrowsingContext::navigate_to_a_fragment(AK::URL const& url, HistoryHandlingBehavior history_handling, DeprecatedString navigation_id)
+WebIDL::ExceptionOr<void> BrowsingContext::navigate_to_a_fragment(AK::URL const& url, HistoryHandlingBehavior history_handling, String navigation_id)
 {
     // 1. If historyHandling is not "replace",
     if (history_handling != HistoryHandlingBehavior::Replace) {

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -235,11 +235,11 @@ public:
         HistoryHandlingBehavior history_handling = HistoryHandlingBehavior::Default,
         Optional<PolicyContainer> history_policy_container = {},
         DeprecatedString navigation_type = "other",
-        Optional<DeprecatedString> navigation_id = {},
+        Optional<String> navigation_id = {},
         Function<void(JS::NonnullGCPtr<Fetch::Infrastructure::Response>)> process_response_end_of_body = {}) override;
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid
-    WebIDL::ExceptionOr<void> navigate_to_a_fragment(AK::URL const&, HistoryHandlingBehavior, DeprecatedString navigation_id);
+    WebIDL::ExceptionOr<void> navigate_to_a_fragment(AK::URL const&, HistoryHandlingBehavior, String navigation_id);
 
     // https://html.spec.whatwg.org/multipage/origin.html#one-permitted-sandboxed-navigator
     BrowsingContext const* the_one_permitted_sandboxed_navigator() const;

--- a/Userland/Libraries/LibWeb/HTML/NavigationParams.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigationParams.h
@@ -20,7 +20,7 @@ namespace Web::HTML {
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params
 struct NavigationParams {
     // a navigation id
-    DeprecatedString id;
+    String id;
 
     // null or a request that started the navigation
     JS::GCPtr<Fetch::Infrastructure::Request> request;

--- a/Userland/Libraries/LibWeb/HTML/RemoteBrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/RemoteBrowsingContext.h
@@ -29,7 +29,7 @@ public:
         HistoryHandlingBehavior,
         Optional<PolicyContainer>,
         DeprecatedString,
-        Optional<DeprecatedString>,
+        Optional<String>,
         Function<void(JS::NonnullGCPtr<Fetch::Infrastructure::Response>)>) override
     {
         return {};


### PR DESCRIPTION
A part of #18219