### PR TITLE
Base: Run `SpiceAgent` as a user service

### DIFF
--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -59,9 +59,6 @@ User=root
 WorkingDirectory=/root/
 SystemModes=generate-manpages
 
-[SpiceAgent]
-KeepAlive=false
-
 [LoginServer]
 User=root
 Arguments=--auto-login anon

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -129,3 +129,6 @@ WorkingDirectory=/home/anon
 
 [CrashDaemon]
 KeepAlive=true
+
+[SpiceAgent]
+KeepAlive=false


### PR DESCRIPTION
This allows it to read/write to the user's clipboard properly. Prior to this, it would be writing to the Clipboard server running under the window user, which doesn't impact other users (like anon).

When building QEMU with `Toolchain/BuildQEMU.sh` (and having the relevant headers installed for [Spice](https://www.spice-space.org/spice-user-manual.html)), and having `SERENITY_SPICE=1` exported, you can now share the clipboard's content between the host and the guest!