### PR TITLE
Help: Fix link to Contents page

### DIFF
--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -213,7 +213,7 @@ ErrorOr<void> MainWidget::initialize_fallibles(GUI::Window& window)
     TRY(go_menu->try_add_action(*m_go_home_action));
 
     auto help_menu = TRY(window.try_add_menu("&Help"_short_string));
-    String help_page_path = TRY(TRY(try_make_ref_counted<Manual::PageNode>(Manual::sections[1 - 1], TRY("Help"_string)))->path());
+    String help_page_path = TRY(TRY(try_make_ref_counted<Manual::PageNode>(Manual::sections[1 - 1], TRY("Applications/Help"_string)))->path());
     TRY(help_menu->try_add_action(GUI::CommonActions::make_command_palette_action(&window)));
     TRY(help_menu->try_add_action(GUI::Action::create("&Contents", { Key_F1 }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-unknown.png"sv)), [this, help_page_path = move(help_page_path)](auto&) {
         open_page(help_page_path);


### PR DESCRIPTION
Fixes the link to the Contents page (Help->Contents, `F1`) after the Help manpage was [moved under Applications/](https://github.com/SerenityOS/serenity/pull/16885)

Before:

<img width="586" alt="image" src="https://github.com/SerenityOS/serenity/assets/4476568/236ed9ff-57ce-4fbe-a995-a500ab491d66">

After:

<img width="601" alt="image" src="https://github.com/SerenityOS/serenity/assets/4476568/2b1fc321-d2d1-4f80-9ebc-7fca65d94526">
