### PR TITLE
Ports: SDL2, GLtron and ScummVM improvements

### DIFF
--- a/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
+++ b/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
@@ -38,9 +38,9 @@ Co-Authored-By: kleines Filmröllchen <filmroellchen@serenityos.org>
  src/video/serenity/SDL_serenitymessagebox.h   |  38 ++
  src/video/serenity/SDL_serenitymouse.cpp      | 142 ++++
  src/video/serenity/SDL_serenitymouse.h        |  39 ++
- src/video/serenity/SDL_serenityvideo.cpp      | 611 ++++++++++++++++++
+ src/video/serenity/SDL_serenityvideo.cpp      | 607 ++++++++++++++++++
  src/video/serenity/SDL_serenityvideo.h        | 101 +++
- 20 files changed, 1312 insertions(+), 25 deletions(-)
+ 20 files changed, 1308 insertions(+), 25 deletions(-)
  create mode 100644 src/audio/serenity/SDL_serenityaudio.cpp
  create mode 100644 src/audio/serenity/SDL_serenityaudio.h
  create mode 100644 src/video/serenity/SDL_serenityevents.cpp
@@ -872,10 +872,10 @@ index 0000000000000000000000000000000000000000..039f0361b3d1b248e218ea69495f58e5
 +/* vi: set ts=4 sw=4 expandtab: */
 diff --git a/src/video/serenity/SDL_serenityvideo.cpp b/src/video/serenity/SDL_serenityvideo.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..d3ebc9917e880488862b86aebf93c7e3105e3a4e
+index 0000000000000000000000000000000000000000..f26040845dd05f425ba464af385e133c6c3eab93
 --- /dev/null
 +++ b/src/video/serenity/SDL_serenityvideo.cpp
-@@ -0,0 +1,611 @@
+@@ -0,0 +1,607 @@
 +/*
 +  Simple DirectMedia Layer
 +  Copyright (C) 1997-2019 Sam Lantinga <slouken@libsdl.org>
@@ -1266,12 +1266,8 @@ index 0000000000000000000000000000000000000000..d3ebc9917e880488862b86aebf93c7e3
 +    w->window()->set_double_buffering_enabled(false);
 +    w->widget()->set_fill_with_background_color(false);
 +    w->window()->set_main_widget(w->widget());
-+    w->window()->on_close = [&window] {
++    w->window()->on_close_request = [window] {
 +        SDL_SendWindowEvent(window, SDL_WINDOWEVENT_CLOSE, 0, 0);
-+    };
-+    w->window()->on_close_request = [] {
-+        if (SDL_SendQuit())
-+            return GUI::Window::CloseRequestDecision::Close;
 +        return GUI::Window::CloseRequestDecision::StayOpen;
 +    };
 +    w->window()->on_active_window_change = [window](bool is_active_window) {

--- a/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
+++ b/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
@@ -27,7 +27,7 @@ Co-Authored-By: kleines Filmröllchen <filmroellchen@serenityos.org>
  src/SDL_error.c                               |   7 +-
  src/audio/SDL_audio.c                         |   3 +
  src/audio/SDL_sysaudio.h                      |   1 +
- src/audio/serenity/SDL_serenityaudio.cpp      | 160 +++++
+ src/audio/serenity/SDL_serenityaudio.cpp      | 166 +++++
  src/audio/serenity/SDL_serenityaudio.h        |  38 ++
  src/stdlib/SDL_stdlib.c                       |   2 +-
  src/video/SDL_sysvideo.h                      |   1 +
@@ -40,7 +40,7 @@ Co-Authored-By: kleines Filmröllchen <filmroellchen@serenityos.org>
  src/video/serenity/SDL_serenitymouse.h        |  39 ++
  src/video/serenity/SDL_serenityvideo.cpp      | 611 ++++++++++++++++++
  src/video/serenity/SDL_serenityvideo.h        | 101 +++
- 20 files changed, 1306 insertions(+), 25 deletions(-)
+ 20 files changed, 1312 insertions(+), 25 deletions(-)
  create mode 100644 src/audio/serenity/SDL_serenityaudio.cpp
  create mode 100644 src/audio/serenity/SDL_serenityaudio.h
  create mode 100644 src/video/serenity/SDL_serenityevents.cpp
@@ -213,10 +213,10 @@ index 6afaae195c6cedb6f9d7b00ca840907e280c0575..6c7009afd966ab384848a63b51c35ec2
  
 diff --git a/src/audio/serenity/SDL_serenityaudio.cpp b/src/audio/serenity/SDL_serenityaudio.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..8a5abd58967dee12619c45d0e0d6cfc8e00f5445
+index 0000000000000000000000000000000000000000..e1cd5348b67c23c49b25f99f4f36e020658aa049
 --- /dev/null
 +++ b/src/audio/serenity/SDL_serenityaudio.cpp
-@@ -0,0 +1,160 @@
+@@ -0,0 +1,166 @@
 +/*
 +  Simple DirectMedia Layer
 +  Copyright (C) 1997-2019 Sam Lantinga <slouken@libsdl.org>
@@ -261,6 +261,12 @@ index 0000000000000000000000000000000000000000..8a5abd58967dee12619c45d0e0d6cfc8
 +
 +static void SERENITYAUDIO_CloseDevice(_THIS)
 +{
++    dbgln("SERENITYAUDIO_CloseDevice");
++
++    struct SDL_PrivateAudioData* h = that->hidden;
++    if (h->client)
++        h->client->die();
++
 +    SDL_free(that->hidden->mixbuf);
 +    SDL_free(that->hidden);
 +}
@@ -866,7 +872,7 @@ index 0000000000000000000000000000000000000000..039f0361b3d1b248e218ea69495f58e5
 +/* vi: set ts=4 sw=4 expandtab: */
 diff --git a/src/video/serenity/SDL_serenityvideo.cpp b/src/video/serenity/SDL_serenityvideo.cpp
 new file mode 100644
