### PR TITLE
LibGUI: Increase autoscroll threshold value

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
@@ -333,9 +333,9 @@ Gfx::IntPoint AbstractScrollableWidget::automatic_scroll_delta_from_position(Gfx
     Gfx::IntPoint delta { 0, 0 };
 
     if (pos.y() < m_autoscroll_threshold)
-        delta.set_y(clamp(-(m_autoscroll_threshold - pos.y()), -m_autoscroll_threshold, 0));
+        delta.set_y(AK::min(pos.y() - m_autoscroll_threshold, 0));
     else if (pos.y() > widget_inner_rect().height() - m_autoscroll_threshold)
-        delta.set_y(clamp(m_autoscroll_threshold - (widget_inner_rect().height() - pos.y()), 0, m_autoscroll_threshold));
+        delta.set_y(AK::max(pos.y() + m_autoscroll_threshold - widget_inner_rect().height(), 0));
 
     if (pos.x() < m_autoscroll_threshold)
         delta.set_x(clamp(-(m_autoscroll_threshold - pos.x()), -m_autoscroll_threshold, 0));


### PR DESCRIPTION
Resolves #18398

The current auto-scroll threshold value of `20` is a little too low which causes a very slow rubberband auto-scroll.

I played with multiple values and `70` feels like a sweet spot.