### PR TITLE
LibWeb: Get rid of weird CSS::Length::resolved() API

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -61,15 +61,6 @@ Length Length::percentage_of(Percentage const& percentage) const
     return Length { percentage.as_fraction() * raw_value(), m_type };
 }
 
-Length Length::resolved(Layout::Node const& layout_node) const
-{
-    if (is_relative())
-        return make_px(to_px(layout_node));
-    if (!isfinite(m_value))
-        return make_auto();
-    return *this;
-}
-
 CSSPixels Length::font_relative_length_to_px(Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
 {
     switch (m_type) {

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -90,8 +90,6 @@ public:
     static Length make_px(CSSPixels value);
     Length percentage_of(Percentage const&) const;
 
-    Length resolved(Layout::Node const& layout_node) const;
-
     bool is_auto() const { return m_type == Type::Auto; }
     bool is_px() const { return m_type == Type::Px; }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
@@ -18,7 +18,7 @@ float Filter::Blur::resolved_radius(Layout::Node const& node) const
     // Default value when omitted is 0px.
     auto sigma = 0;
     if (radius.has_value())
-        sigma = radius->resolved(node).to_px(node).value();
+        sigma = radius->to_px(node).value();
     // Note: The radius/sigma of the blur needs to be doubled for LibGfx's blur functions.
     return sigma * 2;
 }
@@ -28,9 +28,9 @@ Filter::DropShadow::Resolved Filter::DropShadow::resolved(Layout::Node const& no
     // The default value for omitted values is missing length values set to 0
     // and the missing used color is taken from the color property.
     return Resolved {
-        offset_x.resolved(node).to_px(node).value(),
-        offset_y.resolved(node).to_px(node).value(),
-        radius.has_value() ? radius->resolved(node).to_px(node).value() : 0.0f,
+        offset_x.to_px(node).value(),
+        offset_y.to_px(node).value(),
+        radius.has_value() ? radius->to_px(node).value() : 0.0f,
         color.has_value() ? *color : node.computed_values().color()
     };
 }

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -171,8 +171,8 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     auto try_compute_width = [&](auto const& a_width) {
         CSS::Length width = a_width;
-        margin_left = computed_values.margin().left().resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
-        margin_right = computed_values.margin().right().resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
+        margin_left = computed_values.margin().left().resolved(box, width_of_containing_block_as_length_for_resolve);
+        margin_right = computed_values.margin().right().resolved(box, width_of_containing_block_as_length_for_resolve);
         CSSPixels total_px = computed_values.border_left().width + computed_values.border_right().width;
         for (auto& value : { margin_left, CSS::Length::make_px(padding_left), width, CSS::Length::make_px(padding_right), margin_right }) {
             total_px += value.to_px(box);
@@ -279,8 +279,8 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     if (!available_space.width.is_definite())
         width_of_containing_block_as_length_for_resolve = CSS::Length::make_px(0);
 
-    auto margin_left = computed_values.margin().left().resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
-    auto margin_right = computed_values.margin().right().resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
+    auto margin_left = computed_values.margin().left().resolved(box, width_of_containing_block_as_length_for_resolve);
+    auto margin_right = computed_values.margin().right().resolved(box, width_of_containing_block_as_length_for_resolve);
     auto const padding_left = computed_values.padding().left().to_px(box, width_of_containing_block);
     auto const padding_right = computed_values.padding().right().to_px(box, width_of_containing_block);
 
@@ -362,8 +362,8 @@ CSSPixels BlockFormattingContext::compute_width_for_table_wrapper(Box const& box
 
     auto zero_value = CSS::Length::make_px(0);
 
-    auto margin_left = computed_values.margin().left().resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
-    auto margin_right = computed_values.margin().right().resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
+    auto margin_left = computed_values.margin().left().resolved(box, width_of_containing_block_as_length_for_resolve);
+    auto margin_right = computed_values.margin().right().resolved(box, width_of_containing_block_as_length_for_resolve);
 
     // If 'margin-left', or 'margin-right' are computed as 'auto', their used value is '0'.
     if (margin_left.is_auto())

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -154,14 +154,14 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     auto margin_left = CSS::Length::make_auto();
     auto margin_right = CSS::Length::make_auto();
-    auto const padding_left = computed_values.padding().left().resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
-    auto const padding_right = computed_values.padding().right().resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
+    auto const padding_left = computed_values.padding().left().to_px(box, width_of_containing_block);
+    auto const padding_right = computed_values.padding().right().to_px(box, width_of_containing_block);
 
     auto& box_state = m_state.get_mutable(box);
     box_state.border_left = computed_values.border_left().width;
     box_state.border_right = computed_values.border_right().width;
-    box_state.padding_left = padding_left.to_px(box);
-    box_state.padding_right = padding_right.to_px(box);
+    box_state.padding_left = padding_left;
+    box_state.padding_right = padding_right;
 
     // NOTE: If we are calculating the min-content or max-content width of this box,
     //       and the width should be treated as auto, then we can simply return here,
@@ -174,7 +174,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
         margin_left = computed_values.margin().left().resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
         margin_right = computed_values.margin().right().resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
         CSSPixels total_px = computed_values.border_left().width + computed_values.border_right().width;
-        for (auto& value : { margin_left, padding_left, width, padding_right, margin_right }) {
+        for (auto& value : { margin_left, CSS::Length::make_px(padding_left), width, CSS::Length::make_px(padding_right), margin_right }) {
             total_px += value.to_px(box);
         }
 
@@ -281,8 +281,8 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
 
     auto margin_left = computed_values.margin().left().resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
     auto margin_right = computed_values.margin().right().resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
-    auto const padding_left = computed_values.padding().left().resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
-    auto const padding_right = computed_values.padding().right().resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
+    auto const padding_left = computed_values.padding().left().to_px(box, width_of_containing_block);
+    auto const padding_right = computed_values.padding().right().to_px(box, width_of_containing_block);
 
     // If 'margin-left', or 'margin-right' are computed as 'auto', their used value is '0'.
     if (margin_left.is_auto())
@@ -298,8 +298,8 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
             // block minus the used values of 'margin-left', 'border-left-width', 'padding-left',
             // 'padding-right', 'border-right-width', 'margin-right', and the widths of any relevant scroll bars.
             auto available_width = width_of_containing_block
-                - margin_left.to_px(box) - computed_values.border_left().width - padding_left.to_px(box)
-                - padding_right.to_px(box) - computed_values.border_right().width - margin_right.to_px(box);
+                - margin_left.to_px(box) - computed_values.border_left().width - padding_left
+                - padding_right - computed_values.border_right().width - margin_right.to_px(box);
 
             auto result = calculate_shrink_to_fit_widths(box);
 
@@ -341,8 +341,8 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     box_state.margin_right = margin_right.to_px(box);
     box_state.border_left = computed_values.border_left().width;
     box_state.border_right = computed_values.border_right().width;
-    box_state.padding_left = padding_left.to_px(box);
-    box_state.padding_right = padding_right.to_px(box);
+    box_state.padding_left = padding_left;
+    box_state.padding_right = padding_right;
 }
 
 void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_normal_flow(ReplacedBox const& box, AvailableSpace const& available_space)

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -429,8 +429,8 @@ CSSPixels FormattingContext::compute_width_for_replaced_element(LayoutState cons
     auto width_of_containing_block = available_space.width.to_px();
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
 
-    auto margin_left = box.computed_values().margin().left().resolved(box, width_of_containing_block_as_length).resolved(box);
-    auto margin_right = box.computed_values().margin().right().resolved(box, width_of_containing_block_as_length).resolved(box);
+    auto margin_left = box.computed_values().margin().left().resolved(box, width_of_containing_block_as_length);
+    auto margin_right = box.computed_values().margin().right().resolved(box, width_of_containing_block_as_length);
 
     // A computed value of 'auto' for 'margin-left' or 'margin-right' becomes a used value of '0'.
     if (margin_left.is_auto())
@@ -531,8 +531,8 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
     auto computed_right = computed_values.inset().right();
 
     auto try_compute_width = [&](auto const& a_width) {
-        margin_left = computed_values.margin().left().resolved(box, width_of_containing_block_as_length).resolved(box);
-        margin_right = computed_values.margin().right().resolved(box, width_of_containing_block_as_length).resolved(box);
+        margin_left = computed_values.margin().left().resolved(box, width_of_containing_block_as_length);
+        margin_right = computed_values.margin().right().resolved(box, width_of_containing_block_as_length);
 
         auto left = computed_values.inset().left().to_px(box, width_of_containing_block);
         auto right = computed_values.inset().right().to_px(box, width_of_containing_block);

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -938,8 +938,6 @@ void FormattingContext::layout_absolutely_positioned_element(Box const& box, Ava
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
     auto height_of_containing_block_as_length = CSS::Length::make_px(height_of_containing_block);
 
-    auto specified_width = box.computed_values().width().resolved(box, width_of_containing_block_as_length).resolved(box);
-
     compute_width_for_absolutely_positioned_element(box, available_space);
 
     // NOTE: We compute height before *and* after doing inside layout.

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1293,7 +1293,7 @@ CSS::Length FormattingContext::calculate_inner_width(Layout::Box const& box, Ava
     auto width_of_containing_block = available_width.to_px();
     auto width_of_containing_block_as_length_for_resolve = CSS::Length::make_px(width_of_containing_block);
     if (width.is_auto()) {
-        return width.resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
+        return width.resolved(box, width_of_containing_block_as_length_for_resolve);
     }
 
     auto& computed_values = box.computed_values();
@@ -1309,7 +1309,7 @@ CSS::Length FormattingContext::calculate_inner_width(Layout::Box const& box, Ava
         return CSS::Length::make_px(max(inner_width, 0));
     }
 
-    return width.resolved(box, width_of_containing_block_as_length_for_resolve).resolved(box);
+    return width.resolved(box, width_of_containing_block_as_length_for_resolve);
 }
 
 CSS::Length FormattingContext::calculate_inner_height(Layout::Box const& box, AvailableSize const& available_height, CSS::Size const& height) const
@@ -1317,7 +1317,7 @@ CSS::Length FormattingContext::calculate_inner_height(Layout::Box const& box, Av
     auto height_of_containing_block = available_height.to_px();
     auto height_of_containing_block_as_length_for_resolve = CSS::Length::make_px(height_of_containing_block);
     if (height.is_auto()) {
-        return height.resolved(box, height_of_containing_block_as_length_for_resolve).resolved(box);
+        return height.resolved(box, height_of_containing_block_as_length_for_resolve);
     }
 
     auto& computed_values = box.computed_values();
@@ -1335,7 +1335,7 @@ CSS::Length FormattingContext::calculate_inner_height(Layout::Box const& box, Av
         return CSS::Length::make_px(max(inner_height, 0));
     }
 
-    return height.resolved(box, height_of_containing_block_as_length_for_resolve).resolved(box);
+    return height.resolved(box, height_of_containing_block_as_length_for_resolve);
 }
 
 CSSPixels FormattingContext::containing_block_width_for(Box const& box, LayoutState const& state)

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -849,9 +849,9 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     auto const& computed_max_height = box.computed_values().max_height();
 
     if (!computed_max_height.is_none())
-        used_height = min(used_height, computed_max_height.resolved(box, height_of_containing_block_as_length).resolved(box).to_px(box));
+        used_height = min(used_height, computed_max_height.to_px(box, height_of_containing_block));
     if (!computed_min_height.is_auto())
-        used_height = max(used_height, computed_min_height.resolved(box, height_of_containing_block_as_length).resolved(box).to_px(box));
+        used_height = max(used_height, computed_min_height.to_px(box, height_of_containing_block));
 
     // NOTE: The following is not directly part of any spec, but this is where we resolve
     //       the final used values for vertical margin/border/padding.

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -239,14 +239,14 @@ void LayoutState::UsedValues::set_node(NodeWithStyleAndBoxModelMetrics& node, Us
 
         if (width) {
             border_and_padding = CSSPixels(computed_values.border_left().width)
-                + computed_values.padding().left().resolved(*m_node, CSS::Length::make_px(containing_block_used_values->content_width())).resolved(*m_node).to_px(*m_node)
+                + computed_values.padding().left().to_px(*m_node, containing_block_used_values->content_width())
                 + CSSPixels(computed_values.border_right().width)
-                + computed_values.padding().right().resolved(*m_node, CSS::Length::make_px(containing_block_used_values->content_width())).resolved(*m_node).to_px(*m_node);
+                + computed_values.padding().right().to_px(*m_node, containing_block_used_values->content_width());
         } else {
             border_and_padding = CSSPixels(computed_values.border_top().width)
-                + computed_values.padding().top().resolved(*m_node, CSS::Length::make_px(containing_block_used_values->content_width())).resolved(*m_node).to_px(*m_node)
+                + computed_values.padding().top().to_px(*m_node, containing_block_used_values->content_width())
                 + CSSPixels(computed_values.border_bottom().width)
-                + computed_values.padding().bottom().resolved(*m_node, CSS::Length::make_px(containing_block_used_values->content_width())).resolved(*m_node).to_px(*m_node);
+                + computed_values.padding().bottom().to_px(*m_node, containing_block_used_values->content_width());
         }
 
         return unadjusted_pixels - border_and_padding;


### PR DESCRIPTION
There `CSS::Length::resolved()` turns non-finite lengths into "auto".
This is a very strange ad-hoc behavior that we need to get rid of.

This PR removes it across a number of commits, to aid in bisecting in case this ends up breaking something.

