### PR TITLE
Meta/ShellCompletions: Add toolchain and Lagom binary zsh completion

### DIFF
--- a/Meta/ShellCompletions/zsh/_serenity
+++ b/Meta/ShellCompletions/zsh/_serenity
@@ -5,6 +5,7 @@ _serenity() {
     args=(
         '1:command:->commands'
         '2:target:->targets'
+        '3:toolchain:->toolchains'
         '*:: :->args'
     )
 
@@ -34,6 +35,12 @@ _serenity() {
         'lagom:Target host machine'
     )
 
+    local toolchains
+    toolchains=(
+        'GNU:Toolchain gcc or $SERENITY_TOOLCHAIN (default)'
+        'Clang:Toolchain clang'
+    )
+
     _arguments -C -S "$args[@]"
 
     local command
@@ -41,6 +48,9 @@ _serenity() {
 
     local target
     target="$line[2]"
+
+    local toolchain
+    toolchain="$line[3]"
 
     case "$state" in
         commands)
@@ -58,6 +68,12 @@ _serenity() {
                     ;;
             esac
             _describe 'target' targets
+            ;;
+        toolchains)
+            if [[ "$command" != help && "$target" != lagom ]]; then
+                # Toolchain-dependent invocations.
+                _describe 'toolchain' toolchains
+            fi
             ;;
         args)
             ;;

--- a/Meta/ShellCompletions/zsh/_serenity
+++ b/Meta/ShellCompletions/zsh/_serenity
@@ -30,7 +30,7 @@ _serenity() {
 
     local targets
     targets=(
-        'x86_64:Target x86_64 (default)'
+        'x86_64:Target x86_64 or $SERENITY_ARCH (default)'
         'aarch64:Target aarch64'
         'lagom:Target host machine'
     )

--- a/Meta/ShellCompletions/zsh/_serenity
+++ b/Meta/ShellCompletions/zsh/_serenity
@@ -79,7 +79,7 @@ _serenity() {
         targets)
             case "$command" in
                 install|image|copy-src|kaddr2line|rebuild-toolchain|rebuild-world)
-                    # lagom target is not supported for these, remove from targets
+                    # Lagom target is not supported for these, remove from targets.
                     targets[$targets[(i)lagom]]=()
                     ;;
                 help)

--- a/Meta/ShellCompletions/zsh/_serenity
+++ b/Meta/ShellCompletions/zsh/_serenity
@@ -10,10 +10,10 @@ _serenity() {
 
     local commands
     commands=(
+        'help'
         'build'
         'install'
         'image'
-        'copy-src'
         'run'
         'gdb'
         'test'
@@ -24,6 +24,7 @@ _serenity() {
         'addr2line'
         'rebuild-toolchain'
         'rebuild-world'
+        'copy-src'
     )
 
     local targets
@@ -50,6 +51,10 @@ _serenity() {
                 install|image|copy-src|kaddr2line|rebuild-toolchain|rebuild-world)
                     # lagom target is not supported for these, remove from targets
                     targets[$targets[(i)lagom]]=()
+                    ;;
+                help)
+                    # Help command has no targets.
+                    targets=()
                     ;;
             esac
             _describe 'target' targets

--- a/Meta/ShellCompletions/zsh/_serenity
+++ b/Meta/ShellCompletions/zsh/_serenity
@@ -1,11 +1,25 @@
 #compdef serenity serenity.sh
 
+get_top_dir() {
+    git rev-parse --show-toplevel
+}
+
+get_lagom_executables() {
+    # Make completion work with user-defined source directory.
+    SERENITY_SOURCE_DIR="${SERENITY_SOURCE_DIR:-$(get_top_dir)}"
+    # If the Lagom binary directory is missing, this creates an empty list instead of erroring.
+    # Known false positives need to be filtered manually; please add new ones.
+    find "${SERENITY_SOURCE_DIR}/Build/lagom" -mindepth 1 -type f -executable -not -name '*.so*' \
+        -not \( -name 'SQLServer' -o -name 'a.out' -o -name 'CMake*.bin' \) \
+        -printf '%f\n' 2>/dev/null || true
+}
+
 _serenity() {
     local args
     args=(
         '1:command:->commands'
         '2:target:->targets'
-        '3:toolchain:->toolchains'
+        '3:toolchain_or_executable:->toolchains_or_executables'
         '*:: :->args'
     )
 
@@ -41,6 +55,12 @@ _serenity() {
         'Clang:Toolchain clang'
     )
 
+    local lagom_executables
+    # Prevent splitting array on spaces with IFS; bash would have `mapfile` for this.
+    IFS=$'\n'; set -f
+    lagom_executables=($(get_lagom_executables))
+    unset IFS; set +f
+
     _arguments -C -S "$args[@]"
 
     local command
@@ -69,10 +89,13 @@ _serenity() {
             esac
             _describe 'target' targets
             ;;
-        toolchains)
+        toolchains_or_executables)
             if [[ "$command" != help && "$target" != lagom ]]; then
                 # Toolchain-dependent invocations.
-                _describe 'toolchain' toolchains
+                _describe 'toolchain_or_executable' toolchains
+            elif [[ "$command" = run && "$target" = lagom ]]; then
+                # With `run lagom` this already is the executable.
+                _describe 'toolchain_or_executable' lagom_executables
             fi
             ;;
         args)


### PR DESCRIPTION
With these improvements to the zsh completion script, you can now tab-complete:
- all base commands, including `help`
- the toolchain; which is the reason I started hacking on this script in the first place
- Lagom binaries for `run lagom`; works if the binary is already built and independent of your build tool.

Some examples:
```zsh
 ~/serenity  zsh-is-cool *14 ?6  Meta/serenity.sh run lagom TestF                                                                                                INT х 
TestFeedFilter            TestFixedArray            TestFLACSpec              TestFloatingPointParsing  TestFontHandling                                  
TestFind                  TestFixedPoint            TestFloatingPoint         TestFlyString             TestFormat    
```

```zsh
 ~/serenity  zsh-is-cool *14 ?6  Meta/serenity.sh run x86_64                                                                                                     INT х 
Clang  -- Toolchain clang
GNU    -- Toolchain gcc or $SERENITY_TOOLCHAIN (default)
```