### PR TITLE
Kernel: Add MSIx interrupt mechanism for PCI devices

### DIFF
--- a/Documentation/BareMetalInstallation.md
+++ b/Documentation/BareMetalInstallation.md
@@ -8,7 +8,7 @@ Whilst it is possible to run Serenity on physical x86-compatible hardware, it is
 ## Hardware support and requirements
 
 Storage-wise Serenity requires a >= 2 GB parallel ATA or SATA disk for IDE/AHCI. Some older SATA chipsets already operate in IDE mode whilst some newer ones will depend upon adjusting a BIOS option to run your SATA controller in IDE (sometimes referred to as Legacy or PATA) mode. SATA AHCI is supported, but may not work on every controller due to bugs in the implementation.
-NVMe drives are supported but it is recommended to use `nvme_poll` boot parameter in newer hardwares as we lack MSI(X) support at the moment. SCSI, SAS and eMMC HBAs are all presently unsupported.
+NVMe drives are supported but it is recommended to use `nvme_poll` boot parameter in newer hardwares at the moment. SCSI, SAS and eMMC HBAs are all presently unsupported.
 
 You must be willing to wipe your disk's contents to allow for writing the Serenity image so be sure to back up any important data on your disk first! Serenity uses the GRUB2 bootloader so it should be possible to multiboot it with any other OS that can be booted from GRUB2 post-installation.
 

--- a/Kernel/Arch/Interrupts.h
+++ b/Kernel/Arch/Interrupts.h
@@ -20,6 +20,7 @@ class GenericInterruptHandler;
 GenericInterruptHandler& get_interrupt_handler(u8 interrupt_number);
 void register_generic_interrupt_handler(u8 number, GenericInterruptHandler&);
 void unregister_generic_interrupt_handler(u8 number, GenericInterruptHandler&);
+ErrorOr<u8> reserve_interrupt_handlers(u8 number_of_irqs);
 
 void initialize_interrupts();
 

--- a/Kernel/Arch/PCIMSI.h
+++ b/Kernel/Arch/PCIMSI.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023, Pankaj R <dev@pankajraghav.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Kernel {
+#if ARCH(X86_64)
+u64 msi_address_register(u8 destination_id, bool redirection_hint, bool destination_mode);
+u32 msi_data_register(u8 vector, bool level_trigger, bool assert);
+u32 msix_vector_control_register(u32 vector_control, bool mask);
+void msi_signal_eoi();
+#elif ARCH(AARCH64)
+[[maybe_unused]] static u64 msi_address_register([[maybe_unused]] u8 destination_id, [[maybe_unused]] bool redirection_hint, [[maybe_unused]] bool destination_mode)
+{
+    TODO_AARCH64();
+    return 0;
+}
+
+[[maybe_unused]] static u32 msi_data_register([[maybe_unused]] u8 vector, [[maybe_unused]] bool level_trigger, [[maybe_unused]] bool assert)
+{
+    TODO_AARCH64();
+    return 0;
+}
+
+[[maybe_unused]] static u32 msix_vector_control_register([[maybe_unused]] u32 vector_control, [[maybe_unused]] bool mask)
+{
+    TODO_AARCH64();
+    return 0;
+}
+
+[[maybe_unused]] static void msi_signal_eoi()
+{
+    TODO_AARCH64();
+    return;
+}
+#endif
+}

--- a/Kernel/Arch/aarch64/Interrupts.cpp
+++ b/Kernel/Arch/aarch64/Interrupts.cpp
@@ -220,4 +220,12 @@ void initialize_interrupts()
     }
 }
 
+// Sets the reserved flag on `number_of_irqs` if it finds unused interrupt handler on
+// a contiguous range.
+ErrorOr<u8> reserve_interrupt_handlers([[maybe_unused]] u8 number_of_irqs)
+{
+    TODO();
+    return Error::from_errno(EINVAL);
+}
+
 }

