### PR TITLE
Tests: Prefer MUST() over EXPECT(!.is_error())

### DIFF
--- a/Tests/AK/TestBase64.cpp
+++ b/Tests/AK/TestBase64.cpp
@@ -13,9 +13,7 @@
 TEST_CASE(test_decode)
 {
     auto decode_equal = [&](StringView input, StringView expected) {
-        auto decoded_option = decode_base64(input);
-        EXPECT(!decoded_option.is_error());
-        auto decoded = decoded_option.release_value();
+        auto decoded = TRY_OR_FAIL(decode_base64(input));
         EXPECT(DeprecatedString::copy(decoded) == expected);
         EXPECT(expected.length() <= calculate_base64_decoded_length(input.bytes()));
     };

--- a/Tests/AK/TestCircularBuffer.cpp
+++ b/Tests/AK/TestCircularBuffer.cpp
@@ -12,10 +12,7 @@ namespace {
 
 CircularBuffer create_circular_buffer(size_t size)
 {
-    auto buffer_or_error = CircularBuffer::create_empty(size);
-    EXPECT(!buffer_or_error.is_error());
-
-    return buffer_or_error.release_value();
+    return MUST(CircularBuffer::create_empty(size));
 }
 
 void safe_write(CircularBuffer& buffer, u8 i)
@@ -36,8 +33,7 @@ void safe_read(CircularBuffer& buffer, u8 supposed_result)
 
 void safe_discard(CircularBuffer& buffer, size_t size)
 {
-    auto result = buffer.discard(size);
-    EXPECT(!result.is_error());
+    TRY_OR_FAIL(buffer.discard(size));
 };
 
 }
@@ -177,13 +173,9 @@ TEST_CASE(full_write_non_aligned)
 TEST_CASE(create_from_bytebuffer)
 {
     u8 const source[] = { 2, 4, 6 };
-    auto byte_buffer_or_error = ByteBuffer::copy(source, AK::array_size(source));
-    EXPECT(!byte_buffer_or_error.is_error());
-    auto byte_buffer = byte_buffer_or_error.release_value();
+    auto byte_buffer = TRY_OR_FAIL(ByteBuffer::copy(source, AK::array_size(source)));
 
-    auto circular_buffer_or_error = CircularBuffer::create_initialized(move(byte_buffer));
-    EXPECT(!circular_buffer_or_error.is_error());
-    auto circular_buffer = circular_buffer_or_error.release_value();
+    auto circular_buffer = TRY_OR_FAIL(CircularBuffer::create_initialized(move(byte_buffer)));
     EXPECT_EQ(circular_buffer.used_space(), circular_buffer.capacity());
     EXPECT_EQ(circular_buffer.used_space(), 3ul);
 
@@ -247,13 +239,9 @@ TEST_CASE(discard_too_much)
 TEST_CASE(offset_of)
 {
     auto const source = "Well Hello Friends!"sv;
-    auto byte_buffer_or_error = ByteBuffer::copy(source.bytes());
-    EXPECT(!byte_buffer_or_error.is_error());
-    auto byte_buffer = byte_buffer_or_error.release_value();
+    auto byte_buffer = TRY_OR_FAIL(ByteBuffer::copy(source.bytes()));
 
-    auto circular_buffer_or_error = CircularBuffer::create_initialized(byte_buffer);
-    EXPECT(!circular_buffer_or_error.is_error());
-    auto circular_buffer = circular_buffer_or_error.release_value();
+    auto circular_buffer = TRY_OR_FAIL(CircularBuffer::create_initialized(byte_buffer));
 
     auto result = circular_buffer.offset_of("Well"sv);
     EXPECT(result.has_value());
@@ -283,13 +271,9 @@ TEST_CASE(offset_of)
 TEST_CASE(offset_of_with_until_and_after)
 {
     auto const source = "Well Hello Friends!"sv;
-    auto byte_buffer_or_error = ByteBuffer::copy(source.bytes());
-    EXPECT(!byte_buffer_or_error.is_error());
-    auto byte_buffer = byte_buffer_or_error.release_value();
+    auto byte_buffer = TRY_OR_FAIL(ByteBuffer::copy(source.bytes()));
 
-    auto circular_buffer_or_error = CircularBuffer::create_initialized(byte_buffer);
-    EXPECT(!circular_buffer_or_error.is_error());
-    auto circular_buffer = circular_buffer_or_error.release_value();
+    auto circular_buffer = TRY_OR_FAIL(CircularBuffer::create_initialized(byte_buffer));
 
     auto result = circular_buffer.offset_of("Well Hello Friends!"sv, 0, 19);
     EXPECT_EQ(result.value_or(42), 0ul);
@@ -317,13 +301,9 @@ TEST_CASE(offset_of_with_until_and_after)
 TEST_CASE(offset_of_with_until_and_after_wrapping_around)
 {
     auto const source = "Well Hello Friends!"sv;
-    auto byte_buffer_or_error = ByteBuffer::copy(source.bytes());
-    EXPECT(!byte_buffer_or_error.is_error());
-    auto byte_buffer = byte_buffer_or_error.release_value();
+    auto byte_buffer = TRY_OR_FAIL(ByteBuffer::copy(source.bytes()));
 
-    auto circular_buffer_or_error = CircularBuffer::create_empty(19);
-    EXPECT(!circular_buffer_or_error.is_error());
-    auto circular_buffer = circular_buffer_or_error.release_value();
+    auto circular_buffer = TRY_OR_FAIL(CircularBuffer::create_empty(19));
 
     auto written_bytes = circular_buffer.write(byte_buffer.span().trim(5));
     EXPECT_EQ(written_bytes, 5ul);

--- a/Tests/Kernel/TestKernelFilePermissions.cpp
+++ b/Tests/Kernel/TestKernelFilePermissions.cpp
@@ -81,10 +81,9 @@ TEST_CASE(test_change_file_location)
     ftruncate(fd, 0);
     EXPECT(fchmod(fd, 06755) != -1);
 
-    auto suid_path_or_error = FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd));
-    EXPECT(!suid_path_or_error.is_error());
+    auto suid_path_string = TRY_OR_FAIL(FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd)));
 
-    auto suid_path = suid_path_or_error.release_value().to_deprecated_string();
+    auto suid_path = suid_path_string.to_deprecated_string();
     EXPECT(suid_path.characters());
     auto new_path = DeprecatedString::formatted("{}.renamed", suid_path);
 

--- a/Tests/LibC/TestIo.cpp
+++ b/Tests/LibC/TestIo.cpp
@@ -217,10 +217,7 @@ TEST_CASE(unlink_symlink)
         perror("symlink");
     }
 
-    auto target_or_error = FileSystem::read_link("/tmp/linky"sv);
-    EXPECT(!target_or_error.is_error());
-
-    auto target = target_or_error.release_value();
+    auto target = TRY_OR_FAIL(FileSystem::read_link("/tmp/linky"sv));
     EXPECT_EQ(target.bytes_as_string_view(), "/proc/2/foo"sv);
 
     rc = unlink("/tmp/linky");

