### PR TITLE
ICC: Implement some of Profile::from_pcs()

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -1445,13 +1445,13 @@ ErrorOr<FloatVector3> Profile::to_pcs(ReadonlyBytes color) const
             float linear_g = evaluate_curve(greenTRCTag, color[1] / 255.f);
             float linear_b = evaluate_curve(blueTRCTag, color[2] / 255.f);
 
-            auto const& redMatrixColumn = red_matrix_column();
-            auto const& greenMatrixColumn = green_matrix_column();
-            auto const& blueMatrixColumn = blue_matrix_column();
+            auto const& red_matrix_column = this->red_matrix_column();
+            auto const& green_matrix_column = this->green_matrix_column();
+            auto const& blue_matrix_column = this->blue_matrix_column();
 
-            float X = redMatrixColumn.X * linear_r + greenMatrixColumn.X * linear_g + blueMatrixColumn.X * linear_b;
-            float Y = redMatrixColumn.Y * linear_r + greenMatrixColumn.Y * linear_g + blueMatrixColumn.Y * linear_b;
-            float Z = redMatrixColumn.Z * linear_r + greenMatrixColumn.Z * linear_g + blueMatrixColumn.Z * linear_b;
+            float X = red_matrix_column.X * linear_r + green_matrix_column.X * linear_g + blue_matrix_column.X * linear_b;
+            float Y = red_matrix_column.Y * linear_r + green_matrix_column.Y * linear_g + blue_matrix_column.Y * linear_b;
+            float Z = red_matrix_column.Z * linear_r + green_matrix_column.Z * linear_g + blue_matrix_column.Z * linear_b;
 
             return FloatVector3 { X, Y, Z };
         }

--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -1357,7 +1357,7 @@ Crypto::Hash::MD5::DigestType Profile::compute_id(ReadonlyBytes bytes)
     return md5.digest();
 }
 
-static TagSignature tag_for_rendering_intent(RenderingIntent rendering_intent)
+static TagSignature forward_transform_tag_for_rendering_intent(RenderingIntent rendering_intent)
 {
     // ICCv4, Table 25 — Profile type/profile tag and defined rendering intents
     // This function assumes a profile class of InputDevice, DisplayDevice, OutputDevice, or ColorSpace.
@@ -1399,7 +1399,7 @@ ErrorOr<FloatVector3> Profile::to_pcs(ReadonlyBytes color) const
 
         // "b) Use the BToA0Tag, BToA1Tag, BToA2Tag, AToB0Tag, AToB1Tag, or AToB2Tag designated for the
         //     rendering intent if present, when the tag in a) is not used."
-        if (has_tag(tag_for_rendering_intent(rendering_intent()))) {
+        if (has_tag(forward_transform_tag_for_rendering_intent(rendering_intent()))) {
             // FIXME
             return Error::from_string_literal("ICC::Profile::to_pcs: AToB0Tag handling not yet implemented");
         }

--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -1401,7 +1401,7 @@ ErrorOr<FloatVector3> Profile::to_pcs(ReadonlyBytes color) const
         //     rendering intent if present, when the tag in a) is not used."
         if (has_tag(forward_transform_tag_for_rendering_intent(rendering_intent()))) {
             // FIXME
-            return Error::from_string_literal("ICC::Profile::to_pcs: AToB0Tag handling not yet implemented");
+            return Error::from_string_literal("ICC::Profile::to_pcs: AToB*Tag handling not yet implemented");
         }
 
         // "c) Use the BToA0Tag or AToB0Tag if present, when the tags in a) and b) are not used."

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -267,6 +267,10 @@ public:
     // Call connection_space() to find out the space the result is in.
     ErrorOr<FloatVector3> to_pcs(ReadonlyBytes) const;
 
+    // Converts from the profile connection space to an 8-bits-per-channel color.
+    // The notes on `to_pcs()` apply to this too.
+    ErrorOr<void> from_pcs(FloatVector3 const&, Bytes) const;
+
     ErrorOr<CIELAB> to_lab(ReadonlyBytes) const;
 
     // Only call these if you know that this is an RGB matrix-based profile.

--- a/Userland/Libraries/LibGfx/Matrix.h
+++ b/Userland/Libraries/LibGfx/Matrix.h
@@ -225,7 +225,7 @@ public:
 
     constexpr bool is_invertible() const
     {
-        return determinant() != 0.0;
+        return determinant() != static_cast<T>(0.0);
     }
 
 private:


### PR DESCRIPTION
This implements conversion from profile connection space to the
device-dependent color for matrix-based profiles.

Inverting non-parametric curves is a TODO for now.