### PR TITLE
LibCore+LibThreading: Fix event loop UAF, *again*

### DIFF
--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -48,6 +48,7 @@ EventLoop& EventLoop::current()
 
 void EventLoop::quit(int code)
 {
+    ThreadEventQueue::current().cancel_all_pending_jobs();
     m_impl->quit(code);
 }
 

--- a/Userland/Libraries/LibCore/ThreadEventQueue.h
+++ b/Userland/Libraries/LibCore/ThreadEventQueue.h
@@ -29,6 +29,7 @@ public:
 
     // Used by Threading::BackgroundAction.
     void add_job(NonnullRefPtr<Promise<NonnullRefPtr<Object>>>);
+    void cancel_all_pending_jobs();
 
     // Returns true if there are events waiting to be flushed.
     bool has_pending_events() const;

--- a/Userland/Libraries/LibThreading/BackgroundAction.h
+++ b/Userland/Libraries/LibThreading/BackgroundAction.h
@@ -100,13 +100,15 @@ private:
                     error = result.release_error();
 
                 m_promise->cancel(Error::from_errno(ECANCELED));
-                if (m_on_error) {
+                if (!m_canceled && m_on_error) {
                     callback_scheduled = true;
                     origin_event_loop->deferred_invoke([this, error = move(error)]() mutable {
                         m_on_error(move(error));
                         remove_from_parent();
                     });
                     origin_event_loop->wake();
+                } else if (m_on_error) {
+                    m_on_error(move(error));
                 }
             }
 


### PR DESCRIPTION
Two fixes for a regression and a forgotten UAF protection which make thumbnail generation not crash again.