### PR TITLE
WebP: Add test for animated lossless decoding, and implement alpha chunk decoding

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -288,6 +288,8 @@ TEST_CASE(test_webp_simple_lossy)
     EXPECT(!plugin_decoder->loop_count());
 
     EXPECT_EQ(plugin_decoder->size(), Gfx::IntSize(240, 240));
+
+    // FIXME: test plugin_decoder->frame(0) once webp lossy decoding is implemented.
 }
 
 TEST_CASE(test_webp_simple_lossless)
@@ -328,6 +330,8 @@ TEST_CASE(test_webp_extended_lossy)
     EXPECT(!plugin_decoder->loop_count());
 
     EXPECT_EQ(plugin_decoder->size(), Gfx::IntSize(417, 223));
+
+    // FIXME: test plugin_decoder->frame(0) once webp lossy decoding is implemented.
 }
 
 TEST_CASE(test_webp_extended_lossless)
@@ -453,4 +457,15 @@ TEST_CASE(test_webp_extended_lossless_animated)
     EXPECT_EQ(plugin_decoder->loop_count(), 42u);
 
     EXPECT_EQ(plugin_decoder->size(), Gfx::IntSize(990, 1050));
+
+    for (size_t frame_index = 0; frame_index < plugin_decoder->frame_count(); ++frame_index) {
+        auto frame = MUST(plugin_decoder->frame(frame_index));
+        EXPECT_EQ(frame.image->size(), Gfx::IntSize(990, 1050));
+
+        // This pixel happens to be the same color in all frames.
+        EXPECT_EQ(frame.image->get_pixel(500, 700), Gfx::Color::Yellow);
+
+        // This one isn't the same in all frames.
+        EXPECT_EQ(frame.image->get_pixel(500, 0), (frame_index == 2 || frame_index == 6) ? Gfx::Color::Black : Gfx::Color(255, 255, 255, 0));
+    }
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -299,6 +299,14 @@ static ErrorOr<VP8Header> decode_webp_chunk_VP8_header(WebPLoadingContext& conte
     return VP8Header { version, show_frame, size_of_first_partition, width, horizontal_scale, height, vertical_scale };
 }
 
+static ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8(WebPLoadingContext& context, Chunk const& vp8_chunk)
+{
+    VERIFY(vp8_chunk.type == FourCC("VP8 "));
+
+    // FIXME: Implement webp lossy decoding.
+    return context.error("WebPImageDecoderPlugin: decoding lossy webps not yet implemented");
+}
+
 // https://developers.google.com/speed/webp/docs/riff_container#simple_file_format_lossless
 // https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#7_overall_structure_of_the_format
 static ErrorOr<VP8LHeader> decode_webp_chunk_VP8L_header(WebPLoadingContext& context, Chunk const& vp8l_chunk)
@@ -1584,9 +1592,13 @@ static ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_image_data(WebPLoadingContext&
     }
 
     VERIFY(image_data.image_data_chunk->type == FourCC("VP8 "));
+    auto bitmap = TRY(decode_webp_chunk_VP8(context, image_data.image_data_chunk.value()));
 
-    // FIXME: Implement.
-    return context.error("WebPImageDecoderPlugin: decoding lossy webps not yet implemented");
+    if (image_data.alpha_chunk.has_value()) {
+        // FIXME: Decode alpha chunk and store decoded alpha in `bitmap`.
+    }
+
+    return bitmap;
 }
 
 // https://developers.google.com/speed/webp/docs/riff_container#assembling_the_canvas_from_frames


### PR DESCRIPTION
ALPH chunks are only used to give lossy webp frames an alpha channel,
and lossy decompression isn't implemented yet. So this can currently
never be hit in practice -- but for debugging and testing, I put in
some code behind `#if 0` for now that fake-decompresses a lossy webp
frame by returning an empty bitmap.

When someone implements lossy webp decoding, lossy-with-alpha
webp files will then Just Work.

Part of the motivation is that I want to move the lossless decoding
code into its own file (WebPLoader.cpp has gotten too big), and
this was the last part of the spec that still had to call the lossless
decoding code. So now I have a good idea of the public interface that
that code needs.