### PR TITLE
SpiceAgent: Gracefully handle the host clearing the clipboard

### DIFF
--- a/Userland/Services/SpiceAgent/SpiceAgent.cpp
+++ b/Userland/Services/SpiceAgent/SpiceAgent.cpp
@@ -132,11 +132,15 @@ void SpiceAgent::on_message_received()
 
         m_just_set_clip = true;
         if (type == ClipboardType::Text) {
-            auto anon_buffer_or_error = Core::AnonymousBuffer::create_with_size(data_buffer.size());
-            VERIFY(!anon_buffer_or_error.is_error());
-            auto anon_buffer = anon_buffer_or_error.release_value();
-            memcpy(anon_buffer.data<void>(), data_buffer.data(), data_buffer.size());
-            m_clipboard_connection.async_set_clipboard_data(anon_buffer, "text/plain", {});
+            if (data_buffer.is_empty()) {
+                m_clipboard_connection.async_set_clipboard_data({}, "text/plain", {});
+            } else {
+                auto anon_buffer_or_error = Core::AnonymousBuffer::create_with_size(data_buffer.size());
+                VERIFY(!anon_buffer_or_error.is_error());
+                auto anon_buffer = anon_buffer_or_error.release_value();
+                memcpy(anon_buffer.data<void>(), data_buffer.data(), data_buffer.size());
+                m_clipboard_connection.async_set_clipboard_data(anon_buffer, "text/plain", {});
+            }
             return;
         } else {
             ErrorOr<Gfx::ImageFrameDescriptor> frame_or_error = Gfx::ImageFrameDescriptor {};


### PR DESCRIPTION
When the host clears the clipboard (e.g. by running `pbcopy </dev/null`) the Spice server sends an empty string to us. Previously, we would crash as `AnonymousBuffer::create_with_size` doesn't accept a size of 0. Fix this by passing `{}` to `async_set_clipboard_data` in this case.