### PR TITLE
ICC+image: Add conversion between color spaces for images :^)

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -1570,10 +1570,8 @@ ErrorOr<void> Profile::from_pcs(FloatVector3 const& pcs, Bytes color) const
             auto evaluate_curve_inverse = [this](TagSignature curve_tag, float f) {
                 auto const& trc = *m_tag_table.get(curve_tag).value();
                 VERIFY(trc.type() == CurveTagData::Type || trc.type() == ParametricCurveTagData::Type);
-                if (trc.type() == CurveTagData::Type) {
-                    TODO();
-                    return 0.f;
-                }
+                if (trc.type() == CurveTagData::Type)
+                    return static_cast<CurveTagData const&>(trc).evaluate_inverse(f);
                 return static_cast<ParametricCurveTagData const&>(trc).evaluate_inverse(f);
             };
 

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -14,6 +14,7 @@
 #include <AK/Span.h>
 #include <AK/URL.h>
 #include <LibCrypto/Hash/MD5.h>
+#include <LibGfx/Bitmap.h>
 #include <LibGfx/CIELAB.h>
 #include <LibGfx/ICC/DistinctFourCC.h>
 #include <LibGfx/ICC/TagTypes.h>
@@ -272,6 +273,8 @@ public:
     ErrorOr<void> from_pcs(FloatVector3 const&, Bytes) const;
 
     ErrorOr<CIELAB> to_lab(ReadonlyBytes) const;
+
+    ErrorOr<void> convert_image(Bitmap&, Profile const& source_profile) const;
 
     // Only call these if you know that this is an RGB matrix-based profile.
     XYZ const& red_matrix_column() const;


### PR DESCRIPTION
For now, only for color spaces that are supported by Profile::to_pcs()
and Profile::from_pcs(), which currently means that all matrix profiles
(but not LUT profiles) in the source color space work, and that
matrix profiles with parametric curves in the destination color
space work.

This adds Profile::convert_image(Bitmap, source_profile), and
adds a `--convert-to-color-profile file.icc` flag to `image`.

It only takes a file path, so to use it with the built-in
sRGB profile, you have to write it to a file first:

```sh
% Build/lagom/icc -n sRGB --reencode-to serenity-sRGB.icc
```

`image` by default writes the source image's color profile
to the output image, and most image viewers display images
looking at the profile.

For example, take `Seven_Coloured_Pencils_(rg-switch_sRGB).jpg`
from https://commons.wikimedia.org/wiki/User:Colin/BrowserTest.

It looks normal in image viewers because they apply the unusual
profile embedded in the profile. But if you run

```sh
% Build/lagom/image -o huh.png --strip-color-profile \
    'Seven_Coloured_Pencils_(rg-switch_sRGB).jpeg'
```

and then look at huh.png, you can see how the image's colors
look like when interpreted as sRGB (which is the color space
PNG data is in if the PNG doesn't store an embedded profile).

If you now run

```sh
% Build/lagom/image -o wow.png \
    --convert-to-color-profile serenity-sRGB.icc --strip-color-profile \
    'Seven_Coloured_Pencils_(rg-switch_sRGB).jpeg'
```

this will convert that image to sRGB, but then not write
the profile to the output image (verify with `Build/lagom/icc wow.png`).
It will look correct in image viewers, since they display PNGs without
an embedded color profile as sRGB.

(This works because 'Seven_Coloured_Pencils_(rg-switch_sRGB).jpeg'
contains a matrix profile, and Serenity's built-in sRGB profile
uses a matrix profile with a parametric curve.)

------------

ICC: Implement TRC inversion in from_pcs for point curves

This allows converting to a color space that uses a non-parametric
curve, for example:

```sh
    Build/lagom/image -o foo.png \
        --convert-to-color-profile .../profiles/sRGB-v2-micro.icc \
        input.jpg
```

...where profiles/sRGB-v2-micro.icc is from
https://github.com/saucecontrol/Compact-ICC-Profiles/

(Parametric curves are new in ICC v4, which means all v2 profiles
use point curves.)

