### PR TITLE
LibVideo: Do not invoke Vector2D's destructor in order to resize it

### DIFF
--- a/Userland/Libraries/LibVideo/VP9/ContextStorage.h
+++ b/Userland/Libraries/LibVideo/VP9/ContextStorage.h
@@ -103,17 +103,14 @@ class Vector2D {
 public:
     ~Vector2D()
     {
-        if (m_storage)
-            free(m_storage);
-        m_storage = nullptr;
-        m_width = 0;
-        m_height = 0;
+        clear_storage();
     }
 
     ErrorOr<void> try_resize(u32 height, u32 width)
     {
         if (height != m_height && width != m_width) {
-            this->~Vector2D();
+            clear_storage();
+
             size_t size = height * width;
             auto* new_storage = static_cast<T*>(malloc(size * sizeof(T)));
             if (!new_storage)
@@ -195,6 +192,15 @@ public:
     }
 
 private:
+    void clear_storage()
+    {
+        if (m_storage)
+            free(m_storage);
+        m_storage = nullptr;
+        m_width = 0;
+        m_height = 0;
+    }
+
     u32 m_height { 0 };
     u32 m_width { 0 };
     T* m_storage { nullptr };


### PR DESCRIPTION
This leads to all kinds of undefined behavior, especially when callers have a view into the Vector2D.