### PR TITLE
LibWeb: Narrow width of boxes that create BFC to avoid overlap of float

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/narrow-bfc-width-to-avoid-overlap-with-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/narrow-bfc-width-to-avoid-overlap-with-floats.txt
@@ -1,0 +1,22 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x1008 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x108.21875 children: not-inline
+      BlockContainer <div.wrapper> at (8,8) content-size 784x108.21875 children: not-inline
+        BlockContainer <div.float> at (592,8) content-size 200x1000 floating [BFC] children: not-inline
+        BlockContainer <div.bfc> at (18,18) content-size 564x88.21875 [BFC] children: inline
+          line 0 width: 458.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 56, rect: [18,18 458.125x17.46875]
+              "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+          line 1 width: 511.796875, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+            frag 0 from TextNode start: 57, length: 60, rect: [18,35 511.796875x17.46875]
+              "Pellentesque vitae neque nunc. Nam fermentum libero a lectus"
+          line 2 width: 537.078125, height: 18.40625, bottom: 53.34375, baseline: 13.53125
+            frag 0 from TextNode start: 118, length: 67, rect: [18,52 537.078125x17.46875]
+              "vulputate eleifend. Nam sagittis tristique augue, id sodales mauris"
+          line 3 width: 537.34375, height: 17.875, bottom: 70.28125, baseline: 13.53125
+            frag 0 from TextNode start: 186, length: 65, rect: [18,70 537.34375x17.46875]
+              "suscipit at. Vivamus eget placerat ex. Suspendisse potenti. Morbi"
+          line 4 width: 455.375, height: 18.34375, bottom: 88.21875, baseline: 13.53125
+            frag 0 from TextNode start: 252, length: 57, rect: [18,87 455.375x17.46875]
+              "pulvinar ipsum eget nulla dapibus, ac varius mi eleifend."
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/block-and-inline/narrow-bfc-width-to-avoid-overlap-with-floats.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/narrow-bfc-width-to-avoid-overlap-with-floats.html
@@ -1,0 +1,23 @@
+<style>
+* {
+    font-family: 'SerenitySans';
+}
+
+.float {
+    width: 200px;
+    height: 1000px;
+    background-color: royalblue;
+    float: right;
+}
+
+.bfc {
+    background-color: mediumseagreen;
+    border: 10px solid skyblue;
+    display: flow-root;
+}
+</style>
+<div class="wrapper"><div class="float"></div><div class="bfc">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vitae
+    neque nunc. Nam fermentum libero a lectus vulputate eleifend. Nam sagittis
+    tristique augue, id sodales mauris suscipit at. Vivamus eget placerat ex.
+    Suspendisse potenti. Morbi pulvinar ipsum eget nulla dapibus, ac varius mi
+    eleifend.

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -250,8 +250,6 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     box_state.margin_left = margin_left.to_px(box);
     box_state.margin_right = margin_right.to_px(box);
-
-    resolve_vertical_box_model_metrics(box, m_state);
 }
 
 void BlockFormattingContext::compute_width_for_floating_box(Box const& box, AvailableSpace const& available_space)
@@ -329,8 +327,6 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     box_state.border_right = computed_values.border_right().width;
     box_state.padding_left = padding_left.to_px(box);
     box_state.padding_right = padding_right.to_px(box);
-
-    resolve_vertical_box_model_metrics(box, m_state);
 }
 
 void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_normal_flow(ReplacedBox const& box, AvailableSpace const& available_space)
@@ -521,6 +517,8 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     if (is<ListItemMarkerBox>(box))
         return;
 
+    resolve_vertical_box_model_metrics(box, m_state);
+
     auto const y = m_y_offset_of_current_block_container.value();
 
     if (box.is_floating()) {
@@ -529,8 +527,6 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, box_state.offset.y() + box_state.content_height() + box_state.margin_box_bottom());
         return;
     }
-
-    compute_width(box, available_space, layout_mode);
 
     if (box_state.has_definite_height()) {
         compute_height(box, available_space);
@@ -550,6 +546,9 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     }
 
     place_block_level_element_in_normal_flow_vertically(box, y + margin_top);
+
+    compute_width(box, available_space, layout_mode);
+
     place_block_level_element_in_normal_flow_horizontally(box, available_space);
 
     OwnPtr<FormattingContext> independent_formatting_context;
@@ -795,6 +794,8 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
 
     auto& box_state = m_state.get_mutable(box);
     CSSPixels width_of_containing_block = available_space.width.to_px();
+
+    resolve_vertical_box_model_metrics(box, m_state);
 
     compute_width(box, available_space, layout_mode);
     auto independent_formatting_context = layout_inside(box, layout_mode, box_state.available_inner_space_or_constraints_from(available_space));


### PR DESCRIPTION
https://www.w3.org/TR/CSS22/visuren.html#floats says that when a box establishes BFC it should not overlap with floats. The way to avoid overlaps is up to implementor. This change implements avoiding overlap by narrowing width of a box because it seems like what other engines do (in the scenarios I tested).