### PR TITLE
LibWeb: Don't resolve CSS property values for unconnected elements

### DIFF
--- a/Tests/LibWeb/Layout/expected/getComputedStyle-on-unconnected-element.txt
+++ b/Tests/LibWeb/Layout/expected/getComputedStyle-on-unconnected-element.txt
@@ -1,0 +1,7 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x37.835937 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x21.835937 children: inline
+      line 0 width: 362.617187, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+        frag 0 from TextNode start: 0, length: 35, rect: [8,8 362.617187x21.835937]
+          "This test passes if we don't crash."
+      TextNode <#text>

--- a/Tests/LibWeb/Layout/input/getComputedStyle-on-unconnected-element.html
+++ b/Tests/LibWeb/Layout/input/getComputedStyle-on-unconnected-element.html
@@ -1,0 +1,11 @@
+<!doctype html><style>
+* { font: 20px SerenitySans; }
+</style><script>
+let fragment = document.createDocumentFragment()
+let a = document.createElement("a")
+fragment.appendChild(a)
+let b = document.createElement("b")
+a.appendChild(b)
+window.getComputedStyle(b).display
+</script>
+This test passes if we don't crash.

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -666,6 +666,11 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
 
 Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID property_id) const
 {
+    // https://www.w3.org/TR/cssom-1/#dom-window-getcomputedstyle
+    // NOTE: This is a partial enforcement of step 5 ("If elt is connected, ...")
+    if (!m_element->is_connected())
+        return {};
+
     if (CSS::property_affects_layout(property_id)) {
         const_cast<DOM::Document&>(m_element->document()).update_layout();
     } else {


### PR DESCRIPTION
While it's possible to `getComputedStyle()` on an unconnected element, the resulting object is not supposed to have any values, since we can't resolve style without a document root anyway.

This fixes a crash on https://bandcamp.com