### PR TITLE
pidof: Add -S option to specify a pid separator

### DIFF
--- a/Base/usr/share/man/man1/pidof.md
+++ b/Base/usr/share/man/man1/pidof.md
@@ -1,0 +1,19 @@
+## Name
+
+pidof - list pids for a given process name
+
+## Synopsis
+
+```sh
+$ pidof [-s] [-o pid] [-S separator] <process-name>
+```
+
+## Options
+
+* `-o pid`: Omit the given pid, or the parent process if the special value %PPID is passed
+* `-s`: Only return one pid
+* `-S separator`: Use `separator` to separate multiple pids
+
+## Arguments
+
+* `process-name`: Process name to search for

--- a/Userland/Utilities/pidof.cpp
+++ b/Userland/Utilities/pidof.cpp
@@ -17,6 +17,7 @@ struct Options {
     bool single_shot { false };
     Optional<pid_t> pid_to_omit;
     StringView process_name;
+    StringView pid_separator { " "sv };
 };
 
 static ErrorOr<int> pid_of(Options const& options)
@@ -29,7 +30,11 @@ static ErrorOr<int> pid_of(Options const& options)
         if (it.name != options.process_name || options.pid_to_omit == it.pid)
             continue;
 
-        out(displayed_at_least_one ? " {}"sv : "{}"sv, it.pid);
+        if (displayed_at_least_one)
+            out("{}{}"sv, options.pid_separator, it.pid);
+        else
+            out("{}"sv, it.pid);
+
         displayed_at_least_one = true;
 
         if (options.single_shot)
@@ -75,6 +80,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         },
     });
     args_parser.add_option(options.single_shot, "Only return one pid", nullptr, 's');
+    args_parser.add_option(options.pid_separator, "Use `separator` to separate multiple pids", nullptr, 'S', "separator");
     args_parser.add_positional_argument(options.process_name, "Process name to search for", "process-name");
 
     args_parser.parse(args);


### PR DESCRIPTION
This is useful for commands which expect a comma-separated list of
pids, such as `top -p` or `ps -q`.

I've also moved all options into a struct to make them easier to pass around, use `ArgsParser` to validate the `-o` option and have reorganized some logic to reduce nesting.

Example usage:

![pidof_custom_separator](https://github.com/SerenityOS/serenity/assets/2817754/fc53ce13-6e8b-4427-b511-b7353f154d2d)
