### PR TITLE
Services: Port to `Core::File`

### DIFF
--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
+#include <LibCore/File.h>
 #include <LibCore/MimeData.h>
 
 namespace Core {
@@ -184,4 +185,19 @@ Optional<DeprecatedString> guess_mime_type_based_on_sniffed_bytes(ReadonlyBytes 
 #undef __ENUMERATE_MIME_TYPE_HEADER
     return {};
 }
+
+Optional<DeprecatedString> guess_mime_type_based_on_sniffed_bytes(Core::File& file)
+{
+    // Read accounts for longest possible offset + signature we currently match against (extra/iso-9660)
+    auto maybe_buffer = ByteBuffer::create_uninitialized(0x9006);
+    if (maybe_buffer.is_error())
+        return {};
+
+    auto maybe_bytes = file.read_some(maybe_buffer.value());
+    if (maybe_bytes.is_error())
+        return {};
+
+    return Core::guess_mime_type_based_on_sniffed_bytes(maybe_bytes.value());
+}
+
 }

--- a/Userland/Libraries/LibCore/MimeData.h
+++ b/Userland/Libraries/LibCore/MimeData.h
@@ -51,5 +51,6 @@ private:
 StringView guess_mime_type_based_on_filename(StringView);
 
 Optional<DeprecatedString> guess_mime_type_based_on_sniffed_bytes(ReadonlyBytes);
+Optional<DeprecatedString> guess_mime_type_based_on_sniffed_bytes(Core::File&);
 
 }

--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -14,7 +14,7 @@
 #include <AK/Random.h>
 #include <AK/ScopeGuard.h>
 #include <AK/Try.h>
-#include <LibCore/DeprecatedFile.h>
+#include <LibCore/File.h>
 #include <LibCore/Timer.h>
 #include <stdio.h>
 
@@ -179,9 +179,9 @@ void DHCPv4Client::try_discover_ifs()
 
 ErrorOr<DHCPv4Client::Interfaces> DHCPv4Client::get_discoverable_interfaces()
 {
-    auto file = TRY(Core::DeprecatedFile::open("/sys/kernel/net/adapters", Core::OpenMode::ReadOnly));
+    auto file = TRY(Core::File::open("/sys/kernel/net/adapters"sv, Core::File::OpenMode::Read));
 
-    auto file_contents = file->read_all();
+    auto file_contents = TRY(file->read_until_eof());
     auto json = JsonValue::from_string(file_contents);
 
     if (json.is_error() || !json.value().is_array()) {

--- a/Userland/Services/KeyboardPreferenceLoader/main.cpp
+++ b/Userland/Services/KeyboardPreferenceLoader/main.cpp
@@ -5,15 +5,11 @@
  */
 
 #include <LibCore/ConfigFile.h>
-#include <LibCore/DeprecatedFile.h>
+#include <LibCore/File.h>
 #include <LibCore/Process.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
-#include <errno.h>
-#include <spawn.h>
-#include <stdio.h>
 #include <sys/ioctl.h>
-#include <unistd.h>
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
@@ -34,7 +30,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::Process::spawn("/bin/keymap"sv, Array { "-m", keymaps_vector.first().characters() }, {}, Core::Process::KeepAsChild::Yes));
 
     bool enable_num_lock = keyboard_settings_config->read_bool_entry("StartupEnable", "NumLock", true);
-    auto keyboard_device = TRY(Core::DeprecatedFile::open("/dev/input/keyboard/0", Core::OpenMode::ReadOnly));
+    auto keyboard_device = TRY(Core::File::open("/dev/input/keyboard/0"sv, Core::File::OpenMode::Read));
     TRY(Core::System::ioctl(keyboard_device->fd(), KEYBOARD_IOCTL_SET_NUM_LOCK, enable_num_lock));
 
     return 0;

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -179,16 +179,11 @@ Vector<DeprecatedString> Launcher::handlers_with_details_for_url(const URL& url)
 
 Optional<DeprecatedString> Launcher::mime_type_for_file(DeprecatedString path)
 {
-    auto file_or_error = Core::DeprecatedFile::open(path, Core::OpenMode::ReadOnly);
-    if (file_or_error.is_error()) {
+    auto file_or_error = Core::File::open(path, Core::File::OpenMode::Read);
+    if (file_or_error.is_error())
         return {};
-    } else {
-        auto file = file_or_error.release_value();
-        // Read accounts for longest possible offset + signature we currently match against.
-        auto bytes = file->read(0x9006);
 
-        return Core::guess_mime_type_based_on_sniffed_bytes(bytes.bytes());
-    }
+    return Core::guess_mime_type_based_on_sniffed_bytes(*file_or_error.release_value());
 }
 
 bool Launcher::open_url(const URL& url, DeprecatedString const& handler_name)

--- a/Userland/Utilities/file.cpp
+++ b/Userland/Utilities/file.cpp
@@ -210,8 +210,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.parse(arguments);
 
     bool all_ok = true;
-    // Read accounts for longest possible offset + signature we currently match against.
-    auto buffer = TRY(ByteBuffer::create_uninitialized(0x9006));
 
     for (auto const& path : paths) {
         auto file_or_error = Core::File::open(path, Core::File::OpenMode::Read);
@@ -230,9 +228,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         } else if (!file_size_in_bytes) {
             outln("{}: empty", path);
         } else {
-            auto bytes = TRY(file->read_some(buffer));
             auto file_name_guess = Core::guess_mime_type_based_on_filename(path);
-            auto mime_type = Core::guess_mime_type_based_on_sniffed_bytes(bytes).value_or(file_name_guess);
+            auto mime_type = Core::guess_mime_type_based_on_sniffed_bytes(*file).value_or(file_name_guess);
             auto human_readable_description = get_description_from_mime_type(mime_type, path).value_or(mime_type);
             outln("{}: {}", path, flag_mime_only ? mime_type : human_readable_description);
         }


### PR DESCRIPTION
Some :yakgraph: work!

That's three low-hanging fruits that allow us to completely remove `DeprecatesFile` from services.