--- a/Tests/LibC/TestLibCMkTemp.cpp
+++ b/Tests/LibC/TestLibCMkTemp.cpp
@@ -86,10 +86,8 @@ TEST_CASE(test_mkstemp_unique_filename)
         auto fd = mkstemp(path);
         EXPECT_NE(fd, -1);
 
-        auto temp_path_or_error = FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd));
-        EXPECT(!temp_path_or_error.is_error());
-
-        auto temp_path = temp_path_or_error.release_value().to_deprecated_string();
+        auto temp_path_string = TRY_OR_FAIL(FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd)));
+        auto temp_path = temp_path_string.to_deprecated_string();
         EXPECT(temp_path.characters());
 
         close(fd);
@@ -107,10 +105,8 @@ TEST_CASE(test_mkstemp_unique_filename)
         auto fd = mkstemp(path);
         EXPECT(fd != -1);
 
-        auto path2_or_error = FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd));
-        EXPECT(!path2_or_error.is_error());
-
-        auto path2 = path2_or_error.release_value().to_deprecated_string();
+        auto path2_string = TRY_OR_FAIL(FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd)));
+        auto path2 = path2_string.to_deprecated_string();
         EXPECT(path2.characters());
 
         close(fd);
@@ -132,10 +128,8 @@ TEST_CASE(test_mkstemps_unique_filename)
         auto fd = mkstemps(path, 6);
         EXPECT_NE(fd, -1);
 
-        auto temp_path_or_error = FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd));
-        EXPECT(!temp_path_or_error.is_error());
-
-        auto temp_path = temp_path_or_error.release_value().to_deprecated_string();
+        auto temp_path_string = TRY_OR_FAIL(FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd)));
+        auto temp_path = temp_path_string.to_deprecated_string();
         EXPECT(temp_path.characters());
 
         close(fd);
@@ -157,10 +151,8 @@ TEST_CASE(test_mkstemps_unique_filename)
         auto fd = mkstemps(path, 6);
         EXPECT(fd != -1);
 
-        auto path2_or_error = FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd));
-        EXPECT(!path2_or_error.is_error());
-
-        auto path2 = path2_or_error.release_value().to_deprecated_string();
+        auto path2_string = TRY_OR_FAIL(FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd)));
+        auto path2 = path2_string.to_deprecated_string();
         EXPECT(path2.characters());
 
         close(fd);

--- a/Tests/LibCompress/TestDeflate.cpp
+++ b/Tests/LibCompress/TestDeflate.cpp
@@ -116,11 +116,9 @@ TEST_CASE(deflate_round_trip_store)
 {
     auto original = ByteBuffer::create_uninitialized(1024).release_value();
     fill_with_random(original);
-    auto compressed = Compress::DeflateCompressor::compress_all(original, Compress::DeflateCompressor::CompressionLevel::STORE);
-    EXPECT(!compressed.is_error());
-    auto uncompressed = Compress::DeflateDecompressor::decompress_all(compressed.value());
-    EXPECT(!uncompressed.is_error());
-    EXPECT(uncompressed.value() == original);
+    auto compressed = TRY_OR_FAIL(Compress::DeflateCompressor::compress_all(original, Compress::DeflateCompressor::CompressionLevel::STORE));
+    auto uncompressed = TRY_OR_FAIL(Compress::DeflateDecompressor::decompress_all(compressed));
+    EXPECT(uncompressed == original);
 }
 
 TEST_CASE(deflate_round_trip_compress)
@@ -128,11 +126,9 @@ TEST_CASE(deflate_round_trip_compress)
     auto original = ByteBuffer::create_zeroed(2048).release_value();
     fill_with_random(original.bytes().trim(1024)); // we pre-filled the second half with 0s to make sure we test back references as well
     // Since the different levels just change how much time is spent looking for better matches, just use fast here to reduce test time
-    auto compressed = Compress::DeflateCompressor::compress_all(original, Compress::DeflateCompressor::CompressionLevel::FAST);
-    EXPECT(!compressed.is_error());
-    auto uncompressed = Compress::DeflateDecompressor::decompress_all(compressed.value());
-    EXPECT(!uncompressed.is_error());
-    EXPECT(uncompressed.value() == original);
+    auto compressed = TRY_OR_FAIL(Compress::DeflateCompressor::compress_all(original, Compress::DeflateCompressor::CompressionLevel::FAST));
+    auto uncompressed = TRY_OR_FAIL(Compress::DeflateDecompressor::decompress_all(compressed));
+    EXPECT(uncompressed == original);
 }
 
 TEST_CASE(deflate_round_trip_compress_large)
@@ -141,17 +137,14 @@ TEST_CASE(deflate_round_trip_compress_large)
     auto original = ByteBuffer::create_uninitialized(size).release_value(); // Compress a buffer larger than the maximum block size to test the sliding window mechanism
     fill_with_random(original);
     // Since the different levels just change how much time is spent looking for better matches, just use fast here to reduce test time
-    auto compressed = Compress::DeflateCompressor::compress_all(original, Compress::DeflateCompressor::CompressionLevel::FAST);
-    EXPECT(!compressed.is_error());
-    auto uncompressed = Compress::DeflateDecompressor::decompress_all(compressed.value());
-    EXPECT(!uncompressed.is_error());
-    EXPECT(uncompressed.value() == original);
+    auto compressed = TRY_OR_FAIL(Compress::DeflateCompressor::compress_all(original, Compress::DeflateCompressor::CompressionLevel::FAST));
+    auto uncompressed = TRY_OR_FAIL(Compress::DeflateDecompressor::decompress_all(compressed));
+    EXPECT(uncompressed == original);
 }
 
 TEST_CASE(deflate_compress_literals)
 {
     // This byte array is known to not produce any back references with our lz77 implementation even at the highest compression settings
     Array<u8, 0x13> test { 0, 0, 0, 0, 0x72, 0, 0, 0xee, 0, 0, 0, 0x26, 0, 0, 0, 0x28, 0, 0, 0x72 };
-    auto compressed = Compress::DeflateCompressor::compress_all(test, Compress::DeflateCompressor::CompressionLevel::GOOD);
-    EXPECT(!compressed.is_error());
+    auto compressed = TRY_OR_FAIL(Compress::DeflateCompressor::compress_all(test, Compress::DeflateCompressor::CompressionLevel::GOOD));
 }

