### PR TITLE
WindowServer: Draw stretched wallpapers with bilinear blending

### DIFF
--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -873,7 +873,7 @@ void Compositor::update_wallpaper_bitmap()
             auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, screen.size(), screen.scale_factor()).release_value_but_fixme_should_propagate_errors();
 
             Gfx::Painter painter(*bitmap);
-            painter.draw_scaled_bitmap(bitmap->rect(), *m_wallpaper, m_wallpaper->rect());
+            painter.draw_scaled_bitmap(bitmap->rect(), *m_wallpaper, m_wallpaper->rect(), 1.f, Gfx::Painter::ScalingMode::BilinearBlend);
 
             screen_data.m_wallpaper_bitmap = move(bitmap);
         }


### PR DESCRIPTION
This improves the quality of stretched photos and artwork considerably, and I'd argue that this is what users will expect by default.

Before:
![image](https://user-images.githubusercontent.com/3210731/234377984-b27e03b5-4a8c-4518-80b6-9c148c8e0085.png)

After:
![image](https://user-images.githubusercontent.com/3210731/234378301-c532e3e2-a755-44d8-9ca2-9d144d36f50b.png)
