### PR TITLE
Ladybird: Allow right clicking and inspecting elements

### DIFF
--- a/Ladybird/BrowserWindow.cpp
+++ b/Ladybird/BrowserWindow.cpp
@@ -330,9 +330,26 @@ BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdrive
     QObject::connect(m_tabs_container, &QTabWidget::tabCloseRequested, this, &BrowserWindow::close_tab);
     QObject::connect(close_current_tab_action, &QAction::triggered, this, &BrowserWindow::close_current_tab);
 
+    setContextMenuPolicy(Qt::CustomContextMenu);
+    QObject::connect(this, &QWidget::customContextMenuRequested, this, &BrowserWindow::show_context_menu);
+
     new_tab(s_settings->new_tab_page(), Web::HTML::ActivateTab::Yes);
 
     setCentralWidget(m_tabs_container);
+}
+
+void BrowserWindow::show_context_menu(QPoint const& point)
+{
+    QMenu contextMenu("Context menu", this);
+
+    QAction inspect_action("&Inspect Element", this);
+    connect(&inspect_action, &QAction::triggered, this, [this] {
+        if (!m_current_tab)
+            return;
+        m_current_tab->view().show_inspector(WebContentView::InspectorTarget::HoveredElement);
+    });
+    contextMenu.addAction(&inspect_action);
+    contextMenu.exec(mapToGlobal(point));
 }
 
 void BrowserWindow::set_current_tab(Tab* tab)

--- a/Ladybird/BrowserWindow.h
+++ b/Ladybird/BrowserWindow.h
@@ -49,6 +49,7 @@ public slots:
     void reset_zoom();
     void select_all();
     void copy_selected_text();
+    void show_context_menu(QPoint const&);
 
 protected:
     bool eventFilter(QObject* obj, QEvent* event) override;

--- a/Ladybird/InspectorWidget.h
+++ b/Ladybird/InspectorWidget.h
@@ -30,6 +30,13 @@ public:
         bool operator==(Selection const& other) const = default;
     };
 
+    bool dom_loaded() const { return m_dom_loaded; }
+
+    void set_selection(Selection);
+    void clear_selection();
+
+    void select_default_node();
+
     void clear_dom_json();
     void set_dom_json(StringView dom_json);
 
@@ -52,6 +59,11 @@ private:
     ModelTranslator m_computed_style_model {};
     ModelTranslator m_resolved_style_model {};
     ModelTranslator m_custom_properties_model {};
+
+    QTreeView* m_dom_tree_view { nullptr };
+
+    bool m_dom_loaded { false };
+    Optional<Selection> m_pending_selection {};
 };
 
 }

--- a/Ladybird/ModelTranslator.h
+++ b/Ladybird/ModelTranslator.h
@@ -23,6 +23,11 @@ public:
         endResetModel();
     }
 
+    RefPtr<GUI::Model> underlying_model()
+    {
+        return m_model;
+    }
+
     virtual int columnCount(QModelIndex const& parent) const override;
     virtual int rowCount(QModelIndex const& parent) const override;
     virtual QVariant data(QModelIndex const&, int role) const override;

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -540,12 +540,22 @@ bool WebContentView::is_inspector_open() const
     return m_inspector_widget && m_inspector_widget->isVisible();
 }
 
-void WebContentView::show_inspector()
+void WebContentView::show_inspector(InspectorTarget inspector_target)
 {
+    bool inspector_previously_loaded = m_inspector_widget;
     ensure_inspector_widget();
+    if (!inspector_previously_loaded || !m_inspector_widget->dom_loaded()) {
+        inspect_dom_tree();
+        inspect_accessibility_tree();
+    }
     m_inspector_widget->show();
-    inspect_dom_tree();
-    inspect_accessibility_tree();
+
+    if (inspector_target == InspectorTarget::HoveredElement) {
+        auto hovered_node = get_hovered_node_id();
+        m_inspector_widget->set_selection({ hovered_node });
+    } else {
+        m_inspector_widget->select_default_node();
+    }
 }
 
 void WebContentView::update_zoom()

--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -93,7 +93,12 @@ public:
     void did_get_js_console_messages(i32 start_index, Vector<DeprecatedString> message_types, Vector<DeprecatedString> messages);
 
     void show_js_console();
-    void show_inspector();
+
+    enum class InspectorTarget {
+        Document,
+        HoveredElement
+    };
+    void show_inspector(InspectorTarget = InspectorTarget::Document);
 
     Ladybird::ConsoleWidget* console() { return m_console_widget; };
 


### PR DESCRIPTION
This adds "Inspect Element" (currently the only entry) to the context menu for the page, which will do what you expect (most of the time*), and bring up the Inspector with hovered element selected. 

This is a small feature I've been missing on Ladybird, since manually expanding the TreeView is quite a chore.  

https://user-images.githubusercontent.com/11597044/236926280-0d2d02bb-8128-4360-91cd-161b21f855da.mp4

\* Some of the time the response for `get_hovered_node_id()` never comes back and we spin in   `wait_for_specific_endpoint_message_impl()` forever :^(, but I don't _think_ that's caused by these changes.  