### PR TITLE
LibWeb: Resolve horizontal auto margins for images with display: block

### DIFF
--- a/Tests/LibWeb/Layout/expected/image-display-block-margin-auto.txt
+++ b/Tests/LibWeb/Layout/expected/image-display-block-margin-auto.txt
@@ -1,0 +1,4 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 children: not-inline
+    BlockContainer <body> at (8,8) content-size 400x100 children: not-inline
+      ImageBox <img> at (158,8) content-size 100x100 children: not-inline

--- a/Tests/LibWeb/Layout/input/image-display-block-margin-auto.html
+++ b/Tests/LibWeb/Layout/input/image-display-block-margin-auto.html
@@ -1,0 +1,11 @@
+<!doctype html><style>
+body {
+    width: 400px;
+}
+img {
+    margin: 0 auto;
+    display: block;
+    width: 100px;
+    height: 100px;
+}
+</style><img/>

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -210,6 +210,11 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     };
 
     auto input_width = [&] {
+        if (is<ReplacedBox>(box)) {
+            // NOTE: Replaced elements had their width calculated independently above.
+            //       We use that width as the input here to ensure that margins get resolved.
+            return CSS::Length::make_px(box_state.content_width());
+        }
         if (is<TableWrapper>(box))
             return CSS::Length::make_px(compute_width_for_table_wrapper(box, available_space));
         if (should_treat_width_as_auto(box, available_space))


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5954907/235318699-b2a0a193-8613-45c2-93d9-29ba83f1e3d9.png)

After:
![image](https://user-images.githubusercontent.com/5954907/235318701-50b370ba-5c53-44c4-8e0d-4f40310f62a0.png)