### PR TITLE
Kernel: Create all kernel processes before enabling boot profiling

### DIFF
--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -421,6 +421,10 @@ void init_stage2(void*)
     g_init_pid = init_process->pid();
     init_thread->set_priority(THREAD_PRIORITY_HIGH);
 
+    NetworkTask::spawn();
+
+    // NOTE: All kernel processes must be created before enabling boot profiling.
+    //       This is so profiling_enable() can emit process created performance events for them.
     if (boot_profiling) {
         dbgln("Starting full system boot profiling");
         MutexLocker mutex_locker(Process::current().big_lock());
@@ -428,8 +432,6 @@ void init_stage2(void*)
         auto result = Process::current().profiling_enable(-1, enable_all);
         VERIFY(!result.is_error());
     }
-
-    NetworkTask::spawn();
 
     Process::current().sys$exit(0);
     VERIFY_NOT_REACHED();


### PR DESCRIPTION
Process created performance events for kernel processes are only ever emitted for the kernel processes that exist when profiling is enabled. Any new kernel processes created after profiling is enabled will not have corresponding process created performance events, so all kernel processes should be created before enabling profiling.

NetworkTask was the only kernel process being created after enabling profiling, so we now just create it before enabling profiling. This fixes an issue where Profiler was failing to parse boot profiles as a result of NetworkTask not having a process created event.