### PR TITLE
FileSystemAccessServer: Use `ECANCELED` instead of -1

### DIFF
--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -122,7 +122,7 @@ void Client::handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> co
     if (error != 0) {
         // We don't want to show an error message for non-existent files since some applications may want
         // to handle it as opening a new, named file.
-        if (error != -1 && error != ENOENT)
+        if (error != ECANCELED && error != ENOENT)
             GUI::MessageBox::show_error(request_data.parent_window, DeprecatedString::formatted("Opening \"{}\" failed: {}", *chosen_file, strerror(error)));
         request_data.promise->resolve(Error::from_errno(error)).release_value_but_fixme_should_propagate_errors();
         return;

--- a/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
+++ b/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
@@ -156,7 +156,7 @@ void ConnectionFromClient::prompt_helper(i32 request_id, Optional<DeprecatedStri
             async_handle_prompt_end(request_id, 0, IPC::File(*file.release_value(), IPC::File::CloseAfterSending), user_picked_file);
         }
     } else {
-        async_handle_prompt_end(request_id, -1, Optional<IPC::File> {}, Optional<DeprecatedString> {});
+        async_handle_prompt_end(request_id, ECANCELED, Optional<IPC::File> {}, Optional<DeprecatedString> {});
     }
 }
 


### PR DESCRIPTION
-1 was used when the user cancel the dialog, `ECANCELED` is a bit more explicit about what it is.