### PR TITLE
Ports: Remove getconf from bash examples

### DIFF
--- a/Ports/bash/patches/0001-accept.c-Include-sys-select.h.patch
+++ b/Ports/bash/patches/0001-accept.c-Include-sys-select.h.patch
@@ -10,10 +10,10 @@ serenity is not one of them.
  1 file changed, 1 insertion(+)
 
 diff --git a/examples/loadables/accept.c b/examples/loadables/accept.c
-index 54cf38c..fd8e7ed 100644
+index ff98423dd0b256a79cd6d033abb381705daac868..0099f97f635885f6672f52efda2e90415659340a 100644
 --- a/examples/loadables/accept.c
 +++ b/examples/loadables/accept.c
-@@ -35,6 +35,7 @@
+@@ -36,6 +36,7 @@
  #include <sys/socket.h>
  #include <arpa/inet.h>
  #include <netinet/in.h>

--- a/Ports/bash/patches/0002-Remove-getopt-from-examples.patch
+++ b/Ports/bash/patches/0002-Remove-getopt-from-examples.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Fabian Dellwing <fabian.dellwing@gmail.com>
+Date: Mon, 24 Apr 2023 18:54:29 +0200
+Subject: [PATCH] Remove getopt from examples
+
+We currently fail to build getconf.c because we are missing libintl.h and don't support multiple needed syscalls (from around 300 total syscalls).
+---
+ examples/loadables/Makefile.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/examples/loadables/Makefile.in b/examples/loadables/Makefile.in
+index 956f018933f861ff157841f42247a778f04ba909..4852f0419cb2ae039e2b5a403d66eff7975ede25 100644
+--- a/examples/loadables/Makefile.in
++++ b/examples/loadables/Makefile.in
+@@ -104,7 +104,7 @@ INC = -I. -I.. -I$(topdir) -I$(topdir)/lib -I$(topdir)/builtins -I${srcdir} \
+ ALLPROG = print truefalse sleep finfo logname basename dirname fdflags \
+ 	  tty pathchk tee head mkdir rmdir mkfifo mktemp printenv id whoami \
+ 	  uname sync push ln unlink realpath strftime mypid setpgid seq rm \
+-	  accept csv dsv cut stat getconf
++	  accept csv dsv cut stat
+ OTHERPROG = necho hello cat pushd asort
+ 
+ all:	$(SHOBJ_STATUS)

--- a/Ports/bash/patches/ReadMe.md
+++ b/Ports/bash/patches/ReadMe.md
@@ -7,3 +7,9 @@ accept.c: Include sys/select.h
 This is transitively pulled in by other headers in some systems,
 serenity is not one of them.
 
+## `0002-Remove-getopt-from-examples.patch`
+
+Remove getopt from examples
+
+We currently fail to build getconf.c because we are missing libintl.h and don't support multiple needed syscalls (from around 300 total syscalls).
+


### PR DESCRIPTION
We fail to build `getconf.c` from the builtin examples. And therefore dont install the rest. If we remove it, we successfully build the rest of the examples.

Before:
```
[bash/install] getconf.c:24:10: fatal error: libintl.h: No such file or directory
[bash/install]    24 | #include <libintl.h>
[bash/install]       |          ^~~~~~~~~~~
[bash/install] compilation terminated.
[bash/install] make[1]: *** [Makefile:101: getconf.o] Error 1
[bash/install] make[1]: Leaving directory '/home/ubuntu/serenity/Build/x86_64/Ports/bash/bash-5.2.15/examples/loadables'
[bash/install] make: [Makefile:846: install] Error 2 (ignored)
```

After:
```
[bash/install] installing example loadable builtins in /home/ubuntu/serenity/Build/x86_64/Root/usr/local/lib/bash
[bash/install] print
[bash/install] truefalse
[bash/install] sleep
[bash/install] finfo
[bash/install] logname
[bash/install] basename
[bash/install] dirname
[bash/install] fdflags
[bash/install] tty
[bash/install] pathchk
[bash/install] tee
[bash/install] head
[bash/install] mkdir
[bash/install] rmdir
[bash/install] mkfifo
[bash/install] mktemp
[bash/install] printenv
[bash/install] id
[bash/install] whoami
[bash/install] uname
[bash/install] sync
[bash/install] push
[bash/install] ln
[bash/install] unlink
[bash/install] realpath
[bash/install] strftime
[bash/install] mypid
[bash/install] setpgid
[bash/install] seq
[bash/install] rm
[bash/install] accept
[bash/install] csv
[bash/install] dsv
[bash/install] cut
[bash/install] stat
[bash/install] make[1]: Leaving directory '/home/ubuntu/serenity/Build/x86_64/Ports/bash/bash-5.2.15/examples/loadables'
```