### PR TITLE
Everywhere: Fix all the typos

### DIFF
--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -668,7 +668,7 @@ private:
         // that we can still probe for buckets with collisions, and we automatically optimize the
         // probe lengths. To do so, we shift the following buckets up until we reach a free bucket,
         // or a bucket with a probe length of 0 (the ideal index for that bucket).
-        auto update_bucket_neighbours = [&](BucketType* bucket) {
+        auto update_bucket_neighbors = [&](BucketType* bucket) {
             if constexpr (IsOrdered) {
                 if (bucket->previous)
                     bucket->previous->next = bucket;
@@ -704,7 +704,7 @@ private:
                 shift_from_bucket->next = nullptr;
             }
             shift_to_bucket->state = bucket_state_for_probe_length(shift_from_probe_length - 1);
-            update_bucket_neighbours(shift_to_bucket);
+            update_bucket_neighbors(shift_to_bucket);
 
             if (++shift_to_index == m_capacity) [[unlikely]]
                 shift_to_index = 0;

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -304,9 +304,9 @@ public:
         return write_value(forward<U>(value), existing_entry_behavior);
     }
     template<typename U = T>
-    HashSetResult set(U&& value, HashSetExistingEntryBehavior existing_entry_behaviour = HashSetExistingEntryBehavior::Replace)
+    HashSetResult set(U&& value, HashSetExistingEntryBehavior existing_entry_behavior = HashSetExistingEntryBehavior::Replace)
     {
-        return MUST(try_set(forward<U>(value), existing_entry_behaviour));
+        return MUST(try_set(forward<U>(value), existing_entry_behavior));
     }
 
     template<typename TUnaryPredicate>

--- a/AK/RedBlackTree.h
+++ b/AK/RedBlackTree.h
@@ -243,9 +243,9 @@ protected:
         //  in place, this is quite a bit more expensive, as well as much less readable, is there a better way?
         if (node->left_child && node->right_child) {
             auto* successor_node = successor(node); // this is always non-null as all nodes besides the maximum node have a successor, and the maximum node has no right child
-            auto neighbour_swap = successor_node->parent == node;
+            auto neighbor_swap = successor_node->parent == node;
             node->left_child->parent = successor_node;
-            if (!neighbour_swap)
+            if (!neighbor_swap)
                 node->right_child->parent = successor_node;
             if (node->parent) {
                 if (node->parent->left_child == node) {
@@ -258,7 +258,7 @@ protected:
             }
             if (successor_node->right_child)
                 successor_node->right_child->parent = node;
-            if (neighbour_swap) {
+            if (neighbor_swap) {
                 successor_node->parent = node->parent;
                 node->parent = successor_node;
             } else {
@@ -274,7 +274,7 @@ protected:
                 swap(node->parent, successor_node->parent);
             }
             swap(node->left_child, successor_node->left_child);
-            if (neighbour_swap) {
+            if (neighbor_swap) {
                 node->right_child = successor_node->right_child;
                 successor_node->right_child = node;
             } else {

--- a/Base/usr/share/man/man5/GML/Widget/Toolbar.md
+++ b/Base/usr/share/man/man5/GML/Widget/Toolbar.md
@@ -8,7 +8,7 @@ Defines a GUI toolbar widget.
 
 When `collapsible` is set to `true`, the toolbar can be resized below the size of its items.
 Any items that do not fit the current size, will be placed in an overflow menu.
-To keep groups (i.e. Buttons/items separated by Separators) together, and move them to the overflow menu as one, set the `gouped` property.
+To keep groups (i.e. Buttons/items separated by Separators) together, and move them to the overflow menu as one, set the `grouped` property.
 
 ## Synopsis
 

--- a/Base/usr/share/man/man5/postcreate.md
+++ b/Base/usr/share/man/man5/postcreate.md
@@ -8,7 +8,7 @@ postcreate - HackStudio postcreate scripts
 
 ## Description
 
-It is possible to define project templates that set up HackStudio projects. These templates can contain custom setup logic in the form of a `*.postcreate` script in the template directory. The script name must match the template's (directory) name. Postcreate scripts are regular shell scripts. They are executed from an undeterminate directory with the following arguments:
+It is possible to define project templates that set up HackStudio projects. These templates can contain custom setup logic in the form of a `*.postcreate` script in the template directory. The script name must match the template's (directory) name. Postcreate scripts are regular shell scripts. They are executed from an indeterminate directory with the following arguments:
 
 - The path to the postcreate script
 - The name of the new project

--- a/Base/usr/share/man/man6/Minesweeper.md
+++ b/Base/usr/share/man/man6/Minesweeper.md
@@ -14,6 +14,6 @@ $ Minesweeper
 
 The goal is to find all the mines without detonating them.
 
-The player reveals what is underneath a tile by clicking on it. If it is a mine underneath the player loses. Otherwise the tile will show how many neighbouring mines there are to the tile. If there are no neighboring mines, all the neighboring tiles are revealed recursively.
+The player reveals what is underneath a tile by clicking on it. If it is a mine underneath the player loses. Otherwise the tile will show how many neighboring mines there are to the tile. If there are no neighboring mines, all the neighboring tiles are revealed recursively.
 
 The player can mark a tile as being a mine by right-clicking the tile. This is then shown with a flag.

--- a/Base/usr/share/man/man7/Mitigations.md
+++ b/Base/usr/share/man/man7/Mitigations.md
@@ -341,7 +341,7 @@ Build + LibC: Enable -fstack-protector-strong in user space
 
 The kernel applies a exploit mitigation technique where vulnerable data
 related to the state of a process is separated out into it's own region
-in memory which is always remmaped as read-only after it's initialized
+in memory which is always remapped as read-only after it's initialized
 or updated. This means that an attacker needs more than an arbitrary
 kernel write primitive to be able to elevate a process to root for example.
 

--- a/Documentation/LadybirdBuildInstructions.md
+++ b/Documentation/LadybirdBuildInstructions.md
@@ -48,7 +48,7 @@ brew install cmake qt ninja
 
 On OpenIndiana:
 
-Note that OpenIndianas latest GCC port (GCC 11) is too old to build Ladybird, so you need Clang, which is available in the repository.
+Note that OpenIndiana's latest GCC port (GCC 11) is too old to build Ladybird, so you need Clang, which is available in the repository.
 
 ```
 pfexec pkg install cmake ninja clang-15 libglvnd qt6
@@ -130,7 +130,7 @@ The `serenity.sh` build script does not know how to generate Xcode projects, so 
 To be compatible with the script, a few extra options are required. If there is a previous Lagom build directory, CMake will likely complain that the generator has changed.
 
 ```
-cmake -GXcode -S Meta/Lagom -B Build/lagom -DBUILD_LAGOM=ON -DENABLE_LAGOM_LADBIRD=ON
+cmake -GXcode -S Meta/Lagom -B Build/lagom -DBUILD_LAGOM=ON -DENABLE_LAGOM_LADYBIRD=ON
 ```
 
 Alternatively, if you don't need your ladybird build to be compatible with `serenity.sh`, you can use Ladybird as the source directory like so:
@@ -139,7 +139,7 @@ Alternatively, if you don't need your ladybird build to be compatible with `sere
 cmake -GXcode -S Ladybird -B Build/ladybird
 ```
 
-After generating an Xcode project into the specified build directory, you can open `ladbyird.xcodeproj` in Xcode. The project has a ton of targets, many of which are generated code.
+After generating an Xcode project into the specified build directory, you can open `ladybird.xcodeproj` in Xcode. The project has a ton of targets, many of which are generated code.
 The only target that needs a scheme is the ladybird app bundle.
 
 In order for the application to launch properly through Xcode, the `SERENITY_SOURCE_DIR` environment variable must be set to your serenity checkout in the ladybird scheme, per the
@@ -193,7 +193,7 @@ Next, create a build configuration in Qt Creator that uses an ``Android Qt 6.4.0
 
 Ensure that you get Android API 30 or higher, and Android NDK 24 or higher. In the initial standup, an API 33 SDK for Android 13 was used.
 
-Setup Android device settings in Qt Creator following this [link](https://doc.qt.io/qtcreator/creator-developing-android.html). Note that Qt Creator might not like the Android NDK version 24 we downloaded earlier, as it's "too new" and "not supported". No worries, we can force it to like our version by editing the ``sdk_defintions.json`` file as described under [Viewing Android Tool Chain Settings](https://doc.qt.io/qtcreator/creator-developing-android.html#viewing-android-tool-chain-settings).
+Setup Android device settings in Qt Creator following this [link](https://doc.qt.io/qtcreator/creator-developing-android.html). Note that Qt Creator might not like the Android NDK version 24 we downloaded earlier, as it's "too new" and "not supported". No worries, we can force it to like our version by editing the ``sdk_definitions.json`` file as described under [Viewing Android Tool Chain Settings](https://doc.qt.io/qtcreator/creator-developing-android.html#viewing-android-tool-chain-settings).
 
 The relevant snippets of that JSON file are reproduced below. Just have to make sure it's happy with "platforms;android-33" and the exact installed NDK version.
 

--- a/Documentation/RunningOnRaspberryPi.md
+++ b/Documentation/RunningOnRaspberryPi.md
@@ -2,11 +2,11 @@
 
 ## NOTE
 
-This is for development purposes only - Serenity doesn't currently boot on Rasperry Pi! Use this guide if you want to set up a development environment.
+This is for development purposes only - Serenity doesn't currently boot on Raspberry Pi! Use this guide if you want to set up a development environment.
 
 Currently only UART output is supported, no display.
 
-64-bit only, so you need a Rasperry Pi 3 or newer.
+64-bit only, so you need a Raspberry Pi 3 or newer.
 
 ## Running in QEMU
 

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -812,7 +812,7 @@ ErrorOr<NonnullOwnPtr<Region>> MemoryManager::allocate_contiguous_kernel_region(
 ErrorOr<NonnullOwnPtr<Memory::Region>> MemoryManager::allocate_dma_buffer_page(StringView name, Memory::Region::Access access, RefPtr<Memory::PhysicalPage>& dma_buffer_page)
 {
     dma_buffer_page = TRY(allocate_physical_page());
-    // Do not enable Cache for this region as physical memory transfers are performed (Most architectures have this behaviour by default)
+    // Do not enable Cache for this region as physical memory transfers are performed (Most architectures have this behavior by default)
     return allocate_kernel_region(dma_buffer_page->paddr(), PAGE_SIZE, name, access, Region::Cacheable::No);
 }
 
@@ -827,7 +827,7 @@ ErrorOr<NonnullOwnPtr<Memory::Region>> MemoryManager::allocate_dma_buffer_pages(
 {
     VERIFY(!(size % PAGE_SIZE));
     dma_buffer_pages = TRY(allocate_contiguous_physical_pages(size));
-    // Do not enable Cache for this region as physical memory transfers are performed (Most architectures have this behaviour by default)
+    // Do not enable Cache for this region as physical memory transfers are performed (Most architectures have this behavior by default)
     return allocate_kernel_region(dma_buffer_pages.first()->paddr(), size, name, access, Region::Cacheable::No);
 }
 

--- a/Ports/README.md
+++ b/Ports/README.md
@@ -295,7 +295,7 @@ filename.
 #### `workdir`
 
 The working directory used for executing other commands via `run` as well as
-cleanup. Usually the directory name of the upacked source archive.
+cleanup. Usually the directory name of the unpacked source archive.
 
 Defaults to `$port-$version`.
 

--- a/Ports/README.md
+++ b/Ports/README.md
@@ -302,7 +302,7 @@ Defaults to `$port-$version`.
 ### Functions
 
 The various steps of the port installation process are split into individual
-Bash functions, some of which can be overridden to provide custom behaviour,
+Bash functions, some of which can be overridden to provide custom behavior,
 like this:
 
 ```bash

--- a/Ports/dungeonrush/patches/0001-chdir-to-the-resource-install-path-at-program-startu.patch
+++ b/Ports/dungeonrush/patches/0001-chdir-to-the-resource-install-path-at-program-startu.patch
@@ -4,13 +4,13 @@ Date: Wed, 16 Jun 2021 11:23:34 +0200
 Subject: [PATCH] chdir() to the resource install path at program startup
 
 The game tries to open its resource files using relative paths, and we
-install them into /opt, so chdr() there.
+install them into /opt, so chdir() there.
 ---
  src/main.c | 2 ++
  1 file changed, 2 insertions(+)
 
 diff --git a/src/main.c b/src/main.c
-index 8fa842f..e16c35e 100644
+index 8fa842f951fa2cd0a365623d1b6650c536695f59..e16c35e81cc94af006dbb63b0329a60750bd6846 100644
 --- a/src/main.c
 +++ b/src/main.c
 @@ -12,6 +12,8 @@

--- a/Ports/dungeonrush/patches/0002-Make-it-use-software-rendering.patch
+++ b/Ports/dungeonrush/patches/0002-Make-it-use-software-rendering.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Make it use software rendering
  1 file changed, 2 insertions(+)
 
 diff --git a/src/res.c b/src/res.c
-index ef4945a..6c46184 100644
+index ef4945ab4d115c8d2877be4f74b4596e4cb37c77..6c46184f12e006a8a1258df5ed7772aa2407d88b 100644
 --- a/src/res.c
 +++ b/src/res.c
 @@ -89,6 +89,8 @@ Mix_Music *bgms[AUDIO_BGM_SIZE];

--- a/Ports/dungeonrush/patches/ReadMe.md
+++ b/Ports/dungeonrush/patches/ReadMe.md
@@ -5,7 +5,7 @@
 chdir() to the resource install path at program startup
 
 The game tries to open its resource files using relative paths, and we
-install them into /opt, so chdr() there.
+install them into /opt, so chdir() there.
 
 ## `0002-Make-it-use-software-rendering.patch`
 

--- a/Tests/AK/TestHashTable.cpp
+++ b/Tests/AK/TestHashTable.cpp
@@ -347,7 +347,7 @@ TEST_CASE(ordered_deletion_and_reinsertion)
     EXPECT_EQ(table.size(), 1u);
 
     // By adding 1 again but this time in a different position, we
-    // test whether the bucket's neighbours are reset properly.
+    // test whether the bucket's neighbors are reset properly.
     table.set(1);
     EXPECT_EQ(table.size(), 2u);
 

--- a/Tests/AK/TestMemoryStream.cpp
+++ b/Tests/AK/TestMemoryStream.cpp
@@ -72,7 +72,7 @@ TEST_CASE(allocating_memory_stream_offset_of_oob)
 {
     AllocatingMemoryStream stream;
     // NOTE: This test is to make sure that offset_of() doesn't read past the end of the "initialized" data.
-    //       So we have to assume some things about the behaviour of this class:
+    //       So we have to assume some things about the behavior of this class:
     //       - The chunk size is 4096 bytes.
     //       - A chunk is moved to the end when it's fully read from
     //       - A free chunk is used as-is, no new ones are allocated if one exists.

--- a/Userland/Libraries/LibGUI/Variant.cpp
+++ b/Userland/Libraries/LibGUI/Variant.cpp
@@ -65,12 +65,12 @@ bool Variant::operator==(Variant const& other) const
                     return own_value == other_value;
                 else if constexpr (IsSame<T, GUI::Icon>)
                     return &own_value.impl() == &other_value.impl();
-                // FIXME: Figure out if this silly behaviour is actually used anywhere, then get rid of it.
+                // FIXME: Figure out if this silly behavior is actually used anywhere, then get rid of it.
                 else
                     return to_deprecated_string() == other.to_deprecated_string();
             },
             [&](auto const&) {
-                // FIXME: Figure out if this silly behaviour is actually used anywhere, then get rid of it.
+                // FIXME: Figure out if this silly behavior is actually used anywhere, then get rid of it.
                 return to_deprecated_string() == other.to_deprecated_string();
             });
     });
@@ -91,12 +91,12 @@ bool Variant::operator<(Variant const& other) const
                     return own_value->name() < other_value->name();
                 else if constexpr (requires { own_value < other_value; })
                     return own_value < other_value;
-                // FIXME: Figure out if this silly behaviour is actually used anywhere, then get rid of it.
+                // FIXME: Figure out if this silly behavior is actually used anywhere, then get rid of it.
                 else
                     return to_deprecated_string() < other.to_deprecated_string();
             },
             [&](auto const&) -> bool {
-                return to_deprecated_string() < other.to_deprecated_string(); // FIXME: Figure out if this silly behaviour is actually used anywhere, then get rid of it.
+                return to_deprecated_string() < other.to_deprecated_string(); // FIXME: Figure out if this silly behavior is actually used anywhere, then get rid of it.
             });
     });
 }

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -709,7 +709,7 @@ void AntiAliasingPainter::stroke_segment_intersection(FloatPoint current_line_a,
         return;
     if ((previous_horizontal || previous_vertical) && (current_horizontal || current_vertical)) {
         intersection = m_transform.map(current_line_a);
-        // Note: int_thickness used here to match behaviour of draw_line()
+        // Note: int_thickness used here to match behavior of draw_line()
         int int_thickness = AK::ceil(thickness);
         return fill_rect(FloatRect(intersection, { thickness, thickness }).translated(-int_thickness / 2), color);
     }

--- a/Userland/Libraries/LibGfx/GradientPainting.cpp
+++ b/Userland/Libraries/LibGfx/GradientPainting.cpp
@@ -111,7 +111,7 @@ public:
         auto int_loc = static_cast<i64>(floor(loc));
         auto blend = loc - int_loc;
         auto color = get_color(repeat_wrap_if_required(int_loc));
-        // Blend between the two neighbouring colors (this fixes some nasty aliasing issues at small angles)
+        // Blend between the two neighboring colors (this fixes some nasty aliasing issues at small angles)
         if (blend >= 0.004f)
             color = color_blend(color, get_color(repeat_wrap_if_required(int_loc + 1)), blend);
         return color;

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -159,7 +159,7 @@ Bytecode::CodeGenerationErrorOr<void> ScopeNode::generate_bytecode(Bytecode::Gen
             });
         });
 
