### PR TITLE
AK: Don't refer to AK::swap() as ::swap()

### DIFF
--- a/AK/FixedArray.h
+++ b/AK/FixedArray.h
@@ -142,7 +142,7 @@ public:
 
     void swap(FixedArray<T>& other)
     {
-        ::swap(m_storage, other.m_storage);
+        AK::swap(m_storage, other.m_storage);
     }
 
     void fill_with(T const& value)

--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -110,13 +110,13 @@ public:
 
     void swap(NonnullOwnPtr& other)
     {
-        ::swap(m_ptr, other.m_ptr);
+        AK::swap(m_ptr, other.m_ptr);
     }
 
     template<typename U>
     void swap(NonnullOwnPtr<U>& other)
     {
-        ::swap(m_ptr, other.m_ptr);
+        AK::swap(m_ptr, other.m_ptr);
     }
 
     template<typename U>

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -152,13 +152,13 @@ public:
 
     void swap(OwnPtr& other)
     {
-        ::swap(m_ptr, other.m_ptr);
+        AK::swap(m_ptr, other.m_ptr);
     }
 
     template<typename U>
     void swap(OwnPtr<U>& other)
     {
-        ::swap(m_ptr, other.m_ptr);
+        AK::swap(m_ptr, other.m_ptr);
     }
 
     static OwnPtr lift(T* ptr)


### PR DESCRIPTION
Just a small thing that popped up while messing with jakt.

While swap() is available in the global namespace in normal conditions, !USING_AK_GLOBALLY will make this name unavailable in the global namespace, making these calls fail to compile.