### PR TITLE
Toolchain: Use ninja to bootstrap CMake

### DIFF
--- a/Toolchain/BuildCMake.sh
+++ b/Toolchain/BuildCMake.sh
@@ -77,7 +77,7 @@ mkdir -p "${PREFIX_DIR}"
 mkdir -p "${BUILD_DIR}"
 
 pushd "${BUILD_DIR}"
-    "${TARBALLS_DIR}"/cmake-"${CMAKE_VERSION}"/bootstrap --prefix="${PREFIX_DIR}" --parallel="${MAKEJOBS}"
-    make -j "${MAKEJOBS}"
-    make install
+    "${TARBALLS_DIR}"/cmake-"${CMAKE_VERSION}"/bootstrap --generator="Ninja" --prefix="${PREFIX_DIR}" --parallel="${MAKEJOBS}"
+    ninja -j "${MAKEJOBS}"
+    ninja install
 popd


### PR DESCRIPTION
For some reason (for me) on Ubuntu 22.04 the standard make generator fails:
```
  ---------------------------------------------
  CMake has bootstrapped.  Now run gmake.
  make: make: Permission denied
  make: *** [Makefile:166: all] Error 127
```
This seems to be because `Source/kwsys/CMakeFiles/cmsys.dir/depend` is missing or not generated. Using ninja works fine though, and as it is already the default for Serenity proper, it seems reasonable to switch it here too.