### PR TITLE
AK: Rename `Stream::format()` to `Stream::write_formatted()`

### DIFF
--- a/AK/Stream.cpp
+++ b/AK/Stream.cpp
@@ -98,7 +98,7 @@ ErrorOr<void> Stream::write_until_depleted(ReadonlyBytes buffer)
     return {};
 }
 
-ErrorOr<void> Stream::format_impl(StringView fmtstr, TypeErasedFormatParams& parameters)
+ErrorOr<void> Stream::write_formatted_impl(StringView fmtstr, TypeErasedFormatParams& parameters)
 {
     StringBuilder builder;
     TRY(vformat(builder, fmtstr, parameters));

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -77,13 +77,11 @@ public:
         return write_until_depleted({ &value, sizeof(value) });
     }
 
-    virtual ErrorOr<void> format_impl(StringView, TypeErasedFormatParams&);
-
     template<typename... Parameters>
-    ErrorOr<void> format(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
+    ErrorOr<void> write_formatted(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
     {
         VariadicFormatParams<AllowDebugOnlyFormatters::No, Parameters...> variadic_format_params { parameters... };
-        TRY(format_impl(fmtstr.view(), variadic_format_params));
+        TRY(write_formatted_impl(fmtstr.view(), variadic_format_params));
         return {};
     }
 
@@ -108,6 +106,9 @@ protected:
     /// content size to be in order to reduce allocations (does not affect
     /// actual reading).
     ErrorOr<ByteBuffer> read_until_eof_impl(size_t block_size, size_t expected_file_size = 0);
+
+private:
+    ErrorOr<void> write_formatted_impl(StringView, TypeErasedFormatParams&);
 };
 
 enum class SeekMode {

--- a/Userland/Libraries/LibJS/Print.cpp
+++ b/Userland/Libraries/LibJS/Print.cpp
@@ -141,9 +141,9 @@ ErrorOr<void> js_out(JS::PrintContext& print_context, CheckedFormatString<Args..
 {
     if (print_context.strip_ansi) {
         auto format_string_without_ansi = TRY(strip_ansi(format_string.view()));
-        TRY(print_context.stream.format(format_string_without_ansi, args...));
+        TRY(print_context.stream.write_formatted(format_string_without_ansi, args...));
     } else {
-        TRY(print_context.stream.format(format_string.view(), args...));
+        TRY(print_context.stream.write_formatted(format_string.view(), args...));
     }
 
     return {};


### PR DESCRIPTION
This brings the function name in line with how we usually name those functions, which is with a `read_` or `write_` prefix depending on what they do.

While at it, make the internal `_impl` function private and not-virtual, since there is no good reason to ever override that function.

Ideally, I'd also like to adapt `FormatBuilder` to directly write parts to the stream instead of having to copy into and out of a StringBuilder, but that isn't trivial at the moment, so that is skipped for now.