--- a/Tests/LibCompress/TestGzip.cpp
+++ b/Tests/LibCompress/TestGzip.cpp
@@ -89,11 +89,9 @@ TEST_CASE(gzip_round_trip)
 {
     auto original = ByteBuffer::create_uninitialized(1024).release_value();
     fill_with_random(original);
-    auto compressed = Compress::GzipCompressor::compress_all(original);
-    EXPECT(!compressed.is_error());
-    auto uncompressed = Compress::GzipDecompressor::decompress_all(compressed.value());
-    EXPECT(!uncompressed.is_error());
-    EXPECT(uncompressed.value() == original);
+    auto compressed = TRY_OR_FAIL(Compress::GzipCompressor::compress_all(original));
+    auto uncompressed = TRY_OR_FAIL(Compress::GzipDecompressor::decompress_all(compressed));
+    EXPECT(uncompressed == original);
 }
 
 TEST_CASE(gzip_truncated_uncompressed_block)

--- a/Tests/LibCore/TestLibCoreFilePermissionsMask.cpp
+++ b/Tests/LibCore/TestLibCoreFilePermissionsMask.cpp
@@ -9,106 +9,96 @@
 
 TEST_CASE(file_permission_mask_from_symbolic_notation)
 {
-    auto mask = Core::FilePermissionsMask::from_symbolic_notation(""sv);
-    EXPECT(!mask.is_error());
-    EXPECT_EQ(mask.value().clear_mask(), 0);
-    EXPECT_EQ(mask.value().write_mask(), 0);
-    EXPECT_EQ(mask.value().apply(0), 0);
-    EXPECT_EQ(mask.value().apply(0664), 0664);
+    auto mask = TRY_OR_FAIL(Core::FilePermissionsMask::from_symbolic_notation(""sv));
+    EXPECT_EQ(mask.clear_mask(), 0);
+    EXPECT_EQ(mask.write_mask(), 0);
+    EXPECT_EQ(mask.apply(0), 0);
+    EXPECT_EQ(mask.apply(0664), 0664);
 
-    mask = Core::FilePermissionsMask::from_symbolic_notation("u+rwx"sv);
-    EXPECT(!mask.is_error());
-    EXPECT_EQ(mask.value().clear_mask(), 0);
-    EXPECT_EQ(mask.value().write_mask(), 0700);
-    EXPECT_EQ(mask.value().apply(0), 0700);
-    EXPECT_EQ(mask.value().apply(0664), 0764);
+    mask = TRY_OR_FAIL(Core::FilePermissionsMask::from_symbolic_notation("u+rwx"sv));
+    EXPECT_EQ(mask.clear_mask(), 0);
+    EXPECT_EQ(mask.write_mask(), 0700);
+    EXPECT_EQ(mask.apply(0), 0700);
+    EXPECT_EQ(mask.apply(0664), 0764);
 
-    mask = Core::FilePermissionsMask::from_symbolic_notation("g+rwx"sv);
-    EXPECT(!mask.is_error());
-    EXPECT_EQ(mask.value().clear_mask(), 0);
-    EXPECT_EQ(mask.value().write_mask(), 0070);
-    EXPECT_EQ(mask.value().apply(0), 0070);
-    EXPECT_EQ(mask.value().apply(0664), 0674);
+    mask = TRY_OR_FAIL(Core::FilePermissionsMask::from_symbolic_notation("g+rwx"sv));
+    EXPECT_EQ(mask.clear_mask(), 0);
+    EXPECT_EQ(mask.write_mask(), 0070);
+    EXPECT_EQ(mask.apply(0), 0070);
+    EXPECT_EQ(mask.apply(0664), 0674);
 
-    mask = Core::FilePermissionsMask::from_symbolic_notation("o+rwx"sv);
-    EXPECT(!mask.is_error());
-    EXPECT_EQ(mask.value().clear_mask(), 0);
-    EXPECT_EQ(mask.value().write_mask(), 0007);
-    EXPECT_EQ(mask.value().apply(0), 0007);
-    EXPECT_EQ(mask.value().apply(0664), 0667);
+    mask = TRY_OR_FAIL(Core::FilePermissionsMask::from_symbolic_notation("o+rwx"sv));
+    EXPECT_EQ(mask.clear_mask(), 0);
+    EXPECT_EQ(mask.write_mask(), 0007);
+    EXPECT_EQ(mask.apply(0), 0007);
+    EXPECT_EQ(mask.apply(0664), 0667);
 
-    mask = Core::FilePermissionsMask::from_symbolic_notation("a=rx"sv);
-    EXPECT(!mask.is_error());
-    EXPECT_EQ(mask.value().clear_mask(), 0777);
-    EXPECT_EQ(mask.value().write_mask(), 0555);
-    EXPECT_EQ(mask.value().apply(0), 0555);
-    EXPECT_EQ(mask.value().apply(0664), 0555);
+    mask = TRY_OR_FAIL(Core::FilePermissionsMask::from_symbolic_notation("a=rx"sv));
+    EXPECT_EQ(mask.clear_mask(), 0777);
+    EXPECT_EQ(mask.write_mask(), 0555);
+    EXPECT_EQ(mask.apply(0), 0555);
+    EXPECT_EQ(mask.apply(0664), 0555);
 
-    mask = Core::FilePermissionsMask::from_symbolic_notation("ugo=rx"sv);
-    EXPECT(!mask.is_error());
-    EXPECT_EQ(mask.value().clear_mask(), 0777);
-    EXPECT_EQ(mask.value().write_mask(), 0555);
-    EXPECT_EQ(mask.value().apply(0), 0555);
-    EXPECT_EQ(mask.value().apply(0664), 0555);
+    mask = TRY_OR_FAIL(Core::FilePermissionsMask::from_symbolic_notation("ugo=rx"sv));
+    EXPECT_EQ(mask.clear_mask(), 0777);
+    EXPECT_EQ(mask.write_mask(), 0555);
+    EXPECT_EQ(mask.apply(0), 0555);
+    EXPECT_EQ(mask.apply(0664), 0555);
 
-    mask = Core::FilePermissionsMask::from_symbolic_notation("u+rw,g=rx,o-rwx"sv);
-    EXPECT(!mask.is_error());
-    EXPECT_EQ(mask.value().clear_mask(), 0077);
-    EXPECT_EQ(mask.value().write_mask(), 0650);
-    EXPECT_EQ(mask.value().apply(0), 0650);
-    EXPECT_EQ(mask.value().apply(0177), 0750);
+    mask = TRY_OR_FAIL(Core::FilePermissionsMask::from_symbolic_notation("u+rw,g=rx,o-rwx"sv));
+    EXPECT_EQ(mask.clear_mask(), 0077);
+    EXPECT_EQ(mask.write_mask(), 0650);
+    EXPECT_EQ(mask.apply(0), 0650);
+    EXPECT_EQ(mask.apply(0177), 0750);
 
-    mask = Core::FilePermissionsMask::from_symbolic_notation("+r"sv);
-    EXPECT(!mask.is_error());
-    EXPECT_EQ(mask.value().clear_mask(), 0);
-    EXPECT_EQ(mask.value().write_mask(), 0444);
-    EXPECT_EQ(mask.value().apply(0), 0444);
-    EXPECT_EQ(mask.value().apply(0123), 0567);
+    mask = TRY_OR_FAIL(Core::FilePermissionsMask::from_symbolic_notation("+r"sv));
+    EXPECT_EQ(mask.clear_mask(), 0);
+    EXPECT_EQ(mask.write_mask(), 0444);
+    EXPECT_EQ(mask.apply(0), 0444);
+    EXPECT_EQ(mask.apply(0123), 0567);
 
-    mask = Core::FilePermissionsMask::from_symbolic_notation("=rx"sv);
-    EXPECT(!mask.is_error());
-    EXPECT_EQ(mask.value().clear_mask(), 0777);
-    EXPECT_EQ(mask.value().write_mask(), 0555);
-    EXPECT_EQ(mask.value().apply(0), 0555);
-    EXPECT_EQ(mask.value().apply(0664), 0555);
+    mask = TRY_OR_FAIL(Core::FilePermissionsMask::from_symbolic_notation("=rx"sv));
+    EXPECT_EQ(mask.clear_mask(), 0777);
+    EXPECT_EQ(mask.write_mask(), 0555);
+    EXPECT_EQ(mask.apply(0), 0555);
+    EXPECT_EQ(mask.apply(0664), 0555);
 
-    mask = Core::FilePermissionsMask::from_symbolic_notation("a+X"sv);
-    EXPECT(!mask.is_error());
-    EXPECT_EQ(mask.value().clear_mask(), 0);
-    EXPECT_EQ(mask.value().write_mask(), 0);
-    EXPECT_EQ(mask.value().directory_or_executable_mask().clear_mask(), 0);
-    EXPECT_EQ(mask.value().directory_or_executable_mask().write_mask(), 0111);
-    EXPECT_EQ(mask.value().apply(0), 0);
-    EXPECT_EQ(mask.value().apply(0100), 0111);
-    EXPECT_EQ(mask.value().apply(S_IFDIR | 0), S_IFDIR | 0111);
+    mask = TRY_OR_FAIL(Core::FilePermissionsMask::from_symbolic_notation("a+X"sv));
+    EXPECT_EQ(mask.clear_mask(), 0);
+    EXPECT_EQ(mask.write_mask(), 0);
+    EXPECT_EQ(mask.directory_or_executable_mask().clear_mask(), 0);
+    EXPECT_EQ(mask.directory_or_executable_mask().write_mask(), 0111);
+    EXPECT_EQ(mask.apply(0), 0);
+    EXPECT_EQ(mask.apply(0100), 0111);
+    EXPECT_EQ(mask.apply(S_IFDIR | 0), S_IFDIR | 0111);
 
-    mask = Core::FilePermissionsMask::from_symbolic_notation("z+rw"sv);
-    EXPECT(mask.is_error());
-    EXPECT(mask.error().string_literal().starts_with("invalid class"sv));
+    auto mask_error = Core::FilePermissionsMask::from_symbolic_notation("z+rw"sv);
+    EXPECT(mask_error.is_error());
+    EXPECT(mask_error.error().string_literal().starts_with("invalid class"sv));
 
-    mask = Core::FilePermissionsMask::from_symbolic_notation("u*rw"sv);
-    EXPECT(mask.is_error());
-    EXPECT(mask.error().string_literal().starts_with("invalid operation"sv));
+    mask_error = Core::FilePermissionsMask::from_symbolic_notation("u*rw"sv);
+    EXPECT(mask_error.is_error());
+    EXPECT(mask_error.error().string_literal().starts_with("invalid operation"sv));
 
-    mask = Core::FilePermissionsMask::from_symbolic_notation("u+rz"sv);
-    EXPECT(mask.is_error());
-    EXPECT(mask.error().string_literal().starts_with("invalid symbolic permission"sv));
+    mask_error = Core::FilePermissionsMask::from_symbolic_notation("u+rz"sv);
+    EXPECT(mask_error.is_error());
+    EXPECT(mask_error.error().string_literal().starts_with("invalid symbolic permission"sv));
 
-    mask = Core::FilePermissionsMask::from_symbolic_notation("u+rw;g+rw"sv);
-    EXPECT(mask.is_error());
-    EXPECT(mask.error().string_literal().starts_with("invalid symbolic permission"sv));
+    mask_error = Core::FilePermissionsMask::from_symbolic_notation("u+rw;g+rw"sv);
+    EXPECT(mask_error.is_error());
+    EXPECT(mask_error.error().string_literal().starts_with("invalid symbolic permission"sv));
 }
 
 TEST_CASE(file_permission_mask_parse)
 {
-    auto numeric_mask = Core::FilePermissionsMask::parse("750"sv);
-    auto symbolic_mask = Core::FilePermissionsMask::parse("u=rwx,g=rx,o-rwx"sv);
+    auto numeric_mask = TRY_OR_FAIL(Core::FilePermissionsMask::parse("750"sv));
+    auto symbolic_mask = TRY_OR_FAIL(Core::FilePermissionsMask::parse("u=rwx,g=rx,o-rwx"sv));
 
-    EXPECT_EQ(numeric_mask.value().apply(0), 0750);
-    EXPECT_EQ(symbolic_mask.value().apply(0), 0750);
+    EXPECT_EQ(numeric_mask.apply(0), 0750);
+    EXPECT_EQ(symbolic_mask.apply(0), 0750);
 
-    EXPECT_EQ(numeric_mask.value().clear_mask(), symbolic_mask.value().clear_mask());
-    EXPECT_EQ(numeric_mask.value().write_mask(), symbolic_mask.value().write_mask());
+    EXPECT_EQ(numeric_mask.clear_mask(), symbolic_mask.clear_mask());
+    EXPECT_EQ(numeric_mask.write_mask(), symbolic_mask.write_mask());
 
     auto mask = Core::FilePermissionsMask::parse("888"sv);
     EXPECT(mask.is_error());
@@ -120,20 +110,17 @@ TEST_CASE(file_permission_mask_parse)
 TEST_CASE(numeric_mask_special_bits)
 {
     {
-        auto mask = Core::FilePermissionsMask::parse("750"sv);
-        EXPECT(!mask.is_error());
-        EXPECT_EQ(mask.value().apply(07000), 07750);
+        auto mask = TRY_OR_FAIL(Core::FilePermissionsMask::parse("750"sv));
+        EXPECT_EQ(mask.apply(07000), 07750);
     }
 
     {
-        auto mask = Core::FilePermissionsMask::parse("7750"sv);
-        EXPECT(!mask.is_error());
-        EXPECT_EQ(mask.value().apply(0), 07750);
+        auto mask = TRY_OR_FAIL(Core::FilePermissionsMask::parse("7750"sv));
+        EXPECT_EQ(mask.apply(0), 07750);
     }
 
     {
-        auto mask = Core::FilePermissionsMask::parse("0750"sv);
-        EXPECT(!mask.is_error());
-        EXPECT_EQ(mask.value().apply(07000), 0750);
+        auto mask = TRY_OR_FAIL(Core::FilePermissionsMask::parse("0750"sv));
+        EXPECT_EQ(mask.apply(07000), 0750);
     }
 }

--- a/Tests/LibCore/TestLibCoreSharedSingleProducerCircularQueue.cpp
+++ b/Tests/LibCore/TestLibCoreSharedSingleProducerCircularQueue.cpp
@@ -20,7 +20,7 @@ TEST_CASE(simple_enqueue)
 {
     auto queue = MUST(TestQueue::create());
     for (size_t i = 0; i < queue.size() - 1; ++i)
-        EXPECT(!queue.enqueue((int)i).is_error());
+        MUST(queue.enqueue((int)i));
 
     auto result = queue.enqueue(0);
     EXPECT(result.is_error());
@@ -34,9 +34,9 @@ TEST_CASE(simple_dequeue)
     for (int i = 0; i < test_count; ++i)
         (void)queue.enqueue(i);
     for (int i = 0; i < test_count; ++i) {
-        auto const element = queue.dequeue();
-        EXPECT(!element.is_error());
-        EXPECT_EQ(element.value(), i);
+        // TODO: This could be TRY_OR_FAIL(), if someone implements Formatter<SharedSingleProducerCircularQueue::QueueStatus>.
+        auto const element = MUST(queue.dequeue());
+        EXPECT_EQ(element, i);
     }
 }
 

--- a/Tests/LibELF/test-elf.cpp
+++ b/Tests/LibELF/test-elf.cpp
@@ -58,10 +58,8 @@ TEST_CASE(test_interp_header_tiny_p_filesz)
     int nwritten = write(fd, buffer, sizeof(buffer));
     EXPECT(nwritten);
 
-    auto elf_path_or_error = FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd));
-    EXPECT(!elf_path_or_error.is_error());
-
-    auto elf_path = elf_path_or_error.release_value().to_deprecated_string();
+    auto elf_path_string = TRY_OR_FAIL(FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd)));
+    auto elf_path = elf_path_string.to_deprecated_string();
     EXPECT(elf_path.characters());
 
     int rc = execl(elf_path.characters(), "test-elf", nullptr);
