### PR TITLE
Everywhere: Mark most HashMap copies explicitly, avoid some unnecessary copies

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -40,6 +40,11 @@ public:
             set(item.key, item.value);
     }
 
+    HashMap(HashMap const&) = default; // FIXME: Not OOM-safe! Use clone() instead.
+    HashMap(HashMap&& other) noexcept = default;
+    HashMap& operator=(HashMap const& other) = default; // FIXME: Not OOM-safe! Use clone() instead.
+    HashMap& operator=(HashMap&& other) noexcept = default;
+
     [[nodiscard]] bool is_empty() const
     {
         return m_table.is_empty();

--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -281,9 +281,10 @@ public:
         return hash;
     }
 
-    ErrorOr<HashMap<K, V>> clone()
+    template<typename NewKeyTraits = KeyTraits, typename NewValueTraits = ValueTraits, bool NewIsOrdered = IsOrdered>
+    ErrorOr<HashMap<K, V, NewKeyTraits, NewValueTraits, NewIsOrdered>> clone() const
     {
-        HashMap<K, V> hash_map_clone;
+        HashMap<K, V, NewKeyTraits, NewValueTraits, NewIsOrdered> hash_map_clone;
         for (auto& it : *this)
             TRY(hash_map_clone.try_set(it.key, it.value));
         return hash_map_clone;

--- a/AK/JsonObject.cpp
+++ b/AK/JsonObject.cpp
@@ -14,7 +14,7 @@ JsonObject::JsonObject() = default;
 JsonObject::~JsonObject() = default;
 
 JsonObject::JsonObject(JsonObject const& other)
-    : m_members(other.m_members)
+    : m_members(other.m_members.clone().release_value_but_fixme_should_propagate_errors())
 {
 }
 
@@ -26,7 +26,7 @@ JsonObject::JsonObject(JsonObject&& other)
 JsonObject& JsonObject::operator=(JsonObject const& other)
 {
     if (this != &other)
-        m_members = other.m_members;
+        m_members = other.m_members.clone().release_value_but_fixme_should_propagate_errors();
     return *this;
 }
 

--- a/AK/SourceGenerator.h
+++ b/AK/SourceGenerator.h
@@ -27,7 +27,7 @@ public:
     }
     explicit SourceGenerator(StringBuilder& builder, MappingType const& mapping, char opening = '@', char closing = '@')
         : m_builder(builder)
