### PR TITLE
AK: Include Array.h in Base64.h

### DIFF
--- a/AK/Base64.cpp
+++ b/AK/Base64.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Array.h>
 #include <AK/Assertions.h>
 #include <AK/Base64.h>
 #include <AK/CharacterTypes.h>

--- a/AK/Base64.h
+++ b/AK/Base64.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <AK/ByteBuffer.h>
 #include <AK/Error.h>
 #include <AK/String.h>


### PR DESCRIPTION
Array.h should be included in Base64.h and removed from Base64.cpp