--- a/Kernel/Arch/x86_64/Interrupts.cpp
+++ b/Kernel/Arch/x86_64/Interrupts.cpp
@@ -44,6 +44,8 @@ namespace Kernel {
 READONLY_AFTER_INIT static DescriptorTablePointer s_idtr;
 READONLY_AFTER_INIT static IDTEntry s_idt[256];
 
+// This spinlock is used to reserve IRQs that can be later used by interrupt mechanism such as MSIx
+static Spinlock<LockRank::None> s_interrupt_handler_lock {};
 static GenericInterruptHandler* s_interrupt_handler[GENERIC_INTERRUPT_HANDLERS_COUNT];
 static GenericInterruptHandler* s_disabled_interrupt_handler[2];
 
@@ -332,6 +334,53 @@ static void revert_to_unused_handler(u8 interrupt_number)
 {
     auto handler = new UnhandledInterruptHandler(interrupt_number);
     handler->register_interrupt_handler();
+}
+
+static bool is_unused_handler(GenericInterruptHandler* handler_slot)
+{
+    return (handler_slot->type() == HandlerType::UnhandledInterruptHandler) && !handler_slot->reserved();
+}
+
+// Sets the reserved flag on `number_of_irqs` if it finds unused interrupt handler on
+// a contiguous range.
+ErrorOr<u8> reserve_interrupt_handlers(u8 number_of_irqs)
+{
+    bool found_range = false;
+    u8 first_irq = 0;
+    SpinlockLocker locker(s_interrupt_handler_lock);
+    for (int start_irq = 0; start_irq < GENERIC_INTERRUPT_HANDLERS_COUNT; start_irq++) {
+        auto*& handler_slot = s_interrupt_handler[start_irq];
+        VERIFY(handler_slot != nullptr);
+
+        if (!is_unused_handler(handler_slot))
+            continue;
+
+        found_range = true;
+        for (auto off = 1; off < number_of_irqs; off++) {
+            auto*& handler = s_interrupt_handler[start_irq + off];
+            VERIFY(handler_slot != nullptr);
+
+            if (!is_unused_handler(handler)) {
+                found_range = false;
+                break;
+            }
+        }
+
+        if (found_range == true) {
+            first_irq = start_irq;
+            break;
+        }
+    }
+
+    if (!found_range)
+        return Error::from_errno(EAGAIN);
+
+    for (auto irq = first_irq; irq < number_of_irqs; irq++) {
+        auto*& handler_slot = s_interrupt_handler[irq];
+        handler_slot->set_reserved();
+    }
+
+    return first_irq;
 }
 
 void register_disabled_interrupt_handler(u8 number, GenericInterruptHandler& handler)

--- a/Kernel/Arch/x86_64/PCI/MSI.cpp
+++ b/Kernel/Arch/x86_64/PCI/MSI.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, Pankaj R <dev@pankajraghav.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/Interrupts.h>
+#include <Kernel/Arch/PCIMSI.h>
+#include <Kernel/Arch/x86_64/Interrupts/APIC.h>
+#include <Kernel/Arch/x86_64/PCI/MSI.h>
+#include <Kernel/InterruptDisabler.h>
+
+namespace Kernel {
+u64 msi_address_register(u8 destination_id, bool redirection_hint, bool destination_mode)
+{
+    u64 flags = 0;
+    if (redirection_hint) {
+        flags |= msi_redirection_hint;
+        if (destination_mode)
+            flags |= msi_destination_mode_logical;
+    }
+    return (msi_address_base | (destination_id << msi_destination_shift) | flags);
+}
+
+u32 msi_data_register(u8 vector, bool level_trigger, bool assert)
+{
+    u32 flags = 0;
+
+    if (level_trigger) {
+        flags |= msi_trigger_mode_level;
+        if (assert)
+            flags |= msi_level_assert;
+    }
+    return ((vector + IRQ_VECTOR_BASE) & msi_data_vector_mask) | flags;
+}
+
+u32 msix_vector_control_register(u32 vector_control, bool mask)
+{
+    if (!mask)
+        return (vector_control & msi_vector_control_unmask);
+    return (vector_control | msi_vector_control_mask);
+}
+
+void msi_signal_eoi()
+{
+    InterruptDisabler disabler;
+    APIC::the().eoi();
+}
+
+}

--- a/Kernel/Arch/x86_64/PCI/MSI.h
+++ b/Kernel/Arch/x86_64/PCI/MSI.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023, Pankaj R <dev@pankajraghav.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+// Address register
+static constexpr u32 msi_address_base = 0xfee00000;
+static constexpr u8 msi_destination_shift = 12;
+static constexpr u32 msi_redirection_hint = 0x00000008;
+static constexpr u32 msi_destination_mode_logical = 0x00000004;
+
+// Data register
+static constexpr u8 msi_data_vector_mask = 0xff;
+static constexpr u32 msi_trigger_mode_level = 0x00008000;
+static constexpr u32 msi_level_assert = 0x00004000;
+
+// Vector control
+static constexpr u32 msi_vector_control_mask = 0x1;
+static constexpr u32 msi_vector_control_unmask = ~(0x1);

--- a/Kernel/Bus/PCI/API.cpp
+++ b/Kernel/Bus/PCI/API.cpp
@@ -285,6 +285,27 @@ u32 Capability::read32(size_t offset) const
     return read32_offsetted(identifier, m_ptr + offset);
 }
 
