### PR TITLE
LibCrypto+LibTLS: Avoid crashing on invalid input

### DIFF
--- a/Userland/Libraries/LibCrypto/ASN1/DER.h
+++ b/Userland/Libraries/LibCrypto/ASN1/DER.h
@@ -22,9 +22,10 @@ public:
     {
     }
 
-    ReadonlyBytes raw_bytes() const
+    ErrorOr<ReadonlyBytes> raw_bytes() const
     {
-        VERIFY(m_unused_bits == 0);
+        if (m_unused_bits != 0)
+            return Error::from_string_literal("ASN1::Decoder: BitStringView contains unexpected partial bytes");
         return m_data;
     }
 

--- a/Userland/Libraries/LibTLS/Certificate.cpp
+++ b/Userland/Libraries/LibTLS/Certificate.cpp
@@ -365,10 +365,10 @@ static ErrorOr<SubjectPublicKey> parse_subject_public_key_info(Crypto::ASN1::Dec
     READ_OBJECT(BitString, Crypto::ASN1::BitStringView, value);
     POP_SCOPE();
 
-    public_key.raw_key = TRY(ByteBuffer::copy(value.raw_bytes()));
+    public_key.raw_key = TRY(ByteBuffer::copy(TRY(value.raw_bytes())));
 
     if (public_key.algorithm.identifier.span() == rsa_encryption_oid.span()) {
-        auto key = Crypto::PK::RSA::parse_rsa_key(value.raw_bytes());
+        auto key = Crypto::PK::RSA::parse_rsa_key(TRY(value.raw_bytes()));
         if (!key.public_key.length()) {
             return Error::from_string_literal("Invalid RSA key");
         }
@@ -773,7 +773,7 @@ ErrorOr<Certificate> Certificate::parse_certificate(ReadonlyBytes buffer, bool)
 
     PUSH_SCOPE("signature"sv);
     READ_OBJECT(BitString, Crypto::ASN1::BitStringView, signature);
-    certificate.signature_value = TRY(ByteBuffer::copy(signature.raw_bytes()));
+    certificate.signature_value = TRY(ByteBuffer::copy(TRY(signature.raw_bytes())));
     POP_SCOPE();
 
     if (!decoder.eof()) {


### PR DESCRIPTION
Fixes #18307.

A library should rarely, if ever, crash on invalid input. Especially if it's something that is used prominently in a security context.

CC @stelar7, since I don't quite understand why this was a `VERIFY` to begin with.