### PR TITLE
Aplay: Determine absolute path before first `unveil`

### DIFF
--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -35,8 +35,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(show_sample_progress, "Show playback progress in samples", "sample-progress", 's');
     args_parser.parse(arguments);
 
+    auto absolute_path = Core::DeprecatedFile::absolute_path(path);
+
     TRY(Core::System::unveil("/tmp/session/%sid/portal/audio", "rw"));
-    TRY(Core::System::unveil(Core::DeprecatedFile::absolute_path(path), "r"sv));
+    TRY(Core::System::unveil(absolute_path, "r"sv));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     Core::EventLoop loop;


### PR DESCRIPTION
`Core::DeprecatedFile::absolute_path` uses `stat` to determine whether a file exists, which will always fail after the first `unveil` call `aplay` does. Reorder things so we don't get a stack trace thrown at us for each file being played.