+void Capability::write8(size_t offset, u8 value) const
+{
+    auto& identifier = get_device_identifier(m_address);
+    SpinlockLocker locker(identifier.operation_lock());
+    write8_offsetted(identifier, m_ptr + offset, value);
+}
+
+void Capability::write16(size_t offset, u16 value) const
+{
+    auto& identifier = get_device_identifier(m_address);
+    SpinlockLocker locker(identifier.operation_lock());
+    write16_offsetted(identifier, m_ptr + offset, value);
+}
+
+void Capability::write32(size_t offset, u32 value) const
+{
+    auto& identifier = get_device_identifier(m_address);
+    SpinlockLocker locker(identifier.operation_lock());
+    write32_offsetted(identifier, m_ptr + offset, value);
+}
+
 DeviceIdentifier const& get_device_identifier(Address address)
 {
     return Access::the().get_device_identifier(address);

--- a/Kernel/Bus/PCI/Definitions.h
+++ b/Kernel/Bus/PCI/Definitions.h
@@ -79,6 +79,9 @@ static constexpr size_t mmio_device_space_size = 4096;
 static constexpr u16 none_value = 0xffff;
 static constexpr size_t memory_range_per_bus = mmio_device_space_size * to_underlying(Limits::MaxFunctionsPerDevice) * to_underlying(Limits::MaxDevicesPerBus);
 static constexpr u32 bar_address_mask = 0xfffffff0;
+static constexpr u16 msix_control_table_mask = 0x07ff;
+static constexpr u8 msix_table_bir_mask = 0x7;
+static constexpr u16 msix_table_offset_mask = 0xfff8;
 
 // Taken from https://pcisig.com/sites/default/files/files/PCI_Code-ID_r_1_11__v24_Jan_2019.pdf
 enum class ClassID {
@@ -319,6 +322,22 @@ protected:
     Vector<Capability> m_capabilities;
 };
 
+class MSIxInfo {
+public:
+    MSIxInfo(u16 table_size, u8 table_bar, u32 table_offset)
+        : table_size(table_size)
+        , table_bar(table_bar)
+        , table_offset(table_offset)
+    {
+    }
+
+    MSIxInfo() = default;
+
+    u16 table_size {};
+    u8 table_bar {};
+    u32 table_offset {};
+};
+
 class DeviceIdentifier
     : public RefCounted<DeviceIdentifier>
     , public EnumerableDeviceIdentifier {
@@ -326,6 +345,11 @@ class DeviceIdentifier
 
 public:
     static ErrorOr<NonnullRefPtr<DeviceIdentifier>> from_enumerable_identifier(EnumerableDeviceIdentifier const& other_identifier);
+
+    void initialize();
+    bool is_msix_capable() const { return m_msix_info.table_size > 0; }
+    u8 get_msix_table_bar() const { return m_msix_info.table_bar; }
+    u32 get_msix_table_offset() const { return m_msix_info.table_offset; }
 
     Spinlock<LockRank::None>& operation_lock() { return m_operation_lock; }
     Spinlock<LockRank::None>& operation_lock() const { return m_operation_lock; }
@@ -349,6 +373,7 @@ private:
     }
 
     mutable Spinlock<LockRank::None> m_operation_lock;
+    MSIxInfo m_msix_info {};
 };
 
 class Domain;

--- a/Kernel/Bus/PCI/Definitions.h
+++ b/Kernel/Bus/PCI/Definitions.h
@@ -82,6 +82,8 @@ static constexpr u32 bar_address_mask = 0xfffffff0;
 static constexpr u16 msix_control_table_mask = 0x07ff;
 static constexpr u8 msix_table_bir_mask = 0x7;
 static constexpr u16 msix_table_offset_mask = 0xfff8;
