### PR TITLE
LibJS: Guard against stack overflow in some ProxyObject methods

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-has.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-has.js
@@ -85,3 +85,20 @@ describe("[[Has]] invariants", () => {
         );
     });
 });
+
+test("Proxy handler that has the Proxy itself as its prototype", () => {
+    const handler = {};
+    const proxy = new Proxy({}, handler);
+    handler.__proto__ = proxy;
+    expect(() => {
+        "foo" in proxy;
+    }).toThrowWithMessage(InternalError, "Call stack size limit exceeded");
+});
+
+test("Proxy that has the Proxy itself as its prototype", () => {
+    const proxy = new Proxy({}, {});
+    proxy.__proto__ = Object.create(proxy);
+    expect(() => {
+        "foo" in proxy;
+    }).toThrowWithMessage(InternalError, "Call stack size limit exceeded");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-set.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-set.js
@@ -112,3 +112,20 @@ describe("[[Set]] invariants", () => {
         );
     });
 });
+
+test("Proxy handler that has the Proxy itself as its prototype", () => {
+    const handler = {};
+    const proxy = new Proxy({}, handler);
+    handler.__proto__ = proxy;
+    expect(() => {
+        proxy["foo"] = "bar";
+    }).toThrowWithMessage(InternalError, "Call stack size limit exceeded");
+});
+
+test("Proxy that has the Proxy itself as its prototype", () => {
+    const proxy = new Proxy({}, {});
+    proxy.__proto__ = Object.create(proxy);
+    expect(() => {
+        proxy["foo"] = "bar";
+    }).toThrowWithMessage(InternalError, "Call stack size limit exceeded");
+});


### PR DESCRIPTION
The has_property() crash was reproduced with the following JS reduced from [CreepJS](https://abrahamjuliot.github.io/creepjs/creep.js):

```js
const HE = new Proxy({}, {});
Reflect.setPrototypeOf(HE, Object.create(HE));
"foo" in HE;
```

Similar for set_property:

```js
const HE = new Proxy({}, {});
Reflect.setPrototypeOf(HE, Object.create(HE));
HE["foo"] = "test";
```

This PR adds a guard agains stack overflows, in a similar way as it is done in ProxyObject::internal_get().

- LibJS: Guard against stack overflow in ProxyObject has_property()
- LibJS: Guard against stack overflow in ProxyObject set_property()
