### PR TITLE
Chess: Don't attempt to update the board when clicking out of bounds

### DIFF
--- a/Userland/Games/Chess/ChessWidget.h
+++ b/Userland/Games/Chess/ChessWidget.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020-2022, the SerenityOS developers.
  * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -44,7 +45,7 @@ public:
     void set_piece_set(StringView set);
     DeprecatedString const& piece_set() const { return m_piece_set; };
 
-    Chess::Square mouse_to_square(GUI::MouseEvent& event) const;
+    Optional<Chess::Square> mouse_to_square(GUI::MouseEvent& event) const;
 
     bool drag_enabled() const { return m_drag_enabled; }
     void set_drag_enabled(bool e) { m_drag_enabled = e; }


### PR DESCRIPTION
Previously, clicking outside the bounds of the board when the window was resized, could cause a crash.

To reproduce the issue:
1. Maximize the window
2. Click in the black area in the bottom right of the window.
3. :fire: 