### PR TITLE
LibWeb: Add missing valid-identifiers for display CSS property

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -602,7 +602,9 @@
     "initial": "inline",
     "valid-identifiers": [
       "block",
+      "contents",
       "flex",
+      "flow-root",
       "grid",
       "inline",
       "inline-block",
@@ -610,6 +612,8 @@
       "inline-table",
       "list-item",
       "none",
+      "ruby",
+      "run-in",
       "table",
       "table-caption",
       "table-cell",


### PR DESCRIPTION
Adding "flow-root" makes "display: flow-root" work. I added the other valid-identifiers to complete the list.