### PR TITLE
ICC: Add Profile::to_lab() 

### DIFF
--- a/Tests/LibGfx/TestICCProfile.cpp
+++ b/Tests/LibGfx/TestICCProfile.cpp
@@ -153,3 +153,53 @@ TEST_CASE(to_pcs)
     float f192 = sRGB_curve.evaluate(192 / 255.f);
     EXPECT_APPROXIMATE_VECTOR3(xyz_from_sRGB(64, 128, 192), r_xyz * f64 + g_xyz * f128 + b_xyz * f192);
 }
+
+TEST_CASE(to_lab)
+{
+    auto sRGB = MUST(Gfx::ICC::sRGB());
+    auto lab_from_sRGB = [sRGB](u8 r, u8 g, u8 b) {
+        u8 rgb[3] = { r, g, b };
+        return MUST(sRGB->to_lab(rgb));
+    };
+
+    // The `expected` numbers are from https://colorjs.io/notebook/ for this snippet of code:
+    //     new Color("srgb", [0, 0, 0]).lab.toString();
+    //
+    //     new Color("srgb", [1, 0, 0]).lab.toString();
+    //     new Color("srgb", [0, 1, 0]).lab.toString();
+    //     new Color("srgb", [0, 0, 1]).lab.toString();
+    //
+    //     new Color("srgb", [1, 1, 0]).lab.toString();
+    //     new Color("srgb", [1, 0, 1]).lab.toString();
+    //     new Color("srgb", [0, 1, 1]).lab.toString();
+    //
+    //     new Color("srgb", [1, 1, 1]).lab.toString();
+
+    Gfx::ICC::Profile::CIELAB expected[] = {
+        { 0, 0, 0 },
+        { 54.29054294696968, 80.80492033462421, 69.89098825896275 },
+        { 87.81853633115202, -79.27108223854806, 80.99459785152247 },
+        { 29.56829715344471, 68.28740665215547, -112.02971798617645 },
+        { 97.60701009682253, -15.749846639252663, 93.39361164266089 },
+        { 60.16894098715946, 93.53959546199253, -60.50080231921204 },
+        { 90.66601315791455, -50.65651077286893, -14.961666625736525 },
+        { 100.00000139649632, -0.000007807961277528364, 0.000006766250648659877 },
+    };
+
+    // We're off by more than the default EXPECT_APPROXIMATE() error, so use EXPECT_APPROXIMATE_WITH_ERROR().
+    // The difference is not too bad: ranges for L*, a*, b* are [0, 100], [-125, 125], [-125, 125],
+    // so this is an error of considerably less than 0.1 for u8 channels.
+#define EXPECT_APPROXIMATE_LAB(l1, l2)                   \
+    EXPECT_APPROXIMATE_WITH_ERROR((l1).L, (l2).L, 0.01); \
+    EXPECT_APPROXIMATE_WITH_ERROR((l1).a, (l2).a, 0.03); \
+    EXPECT_APPROXIMATE_WITH_ERROR((l1).b, (l2).b, 0.02);
+
+    EXPECT_APPROXIMATE_LAB(lab_from_sRGB(0, 0, 0), expected[0]);
+    EXPECT_APPROXIMATE_LAB(lab_from_sRGB(255, 0, 0), expected[1]);
+    EXPECT_APPROXIMATE_LAB(lab_from_sRGB(0, 255, 0), expected[2]);
+    EXPECT_APPROXIMATE_LAB(lab_from_sRGB(0, 0, 255), expected[3]);
+    EXPECT_APPROXIMATE_LAB(lab_from_sRGB(255, 255, 0), expected[4]);
+    EXPECT_APPROXIMATE_LAB(lab_from_sRGB(255, 0, 255), expected[5]);
+    EXPECT_APPROXIMATE_LAB(lab_from_sRGB(0, 255, 255), expected[6]);
+    EXPECT_APPROXIMATE_LAB(lab_from_sRGB(255, 255, 255), expected[7]);
+}

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -266,6 +266,13 @@ public:
     // Call connection_space() to find out the space the result is in.
     ErrorOr<FloatVector3> to_pcs(ReadonlyBytes);
 
+    struct CIELAB {
+        float L; // L*
+        float a; // a*
+        float b; // b*
+    };
+    ErrorOr<CIELAB> to_lab(ReadonlyBytes);
+
     // Only call these if you know that this is an RGB matrix-based profile.
     XYZ const& red_matrix_column() const;
     XYZ const& green_matrix_column() const;

--- a/Userland/Libraries/LibTest/Macros.h
+++ b/Userland/Libraries/LibTest/Macros.h
@@ -98,18 +98,20 @@ void current_test_case_did_fail();
         }                                                                                            \
     } while (false)
 
-#define EXPECT_APPROXIMATE(a, b)                                                                                \
+#define EXPECT_APPROXIMATE_WITH_ERROR(a, b, err)                                                                \
     do {                                                                                                        \
         auto expect_close_lhs = a;                                                                              \
         auto expect_close_rhs = b;                                                                              \
         auto expect_close_diff = static_cast<double>(expect_close_lhs) - static_cast<double>(expect_close_rhs); \
-        if (AK::fabs(expect_close_diff) > 0.0000005) {                                                          \
+        if (AK::fabs(expect_close_diff) > (err)) {                                                              \
             ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_APPROXIMATE({}, {})"                             \
                          " failed with lhs={}, rhs={}, (lhs-rhs)={}",                                           \
                 __FILE__, __LINE__, #a, #b, expect_close_lhs, expect_close_rhs, expect_close_diff);             \
             ::Test::current_test_case_did_fail();                                                               \
         }                                                                                                       \
     } while (false)
+
+#define EXPECT_APPROXIMATE(a, b) EXPECT_APPROXIMATE_WITH_ERROR(a, b, 0.0000005)
 
 #define FAIL(message)                                                                  \
     do {                                                                               \


### PR DESCRIPTION
This can be used to convert a profile-dependent color to the L*a*b*
color space.

(I'd like to use this to implement the DeltaE (CIE 2000) algorithm,
which is a metric for how similar two colors are perceived.
(And I'd like to use that to evaluate color conversion roundtrip
quality, once I've implemented full conversions.)