### PR TITLE
LibWeb: Implement the EventTarget constructor

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -42,6 +42,25 @@ EventTarget::EventTarget(JS::Realm& realm)
 
 EventTarget::~EventTarget() = default;
 
+// https://dom.spec.whatwg.org/#dom-eventtarget-eventtarget
+WebIDL::ExceptionOr<JS::NonnullGCPtr<EventTarget>> EventTarget::construct_impl(JS::Realm& realm)
+{
+    // The new EventTarget() constructor steps are to do nothing.
+    return MUST_OR_THROW_OOM(realm.heap().allocate<EventTarget>(realm, realm));
+}
+
+JS::ThrowCompletionOr<void> EventTarget::initialize(JS::Realm& realm)
+{
+    MUST_OR_THROW_OOM(Base::initialize(realm));
+
+    // FIXME: We can't do this for HTML::Window currently, as this will run when creating the initial global object.
+    //        During this time, the ESO is not setup, so it will cause a nullptr dereference in host_defined_intrinsics.
+    if (!is<HTML::Window>(this))
+        set_prototype(&Bindings::ensure_web_prototype<Bindings::EventTargetPrototype>(realm, "EventTarget"));
+
+    return {};
+}
+
 void EventTarget::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.h
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.h
@@ -24,6 +24,8 @@ class EventTarget : public Bindings::PlatformObject {
 public:
     virtual ~EventTarget() override;
 
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<EventTarget>> construct_impl(JS::Realm&);
+
     virtual bool is_focusable() const { return false; }
 
     void add_event_listener(FlyString const& type, IDLEventListener* callback, Variant<AddEventListenerOptions, bool> const& options);
@@ -62,6 +64,7 @@ protected:
 
     void element_event_handler_attribute_changed(FlyString const& local_name, Optional<String> const& value);
 
+    virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.idl
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.idl
@@ -4,6 +4,8 @@
 [Exposed=*, UseNewAKString]
 interface EventTarget {
 
+    constructor();
+
     undefined addEventListener(DOMString type, EventListener? callback, optional (AddEventListenerOptions or boolean) options = {});
     undefined removeEventListener(DOMString type, EventListener? callback, optional (EventListenerOptions or boolean) options = {});
 


### PR DESCRIPTION
This is typically used as `class A extends EventTarget`. It's usage can be found on websites such as https://loadout.tf/

This has the quirk that we don't do set the EventTarget prototype for HTML::Window, as it would cause a null deref on startup. However, given it wasn't doing this before, I don't think it should cause any issues.