### PR TITLE
AK: Eliminate superfluous copies in Array min/max

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -103,21 +103,25 @@ struct Array {
     {
         static_assert(Size > 0, "No values to max() over");
 
-        T value = __data[0];
+        size_t candidate = 0;
         for (size_t i = 1; i < Size; ++i)
-            value = AK::max(__data[i], value);
-        return value;
+            if (__data[candidate] < __data[i])
+                candidate = i;
+
+        return __data[candidate];
     }
 
     [[nodiscard]] constexpr T min() const
-    requires(requires(T x, T y) { x > y; })
+    requires(requires(T x, T y) { x < y; })
     {
         static_assert(Size > 0, "No values to min() over");
 
-        T value = __data[0];
+        size_t candidate = 0;
         for (size_t i = 1; i < Size; ++i)
-            value = AK::min(__data[i], value);
-        return value;
+            if (__data[i] < __data[candidate])
+                candidate = i;
+
+        return __data[candidate];
     }
 
     bool contains_slow(T const& value) const

--- a/AK/Array.h
+++ b/AK/Array.h
@@ -104,9 +104,11 @@ struct Array {
         static_assert(Size > 0, "No values to max() over");
 
         size_t candidate = 0;
-        for (size_t i = 1; i < Size; ++i)
-            if (__data[candidate] < __data[i])
+        for (size_t i = 1; i < Size; ++i) {
+            if (__data[candidate] < __data[i]) {
                 candidate = i;
+            }
+        }
 
         return __data[candidate];
     }
@@ -117,9 +119,11 @@ struct Array {
         static_assert(Size > 0, "No values to min() over");
 
         size_t candidate = 0;
-        for (size_t i = 1; i < Size; ++i)
-            if (__data[i] < __data[candidate])
+        for (size_t i = 1; i < Size; ++i) {
+            if (__data[i] < __data[candidate]) {
                 candidate = i;
+            }
+        }
 
         return __data[candidate];
     }

--- a/Tests/AK/TestArray.cpp
+++ b/Tests/AK/TestArray.cpp
@@ -46,3 +46,15 @@ TEST_CASE(first_index_of)
     EXPECT(array.first_index_of(7) == 7u);
     EXPECT(!array.first_index_of(42).has_value());
 }
+
+TEST_CASE(max)
+{
+    constexpr Array<int, 8> array = { 0, 31, 2, 3, 41, 5, -6, 7 };
+    EXPECT(array.max() == 41);
+}
+
+TEST_CASE(min)
+{
+    constexpr Array<int, 8> array = { 0, 31, 2, 3, 41, 5, -6, 7 };
+    EXPECT(array.min() == -6);
+}


### PR DESCRIPTION
Array::max and Array::min make unneded copies while iterating over the array to find the extreme value. Implement without copies.