### PR TITLE
Browser+Ladybird: Render text in the JS console with a monospace font

### DIFF
--- a/Ladybird/ConsoleWidget.cpp
+++ b/Ladybird/ConsoleWidget.cpp
@@ -12,6 +12,7 @@
 #include "WebContentView.h"
 #include <AK/StringBuilder.h>
 #include <LibJS/MarkupGenerator.h>
+#include <QFontDatabase>
 #include <QLineEdit>
 #include <QPalette>
 #include <QPushButton>
@@ -41,7 +42,7 @@ ConsoleWidget::ConsoleWidget()
     if (is_using_dark_system_theme(*this))
         m_output_view->update_palette(WebContentView::PaletteMode::Dark);
 
-    m_output_view->load("data:text/html,<html></html>"sv);
+    m_output_view->load("data:text/html,<html style=\"font: 10pt monospace;\"></html>"sv);
     // Wait until our output WebView is loaded, and then request any messages that occurred before we existed
     m_output_view->on_load_finish = [this](auto&) {
         if (on_request_messages)
@@ -56,6 +57,7 @@ ConsoleWidget::ConsoleWidget()
     layout()->addWidget(bottom_container);
 
     m_input = new QLineEdit(bottom_container);
+    m_input->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
     bottom_container->layout()->addWidget(m_input);
 
     QObject::connect(m_input, &QLineEdit::returnPressed, [this] {

--- a/Ladybird/FontPluginQt.cpp
+++ b/Ladybird/FontPluginQt.cpp
@@ -68,9 +68,19 @@ void FontPluginQt::update_generic_fonts()
 
     m_generic_font_names.resize(static_cast<size_t>(Web::Platform::GenericFont::__Count));
 
-    auto update_mapping = [&](Web::Platform::GenericFont generic_font, QFont::StyleHint qfont_style_hint, Vector<DeprecatedString> fallbacks = {}) {
+    auto update_mapping = [&](Web::Platform::GenericFont generic_font, QFont::StyleHint qfont_style_hint, ReadonlySpan<DeprecatedString> fallbacks) {
         QFont qt_font;
         qt_font.setStyleHint(qfont_style_hint);
+
+        // NOTE: This is a workaround for setStyleHint being a no-op on X11 systems. See:
+        //       https://doc.qt.io/qt-6/qfont.html#setStyleHint
+        if (generic_font == Web::Platform::GenericFont::Monospace)
+            qt_font.setFamily("monospace");
+        else if (generic_font == Web::Platform::GenericFont::Fantasy)
+            qt_font.setFamily("fantasy");
+        else if (generic_font == Web::Platform::GenericFont::Cursive)
+            qt_font.setFamily("cursive");
+
         QFontInfo qt_info(qt_font);
         auto qt_font_family = qt_info.family();
 

--- a/Userland/Applications/Browser/ConsoleWidget.cpp
+++ b/Userland/Applications/Browser/ConsoleWidget.cpp
@@ -25,7 +25,7 @@ ConsoleWidget::ConsoleWidget()
     set_fill_with_background_color(true);
 
     m_output_view = add<WebView::OutOfProcessWebView>();
-    m_output_view->load("data:text/html,<html></html>"sv);
+    m_output_view->load("data:text/html,<html style=\"font: 10pt monospace;\"></html>"sv);
     // Wait until our output WebView is loaded, and then request any messages that occurred before we existed
     m_output_view->on_load_finish = [this](auto&) {
         if (on_request_messages)


### PR DESCRIPTION
Regarding the first commit - I wasn't actually able to get `cursive` or `fantasy` fonts to render, as they are .otf on my system (and if I force .otf to load, I get "CFF fonts not supported yet"). But I did check that Qt finds the right fonts for those families.

Browser before:
![browser_before](https://user-images.githubusercontent.com/5600524/234576297-6489f99b-89f5-47ac-b441-f3158c5aaa43.png)

Browser after:
![browser_after](https://user-images.githubusercontent.com/5600524/234576310-4a4fa6ad-1785-40b1-be66-efd43c800045.png)

Ladybird before:
![ladybird_before](https://user-images.githubusercontent.com/5600524/234576326-0ca58457-ddfe-432e-825a-f2bdaea7f8af.png)

Ladybird after
![ladybird_after](https://user-images.githubusercontent.com/5600524/234576335-b14bbb26-ebb8-401e-b4ef-65d787e9929a.png)
