### PR TITLE
LibWeb: Invalidate style *and* layout when removing a DOM node

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -659,6 +659,9 @@ void Node::remove(bool suppress_observers)
     // 21. Run the children changed steps for parent.
     parent->children_changed();
 
+    // Since the tree structure has changed, we need to invalidate both style and layout.
+    // In the future, we should find a way to only invalidate the parts that actually need it.
+    document().invalidate_style();
     document().invalidate_layout();
 }
 


### PR DESCRIPTION
It's not enough to invalidate only layout, since changes to the DOM tree may also cause different selectors to apply.

This brings Acid3 back to a score of 100/100. The problem was that a :last-child selector wasn't rechecked after removing a node that was previously the last child of its parent.

Regression from f36cbd3b65217f0007326f1719f6dab5da34de91.