### PR TITLE
LibGfx: Generate valid elliptical arc segments in Path::copy_transformed()

### DIFF
--- a/Userland/Libraries/LibGfx/AffineTransform.cpp
+++ b/Userland/Libraries/LibGfx/AffineTransform.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Math.h>
 #include <AK/Optional.h>
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Quad.h>
@@ -227,6 +228,16 @@ Quad<float> AffineTransform::map_to_quad(Rect<float> const& rect) const
         map(rect.bottom_right()),
         map(rect.bottom_left()),
     };
+}
+
+float AffineTransform::rotation() const
+{
+    auto rotation = AK::atan2(b(), a());
+    while (rotation < -AK::Pi<float>)
+        rotation += 2.0f * AK::Pi<float>;
+    while (rotation > AK::Pi<float>)
+        rotation -= 2.0f * AK::Pi<float>;
+    return rotation;
 }
 
 }

--- a/Userland/Libraries/LibGfx/AffineTransform.h
+++ b/Userland/Libraries/LibGfx/AffineTransform.h
@@ -54,6 +54,7 @@ public:
     [[nodiscard]] float x_translation() const;
     [[nodiscard]] float y_translation() const;
     [[nodiscard]] FloatPoint translation() const;
+    [[nodiscard]] float rotation() const;
 
     AffineTransform& scale(float sx, float sy);
     AffineTransform& scale(FloatPoint s);

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -363,7 +363,7 @@ Path Path::copy_transformed(Gfx::AffineTransform const& transform) const
                 transform.map(segment->point()),
                 transform.map(arc_segment.center()),
                 transform.map(arc_segment.radii()),
-                arc_segment.x_axis_rotation(),
+                arc_segment.x_axis_rotation() + transform.rotation(),
                 arc_segment.theta_1(),
                 arc_segment.theta_delta(),
                 arc_segment.large_arc(),


### PR DESCRIPTION
Testcase:
```html
<!doctype html>
<svg
    style="border: 1px solid black;"
    width="240"
    height="240"
    viewBox="0 0 48 48"
>
    <ellipse
        cx="24"
        cy="24"
        rx="7"
        ry="19"
        transform="rotate(90 24 24)"
        fill="#000"
        fill-opacity=".1"
        stroke="#000"
        stroke-width="2">
    </ellipse>
```

Before (us vs Firefox):

![image](https://user-images.githubusercontent.com/5954907/234619684-6dee6ebe-9044-407e-ab2c-39d10a3510cf.png)

After:
![image](https://user-images.githubusercontent.com/5954907/234620192-8311f37d-3efe-4e44-b1a1-608e7114fa98.png)
