### PR TITLE
LibWeb: Honor fill, stroke and stroke-width attribute on SVGSVGElement

### DIFF
--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -37,6 +37,8 @@ JS::GCPtr<Layout::Node> SVGSVGElement::create_layout_node(NonnullRefPtr<CSS::Sty
 
 void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) const
 {
+    Base::apply_presentational_hints(style);
+
     // NOTE: Hack to ensure SVG unitless widths/heights are parsed even with <!DOCTYPE html>
     auto previous_quirks_mode = document().mode();
     const_cast<DOM::Document&>(document()).set_quirks_mode(DOM::QuirksMode::Yes);


### PR DESCRIPTION
These are presentational hints and are handled by SVGGraphicsElement (a superclass of SVGSVGElement) so we just need to call up to it. :^)