### PR TITLE
LibWeb: Don't force relayout on scheduled layout update

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -313,7 +313,7 @@ Document::Document(JS::Realm& realm, const AK::URL& url)
     });
 
     m_layout_update_timer = Platform::Timer::create_single_shot(0, [this] {
-        force_layout();
+        update_layout();
     });
 }
 


### PR DESCRIPTION
If something else has already caused a layout, there's no need to force a new relayout when the layout timer fires.

This avoids a lot of redundant work on many pages. :^)