### PR TITLE
Chess+LibSQL: Remove IODevice, improve error propagation

### DIFF
--- a/Userland/Games/Chess/Engine.cpp
+++ b/Userland/Games/Chess/Engine.cpp
@@ -55,7 +55,7 @@ void Engine::connect_to_engine_service()
     close(rpipefds[1]);
 
     auto infile = Core::File::adopt_fd(rpipefds[0], Core::File::OpenMode::Read).release_value_but_fixme_should_propagate_errors();
-    set_in(move(infile));
+    set_in(move(infile)).release_value_but_fixme_should_propagate_errors();
 
     auto outfile = Core::File::adopt_fd(wpipefds[1], Core::File::OpenMode::Write).release_value_but_fixme_should_propagate_errors();
     set_out(move(outfile));

--- a/Userland/Libraries/LibChess/UCIEndpoint.cpp
+++ b/Userland/Libraries/LibChess/UCIEndpoint.cpp
@@ -12,14 +12,6 @@
 
 namespace Chess::UCI {
 
-Endpoint::Endpoint(NonnullOwnPtr<Core::File> in, NonnullOwnPtr<Core::File> out)
-    : m_in_fd(in->fd())
-    , m_in(Core::BufferedFile::create(move(in)).release_value_but_fixme_should_propagate_errors())
-    , m_out(move(out))
-{
-    set_in_notifier();
-}
-
 void Endpoint::send_command(Command const& command)
 {
     auto command_string = command.to_string().release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibChess/UCIEndpoint.h
+++ b/Userland/Libraries/LibChess/UCIEndpoint.h
@@ -41,17 +41,17 @@ public:
 
     virtual void event(Core::Event&) override;
 
-    void set_in(NonnullOwnPtr<Core::File> in)
+    ErrorOr<void> set_in(NonnullOwnPtr<Core::File> in)
     {
         m_in_fd = in->fd();
-        m_in = Core::BufferedFile::create(move(in)).release_value_but_fixme_should_propagate_errors();
+        m_in = TRY(Core::BufferedFile::create(move(in)));
         set_in_notifier();
+        return {};
     }
     void set_out(NonnullOwnPtr<Core::File> out) { m_out = move(out); }
 
 protected:
     Endpoint() = default;
-    Endpoint(NonnullOwnPtr<Core::File> in, NonnullOwnPtr<Core::File> out);
     virtual void custom_event(Core::CustomEvent&) override;
 
 private:

--- a/Userland/Libraries/LibSQL/Heap.cpp
+++ b/Userland/Libraries/LibSQL/Heap.cpp
@@ -8,7 +8,6 @@
 #include <AK/DeprecatedString.h>
 #include <AK/Format.h>
 #include <AK/QuickSort.h>
-#include <LibCore/IODevice.h>
 #include <LibCore/System.h>
 #include <LibSQL/Heap.h>
 #include <sys/stat.h>

--- a/Userland/Services/ChessEngine/ChessEngine.h
+++ b/Userland/Services/ChessEngine/ChessEngine.h
@@ -26,8 +26,8 @@ public:
     Function<void(int)> on_quit;
 
 private:
-    ChessEngine(NonnullRefPtr<Core::IODevice> in, NonnullRefPtr<Core::IODevice> out)
-        : Endpoint(in, out)
+    ChessEngine(NonnullOwnPtr<Core::File> in, NonnullOwnPtr<Core::File> out)
+        : Endpoint(move(in), move(out))
     {
         on_command_read_error = [](auto command, auto error) {
             outln("{}: '{}'", error, command);

--- a/Userland/Services/ChessEngine/ChessEngine.h
+++ b/Userland/Services/ChessEngine/ChessEngine.h
@@ -12,8 +12,15 @@
 #include <LibChess/UCIEndpoint.h>
 
 class ChessEngine : public Chess::UCI::Endpoint {
-    C_OBJECT(ChessEngine)
+    C_OBJECT_ABSTRACT(ChessEngine)
 public:
+    static ErrorOr<NonnullRefPtr<ChessEngine>> try_create(NonnullOwnPtr<Core::File> in, NonnullOwnPtr<Core::File> out)
+    {
+        auto engine = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ChessEngine()));
+        TRY(engine->set_in(move(in)));
+        engine->set_out(move(out));
+        return engine;
+    }
     virtual ~ChessEngine() override = default;
 
     virtual void handle_uci() override;
@@ -26,8 +33,8 @@ public:
     Function<void(int)> on_quit;
 
 private:
-    ChessEngine(NonnullOwnPtr<Core::File> in, NonnullOwnPtr<Core::File> out)
-        : Endpoint(move(in), move(out))
+    ChessEngine()
+        : Endpoint()
     {
         on_command_read_error = [](auto command, auto error) {
             outln("{}: '{}'", error, command);

--- a/Userland/Services/ChessEngine/main.cpp
+++ b/Userland/Services/ChessEngine/main.cpp
@@ -5,8 +5,8 @@
  */
 
 #include "ChessEngine.h"
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/File.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 
@@ -16,7 +16,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     Core::EventLoop loop;
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    auto engine = TRY(ChessEngine::try_create(Core::DeprecatedFile::standard_input(), Core::DeprecatedFile::standard_output()));
+    auto engine = TRY(ChessEngine::try_create(TRY(Core::File::standard_input()), TRY(Core::File::standard_output())));
     engine->on_quit = [&](auto status_code) {
         loop.quit(status_code);
     };


### PR DESCRIPTION
This migrates Chess and ChessEngine from IODevice to Core::File (and removes an unused include from LibSQL).

Advances #17129, so CC @AtkinsSJ 

Note that now IODevice seems to be only used by DeprecatedFile and Ladybird (looks like an unused include, but I'm not sure).