### PR TITLE
SystemServer: Remove unused code for generating /dev/hwrng

### DIFF
--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -235,10 +235,6 @@ static ErrorOr<void> populate_devtmpfs_devices_based_on_devctl()
                     TRY(create_devtmpfs_char_device("/dev/input/mouse/0"sv, 0666, 10, 0));
                     break;
                 }
-                case 183: {
-                    TRY(create_devtmpfs_char_device("/dev/hwrng"sv, 0666, 10, 183));
-                    break;
-                }
                 default:
                     warnln("Unknown character device {}:{}", major_number, minor_number);
                 }


### PR DESCRIPTION
This device was removed in b596af363c30de5323641fab69ad50c712f526e2, so we can't really create anything related to it, therefore this piece of code should be removed too.