### PR TITLE
LibWeb: Use SerenitySans by default for layout tests

### DIFF
--- a/Ladybird/FontPluginQt.cpp
+++ b/Ladybird/FontPluginQt.cpp
@@ -18,7 +18,8 @@ extern DeprecatedString s_serenity_resource_root;
 
 namespace Ladybird {
 
-FontPluginQt::FontPluginQt()
+FontPluginQt::FontPluginQt(bool is_layout_test_mode)
+    : m_is_layout_test_mode(is_layout_test_mode)
 {
     // Load the default SerenityOS fonts...
     Gfx::FontDatabase::set_default_fonts_lookup_path(DeprecatedString::formatted("{}/res/fonts", s_serenity_resource_root));
@@ -69,6 +70,11 @@ void FontPluginQt::update_generic_fonts()
     m_generic_font_names.resize(static_cast<size_t>(Web::Platform::GenericFont::__Count));
 
     auto update_mapping = [&](Web::Platform::GenericFont generic_font, QFont::StyleHint qfont_style_hint, ReadonlySpan<DeprecatedString> fallbacks) {
+        if (m_is_layout_test_mode) {
+            m_generic_font_names[static_cast<size_t>(generic_font)] = "SerenitySans";
+            return;
+        }
+
         QFont qt_font;
         qt_font.setStyleHint(qfont_style_hint);
 

--- a/Ladybird/FontPluginQt.h
+++ b/Ladybird/FontPluginQt.h
@@ -14,7 +14,7 @@ namespace Ladybird {
 
 class FontPluginQt final : public Web::Platform::FontPlugin {
 public:
-    FontPluginQt();
+    FontPluginQt(bool is_layout_test_mode);
     virtual ~FontPluginQt();
 
     virtual Gfx::Font& default_font() override;
@@ -27,6 +27,7 @@ private:
     Vector<DeprecatedString> m_generic_font_names;
     RefPtr<Gfx::Font> m_default_font;
     RefPtr<Gfx::Font> m_default_fixed_width_font;
+    bool m_is_layout_test_mode { false };
 };
 
 }

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -62,6 +62,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Web::FrameLoader::set_default_favicon_path(DeprecatedString::formatted("{}/res/icons/16x16/app-browser.png", s_serenity_resource_root));
 
+    int webcontent_fd_passing_socket { -1 };
+
+    Core::ArgsParser args_parser;
+    args_parser.add_option(webcontent_fd_passing_socket, "File descriptor of the passing socket for the WebContent connection", "webcontent-fd-passing-socket", 'c', "webcontent_fd_passing_socket");
+    args_parser.parse(arguments);
+
+    VERIFY(webcontent_fd_passing_socket >= 0);
+
     Web::Platform::FontPlugin::install(*new Ladybird::FontPluginQt);
 
     Web::FrameLoader::set_error_page_url(DeprecatedString::formatted("file://{}/res/html/error.html", s_serenity_resource_root));
@@ -75,14 +83,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto maybe_autoplay_allowlist_error = load_autoplay_allowlist();
     if (maybe_autoplay_allowlist_error.is_error())
         dbgln("Failed to load autoplay allowlist: {}", maybe_autoplay_allowlist_error.error());
-
-    int webcontent_fd_passing_socket { -1 };
-
-    Core::ArgsParser args_parser;
-    args_parser.add_option(webcontent_fd_passing_socket, "File descriptor of the passing socket for the WebContent connection", "webcontent-fd-passing-socket", 'c', "webcontent_fd_passing_socket");
-    args_parser.parse(arguments);
-
-    VERIFY(webcontent_fd_passing_socket >= 0);
 
     auto webcontent_socket = TRY(Core::take_over_socket_from_system_server("WebContent"sv));
     auto webcontent_client = TRY(WebContent::ConnectionFromClient::try_create(move(webcontent_socket)));

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -63,14 +63,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Web::FrameLoader::set_default_favicon_path(DeprecatedString::formatted("{}/res/icons/16x16/app-browser.png", s_serenity_resource_root));
 
     int webcontent_fd_passing_socket { -1 };
+    bool is_layout_test_mode = false;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(webcontent_fd_passing_socket, "File descriptor of the passing socket for the WebContent connection", "webcontent-fd-passing-socket", 'c', "webcontent_fd_passing_socket");
+    args_parser.add_option(is_layout_test_mode, "Is layout test mode", "layout-test-mode", 0);
     args_parser.parse(arguments);
 
     VERIFY(webcontent_fd_passing_socket >= 0);
 
-    Web::Platform::FontPlugin::install(*new Ladybird::FontPluginQt);
+    Web::Platform::FontPlugin::install(*new Ladybird::FontPluginQt(is_layout_test_mode));
 
     Web::FrameLoader::set_error_page_url(DeprecatedString::formatted("file://{}/res/html/error.html", s_serenity_resource_root));
 

--- a/Tests/LibWeb/Layout/input/grid/auto-fill.html
+++ b/Tests/LibWeb/Layout/input/grid/auto-fill.html
@@ -1,8 +1,4 @@
 <style>
-  body {
-    font-family: 'SerenitySans';
-  }
-
   .grid-container {
     display: grid;
     background-color: lightsalmon;

--- a/Tests/LibWeb/Layout/input/grid/auto-fit.html
+++ b/Tests/LibWeb/Layout/input/grid/auto-fit.html
@@ -1,8 +1,4 @@
 <style>
-  body {
-    font-family: 'SerenitySans';
-  }
-
   .grid-container {
     display: grid;
     background-color: lightsalmon;

--- a/Tests/LibWeb/Layout/input/grid/basic.html
+++ b/Tests/LibWeb/Layout/input/grid/basic.html
@@ -1,8 +1,4 @@
 <style>
-  body {
-    font-family: 'SerenitySans';
-  }
-
   .grid-container {
     display: grid;
     background-color: lightsalmon;

--- a/Tests/LibWeb/Layout/input/grid/borders.html
+++ b/Tests/LibWeb/Layout/input/grid/borders.html
@@ -1,8 +1,4 @@
 <style>
-  body {
-    font-family: 'SerenitySans';
-  }
-
   .grid-container {
     display: grid;
     background-color: lightsalmon;

--- a/Tests/LibWeb/Layout/input/grid/different-column-sizes.html
+++ b/Tests/LibWeb/Layout/input/grid/different-column-sizes.html
@@ -1,8 +1,4 @@
 <style>
-  body {
-    font-family: 'SerenitySans';
-  }
-
   .grid-container {
     display: grid;
     background-color: lightsalmon;

--- a/Tests/LibWeb/Layout/input/grid/gap.html
+++ b/Tests/LibWeb/Layout/input/grid/gap.html
@@ -1,8 +1,4 @@
 <style>
-  body {
-    font-family: 'SerenitySans';
-  }
-
   .grid-container {
     display: grid;
     background-color: lightsalmon;

--- a/Tests/LibWeb/Layout/input/grid/grid-template.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-template.html
@@ -1,7 +1,4 @@
 <style>
-  body {
-    font-family: 'SerenitySans';
-  }
   .mw-page-container-inner {
     display: grid;
     grid-template: min-content min-content 1fr min-content / 12.25em minmax(0, 1fr);

--- a/Tests/LibWeb/Layout/input/grid/image-in-grid.html
+++ b/Tests/LibWeb/Layout/input/grid/image-in-grid.html
@@ -1,8 +1,4 @@
 <style>
-  body {
-    font-family: 'SerenitySans';
-  }
-
   .grid-container {
     display: grid;
     background-color: lightsalmon;

--- a/Tests/LibWeb/Layout/input/grid/intrinsic-sized-column.html
+++ b/Tests/LibWeb/Layout/input/grid/intrinsic-sized-column.html
@@ -5,7 +5,6 @@
   <style>
     body {
       float: left;
-      font-family: 'SerenitySans';
     }
 
     .grid {

--- a/Tests/LibWeb/Layout/input/grid/intrinsic-sized-grid.html
+++ b/Tests/LibWeb/Layout/input/grid/intrinsic-sized-grid.html
@@ -4,7 +4,6 @@
   }
   body {
     float: left;
-    font-family: 'SerenitySans';
   }
   .grid {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/min-max-content.html
+++ b/Tests/LibWeb/Layout/input/grid/min-max-content.html
@@ -1,8 +1,4 @@
 <style>
-  body {
-    font-family: 'SerenitySans';
-  }
-
   .grid-container {
     display: grid;
     background-color: lightsalmon;

--- a/Tests/LibWeb/Layout/input/grid/minmax.html
+++ b/Tests/LibWeb/Layout/input/grid/minmax.html
@@ -1,8 +1,4 @@
 <style>
-  body {
-    font-family: 'SerenitySans';
-  }
-
   .grid-container {
     display: grid;
     background-color: lightsalmon;

--- a/Tests/LibWeb/Layout/input/grid/named-tracks.html
+++ b/Tests/LibWeb/Layout/input/grid/named-tracks.html
@@ -1,8 +1,4 @@
 <style>
-  body {
-    font-family: 'SerenitySans';
-  }
-
   .grid-container {
     display: grid;
     background-color: lightsalmon;

--- a/Tests/LibWeb/Layout/input/grid/positions-and-spans.html
+++ b/Tests/LibWeb/Layout/input/grid/positions-and-spans.html
@@ -1,8 +1,4 @@
 <style>
-  body {
-    font-family: 'SerenitySans';
-  }
-
   .grid-container {
     display: grid;
     background-color: lightsalmon;

--- a/Tests/LibWeb/Layout/input/grid/repeat.html
+++ b/Tests/LibWeb/Layout/input/grid/repeat.html
@@ -1,8 +1,4 @@
 <style>
-  body {
-    font-family: 'SerenitySans';
-  }
-
   .grid-container {
     display: grid;
     background-color: lightsalmon;

--- a/Tests/LibWeb/Layout/input/grid/row-height.html
+++ b/Tests/LibWeb/Layout/input/grid/row-height.html
@@ -1,8 +1,4 @@
 <style>
-  body {
-    font-family: 'SerenitySans';
-  }
-
   .grid-container {
     display: grid;
     background-color: lightsalmon;

--- a/Tests/LibWeb/Layout/input/grid/template-areas.html
+++ b/Tests/LibWeb/Layout/input/grid/template-areas.html
@@ -1,8 +1,4 @@
 <style>
-  body {
-    font-family: 'SerenitySans';
-  }
-
   .grid-container {
     display: grid;
     background-color: lightsalmon;

--- a/Tests/LibWeb/Layout/layout_test.sh
+++ b/Tests/LibWeb/Layout/layout_test.sh
@@ -16,7 +16,7 @@ find "${SCRIPT_DIR}/input/" -type f -name "*.html" -print0 | while IFS= read -r 
     input_html_file=${input_html_path/${SCRIPT_DIR}"/input/"/}
     input_html_file=${input_html_file/".html"/}
 
-    output_layout_dump=$(cd "${LADYBIRD_BUILD_DIR}"; timeout 300s "${BROWSER_BINARY}" -d "${input_html_path}")
+    output_layout_dump=$(cd "${LADYBIRD_BUILD_DIR}"; timeout 300s "${BROWSER_BINARY}" --layout-test-mode -d "${input_html_path}")
     expected_layout_dump_path="${SCRIPT_DIR}/expected/${input_html_file}.txt"
 
     if cmp <(echo "${output_layout_dump}") "${expected_layout_dump_path}"; then

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -152,7 +152,7 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> ViewImplementation::launch_web
         ErrorOr<void> result;
         for (auto const& path : candidate_web_content_paths) {
             constexpr auto callgrind_prefix_length = 3;
-            auto arguments_with_callgrind_prefix = Array {
+            auto arguments = Vector {
                 "valgrind"sv,
                 "--tool=callgrind"sv,
                 "--instr-atstart=no"sv,
@@ -160,11 +160,10 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> ViewImplementation::launch_web
                 "--webcontent-fd-passing-socket"sv,
                 webcontent_fd_passing_socket_string
             };
-            auto arguments = arguments_with_callgrind_prefix.span();
             if (enable_callgrind_profiling == EnableCallgrindProfiling::No)
-                arguments = arguments.slice(callgrind_prefix_length);
+                arguments.remove(0, callgrind_prefix_length);
 
-            result = Core::System::exec(arguments[0], arguments, Core::System::SearchInPath::Yes);
+            result = Core::System::exec(arguments[0], arguments.span(), Core::System::SearchInPath::Yes);
             if (!result.is_error())
                 break;
         }

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -126,7 +126,7 @@ void ViewImplementation::run_javascript(StringView js_source)
 
 #if !defined(AK_OS_SERENITY)
 
-ErrorOr<NonnullRefPtr<WebView::WebContentClient>> ViewImplementation::launch_web_content_process(ReadonlySpan<String> candidate_web_content_paths, EnableCallgrindProfiling enable_callgrind_profiling)
+ErrorOr<NonnullRefPtr<WebView::WebContentClient>> ViewImplementation::launch_web_content_process(ReadonlySpan<String> candidate_web_content_paths, EnableCallgrindProfiling enable_callgrind_profiling, IsLayoutTestMode is_layout_test_mode)
 {
     int socket_fds[2] {};
     TRY(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, socket_fds));
@@ -162,6 +162,8 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> ViewImplementation::launch_web
             };
             if (enable_callgrind_profiling == EnableCallgrindProfiling::No)
                 arguments.remove(0, callgrind_prefix_length);
+            if (is_layout_test_mode == IsLayoutTestMode::Yes)
+                arguments.append("--layout-test-mode"sv);
 
             result = Core::System::exec(arguments[0], arguments.span(), Core::System::SearchInPath::Yes);
             if (!result.is_error())

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -24,6 +24,11 @@ enum class EnableCallgrindProfiling {
     Yes
 };
 
+enum class IsLayoutTestMode {
+    No,
+    Yes
+};
+
 class ViewImplementation {
 public:
     virtual ~ViewImplementation() { }
@@ -131,7 +136,7 @@ protected:
     virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No) {};
 
 #if !defined(AK_OS_SERENITY)
-    ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(ReadonlySpan<String> candidate_web_content_paths, EnableCallgrindProfiling = EnableCallgrindProfiling::No);
+    ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(ReadonlySpan<String> candidate_web_content_paths, EnableCallgrindProfiling = EnableCallgrindProfiling::No, IsLayoutTestMode = IsLayoutTestMode::No);
 #endif
 
     struct SharedBitmap {


### PR DESCRIPTION
The layout tests now run with SerenitySans by default (which is the preferred font for cross-platform compatibility reasons).

This way don't have to remember to set the font to this in the CSS of each test.