### PR TITLE
LibWeb: Clear the mouse event tracking node when it stops wanting events

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -71,6 +71,7 @@ public:
     DeprecatedString debug_description() const;
 
     bool has_style() const { return m_has_style; }
+    bool has_style_or_parent_with_style() const;
 
     virtual bool can_have_children() const { return true; }
 
@@ -233,8 +234,15 @@ private:
 template<>
 inline bool Node::fast_is<NodeWithStyleAndBoxModelMetrics>() const { return is_node_with_style_and_box_model_metrics(); }
 
+inline bool Node::has_style_or_parent_with_style() const
+{
+    return m_has_style || (parent() != nullptr && parent()->has_style_or_parent_with_style());
+}
+
 inline Gfx::Font const& Node::font() const
 {
+    VERIFY(has_style_or_parent_with_style());
+
     if (m_has_style)
         return static_cast<NodeWithStyle const*>(this)->font();
     return parent()->font();
@@ -247,6 +255,8 @@ inline Gfx::Font const& Node::scaled_font(PaintContext& context) const
 
 inline const CSS::ImmutableComputedValues& Node::computed_values() const
 {
+    VERIFY(has_style_or_parent_with_style());
+
     if (m_has_style)
         return static_cast<NodeWithStyle const*>(this)->computed_values();
     return parent()->computed_values();
@@ -254,6 +264,8 @@ inline const CSS::ImmutableComputedValues& Node::computed_values() const
 
 inline CSSPixels Node::line_height() const
 {
+    VERIFY(has_style_or_parent_with_style());
+
     if (m_has_style)
         return static_cast<NodeWithStyle const*>(this)->line_height();
     return parent()->line_height();

--- a/Userland/Libraries/LibWeb/Page/EventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.h
@@ -12,6 +12,7 @@
 #include <Kernel/API/KeyCode.h>
 #include <LibGUI/Forward.h>
 #include <LibGfx/Forward.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Page/EditEventHandler.h>
 #include <LibWeb/PixelUnits.h>
@@ -43,6 +44,12 @@ private:
     bool fire_keyboard_event(FlyString const& event_name, HTML::BrowsingContext& browsing_context, KeyCode key, unsigned modifiers, u32 code_point);
     CSSPixelPoint compute_mouse_event_client_offset(CSSPixelPoint event_page_position) const;
     CSSPixelPoint compute_mouse_event_page_offset(CSSPixelPoint event_client_offset) const;
+
+    struct Target {
+        JS::GCPtr<Painting::Paintable> paintable;
+        Optional<int> index_in_node;
+    };
+    Optional<Target> target_for_mouse_position(CSSPixelPoint position);
 
     Layout::Viewport* layout_root();
     Layout::Viewport const* layout_root() const;


### PR DESCRIPTION
This can occur if a mouse click on a mouse event tracking node causes a
page navigation. As the old document is torn down, the event handler may
have a stale reference to the tracking node. If a subsequent mouse event
occurs on that node, we would crash trying to access the node's styled
properties that are no longer valid.

To fix this, when we are deciding what node to send the event to, and we
have a mouse event tracking node, check if that node still wants the
event. If not, clear the tracking node.