### PR TITLE
LibGUI: Use Variant's built-in equality operator in Window and Widget

### DIFF
--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -1128,15 +1128,7 @@ Gfx::IntRect Widget::children_clip_rect() const
 
 void Widget::set_override_cursor(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor)
 {
-    auto const& are_cursors_the_same = [](auto const& a, auto const& b) {
-        if (a.template has<Gfx::StandardCursor>() != b.template has<Gfx::StandardCursor>())
-            return false;
-        if (a.template has<Gfx::StandardCursor>())
-            return a.template get<Gfx::StandardCursor>() == b.template get<Gfx::StandardCursor>();
-        return a.template get<NonnullRefPtr<Gfx::Bitmap const>>().ptr() == b.template get<NonnullRefPtr<Gfx::Bitmap const>>().ptr();
-    };
-
-    if (are_cursors_the_same(m_override_cursor, cursor))
+    if (m_override_cursor == cursor)
         return;
 
     m_override_cursor = move(cursor);

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -336,18 +336,9 @@ void Window::make_window_manager(unsigned event_mask)
     GUI::ConnectionToWindowManagerServer::the().async_set_manager_window(m_window_id);
 }
 
-bool Window::are_cursors_the_same(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> const& left, AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> const& right) const
-{
-    if (left.has<Gfx::StandardCursor>() != right.has<Gfx::StandardCursor>())
-        return false;
-    if (left.has<Gfx::StandardCursor>())
-        return left.get<Gfx::StandardCursor>() == right.get<Gfx::StandardCursor>();
-    return left.get<NonnullRefPtr<Gfx::Bitmap const>>().ptr() == right.get<NonnullRefPtr<Gfx::Bitmap const>>().ptr();
-}
-
 void Window::set_cursor(Gfx::StandardCursor cursor)
 {
-    if (are_cursors_the_same(m_cursor, cursor))
+    if (m_cursor == cursor)
         return;
     m_cursor = cursor;
     update_cursor();
@@ -355,7 +346,7 @@ void Window::set_cursor(Gfx::StandardCursor cursor)
 
 void Window::set_cursor(NonnullRefPtr<Gfx::Bitmap const> cursor)
 {
-    if (are_cursors_the_same(m_cursor, cursor))
+    if (m_cursor == cursor)
         return;
     m_cursor = cursor;
     update_cursor();
@@ -1281,7 +1272,7 @@ void Window::update_cursor()
             new_cursor = widget->override_cursor();
     }
 
-    if (are_cursors_the_same(m_effective_cursor, new_cursor))
+    if (m_effective_cursor == new_cursor)
         return;
     m_effective_cursor = new_cursor;
 

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -279,8 +279,6 @@ private:
     void flip(Vector<Gfx::IntRect, 32> const& dirty_rects);
     void force_update();
 
-    bool are_cursors_the_same(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> const&, AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> const&) const;
-
     WeakPtr<Widget> m_previously_focused_widget;
 
     OwnPtr<WindowBackingStore> m_front_store;


### PR DESCRIPTION
Now that Variant has operator==(), we don't need to go through all this trouble to compare two Variant values.