### PR TITLE
LibWeb+WebContent: Make document background and Viewport transparent

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -722,7 +722,7 @@ void Document::tear_down_layout_tree()
     m_layout_root = nullptr;
 }
 
-Color Document::background_color(Gfx::Palette const& palette) const
+Color Document::background_color() const
 {
     // CSS2 says we should use the HTML element's background color unless it's transparent...
     if (auto* html_element = this->html_element(); html_element && html_element->layout_node()) {
@@ -734,12 +734,12 @@ Color Document::background_color(Gfx::Palette const& palette) const
     // ...in which case we use the BODY element's background color.
     if (auto* body_element = body(); body_element && body_element->layout_node()) {
         auto color = body_element->layout_node()->computed_values().background_color();
-        if (color.alpha())
-            return color;
+        return color;
     }
 
-    // If both HTML and BODY are transparent, we fall back to the system's "base" palette color.
-    return palette.base();
+    // By default, the document is transparent.
+    // The outermost canvas is colored by the PageHost.
+    return Color::Transparent;
 }
 
 Vector<CSS::BackgroundLayerData> const* Document::background_layers() const

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -179,7 +179,7 @@ public:
     Page* page();
     Page const* page() const;
 
-    Color background_color(Gfx::Palette const&) const;
+    Color background_color() const;
     Vector<CSS::BackgroundLayerData> const* background_layers() const;
 
     Color link_color() const;

--- a/Userland/Libraries/LibWeb/Layout/Viewport.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Viewport.cpp
@@ -55,7 +55,6 @@ void Viewport::build_stacking_context_tree()
 void Viewport::paint_all_phases(PaintContext& context)
 {
     build_stacking_context_tree_if_needed();
-    context.painter().fill_rect(context.enclosing_device_rect(paintable_box()->absolute_rect()).to_type<int>(), document().background_color(context.palette()));
     context.painter().translate(-context.device_viewport_rect().location().to_type<int>());
     paintable_box()->stacking_context()->paint(context);
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -257,7 +257,7 @@ void PaintableBox::paint_background(PaintContext& context) const
         // user agents must instead propagate the computed values of the background properties from that element’s first HTML BODY child element.
         if (document().html_element()->should_use_body_background_properties()) {
             background_layers = document().background_layers();
-            background_color = document().background_color(context.palette());
+            background_color = document().background_color();
         }
     } else {
         background_rect = absolute_padding_box_rect();

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -116,9 +116,10 @@ void PageHost::paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& targ
     if (auto* document = page().top_level_browsing_context().active_document())
         document->update_layout();
 
+    painter.fill_rect(bitmap_rect, palette().base());
+
     auto* layout_root = this->layout_root();
     if (!layout_root) {
-        painter.fill_rect(bitmap_rect, palette().base());
         return;
     }
 


### PR DESCRIPTION
This means iframes are transparent by default (as in firefox/chrome).

Painting the outermost canvas background is moved to the PageHost.

Solves #18444.