### PR TITLE
Chess: Display appropriate dialog when engine move ends the game

### DIFF
--- a/Userland/Games/Chess/ChessWidget.h
+++ b/Userland/Games/Chess/ChessWidget.h
@@ -111,10 +111,17 @@ public:
     };
 
 private:
+    enum class ClaimDrawBehavior {
+        Always,
+        Prompt
+    };
+
     ChessWidget() = default;
 
     virtual void config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value) override;
     virtual void config_bool_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, bool value) override;
+
+    bool check_game_over(ClaimDrawBehavior);
 
     Chess::Board m_board;
     Chess::Board m_board_playback;


### PR DESCRIPTION
A dialog is now displayed when an engine move results in a checkmate or a draw. In the case of threefold repetition or the fifty move rule, the engine will always accept a draw. A human player is asked if they would like to accept a draw.

Previously, a dialog was only displayed if a move by a human player ended the game.