### PR TITLE
test-imap+LibCore: Remove standard I/O from DeprecatedFile

### DIFF
--- a/Userland/Libraries/LibCore/DeprecatedFile.cpp
+++ b/Userland/Libraries/LibCore/DeprecatedFile.cpp
@@ -242,37 +242,6 @@ ErrorOr<DeprecatedString> DeprecatedFile::read_link(DeprecatedString const& link
 
 #endif
 
-static RefPtr<DeprecatedFile> stdin_file;
-static RefPtr<DeprecatedFile> stdout_file;
-static RefPtr<DeprecatedFile> stderr_file;
-
-NonnullRefPtr<DeprecatedFile> DeprecatedFile::standard_input()
-{
-    if (!stdin_file) {
-        stdin_file = DeprecatedFile::construct();
-        stdin_file->open(STDIN_FILENO, OpenMode::ReadOnly, ShouldCloseFileDescriptor::No);
-    }
-    return *stdin_file;
-}
-
-NonnullRefPtr<DeprecatedFile> DeprecatedFile::standard_output()
-{
-    if (!stdout_file) {
-        stdout_file = DeprecatedFile::construct();
-        stdout_file->open(STDOUT_FILENO, OpenMode::WriteOnly, ShouldCloseFileDescriptor::No);
-    }
-    return *stdout_file;
-}
-
-NonnullRefPtr<DeprecatedFile> DeprecatedFile::standard_error()
-{
-    if (!stderr_file) {
-        stderr_file = DeprecatedFile::construct();
-        stderr_file->open(STDERR_FILENO, OpenMode::WriteOnly, ShouldCloseFileDescriptor::No);
-    }
-    return *stderr_file;
-}
-
 static DeprecatedString get_duplicate_name(DeprecatedString const& path, int duplicate_count)
 {
     if (duplicate_count == 0) {

--- a/Userland/Libraries/LibCore/DeprecatedFile.h
+++ b/Userland/Libraries/LibCore/DeprecatedFile.h
@@ -82,10 +82,6 @@ public:
     bool open(int fd, OpenMode, ShouldCloseFileDescriptor);
     [[nodiscard]] int leak_fd();
 
-    static NonnullRefPtr<DeprecatedFile> standard_input();
-    static NonnullRefPtr<DeprecatedFile> standard_output();
-    static NonnullRefPtr<DeprecatedFile> standard_error();
-
     static Optional<DeprecatedString> resolve_executable_from_environment(StringView filename);
 
 private:

--- a/Userland/Utilities/test-imap.cpp
+++ b/Userland/Utilities/test-imap.cpp
@@ -5,11 +5,11 @@
  */
 
 #include <LibCore/ArgsParser.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/GetPassword.h>
 #include <LibIMAP/Client.h>
 #include <LibMain/Main.h>
+#include <unistd.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -24,7 +24,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     DeprecatedString username;
     Core::SecretString password;
-
     bool interactive_password;
 
     Core::ArgsParser args_parser;
@@ -38,8 +37,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (interactive_password) {
         password = TRY(Core::get_password());
     } else {
-        auto standard_input = Core::DeprecatedFile::standard_input();
-        password = Core::SecretString::take_ownership(standard_input->read_all());
+        auto standard_input = TRY(Core::File::standard_input());
+        // This might leave the clear password in unused memory, but this is only a test program anyway.
+        password = Core::SecretString::take_ownership(TRY(standard_input->read_until_eof()));
     }
 
     Core::EventLoop loop;


### PR DESCRIPTION
test-imap is the last user of this API, so let's convert it. I have no easy way to check whether test-imap still does what it's supposed to do, and the `git log` looks very sparse. Running against a `python3 -m aiosmtpd -n -l 0.0.0.0:1025` it crashes basically immediately, maybe because python doesn't do TLS I guess?

@sin-ack and @X-yl, can you help with this?

Advances #17129.