### PR TITLE
Piano: Don't use get_note_for_x when deleting notes

### DIFF
--- a/Userland/Applications/Piano/RollWidget.h
+++ b/Userland/Applications/Piano/RollWidget.h
@@ -51,5 +51,6 @@ private:
     int m_prev_scroll_y { vertical_scrollbar().value() };
 
     u8 get_pitch_for_y(int y) const;
-    int get_note_for_x(int x) const;
+    u32 get_sample_for_x(int x) const;
+    u32 round_sample_to_note(u32 sample) const;
 };


### PR DESCRIPTION
There were cases when calculated sample was off by -1, causing invalid
note to be deleted (and every second note could not be deleted at all).
Now we just calculate exact sample that corresponds to the note as this
is used in note_at() anyway.
