### PR TITLE
LibGfx/JPEG: Performance work regarding the Huffman stream

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -187,7 +187,7 @@ struct HuffmanTableSpec {
     Vector<u16> codes;
 };
 
-struct HuffmanStreamState {
+struct HuffmanStream {
     Vector<u8> stream;
     u8 bit_offset { 0 };
     size_t byte_offset { 0 };
@@ -207,7 +207,7 @@ struct Scan {
     u8 successive_approximation_high {}; // Ah
     u8 successive_approximation_low {};  // Al
 
-    HuffmanStreamState huffman_stream;
+    HuffmanStream huffman_stream;
 
     u64 end_of_bands_run_count { 0 };
 
@@ -270,7 +270,7 @@ static void generate_huffman_codes(HuffmanTableSpec& table)
     }
 }
 
-static ErrorOr<size_t> read_huffman_bits(HuffmanStreamState& hstream, size_t count = 1)
+static ErrorOr<size_t> read_huffman_bits(HuffmanStream& hstream, size_t count = 1)
 {
     if (count > (8 * sizeof(size_t))) {
         dbgln_if(JPEG_DEBUG, "Can't read {} bits at once!", count);
@@ -294,7 +294,7 @@ static ErrorOr<size_t> read_huffman_bits(HuffmanStreamState& hstream, size_t cou
     return value;
 }
 
-static ErrorOr<u8> get_next_symbol(HuffmanStreamState& hstream, HuffmanTableSpec const& table)
+static ErrorOr<u8> get_next_symbol(HuffmanStream& hstream, HuffmanTableSpec const& table)
 {
     unsigned code = 0;
     size_t code_cursor = 0;
@@ -1640,7 +1640,7 @@ static ErrorOr<void> parse_header(Stream& stream, JPEGLoadingContext& context)
     VERIFY_NOT_REACHED();
 }
 
-static ErrorOr<void> scan_huffman_stream(AK::SeekableStream& stream, HuffmanStreamState& huffman_stream)
+static ErrorOr<void> scan_huffman_stream(AK::SeekableStream& stream, HuffmanStream& huffman_stream)
 {
     u8 last_byte;
     u8 current_byte = TRY(stream.read_value<u8>());

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -892,6 +892,7 @@ static ErrorOr<void> read_huffman_table(Stream& stream, JPEGLoadingContext& cont
         }
 
         table.codes.ensure_capacity(total_codes);
+        table.symbols.ensure_capacity(total_codes);
 
         // Read symbols. Read X bytes, where X is the sum of the counts of codes read in the previous step.
         for (u32 i = 0; i < total_codes; i++) {

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -250,7 +250,7 @@ struct JPEGLoadingContext {
     u16 dc_restart_interval { 0 };
     HashMap<u8, HuffmanTableSpec> dc_tables;
     HashMap<u8, HuffmanTableSpec> ac_tables;
-    Array<i32, 4> previous_dc_values {};
+    Array<i16, 4> previous_dc_values {};
     MacroblockMeta mblock_meta;
     OwnPtr<FixedMemoryStream> stream;
 
@@ -366,7 +366,7 @@ static ErrorOr<void> add_dc(JPEGLoadingContext& context, Macroblock& macroblock,
     }
 
     // DC coefficients are encoded as the difference between previous and current DC values.
-    i32 dc_diff = TRY(read_huffman_bits(scan.huffman_stream, dc_length));
+    i16 dc_diff = TRY(read_huffman_bits(scan.huffman_stream, dc_length));
 
     // If MSB in diff is 0, the difference is -ve. Otherwise +ve.
     if (dc_length != 0 && dc_diff < (1 << (dc_length - 1)))

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -180,7 +180,7 @@ struct StartOfFrame {
     u16 width { 0 };
 };
 
-struct HuffmanTableSpec {
+struct HuffmanTable {
     u8 type { 0 };
     u8 destination_id { 0 };
     u8 code_counts[16] = { 0 };
@@ -227,7 +227,7 @@ public:
         VERIFY_NOT_REACHED();
     }
 
-    ErrorOr<u8> next_symbol(HuffmanTableSpec const& table)
+    ErrorOr<u8> next_symbol(HuffmanTable const& table)
     {
         u16 const code = peek_bits(16);
         u64 code_cursor = 0;
@@ -366,8 +366,8 @@ struct JPEGLoadingContext {
     Vector<Component, 4> components;
     RefPtr<Gfx::Bitmap> bitmap;
     u16 dc_restart_interval { 0 };
-    HashMap<u8, HuffmanTableSpec> dc_tables;
-    HashMap<u8, HuffmanTableSpec> ac_tables;
+    HashMap<u8, HuffmanTable> dc_tables;
+    HashMap<u8, HuffmanTable> ac_tables;
     Array<i16, 4> previous_dc_values {};
     MacroblockMeta mblock_meta;
     OwnPtr<FixedMemoryStream> stream;
@@ -378,7 +378,7 @@ struct JPEGLoadingContext {
     Optional<ByteBuffer> icc_data;
 };
 
-static void generate_huffman_codes(HuffmanTableSpec& table)
+static void generate_huffman_codes(HuffmanTable& table)
 {
     unsigned code = 0;
     for (auto number_of_codes : table.code_counts) {
@@ -867,7 +867,7 @@ static ErrorOr<void> read_huffman_table(Stream& stream, JPEGLoadingContext& cont
     u16 bytes_to_read = TRY(read_effective_chunk_size(stream));
 
     while (bytes_to_read > 0) {
-        HuffmanTableSpec table;
+        HuffmanTable table;
         u8 table_info = TRY(stream.read_value<u8>());
         u8 table_type = table_info >> 4;
         u8 table_destination_id = table_info & 0x0F;

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -229,15 +229,16 @@ public:
 
     ErrorOr<u8> next_symbol(HuffmanTableSpec const& table)
     {
-        unsigned code = 0;
+        u16 const code = peek_bits(16);
         u64 code_cursor = 0;
 
         for (int i = 0; i < 16; i++) { // Codes can't be longer than 16 bits.
-            auto result = TRY(read_bits());
-            code = (code << 1) | result;
+            auto const result = code >> (15 - i);
             for (int j = 0; j < table.code_counts[i]; j++) {
-                if (code == table.codes[code_cursor])
+                if (result == table.codes[code_cursor]) {
+                    discard_bits(i + 1);
                     return table.symbols[code_cursor];
+                }
                 code_cursor++;
             }
         }


### PR DESCRIPTION
If this PR is too much to review in a single shot, I can easily split it!

Results of `BenchmarkJPEGLoader`:

<table>
<tr>
 <td>
 <td>small_image
 <td>big_image
 <td>rgb_image
 <td>several_scans
<tr>
 <td>Master
 <td>0.0±0.0ms
 <td>601.7±4.7ms
 <td>9.0±0.0ms
 <td>7.9±0.3ms
<tr>
 <td>Using `peek` in `read`
 <td>0.0±0.0ms
 <td>557.7±32.3ms
 <td>8.1±0.6ms
 <td>7.9±0.3ms
<tr>
 <td>Using `peek` in `next_symbol`
 <td>0.0±0.0ms
 <td>526.1±40.6ms
 <td>8.0±0.3ms
 <td>7.7±0.6ms
<tr>
 <td>Using the Lookup table
 <td>0.0±0.0ms
 <td>459.8±34ms
 <td>7.9±0.3ms
 <td>7.2±0.4ms
</table>

With this image:
https://commons.wikimedia.org/wiki/File:Seven_Coloured_Pencils_(sRGB).jpg
`image` is now only 3x (previously 4) slower than libjpeg-turbo's `djpeg`!
