### PR TITLE
LibGfx+LibWeb: Don't divide by 0 in DOMMatrix::invert_self()

### DIFF
--- a/Userland/Libraries/LibGL/Texture.cpp
+++ b/Userland/Libraries/LibGL/Texture.cpp
@@ -536,7 +536,7 @@ void GLContext::gl_tex_gen_floatv(GLenum coord, GLenum pname, GLfloat const* par
         texture_coordinate_generation(m_active_texture_unit_index, capability).object_plane_coefficients = { params[0], params[1], params[2], params[3] };
         break;
     case GL_EYE_PLANE: {
-        auto const& inverse_model_view = model_view_matrix().inverse();
+        auto const& inverse_model_view = model_view_matrix().inverse().value();
         auto input_coefficients = FloatVector4 { params[0], params[1], params[2], params[3] };
 
         // Note: we are allowed to store transformed coefficients here, according to the documentation on

--- a/Userland/Libraries/LibGfx/Matrix.h
+++ b/Userland/Libraries/LibGfx/Matrix.h
@@ -196,8 +196,10 @@ public:
         return result;
     }
 
-    [[nodiscard]] constexpr Matrix inverse() const
+    [[nodiscard]] constexpr Optional<Matrix> inverse() const
     {
+        if (determinant() == 0)
+            return {};
         return adjugate() / determinant();
     }
 
@@ -221,11 +223,6 @@ public:
                 result.m_elements[i][j] = m_elements[i][j];
         }
         return result;
-    }
-
-    constexpr bool is_invertible() const
-    {
-        return determinant() != 0.0;
     }
 
 private:

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -969,7 +969,7 @@ void Device::draw_primitives(GPU::PrimitiveType primitive_type, FloatMatrix4x4 c
 
     // Set up normals transform by taking the upper left 3x3 elements from the model view matrix
     // See section 2.11.3 of the OpenGL 1.5 spec
-    auto const normal_transform = model_view_transform.submatrix_from_topleft<3>().transpose().inverse();
+    auto const normal_transform = model_view_transform.submatrix_from_topleft<3>().transpose().inverse().value();
 
     // First, transform all vertices
     for (auto& vertex : vertices) {

--- a/Userland/Libraries/LibVideo/Color/ColorPrimaries.cpp
+++ b/Userland/Libraries/LibVideo/Color/ColorPrimaries.cpp
@@ -46,7 +46,7 @@ ALWAYS_INLINE constexpr FloatMatrix3x3 generate_rgb_to_xyz_matrix(FloatVector2 r
 {
     // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
     const FloatMatrix3x3 matrix = primaries_matrix(red_xy, green_xy, blue_xy);
-    const FloatVector3 scale_vector = matrix.inverse() * primaries_to_xyz(white_xy);
+    const FloatVector3 scale_vector = matrix.inverse().value() * primaries_to_xyz(white_xy);
     return vectors_to_matrix(matrix_row(matrix, 0) * scale_vector, matrix_row(matrix, 1) * scale_vector, matrix_row(matrix, 2) * scale_vector);
 }
 
@@ -80,10 +80,10 @@ DecoderErrorOr<FloatMatrix3x3> get_conversion_matrix(ColorPrimaries input_primar
     FloatMatrix3x3 output_conversion_matrix;
     switch (output_primaries) {
     case ColorPrimaries::BT709:
-        output_conversion_matrix = bt_709_rgb_to_xyz.inverse();
+        output_conversion_matrix = bt_709_rgb_to_xyz.inverse().value();
         break;
     case ColorPrimaries::BT2020:
-        output_conversion_matrix = bt_2020_rgb_to_xyz.inverse();
+        output_conversion_matrix = bt_2020_rgb_to_xyz.inverse().value();
         break;
     default:
         return DecoderError::format(DecoderErrorCategory::NotImplemented, "Conversion of primaries {} is not implemented", color_primaries_to_string(output_primaries));

--- a/Userland/Libraries/LibWeb/Geometry/DOMMatrix.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMMatrix.cpp
@@ -253,10 +253,12 @@ void DOMMatrix::set_f(double value)
 JS::NonnullGCPtr<DOMMatrix> DOMMatrix::invert_self()
 {
     // 1. Invert the current matrix.
-    m_matrix = m_matrix.inverse();
+    auto inverted_matrix = m_matrix.inverse();
+    if (inverted_matrix.has_value())
+        m_matrix = inverted_matrix.value();
 
     // 2. If the current matrix is not invertible set all attributes to NaN and set is 2D to false.
-    if (!m_matrix.is_invertible()) {
+    if (!inverted_matrix.has_value()) {
         for (u8 i = 0; i < 4; i++) {
             for (u8 j = 0; j < 4; j++)
                 m_matrix.elements()[i][j] = NAN;


### PR DESCRIPTION
We'd only check is_invertible() after calling inverse(), which would do a divide-by-0 for non-invertible matrices.

Instead, make inverse() return an Optional, like already done in AffineTransform::inverse().