@@ -115,10 +113,8 @@ TEST_CASE(test_interp_header_p_filesz_larger_than_p_memsz)
     int nwritten = write(fd, buffer, sizeof(buffer));
     EXPECT(nwritten);
 
-    auto elf_path_or_error = FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd));
-    EXPECT(!elf_path_or_error.is_error());
-
-    auto elf_path = elf_path_or_error.release_value().to_deprecated_string();
+    auto elf_path_string = TRY_OR_FAIL(FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd)));
+    auto elf_path = elf_path_string.to_deprecated_string();
     EXPECT(elf_path.characters());
 
     int rc = execl(elf_path.characters(), "test-elf", nullptr);
@@ -176,10 +172,8 @@ TEST_CASE(test_interp_header_p_filesz_plus_p_offset_overflow_p_memsz)
     int nwritten = write(fd, buffer, sizeof(buffer));
     EXPECT(nwritten);
 
-    auto elf_path_or_error = FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd));
-    EXPECT(!elf_path_or_error.is_error());
-
-    auto elf_path = elf_path_or_error.release_value().to_deprecated_string();
+    auto elf_path_string = TRY_OR_FAIL(FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd)));
+    auto elf_path = elf_path_string.to_deprecated_string();
     EXPECT(elf_path.characters());
 
     int rc = execl(elf_path.characters(), "test-elf", nullptr);
