### PR TITLE
LibWeb: Blockify pseudo elements that are flex items

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-blockification.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-blockification.txt
@@ -1,0 +1,19 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
+      Box <div.foo> at (8,8) content-size 784x17.46875 flex-container(row) children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 28.40625x17.46875 flex-item children: inline
+          line 0 width: 28.40625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 4, rect: [8,8 28.40625x17.46875]
+              "well"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (46,8) content-size 36.84375x17.46875 flex-item children: inline
+          line 0 width: 36.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [46,8 36.84375x17.46875]
+              "hello"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (92.4375,8) content-size 55.359375x17.46875 flex-item children: inline
+          line 0 width: 55.359375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 7, rect: [92.4375,8 55.359375x17.46875]
+              "friends"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/css-pseudo-element-blockification.html
+++ b/Tests/LibWeb/Layout/input/css-pseudo-element-blockification.html
@@ -1,0 +1,15 @@
+<style>
+* {
+    font: 16px SerenitySans;
+}
+.foo {
+    display: flex;
+    gap: 1ch;
+}
+.foo:before {
+    content: "well";
+}
+.foo:after {
+    content: "friends";
+}
+</style><div class="foo">hello</div>


### PR DESCRIPTION
When deciding on a box type transformation (blockify/inlinify) for a pseudo element, we have to use the originating element as a reference rather than the parent.

(The originating element *is* the parent for its pseudo elements.)