### PR TITLE
LibWeb: Enforce min/max height constraints on abspos replaced boxes

### DIFF
--- a/Tests/LibWeb/Layout/expected/abspos-image-with-min-height-constraint.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-image-with-min-height-constraint.txt
@@ -1,0 +1,4 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      ImageBox <img#zero-dimensions-but-min-percentages> at (8,8) content-size 800x600 positioned children: not-inline

--- a/Tests/LibWeb/Layout/input/abspos-image-with-min-height-constraint.html
+++ b/Tests/LibWeb/Layout/input/abspos-image-with-min-height-constraint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html><html><head><style>
+#zero-dimensions-but-min-percentages {
+    width: 0;
+    height: 0;
+    min-width: 100%;
+    min-height: 100%;
+    position: absolute;
+}
+</style><body><img id="zero-dimensions-but-min-percentages">


### PR DESCRIPTION
Fixes #18658

Before:
![image](https://user-images.githubusercontent.com/5954907/236642745-29b4158b-7e55-44ee-8713-022b76fd5297.png)

After:
![image](https://user-images.githubusercontent.com/5954907/236642750-5618ac3a-a34b-4958-9dfb-4b87f96c7a4e.png)
