### PR TITLE
LibWeb: Don't shrink flex items in main axis flexing during max-content

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/text-flex-item-with-automatic-main-size-during-max-content-sizing.txt
+++ b/Tests/LibWeb/Layout/expected/flex/text-flex-item-with-automatic-main-size-during-max-content-sizing.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x0 [BFC] children: not-inline
+    BlockContainer <body> at (2,2) content-size 311.675781x25.835937 positioned [BFC] children: not-inline
+      Box <div.inner> at (3,3) content-size 309.675781x23.835937 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div.moo> at (4,4) content-size 307.675781x21.835937 flex-item [BFC] children: inline
+          line 0 width: 307.675781, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+            frag 0 from TextNode start: 0, length: 30, rect: [4,4 307.675781x21.835937]
+              "This should all be on one line"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/flex/text-flex-item-with-automatic-main-size-during-max-content-sizing.html
+++ b/Tests/LibWeb/Layout/input/flex/text-flex-item-with-automatic-main-size-during-max-content-sizing.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+  * {
+    border: 1px solid black !important;
+    font: 20px SerenitySans;
+    margin: 0;
+    padding: 0;
+  }
+  body {
+    position: absolute;
+  }
+  .inner {
+    display: flex;
+    background: pink;
+  }
+  .moo {
+    background: orange;
+  }
+</style><div class="inner"><div class="moo">This should all be on one line


### PR DESCRIPTION
When we're sizing a flex container under a max-content constraint in the main axis, the "resolve flexible lengths" algorithm now acts as if the flex container's inner size is infinite.

This allows flex items to flex fully in the main axis, without being incorrectly constrained by believing that there is zero available space.

It's very likely that there's a cleaner solution for this, but this fixes a layout issue seen on multiple websites, and appears consistent with other engines.