### PR TITLE
LibWeb: Clamp CSS z-index to the range of a 32-bit integer

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -216,8 +216,16 @@ Optional<int> StyleProperties::z_index() const
     auto value = property(CSS::PropertyID::ZIndex);
     if (value->has_auto())
         return {};
-    if (value->has_integer())
-        return value->to_integer();
+    if (value->has_integer()) {
+        // Clamp z-index to the range of a signed 32-bit integer for consistency with other engines.
+        // NOTE: Casting between 32-bit float and 32-bit integer is finicky here, since INT32_MAX is not representable as a 32-bit float!
+        auto integer = value->to_integer();
+        if (integer >= static_cast<float>(NumericLimits<int>::max()))
+            return NumericLimits<int>::max();
+        if (integer <= static_cast<float>(NumericLimits<int>::min()))
+            return NumericLimits<int>::min();
+        return static_cast<int>(integer);
+    }
     return {};
 }
 


### PR DESCRIPTION
This appears to be consistent with other engines, and fixes many pages where we were misinterpreting super large z-index values as something else entirely.

As an example, here is https://osnews.com/

Before:
![Screenshot at 2023-04-26 07-14-54](https://user-images.githubusercontent.com/5954907/234476863-c3f4c92b-4692-4567-a3dd-166c6e931e56.png)

After:
![Screenshot at 2023-04-26 07-13-28](https://user-images.githubusercontent.com/5954907/234476874-a8ffc429-ef8d-41e4-8fa8-387ce324cae5.png)