@@ -234,10 +228,8 @@ TEST_CASE(test_load_header_p_memsz_zero)
     int nwritten = write(fd, buffer, sizeof(buffer));
     EXPECT(nwritten);
 
-    auto elf_path_or_error = FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd));
-    EXPECT(!elf_path_or_error.is_error());
-
-    auto elf_path = elf_path_or_error.release_value().to_deprecated_string();
+    auto elf_path_string = TRY_OR_FAIL(FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd)));
+    auto elf_path = elf_path_string.to_deprecated_string();
     EXPECT(elf_path.characters());
 
     int rc = execl(elf_path.characters(), "test-elf", nullptr);
@@ -292,10 +284,8 @@ TEST_CASE(test_load_header_p_memsz_not_equal_to_p_align)
     int nwritten = write(fd, buffer, sizeof(buffer));
     EXPECT(nwritten);
 
-    auto elf_path_or_error = FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd));
-    EXPECT(!elf_path_or_error.is_error());
-
-    auto elf_path = elf_path_or_error.release_value().to_deprecated_string();
+    auto elf_path_string = TRY_OR_FAIL(FileSystem::read_link(DeprecatedString::formatted("/proc/{}/fd/{}", getpid(), fd)));
+    auto elf_path = elf_path_string.to_deprecated_string();
     EXPECT(elf_path.characters());
 
     int rc = execl(elf_path.characters(), "test-elf", nullptr);

--- a/Tests/LibGfx/TestFontHandling.cpp
+++ b/Tests/LibGfx/TestFontHandling.cpp
@@ -146,24 +146,21 @@ TEST_CASE(test_write_to_file)
 
     char path[] = "/tmp/new.font.XXXXXX";
     EXPECT(mkstemp(path) != -1);
-    EXPECT(!font->write_to_file(path).is_error());
+    TRY_OR_FAIL(font->write_to_file(path));
     unlink(path);
 }
 
 TEST_CASE(test_character_set_masking)
 {
-    auto font = Gfx::BitmapFont::try_load_from_file(TEST_INPUT("TestFont.font"sv));
-    EXPECT(!font.is_error());
+    auto font = TRY_OR_FAIL(Gfx::BitmapFont::try_load_from_file(TEST_INPUT("TestFont.font"sv)));
 
-    auto unmasked_font = font.value()->unmasked_character_set();
-    EXPECT(!unmasked_font.is_error());
-    EXPECT(unmasked_font.value()->glyph_index(0x0041).value() == 0x0041);
-    EXPECT(unmasked_font.value()->glyph_index(0x0100).value() == 0x0100);
-    EXPECT(unmasked_font.value()->glyph_index(0xFFFD).value() == 0xFFFD);
+    auto unmasked_font = TRY_OR_FAIL(font->unmasked_character_set());
+    EXPECT(unmasked_font->glyph_index(0x0041).value() == 0x0041);
+    EXPECT(unmasked_font->glyph_index(0x0100).value() == 0x0100);
+    EXPECT(unmasked_font->glyph_index(0xFFFD).value() == 0xFFFD);
 
-    auto masked_font = unmasked_font.value()->masked_character_set();
-    EXPECT(!masked_font.is_error());
-    EXPECT(masked_font.value()->glyph_index(0x0041).value() == 0x0041);
-    EXPECT(!masked_font.value()->glyph_index(0x0100).has_value());
-    EXPECT(masked_font.value()->glyph_index(0xFFFD).value() == 0x1FD);
+    auto masked_font = TRY_OR_FAIL(unmasked_font->masked_character_set());
+    EXPECT(masked_font->glyph_index(0x0041).value() == 0x0041);
+    EXPECT(!masked_font->glyph_index(0x0100).has_value());
+    EXPECT(masked_font->glyph_index(0xFFFD).value() == 0x1FD);
 }

