### PR TITLE
LibWeb: Show formatting context roots in layout tree dumps

### DIFF
--- a/Tests/LibWeb/Layout/expected/acid1.txt
+++ b/Tests/LibWeb/Layout/expected/acid1.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x420 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x420 [BFC] children: not-inline
     BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
       TextNode <#text>
     BlockContainer <body> at (20,20) content-size 480x380 children: not-inline
@@ -7,24 +7,24 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <dl> at (25,25) content-size 470x0 children: inline
         TextNode <#text>
-        BlockContainer <dt> at (40,40) content-size 49.998596x280 floating children: inline
+        BlockContainer <dt> at (40,40) content-size 49.998596x280 floating [BFC] children: inline
           line 0 width: 28.310546, height: 10, bottom: 10, baseline: 7.998046
             frag 0 from TextNode start: 0, length: 6, rect: [40,40 28.310546x10]
               "toggle"
           TextNode <#text>
         TextNode <#text>
-        BlockContainer <dd> at (135,45) content-size 340x270 floating children: not-inline
+        BlockContainer <dd> at (135,45) content-size 340x270 floating [BFC] children: not-inline
           BlockContainer <(anonymous)> at (135,45) content-size 340x0 children: inline
             TextNode <#text>
           BlockContainer <ul> at (135,45) content-size 340x0 children: inline
             TextNode <#text>
-            BlockContainer <li> at (150,60) content-size 50x90 floating children: inline
+            BlockContainer <li> at (150,60) content-size 50x90 floating [BFC] children: inline
               line 0 width: 37.880859, height: 10, bottom: 10, baseline: 7.998046
                 frag 0 from TextNode start: 0, length: 7, rect: [150,60 37.880859x10]
                   "the way"
               TextNode <#text>
             TextNode <#text>
-            BlockContainer <li#bar> at (235,55) content-size 139.977996x90 floating children: not-inline
+            BlockContainer <li#bar> at (235,55) content-size 139.977996x90 floating [BFC] children: not-inline
               BlockContainer <(anonymous)> at (235,55) content-size 139.977996x0 children: inline
                 TextNode <#text>
               BlockContainer <p> at (235,55) content-size 139.977996x10 children: inline
@@ -57,7 +57,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> at (235,103) content-size 139.977996x0 children: inline
                 TextNode <#text>
             TextNode <#text>
-            BlockContainer <li> at (409.977996,60) content-size 50x90 floating children: inline
+            BlockContainer <li> at (409.977996,60) content-size 50x90 floating [BFC] children: inline
               line 0 width: 31.582031, height: 10, bottom: 10, baseline: 7.998046
                 frag 0 from TextNode start: 0, length: 6, rect: [409.977996,60 31.582031x10]
                   "i grow"
@@ -66,7 +66,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   "old"
               TextNode <#text>
             TextNode <#text>
-            BlockContainer <li#baz> at (145,185) content-size 100x100 floating children: inline
+            BlockContainer <li#baz> at (145,185) content-size 100x100 floating [BFC] children: inline
               line 0 width: 29.423828, height: 10, bottom: 10, baseline: 7.998046
                 frag 0 from TextNode start: 0, length: 6, rect: [145,185 29.423828x10]
                   "pluot?"
@@ -74,7 +74,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           BlockContainer <(anonymous)> at (135,45) content-size 340x0 children: inline
             TextNode <#text>
-            BlockContainer <blockquote> at (280,195) content-size 50x90 floating children: not-inline
+            BlockContainer <blockquote> at (280,195) content-size 50x90 floating [BFC] children: not-inline
               BlockContainer <(anonymous)> at (280,195) content-size 50x0 children: inline
                 TextNode <#text>
               BlockContainer <address> at (280,195) content-size 50x20 children: inline
@@ -88,7 +88,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> at (280,215) content-size 50x0 children: inline
                 TextNode <#text>
             TextNode <#text>
-            BlockContainer <h1> at (365,185) content-size 100x100 floating children: inline
+            BlockContainer <h1> at (365,185) content-size 100x100 floating [BFC] children: inline
               line 0 width: 56.416015, height: 10, bottom: 10, baseline: 7.998046
                 frag 0 from TextNode start: 0, length: 11, rect: [365,185 56.416015x10]
                   "sing to me,"

