### PR TITLE
Browser: Don't show error message box when canceling editor dialog

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.h
+++ b/Userland/Applications/Browser/BookmarksBarWidget.h
@@ -44,7 +44,7 @@ public:
     bool contains_bookmark(StringView url);
     ErrorOr<void> remove_bookmark(StringView url);
     ErrorOr<void> add_bookmark(StringView url, StringView title);
-    ErrorOr<void> edit_bookmark(StringView url, PerformEditOn perform_edit_on = PerformEditOn::ExistingBookmark);
+    ErrorOr<void> edit_bookmark(StringView url);
 
     virtual Optional<GUI::UISize> calculated_min_size() const override
     {


### PR DESCRIPTION
Currently, an error message box appears when a user tries to cancel the editor dialog while editing or adding a bookmark.

This snapshot resolves this by having `add_bookmark()` and `BookmarksBarWidget::edit_bookmark()` perform an if check on the
result of `BookmarkEditor::edit_bookmark()` to see if the dialog was canceled.

Example of the issue with me canceling the editor dialog when trying to add a bookmark:

![Screenshot 2023-05-03 152037](https://user-images.githubusercontent.com/60799661/236062480-a148ec8c-1db3-4f93-9332-1b1ac3c87af2.png)
