### PR TITLE
Chess+GameSettings: Optionally highlight the king when in check

### DIFF
--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
@@ -276,6 +276,12 @@ ErrorOr<void> ChessSettingsWidget::initialize()
         m_preview->set_show_coordinates(checked);
     };
 
+    m_highlight_checks_checkbox = find_descendant_of_type_named<GUI::CheckBox>("highlight_checks");
+    m_highlight_checks_checkbox->set_checked(show_coordinates, GUI::AllowCallback::No);
+    m_highlight_checks_checkbox->on_checked = [&](bool) {
+        set_modified(true);
+    };
+
     TRY(m_preview->set_piece_set_name(piece_set_name));
     m_preview->set_dark_square_color(board_theme.dark_square_color);
     m_preview->set_light_square_color(board_theme.light_square_color);
@@ -289,6 +295,7 @@ void ChessSettingsWidget::apply_settings()
     Config::write_string("Games"sv, "Chess"sv, "PieceSet"sv, m_piece_set_combobox->text());
     Config::write_string("Games"sv, "Chess"sv, "BoardTheme"sv, m_board_theme_combobox->text());
     Config::write_bool("Games"sv, "Chess"sv, "ShowCoordinates"sv, m_show_coordinates_checkbox->is_checked());
+    Config::write_bool("Games"sv, "Chess"sv, "HighlightChecks"sv, m_highlight_checks_checkbox->is_checked());
 }
 
 void ChessSettingsWidget::reset_default_values()
@@ -302,6 +309,7 @@ void ChessSettingsWidget::reset_default_values()
     m_preview->set_dark_square_color(board_theme.dark_square_color);
     m_preview->set_light_square_color(board_theme.light_square_color);
     m_show_coordinates_checkbox->set_checked(true);
+    m_highlight_checks_checkbox->set_checked(true);
 }
 
 }

--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.gml
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.gml
@@ -54,5 +54,11 @@
             text: "Show coordinates"
             checkbox_position: "Right"
         }
+
+        @GUI::CheckBox {
+            name: "highlight_checks"
+            text: "Highlight checks"
+            checkbox_position: "Right"
+        }
     }
 }

--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.h
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.h
@@ -34,6 +34,7 @@ private:
     RefPtr<GUI::ComboBox> m_piece_set_combobox;
     RefPtr<GUI::ComboBox> m_board_theme_combobox;
     RefPtr<GUI::CheckBox> m_show_coordinates_checkbox;
+    RefPtr<GUI::CheckBox> m_highlight_checks_checkbox;
 };
 
 }

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -62,8 +62,20 @@ void ChessWidget::paint_event(GUI::PaintEvent& event)
 
         painter.fill_rect(tile_rect, (sq.is_light()) ? board_theme().light_square_color : board_theme().dark_square_color);
 
-        if (active_board.last_move().has_value() && (active_board.last_move().value().to == sq || active_board.last_move().value().from == sq)) {
-            painter.fill_rect(tile_rect, m_move_highlight_color);
+        if (active_board.last_move().has_value()) {
+            auto const last_move = active_board.last_move().value();
+            if (last_move.to == sq || last_move.from == sq)
+                painter.fill_rect(tile_rect, m_move_highlight_color);
+
+            auto const piece = active_board.get_piece(sq);
+            if (m_highlight_checks && last_move.is_check && piece.type == Chess::Type::King && piece.color == active_board.turn()) {
+                Array<Gfx::ColorStop, 2> colors = {
+                    Gfx::ColorStop { .color = Color::Red, .position = 0.16f },
+                    Gfx::ColorStop { .color = Color::Transparent, .position = .66f }
+                };
+
+                painter.fill_rect_with_radial_gradient(tile_rect, colors, tile_rect.center() - tile_rect.top_left(), tile_rect.size());
+            }
         }
 
         if (m_coordinates) {
@@ -749,6 +761,9 @@ void ChessWidget::config_bool_did_change(DeprecatedString const& domain, Depreca
 
     if (key == "ShowCoordinates"sv) {
         set_coordinates(value);
+        update();
+    } else if (key == "HighlightChecks"sv) {
+        set_highlight_checks(value);
         update();
     }
 }

--- a/Userland/Games/Chess/ChessWidget.h
+++ b/Userland/Games/Chess/ChessWidget.h
@@ -89,6 +89,9 @@ public:
     void set_coordinates(bool coordinates) { m_coordinates = coordinates; }
     bool coordinates() const { return m_coordinates; }
 
+    void set_highlight_checks(bool highlight_checks) { m_highlight_checks = highlight_checks; }
+    bool highlight_checks() const { return m_highlight_checks; }
+
     struct BoardMarking {
         Chess::Square from { 50, 50 };
         Chess::Square to { 50, 50 };
@@ -146,4 +149,5 @@ private:
     Vector<Chess::Square> m_available_moves;
     RefPtr<Engine> m_engine;
     bool m_coordinates { true };
+    bool m_highlight_checks { true };
 };

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -87,6 +87,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     widget->set_board_theme(Config::read_string("Games"sv, "Chess"sv, "BoardTheme"sv, "Beige"sv));
     widget->set_coordinates(Config::read_bool("Games"sv, "Chess"sv, "ShowCoordinates"sv, true));
     widget->set_show_available_moves(Config::read_bool("Games"sv, "Chess"sv, "ShowAvailableMoves"sv, true));
+    widget->set_highlight_checks(Config::read_bool("Games"sv, "Chess"sv, "HighlightChecks"sv, true));
 
     auto game_menu = TRY(window->try_add_menu("&Game"_short_string));
 


### PR DESCRIPTION
When either king is in check, its square is now highlighted with a red background. This behavior can be toggled in GameSettings.

This is similar to several other chess programs I've used. An alternative might be make the King square flash if the player attempts to make an illegal move. To be honest, I did it this way because it was easier to implement (and I thought there was a distressing lack of radial gradients.)

Video:

https://github.com/SerenityOS/serenity/assets/2817754/8d657212-8a18-4c13-9458-7f8f15aa4fe6


