### PR TITLE
LibDebug: Propagate errors around LineProgram

### DIFF
--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
@@ -59,7 +59,7 @@ ErrorOr<void> DwarfInfo::populate_compilation_units()
 
         u32 length_after_header = compilation_unit_header.length() - (compilation_unit_header.header_size() - offsetof(CompilationUnitHeader, common.version));
 
-        auto line_program = make<LineProgram>(*this, line_info_stream);
+        auto line_program = TRY(LineProgram::create(*this, line_info_stream));
 
         // HACK: Clang generates line programs for embedded resource assembly files, but not compile units.
         // Meaning that for graphical applications, some line info data would be unread, triggering the assertion below.

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/DeprecatedFlyString.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/Vector.h>
 #include <LibDebug/Dwarf/DwarfTypes.h>
 
@@ -108,7 +109,7 @@ class LineProgram {
     AK_MAKE_NONMOVABLE(LineProgram);
 
 public:
-    explicit LineProgram(DwarfInfo& dwarf_info, SeekableStream& stream);
+    static ErrorOr<NonnullOwnPtr<LineProgram>> create(DwarfInfo& dwarf_info, SeekableStream& stream);
 
     struct LineInfo {
         FlatPtr address { 0 };
@@ -133,6 +134,8 @@ public:
     bool looks_like_embedded_resource() const;
 
 private:
+    LineProgram(DwarfInfo& dwarf_info, SeekableStream& stream, size_t unit_offset);
+
     ErrorOr<void> parse_unit_header();
     ErrorOr<void> parse_source_directories();
     ErrorOr<void> parse_source_files();


### PR DESCRIPTION
Found while playing Fixme-Roulette.

This was pleasantly easy because both caller and callee already were set up for proper error propagation.