### PR TITLE
AK: Make the Optional formatter always available and tweak its format

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -717,13 +717,11 @@ struct Formatter<ErrorOr<T, ErrorType>> : Formatter<FormatString> {
 
 template<typename T>
 struct Formatter<Optional<T>> : Formatter<FormatString> {
-    static constexpr bool is_debug_only() { return true; }
-
     ErrorOr<void> format(FormatBuilder& builder, Optional<T> const& optional)
     {
         if (optional.has_value())
-            return Formatter<FormatString>::format(builder, "Optional({})"sv, *optional);
-        return builder.put_literal("OptionalNone"sv);
+            return Formatter<FormatString>::format(builder, "{}"sv, *optional);
+        return builder.put_literal("None"sv);
     }
 };
 


### PR DESCRIPTION
There's no real reason to make this a debug-only formatter, on top of that, jakt has a optional formatter that prints None/foo instead of OptionalNone/Optional(foo), which is more concise anyway, so switch to that.

cc @MacDue: does this sound okay? we can also ifdef out the definition for jakt I think.