-index 0000000000000000000000000000000000000000..9c7d4f3f5cedf86ae885330aaf6fae7ec88be286
+index 0000000000000000000000000000000000000000..d3ebc9917e880488862b86aebf93c7e3105e3a4e
 --- /dev/null
 +++ b/src/video/serenity/SDL_serenityvideo.cpp
 @@ -0,0 +1,611 @@

--- a/Ports/gltron/patches/0004-System-Make-sure-to-exit-the-loop-on-receiving-SDL_Q.patch
+++ b/Ports/gltron/patches/0004-System-Make-sure-to-exit-the-loop-on-receiving-SDL_Q.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jelle Raaijmakers <jelle@gmta.nl>
+Date: Tue, 25 Apr 2023 17:53:50 +0200
+Subject: [PATCH] System: Make sure to exit the loop on receiving SDL_QUIT
+
+This is fixed in more modern adaptations, as can be seen here:
+
+https://github.com/laanwj/gltron/blob/336dbbb75afe0aed1d9faaa5bbaa867b2b13d10b/nebu/base/system.c#L135
+
+Since we work with the original source material, we better patch this
+ourselves.
+---
+ nebu/base/system.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/nebu/base/system.c b/nebu/base/system.c
+index 07a75e7b069a73a203950a4f0d0a8a345f76518a..794848e91cb22d1099d5a61e2e01974dde69861e 100644
+--- a/nebu/base/system.c
++++ b/nebu/base/system.c
+@@ -37,6 +37,8 @@ int SystemMainLoop() {
+ 				break;
+ 			case SDL_QUIT:
+ 				SystemExit();
++				// status 10 is the only way to break free from main.lua
++				SystemExitLoop(10);
+ 				break;
+ 			default:
+ 				/* ignore event */

--- a/Ports/gltron/patches/ReadMe.md
+++ b/Ports/gltron/patches/ReadMe.md
@@ -17,3 +17,14 @@ Build: Fix `char*` vs. `const char*` arguments
 These arguments are of the wrong constness, which will trip our
 compiler.
 
+## `0004-System-Make-sure-to-exit-the-loop-on-receiving-SDL_Q.patch`
+
+System: Make sure to exit the loop on receiving SDL_QUIT
+
+This is fixed in more modern adaptations, as can be seen here:
+
+https://github.com/laanwj/gltron/blob/336dbbb75afe0aed1d9faaa5bbaa867b2b13d10b/nebu/base/system.c#L135
+
+Since we work with the original source material, we better patch this
+ourselves.
+

--- a/Ports/scummvm/package.sh
+++ b/Ports/scummvm/package.sh
@@ -7,7 +7,7 @@ auth_type=sha256
 depends=("freetype" "libiconv" "libjpeg" "libmad" "libmpeg2" "libpng" "libtheora" "SDL2")
 configopts=(
     "--enable-engine=monkey4"
-    "--enable-optimizations"
+    "--enable-release"
     "--with-sdl-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
 )
 launcher_name=ScummVM


### PR DESCRIPTION
Featuring:

:speaker: SDL2's audio subsystem has learned to _shut up_
:window: SDL2 now actually understands how to deal with window close requests
:motorcycle: GLtron no longer crashes or hangs when closing the main window
:pinching_hand: ScummVM now weighs in at ~100 MiB instead of ~600 MiB

PrBoom+ before:
<video src="https://user-images.githubusercontent.com/3210731/234368580-4ad4040b-23e9-41cd-8809-42db80dac4e9.mp4"/>

PrBoom+ after:
<video src="https://user-images.githubusercontent.com/3210731/234368679-6eaaa380-ee63-4652-919c-b78c9191a588.mp4"/>

GLtron before:
<video src="https://user-images.githubusercontent.com/3210731/234368747-531106a0-8dca-4ffb-b0d2-24af97a89b7f.mp4"/>

GLtron after:
<video src="https://user-images.githubusercontent.com/3210731/234368796-f8b8ed2b-9ed1-40ca-a474-85e315cba77d.mp4"/>
