### PR TITLE
LibWeb: Pause HTMLMediaElement when it is removed from the DOM tree or its document becomes inactive

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -126,9 +126,10 @@ set(SOURCES
     DOM/DOMTokenList.cpp
     DOM/DOMTokenList.idl
     DOM/Document.cpp
-    DOM/DocumentLoading.cpp
     DOM/DocumentFragment.cpp
     DOM/DocumentLoadEventDelayer.cpp
+    DOM/DocumentLoading.cpp
+    DOM/DocumentObserver.cpp
     DOM/DocumentType.cpp
     DOM/Element.cpp
     DOM/ElementFactory.cpp

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -394,6 +394,9 @@ public:
     void register_node_iterator(Badge<NodeIterator>, NodeIterator&);
     void unregister_node_iterator(Badge<NodeIterator>, NodeIterator&);
 
+    void register_document_observer(Badge<DocumentObserver>, DocumentObserver&);
+    void unregister_document_observer(Badge<DocumentObserver>, DocumentObserver&);
+
     template<typename Callback>
     void for_each_node_iterator(Callback callback)
     {
@@ -587,6 +590,8 @@ private:
     bool m_needs_full_style_update { false };
 
     HashTable<JS::GCPtr<NodeIterator>> m_node_iterators;
+
+    HashTable<JS::NonnullGCPtr<DocumentObserver>> m_document_observers;
 
     // https://html.spec.whatwg.org/multipage/dom.html#is-initial-about:blank
     bool m_is_initial_about_blank { false };

--- a/Userland/Libraries/LibWeb/DOM/DocumentObserver.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentObserver.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/Realm.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/DocumentObserver.h>
+
+namespace Web::DOM {
+
+DocumentObserver::DocumentObserver(JS::Realm& realm, DOM::Document& document)
+    : Bindings::PlatformObject(realm)
+    , m_document(document)
+{
+    m_document->register_document_observer({}, *this);
+}
+
+void DocumentObserver::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_document);
+}
+
+void DocumentObserver::finalize()
+{
+    Base::finalize();
+    m_document->unregister_document_observer({}, *this);
+}
+
+}

--- a/Userland/Libraries/LibWeb/DOM/DocumentObserver.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentObserver.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Forward.h>
+#include <LibJS/SafeFunction.h>
+#include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::DOM {
+
+class DocumentObserver final : public Bindings::PlatformObject {
+    WEB_PLATFORM_OBJECT(DocumentObserver, Bindings::PlatformObject);
+
+public:
+    JS::SafeFunction<void()> document_became_inactive;
+
+private:
+    explicit DocumentObserver(JS::Realm&, DOM::Document&);
+
+    virtual void visit_edges(Cell::Visitor&) override;
+    virtual void finalize() override;
+
+    JS::NonnullGCPtr<DOM::Document> m_document;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -189,6 +189,7 @@ class CustomEvent;
 class Document;
 class DocumentFragment;
 class DocumentLoadEventDelayer;
+class DocumentObserver;
 class DocumentType;
 class DOMEventListener;
 class DOMImplementation;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -84,6 +84,25 @@ void HTMLMediaElement::did_remove_attribute(DeprecatedFlyString const& name)
         m_crossorigin = cors_setting_attribute_from_keyword({});
 }
 
+// https://html.spec.whatwg.org/multipage/media.html#playing-the-media-resource:media-element-83
+void HTMLMediaElement::removed_from(DOM::Node* node)
+{
+    Base::removed_from(node);
+
+    // When a media element is removed from a Document, the user agent must run the following steps:
+
+    // FIXME: 1. Await a stable state, allowing the task that removed the media element from the Document to continue. The
+    //           synchronous section consists of all the remaining steps of this algorithm. (Steps in the synchronous section
+    //           are marked with ⌛.)
+
+    // 2. ⌛ If the media element is in a document, return.
+    if (in_a_document_tree())
+        return;
+
+    // 3. ⌛ Run the internal pause steps for the media element.
+    pause_element().release_value_but_fixme_should_propagate_errors();
+}
+
 // https://html.spec.whatwg.org/multipage/media.html#fatal-decode-error
 WebIDL::ExceptionOr<void> HTMLMediaElement::set_decoder_error(String error_message)
 {

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -208,6 +208,8 @@ private:
     bool m_running_time_update_event_handler { false };
     Optional<Time> m_last_time_update_event_time;
 
+    JS::GCPtr<DOM::DocumentObserver> m_document_observer;
+
     JS::GCPtr<Fetch::Infrastructure::FetchController> m_fetch_controller;
 
     bool m_seek_in_progress = false;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -89,6 +89,7 @@ protected:
 
     virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
     virtual void did_remove_attribute(DeprecatedFlyString const&) override;
+    virtual void removed_from(DOM::Node*) override;
 
     // Override in subclasses to handle implementation-specific behavior when the element state changes
     // to playing or paused, e.g. to start/stop play timers.


### PR DESCRIPTION
For example, when navigating to another page, this ensures any media
resource will not continue playing.