### PR TITLE
Ladybird: Let WebContent know if the current system theme is dark

### DIFF
--- a/Ladybird/ConsoleWidget.cpp
+++ b/Ladybird/ConsoleWidget.cpp
@@ -19,20 +19,9 @@
 #include <QTextEdit>
 #include <QVBoxLayout>
 
+bool is_using_dark_system_theme(QWidget&);
+
 namespace Ladybird {
-
-static bool is_using_dark_system_theme(QWidget& widget)
-{
-    // FIXME: Qt does not provide any method to query if the system is using a dark theme. We will have to implement
-    //        platform-specific methods if we wish to have better detection. For now, this inspects if Qt is using a
-    //        dark color for widget backgrounds using Rec. 709 luma coefficients.
-    //        https://en.wikipedia.org/wiki/Rec._709#Luma_coefficients
-
-    auto color = widget.palette().color(widget.backgroundRole());
-    auto luma = 0.2126f * color.redF() + 0.7152f * color.greenF() + 0.0722f * color.blueF();
-
-    return luma <= 0.5f;
-}
 
 ConsoleWidget::ConsoleWidget()
 {

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -53,6 +53,8 @@
 #include <QTimer>
 #include <QToolTip>
 
+bool is_using_dark_system_theme(QWidget&);
+
 WebContentView::WebContentView(StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling)
     : m_webdriver_content_ipc_path(webdriver_content_ipc_path)
 {
@@ -589,6 +591,8 @@ static Core::AnonymousBuffer make_system_theme_from_qt_palette(QWidget& widget, 
     translate(Gfx::ColorRole::ButtonText, QPalette::ColorRole::ButtonText);
     translate(Gfx::ColorRole::Selection, QPalette::ColorRole::Highlight);
     translate(Gfx::ColorRole::SelectionText, QPalette::ColorRole::HighlightedText);
+
+    palette.set_flag(Gfx::FlagRole::IsDark, is_using_dark_system_theme(widget));
 
     return theme;
 }

--- a/Ladybird/main.cpp
+++ b/Ladybird/main.cpp
@@ -113,3 +113,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     return event_loop.exec();
 }
+
+bool is_using_dark_system_theme(QWidget& widget)
+{
+    // FIXME: Qt does not provide any method to query if the system is using a dark theme. We will have to implement
+    //        platform-specific methods if we wish to have better detection. For now, this inspects if Qt is using a
+    //        dark color for widget backgrounds using Rec. 709 luma coefficients.
+    //        https://en.wikipedia.org/wiki/Rec._709#Luma_coefficients
+
+    auto color = widget.palette().color(widget.backgroundRole());
+    auto luma = 0.2126f * color.redF() + 0.7152f * color.greenF() + 0.0722f * color.blueF();
+
+    return luma <= 0.5f;
+}


### PR DESCRIPTION
This means we now actually respect @media (prefers-color-scheme: dark) by default when in dark mode. :^)