### PR TITLE
LibCore: Unbreak cross-thread event posting

### DIFF
--- a/Ladybird/EventLoopImplementationQt.cpp
+++ b/Ladybird/EventLoopImplementationQt.cpp
@@ -74,12 +74,11 @@ void EventLoopImplementationQt::wake()
         m_event_loop.wakeUp();
 }
 
-void EventLoopManagerQt::deferred_invoke(Function<void()> function)
+void EventLoopImplementationQt::post_event(Core::Object& receiver, NonnullOwnPtr<Core::Event>&& event)
 {
-    VERIFY(function);
-    QTimer::singleShot(0, [function = move(function)] {
-        function();
-    });
+    m_thread_event_queue.post_event(receiver, move(event));
+    if (&m_thread_event_queue != &Core::ThreadEventQueue::current())
+        wake();
 }
 
 static void qt_timer_fired(int timer_id, Core::TimerShouldFireWhenNotVisible should_fire_when_not_visible, Core::Object& object)

--- a/Ladybird/EventLoopImplementationQt.cpp
+++ b/Ladybird/EventLoopImplementationQt.cpp
@@ -165,10 +165,6 @@ EventLoopManagerQt::EventLoopManagerQt()
 
 EventLoopManagerQt::~EventLoopManagerQt() = default;
 
-void EventLoopManagerQt::wake()
-{
-}
-
 NonnullOwnPtr<Core::EventLoopImplementation> EventLoopManagerQt::make_implementation()
 {
     return adopt_own(*new EventLoopImplementationQt);

--- a/Ladybird/EventLoopImplementationQt.h
+++ b/Ladybird/EventLoopImplementationQt.h
@@ -30,8 +30,6 @@ public:
 
     virtual void did_post_event() override;
 
-    virtual void wake() override;
-
     // FIXME: These APIs only exist for obscure use-cases inside SerenityOS. Try to get rid of them.
     virtual int register_signal(int, Function<void(int)>) override { return 0; }
     virtual void unregister_signal(int) override { }

--- a/Ladybird/EventLoopImplementationQt.h
+++ b/Ladybird/EventLoopImplementationQt.h
@@ -22,8 +22,6 @@ public:
     virtual ~EventLoopManagerQt() override;
     virtual NonnullOwnPtr<Core::EventLoopImplementation> make_implementation() override;
 
-    virtual void deferred_invoke(Function<void()>) override;
-
     virtual int register_timer(Core::Object&, int milliseconds, bool should_reload, Core::TimerShouldFireWhenNotVisible) override;
     virtual bool unregister_timer(int timer_id) override;
 
@@ -52,6 +50,7 @@ public:
     virtual size_t pump(PumpMode) override;
     virtual void quit(int) override;
     virtual void wake() override;
+    virtual void post_event(Core::Object& receiver, NonnullOwnPtr<Core::Event>&&) override;
 
     // FIXME: These APIs only exist for obscure use-cases inside SerenityOS. Try to get rid of them.
     virtual void unquit() override { }

--- a/Tests/LibCore/TestLibCoreFileWatcher.cpp
+++ b/Tests/LibCore/TestLibCoreFileWatcher.cpp
@@ -12,8 +12,6 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-// FIXME: Figure out why this breaks on macOS.
-#ifndef AK_OS_MACOS
 TEST_CASE(file_watcher_child_events)
 {
     auto event_loop = Core::EventLoop();
@@ -64,4 +62,3 @@ TEST_CASE(file_watcher_child_events)
 
     event_loop.exec();
 }
-#endif

--- a/Userland/Libraries/LibAudio/ConnectionToServer.cpp
+++ b/Userland/Libraries/LibAudio/ConnectionToServer.cpp
@@ -63,6 +63,8 @@ ErrorOr<void> ConnectionToServer::async_enqueue(FixedArray<Sample>&& samples)
 {
     if (!m_background_audio_enqueuer->is_started()) {
         m_background_audio_enqueuer->start();
+        while (!m_enqueuer_loop)
+            usleep(1);
         TRY(m_background_audio_enqueuer->set_priority(THREAD_PRIORITY_MAX));
     }
 

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -88,7 +88,7 @@ size_t EventLoop::pump(WaitMode mode)
 
 void EventLoop::post_event(Object& receiver, NonnullOwnPtr<Event>&& event)
 {
-    EventLoopManager::the().post_event(receiver, move(event));
+    m_impl->post_event(receiver, move(event));
 }
 
 void EventLoop::add_job(NonnullRefPtr<Promise<NonnullRefPtr<Object>>> job_promise)

--- a/Userland/Libraries/LibCore/EventLoopImplementation.cpp
+++ b/Userland/Libraries/LibCore/EventLoopImplementation.cpp
@@ -12,7 +12,10 @@
 
 namespace Core {
 
-EventLoopImplementation::EventLoopImplementation() = default;
+EventLoopImplementation::EventLoopImplementation()
+    : m_thread_event_queue(ThreadEventQueue::current())
+{
+}
 
 EventLoopImplementation::~EventLoopImplementation() = default;
 
@@ -29,20 +32,8 @@ void EventLoopManager::install(Core::EventLoopManager& manager)
     s_event_loop_manager = &manager;
 }
 
-EventLoopManager::EventLoopManager()
-    : m_thread_event_queue(ThreadEventQueue::current())
-{
-}
+EventLoopManager::EventLoopManager() = default;
 
 EventLoopManager::~EventLoopManager() = default;
-
-void EventLoopManager::post_event(Object& receiver, NonnullOwnPtr<Event>&& event)
-{
-    m_thread_event_queue.post_event(receiver, move(event));
-
-    // Wake up this EventLoopImplementation if this is a cross-thread event posting.
-    if (&ThreadEventQueue::current() != &m_thread_event_queue)
-        wake();
-}
 
 }

--- a/Userland/Libraries/LibCore/EventLoopImplementation.h
+++ b/Userland/Libraries/LibCore/EventLoopImplementation.h
@@ -35,8 +35,6 @@ public:
     virtual int register_signal(int signal_number, Function<void(int)> handler) = 0;
     virtual void unregister_signal(int handler_id) = 0;
 
-    virtual void wake() = 0;
-
 protected:
     EventLoopManager();
 };

