### PR TITLE
LibC: Handle out-of-memory conditions in posix_spawn_file_actions_init

### DIFF
--- a/Userland/Libraries/LibC/spawn.cpp
+++ b/Userland/Libraries/LibC/spawn.cpp
@@ -179,7 +179,9 @@ int posix_spawn_file_actions_destroy(posix_spawn_file_actions_t* actions)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawn_file_actions_init.html
 int posix_spawn_file_actions_init(posix_spawn_file_actions_t* actions)
 {
-    actions->state = new posix_spawn_file_actions_state;
+    actions->state = new (nothrow) posix_spawn_file_actions_state;
+    if (actions->state == nullptr)
+        return ENOMEM;
     return 0;
 }
 


### PR DESCRIPTION
Tiny thing I noticed while reviewing another PR