### PR TITLE
VideoPlayer+LibVideo: Various improvements to the VideoPlayer application

### DIFF
--- a/Userland/Applications/VideoPlayer/CMakeLists.txt
+++ b/Userland/Applications/VideoPlayer/CMakeLists.txt
@@ -17,4 +17,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_app(VideoPlayer ICON app-video-player)
-target_link_libraries(VideoPlayer PRIVATE LibVideo LibAudio LibCore LibGfx LibGUI LibMain LibFileSystemAccessClient)
+target_link_libraries(VideoPlayer PRIVATE LibVideo LibAudio LibConfig LibCore LibGfx LibGUI LibMain LibFileSystemAccessClient)

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
@@ -35,6 +35,7 @@ public:
 
     Video::PlaybackManager::SeekMode seek_mode();
     void set_seek_mode(Video::PlaybackManager::SeekMode seek_mode);
+    void set_sizing_mode(VideoSizingMode sizing_mode);
 
     ErrorOr<void> initialize_menubar(GUI::Window&);
 
@@ -48,6 +49,7 @@ private:
     void on_decoding_error(Video::DecoderError const&);
 
     void cycle_sizing_modes();
+    void set_current_sizing_mode_checked();
 
     void toggle_fullscreen();
 

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.h
@@ -8,6 +8,7 @@
 
 #include <AK/FixedArray.h>
 #include <AK/NonnullRefPtr.h>
+#include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/Widget.h>
@@ -26,7 +27,7 @@ public:
     static ErrorOr<NonnullRefPtr<VideoPlayerWidget>> try_create();
     virtual ~VideoPlayerWidget() override = default;
     void close_file();
-    void open_file(StringView filename);
+    void open_file(FileSystemAccessClient::File filename);
     void resume_playback();
     void pause_playback();
     void toggle_pause();
@@ -55,7 +56,7 @@ private:
 
     virtual void drop_event(GUI::DropEvent&) override;
 
-    DeprecatedString m_path;
+    String m_path;
 
     RefPtr<VideoFrameWidget> m_video_display;
     RefPtr<GUI::HorizontalSlider> m_seek_slider;

--- a/Userland/Applications/VideoPlayer/main.cpp
+++ b/Userland/Applications/VideoPlayer/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibConfig/Client.h>
 #include <LibCore/ArgsParser.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
@@ -19,7 +20,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(filename, "The video file to display.", "filename", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
+    Config::pledge_domain("VideoPlayer");
+
     auto app = TRY(GUI::Application::create(arguments));
+    app->set_config_domain(TRY("VideoPlayer"_string));
+
     auto window = TRY(GUI::Window::try_create());
     window->resize(640, 480);
     window->set_resizable(true);

--- a/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.cpp
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.cpp
@@ -14,6 +14,11 @@ DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> MatroskaDemuxer::from_file(String
     return make<MatroskaDemuxer>(TRY(Reader::from_file(filename)));
 }
 
+DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> MatroskaDemuxer::from_mapped_file(NonnullRefPtr<Core::MappedFile> mapped_file)
+{
+    return make<MatroskaDemuxer>(TRY(Reader::from_mapped_file(move(mapped_file))));
+}
+
 DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> MatroskaDemuxer::from_data(ReadonlyBytes data)
 {
     return make<MatroskaDemuxer>(TRY(Reader::from_data(data)));

--- a/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.h
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.h
@@ -18,6 +18,8 @@ public:
     // FIXME: We should instead accept some abstract data streaming type so that the demuxer
     //        can work with non-contiguous data.
     static DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> from_file(StringView filename);
+    static DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> from_mapped_file(NonnullRefPtr<Core::MappedFile> mapped_file);
+
     static DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> from_data(ReadonlyBytes data);
 
     MatroskaDemuxer(Reader&& reader)

--- a/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
@@ -81,8 +81,13 @@ constexpr u32 CUE_REFERENCE_ID = 0xDB;
 DecoderErrorOr<Reader> Reader::from_file(StringView path)
 {
     auto mapped_file = DECODER_TRY(DecoderErrorCategory::IO, Core::MappedFile::map(path));
+    return from_mapped_file(mapped_file);
+}
+
+DecoderErrorOr<Reader> Reader::from_mapped_file(NonnullRefPtr<Core::MappedFile> mapped_file)
+{
     auto reader = TRY(from_data(mapped_file->bytes()));
-    reader.m_mapped_file = mapped_file;
+    reader.m_mapped_file = move(mapped_file);
     return reader;
 }
 

--- a/Userland/Libraries/LibVideo/Containers/Matroska/Reader.h
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/Reader.h
@@ -25,6 +25,8 @@ public:
     typedef Function<DecoderErrorOr<IterationDecision>(TrackEntry const&)> TrackEntryCallback;
 
     static DecoderErrorOr<Reader> from_file(StringView path);
+    static DecoderErrorOr<Reader> from_mapped_file(NonnullRefPtr<Core::MappedFile> mapped_file);
+
     static DecoderErrorOr<Reader> from_data(ReadonlyBytes data);
 
     EBMLHeader const& header() const { return m_header.value(); }

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -31,6 +31,12 @@ DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> PlaybackManager::from_file(String
     return create_with_demuxer(move(demuxer));
 }
 
+DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> PlaybackManager::from_mapped_file(NonnullRefPtr<Core::MappedFile> mapped_file)
+{
+    auto demuxer = TRY(Matroska::MatroskaDemuxer::from_mapped_file(move(mapped_file)));
+    return create_with_demuxer(move(demuxer));
+}
+
 DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> PlaybackManager::from_data(ReadonlyBytes data)
 {
     auto demuxer = TRY(Matroska::MatroskaDemuxer::from_data(data));

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -101,6 +101,8 @@ public:
     static constexpr SeekMode DEFAULT_SEEK_MODE = SeekMode::Accurate;
 
     static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_file(StringView file);
+    static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_mapped_file(NonnullRefPtr<Core::MappedFile> file);
+
     static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_data(ReadonlyBytes data);
 
     PlaybackManager(NonnullOwnPtr<Demuxer>& demuxer, Track video_track, NonnullOwnPtr<VideoDecoder>&& decoder);


### PR DESCRIPTION
I saw some low-hanging fruit in VideoPlayer, so I decided to fix a few of them in this PR!

Since some of the changes that I made aren't exactly related, it's best to take a look at the code in individual commits in order for it to make sense.

1. VideoPlayer now stores the current sizing mode (Playback > Sizing Mode) in its configuration. This means it will persist between sessions. (f88d6e8de42f3236d24b18ac1b4cc338accdec18 & c1dfcf076064c681b1793dc90454b09f9d1ffd8c)

2. VideoPlayer will now use `LibFileSystemAccessClient` for all file-based operations. (f118bcf1301803b82fb562aea735cdbe03f1250d & b1110b07e6115b2f98becae0e074a2310e8f4618)
    - To achieve this, I also had to add a new `from_mapped_file` function to `LibVideo`'s `PlaybackManager` (and other related files which also needed it) in f118bcf1301803b82fb562aea735cdbe03f1250d.