-        , m_mapping(mapping)
+        , m_mapping(mapping.clone().release_value_but_fixme_should_propagate_errors())
         , m_opening(opening)
         , m_closing(closing)
     {

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
@@ -577,7 +577,7 @@ static constexpr Array<PluralCategory, @size@> @name@ { { PluralCategory::Other)
         generator.append("} };");
     };
 
-    for (auto [locale, rules] : cldr.locales) {
+    for (auto const& [locale, rules] : cldr.locales) {
         append_rules("cardinal"sv, locale, rules.cardinal_rules);
         append_rules("ordinal"sv, locale, rules.ordinal_rules);
         append_ranges(locale, rules.plural_ranges);

--- a/Userland/Libraries/LibCore/MimeData.h
+++ b/Userland/Libraries/LibCore/MimeData.h
@@ -41,7 +41,7 @@ public:
 private:
     MimeData() = default;
     explicit MimeData(HashMap<DeprecatedString, ByteBuffer> const& data)
-        : m_data(data)
+        : m_data(data.clone().release_value_but_fixme_should_propagate_errors())
     {
     }
 

--- a/Userland/Libraries/LibGUI/Clipboard.cpp
+++ b/Userland/Libraries/LibGUI/Clipboard.cpp
@@ -150,7 +150,7 @@ ErrorOr<JsonObject> Clipboard::DataAndType::to_json() const
 void Clipboard::set_data(ReadonlyBytes data, DeprecatedString const& type, HashMap<DeprecatedString, DeprecatedString> const& metadata)
 {
     if (data.is_empty()) {
-        connection().async_set_clipboard_data({}, type, metadata);
+        connection().async_set_clipboard_data({}, type, metadata.clone().release_value_but_fixme_should_propagate_errors());
         return;
     }
 
@@ -161,18 +161,18 @@ void Clipboard::set_data(ReadonlyBytes data, DeprecatedString const& type, HashM
     }
     auto buffer = buffer_or_error.release_value();
     memcpy(buffer.data<void>(), data.data(), data.size());
-    connection().async_set_clipboard_data(move(buffer), type, metadata);
+    connection().async_set_clipboard_data(move(buffer), type, metadata.clone().release_value_but_fixme_should_propagate_errors());
 }
 
 void Clipboard::set_bitmap(Gfx::Bitmap const& bitmap, HashMap<DeprecatedString, DeprecatedString> const& additional_metadata)
 {
-    HashMap<DeprecatedString, DeprecatedString> metadata(additional_metadata);
+    HashMap<DeprecatedString, DeprecatedString> metadata = additional_metadata.clone().release_value_but_fixme_should_propagate_errors();
     metadata.set("width", DeprecatedString::number(bitmap.width()));
     metadata.set("height", DeprecatedString::number(bitmap.height()));
     metadata.set("scale", DeprecatedString::number(bitmap.scale()));
     metadata.set("format", DeprecatedString::number((int)bitmap.format()));
     metadata.set("pitch", DeprecatedString::number(bitmap.pitch()));
-    set_data({ bitmap.scanline(0), bitmap.size_in_bytes() }, "image/x-serenityos", metadata);
+    set_data({ bitmap.scanline(0), bitmap.size_in_bytes() }, "image/x-serenityos", move(metadata));
 }
 
 void Clipboard::clear()

--- a/Userland/Libraries/LibIDL/IDLParser.cpp
+++ b/Userland/Libraries/LibIDL/IDLParser.cpp
@@ -312,7 +312,7 @@ Vector<Parameter> Parser::parse_parameters()
         bool variadic = lexer.consume_specific("..."sv);
         consume_whitespace();
         auto name = lexer.consume_until([](auto ch) { return is_ascii_space(ch) || ch == ',' || ch == ')' || ch == '='; });
-        Parameter parameter = { move(type), move(name), optional, {}, extended_attributes, variadic };
+        Parameter parameter = { move(type), move(name), optional, {}, move(extended_attributes), variadic };
         consume_whitespace();
         if (variadic) {
             // Variadic parameters must be last and do not have default values.

--- a/Userland/Libraries/LibIPC/Dictionary.h
+++ b/Userland/Libraries/LibIPC/Dictionary.h
@@ -17,8 +17,8 @@ class Dictionary {
 public:
     Dictionary() = default;
 
-    Dictionary(HashMap<DeprecatedString, DeprecatedString> const& initial_entries)
-        : m_entries(initial_entries)
+    Dictionary(HashMap<DeprecatedString, DeprecatedString>&& initial_entries)
+        : m_entries(move(initial_entries))
     {
     }
 

--- a/Userland/Libraries/LibPDF/Encoding.cpp
+++ b/Userland/Libraries/LibPDF/Encoding.cpp
@@ -43,8 +43,8 @@ PDFErrorOr<NonnullRefPtr<Encoding>> Encoding::from_object(Document* document, No
 
     auto encoding = adopt_ref(*new Encoding());
 
-    encoding->m_descriptors = base_encoding->m_descriptors;
-    encoding->m_name_mapping = base_encoding->m_name_mapping;
+    encoding->m_descriptors = TRY(base_encoding->m_descriptors.clone());
+    encoding->m_name_mapping = TRY(base_encoding->m_name_mapping.clone());
 
     auto differences_array = TRY(dict->get_array(document, CommonNames::Differences));
 

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -432,7 +432,7 @@ PDFErrorOr<NonnullRefPtr<DictObject>> Parser::parse_dict()
         return error("Expected dict to end with \">>\"");
     m_reader.consume_whitespace();
 
-    return make_object<DictObject>(map);
+    return make_object<DictObject>(move(map));
 }
 
 PDFErrorOr<NonnullRefPtr<StreamObject>> Parser::parse_stream(NonnullRefPtr<DictObject> dict)

--- a/Userland/Libraries/LibTLS/Certificate.cpp
+++ b/Userland/Libraries/LibTLS/Certificate.cpp
@@ -794,7 +794,7 @@ ErrorOr<Certificate> Certificate::parse_certificate(ReadonlyBytes buffer, bool)
 #undef DROP_OBJECT
 #undef REWRITE_TAG
 
-ErrorOr<String> RelativeDistinguishedName::to_string()
+ErrorOr<String> RelativeDistinguishedName::to_string() const
 {
 #define ADD_IF_RECOGNIZED(identifier, shorthand_code)             \
     if (it->key == identifier) {                                  \

--- a/Userland/Libraries/LibTLS/Certificate.h
+++ b/Userland/Libraries/LibTLS/Certificate.h
@@ -192,29 +192,29 @@ struct BasicConstraints {
 
 class RelativeDistinguishedName {
 public:
-    ErrorOr<String> to_string();
+    ErrorOr<String> to_string() const;
 
     ErrorOr<AK::HashSetResult> set(String key, String value)
     {
         return m_members.try_set(key, value);
     }
 
-    Optional<String> get(StringView key)
+    Optional<String> get(StringView key) const
     {
         return m_members.get(key);
     }
 
-    Optional<String> get(AttributeType key)
+    Optional<String> get(AttributeType key) const
     {
         return m_members.get(enum_value(key));
     }
 
-    Optional<String> get(ObjectClass key)
+    Optional<String> get(ObjectClass key) const
     {
         return m_members.get(enum_value(key));
     }
 
-    String common_name()
+    String common_name() const
     {
         auto entry = get(AttributeType::Cn);
         if (entry.has_value()) {

--- a/Userland/Libraries/LibTLS/HandshakeCertificate.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeCertificate.cpp
@@ -78,7 +78,7 @@ ssize_t TLSv12::handle_certificate(ReadonlyBytes buffer)
 
             auto certificate = Certificate::parse_certificate(buffer.slice(res_cert, certificate_size_specific), false);
             if (!certificate.is_error()) {
-                m_context.certificates.append(certificate.value());
+                m_context.certificates.empend(certificate.value());
                 valid_certificate = true;
             } else {
                 dbgln("Failed to parse client cert: {}", certificate.error());

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -231,7 +231,7 @@ static bool wildcard_matches(StringView host, StringView subject)
     return false;
 }
 
-static bool certificate_subject_matches_host(Certificate& cert, StringView host)
+static bool certificate_subject_matches_host(Certificate const& cert, StringView host)
 {
     if (wildcard_matches(host, cert.subject.common_name()))
         return true;
@@ -269,7 +269,7 @@ bool Context::verify_chain(StringView host) const
     // it in any case.
 
     if (!host.is_empty()) {
-        auto first_certificate = local_chain->first();
+        auto const& first_certificate = local_chain->first();
         auto subject_matches = certificate_subject_matches_host(first_certificate, host);
         if (!subject_matches) {
             dbgln("verify_chain: First certificate does not match the hostname");
@@ -282,7 +282,7 @@ bool Context::verify_chain(StringView host) const
     }
 
     for (size_t cert_index = 0; cert_index < local_chain->size(); ++cert_index) {
-        auto cert = local_chain->at(cert_index);
+        auto const& cert = local_chain->at(cert_index);
 
         auto subject_string = MUST(cert.subject.to_string());
         auto issuer_string = MUST(cert.issuer.to_string());
@@ -316,7 +316,7 @@ bool Context::verify_chain(StringView host) const
             return false;
         }
 
-        auto parent_certificate = local_chain->at(cert_index + 1);
+        auto const& parent_certificate = local_chain->at(cert_index + 1);
         if (issuer_string != MUST(parent_certificate.subject.to_string())) {
             dbgln("verify_chain: Next certificate in the chain is not the issuer of this certificate");
             return false;

--- a/Userland/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/Resource.cpp
@@ -92,7 +92,7 @@ void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, HashMap<Depre
     VERIFY(!m_loaded);
     // FIXME: Handle OOM failure.
     m_encoded_data = ByteBuffer::copy(data).release_value_but_fixme_should_propagate_errors();
-    m_response_headers = headers;
+    m_response_headers = headers.clone().release_value_but_fixme_should_propagate_errors();
     m_status_code = move(status_code);
     m_loaded = true;
 

--- a/Userland/Services/Clipboard/ConnectionFromClient.cpp
+++ b/Userland/Services/Clipboard/ConnectionFromClient.cpp
@@ -38,7 +38,7 @@ void ConnectionFromClient::set_clipboard_data(Core::AnonymousBuffer const& data,
 Messages::ClipboardServer::GetClipboardDataResponse ConnectionFromClient::get_clipboard_data()
 {
     auto& storage = Storage::the();
-    return { storage.buffer(), storage.mime_type(), storage.metadata() };
+    return { storage.buffer(), storage.mime_type(), storage.metadata().clone().release_value_but_fixme_should_propagate_errors() };
 }
 
 void ConnectionFromClient::notify_about_clipboard_change()

--- a/Userland/Services/SpiceAgent/ConnectionToClipboardServer.cpp
+++ b/Userland/Services/SpiceAgent/ConnectionToClipboardServer.cpp
@@ -71,5 +71,5 @@ void ConnectionToClipboardServer::set_bitmap(Gfx::Bitmap const& bitmap)
     VERIFY(!buffer_or_error.is_error());
     auto buffer = buffer_or_error.release_value();
     memcpy(buffer.data<u8>(), data.data(), data.size());
-    this->async_set_clipboard_data(buffer, "image/x-serenityos", metadata);
+    this->async_set_clipboard_data(buffer, "image/x-serenityos", move(metadata));
 }


### PR DESCRIPTION
While working on #18759, I noticed that we permitted implicit copy-construct and copy-assign for `HashMap`. Since this type can become reasonably large, it seems like a good idea to avoid implicit copies of these, as they are more likely to encounter `ENOMEM` than, say, a 16-byte struct.

This PR looks at most implicit HashMap copies, and either:
- avoids the copy entirely, e.g. turning it into a move or a reference, or
- marks the copy explicitly as copies (using `HashMap::clone`), or
- leaves it as an implicit copy, if it is buried in another implicit copy (e.g. the implicit copy-constructor of a `struct Foo {HashMap<Bar, Baz> entries;};`). Examples are `TLS::Certificate`, or `Web::HTML::ImportMap`.

The effect should be:
- marginal memory saving, if any; and
- easier error handling if the copying fails; and
- ideally in the future someone can finish the hunt and turn it into `AK_MAKE_NONCOPYABLE(HashMap);`

In case you're curious, you can do a checkout and see how many callsites remain:
```
    HashMap(HashMap const&) = delete;
    HashMap(HashMap&& other) noexcept = default;
    HashMap& operator=(HashMap const& other) = delete;
    HashMap& operator=(HashMap&& other) noexcept = default;
```