### PR TITLE
AK+LibWeb: Convert csp_navigation_type to an enum, use consteval String factories on macOS

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -29,8 +29,8 @@ namespace Detail {
 class StringData;
 }
 
-// FIXME: Remove this when Apple Clang and OpenBSD Clang fully supports consteval.
-#if defined(AK_OS_MACOS) || defined(AK_OS_OPENBSD)
+// FIXME: Remove this when OpenBSD Clang fully supports consteval.
+#if defined(AK_OS_OPENBSD)
 #    define AK_SHORT_STRING_CONSTEVAL constexpr
 #else
 #    define AK_SHORT_STRING_CONSTEVAL consteval

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -692,7 +692,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate(
     JS::GCPtr<Fetch::Infrastructure::Response> response,
     bool exceptions_enabled,
     HistoryHandlingBehavior history_handling,
-    String csp_navigation_type,
+    CSPNavigationType csp_navigation_type,
     ReferrerPolicy::ReferrerPolicy referrer_policy)
 {
     // FIXME: 1. Let sourceSnapshotParams be the result of snapshotting source snapshot params given sourceDocument.
@@ -835,7 +835,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate_to_a_fragment(AK::URL const&, Hist
     TODO();
 }
 
-WebIDL::ExceptionOr<void> Navigable::navigate_to_a_javascript_url(AK::URL const&, HistoryHandlingBehavior, Origin const& initiator_origin, String csp_navigation_type)
+WebIDL::ExceptionOr<void> Navigable::navigate_to_a_javascript_url(AK::URL const&, HistoryHandlingBehavior, Origin const& initiator_origin, CSPNavigationType csp_navigation_type)
 {
     (void)initiator_origin;
     (void)csp_navigation_type;

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -15,6 +15,11 @@
 
 namespace Web::HTML {
 
+enum class CSPNavigationType {
+    Other,
+    FormSubmission,
+};
+
 // https://html.spec.whatwg.org/multipage/document-sequences.html#navigable
 class Navigable : public JS::Cell {
     JS_CELL(Navigable, JS::Cell);
@@ -70,12 +75,12 @@ public:
         JS::GCPtr<Fetch::Infrastructure::Response> = nullptr,
         bool exceptions_enabled = false,
         HistoryHandlingBehavior = HistoryHandlingBehavior::Push,
-        String csp_navigation_type = String::from_utf8_short_string("other"sv),
+        CSPNavigationType csp_navigation_type = CSPNavigationType::Other,
         ReferrerPolicy::ReferrerPolicy = ReferrerPolicy::ReferrerPolicy::EmptyString);
 
     WebIDL::ExceptionOr<void> navigate_to_a_fragment(AK::URL const&, HistoryHandlingBehavior, String navigation_id);
 
-    WebIDL::ExceptionOr<void> navigate_to_a_javascript_url(AK::URL const&, HistoryHandlingBehavior, Origin const& initiator_origin, String csp_navigation_type);
+    WebIDL::ExceptionOr<void> navigate_to_a_javascript_url(AK::URL const&, HistoryHandlingBehavior, Origin const& initiator_origin, CSPNavigationType csp_navigation_type);
 
 protected:
     Navigable();


### PR DESCRIPTION
Some versions of clang will have an issue using a consteval function to
set the optional parameter's default value. For example, see:
https://stackoverflow.com/questions/68789984/immediate-function-as-default-function-argument-initializer-in-clang

This doesn't need to be a String anyways, so let's make it an enum.