### PR TITLE
AK+LookupServer: Migrate from DeprecatedFile to File

### DIFF
--- a/Userland/Services/LookupServer/LookupServer.h
+++ b/Userland/Services/LookupServer/LookupServer.h
@@ -29,6 +29,7 @@ public:
 private:
     LookupServer();
 
+    ErrorOr<HashMap<Name, Vector<Answer>, Name::Traits>> try_load_etc_hosts();
     void load_etc_hosts();
     void put_in_cache(Answer const&);
 


### PR DESCRIPTION
This PR:
- Switches LookupServer from DeprecatedFile to File
- Implements move-assign and move-construct for HashMap in order to do so efficiently and with few (if any) allocations.

Advances #17129.