### PR TITLE
LibWeb: Change implicit background-size height to auto

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4606,12 +4606,13 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_single_background_size_value(TokenStre
 
     auto maybe_y_value = TRY(parse_css_value(tokens.peek_token()));
     if (!maybe_y_value || !property_accepts_value(PropertyID::BackgroundSize, *maybe_y_value)) {
+        auto y_value = LengthPercentage { Length::make_auto() };
         auto x_size = get_length_percentage(*x_value);
         if (!x_size.has_value())
             return nullptr;
 
         transaction.commit();
-        return BackgroundSizeStyleValue::create(x_size.value(), x_size.value());
+        return BackgroundSizeStyleValue::create(x_size.value(), y_value);
     }
     tokens.next_token();
 


### PR DESCRIPTION
The [spec](https://www.w3.org/TR/css-backgrounds-3/#propdef-background-size) says: "The first value gives the width of the corresponding image, the second value its height. If only one value is given the second is assumed to be auto."

Fixes #18782

This is my first pull request for serenity so all kinds of feedback are welcome.