### PR TITLE
SoundPlayer: Fix glitchy visualization on pause/stop 

### DIFF
--- a/Userland/Applications/SoundPlayer/Player.cpp
+++ b/Userland/Applications/SoundPlayer/Player.cpp
@@ -21,7 +21,8 @@ Player::Player(Audio::ConnectionToServer& audio_client_connection)
 
         auto played_seconds = samples_played / sample_rate;
         time_elapsed(played_seconds);
-        sound_buffer_played(m_playback_manager.current_buffer(), m_playback_manager.device_sample_rate(), samples_played);
+        if (play_state() == PlayState::Playing)
+            sound_buffer_played(m_playback_manager.current_buffer(), m_playback_manager.device_sample_rate(), samples_played);
     };
     m_playback_manager.on_finished_playing = [&]() {
         set_play_state(PlayState::Stopped);

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -213,6 +213,10 @@ void SoundPlayerWidgetAdvancedView::play_state_changed(Player::PlayState state)
     m_stop_action->set_enabled(state != PlayState::Stopped && state != PlayState::NoFileLoaded);
 
     m_playback_progress_slider->set_enabled(state != PlayState::NoFileLoaded);
+    if (state == PlayState::Stopped) {
+        m_playback_progress_slider->set_value(m_playback_progress_slider->min(), GUI::AllowCallback::No);
+        m_visualization->reset_buffer();
+    }
 }
 
 void SoundPlayerWidgetAdvancedView::loop_mode_changed(Player::LoopMode)

--- a/Userland/Applications/SoundPlayer/VisualizationWidget.h
+++ b/Userland/Applications/SoundPlayer/VisualizationWidget.h
@@ -33,6 +33,13 @@ public:
         m_frame_count = 0;
     }
 
+    void reset_buffer()
+    {
+        m_sample_buffer.clear();
+        m_render_buffer.fill_with(.0f);
+        m_frame_count = 0;
+    }
+
     virtual void set_samplerate(int samplerate)
     {
         m_samplerate = samplerate;


### PR DESCRIPTION
Previously when pausing or stoping a track in SoundPlayer, the visualizations would glitch out. This was caused by them
being updated with the same buffer over and over. With this patch a pause action will freeze the visualization at the
point of the pause and a stop action will reset the visualization so it displays nothing until a track is started.

Before:
https://user-images.githubusercontent.com/34097701/235499130-877ea626-df5d-4422-b9c8-f1e02221c8e0.mp4

After:

https://user-images.githubusercontent.com/34097701/235499220-5b03caa7-11a8-4ce9-aee9-155525249c45.mp4

