### PR TITLE
Userland: Some more straight-forward DeprecatedFile migrations

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -27,7 +27,6 @@
 #include <AK/StringBuilder.h>
 #include <Kernel/API/InodeWatcherEvent.h>
 #include <LibConfig/Client.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/Event.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/FileWatcher.h>
@@ -903,10 +902,11 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_save_as_action()
         auto const old_filename = current_editor_wrapper().filename();
         LexicalPath const old_path(old_filename);
 
+        auto suggested_path = FileSystem::absolute_path(old_path.string()).release_value_but_fixme_should_propagate_errors();
         Optional<DeprecatedString> save_path = GUI::FilePicker::get_save_filepath(window(),
             old_filename.is_null() ? "Untitled"sv : old_path.title(),
             old_filename.is_null() ? "txt"sv : old_path.extension(),
-            Core::DeprecatedFile::absolute_path(old_path.dirname()));
+            suggested_path);
         if (!save_path.has_value()) {
             return;
         }

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -71,7 +71,7 @@ install(CODE "file(CREATE_LINK grep ${CMAKE_INSTALL_PREFIX}/bin/egrep SYMBOLIC)"
 install(CODE "file(CREATE_LINK grep ${CMAKE_INSTALL_PREFIX}/bin/fgrep SYMBOLIC)")
 install(CODE "file(CREATE_LINK grep ${CMAKE_INSTALL_PREFIX}/bin/rgrep SYMBOLIC)")
 
-target_link_libraries(abench PRIVATE LibAudio)
+target_link_libraries(abench PRIVATE LibAudio LibFileSystem)
 target_link_libraries(aplay PRIVATE LibAudio LibIPC)
 target_link_libraries(asctl PRIVATE LibAudio LibIPC)
 target_link_libraries(bt PRIVATE LibSymbolication)

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -72,7 +72,7 @@ install(CODE "file(CREATE_LINK grep ${CMAKE_INSTALL_PREFIX}/bin/fgrep SYMBOLIC)"
 install(CODE "file(CREATE_LINK grep ${CMAKE_INSTALL_PREFIX}/bin/rgrep SYMBOLIC)")
 
 target_link_libraries(abench PRIVATE LibAudio LibFileSystem)
-target_link_libraries(aplay PRIVATE LibAudio LibIPC)
+target_link_libraries(aplay PRIVATE LibAudio LibFileSystem LibIPC)
 target_link_libraries(asctl PRIVATE LibAudio LibIPC)
 target_link_libraries(bt PRIVATE LibSymbolication)
 target_link_libraries(checksum PRIVATE LibCrypto)

--- a/Userland/Utilities/abench.cpp
+++ b/Userland/Utilities/abench.cpp
@@ -8,9 +8,9 @@
 #include <AK/Types.h>
 #include <LibAudio/Loader.h>
 #include <LibCore/ArgsParser.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibMain/Main.h>
 #include <stdio.h>
 
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     args_parser.add_option(sample_count, "How many samples to load at maximum", "sample-count", 's', "samples");
     args_parser.parse(args);
 
-    TRY(Core::System::unveil(Core::DeprecatedFile::absolute_path(path), "r"sv));
+    TRY(Core::System::unveil(TRY(FileSystem::absolute_path(path)), "r"sv));
     TRY(Core::System::unveil(nullptr, nullptr));
     TRY(Core::System::pledge("stdio recvfd rpath"));
 

--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -10,9 +10,9 @@
 #include <LibAudio/Loader.h>
 #include <LibAudio/Resampler.h>
 #include <LibCore/ArgsParser.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibMain/Main.h>
 #include <math.h>
 #include <stdio.h>
@@ -35,10 +35,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(show_sample_progress, "Show playback progress in samples", "sample-progress", 's');
     args_parser.parse(arguments);
 
-    auto absolute_path = Core::DeprecatedFile::absolute_path(path);
-
     TRY(Core::System::unveil("/tmp/session/%sid/portal/audio", "rw"));
-    TRY(Core::System::unveil(absolute_path, "r"sv));
+    TRY(Core::System::unveil(TRY(FileSystem::absolute_path(path)), "r"sv));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     Core::EventLoop loop;


### PR DESCRIPTION
This PR converts abench, aplay, parts of HackStudio, and tar away from DeprecatedFile and to Core::File and LibFileSystem.

Advances #17129.