--- a/Tests/LibPDF/TestPDF.cpp
+++ b/Tests/LibPDF/TestPDF.cpp
@@ -14,28 +14,25 @@
 TEST_CASE(linearized_pdf)
 {
     auto file = Core::MappedFile::map("linearized.pdf"sv).release_value();
-    auto document = PDF::Document::create(file->bytes());
-    EXPECT(!document.is_error());
-    EXPECT(!document.value()->initialize().is_error());
-    EXPECT_EQ(document.value()->get_page_count(), 1U);
+    auto document = MUST(PDF::Document::create(file->bytes()));
+    MUST(document->initialize());
+    EXPECT_EQ(document->get_page_count(), 1U);
 }
 
 TEST_CASE(non_linearized_pdf)
 {
     auto file = Core::MappedFile::map("non-linearized.pdf"sv).release_value();
-    auto document = PDF::Document::create(file->bytes());
-    EXPECT(!document.is_error());
-    EXPECT(!document.value()->initialize().is_error());
-    EXPECT_EQ(document.value()->get_page_count(), 1U);
+    auto document = MUST(PDF::Document::create(file->bytes()));
+    MUST(document->initialize());
+    EXPECT_EQ(document->get_page_count(), 1U);
 }
 
 TEST_CASE(complex_pdf)
 {
     auto file = Core::MappedFile::map("complex.pdf"sv).release_value();
-    auto document = PDF::Document::create(file->bytes());
-    EXPECT(!document.is_error());
-    EXPECT(!document.value()->initialize().is_error());
-    EXPECT_EQ(document.value()->get_page_count(), 3U);
+    auto document = MUST(PDF::Document::create(file->bytes()));
+    MUST(document->initialize());
+    EXPECT_EQ(document->get_page_count(), 3U);
 }
 
 TEST_CASE(empty_file_issue_10702)

--- a/Tests/LibSQL/TestSqlBtreeIndex.cpp
+++ b/Tests/LibSQL/TestSqlBtreeIndex.cpp
@@ -146,7 +146,7 @@ void insert_and_get_to_and_from_btree(int num_keys)
     ScopeGuard guard([]() { unlink("/tmp/test.db"); });
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
-        EXPECT(!heap->open().is_error());
+        TRY_OR_FAIL(heap->open());
         SQL::Serializer serializer(heap);
         auto btree = setup_btree(serializer);
 
@@ -163,7 +163,7 @@ void insert_and_get_to_and_from_btree(int num_keys)
 
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
-        EXPECT(!heap->open().is_error());
+        TRY_OR_FAIL(heap->open());
         SQL::Serializer serializer(heap);
         auto btree = setup_btree(serializer);
 
@@ -182,7 +182,7 @@ void insert_into_and_scan_btree(int num_keys)
     ScopeGuard guard([]() { unlink("/tmp/test.db"); });
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
-        EXPECT(!heap->open().is_error());
+        TRY_OR_FAIL(heap->open());
         SQL::Serializer serializer(heap);
         auto btree = setup_btree(serializer);
 
@@ -200,7 +200,7 @@ void insert_into_and_scan_btree(int num_keys)
 
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
-        EXPECT(!heap->open().is_error());
+        TRY_OR_FAIL(heap->open());
         SQL::Serializer serializer(heap);
         auto btree = setup_btree(serializer);
 

--- a/Tests/LibSQL/TestSqlExpressionParser.cpp
+++ b/Tests/LibSQL/TestSqlExpressionParser.cpp
@@ -58,10 +58,7 @@ TEST_CASE(numeric_literal)
     // EXPECT(parse("0x"sv).is_error());
 
     auto validate = [](StringView sql, double expected_value) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::NumericLiteral>(*expression));
 
         const auto& literal = static_cast<const SQL::AST::NumericLiteral&>(*expression);
@@ -82,10 +79,7 @@ TEST_CASE(string_literal)
     EXPECT(parse("'unterminated"sv).is_error());
 
     auto validate = [](StringView sql, StringView expected_value) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::StringLiteral>(*expression));
 
         const auto& literal = static_cast<const SQL::AST::StringLiteral&>(*expression);
@@ -104,10 +98,7 @@ TEST_CASE(blob_literal)
     EXPECT(parse("x'NOTHEX'"sv).is_error());
 
     auto validate = [](StringView sql, StringView expected_value) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::BlobLiteral>(*expression));
 
         const auto& literal = static_cast<const SQL::AST::BlobLiteral&>(*expression);
@@ -121,10 +112,7 @@ TEST_CASE(blob_literal)
 TEST_CASE(boolean_literal)
 {
     auto validate = [](StringView sql, bool expected_value) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::BooleanLiteral>(*expression));
 
         auto const& literal = static_cast<SQL::AST::BooleanLiteral const&>(*expression);
@@ -138,10 +126,7 @@ TEST_CASE(boolean_literal)
 TEST_CASE(null_literal)
 {
     auto validate = [](StringView sql) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::NullLiteral>(*expression));
     };
 
@@ -151,10 +136,7 @@ TEST_CASE(null_literal)
 TEST_CASE(bind_parameter)
 {
     auto validate = [](StringView sql) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::Placeholder>(*expression));
     };
 
@@ -169,10 +151,7 @@ TEST_CASE(column_name)
     EXPECT(parse("\"unterminated"sv).is_error());
 
     auto validate = [](StringView sql, StringView expected_schema, StringView expected_table, StringView expected_column) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::ColumnNameExpression>(*expression));
 
         const auto& column = static_cast<const SQL::AST::ColumnNameExpression&>(*expression);
@@ -199,10 +178,7 @@ TEST_CASE(unary_operator)
     EXPECT(parse("NOT"sv).is_error());
 
     auto validate = [](StringView sql, SQL::AST::UnaryOperator expected_operator) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::UnaryOperatorExpression>(*expression));
 
         const auto& unary = static_cast<const SQL::AST::UnaryOperatorExpression&>(*expression);
@@ -261,10 +237,7 @@ TEST_CASE(binary_operator)
     }
 
     auto validate = [](StringView sql, SQL::AST::BinaryOperator expected_operator) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::BinaryOperatorExpression>(*expression));
 
         const auto& binary = static_cast<const SQL::AST::BinaryOperatorExpression&>(*expression);
