### PR TITLE
LibCore: Include sys/ucred.h in System.h for FreeBSD

### DIFF
--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -39,6 +39,10 @@
 #    include <shadow.h>
 #endif
 
+#ifdef AK_OS_FREEBSD
+#    include <sys/ucred.h>
+#endif
+
 #ifdef AK_OS_SOLARIS
 #    include <sys/filio.h>
 #    include <ucred.h>


### PR DESCRIPTION
Add an ifdef for including sys/ucred.h when compiling on FreeBSD.
That was somehow forgotten to re-add when moving socket credentials from Socket.cpp to System.cpp some months ago and broke building Ladybird on FreeBSD.
I know I'm quite late with this, but I was busy the last weeks.