### PR TITLE
errno: Include error code names in output and allow lookup by name

### DIFF
--- a/Userland/Utilities/errno.cpp
+++ b/Userland/Utilities/errno.cpp
@@ -47,7 +47,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (search) {
         for (int i = 0; i < sys_nerr; i++) {
-            auto error = DeprecatedString::formatted("{}", strerror(i));
+            auto error_string = strerror(i);
+            StringView error { error_string, strlen(error_string) };
             if (error.contains(keyword, CaseSensitivity::CaseInsensitive))
                 output_errno_description(i, error);
         }


### PR DESCRIPTION
![image](https://github.com/SerenityOS/serenity/assets/222642/8751919c-1959-42f1-9395-03bff11dc431)

Also, align things nicely so it's easier to read.