### PR TITLE
LibXML: Notify the listener about the root node as well

### DIFF
--- a/Userland/Libraries/LibXML/Parser/Parser.cpp
+++ b/Userland/Libraries/LibXML/Parser/Parser.cpp
@@ -74,7 +74,7 @@ void Parser::append_node(NonnullOwnPtr<Node> node)
         m_entered_node->content.get<Node::Element>().children.append(move(node));
     } else {
         m_root_node = move(node);
-        m_entered_node = m_root_node.ptr();
+        enter_node(*m_root_node);
     }
 }
 


### PR DESCRIPTION
We previously did not notify the listener about entering the root node, which caused the following snippet to produce the wrong output:
```js
a = new DOMParser
a.parseFromString("<x/>", "text/xml").documentElement // != null
```