### PR TITLE
LibWeb: Prevent margin double-counting with "collapse through" boxes

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-5.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-5.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x134.46875 children: inline
+    line 0 width: 170.96875, height: 134.46875, bottom: 134.46875, baseline: 13.53125
+      frag 0 from BlockContainer start: 0, length: 0, rect: [2,15 168.96875x119.46875]
+    BlockContainer <body> at (2,15) content-size 168.96875x119.46875 inline-block children: not-inline
+      BlockContainer <div.hmm> at (3,16) content-size 166.96875x17.46875 children: inline
+        line 0 width: 166.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 21, rect: [3,16 166.96875x17.46875]
+            "suspiciously tall box"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (2,134.46875) content-size 168.96875x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/block-and-inline/margin-collapse-5.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/margin-collapse-5.html
@@ -1,0 +1,14 @@
+<!doctype html><style>
+* {
+    border: 1px solid black;
+    font-family: 'SerenitySans';
+}
+body {
+    padding: 0;
+    margin: 0;
+    display: inline-block;
+}
+.hmm {
+    margin-bottom: 100px;
+}
+</style><body><div class=hmm>suspiciously tall box</div> </body></html>


### PR DESCRIPTION
https://github.com/SerenityOS/serenity/issues/18509

If there is a remaining margin-bottom in margin collapsing state tracker after laying out all boxes in the current BFC, it must be assigned to the last in-flow child since margin collapsing cannot occur across a formatting context boundary.

The current issue where margin-bottom may be counted twice due to "collapse through" margins in the last in-flow child box is addressed with this fix by excluding such boxes during the search for a box to assign the remaining margin.

Test case coming with this fix has a layout bug with incorrectly computed line height.

Before (100px margin-bottom is double counted):
![Screenshot 2023-04-27 at 05 06 49](https://user-images.githubusercontent.com/45686940/234741687-f5573092-c64f-446a-93f0-cc8ff61120b6.png)

After (double counting is fixed but it revealed another bug that height for inline bottom is more than needed hence extra space at the top):
![Screenshot 2023-04-27 at 05 05 57](https://user-images.githubusercontent.com/45686940/234741597-31cd5c73-31bb-4e74-badc-e84e449d9a04.png)

Firefox:
![Screenshot 2023-04-27 at 05 07 34](https://user-images.githubusercontent.com/45686940/234741770-0aede9ad-5731-435a-b04d-de8e01c374c8.png)
