### PR TITLE
LibWeb: Add fast_is<T>() helper for HTMLScriptElement

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -89,6 +89,7 @@ public:
     virtual bool is_html_body_element() const { return false; }
     virtual bool is_html_input_element() const { return false; }
     virtual bool is_html_progress_element() const { return false; }
+    virtual bool is_html_script_element() const { return false; }
     virtual bool is_html_template_element() const { return false; }
     virtual bool is_navigable_container() const { return false; }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -58,6 +58,8 @@ public:
 private:
     HTMLScriptElement(DOM::Document&, DOM::QualifiedName);
 
+    virtual bool is_html_script_element() const override { return true; }
+
     virtual void resource_did_load() override;
     virtual void resource_did_fail() override;
 
@@ -123,4 +125,9 @@ private:
     size_t m_source_line_number { 1 };
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::HTMLScriptElement>() const { return is_html_script_element(); }
 }


### PR DESCRIPTION
This makes loading Google Groups quite a bit faster, as 20% of runtime while loading was spent asking if DOM nodes are HTMLScriptElement.

cc @ADKaster :^)