### PR TITLE
PixelPaint: Clip the gradient tool preview to the active layer rect

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
@@ -176,7 +176,8 @@ void GradientTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
 
     GUI::Painter painter(*m_editor);
     painter.add_clip_rect(event.rect());
-    draw_gradient(painter, true, m_editor->content_to_frame_position(layer->location()), m_editor->scale(), m_editor->content_rect());
+    auto gradient_clip_rect = m_editor->content_to_frame_rect(layer->relative_rect()).to_type<int>().intersected(m_editor->content_rect());
+    draw_gradient(painter, true, m_editor->content_to_frame_position(layer->location()), m_editor->scale(), gradient_clip_rect);
 }
 
 void GradientTool::on_primary_color_change(Color)


### PR DESCRIPTION
The gradient tool preview is no longer drawn outside of the active layer.

This makes it easier to see what the result will be when using two solid colors.

Before:

https://user-images.githubusercontent.com/2817754/235318512-efee6988-05d4-463b-bb0e-af79693d1643.mp4

After:

https://user-images.githubusercontent.com/2817754/235318520-278e941d-b348-4adf-9b9c-77a5589a6d0b.mp4