### PR TITLE
Meta: Only enable SPICE integration when using the SPICE display

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -351,7 +351,7 @@ $SERENITY_SPICE_SERVER_CHARDEV
 "
 
 if [ "$SERENITY_ARCH" != "aarch64" ]; then
-    if "${SERENITY_QEMU_BIN}" -chardev help | grep -iq spice; then
+    if [ "${SERENITY_SPICE}" ] && "${SERENITY_QEMU_BIN}" -chardev help | grep -iq spice; then
         SERENITY_COMMON_QEMU_ARGS="$SERENITY_COMMON_QEMU_ARGS
         -spice port=5930,agent-mouse=off,disable-ticketing=on
         "


### PR DESCRIPTION
Newer versions of QEMU prevent the user from running a GL-rendered display while a SPICE display is active due to incompatibilities.

Since there is no way to disable QEMUs (apparently implicit) SPICE display, make sure that we only enable SPICE support if the user requested running with SPICE specifically. In this case, QEMU picks the default SPICE client instead of rendering a display using whatever our default on that platform would be.