### PR TITLE
LibGfx+WindowServer: Ensure constrain-to-rect ends up inside the rect

### DIFF
--- a/Userland/Libraries/LibGfx/Point.cpp
+++ b/Userland/Libraries/LibGfx/Point.cpp
@@ -15,8 +15,8 @@ namespace Gfx {
 template<typename T>
 void Point<T>::constrain(Rect<T> const& rect)
 {
-    m_x = AK::clamp<T>(x(), rect.left(), rect.left() + rect.width());
-    m_y = AK::clamp<T>(y(), rect.top(), rect.top() + rect.height());
+    m_x = AK::clamp<T>(x(), rect.left(), rect.right());
+    m_y = AK::clamp<T>(y(), rect.top(), rect.bottom());
 }
 
 template<typename T>

--- a/Userland/Services/WindowServer/Screen.cpp
+++ b/Userland/Services/WindowServer/Screen.cpp
@@ -421,7 +421,7 @@ void ScreenInput::on_receive_mouse_data(MousePacket const& packet)
 
     auto* moved_to_screen = Screen::find_by_location(m_cursor_location);
     if (!moved_to_screen) {
-        m_cursor_location = m_cursor_location.constrained(current_screen.rect());
+        m_cursor_location.constrain(current_screen.rect());
         moved_to_screen = &current_screen;
     }
 


### PR DESCRIPTION
The method `Point::constrain(Rect&)` sometimes resulted in a Point that was still slightly outside the given Rect. In most cases this affected at most some slight rendering, but in case of WindowServer caused a crash #18668 

https://user-images.githubusercontent.com/2690845/236641958-00d65154-f263-482b-affd-1ce348e86536.mp4

This PR fixes the method, and also simplifies the corresponding invocation in WindowServer.