### PR TITLE
LibWeb: Include row computed height into total row min height

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
@@ -1,13 +1,13 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x47.835937 children: not-inline
-    BlockContainer <body> at (10,10) content-size 780x29.835937 children: not-inline
-      TableWrapper <(anonymous)> at (10,10) content-size 104x29.835937 children: not-inline
-        TableBox <table> at (11,11) content-size 104x27.835937 children: not-inline
-          TableRowGroupBox <tbody> at (11,11) content-size 104x27.835937 children: not-inline
-            TableRowBox <tr> at (11,11) content-size 104x27.835937 children: not-inline
-              TableCellBox <td> at (13,13) content-size 100x23.835937 children: not-inline
-                BlockContainer <(anonymous)> at (14,14) content-size 98x21.835937 children: inline
+  BlockContainer <html> at (1,1) content-size 798x120 children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x102 children: not-inline
+      TableWrapper <(anonymous)> at (10,10) content-size 104x102 children: not-inline
+        TableBox <table> at (11,11) content-size 104x100 children: not-inline
+          TableRowGroupBox <tbody> at (11,11) content-size 104x100 children: not-inline
+            TableRowBox <tr> at (11,11) content-size 104x100 children: not-inline
+              TableCellBox <td> at (13,49.082031) content-size 100x23.835937 children: not-inline
+                BlockContainer <(anonymous)> at (14,50.082031) content-size 98x21.835937 children: inline
                   line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-                    frag 0 from TextNode start: 0, length: 0, rect: [14,14 0x21.835937]
+                    frag 0 from TextNode start: 0, length: 0, rect: [14,50.082031 0x21.835937]
                       ""
                   TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/cell-px-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-px-height.txt
@@ -1,0 +1,6 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 children: not-inline
+    TableWrapper <(anonymous)> at (8,8) content-size 102x100 children: not-inline
+      TableBox <body> at (8,8) content-size 102x100 children: not-inline
+        TableRowBox <div.row> at (8,8) content-size 102x100 children: not-inline
+          TableCellBox <div.cell> at (9,9) content-size 100x0 children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/row-px-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-px-height.txt
@@ -1,0 +1,6 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 children: not-inline
+    TableWrapper <(anonymous)> at (8,8) content-size 102x100 children: not-inline
+      TableBox <body> at (8,8) content-size 102x100 children: not-inline
+        TableRowBox <div.row> at (8,8) content-size 102x100 children: not-inline
+          TableCellBox <div.cell> at (9,9) content-size 100x0 children: not-inline

--- a/Tests/LibWeb/Layout/input/table/cell-px-height.html
+++ b/Tests/LibWeb/Layout/input/table/cell-px-height.html
@@ -1,0 +1,17 @@
+<style>
+body {
+    display: table;
+}
+
+.row {
+    display: table-row;
+}
+
+.cell {
+    display: table-cell;
+    border: 1px solid black;
+    width: 100px;
+    height: 100px;
+}
+</style>
+<div class="row"><div class="cell"></div></div>

--- a/Tests/LibWeb/Layout/input/table/row-px-height.html
+++ b/Tests/LibWeb/Layout/input/table/row-px-height.html
@@ -1,0 +1,17 @@
+<style>
+body {
+    display: table;
+}
+
+.row {
+    display: table-row;
+    height: 100px;
+}
+
+.cell {
+    display: table-cell;
+    border: 1px solid black;
+    width: 100px;
+}
+</style>
+<div class="row"><div class="cell"></div></div>

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -425,6 +425,16 @@ void TableFormattingContext::calculate_row_heights(LayoutMode layout_mode)
         row.used_height = max(row.used_height, cell_state.border_box_height());
         row.baseline = max(row.baseline, cell.baseline);
     }
+
+    for (auto& row : m_rows) {
+        auto row_computed_height = row.box->computed_values().height();
+        if (row_computed_height.is_length()) {
+            auto height_of_containing_block = m_state.get(*row.box->containing_block()).content_height();
+            auto height_of_containing_block_as_length = CSS::Length::make_px(height_of_containing_block);
+            auto row_used_height = row_computed_height.resolved(row.box, height_of_containing_block_as_length).to_px(row.box);
+            row.used_height = max(row.used_height, row_used_height);
+        }
+    }
 }
 
 void TableFormattingContext::position_row_boxes(CSSPixels& total_content_height)


### PR DESCRIPTION
Fixes the issue that currently we do not consider table rows height while calculating min row height even if it is definite value.