### PR TITLE
Meta+Toolchain: Add common method exit_if_running_as_root() and use this from Meta/serenity.sh and Toolchain/Build*.sh scripts

### DIFF
--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -66,11 +66,6 @@ Usage: $NAME COMMAND [TARGET] [TOOLCHAIN] [ARGS...]
 EOF
 }
 
-die() {
-    >&2 echo "die: $*"
-    exit 1
-}
-
 usage() {
     >&2 print_help
     exit 1
@@ -84,9 +79,12 @@ if [ "$CMD" = "help" ]; then
     exit 0
 fi
 
-if [ "$(id -u)" -eq 0 ]; then
-   die "Do not run serenity.sh as root, your Build directory will become root-owned"
-fi
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# shellcheck source=/dev/null
+. "${DIR}/shell_include.sh"
+
+exit_if_running_as_root "Do not run serenity.sh as root, your Build directory will become root-owned"
 
 if [ -n "$1" ]; then
     TARGET="$1"; shift

--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -17,6 +17,12 @@ die() {
     exit 1
 }
 
+exit_if_running_as_root() {
+    if [ "$(id -u)" -eq 0 ]; then
+       die "$*"
+    fi
+}
+
 find_executable() {
   paths=("/usr/sbin" "/sbin")
 

--- a/Toolchain/BuildCMake.sh
+++ b/Toolchain/BuildCMake.sh
@@ -5,6 +5,11 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# shellcheck source=/dev/null
+. "${DIR}/../Meta/shell_include.sh"
+
+exit_if_running_as_root "Do not run BuildCMake.sh as root, parts of your Toolchain directory will become root-owned"
+
 PREFIX_DIR="$DIR/Local/cmake"
 BUILD_DIR="$DIR/Build/cmake"
 TARBALLS_DIR="$DIR/Tarballs"

--- a/Toolchain/BuildClang.sh
+++ b/Toolchain/BuildClang.sh
@@ -5,6 +5,11 @@ set -eo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# shellcheck source=/dev/null
+. "${DIR}/../Meta/shell_include.sh"
+
+exit_if_running_as_root "Do not run BuildClang.sh as root, parts of your Toolchain directory will become root-owned"
+
 echo "$DIR"
 
 PREFIX="$DIR/Local/clang/"

--- a/Toolchain/BuildFuseExt2.sh
+++ b/Toolchain/BuildFuseExt2.sh
@@ -3,6 +3,12 @@ set -e
 # This file will need to be run in bash.
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# shellcheck source=/dev/null
+. "${DIR}/../Meta/shell_include.sh"
+
+exit_if_running_as_root "Do not run BuildFuseExt2.sh as root, parts of your Toolchain directory will become root-owned"
+
 export PATH="/usr/local/opt/m4/bin:$PATH"
 
 die() {

--- a/Toolchain/BuildGDB.sh
+++ b/Toolchain/BuildGDB.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 set -e
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# shellcheck source=/dev/null
+. "${DIR}/../Meta/shell_include.sh"
+
+exit_if_running_as_root "Do not run BuildGDB.sh as root, parts of your Toolchain directory will become root-owned"
+
 GDB_VERSION="13.1"
 GDB_MD5SUM="4aaad768ff2585464173c091947287ec"
 GDB_NAME="gdb-$GDB_VERSION"
 GDB_PKG="${GDB_NAME}.tar.xz"
 GDB_BASE_URL="https://ftp.gnu.org/gnu/gdb"
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 ARCH=${1:-"x86_64"}
 TARGET="$ARCH-pc-serenity"

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -2,10 +2,14 @@
 set -eo pipefail
 # This file will need to be run in bash, for now.
 
-
 # === CONFIGURATION AND SETUP ===
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# shellcheck source=/dev/null
+. "${DIR}/../Meta/shell_include.sh"
+
+exit_if_running_as_root "Do not run BuildIt.sh as root, your Build directory will become root-owned"
 
 echo "$DIR"
 

--- a/Toolchain/BuildMold.sh
+++ b/Toolchain/BuildMold.sh
@@ -6,6 +6,11 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# shellcheck source=/dev/null
+. "${DIR}/../Meta/shell_include.sh"
+
+exit_if_running_as_root "Do not run BuildMold.sh as root, parts of your Toolchain directory will become root-owned"
+
 NPROC="nproc"
 SYSTEM_NAME="$(uname -s)"
 

--- a/Toolchain/BuildPython.sh
+++ b/Toolchain/BuildPython.sh
@@ -5,6 +5,11 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# shellcheck source=/dev/null
+. "${DIR}/../Meta/shell_include.sh"
+
+exit_if_running_as_root "Do not run BuildPython.sh as root, parts of your Toolchain directory will become root-owned"
+
 PREFIX_DIR="$DIR/Local/python"
 BUILD_DIR="$DIR/Build/python"
 TARBALLS_DIR="$DIR/Tarballs"

--- a/Toolchain/BuildQemu.sh
+++ b/Toolchain/BuildQemu.sh
@@ -5,6 +5,11 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# shellcheck source=/dev/null
+. "${DIR}/../Meta/shell_include.sh"
+
+exit_if_running_as_root "Do not run BuildQemu.sh as root, parts of your Toolchain directory will become root-owned"
+
 echo "$DIR"
 
 PREFIX="$DIR/Local/qemu"

--- a/Toolchain/BuildRuby.sh
+++ b/Toolchain/BuildRuby.sh
@@ -5,6 +5,11 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# shellcheck source=/dev/null
+. "${DIR}/../Meta/shell_include.sh"
+
+exit_if_running_as_root "Do not run BuildRuby.sh as root, parts of your Toolchain directory will become root-owned"
+
 PREFIX_DIR="$DIR/Local/ruby"
 BUILD_DIR="$DIR/Build/ruby"
 TARBALLS_DIR="$DIR/Tarballs"


### PR DESCRIPTION
This adds a common method `exit_if_running_as_root()` to shell_include.sh. Updates `Meta/serenity.sh` to use `exit_if_running_as_root()`, instead of the previous inline root check. And updates our `Build*.sh` scripts in the `Toolchain` folder to bail out if they are mistakenly run under root.