### PR TITLE
Meta+Toolchain: Replace inline nproc with get_number_of_processing_units()

### DIFF
--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -57,3 +57,18 @@ FUSE2FS_PATH="$(find_executable fuse2fs)"
 RESIZE2FS_PATH="$(find_executable resize2fs)"
 E2FSCK_PATH="$(find_executable e2fsck)"
 MKE2FS_PATH="$(find_executable mke2fs)"
+
+get_number_of_processing_units() {
+  number_of_processing_units="nproc"
+  SYSTEM_NAME="$(uname -s)"
+
+  if [ "$SYSTEM_NAME" = "OpenBSD" ]; then
+      number_of_processing_units="sysctl -n hw.ncpuonline"
+  elif [ "$SYSTEM_NAME" = "FreeBSD" ]; then
+      number_of_processing_units="sysctl -n hw.ncpu"
+  elif [ "$SYSTEM_NAME" = "Darwin" ]; then
+      number_of_processing_units="sysctl -n hw.ncpu"
+  fi
+
+  ($number_of_processing_units)
+}

--- a/Toolchain/BuildCMake.sh
+++ b/Toolchain/BuildCMake.sh
@@ -14,18 +14,8 @@ PREFIX_DIR="$DIR/Local/cmake"
 BUILD_DIR="$DIR/Build/cmake"
 TARBALLS_DIR="$DIR/Tarballs"
 