-        // 11. NOTE: No abnormal terminations occur after this algorithm step if the global object is an ordinary object. However, if the global object is a Proxy exotic object it may exhibit behaviours that cause abnormal terminations in some of the following steps.
+        // 11. NOTE: No abnormal terminations occur after this algorithm step if the global object is an ordinary object. However, if the global object is a Proxy exotic object it may exhibit behaviors that cause abnormal terminations in some of the following steps.
         // 12. NOTE: Annex B.3.2.2 adds additional steps at this point.
 
         // 12. Let strict be IsStrict of script.

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainTime/PlainTime.prototype.with.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainTime/PlainTime.prototype.with.js
@@ -15,7 +15,7 @@ const REJECTED_CALENDAR_TYPES_THREE_ARGUMENTS = [
 
 const REJECTED_CALENDAR_TYPES_TWO_ARGUMENTS = [Temporal.PlainMonthDay, Temporal.PlainYearMonth];
 
-describe("correct behaviour", () => {
+describe("correct behavior", () => {
     test("length is 1", () => {
         expect(Temporal.PlainTime.prototype.with).toHaveLength(1);
     });

--- a/Userland/Libraries/LibVideo/VP9/LookupTables.h
+++ b/Userland/Libraries/LibVideo/VP9/LookupTables.h
@@ -295,7 +295,7 @@ static constexpr u8 cat_probs[7][14] = {
     { 254, 254, 254, 252, 249, 243, 230, 196, 177, 153, 140, 133, 130, 129 }
 };
 
-static constexpr MotionVector mv_ref_blocks[BLOCK_SIZES][MVREF_NEIGHBOURS] = {
+static constexpr MotionVector mv_ref_blocks[BLOCK_SIZES][MVREF_NEIGHBORS] = {
     { { -1, 0 }, { 0, -1 }, { -1, -1 }, { -2, 0 }, { 0, -2 }, { -2, -1 }, { -1, -2 }, { -2, -2 } },
     { { -1, 0 }, { 0, -1 }, { -1, -1 }, { -2, 0 }, { 0, -2 }, { -2, -1 }, { -1, -2 }, { -2, -2 } },
     { { -1, 0 }, { 0, -1 }, { -1, -1 }, { -2, 0 }, { 0, -2 }, { -2, -1 }, { -1, -2 }, { -2, -2 } },

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -1705,7 +1705,7 @@ MotionVectorPair Parser::find_reference_motion_vectors(BlockContext& block_conte
     }
     block_context.mode_context[reference_frame] = counter_to_context[context_counter];
 
-    for (auto i = 2u; i < MVREF_NEIGHBOURS; i++) {
+    for (auto i = 2u; i < MVREF_NEIGHBORS; i++) {
         MotionVector candidate = base_coordinates + mv_ref_blocks[block_context.size][i];
         if (motion_vector_is_inside_tile(block_context.tile_context, candidate)) {
             different_ref_found = true;
@@ -1716,7 +1716,7 @@ MotionVectorPair Parser::find_reference_motion_vectors(BlockContext& block_conte
         add_motion_vector_if_reference_frame_type_is_same(block_context, base_coordinates, reference_frame, list, true);
 
     if (different_ref_found) {
-        for (auto i = 0u; i < MVREF_NEIGHBOURS; i++) {
+        for (auto i = 0u; i < MVREF_NEIGHBORS; i++) {
             MotionVector candidate = base_coordinates + mv_ref_blocks[block_context.size][i];
             if (motion_vector_is_inside_tile(block_context.tile_context, candidate))
                 add_motion_vector_if_reference_frame_type_is_different(block_context, candidate, reference_frame, list, false);

--- a/Userland/Libraries/LibVideo/VP9/ProbabilityTables.cpp
+++ b/Userland/Libraries/LibVideo/VP9/ProbabilityTables.cpp
@@ -402,8 +402,8 @@ static constexpr InterModeProbs default_inter_mode_probs = {
     { 7, 166, 63 }, // 2 = two predicted mvs
     { 7, 94, 66 },  // 3 = one predicted/zero and one new mv
     { 8, 64, 46 },  // 4 = two new mvs
-    { 17, 81, 31 }, // 5 = one intra neighbour + x
-    { 25, 29, 30 }, // 6 = two intra neighbours
+    { 17, 81, 31 }, // 5 = one intra neighbor + x
+    { 25, 29, 30 }, // 6 = two intra neighbors
 };
 
 static constexpr InterpFilterProbs default_interp_filter_probs = {

--- a/Userland/Libraries/LibVideo/VP9/Symbols.h
+++ b/Userland/Libraries/LibVideo/VP9/Symbols.h
@@ -17,7 +17,7 @@ namespace Video::VP9 {
 
 #define REFS_PER_FRAME 3
 #define MV_FR_SIZE 4
-#define MVREF_NEIGHBOURS 8
+#define MVREF_NEIGHBORS 8
 #define BLOCK_SIZE_GROUPS 4
 #define BLOCK_SIZES 13
 #define BLOCK_INVALID 14

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -309,7 +309,7 @@ void HTMLHyperlinkElementUtils::set_pathname(DeprecatedString pathname)
         return;
 
     // 4. Set url's path to the empty list.
-    auto url = m_url; // We copy the URL here to follow other browser's behaviour of reverting the path change if the parse failed.
+    auto url = m_url; // We copy the URL here to follow other browser's behavior of reverting the path change if the parse failed.
     url->set_paths({});
 
     // 5. Basic URL parse the given value, with url as url and path start state as state override.
@@ -356,7 +356,7 @@ void HTMLHyperlinkElementUtils::set_search(DeprecatedString search)
         auto input = search.substring_view(search.starts_with('?'));
 
         //    2. Set url's query to the empty string.
-        auto url_copy = m_url; // We copy the URL here to follow other browser's behaviour of reverting the search change if the parse failed.
+        auto url_copy = m_url; // We copy the URL here to follow other browser's behavior of reverting the search change if the parse failed.
         url_copy->set_query(DeprecatedString::empty());
 
         //    3. Basic URL parse input, with null, this element's node document's document's character encoding, url as url, and query state as state override.
@@ -404,7 +404,7 @@ void HTMLHyperlinkElementUtils::set_hash(DeprecatedString hash)
         auto input = hash.substring_view(hash.starts_with('#'));
 
         //    2. Set url's fragment to the empty string.
-        auto url_copy = m_url; // We copy the URL here to follow other browser's behaviour of reverting the hash change if the parse failed.
+        auto url_copy = m_url; // We copy the URL here to follow other browser's behavior of reverting the hash change if the parse failed.
         url_copy->set_fragment(DeprecatedString::empty());
 
         //    3. Basic URL parse input, with url as url and fragment state as state override.

--- a/Userland/Libraries/LibWeb/URL/URL.cpp
+++ b/Userland/Libraries/LibWeb/URL/URL.cpp
@@ -335,7 +335,7 @@ void URL::set_pathname(String const& pathname)
         return;
 
     // 2. Empty this’s URL’s path.
-    auto url = m_url; // We copy the URL here to follow other browser's behaviour of reverting the path change if the parse failed.
+    auto url = m_url; // We copy the URL here to follow other browser's behavior of reverting the path change if the parse failed.
     url.set_paths({});
 
     // 3. Basic URL parse the given value with this’s URL as url and path start state as state override.
@@ -384,7 +384,7 @@ WebIDL::ExceptionOr<void> URL::set_search(String const& search)
     auto input = search_as_string_view.substring_view(search_as_string_view.starts_with('?'));
 
     // 4. Set url’s query to the empty string.
-    auto url_copy = url; // We copy the URL here to follow other browser's behaviour of reverting the search change if the parse failed.
+    auto url_copy = url; // We copy the URL here to follow other browser's behavior of reverting the search change if the parse failed.
     url_copy.set_query(DeprecatedString::empty());
 
     // 5. Basic URL parse input with url as url and query state as state override.
@@ -438,7 +438,7 @@ void URL::set_hash(String const& hash)
     auto input = hash_as_string_view.substring_view(hash_as_string_view.starts_with('#'));
 
     // 3. Set this’s URL’s fragment to the empty string.
-    auto url = m_url; // We copy the URL here to follow other browser's behaviour of reverting the hash change if the parse failed.
+    auto url = m_url; // We copy the URL here to follow other browser's behavior of reverting the hash change if the parse failed.
     url.set_fragment(DeprecatedString::empty());
 
     // 4. Basic URL parse input with this’s URL as url and fragment state as state override.

--- a/Userland/Utilities/sql.cpp
+++ b/Userland/Utilities/sql.cpp
@@ -188,7 +188,7 @@ private:
             }
             return line.release_value();
             // If the last file is exhausted but m_quit_when_files_read is false
-            // we fall through to the standard reading from the editor behaviour
+            // we fall through to the standard reading from the editor behavior
         }
         auto line_result = m_editor->get_line(prompt_for_level(m_repl_line_level));
         if (line_result.is_error())


### PR DESCRIPTION
These typos were found by running:

```
git ls-files -z '*.md' | xargs -0 cat Base/home/anon/Documents/tips.txt | aspell --lang=en_US list --ignore=3 | sort -u > words_flagged.lst
join --nocheck-order -v1 words_flagged.lst words_allow_extra.lst | tee words_misspelled.lst
```

… and then hand-filtering all the words that aren't known to aspell. Most notably:
- Due to sheer volume, I skipped all words with three or fewer letters.
- Due to sheer volume, I only searched for misspells in `.md` files (but fixed any finds in all files)
- I may have accidentally accepted a misspelling in this list of 2443 "new" words, which you can inspect here: https://gist.github.com/BenWiederhake/6d118d8fe8f66d1515d17bf9fa65532a
- I changed "neighbour" to "neighbor" and "behaviour" to "behavior", given that these are by far the most popular spellings in the project, and that the project's language is American English.

My favorite typo is either "gouped" or "LADBIRD", I can't decide :D