### PR TITLE
TextEditor: Prevent autoscroll looping over

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -181,7 +181,7 @@ TextPosition TextEditor::text_position_at_content_position(Gfx::IntPoint content
     switch (m_text_alignment) {
     case Gfx::TextAlignment::CenterLeft:
         for_each_visual_line(line_index, [&](Gfx::IntRect const& rect, auto& view, size_t start_of_line, [[maybe_unused]] bool is_last_visual_line) {
-            if (is_multi_line() && !rect.contains_vertically(position.y()) && !is_last_visual_line)
+            if (is_multi_line() && !rect.contains_vertically(position.y()) && !is_last_visual_line && position.y() >= 0)
                 return IterationDecision::Continue;
 
             column_index = start_of_line;


### PR DESCRIPTION
When a text file has only 1 line with long text auto-scroll to the top will no longer loop over and set the cursor to the end of the line.

Before the fix:

[Screencast from 2023-05-12 14-09-59.webm](https://github.com/SerenityOS/serenity/assets/1913834/8d4a5d25-c833-4504-b390-dc4e9d7e160b)

After:

[Screencast from 2023-05-12 14-10-44.webm](https://github.com/SerenityOS/serenity/assets/1913834/5ddbdaca-0ee9-4461-81f2-8b52a2e85dd8)
