### PR TITLE
Kernel/aarch64: Support reading the command line via the RPi Mailbox

### DIFF
--- a/AK/Span.h
+++ b/AK/Span.h
@@ -167,6 +167,16 @@ public:
         return { this->m_values, min(size(), length) };
     }
 
+    [[nodiscard]] Span align_to(size_t alignment) const
+    {
+        auto* start = reinterpret_cast<T*>(align_up_to((FlatPtr)data(), alignment));
+        auto* end = reinterpret_cast<T*>(align_down_to((FlatPtr)(data() + size()), alignment));
+        if (end < start)
+            return {};
+        size_t length = end - start;
+        return { start, length };
+    }
+
     [[nodiscard]] ALWAYS_INLINE constexpr T* offset(size_t start) const
     {
         VERIFY(start < this->m_size);

--- a/Kernel/Arch/aarch64/RPi/Mailbox.h
+++ b/Kernel/Arch/aarch64/RPi/Mailbox.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <AK/Types.h>
 
 namespace Kernel::RPi {
@@ -51,6 +52,9 @@ public:
     bool send_queue(void* queue, u32 queue_size) const;
 
     u32 query_firmware_version();
+
+    // Returns the kernel command line as a StringView into the given buffer.
+    StringView query_kernel_command_line(Bytes buffer);
 };
 
 }

--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -130,7 +130,7 @@ READONLY_AFTER_INIT PhysicalAddress boot_pdpt;
 READONLY_AFTER_INIT PhysicalAddress boot_pd0;
 READONLY_AFTER_INIT PhysicalAddress boot_pd_kernel;
 READONLY_AFTER_INIT Memory::PageTableEntry* boot_pd_kernel_pt1023;
-READONLY_AFTER_INIT char const* kernel_cmdline;
+READONLY_AFTER_INIT StringView kernel_cmdline;
 READONLY_AFTER_INIT u32 multiboot_flags;
 READONLY_AFTER_INIT multiboot_memory_map_t* multiboot_memory_map;
 READONLY_AFTER_INIT size_t multiboot_memory_map_count;
