### PR TITLE
LibGUI: Fix stuck and crash on deleting word forward/backword

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -791,7 +791,7 @@ TextPosition TextDocument::first_word_break_after(TextPosition const& position) 
             auto view_between_target_and_index = line.view().substring_view(target.column(), *index - target.column());
 
             if (should_continue_beyond_word(view_between_target_and_index)) {
-                target.set_column(*index + 1);
+                target.set_column(min(*index + 1, line.length()));
                 continue;
             }
 

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -754,6 +754,9 @@ TextPosition TextDocument::first_word_break_before(TextPosition const& position,
 
     target.set_column(target.column() - modifier);
 
+    if (target.column() == 0)
+        return target;
+
     while (target.column() < line.length()) {
         if (auto index = Unicode::previous_word_segmentation_boundary(line.view(), target.column()); index.has_value()) {
             auto view_between_target_and_index = line.view().substring_view(*index, target.column() - *index);


### PR DESCRIPTION
`<Ctrl-Backspace>` for deleting word backward:
- Before: 

  https://user-images.githubusercontent.com/57862491/235665710-4e891a35-01f8-4466-b185-d68583fb9f0d.mp4

- After: 

  https://user-images.githubusercontent.com/57862491/235665744-7352798a-4eb9-4703-89be-4c8a6274306e.mp4

`<Ctrl-Del>` for deleting word forward:
- Before:

  https://user-images.githubusercontent.com/57862491/235666210-f4c6cf68-7988-4e5e-8717-bda5b5d8d7ba.mp4

- After:

  https://user-images.githubusercontent.com/57862491/235666218-09307476-b516-44d9-b4b3-79c8f140724f.mp4