### PR TITLE
ICC: Add method to convert a color to the profile connection space

### DIFF
--- a/Tests/LibGfx/TestICCProfile.cpp
+++ b/Tests/LibGfx/TestICCProfile.cpp
@@ -114,7 +114,7 @@ TEST_CASE(to_pcs)
     };
 
     auto vec3_from_xyz = [](Gfx::ICC::XYZ const& xyz) {
-        return FloatVector3 { xyz.x, xyz.y, xyz.z };
+        return FloatVector3 { xyz.X, xyz.Y, xyz.Z };
     };
 
 #define EXPECT_APPROXIMATE_VECTOR3(v1, v2) \

--- a/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
+++ b/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
@@ -48,7 +48,7 @@ struct XYZNumber {
 
     operator XYZ() const
     {
-        return XYZ { x / (double)0x1'0000, y / (double)0x1'0000, z / (double)0x1'0000 };
+        return XYZ { x / (float)0x1'0000, y / (float)0x1'0000, z / (float)0x1'0000 };
     }
 };
 

--- a/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
+++ b/Userland/Libraries/LibGfx/ICC/BinaryFormat.h
@@ -33,22 +33,22 @@ using u16Fixed16Number = u32;
 
 // ICC V4, 4.14 XYZNumber
 struct XYZNumber {
-    BigEndian<s15Fixed16Number> x;
-    BigEndian<s15Fixed16Number> y;
-    BigEndian<s15Fixed16Number> z;
+    BigEndian<s15Fixed16Number> X;
+    BigEndian<s15Fixed16Number> Y;
+    BigEndian<s15Fixed16Number> Z;
 
     XYZNumber() = default;
 
     XYZNumber(XYZ const& xyz)
-        : x(round(xyz.x * 0x1'0000))
-        , y(round(xyz.y * 0x1'0000))
-        , z(round(xyz.z * 0x1'0000))
+        : X(round(xyz.X * 0x1'0000))
+        , Y(round(xyz.Y * 0x1'0000))
+        , Z(round(xyz.Z * 0x1'0000))
     {
     }
 
     operator XYZ() const
     {
-        return XYZ { x / (float)0x1'0000, y / (float)0x1'0000, z / (float)0x1'0000 };
+        return XYZ { X / (float)0x1'0000, Y / (float)0x1'0000, Z / (float)0x1'0000 };
     }
 };
 

--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -744,7 +744,7 @@ ErrorOr<void> Profile::check_required_tags()
         //  [...] Only the PCSXYZ encoding can be used with matrix/TRC models.
         //  8.3.4 Monochrome Input profiles
         //  In addition to the tags listed in 8.2, a monochrome Input profile shall contain the following tag:
-        //  - grayTRCTag (see 9.2.29).
+        //  - grayTRCTag (see 9.2.29)."
         bool has_n_component_lut_based_tags = has_tag(AToB0Tag);
         bool has_three_component_matrix_based_tags = has_all_tags(Array { redMatrixColumnTag, greenMatrixColumnTag, blueMatrixColumnTag, redTRCTag, greenTRCTag, blueTRCTag });
         bool has_monochrome_tags = has_tag(grayTRCTag);

--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -273,7 +273,7 @@ ErrorOr<XYZ> parse_pcs_illuminant(ICCHeader const& header)
     XYZ xyz = (XYZ)header.pcs_illuminant;
 
     /// "The value, when rounded to four decimals, shall be X = 0,9642, Y = 1,0 and Z = 0,8249."
-    if (round(xyz.x * 10'000) != 9'642 || round(xyz.y * 10'000) != 10'000 || round(xyz.z * 10'000) != 8'249)
+    if (round(xyz.X * 10'000) != 9'642 || round(xyz.Y * 10'000) != 10'000 || round(xyz.Z * 10'000) != 8'249)
         return Error::from_string_literal("ICC::Profile: Invalid pcs illuminant");
 
     return xyz;
@@ -1124,9 +1124,9 @@ ErrorOr<void> Profile::check_tag_types()
         auto& xyz_type = static_cast<XYZTagData const&>(*type.value());
         if (xyz_type.xyzs().size() != 1)
             return Error::from_string_literal("ICC::Profile: luminanceTag has unexpected size");
-        if (is_v4() && xyz_type.xyzs()[0].x != 0)
+        if (is_v4() && xyz_type.xyzs()[0].X != 0)
             return Error::from_string_literal("ICC::Profile: luminanceTag.x unexpectedly not 0");
-        if (is_v4() && xyz_type.xyzs()[0].z != 0)
+        if (is_v4() && xyz_type.xyzs()[0].Z != 0)
             return Error::from_string_literal("ICC::Profile: luminanceTag.z unexpectedly not 0");
     }
 
@@ -1448,9 +1448,9 @@ ErrorOr<FloatVector3> Profile::to_pcs(ReadonlyBytes color)
             auto const& greenMatrixColumn = green_matrix_column();
             auto const& blueMatrixColumn = blue_matrix_column();
 
-            float X = redMatrixColumn.x * linear_r + greenMatrixColumn.x * linear_g + blueMatrixColumn.x * linear_b;
-            float Y = redMatrixColumn.y * linear_r + greenMatrixColumn.y * linear_g + blueMatrixColumn.y * linear_b;
-            float Z = redMatrixColumn.z * linear_r + greenMatrixColumn.z * linear_g + blueMatrixColumn.z * linear_b;
+            float X = redMatrixColumn.X * linear_r + greenMatrixColumn.X * linear_g + blueMatrixColumn.X * linear_b;
+            float Y = redMatrixColumn.Y * linear_r + greenMatrixColumn.Y * linear_g + blueMatrixColumn.Y * linear_b;
+            float Z = redMatrixColumn.Z * linear_r + greenMatrixColumn.Z * linear_g + blueMatrixColumn.Z * linear_b;
 
             return FloatVector3 { X, Y, Z };
         }

--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -421,7 +421,19 @@ StringView data_color_space_name(ColorSpace color_space)
     VERIFY_NOT_REACHED();
 }
 
-static int number_of_components_in_color_space(ColorSpace color_space)
+StringView profile_connection_space_name(ColorSpace color_space)
+{
+    switch (color_space) {
+    case ColorSpace::PCSXYZ:
+        return "PCSXYZ"sv;
+    case ColorSpace::PCSLAB:
+        return "PCSLAB"sv;
+    default:
+        return data_color_space_name(color_space);
+    }
+}
+
+unsigned number_of_components_in_color_space(ColorSpace color_space)
 {
     switch (color_space) {
     case ColorSpace::Gray:
@@ -466,18 +478,6 @@ static int number_of_components_in_color_space(ColorSpace color_space)
         return 15;
     }
     VERIFY_NOT_REACHED();
-}
-
-StringView profile_connection_space_name(ColorSpace color_space)
-{
-    switch (color_space) {
-    case ColorSpace::PCSXYZ:
-        return "PCSXYZ"sv;
-    case ColorSpace::PCSLAB:
-        return "PCSLAB"sv;
-    default:
-        return data_color_space_name(color_space);
-    }
 }
 
 StringView primary_platform_name(PrimaryPlatform primary_platform)
@@ -1178,7 +1178,7 @@ ErrorOr<void> Profile::check_tag_types()
         // "The device representation corresponds to the header’s “data colour space” field.
         //  This representation should be consistent with the “number of device coordinates” field in the namedColor2Type.
         //  If this field is 0, device coordinates are not provided."
-        if (int number_of_device_coordinates = static_cast<NamedColor2TagData const&>(*type.value()).number_of_device_coordinates();
+        if (auto number_of_device_coordinates = static_cast<NamedColor2TagData const&>(*type.value()).number_of_device_coordinates();
             number_of_device_coordinates != 0 && number_of_device_coordinates != number_of_components_in_color_space(data_color_space())) {
             return Error::from_string_literal("ICC::Profile: namedColor2Tag number of device coordinates inconsistent with data color space");
         }

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -87,6 +87,7 @@ enum class ColorSpace : u32 {
 };
 StringView data_color_space_name(ColorSpace);
 StringView profile_connection_space_name(ColorSpace);
+unsigned number_of_components_in_color_space(ColorSpace);
 
 // ICC v4, 7.2.10 Primary platform field, Table 20 — Primary platforms
 enum class PrimaryPlatform : u32 {

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -16,6 +16,7 @@
 #include <LibCrypto/Hash/MD5.h>
 #include <LibGfx/ICC/DistinctFourCC.h>
 #include <LibGfx/ICC/TagTypes.h>
+#include <LibGfx/Vector3.h>
 
 namespace Gfx::ICC {
 
@@ -257,11 +258,31 @@ public:
     bool is_v2() const { return version().major_version() == 2; }
     bool is_v4() const { return version().major_version() == 4; }
 
+    // FIXME: The color conversion stuff should be in some other class.
+
+    // Converts an 8-bits-per-channel color to the profile connection space.
+    // The color's number of channels must match number_of_components_in_color_space(data_color_space()).
+    // Do not call for DeviceLink or NamedColor profiles. (XXX others?)
+    // Call connection_space() to find out the space the result is in.
+    ErrorOr<FloatVector3> to_pcs(ReadonlyBytes);
+
+    // Only call these if you know that this is an RGB matrix-based profile.
+    XYZ const& red_matrix_column() const;
+    XYZ const& green_matrix_column() const;
+    XYZ const& blue_matrix_column() const;
+
 private:
     Profile(ProfileHeader const& header, OrderedHashMap<TagSignature, NonnullRefPtr<TagData>> tag_table)
         : m_header(header)
         , m_tag_table(move(tag_table))
     {
+    }
+
+    XYZ const& xyz_data(TagSignature tag) const
+    {
+        auto const& data = *m_tag_table.get(tag).value();
+        VERIFY(data.type() == XYZTagData::Type);
+        return static_cast<XYZTagData const&>(data).xyz();
     }
 
     ErrorOr<void> check_required_tags();

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -21,9 +21,9 @@ using S15Fixed16 = FixedPoint<16, i32>;
 using U16Fixed16 = FixedPoint<16, u32>;
 
 struct XYZ {
-    float x { 0 };
-    float y { 0 };
-    float z { 0 };
+    float X { 0 };
+    float Y { 0 };
+    float Z { 0 };
 
     bool operator==(const XYZ&) const = default;
 };
@@ -906,6 +906,6 @@ template<>
 struct AK::Formatter<Gfx::ICC::XYZ> : Formatter<FormatString> {
     ErrorOr<void> format(FormatBuilder& builder, Gfx::ICC::XYZ const& xyz)
     {
-        return Formatter<FormatString>::format(builder, "X = {}, Y = {}, Z = {}"sv, xyz.x, xyz.y, xyz.z);
+        return Formatter<FormatString>::format(builder, "X = {}, Y = {}, Z = {}"sv, xyz.X, xyz.Y, xyz.Z);
     }
 };

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -21,9 +21,9 @@ using S15Fixed16 = FixedPoint<16, i32>;
 using U16Fixed16 = FixedPoint<16, u32>;
 
 struct XYZ {
-    double x { 0 };
-    double y { 0 };
-    double z { 0 };
+    float x { 0 };
+    float y { 0 };
+    float z { 0 };
 
     bool operator==(const XYZ&) const = default;
 };

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -890,6 +890,12 @@ public:
 
     Vector<XYZ, 1> const& xyzs() const { return m_xyzs; }
 
+    XYZ const& xyz() const
+    {
+        VERIFY(m_xyzs.size() == 1);
+        return m_xyzs[0];
+    }
+
 private:
     Vector<XYZ, 1> m_xyzs;
 };

--- a/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.cpp
+++ b/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.cpp
@@ -52,6 +52,7 @@ ErrorOr<NonnullRefPtr<Profile>> sRGB()
 
     // FIXME: There are many different sRGB ICC profiles in the wild.
     //        Explain why, and why this picks the numbers it does.
+    //        In the meantime, https://github.com/SerenityOS/serenity/pull/17714 has a few notes.
 
     auto header = rgb_header();
 


### PR DESCRIPTION
This adds a tiny bit of color transforming to the ICC code. It's only from device-dependent colors to the device-independent "profile connection space" (PCS). For full transforms, we also need to the transform back from PCS to a (different) device-dependent space. Also, in between these two, Bradford adaptation and gamut mapping should happen. What's more, this only implements the forward transform for matrix profiles.

This code is only used from tests for now.

Also, the API for it is inefficient and clunky. But gotta start somewhere.