### PR TITLE
Ladybird: Don't ask Qt to decode SVG images for us

### DIFF
--- a/Ladybird/ImageCodecPluginLadybird.cpp
+++ b/Ladybird/ImageCodecPluginLadybird.cpp
@@ -72,6 +72,12 @@ Optional<Web::Platform::DecodedImage> ImageCodecPluginLadybird::decode_image(Rea
     auto image = decode_image_with_libgfx(data);
     if (image.has_value())
         return image;
+
+    // NOTE: Even though Qt can decode SVG images for us, let's not do that.
+    //       We should handle <img src="foo.svg"> ourselves instead of cheating by using Qt.
+    if (data.starts_with("<?xml"sv.bytes()) || data.starts_with("<svg"sv.bytes()))
+        return {};
+
     return decode_image_with_qt(data);
 }
 


### PR DESCRIPTION
While it's nice to see `<img src="foo.svg">` suddenly work in Ladybird after linking with the Qt SVG module, this is cheating.

We should implement SVG-as-image ourselves instead of relying on 3rd party code to do it. :^)