### PR TITLE
Ports: Unbreak SDL2 by using GUI::Application::create()

### DIFF
--- a/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
+++ b/Ports/SDL2/patches/0001-Add-SerenityOS-platform-support.patch
@@ -921,6 +921,7 @@ index 0000000000000000000000000000000000000000..f26040845dd05f425ba464af385e133c
 +#    include <LibGUI/Widget.h>
 +#    include <LibGUI/Window.h>
 +#    include <LibGfx/Bitmap.h>
++#    include <LibMain/Main.h>
 +#    include <dlfcn.h>
 +
 +static SDL_Scancode scancode_map[] = {
@@ -1125,7 +1126,7 @@ index 0000000000000000000000000000000000000000..f26040845dd05f425ba464af385e133c
 +    dbgln("{}: Initialising SDL application", __FUNCTION__);
 +
 +    if (!g_app) {
-+        g_app = GUI::Application::construct(0, nullptr);
++        g_app = MUST(GUI::Application::create(Main::Arguments {}));
 +        g_app->set_quit_when_last_window_deleted(false);
 +    }
 +


### PR DESCRIPTION
Commit 1a97382 introduced the fallible GUI::Application::create() and removed GUI::Application::construct() breaking the SDL2 port, let's update it to use the fallible version.