--- a/Tests/LibWeb/Layout/expected/automatic-height-of-non-replaced-abspos-element-must-not-be-negative.txt
+++ b/Tests/LibWeb/Layout/expected/automatic-height-of-non-replaced-abspos-element-must-not-be-negative.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x0 children: not-inline
-    BlockContainer <body.outer> at (8,8) content-size 0x0 positioned children: not-inline
-      BlockContainer <div.inner> at (9,9) content-size 0x0 positioned children: inline
+  BlockContainer <html> at (0,0) content-size 800x0 [BFC] children: not-inline
+    BlockContainer <body.outer> at (8,8) content-size 0x0 positioned [BFC] children: not-inline
+      BlockContainer <div.inner> at (9,9) content-size 0x0 positioned [BFC] children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/automatic-width-of-non-replaced-abspos-element-must-not-be-negative.txt
+++ b/Tests/LibWeb/Layout/expected/automatic-width-of-non-replaced-abspos-element-must-not-be-negative.txt
@@ -1,4 +1,4 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x0 children: not-inline
-    BlockContainer <body.outer> at (8,8) content-size 0x0 positioned children: not-inline
-      BlockContainer <div.inner> at (9,9) content-size 0x0 positioned children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x0 [BFC] children: not-inline
+    BlockContainer <body.outer> at (8,8) content-size 0x0 positioned [BFC] children: not-inline
+      BlockContainer <div.inner> at (9,9) content-size 0x0 positioned [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/blank.txt
+++ b/Tests/LibWeb/Layout/expected/blank.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x16 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
       TextNode <#text>
     BlockContainer <body> at (8,8) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-percentage-vertical-align.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-percentage-vertical-align.txt
@@ -1,10 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x62.506248 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x62.506248 [BFC] children: not-inline
     BlockContainer <body> at (2,2) content-size 796x60.506248 children: inline
       line 0 width: 34, height: 28.50625, bottom: 28.50625, baseline: 28.50625
         frag 0 from BlockContainer start: 0, length: 0, rect: [4,3 30x30]
       line 1 width: 32, height: 28.506248, bottom: 60.506248, baseline: 28.50625
         frag 0 from BlockContainer start: 0, length: 0, rect: [3,35 30x30]
-      BlockContainer <div.clump> at (4,3) content-size 30x30 inline-block children: not-inline
+      BlockContainer <div.clump> at (4,3) content-size 30x30 inline-block [BFC] children: not-inline
       BreakNode <br>
-      BlockContainer <div.clump> at (3,35) content-size 30x30 inline-block children: not-inline
+      BlockContainer <div.clump> at (3,35) content-size 30x30 inline-block [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/bfc-consider-all-currently-stacked-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/bfc-consider-all-currently-stacked-floats.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x108 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x108 [BFC] children: not-inline
     BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
       TextNode <#text>
     BlockContainer <body> at (8,8) content-size 784x34.9375 children: not-inline
@@ -7,9 +7,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         line 0 width: 27.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
           frag 0 from TextNode start: 1, length: 3, rect: [137,8 27.640625x17.46875]
             "bar"
-        BlockContainer <div.big-float> at (8,8) content-size 100x100 floating children: not-inline
+        BlockContainer <div.big-float> at (8,8) content-size 100x100 floating [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div.xxx> at (108,8) content-size 29.109375x17.46875 floating children: inline
+        BlockContainer <div.xxx> at (108,8) content-size 29.109375x17.46875 floating [BFC] children: inline
           line 0 width: 29.109375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 3, rect: [108,8 29.109375x17.46875]
               "xxx"
@@ -20,7 +20,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 1, length: 3, rect: [130,25.46875 27.203125x17.46875]
             "baz"
         TextNode <#text>
-        BlockContainer <div.yyy> at (108,25.46875) content-size 21.515625x17.46875 floating children: inline
+        BlockContainer <div.yyy> at (108,25.46875) content-size 21.515625x17.46875 floating [BFC] children: inline
           line 0 width: 21.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 3, rect: [108,25.46875 21.515625x17.46875]
               "yyy"

--- a/Tests/LibWeb/Layout/expected/block-and-inline/bfc-float-left-break-vertically-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/bfc-float-left-break-vertically-2.txt
@@ -1,10 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x150 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x150 [BFC] children: not-inline
     BlockContainer <body> at (0,0) content-size 200x0 children: not-inline
       BlockContainer <ul> at (0,0) content-size 200x0 children: inline
-        BlockContainer <div.red> at (0,0) content-size 150x50 floating children: not-inline
-        BlockContainer <div.green> at (0,50) content-size 150x50 floating children: not-inline
+        BlockContainer <div.red> at (0,0) content-size 150x50 floating [BFC] children: not-inline
+        BlockContainer <div.green> at (0,50) content-size 150x50 floating [BFC] children: not-inline
         TextNode <#text>
-      BlockContainer <div.orange> at (0,100) content-size 150x50 floating children: not-inline
+      BlockContainer <div.orange> at (0,100) content-size 150x50 floating [BFC] children: not-inline
       BlockContainer <(anonymous)> at (0,0) content-size 200x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/bfc-float-left-break-vertically.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/bfc-float-left-break-vertically.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x106 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x106 [BFC] children: not-inline
     BlockContainer <(anonymous)> at (1,1) content-size 798x0 children: inline
       TextNode <#text>
     BlockContainer <body> at (2,2) content-size 400x2 children: not-inline
@@ -7,11 +7,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <div.ul> at (3,3) content-size 398x0 children: inline
         TextNode <#text>
-        BlockContainer <div.yellow> at (4,4) content-size 60x50 floating children: not-inline
+        BlockContainer <div.yellow> at (4,4) content-size 60x50 floating [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div.orange> at (66,4) content-size 250x50 floating children: not-inline
+        BlockContainer <div.orange> at (66,4) content-size 250x50 floating [BFC] children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (2,4) content-size 400x0 children: inline
         TextNode <#text>
-        BlockContainer <div.green> at (3,56) content-size 100x50 floating children: not-inline
+        BlockContainer <div.green> at (3,56) content-size 100x50 floating [BFC] children: not-inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/clearfix.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/clearfix.txt
@@ -1,15 +1,15 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x157 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x157 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x100 children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
           TextNode <#text>
-          BlockContainer <div.square.white> at (8,8) content-size 100x100 floating children: not-inline
+          BlockContainer <div.square.white> at (8,8) content-size 100x100 floating [BFC] children: not-inline
           TextNode <#text>
         BlockContainer <div.clearfix> at (8,108) content-size 784x0 children: not-inline
         BlockContainer <(anonymous)> at (8,108) content-size 784x0 children: inline
           TextNode <#text>
-          BlockContainer <div.square.black> at (8,108) content-size 49x49 floating children: not-inline
+          BlockContainer <div.square.black> at (8,108) content-size 49x49 floating [BFC] children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,108) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-1.txt
@@ -1,17 +1,17 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x348.34375 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x348.34375 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x332.34375 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
-        BlockContainer <div#lefty> at (8,8) content-size 100x100 floating children: inline
+        BlockContainer <div#lefty> at (8,8) content-size 100x100 floating [BFC] children: inline
           line 0 width: 10.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 10.859375x17.46875]
               "L"
           TextNode <#text>
         TextNode <#text>
-        BlockContainer <div#righty> at (742,8) content-size 50x50 floating children: inline
+        BlockContainer <div#righty> at (742,8) content-size 50x50 floating [BFC] children: inline
           line 0 width: 13.6875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [742,8 13.6875x17.46875]
               "R"
@@ -21,13 +21,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <div> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
-        BlockContainer <div#lefty2> at (108,8) content-size 80x80 floating children: inline
+        BlockContainer <div#lefty2> at (108,8) content-size 80x80 floating [BFC] children: inline
           line 0 width: 19.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 2, rect: [108,8 19.671875x17.46875]
               "L2"
           TextNode <#text>
         TextNode <#text>
-        BlockContainer <div#righty2> at (712,8) content-size 30x30 floating children: inline
+        BlockContainer <div#righty2> at (712,8) content-size 30x30 floating [BFC] children: inline
           line 0 width: 22.5, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 2, rect: [712,8 22.5x17.46875]
               "R2"
@@ -37,13 +37,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <div> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
-        BlockContainer <div#lefty3> at (188,8) content-size 40x40 floating children: inline
+        BlockContainer <div#lefty3> at (188,8) content-size 40x40 floating [BFC] children: inline
           line 0 width: 19.953125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 2, rect: [188,8 19.953125x17.46875]
               "L3"
           TextNode <#text>
         TextNode <#text>
-        BlockContainer <div#righty3> at (692,8) content-size 20x20 floating children: inline
+        BlockContainer <div#righty3> at (692,8) content-size 20x20 floating [BFC] children: inline
           line 0 width: 22.78125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 2, rect: [692,8 22.78125x17.46875]
               "R3"

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-2.txt
@@ -1,11 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x60 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x60 [BFC] children: not-inline
     BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
       TextNode <#text>
     BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
-        BlockContainer <div#b> at (9,9) content-size 50x50 floating children: not-inline
+        BlockContainer <div#b> at (9,9) content-size 50x50 floating [BFC] children: not-inline
         TextNode <#text>
       BlockContainer <div#a> at (8,8) content-size 784x17.46875 children: inline
         line 0 width: 37.578125, height: 17.46875, bottom: 17.46875, baseline: 13.53125

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-3.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-3.txt
@@ -1,13 +1,13 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x135.46875 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x135.46875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 780x119.46875 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 780x0 children: inline
         TextNode <#text>
-      BlockContainer <div#top> at (8,8) content-size 780x100 children: inline
+      BlockContainer <div#top> at (8,8) content-size 780x100 [BFC] children: inline
         TextNode <#text>
-        BlockContainer <div#top-left.box> at (8,8) content-size 300x100 floating children: not-inline
+        BlockContainer <div#top-left.box> at (8,8) content-size 300x100 floating [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div#top-right.box> at (488,8) content-size 300x100 floating children: not-inline
+        BlockContainer <div#top-right.box> at (488,8) content-size 300x100 floating [BFC] children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,108) content-size 780x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-1.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x268 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x268 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x252 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
@@ -65,15 +65,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 125, length: 19, rect: [9,269 168.84375x16]
             "bar baz foo bar baz"
         TextNode <#text>
-        BlockContainer <div.lefty> at (10,10) content-size 50x50 floating children: not-inline
+        BlockContainer <div.lefty> at (10,10) content-size 50x50 floating [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div.one> at (62,26) content-size 200x50 floating children: not-inline
+        BlockContainer <div.one> at (62,26) content-size 200x50 floating [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div.two> at (108,78) content-size 200x50 floating children: not-inline
+        BlockContainer <div.two> at (108,78) content-size 200x50 floating [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div.righty> at (76,126) content-size 30x30 floating children: not-inline
+        BlockContainer <div.righty> at (76,126) content-size 30x30 floating [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div.lefty.shwifty> at (10,174) content-size 50x50 floating children: not-inline
+        BlockContainer <div.lefty.shwifty> at (10,174) content-size 50x50 floating [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div.righty> at (278,190) content-size 30x30 floating children: not-inline
+        BlockContainer <div.righty> at (278,190) content-size 30x30 floating [BFC] children: not-inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-2.txt
@@ -1,14 +1,14 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html.js> at (0,0) content-size 800x200 children: not-inline
+  BlockContainer <html.js> at (0,0) content-size 800x200 [BFC] children: not-inline
     BlockContainer <body> at (0,0) content-size 800x50 children: not-inline
       BlockContainer <div#page> at (50,50) content-size 750x0 children: not-inline
-        BlockContainer <div#content_box> at (50,50) content-size 400x150 floating children: inline
-          BlockContainer <article.first> at (50,50) content-size 300x100 floating children: inline
+        BlockContainer <div#content_box> at (50,50) content-size 400x150 floating [BFC] children: inline
+          BlockContainer <article.first> at (50,50) content-size 300x100 floating [BFC] children: inline
             line 0 width: 36.03125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
               frag 0 from TextNode start: 0, length: 5, rect: [50,50 36.03125x17.46875]
                 "first"
             TextNode <#text>
-          BlockContainer <article.second> at (50,150) content-size 200x50 floating children: inline
+          BlockContainer <article.second> at (50,150) content-size 200x50 floating [BFC] children: inline
             line 0 width: 54.78125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
               frag 0 from TextNode start: 0, length: 6, rect: [50,150 54.78125x17.46875]
                 "second"

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-3.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-3.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x268 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x268 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x252 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
@@ -8,9 +8,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 1, length: 23, rect: [61,9 204x16]
             "foo bar baz foo bar baz"
         TextNode <#text>
-        BlockContainer <div.lefty> at (10,10) content-size 50x50 floating children: not-inline
+        BlockContainer <div.lefty> at (10,10) content-size 50x50 floating [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div.one> at (62,26) content-size 200x50 floating children: not-inline
+        BlockContainer <div.one> at (62,26) content-size 200x50 floating [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div.two> at (108,78) content-size 200x50 floating children: not-inline
+        BlockContainer <div.two> at (108,78) content-size 200x50 floating [BFC] children: not-inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/ifc-float-left-and-sibling-with-margin-left.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/ifc-float-left-and-sibling-with-margin-left.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x61 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x61 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x19.46875 children: not-inline
-      BlockContainer <div.thumbnail> at (11,11) content-size 50x50 floating children: not-inline
+      BlockContainer <div.thumbnail> at (11,11) content-size 50x50 floating [BFC] children: not-inline
       BlockContainer <div.title> at (91,11) content-size 698x17.46875 children: inline
         line 0 width: 125.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
           frag 0 from TextNode start: 0, length: 14, rect: [91,11 125.125x17.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-positioned-with-top-left.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-positioned-with-top-left.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x36 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x36 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x20 children: inline
       line 0 width: 352.34375, height: 20, bottom: 20, baseline: 13.53125
         frag 0 from TextNode start: 0, length: 14, rect: [8,8 112.421875x17.46875]
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 2 from TextNode start: 0, length: 16, rect: [231,8 129.546875x17.46875]
           "more inline text"
       TextNode <#text>
-      BlockContainer <span.displaced_text> at (150,48) content-size 110.375x20 positioned inline-block children: inline
+      BlockContainer <span.displaced_text> at (150,48) content-size 110.375x20 positioned inline-block [BFC] children: inline
         line 0 width: 110.375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
           frag 0 from TextNode start: 0, length: 14, rect: [150,48 110.375x17.46875]
             "displaced text"

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins-vertical-align-top.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins-vertical-align-top.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x191 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x191 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x175 children: inline
       line 0 width: 210.828125, height: 175, bottom: 175, baseline: 13.53125
         frag 0 from TextNode start: 0, length: 6, rect: [8,8 43.125x17.46875]
@@ -8,5 +8,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 2 from TextNode start: 0, length: 9, rect: [151,8 67.703125x17.46875]
           " friends."
       TextNode <#text>
-      BlockContainer <div#inline-box> at (51,58) content-size 100x100 inline-block children: not-inline
+      BlockContainer <div#inline-box> at (51,58) content-size 100x100 inline-block [BFC] children: not-inline
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x194.46875 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x194.46875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x178.46875 children: inline
       line 0 width: 210.828125, height: 178.46875, bottom: 178.46875, baseline: 175
         frag 0 from TextNode start: 0, length: 6, rect: [8,169 43.125x17.46875]
@@ -8,5 +8,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 2 from TextNode start: 0, length: 9, rect: [151,169 67.703125x17.46875]
           " friends."
       TextNode <#text>
-      BlockContainer <div#inline-box> at (51,58) content-size 100x100 inline-block children: not-inline
+      BlockContainer <div#inline-box> at (51,58) content-size 100x100 inline-block [BFC] children: not-inline
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/intrinsic-sizing-with-min-width-specified.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/intrinsic-sizing-with-min-width-specified.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x52 children: not-inline
-    BlockContainer <body> at (10,10) content-size 104x34 floating children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x52 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 104x34 floating [BFC] children: not-inline
       BlockContainer <div.outer> at (11,11) content-size 102x32 children: not-inline
         BlockContainer <div.inner> at (12,12) content-size 100x30 children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/join-out-of-flow-box-with-previous-sibling-if-wrapped-in-anonymous-box.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/join-out-of-flow-box-with-previous-sibling-if-wrapped-in-anonymous-box.txt
@@ -1,9 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x76 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x76 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x60 children: not-inline
       BlockContainer <div.banner> at (8,8) content-size 200x30 children: not-inline
       BlockContainer <(anonymous)> at (8,38) content-size 784x30 children: inline
         line 0 width: 200, height: 30, bottom: 30, baseline: 30
           frag 0 from BlockContainer start: 0, length: 0, rect: [8,38 200x30]
-        BlockContainer <div.tab> at (8,38) content-size 200x30 inline-block children: not-inline
-        BlockContainer <div.timeline> at (592,38) content-size 200x30 floating children: not-inline
+        BlockContainer <div.tab> at (8,38) content-size 200x30 inline-block [BFC] children: not-inline
+        BlockContainer <div.timeline> at (592,38) content-size 200x30 floating [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-1.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x262 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x262 [BFC] children: not-inline
     BlockContainer <body> at (8,25) content-size 784x229 children: not-inline
       BlockContainer <div#foo> at (34,26) content-size 100x100 children: inline
         line 0 width: 27.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-2.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x352 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x352 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x336 children: not-inline
       BlockContainer <div#foo> at (9,9) content-size 100x100 children: inline
         line 0 width: 27.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-3.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-3.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x366 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x366 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x350 children: not-inline
       BlockContainer <div#foo> at (8,8) content-size 100x100 children: not-inline
       BlockContainer <(anonymous)> at (8,133) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-4.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-4.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x166 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x166 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x150 children: not-inline
       BlockContainer <div#foo> at (8,8) content-size 100x50 children: not-inline
         BlockContainer <div#baz> at (8,8) content-size 50x50 children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-5.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-5.txt
@@ -1,8 +1,8 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x134.46875 children: inline
+  BlockContainer <html> at (1,1) content-size 798x134.46875 [BFC] children: inline
     line 0 width: 170.96875, height: 134.46875, bottom: 134.46875, baseline: 13.53125
       frag 0 from BlockContainer start: 0, length: 0, rect: [2,15 168.96875x119.46875]
-    BlockContainer <body> at (2,15) content-size 168.96875x119.46875 inline-block children: not-inline
+    BlockContainer <body> at (2,15) content-size 168.96875x119.46875 inline-block [BFC] children: not-inline
       BlockContainer <div.hmm> at (3,16) content-size 166.96875x17.46875 children: inline
         line 0 width: 166.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
           frag 0 from TextNode start: 0, length: 21, rect: [3,16 166.96875x17.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-on-child-block-with-width-auto-contributes-to-intrinsic-size-of-parent.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-on-child-block-with-width-auto-contributes-to-intrinsic-size-of-parent.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x39.46875 children: not-inline
-    Box <body.outer> at (10,10) content-size 764x21.46875 flex-container(row) children: not-inline
-      BlockContainer <div.middle> at (11,11) content-size 202x19.46875 flex-item children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x39.46875 [BFC] children: not-inline
+    Box <body.outer> at (10,10) content-size 764x21.46875 flex-container(row) [FFC] children: not-inline
+      BlockContainer <div.middle> at (11,11) content-size 202x19.46875 flex-item [BFC] children: not-inline
         BlockContainer <div.inner> at (12,12) content-size 200x17.46875 children: inline
           line 0 width: 45.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 4, rect: [12,12 45.15625x17.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/single-br-inline-layout.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/single-br-inline-layout.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x37.46875 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x37.46875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x21.46875 children: not-inline
       BlockContainer <div#begin> at (8,8) content-size 784x2 children: not-inline
       BlockContainer <(anonymous)> at (8,10) content-size 784x17.46875 children: inline

--- a/Tests/LibWeb/Layout/expected/box-sizing-border-box-for-definite-sizes-without-layout.txt
+++ b/Tests/LibWeb/Layout/expected/box-sizing-border-box-for-definite-sizes-without-layout.txt
@@ -1,10 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x66 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x66 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x50 children: inline
       line 0 width: 89.726562, height: 50, bottom: 50, baseline: 16.914062
         frag 0 from Box start: 0, length: 0, rect: [28,38 49.726562x0]
-      Box <div.button> at (28,38) content-size 49.726562x0 flex-container(row) children: not-inline
-        BlockContainer <(anonymous)> at (28,27.082031) content-size 49.726562x21.835937 flex-item children: inline
+      Box <div.button> at (28,38) content-size 49.726562x0 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (28,27.082031) content-size 49.726562x21.835937 flex-item [BFC] children: inline
           line 0 width: 49.726562, height: 21.835937, bottom: 21.835937, baseline: 16.914062
             frag 0 from TextNode start: 0, length: 5, rect: [28,27.082031 49.726562x21.835937]
               "Hello"

--- a/Tests/LibWeb/Layout/expected/css-import-rule.txt
+++ b/Tests/LibWeb/Layout/expected/css-import-rule.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x70.589843 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x70.589843 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x54.589843 children: inline
       line 0 width: 137.646484, height: 54.589843, bottom: 54.589843, baseline: 42.285156
         frag 0 from TextNode start: 0, length: 5, rect: [8,8 137.646484x54.589843]

--- a/Tests/LibWeb/Layout/expected/css-imported-sheet-with-media-rule.txt
+++ b/Tests/LibWeb/Layout/expected/css-imported-sheet-with-media-rule.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x125.179687 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x125.179687 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x109.179687 children: inline
       line 0 width: 275.292968, height: 109.179687, bottom: 109.179687, baseline: 84.570312
         frag 0 from TextNode start: 0, length: 5, rect: [8,8 275.292968x109.179687]

--- a/Tests/LibWeb/Layout/expected/css-line-height-percentage-inheritance.txt
+++ b/Tests/LibWeb/Layout/expected/css-line-height-percentage-inheritance.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x52 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x52 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x34 children: not-inline
       BlockContainer <div> at (11,11) content-size 778x32 children: inline
         line 0 width: 552.109375, height: 32, bottom: 32, baseline: 27.992187

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-blockification.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-blockification.txt
@@ -1,18 +1,18 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x33.46875 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
-      Box <div.foo> at (8,8) content-size 784x17.46875 flex-container(row) children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 28.40625x17.46875 flex-item children: inline
+      Box <div.foo> at (8,8) content-size 784x17.46875 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 28.40625x17.46875 flex-item [BFC] children: inline
           line 0 width: 28.40625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 4, rect: [8,8 28.40625x17.46875]
               "well"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (46,8) content-size 36.84375x17.46875 flex-item children: inline
+        BlockContainer <(anonymous)> at (46,8) content-size 36.84375x17.46875 flex-item [BFC] children: inline
           line 0 width: 36.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 5, rect: [46,8 36.84375x17.46875]
               "hello"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (92.4375,8) content-size 55.359375x17.46875 flex-item children: inline
+        BlockContainer <(anonymous)> at (92.4375,8) content-size 55.359375x17.46875 flex-item [BFC] children: inline
           line 0 width: 55.359375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 7, rect: [92.4375,8 55.359375x17.46875]
               "friends"

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-inline-style.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-inline-style.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x120 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x120 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x102 children: not-inline
       BlockContainer <div.outer> at (11,11) content-size 100x100 children: not-inline
         BlockContainer <(anonymous)> at (12,12) content-size 50x50 children: inline

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
@@ -1,11 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x120 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x120 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x102 children: not-inline
-      TableWrapper <(anonymous)> at (10,10) content-size 102x102 children: not-inline
-        TableBox <table> at (11,11) content-size 102x100 children: not-inline
+      TableWrapper <(anonymous)> at (10,10) content-size 102x102 [BFC] children: not-inline
+        TableBox <table> at (11,11) content-size 102x100 [TFC] children: not-inline
           TableRowGroupBox <tbody> at (11,11) content-size 102x100 children: not-inline
             TableRowBox <tr> at (11,11) content-size 102x100 children: not-inline
-              TableCellBox <td> at (13,49.082031) content-size 98x23.835937 children: not-inline
+              TableCellBox <td> at (13,49.082031) content-size 98x23.835937 [BFC] children: not-inline
                 BlockContainer <(anonymous)> at (14,50.082031) content-size 96x21.835937 children: inline
                   line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
                     frag 0 from TextNode start: 0, length: 0, rect: [14,50.082031 0x21.835937]

--- a/Tests/LibWeb/Layout/expected/flex-abspos-item-with-preceding-whitespace.txt
+++ b/Tests/LibWeb/Layout/expected/flex-abspos-item-with-preceding-whitespace.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x20 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x20 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x2 children: not-inline
-      Box <div.pink> at (11,11) content-size 778x0 flex-container(row) children: not-inline
-        BlockContainer <(anonymous)> at (11,11) content-size 0x0 children: inline
+      Box <div.pink> at (11,11) content-size 778x0 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (11,11) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.orange> at (11,-39) content-size 100x100 positioned children: not-inline
+        BlockContainer <div.orange> at (11,-39) content-size 100x100 positioned [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/flex-auto.txt
+++ b/Tests/LibWeb/Layout/expected/flex-auto.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x120 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x120 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x104 children: not-inline
-      Box <div.container> at (9,9) content-size 500x102 flex-container(row) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.container> at (9,9) content-size 500x102 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 164.666671x100 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 164.666671x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (176.666671,10) content-size 164.666671x100 flex-item children: inline
+        BlockContainer <div.box> at (176.666671,10) content-size 164.666671x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [176.666671,10 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (343.333343,10) content-size 164.666671x100 flex-item children: inline
+        BlockContainer <div.box> at (343.333343,10) content-size 164.666671x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [343.333343,10 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-column-constained-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-constained-wrap.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x268 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x268 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x252 children: not-inline
-      Box <div.container.column> at (9,9) content-size 250x250 flex-container(column) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.container.column> at (9,9) content-size 250x250 flex-container(column) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,112) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (10,112) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,112 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (135,10) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (135,10) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [135,10 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,260) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-column-constrained-nowrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-constrained-nowrap.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x268 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x268 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x252 children: not-inline
-      Box <div.container.column> at (9,9) content-size 782x250 flex-container(column) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.container.column> at (9,9) content-size 782x250 flex-container(column) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 100x81.333328 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 100x81.333328 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,93.333328) content-size 100x81.333328 flex-item children: inline
+        BlockContainer <div.box> at (10,93.333328) content-size 100x81.333328 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,93.333328 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,176.666656) content-size 100x81.333328 flex-item children: inline
+        BlockContainer <div.box> at (10,176.666656) content-size 100x81.333328 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,176.666656 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,260) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-column-height-constrained-width-constrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-height-constrained-width-constrained.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x268 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x268 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x252 children: not-inline
-      Box <div.container.column> at (9,9) content-size 250x250 flex-container(column) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.container.column> at (9,9) content-size 250x250 flex-container(column) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 100x81.333328 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 100x81.333328 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,93.333328) content-size 100x81.333328 flex-item children: inline
+        BlockContainer <div.box> at (10,93.333328) content-size 100x81.333328 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,93.333328 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,176.666656) content-size 100x81.333328 flex-item children: inline
+        BlockContainer <div.box> at (10,176.666656) content-size 100x81.333328 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,176.666656 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,260) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-column-height-constrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-height-constrained.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x268 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x268 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x252 children: not-inline
-      Box <div.container> at (9,9) content-size 782x250 flex-container(column) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.container> at (9,9) content-size 782x250 flex-container(column) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 100x81.333328 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 100x81.333328 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,93.333328) content-size 100x81.333328 flex-item children: inline
+        BlockContainer <div.box> at (10,93.333328) content-size 100x81.333328 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,93.333328 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,176.666656) content-size 100x81.333328 flex-item children: inline
+        BlockContainer <div.box> at (10,176.666656) content-size 100x81.333328 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,176.666656 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,260) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-column-height-unconstrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-height-unconstrained.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x324 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x324 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x308 children: not-inline
-      Box <div.my-container.column> at (9,9) content-size 782x306 flex-container(column) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.my-container.column> at (9,9) content-size 782x306 flex-container(column) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,112) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (10,112) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,112 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,214) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (10,214) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,214 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,316) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-and-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-and-max-width.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x92.21875 children: not-inline
-    Box <body> at (2,2) content-size 796x90.21875 flex-container(column) children: not-inline
-      BlockContainer <main> at (3,3) content-size 400x88.21875 flex-item children: inline
+  BlockContainer <html> at (1,1) content-size 798x92.21875 [BFC] children: not-inline
+    Box <body> at (2,2) content-size 796x90.21875 flex-container(column) [FFC] children: not-inline
+      BlockContainer <main> at (3,3) content-size 400x88.21875 flex-item [BFC] children: inline
         line 0 width: 346.984375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
           frag 0 from TextNode start: 0, length: 41, rect: [3,3 346.984375x17.46875]
             "For my day job I'm currently working as a"

--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-auto-width-with-max-width-constraint.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-auto-width-with-max-width-constraint.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x331.570312 children: not-inline
-    Box <body.hero> at (2,2) content-size 600x329.570312 flex-container(column) children: not-inline
-      BlockContainer <div.header> at (102,3) content-size 400x327.570312 flex-item children: inline
+  BlockContainer <html> at (1,1) content-size 798x331.570312 [BFC] children: not-inline
+    Box <body.hero> at (2,2) content-size 600x329.570312 flex-container(column) [FFC] children: not-inline
+      BlockContainer <div.header> at (102,3) content-size 400x327.570312 flex-item [BFC] children: inline
         line 0 width: 340.488281, height: 65.507812, bottom: 65.507812, baseline: 50.742187
           frag 0 from TextNode start: 0, length: 11, rect: [102,3 340.488281x65.507812]
             "This entire"

--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-on-auto-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-on-auto-width.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x457.09375 children: not-inline
-    Box <body.hero> at (10,10) content-size 500x439.09375 flex-container(column) children: not-inline
-      BlockContainer <div.upper> at (10,11) content-size 500x437.09375 flex-item children: inline
+  BlockContainer <html> at (1,1) content-size 798x457.09375 [BFC] children: not-inline
+    Box <body.hero> at (10,10) content-size 500x439.09375 flex-container(column) [FFC] children: not-inline
+      BlockContainer <div.upper> at (10,11) content-size 500x437.09375 flex-item [BFC] children: inline
         line 0 width: 453.984375, height: 87.34375, bottom: 87.34375, baseline: 67.65625
           frag 0 from TextNode start: 0, length: 11, rect: [10,11 453.984375x87.34375]
             "This entire"
@@ -18,5 +18,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 37, length: 11, rect: [10,360 468.75x87.34375]
             "background."
         TextNode <#text>
-      BlockContainer <(anonymous)> at (10,10) content-size 0x0 children: inline
+      BlockContainer <(anonymous)> at (10,10) content-size 0x0 [BFC] children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-container-constrained-nowrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-constrained-nowrap.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x120 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x120 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x104 children: not-inline
-      Box <div.container> at (9,9) content-size 250x102 flex-container(row) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.container> at (9,9) content-size 250x102 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 81.333328x100 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 81.333328x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (93.333328,10) content-size 81.333328x100 flex-item children: inline
+        BlockContainer <div.box> at (93.333328,10) content-size 81.333328x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [93.333328,10 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (176.666656,10) content-size 81.333328x100 flex-item children: inline
+        BlockContainer <div.box> at (176.666656,10) content-size 81.333328x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [176.666656,10 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-container-constrained-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-constrained-wrap.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x222 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x222 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x206 children: not-inline
-      Box <div.container> at (9,9) content-size 250x204 flex-container(row) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.container> at (9,9) content-size 250x204 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (112,10) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (112,10) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [112,10 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,112) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (10,112) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,112 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,214) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-container-width-constrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-width-constrained.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x120 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x120 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x104 children: not-inline
-      Box <div.container.width-constrained> at (9,9) content-size 250x102 flex-container(row) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.container.width-constrained> at (9,9) content-size 250x102 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 81.333328x100 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 81.333328x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (93.333328,10) content-size 81.333328x100 flex-item children: inline
+        BlockContainer <div.box> at (93.333328,10) content-size 81.333328x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [93.333328,10 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (176.666656,10) content-size 81.333328x100 flex-item children: inline
+        BlockContainer <div.box> at (176.666656,10) content-size 81.333328x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [176.666656,10 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-frozen-items-should-be-respected.txt
+++ b/Tests/LibWeb/Layout/expected/flex-frozen-items-should-be-respected.txt
@@ -1,28 +1,28 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x70 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x70 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x52 children: not-inline
-      Box <div.flexbox> at (11,11) content-size 778x50 flex-container(row) children: not-inline
-        BlockContainer <div> at (12,12) content-size 136.3125x48 flex-item children: inline
+      Box <div.flexbox> at (11,11) content-size 778x50 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (12,12) content-size 136.3125x48 flex-item [BFC] children: inline
           line 0 width: 136.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 15, rect: [12,12 136.3125x17.46875]
               "LongPieceOfText"
           TextNode <#text>
-        BlockContainer <div> at (150.3125,12) content-size 136.3125x48 flex-item children: inline
+        BlockContainer <div> at (150.3125,12) content-size 136.3125x48 flex-item [BFC] children: inline
           line 0 width: 136.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 15, rect: [150.3125,12 136.3125x17.46875]
               "LongPieceOfText"
           TextNode <#text>
-        BlockContainer <div> at (288.625,12) content-size 136.3125x48 flex-item children: inline
+        BlockContainer <div> at (288.625,12) content-size 136.3125x48 flex-item [BFC] children: inline
           line 0 width: 136.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 15, rect: [288.625,12 136.3125x17.46875]
               "LongPieceOfText"
           TextNode <#text>
-        BlockContainer <div> at (426.9375,12) content-size 136.3125x48 flex-item children: inline
+        BlockContainer <div> at (426.9375,12) content-size 136.3125x48 flex-item [BFC] children: inline
           line 0 width: 136.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 15, rect: [426.9375,12 136.3125x17.46875]
               "LongPieceOfText"
           TextNode <#text>
-        BlockContainer <div.last.item> at (565.25,12) content-size 222.75x48 flex-item children: inline
+        BlockContainer <div.last.item> at (565.25,12) content-size 222.75x48 flex-item [BFC] children: inline
           line 0 width: 136.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 15, rect: [565.25,12 136.3125x17.46875]
               "LongPieceOfText"

--- a/Tests/LibWeb/Layout/expected/flex-grow-0-column.txt
+++ b/Tests/LibWeb/Layout/expected/flex-grow-0-column.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x76.40625 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x76.40625 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x60.40625 children: not-inline
-      Box <div.container> at (9,9) content-size 500x58.40625 flex-container(column) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.container> at (9,9) content-size 500x58.40625 flex-container(column) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 100x17.46875 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 100x17.46875 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,29.46875) content-size 100x17.46875 flex-item children: inline
+        BlockContainer <div.box> at (10,29.46875) content-size 100x17.46875 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,29.46875 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,48.9375) content-size 100x17.46875 flex-item children: inline
+        BlockContainer <div.box> at (10,48.9375) content-size 100x17.46875 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,48.9375 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,68.40625) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-grow-1.txt
+++ b/Tests/LibWeb/Layout/expected/flex-grow-1.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x120 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x120 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x104 children: not-inline
-      Box <div.container> at (9,9) content-size 500x102 flex-container(row) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.container> at (9,9) content-size 500x102 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 229.333343x100 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 229.333343x100 flex-item [BFC] children: inline
           line 0 width: 144.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 17, rect: [10,10 144.546875x17.46875]
               "1 I grow the most"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (241.333343,10) content-size 164.666671x100 flex-item children: inline
+        BlockContainer <div.box> at (241.333343,10) content-size 164.666671x100 flex-item [BFC] children: inline
           line 0 width: 67.375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 8, rect: [241.333343,10 67.375x17.46875]
               "2 I grow"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (408,10) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (408,10) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 68, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 9, rect: [408,10 68x17.46875]
               "3 I don't"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-grow-2.txt
+++ b/Tests/LibWeb/Layout/expected/flex-grow-2.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x120 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x120 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x104 children: not-inline
-      Box <div.container> at (9,9) content-size 500x102 flex-container(row) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.container> at (9,9) content-size 500x102 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 82.333335x100 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 82.333335x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (94.333335,10) content-size 164.666671x100 flex-item children: inline
+        BlockContainer <div.box> at (94.333335,10) content-size 164.666671x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [94.333335,10 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (261,10) content-size 247x100 flex-item children: inline
+        BlockContainer <div.box> at (261,10) content-size 247x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [261,10 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-item-auto-height-with-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-auto-height-with-wrap.txt
@@ -1,11 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x116 children: not-inline
-    Box <body.outer> at (8,8) content-size 400x100 flex-container(column) children: not-inline
-      Box <div.inner> at (8,8) content-size 400x17.46875 flex-container(row) flex-item children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 348.609375x17.46875 flex-item children: inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    Box <body.outer> at (8,8) content-size 400x100 flex-container(column) [FFC] children: not-inline
+      Box <div.inner> at (8,8) content-size 400x17.46875 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 348.609375x17.46875 flex-item [BFC] children: inline
           line 0 width: 348.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 40, rect: [8,8 348.609375x17.46875]
               "The orange box should have a snug height"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-item-on-row-with-intrinsic-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-on-row-with-intrinsic-aspect-ratio.txt
@@ -1,4 +1,4 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x200 children: not-inline
-    Box <body> at (0,0) content-size 800x200 flex-container(row) children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x200 [BFC] children: not-inline
+    Box <body> at (0,0) content-size 800x200 flex-container(row) [FFC] children: not-inline
       ImageBox <img> at (0,0) content-size 400x200 flex-item children: not-inline

--- a/Tests/LibWeb/Layout/expected/flex-item-vertical-padding-relative-to-flex-container-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-vertical-padding-relative-to-flex-container-width.txt
@@ -1,15 +1,15 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x30 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x30 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x12 children: not-inline
       BlockContainer <(anonymous)> at (10,10) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.flex-container> at (11,11) content-size 600x10 flex-container(row) children: not-inline
-        BlockContainer <(anonymous)> at (11,11) content-size 0x0 children: inline
+      Box <div.flex-container> at (11,11) content-size 600x10 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (11,11) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.flex-item> at (12,72) content-size 27.15625x18.000007 flex-item children: inline
+        BlockContainer <div.flex-item> at (12,72) content-size 27.15625x18.000007 flex-item [BFC] children: inline
           line 0 width: 27.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 3, rect: [12,72 27.15625x17.46875]
               "foo"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (11,11) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (11,11) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-item-with-cyclic-percentage-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-with-cyclic-percentage-height.txt
@@ -1,9 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x39.46875 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x39.46875 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x21.46875 children: not-inline
-      Box <div.flexrow> at (11,11) content-size 778x19.46875 flex-container(row) children: not-inline
-        Box <div.project> at (12,12) content-size 44.03125x17.46875 flex-container(column) flex-item children: not-inline
-          BlockContainer <(anonymous)> at (12,12) content-size 44.03125x17.46875 flex-item children: inline
+      Box <div.flexrow> at (11,11) content-size 778x19.46875 flex-container(row) [FFC] children: not-inline
+        Box <div.project> at (12,12) content-size 44.03125x17.46875 flex-container(column) flex-item [FFC] children: not-inline
+          BlockContainer <(anonymous)> at (12,12) content-size 44.03125x17.46875 flex-item [BFC] children: inline
             line 0 width: 44.03125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
               frag 0 from TextNode start: 0, length: 6, rect: [12,12 44.03125x17.46875]
                 "pillow"

--- a/Tests/LibWeb/Layout/expected/flex-item-with-intrinsic-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-with-intrinsic-aspect-ratio.txt
@@ -1,4 +1,4 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x200 children: not-inline
-    Box <body> at (0,0) content-size 400x200 flex-container(column) children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x200 [BFC] children: not-inline
+    Box <body> at (0,0) content-size 400x200 flex-container(column) [FFC] children: not-inline
       ImageBox <img> at (0,0) content-size 400x200 flex-item children: not-inline

--- a/Tests/LibWeb/Layout/expected/flex-margin-auto-justify-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex-margin-auto-justify-content.txt
@@ -1,18 +1,18 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x70 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x70 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x54 children: not-inline
-      Box <div.container> at (9,9) content-size 600x52 flex-container(row) children: not-inline
-        BlockContainer <div.box> at (20,10) content-size 150x50 flex-item children: inline
+      Box <div.container> at (9,9) content-size 600x52 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div.box> at (20,10) content-size 150x50 flex-item [BFC] children: inline
           line 0 width: 86.359375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 11, rect: [20,10 86.359375x17.46875]
               "left margin"
           TextNode <#text>
-        BlockContainer <div.box> at (172,10) content-size 150x50 flex-item children: inline
+        BlockContainer <div.box> at (172,10) content-size 150x50 flex-item [BFC] children: inline
           line 0 width: 141.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 18, rect: [172,10 141.28125x17.46875]
               "follow immediately"
           TextNode <#text>
-        BlockContainer <div.box> at (458,10) content-size 150x50 flex-item children: inline
+        BlockContainer <div.box> at (458,10) content-size 150x50 flex-item [BFC] children: inline
           line 0 width: 138.296875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 17, rect: [458,10 138.296875x17.46875]
               "over at the right"

--- a/Tests/LibWeb/Layout/expected/flex-row.txt
+++ b/Tests/LibWeb/Layout/expected/flex-row.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x120 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x120 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x104 children: not-inline
-      Box <div.container> at (9,9) content-size 782x102 flex-container(row) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.container> at (9,9) content-size 782x102 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (112,10) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (112,10) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [112,10 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (214,10) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (214,10) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [214,10 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-shrink-1.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-1.txt
@@ -1,10 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x120 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x120 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x104 children: not-inline
-      Box <div.container> at (9,9) content-size 250x102 flex-container(row) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.container> at (9,9) content-size 250x102 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 62.666664x100 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 62.666664x100 flex-item [BFC] children: inline
           line 0 width: 18.9375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 3, rect: [10,10 18.9375x17.46875]
               "1 I"
@@ -18,21 +18,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 15, length: 4, rect: [10,62 38.765625x17.46875]
               "most"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (74.666664,10) content-size 81.333328x100 flex-item children: inline
+        BlockContainer <div.box> at (74.666664,10) content-size 81.333328x100 flex-item [BFC] children: inline
           line 0 width: 78.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 10, rect: [74.666664,10 78.765625x17.46875]
               "2 I shrink"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (158,10) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (158,10) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 68, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 9, rect: [158,10 68x17.46875]
               "3 I don't"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-shrink-2.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-2.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x120 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x120 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x104 children: not-inline
-      Box <div.container> at (9,9) content-size 500x102 flex-container(row) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.container> at (9,9) content-size 500x102 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 47.000030x100 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 47.000030x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (59.000030,10) content-size 164.666671x100 flex-item children: inline
+        BlockContainer <div.box> at (59.000030,10) content-size 164.666671x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [59.000030,10 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (225.666702,10) content-size 282.333312x100 flex-item children: inline
+        BlockContainer <div.box> at (225.666702,10) content-size 282.333312x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [225.666702,10 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-shrink-3.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-3.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x120 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x120 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x104 children: not-inline
-      Box <div.container> at (9,9) content-size 500x102 flex-container(row) children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+      Box <div.container> at (9,9) content-size 500x102 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (10,10) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (112,10) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (112,10) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [112,10 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (214,10) content-size 100x100 flex-item children: inline
+        BlockContainer <div.box> at (214,10) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [214,10 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex/cross-size-of-item-with-box-sizing-border-box-and-nonzero-padding.txt
+++ b/Tests/LibWeb/Layout/expected/flex/cross-size-of-item-with-box-sizing-border-box-and-nonzero-padding.txt
@@ -1,8 +1,8 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x245.09375 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x245.09375 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x227.09375 children: not-inline
-      Box <div.outer.flex.flex-wrap> at (11,11) content-size 778x225.09375 flex-container(row) children: not-inline
-        BlockContainer <div.inner> at (12,62) content-size 776x123.09375 flex-item children: inline
+      Box <div.outer.flex.flex-wrap> at (11,11) content-size 778x225.09375 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div.inner> at (12,62) content-size 776x123.09375 flex-item [BFC] children: inline
           line 0 width: 741.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 90, rect: [12,62 741.640625x17.46875]
               "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus interdum libero et urna"

--- a/Tests/LibWeb/Layout/expected/flex/flex-gap-between-items-and-lines.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-gap-between-items-and-lines.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x268 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x268 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x250 children: not-inline
-      Box <div.flexbox> at (11,11) content-size 100x248 flex-container(row) children: not-inline
-        BlockContainer <div> at (12,12) content-size 30x30 flex-item children: not-inline
-        BlockContainer <div> at (64,12) content-size 30x30 flex-item children: not-inline
-        BlockContainer <div> at (12,84) content-size 30x30 flex-item children: not-inline
-        BlockContainer <div> at (64,84) content-size 30x30 flex-item children: not-inline
-        BlockContainer <div> at (12,156) content-size 30x30 flex-item children: not-inline
-        BlockContainer <div> at (64,156) content-size 30x30 flex-item children: not-inline
-        BlockContainer <div> at (12,228) content-size 30x30 flex-item children: not-inline
-        BlockContainer <div> at (64,228) content-size 30x30 flex-item children: not-inline
+      Box <div.flexbox> at (11,11) content-size 100x248 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (12,12) content-size 30x30 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (64,12) content-size 30x30 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (12,84) content-size 30x30 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (64,84) content-size 30x30 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (12,156) content-size 30x30 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (64,156) content-size 30x30 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (12,228) content-size 30x30 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (64,228) content-size 30x30 flex-item [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/flex/multi-line-column-container-with-automatic-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/multi-line-column-container-with-automatic-height.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x176 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x176 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x158 children: not-inline
-      Box <div.flexbox> at (11,11) content-size 200x156 flex-container(column) children: not-inline
-        BlockContainer <div> at (12,12) content-size 50x50 flex-item children: not-inline
-        BlockContainer <div> at (12,64) content-size 50x50 flex-item children: not-inline
-        BlockContainer <div> at (12,116) content-size 50x50 flex-item children: not-inline
+      Box <div.flexbox> at (11,11) content-size 200x156 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,12) content-size 50x50 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (12,64) content-size 50x50 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (12,116) content-size 50x50 flex-item [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/flex/percentage-flex-basis-with-indefinite-flex-container-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/percentage-flex-basis-with-indefinite-flex-container-size.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x33.46875 children: not-inline
-    Box <body.outer> at (8,8) content-size 200x17.46875 flex-container(column) children: not-inline
-      BlockContainer <div.middle> at (8,8) content-size 200x17.46875 flex-item children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
+    Box <body.outer> at (8,8) content-size 200x17.46875 flex-container(column) [FFC] children: not-inline
+      BlockContainer <div.middle> at (8,8) content-size 200x17.46875 flex-item [BFC] children: not-inline
         BlockContainer <div.inner> at (8,8) content-size 200x17.46875 children: inline
           line 0 width: 174.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 20, rect: [8,8 174.234375x17.46875]

--- a/Tests/LibWeb/Layout/expected/flex/specified-size-suggestion-with-box-sizing-border-box.txt
+++ b/Tests/LibWeb/Layout/expected/flex/specified-size-suggestion-with-box-sizing-border-box.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x100 children: not-inline
-    Box <body> at (0,0) content-size 800x100 flex-container(row) children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x100 [BFC] children: not-inline
+    Box <body> at (0,0) content-size 800x100 flex-container(row) [FFC] children: not-inline
       ImageBox <img> at (0,0) content-size 400x100 flex-item children: not-inline
       ImageBox <img.padded> at (600,0) content-size 200x100 flex-item children: not-inline

--- a/Tests/LibWeb/Layout/expected/flex/stretch-alignment-with-cross-gap.txt
+++ b/Tests/LibWeb/Layout/expected/flex/stretch-alignment-with-cross-gap.txt
@@ -1,10 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x220 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x220 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x202 children: not-inline
-      Box <div.flex> at (11,11) content-size 300x200 flex-container(row) children: not-inline
-        BlockContainer <div> at (12,12) content-size 100x20 flex-item children: not-inline
-        BlockContainer <div> at (114,12) content-size 100x20 flex-item children: not-inline
-        BlockContainer <div> at (12,95.333328) content-size 100x20 flex-item children: not-inline
-        BlockContainer <div> at (114,95.333328) content-size 100x20 flex-item children: not-inline
-        BlockContainer <div> at (12,178.666656) content-size 100x20 flex-item children: not-inline
-        BlockContainer <div> at (114,178.666656) content-size 100x20 flex-item children: not-inline
+      Box <div.flex> at (11,11) content-size 300x200 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (12,12) content-size 100x20 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (114,12) content-size 100x20 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (12,95.333328) content-size 100x20 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (114,95.333328) content-size 100x20 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (12,178.666656) content-size 100x20 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (114,178.666656) content-size 100x20 flex-item [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/grid/auto-fill.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fill.txt
@@ -1,27 +1,27 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x33.46875 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 261.333343x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 261.333343x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (269.333343,8) content-size 261.333343x17.46875 children: inline
+        BlockContainer <div.grid-item> at (269.333343,8) content-size 261.333343x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [269.333343,8 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (530.666687,8) content-size 261.333312x17.46875 children: inline
+        BlockContainer <div.grid-item> at (530.666687,8) content-size 261.333312x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [530.666687,8 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/auto-fit.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fit.txt
@@ -1,27 +1,27 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x33.46875 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 261.333343x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 261.333343x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (269.333343,8) content-size 261.333343x17.46875 children: inline
+        BlockContainer <div.grid-item> at (269.333343,8) content-size 261.333343x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [269.333343,8 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (530.666687,8) content-size 261.333312x17.46875 children: inline
+        BlockContainer <div.grid-item> at (530.666687,8) content-size 261.333312x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [530.666687,8 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/basic.txt
+++ b/Tests/LibWeb/Layout/expected/grid/basic.txt
@@ -1,34 +1,34 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x50.9375 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x50.9375 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x34.9375 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x34.9375 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,8) content-size 784x34.9375 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 392.140625x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 392.140625x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (400.140625,8) content-size 392x17.46875 children: inline
+        BlockContainer <div.grid-item> at (400.140625,8) content-size 392x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [400.140625,8 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,25.46875) content-size 392.140625x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,25.46875) content-size 392.140625x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,25.46875 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (400.140625,25.46875) content-size 392x17.46875 children: inline
+        BlockContainer <div.grid-item> at (400.140625,25.46875) content-size 392x17.46875 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [400.140625,25.46875 7.75x17.46875]
               "4"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/borders.txt
+++ b/Tests/LibWeb/Layout/expected/grid/borders.txt
@@ -1,164 +1,164 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x444.28125 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x444.28125 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x428.28125 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x74.9375 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,8) content-size 784x74.9375 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (18,18) content-size 372.140625x17.46875 children: inline
+        BlockContainer <div.grid-item> at (18,18) content-size 372.140625x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [18,18 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (410.140625,18) content-size 372x17.46875 children: inline
+        BlockContainer <div.grid-item> at (410.140625,18) content-size 372x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [410.140625,18 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (18,55.46875) content-size 372.140625x17.46875 children: inline
+        BlockContainer <div.grid-item> at (18,55.46875) content-size 372.140625x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [18,55.46875 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (410.140625,55.46875) content-size 372x17.46875 children: inline
+        BlockContainer <div.grid-item> at (410.140625,55.46875) content-size 372x17.46875 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [410.140625,55.46875 7.75x17.46875]
               "4"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,82.9375) content-size 784x0 children: inline
         TextNode <#text>
-      Box <div.grid-container> at (8,82.9375) content-size 784x107.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,82.9375) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,82.9375) content-size 784x107.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,82.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (18,92.9375) content-size 372.140625x50 children: inline
+        BlockContainer <div.grid-item> at (18,92.9375) content-size 372.140625x50 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [18,92.9375 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,82.9375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,82.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (410.140625,92.9375) content-size 372x50 children: inline
+        BlockContainer <div.grid-item> at (410.140625,92.9375) content-size 372x50 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [410.140625,92.9375 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,82.9375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,82.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (18,162.9375) content-size 372.140625x17.46875 children: inline
+        BlockContainer <div.grid-item> at (18,162.9375) content-size 372.140625x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [18,162.9375 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,82.9375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,82.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (410.140625,162.9375) content-size 372x17.46875 children: inline
+        BlockContainer <div.grid-item> at (410.140625,162.9375) content-size 372x17.46875 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [410.140625,162.9375 7.75x17.46875]
               "4"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,82.9375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,82.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,190.40625) content-size 784x0 children: inline
         TextNode <#text>
-      Box <div.grid-container> at (8,190.40625) content-size 784x84.9375 children: not-inline
-        BlockContainer <(anonymous)> at (8,190.40625) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,190.40625) content-size 784x84.9375 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,190.40625) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (18,200.40625) content-size 347.140625x17.46875 children: inline
+        BlockContainer <div.grid-item> at (18,200.40625) content-size 347.140625x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [18,200.40625 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,190.40625) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,190.40625) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (435.140625,200.40625) content-size 347x17.46875 children: inline
+        BlockContainer <div.grid-item> at (435.140625,200.40625) content-size 347x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [435.140625,200.40625 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,190.40625) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,190.40625) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (18,247.875) content-size 347.140625x17.46875 children: inline
+        BlockContainer <div.grid-item> at (18,247.875) content-size 347.140625x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [18,247.875 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,190.40625) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,190.40625) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (435.140625,247.875) content-size 347x17.46875 children: inline
+        BlockContainer <div.grid-item> at (435.140625,247.875) content-size 347x17.46875 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [435.140625,247.875 7.75x17.46875]
               "4"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,190.40625) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,190.40625) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,275.34375) content-size 784x0 children: inline
         TextNode <#text>
-      Box <div.grid-container> at (8,275.34375) content-size 784x90.9375 children: not-inline
-        BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,275.34375) content-size 784x90.9375 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (445.934356,285.34375) content-size 337.300018x17.46875 children: inline
+        BlockContainer <div.grid-item> at (445.934356,285.34375) content-size 337.300018x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [445.934356,285.34375 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (18,338.8125) content-size 338.534362x17.46875 children: inline
+        BlockContainer <div.grid-item> at (18,338.8125) content-size 338.534362x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [18,338.8125 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,366.28125) content-size 784x0 children: inline
         TextNode <#text>
-      Box <div.grid-container> at (8,366.28125) content-size 784x50 children: not-inline
-        BlockContainer <(anonymous)> at (8,366.28125) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,366.28125) content-size 784x50 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,366.28125) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (18,376.28125) content-size 280x5 children: inline
+        BlockContainer <div.grid-item> at (18,376.28125) content-size 280x5 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [18,376.28125 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,366.28125) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,366.28125) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (318,376.28125) content-size 280x5 children: inline
+        BlockContainer <div.grid-item> at (318,376.28125) content-size 280x5 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [318,376.28125 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,366.28125) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,366.28125) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (18,401.28125) content-size 280x5 children: inline
+        BlockContainer <div.grid-item> at (18,401.28125) content-size 280x5 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [18,401.28125 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,366.28125) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,366.28125) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (318,401.28125) content-size 280x5 children: inline
+        BlockContainer <div.grid-item> at (318,401.28125) content-size 280x5 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [318,401.28125 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,366.28125) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,366.28125) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,416.28125) content-size 784x0 children: inline
         TextNode <#text>
-      Box <div.grid-container> at (8,416.28125) content-size 784x20 children: not-inline
-        BlockContainer <(anonymous)> at (8,416.28125) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,416.28125) content-size 784x20 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,416.28125) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (18,426.28125) content-size 764x0 children: inline
+        BlockContainer <div.grid-item> at (18,426.28125) content-size 764x0 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [18,426.28125 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,416.28125) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,416.28125) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/different-column-sizes.txt
+++ b/Tests/LibWeb/Layout/expected/grid/different-column-sizes.txt
@@ -1,34 +1,34 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x50.9375 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x50.9375 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x34.9375 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x34.9375 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,8) content-size 784x34.9375 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 50x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 50x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (58,8) content-size 392x17.46875 children: inline
+        BlockContainer <div.grid-item> at (58,8) content-size 392x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [58,8 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,25.46875) content-size 50x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,25.46875) content-size 50x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,25.46875 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (58,25.46875) content-size 392x17.46875 children: inline
+        BlockContainer <div.grid-item> at (58,25.46875) content-size 392x17.46875 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [58,25.46875 7.75x17.46875]
               "4"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/gap.txt
