### PR TITLE
Ladybird: Don't ask Qt to decode any images for us

### DIFF
--- a/Ladybird/ImageCodecPluginLadybird.cpp
+++ b/Ladybird/ImageCodecPluginLadybird.cpp
@@ -8,35 +8,12 @@
 #include "ImageCodecPluginLadybird.h"
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageFormats/ImageDecoder.h>
-#include <QImage>
 
 namespace Ladybird {
 
 ImageCodecPluginLadybird::~ImageCodecPluginLadybird() = default;
 
-static Optional<Web::Platform::DecodedImage> decode_image_with_qt(ReadonlyBytes data)
-{
-    auto image = QImage::fromData(data.data(), static_cast<int>(data.size()));
-    if (image.isNull())
-        return {};
-    image = image.convertToFormat(QImage::Format::Format_ARGB32);
-    auto bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, Gfx::IntSize(image.width(), image.height())));
-    for (int y = 0; y < image.height(); ++y) {
-        memcpy(bitmap->scanline_u8(y), image.scanLine(y), image.width() * 4);
-    }
-    Vector<Web::Platform::Frame> frames;
-
-    frames.append(Web::Platform::Frame {
-        bitmap,
-    });
-    return Web::Platform::DecodedImage {
-        false,
-        0,
-        move(frames),
-    };
-}
-
-static Optional<Web::Platform::DecodedImage> decode_image_with_libgfx(ReadonlyBytes data)
+Optional<Web::Platform::DecodedImage> ImageCodecPluginLadybird::decode_image(ReadonlyBytes data)
 {
     auto decoder = Gfx::ImageDecoder::try_create_for_raw_bytes(data);
 
@@ -65,20 +42,6 @@ static Optional<Web::Platform::DecodedImage> decode_image_with_libgfx(ReadonlyBy
         static_cast<u32>(decoder->loop_count()),
         move(frames),
     };
-}
-
-Optional<Web::Platform::DecodedImage> ImageCodecPluginLadybird::decode_image(ReadonlyBytes data)
-{
-    auto image = decode_image_with_libgfx(data);
-    if (image.has_value())
-        return image;
-
-    // NOTE: Even though Qt can decode SVG images for us, let's not do that.
-    //       We should handle <img src="foo.svg"> ourselves instead of cheating by using Qt.
-    if (data.starts_with("<?xml"sv.bytes()) || data.starts_with("<svg"sv.bytes()))
-        return {};
-
-    return decode_image_with_qt(data);
 }
 
 }


### PR DESCRIPTION
We should only rely on LibGfx to decode images for us, if LibGfx can't decode an image that should be motivation to improve LibGfx, not hidden by Qt picking up the slack :^)