### PR TITLE
AK+Userland: Introduce custom error codes and start using them for Streams

### DIFF
--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -25,6 +25,8 @@ Error Error::from_string_view_or_print_error_and_return_errno(StringView string_
 StringView Error::custom_error_as_string() const
 {
     switch (m_code.get<CustomError>()) {
+    case CustomError::NotEnoughData:
+        return "Not enough data to read value"sv;
     }
 
     VERIFY_NOT_REACHED();

--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -22,4 +22,12 @@ Error Error::from_string_view_or_print_error_and_return_errno(StringView string_
 #endif
 }
 
+StringView Error::custom_error_as_string() const
+{
+    switch (m_code.get<CustomError>()) {
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
 }

--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -22,6 +22,22 @@ Error Error::from_string_view_or_print_error_and_return_errno(StringView string_
 #endif
 }
 
+bool Error::operator==(int code) const
+{
+    if (!m_code.has<int>())
+        return false;
+
+    return m_code.get<int>() == code;
+}
+
+bool Error::operator==(CustomError custom_error) const
+{
+    if (!m_code.has<CustomError>())
+        return false;
+
+    return m_code.get<CustomError>() == custom_error;
+}
+
 StringView Error::custom_error_as_string() const
 {
     switch (m_code.get<CustomError>()) {

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -85,10 +85,10 @@ public:
 #endif
     }
 
-    int code() const { return m_code; }
+    int code() const { return m_code.get<int>(); }
     bool is_errno() const
     {
-        return m_code != 0;
+        return m_code.has<int>();
     }
 #ifndef KERNEL
     bool is_syscall() const
@@ -129,7 +129,7 @@ private:
     StringView m_string_literal;
 #endif
 
-    int m_code { 0 };
+    Variant<Empty, int> m_code { Empty {} };
 
 #ifndef KERNEL
     bool m_syscall { false };

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -23,6 +23,7 @@ class Error {
 public:
     // The Variant can't get any smaller than its largest member (errno), so we might as well just specify `int` here.
     enum CustomError : int {
+        NotEnoughData,
     };
 
     ALWAYS_INLINE Error(Error&&) = default;

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -96,10 +96,12 @@ public:
     {
         return m_code.has<int>();
     }
+    bool operator==(int) const;
 
     CustomError custom_error() const { return m_code.get<CustomError>(); }
     StringView custom_error_as_string() const;
     bool is_custom_error() const { return m_code.has<CustomError>(); }
+    bool operator==(CustomError) const;
 
 #ifndef KERNEL
     bool is_syscall() const

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -690,6 +690,9 @@ template<>
 struct Formatter<Error> : Formatter<FormatString> {
     ErrorOr<void> format(FormatBuilder& builder, Error const& error)
     {
+        if (error.is_custom_error())
+            return Formatter<FormatString>::format(builder, "{}"sv, error.custom_error_as_string());
+
 #if defined(AK_OS_SERENITY) && defined(KERNEL)
         return Formatter<FormatString>::format(builder, "Error(errno={})"sv, error.code());
 #else

--- a/AK/LEB128.h
+++ b/AK/LEB128.h
@@ -31,7 +31,7 @@ public:
         size_t num_bytes = 0;
         while (true) {
             if (stream.is_eof())
-                return Error::from_string_literal("Stream reached end-of-file while reading LEB128 value");
+                return Error::from_custom_error(Error::CustomError::NotEnoughData);
 
             auto byte = TRY(stream.read_value<u8>());
 
@@ -67,7 +67,7 @@ public:
 
         do {
             if (stream.is_eof())
-                return Error::from_string_literal("Stream reached end-of-file while reading LEB128 value");
+                return Error::from_custom_error(Error::CustomError::NotEnoughData);
 
             byte = TRY(stream.read_value<u8>());
 

--- a/AK/Stream.cpp
+++ b/AK/Stream.cpp
@@ -17,7 +17,7 @@ ErrorOr<void> Stream::read_until_filled(Bytes buffer)
     size_t nread = 0;
     while (nread < buffer.size()) {
         if (is_eof())
-            return Error::from_string_view_or_print_error_and_return_errno("Reached end-of-file before filling the entire buffer"sv, EIO);
+            return Error::from_custom_error(Error::CustomError::NotEnoughData);
 
         auto result = read_some(buffer.slice(nread));
         if (result.is_error()) {
@@ -70,7 +70,7 @@ ErrorOr<void> Stream::discard(size_t discarded_bytes)
 
     while (discarded_bytes > 0) {
         if (is_eof())
-            return Error::from_string_view_or_print_error_and_return_errno("Reached end-of-file before reading all discarded bytes"sv, EIO);
+            return Error::from_custom_error(Error::CustomError::NotEnoughData);
 
         auto slice = TRY(read_some(buffer.span().slice(0, min(discarded_bytes, continuous_read_size))));
         discarded_bytes -= slice.size();

--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -216,6 +216,7 @@ using MergeAndDeduplicatePacks = InheritFromPacks<MakeIndexSequence<sizeof...(Ps
 namespace AK {
 
 struct Empty {
+    bool operator==(Empty const&) const { return true; }
 };
 
 template<typename T>

--- a/Userland/Libraries/LibCompress/Xz.cpp
+++ b/Userland/Libraries/LibCompress/Xz.cpp
@@ -217,7 +217,7 @@ ErrorOr<bool> XzDecompressor::load_next_stream()
             // Read the first byte until we either get a non-null byte or reach EOF.
             auto byte_or_error = m_stream->read_value<u8>();
 
-            if (byte_or_error.is_error() && m_stream->is_eof())
+            if (byte_or_error.is_error() && byte_or_error.error().is_custom_error() && byte_or_error.error().custom_error() == Error::CustomError::NotEnoughData)
                 break;
 
             auto byte = TRY(byte_or_error);

--- a/Userland/Libraries/LibCompress/Xz.cpp
+++ b/Userland/Libraries/LibCompress/Xz.cpp
@@ -217,7 +217,7 @@ ErrorOr<bool> XzDecompressor::load_next_stream()
             // Read the first byte until we either get a non-null byte or reach EOF.
             auto byte_or_error = m_stream->read_value<u8>();
 
-            if (byte_or_error.is_error() && byte_or_error.error().is_custom_error() && byte_or_error.error().custom_error() == Error::CustomError::NotEnoughData)
+            if (byte_or_error.is_error() && byte_or_error.error() == Error::CustomError::NotEnoughData)
                 break;
 
             auto byte = TRY(byte_or_error);


### PR DESCRIPTION
For various file formats, we need to know whether we failed to read a value due to encountering EOF or if it errored due to a different reasons.

Since comparing string literals is not great and we can't easily add a new errno due to portability problems with Lagom, this adds a new, AK-specific enum for self-invented errors and allows storing it inside the existing `Error` instead of a POSIX errno.