### PR TITLE
LibWeb: Include fewer headers from DOM/Element.h

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -64,6 +64,7 @@ set(SOURCES
     CSS/Size.cpp
     CSS/StyleComputer.cpp
     CSS/StyleProperties.cpp
+    CSS/StyleProperty.cpp
     CSS/StyleSheet.cpp
     CSS/StyleSheetList.cpp
     CSS/StyleValue.cpp

--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Loader/ResourceLoader.h>

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -9,21 +9,10 @@
 #include <AK/DeprecatedString.h>
 #include <AK/Vector.h>
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/CSS/StyleProperty.h>
 #include <LibWeb/CSS/StyleValue.h>
 
 namespace Web::CSS {
-
-enum class Important {
-    No,
-    Yes,
-};
-
-struct StyleProperty {
-    Important important { Important::No };
-    CSS::PropertyID property_id;
-    NonnullRefPtr<StyleValue const> value;
-    DeprecatedString custom_name {};
-};
 
 class CSSStyleDeclaration : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(CSSStyleDeclaration, Bindings::PlatformObject);

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleSheetList.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
+#include <LibWeb/Layout/Node.h>
 
 namespace Web::CSS {
 

--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/CSS/MediaQuery.h>
 #include <LibWeb/CSS/Serialize.h>
+#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/Window.h>
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -54,6 +54,7 @@
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/FontCache.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
+#include <LibWeb/Layout/Node.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Platform/FontPlugin.h>
 #include <stdio.h>

--- a/Userland/Libraries/LibWeb/CSS/StyleProperty.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperty.cpp
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/CSS/StyleProperty.h>
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+StyleProperty::~StyleProperty() = default;
+
+}

--- a/Userland/Libraries/LibWeb/CSS/StyleProperty.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperty.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Web::CSS {
+
+enum class Important {
+    No,
+    Yes,
+};
+
+struct StyleProperty {
+    Important important { Important::No };
+    CSS::PropertyID property_id;
+    NonnullRefPtr<StyleValue const> value;
+    DeprecatedString custom_name {};
+};
+
+}

--- a/Userland/Libraries/LibWeb/CSS/StyleProperty.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperty.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <AK/DeprecatedString.h>
+#include <LibWeb/CSS/PropertyID.h>
+
 namespace Web::CSS {
 
 enum class Important {
@@ -14,6 +17,8 @@ enum class Important {
 };
 
 struct StyleProperty {
+    ~StyleProperty();
+
     Important important { Important::No };
     CSS::PropertyID property_id;
     NonnullRefPtr<StyleValue const> value;

--- a/Userland/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -7,6 +7,7 @@
 #include <AK/QuickSort.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/StyleSheetListPrototype.h>
+#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleSheetList.h>
 #include <LibWeb/DOM/Document.h>
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -8,9 +8,11 @@
  */
 
 #include "ImageStyleValue.h"
+#include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/Serialize.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Loader/ResourceLoader.h>
+#include <LibWeb/Painting/PaintContext.h>
 #include <LibWeb/Platform/Timer.h>
 
 namespace Web::CSS {

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -18,6 +18,7 @@
 #include <LibWeb/CSS/MediaQueryListEvent.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
+#include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/Comment.h>
 #include <LibWeb/DOM/CustomEvent.h>
 #include <LibWeb/DOM/DOMImplementation.h>

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -18,7 +18,6 @@
 #include <LibCore/Forward.h>
 #include <LibJS/Forward.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
-#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleSheetList.h>
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/DOM/NonElementParentNode.h>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1703,4 +1703,9 @@ size_t Element::attribute_list_size() const
     return m_attributes->length();
 }
 
+void Element::set_computed_css_values(RefPtr<CSS::StyleProperties> style)
+{
+    m_computed_css_values = move(style);
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/CSS/ResolvedCSSStyleDeclaration.h>
 #include <LibWeb/CSS/SelectorEngine.h>
 #include <LibWeb/CSS/StyleComputer.h>
+#include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/DOMTokenList.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
@@ -1671,6 +1672,14 @@ void Element::setup_custom_element_from_constructor(HTML::CustomElementDefinitio
 void Element::set_prefix(DeprecatedFlyString const& value)
 {
     m_qualified_name.set_prefix(value);
+}
+
+void Element::for_each_attribute(Function<void(DeprecatedFlyString const&, DeprecatedString const&)> callback) const
+{
+    for (size_t i = 0; i < m_attributes->length(); ++i) {
+        auto const* attribute = m_attributes->item(i);
+        callback(attribute->name(), attribute->value());
+    }
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1682,4 +1682,14 @@ void Element::for_each_attribute(Function<void(DeprecatedFlyString const&, Depre
     }
 }
 
+Layout::NodeWithStyle* Element::layout_node()
+{
+    return static_cast<Layout::NodeWithStyle*>(Node::layout_node());
+}
+
+Layout::NodeWithStyle const* Element::layout_node() const
+{
+    return static_cast<Layout::NodeWithStyle const*>(Node::layout_node());
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/ResolvedCSSStyleDeclaration.h>
 #include <LibWeb/CSS/SelectorEngine.h>
+#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/DOMTokenList.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/HTMLCollection.h>
+#include <LibWeb/DOM/NamedNodeMap.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/DOMParsing/InnerHTML.h>
@@ -1690,6 +1691,16 @@ Layout::NodeWithStyle* Element::layout_node()
 Layout::NodeWithStyle const* Element::layout_node() const
 {
     return static_cast<Layout::NodeWithStyle const*>(Node::layout_node());
+}
+
+bool Element::has_attributes() const
+{
+    return !m_attributes->is_empty();
+}
+
+size_t Element::attribute_list_size() const
+{
+    return m_attributes->length();
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -12,7 +12,7 @@
 #include <LibWeb/Bindings/ElementPrototype.h>
 #include <LibWeb/Bindings/ShadowRootPrototype.h>
 #include <LibWeb/Bindings/WindowGlobalMixin.h>
-#include <LibWeb/CSS/CSSStyleDeclaration.h>
+#include <LibWeb/CSS/StyleProperty.h>
 #include <LibWeb/DOM/ChildNode.h>
 #include <LibWeb/DOM/NamedNodeMap.h>
 #include <LibWeb/DOM/NonDocumentTypeChildNode.h>
@@ -132,8 +132,8 @@ public:
     };
     NeedsRelayout recompute_style();
 
-    Layout::NodeWithStyle* layout_node() { return static_cast<Layout::NodeWithStyle*>(Node::layout_node()); }
-    Layout::NodeWithStyle const* layout_node() const { return static_cast<Layout::NodeWithStyle const*>(Node::layout_node()); }
+    Layout::NodeWithStyle* layout_node();
+    Layout::NodeWithStyle const* layout_node() const;
 
     DeprecatedString name() const { return attribute(HTML::AttributeNames::name); }
 

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -15,7 +15,6 @@
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleProperty.h>
 #include <LibWeb/DOM/ChildNode.h>
-#include <LibWeb/DOM/NamedNodeMap.h>
 #include <LibWeb/DOM/NonDocumentTypeChildNode.h>
 #include <LibWeb/DOM/ParentNode.h>
 #include <LibWeb/DOM/QualifiedName.h>
@@ -89,7 +88,7 @@ public:
     DeprecatedFlyString const& namespace_uri() const { return namespace_(); }
 
     bool has_attribute(DeprecatedFlyString const& name) const;
-    bool has_attributes() const { return !m_attributes->is_empty(); }
+    bool has_attributes() const;
     DeprecatedString attribute(DeprecatedFlyString const& name) const { return get_attribute(name); }
     DeprecatedString get_attribute(DeprecatedFlyString const& name) const;
     WebIDL::ExceptionOr<void> set_attribute(DeprecatedFlyString const& name, DeprecatedString const& value);
@@ -98,7 +97,7 @@ public:
     WebIDL::ExceptionOr<JS::GCPtr<Attr>> set_attribute_node_ns(Attr&);
     void remove_attribute(DeprecatedFlyString const& name);
     WebIDL::ExceptionOr<bool> toggle_attribute(DeprecatedFlyString const& name, Optional<bool> force);
-    size_t attribute_list_size() const { return m_attributes->length(); }
+    size_t attribute_list_size() const;
     NamedNodeMap const* attributes() const { return m_attributes.ptr(); }
     Vector<DeprecatedString> get_attribute_names() const;
 

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -12,6 +12,7 @@
 #include <LibWeb/Bindings/ElementPrototype.h>
 #include <LibWeb/Bindings/ShadowRootPrototype.h>
 #include <LibWeb/Bindings/WindowGlobalMixin.h>
+#include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleProperty.h>
 #include <LibWeb/DOM/ChildNode.h>
 #include <LibWeb/DOM/NamedNodeMap.h>
@@ -23,7 +24,6 @@
 #include <LibWeb/HTML/TagNames.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Node.h>
-#include <LibWeb/Layout/TreeBuilder.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::DOM {

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -13,7 +13,6 @@
 #include <LibWeb/Bindings/ShadowRootPrototype.h>
 #include <LibWeb/Bindings/WindowGlobalMixin.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
-#include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/ChildNode.h>
 #include <LibWeb/DOM/NamedNodeMap.h>
 #include <LibWeb/DOM/NonDocumentTypeChildNode.h>
@@ -118,14 +117,7 @@ public:
     int client_width() const;
     int client_height() const;
 
-    template<typename Callback>
-    void for_each_attribute(Callback callback) const
-    {
-        for (size_t i = 0; i < m_attributes->length(); ++i) {
-            auto const* attribute = m_attributes->item(i);
-            callback(attribute->name(), attribute->value());
-        }
-    }
+    void for_each_attribute(Function<void(DeprecatedFlyString const&, DeprecatedString const&)>) const;
 
     bool has_class(FlyString const&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
     Vector<FlyString> const& class_names() const { return m_classes; }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -19,8 +19,8 @@
 #include <LibWeb/DOM/QualifiedName.h>
 #include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/EventLoop/Task.h>
+#include <LibWeb/HTML/ScrollOptions.h>
 #include <LibWeb/HTML/TagNames.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -21,7 +21,6 @@
 #include <LibWeb/HTML/EventLoop/Task.h>
 #include <LibWeb/HTML/ScrollOptions.h>
 #include <LibWeb/HTML/TagNames.h>
-#include <LibWeb/Layout/Node.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::DOM {
@@ -137,7 +136,7 @@ public:
 
     CSS::StyleProperties* computed_css_values() { return m_computed_css_values.ptr(); }
     CSS::StyleProperties const* computed_css_values() const { return m_computed_css_values.ptr(); }
-    void set_computed_css_values(RefPtr<CSS::StyleProperties> style) { m_computed_css_values = move(style); }
+    void set_computed_css_values(RefPtr<CSS::StyleProperties>);
     NonnullRefPtr<CSS::StyleProperties> resolved_css_values();
 
     CSS::CSSStyleDeclaration const* inline_style() const;

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -11,7 +11,6 @@
 #include <LibWeb/ARIA/ARIAMixin.h>
 #include <LibWeb/Bindings/ElementPrototype.h>
 #include <LibWeb/Bindings/ShadowRootPrototype.h>
-#include <LibWeb/Bindings/WindowGlobalMixin.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleProperty.h>
 #include <LibWeb/DOM/ChildNode.h>

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -13,7 +13,6 @@
 #include <LibWeb/Bindings/ShadowRootPrototype.h>
 #include <LibWeb/Bindings/WindowGlobalMixin.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
-#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/ChildNode.h>
 #include <LibWeb/DOM/NamedNodeMap.h>

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -14,6 +14,7 @@
 #include <LibRegex/Regex.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Bindings/NodePrototype.h>
+#include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/Comment.h>
 #include <LibWeb/DOM/DocumentType.h>
 #include <LibWeb/DOM/Element.h>

--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/DOM/DocumentFragment.h>
 #include <LibWeb/DOM/DocumentType.h>
 #include <LibWeb/DOM/Element.h>
+#include <LibWeb/DOM/NamedNodeMap.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/ProcessingInstruction.h>
 #include <LibWeb/DOM/Text.h>

--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/CDATASection.h>
 #include <LibWeb/DOM/Comment.h>
 #include <LibWeb/DOM/Document.h>

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -448,6 +448,7 @@ class RadioButton;
 class ReplacedBox;
 class TableWrapper;
 class TextNode;
+class TreeBuilder;
 class VideoBox;
 class Viewport;
 

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <LibJS/Forward.h>
 #include <LibWeb/Bindings/Forward.h>
 
 namespace Web {
@@ -582,6 +583,8 @@ class DOMException;
 
 template<typename ValueType>
 class ExceptionOr;
+
+using Promise = JS::PromiseCapability;
 }
 
 namespace Web::WebSockets {

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -163,6 +163,8 @@ class URLStyleValue;
 enum class MediaFeatureID;
 enum class PropertyID;
 enum class ValueID;
+
+struct BackgroundLayerData;
 }
 
 namespace Web::CSS::Parser {

--- a/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/GenericLexer.h>
+#include <AK/Random.h>
 #include <LibWeb/HTML/FormControlInfrastructure.h>
 #include <LibWeb/HTML/FormDataEvent.h>
 #include <LibWeb/HTML/HTMLButtonElement.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLBlinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBlinkElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/HTML/HTMLBlinkElement.h>
+#include <LibWeb/Layout/Node.h>
 #include <LibWeb/Platform/Timer.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLBodyElement.h>
 #include <LibWeb/HTML/Window.h>
+#include <LibWeb/Layout/Node.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
 #include <LibWeb/HTML/HTMLHeadingElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
+#include <LibWeb/Layout/Node.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/HTML/HTMLMarqueeElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -28,6 +28,7 @@
 #include <LibWeb/HTML/TrackEvent.h>
 #include <LibWeb/HTML/VideoTrack.h>
 #include <LibWeb/HTML/VideoTrackList.h>
+#include <LibWeb/Layout/Node.h>
 #include <LibWeb/MimeSniff/MimeType.h>
 #include <LibWeb/WebIDL/Promise.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
 #include <LibWeb/HTML/HTMLParagraphElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLPreElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLPreElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
 #include <LibWeb/HTML/HTMLPreElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCaptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCaptionElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
 #include <LibWeb/HTML/HTMLTableCaptionElement.h>
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
 #include <LibWeb/HTML/HTMLTableCellElement.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -7,6 +7,7 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/HTMLCollection.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -8,9 +8,11 @@
 
 #include <AK/Optional.h>
 #include <LibGfx/Forward.h>
+#include <LibGfx/Rect.h>
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>
+#include <LibWeb/PixelUnits.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
+#include <AK/GenericShorthands.h>
 #include <AK/SourceLocation.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibWeb/HTML/Parser/Entities.h>

--- a/Userland/Libraries/LibWeb/HTML/ScrollOptions.h
+++ b/Userland/Libraries/LibWeb/HTML/ScrollOptions.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Bindings/WindowGlobalMixin.h>
+
+namespace Web::HTML {
+
+// https://w3c.github.io/csswg-drafts/cssom-view/#dictdef-scrolloptions
+struct ScrollOptions {
+    Bindings::ScrollBehavior behavior { Bindings::ScrollBehavior::Auto };
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -22,6 +22,7 @@
 #include <LibWeb/HTML/MimeType.h>
 #include <LibWeb/HTML/Plugin.h>
 #include <LibWeb/HTML/Scripting/ImportMap.h>
+#include <LibWeb/HTML/ScrollOptions.h>
 #include <LibWeb/HTML/WindowEventHandlers.h>
 #include <LibWeb/HTML/WindowOrWorkerGlobalScope.h>
 #include <LibWeb/RequestIdleCallback/IdleRequest.h>
@@ -29,11 +30,6 @@
 namespace Web::HTML {
 
 class IdleCallback;
-
-// https://w3c.github.io/csswg-drafts/cssom-view/#dictdef-scrolloptions
-struct ScrollOptions {
-    Bindings::ScrollBehavior behavior { Bindings::ScrollBehavior::Auto };
-};
 
 // https://w3c.github.io/csswg-drafts/cssom-view/#dictdef-scrolltooptions
 struct ScrollToOptions : public ScrollOptions {

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -9,6 +9,7 @@
 #include <AK/Error.h>
 #include <AK/Optional.h>
 #include <AK/TemporaryChange.h>
+#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibGfx/PaintStyle.h>
+#include <LibGfx/Painter.h>
 #include <LibGfx/Path.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/SVG/AttributeParser.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/SVGRadialGradientElement.h>
 

--- a/Userland/Libraries/LibWeb/SVG/SVGStopElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGStopElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/Color.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGAnimatedNumber.h>
 #include <LibWeb/SVG/SVGElement.h>

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -7,6 +7,7 @@
 #include <AK/Debug.h>
 #include <LibGL/GLContext.h>
 #include <LibWeb/HTML/HTMLCanvasElement.h>
+#include <LibWeb/Layout/Node.h>
 #include <LibWeb/WebGL/WebGLRenderingContextBase.h>
 
 namespace Web::WebGL {

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -18,6 +18,7 @@
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/ConsoleObject.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Dump.h>
 #include <LibWeb/HTML/BrowsingContext.h>


### PR DESCRIPTION
Editing DOM/Element.h currently causes a rebuild of ~650 translation units. This is hard to avoid, since it's included all over the place (including generated JS bindings.)

This PR aims to remove some includes from Element.h, partly to make it a bit lighter, but primarily to make it possible to edit certain other headers without triggering a 650+ TU rebuild.

After these changes, number of TUs rebuilt after touching...

* CSS/StyleComputer.h: 24
* Layout/Node.h: 125
* DOM/Attr.h: 135
* HTML/Window.h: 545

THe StyleComputer one is especially night-and-day, as you can see. :^)