### PR TITLE
LibWeb: Add a whole lot more length units

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -109,6 +109,18 @@ CSSPixels Length::relative_length_to_px(CSSPixelRect const& viewport_rect, FontM
     case Type::Lvh:
     case Type::Dvh:
         return viewport_rect.height() * (m_value / 100);
+    case Type::Vi:
+    case Type::Svi:
+    case Type::Lvi:
+    case Type::Dvi:
+        // FIXME: Select the width or height based on which is the inline axis.
+        return viewport_rect.width() * (m_value / 100);
+    case Type::Vb:
+    case Type::Svb:
+    case Type::Lvb:
+    case Type::Dvb:
+        // FIXME: Select the width or height based on which is the block axis.
+        return viewport_rect.height() * (m_value / 100);
     case Type::Vmin:
     case Type::Svmin:
     case Type::Lvmin:
@@ -200,6 +212,22 @@ char const* Length::unit_name() const
         return "lvh";
     case Type::Dvh:
         return "dvh";
+    case Type::Vi:
+        return "vi";
+    case Type::Svi:
+        return "svi";
+    case Type::Lvi:
+        return "lvi";
+    case Type::Dvi:
+        return "dvi";
+    case Type::Vb:
+        return "vb";
+    case Type::Svb:
+        return "svb";
+    case Type::Lvb:
+        return "lvb";
+    case Type::Dvb:
+        return "dvb";
     case Type::Vmin:
         return "vmin";
     case Type::Svmin:
@@ -278,6 +306,22 @@ Optional<Length::Type> Length::unit_from_name(StringView name)
         return Length::Type::Lvh;
     } else if (name.equals_ignoring_ascii_case("dvh"sv)) {
         return Length::Type::Dvh;
+    } else if (name.equals_ignoring_ascii_case("vi"sv)) {
+        return Length::Type::Vi;
+    } else if (name.equals_ignoring_ascii_case("svi"sv)) {
+        return Length::Type::Svi;
+    } else if (name.equals_ignoring_ascii_case("lvi"sv)) {
+        return Length::Type::Lvi;
+    } else if (name.equals_ignoring_ascii_case("dvi"sv)) {
+        return Length::Type::Dvi;
+    } else if (name.equals_ignoring_ascii_case("vb"sv)) {
+        return Length::Type::Vb;
+    } else if (name.equals_ignoring_ascii_case("svb"sv)) {
+        return Length::Type::Svb;
+    } else if (name.equals_ignoring_ascii_case("lvb"sv)) {
+        return Length::Type::Lvb;
+    } else if (name.equals_ignoring_ascii_case("dvb"sv)) {
+        return Length::Type::Dvb;
     } else if (name.equals_ignoring_ascii_case("vmin"sv)) {
         return Length::Type::Vmin;
     } else if (name.equals_ignoring_ascii_case("svmin"sv)) {

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -62,15 +62,19 @@ Length Length::resolved(Layout::Node const& layout_node) const
 CSSPixels Length::relative_length_to_px(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const
 {
     switch (m_type) {
-    case Type::Ex:
-        return m_value * font_metrics.x_height;
     case Type::Em:
         return m_value * font_size;
+    case Type::Rem:
+        return m_value * root_font_size;
+    case Type::Ex:
+        return m_value * font_metrics.x_height;
     case Type::Ch:
         // FIXME: Use layout_node.font().pixel_size() when writing-mode is not horizontal-tb (it has to be implemented first)
         return m_value * (font_metrics.advance_of_ascii_zero + font_metrics.glyph_spacing);
-    case Type::Rem:
-        return m_value * root_font_size;
+    case Type::Lh:
+        return m_value * line_height;
+    case Type::Rlh:
+        return m_value * root_line_height;
     case Type::Vw:
         return viewport_rect.width() * (m_value / 100);
     case Type::Vh:
@@ -79,10 +83,6 @@ CSSPixels Length::relative_length_to_px(CSSPixelRect const& viewport_rect, Gfx::
         return min(viewport_rect.width(), viewport_rect.height()) * (m_value / 100);
     case Type::Vmax:
         return max(viewport_rect.width(), viewport_rect.height()) * (m_value / 100);
-    case Type::Lh:
-        return m_value * line_height;
-    case Type::Rlh:
-        return m_value * root_line_height;
     default:
         VERIFY_NOT_REACHED();
     }
@@ -112,82 +112,82 @@ ErrorOr<String> Length::to_string() const
 char const* Length::unit_name() const
 {
     switch (m_type) {
-    case Type::Cm:
-        return "cm";
-    case Type::In:
-        return "in";
-    case Type::Px:
-        return "px";
-    case Type::Pt:
-        return "pt";
-    case Type::Mm:
-        return "mm";
-    case Type::Q:
-        return "Q";
-    case Type::Pc:
-        return "pc";
-    case Type::Ex:
-        return "ex";
     case Type::Em:
         return "em";
-    case Type::Ch:
-        return "ch";
     case Type::Rem:
         return "rem";
-    case Type::Auto:
-        return "auto";
-    case Type::Vh:
-        return "vh";
-    case Type::Vw:
-        return "vw";
-    case Type::Vmax:
-        return "vmax";
-    case Type::Vmin:
-        return "vmin";
+    case Type::Ex:
+        return "ex";
+    case Type::Ch:
+        return "ch";
     case Type::Lh:
         return "lh";
     case Type::Rlh:
         return "rlh";
+    case Type::Vw:
+        return "vw";
+    case Type::Vh:
+        return "vh";
+    case Type::Vmin:
+        return "vmin";
+    case Type::Vmax:
+        return "vmax";
+    case Type::Cm:
+        return "cm";
+    case Type::Mm:
+        return "mm";
+    case Type::Q:
+        return "Q";
+    case Type::In:
+        return "in";
+    case Type::Pt:
+        return "pt";
+    case Type::Pc:
+        return "pc";
+    case Type::Px:
+        return "px";
+    case Type::Auto:
+        return "auto";
     }
     VERIFY_NOT_REACHED();
 }
 
 Optional<Length::Type> Length::unit_from_name(StringView name)
 {
-    if (name.equals_ignoring_ascii_case("px"sv)) {
-        return Length::Type::Px;
-    } else if (name.equals_ignoring_ascii_case("pt"sv)) {
-        return Length::Type::Pt;
-    } else if (name.equals_ignoring_ascii_case("pc"sv)) {
-        return Length::Type::Pc;
-    } else if (name.equals_ignoring_ascii_case("mm"sv)) {
-        return Length::Type::Mm;
+    if (name.equals_ignoring_ascii_case("em"sv)) {
+        return Length::Type::Em;
     } else if (name.equals_ignoring_ascii_case("rem"sv)) {
         return Length::Type::Rem;
-    } else if (name.equals_ignoring_ascii_case("em"sv)) {
-        return Length::Type::Em;
     } else if (name.equals_ignoring_ascii_case("ex"sv)) {
         return Length::Type::Ex;
     } else if (name.equals_ignoring_ascii_case("ch"sv)) {
         return Length::Type::Ch;
-    } else if (name.equals_ignoring_ascii_case("vw"sv)) {
-        return Length::Type::Vw;
-    } else if (name.equals_ignoring_ascii_case("vh"sv)) {
-        return Length::Type::Vh;
-    } else if (name.equals_ignoring_ascii_case("vmax"sv)) {
-        return Length::Type::Vmax;
-    } else if (name.equals_ignoring_ascii_case("vmin"sv)) {
-        return Length::Type::Vmin;
-    } else if (name.equals_ignoring_ascii_case("cm"sv)) {
-        return Length::Type::Cm;
-    } else if (name.equals_ignoring_ascii_case("in"sv)) {
-        return Length::Type::In;
-    } else if (name.equals_ignoring_ascii_case("Q"sv)) {
-        return Length::Type::Q;
     } else if (name.equals_ignoring_ascii_case("lh"sv)) {
         return Length::Type::Lh;
     } else if (name.equals_ignoring_ascii_case("rlh"sv)) {
         return Length::Type::Rlh;
+    } else if (name.equals_ignoring_ascii_case("vw"sv)) {
+        return Length::Type::Vw;
+    } else if (name.equals_ignoring_ascii_case("vh"sv)) {
+        return Length::Type::Vh;
+    } else if (name.equals_ignoring_ascii_case("vmin"sv)) {
+        return Length::Type::Vmin;
+    } else if (name.equals_ignoring_ascii_case("vmax"sv)) {
+        return Length::Type::Vmax;
+    } else if (name.equals_ignoring_ascii_case("cm"sv)) {
+        return Length::Type::Cm;
+    } else if (name.equals_ignoring_ascii_case("mm"sv)) {
+        return Length::Type::Mm;
+    } else if (name.equals_ignoring_ascii_case("Q"sv)) {
+        return Length::Type::Q;
+    } else if (name.equals_ignoring_ascii_case("in"sv)) {
+        return Length::Type::In;
+    } else if (name.equals_ignoring_ascii_case("pt"sv)) {
+        return Length::Type::Pt;
+    } else if (name.equals_ignoring_ascii_case("pc"sv)) {
+        return Length::Type::Pc;
+    } else if (name.equals_ignoring_ascii_case("px"sv)) {
+        return Length::Type::Px;
     }
 
     return {};

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -89,6 +89,12 @@ CSSPixels Length::relative_length_to_px(CSSPixelRect const& viewport_rect, FontM
         return m_value * font_metrics.zero_advance;
     case Type::Rch:
         return m_value * root_font_metrics.zero_advance;
+    case Type::Ic:
+        // FIXME: Use the "advance measure of the “水” (CJK water ideograph, U+6C34) glyph"
+        return m_value * font_metrics.font_size;
+    case Type::Ric:
+        // FIXME: Use the "advance measure of the “水” (CJK water ideograph, U+6C34) glyph"
+        return m_value * root_font_metrics.font_size;
     case Type::Lh:
         return m_value * font_metrics.line_height;
     case Type::Rlh:
@@ -158,6 +164,10 @@ char const* Length::unit_name() const
         return "ch";
     case Type::Rch:
         return "rch";
+    case Type::Ic:
+        return "ic";
+    case Type::Ric:
+        return "ric";
     case Type::Lh:
         return "lh";
     case Type::Rlh:
@@ -208,6 +218,10 @@ Optional<Length::Type> Length::unit_from_name(StringView name)
         return Length::Type::Ch;
     } else if (name.equals_ignoring_ascii_case("rch"sv)) {
         return Length::Type::Rch;
+    } else if (name.equals_ignoring_ascii_case("ic"sv)) {
+        return Length::Type::Ic;
+    } else if (name.equals_ignoring_ascii_case("ric"sv)) {
+        return Length::Type::Ric;
     } else if (name.equals_ignoring_ascii_case("lh"sv)) {
         return Length::Type::Lh;
     } else if (name.equals_ignoring_ascii_case("rlh"sv)) {

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -76,8 +76,12 @@ CSSPixels Length::relative_length_to_px(CSSPixelRect const& viewport_rect, FontM
         return m_value * root_font_metrics.font_size;
     case Type::Ex:
         return m_value * font_metrics.x_height;
+    case Type::Rex:
+        return m_value * root_font_metrics.x_height;
     case Type::Ch:
         return m_value * font_metrics.zero_advance;
+    case Type::Rch:
+        return m_value * root_font_metrics.zero_advance;
     case Type::Lh:
         return m_value * font_metrics.line_height;
     case Type::Rlh:
@@ -137,8 +141,12 @@ char const* Length::unit_name() const
         return "rem";
     case Type::Ex:
         return "ex";
+    case Type::Rex:
+        return "rex";
     case Type::Ch:
         return "ch";
+    case Type::Rch:
+        return "rch";
     case Type::Lh:
         return "lh";
     case Type::Rlh:
@@ -179,8 +187,12 @@ Optional<Length::Type> Length::unit_from_name(StringView name)
         return Length::Type::Rem;
     } else if (name.equals_ignoring_ascii_case("ex"sv)) {
         return Length::Type::Ex;
+    } else if (name.equals_ignoring_ascii_case("rex"sv)) {
+        return Length::Type::Rex;
     } else if (name.equals_ignoring_ascii_case("ch"sv)) {
         return Length::Type::Ch;
+    } else if (name.equals_ignoring_ascii_case("rch"sv)) {
+        return Length::Type::Rch;
     } else if (name.equals_ignoring_ascii_case("lh"sv)) {
         return Length::Type::Lh;
     } else if (name.equals_ignoring_ascii_case("rlh"sv)) {

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -100,12 +100,24 @@ CSSPixels Length::relative_length_to_px(CSSPixelRect const& viewport_rect, FontM
     case Type::Rlh:
         return m_value * root_font_metrics.line_height;
     case Type::Vw:
+    case Type::Svw:
+    case Type::Lvw:
+    case Type::Dvw:
         return viewport_rect.width() * (m_value / 100);
     case Type::Vh:
+    case Type::Svh:
+    case Type::Lvh:
+    case Type::Dvh:
         return viewport_rect.height() * (m_value / 100);
     case Type::Vmin:
+    case Type::Svmin:
+    case Type::Lvmin:
+    case Type::Dvmin:
         return min(viewport_rect.width(), viewport_rect.height()) * (m_value / 100);
     case Type::Vmax:
+    case Type::Svmax:
+    case Type::Lvmax:
+    case Type::Dvmax:
         return max(viewport_rect.width(), viewport_rect.height()) * (m_value / 100);
     default:
         VERIFY_NOT_REACHED();
@@ -174,12 +186,36 @@ char const* Length::unit_name() const
         return "rlh";
     case Type::Vw:
         return "vw";
+    case Type::Svw:
+        return "svw";
+    case Type::Lvw:
+        return "lvw";
+    case Type::Dvw:
+        return "dvw";
     case Type::Vh:
         return "vh";
+    case Type::Svh:
+        return "svh";
+    case Type::Lvh:
+        return "lvh";
+    case Type::Dvh:
+        return "dvh";
     case Type::Vmin:
         return "vmin";
+    case Type::Svmin:
+        return "svmin";
+    case Type::Lvmin:
+        return "lvmin";
+    case Type::Dvmin:
+        return "dvmin";
     case Type::Vmax:
         return "vmax";
+    case Type::Svmax:
+        return "svmax";
+    case Type::Lvmax:
+        return "lvmax";
+    case Type::Dvmax:
+        return "dvmax";
     case Type::Cm:
         return "cm";
     case Type::Mm:
@@ -228,12 +264,36 @@ Optional<Length::Type> Length::unit_from_name(StringView name)
         return Length::Type::Rlh;
     } else if (name.equals_ignoring_ascii_case("vw"sv)) {
         return Length::Type::Vw;
+    } else if (name.equals_ignoring_ascii_case("svw"sv)) {
+        return Length::Type::Svw;
+    } else if (name.equals_ignoring_ascii_case("lvw"sv)) {
+        return Length::Type::Lvw;
+    } else if (name.equals_ignoring_ascii_case("dvw"sv)) {
+        return Length::Type::Dvw;
     } else if (name.equals_ignoring_ascii_case("vh"sv)) {
         return Length::Type::Vh;
+    } else if (name.equals_ignoring_ascii_case("svh"sv)) {
+        return Length::Type::Svh;
+    } else if (name.equals_ignoring_ascii_case("lvh"sv)) {
+        return Length::Type::Lvh;
+    } else if (name.equals_ignoring_ascii_case("dvh"sv)) {
+        return Length::Type::Dvh;
     } else if (name.equals_ignoring_ascii_case("vmin"sv)) {
         return Length::Type::Vmin;
+    } else if (name.equals_ignoring_ascii_case("svmin"sv)) {
+        return Length::Type::Svmin;
+    } else if (name.equals_ignoring_ascii_case("lvmin"sv)) {
+        return Length::Type::Lvmin;
+    } else if (name.equals_ignoring_ascii_case("dvmin"sv)) {
+        return Length::Type::Dvmin;
     } else if (name.equals_ignoring_ascii_case("vmax"sv)) {
         return Length::Type::Vmax;
+    } else if (name.equals_ignoring_ascii_case("svmax"sv)) {
+        return Length::Type::Svmax;
+    } else if (name.equals_ignoring_ascii_case("lvmax"sv)) {
+        return Length::Type::Lvmax;
+    } else if (name.equals_ignoring_ascii_case("dvmax"sv)) {
+        return Length::Type::Dvmax;
     } else if (name.equals_ignoring_ascii_case("cm"sv)) {
         return Length::Type::Cm;
     } else if (name.equals_ignoring_ascii_case("mm"sv)) {

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -21,6 +21,9 @@ namespace Web::CSS {
 Length::FontMetrics::FontMetrics(CSSPixels font_size, Gfx::FontPixelMetrics const& pixel_metrics, CSSPixels line_height)
     : font_size(font_size)
     , x_height(pixel_metrics.x_height)
+    // FIXME: This is only approximately the cap height. The spec suggests measuring the "O" glyph:
+    //        https://www.w3.org/TR/css-values-4/#cap
+    , cap_height(pixel_metrics.ascent)
     , zero_advance(pixel_metrics.advance_of_ascii_zero + pixel_metrics.glyph_spacing)
     , line_height(line_height)
 {
@@ -78,6 +81,10 @@ CSSPixels Length::relative_length_to_px(CSSPixelRect const& viewport_rect, FontM
         return m_value * font_metrics.x_height;
     case Type::Rex:
         return m_value * root_font_metrics.x_height;
+    case Type::Cap:
+        return m_value * font_metrics.cap_height;
+    case Type::Rcap:
+        return m_value * root_font_metrics.cap_height;
     case Type::Ch:
         return m_value * font_metrics.zero_advance;
     case Type::Rch:
@@ -143,6 +150,10 @@ char const* Length::unit_name() const
         return "ex";
     case Type::Rex:
         return "rex";
+    case Type::Cap:
+        return "cap";
+    case Type::Rcap:
+        return "rcap";
     case Type::Ch:
         return "ch";
     case Type::Rch:
@@ -189,6 +200,10 @@ Optional<Length::Type> Length::unit_from_name(StringView name)
         return Length::Type::Ex;
     } else if (name.equals_ignoring_ascii_case("rex"sv)) {
         return Length::Type::Rex;
+    } else if (name.equals_ignoring_ascii_case("cap"sv)) {
+        return Length::Type::Cap;
+    } else if (name.equals_ignoring_ascii_case("rcap"sv)) {
+        return Length::Type::Rcap;
     } else if (name.equals_ignoring_ascii_case("ch"sv)) {
         return Length::Type::Ch;
     } else if (name.equals_ignoring_ascii_case("rch"sv)) {

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -33,9 +33,21 @@ public:
 
         // Viewport-relative
         Vw,
+        Svw,
+        Lvw,
+        Dvw,
         Vh,
+        Svh,
+        Lvh,
+        Dvh,
         Vmin,
+        Svmin,
+        Lvmin,
+        Dvmin,
         Vmax,
+        Svmax,
+        Lvmax,
+        Dvmax,
 
         // Absolute
         Cm,
@@ -105,9 +117,21 @@ public:
     bool is_viewport_relative() const
     {
         return m_type == Type::Vw
+            || m_type == Type::Svw
+            || m_type == Type::Lvw
+            || m_type == Type::Dvw
             || m_type == Type::Vh
+            || m_type == Type::Svh
+            || m_type == Type::Lvh
+            || m_type == Type::Dvh
             || m_type == Type::Vmin
-            || m_type == Type::Vmax;
+            || m_type == Type::Svmin
+            || m_type == Type::Lvmin
+            || m_type == Type::Dvmin
+            || m_type == Type::Vmax
+            || m_type == Type::Svmax
+            || m_type == Type::Lvmax
+            || m_type == Type::Dvmax;
     }
 
     bool is_relative() const

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -17,24 +17,31 @@ namespace Web::CSS {
 class Length {
 public:
     enum class Type {
-        Auto,
-        Cm,
-        In,
-        Mm,
-        Q,
-        Px,
-        Pt,
-        Pc,
-        Ex,
+        // Font-relative
         Em,
-        Ch,
         Rem,
-        Vh,
-        Vw,
-        Vmax,
-        Vmin,
+        Ex,
+        Ch,
         Lh,
         Rlh,
+
+        // Viewport-relative
+        Vw,
+        Vh,
+        Vmin,
+        Vmax,
+
+        // Absolute
+        Cm,
+        Mm,
+        Q,
+        In,
+        Pt,
+        Pc,
+        Px,
+
+        // FIXME: Remove auto somehow
+        Auto,
     };
 
     static Optional<Type> unit_from_name(StringView);

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -26,6 +26,8 @@ public:
         Rcap,
         Ch,
         Rch,
+        Ic,
+        Ric,
         Lh,
         Rlh,
 
@@ -94,6 +96,8 @@ public:
             || m_type == Type::Rcap
             || m_type == Type::Ch
             || m_type == Type::Rch
+            || m_type == Type::Ic
+            || m_type == Type::Ric
             || m_type == Type::Lh
             || m_type == Type::Rlh;
     }

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -46,8 +46,6 @@ public:
 
     static Optional<Type> unit_from_name(StringView);
 
-    // We have a RefPtr<CalculatedStyleValue> member, but can't include the header StyleValue.h as it includes
-    // this file already. To break the cyclic dependency, we must move all method definitions out.
     Length(int value, Type type);
     Length(float value, Type type);
     ~Length();
@@ -64,26 +62,26 @@ public:
     bool is_absolute() const
     {
         return m_type == Type::Cm
-            || m_type == Type::In
             || m_type == Type::Mm
-            || m_type == Type::Px
+            || m_type == Type::Q
+            || m_type == Type::In
             || m_type == Type::Pt
             || m_type == Type::Pc
-            || m_type == Type::Q;
+            || m_type == Type::Px;
     }
 
     bool is_relative() const
     {
-        return m_type == Type::Ex
-            || m_type == Type::Em
-            || m_type == Type::Ch
+        return m_type == Type::Em
             || m_type == Type::Rem
-            || m_type == Type::Vh
-            || m_type == Type::Vw
-            || m_type == Type::Vmax
-            || m_type == Type::Vmin
+            || m_type == Type::Ex
+            || m_type == Type::Ch
             || m_type == Type::Lh
-            || m_type == Type::Rlh;
+            || m_type == Type::Rlh
+            || m_type == Type::Vw
+            || m_type == Type::Vh
+            || m_type == Type::Vmin
+            || m_type == Type::Vmax;
     }
 
     Type type() const { return m_type; }

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -22,6 +22,8 @@ public:
         Rem,
         Ex,
         Rex,
+        Cap,
+        Rcap,
         Ch,
         Rch,
         Lh,
@@ -51,6 +53,7 @@ public:
 
         CSSPixels font_size;
         CSSPixels x_height;
+        CSSPixels cap_height;
         CSSPixels zero_advance;
         CSSPixels line_height;
     };
@@ -87,6 +90,8 @@ public:
             || m_type == Type::Rem
             || m_type == Type::Ex
             || m_type == Type::Rex
+            || m_type == Type::Cap
+            || m_type == Type::Rcap
             || m_type == Type::Ch
             || m_type == Type::Rch
             || m_type == Type::Lh

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -21,7 +21,9 @@ public:
         Em,
         Rem,
         Ex,
+        Rex,
         Ch,
+        Rch,
         Lh,
         Rlh,
 
@@ -84,7 +86,9 @@ public:
         return m_type == Type::Em
             || m_type == Type::Rem
             || m_type == Type::Ex
+            || m_type == Type::Rex
             || m_type == Type::Ch
+            || m_type == Type::Rch
             || m_type == Type::Lh
             || m_type == Type::Rlh;
     }

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -70,18 +70,27 @@ public:
             || m_type == Type::Px;
     }
 
-    bool is_relative() const
+    bool is_font_relative() const
     {
         return m_type == Type::Em
             || m_type == Type::Rem
             || m_type == Type::Ex
             || m_type == Type::Ch
             || m_type == Type::Lh
-            || m_type == Type::Rlh
-            || m_type == Type::Vw
+            || m_type == Type::Rlh;
+    }
+
+    bool is_viewport_relative() const
+    {
+        return m_type == Type::Vw
             || m_type == Type::Vh
             || m_type == Type::Vmin
             || m_type == Type::Vmax;
+    }
+
+    bool is_relative() const
+    {
+        return is_font_relative() || is_viewport_relative();
     }
 
     Type type() const { return m_type; }

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -44,6 +44,15 @@ public:
         Auto,
     };
 
+    struct FontMetrics {
+        FontMetrics(CSSPixels font_size, Gfx::FontPixelMetrics const&, CSSPixels line_height);
+
+        CSSPixels font_size;
+        CSSPixels x_height;
+        CSSPixels zero_advance;
+        CSSPixels line_height;
+    };
+
     static Optional<Type> unit_from_name(StringView);
 
     Length(int value, Type type);
@@ -98,12 +107,12 @@ public:
 
     CSSPixels to_px(Layout::Node const&) const;
 
-    ALWAYS_INLINE CSSPixels to_px(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const
+    ALWAYS_INLINE CSSPixels to_px(CSSPixelRect const& viewport_rect, FontMetrics const& font_metrics, FontMetrics const& root_font_metrics) const
     {
         if (is_auto())
             return 0;
         if (is_relative())
-            return relative_length_to_px(viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height);
+            return relative_length_to_px(viewport_rect, font_metrics, root_font_metrics);
         return absolute_length_to_px();
     }
 
@@ -138,11 +147,11 @@ public:
         return m_type == other.m_type && m_value == other.m_value;
     }
 
-    CSSPixels relative_length_to_px(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const;
+    CSSPixels relative_length_to_px(CSSPixelRect const& viewport_rect, FontMetrics const& font_metrics, FontMetrics const& root_font_metrics) const;
 
     // Returns empty optional if it's already absolute.
-    Optional<Length> absolutize(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const;
-    Length absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const;
+    Optional<Length> absolutize(CSSPixelRect const& viewport_rect, FontMetrics const& font_metrics, FontMetrics const& root_font_metrics) const;
+    Length absolutized(CSSPixelRect const& viewport_rect, FontMetrics const& font_metrics, FontMetrics const& root_font_metrics) const;
 
 private:
     char const* unit_name() const;

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -164,8 +164,10 @@ public:
     {
         if (is_auto())
             return 0;
-        if (is_relative())
-            return relative_length_to_px(viewport_rect, font_metrics, root_font_metrics);
+        if (is_font_relative())
+            return font_relative_length_to_px(font_metrics, root_font_metrics);
+        if (is_viewport_relative())
+            return viewport_relative_length_to_px(viewport_rect);
         return absolute_length_to_px();
     }
 
@@ -200,7 +202,8 @@ public:
         return m_type == other.m_type && m_value == other.m_value;
     }
 
-    CSSPixels relative_length_to_px(CSSPixelRect const& viewport_rect, FontMetrics const& font_metrics, FontMetrics const& root_font_metrics) const;
+    CSSPixels font_relative_length_to_px(FontMetrics const& font_metrics, FontMetrics const& root_font_metrics) const;
+    CSSPixels viewport_relative_length_to_px(CSSPixelRect const& viewport_rect) const;
 
     // Returns empty optional if it's already absolute.
     Optional<Length> absolutize(CSSPixelRect const& viewport_rect, FontMetrics const& font_metrics, FontMetrics const& root_font_metrics) const;

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -40,6 +40,14 @@ public:
         Svh,
         Lvh,
         Dvh,
+        Vi,
+        Svi,
+        Lvi,
+        Dvi,
+        Vb,
+        Svb,
+        Lvb,
+        Dvb,
         Vmin,
         Svmin,
         Lvmin,
@@ -124,6 +132,14 @@ public:
             || m_type == Type::Svh
             || m_type == Type::Lvh
             || m_type == Type::Dvh
+            || m_type == Type::Vi
+            || m_type == Type::Svi
+            || m_type == Type::Lvi
+            || m_type == Type::Dvi
+            || m_type == Type::Vb
+            || m_type == Type::Svb
+            || m_type == Type::Lvb
+            || m_type == Type::Dvb
             || m_type == Type::Vmin
             || m_type == Type::Svmin
             || m_type == Type::Lvmin

--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -167,11 +167,10 @@ bool MediaFeature::compare(HTML::Window const& window, MediaFeatureValue left, C
 
             auto const& initial_font = window.associated_document().style_computer().initial_font();
             Gfx::FontPixelMetrics const& initial_font_metrics = initial_font.pixel_metrics();
-            float initial_font_size = initial_font.presentation_size();
-            float initial_line_height = initial_font_metrics.line_spacing();
+            Length::FontMetrics font_metrics { static_cast<CSSPixels>(initial_font.presentation_size()), initial_font_metrics, initial_font_metrics.line_spacing() };
 
-            left_px = left.length().to_px(viewport_rect, initial_font_metrics, initial_font_size, initial_font_size, initial_line_height, initial_line_height);
-            right_px = right.length().to_px(viewport_rect, initial_font_metrics, initial_font_size, initial_font_size, initial_line_height, initial_line_height);
+            left_px = left.length().to_px(viewport_rect, font_metrics, font_metrics);
+            right_px = right.length().to_px(viewport_rect, font_metrics, font_metrics);
         }
 
         switch (comparison) {

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -406,6 +406,20 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_wrap()));
     case CSS::PropertyID::Float:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().float_()));
+    case CSS::PropertyID::FontSize:
+        return LengthStyleValue::create(Length::make_px(layout_node.computed_values().font_size()));
+    case CSS::PropertyID::FontVariant: {
+        auto font_variant = layout_node.computed_values().font_variant();
+        switch (font_variant) {
+        case FontVariant::Normal:
+            return IdentifierStyleValue::create(ValueID::Normal);
+        case FontVariant::SmallCaps:
+            return IdentifierStyleValue::create(ValueID::SmallCaps);
+        }
+        VERIFY_NOT_REACHED();
+    }
+    case CSS::PropertyID::FontWeight:
+        return NumericStyleValue::create_integer(layout_node.computed_values().font_weight());
     case CSS::PropertyID::GridArea: {
         auto maybe_grid_row_start = property(CSS::PropertyID::GridRowStart);
         auto maybe_grid_column_start = property(CSS::PropertyID::GridColumnStart);
@@ -482,6 +496,8 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().justify_content()));
     case CSS::PropertyID::Left:
         return style_value_for_length_percentage(layout_node.computed_values().inset().left());
+    case CSS::PropertyID::LineHeight:
+        return LengthStyleValue::create(Length::make_px(layout_node.line_height()));
     case CSS::PropertyID::ListStyleType:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().list_style_type()));
     case CSS::PropertyID::Margin: {

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -102,8 +102,7 @@ private:
     void for_each_stylesheet(CascadeOrigin, Callback) const;
 
     CSSPixelRect viewport_rect() const;
-    CSSPixels root_element_font_size() const;
-    CSSPixels root_element_line_height() const;
+    Length::FontMetrics root_element_font_metrics() const;
     CSSPixels parent_or_root_element_line_height(DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const;
 
     struct MatchingRuleSet {

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -153,34 +153,34 @@ NonnullRefPtr<Gfx::Font const> StyleProperties::font_fallback(bool monospace, bo
 }
 
 // FIXME: This implementation is almost identical to line_height(Layout::Node) below. Maybe they can be combined somehow.
-CSSPixels StyleProperties::line_height(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels parent_line_height, CSSPixels root_line_height) const
+CSSPixels StyleProperties::line_height(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
 {
     auto line_height = property(CSS::PropertyID::LineHeight);
 
     if (line_height->is_identifier() && line_height->to_identifier() == ValueID::Normal)
-        return font_metrics.line_spacing();
+        return font_metrics.line_height;
 
     if (line_height->is_length()) {
         auto line_height_length = line_height->to_length();
         if (!line_height_length.is_auto())
-            return line_height_length.to_px(viewport_rect, font_metrics, font_size, root_font_size, parent_line_height, root_line_height);
+            return line_height_length.to_px(viewport_rect, font_metrics, root_font_metrics);
     }
 
     if (line_height->is_numeric())
-        return Length(line_height->to_number(), Length::Type::Em).to_px(viewport_rect, font_metrics, font_size, root_font_size, parent_line_height, root_line_height);
+        return Length(line_height->to_number(), Length::Type::Em).to_px(viewport_rect, font_metrics, root_font_metrics);
 
     if (line_height->is_percentage()) {
         // Percentages are relative to 1em. https://www.w3.org/TR/css-inline-3/#valdef-line-height-percentage
         auto& percentage = line_height->as_percentage().percentage();
-        return Length(percentage.as_fraction(), Length::Type::Em).to_px(viewport_rect, font_metrics, font_size, root_font_size, parent_line_height, root_line_height);
+        return Length(percentage.as_fraction(), Length::Type::Em).to_px(viewport_rect, font_metrics, root_font_metrics);
     }
 
     if (line_height->is_calculated()) {
         // FIXME: Handle `line-height: calc(...)` despite not having a LayoutNode here.
-        return font_metrics.line_spacing();
+        return font_metrics.line_height;
     }
 
-    return font_metrics.line_spacing();
+    return font_metrics.line_height;
 }
 
 CSSPixels StyleProperties::line_height(Layout::Node const& layout_node) const

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -109,7 +109,7 @@ public:
         m_font = move(font);
     }
 
-    CSSPixels line_height(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const&, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const;
+    CSSPixels line_height(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const;
     CSSPixels line_height(Layout::Node const&) const;
 
     bool operator==(StyleProperties const&) const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -331,7 +331,7 @@ StyleValueList const& StyleValue::as_value_list() const
     return static_cast<StyleValueList const&>(*this);
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> StyleValue::absolutized(CSSPixelRect const&, Gfx::FontPixelMetrics const&, CSSPixels, CSSPixels, CSSPixels, CSSPixels) const
+ValueComparingNonnullRefPtr<StyleValue const> StyleValue::absolutized(CSSPixelRect const&, Length::FontMetrics const&, Length::FontMetrics const&) const
 {
     return *this;
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -283,7 +283,7 @@ public:
     virtual bool has_number() const { return false; }
     virtual bool has_integer() const { return false; }
 
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const;
 
     virtual Color to_color(Layout::NodeWithStyle const&) const { return {}; }
     ValueID to_identifier() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.cpp
@@ -18,16 +18,16 @@ ErrorOr<String> BorderRadiusStyleValue::to_string() const
     return String::formatted("{} / {}", TRY(m_properties.horizontal_radius.to_string()), TRY(m_properties.vertical_radius.to_string()));
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> BorderRadiusStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const
+ValueComparingNonnullRefPtr<StyleValue const> BorderRadiusStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
 {
     if (m_properties.horizontal_radius.is_percentage() && m_properties.vertical_radius.is_percentage())
         return *this;
     auto absolutized_horizontal_radius = m_properties.horizontal_radius;
     auto absolutized_vertical_radius = m_properties.vertical_radius;
     if (!m_properties.horizontal_radius.is_percentage())
-        absolutized_horizontal_radius = m_properties.horizontal_radius.length().absolutized(viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height);
+        absolutized_horizontal_radius = m_properties.horizontal_radius.length().absolutized(viewport_rect, font_metrics, root_font_metrics);
     if (!m_properties.vertical_radius.is_percentage())
-        absolutized_vertical_radius = m_properties.vertical_radius.length().absolutized(viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height);
+        absolutized_vertical_radius = m_properties.vertical_radius.length().absolutized(viewport_rect, font_metrics, root_font_metrics);
     return BorderRadiusStyleValue::create(absolutized_horizontal_radius, absolutized_vertical_radius);
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h
@@ -38,7 +38,7 @@ private:
     {
     }
 
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
 
     struct Properties {
         bool is_elliptical;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.cpp
@@ -27,9 +27,9 @@ ValueComparingNonnullRefPtr<LengthStyleValue> LengthStyleValue::create(Length co
     return adopt_ref(*new LengthStyleValue(length));
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> LengthStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const
+ValueComparingNonnullRefPtr<StyleValue const> LengthStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
 {
-    if (auto length = m_length.absolutize(viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height); length.has_value())
+    if (auto length = m_length.absolutize(viewport_rect, font_metrics, root_font_metrics); length.has_value())
         return LengthStyleValue::create(length.release_value());
     return *this;
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
@@ -23,7 +23,7 @@ public:
     virtual bool has_length() const override { return true; }
     virtual ErrorOr<String> to_string() const override { return m_length.to_string(); }
     virtual Length to_length() const override { return m_length; }
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
 
     bool properties_equal(LengthStyleValue const& other) const { return m_length == other.m_length; }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.cpp
@@ -20,12 +20,12 @@ ErrorOr<String> ShadowStyleValue::to_string() const
     return builder.to_string();
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> ShadowStyleValue::absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const
+ValueComparingNonnullRefPtr<StyleValue const> ShadowStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
 {
-    auto absolutized_offset_x = m_properties.offset_x.absolutized(viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height);
-    auto absolutized_offset_y = m_properties.offset_y.absolutized(viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height);
-    auto absolutized_blur_radius = m_properties.blur_radius.absolutized(viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height);
-    auto absolutized_spread_distance = m_properties.spread_distance.absolutized(viewport_rect, font_metrics, font_size, root_font_size, line_height, root_line_height);
+    auto absolutized_offset_x = m_properties.offset_x.absolutized(viewport_rect, font_metrics, root_font_metrics);
+    auto absolutized_offset_y = m_properties.offset_y.absolutized(viewport_rect, font_metrics, root_font_metrics);
+    auto absolutized_blur_radius = m_properties.blur_radius.absolutized(viewport_rect, font_metrics, root_font_metrics);
+    auto absolutized_spread_distance = m_properties.spread_distance.absolutized(viewport_rect, font_metrics, root_font_metrics);
     return ShadowStyleValue::create(m_properties.color, absolutized_offset_x, absolutized_offset_y, absolutized_blur_radius, absolutized_spread_distance, m_properties.placement);
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.h
@@ -46,7 +46,7 @@ private:
     {
     }
 
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Gfx::FontPixelMetrics const& font_metrics, CSSPixels font_size, CSSPixels root_font_size, CSSPixels line_height, CSSPixels root_line_height) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
 
     struct Properties {
         Color color;


### PR DESCRIPTION
Did you think the existing set of length units was not enough? Are you bored of `ex` and `vw`? Do you crave dozens of arcane letter combinations to try and memorise the meanings of? Well do I have a treat for you!

This PR adds:
- rex
- cap
- rcap
- rch
- ic
- ric
- svw
- lvw
- dvw
- svh
- lvh
- dvh
- vi
- svi
- lvi
- dvi
- vb
- svb
- lvb
- dvb
- svmin
- lvmin
- dvmin
- svmax
- lvmax
- dvmax

Also, organise things based on whether a length is relative to the font, or the viewport. This lets us skip calculating measurements that we know we won't need. (This could be taken further at some point, but I don't know if it actually makes much of a performance difference. This is more about organisation.)