### PR TITLE
Chess: Allow stockfish to be used if it is available

### DIFF
--- a/Userland/Games/Chess/CMakeLists.txt
+++ b/Userland/Games/Chess/CMakeLists.txt
@@ -13,4 +13,4 @@ set(SOURCES
 )
 
 serenity_app(Chess ICON app-chess)
-target_link_libraries(Chess PRIVATE LibChess LibConfig LibFileSystemAccessClient LibGfx LibGUI LibCore LibMain LibDesktop)
+target_link_libraries(Chess PRIVATE LibChess LibConfig LibFileSystem LibFileSystemAccessClient LibGfx LibGUI LibCore LibMain LibDesktop)

--- a/Userland/Games/Chess/Engine.cpp
+++ b/Userland/Games/Chess/Engine.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -19,6 +20,7 @@ Engine::~Engine()
 Engine::Engine(StringView command)
     : m_command(command)
 {
+    connect_to_engine_service();
 }
 
 void Engine::connect_to_engine_service()

--- a/Userland/Libraries/LibChess/UCICommand.h
+++ b/Userland/Libraries/LibChess/UCICommand.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020-2022, the SerenityOS developers.
  * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -246,6 +247,23 @@ private:
 
 class InfoCommand : public Command {
 public:
+    enum class ScoreType {
+        Centipawns,
+        Mate
+    };
+
+    enum class ScoreBound {
+        None,
+        Lower,
+        Upper
+    };
+
+    struct Score {
+        ScoreType type;
+        int value;
+        ScoreBound bound;
+    };
+
     explicit InfoCommand()
         : Command(Command::Type::Info)
     {
@@ -255,18 +273,23 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
 
-    Optional<int> depth;
-    Optional<int> seldepth;
-    Optional<int> time;
-    Optional<int> nodes;
-    Optional<Vector<Chess::Move>> pv;
-    // FIXME: Add multipv.
-    Optional<int> score_cp;
-    Optional<int> score_mate;
-    // FIXME: Add score bounds.
-    Optional<Chess::Move> currmove;
-    Optional<int> currmove_number;
-    // FIXME: Add additional fields.
+private:
+    Optional<int> m_depth;
+    Optional<int> m_seldepth;
+    Optional<int> m_time;
+    Optional<int> m_nodes;
+    Optional<Vector<Chess::Move>> m_pv;
+    Optional<int> m_multipv;
+    Optional<Score> m_score;
+    Optional<Chess::Move> m_currmove;
+    Optional<int> m_currmovenumber;
+    Optional<int> m_hashfull;
+    Optional<int> m_nps;
+    Optional<int> m_tbhits;
+    Optional<int> m_cpuload;
+    Optional<String> m_string;
+    Optional<Vector<Chess::Move>> m_refutation;
+    Optional<Vector<Chess::Move>> m_currline;
 };
 
 class QuitCommand : public Command {

--- a/Userland/Libraries/LibChess/UCICommand.h
+++ b/Userland/Libraries/LibChess/UCICommand.h
@@ -229,9 +229,10 @@ public:
 
 class BestMoveCommand : public Command {
 public:
-    explicit BestMoveCommand(Chess::Move move)
+    explicit BestMoveCommand(Chess::Move move, Optional<Chess::Move> move_to_ponder = {})
         : Command(Command::Type::BestMove)
         , m_move(::move(move))
+        , m_move_to_ponder(::move(move_to_ponder))
     {
     }
 
@@ -240,9 +241,11 @@ public:
     virtual ErrorOr<String> to_string() const override;
 
     Chess::Move move() const { return m_move; }
+    Optional<Chess::Move> move_to_ponder() const { return m_move_to_ponder; }
 
 private:
     Chess::Move m_move;
+    Optional<Chess::Move> m_move_to_ponder;
 };
 
 class InfoCommand : public Command {

--- a/Userland/Libraries/LibChess/UCICommand.h
+++ b/Userland/Libraries/LibChess/UCICommand.h
@@ -247,7 +247,7 @@ private:
 class InfoCommand : public Command {
 public:
     explicit InfoCommand()
-        : Command(Command::Type::BestMove)
+        : Command(Command::Type::Info)
     {
     }
 

--- a/Userland/Libraries/LibChess/UCIEndpoint.h
+++ b/Userland/Libraries/LibChess/UCIEndpoint.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2022, the SerenityOS developers.
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -17,6 +18,8 @@ class Endpoint : public Core::Object {
     C_OBJECT(Endpoint)
 public:
     virtual ~Endpoint() override = default;
+
+    Function<void(DeprecatedString, Error)> on_command_read_error;
 
     virtual void handle_uci() { }
     virtual void handle_debug(DebugCommand const&) { }
@@ -58,7 +61,7 @@ private:
         UnexpectedEof
     };
     void set_in_notifier();
-    NonnullOwnPtr<Command> read_command();
+    ErrorOr<NonnullOwnPtr<Command>> read_command(StringView line) const;
 
     RefPtr<Core::IODevice> m_in;
     RefPtr<Core::IODevice> m_out;

--- a/Userland/Services/ChessEngine/ChessEngine.h
+++ b/Userland/Services/ChessEngine/ChessEngine.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -25,10 +26,12 @@ public:
     Function<void(int)> on_quit;
 
 private:
-    ChessEngine() = default;
     ChessEngine(NonnullRefPtr<Core::IODevice> in, NonnullRefPtr<Core::IODevice> out)
         : Endpoint(in, out)
     {
+        on_command_read_error = [](auto command, auto error) {
+            outln("{}: '{}'", error, command);
+        };
     }
 
     Chess::Board m_board;


### PR DESCRIPTION
This PR implements the UCI commands necessary to get stockfish working and allows the player to select stockfish from the engine menu if the port is installed. If the port is not installed, there is no change to the GUI.

Currently, the GUI allows the engine to take a maximum of 4 seconds per move. Stockfish probably doesn't need that long.

A video showing stockfish playing a boring opening:

https://user-images.githubusercontent.com/2817754/235368292-097d2db4-43c6-44c0-b76f-a5adc0f81b96.mp4

