### PR TITLE
LibGUI: Guard us from trying to slice an empty Arguments::strings

### DIFF
--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -93,8 +93,10 @@ ErrorOr<NonnullRefPtr<Application>> Application::create(Main::Arguments const& a
     if (getenv("GUI_DND_DEBUG"))
         application->m_dnd_debugging_enabled = true;
 
-    for (auto arg : arguments.strings.slice(1))
-        TRY(application->m_args.try_append(arg));
+    if (!arguments.strings.is_empty()) {
+        for (auto arg : arguments.strings.slice(1))
+            TRY(application->m_args.try_append(arg));
+    }
 
     application->m_tooltip_show_timer = TRY(Core::Timer::create_single_shot(700, [weak_application = application->make_weak_ptr<Application>()] {
         weak_application->request_tooltip_show();


### PR DESCRIPTION
This fixes an issue when we sometime pass in an empty Main::Arguments to GUI::Application::create().

Also, this mimics the behavior that Application::construct() had which only iterated over argv when more than one argument was passed to it.

This fixes an issue from PR #18665.