### PR TITLE
SystemMonitor: Prefer Core::File, fix username polling

### DIFF
--- a/Userland/Applications/SystemMonitor/ProcessModel.h
+++ b/Userland/Applications/SystemMonitor/ProcessModel.h
@@ -244,7 +244,6 @@ private:
     HashMap<int, NonnullRefPtr<Thread>> m_threads;
     Vector<NonnullOwnPtr<Process>> m_processes;
     Vector<NonnullOwnPtr<CpuInfo>> m_cpus;
-    RefPtr<Core::DeprecatedFile> m_proc_all;
     GUI::Icon m_kernel_process_icon;
     u64 m_total_time_scheduled { 0 };
     u64 m_total_time_scheduled_kernel { 0 };


### PR DESCRIPTION
This PR:
- Advances #17129.
- Fixes a subtle bug that caused usernames to be blank.

Before, the `RefPtr<Core::DeprecatedFile> m_proc_all;` field was never set, and in the invocation `Core::ProcessStatisticsReader::get_all(m_proc_all);` it was implicitly converted to bool (due to `RefPtr::operator bool`). 

Before this PR:
![sm_before](https://github.com/SerenityOS/serenity/assets/2690845/9d38684a-3513-4f16-b2e8-d37a4c80a4b0)

After this PR:
![sm_after](https://github.com/SerenityOS/serenity/assets/2690845/8f330014-755b-48a1-a81e-c5305f7fe0c8)



