### PR TITLE
LibWeb: Cache the root element font metrics when calculating them

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -102,7 +102,7 @@ private:
     void for_each_stylesheet(CascadeOrigin, Callback) const;
 
     CSSPixelRect viewport_rect() const;
-    Length::FontMetrics root_element_font_metrics() const;
+    [[nodiscard]] Length::FontMetrics calculate_root_element_font_metrics(StyleProperties const&) const;
     CSSPixels parent_or_root_element_line_height(DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const;
 
     struct MatchingRuleSet {
@@ -133,6 +133,9 @@ private:
 
     class FontLoader;
     HashMap<String, NonnullOwnPtr<FontLoader>> m_loaded_fonts;
+
+    Length::FontMetrics m_default_font_metrics;
+    Length::FontMetrics m_root_element_font_metrics;
 };
 
 }


### PR DESCRIPTION
The root element font metrics were getting queried again and again during style computation. Before this change we would do some work to recalculate them each time.

This patch simply caches them in a StyleComputer member. Since style updates always start with the root element, we know that it'll be up-to-date by the time we look at any other element.

Before this change, we were spending ~5% of CPU time on Google Groups in root_element_font_metrics().