### PR TITLE
LibWeb: Implement the HTMLMediaElement child <source> selection steps

### DIFF
--- a/Base/res/html/misc/video-source-children.html
+++ b/Base/res/html/misc/video-source-children.html
@@ -1,0 +1,59 @@
+<html>
+<head>
+<style type="text/css">
+    video {
+        border: 1px solid #333;
+    }
+
+    table, td {
+        border: 1px solid #333;
+        border-collapse: collapse;
+    }
+
+    thead, tfoot {
+        background-color: #333333;
+        color: #ffffff;
+    }
+</style>
+</head>
+<body>
+    <table>
+        <thead>
+            <tr>
+                <th colspan="2">Metadata</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Current Source</td>
+                <td id=src>null</td>
+            </tr>
+            <tr>
+                <td>Is Selected</td>
+                <td id=selected>false</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <br />
+
+    <video id=video controls>
+        <source>
+        <source src="">
+        <source src="Yo I don't exist!">
+        <source src="../../../home/anon/Videos/test-webm.webm">
+    </video>
+
+    <script type="text/javascript">
+        let video = document.getElementById('video');
+
+        video.videoTracks.onaddtrack = (event) => {
+            document.getElementById('selected').textContent = event.track.selected;
+        };
+
+        video.addEventListener('loadedmetadata', () => {
+            document.getElementById('src').textContent = video.currentSrc;
+        });
+    </script>
+</body>
+</html>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -811,7 +811,7 @@ AK::URL Document::base_url() const
 }
 
 // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url
-AK::URL Document::parse_url(DeprecatedString const& url) const
+AK::URL Document::parse_url(StringView url) const
 {
     // FIXME: Pass in document's character encoding.
     return base_url().complete_url(url);

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -123,7 +123,7 @@ public:
     HTML::CrossOriginOpenerPolicy const& cross_origin_opener_policy() const { return m_cross_origin_opener_policy; }
     void set_cross_origin_opener_policy(HTML::CrossOriginOpenerPolicy policy) { m_cross_origin_opener_policy = move(policy); }
 
-    AK::URL parse_url(DeprecatedString const&) const;
+    AK::URL parse_url(StringView) const;
 
     CSS::StyleComputer& style_computer() { return *m_style_computer; }
     const CSS::StyleComputer& style_computer() const { return *m_style_computer; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -26,6 +26,8 @@ enum class MediaSeekMode {
     ApproximateForSpeed,
 };
 
+class SourceElementSelector;
+
 class HTMLMediaElement : public HTMLElement {
     WEB_PLATFORM_OBJECT(HTMLMediaElement, HTMLElement);
 
@@ -101,6 +103,8 @@ protected:
     virtual void on_seek(double, MediaSeekMode) { m_seek_in_progress = false; }
 
 private:
+    friend SourceElementSelector;
+
     struct EntireResource { };
     using ByteRange = Variant<EntireResource>; // FIXME: This will need to include "until end" and an actual byte range.
 
@@ -209,6 +213,8 @@ private:
     Optional<Time> m_last_time_update_event_time;
 
     JS::GCPtr<DOM::DocumentObserver> m_document_observer;
+
+    JS::GCPtr<SourceElementSelector> m_source_element_selector;
 
     JS::GCPtr<Fetch::Infrastructure::FetchController> m_fetch_controller;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -40,6 +40,7 @@ public:
     WebIDL::ExceptionOr<void> set_decoder_error(String error_message);
 
     String const& current_src() const { return m_current_src; }
+    WebIDL::ExceptionOr<void> select_resource();
 
     enum class NetworkState : u16 {
         Empty,
@@ -111,7 +112,6 @@ private:
     Task::Source media_element_event_task_source() const { return m_media_element_event_task_source.source; }
 
     WebIDL::ExceptionOr<void> load_element();
-    WebIDL::ExceptionOr<void> select_resource();
     WebIDL::ExceptionOr<void> fetch_resource(AK::URL const&, Function<void(String)> failure_callback);
     static bool verify_response(JS::NonnullGCPtr<Fetch::Infrastructure::Response>, ByteRange const&);
     WebIDL::ExceptionOr<void> process_media_data(Function<void(String)> failure_callback);

--- a/Userland/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
@@ -5,6 +5,8 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/HTML/AttributeNames.h>
+#include <LibWeb/HTML/HTMLMediaElement.h>
 #include <LibWeb/HTML/HTMLSourceElement.h>
 
 namespace Web::HTML {
@@ -22,6 +24,35 @@ JS::ThrowCompletionOr<void> HTMLSourceElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLSourceElementPrototype>(realm, "HTMLSourceElement"));
 
     return {};
+}
+
+// https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element:the-source-element-15
+void HTMLSourceElement::inserted()
+{
+    // The source HTML element insertion steps, given insertedNode, are:
+    Base::inserted();
+
+    // 1. If insertedNode's parent is a media element that has no src attribute and whose networkState has the value
+    //    NETWORK_EMPTY, then invoke that media element's resource selection algorithm.
+    if (is<HTMLMediaElement>(parent())) {
+        auto& media_element = static_cast<HTMLMediaElement&>(*parent());
+
+        if (!media_element.has_attribute(HTML::AttributeNames::src) && media_element.network_state() == HTMLMediaElement::NetworkState::Empty)
+            media_element.select_resource().release_value_but_fixme_should_propagate_errors();
+    }
+
+    // FIXME: 2. If insertedNode's next sibling is an img element and its parent is a picture element, then, count this as a
+    //           relevant mutation for the img element.
+}
+
+// https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element:the-source-element-16
+void HTMLSourceElement::removed_from(DOM::Node* old_parent)
+{
+    // The source HTML element removing steps, given removedNode and oldParent, are:
+    Base::removed_from(old_parent);
+
+    // FIXME: 1. If removedNode's next sibling was an img element and oldParent is a picture element, then, count this as a
+    //           relevant mutation for the img element.
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLSourceElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSourceElement.h
@@ -20,6 +20,9 @@ private:
     HTMLSourceElement(DOM::Document&, DOM::QualifiedName);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
+
+    virtual void inserted() override;
+    virtual void removed_from(DOM::Node*) override;
 };
 
 }


### PR DESCRIPTION
Live test page courtesy of Luke:

https://github.com/SerenityOS/serenity/assets/5600524/2a5db95e-047b-4cf5-ac57-44d3995b277e

(BrowserAutoplayAllowlist.txt has to be manually changed for Ladybird to play this currently, will be much nicer to have in-browser controls for autoplay).