+static constexpr u8 msi_control_offset = 2;
+static constexpr u16 msix_control_enable = 0x8000;
 
 // Taken from https://pcisig.com/sites/default/files/files/PCI_Code-ID_r_1_11__v24_Jan_2019.pdf
 enum class ClassID {

--- a/Kernel/Bus/PCI/Definitions.h
+++ b/Kernel/Bus/PCI/Definitions.h
@@ -238,6 +238,9 @@ public:
     u8 read8(size_t offset) const;
     u16 read16(size_t offset) const;
     u32 read32(size_t offset) const;
+    void write8(size_t offset, u8 value) const;
+    void write16(size_t offset, u16 value) const;
+    void write32(size_t offset, u32 value) const;
 
 private:
     const Address m_address;

--- a/Kernel/Bus/PCI/Device.cpp
+++ b/Kernel/Bus/PCI/Device.cpp
@@ -13,6 +13,7 @@ namespace Kernel::PCI {
 Device::Device(DeviceIdentifier const& pci_identifier)
     : m_pci_identifier(pci_identifier)
 {
+    m_pci_identifier->initialize();
 }
 
 bool Device::is_msi_capable() const

--- a/Kernel/Bus/PCI/Device.cpp
+++ b/Kernel/Bus/PCI/Device.cpp
@@ -44,13 +44,21 @@ void Device::disable_message_signalled_interrupts()
 {
     TODO();
 }
+
 void Device::enable_extended_message_signalled_interrupts()
 {
-    TODO();
+    for (auto& capability : m_pci_identifier->capabilities()) {
+        if (capability.id().value() == PCI::Capabilities::ID::MSIX)
+            capability.write16(msi_control_offset, capability.read16(msi_control_offset) | msix_control_enable);
+    }
 }
+
 void Device::disable_extended_message_signalled_interrupts()
 {
-    TODO();
+    for (auto& capability : m_pci_identifier->capabilities()) {
+        if (capability.id().value() == PCI::Capabilities::ID::MSIX)
+            capability.write16(msi_control_offset, capability.read16(msi_control_offset) & ~(msix_control_enable));
+    }
 }
 
 }

--- a/Kernel/Bus/PCI/Device.cpp
+++ b/Kernel/Bus/PCI/Device.cpp
@@ -5,8 +5,11 @@
  */
 
 #include <AK/AnyOf.h>
+#include <Kernel/Arch/Interrupts.h>
+#include <Kernel/Arch/PCIMSI.h>
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Device.h>
+#include <Kernel/Memory/TypedMapping.h>
 
 namespace Kernel::PCI {
 
@@ -14,6 +17,8 @@ Device::Device(DeviceIdentifier const& pci_identifier)
     : m_pci_identifier(pci_identifier)
 {
     m_pci_identifier->initialize();
+    m_interrupt_range.m_start_irq = m_pci_identifier->interrupt_line().value();
+    m_interrupt_range.m_irq_count = 1;
 }
 
 bool Device::is_msi_capable() const
@@ -58,6 +63,110 @@ void Device::disable_extended_message_signalled_interrupts()
     for (auto& capability : m_pci_identifier->capabilities()) {
         if (capability.id().value() == PCI::Capabilities::ID::MSIX)
             capability.write16(msi_control_offset, capability.read16(msi_control_offset) & ~(msix_control_enable));
+    }
+}
+
+PCI::InterruptType Device::get_interrupt_type()
+{
+    return m_interrupt_range.m_type;
+}
+
+// Reserve `numbers_of_irqs` for this device. Returns the interrupt type
+// that was reserved. It is a noop for pin based interrupts as there
+// is nothing left to do. The second parameter `msi` is used by the
+// driver to indicate its intent to use message signalled interrupts.
+// MSI(x) is preferred over MSI if the device supports both.
+ErrorOr<InterruptType> Device::reserve_irqs(u8 number_of_irqs, bool msi)
+{
+    // Let us not allow partial allocation of IRQs for MSIx.
+    if (msi && is_msix_capable()) {
+        m_interrupt_range.m_start_irq = TRY(reserve_interrupt_handlers(number_of_irqs));
+        m_interrupt_range.m_irq_count = number_of_irqs;
+        m_interrupt_range.m_type = InterruptType::MSIX;
+        // If MSIx is available, disable the pin based interrupts
+        disable_pin_based_interrupts();
+        enable_extended_message_signalled_interrupts();
+    } else if (msi && is_msi_capable()) {
+        TODO();
+    }
+    return m_interrupt_range.m_type;
+}
+
+PhysicalAddress Device::msix_table_entry_address(u8 irq)
+{
+    auto index = static_cast<int>(irq) - m_interrupt_range.m_start_irq;
+
+    VERIFY(index < m_interrupt_range.m_irq_count);
+    VERIFY(index >= 0);
+    auto table_bar_ptr = PCI::get_BAR(device_identifier(), static_cast<PCI::HeaderType0BaseRegister>(m_pci_identifier->get_msix_table_bar())) & PCI::bar_address_mask;
+    auto table_offset = m_pci_identifier->get_msix_table_offset();
+
+    return PhysicalAddress(table_bar_ptr + table_offset + (index * 16));
+}
+
+// This function is used to allocate an irq at an index and returns
+// the actual IRQ that was programmed at that index. This function is
+// mainly useful for MSI/MSIx based interrupt mechanism where the driver
+// needs to program. If the PCI device doesn't support MSIx interrupts, then
+// this function will just return the irq used for pin based interrupt.
+ErrorOr<u8> Device::allocate_irq(u8 index)
+{
+    if (Checked<u8>::addition_would_overflow(m_interrupt_range.m_start_irq, index))
+        return Error::from_errno(EINVAL);
+
+    if ((m_interrupt_range.m_type == InterruptType::MSIX) && is_msix_capable()) {
+        auto entry_ptr = TRY(Memory::map_typed_writable<MSIxTableEntry volatile>(msix_table_entry_address(index + m_interrupt_range.m_start_irq)));
+        entry_ptr->data = msi_data_register(m_interrupt_range.m_start_irq + index, false, false);
+        // TODO: we map all the IRQs to cpu 0 by default. We could attach
+        //  cpu affinity in the future where specific LAPIC id could be used.
+        u64 addr = msi_address_register(0, false, false);
+        entry_ptr->address_low = addr & 0xffffffff;
+        entry_ptr->address_high = addr >> 32;
+
+        u32 vector_ctrl = msix_vector_control_register(entry_ptr->vector_control, true);
+        entry_ptr->vector_control = vector_ctrl;
+
+        return m_interrupt_range.m_start_irq + index;
+    } else if ((m_interrupt_range.m_type == InterruptType::MSI) && is_msi_capable()) {
+        TODO();
+    }
+    // For pin based interrupts, we share the IRQ.
+    return m_interrupt_range.m_start_irq;
+}
+
+void Device::enable_interrupt(u8 irq)
+{
+    if ((m_interrupt_range.m_type == InterruptType::MSIX) && is_msix_capable()) {
+        auto entry = Memory::map_typed_writable<MSIxTableEntry volatile>(PhysicalAddress(msix_table_entry_address(irq)));
+
+        if (entry.is_error()) {
+            dmesgln_pci(*this, "Unable to map the MSIx table area");
+            return;
+        }
+
+        auto entry_ptr = entry.release_value();
+        u32 vector_ctrl = msix_vector_control_register(entry_ptr->vector_control, false);
+        entry_ptr->vector_control = vector_ctrl;
+    } else if ((m_interrupt_range.m_type == InterruptType::MSI) && is_msi_capable()) {
+        TODO();
+    }
+}
+
+void Device::disable_interrupt(u8 irq)
+{
+    if ((m_interrupt_range.m_type == InterruptType::MSIX) && is_msix_capable()) {
+        auto entry = Memory::map_typed_writable<MSIxTableEntry volatile>(PhysicalAddress(msix_table_entry_address(irq)));
+
+        if (entry.is_error()) {
+            dmesgln_pci(*this, "Unable to map the MSIx table area");
+            return;
+        }
+
+        auto entry_ptr = entry.release_value();
+        u32 vector_ctrl = msix_vector_control_register(entry_ptr->vector_control, true);
+        entry_ptr->vector_control = vector_ctrl;
+    } else if ((m_interrupt_range.m_type == InterruptType::MSI) && is_msi_capable()) {
+        TODO();
     }
 }
 

--- a/Kernel/Bus/PCI/Device.cpp
+++ b/Kernel/Bus/PCI/Device.cpp
@@ -24,9 +24,7 @@ bool Device::is_msi_capable() const
 }
 bool Device::is_msix_capable() const
 {
-    return AK::any_of(
-        m_pci_identifier->capabilities(),
-        [](auto const& capability) { return capability.id().value() == PCI::Capabilities::ID::MSIX; });
+    return m_pci_identifier->is_msix_capable();
 }
 
 void Device::enable_pin_based_interrupts() const

