### PR TITLE
Everywhere: Some easy "DeprecatedFile" migrations

### DIFF
--- a/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
+++ b/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
@@ -7,7 +7,7 @@
 #include "CharacterMapFile.h"
 #include <AK/ByteBuffer.h>
 #include <AK/Utf8View.h>
-#include <LibCore/DeprecatedFile.h>
+#include <LibCore/File.h>
 
 namespace Keyboard {
 
@@ -22,8 +22,8 @@ ErrorOr<CharacterMapData> CharacterMapFile::load_from_file(DeprecatedString cons
         path = full_path.to_deprecated_string();
     }
 
-    auto file = TRY(Core::DeprecatedFile::open(path, Core::OpenMode::ReadOnly));
-    auto file_contents = file->read_all();
+    auto file = TRY(Core::File::open(path, Core::File::OpenMode::Read));
+    auto file_contents = TRY(file->read_until_eof());
     auto json_result = TRY(JsonValue::from_string(file_contents));
     auto const& json = json_result.as_object();
 


### PR DESCRIPTION
This advances #17129 by doing I/O through `Core::File` instead of `Core::DeprecatedFile`, which gives us better OOM-handling for free, and (in the case of SystemServer) also should improve the ability to detect an extremely obscure bug (which apparently never occurs anyway).