### PR TITLE
AK: Have `JsonArray::set()` change values instead of inserting values

### DIFF
--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -66,7 +66,7 @@ public:
 
     void clear() { m_values.clear(); }
     ErrorOr<void> append(JsonValue value) { return m_values.try_append(move(value)); }
-    ErrorOr<void> set(size_t index, JsonValue value) { return m_values.try_insert(index, move(value)); }
+    void set(size_t index, JsonValue value) { m_values.at(index) = move(value); }
 
     template<typename Builder>
     typename Builder::OutputType serialized() const;

--- a/Userland/Libraries/LibGUI/JsonArrayModel.cpp
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.cpp
@@ -97,7 +97,7 @@ ErrorOr<void> JsonArrayModel::set(int row, Vector<JsonValue>&& fields)
         obj.set(field_spec.json_field_name, move(fields.at(i)));
     }
 
-    TRY(m_array.set(row, move(obj)));
+    m_array.set(row, move(obj));
     did_update();
 
     return {};


### PR DESCRIPTION
Resolves #18618.

8134dcc changed `JsonArray::set()` to insert values at an index instead of changing existing elements in-place. Since no behavior such as `Vector::try_at()` exists yet, it returns nothing.