### PR TITLE
AK: Eliminate extra copies in Array::max and min

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -103,21 +103,25 @@ struct Array {
     {
         static_assert(Size > 0, "No values to max() over");
 
-        T value = __data[0];
+        size_t candidate = 0;
         for (size_t i = 1; i < Size; ++i)
-            value = AK::max(__data[i], value);
-        return value;
+            if (__data[candidate] < __data[i])
+                candidate = i;
+
+        return __data[candidate];
     }
 
     [[nodiscard]] constexpr T min() const
-    requires(requires(T x, T y) { x > y; })
+    requires(requires(T x, T y) { x < y; })
     {
         static_assert(Size > 0, "No values to min() over");
 
-        T value = __data[0];
+        size_t candidate = 0;;
         for (size_t i = 1; i < Size; ++i)
-            value = AK::min(__data[i], value);
-        return value;
+            if (__data[i] < __data[candidate])
+                candidate = i;
+
+        return __data[candidate];
     }
 
     bool contains_slow(T const& value) const

--- a/AK/Array.h
+++ b/AK/Array.h
@@ -116,7 +116,7 @@ struct Array {
     {
         static_assert(Size > 0, "No values to min() over");
 
-        size_t candidate = 0;;
+        size_t candidate = 0;
         for (size_t i = 1; i < Size; ++i)
             if (__data[i] < __data[candidate])
                 candidate = i;


### PR DESCRIPTION
Array::max and Array::min made N copies
while iterating over the array to find the extreme value. This fix will elemenate the waste.