### PR TITLE
Userland: Tighten API to DeprecatedFile to prevent accidental new usages

### DIFF
--- a/Userland/Libraries/LibCore/DeprecatedFile.cpp
+++ b/Userland/Libraries/LibCore/DeprecatedFile.cpp
@@ -143,11 +143,6 @@ bool DeprecatedFile::is_link() const
     return S_ISLNK(stat.st_mode);
 }
 
-bool DeprecatedFile::looks_like_shared_library() const
-{
-    return m_filename.ends_with(".so"sv) || m_filename.contains(".so."sv);
-}
-
 DeprecatedString DeprecatedFile::real_path_for(DeprecatedString const& filename)
 {
     if (filename.is_null())

--- a/Userland/Libraries/LibCore/DeprecatedFile.cpp
+++ b/Userland/Libraries/LibCore/DeprecatedFile.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/DeprecatedFile.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <libgen.h>

--- a/Userland/Libraries/LibCore/DeprecatedFile.h
+++ b/Userland/Libraries/LibCore/DeprecatedFile.h
@@ -11,10 +11,6 @@
 #include <LibCore/IODevice.h>
 #include <sys/stat.h>
 
-// FIXME: Make this a bit prettier.
-#define DEFAULT_PATH "/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"
-#define DEFAULT_PATH_SV "/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"sv
-
 namespace Core {
 
 ///

--- a/Userland/Libraries/LibCore/DeprecatedFile.h
+++ b/Userland/Libraries/LibCore/DeprecatedFile.h
@@ -25,14 +25,12 @@ public:
     static ErrorOr<NonnullRefPtr<DeprecatedFile>> open(DeprecatedString filename, OpenMode, mode_t = 0644);
 
     DeprecatedString filename() const { return m_filename; }
-    void set_filename(const DeprecatedString filename) { m_filename = move(filename); }
 
     bool is_directory() const;
     bool is_device() const;
     bool is_block_device() const;
     bool is_char_device() const;
     bool is_link() const;
-    bool looks_like_shared_library() const;
 
     static DeprecatedString current_working_directory();
     static DeprecatedString absolute_path(DeprecatedString const& path);

--- a/Userland/Services/ChessEngine/ChessEngine.cpp
+++ b/Userland/Services/ChessEngine/ChessEngine.cpp
@@ -7,7 +7,6 @@
 #include "ChessEngine.h"
 #include "MCTSTree.h"
 #include <AK/Random.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/ElapsedTimer.h>
 
 using namespace Chess::UCI;

--- a/Userland/Services/TelnetServer/main.cpp
+++ b/Userland/Services/TelnetServer/main.cpp
@@ -9,10 +9,10 @@
 #include <AK/HashMap.h>
 #include <AK/Types.h>
 #include <LibCore/ArgsParser.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Socket.h>
 #include <LibCore/TCPServer.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibMain/Main.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -16,6 +16,7 @@
 #include <LibCore/DeprecatedFile.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
+#include <LibFileSystem/FileSystem.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <limits.h>

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -25,6 +25,7 @@
 #include <LibCore/EventLoop.h>
 #include <LibCore/System.h>
 #include <LibCore/Timer.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibLine/Editor.h>
 #include <Shell/PosixParser.h>
 #include <errno.h>


### PR DESCRIPTION
This PR:
- Merges `DEFAULT_PATH` to a new home in `Core::File`, instead of having it in two different places
- Removes two unused functions from `DeprecatedFile`, to ensure we don't accidentally use more of this old API.

Advances #17129.