### PR TITLE
Kernel/FS: Promote the entry to the front during a cache hit

### DIFF
--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -60,6 +60,10 @@ public:
             return nullptr;
         auto& entry = const_cast<CacheEntry&>(*it->value);
         VERIFY(entry.block_index == block_index);
+        if (!entry_is_dirty(entry) && (m_clean_list.first() != &entry)) {
+            // Cache hit! Promote the entry to the front of the list.
+            m_clean_list.prepend(entry);
+        }
         return &entry;
     }
 


### PR DESCRIPTION
Whenever an entry is added to the cache, the last element is removed to make space for the new entry(if the cache is full). To make this an LRU cache, the entry needs to be moved to the front of the list when there is a cache hit so that the least recently used entry moves to the end to be evicted first.