### PR TITLE
Userland+Meta+Base: Dont' run NetworkSettings in elevated mode

### DIFF
--- a/Base/res/apps/NetworkSettings.af
+++ b/Base/res/apps/NetworkSettings.af
@@ -1,7 +1,6 @@
 [App]
 Name=Network Settings
 Executable=/bin/NetworkSettings
-RequiresRoot=true
 Category=Settings
 Description=Configure network connections
 ExcludeFromSystemMenu=true

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -129,6 +129,11 @@ if [ -f mnt/boot/Kernel.debug ]; then
     chmod 0400 mnt/boot/Kernel.debug
 fi
 
+if [ -f mnt/bin/network-settings ]; then
+    chown 0:0 mnt/bin/network-settings
+    chmod 500 mnt/bin/network-settings
+fi
+
 chmod 600 mnt/etc/shadow
 chmod 755 mnt/res/devel/templates/*.postcreate
 echo "done"

--- a/Userland/Applications/Escalator/EscalatorWindow.h
+++ b/Userland/Applications/Escalator/EscalatorWindow.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2022, Ashley N. <dev-serenity@ne0ndrag0n.com>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2023, Fabian Dellwing <fabian@dellwing.net>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -23,6 +24,8 @@ public:
         StringView description;
         Core::Account current_user;
         bool preserve_env { false };
+        bool forward_stdin { false };
+        bool forward_stdout { false };
     };
 
     virtual ~EscalatorWindow() override = default;
@@ -38,6 +41,8 @@ private:
     StringView m_executable;
     Core::Account m_current_user;
     bool m_preserve_env { false };
+    bool m_forward_stdin { false };
+    bool m_forward_stdout { false };
 
     RefPtr<GUI::ImageWidget> m_icon_image_widget;
     RefPtr<GUI::Button> m_ok_button;

--- a/Userland/Applications/NetworkSettings/NetworkSettingsWidget.h
+++ b/Userland/Applications/NetworkSettings/NetworkSettingsWidget.h
@@ -32,6 +32,8 @@ private:
 
     void on_switch_adapter(DeprecatedString const& adapter);
     void on_switch_enabled_or_dhcp();
+    ErrorOr<void> apply_settings_impl();
+    ErrorOr<Optional<JsonObject>> create_settings_object();
 
     HashMap<DeprecatedString, NetworkAdapterData> m_network_adapters;
     Vector<DeprecatedString> m_adapter_names;

--- a/Userland/Applications/NetworkSettings/main.cpp
+++ b/Userland/Applications/NetworkSettings/main.cpp
@@ -19,8 +19,8 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 {
     TRY(Core::System::pledge("stdio rpath wpath cpath recvfd sendfd unix proc exec"));
 
-    TRY(Core::System::unveil("/bin/NetworkServer", "x"));
-    TRY(Core::System::unveil("/etc/Network.ini", "rwc"));
+    TRY(Core::System::unveil("/bin/Escalator", "x"));
+    TRY(Core::System::unveil("/etc/Network.ini", "r"));
     TRY(Core::System::unveil("/sys/kernel/net/adapters", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/session/%sid/portal/clipboard", "rw"));

--- a/Userland/Applications/NetworkSettings/main.cpp
+++ b/Userland/Applications/NetworkSettings/main.cpp
@@ -6,9 +6,6 @@
 
 #include "NetworkSettingsWidget.h"
 #include <LibCore/ArgsParser.h>
-#include <LibGUI/MessageBox.h>
-#include <unistd.h>
-
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
@@ -34,11 +31,6 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     parser.parse(args);
 
     auto app = TRY(GUI::Application::create(args));
-
-    if (getuid() != 0) {
-        GUI::MessageBox::show_error(nullptr, "You need to be root to run Network Settings!"sv);
-        return 1;
-    }
 
     TRY(Core::System::pledge("stdio rpath wpath cpath recvfd sendfd proc exec"));
 

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -76,7 +76,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
             "Open in Network Settings...", MUST(Gfx::Bitmap::load_from_file("/res/icons/16x16/network.png"sv)), [this](GUI::Action&) {
                 m_adapter_table_view->selection().for_each_index([this](GUI::ModelIndex const& index) {
                     auto adapter_name = index.sibling_at_column(1).data().as_string();
-                    GUI::Process::spawn_or_show_error(window(), "/bin/Escalator"sv, Array { "/bin/NetworkSettings", adapter_name.characters() });
+                    GUI::Process::spawn_or_show_error(window(), "/bin/NetworkSettings"sv, Array { adapter_name.characters() });
                 });
             },
             this));

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -248,6 +248,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/dev", "r"));
     TRY(Core::System::unveil("/bin", "r"));
     TRY(Core::System::unveil("/bin/Escalator", "x"));
+    TRY(Core::System::unveil("/bin/NetworkSettings", "x"));
     TRY(Core::System::unveil("/usr/lib", "r"));
 
     // This directory only exists if ports are installed

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1549,7 +1549,7 @@ ErrorOr<void> unlockpt(int fildes)
     return {};
 }
 
-ErrorOr<void> access(StringView pathname, int mode)
+ErrorOr<void> access(StringView pathname, int mode, int flags)
 {
     if (pathname.is_null())
         return Error::from_syscall("access"sv, -EFAULT);
@@ -1559,12 +1559,13 @@ ErrorOr<void> access(StringView pathname, int mode)
         .dirfd = AT_FDCWD,
         .pathname = { pathname.characters_without_null_termination(), pathname.length() },
         .mode = mode,
-        .flags = 0,
+        .flags = flags,
     };
     int rc = ::syscall(Syscall::SC_faccessat, &params);
     HANDLE_SYSCALL_RETURN_VALUE("access", rc, {});
 #else
     DeprecatedString path_string = pathname;
+    (void)flags;
     if (::access(path_string.characters(), mode) < 0)
         return Error::from_syscall("access"sv, -errno);
     return {};

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -228,7 +228,7 @@ ErrorOr<void> putenv(StringView);
 ErrorOr<int> posix_openpt(int flags);
 ErrorOr<void> grantpt(int fildes);
 ErrorOr<void> unlockpt(int fildes);
-ErrorOr<void> access(StringView pathname, int mode);
+ErrorOr<void> access(StringView pathname, int mode, int flags = 0);
 ErrorOr<DeprecatedString> readlink(StringView pathname);
 ErrorOr<int> poll(Span<struct pollfd>, int timeout);
 

--- a/Userland/Libraries/LibFileSystem/FileSystem.cpp
+++ b/Userland/Libraries/LibFileSystem/FileSystem.cpp
@@ -359,14 +359,14 @@ ErrorOr<void> link_file(StringView destination_path, StringView source_path)
     return TRY(Core::System::symlink(source_path, TRY(get_duplicate_file_name(destination_path))));
 }
 
-ErrorOr<String> resolve_executable_from_environment(StringView filename)
+ErrorOr<String> resolve_executable_from_environment(StringView filename, int flags)
 {
     if (filename.is_empty())
         return Error::from_errno(ENOENT);
 
     // Paths that aren't just a file name generally count as already resolved.
     if (filename.contains('/')) {
-        TRY(Core::System::access(filename, X_OK));
+        TRY(Core::System::access(filename, X_OK, flags));
         return TRY(String::from_utf8(filename));
     }
 
@@ -382,7 +382,7 @@ ErrorOr<String> resolve_executable_from_environment(StringView filename)
     for (auto directory : directories) {
         auto file = TRY(String::formatted("{}/{}", directory, filename));
 
-        if (!Core::System::access(file, X_OK).is_error())
+        if (!Core::System::access(file, X_OK, flags).is_error())
             return file;
     }
 

--- a/Userland/Libraries/LibFileSystem/FileSystem.h
+++ b/Userland/Libraries/LibFileSystem/FileSystem.h
@@ -73,7 +73,7 @@ bool can_delete_or_move(StringView path);
 ErrorOr<String> read_link(StringView link_path);
 ErrorOr<void> link_file(StringView destination_path, StringView source_path);
 
-ErrorOr<String> resolve_executable_from_environment(StringView filename);
+ErrorOr<String> resolve_executable_from_environment(StringView filename, int flags = 0);
 bool looks_like_shared_library(StringView path);
 
 }

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -2,7 +2,7 @@ file(GLOB CMD_SOURCES  CONFIGURE_DEPENDS "*.cpp")
 list(APPEND SPECIAL_TARGETS test install)
 list(APPEND REQUIRED_TARGETS
     arp base64 basename cat chmod chown clear comm cp cut date dd df diff dirname dmesg du echo env expr false
-    file find grep groups head host hostname id ifconfig kill killall ln logout ls mkdir mount mv nproc
+    file find grep groups head host hostname id ifconfig kill killall ln logout ls mkdir mount mv network-settings nproc
     pgrep pidof ping pkill pmap ps readlink realpath reboot rm rmdir sed route seq shutdown sleep sort stat stty su tail test
     touch tr true umount uname uniq uptime w wc which whoami xargs yes
 )
@@ -115,6 +115,7 @@ target_link_libraries(markdown-check PRIVATE LibFileSystem LibMarkdown)
 target_link_libraries(matroska PRIVATE LibVideo)
 target_link_libraries(md PRIVATE LibMarkdown)
 target_link_libraries(mv PRIVATE LibFileSystem)
+target_link_libraries(network-settings PRIVATE LibCore LibMain)
 target_link_libraries(notify PRIVATE LibGfx LibGUI)
 target_link_libraries(open PRIVATE LibDesktop)
 target_link_libraries(passwd PRIVATE LibCrypt)

--- a/Userland/Utilities/network-settings.cpp
+++ b/Userland/Utilities/network-settings.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Fabian Dellwing <fabian@dellwing.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonObject.h>
+#include <AK/JsonParser.h>
+#include <LibCore/ConfigFile.h>
+#include <LibCore/System.h>
+#include <LibMain/Main.h>
+#include <unistd.h>
+
+ErrorOr<int> serenity_main(Main::Arguments)
+{
+    TRY(Core::System::pledge("stdio rpath wpath cpath recvfd sendfd proc exec"));
+
+    TRY(Core::System::unveil("/bin/NetworkServer", "x"));
+    TRY(Core::System::unveil("/etc/Network.ini", "rwc"));
+    TRY(Core::System::unveil(nullptr, nullptr));
+
+    auto infile = TRY(Core::File::standard_input());
+
+    auto input_bytes = TRY(infile->read_until_eof());
+    StringView json_data = input_bytes;
+
+    if (json_data.is_empty() || json_data.is_whitespace())
+        return Error::from_errno(EINVAL);
+
+    auto json = TRY(JsonParser(json_data).parse());
+
+    if (!json.is_object())
+        return Error::from_errno(EINVAL);
+
+    auto json_object = json.as_object();
+
+    auto config_file = TRY(Core::ConfigFile::open_for_system("Network", Core::ConfigFile::AllowWriting::Yes));
+    json_object.for_each_member([&](DeprecatedString const& adapter_name, JsonValue const& adapter_data) {
+        adapter_data.as_object().for_each_member([&](const DeprecatedString& key, const JsonValue& value) {
+            switch (value.type()) {
+            case JsonValue::Type::String:
+                config_file->write_entry(adapter_name, key, value.as_string());
+                break;
+            case JsonValue::Type::Bool:
+                config_file->write_bool_entry(adapter_name, key, value.as_bool());
+                break;
+            case JsonValue::Type::Null:
+                break;
+            default:
+                dbgln("Extend switch/case key={}, value={}", key, value);
+                VERIFY_NOT_REACHED();
+            }
+        });
+    });
+    TRY(config_file->sync());
+
+    // FIXME: This should be done in a nicer way, but for that out NetworkServer implementation needs to actually be a server that we can talk to and not just a oneshot binary.
+    auto command = Vector<StringView>();
+    TRY(command.try_append("/bin/NetworkServer"sv));
+    TRY(Core::System::exec_command(command, true));
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds a small binary that takes a JsonObject on STDIN and uses that to write to the global network settings config and applies the change afterwards.

To do that we also need to refactor Escalator and touch a syscall.

This allows us to not run NetworkSettings in elevated mode :^)