### PR TITLE
LibManual: Open page from a help URL

### DIFF
--- a/Userland/Libraries/LibManual/Node.cpp
+++ b/Userland/Libraries/LibManual/Node.cpp
@@ -89,16 +89,24 @@ ErrorOr<NonnullRefPtr<Node const>> Node::try_find_from_help_url(URL const& url)
         return Error::from_string_view("Section number out of bounds"sv);
 
     NonnullRefPtr<Node const> current_node = sections[section_number - 1];
-
+    bool child_node_found;
     for (size_t i = 1; i < url.path_segment_count(); i++) {
+        child_node_found = false;
         auto children = TRY(current_node->children());
         for (auto const& child : children) {
             if (TRY(child->name()) == url.path_segment_at_index(i).view()) {
+                child_node_found = true;
                 current_node = child;
                 break;
             }
         }
+
+        if (!child_node_found)
+            break;
     }
+
+    if (!child_node_found)
+        return Error::from_string_view("Page not found"sv);
 
     return current_node;
 }

--- a/Userland/Libraries/LibManual/Node.cpp
+++ b/Userland/Libraries/LibManual/Node.cpp
@@ -22,6 +22,12 @@ ErrorOr<NonnullRefPtr<PageNode const>> Node::try_create_from_query(Vector<String
     if (query_parameters.size() > 2)
         return Error::from_string_literal("Queries longer than 2 strings are not supported yet");
 
+    if (query_parameters.size() == 1 && query_parameters[0].starts_with("help://"sv)) {
+        auto help_url = URL::create_with_url_or_path(query_parameters[0].trim("/"sv, TrimMode::Right));
+        auto node_from_url = TRY(Manual::Node::try_find_from_help_url(help_url));
+        return *node_from_url->document();
+    }
+
     auto query_parameter_iterator = query_parameters.begin();
 
     if (query_parameter_iterator.is_end())


### PR DESCRIPTION
This PR allows both `Help` and `man` to open pages from a `help://` URL specified on the command line.

Fixes #17987

Video:

https://user-images.githubusercontent.com/2817754/234344227-ceba092c-b052-44ba-94a2-1e4b17eee149.mp4

