### PR TITLE
LibWeb: Improve handling of min/max constraint violations on images

### DIFF
--- a/Tests/LibWeb/Layout/expected/image-with-multiple-constraint-violations.txt
+++ b/Tests/LibWeb/Layout/expected/image-with-multiple-constraint-violations.txt
@@ -1,0 +1,6 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x80 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x62 children: inline
+      line 0 width: 82, height: 62, bottom: 62, baseline: 62
+        frag 0 from ImageBox start: 0, length: 0, rect: [11,11 80x60]
+      ImageBox <img> at (11,11) content-size 80x60 children: not-inline

--- a/Tests/LibWeb/Layout/input/image-with-multiple-constraint-violations.html
+++ b/Tests/LibWeb/Layout/input/image-with-multiple-constraint-violations.html
@@ -1,0 +1,9 @@
+<!doctype html><style>
+* { border: 1px solid black; }
+body { background: #444; }
+img {
+    max-height: 60px;
+    height: auto;
+    max-width: 100%;
+}
+</style><img src="data:image/gif;base64,R0lGODdhgALgAYAAAP///////ywAAAAAgALgAQAC/oSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gvH8kzX9o3n+s73/g8MCofEovGITCqXzKbzCY1Kp9Sq9YrNarfcrvcLDovH5LL5jE6r1+y2+w2Py+f0uv2Oz+v3/L7/DxgoOEhYaHiImKi4yNjo+AgZKTlJWWl5iZmpucnZ6fkJGio6SlpqeoqaqrrK2ur6ChsrO0tba3uLm6u7y9vr+wscLDxMXGx8jJysvMzc7PwMHS09TV1tfY2drb3N3e39DR4uPk5ebn6Onq6+zt7u/g4fLz9PX29/j5+vv8/f7/8PMKDAgQQLGjyIMKHChQwbOnwIMaLEiRQrWryIMaPG/o0cO3r8CDKkyJEkS5o8iTKlypUsW7p8CTOmzJk0a9q8iTOnzp08e/r8CTSo0KFEixo9ijSp0qVMmzp9CjWq1KlUq1q9ijWr1q1cu3r9Cjas2LFky5o9izat2rVs27p9Czeu3Ll069q9izev3r18+/r9Cziw4MGECxs+jDix4sWMGzt+DDmy5MmUK1u+jDmz5s2cO3v+DDq06NGkS5s+jTq16tWsW7t+DTu27Nm0a9u+jTu37t28e/v+DTy48OHEixs/jjy58uXMmzt/Dj269OnUq1u/jj279u3cu3v/Dj68+PHky5s/jz69+vXs27t/Dz++/Pn069u/jz+//v38/vv7/w9ggAIOSGCBBh6IYIIKLshggw4+CGGEEk5IYYUWXohhhhpuyGGHHn4IYogijkhiiSaeiGKKKq7IYosuvghjjDLOSGONNt6IY4467shjjz7+CGSQQg5JZJFGHolkkkouyWSTTj4JZZRSTklllVZeiWWWWm7JZZdefglmmGKOSWaZZp6JZppqrslmm26+CWeccs5JZ5123olnnnruyWeffv4JaKCCDkpooYYeimiiii7KaKOOPgpppJJOSmmlll6Kaaaabsppp55+Cmqooo5Kaqmmnopqqqquymqrrr4Ka6yyzkprrbbeimuuuu7Ka6++/gpssMIOS2yxxh6LYWyyyi7LbLPOPgtttNJOS2211l6Lbbbabsttt95+C2644o5Lbrnmnotuuuquy2677r4Lb7zyzktvvfbei2+++u7Lb7/+/gtwwAIPTHDBBh+McMIKL8xwww4/DHHEEk/MUAEAOw==" />

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -429,15 +429,6 @@ CSSPixels FormattingContext::compute_width_for_replaced_element(LayoutState cons
     auto width_of_containing_block = available_space.width.to_px();
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
 
-    auto margin_left = box.computed_values().margin().left().resolved(box, width_of_containing_block_as_length);
-    auto margin_right = box.computed_values().margin().right().resolved(box, width_of_containing_block_as_length);
-
-    // A computed value of 'auto' for 'margin-left' or 'margin-right' becomes a used value of '0'.
-    if (margin_left.is_auto())
-        margin_left = zero_value;
-    if (margin_right.is_auto())
-        margin_right = zero_value;
-
     auto computed_width = should_treat_width_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().width();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')


### PR DESCRIPTION
Instead of bailing after resolving one violated constraint, we have to continue down the list of remaining constraints.
    
We now also call the constraint solver for all replaced elements with "auto" for both width and height.
    