@@ -289,10 +262,7 @@ TEST_CASE(chained_expression)
     EXPECT(parse("(15,)"sv).is_error());
 
     auto validate = [](StringView sql, size_t expected_chain_size) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::ChainedExpression>(*expression));
 
         const auto& chain = static_cast<const SQL::AST::ChainedExpression&>(*expression).expressions();
@@ -318,12 +288,7 @@ TEST_CASE(cast_expression)
     EXPECT(parse("CAST (15 AS int"sv).is_error());
 
     auto validate = [](StringView sql, StringView expected_type_name) {
-        auto result = parse(sql);
-        if (result.is_error())
-            outln("{}: {}", sql, result.error());
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::CastExpression>(*expression));
 
         const auto& cast = static_cast<const SQL::AST::CastExpression&>(*expression);
@@ -354,10 +319,7 @@ TEST_CASE(case_expression)
     EXPECT(parse("CASE WHEN 15 THEN 16 ELSE END"sv).is_error());
 
     auto validate = [](StringView sql, bool expect_case_expression, size_t expected_when_then_size, bool expect_else_expression) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::CaseExpression>(*expression));
 
         const auto& case_ = static_cast<const SQL::AST::CaseExpression&>(*expression);
@@ -407,10 +369,7 @@ TEST_CASE(exists_expression)
     EXPECT(parse("(SELECT * FROM table_name"sv).is_error());
 
     auto validate = [](StringView sql, bool expected_invert_expression) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::ExistsExpression>(*expression));
 
         const auto& exists = static_cast<const SQL::AST::ExistsExpression&>(*expression);
@@ -429,10 +388,7 @@ TEST_CASE(collate_expression)
     EXPECT(parse("15 COLLATE"sv).is_error());
 
     auto validate = [](StringView sql, StringView expected_collation_name) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::CollateExpression>(*expression));
 
         const auto& collate = static_cast<const SQL::AST::CollateExpression&>(*expression);
@@ -454,10 +410,7 @@ TEST_CASE(is_expression)
     EXPECT(parse("1 IS NOT"sv).is_error());
 
     auto validate = [](StringView sql, bool expected_invert_expression) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::IsExpression>(*expression));
 
         const auto& is_ = static_cast<const SQL::AST::IsExpression&>(*expression);
@@ -494,10 +447,7 @@ TEST_CASE(match_expression)
     }
 
     auto validate = [](StringView sql, SQL::AST::MatchOperator expected_operator, bool expected_invert_expression, bool expect_escape) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::MatchExpression>(*expression));
 
         const auto& match = static_cast<const SQL::AST::MatchExpression&>(*expression);
@@ -536,10 +486,7 @@ TEST_CASE(null_expression)
     EXPECT(parse("15 NOT"sv).is_error());
 
     auto validate = [](StringView sql, bool expected_invert_expression) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::NullExpression>(*expression));
 
         const auto& null = static_cast<const SQL::AST::NullExpression&>(*expression);
@@ -563,10 +510,7 @@ TEST_CASE(between_expression)
     EXPECT(parse("15 BETWEEN 10 OR 20"sv).is_error());
 
     auto validate = [](StringView sql, bool expected_invert_expression) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::BetweenExpression>(*expression));
 
         const auto& between = static_cast<const SQL::AST::BetweenExpression&>(*expression);
@@ -588,10 +532,7 @@ TEST_CASE(in_table_expression)
     EXPECT(parse("NOT IN table_name"sv).is_error());
 
     auto validate = [](StringView sql, StringView expected_schema, StringView expected_table, bool expected_invert_expression) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::InTableExpression>(*expression));
 
         const auto& in = static_cast<const SQL::AST::InTableExpression&>(*expression);
@@ -614,10 +555,7 @@ TEST_CASE(in_chained_expression)
     EXPECT(parse("NOT IN ()"sv).is_error());
 
     auto validate = [](StringView sql, size_t expected_chain_size, bool expected_invert_expression) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::InChainedExpression>(*expression));
 
         const auto& in = static_cast<const SQL::AST::InChainedExpression&>(*expression);
@@ -646,10 +584,7 @@ TEST_CASE(in_selection_expression)
     EXPECT(parse("NOT IN (SELECT * FROM table_name, SELECT * FROM table_name);"sv).is_error());
 
     auto validate = [](StringView sql, bool expected_invert_expression) {
-        auto result = parse(sql);
-        EXPECT(!result.is_error());
-
-        auto expression = result.release_value();
+        auto expression = TRY_OR_FAIL(parse(sql));
         EXPECT(is<SQL::AST::InSelectionExpression>(*expression));
 
         const auto& in = static_cast<const SQL::AST::InSelectionExpression&>(*expression);

--- a/Tests/LibSQL/TestSqlHashIndex.cpp
+++ b/Tests/LibSQL/TestSqlHashIndex.cpp
@@ -141,7 +141,7 @@ void insert_and_get_to_and_from_hash_index(int num_keys)
     ScopeGuard guard([]() { unlink("/tmp/test.db"); });
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
-        EXPECT(!heap->open().is_error());
+        TRY_OR_FAIL(heap->open());
         SQL::Serializer serializer(heap);
         auto hash_index = setup_hash_index(serializer);
 
@@ -159,7 +159,7 @@ void insert_and_get_to_and_from_hash_index(int num_keys)
 
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
-        EXPECT(!heap->open().is_error());
+        TRY_OR_FAIL(heap->open());
         SQL::Serializer serializer(heap);
         auto hash_index = setup_hash_index(serializer);
 
@@ -239,7 +239,7 @@ void insert_into_and_scan_hash_index(int num_keys)
     ScopeGuard guard([]() { unlink("/tmp/test.db"); });
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
-        EXPECT(!heap->open().is_error());
+        TRY_OR_FAIL(heap->open());
         SQL::Serializer serializer(heap);
         auto hash_index = setup_hash_index(serializer);
 
@@ -257,7 +257,7 @@ void insert_into_and_scan_hash_index(int num_keys)
 
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
-        EXPECT(!heap->open().is_error());
+        TRY_OR_FAIL(heap->open());
         SQL::Serializer serializer(heap);
         auto hash_index = setup_hash_index(serializer);
         Vector<bool> found;

--- a/Tests/LibSQL/TestSqlValueAndTuple.cpp
+++ b/Tests/LibSQL/TestSqlValueAndTuple.cpp
@@ -688,7 +688,6 @@ TEST_CASE(add)
         SQL::Value value2 { 42 };
 
         auto result = value1.add(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 63);
     }
@@ -697,7 +696,6 @@ TEST_CASE(add)
         SQL::Value value2 { static_cast<u8>(42) };
 
         auto result = value1.add(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 63);
     }
@@ -706,7 +704,6 @@ TEST_CASE(add)
         SQL::Value value2 { 42 };
 
         auto result = value1.add(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 63);
     }
