### PR TITLE
AK: Support Clang 14 for fuzzing

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -30,7 +30,7 @@ class StringData;
 }
 
 // FIXME: Remove this when Apple Clang and OpenBSD Clang fully supports consteval.
-#if defined(AK_OS_MACOS) || defined(AK_OS_OPENBSD)
+#if defined(AK_OS_MACOS) || defined(AK_OS_OPENBSD) || (defined(__clang__) && __clang_major__ < 15)
 #    define AK_SHORT_STRING_CONSTEVAL constexpr
 #else
 #    define AK_SHORT_STRING_CONSTEVAL consteval


### PR DESCRIPTION
OSS Fuzz is currently broken: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58457&q=label%3AProj-serenity&sort=summary

This is because we're incompatible with clang 14, which is what OSS Fuzz (and btw also Debian Testing) currently uses.

This PR adds Clang 14 to the list of reasons to avoid fully-consteval string-ops, and enables fuzz-builds with clang 14.