### PR TITLE
AK: Fix typo in instructions for adopt_nonnull_REF_or_enomem

### DIFF
--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -226,7 +226,7 @@ inline NonnullRefPtr<T> adopt_ref(T& object)
     return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, object);
 }
 
-// Use like `adopt_nonnull_own_or_enomem(new (nothrow) T(args...))`.
+// Use like `adopt_nonnull_ref_or_enomem(new (nothrow) T(args...))`.
 template<typename T>
 inline ErrorOr<NonnullRefPtr<T>> adopt_nonnull_ref_or_enomem(T* object)
 {


### PR DESCRIPTION
The instructions for `adopt_nonnull_REF_or_enomem` shouldn't use `adopt_nonnull_OWN_or_enomem` in the example :D