+++ b/Tests/LibWeb/Layout/expected/grid/gap.txt
@@ -1,102 +1,102 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x166.8125 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x166.8125 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x150.8125 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x44.9375 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,8) content-size 784x44.9375 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 367.140625x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 367.140625x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (425.140625,8) content-size 367x17.46875 children: inline
+        BlockContainer <div.grid-item> at (425.140625,8) content-size 367x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [425.140625,8 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,35.46875) content-size 367.140625x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,35.46875) content-size 367.140625x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,35.46875 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (425.140625,35.46875) content-size 367x17.46875 children: inline
+        BlockContainer <div.grid-item> at (425.140625,35.46875) content-size 367x17.46875 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [425.140625,35.46875 7.75x17.46875]
               "4"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,52.9375) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,52.9375) content-size 784x50.9375 children: not-inline
-        BlockContainer <(anonymous)> at (8,52.9375) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,52.9375) content-size 784x50.9375 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,52.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (435.934356,52.9375) content-size 357.300018x17.46875 children: inline
+        BlockContainer <div.grid-item> at (435.934356,52.9375) content-size 357.300018x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [435.934356,52.9375 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,52.9375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,52.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,86.40625) content-size 358.534362x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,86.40625) content-size 358.534362x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,86.40625 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,52.9375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,52.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,103.875) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,103.875) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,103.875) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,103.875) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,103.875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (408,103.875) content-size 384x17.46875 children: inline
+        BlockContainer <div.grid-item> at (408,103.875) content-size 384x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [408,103.875 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,103.875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,103.875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,121.34375) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,121.34375) content-size 784x20 children: not-inline
-        BlockContainer <(anonymous)> at (8,121.34375) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,121.34375) content-size 784x20 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,121.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (408,121.34375) content-size 384x20 children: inline
+        BlockContainer <div.grid-item> at (408,121.34375) content-size 384x20 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [408,121.34375 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,121.34375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,121.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,141.34375) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container.with-border> at (8,141.34375) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,141.34375) content-size 0x0 children: inline
+      Box <div.grid-container.with-border> at (8,141.34375) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,141.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.with-border> at (8,141.34375) content-size 387x17.46875 children: inline
+        BlockContainer <div.grid-item.with-border> at (8,141.34375) content-size 387x17.46875 [BFC] children: inline
           line 0 width: 104.875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 14, rect: [8,141.34375 104.875x17.46875]
               "left side text"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,141.34375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,141.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.with-border> at (405,141.34375) content-size 387x17.46875 children: inline
