### PR TITLE
AK: Remove `must_set()` from `JsonArray`

### DIFF
--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -62,7 +62,6 @@ public:
     [[nodiscard]] JsonValue take(size_t index) { return m_values.take(index); }
 
     void must_append(JsonValue value) { m_values.append(move(value)); }
-    void must_set(size_t index, JsonValue value) { m_values.insert(index, move(value)); }
 
     void clear() { m_values.clear(); }
     ErrorOr<void> append(JsonValue value) { return m_values.try_append(move(value)); }

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -203,7 +203,7 @@ static ErrorOr<JsonValue, ExecuteScriptResultType> clone_an_object(JS::Realm& re
                 [&](JsonArray& array) {
                     // NOTE: If this was a JS array, only indexed properties would be serialized anyway.
                     if (name.is_number())
-                        array.must_set(name.as_number(), cloned_property_result.value());
+                        array.set(name.as_number(), cloned_property_result.value());
                 },
                 [&](JsonObject& object) {
                     object.set(name.to_string(), cloned_property_result.value());


### PR DESCRIPTION
Due to 582c55a, both `must_set()` and `set()` should be providing the same behavior. Not only is that a reason to remove `must_set()`, but it also performs erroneous behavior since it inserts an element at a specified index instead of modifying an element at that index.