### PR TITLE
LibGUI: Only clear `TreeView::m_view_metadata` when required

### DIFF
--- a/Userland/Libraries/LibGUI/TreeView.cpp
+++ b/Userland/Libraries/LibGUI/TreeView.cpp
@@ -414,7 +414,10 @@ void TreeView::scroll_into_view(ModelIndex const& a_index, bool, bool scroll_ver
 
 void TreeView::model_did_update(unsigned flags)
 {
-    m_view_metadata.clear();
+    if (flags == Model::UpdateFlag::InvalidateAllIndices) {
+        m_view_metadata.clear();
+    }
+
     AbstractTableView::model_did_update(flags);
 }
 


### PR DESCRIPTION
Prior to this commit, we were always clearing the TreeView's metadata, even if it wasn't needed. Now, we only clear it if the caller says that we should invalidate indices.

This fixes an issue in FileManager (#6903), where updating the file system by creating/deleting any file/folder would cause the tree to collapse completely.

This may be more of a 'patch' than an actual fix, since I don't have a lot of experience with `GUI::TreeView` or `GUI::Model`, but it doesn't appear to break any other `TreeView` use-cases and using FileManager is now much nicer than it was before :^)

### Before vs. After:

https://user-images.githubusercontent.com/71222289/235490627-881bf55e-d75c-4de2-85b5-22759cf6c79d.mp4