+        BlockContainer <div.grid-item.with-border> at (405,141.34375) content-size 387x17.46875 [BFC] children: inline
           line 0 width: 363.203125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 47, rect: [405,141.34375 363.203125x17.46875]
               "right side text right side text right side text"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,141.34375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,141.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/grid-template.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-template.txt
@@ -1,54 +1,54 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x216 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x200 children: not-inline
-      Box <div.mw-page-container-inner> at (8,8) content-size 784x0 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <div.mw-page-container-inner> at (8,8) content-size 784x0 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.vector-main-menu-container> at (8,8) content-size 196x0 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <div.vector-main-menu-container> at (8,8) content-size 196x0 [BFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.vector-sitenotice-container> at (8,8) content-size 784x0 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <div.vector-sitenotice-container> at (8,8) content-size 784x0 [BFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.mw-content-container> at (204,8) content-size 588x0 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <div.mw-content-container> at (204,8) content-size 588x0 [BFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.mw-footer-container> at (8,8) content-size 784x0 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <div.mw-footer-container> at (8,8) content-size 784x0 [BFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      Box <section#page> at (8,8) content-size 784x200 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <section#page> at (8,8) content-size 784x200 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <header> at (8,8) content-size 784x30 children: inline
+        BlockContainer <header> at (8,8) content-size 784x30 [BFC] children: inline
           line 0 width: 55.703125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 6, rect: [8,8 55.703125x17.46875]
               "Header"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <nav> at (8,38) content-size 120x170 children: inline
+        BlockContainer <nav> at (8,38) content-size 120x170 [BFC] children: inline
           line 0 width: 80.6875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 10, rect: [8,38 80.6875x17.46875]
               "Navigation"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <main> at (128,38) content-size 664x140 children: inline
+        BlockContainer <main> at (128,38) content-size 664x140 [BFC] children: inline
           line 0 width: 79.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 9, rect: [128,38 79.515625x17.46875]
               "Main area"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <footer> at (128,178) content-size 664x30 children: inline
+        BlockContainer <footer> at (128,178) content-size 664x30 [BFC] children: inline
           line 0 width: 57.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 6, rect: [128,178 57.671875x17.46875]
               "Footer"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,208) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
+++ b/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
@@ -1,14 +1,14 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x40 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x40 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x24 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x24 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,8) content-size 784x24 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.wrapper> at (8,8) content-size 64x24 children: inline
+        BlockContainer <div.wrapper> at (8,8) content-size 64x24 [BFC] children: inline
           line 0 width: 64, height: 24, bottom: 24, baseline: 24
             frag 0 from ImageBox start: 0, length: 0, rect: [8,8 64x24]
           TextNode <#text>
           ImageBox <img> at (8,8) content-size 64x24 children: not-inline
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-column.txt
+++ b/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-column.txt
@@ -1,13 +1,13 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x35.46875 children: inline
+  BlockContainer <html> at (0,0) content-size 800x35.46875 [BFC] children: inline
     TextNode <#text>
-    BlockContainer <body> at (8,8) content-size 0x19.46875 floating children: not-inline
+    BlockContainer <body> at (8,8) content-size 0x19.46875 floating [BFC] children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
         TextNode <#text>
-      Box <div.grid> at (8,8) content-size 0x19.46875 children: not-inline
-        BlockContainer <(anonymous)>  children: inline
+      Box <div.grid> at (8,8) content-size 0x19.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)>  [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.whee> at (9,9) content-size 18x17.46875 children: inline
+        BlockContainer <div.whee> at (9,9) content-size 18x17.46875 [BFC] children: inline
           line 0 width: 37.953125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 4, rect: [9,9 37.953125x17.46875]
               "whee"

--- a/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid.txt
+++ b/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid.txt
@@ -1,8 +1,8 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x39.46875 children: not-inline
-    BlockContainer <body> at (10,10) content-size 2x21.46875 floating children: not-inline
-      Box <div.grid> at (11,11) content-size 0x19.46875 children: not-inline
-        BlockContainer <div.whee> at (12,12) content-size 35.953125x17.46875 children: inline
+  BlockContainer <html> at (1,1) content-size 798x39.46875 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 2x21.46875 floating [BFC] children: not-inline
+      Box <div.grid> at (11,11) content-size 0x19.46875 [GFC] children: not-inline
+        BlockContainer <div.whee> at (12,12) content-size 35.953125x17.46875 [BFC] children: inline
           line 0 width: 37.953125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 4, rect: [12,12 37.953125x17.46875]
               "whee"

--- a/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
@@ -1,27 +1,27 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x33.46875 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 93.765625x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 93.765625x17.46875 [BFC] children: inline
           line 0 width: 93.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 11, rect: [8,8 93.765625x17.46875]
               "min-content"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (101.765625,8) content-size 98.640625x17.46875 children: inline
+        BlockContainer <div.grid-item> at (101.765625,8) content-size 98.640625x17.46875 [BFC] children: inline
           line 0 width: 98.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 11, rect: [101.765625,8 98.640625x17.46875]
               "max-content"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (200.40625,8) content-size 591.59375x17.46875 children: inline
+        BlockContainer <div.grid-item> at (200.40625,8) content-size 591.59375x17.46875 [BFC] children: inline
           line 0 width: 21.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 3, rect: [200.40625,8 21.609375x17.46875]
               "1fr"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/minmax.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax.txt
@@ -1,168 +1,168 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x288.28125 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x288.28125 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x272.28125 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 300x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 300x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (308,8) content-size 300x17.46875 children: inline
+        BlockContainer <div.grid-item> at (308,8) content-size 300x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [308,8 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,25.46875) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,25.46875) content-size 784x100 children: not-inline
-        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,25.46875) content-size 784x100 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,25.46875) content-size 300x50 children: inline
+        BlockContainer <div.grid-item> at (8,25.46875) content-size 300x50 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,25.46875 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (308,25.46875) content-size 300x50 children: inline
+        BlockContainer <div.grid-item> at (308,25.46875) content-size 300x50 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [308,25.46875 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,125.46875) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,125.46875) content-size 784x34.9375 children: not-inline
-        BlockContainer <(anonymous)> at (8,125.46875) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,125.46875) content-size 784x34.9375 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,125.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,125.46875) content-size 784x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,125.46875) content-size 784x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,125.46875 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,125.46875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,125.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,142.9375) content-size 784x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,142.9375) content-size 784x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,142.9375 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,125.46875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,125.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,160.40625) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,160.40625) content-size 784x34.9375 children: not-inline
-        BlockContainer <(anonymous)> at (8,160.40625) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,160.40625) content-size 784x34.9375 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,160.40625) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,160.40625) content-size 784x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,160.40625) content-size 784x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,160.40625 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,160.40625) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,160.40625) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,177.875) content-size 784x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,177.875) content-size 784x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,177.875 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,160.40625) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,160.40625) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,195.34375) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,195.34375) content-size 784x50 children: not-inline
-        BlockContainer <(anonymous)> at (8,195.34375) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,195.34375) content-size 784x50 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,195.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,195.34375) content-size 300x25 children: inline
+        BlockContainer <div.grid-item> at (8,195.34375) content-size 300x25 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,195.34375 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,195.34375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,195.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (308,195.34375) content-size 300x25 children: inline
+        BlockContainer <div.grid-item> at (308,195.34375) content-size 300x25 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [308,195.34375 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,195.34375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,195.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,220.34375) content-size 300x25 children: inline
+        BlockContainer <div.grid-item> at (8,220.34375) content-size 300x25 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,220.34375 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,195.34375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,195.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (308,220.34375) content-size 300x25 children: inline
+        BlockContainer <div.grid-item> at (308,220.34375) content-size 300x25 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [308,220.34375 7.75x17.46875]
               "4"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,195.34375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,195.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,245.34375) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,245.34375) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,245.34375) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,245.34375) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,245.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,245.34375) content-size 261.333343x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,245.34375) content-size 261.333343x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,245.34375 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,245.34375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,245.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (269.333343,245.34375) content-size 261.333343x17.46875 children: inline
