### PR TITLE
Documentation: Add libslirp-dev as a required dependency for QEMU

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -38,7 +38,7 @@ you can build the recommended version of QEMU as provided by the toolchain by ru
 Note that you might need additional dev packages in order to build QEMU on your machine:
 
 ```console
-sudo apt install libgtk-3-dev libpixman-1-dev libsdl2-dev libspice-server-dev
+sudo apt install libgtk-3-dev libpixman-1-dev libsdl2-dev libslirp-dev libspice-server-dev
 ```
 
 #### CMake version 3.25.0 or later


### PR DESCRIPTION
After the update to QEMU 8.0 `libslirp-dev` is a required dependency.