### PR TITLE
Meta: Speed up `lint-ports` by ~99.2%

### DIFF
--- a/Meta/lint-ports.py
+++ b/Meta/lint-ports.py
@@ -75,6 +75,8 @@ def read_port_dirs():
             print(f"Ports/{entry} is neither a port (not a directory) nor an ignored file?!")
             all_good = False
             continue
+        if os.listdir(entry) == []:
+            continue
         if not os.path.exists(entry + '/package.sh'):
             print(f"Ports/{entry}/ is missing its package.sh?!")
             all_good = False


### PR DESCRIPTION
This reduces the runtime of `lint-ports` from 72s down to 0.5s on my computer (a reduction of ~99.2%)! While it may not be as accurate as running `package.sh showproperty` it makes using `precommit` while editing ports much nicer!