@@ -165,7 +165,8 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init([[maybe_unused]] BootInfo con
     boot_pd0 = PhysicalAddress { boot_info.boot_pd0 };
     boot_pd_kernel = PhysicalAddress { boot_info.boot_pd_kernel };
     boot_pd_kernel_pt1023 = (Memory::PageTableEntry*)boot_info.boot_pd_kernel_pt1023;
-    kernel_cmdline = (char const*)boot_info.kernel_cmdline;
+    char const* cmdline = (char const*)boot_info.kernel_cmdline;
+    kernel_cmdline = StringView { cmdline, strlen(cmdline) };
     multiboot_flags = boot_info.multiboot_flags;
     multiboot_memory_map = (multiboot_memory_map_t*)boot_info.multiboot_memory_map;
     multiboot_memory_map_count = boot_info.multiboot_memory_map_count;
@@ -193,7 +194,7 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init([[maybe_unused]] BootInfo con
     multiboot_module_entry_t modules[] = {};
     multiboot_modules = modules;
     multiboot_modules_count = 0;
-    kernel_cmdline = "";
+    kernel_cmdline = ""sv;
 #endif
 
     setup_serial_debug();
@@ -441,7 +442,7 @@ UNMAP_AFTER_INIT void setup_serial_debug()
     // serial_debug will output all the dbgln() data to COM1 at
     // 8-N-1 57600 baud. this is particularly useful for debugging the boot
     // process on live hardware.
-    if (StringView { kernel_cmdline, strlen(kernel_cmdline) }.contains("serial_debug"sv)) {
+    if (kernel_cmdline.contains("serial_debug"sv)) {
         set_serial_debug_enabled(true);
     }
 }

--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -148,6 +148,10 @@ READONLY_AFTER_INIT u8 multiboot_framebuffer_type;
 
 Atomic<Graphics::Console*> g_boot_console;
 
+#if ARCH(AARCH64)
+READONLY_AFTER_INIT static u8 s_command_line_buffer[512];
+#endif
+
 extern "C" [[noreturn]] UNMAP_AFTER_INIT void init([[maybe_unused]] BootInfo const& boot_info)
 {
     g_in_early_boot = true;
@@ -194,7 +198,8 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init([[maybe_unused]] BootInfo con
     multiboot_module_entry_t modules[] = {};
     multiboot_modules = modules;
     multiboot_modules_count = 0;
-    kernel_cmdline = ""sv;
+    // FIXME: Read the /chosen/bootargs property.
+    kernel_cmdline = RPi::Mailbox::the().query_kernel_command_line(s_command_line_buffer);
 #endif
 
     setup_serial_debug();

--- a/Kernel/BootInfo.h
+++ b/Kernel/BootInfo.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <Kernel/Multiboot.h>
 #include <Kernel/PhysicalAddress.h>
 #include <Kernel/VirtualAddress.h>
@@ -28,7 +29,7 @@ extern "C" PhysicalAddress boot_pdpt;
 extern "C" PhysicalAddress boot_pd0;
 extern "C" PhysicalAddress boot_pd_kernel;
 extern "C" Kernel::Memory::PageTableEntry* boot_pd_kernel_pt1023;
-extern "C" char const* kernel_cmdline;
+extern "C" StringView kernel_cmdline;
 extern "C" u32 multiboot_flags;
 extern "C" multiboot_memory_map_t* multiboot_memory_map;
 extern "C" size_t multiboot_memory_map_count;

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -16,15 +16,9 @@ static char s_cmd_line[1024];
 static constexpr StringView s_embedded_cmd_line = ""sv;
 static CommandLine* s_the;
 
-UNMAP_AFTER_INIT void CommandLine::early_initialize(char const* cmd_line)
+UNMAP_AFTER_INIT void CommandLine::early_initialize(StringView cmd_line)
 {
-    if (!cmd_line)
-        return;
-    size_t length = strlen(cmd_line);
-    if (length >= sizeof(s_cmd_line))
-        length = sizeof(s_cmd_line) - 1;
-    memcpy(s_cmd_line, cmd_line, length);
-    s_cmd_line[length] = '\0';
+    (void)cmd_line.copy_characters_to_buffer(s_cmd_line, sizeof(s_cmd_line));
 }
 
 bool CommandLine::was_initialized()

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -52,7 +52,7 @@ enum class AHCIResetMode {
 class CommandLine {
 
 public:
-    static void early_initialize(char const* cmd_line);
+    static void early_initialize(StringView cmd_line);
     static void initialize();
     static bool was_initialized();
 

--- a/Toolchain/BuildQemu.sh
+++ b/Toolchain/BuildQemu.sh
@@ -37,13 +37,19 @@ pushd "$DIR/Tarballs"
         exit 1
     fi
 
-    if [ ! -d "$QEMU_VERSION" ]; then
-        echo "Extracting qemu..."
-        tar -xf "${QEMU_ARCHIVE}"
-    else
-        echo "Skipped extracting qemu"
+    # If the source directory exists, re-extract it again in case the patches have changed.
+    if [ -d "qemu-$QEMU_VERSION" ]; then
+        rm -rf "qemu-$QEMU_VERSION"
     fi
 
+    echo "Extracting qemu..."
+    tar -xf "${QEMU_ARCHIVE}"
+
+    pushd "qemu-$QEMU_VERSION"
+        for patch in "${DIR}"/Patches/qemu/*.patch; do
+            patch -p1 < "${patch}" > /dev/null
+        done
+    popd
 popd
 
 mkdir -p "$PREFIX"

--- a/Toolchain/BuildQemu.sh
+++ b/Toolchain/BuildQemu.sh
@@ -53,9 +53,13 @@ if [ -z "$MAKEJOBS" ]; then
     MAKEJOBS=$(nproc)
 fi
 
+EXTRA_ARGS=""
 if [[ $(uname) == "Darwin" ]]
 then
     UI_LIB=cocoa
+
+    # SDL causes a crash on startup: "NSWindow drag regions should only be invalidated on the Main Thread!"
+    EXTRA_ARGS="--disable-sdl"
 else
     UI_LIB=gtk
 fi
@@ -66,7 +70,8 @@ pushd "$DIR/Build/qemu"
     "$DIR"/Tarballs/qemu-"${QEMU_VERSION}"/configure --prefix="$PREFIX" \
                                             --target-list=aarch64-softmmu,x86_64-softmmu \
                                             --enable-$UI_LIB \
-                                            --enable-slirp || exit 1
+                                            --enable-slirp \
+                                            $EXTRA_ARGS || exit 1
     make -j "$MAKEJOBS" || exit 1
     make install || exit 1
 popd

--- a/Toolchain/Patches/qemu/raspberry-pi-command-line.patch
+++ b/Toolchain/Patches/qemu/raspberry-pi-command-line.patch
@@ -1,0 +1,109 @@
+From 8b4eba1d4f41c5e07d2be1de6deb545dee4a2eb1 Mon Sep 17 00:00:00 2001
+From: Daniel Bertalan <dani@danielbertalan.dev>
+Date: Tue, 25 Apr 2023 11:35:52 +0200
+Subject: [PATCH] hw/arm/bcm2835_property: Implement "get command line" message
+
+This query copies the kernel command line into the message buffer. It
+was previously stubbed out to return empty, this commit makes it reflect
+the arguments specified with `-append`.
+
+I observed the following peculiarities on my Pi 3B+:
+- If the buffer is shorter than the string, the response header gives
+  the full length, but no data is actually copied.
+- No NUL terminator is added: even if the buffer is long enough to fit
+  one, the buffer's original contents are preserved past the string's
+  end.
+- The VC firmware adds the following extra parameters beside the
+  user-supplied ones (via /boot/cmdline.txt): `video`, `vc_mem.mem_base`
+  and `vc_mem.mem_size`. This is currently not implemented in qemu.
+
+Signed-off-by: Daniel Bertalan <dani@danielbertalan.dev>
+---
+ hw/arm/bcm2835_peripherals.c       | 2 ++
+ hw/arm/bcm2836.c                   | 2 ++
+ hw/arm/raspi.c                     | 2 ++
+ hw/misc/bcm2835_property.c         | 7 ++++++-
+ include/hw/misc/bcm2835_property.h | 1 +
+ 5 files changed, 13 insertions(+), 1 deletion(-)
+
+This patch has been submitted upstream: https://lists.nongnu.org/archive/html/qemu-arm/2023-04/msg00549
+
+diff --git a/hw/arm/bcm2835_peripherals.c b/hw/arm/bcm2835_peripherals.c
+index 3c2a4160cd..0233038b95 100644
+--- a/hw/arm/bcm2835_peripherals.c
++++ b/hw/arm/bcm2835_peripherals.c
+@@ -90,6 +90,8 @@ static void bcm2835_peripherals_init(Object *obj)
+                             TYPE_BCM2835_PROPERTY);
+     object_property_add_alias(obj, "board-rev", OBJECT(&s->property),
+                               "board-rev");
++    object_property_add_alias(obj, "command-line", OBJECT(&s->property),
++                              "command-line");
+ 
+     object_property_add_const_link(OBJECT(&s->property), "fb",
+                                    OBJECT(&s->fb));
+diff --git a/hw/arm/bcm2836.c b/hw/arm/bcm2836.c
+index f894338fc6..166dc896c0 100644
+--- a/hw/arm/bcm2836.c
++++ b/hw/arm/bcm2836.c
+@@ -55,6 +55,8 @@ static void bcm2836_init(Object *obj)
+                             TYPE_BCM2835_PERIPHERALS);
+     object_property_add_alias(obj, "board-rev", OBJECT(&s->peripherals),
+                               "board-rev");
++    object_property_add_alias(obj, "command-line", OBJECT(&s->peripherals),
++                              "command-line");
+     object_property_add_alias(obj, "vcram-size", OBJECT(&s->peripherals),
+                               "vcram-size");
+ }
+diff --git a/hw/arm/raspi.c b/hw/arm/raspi.c
+index 92d068d1f9..7b9221c924 100644
+--- a/hw/arm/raspi.c
++++ b/hw/arm/raspi.c
+@@ -280,6 +280,8 @@ static void raspi_machine_init(MachineState *machine)
+     object_property_add_const_link(OBJECT(&s->soc), "ram", OBJECT(machine->ram));
+     object_property_set_int(OBJECT(&s->soc), "board-rev", board_rev,
+                             &error_abort);
++    object_property_set_str(OBJECT(&s->soc), "command-line",
++                            machine->kernel_cmdline, &error_abort);
+     qdev_realize(DEVICE(&s->soc), NULL, &error_fatal);
+ 
+     /* Create and plug in the SD cards */
+diff --git a/hw/misc/bcm2835_property.c b/hw/misc/bcm2835_property.c
+index 890ae7bae5..225bce2ba4 100644
+--- a/hw/misc/bcm2835_property.c
++++ b/hw/misc/bcm2835_property.c
+@@ -282,7 +282,11 @@ static void bcm2835_property_mbox_push(BCM2835PropertyState *s, uint32_t value)
+             break;
+ 
+         case 0x00050001: /* Get command line */
+-            resplen = 0;
++            resplen = strlen(s->command_line);
++            if (bufsize >= resplen)
++                address_space_write(&s->dma_as, value + 12,
++                                    MEMTXATTRS_UNSPECIFIED, s->command_line,
++                                    resplen);
+             break;
+ 
+         default:
+@@ -413,6 +417,7 @@ static void bcm2835_property_realize(DeviceState *dev, Error **errp)
+ 
+ static Property bcm2835_property_props[] = {
+     DEFINE_PROP_UINT32("board-rev", BCM2835PropertyState, board_rev, 0),
++    DEFINE_PROP_STRING("command-line", BCM2835PropertyState, command_line),
+     DEFINE_PROP_END_OF_LIST()
+ };
+ 
+diff --git a/include/hw/misc/bcm2835_property.h b/include/hw/misc/bcm2835_property.h
+index 712b76b7a3..ba8896610c 100644
+--- a/include/hw/misc/bcm2835_property.h
++++ b/include/hw/misc/bcm2835_property.h
+@@ -30,6 +30,7 @@ struct BCM2835PropertyState {
+     MACAddr macaddr;
+     uint32_t board_rev;
+     uint32_t addr;
++    char *command_line;
+     bool pending;
+ };
+ 
+-- 
+2.40.0
+


### PR DESCRIPTION
![Image showing the kernel command line printed in the debug console](https://cdn.discordapp.com/attachments/897113928168013855/1100470784335548547/Schermafbeelding_2023-04-25_om_19.15.17.png)

This PR reuses the existing `RPi::Mailbox` interface to read the command line via a VideoCore-specific mailbox message.

It will eventually allow us to run the system in self-test mode by passing the appropriate parameter via the command line.

This will have to be replaced if that interface starts being smarter, as this is needed very early, and nothing guarantees that a smarter Mailbox interface wouldn't need to allocate or log, which is a no-no during early boot. The portable way would be to parse the `/chosen/bootargs` property of the device tree, but we currently lack the scaffolding for doing that.

Support for this in QEMU relies on a patch that has not yet been accepted upstream, but is available via our `Toolchain/BuildQEMU.sh` script. It should, however, work on bare metal.