### PR TITLE
LibWeb: Fix OOM when loading https://www.polygon.com/

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2128,7 +2128,10 @@ static bool can_approximate_bezier_curve(FloatPoint p1, FloatPoint p2, FloatPoin
     p2x = p2x * p2x;
     p2y = p2y * p2y;
 
-    return max(p1x, p2x) + max(p1y, p2y) <= tolerance;
+    auto error = max(p1x, p2x) + max(p1y, p2y);
+    VERIFY(isfinite(error));
+
+    return error <= tolerance;
 }
 
 // static
@@ -2202,7 +2205,10 @@ static bool can_approximate_cubic_bezier_curve(FloatPoint p1, FloatPoint p2, Flo
     bx *= bx;
     by *= by;
 
-    return max(ax, bx) + max(ay, by) <= tolerance;
+    auto error = max(ax, bx) + max(ay, by);
+    VERIFY(isfinite(error));
+
+    return error <= tolerance;
 }
 
 // static

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -495,7 +495,8 @@ CSSPixels FormattingContext::tentative_height_for_replaced_element(LayoutState c
     if (computed_height.is_auto())
         return 150;
 
-    return computed_height.to_px(box, available_space.height.to_px());
+    // FIXME: Handle cases when available_space is not definite.
+    return computed_height.to_px(box, available_space.height.to_px_or_zero());
 }
 
 CSSPixels FormattingContext::compute_height_for_replaced_element(LayoutState const& state, ReplacedBox const& box, AvailableSpace const& available_space)


### PR DESCRIPTION
This fixes the OOM @ADKaster came across loading: https://www.polygon.com/23718068/hollow-knight-silksong-release-date-delay?utm_campaign=polygon&utm_content=chorus&utm_medium=social&utm_source=twitter

With this change the page now loads, and you can scroll around a bit till you hit #16047