@@ -715,7 +712,6 @@ TEST_CASE(add)
         SQL::Value value2 { 42 };
 
         auto result = value1.add(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 63);
     }
@@ -724,7 +720,6 @@ TEST_CASE(add)
         SQL::Value value2 { 42 };
 
         auto result = value1.add(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Float);
         EXPECT((result.value().to_double().value() - 63.5) < NumericLimits<double>().epsilon());
     }
@@ -777,7 +772,6 @@ TEST_CASE(subtract)
         SQL::Value value2 { 42 };
 
         auto result = value1.subtract(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), -21);
     }
@@ -786,7 +780,6 @@ TEST_CASE(subtract)
         SQL::Value value2 { static_cast<u8>(42) };
 
         auto result = value1.subtract(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), -21);
     }
@@ -795,7 +788,6 @@ TEST_CASE(subtract)
         SQL::Value value2 { 21 };
 
         auto result = value1.subtract(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 21);
     }
@@ -804,7 +796,6 @@ TEST_CASE(subtract)
         SQL::Value value2 { 42 };
 
         auto result = value1.subtract(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), -21);
     }
@@ -813,7 +804,6 @@ TEST_CASE(subtract)
         SQL::Value value2 { 42 };
 
         auto result = value1.subtract(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Float);
         EXPECT((result.value().to_double().value() - 20.5) < NumericLimits<double>().epsilon());
     }
@@ -866,7 +856,6 @@ TEST_CASE(multiply)
         SQL::Value value2 { 21 };
 
         auto result = value1.multiply(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 42);
     }
@@ -875,7 +864,6 @@ TEST_CASE(multiply)
         SQL::Value value2 { static_cast<u8>(21) };
 
         auto result = value1.multiply(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 42);
     }
@@ -884,7 +872,6 @@ TEST_CASE(multiply)
         SQL::Value value2 { 21 };
 
         auto result = value1.multiply(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 42);
     }
@@ -893,7 +880,6 @@ TEST_CASE(multiply)
         SQL::Value value2 { 21 };
 
         auto result = value1.multiply(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 42);
     }
@@ -902,7 +888,6 @@ TEST_CASE(multiply)
         SQL::Value value2 { 21 };
 
         auto result = value1.multiply(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Float);
         EXPECT((result.value().to_double().value() - 52.5) < NumericLimits<double>().epsilon());
     }
@@ -955,7 +940,6 @@ TEST_CASE(divide)
         SQL::Value value2 { -2 };
 
         auto result = value1.divide(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), -21);
     }
@@ -964,7 +948,6 @@ TEST_CASE(divide)
         SQL::Value value2 { static_cast<u8>(2) };
 
         auto result = value1.divide(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 21);
     }
@@ -973,7 +956,6 @@ TEST_CASE(divide)
         SQL::Value value2 { 2 };
 
         auto result = value1.divide(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 21);
     }
@@ -982,7 +964,6 @@ TEST_CASE(divide)
         SQL::Value value2 { 2 };
 
         auto result = value1.divide(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 21);
     }
@@ -991,7 +972,6 @@ TEST_CASE(divide)
         SQL::Value value2 { 2 };
 
         auto result = value1.divide(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Float);
         EXPECT((result.value().to_double().value() - 21.5) < NumericLimits<double>().epsilon());
     }
@@ -1026,7 +1006,6 @@ TEST_CASE(modulo)
         SQL::Value value2 { 2 };
 
         auto result = value1.modulo(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 1);
     }
@@ -1035,7 +1014,6 @@ TEST_CASE(modulo)
         SQL::Value value2 { static_cast<u8>(2) };
 
         auto result = value1.modulo(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 1);
     }
@@ -1044,7 +1022,6 @@ TEST_CASE(modulo)
         SQL::Value value2 { 2 };
 
         auto result = value1.modulo(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 1);
     }
@@ -1053,7 +1030,6 @@ TEST_CASE(modulo)
         SQL::Value value2 { 2 };
 
         auto result = value1.modulo(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 1);
     }
@@ -1115,7 +1091,6 @@ TEST_CASE(shift_left)
         SQL::Value value2 { 2 };
 
         auto result = value1.shift_left(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 0b1100'0000);
     }
@@ -1124,7 +1099,6 @@ TEST_CASE(shift_left)
         SQL::Value value2 { static_cast<u8>(2) };
 
         auto result = value1.shift_left(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 0b1100'0000);
     }
@@ -1133,7 +1107,6 @@ TEST_CASE(shift_left)
         SQL::Value value2 { 2 };
 
         auto result = value1.shift_left(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 0b1100'0000);
     }
@@ -1142,7 +1115,6 @@ TEST_CASE(shift_left)
         SQL::Value value2 { 2 };
 
         auto result = value1.shift_left(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 0b1100'0000);
     }
@@ -1213,7 +1185,6 @@ TEST_CASE(shift_right)
         SQL::Value value2 { 2 };
 
         auto result = value1.shift_right(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 0b0000'1100);
     }
@@ -1222,7 +1193,6 @@ TEST_CASE(shift_right)
         SQL::Value value2 { static_cast<u8>(2) };
 
         auto result = value1.shift_right(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 0b0000'1100);
     }
@@ -1231,7 +1201,6 @@ TEST_CASE(shift_right)
         SQL::Value value2 { 2 };
 
         auto result = value1.shift_right(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 0b0000'1100);
     }
@@ -1240,7 +1209,6 @@ TEST_CASE(shift_right)
         SQL::Value value2 { 2 };
 
         auto result = value1.shift_right(value2);
-        EXPECT(!result.is_error());
         EXPECT_EQ(result.value().type(), SQL::SQLType::Integer);
         EXPECT_EQ(result.value(), 0b0000'1100);
     }

--- a/Tests/LibThreading/TestThread.cpp
+++ b/Tests/LibThreading/TestThread.cpp
@@ -50,8 +50,6 @@ TEST_CASE(join_dead_thread)
     // The thread should have exited by then.
     usleep(40 * 1000);
 
-    auto join_result = thread->join<int*>();
-
-    EXPECT(!join_result.is_error());
-    EXPECT_EQ(join_result.value(), static_cast<int*>(0));
+    auto join_result = TRY_OR_FAIL(thread->join<int*>());
+    EXPECT_EQ(join_result, static_cast<int*>(0));
 }


### PR DESCRIPTION
Inspired by: https://github.com/SerenityOS/serenity/pull/18710#discussion_r1186892445

Should I add a linter for this? It seems like overkill, so I didn't.

Note that `TestLibCoreSharedSingleProducerCircularQueue.cpp::simple_dequeue` is the only non-trivial change; and makes the code even simpler.

<details><summary><code>sed</code> invocation</summary>

Changed by doing:
```
git ls-files '*.cpp' | xargs sed -i -Ee 's,EXPECT\(!(.+)\.is_error\(\)\),MUST(\1),'
```
(… and then reformatting with clang-format.)

</details>