### PR TITLE
LibWeb: Fix the update of the favicon during navigation

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -267,10 +267,6 @@ bool FrameLoader::load(LoadRequest& request, Type type)
     if (type == Type::IFrame)
         return true;
 
-    auto* document = browsing_context().active_document();
-    if (document && document->has_active_favicon())
-        return true;
-
     if (url.scheme() == "http" || url.scheme() == "https") {
         AK::URL favicon_url;
         favicon_url.set_scheme(url.scheme());


### PR DESCRIPTION
The check on the currently active document for an existing favicon has been removed. It caused an issue during navigation because the active document will only be updated after the load and the favicon check has been executed against the old document.

The override of the favicon with the <link rel="icon" ... /> tag still works. This change fixes #15744 