### PR TITLE
LibWeb: Use JS::SafeFunction for module fetching callbacks

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
@@ -12,7 +12,7 @@
 
 namespace Web::HTML {
 
-using ModuleCallback = Function<void(JavaScriptModuleScript*)>;
+using ModuleCallback = JS::SafeFunction<void(JavaScriptModuleScript*)>;
 
 class DescendantFetchingContext : public RefCounted<DescendantFetchingContext> {
 public:


### PR DESCRIPTION
This fixes another GC crash seen on https://shopify.com/

Found it by collecting garbage after every 500th heap allocation.