### PR TITLE
LibWeb: Account for box-sizing:border-box in layout-less definite sizes

### DIFF
--- a/Tests/LibWeb/Layout/expected/box-sizing-border-box-for-definite-sizes-without-layout.txt
+++ b/Tests/LibWeb/Layout/expected/box-sizing-border-box-for-definite-sizes-without-layout.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x66 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x50 children: inline
+      line 0 width: 89.726562, height: 50, bottom: 50, baseline: 16.914062
+        frag 0 from Box start: 0, length: 0, rect: [28,38 49.726562x0]
+      Box <div.button> at (28,38) content-size 49.726562x0 flex-container(row) children: not-inline
+        BlockContainer <(anonymous)> at (28,27.082031) content-size 49.726562x21.835937 flex-item children: inline
+          line 0 width: 49.726562, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+            frag 0 from TextNode start: 0, length: 5, rect: [28,27.082031 49.726562x21.835937]
+              "Hello"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/box-sizing-border-box-for-definite-sizes-without-layout.html
+++ b/Tests/LibWeb/Layout/input/box-sizing-border-box-for-definite-sizes-without-layout.html
@@ -1,0 +1,14 @@
+<!doctype html><html><head><style>
+    * {
+        font: 20px SerenitySans;
+    }
+    .button {
+        align-items: center;
+        background-color: orange;
+        display: inline-flex;
+        height: 30px;
+        padding: 20px;
+        font-size: 20px;
+        box-sizing: border-box;
+    }
+</style></head><body><div class="button">Hello

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1088,15 +1088,7 @@ void FlexFormattingContext::determine_hypothetical_cross_size_of_item(FlexItem& 
             return;
         }
 
-        auto cross_size = [&]() {
-            if (item.box->computed_values().box_sizing() == CSS::BoxSizing::BorderBox && !should_treat_cross_size_as_auto(item.box)) {
-                return max(CSSPixels(0.0f), inner_cross_size(item.box) - item.padding.cross_before - item.padding.cross_after - item.borders.cross_before - item.borders.cross_after);
-            }
-
-            return inner_cross_size(item.box);
-        }();
-
-        item.hypothetical_cross_size = css_clamp(cross_size, clamp_min, clamp_max);
+        item.hypothetical_cross_size = css_clamp(inner_cross_size(item.box), clamp_min, clamp_max);
         return;
     }
 

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -118,8 +118,6 @@ private:
     bool has_definite_cross_size(Box const&) const;
     CSSPixels inner_main_size(Box const&) const;
     CSSPixels inner_cross_size(Box const&) const;
-    CSSPixels resolved_definite_main_size(FlexItem const&) const;
-    CSSPixels resolved_definite_cross_size(FlexItem const&) const;
     bool has_main_min_size(Box const&) const;
     bool has_cross_min_size(Box const&) const;
     CSSPixels specified_main_max_size(Box const&) const;

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -354,16 +354,6 @@ void LayoutState::UsedValues::set_temporary_content_height(CSSPixels height)
     m_content_height = height;
 }
 
-CSSPixels LayoutState::resolved_definite_width(Box const& box) const
-{
-    return get(box).content_width();
-}
-
-CSSPixels LayoutState::resolved_definite_height(Box const& box) const
-{
-    return get(box).content_height();
-}
-
 AvailableSize LayoutState::UsedValues::available_width_inside() const
 {
     if (width_constraint == SizeConstraint::MinContent)

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -145,9 +145,6 @@ struct LayoutState {
         HashTable<JS::GCPtr<Box const>> m_floating_descendants;
     };
 
-    CSSPixels resolved_definite_width(Box const&) const;
-    CSSPixels resolved_definite_height(Box const&) const;
-
     void commit();
 
     // NOTE: get_mutable() will CoW the UsedValues if it's inherited from an ancestor state;


### PR DESCRIPTION
When we determine that a size is definite because it can be resolved now
without performing layout, we also need to account for the box-sizing
property.
    
This lets us remove a hack from flex layout where box-sizing:border-box
was manually undone at one point in the layout algorithm.

Note the "Tell me more" and "Download" buttons on https://www.minetest.net/ below.

Before:
![image](https://user-images.githubusercontent.com/5954907/235582772-801e4dde-63c5-471e-84b1-2169afd3704f.png)

After:
![image](https://user-images.githubusercontent.com/5954907/235582787-fd550a86-b77c-481b-9c4b-e63076a2cf4c.png)
