### PR TITLE
Ladybird: Make resizing faster(and less glitchy)

### DIFF
--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -1105,7 +1105,7 @@ void WebContentView::request_repaint()
         return;
     }
     m_client_state.back_bitmap.pending_paints++;
-    client().async_paint(m_client_state.back_bitmap.bitmap->rect().translated(horizontalScrollBar()->value(), verticalScrollBar()->value()), m_client_state.back_bitmap.id);
+    client().async_paint(m_viewport_rect, m_client_state.back_bitmap.id);
 }
 
 bool WebContentView::event(QEvent* event)

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -680,11 +680,12 @@ void WebContentView::handle_web_content_process_crash()
     load_html(builder.to_deprecated_string(), m_url);
 }
 
-void WebContentView::notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id)
+void WebContentView::notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize size)
 {
     if (m_client_state.back_bitmap.id == bitmap_id) {
         m_client_state.has_usable_bitmap = true;
         m_client_state.back_bitmap.pending_paints--;
+        m_client_state.back_bitmap.last_painted_size = size;
         swap(m_client_state.back_bitmap, m_client_state.front_bitmap);
         // We don't need the backup bitmap anymore, so drop it.
         m_backup_bitmap = nullptr;

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -397,12 +397,12 @@ void WebContentView::focusOutEvent(QFocusEvent*)
 
 Gfx::IntPoint WebContentView::to_content(Gfx::IntPoint viewport_position) const
 {
-    return viewport_position.translated(horizontalScrollBar()->value(), verticalScrollBar()->value());
+    return viewport_position.translated(max(0, horizontalScrollBar()->value()), max(0, verticalScrollBar()->value()));
 }
 
 Gfx::IntPoint WebContentView::to_widget(Gfx::IntPoint content_position) const
 {
-    return content_position.translated(-horizontalScrollBar()->value(), -verticalScrollBar()->value());
+    return content_position.translated(-(max(0, horizontalScrollBar()->value())), -(max(0, verticalScrollBar()->value())));
 }
 
 void WebContentView::paintEvent(QPaintEvent*)
@@ -484,7 +484,7 @@ void WebContentView::update_viewport_rect()
 {
     auto scaled_width = int(viewport()->width() / m_inverse_pixel_scaling_ratio);
     auto scaled_height = int(viewport()->height() / m_inverse_pixel_scaling_ratio);
-    Gfx::IntRect rect(horizontalScrollBar()->value(), verticalScrollBar()->value(), scaled_width, scaled_height);
+    Gfx::IntRect rect(max(0, horizontalScrollBar()->value()), max(0, verticalScrollBar()->value()), scaled_width, scaled_height);
 
     set_viewport_rect(rect);
 
@@ -787,8 +787,8 @@ void WebContentView::notify_server_did_change_title(Badge<WebContentClient>, Dep
 
 void WebContentView::notify_server_did_request_scroll(Badge<WebContentClient>, i32 x_delta, i32 y_delta)
 {
-    horizontalScrollBar()->setValue(horizontalScrollBar()->value() + x_delta);
-    verticalScrollBar()->setValue(verticalScrollBar()->value() + y_delta);
+    horizontalScrollBar()->setValue(max(0, horizontalScrollBar()->value() + x_delta));
+    verticalScrollBar()->setValue(max(0, verticalScrollBar()->value() + y_delta));
 }
 
 void WebContentView::notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint scroll_position)

--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2023, Linus Groh <linusg@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -203,6 +203,12 @@ private:
     void update_viewport_rect();
     void handle_resize();
 
+    enum class WindowResizeInProgress {
+        No,
+        Yes,
+    };
+    void resize_backing_stores_if_needed(WindowResizeInProgress);
+
     void ensure_js_console_widget();
     void ensure_inspector_widget();
 
@@ -222,6 +228,9 @@ private:
     void handle_web_content_process_crash();
 
     RefPtr<Gfx::Bitmap> m_backup_bitmap;
+    Gfx::IntSize m_backup_bitmap_size;
 
     StringView m_webdriver_content_ipc_path;
+
+    RefPtr<Core::Timer> m_backing_store_shrink_timer;
 };

--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -119,7 +119,7 @@ public:
     void update_palette(PaletteMode = PaletteMode::Default);
 
     virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) override;
-    virtual void notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id) override;
+    virtual void notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize) override;
     virtual void notify_server_did_invalidate_content_rect(Badge<WebContentClient>, Gfx::IntRect const&) override;
     virtual void notify_server_did_change_selection(Badge<WebContentClient>) override;
     virtual void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor) override;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -205,11 +205,12 @@ void OutOfProcessWebView::screen_rects_change_event(GUI::ScreenRectsChangeEvent&
     client().async_update_screen_rects(event.rects(), event.main_screen_index());
 }
 