--- a/Kernel/Bus/PCI/Device.h
+++ b/Kernel/Bus/PCI/Device.h
@@ -38,7 +38,7 @@ protected:
     explicit Device(DeviceIdentifier const& pci_identifier);
 
 private:
-    NonnullRefPtr<DeviceIdentifier const> const m_pci_identifier;
+    NonnullRefPtr<DeviceIdentifier> const m_pci_identifier;
 };
 
 template<typename... Parameters>

--- a/Kernel/Bus/PCI/DeviceIdentifier.cpp
+++ b/Kernel/Bus/PCI/DeviceIdentifier.cpp
@@ -17,4 +17,16 @@ ErrorOr<NonnullRefPtr<DeviceIdentifier>> DeviceIdentifier::from_enumerable_ident
     return adopt_nonnull_ref_or_enomem(new (nothrow) DeviceIdentifier(other_identifier));
 }
 
+void DeviceIdentifier::initialize()
+{
+    for (auto cap : capabilities()) {
+        if (cap.id() == PCI::Capabilities::ID::MSIX) {
+            auto msix_bir_bar = (cap.read8(4) & msix_table_bir_mask);
+            auto msix_bir_offset = (cap.read32(4) & msix_table_offset_mask);
+            auto msix_count = (cap.read16(2) & msix_control_table_mask) + 1;
+            m_msix_info = MSIxInfo(msix_count, msix_bir_bar, msix_bir_offset);
+        }
+    }
+}
+
 }

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -393,6 +393,7 @@ if ("${SERENITY_ARCH}" STREQUAL "x86_64")
         Arch/x86_64/PCI/Controller/HostBridge.cpp
         Arch/x86_64/PCI/IDELegacyModeController.cpp
         Arch/x86_64/PCI/Initializer.cpp