--- a/Userland/Libraries/LibCore/EventLoopImplementation.h
+++ b/Userland/Libraries/LibCore/EventLoopImplementation.h
@@ -29,10 +29,7 @@ public:
     virtual void register_notifier(Notifier&) = 0;
     virtual void unregister_notifier(Notifier&) = 0;
 
-    void post_event(Object& receiver, NonnullOwnPtr<Event>&&);
     virtual void did_post_event() = 0;
-
-    virtual void deferred_invoke(Function<void()>) = 0;
 
     // FIXME: These APIs only exist for obscure use-cases inside SerenityOS. Try to get rid of them.
     virtual int register_signal(int signal_number, Function<void(int)> handler) = 0;
@@ -42,7 +39,6 @@ public:
 
 protected:
     EventLoopManager();
-    ThreadEventQueue& m_thread_event_queue;
 };
 
 class EventLoopImplementation {
@@ -59,6 +55,8 @@ public:
     virtual void quit(int) = 0;
     virtual void wake() = 0;
 
+    virtual void post_event(Object& receiver, NonnullOwnPtr<Event>&&) = 0;
+
     // FIXME: These APIs only exist for obscure use-cases inside SerenityOS. Try to get rid of them.
     virtual void unquit() = 0;
     virtual bool was_exit_requested() const = 0;
@@ -66,6 +64,7 @@ public:
 
 protected:
     EventLoopImplementation();
+    ThreadEventQueue& m_thread_event_queue;
 };
 
 }

--- a/Userland/Libraries/LibCore/EventLoopImplementationUnix.cpp
+++ b/Userland/Libraries/LibCore/EventLoopImplementationUnix.cpp
@@ -139,12 +139,6 @@ void EventLoopImplementationUnix::wake()
     MUST(Core::System::write((*m_wake_pipe_fds)[1], { &wake_event, sizeof(wake_event) }));
 }
 
-void EventLoopManagerUnix::wake()
-{
-    int wake_event = 0;
-    MUST(Core::System::write(ThreadData::the().wake_pipe_fds[1], { &wake_event, sizeof(wake_event) }));
-}
-
 void EventLoopManagerUnix::wait_for_events(EventLoopImplementation::PumpMode mode)
 {
     auto& thread_data = ThreadData::the();

--- a/Userland/Libraries/LibCore/EventLoopImplementationUnix.h
+++ b/Userland/Libraries/LibCore/EventLoopImplementationUnix.h
@@ -27,8 +27,6 @@ public:
     virtual int register_signal(int signal_number, Function<void(int)> handler) override;
     virtual void unregister_signal(int handler_id) override;
 
-    virtual void wake() override;
-
     void wait_for_events(EventLoopImplementation::PumpMode);
     static Optional<Time> get_next_timer_expiration();
 

--- a/Userland/Libraries/LibCore/EventLoopImplementationUnix.h
+++ b/Userland/Libraries/LibCore/EventLoopImplementationUnix.h
@@ -16,8 +16,6 @@ public:
 
     virtual NonnullOwnPtr<EventLoopImplementation> make_implementation() override;
 
-    virtual void deferred_invoke(Function<void()>) override;
-
     virtual int register_timer(Object&, int milliseconds, bool should_reload, TimerShouldFireWhenNotVisible) override;
     virtual bool unregister_timer(int timer_id) override;
 
@@ -55,6 +53,7 @@ public:
     virtual void unquit() override;
     virtual bool was_exit_requested() const override;
     virtual void notify_forked_and_in_child() override;
+    virtual void post_event(Object& receiver, NonnullOwnPtr<Event>&&) override;
 
 private:
     bool m_exit_requested { false };


### PR DESCRIPTION
This should make TestLibCoreFileWatcher work on macOS again (thanks trflynn89 for figuring out the cause!)

...and also LibAudio, etc.