### PR TITLE
ClipboardHistory: Use titlecasing in the applet's window title

### DIFF
--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -39,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("edit-copy"sv));
 
     auto main_window = TRY(GUI::Window::try_create());
-    main_window->set_title("Clipboard history");
+    main_window->set_title("Clipboard History");
     main_window->set_rect(670, 65, 325, 500);
     main_window->set_icon(app_icon.bitmap_for_size(16));
 


### PR DESCRIPTION
Stuck out like a sore thumb to me on https://lunduke.locals.com/post/3989186/5-amazing-features-of-serenity-os :)