### PR TITLE
SystemServer: Handle waitpid's status correctly

### DIFF
--- a/Userland/Services/SystemServer/Service.h
+++ b/Userland/Services/SystemServer/Service.h
@@ -22,7 +22,8 @@ public:
 
     bool is_enabled() const;
     ErrorOr<void> activate();
-    ErrorOr<void> did_exit(int exit_code);
+    // Note: This is a `status` as in POSIX's wait syscall, not an exit-code.
+    ErrorOr<void> did_exit(int status);
 
     static Service* find_by_pid(pid_t);
 


### PR DESCRIPTION
We used to call `did_exit()` directly with the status returned from
`waitpid` but the function expected an exit code. We now use several
of `wait`-related macros to deduce the correct information.