+        BlockContainer <div.grid-item> at (269.333343,245.34375) content-size 261.333343x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [269.333343,245.34375 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,245.34375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,245.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (530.666687,245.34375) content-size 261.333312x17.46875 children: inline
+        BlockContainer <div.grid-item> at (530.666687,245.34375) content-size 261.333312x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [530.666687,245.34375 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,245.34375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,245.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,262.8125) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,262.8125) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,262.8125) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,262.8125) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,262.8125) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,262.8125) content-size 56.218711x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,262.8125) content-size 56.218711x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,262.8125 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,262.8125) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,262.8125) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (64.218711,262.8125) content-size 671.5625x17.46875 children: inline
+        BlockContainer <div.grid-item> at (64.218711,262.8125) content-size 671.5625x17.46875 [BFC] children: inline
           line 0 width: 125.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 15, rect: [64.218711,262.8125 125.265625x17.46875]
               "Article content"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,262.8125) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,262.8125) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (735.781188,262.8125) content-size 56.218688x17.46875 children: inline
+        BlockContainer <div.grid-item> at (735.781188,262.8125) content-size 56.218688x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [735.781188,262.8125 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,262.8125) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,262.8125) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/named-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/named-tracks.txt
@@ -1,90 +1,90 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x143.40625 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x143.40625 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x127.40625 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 392x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 392x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (400,8) content-size 393.234375x17.46875 children: inline
+        BlockContainer <div.grid-item> at (400,8) content-size 393.234375x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [400,8 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,25.46875) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,25.46875) content-size 784x75 children: not-inline
-        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,25.46875) content-size 784x75 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,25.46875) content-size 261.333343x75 children: inline
+        BlockContainer <div.grid-item> at (8,25.46875) content-size 261.333343x75 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,25.46875 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (530.666687,25.46875) content-size 261.333312x50 children: inline
+        BlockContainer <div.grid-item> at (530.666687,25.46875) content-size 261.333312x50 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [530.666687,25.46875 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (269.333343,25.46875) content-size 261.333343x25 children: inline
+        BlockContainer <div.grid-item> at (269.333343,25.46875) content-size 261.333343x25 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [269.333343,25.46875 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (269.333343,75.46875) content-size 522.666625x25 children: inline
+        BlockContainer <div.grid-item> at (269.333343,75.46875) content-size 522.666625x25 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [269.333343,75.46875 7.75x17.46875]
               "4"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,100.46875) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,100.46875) content-size 784x34.9375 children: not-inline
-        BlockContainer <(anonymous)> at (8,100.46875) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,100.46875) content-size 784x34.9375 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,100.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (58,100.46875) content-size 100x17.46875 children: inline
+        BlockContainer <div.grid-item> at (58,100.46875) content-size 100x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [58,100.46875 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,100.46875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,100.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (158,100.46875) content-size 50x17.46875 children: inline
+        BlockContainer <div.grid-item> at (158,100.46875) content-size 50x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [158,100.46875 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,100.46875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,100.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (208,100.46875) content-size 100x17.46875 children: inline
+        BlockContainer <div.grid-item> at (208,100.46875) content-size 100x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [208,100.46875 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,100.46875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,100.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,117.9375) content-size 50x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,117.9375) content-size 50x17.46875 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,117.9375 7.75x17.46875]
               "4"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,100.46875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,100.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/positions-and-spans.txt
+++ b/Tests/LibWeb/Layout/expected/grid/positions-and-spans.txt
@@ -1,83 +1,83 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x185.875 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x185.875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x169.875 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 522.666748x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 522.666748x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (530.666748,8) content-size 261.333496x17.46875 children: inline
+        BlockContainer <div.grid-item> at (530.666748,8) content-size 261.333496x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [530.666748,8 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,25.46875) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,25.46875) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,25.46875) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,25.46875) content-size 261.333374x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,25.46875) content-size 261.333374x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,25.46875 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (269.333374,25.46875) content-size 522.66687x17.46875 children: inline
+        BlockContainer <div.grid-item> at (269.333374,25.46875) content-size 522.66687x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [269.333374,25.46875 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,25.46875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,42.9375) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,42.9375) content-size 784x100 children: not-inline
-        BlockContainer <(anonymous)> at (8,42.9375) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,42.9375) content-size 784x100 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,42.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,42.9375) content-size 784x40 children: inline
+        BlockContainer <div.grid-item> at (8,42.9375) content-size 784x40 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,42.9375 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,42.9375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,42.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,82.9375) content-size 784x60 children: inline
+        BlockContainer <div.grid-item> at (8,82.9375) content-size 784x60 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,82.9375 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,42.9375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,42.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,142.9375) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,142.9375) content-size 784x34.9375 children: not-inline
-        BlockContainer <(anonymous)> at (8,142.9375) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,142.9375) content-size 784x34.9375 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,142.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,142.9375) content-size 784x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,142.9375) content-size 784x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,142.9375 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,142.9375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,142.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,160.40625) content-size 392x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,160.40625) content-size 392x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,160.40625 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,142.9375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,142.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/repeat.txt
+++ b/Tests/LibWeb/Layout/expected/grid/repeat.txt
@@ -1,83 +1,83 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x233.46875 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x233.46875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x217.46875 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x200 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,8) content-size 784x200 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 392x200 children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 392x200 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (400,8) content-size 392x100 children: inline
+        BlockContainer <div.grid-item> at (400,8) content-size 392x100 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [400,8 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (400,108) content-size 196x50 children: inline
+        BlockContainer <div.grid-item> at (400,108) content-size 196x50 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [400,108 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (596,108) content-size 196x50 children: inline
+        BlockContainer <div.grid-item> at (596,108) content-size 196x50 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [596,108 7.75x17.46875]
               "4"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (400,158) content-size 196x50 children: inline
+        BlockContainer <div.grid-item> at (400,158) content-size 196x50 [BFC] children: inline
           line 0 width: 8.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [400,158 8.453125x17.46875]
               "5"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (596,158) content-size 196x50 children: inline
+        BlockContainer <div.grid-item> at (596,158) content-size 196x50 [BFC] children: inline
           line 0 width: 8.734375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [596,158 8.734375x17.46875]
               "6"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,208) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,208) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,208) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,208) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,208) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,208) content-size 50x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,208) content-size 50x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,208 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,208) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,208) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (58,208) content-size 50x17.46875 children: inline
+        BlockContainer <div.grid-item> at (58,208) content-size 50x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [58,208 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,208) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,208) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (108,208) content-size 100x17.46875 children: inline
+        BlockContainer <div.grid-item> at (108,208) content-size 100x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [108,208 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,208) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,208) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (208,208) content-size 100x17.46875 children: inline
+        BlockContainer <div.grid-item> at (208,208) content-size 100x17.46875 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [208,208 7.75x17.46875]
               "4"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,208) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,208) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/row-height.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-height.txt
@@ -1,34 +1,34 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x83.46875 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x83.46875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x67.46875 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x67.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,8) content-size 784x67.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 392.140625x50 children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 392.140625x50 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (400.140625,8) content-size 392x50 children: inline
+        BlockContainer <div.grid-item> at (400.140625,8) content-size 392x50 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [400.140625,8 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,58) content-size 392.140625x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,58) content-size 392.140625x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,58 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (400.140625,58) content-size 392x17.46875 children: inline
+        BlockContainer <div.grid-item> at (400.140625,58) content-size 392x17.46875 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [400.140625,58 7.75x17.46875]
               "4"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/template-areas.txt
+++ b/Tests/LibWeb/Layout/expected/grid/template-areas.txt
@@ -1,83 +1,83 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x120.8125 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x120.8125 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x104.8125 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x34.9375 children: not-inline
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,8) content-size 784x34.9375 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div> at (400,25.46875) content-size 392x17.46875 children: inline
+        BlockContainer <div> at (400,25.46875) content-size 392x17.46875 [BFC] children: inline
           line 0 width: 99.703125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 1, length: 12, rect: [400,25.46875 99.703125x17.46875]
               "right-bottom"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div> at (8,8) content-size 392x34.9375 children: inline
