### PR TITLE
Everywhere: Make Lagom build with GCC 13

### DIFF
--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -130,15 +130,16 @@ struct VariantConstructTag {
 
 template<typename T, typename Base>
 struct VariantConstructors {
+    // The pointless `typename Base` constraints are a workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109683
     ALWAYS_INLINE VariantConstructors(T&& t)
-    requires(requires { T(move(t)); })
+    requires(requires { T(move(t)); typename Base; })
     {
         internal_cast().clear_without_destruction();
         internal_cast().set(move(t), VariantNoClearTag {});
     }
 
     ALWAYS_INLINE VariantConstructors(T const& t)
-    requires(requires { T(t); })
+    requires(requires { T(t); typename Base; })
     {
         internal_cast().clear_without_destruction();
         internal_cast().set(t, VariantNoClearTag {});

--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -28,4 +28,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # Only ignore expansion-to-defined for g++, clang's implementation doesn't complain about function-like macros
     add_compile_options(-Wno-expansion-to-defined)
     add_compile_options(-Wno-literal-suffix)
+
+    # FIXME: This warning seems useful but has too many false positives with GCC 13.
+    add_compile_options(-Wno-dangling-reference)
 endif()

--- a/Tests/AK/TestRefPtr.cpp
+++ b/Tests/AK/TestRefPtr.cpp
@@ -97,14 +97,11 @@ TEST_CASE(assign_moved_self)
 {
     RefPtr<Object> object = adopt_ref(*new Object);
     EXPECT_EQ(object->ref_count(), 1u);
-#if defined(AK_COMPILER_CLANG)
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wself-move"
-#endif
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wself-move"
     object = move(object);
-#if defined(AK_COMPILER_CLANG)
-#    pragma clang diagnostic pop
-#endif
+#pragma GCC diagnostic pop
     EXPECT_EQ(object->ref_count(), 1u);
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Pass/GenerateCFG.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/GenerateCFG.cpp
@@ -135,7 +135,7 @@ static void generate_cfg_for_block(BasicBlock const& current_block, PassPipeline
                         generate_cfg_for_block(*block, executable);
                 }
             } else {
-                VERIFY(unwind_frames.last() = &frame);
+                VERIFY(unwind_frames.last() == &frame);
                 unwind_frames.take_last();
                 VERIFY(frame.finalizer_targets.is_empty());
             }


### PR DESCRIPTION
GCC 13 was released on 2023-04-26. This commit fixes Lagom build errors when using an updated host toolchain:
- Adds a workaround for a bug in constraint handling, which made LibJS fail to compile: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109683
- Silences the new `-Wdangling-reference` diagnostic globally. It produces multiple false positives with no clear way to silence them without `#pragmas`.
- Silences `-Wself-move` in `RefPtr` tests as GCC 13 adds this previously Clang-exclusive warning.

---
The second commit fixes an *assignment instead of comparison bug* in LibJS which was found using GCC 13's improved diagnostics.