### PR TITLE
LibWeb: Align calculate_min/max_content_contribution with the spec

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -82,6 +82,7 @@ private:
         CSS::GridSize min_track_sizing_function;
         CSS::GridSize max_track_sizing_function;
         CSSPixels base_size { 0 };
+        bool has_definite_base_size { false };
         CSSPixels growth_limit { 0 };
         CSSPixels space_to_distribute { 0 };
         CSSPixels planned_increase { 0 };
@@ -173,7 +174,16 @@ private:
     void stretch_auto_tracks(AvailableSize const& available_size, Vector<TemporaryTrack>& tracks);
     void run_track_sizing(GridDimension const dimension, AvailableSpace const& available_space, Vector<TemporaryTrack>& tracks);
 
-    CSSPixels content_based_minimum_height(GridItem const&);
+    CSS::Size const& get_item_preferred_size(GridItem const&, GridDimension const) const;
+
+    CSSPixels calculate_min_content_size(GridItem const&, GridDimension const) const;
+    CSSPixels calculate_max_content_size(GridItem const&, GridDimension const) const;
+
+    CSSPixels calculate_min_content_contribution(GridItem const&, GridDimension const) const;
+    CSSPixels calculate_max_content_contribution(GridItem const&, GridDimension const) const;
+
+    CSSPixels containing_block_size_for_item(GridItem const&, GridDimension const) const;
+    AvailableSpace get_available_space_for_item(GridItem const&) const;
 };
 
 }


### PR DESCRIPTION
This change brings more spec compliant implementation of functions to calculate min/max contributions of grid items in containing block size.

Unfortunately I haven't created any new tests while working on this but I noticed that profile pages on github started to look better.

Before:
![Screenshot 2023-05-13 at 06 17 30](https://github.com/SerenityOS/serenity/assets/45686940/f4fc31f8-48a3-4dd1-abfc-1fa41dc10901)

After:
![Screenshot 2023-05-13 at 06 17 02](https://github.com/SerenityOS/serenity/assets/45686940/4e22f6ca-6ca5-4d88-87fe-8c7951c3f622)
