### PR TITLE
top: Add -p option to filter by pid

### DIFF
--- a/Base/usr/share/man/man1/top.md
+++ b/Base/usr/share/man/man1/top.md
@@ -1,0 +1,15 @@
+## Name
+
+top - display information about processes
+
+## Synopsis
+
+```sh
+$ top [--delay-time secs] [--pids pid-list] [--sort-by field]
+```
+
+## Options
+
+* `-d`, `--delay-time`: Delay time interval in seconds
+* `-p`, `--pids`: A comma-separated list of pids to filter by. This option may be used multiple times.
+* `-s`, `--sort-by`: Sort by field [pid, tid, pri, user, state, virt, phys, cpu, name]


### PR DESCRIPTION
The -p option can now be used to only monitor processes with the
specified pids. Pids are given as a comma-separated list. This option
may be used multiple times.

Video:

https://github.com/SerenityOS/serenity/assets/2817754/9206d4bd-3818-483b-8aff-a98a3252226e



