### PR TITLE
Chess: Ensure the engine is fully reset when starting a new game

### DIFF
--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -439,6 +439,9 @@ void ChessWidget::reset()
     m_board = Chess::Board();
     m_side = (get_random<u32>() % 2) ? Chess::Color::White : Chess::Color::Black;
     m_drag_enabled = true;
+    if (m_engine)
+        m_engine->start_new_game();
+
     input_engine_move();
     update();
 }

--- a/Userland/Games/Chess/Engine.h
+++ b/Userland/Games/Chess/Engine.h
@@ -38,6 +38,15 @@ public:
         m_bestmove_callback = move(callback);
     }
 
+    void start_new_game()
+    {
+        if (!m_connected)
+            return;
+
+        Chess::UCI::UCINewGameCommand ucinewgame_command;
+        send_command(ucinewgame_command);
+    }
+
 private:
     void quit();
     void connect_to_engine_service();

--- a/Userland/Libraries/LibChess/UCICommand.cpp
+++ b/Userland/Libraries/LibChess/UCICommand.cpp
@@ -348,4 +348,17 @@ ErrorOr<String> QuitCommand::to_string() const
     return "quit\n"_short_string;
 }
 
+ErrorOr<NonnullOwnPtr<UCINewGameCommand>> UCINewGameCommand::from_string(StringView command)
+{
+    auto tokens = command.split_view(' ');
+    VERIFY(tokens[0] == "ucinewgame");
+    VERIFY(tokens.size() == 1);
+    return adopt_nonnull_own_or_enomem(new (nothrow) UCINewGameCommand);
+}
+
+ErrorOr<String> UCINewGameCommand::to_string() const
+{
+    return "ucinewgame\n"_string;
+}
+
 }

--- a/Userland/Libraries/LibChess/UCICommand.h
+++ b/Userland/Libraries/LibChess/UCICommand.h
@@ -281,4 +281,16 @@ public:
     virtual ErrorOr<String> to_string() const override;
 };
 
+class UCINewGameCommand : public Command {
+public:
+    explicit UCINewGameCommand()
+        : Command(Command::Type::UCINewGame)
+    {
+    }
+
+    static ErrorOr<NonnullOwnPtr<UCINewGameCommand>> from_string(StringView command);
+
+    virtual ErrorOr<String> to_string() const override;
+};
+
 }

--- a/Userland/Libraries/LibChess/UCIEndpoint.cpp
+++ b/Userland/Libraries/LibChess/UCIEndpoint.cpp
@@ -56,6 +56,8 @@ void Endpoint::event(Core::Event& event)
         return handle_info(static_cast<InfoCommand const&>(event));
     case Command::Type::Quit:
         return handle_quit();
+    case Command::Type::UCINewGame:
+        return handle_ucinewgame();
     default:
         Object::event(event);
         break;
@@ -115,6 +117,8 @@ NonnullOwnPtr<Command> Endpoint::read_command()
         return InfoCommand::from_string(line).release_value_but_fixme_should_propagate_errors();
     } else if (line.starts_with("quit"sv)) {
         return QuitCommand::from_string(line).release_value_but_fixme_should_propagate_errors();
+    } else if (line.starts_with("ucinewgame"sv)) {
+        return UCINewGameCommand::from_string(line).release_value_but_fixme_should_propagate_errors();
     }
 
     dbgln("command line: {}", line);

--- a/Userland/Libraries/LibChess/UCIEndpoint.h
+++ b/Userland/Libraries/LibChess/UCIEndpoint.h
@@ -31,6 +31,7 @@ public:
     virtual void handle_bestmove(BestMoveCommand const&) { }
     virtual void handle_info(InfoCommand const&) { }
     virtual void handle_quit() { }
+    virtual void handle_ucinewgame() { }
     virtual void handle_unexpected_eof() { }
 
     void send_command(Command const&);

--- a/Userland/Services/ChessEngine/ChessEngine.cpp
+++ b/Userland/Services/ChessEngine/ChessEngine.cpp
@@ -74,3 +74,9 @@ void ChessEngine::handle_unexpected_eof()
     if (on_quit)
         on_quit(EPIPE);
 }
+
+void ChessEngine::handle_ucinewgame()
+{
+    m_board = Chess::Board();
+    m_last_tree = {};
+}

--- a/Userland/Services/ChessEngine/ChessEngine.h
+++ b/Userland/Services/ChessEngine/ChessEngine.h
@@ -19,6 +19,7 @@ public:
     virtual void handle_position(Chess::UCI::PositionCommand const&) override;
     virtual void handle_go(Chess::UCI::GoCommand const&) override;
     virtual void handle_quit() override;
+    virtual void handle_ucinewgame() override;
     virtual void handle_unexpected_eof() override;
 
     Function<void(int)> on_quit;


### PR DESCRIPTION
This PR fixes an issue where `ChessEngine` would crash when starting a new game playing as white after game was reset.

To recreate the issue:
1. Select `ChessEngine` from the `Engine` menu.
2. Let the engine make at least 1 move.
3. Click `Game->New Game`.
4. The engine will crash when starting a new game as white. If the engine is playing as black you can make it crash by clicking `Game->Flip Board`.