+        Arch/x86_64/PCI/MSI.cpp
 
         Arch/x86_64/VGA/IOArbiter.cpp
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -220,6 +220,7 @@ set(KERNEL_SOURCES
     FutexQueue.cpp
     Interrupts/GenericInterruptHandler.cpp
     Interrupts/IRQHandler.cpp
+    Interrupts/PCIIRQHandler.cpp
     Interrupts/SharedIRQHandler.cpp
     Interrupts/UnhandledInterruptHandler.cpp
     KBufferBuilder.cpp

--- a/Kernel/Interrupts/GenericInterruptHandler.h
+++ b/Kernel/Interrupts/GenericInterruptHandler.h
@@ -48,6 +48,8 @@ public:
 
     virtual bool eoi() = 0;
     void increment_call_count();
+    void set_reserved() { m_reserved = true; };
+    bool reserved() const { return m_reserved; };
 
 protected:
     void change_interrupt_number(u8 number);
@@ -61,6 +63,7 @@ private:
     u8 m_interrupt_number { 0 };
     bool m_disable_remap { false };
     bool m_registered { false };
+    bool m_reserved { false };
 
     IntrusiveListNode<GenericInterruptHandler> m_list_node;
 

--- a/Kernel/Interrupts/PCIIRQHandler.cpp
+++ b/Kernel/Interrupts/PCIIRQHandler.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, Pankaj R <dev@pankajraghav.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/InterruptManagement.h>
+#include <Kernel/Arch/PCIMSI.h>
+#include <Kernel/Debug.h>
+#include <Kernel/Interrupts/PCIIRQHandler.h>
+
+namespace Kernel {
+
+PCIIRQHandler::PCIIRQHandler(PCI::Device& device, u8 irq)
+    : GenericInterruptHandler(irq)
+    , device(device)
+{
+    auto type = device.get_interrupt_type();
+
+    if (type == PCI::InterruptType::PIN)
+        m_responsible_irq_controller = InterruptManagement::the().get_responsible_irq_controller(irq);
+
+    if (is_registered())
+        disable_irq();
+}
+
+bool PCIIRQHandler::eoi()
+{
+    dbgln_if(IRQ_DEBUG, "EOI IRQ {}", interrupt_number());
+    if (m_shared_with_others)
+        return false;
+    if (!m_responsible_irq_controller.is_null())
+        m_responsible_irq_controller->eoi(*this);
+    else
+        msi_signal_eoi();
+    return true;
+}
+
+void PCIIRQHandler::enable_irq()
+{
+    dbgln_if(IRQ_DEBUG, "Enable IRQ {}", interrupt_number());
+    if (!is_registered())
+        register_interrupt_handler();
+    m_enabled = true;
+    if (m_shared_with_others)
+        return;
+    if (!m_responsible_irq_controller.is_null())
+        m_responsible_irq_controller->enable(*this);
+    else
+        device.enable_interrupt(interrupt_number());
+}
+
+void PCIIRQHandler::disable_irq()
+{
+    dbgln_if(IRQ_DEBUG, "Disable IRQ {}", interrupt_number());
+    m_enabled = false;
+
+    if (m_shared_with_others)
+        return;
+    if (!m_responsible_irq_controller.is_null())
+        m_responsible_irq_controller->disable(*this);
+    else
+        device.disable_interrupt(interrupt_number());
+}
+
+}

--- a/Kernel/Interrupts/PCIIRQHandler.h
+++ b/Kernel/Interrupts/PCIIRQHandler.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, Pankaj R <dev@pankajraghav.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <Kernel/Arch/IRQController.h>
+#include <Kernel/Bus/PCI/Device.h>
+#include <Kernel/Interrupts/GenericInterruptHandler.h>
+#include <Kernel/Library/LockRefPtr.h>
+
+namespace Kernel {
+
+class PCIIRQHandler : public GenericInterruptHandler {
+public:
+    virtual ~PCIIRQHandler() = default;
+
+    virtual bool handle_interrupt(RegisterState const& regs) override { return handle_irq(regs); }
+    virtual bool handle_irq(RegisterState const&) = 0;
+
+    void enable_irq();
+    void disable_irq();
+
+    virtual bool eoi() override;
+
+    virtual HandlerType type() const override { return HandlerType::IRQHandler; }
+    virtual StringView purpose() const override { return "IRQ Handler"sv; }
+    virtual StringView controller() const override { return m_responsible_irq_controller.is_null() ? "PCI-MSI"sv : m_responsible_irq_controller->model(); }
+
+    virtual size_t sharing_devices_count() const override { return 0; }
+    virtual bool is_shared_handler() const override { return false; }
+    void set_shared_with_others(bool status) { m_shared_with_others = status; }
+
+protected:
+    PCIIRQHandler(PCI::Device& device, u8 irq);
+
+private:
+    bool m_shared_with_others { false };
+    bool m_enabled { false };
+    LockRefPtr<IRQController> m_responsible_irq_controller { nullptr };
+    PCI::Device& device;
+};
+
+}

--- a/Kernel/Storage/NVMe/NVMeController.cpp
+++ b/Kernel/Storage/NVMe/NVMeController.cpp
@@ -287,7 +287,7 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::create_admin_queue(QueueType queu
         return maybe_error;
     }
     set_admin_queue_ready_flag();
-    m_admin_queue = TRY(NVMeQueue::try_create(0, device_identifier().interrupt_line().value(), qdepth, move(cq_dma_region), cq_dma_pages, move(sq_dma_region), sq_dma_pages, move(doorbell_regs), queue_type));
+    m_admin_queue = TRY(NVMeQueue::try_create(*this, 0, device_identifier().interrupt_line().value(), qdepth, move(cq_dma_region), cq_dma_pages, move(sq_dma_region), sq_dma_pages, move(doorbell_regs), queue_type));
 
     dbgln_if(NVME_DEBUG, "NVMe: Admin queue created");
     return {};
@@ -347,7 +347,7 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::create_io_queue(u8 qid, QueueType
     auto queue_doorbell_offset = REG_SQ0TDBL_START + ((2 * qid) * (4 << m_dbl_stride));
     auto doorbell_regs = TRY(Memory::map_typed_writable<DoorbellRegister volatile>(PhysicalAddress(m_bar + queue_doorbell_offset)));
 
-    m_queues.append(TRY(NVMeQueue::try_create(qid, device_identifier().interrupt_line().value(), IO_QUEUE_SIZE, move(cq_dma_region), cq_dma_pages, move(sq_dma_region), sq_dma_pages, move(doorbell_regs), queue_type)));
+    m_queues.append(TRY(NVMeQueue::try_create(*this, qid, device_identifier().interrupt_line().value(), IO_QUEUE_SIZE, move(cq_dma_region), cq_dma_pages, move(sq_dma_region), sq_dma_pages, move(doorbell_regs), queue_type)));
     dbgln_if(NVME_DEBUG, "NVMe: Created IO Queue with QID{}", m_queues.size());
     return {};
 }

--- a/Kernel/Storage/NVMe/NVMeController.h
+++ b/Kernel/Storage/NVMe/NVMeController.h
@@ -77,6 +77,7 @@ private:
     AK::Time m_ready_timeout;
     u32 m_bar { 0 };
     u8 m_dbl_stride { 0 };
+    PCI::InterruptType m_irq_type;
     QueueType m_queue_type { QueueType::IRQ };
     static Atomic<u8> s_controller_id;
 };

--- a/Kernel/Storage/NVMe/NVMeController.h
+++ b/Kernel/Storage/NVMe/NVMeController.h
@@ -59,8 +59,8 @@ private:
 
     ErrorOr<void> identify_and_init_namespaces();
     Tuple<u64, u8> get_ns_features(IdentifyNamespace& identify_data_struct);
-    ErrorOr<void> create_admin_queue(Optional<u8> irq);
-    ErrorOr<void> create_io_queue(u8 qid, Optional<u8> irq);
+    ErrorOr<void> create_admin_queue(QueueType queue_type);
+    ErrorOr<void> create_io_queue(u8 qid, QueueType queue_type);
     void calculate_doorbell_stride()
     {
         m_dbl_stride = (m_controller_regs->cap >> CAP_DBL_SHIFT) & CAP_DBL_MASK;
@@ -77,6 +77,7 @@ private:
     AK::Time m_ready_timeout;
     u32 m_bar { 0 };
     u8 m_dbl_stride { 0 };
+    QueueType m_queue_type { QueueType::IRQ };
     static Atomic<u8> s_controller_id;
 };
 }

