### PR TITLE
WebP: Redo error handling, and move lossy decoding to its own file

### DIFF
--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SOURCES
     ImageFormats/TGALoader.cpp
     ImageFormats/WebPLoader.cpp
     ImageFormats/WebPLoaderLossless.cpp
+    ImageFormats/WebPLoaderLossy.cpp
     Painter.cpp
     Palette.cpp
     Path.cpp

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -11,11 +11,11 @@
 #include <AK/Vector.h>
 #include <LibGfx/ImageFormats/WebPLoader.h>
 #include <LibGfx/ImageFormats/WebPLoaderLossless.h>
+#include <LibGfx/ImageFormats/WebPLoaderLossy.h>
 #include <LibGfx/Painter.h>
 
 // Overview: https://developers.google.com/speed/webp/docs/compression
 // Container: https://developers.google.com/speed/webp/docs/riff_container
-// Lossy format: https://datatracker.ietf.org/doc/html/rfc6386
 
 namespace Gfx {
 
@@ -53,17 +53,6 @@ static_assert(AssertSize<ChunkHeader, 8>());
 struct Chunk {
     FourCC type;
     ReadonlyBytes data;
-};
-
-struct VP8Header {
-    u8 version;
-    bool show_frame;
-    u32 size_of_first_partition;
-    u32 width;
-    u8 horizontal_scale;
-    u32 height;
-    u8 vertical_scale;
-    ReadonlyBytes lossy_data;
 };
 
 struct VP8XHeader {
@@ -226,75 +215,6 @@ static ErrorOr<Chunk> decode_webp_advance_chunk(ReadonlyBytes& chunks)
     }
 
     return chunk;
-}
-
-// https://developers.google.com/speed/webp/docs/riff_container#simple_file_format_lossy
-// https://datatracker.ietf.org/doc/html/rfc6386#section-19 "Annex A: Bitstream Syntax"
-static ErrorOr<VP8Header> decode_webp_chunk_VP8_header(ReadonlyBytes vp8_data)
-{
-    if (vp8_data.size() < 10)
-        return Error::from_string_literal("WebPImageDecoderPlugin: 'VP8 ' chunk too small");
-
-    // FIXME: Eventually, this should probably call into LibVideo/VP8,
-    // and image decoders should move into LibImageDecoders which depends on both LibGfx and LibVideo.
-    // (LibVideo depends on LibGfx, so LibGfx can't depend on LibVideo itself.)
-
-    // https://datatracker.ietf.org/doc/html/rfc6386#section-4 "Overview of Compressed Data Format"
-    // "The decoder is simply presented with a sequence of compressed frames [...]
-    //  The first frame presented to the decompressor is [...] a key frame.  [...]
-    //  [E]very compressed frame has three or more pieces. It begins with an uncompressed data chunk comprising 10 bytes in the case of key frames
-
-    u8 const* data = vp8_data.data();
-
-    // https://datatracker.ietf.org/doc/html/rfc6386#section-9.1 "Uncompressed Data Chunk"
-    u32 frame_tag = data[0] | (data[1] << 8) | (data[2] << 16);
-    bool is_key_frame = (frame_tag & 1) == 0; // https://www.rfc-editor.org/errata/eid5534
-    u8 version = (frame_tag & 0xe) >> 1;
-    bool show_frame = (frame_tag & 0x10) != 0;
-    u32 size_of_first_partition = frame_tag >> 5;
-
-    if (!is_key_frame)
-        return Error::from_string_literal("WebPImageDecoderPlugin: 'VP8 ' chunk not a key frame");
-
-    // FIXME: !show_frame does not make sense in a webp file either, probably?
-
-    u32 start_code = data[3] | (data[4] << 8) | (data[5] << 16);
-    if (start_code != 0x2a019d) // https://www.rfc-editor.org/errata/eid7370
-        return Error::from_string_literal("WebPImageDecoderPlugin: 'VP8 ' chunk invalid start_code");
-
-    // "The scaling specifications for each dimension are encoded as follows.
-    //   0     | No upscaling (the most common case).
-    //   1     | Upscale by 5/4.
-    //   2     | Upscale by 5/3.
-    //   3     | Upscale by 2."
-    // This is a display-time operation and doesn't affect decoding.
-    u16 width_and_horizontal_scale = data[6] | (data[7] << 8);
-    u16 width = width_and_horizontal_scale & 0x3fff;
-    u8 horizontal_scale = width_and_horizontal_scale >> 14;
-
-    u16 heigth_and_vertical_scale = data[8] | (data[9] << 8);
-    u16 height = heigth_and_vertical_scale & 0x3fff;
-    u8 vertical_scale = heigth_and_vertical_scale >> 14;
-
-    dbgln_if(WEBP_DEBUG, "version {}, show_frame {}, size_of_first_partition {}, width {}, horizontal_scale {}, height {}, vertical_scale {}",
-        version, show_frame, size_of_first_partition, width, horizontal_scale, height, vertical_scale);
-
-    return VP8Header { version, show_frame, size_of_first_partition, width, horizontal_scale, height, vertical_scale, vp8_data.slice(10) };
-}
-
-static ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8_contents(VP8Header const& vp8_header, bool include_alpha_channel)
-{
-    auto bitmap_format = include_alpha_channel ? BitmapFormat::BGRA8888 : BitmapFormat::BGRx8888;
-
-    // Uncomment this to test ALPH decoding for WebP-lossy-with-alpha images while lossy decoding isn't implemented yet.
-#if 0
-    return Bitmap::create(bitmap_format, { vp8_header.width, vp8_header.height });
-#else
-    // FIXME: Implement webp lossy decoding.
-    (void)vp8_header;
-    (void)bitmap_format;
-    return Error::from_string_literal("WebPImageDecoderPlugin: decoding lossy webps not yet implemented");
-#endif
 }
 
 // https://developers.google.com/speed/webp/docs/riff_container#alpha

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -309,7 +309,6 @@ static ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L(WebPLoadingContext&
 {
     VERIFY(context.first_chunk->type == FourCC("VP8L") || context.first_chunk->type == FourCC("VP8X"));
     VERIFY(vp8l_chunk.type == FourCC("VP8L"));
-
     auto vp8l_header = TRY(decode_webp_chunk_VP8L_header(vp8l_chunk.data));
     return decode_webp_chunk_VP8L_contents(vp8l_header);
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -299,14 +299,6 @@ static ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8(Chunk const& vp8_chu
 #endif
 }
 
-static ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L(WebPLoadingContext const& context, Chunk const& vp8l_chunk)
-{
-    VERIFY(context.first_chunk->type == FourCC("VP8L") || context.first_chunk->type == FourCC("VP8X"));
-    VERIFY(vp8l_chunk.type == FourCC("VP8L"));
-    auto vp8l_header = TRY(decode_webp_chunk_VP8L_header(vp8l_chunk.data));
-    return decode_webp_chunk_VP8L_contents(vp8l_header);
-}
-
 // https://developers.google.com/speed/webp/docs/riff_container#alpha
 static ErrorOr<void> decode_webp_chunk_ALPH(Chunk const& alph_chunk, Bitmap& bitmap)
 {
@@ -640,11 +632,12 @@ static ErrorOr<ImageData> decode_webp_animation_frame_image_data(ANMFChunk const
     return decode_webp_set_image_data(move(alpha), move(image_data));
 }
 
-static ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_image_data(WebPLoadingContext const& context, ImageData const& image_data)
+static ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_image_data(ImageData const& image_data)
 {
     if (image_data.image_data_chunk.type == FourCC("VP8L")) {
         VERIFY(!image_data.alpha_chunk.has_value());
-        return decode_webp_chunk_VP8L(context, image_data.image_data_chunk);
+        auto vp8l_header = TRY(decode_webp_chunk_VP8L_header(image_data.image_data_chunk.data));
+        return decode_webp_chunk_VP8L_contents(vp8l_header);
     }
 
     VERIFY(image_data.image_data_chunk.type == FourCC("VP8 "));
@@ -693,7 +686,7 @@ static ErrorOr<ImageFrameDescriptor> decode_webp_animation_frame(WebPLoadingCont
         }
 
         auto frame_image_data = TRY(decode_webp_animation_frame_image_data(frame_description));
-        auto frame_bitmap = TRY(decode_webp_image_data(context, frame_image_data));
+        auto frame_bitmap = TRY(decode_webp_image_data(frame_image_data));
         if (static_cast<u32>(frame_bitmap->width()) != frame_description.frame_width || static_cast<u32>(frame_bitmap->height()) != frame_description.frame_height)
             return Error::from_string_literal("WebPImageDecoderPlugin: decoded frame bitmap size doesn't match frame description size");
 
@@ -835,7 +828,7 @@ ErrorOr<ImageFrameDescriptor> WebPImageDecoderPlugin::frame(size_t index)
         }
 
         if (m_context->state < WebPLoadingContext::State::BitmapDecoded) {
-            auto bitmap = TRY(decode_webp_image_data(*m_context, m_context->image_data.value()));
+            auto bitmap = TRY(decode_webp_image_data(m_context->image_data.value()));
 
             // Check that size in VP8X chunk matches dimensions in VP8 or VP8L chunk if both are present.
             if (m_context->first_chunk->type == FourCC("VP8X")) {

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.h
@@ -31,6 +31,8 @@ public:
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
+    bool set_error(ErrorOr<void>&&);
+
     WebPImageDecoderPlugin(ReadonlyBytes, OwnPtr<WebPLoadingContext>);
 
     OwnPtr<WebPLoadingContext> m_context;

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.h
@@ -19,7 +19,9 @@ struct VP8LHeader {
     ReadonlyBytes lossless_data;
 };
 
+// Parses the header data in a VP8L chunk. Pass the payload of a `VP8L` chunk, after the tag and after the tag's data size.
 ErrorOr<VP8LHeader> decode_webp_chunk_VP8L_header(ReadonlyBytes vp8l_data);
-ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L_contents(VP8LHeader const& vp8l_header);
+
+ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L_contents(VP8LHeader const&);
 
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossy.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossy.cpp
@@ -29,7 +29,7 @@ ErrorOr<VP8Header> decode_webp_chunk_VP8_header(ReadonlyBytes vp8_data)
     // https://datatracker.ietf.org/doc/html/rfc6386#section-4 "Overview of Compressed Data Format"
     // "The decoder is simply presented with a sequence of compressed frames [...]
     //  The first frame presented to the decompressor is [...] a key frame.  [...]
-    //  [E]very compressed frame has three or more pieces. It begins with an uncompressed data chunk comprising 10 bytes in the case of key frames
+    //  [E]very compressed frame has three or more pieces. It begins with an uncompressed data chunk comprising 10 bytes in the case of key frames"
 
     u8 const* data = vp8_data.data();
 
@@ -54,7 +54,7 @@ ErrorOr<VP8Header> decode_webp_chunk_VP8_header(ReadonlyBytes vp8_data)
     //   1     | Upscale by 5/4.
     //   2     | Upscale by 5/3.
     //   3     | Upscale by 2."
-    // This is a display-time operation and doesn't affect decoding.
+    // This is a display-time operation and doesn't affect decoding."
     u16 width_and_horizontal_scale = data[6] | (data[7] << 8);
     u16 width = width_and_horizontal_scale & 0x3fff;
     u8 horizontal_scale = width_and_horizontal_scale >> 14;

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossy.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossy.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Debug.h>
+#include <AK/Endian.h>
+#include <AK/Format.h>
+#include <AK/MemoryStream.h>
+#include <AK/Vector.h>
+#include <LibGfx/ImageFormats/WebPLoaderLossy.h>
+
+// Lossy format: https://datatracker.ietf.org/doc/html/rfc6386
+
+namespace Gfx {
+
+// https://developers.google.com/speed/webp/docs/riff_container#simple_file_format_lossy
+// https://datatracker.ietf.org/doc/html/rfc6386#section-19 "Annex A: Bitstream Syntax"
+ErrorOr<VP8Header> decode_webp_chunk_VP8_header(ReadonlyBytes vp8_data)
+{
+    if (vp8_data.size() < 10)
+        return Error::from_string_literal("WebPImageDecoderPlugin: 'VP8 ' chunk too small");
+
+    // FIXME: Eventually, this should probably call into LibVideo/VP8,
+    // and image decoders should move into LibImageDecoders which depends on both LibGfx and LibVideo.
+    // (LibVideo depends on LibGfx, so LibGfx can't depend on LibVideo itself.)
+
+    // https://datatracker.ietf.org/doc/html/rfc6386#section-4 "Overview of Compressed Data Format"
+    // "The decoder is simply presented with a sequence of compressed frames [...]
+    //  The first frame presented to the decompressor is [...] a key frame.  [...]
+    //  [E]very compressed frame has three or more pieces. It begins with an uncompressed data chunk comprising 10 bytes in the case of key frames
+
+    u8 const* data = vp8_data.data();
+
+    // https://datatracker.ietf.org/doc/html/rfc6386#section-9.1 "Uncompressed Data Chunk"
+    u32 frame_tag = data[0] | (data[1] << 8) | (data[2] << 16);
+    bool is_key_frame = (frame_tag & 1) == 0; // https://www.rfc-editor.org/errata/eid5534
+    u8 version = (frame_tag & 0xe) >> 1;
+    bool show_frame = (frame_tag & 0x10) != 0;
+    u32 size_of_first_partition = frame_tag >> 5;
+
+    if (!is_key_frame)
+        return Error::from_string_literal("WebPImageDecoderPlugin: 'VP8 ' chunk not a key frame");
+
+    // FIXME: !show_frame does not make sense in a webp file either, probably?
+
+    u32 start_code = data[3] | (data[4] << 8) | (data[5] << 16);
+    if (start_code != 0x2a019d) // https://www.rfc-editor.org/errata/eid7370
+        return Error::from_string_literal("WebPImageDecoderPlugin: 'VP8 ' chunk invalid start_code");
+
+    // "The scaling specifications for each dimension are encoded as follows.
+    //   0     | No upscaling (the most common case).
+    //   1     | Upscale by 5/4.
+    //   2     | Upscale by 5/3.
+    //   3     | Upscale by 2."
+    // This is a display-time operation and doesn't affect decoding.
+    u16 width_and_horizontal_scale = data[6] | (data[7] << 8);
+    u16 width = width_and_horizontal_scale & 0x3fff;
+    u8 horizontal_scale = width_and_horizontal_scale >> 14;
+
+    u16 heigth_and_vertical_scale = data[8] | (data[9] << 8);
+    u16 height = heigth_and_vertical_scale & 0x3fff;
+    u8 vertical_scale = heigth_and_vertical_scale >> 14;
+
+    dbgln_if(WEBP_DEBUG, "version {}, show_frame {}, size_of_first_partition {}, width {}, horizontal_scale {}, height {}, vertical_scale {}",
+        version, show_frame, size_of_first_partition, width, horizontal_scale, height, vertical_scale);
+
+    return VP8Header { version, show_frame, size_of_first_partition, width, horizontal_scale, height, vertical_scale, vp8_data.slice(10) };
+}
+
+ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8_contents(VP8Header const& vp8_header, bool include_alpha_channel)
+{
+    auto bitmap_format = include_alpha_channel ? BitmapFormat::BGRA8888 : BitmapFormat::BGRx8888;
+
+    // Uncomment this to test ALPH decoding for WebP-lossy-with-alpha images while lossy decoding isn't implemented yet.
+#if 0
+    return Bitmap::create(bitmap_format, { vp8_header.width, vp8_header.height });
+#else
+    // FIXME: Implement webp lossy decoding.
+    (void)vp8_header;
+    (void)bitmap_format;
+    return Error::from_string_literal("WebPImageDecoderPlugin: decoding lossy webps not yet implemented");
+#endif
+}
+
+}

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossy.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossy.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Span.h>
+#include <AK/Types.h>
+#include <LibGfx/Bitmap.h>
+
+namespace Gfx {
+
+struct VP8Header {
+    u8 version;
+    bool show_frame;
+    u32 size_of_first_partition;
+    u32 width;
+    u8 horizontal_scale;
+    u32 height;
+    u8 vertical_scale;
+    ReadonlyBytes lossy_data;
+};
+
+// Parses the header data in a VP8 chunk. Pass the payload of a `VP8 ` chunk, after the tag and after the tag's data size.
+ErrorOr<VP8Header> decode_webp_chunk_VP8_header(ReadonlyBytes vp8_data);
+
+ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8_contents(VP8Header const&, bool include_alpha_channel);
+
+}


### PR DESCRIPTION
Basically two commits, plus some preparatory stuff.

1:

[LibGfx/WebP: Redo error handling](https://github.com/SerenityOS/serenity/commit/ae666d14b3639e76f47294c12f5b92bb22f6853f) 

Most places used to call `context.error()` to report an error,
which would set the context's state to `Error` and then return an
`Error::from_string_literal()`.

This is somewhat elegant, but it doesn't work: Some functions this
code calls returns ErrorOr<>s that aren't created by `context.error()`,
and for these we wouldn't enter the error state.

Instead, manually check error-ness at the leaf entry functions of the
class:

1. Add a set_error() helper for functions returning bool
2. In the two functions returning ErrorOr<>, awkwardly check the error
   manually.  If this becomes a very common pattern, maybe we can add
   a `TRY_WITH_HANDLER(expr, error_lambda)` which would invoke a
   lambda on error. We could use that here to set the error code.

No real behavior change (except we enter the error state more often
when something goes wrong).

------

2:

[LibGfx/WebP: Move lossy decoder to its own file](https://github.com/SerenityOS/serenity/commit/9681b961d47ee74947d77b576bf5d2699e72998e) 

Pure code move (except of removing `static` on the two public functions
in the new header), not behavior change.

There isn't a lot of lossy decoder yet, but it'll make implementing it
more convenient.
