### PR TITLE
LibWeb: Remove dead code in resolve_intrinsic_track_sizes() in GFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
+++ b/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
@@ -1,14 +1,14 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x24 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x24 [GFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x24.000022 children: not-inline
+      Box <div.grid-container> at (8,8) content-size 784x24.000022 [GFC] children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.wrapper> at (8,8) content-size 64x24 [BFC] children: inline
-          line 0 width: 64, height: 24, bottom: 24, baseline: 24
-            frag 0 from ImageBox start: 0, length: 0, rect: [8,8 64x24]
+        BlockContainer <div.wrapper> at (8,8) content-size 64.000061x24.000022 [BFC] children: inline
+          line 0 width: 64.000061, height: 24.000022, bottom: 24.000022, baseline: 24.000022
+            frag 0 from ImageBox start: 0, length: 0, rect: [8,8 64.000061x24.000022]
           TextNode <#text>
-          ImageBox <img> at (8,8) content-size 64x24 children: not-inline
+          ImageBox <img> at (8,8) content-size 64.000061x24.000022 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> at (8,8) content-size 0x0 [BFC] children: inline
           TextNode <#text>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1467,7 +1467,6 @@ CSSPixels GridFormattingContext::calculate_min_content_size(GridItem const& item
     } else {
         return calculate_min_content_height(item.box(), get_available_space_for_item(item).width);
     }
-    return calculate_min_content_height(item.box(), AvailableSize::make_definite(m_grid_columns[item.gap_adjusted_column(grid_container())].base_size));
 }
 
 CSSPixels GridFormattingContext::calculate_max_content_size(GridItem const& item, GridDimension const dimension) const


### PR DESCRIPTION
Removes partially implemented algorithm for distributing extra space from spanning item:
https://www.w3.org/TR/css-grid-2/#extra-space

This algorithm should not be part of resolving track sizing on its own but instead be a subfunction of step 3:
https://www.w3.org/TR/css-grid-2/#track-size-max-content-min

There are changes in layout tests but those are not regressions.