--- a/Kernel/Storage/NVMe/NVMeInterruptQueue.cpp
+++ b/Kernel/Storage/NVMe/NVMeInterruptQueue.cpp
@@ -11,7 +11,7 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NVMeInterruptQueue::NVMeInterruptQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_page, Memory::TypedMapping<DoorbellRegister volatile> db_regs)
+UNMAP_AFTER_INIT NVMeInterruptQueue::NVMeInterruptQueue([[maybe_unused]] PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_page, Memory::TypedMapping<DoorbellRegister volatile> db_regs)
     : NVMeQueue(move(rw_dma_region), rw_dma_page, qid, q_depth, move(cq_dma_region), cq_dma_page, move(sq_dma_region), sq_dma_page, move(db_regs))
     , IRQHandler(irq)
 {

--- a/Kernel/Storage/NVMe/NVMeInterruptQueue.cpp
+++ b/Kernel/Storage/NVMe/NVMeInterruptQueue.cpp
@@ -11,9 +11,9 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NVMeInterruptQueue::NVMeInterruptQueue([[maybe_unused]] PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_page, Memory::TypedMapping<DoorbellRegister volatile> db_regs)
+UNMAP_AFTER_INIT NVMeInterruptQueue::NVMeInterruptQueue(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_page, Memory::TypedMapping<DoorbellRegister volatile> db_regs)
     : NVMeQueue(move(rw_dma_region), rw_dma_page, qid, q_depth, move(cq_dma_region), cq_dma_page, move(sq_dma_region), sq_dma_page, move(db_regs))
-    , IRQHandler(irq)
+    , PCIIRQHandler(device, irq)
 {
     enable_irq();
 }

--- a/Kernel/Storage/NVMe/NVMeInterruptQueue.h
+++ b/Kernel/Storage/NVMe/NVMeInterruptQueue.h
@@ -13,7 +13,7 @@ namespace Kernel {
 class NVMeInterruptQueue : public NVMeQueue
     , public IRQHandler {
 public:
-    NVMeInterruptQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_page, Memory::TypedMapping<DoorbellRegister volatile> db_regs);
+    NVMeInterruptQueue(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_page, Memory::TypedMapping<DoorbellRegister volatile> db_regs);
     void submit_sqe(NVMeSubmission& submission) override;
     virtual ~NVMeInterruptQueue() override {};
 

--- a/Kernel/Storage/NVMe/NVMeInterruptQueue.h
+++ b/Kernel/Storage/NVMe/NVMeInterruptQueue.h
@@ -6,16 +6,18 @@
 
 #pragma once
 
+#include <Kernel/Interrupts/PCIIRQHandler.h>
 #include <Kernel/Storage/NVMe/NVMeQueue.h>
 
 namespace Kernel {
 
 class NVMeInterruptQueue : public NVMeQueue
-    , public IRQHandler {
+    , public PCIIRQHandler {
 public:
     NVMeInterruptQueue(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_page, Memory::TypedMapping<DoorbellRegister volatile> db_regs);
     void submit_sqe(NVMeSubmission& submission) override;
     virtual ~NVMeInterruptQueue() override {};
+    virtual StringView purpose() const override { return "NVMe"sv; };
 
 private:
     virtual void complete_current_request(u16 cmdid, u16 status) override;

--- a/Kernel/Storage/NVMe/NVMeQueue.cpp
+++ b/Kernel/Storage/NVMe/NVMeQueue.cpp
@@ -12,16 +12,16 @@
 #include <Kernel/Storage/NVMe/NVMeQueue.h>
 
 namespace Kernel {
-ErrorOr<NonnullLockRefPtr<NVMeQueue>> NVMeQueue::try_create(u16 qid, Optional<u8> irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_page, Memory::TypedMapping<DoorbellRegister volatile> db_regs)
+ErrorOr<NonnullLockRefPtr<NVMeQueue>> NVMeQueue::try_create(u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_page, Memory::TypedMapping<DoorbellRegister volatile> db_regs, QueueType queue_type)
 {
     // Note: Allocate DMA region for RW operation. For now the requests don't exceed more than 4096 bytes (Storage device takes care of it)
     RefPtr<Memory::PhysicalPage> rw_dma_page;
     auto rw_dma_region = TRY(MM.allocate_dma_buffer_page("NVMe Queue Read/Write DMA"sv, Memory::Region::Access::ReadWrite, rw_dma_page));
-    if (!irq.has_value()) {
+    if (queue_type == QueueType::Polled) {
         auto queue = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) NVMePollQueue(move(rw_dma_region), *rw_dma_page, qid, q_depth, move(cq_dma_region), cq_dma_page, move(sq_dma_region), sq_dma_page, move(db_regs))));
         return queue;
     }
-    auto queue = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) NVMeInterruptQueue(move(rw_dma_region), *rw_dma_page, qid, irq.value(), q_depth, move(cq_dma_region), cq_dma_page, move(sq_dma_region), sq_dma_page, move(db_regs))));
+    auto queue = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) NVMeInterruptQueue(move(rw_dma_region), *rw_dma_page, qid, irq, q_depth, move(cq_dma_region), cq_dma_page, move(sq_dma_region), sq_dma_page, move(db_regs))));
     return queue;
 }
 

