### PR TITLE
Ladybird+LibWeb: Send the double click event to WebContent and make it bubble

### DIFF
--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -314,6 +314,21 @@ void WebContentView::mouseReleaseEvent(QMouseEvent* event)
     client().async_mouse_up(to_content(position), button, buttons, modifiers);
 }
 
+void WebContentView::mouseDoubleClickEvent(QMouseEvent* event)
+{
+    Gfx::IntPoint position(event->position().x() / m_inverse_pixel_scaling_ratio, event->position().y() / m_inverse_pixel_scaling_ratio);
+    auto button = get_button_from_qt_event(*event);
+    if (button == 0) {
+        // We could not convert Qt buttons to something that Lagom can
+        // recognize - don't even bother propagating this to the web engine
+        // as it will not handle it anyway, and it will (currently) assert
+        return;
+    }
+    auto modifiers = get_modifiers_from_qt_mouse_event(*event);
+    auto buttons = get_buttons_from_qt_event(*event);
+    client().async_doubleclick(to_content(position), button, buttons, modifiers);
+}
+
 void WebContentView::dragEnterEvent(QDragEnterEvent* event)
 {
     if (event->mimeData()->hasUrls())

--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -79,6 +79,7 @@ public:
     virtual void mouseMoveEvent(QMouseEvent*) override;
     virtual void mousePressEvent(QMouseEvent*) override;
     virtual void mouseReleaseEvent(QMouseEvent*) override;
+    virtual void mouseDoubleClickEvent(QMouseEvent*) override;
     virtual void dragEnterEvent(QDragEnterEvent*) override;
     virtual void dropEvent(QDropEvent*) override;
     virtual void keyPressEvent(QKeyEvent* event) override;

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -77,7 +77,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> MouseEvent::create_from_platfo
 
 void MouseEvent::set_event_characteristics()
 {
-    if (type().is_one_of(EventNames::mousedown, EventNames::mousemove, EventNames::mouseout, EventNames::mouseover, EventNames::mouseup, HTML::EventNames::click)) {
+    if (type().is_one_of(EventNames::mousedown, EventNames::mousemove, EventNames::mouseout, EventNames::mouseover, EventNames::mouseup, HTML::EventNames::click, EventNames::dblclick)) {
         set_bubbles(true);
         set_cancelable(true);
         set_composed(true);


### PR DESCRIPTION
Now you can open Steam chats with your friends that aren't pinned to the top.

https://github.com/SerenityOS/serenity/assets/25595356/146ac91e-6030-4055-98cc-3e05c9045c8d

