### PR TITLE
LibGfx/WebP: Implement decoding of animation frame bitmaps

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -1387,6 +1387,13 @@ static ErrorOr<ANMFChunk> decode_webp_chunk_ANMF(WebPLoadingContext& context, Ch
     dbgln_if(WEBP_DEBUG, "frame_x {} frame_y {} frame_width {} frame_height {} frame_duration {} blending_method {} disposal_method {}",
         frame_x, frame_y, frame_width, frame_height, frame_duration, (int)blending_method, (int)disposal_method);
 
+    // https://developers.google.com/speed/webp/docs/riff_container#assembling_the_canvas_from_frames
+    // "assert VP8X.canvasWidth >= frame_right
+    //  assert VP8X.canvasHeight >= frame_bottom"
+    VERIFY(context.first_chunk->type == FourCC("VP8X"));
+    if (frame_x + frame_width > context.vp8x_header.width || frame_y + frame_height > context.vp8x_header.height)
+        return context.error("WebPImageDecoderPlugin: ANMF dimensions out of bounds");
+
     return ANMFChunk { frame_x, frame_y, frame_width, frame_height, frame_duration, blending_method, disposal_method, frame_data };
 }
 

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -1454,9 +1454,12 @@ static ErrorOr<void> decode_webp_extended(WebPLoadingContext& context, ReadonlyB
 
     // https://developers.google.com/speed/webp/docs/riff_container#color_profile
     // "This chunk MUST appear before the image data."
-    // FIXME: Doesn't check animated files.
-    if (context.iccp_chunk.has_value() && context.image_data_chunk.has_value() && context.iccp_chunk->data.data() > context.image_data_chunk->data.data())
+    if (context.iccp_chunk.has_value()
+        && ((context.image_data_chunk.has_value() && context.iccp_chunk->data.data() > context.image_data_chunk->data.data())
+            || (context.alpha_chunk.has_value() && context.iccp_chunk->data.data() > context.alpha_chunk->data.data())
+            || (!context.animation_frame_chunks.is_empty() && context.iccp_chunk->data.data() > context.animation_frame_chunks[0].data.data()))) {
         return context.error("WebPImageDecoderPlugin: ICCP chunk is after image data");
+    }
 
     context.state = WebPLoadingContext::State::ChunksDecoded;
     return {};

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -1562,7 +1562,7 @@ static ErrorOr<ImageData> decode_webp_animation_frame_image_data(WebPLoadingCont
     }
 
     if (chunk.type != FourCC("VP8 ") && chunk.type != FourCC("VP8L"))
-        return Error::from_string_literal("WebPImageDecoderPlugin: no image data found in animation frame");
+        return context.error("WebPImageDecoderPlugin: no image data found in animation frame");
 
     image_data.image_data_chunk = chunk;
 

--- a/Userland/Utilities/image.cpp
+++ b/Userland/Utilities/image.cpp
@@ -24,7 +24,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView out_path;
     args_parser.add_option(out_path, "Path to output image file", "output", 'o', "FILE");
 
-    bool ppm_ascii;
+    int frame_index = 0;
+    args_parser.add_option(frame_index, "Which frame of a multi-frame input image (0-based)", "frame-index", {}, "INDEX");
+
+    bool ppm_ascii = false;
     args_parser.add_option(ppm_ascii, "Convert to a PPM in ASCII", "ppm-ascii", {});
 
     StringView assign_color_profile_path;
@@ -52,7 +55,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     // This uses ImageDecoder instead of Bitmap::load_from_file() to have more control
     // over selecting a frame, access color profile data, and so on in the future.
-    auto frame = TRY(decoder->frame(0)).image;
+    auto frame = TRY(decoder->frame(frame_index)).image;
     Optional<ReadonlyBytes> icc_data = TRY(decoder->icc_data());
 
     RefPtr<Core::MappedFile> icc_file;


### PR DESCRIPTION
With this, lossless animated webp files work :^)

(Missing: Loop count handling is not yet implemented, and alpha blending
between frames isn't done in linear space.)