### PR TITLE
LibWeb: Remove setting length to 0px if it is not definite

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-100.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-100.txt
@@ -1,0 +1,8 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x0 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 138.609375x19.46875 positioned [BFC] children: not-inline
+      BlockContainer <div> at (11,11) content-size 136.609375x17.46875 children: inline
+        line 0 width: 136.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 18, rect: [11,11 136.609375x17.46875]
+            "well hello friends"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/block-and-inline/max-width-percentage-100.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/max-width-percentage-100.html
@@ -1,0 +1,5 @@
+<!doctype html><style>    
+* { border: 1px solid black; font-family: 'SerenitySans'; }
+body { position: absolute; }
+div { max-width: 100%; }
+</style><body><div>well hello friends

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1289,9 +1289,6 @@ CSS::Length FormattingContext::calculate_inner_width(Layout::Box const& box, Ava
         return width.resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
     }
 
-    if (!available_width.is_definite())
-        width_of_containing_block_as_length_for_resolve = CSS::Length::make_px(0);
-
     auto& computed_values = box.computed_values();
     if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox) {
         auto const padding_left = computed_values.padding().left().resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
@@ -1315,9 +1312,6 @@ CSS::Length FormattingContext::calculate_inner_height(Layout::Box const& box, Av
     if (height.is_auto()) {
         return height.resolved(box, height_of_containing_block_as_length_for_resolve).resolved(box);
     }
-
-    if (!available_height.is_definite())
-        height_of_containing_block_as_length_for_resolve = CSS::Length::make_px(0);
 
     auto& computed_values = box.computed_values();
     if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox) {


### PR DESCRIPTION
If available width (or height) is max-content and width (or height) value is 100% it should be resolved in infinite px, not 0 px.

Fixes #18639