### PR TITLE
Kernel/VirtIO: Some cleanups

### DIFF
--- a/Kernel/Bus/VirtIO/Console.cpp
+++ b/Kernel/Bus/VirtIO/Console.cpp
@@ -19,47 +19,49 @@ UNMAP_AFTER_INIT NonnullLockRefPtr<Console> Console::must_create(PCI::DeviceIden
     return adopt_lock_ref_if_nonnull(new Console(pci_device_identifier)).release_nonnull();
 }
 
-UNMAP_AFTER_INIT void Console::initialize()
+UNMAP_AFTER_INIT ErrorOr<void> Console::initialize_virtio_resources()
 {
-    Device::initialize();
-    if (auto const* cfg = get_config(ConfigurationType::Device)) {
-        bool success = negotiate_features([&](u64 supported_features) {
-            u64 negotiated = 0;
-            if (is_feature_set(supported_features, VIRTIO_CONSOLE_F_SIZE))
-                dbgln("VirtIO::Console: Console size is not yet supported!");
-            if (is_feature_set(supported_features, VIRTIO_CONSOLE_F_MULTIPORT))
-                negotiated |= VIRTIO_CONSOLE_F_MULTIPORT;
-            return negotiated;
-        });
-        if (success) {
-            u32 max_nr_ports = 0;
-            u16 cols = 0, rows = 0;
-            read_config_atomic([&]() {
-                if (is_feature_accepted(VIRTIO_CONSOLE_F_SIZE)) {
-                    cols = config_read16(*cfg, 0x0);
-                    rows = config_read16(*cfg, 0x2);
-                }
-                if (is_feature_accepted(VIRTIO_CONSOLE_F_MULTIPORT)) {
-                    max_nr_ports = config_read32(*cfg, 0x4);
-                    m_ports.resize(max_nr_ports);
-                }
-            });
-            dbgln("VirtIO::Console: cols: {}, rows: {}, max nr ports {}", cols, rows, max_nr_ports);
-            // Base receiveq/transmitq for port0 + optional control queues and 2 per every additional port
-            success = setup_queues(2 + max_nr_ports > 0 ? 2 + 2 * max_nr_ports : 0);
+    TRY(Device::initialize_virtio_resources());
+    auto const* cfg = get_config(VirtIO::ConfigurationType::Device);
+    if (!cfg)
+        return Error::from_errno(ENODEV);
+    bool success = negotiate_features([&](u64 supported_features) {
+        u64 negotiated = 0;
+        if (is_feature_set(supported_features, VIRTIO_CONSOLE_F_SIZE))
+            dbgln("VirtIO::Console: Console size is not yet supported!");
+        if (is_feature_set(supported_features, VIRTIO_CONSOLE_F_MULTIPORT))
+            negotiated |= VIRTIO_CONSOLE_F_MULTIPORT;
+        return negotiated;
+    });
+    if (!success)
+        return Error::from_errno(EIO);
+    u32 max_nr_ports = 0;
+    u16 cols = 0, rows = 0;
+    read_config_atomic([&]() {
+        if (is_feature_accepted(VIRTIO_CONSOLE_F_SIZE)) {
+            cols = config_read16(*cfg, 0x0);
+            rows = config_read16(*cfg, 0x2);
         }
-        if (success) {
-            finish_init();
+        if (is_feature_accepted(VIRTIO_CONSOLE_F_MULTIPORT)) {
+            max_nr_ports = config_read32(*cfg, 0x4);
+            m_ports.resize(max_nr_ports);
+        }
+    });
+    dbgln("VirtIO::Console: cols: {}, rows: {}, max nr ports {}", cols, rows, max_nr_ports);
+    // Base receiveq/transmitq for port0 + optional control queues and 2 per every additional port
+    success = setup_queues(2 + max_nr_ports > 0 ? 2 + 2 * max_nr_ports : 0);
+    if (!success)
+        return Error::from_errno(EIO);
+    finish_init();
 
-            if (is_feature_accepted(VIRTIO_CONSOLE_F_MULTIPORT)) {
-                setup_multiport();
-            } else {
-                auto port = MUST(DeviceManagement::the().try_create_device<VirtIO::ConsolePort>(0u, *this));
-                port->init_receive_buffer({});
-                m_ports.append(port);
-            }
-        }
+    if (is_feature_accepted(VIRTIO_CONSOLE_F_MULTIPORT)) {
+        setup_multiport();
+    } else {
+        auto port = TRY(DeviceManagement::the().try_create_device<VirtIO::ConsolePort>(0u, *this));
+        port->init_receive_buffer({});
+        m_ports.append(port);
     }
+    return {};
 }
 
 UNMAP_AFTER_INIT Console::Console(PCI::DeviceIdentifier const& pci_device_identifier)

--- a/Kernel/Bus/VirtIO/Console.cpp
+++ b/Kernel/Bus/VirtIO/Console.cpp
@@ -22,9 +22,7 @@ UNMAP_AFTER_INIT NonnullLockRefPtr<Console> Console::must_create(PCI::DeviceIden
 UNMAP_AFTER_INIT ErrorOr<void> Console::initialize_virtio_resources()
 {
     TRY(Device::initialize_virtio_resources());
-    auto const* cfg = get_config(VirtIO::ConfigurationType::Device);
-    if (!cfg)
-        return Error::from_errno(ENODEV);
+    auto const* cfg = TRY(get_config(VirtIO::ConfigurationType::Device));
     bool success = negotiate_features([&](u64 supported_features) {
         u64 negotiated = 0;
         if (is_feature_set(supported_features, VIRTIO_CONSOLE_F_SIZE))

--- a/Kernel/Bus/VirtIO/Console.h
+++ b/Kernel/Bus/VirtIO/Console.h
@@ -29,7 +29,7 @@ public:
         return m_device_id;
     }
 
-    virtual void initialize() override;
+    virtual ErrorOr<void> initialize_virtio_resources() override;
 
 private:
     virtual StringView class_name() const override { return "VirtIOConsole"sv; }

--- a/Kernel/Bus/VirtIO/Definitions.h
+++ b/Kernel/Bus/VirtIO/Definitions.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Kernel::VirtIO {
+
+#define REG_DEVICE_FEATURES 0x0
+#define REG_GUEST_FEATURES 0x4
+#define REG_QUEUE_ADDRESS 0x8
+#define REG_QUEUE_SIZE 0xc
+#define REG_QUEUE_SELECT 0xe
+#define REG_QUEUE_NOTIFY 0x10
+#define REG_DEVICE_STATUS 0x12
+#define REG_ISR_STATUS 0x13
+
+#define DEVICE_STATUS_ACKNOWLEDGE (1 << 0)
+#define DEVICE_STATUS_DRIVER (1 << 1)
+#define DEVICE_STATUS_DRIVER_OK (1 << 2)
+#define DEVICE_STATUS_FEATURES_OK (1 << 3)
+#define DEVICE_STATUS_DEVICE_NEEDS_RESET (1 << 6)
+#define DEVICE_STATUS_FAILED (1 << 7)
+
+#define VIRTIO_F_INDIRECT_DESC ((u64)1 << 28)
+#define VIRTIO_F_VERSION_1 ((u64)1 << 32)
+#define VIRTIO_F_RING_PACKED ((u64)1 << 34)
+#define VIRTIO_F_IN_ORDER ((u64)1 << 35)
+
+#define VIRTIO_PCI_CAP_COMMON_CFG 1
+#define VIRTIO_PCI_CAP_NOTIFY_CFG 2
+#define VIRTIO_PCI_CAP_ISR_CFG 3
+#define VIRTIO_PCI_CAP_DEVICE_CFG 4
+#define VIRTIO_PCI_CAP_PCI_CFG 5
+
+// virtio_pci_common_cfg
+#define COMMON_CFG_DEVICE_FEATURE_SELECT 0x0
+#define COMMON_CFG_DEVICE_FEATURE 0x4
+#define COMMON_CFG_DRIVER_FEATURE_SELECT 0x8
+#define COMMON_CFG_DRIVER_FEATURE 0xc
+#define COMMON_CFG_MSIX_CONFIG 0x10
+#define COMMON_CFG_NUM_QUEUES 0x12
+#define COMMON_CFG_DEVICE_STATUS 0x14
+#define COMMON_CFG_CONFIG_GENERATION 0x15
+#define COMMON_CFG_QUEUE_SELECT 0x16
+#define COMMON_CFG_QUEUE_SIZE 0x18
+#define COMMON_CFG_QUEUE_MSIX_VECTOR 0x1a
+#define COMMON_CFG_QUEUE_ENABLE 0x1c
+#define COMMON_CFG_QUEUE_NOTIFY_OFF 0x1e
+#define COMMON_CFG_QUEUE_DESC 0x20
+#define COMMON_CFG_QUEUE_DRIVER 0x28
+#define COMMON_CFG_QUEUE_DEVICE 0x30
+
+#define QUEUE_INTERRUPT 0x1
+#define DEVICE_CONFIG_INTERRUPT 0x2
+
+enum class ConfigurationType : u8 {
+    Common = 1,
+    Notify = 2,
+    ISR = 3,
+    Device = 4,
+    PCICapabilitiesAccess = 5
+};
+
+struct Configuration {
+    ConfigurationType cfg_type;
+    u8 bar;
+    u32 offset;
+    u32 length;
+};
+
+}

--- a/Kernel/Bus/VirtIO/Device.cpp
+++ b/Kernel/Bus/VirtIO/Device.cpp
@@ -151,9 +151,9 @@ UNMAP_AFTER_INIT ErrorOr<void> Device::initialize_virtio_resources()
             auto mapping_io_window = TRY(IOWindow::create_for_pci_device_bar(device_identifier(), static_cast<PCI::HeaderType0BaseRegister>(cfg.bar)));
             m_register_bases[cfg.bar] = move(mapping_io_window);
         }
-        m_common_cfg = get_config(ConfigurationType::Common, 0);
-        m_notify_cfg = get_config(ConfigurationType::Notify, 0);
-        m_isr_cfg = get_config(ConfigurationType::ISR, 0);
+        m_common_cfg = TRY(get_config(ConfigurationType::Common, 0));
+        m_notify_cfg = TRY(get_config(ConfigurationType::Notify, 0));
+        m_isr_cfg = TRY(get_config(ConfigurationType::ISR, 0));
     } else {
         auto mapping_io_window = TRY(IOWindow::create_for_pci_device_bar(device_identifier(), PCI::HeaderType0BaseRegister::BAR0));
         m_register_bases[0] = move(mapping_io_window);

--- a/Kernel/Bus/VirtIO/Device.h
+++ b/Kernel/Bus/VirtIO/Device.h
@@ -8,77 +8,13 @@
 
 #include <Kernel/Bus/PCI/Access.h>
 #include <Kernel/Bus/PCI/Device.h>
+#include <Kernel/Bus/VirtIO/Definitions.h>
 #include <Kernel/Bus/VirtIO/Queue.h>
 #include <Kernel/IOWindow.h>
 #include <Kernel/Interrupts/IRQHandler.h>
 #include <Kernel/Memory/MemoryManager.h>
 
-namespace Kernel {
-
-#define REG_DEVICE_FEATURES 0x0
-#define REG_GUEST_FEATURES 0x4
-#define REG_QUEUE_ADDRESS 0x8
-#define REG_QUEUE_SIZE 0xc
-#define REG_QUEUE_SELECT 0xe
-#define REG_QUEUE_NOTIFY 0x10
-#define REG_DEVICE_STATUS 0x12
-#define REG_ISR_STATUS 0x13
-
-#define DEVICE_STATUS_ACKNOWLEDGE (1 << 0)
-#define DEVICE_STATUS_DRIVER (1 << 1)
-#define DEVICE_STATUS_DRIVER_OK (1 << 2)
-#define DEVICE_STATUS_FEATURES_OK (1 << 3)
-#define DEVICE_STATUS_DEVICE_NEEDS_RESET (1 << 6)
-#define DEVICE_STATUS_FAILED (1 << 7)
-
-#define VIRTIO_F_INDIRECT_DESC ((u64)1 << 28)
-#define VIRTIO_F_VERSION_1 ((u64)1 << 32)
-#define VIRTIO_F_RING_PACKED ((u64)1 << 34)
-#define VIRTIO_F_IN_ORDER ((u64)1 << 35)
-
-#define VIRTIO_PCI_CAP_COMMON_CFG 1
-#define VIRTIO_PCI_CAP_NOTIFY_CFG 2
-#define VIRTIO_PCI_CAP_ISR_CFG 3
-#define VIRTIO_PCI_CAP_DEVICE_CFG 4
-#define VIRTIO_PCI_CAP_PCI_CFG 5
-
-// virtio_pci_common_cfg
-#define COMMON_CFG_DEVICE_FEATURE_SELECT 0x0
-#define COMMON_CFG_DEVICE_FEATURE 0x4
-#define COMMON_CFG_DRIVER_FEATURE_SELECT 0x8
-#define COMMON_CFG_DRIVER_FEATURE 0xc
-#define COMMON_CFG_MSIX_CONFIG 0x10
-#define COMMON_CFG_NUM_QUEUES 0x12
-#define COMMON_CFG_DEVICE_STATUS 0x14
-#define COMMON_CFG_CONFIG_GENERATION 0x15
-#define COMMON_CFG_QUEUE_SELECT 0x16
-#define COMMON_CFG_QUEUE_SIZE 0x18
-#define COMMON_CFG_QUEUE_MSIX_VECTOR 0x1a
-#define COMMON_CFG_QUEUE_ENABLE 0x1c
-#define COMMON_CFG_QUEUE_NOTIFY_OFF 0x1e
-#define COMMON_CFG_QUEUE_DESC 0x20
-#define COMMON_CFG_QUEUE_DRIVER 0x28
-#define COMMON_CFG_QUEUE_DEVICE 0x30
-
-#define QUEUE_INTERRUPT 0x1
-#define DEVICE_CONFIG_INTERRUPT 0x2
-
-namespace VirtIO {
-
-enum class ConfigurationType : u8 {
-    Common = 1,
-    Notify = 2,
-    ISR = 3,
-    Device = 4,
-    PCICapabilitiesAccess = 5
-};
-
-struct Configuration {
-    ConfigurationType cfg_type;
-    u8 bar;
-    u32 offset;
-    u32 length;
-};
+namespace Kernel::VirtIO {
 
 void detect();
 
@@ -208,5 +144,5 @@ private:
     bool m_did_setup_queues { false };
     u32 m_notify_multiplier { 0 };
 };
-};
+
 }

--- a/Kernel/Bus/VirtIO/Device.h
+++ b/Kernel/Bus/VirtIO/Device.h
@@ -30,7 +30,7 @@ protected:
     virtual StringView class_name() const { return "VirtIO::Device"sv; }
     explicit Device(PCI::DeviceIdentifier const&);
 
-    Configuration const* get_config(ConfigurationType cfg_type, u32 index = 0) const
+    ErrorOr<Configuration const*> get_config(ConfigurationType cfg_type, u32 index = 0) const
     {
         for (auto const& cfg : m_configs) {
             if (cfg.cfg_type != cfg_type)
@@ -41,7 +41,7 @@ protected:
             }
             return &cfg;
         }
-        return nullptr;
+        return Error::from_errno(ENXIO);
     }
 
     template<typename F>

--- a/Kernel/Bus/VirtIO/Device.h
+++ b/Kernel/Bus/VirtIO/Device.h
@@ -24,7 +24,7 @@ class Device
 public:
     virtual ~Device() override = default;
 
-    virtual void initialize();
+    virtual ErrorOr<void> initialize_virtio_resources();
 
 protected:
     virtual StringView class_name() const { return "VirtIO::Device"sv; }

--- a/Kernel/Bus/VirtIO/RNG.h
+++ b/Kernel/Bus/VirtIO/RNG.h
@@ -24,7 +24,7 @@ public:
     virtual StringView device_name() const override { return class_name(); }
     virtual ~RNG() override = default;
 
-    virtual void initialize() override;
+    virtual ErrorOr<void> initialize_virtio_resources() override;
 
 private:
     virtual StringView class_name() const override { return "VirtIORNG"sv; }

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
@@ -146,9 +146,7 @@ VirtIOGraphicsAdapter::VirtIOGraphicsAdapter(PCI::DeviceIdentifier const& device
 ErrorOr<void> VirtIOGraphicsAdapter::initialize_virtio_resources()
 {
     TRY(VirtIO::Device::initialize_virtio_resources());
-    auto* config = get_config(VirtIO::ConfigurationType::Device);
-    if (!config)
-        return Error::from_errno(ENODEV);
+    auto* config = TRY(get_config(VirtIO::ConfigurationType::Device));
     m_device_configuration = config;
     bool success = negotiate_features([&](u64 supported_features) {
         u64 negotiated = 0;

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
@@ -40,7 +40,7 @@ public:
     static ErrorOr<bool> probe(PCI::DeviceIdentifier const&);
     static ErrorOr<NonnullLockRefPtr<GenericGraphicsAdapter>> create(PCI::DeviceIdentifier const&);
 
-    virtual void initialize() override;
+    virtual ErrorOr<void> initialize_virtio_resources() override;
 
     virtual StringView device_name() const override { return "VirtIOGraphicsAdapter"sv; }
 


### PR DESCRIPTION
This is a step before implementing a mechanism for the VirtIO bus code so we can attach to devices on other transports (e.g. VirtIO over MMIO).

So far this includes better error propagation and moving some declarations, so it should be enough to continue locally on my intended goal, until this is merged :)