### PR TITLE
test-pthread: Check for correct return value from sem_trywait()

### DIFF
--- a/Userland/Utilities/test-pthread.cpp
+++ b/Userland/Utilities/test-pthread.cpp
@@ -107,7 +107,8 @@ static ErrorOr<void> test_semaphore_as_lock()
 
     VERIFY(v.size() == threads_count * num_times);
     VERIFY(sem_trywait(&semaphore) == 0);
-    VERIFY(sem_trywait(&semaphore) == EAGAIN);
+    VERIFY(sem_trywait(&semaphore) == -1);
+    VERIFY(errno == EAGAIN);
 
     return {};
 }
@@ -136,7 +137,8 @@ static ErrorOr<void> test_semaphore_as_event()
     [[maybe_unused]] auto r1 = reader->join();
     [[maybe_unused]] auto r2 = writer->join();
 
-    VERIFY(sem_trywait(&semaphore) == EAGAIN);
+    VERIFY(sem_trywait(&semaphore) == -1);
+    VERIFY(errno == EAGAIN);
 
     return {};
 }
@@ -181,7 +183,8 @@ static ErrorOr<void> test_semaphore_nonbinary()
     for (size_t i = 0; i < num; i++) {
         VERIFY(sem_trywait(&semaphore) == 0);
     }
-    VERIFY(sem_trywait(&semaphore) == EAGAIN);
+    VERIFY(sem_trywait(&semaphore) == -1);
+    VERIFY(errno == EAGAIN);
 
     return {};
 }


### PR DESCRIPTION
At some point `sem_trywait()` changed from returning an error code on failure to returning -1 and setting the errno. Update test-pthread to expect this behavior.

Note: I'm getting "Should already die" debug spam when running `test-pthread`. This seems to be because `Kernel::Thread::exit()` is called then, shortly after, `Process::die()` is called before the exited thread can be reaped by the Finalizer Task. I assume this is the expected behavior.