+        BlockContainer <div> at (8,8) content-size 392x34.9375 [BFC] children: inline
           line 0 width: 26.25, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 4, rect: [8,8 26.25x17.46875]
               "left"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div> at (400,8) content-size 392x17.46875 children: inline
+        BlockContainer <div> at (400,8) content-size 392x17.46875 [BFC] children: inline
           line 0 width: 70.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 9, rect: [400,8 70.234375x17.46875]
               "right-top"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,42.9375) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,42.9375) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,42.9375) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,42.9375) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,42.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,42.9375) content-size 261.333343x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,42.9375) content-size 261.333343x17.46875 [BFC] children: inline
           line 0 width: 21.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 3, rect: [8,42.9375 21.609375x17.46875]
               "1fr"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,42.9375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,42.9375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,60.40625) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,60.40625) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,60.40625) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,60.40625) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,60.40625) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,60.40625) content-size 392x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,60.40625) content-size 392x17.46875 [BFC] children: inline
           line 0 width: 21.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 3, rect: [8,60.40625 21.609375x17.46875]
               "1fr"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,60.40625) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,60.40625) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,77.875) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,77.875) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,77.875) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,77.875) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,77.875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,77.875) content-size 196x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,77.875) content-size 196x17.46875 [BFC] children: inline
           line 0 width: 21.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 3, rect: [8,77.875 21.609375x17.46875]
               "1fr"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,77.875) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,77.875) content-size 0x0 [BFC] children: inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,95.34375) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,95.34375) content-size 784x17.46875 children: not-inline
-        BlockContainer <(anonymous)> at (8,95.34375) content-size 0x0 children: inline
+      Box <div.grid-container> at (8,95.34375) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,95.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,95.34375) content-size 196x17.46875 children: inline
+        BlockContainer <div.grid-item> at (8,95.34375) content-size 196x17.46875 [BFC] children: inline
           line 0 width: 21.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 3, rect: [8,95.34375 21.609375x17.46875]
               "1fr"
           TextNode <#text>
-        BlockContainer <(anonymous)> at (8,95.34375) content-size 0x0 children: inline
+        BlockContainer <(anonymous)> at (8,95.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/image-display-block-margin-auto.txt
+++ b/Tests/LibWeb/Layout/expected/image-display-block-margin-auto.txt
@@ -1,4 +1,4 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x116 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 400x100 children: not-inline
       ImageBox <img> at (158,8) content-size 100x100 children: not-inline

--- a/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
+++ b/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
@@ -1,9 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x45.835937 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x45.835937 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x27.835937 children: inline
       line 0 width: 202, height: 27.835937, bottom: 27.835937, baseline: 25.835937
         frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 200x25.835937]
-      BlockContainer <input> at (11,11) content-size 200x25.835937 inline-block children: not-inline
+      BlockContainer <input> at (11,11) content-size 200x25.835937 inline-block [BFC] children: not-inline
         BlockContainer <#shadow-root> at (11,11) content-size 0x0 children: not-inline
         BlockContainer <div> at (14,13) content-size 194x21.835937 children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/lh-1.txt
+++ b/Tests/LibWeb/Layout/expected/lh-1.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x116 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
       BlockContainer <div#a> at (8,8) content-size 100x100 children: not-inline
         BlockContainer <div#b> at (8,8) content-size 100x100 children: inline

--- a/Tests/LibWeb/Layout/expected/lh-2.txt
+++ b/Tests/LibWeb/Layout/expected/lh-2.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x116 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
       BlockContainer <div#a> at (8,8) content-size 100x100 children: not-inline
         BlockContainer <div#b> at (8,8) content-size 100x100 children: inline

--- a/Tests/LibWeb/Layout/expected/link-sheet.txt
+++ b/Tests/LibWeb/Layout/expected/link-sheet.txt
@@ -1,4 +1,4 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x16 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
-      BlockContainer <div#foo> at (0,0) content-size 123x456 positioned children: not-inline
+      BlockContainer <div#foo> at (0,0) content-size 123x456 positioned [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/overflow-x-hidden-with-border-radius.txt
+++ b/Tests/LibWeb/Layout/expected/overflow-x-hidden-with-border-radius.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x118 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x118 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x102 children: not-inline
-      BlockContainer <div.box> at (9,9) content-size 100x100 positioned children: not-inline
+      BlockContainer <div.box> at (9,9) content-size 100x100 positioned [BFC] children: not-inline
       BlockContainer <(anonymous)> at (8,110) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/position-absolute-from-edges.txt
+++ b/Tests/LibWeb/Layout/expected/position-absolute-from-edges.txt
@@ -1,14 +1,14 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x16 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: inline
-      BlockContainer <div#container> at (8,8) content-size 500x400 positioned children: inline
+      BlockContainer <div#container> at (8,8) content-size 500x400 positioned [BFC] children: inline
         TextNode <#text>
-        BlockContainer <div#red> at (38,38) content-size 100x100 positioned children: not-inline
+        BlockContainer <div#red> at (38,38) content-size 100x100 positioned [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div#green> at (338,78) content-size 100x100 positioned children: not-inline
+        BlockContainer <div#green> at (338,78) content-size 100x100 positioned [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div#blue> at (28,288) content-size 100x100 positioned children: not-inline
+        BlockContainer <div#blue> at (28,288) content-size 100x100 positioned [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div#yellow> at (388,288) content-size 100x100 positioned children: not-inline
+        BlockContainer <div#yellow> at (388,288) content-size 100x100 positioned [BFC] children: not-inline
         TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/position-absolute-ignores-padding-of-position-relative-floating-parent.txt
+++ b/Tests/LibWeb/Layout/expected/position-absolute-ignores-padding-of-position-relative-floating-parent.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x216 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x200 children: not-inline
       BlockContainer <div#guide> at (8,8) content-size 200x200 children: not-inline
-        BlockContainer <div#container> at (18,18) content-size 0x0 positioned floating children: not-inline
-          BlockContainer <div#box> at (8,8) content-size 100x100 positioned children: not-inline
+        BlockContainer <div#container> at (18,18) content-size 0x0 positioned floating [BFC] children: not-inline
+          BlockContainer <div#box> at (8,8) content-size 100x100 positioned [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/position-absolute-top-left.txt
+++ b/Tests/LibWeb/Layout/expected/position-absolute-top-left.txt
@@ -1,20 +1,20 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x616 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x616 [BFC] children: not-inline
     BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
       TextNode <#text>
     BlockContainer <body> at (8,8) content-size 784x600 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
-        BlockContainer <div.blue.absolute> at (208,208) content-size 200x200 positioned children: inline
+        BlockContainer <div.blue.absolute> at (208,208) content-size 200x200 positioned [BFC] children: inline
           TextNode <#text>
-          BlockContainer <div.red.absolute> at (308,308) content-size 100x100 positioned children: not-inline
+          BlockContainer <div.red.absolute> at (308,308) content-size 100x100 positioned [BFC] children: not-inline
           TextNode <#text>
-          BlockContainer <div.yellow.absolute> at (258,258) content-size 100x100 positioned children: inline
+          BlockContainer <div.yellow.absolute> at (258,258) content-size 100x100 positioned [BFC] children: inline
             TextNode <#text>
-            BlockContainer <div.black.absolute> at (308,308) content-size 50x50 positioned children: not-inline
+            BlockContainer <div.black.absolute> at (308,308) content-size 50x50 positioned [BFC] children: not-inline
             TextNode <#text>
           TextNode <#text>
-          BlockContainer <div.green.absolute> at (508,508) content-size 100x100 positioned children: not-inline
+          BlockContainer <div.green.absolute> at (508,508) content-size 100x100 positioned [BFC] children: not-inline
           TextNode <#text>
         TextNode <#text>
       BlockContainer <div.blue> at (8,8) content-size 200x200 children: not-inline

--- a/Tests/LibWeb/Layout/expected/replaced-box-with-vertical-margins.txt
+++ b/Tests/LibWeb/Layout/expected/replaced-box-with-vertical-margins.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x232.46875 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x232.46875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x216.46875 children: inline
       line 0 width: 174.828125, height: 216.46875, bottom: 216.46875, baseline: 213
         frag 0 from TextNode start: 0, length: 6, rect: [8,207 43.125x17.46875]

--- a/Tests/LibWeb/Layout/expected/svg-preserve-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/svg-preserve-aspect-ratio.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x273.46875 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x273.46875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x257.46875 children: inline
       line 0 width: 772, height: 130.46875, bottom: 130.46875, baseline: 127
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,84 100x50]
@@ -38,67 +38,67 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 7 from TextNode start: 0, length: 1, rect: [240,248 8x17.46875]
           " "
         frag 8 from SVGSVGBox start: 0, length: 0, rect: [249,201 160x60]
-      SVGSVGBox <svg> at (9,84) content-size 100x50 children: inline
+      SVGSVGBox <svg> at (9,84) content-size 100x50 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <circle> at (34,84) content-size 50x50 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (119,84) content-size 100x50 children: inline
+      SVGSVGBox <svg> at (119,84) content-size 100x50 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <circle> at (119,84) content-size 50x50 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (229,84) content-size 100x50 children: inline
+      SVGSVGBox <svg> at (229,84) content-size 100x50 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <circle> at (279,84) content-size 50x50 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (339,84) content-size 100x50 children: inline
+      SVGSVGBox <svg> at (339,84) content-size 100x50 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <circle> at (339,84) content-size 100x100 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (449,84) content-size 100x50 children: inline
+      SVGSVGBox <svg> at (449,84) content-size 100x50 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <circle> at (449,59) content-size 100x100 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (559,84) content-size 100x50 children: inline
+      SVGSVGBox <svg> at (559,84) content-size 100x50 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <circle> at (559,34) content-size 100x100 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (669,9) content-size 50x125 children: inline
+      SVGSVGBox <svg> at (669,9) content-size 50x125 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <circle> at (669,9) content-size 50x50 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (729,9) content-size 50x125 children: inline
+      SVGSVGBox <svg> at (729,9) content-size 50x125 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <circle> at (729,46.5) content-size 50x50 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (9,136) content-size 50x125 children: inline
+      SVGSVGBox <svg> at (9,136) content-size 50x125 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <circle> at (9,211) content-size 50x50 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (69,136) content-size 50x125 children: inline
+      SVGSVGBox <svg> at (69,136) content-size 50x125 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <circle> at (69,136) content-size 125x125 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (129,136) content-size 50x125 children: inline
+      SVGSVGBox <svg> at (129,136) content-size 50x125 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <circle> at (91.5,136) content-size 125x125 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (189,136) content-size 50x125 children: inline
+      SVGSVGBox <svg> at (189,136) content-size 50x125 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <circle> at (114,136) content-size 125x125 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (249,201) content-size 160x60 children: inline
+      SVGSVGBox <svg> at (249,201) content-size 160x60 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <circle> at (299,201) content-size 60x60 children: not-inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
+++ b/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x700 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x700 [BFC] children: not-inline
     BlockContainer <body> at (50,50) content-size 700x600 children: inline
       line 0 width: 616, height: 203.46875, bottom: 203.46875, baseline: 200
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [50,150 200x100]
@@ -19,7 +19,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 4 from SVGSVGBox start: 0, length: 0, rect: [466,250 200x200]
       line 2 width: 200, height: 200, bottom: 600, baseline: 200
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [50,450 200x200]
-      SVGSVGBox <svg> at (50,150) content-size 200x100 children: inline
+      SVGSVGBox <svg> at (50,150) content-size 200x100 [SVG] children: inline
         TextNode <#text>
         SVGGraphicsBox <g>  children: inline
           TextNode <#text>
@@ -32,21 +32,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (258,50) content-size 200x200 children: inline
+      SVGSVGBox <svg> at (258,50) content-size 200x200 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <rect> at (268,60) content-size 30x20 children: not-inline
         TextNode <#text>
         SVGGeometryBox <rect> at (288,130) content-size 110x90 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (466,50) content-size 200x200 children: inline
+      SVGSVGBox <svg> at (466,50) content-size 200x200 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <rect> at (506,90) content-size 120x120 children: not-inline
         TextNode <#text>
         SVGGeometryBox <rect> at (471.358978,90) content-size 189.282043x120 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (50,250) content-size 200x200 children: inline
+      SVGSVGBox <svg> at (50,250) content-size 200x200 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <rect> at (120.588233,320.588256) content-size 58.823524x58.823532 children: not-inline
         TextNode <#text>
@@ -57,7 +57,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         SVGGeometryBox <rect> at (179.411773,321.481903) content-size 68.14447x68.14447 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (258,250) content-size 200x200 children: inline
+      SVGSVGBox <svg> at (258,250) content-size 200x200 [SVG] children: inline
         TextNode <#text>
         TextNode <#text>
         SVGGeometryBox <circle> at (278,270) content-size 160x160 children: not-inline
@@ -72,14 +72,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         SVGGeometryBox <circle> at (338,330) content-size 40x40 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (466,250) content-size 200x200 children: inline
+      SVGSVGBox <svg> at (466,250) content-size 200x200 [SVG] children: inline
         TextNode <#text>
         SVGGeometryBox <rect> at (506,290) content-size 120x120 children: not-inline
         TextNode <#text>
         SVGGeometryBox <rect> at (506,255.358978) content-size 120x189.282043 children: not-inline
         TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (50,450) content-size 200x200 children: inline
+      SVGSVGBox <svg> at (50,450) content-size 200x200 [SVG] children: inline
         TextNode <#text>
         TextNode <#text>
         SVGGeometryBox <rect> at (60,460) content-size 80x80 children: not-inline

--- a/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
@@ -1,10 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x40 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x40 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x24 children: inline
       line 0 width: 24, height: 24, bottom: 24, baseline: 24
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 24x24]
-      SVGSVGBox <svg> at (8,8) content-size 24x24 children: inline
+      SVGSVGBox <svg> at (8,8) content-size 24x24 [SVG] children: inline
         SVGGraphicsBox <g>  children: inline
-          SVGSVGBox <svg> at (8,8) content-size 24x24 children: not-inline
+          SVGSVGBox <svg> at (8,8) content-size 24x24 [SVG] children: not-inline
             SVGGeometryBox <rect> at (8,8) content-size 24x24 children: not-inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/svg/svg-path-with-implicit-lineto.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-path-with-implicit-lineto.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x116 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: inline
       line 0 width: 100, height: 100, bottom: 100, baseline: 60
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100]
-      SVGSVGBox <svg> at (8,8) content-size 100x100 children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: not-inline
         SVGGeometryBox <path> at (28,28) content-size 60x60 children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/auto-height.txt
@@ -1,20 +1,20 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x60.9375 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x60.9375 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x42.9375 children: not-inline
       BlockContainer <div> at (11,11) content-size 778x19.46875 children: not-inline
-        TableWrapper <(anonymous)> at (11,11) content-size 29.15625x19.46875 children: not-inline
-          TableBox <(anonymous)> at (11,11) content-size 29.15625x19.46875 children: not-inline
+        TableWrapper <(anonymous)> at (11,11) content-size 29.15625x19.46875 [BFC] children: not-inline
+          TableBox <(anonymous)> at (11,11) content-size 29.15625x19.46875 [TFC] children: not-inline
             TableRowBox <(anonymous)> at (11,11) content-size 29.15625x19.46875 children: not-inline
-              TableCellBox <span> at (12,12) content-size 27.15625x17.46875 children: inline
+              TableCellBox <span> at (12,12) content-size 27.15625x17.46875 [BFC] children: inline
                 line 0 width: 27.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 3, rect: [12,12 27.15625x17.46875]
                     "foo"
                 TextNode <#text>
       BlockContainer <div> at (11,32.46875) content-size 778x19.46875 children: not-inline
-        TableWrapper <(anonymous)> at (11,32.46875) content-size 29.640625x19.46875 children: not-inline
-          TableBox <(anonymous)> at (11,32.46875) content-size 29.640625x19.46875 children: not-inline
+        TableWrapper <(anonymous)> at (11,32.46875) content-size 29.640625x19.46875 [BFC] children: not-inline
+          TableBox <(anonymous)> at (11,32.46875) content-size 29.640625x19.46875 [TFC] children: not-inline
             TableRowBox <(anonymous)> at (11,32.46875) content-size 29.640625x19.46875 children: not-inline
