### PR TITLE
LibGfx: Migrate from DeprecatedString to String in Gfx::BitMap

### DIFF
--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -299,4 +299,12 @@ Vector<StringView> StringView::split_view_if(Function<bool(char)> const& predica
     return v;
 }
 
+ByteBuffer StringView::characters_with_null_termination() const
+{
+    ByteBuffer characters_null_term;
+    characters_null_term.append(m_characters, m_length);
+    characters_null_term.append('\0');
+    return characters_null_term;
+}
+
 }

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -72,6 +72,7 @@ public:
     [[nodiscard]] constexpr bool is_empty() const { return m_length == 0; }
 
     [[nodiscard]] constexpr char const* characters_without_null_termination() const { return m_characters; }
+    [[nodiscard]] ByteBuffer characters_with_null_termination() const;
     [[nodiscard]] constexpr size_t length() const { return m_length; }
 
     [[nodiscard]] ReadonlyBytes bytes() const { return { m_characters, m_length }; }

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -212,7 +212,7 @@ public:
     [[nodiscard]] bool has_alpha_channel() const { return m_format == BitmapFormat::BGRA8888 || m_format == BitmapFormat::RGBA8888; }
     [[nodiscard]] BitmapFormat format() const { return m_format; }
 
-    void set_mmap_name(DeprecatedString const&);
+    void set_mmap_name(String const&);
 
     [[nodiscard]] static constexpr size_t size_in_bytes(size_t pitch, int physical_height) { return pitch * physical_height; }
     [[nodiscard]] size_t size_in_bytes() const { return size_in_bytes(m_pitch, physical_height()); }


### PR DESCRIPTION
Not sure if this is SerenityOS best practices, so please let me know if there is a more preferred construct to use when returning owning bytes.

In other projects that have `std::unique_ptr` and the bytes + length is known, I would've made the `characters_with_null_termination()` method return `std::unique_ptr<char[]>` ([Godbolt Example](https://godbolt.org/z/G75ojno1c)) and would be implemented something like :
```cpp
std::unique_ptr<char[]> StringView::characters_with_null_termination() const
{
    std::unique_ptr<char[]> s_term(new char[m_length + 1]);
    std::memcpy(s_term.get(), m_characters, m_length + 1);
    s_term[m_length] = '\0';
    return s_term;
}
```

But `NonnullOwnPtr<T>` and `OwnPtr<T>` don't support `T=char[]` so this is why I used `ByteBuffer` as I didn't want to just allocate and return an owning `char*`.
