### PR TITLE
LibGfx/JPEG: Discard the correct number of bytes

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -1042,8 +1042,8 @@ static ErrorOr<void> read_colour_encoding(Stream& stream, [[maybe_unused]] JPEGL
     auto const color_transform = TRY(stream.read_value<u8>());
 
     if (bytes_to_read > 6) {
-        dbgln_if(JPEG_DEBUG, "Unread bytes in App14 segment: {}", bytes_to_read - 1);
-        TRY(stream.discard(bytes_to_read - 1));
+        dbgln_if(JPEG_DEBUG, "Unread bytes in App14 segment: {}", bytes_to_read - 6);
+        TRY(stream.discard(bytes_to_read - 6));
     }
 
     switch (color_transform) {


### PR DESCRIPTION
This path has never been tested as it requires a non-standard APP
segment. We (un?)fortunately found one, and it exposed a silly bug.

Work towards fixing #18720