-              TableCellBox <span> at (12,33.46875) content-size 27.640625x17.46875 children: inline
+              TableCellBox <span> at (12,33.46875) content-size 27.640625x17.46875 [BFC] children: inline
                 line 0 width: 27.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 3, rect: [12,33.46875 27.640625x17.46875]
                     "bar"

--- a/Tests/LibWeb/Layout/expected/table/basic.txt
+++ b/Tests/LibWeb/Layout/expected/table/basic.txt
@@ -1,16 +1,16 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x74.40625 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x74.40625 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x58.40625 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 784x0 children: not-inline
-        TableBox <table#empty-table> at (8,8) content-size 784x0 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 784x0 [BFC] children: not-inline
+        TableBox <table#empty-table> at (8,8) content-size 784x0 [TFC] children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      TableWrapper <(anonymous)> at (8,8) content-size 95.171875x58.40625 children: not-inline
-        TableBox <table#full-table> at (8,8) content-size 95.171875x58.40625 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 95.171875x58.40625 [BFC] children: not-inline
+        TableBox <table#full-table> at (8,8) content-size 95.171875x58.40625 [TFC] children: not-inline
           BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
             TextNode <#text>
-          BlockContainer <caption> at (8,8) content-size 0x0 children: inline
+          BlockContainer <caption> at (8,8) content-size 0x0 [BFC] children: inline
             TextNode <#text>
           BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
             TextNode <#text>
@@ -20,7 +20,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TableRowBox <tr> at (8,8) content-size 95.171875x19.46875 children: not-inline
               BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
                 TextNode <#text>
-              TableCellBox <td> at (9,9) content-size 93.171875x17.46875 children: inline
+              TableCellBox <td> at (9,9) content-size 93.171875x17.46875 [BFC] children: inline
                 line 0 width: 73.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 9, rect: [9,9 73.65625x17.46875]
                     "Head Cell"
@@ -37,7 +37,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TableRowBox <tr> at (8,27.46875) content-size 95.171875x19.46875 children: not-inline
               BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
                 TextNode <#text>
-              TableCellBox <td> at (9,28.46875) content-size 93.171875x17.46875 children: inline
+              TableCellBox <td> at (9,28.46875) content-size 93.171875x17.46875 [BFC] children: inline
                 line 0 width: 70.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 9, rect: [9,28.46875 70.234375x17.46875]
                     "Body Cell"
@@ -54,7 +54,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TableRowBox <tr> at (8,46.9375) content-size 95.171875x19.46875 children: not-inline
               BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
                 TextNode <#text>
-              TableCellBox <td> at (9,47.9375) content-size 93.171875x17.46875 children: inline
+              TableCellBox <td> at (9,47.9375) content-size 93.171875x17.46875 [BFC] children: inline
                 line 0 width: 93.171875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 11, rect: [9,47.9375 93.171875x17.46875]
                     "Footer Cell"

--- a/Tests/LibWeb/Layout/expected/table/borders.txt
+++ b/Tests/LibWeb/Layout/expected/table/borders.txt
@@ -1,22 +1,22 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x293.625 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x293.625 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x277.625 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 164.296875x66.40625 children: not-inline
-        TableBox <table.table-border-black> at (9,9) content-size 164.296875x64.40625 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 164.296875x66.40625 [BFC] children: not-inline
+        TableBox <table.table-border-black> at (9,9) content-size 164.296875x64.40625 [TFC] children: not-inline
           BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
             TextNode <#text>
           TableRowGroupBox <tbody> at (9,9) content-size 166.296875x64.40625 children: not-inline
             TableRowBox <tr> at (9,9) content-size 166.296875x21.46875 children: not-inline
               BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
                 TextNode <#text>
-              TableCellBox <td> at (11,11) content-size 82.015625x17.46875 children: inline
+              TableCellBox <td> at (11,11) content-size 82.015625x17.46875 [BFC] children: inline
                 line 0 width: 82.015625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 9, rect: [11,11 82.015625x17.46875]
                     "Firstname"
                 TextNode <#text>
               BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
                 TextNode <#text>
-              TableCellBox <td> at (97.015625,11) content-size 76.28125x17.46875 children: inline
+              TableCellBox <td> at (97.015625,11) content-size 76.28125x17.46875 [BFC] children: inline
                 line 0 width: 76.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 8, rect: [97.015625,11 76.28125x17.46875]
                     "Lastname"
@@ -28,14 +28,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TableRowBox <tr> at (9,30.46875) content-size 166.296875x21.46875 children: not-inline
               BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
                 TextNode <#text>
-              TableCellBox <td> at (11,32.46875) content-size 82.015625x17.46875 children: inline
+              TableCellBox <td> at (11,32.46875) content-size 82.015625x17.46875 [BFC] children: inline
                 line 0 width: 44.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 5, rect: [11,32.46875 44.65625x17.46875]
                     "Peter"
                 TextNode <#text>
               BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
                 TextNode <#text>
-              TableCellBox <td> at (97.015625,32.46875) content-size 76.28125x17.46875 children: inline
+              TableCellBox <td> at (97.015625,32.46875) content-size 76.28125x17.46875 [BFC] children: inline
                 line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 7, rect: [97.015625,32.46875 53.671875x17.46875]
                     "Griffin"
@@ -47,14 +47,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TableRowBox <tr> at (9,51.9375) content-size 166.296875x21.46875 children: not-inline
               BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
                 TextNode <#text>
-              TableCellBox <td> at (11,53.9375) content-size 82.015625x17.46875 children: inline
+              TableCellBox <td> at (11,53.9375) content-size 82.015625x17.46875 [BFC] children: inline
                 line 0 width: 35.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 4, rect: [11,53.9375 35.125x17.46875]
                     "Lois"
                 TextNode <#text>
               BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
                 TextNode <#text>
-              TableCellBox <td> at (97.015625,53.9375) content-size 76.28125x17.46875 children: inline
+              TableCellBox <td> at (97.015625,53.9375) content-size 76.28125x17.46875 [BFC] children: inline
                 line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 7, rect: [97.015625,53.9375 53.671875x17.46875]
                     "Griffin"
@@ -66,22 +66,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,74.40625) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      TableWrapper <(anonymous)> at (8,74.40625) content-size 164.296875x62.40625 children: not-inline
-        TableBox <table.table-border-black> at (8,74.40625) content-size 164.296875x62.40625 children: not-inline
+      TableWrapper <(anonymous)> at (8,74.40625) content-size 164.296875x62.40625 [BFC] children: not-inline
+        TableBox <table.table-border-black> at (8,74.40625) content-size 164.296875x62.40625 [TFC] children: not-inline
           BlockContainer <(anonymous)> at (8,74.40625) content-size 0x0 children: inline
             TextNode <#text>
           TableRowGroupBox <tbody> at (8,74.40625) content-size 164.296875x62.40625 children: not-inline
             TableRowBox <tr> at (8,74.40625) content-size 164.296875x20.46875 children: not-inline
               BlockContainer <(anonymous)> at (8,74.40625) content-size 0x0 children: inline
                 TextNode <#text>
-              TableCellBox <td> at (9,75.40625) content-size 82.015625x17.46875 children: inline
+              TableCellBox <td> at (9,75.40625) content-size 82.015625x17.46875 [BFC] children: inline
                 line 0 width: 82.015625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 9, rect: [9,75.40625 82.015625x17.46875]
                     "Firstname"
                 TextNode <#text>
               BlockContainer <(anonymous)> at (8,74.40625) content-size 0x0 children: inline
                 TextNode <#text>
-              TableCellBox <td> at (95.015625,75.40625) content-size 76.28125x17.46875 children: inline
+              TableCellBox <td> at (95.015625,75.40625) content-size 76.28125x17.46875 [BFC] children: inline
                 line 0 width: 76.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 8, rect: [95.015625,75.40625 76.28125x17.46875]
                     "Lastname"
@@ -93,14 +93,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TableRowBox <tr> at (8,94.875) content-size 164.296875x21.46875 children: not-inline
               BlockContainer <(anonymous)> at (8,74.40625) content-size 0x0 children: inline
                 TextNode <#text>
-              TableCellBox <td> at (9,96.875) content-size 82.015625x17.46875 children: inline
+              TableCellBox <td> at (9,96.875) content-size 82.015625x17.46875 [BFC] children: inline
                 line 0 width: 44.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 5, rect: [9,96.875 44.65625x17.46875]
                     "Peter"
                 TextNode <#text>
               BlockContainer <(anonymous)> at (8,74.40625) content-size 0x0 children: inline
                 TextNode <#text>
-              TableCellBox <td> at (95.015625,96.875) content-size 76.28125x17.46875 children: inline
+              TableCellBox <td> at (95.015625,96.875) content-size 76.28125x17.46875 [BFC] children: inline
                 line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 7, rect: [95.015625,96.875 53.671875x17.46875]
                     "Griffin"
@@ -112,14 +112,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TableRowBox <tr> at (8,116.34375) content-size 164.296875x20.46875 children: not-inline
               BlockContainer <(anonymous)> at (8,74.40625) content-size 0x0 children: inline
                 TextNode <#text>
-              TableCellBox <td> at (9,118.34375) content-size 82.015625x17.46875 children: inline
+              TableCellBox <td> at (9,118.34375) content-size 82.015625x17.46875 [BFC] children: inline
                 line 0 width: 35.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 4, rect: [9,118.34375 35.125x17.46875]
                     "Lois"
                 TextNode <#text>
               BlockContainer <(anonymous)> at (8,74.40625) content-size 0x0 children: inline
                 TextNode <#text>
-              TableCellBox <td> at (95.015625,118.34375) content-size 76.28125x17.46875 children: inline
+              TableCellBox <td> at (95.015625,118.34375) content-size 76.28125x17.46875 [BFC] children: inline
                 line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 7, rect: [95.015625,118.34375 53.671875x17.46875]
                     "Griffin"
@@ -131,21 +131,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,136.8125) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      TableWrapper <(anonymous)> at (8,136.8125) content-size 160.296875x56.40625 children: not-inline
-        TableBox <div.table.border-black> at (8,136.8125) content-size 160.296875x56.40625 children: not-inline
+      TableWrapper <(anonymous)> at (8,136.8125) content-size 160.296875x56.40625 [BFC] children: not-inline
+        TableBox <div.table.border-black> at (8,136.8125) content-size 160.296875x56.40625 [TFC] children: not-inline
           BlockContainer <(anonymous)> at (8,136.8125) content-size 0x0 children: inline
             TextNode <#text>
           TableRowBox <div.table-row.border-black> at (8,136.8125) content-size 160.296875x18.46875 children: not-inline
             BlockContainer <(anonymous)> at (8,136.8125) content-size 0x0 children: inline
               TextNode <#text>
-            TableCellBox <div.table-cell.border-black> at (8,136.8125) content-size 82.015625x17.46875 children: inline
+            TableCellBox <div.table-cell.border-black> at (8,136.8125) content-size 82.015625x17.46875 [BFC] children: inline
               line 0 width: 82.015625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 9, rect: [8,136.8125 82.015625x17.46875]
                   "Firstname"
               TextNode <#text>
             BlockContainer <(anonymous)> at (8,136.8125) content-size 0x0 children: inline
               TextNode <#text>
-            TableCellBox <div.table-cell.border-black> at (92.015625,136.8125) content-size 76.28125x17.46875 children: inline
+            TableCellBox <div.table-cell.border-black> at (92.015625,136.8125) content-size 76.28125x17.46875 [BFC] children: inline
               line 0 width: 76.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 8, rect: [92.015625,136.8125 76.28125x17.46875]
                   "Lastname"
@@ -157,14 +157,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TableRowBox <div.table-row.border-black> at (8,155.28125) content-size 160.296875x19.46875 children: not-inline
             BlockContainer <(anonymous)> at (8,136.8125) content-size 0x0 children: inline
               TextNode <#text>
-            TableCellBox <div.table-cell.border-black> at (8,156.28125) content-size 82.015625x17.46875 children: inline
+            TableCellBox <div.table-cell.border-black> at (8,156.28125) content-size 82.015625x17.46875 [BFC] children: inline
               line 0 width: 44.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 5, rect: [8,156.28125 44.65625x17.46875]
                   "Peter"
               TextNode <#text>
             BlockContainer <(anonymous)> at (8,136.8125) content-size 0x0 children: inline
               TextNode <#text>
-            TableCellBox <div.table-cell.border-black> at (92.015625,156.28125) content-size 76.28125x17.46875 children: inline
+            TableCellBox <div.table-cell.border-black> at (92.015625,156.28125) content-size 76.28125x17.46875 [BFC] children: inline
               line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 7, rect: [92.015625,156.28125 53.671875x17.46875]
                   "Griffin"
@@ -176,14 +176,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TableRowBox <div.table-row.border-black> at (8,174.75) content-size 160.296875x18.46875 children: not-inline
             BlockContainer <(anonymous)> at (8,136.8125) content-size 0x0 children: inline
               TextNode <#text>
-            TableCellBox <div.table-cell.border-black> at (8,175.75) content-size 82.015625x17.46875 children: inline
+            TableCellBox <div.table-cell.border-black> at (8,175.75) content-size 82.015625x17.46875 [BFC] children: inline
               line 0 width: 35.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 4, rect: [8,175.75 35.125x17.46875]
                   "Lois"
               TextNode <#text>
             BlockContainer <(anonymous)> at (8,136.8125) content-size 0x0 children: inline
               TextNode <#text>
-            TableCellBox <div.table-cell.border-black> at (92.015625,175.75) content-size 76.28125x17.46875 children: inline
+            TableCellBox <div.table-cell.border-black> at (92.015625,175.75) content-size 76.28125x17.46875 [BFC] children: inline
               line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 7, rect: [92.015625,175.75 53.671875x17.46875]
                   "Griffin"
@@ -195,21 +195,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,193.21875) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      TableWrapper <(anonymous)> at (8,193.21875) content-size 178.296875x92.40625 children: not-inline
-        TableBox <div.table.thick-border-black> at (8,193.21875) content-size 178.296875x92.40625 children: not-inline
+      TableWrapper <(anonymous)> at (8,193.21875) content-size 178.296875x92.40625 [BFC] children: not-inline
+        TableBox <div.table.thick-border-black> at (8,193.21875) content-size 178.296875x92.40625 [TFC] children: not-inline
           BlockContainer <(anonymous)> at (8,193.21875) content-size 0x0 children: inline
             TextNode <#text>
           TableRowBox <div.table-row.thick-border-black> at (8,193.21875) content-size 178.296875x27.46875 children: not-inline
             BlockContainer <(anonymous)> at (8,193.21875) content-size 0x0 children: inline
               TextNode <#text>
-            TableCellBox <div.table-cell.thick-border-black> at (8,193.21875) content-size 82.015625x17.46875 children: inline
+            TableCellBox <div.table-cell.thick-border-black> at (8,193.21875) content-size 82.015625x17.46875 [BFC] children: inline
               line 0 width: 82.015625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 9, rect: [8,193.21875 82.015625x17.46875]
                   "Firstname"
               TextNode <#text>
             BlockContainer <(anonymous)> at (8,193.21875) content-size 0x0 children: inline
               TextNode <#text>
-            TableCellBox <div.table-cell.thick-border-black> at (110.015625,193.21875) content-size 76.28125x17.46875 children: inline
+            TableCellBox <div.table-cell.thick-border-black> at (110.015625,193.21875) content-size 76.28125x17.46875 [BFC] children: inline
               line 0 width: 76.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 8, rect: [110.015625,193.21875 76.28125x17.46875]
                   "Lastname"
@@ -221,14 +221,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TableRowBox <div.table-row.thick-border-black> at (8,220.6875) content-size 178.296875x37.46875 children: not-inline
             BlockContainer <(anonymous)> at (8,193.21875) content-size 0x0 children: inline
               TextNode <#text>