--- a/Kernel/Storage/NVMe/NVMeQueue.cpp
+++ b/Kernel/Storage/NVMe/NVMeQueue.cpp
@@ -12,7 +12,7 @@
 #include <Kernel/Storage/NVMe/NVMeQueue.h>
 
 namespace Kernel {
-ErrorOr<NonnullLockRefPtr<NVMeQueue>> NVMeQueue::try_create(u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_page, Memory::TypedMapping<DoorbellRegister volatile> db_regs, QueueType queue_type)
+ErrorOr<NonnullLockRefPtr<NVMeQueue>> NVMeQueue::try_create(NVMeController& device, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_page, Memory::TypedMapping<DoorbellRegister volatile> db_regs, QueueType queue_type)
 {
     // Note: Allocate DMA region for RW operation. For now the requests don't exceed more than 4096 bytes (Storage device takes care of it)
     RefPtr<Memory::PhysicalPage> rw_dma_page;
@@ -21,7 +21,7 @@ ErrorOr<NonnullLockRefPtr<NVMeQueue>> NVMeQueue::try_create(u16 qid, u8 irq, u32
         auto queue = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) NVMePollQueue(move(rw_dma_region), *rw_dma_page, qid, q_depth, move(cq_dma_region), cq_dma_page, move(sq_dma_region), sq_dma_page, move(db_regs))));
         return queue;
     }
-    auto queue = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) NVMeInterruptQueue(move(rw_dma_region), *rw_dma_page, qid, irq, q_depth, move(cq_dma_region), cq_dma_page, move(sq_dma_region), sq_dma_page, move(db_regs))));
+    auto queue = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) NVMeInterruptQueue(device, move(rw_dma_region), *rw_dma_page, qid, irq, q_depth, move(cq_dma_region), cq_dma_page, move(sq_dma_region), sq_dma_page, move(db_regs))));
     return queue;
 }
 

--- a/Kernel/Storage/NVMe/NVMeQueue.h
+++ b/Kernel/Storage/NVMe/NVMeQueue.h
@@ -26,6 +26,11 @@ struct DoorbellRegister {
     u32 cq_head;
 };
 
+enum class QueueType {
+    Polled,
+    IRQ
+};
+
 class AsyncBlockDeviceRequest;
 
 struct NVMeIO {
@@ -36,7 +41,7 @@ struct NVMeIO {
 
 class NVMeQueue : public AtomicRefCounted<NVMeQueue> {
 public:
-    static ErrorOr<NonnullLockRefPtr<NVMeQueue>> try_create(u16 qid, Optional<u8> irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_page, Memory::TypedMapping<DoorbellRegister volatile> db_regs);
+    static ErrorOr<NonnullLockRefPtr<NVMeQueue>> try_create(u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_page, Memory::TypedMapping<DoorbellRegister volatile> db_regs, QueueType queue_type);
     bool is_admin_queue() { return m_admin_queue; };
     u16 submit_sync_sqe(NVMeSubmission&);
     void read(AsyncBlockDeviceRequest& request, u16 nsid, u64 index, u32 count);

--- a/Kernel/Storage/NVMe/NVMeQueue.h
+++ b/Kernel/Storage/NVMe/NVMeQueue.h
@@ -39,9 +39,10 @@ struct NVMeIO {
     Function<void(u16 status)> end_io_handler;
 };
 
+class NVMeController;
 class NVMeQueue : public AtomicRefCounted<NVMeQueue> {
 public:
-    static ErrorOr<NonnullLockRefPtr<NVMeQueue>> try_create(u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_page, Memory::TypedMapping<DoorbellRegister volatile> db_regs, QueueType queue_type);
+    static ErrorOr<NonnullLockRefPtr<NVMeQueue>> try_create(NVMeController& device, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, Vector<NonnullRefPtr<Memory::PhysicalPage>> sq_dma_page, Memory::TypedMapping<DoorbellRegister volatile> db_regs, QueueType queue_type);
     bool is_admin_queue() { return m_admin_queue; };
     u16 submit_sync_sqe(NVMeSubmission&);
     void read(AsyncBlockDeviceRequest& request, u16 nsid, u64 index, u32 count);


### PR DESCRIPTION
This adds support to MSI(x) based interrupt mechanism, an alternative to pin-based interrupts. 

The first 10 commits add the necessary infrastructure to use MSIx interrupt mechanism. The next three commits add MSIx support to the NVMe device. This PR only adds MSIx support. TODOs have been added for the old MSI-based interrupts which could be extended later.

Test:
```
$ SERENITY_NVME_ENABLE=1 Meta/serenity.sh run
```

Trace from QEMU for the NVMe device:
```
...
pci_nvme_io_cmd cid 54 nsid 0x1 sqid 1 opc 0x2 opname 'NVME_NVM_CMD_READ'
<snip>
pci_nvme_irq_msix raising MSI-X IRQ vector 1
pci_nvme_mmio_write addr 0x100c data 0x36 size 4
pci_nvme_mmio_doorbell_cq cqid 1 new_head 54
...
```
