### PR TITLE
LibGfx/JPEG: Fix faded 4-channels images

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -1453,7 +1453,7 @@ static void inverse_dct(JPEGLoadingContext const& context, Vector<Macroblock>& m
                             macroblocks[mb_index].r[i * 8 + j] = clamp(macroblocks[mb_index].r[i * 8 + j] + 128, 0, 255);
                             macroblocks[mb_index].g[i * 8 + j] = clamp(macroblocks[mb_index].g[i * 8 + j] + 128, 0, 255);
                             macroblocks[mb_index].b[i * 8 + j] = clamp(macroblocks[mb_index].b[i * 8 + j] + 128, 0, 255);
-                            macroblocks[mb_index].k[i * 8 + j] = clamp(macroblocks[mb_index].b[i * 8 + j] + 128, 0, 255);
+                            macroblocks[mb_index].k[i * 8 + j] = clamp(macroblocks[mb_index].k[i * 8 + j] + 128, 0, 255);
                         }
                     }
                 }


### PR DESCRIPTION
CMYK images use to look faded, and we blamed the lack of ICC profile.
![faded](https://user-images.githubusercontent.com/26030965/236884682-41ddf517-5d0c-4132-9543-46be316b1e70.png)

But no, it was just a silly mistake that I made :disappointed:

![not faded](https://user-images.githubusercontent.com/26030965/236885251-a9918f31-521f-488b-b87e-7eef12061c7b.png)