-            TableCellBox <div.table-cell.thick-border-black> at (8,230.6875) content-size 82.015625x17.46875 children: inline
+            TableCellBox <div.table-cell.thick-border-black> at (8,230.6875) content-size 82.015625x17.46875 [BFC] children: inline
               line 0 width: 44.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 5, rect: [8,230.6875 44.65625x17.46875]
                   "Peter"
               TextNode <#text>
             BlockContainer <(anonymous)> at (8,193.21875) content-size 0x0 children: inline
               TextNode <#text>
-            TableCellBox <div.table-cell.thick-border-black> at (110.015625,230.6875) content-size 76.28125x17.46875 children: inline
+            TableCellBox <div.table-cell.thick-border-black> at (110.015625,230.6875) content-size 76.28125x17.46875 [BFC] children: inline
               line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 7, rect: [110.015625,230.6875 53.671875x17.46875]
                   "Griffin"
@@ -240,14 +240,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TableRowBox <div.table-row.thick-border-black> at (8,258.15625) content-size 178.296875x27.46875 children: not-inline
             BlockContainer <(anonymous)> at (8,193.21875) content-size 0x0 children: inline
               TextNode <#text>
-            TableCellBox <div.table-cell.thick-border-black> at (8,268.15625) content-size 82.015625x17.46875 children: inline
+            TableCellBox <div.table-cell.thick-border-black> at (8,268.15625) content-size 82.015625x17.46875 [BFC] children: inline
               line 0 width: 35.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 4, rect: [8,268.15625 35.125x17.46875]
                   "Lois"
               TextNode <#text>
             BlockContainer <(anonymous)> at (8,193.21875) content-size 0x0 children: inline
               TextNode <#text>
-            TableCellBox <div.table-cell.thick-border-black> at (110.015625,268.15625) content-size 76.28125x17.46875 children: inline
+            TableCellBox <div.table-cell.thick-border-black> at (110.015625,268.15625) content-size 76.28125x17.46875 [BFC] children: inline
               line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 7, rect: [110.015625,268.15625 53.671875x17.46875]
                   "Griffin"

--- a/Tests/LibWeb/Layout/expected/table/cell-px-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-px-height.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x116 children: not-inline
-    TableWrapper <(anonymous)> at (8,8) content-size 102x100 children: not-inline
-      TableBox <body> at (8,8) content-size 102x100 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    TableWrapper <(anonymous)> at (8,8) content-size 102x100 [BFC] children: not-inline
+      TableBox <body> at (8,8) content-size 102x100 [TFC] children: not-inline
         TableRowBox <div.row> at (8,8) content-size 102x100 children: not-inline
-          TableCellBox <div.cell> at (9,9) content-size 100x0 children: not-inline
+          TableCellBox <div.cell> at (9,9) content-size 100x0 [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
@@ -1,15 +1,15 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x108.21875 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x108.21875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x92.21875 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 782x92.21875 children: not-inline
-        TableBox <table.ambox> at (9,9) content-size 782x90.21875 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 782x92.21875 [BFC] children: not-inline
+        TableBox <table.ambox> at (9,9) content-size 782x90.21875 [TFC] children: not-inline
           BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
             TextNode <#text>
           TableRowGroupBox <tbody> at (9,9) content-size 782x90.21875 children: not-inline
             TableRowBox <tr> at (9,9) content-size 782x90.21875 children: not-inline
-              TableCellBox <td.mbox-image> at (10,29.109375) content-size 50x50 children: not-inline
+              TableCellBox <td.mbox-image> at (10,29.109375) content-size 50x50 [BFC] children: not-inline
                 BlockContainer <div.mbox-image-div> at (10,29.109375) content-size 50x50 children: not-inline
-              TableCellBox <td.mbox-text> at (62,10) content-size 728x88.21875 children: inline
+              TableCellBox <td.mbox-text> at (62,10) content-size 728x88.21875 [BFC] children: inline
                 line 0 width: 689.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 1, length: 84, rect: [62,10 689.640625x17.46875]
                     "In a scene set in a lawyer's office, the lawyer sits alone and bounces a rubber ball"

--- a/Tests/LibWeb/Layout/expected/table/in-auto-height-flex-item.txt
+++ b/Tests/LibWeb/Layout/expected/table/in-auto-height-flex-item.txt
@@ -1,11 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x39.46875 children: not-inline
-    Box <body> at (10,10) content-size 764x21.46875 flex-container(row) children: not-inline
-      BlockContainer <div.upper> at (11,11) content-size 41.78125x19.46875 flex-item children: not-inline
-        TableWrapper <(anonymous)> at (11,11) content-size 41.78125x19.46875 children: not-inline
-          TableBox <(anonymous)> at (11,11) content-size 41.78125x19.46875 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x39.46875 [BFC] children: not-inline
+    Box <body> at (10,10) content-size 764x21.46875 flex-container(row) [FFC] children: not-inline
+      BlockContainer <div.upper> at (11,11) content-size 41.78125x19.46875 flex-item [BFC] children: not-inline
+        TableWrapper <(anonymous)> at (11,11) content-size 41.78125x19.46875 [BFC] children: not-inline
+          TableBox <(anonymous)> at (11,11) content-size 41.78125x19.46875 [TFC] children: not-inline
             TableRowBox <(anonymous)> at (11,11) content-size 41.78125x19.46875 children: not-inline
-              TableCellBox <div.cell> at (12,12) content-size 39.78125x17.46875 children: inline
+              TableCellBox <div.cell> at (12,12) content-size 39.78125x17.46875 [BFC] children: inline
                 line 0 width: 39.78125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 5, rect: [12,12 39.78125x17.46875]
                     "Hello"

--- a/Tests/LibWeb/Layout/expected/table/row-px-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-px-height.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x116 children: not-inline
-    TableWrapper <(anonymous)> at (8,8) content-size 102x100 children: not-inline
-      TableBox <body> at (8,8) content-size 102x100 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    TableWrapper <(anonymous)> at (8,8) content-size 102x100 [BFC] children: not-inline
+      TableBox <body> at (8,8) content-size 102x100 [TFC] children: not-inline
         TableRowBox <div.row> at (8,8) content-size 102x100 children: not-inline
-          TableCellBox <div.cell> at (9,9) content-size 100x0 children: not-inline
+          TableCellBox <div.cell> at (9,9) content-size 100x0 [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-1.txt
@@ -1,9 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x166 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x166 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x150 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 200x150 children: not-inline
-        TableBox <div.table> at (8,8) content-size 200x150 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 200x150 [BFC] children: not-inline
+        TableBox <div.table> at (8,8) content-size 200x150 [TFC] children: not-inline
           TableRowBox <div.row.a> at (8,8) content-size 200x50 children: not-inline
-            TableCellBox <div.cell> at (8,8) content-size 200x0 children: not-inline
+            TableCellBox <div.cell> at (8,8) content-size 200x0 [BFC] children: not-inline
           TableRowBox <div.row.b> at (8,58) content-size 200x100 children: not-inline
-            TableCellBox <div.cell> at (8,58) content-size 200x0 children: not-inline
+            TableCellBox <div.cell> at (8,58) content-size 200x0 [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-2.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-2.txt
@@ -1,9 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x316 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x316 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x300 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 200x300 children: not-inline
-        TableBox <div.table> at (8,8) content-size 200x300 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 200x300 [BFC] children: not-inline
+        TableBox <div.table> at (8,8) content-size 200x300 [TFC] children: not-inline
           TableRowBox <div.row.a> at (8,8) content-size 200x150 children: not-inline
-            TableCellBox <div.cell> at (8,8) content-size 200x0 children: not-inline
+            TableCellBox <div.cell> at (8,8) content-size 200x0 [BFC] children: not-inline
           TableRowBox <div.row.b> at (8,158) content-size 200x150 children: not-inline
-            TableCellBox <div.cell> at (8,158) content-size 200x0 children: not-inline
+            TableCellBox <div.cell> at (8,158) content-size 200x0 [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-3.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-3.txt
@@ -1,16 +1,16 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x316 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x316 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x300 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 200x300 children: not-inline
-        TableBox <div.table> at (8,8) content-size 200x300 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 200x300 [BFC] children: not-inline
+        TableBox <div.table> at (8,8) content-size 200x300 [TFC] children: not-inline
           TableRowBox <div.row.a> at (8,8) content-size 200x150 children: not-inline
-            TableCellBox <div.cell> at (8,8) content-size 200x17.46875 children: inline
+            TableCellBox <div.cell> at (8,8) content-size 200x17.46875 [BFC] children: inline
               line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17.46875]
                   "a"
               TextNode <#text>
           TableRowBox <div.row.b> at (8,158) content-size 200x150 children: not-inline
-            TableCellBox <div.cell> at (8,158) content-size 200x17.46875 children: inline
+            TableCellBox <div.cell> at (8,158) content-size 200x17.46875 [BFC] children: inline
               line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 1, rect: [8,158 9.46875x17.46875]
                   "b"

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-4.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-4.txt
@@ -1,16 +1,16 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x316 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x316 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x300 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 200x300 children: not-inline
-        TableBox <div.table> at (8,8) content-size 200x300 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 200x300 [BFC] children: not-inline
+        TableBox <div.table> at (8,8) content-size 200x300 [TFC] children: not-inline
           TableRowBox <div.row.a> at (8,8) content-size 200x100 children: not-inline
-            TableCellBox <div.cell> at (8,8) content-size 200x17.46875 children: inline
+            TableCellBox <div.cell> at (8,8) content-size 200x17.46875 [BFC] children: inline
               line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17.46875]
                   "a"
               TextNode <#text>
           TableRowBox <div.row.b> at (8,108) content-size 200x200 children: not-inline
-            TableCellBox <div.cell> at (8,108) content-size 200x17.46875 children: inline
+            TableCellBox <div.cell> at (8,108) content-size 200x17.46875 [BFC] children: inline
               line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                 frag 0 from TextNode start: 0, length: 1, rect: [8,108 9.46875x17.46875]
                   "b"

--- a/Tests/LibWeb/Layout/expected/table/size.txt
+++ b/Tests/LibWeb/Layout/expected/table/size.txt
@@ -1,10 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x33.46875 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
-      TableWrapper <(anonymous)> at (350,8) content-size 100x17.46875 children: not-inline
-        TableBox <div> at (350,8) content-size 100x17.46875 children: not-inline
+      TableWrapper <(anonymous)> at (350,8) content-size 100x17.46875 [BFC] children: not-inline
+        TableBox <div> at (350,8) content-size 100x17.46875 [TFC] children: not-inline
           TableRowBox <(anonymous)> at (350,8) content-size 2000x17.46875 children: not-inline
-            TableCellBox <(anonymous)> at (350,8) content-size 2000x17.46875 children: not-inline
+            TableCellBox <(anonymous)> at (350,8) content-size 2000x17.46875 [BFC] children: not-inline
               BlockContainer <(anonymous)> at (350,8) content-size 2000x0 children: inline
                 TextNode <#text>
               BlockContainer <div> at (350,8) content-size 2000x17.46875 children: inline

--- a/Tests/LibWeb/Layout/expected/table/table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-width.txt
@@ -1,8 +1,8 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x226 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x226 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x210 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 584x210 children: not-inline
-        TableBox <table.table> at (108,108) content-size 584x10 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 584x210 [BFC] children: not-inline
+        TableBox <table.table> at (108,108) content-size 584x10 [TFC] children: not-inline
           TableRowGroupBox <tbody> at (108,108) content-size 584x10 children: not-inline
             TableRowBox <tr> at (108,108) content-size 584x10 children: not-inline
-              TableCellBox <td.cell> at (109,113) content-size 582x0 children: not-inline
+              TableCellBox <td.cell> at (109,113) content-size 582x0 [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/zero-columns-gridmax.txt
+++ b/Tests/LibWeb/Layout/expected/table/zero-columns-gridmax.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x16 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 200x0 children: not-inline
-        TableBox <div.table> at (8,8) content-size 200x0 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 200x0 [BFC] children: not-inline
+        TableBox <div.table> at (8,8) content-size 200x0 [TFC] children: not-inline
           TableRowBox <div.row> at (8,8) content-size 200x0 children: not-inline
-            TableCellBox <div.cell> at (8,8) content-size 200x0 children: not-inline
+            TableCellBox <div.cell> at (8,8) content-size 200x0 [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/vertical-padding-relative-to-cb-width.txt
+++ b/Tests/LibWeb/Layout/expected/vertical-padding-relative-to-cb-width.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x30 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x30 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x12 children: not-inline
       BlockContainer <(anonymous)> at (10,10) content-size 780x0 children: inline
         TextNode <#text>

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -24,6 +24,7 @@
 #include <LibWeb/Dump.h>
 #include <LibWeb/HTML/HTMLTemplateElement.h>
 #include <LibWeb/Layout/BlockContainer.h>
+#include <LibWeb/Layout/FormattingContext.h>
 #include <LibWeb/Layout/FrameBox.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/SVGBox.h>
@@ -128,6 +129,7 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
     StringView line_box_color_on = ""sv;
     StringView fragment_color_on = ""sv;
     StringView flex_color_on = ""sv;
+    StringView formatting_context_color_on = ""sv;
     StringView color_off = ""sv;
 
     if (interactive) {
@@ -140,6 +142,7 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
         line_box_color_on = "\033[34;1m"sv;
         fragment_color_on = "\033[35;1m"sv;
         flex_color_on = "\033[34;1m"sv;
+        formatting_context_color_on = "\033[37;1m"sv;
         color_off = "\033[0m"sv;
     }
 
@@ -223,6 +226,28 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
                 box.box_model().padding.bottom,
                 box.box_model().border.bottom,
                 box.box_model().margin.bottom);
+        }
+
+        if (auto formatting_context_type = Layout::FormattingContext::formatting_context_type_created_by_box(box); formatting_context_type.has_value()) {
+            switch (formatting_context_type.value()) {
+            case Layout::FormattingContext::Type::Block:
+                builder.appendff(" [{}BFC{}]", formatting_context_color_on, color_off);
+                break;
+            case Layout::FormattingContext::Type::Flex:
+                builder.appendff(" [{}FFC{}]", formatting_context_color_on, color_off);
+                break;
+            case Layout::FormattingContext::Type::Grid:
+                builder.appendff(" [{}GFC{}]", formatting_context_color_on, color_off);
+                break;
+            case Layout::FormattingContext::Type::Table:
+                builder.appendff(" [{}TFC{}]", formatting_context_color_on, color_off);
+                break;
+            case Layout::FormattingContext::Type::SVG:
+                builder.appendff(" [{}SVG{}]", formatting_context_color_on, color_off);
+                break;
+            default:
+                break;
+            }
         }
 
         builder.appendff(" children: {}", box.children_are_inline() ? "inline" : "not-inline");

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -24,6 +24,8 @@ public:
         Grid,
         Table,
         SVG,
+        InternalReplaced, // Internal hack formatting context for replaced elements. FIXME: Get rid of this.
+        InternalDummy,    // Internal hack formatting context for unimplemented things. FIXME: Get rid of this.
     };
 
     virtual void run(Box const&, LayoutMode, AvailableSpace const&) = 0;
@@ -43,6 +45,8 @@ public:
     bool is_block_formatting_context() const { return type() == Type::Block; }
 
     virtual bool inhibits_floating() const { return false; }
+
+    [[nodiscard]] static Optional<Type> formatting_context_type_created_by_box(Box const&);
 
     static bool creates_block_formatting_context(Box const&);
 


### PR DESCRIPTION
This patch does three things:

- Factors out the code that determines whether a box will create a new formatting context for its children (and which type of context)

- Uses that code to mark all formatting context roots in layout tree dumps. This makes it much easier to follow along with layout since you can now see exactly where control is transferred to a new formatting context.

- Rebaselines all existing layout tests, since the output format has changed slightly.