### PR TITLE
LibWeb: Zero out margins if width is not 'auto' in BFC's compute_width

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/width-auto-margins-set-zero-if-containing-size-smaller.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/width-auto-margins-set-zero-if-containing-size-smaller.txt
@@ -1,0 +1,15 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x0 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 102x57.34375 positioned [BFC] children: not-inline
+      BlockContainer <div#container> at (11,11) content-size 100x55.34375 children: not-inline
+        BlockContainer <div#child> at (72,12) content-size 50x53.34375 children: inline
+          line 0 width: 28.40625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 4, rect: [72,12 28.40625x17.46875]
+              "well"
+          line 1 width: 36.84375, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+            frag 0 from TextNode start: 5, length: 5, rect: [72,29 36.84375x17.46875]
+              "hello"
+          line 2 width: 55.359375, height: 18.40625, bottom: 53.34375, baseline: 13.53125
+            frag 0 from TextNode start: 11, length: 7, rect: [72,46 55.359375x17.46875]
+              "friends"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/block-and-inline/width-auto-margins-set-zero-if-containing-size-smaller.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/width-auto-margins-set-zero-if-containing-size-smaller.html
@@ -1,0 +1,6 @@
+<!doctype html><style>
+* { border: 1px solid black; font-family: 'SerenitySans'; }
+body { position: absolute; }
+#container { width: 100px; }
+#child { width: 50px; padding-left: 60px; padding-right: 60px; margin-right: auto; margin-left: auto; }
+</style><body><div id="container"><div id="child">well hello friends</div>

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -181,7 +181,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
         if (!box.is_inline()) {
             // 10.3.3 Block-level, non-replaced elements in normal flow
             // If 'width' is not 'auto' and 'border-left-width' + 'padding-left' + 'width' + 'padding-right' + 'border-right-width' (plus any of 'margin-left' or 'margin-right' that are not 'auto') is larger than the width of the containing block, then any 'auto' values for 'margin-left' or 'margin-right' are, for the following rules, treated as zero.
-            if (width.is_auto() && total_px > width_of_containing_block) {
+            if (!width.is_auto() && total_px > width_of_containing_block) {
                 if (margin_left.is_auto())
                     margin_left = zero_value;
                 if (margin_right.is_auto())


### PR DESCRIPTION
Reverse the condition to satisfy the spec comment. Probably a typo. A ~3 year old typo! :^)

| Firefox | Browser old | Browser new |
| --- | --- | --- |
| ![obraz](https://user-images.githubusercontent.com/36564831/236433780-3862baba-8926-4177-ab97-8cbec60738e1.png) | ![obraz](https://user-images.githubusercontent.com/36564831/236433855-99d390fb-0a63-44a0-89ea-b20d8d270b08.png) | ![obraz](https://user-images.githubusercontent.com/36564831/236433926-bc6c5c49-909b-442e-bf3f-97535affa4cf.png) |

First time tinkering with Serenity, I hope I didn't screw up the test workflow :v