### PR TITLE
LibWeb: Flesh out basic support for min-width/height for grid items

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/grid-item-min-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-min-size.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      Box <div.grid> at (8,8) content-size 102x204 floating [GFC] children: not-inline
+        BlockContainer <div.first> at (9,9) content-size 100x100 [BFC] children: inline
+          line 0 width: 36.03125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [9,9 36.03125x17.46875]
+              "first"
+          TextNode <#text>
+        BlockContainer <div.second> at (9,111) content-size 100x100 [BFC] children: inline
+          line 0 width: 54.78125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [9,111 54.78125x17.46875]
+              "second"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/grid/grid-item-min-size.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-item-min-size.html
@@ -1,0 +1,22 @@
+<style>
+.grid {
+    float: left;
+    display: grid;
+    grid-template-columns: auto;
+    grid-template-rows: auto;
+}
+
+.first {
+    background: pink;
+    border: 1px solid black;
+    min-width: 100px;
+    min-height: 100px;
+}
+
+.second {
+    background: skyblue;
+    border: 1px solid black;
+    min-width: 100px;
+    min-height: 100px;
+}
+</style><div class="grid"><div class="first">first</div><div class="second">second</div></div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -184,8 +184,18 @@ private:
     CSSPixels calculate_min_content_contribution(GridItem const&, GridDimension const) const;
     CSSPixels calculate_max_content_contribution(GridItem const&, GridDimension const) const;
 
+    CSSPixels calculate_limited_min_content_contribution(GridItem const&, GridDimension const) const;
+    CSSPixels calculate_limited_max_content_contribution(GridItem const&, GridDimension const) const;
+
     CSSPixels containing_block_size_for_item(GridItem const&, GridDimension const) const;
     AvailableSpace get_available_space_for_item(GridItem const&) const;
+
+    CSS::Size const& get_item_minimum_size(GridItem const&, GridDimension const) const;
+    CSSPixels content_size_suggestion(GridItem const&, GridDimension const) const;
+    Optional<CSSPixels> specified_size_suggestion(GridItem const&, GridDimension const) const;
+    CSSPixels content_based_minimum_size(GridItem const&, GridDimension const) const;
+    CSSPixels automatic_minimum_size(GridItem const&, GridDimension const) const;
+    CSSPixels calculate_minimum_contribution(GridItem const&, GridDimension const) const;
 };
 
 }


### PR DESCRIPTION
This change brings calculate_minimum_contribution() for grid items and supporting functions.