### PR TITLE
LibChess+Chess: Ensure no pawns have moved when invoking 50 move rule

### DIFF
--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -674,7 +674,7 @@ bool ChessWidget::check_game_over(ClaimDrawBehavior claim_draw_behavior)
     case Chess::Board::Result::FiftyMoveRule:
         if (claim_draw_behavior == ClaimDrawBehavior::Prompt) {
             update();
-            auto dialog_result = GUI::MessageBox::show(window(), "50 moves have elapsed without a capture. Claim Draw?"sv, "Claim Draw?"sv,
+            auto dialog_result = GUI::MessageBox::show(window(), "50 moves have elapsed without a capture or pawn advance. Claim Draw?"sv, "Claim Draw?"sv,
                 GUI::MessageBox::Type::Information, GUI::MessageBox::InputType::YesNo);
 
             if (dialog_result != GUI::Dialog::ExecResult::Yes)

--- a/Userland/Libraries/LibChess/Chess.cpp
+++ b/Userland/Libraries/LibChess/Chess.cpp
@@ -774,9 +774,11 @@ Board::Result Board::game_result() const
     });
 
     if (are_legal_moves) {
-        if (m_moves_since_capture >= 75 * 2)
+        if (m_moves_since_capture >= 75 * 2 && m_moves_since_pawn_advance >= 75 * 2)
             return Result::SeventyFiveMoveRule;
-        if (m_moves_since_capture == 50 * 2)
+
+        if ((m_moves_since_capture >= 50 * 2 && m_moves_since_pawn_advance == 50 * 2)
+            || (m_moves_since_pawn_advance >= 50 * 2 && m_moves_since_capture == 50 * 2))
             return Result::FiftyMoveRule;
 
         auto repeats = m_previous_states.get(Traits<Board>::hash(*this));


### PR DESCRIPTION
The 50 and 75 move rules are no longer invoked if a pawn has advanced in the last 50 or 75 moves respectively.

This is consistent with the FIDE laws of chess: (https://handbook.fide.com/chapter/E012023):

> 9.3     The game is drawn, upon a correct claim by a player having the move, if:
> 9.3.1    he/she indicates his/her move, which cannot be changed, by writing it on the paper scoresheet or entering it on the electronic scoresheet and declares to the arbiter his/her intention to make this move which will result in the last 50 moves by each player having been made without the movement of any pawn and without any capture, or
> 9.3.2    the last 50 moves by each player have been completed without the movement of any pawn and without any capture.
> ...
> 9.6     If one or both of the following occur(s) then the game is drawn:
> 9.6.1    the same position has appeared, as in 9.2.2 at least five times.
> 9.6.2    any series of at least 75 moves have been made by each player without the movement of any pawn and without 
> 

Technically, the player should be able to claim a draw on any move between moves 50 and 75, but having a dialog box pop up at the end of every move is annoying.

Tested by changing the numbers 50 and 75 to something more manageable.