### PR TITLE
LibAudio: Make `WavWriter` check if a file was set during destruction

### DIFF
--- a/Userland/Libraries/LibAudio/WavWriter.cpp
+++ b/Userland/Libraries/LibAudio/WavWriter.cpp
@@ -58,7 +58,7 @@ void WavWriter::finalize()
     VERIFY(!m_finalized);
     m_finalized = true;
 
-    if (m_file->is_open()) {
+    if (m_file && m_file->is_open()) {
         auto result = [&]() -> ErrorOr<void> {
             TRY(m_file->seek(0, SeekMode::SetPosition));
             return TRY(write_header());


### PR DESCRIPTION
`WavWriter` can be constructed without a file, which should probably be made impossible at some point. For now, let's not crash `Piano` when you close the application.