### PR TITLE
WindowServer: Fix window content scaling when switching from fullscreen

### DIFF
--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -855,9 +855,9 @@ void Window::set_fullscreen(bool fullscreen)
         new_window_rect = m_saved_nonfullscreen_rect;
     }
 
+    set_rect(new_window_rect);
     send_resize_event_to_client();
     send_move_event_to_client();
-    set_rect(new_window_rect);
 }
 
 WindowTileType Window::tile_type_based_on_rect(Gfx::IntRect const& rect) const


### PR DESCRIPTION
Resolves #18624

Switching to and from fullscreen produces a behaviour where window content too big in relation to window size.

This patch fixes sent resize event to contain current window size.