### PR TITLE
LibWeb: Adjust flex item main size through aspect ratio if needed

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
@@ -1,0 +1,6 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x70 [BFC] children: not-inline
+    Box <body> at (10,10) content-size 780x52 flex-container(row) [FFC] children: not-inline
+      ImageBox <img> at (11,11) content-size 66.666671x50 flex-item children: not-inline
+      BlockContainer <(anonymous)> at (10,10) content-size 0x0 [BFC] children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.html
@@ -1,0 +1,10 @@
+<!doctype html><style>
+* { border: 1px solid black; }
+body {
+    background: #444;
+    display: flex;
+}
+img {
+    max-height: 50px;
+}
+</style><img src="data:image/gif;base64,R0lGODdhgALgAYAAAP///////ywAAAAAgALgAQAC/oSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gvH8kzX9o3n+s73/g8MCofEovGITCqXzKbzCY1Kp9Sq9YrNarfcrvcLDovH5LL5jE6r1+y2+w2Py+f0uv2Oz+v3/L7/DxgoOEhYaHiImKi4yNjo+AgZKTlJWWl5iZmpucnZ6fkJGio6SlpqeoqaqrrK2ur6ChsrO0tba3uLm6u7y9vr+wscLDxMXGx8jJysvMzc7PwMHS09TV1tfY2drb3N3e39DR4uPk5ebn6Onq6+zt7u/g4fLz9PX29/j5+vv8/f7/8PMKDAgQQLGjyIMKHChQwbOnwIMaLEiRQrWryIMaPG/o0cO3r8CDKkyJEkS5o8iTKlypUsW7p8CTOmzJk0a9q8iTOnzp08e/r8CTSo0KFEixo9ijSp0qVMmzp9CjWq1KlUq1q9ijWr1q1cu3r9Cjas2LFky5o9izat2rVs27p9Czeu3Ll069q9izev3r18+/r9Cziw4MGECxs+jDix4sWMGzt+DDmy5MmUK1u+jDmz5s2cO3v+DDq06NGkS5s+jTq16tWsW7t+DTu27Nm0a9u+jTu37t28e/v+DTy48OHEixs/jjy58uXMmzt/Dj269OnUq1u/jj279u3cu3v/Dj68+PHky5s/jz69+vXs27t/Dz++/Pn069u/jz+//v38/vv7/w9ggAIOSGCBBh6IYIIKLshggw4+CGGEEk5IYYUWXohhhhpuyGGHHn4IYogijkhiiSaeiGKKKq7IYosuvghjjDLOSGONNt6IY4467shjjz7+CGSQQg5JZJFGHolkkkouyWSTTj4JZZRSTklllVZeiWWWWm7JZZdefglmmGKOSWaZZp6JZppqrslmm26+CWeccs5JZ5123olnnnruyWeffv4JaKCCDkpooYYeimiiii7KaKOOPgpppJJOSmmlll6Kaaaabsppp55+Cmqooo5Kaqmmnopqqqquymqrrr4Ka6yyzkprrbbeimuuuu7Ka6++/gpssMIOS2yxxh6LYWyyyi7LbLPOPgtttNJOS2211l6Lbbbabsttt95+C2644o5Lbrnmnotuuuquy2677r4Lb7zyzktvvfbei2+++u7Lb7/+/gtwwAIPTHDBBh+McMIKL8xwww4/DHHEEk/MUAEAOw==" />

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -34,6 +34,9 @@ private:
     [[nodiscard]] bool should_treat_main_size_as_auto(Box const&) const;
     [[nodiscard]] bool should_treat_cross_size_as_auto(Box const&) const;
 
+    [[nodiscard]] CSSPixels adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(Box const&, CSSPixels main_size, CSS::Size const& min_cross_size, CSS::Size const& max_cross_size) const;
+    [[nodiscard]] CSSPixels calculate_main_size_from_cross_size_and_aspect_ratio(CSSPixels cross_size, float aspect_ratio) const;
+
     void dump_items() const;
 
     struct DirectionAgnosticMargins {


### PR DESCRIPTION
If there are min or max size constraints in the cross axis for a flex item that has a desired aspect ratio, we may need to adjust the main size *after* applying the cross size constraints.

All the steps to achieving this aren't mentioned in the spec, but it seems that all other browsers behave this way, so we should too.

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/af6ab58b-152f-4bd2-aa47-6f983913cc26)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/02bcb07c-3e9b-473f-96b0-d3588148289c)