-NPROC="nproc"
-SYSTEM_NAME="$(uname -s)"
-
-if [ "$SYSTEM_NAME" = "OpenBSD" ]; then
-    NPROC="sysctl -n hw.ncpuonline"
-elif [ "$SYSTEM_NAME" = "FreeBSD" ]; then
-    NPROC="sysctl -n hw.ncpu"
-elif [ "$SYSTEM_NAME" = "Darwin" ]; then
-    NPROC="sysctl -n hw.ncpu"
-fi
-
-[ -z "$MAKEJOBS" ] && MAKEJOBS=$($NPROC)
+NPROC=$(get_number_of_processing_units)
+[ -z "$MAKEJOBS" ] && MAKEJOBS=${NPROC}
 
 check_sha() {
     if [ $# -ne 2 ]; then
@@ -36,6 +26,7 @@ check_sha() {
     FILE="${1}"
     EXPECTED_HASH="${2}"
 
+    SYSTEM_NAME="$(uname -s)"
     if [ "$SYSTEM_NAME" = "Darwin" ]; then
         SEEN_HASH="$(shasum -a 256 "${FILE}" | cut -d " " -f 1)"
     else

--- a/Toolchain/BuildClang.sh
+++ b/Toolchain/BuildClang.sh
@@ -19,7 +19,6 @@ ARCHS="$USERLAND_ARCHS aarch64"
 
 MD5SUM="md5sum"
 REALPATH="realpath"
-NPROC="nproc"
 INSTALL="install"
 SED="sed"
 
@@ -28,25 +27,20 @@ SYSTEM_NAME="$(uname -s)"
 if [ "$SYSTEM_NAME" = "OpenBSD" ]; then
     MD5SUM="md5 -q"
     REALPATH="readlink -f"
-    NPROC="sysctl -n hw.ncpuonline"
     export CC=egcc
     export CXX=eg++
     export LDFLAGS=-Wl,-z,notext
 elif [ "$SYSTEM_NAME" = "FreeBSD" ]; then
     MD5SUM="md5 -q"
-    NPROC="sysctl -n hw.ncpu"
 elif [ "$SYSTEM_NAME" = "Darwin" ]; then
     MD5SUM="md5 -q"
-    NPROC="sysctl -n hw.ncpu"
     REALPATH="grealpath"  # GNU coreutils
     INSTALL="ginstall"    # GNU coreutils
     SED="gsed"            # GNU sed
 fi
 
-if [ -z "$MAKEJOBS" ]; then
-    MAKEJOBS=$($NPROC)
-fi
-
+NPROC=$(get_number_of_processing_units)
+[ -z "$MAKEJOBS" ] && MAKEJOBS=${NPROC}
 
 if [ ! -d "$BUILD" ]; then
     mkdir -p "$BUILD"

--- a/Toolchain/BuildGDB.sh
+++ b/Toolchain/BuildGDB.sh
@@ -21,30 +21,25 @@ PREFIX="$DIR/Local/$ARCH-gdb"
 echo "Building GDB $GDB_VERSION for $TARGET"
 
 MD5SUM="md5sum"
-NPROC="nproc"
 
 SYSTEM_NAME="$(uname -s)"
 
 if [ "$SYSTEM_NAME" = "OpenBSD" ]; then
     MD5SUM="md5 -q"
-    NPROC="sysctl -n hw.ncpuonline"
     export CC=egcc
     export CXX=eg++
     export with_gmp=/usr/local
     export LDFLAGS=-Wl,-z,notext
 elif [ "$SYSTEM_NAME" = "FreeBSD" ]; then
     MD5SUM="md5 -q"
-    NPROC="sysctl -n hw.ncpu"
     export with_gmp=/usr/local
     export with_mpfr=/usr/local
 elif [ "$SYSTEM_NAME" = "Darwin" ]; then
     MD5SUM="md5 -q"
-    NPROC="sysctl -n hw.ncpu"
 fi
 
-if [ -z "$MAKEJOBS" ]; then
-    MAKEJOBS=$($NPROC)
-fi
+NPROC=$(get_number_of_processing_units)
+[ -z "$MAKEJOBS" ] && MAKEJOBS=${NPROC}
 
 buildstep() {
     NAME=$1

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -21,7 +21,6 @@ SYSROOT="$BUILD/Root"
 
 MAKE="make"
 MD5SUM="md5sum"
-NPROC="nproc"
 REALPATH="realpath"
 
 if command -v ginstall &>/dev/null; then
@@ -41,7 +40,6 @@ export CXXFLAGS="-g0 -O2 -mtune=native"
 if [ "$SYSTEM_NAME" = "OpenBSD" ]; then
     MAKE=gmake
     MD5SUM="md5 -q"
-    NPROC="sysctl -n hw.ncpuonline"
     REALPATH="readlink -f"
     export CC=egcc
     export CXX=eg++
@@ -50,12 +48,10 @@ if [ "$SYSTEM_NAME" = "OpenBSD" ]; then
 elif [ "$SYSTEM_NAME" = "FreeBSD" ]; then
     MAKE=gmake
     MD5SUM="md5 -q"
-    NPROC="sysctl -n hw.ncpu"
     export with_gmp=/usr/local
     export with_mpfr=/usr/local
 elif [ "$SYSTEM_NAME" = "Darwin" ]; then
     MD5SUM="md5 -q"
-    NPROC="sysctl -n hw.ncpu"
 fi
 
 # On at least OpenBSD, the path must exist to call realpath(3) on it
@@ -270,9 +266,8 @@ popd
 rm -rf "$PREFIX"
 mkdir -p "$PREFIX"
 
-if [ -z "$MAKEJOBS" ]; then
-    MAKEJOBS=$($NPROC)
-fi
+NPROC=$(get_number_of_processing_units)
+[ -z "$MAKEJOBS" ] && MAKEJOBS=${NPROC}
 
 mkdir -p "$DIR/Build/$ARCH"
 

--- a/Toolchain/BuildMold.sh
+++ b/Toolchain/BuildMold.sh
@@ -11,18 +11,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 exit_if_running_as_root "Do not run BuildMold.sh as root, parts of your Toolchain directory will become root-owned"
 
-NPROC="nproc"
-SYSTEM_NAME="$(uname -s)"
-
-if [ "$SYSTEM_NAME" = "OpenBSD" ]; then
-    NPROC="sysctl -n hw.ncpuonline"
-elif [ "$SYSTEM_NAME" = "FreeBSD" ]; then
-    NPROC="sysctl -n hw.ncpu"
-elif [ "$SYSTEM_NAME" = "Darwin" ]; then
-    NPROC="sysctl -n hw.ncpu"
-fi
-
-[ -z "$MAKEJOBS" ] && MAKEJOBS=$($NPROC)
+NPROC=$(get_number_of_processing_units)
+[ -z "$MAKEJOBS" ] && MAKEJOBS=${NPROC}
 
 mkdir -p "$DIR"/Tarballs
 pushd "$DIR"/Tarballs

--- a/Toolchain/BuildPython.sh
+++ b/Toolchain/BuildPython.sh
@@ -41,9 +41,8 @@ pushd "${TARBALLS_DIR}"
     fi
 popd
 
-if [ -z "$MAKEJOBS" ]; then
-    MAKEJOBS=$(nproc)
-fi
+NPROC=$(get_number_of_processing_units)
+[ -z "$MAKEJOBS" ] && MAKEJOBS=${NPROC}
 
 mkdir -p "${PREFIX_DIR}"
 mkdir -p "${BUILD_DIR}"

--- a/Toolchain/BuildQemu.sh
+++ b/Toolchain/BuildQemu.sh
@@ -55,9 +55,8 @@ popd
 mkdir -p "$PREFIX"
 mkdir -p "$DIR/Build/qemu"
 
-if [ -z "$MAKEJOBS" ]; then
-    MAKEJOBS=$(nproc)
-fi
+NPROC=$(get_number_of_processing_units)
+[ -z "$MAKEJOBS" ] && MAKEJOBS=${NPROC}
 
 EXTRA_ARGS=""
 if [[ $(uname) == "Darwin" ]]

--- a/Toolchain/BuildRuby.sh
+++ b/Toolchain/BuildRuby.sh
@@ -41,9 +41,8 @@ pushd "${TARBALLS_DIR}"
     fi
 popd
 
-if [ -z "$MAKEJOBS" ]; then
-    MAKEJOBS=$(nproc)
-fi
+NPROC=$(get_number_of_processing_units)
+[ -z "$MAKEJOBS" ] && MAKEJOBS=${NPROC}
 
 mkdir -p "${PREFIX_DIR}"
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
This adds the method get_number_of_processing_units() which returns the number of processing units the system has available.