-void OutOfProcessWebView::notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id)
+void OutOfProcessWebView::notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize size)
 {
     if (m_client_state.back_bitmap.id == bitmap_id) {
         m_client_state.has_usable_bitmap = true;
         m_client_state.back_bitmap.pending_paints--;
+        m_client_state.back_bitmap.last_painted_size = size;
         swap(m_client_state.back_bitmap, m_client_state.front_bitmap);
         // We don't need the backup bitmap anymore, so drop it.
         m_backup_bitmap = nullptr;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -126,7 +126,7 @@ private:
     virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No) override;
     virtual void update_zoom() override;
     virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) override;
-    virtual void notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id) override;
+    virtual void notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize) override;
     virtual void notify_server_did_invalidate_content_rect(Badge<WebContentClient>, Gfx::IntRect const&) override;
     virtual void notify_server_did_change_selection(Badge<WebContentClient>) override;
     virtual void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor) override;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -71,7 +71,7 @@ public:
     void run_javascript(StringView);
 
     virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) = 0;
-    virtual void notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id) = 0;
+    virtual void notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize) = 0;
     virtual void notify_server_did_invalidate_content_rect(Badge<WebContentClient>, Gfx::IntRect const&) = 0;
     virtual void notify_server_did_change_selection(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor) = 0;
@@ -142,6 +142,7 @@ protected:
     struct SharedBitmap {
         i32 id { -1 };
         i32 pending_paints { 0 };
+        Gfx::IntSize last_painted_size;
         RefPtr<Gfx::Bitmap> bitmap;
     };
 

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -23,9 +23,9 @@ void WebContentClient::die()
     on_web_content_process_crash();
 }
 
-void WebContentClient::did_paint(Gfx::IntRect const&, i32 bitmap_id)
+void WebContentClient::did_paint(Gfx::IntRect const& rect, i32 bitmap_id)
 {
-    m_view.notify_server_did_paint({}, bitmap_id);
+    m_view.notify_server_did_paint({}, bitmap_id, rect.size());
 }
 
 void WebContentClient::did_finish_loading(AK::URL const& url)

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -84,7 +84,7 @@ private:
     HeadlessWebContentView() = default;
 
     void notify_server_did_layout(Badge<WebView::WebContentClient>, Gfx::IntSize) override { }
-    void notify_server_did_paint(Badge<WebView::WebContentClient>, i32) override { }
+    void notify_server_did_paint(Badge<WebView::WebContentClient>, i32, Gfx::IntSize) override { }
     void notify_server_did_invalidate_content_rect(Badge<WebView::WebContentClient>, Gfx::IntRect const&) override { }
     void notify_server_did_change_selection(Badge<WebView::WebContentClient>) override { }
     void notify_server_did_request_cursor_change(Badge<WebView::WebContentClient>, Gfx::StandardCursor) override { }


### PR DESCRIPTION
See individual commits for details.

Basically:
- Fix glitch where entire page was rendered at a negative offset for a split second sometimes
- Don't reallocate shared bitmap backing stores on every single resize. Instead, pad the bitmaps by 256 pixels in both axes while resizing. Shrink it down a couple seconds after resizing stops.

Before/after:

[ladybird-resize.webm](https://github.com/SerenityOS/serenity/assets/5954907/0c98206e-22b4-416b-885c-264af01805b6)

