### PR TITLE
LibWeb: Refer to the SerenityOS Browser as 'Browser' in the UA (not Ladybird)

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -46,7 +46,12 @@ namespace Web {
 #    error Unknown OS
 #endif
 
-#define BROWSER_NAME "Ladybird"
+#if defined(AK_OS_SERENITY)
+#    define BROWSER_NAME "Browser"
+#else
+#    define BROWSER_NAME "Ladybird"
+#endif
+
 #define BROWSER_VERSION "1.0"
 
 constexpr auto default_user_agent = "Mozilla/5.0 (" OS_STRING "; " CPU_STRING ") LibWeb+LibJS/1.0 " BROWSER_NAME "/" BROWSER_VERSION ""sv;


### PR DESCRIPTION
We only call it Ladybird outside of Serenity... and this makes the UA much easier to regex for uap-core.

This will allow me to PR the following patch to uap-core to correctly identify Browser and Ladybird:
```yaml
  # SerenityOS (https://serenityos.org)
  # https://github.com/SerenityOS/serenity/blob/<TODO commit hash>/Userland/Libraries/LibWeb/Loader/ResourceLoader.h#L57
  - regex: 'LibWeb\+LibJS\/\d+\.\d+ (Browser)\/(\d+)\.(\d+)'
    family_replacement: 'SerenityOS Browser'

  # Ladybird Browser (https://ladybird.dev)
  # https://github.com/SerenityOS/serenity/blob/<TODO commit hash>/Userland/Libraries/LibWeb/Loader/ResourceLoader.h#L57
  # Note: The browser is just called "Browser" inside SerenityOS, and Ladybird everywhere else.
  - regex: 'LibWeb\+LibJS\/\d+\.\d+ (Ladybird)\/(\d+)\.(\d+)'
``` 
(negative lookahead/behind are not allowed, so this change make the regex much easier)

