### PR TITLE
Ladybird: Prohibit GUI interaction of the WebContent process

### DIFF
--- a/Ladybird/WebContent/CMakeLists.txt
+++ b/Ladybird/WebContent/CMakeLists.txt
@@ -17,6 +17,10 @@ set(WEBCONTENT_SOURCES
     main.cpp
 )
 
+if (APPLE)
+    list(APPEND WEBCONTENT_SOURCES MacOSSetup.mm)
+endif()
+
 qt_add_executable(WebContent ${WEBCONTENT_SOURCES})
 
 target_include_directories(WebContent PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)

--- a/Ladybird/WebContent/MacOSSetup.h
+++ b/Ladybird/WebContent/MacOSSetup.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+void prohibit_interaction();

--- a/Ladybird/WebContent/MacOSSetup.mm
+++ b/Ladybird/WebContent/MacOSSetup.mm
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "MacOSSetup.h"
+#import <AppKit/NSApplication.h>
+
+void prohibit_interaction()
+{
+    // This prevents WebContent from being displayed in the macOS Dock and becoming the focused,
+    // interactable application upon launch.
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyProhibited];
+}

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -11,6 +11,7 @@
 #include "../Utilities.h"
 #include "../WebSocketClientManagerLadybird.h"
 #include <AK/LexicalPath.h>
+#include <AK/Platform.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/LocalServer.h>
@@ -31,6 +32,10 @@
 #include <WebContent/PageHost.h>
 #include <WebContent/WebDriverConnection.h>
 
+#if defined(AK_OS_MACOS)
+#    include "MacOSSetup.h"
+#endif
+
 static ErrorOr<void> load_content_filters();
 static ErrorOr<void> load_autoplay_allowlist();
 
@@ -39,6 +44,10 @@ extern DeprecatedString s_serenity_resource_root;
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     QGuiApplication app(arguments.argc, arguments.argv);
+
+#if defined(AK_OS_MACOS)
+    prohibit_interaction();
+#endif
 
     Core::EventLoopManager::install(*new Ladybird::EventLoopManagerQt);
     Core::EventLoop event_loop;


### PR DESCRIPTION
The WebContent process behaves a bit awkwardly on macOS. When we launch the process, we have to create a QGuiApplication to access system fonts. But on macOS, doing so creates an entry in the Dock, and also causes the WebContent to be focused. So if you enter cmd+Q without first focusing the Ladybird GUI, WebContent is closed, while the Ladybird process keeps running.

Here's what that all looked like:
<img width="441" alt="Screenshot 2023-04-26 at 4 51 42 PM" src="https://user-images.githubusercontent.com/5600524/234699933-2c3aee9a-4a16-4ef4-82af-e3e992992265.png">
