### PR TITLE
Userland: Port `Model::column_name()` to String

### DIFF
--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -23,17 +23,17 @@ ClipboardHistoryModel::ClipboardHistoryModel()
 {
 }
 
-DeprecatedString ClipboardHistoryModel::column_name(int column) const
+String ClipboardHistoryModel::column_name(int column) const
 {
     switch (column) {
     case Column::Data:
-        return "Data";
+        return "Data"_short_string;
     case Column::Type:
-        return "Type";
+        return "Type"_short_string;
     case Column::Size:
-        return "Size";
+        return "Size"_short_string;
     case Column::Time:
-        return "Time";
+        return "Time"_short_string;
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
@@ -60,7 +60,7 @@ private:
 
     // ^GUI::Model
     virtual int row_count(const GUI::ModelIndex&) const override { return m_history_items.size(); }
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual int column_count(const GUI::ModelIndex&) const override { return Column::__Count; }
 
     // ^GUI::Clipboard::ClipboardClient

--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -165,8 +165,8 @@ BookmarksBarWidget::BookmarksBarWidget(DeprecatedString const& bookmarks_file, b
         this));
 
     Vector<GUI::JsonArrayModel::FieldSpec> fields;
-    fields.empend("title", "Title", Gfx::TextAlignment::CenterLeft);
-    fields.empend("url", "Url", Gfx::TextAlignment::CenterRight);
+    fields.empend("title", "Title"_short_string, Gfx::TextAlignment::CenterLeft);
+    fields.empend("url", "Url"_short_string, Gfx::TextAlignment::CenterRight);
     set_model(GUI::JsonArrayModel::create(bookmarks_file, move(fields)));
     model()->invalidate();
 }

--- a/Userland/Applications/Browser/CookiesModel.cpp
+++ b/Userland/Applications/Browser/CookiesModel.cpp
@@ -34,21 +34,21 @@ int CookiesModel::row_count(GUI::ModelIndex const& index) const
     return 0;
 }
 
-DeprecatedString CookiesModel::column_name(int column) const
+String CookiesModel::column_name(int column) const
 {
     switch (column) {
     case Column::Domain:
-        return "Domain";
+        return "Domain"_short_string;
     case Column::Path:
-        return "Path";
+        return "Path"_short_string;
     case Column::Name:
-        return "Name";
+        return "Name"_short_string;
     case Column::Value:
-        return "Value";
+        return "Value"_short_string;
     case Column::ExpiryTime:
-        return "Expiry time";
+        return "Expiry time"_string.release_value_but_fixme_should_propagate_errors();
     case Column::SameSite:
-        return "SameSite";
+        return "SameSite"_string.release_value_but_fixme_should_propagate_errors();
     case Column::__Count:
         return {};
     }

--- a/Userland/Applications/Browser/CookiesModel.h
+++ b/Userland/Applications/Browser/CookiesModel.h
@@ -30,7 +30,7 @@ public:
     void clear_items();
     virtual int row_count(GUI::ModelIndex const&) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual DeprecatedString column_name(int column) const override;
+    virtual String column_name(int column) const override;
     virtual GUI::ModelIndex index(int row, int column = 0, GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role = GUI::ModelRole::Display) const override;
     virtual TriState data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const override;

--- a/Userland/Applications/Browser/History/HistoryModel.cpp
+++ b/Userland/Applications/Browser/History/HistoryModel.cpp
@@ -34,13 +34,13 @@ int HistoryModel::row_count(GUI::ModelIndex const& index) const
     return 0;
 }
 
-DeprecatedString HistoryModel::column_name(int column) const
+String HistoryModel::column_name(int column) const
 {
     switch (column) {
     case Column::Title:
-        return "Title";
+        return "Title"_short_string;
     case Column::URL:
-        return "URL";
+        return "URL"_short_string;
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Applications/Browser/History/HistoryModel.h
+++ b/Userland/Applications/Browser/History/HistoryModel.h
@@ -25,7 +25,7 @@ public:
     void clear_items();
     virtual int row_count(GUI::ModelIndex const&) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual DeprecatedString column_name(int column) const override;
+    virtual String column_name(int column) const override;
     virtual GUI::ModelIndex index(int row, int column = 0, GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role = GUI::ModelRole::Display) const override;
     virtual TriState data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const override;

--- a/Userland/Applications/Browser/StorageModel.cpp
+++ b/Userland/Applications/Browser/StorageModel.cpp
@@ -35,13 +35,13 @@ int StorageModel::row_count(GUI::ModelIndex const& index) const
     return 0;
 }
 
-DeprecatedString StorageModel::column_name(int column) const
+String StorageModel::column_name(int column) const
 {
     switch (column) {
     case Column::Key:
-        return "Key";
+        return "Key"_short_string;
     case Column::Value:
-        return "Value";
+        return "Value"_short_string;
     case Column::__Count:
         return {};
     }

--- a/Userland/Applications/Browser/StorageModel.h
+++ b/Userland/Applications/Browser/StorageModel.h
@@ -22,7 +22,7 @@ public:
     void clear_items();
     virtual int row_count(GUI::ModelIndex const&) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual DeprecatedString column_name(int column) const override;
+    virtual String column_name(int column) const override;
     virtual GUI::ModelIndex index(int row, int column = 0, GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role = GUI::ModelRole::Display) const override;
     virtual TriState data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const override;

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
@@ -103,8 +103,8 @@ ErrorOr<void> BrowserSettingsWidget::setup()
     };
 
     Vector<GUI::JsonArrayModel::FieldSpec> search_engine_fields;
-    search_engine_fields.empend("title", "Title", Gfx::TextAlignment::CenterLeft);
-    search_engine_fields.empend("url_format", "Url format", Gfx::TextAlignment::CenterLeft);
+    search_engine_fields.empend("title", "Title"_short_string, Gfx::TextAlignment::CenterLeft);
+    search_engine_fields.empend("url_format", TRY("Url format"_string), Gfx::TextAlignment::CenterLeft);
     auto search_engines_model = GUI::JsonArrayModel::create(DeprecatedString::formatted("{}/SearchEngines.json", Core::StandardPaths::config_directory()), move(search_engine_fields));
     search_engines_model->invalidate();
     Vector<JsonValue> custom_search_engine;

--- a/Userland/Applications/Calendar/AddEventDialog.cpp
+++ b/Userland/Applications/Calendar/AddEventDialog.cpp
@@ -120,21 +120,21 @@ int AddEventDialog::MeridiemListModel::row_count(const GUI::ModelIndex&) const
     return 2;
 }
 
-DeprecatedString AddEventDialog::MonthListModel::column_name(int column) const
+String AddEventDialog::MonthListModel::column_name(int column) const
 {
     switch (column) {
     case Column::Month:
-        return "Month";
+        return "Month"_short_string;
     default:
         VERIFY_NOT_REACHED();
     }
 }
 
-DeprecatedString AddEventDialog::MeridiemListModel::column_name(int column) const
+String AddEventDialog::MeridiemListModel::column_name(int column) const
 {
     switch (column) {
     case Column::Meridiem:
-        return "Meridiem";
+        return "Meridiem"_string.release_value_but_fixme_should_propagate_errors();
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Applications/Calendar/AddEventDialog.h
+++ b/Userland/Applications/Calendar/AddEventDialog.h
@@ -38,7 +38,7 @@ private:
 
         virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
         virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
-        virtual DeprecatedString column_name(int) const override;
+        virtual String column_name(int) const override;
         virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
     private:
@@ -57,7 +57,7 @@ private:
 
         virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
         virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
-        virtual DeprecatedString column_name(int) const override;
+        virtual String column_name(int) const override;
         virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
     private:

--- a/Userland/Applications/CertificateSettings/CertificateStoreWidget.cpp
+++ b/Userland/Applications/CertificateSettings/CertificateStoreWidget.cpp
@@ -34,15 +34,15 @@ ErrorOr<void> CertificateStoreModel::load()
     return {};
 }
 
-DeprecatedString CertificateStoreModel::column_name(int column) const
+String CertificateStoreModel::column_name(int column) const
 {
     switch (column) {
     case Column::IssuedTo:
-        return "Issued To";
+        return "Issued To"_string.release_value_but_fixme_should_propagate_errors();
     case Column::IssuedBy:
-        return "Issued By";
+        return "Issued By"_string.release_value_but_fixme_should_propagate_errors();
     case Column::Expire:
-        return "Expiration Date";
+        return "Expiration Date"_string.release_value_but_fixme_should_propagate_errors();
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Applications/CertificateSettings/CertificateStoreWidget.h
+++ b/Userland/Applications/CertificateSettings/CertificateStoreWidget.h
@@ -44,7 +44,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return m_certificates.size(); }
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual ErrorOr<void> load();
     virtual ErrorOr<size_t> add(Vector<Certificate> const&);

--- a/Userland/Applications/HexEditor/SearchResultsModel.h
+++ b/Userland/Applications/HexEditor/SearchResultsModel.h
@@ -40,13 +40,13 @@ public:
         return 2;
     }
 
-    DeprecatedString column_name(int column) const override
+    String column_name(int column) const override
     {
         switch (column) {
         case Column::Offset:
-            return "Offset";
+            return "Offset"_short_string;
         case Column::Value:
-            return "Value";
+            return "Value"_short_string;
         }
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Applications/HexEditor/ValueInspectorModel.h
+++ b/Userland/Applications/HexEditor/ValueInspectorModel.h
@@ -63,13 +63,13 @@ public:
         return 2;
     }
 
-    DeprecatedString column_name(int column) const override
+    String column_name(int column) const override
     {
         switch (column) {
         case Column::Type:
-            return "Type";
+            return "Type"_short_string;
         case Column::Value:
-            return m_is_little_endian ? "Value (Little Endian)" : "Value (Big Endian)";
+            return m_is_little_endian ? "Value (Little Endian)"_string.release_value_but_fixme_should_propagate_errors() : "Value (Big Endian)"_string.release_value_but_fixme_should_propagate_errors();
         }
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Applications/Mail/InboxModel.cpp
+++ b/Userland/Applications/Mail/InboxModel.cpp
@@ -17,13 +17,13 @@ int InboxModel::row_count(GUI::ModelIndex const&) const
     return m_entries.size();
 }
 
-DeprecatedString InboxModel::column_name(int column_index) const
+String InboxModel::column_name(int column_index) const
 {
     switch (column_index) {
     case Column::From:
-        return "From";
+        return "From"_short_string;
     case Subject:
-        return "Subject";
+        return "Subject"_short_string;
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Applications/Mail/InboxModel.h
+++ b/Userland/Applications/Mail/InboxModel.h
@@ -32,7 +32,7 @@ public:
 
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
 private:

--- a/Userland/Applications/MouseSettings/ThemeWidget.cpp
+++ b/Userland/Applications/MouseSettings/ThemeWidget.cpp
@@ -15,13 +15,13 @@
 #include <LibGUI/SortingProxyModel.h>
 #include <LibGUI/TableView.h>
 
-DeprecatedString MouseCursorModel::column_name(int column_index) const
+String MouseCursorModel::column_name(int column_index) const
 {
     switch (column_index) {
     case Column::Bitmap:
         return {};
     case Column::Name:
-        return "Name";
+        return "Name"_short_string;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Applications/MouseSettings/ThemeWidget.h
+++ b/Userland/Applications/MouseSettings/ThemeWidget.h
@@ -25,7 +25,7 @@ public:
     virtual int row_count(const GUI::ModelIndex&) const override { return m_cursors.size(); }
     virtual int column_count(const GUI::ModelIndex&) const override { return Column::__Count; }
 
-    virtual DeprecatedString column_name(int column_index) const override;
+    virtual String column_name(int column_index) const override;
     virtual GUI::Variant data(const GUI::ModelIndex& index, GUI::ModelRole role) const override;
     virtual void invalidate() override;
 

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -64,13 +64,13 @@ public:
         return Columns::Page;
     }
 
-    DeprecatedString column_name(int index) const override
+    String column_name(int index) const override
     {
         switch (index) {
         case 0:
-            return "Page";
+            return "Page"_short_string;
         case 1:
-            return "Message";
+            return "Message"_short_string;
         default:
             VERIFY_NOT_REACHED();
         }

--- a/Userland/Applications/PartitionEditor/PartitionModel.cpp
+++ b/Userland/Applications/PartitionEditor/PartitionModel.cpp
@@ -18,19 +18,19 @@ NonnullRefPtr<PartitionModel> PartitionModel::create()
     return adopt_ref(*new PartitionModel);
 }
 
-DeprecatedString PartitionModel::column_name(int column) const
+String PartitionModel::column_name(int column) const
 {
     switch (column) {
     case Column::Partition:
-        return "Partition";
+        return "Partition"_string.release_value_but_fixme_should_propagate_errors();
     case Column::StartBlock:
-        return "Start Block";
+        return "Start Block"_string.release_value_but_fixme_should_propagate_errors();
     case Column::EndBlock:
-        return "End Block";
+        return "End Block"_string.release_value_but_fixme_should_propagate_errors();
     case Column::TotalBlocks:
-        return "Total Blocks";
+        return "Total Blocks"_string.release_value_but_fixme_should_propagate_errors();
     case Column::Size:
-        return "Size";
+        return "Size"_short_string;
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Applications/PartitionEditor/PartitionModel.h
+++ b/Userland/Applications/PartitionEditor/PartitionModel.h
@@ -27,7 +27,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return m_partition_table->partitions_count(); }
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
 
     ErrorOr<void> set_device_path(DeprecatedString const&);

--- a/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
+++ b/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
@@ -73,21 +73,21 @@ DeprecatedString PlaylistModel::format_duration(u32 duration_in_seconds)
     return DeprecatedString::formatted("{:02}:{:02}:{:02}", duration_in_seconds / 3600, duration_in_seconds / 60, duration_in_seconds % 60);
 }
 
-DeprecatedString PlaylistModel::column_name(int column) const
+String PlaylistModel::column_name(int column) const
 {
     switch (column) {
     case 0:
-        return "Title";
+        return "Title"_short_string;
     case 1:
-        return "Duration";
+        return "Duration"_string.release_value_but_fixme_should_propagate_errors();
     case 2:
-        return "Group";
+        return "Group"_short_string;
     case 3:
-        return "Album";
+        return "Album"_short_string;
     case 4:
-        return "Artist";
+        return "Artist"_short_string;
     case 5:
-        return "Filesize";
+        return "Filesize"_string.release_value_but_fixme_should_propagate_errors();
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Applications/SoundPlayer/PlaylistWidget.h
+++ b/Userland/Applications/SoundPlayer/PlaylistWidget.h
@@ -24,7 +24,7 @@ public:
     int row_count(const GUI::ModelIndex&) const override { return m_playlist_items.size(); }
     int column_count(const GUI::ModelIndex&) const override { return 6; }
     GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    DeprecatedString column_name(int column) const override;
+    String column_name(int column) const override;
     Vector<M3UEntry>& items() { return m_playlist_items; }
 
 private:

--- a/Userland/Applications/Spreadsheet/ImportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ImportDialog.cpp
@@ -166,10 +166,12 @@ void CSVImportDialogPage::update_preview()
         return;
     }
 
-    auto headers = reader.headers();
+    Vector<String> headers;
+    for (auto const& header : reader.headers())
+        headers.append(String::from_deprecated_string(header).release_value_but_fixme_should_propagate_errors());
 
     m_data_preview_table_view->set_model(
-        GUI::ItemListModel<Reader::XSV::Row, Reader::XSV, Vector<DeprecatedString>>::create(reader, headers, min(8ul, reader.size())));
+        GUI::ItemListModel<Reader::XSV::Row, Reader::XSV, Vector<String>>::create(reader, headers, min(8ul, reader.size())));
     m_data_preview_widget->set_active_widget(m_data_preview_table_view);
     m_data_preview_table_view->update();
 }

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -162,12 +162,12 @@ RefPtr<Core::MimeData> SheetModel::mime_data(const GUI::ModelSelection& selectio
     return mime_data;
 }
 
-DeprecatedString SheetModel::column_name(int index) const
+String SheetModel::column_name(int index) const
 {
     if (index < 0)
         return {};
 
-    return m_sheet->column(index);
+    return String::from_deprecated_string(m_sheet->column(index)).release_value_but_fixme_should_propagate_errors();
 }
 
 bool SheetModel::is_editable(const GUI::ModelIndex& index) const

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.h
@@ -23,7 +23,7 @@ public:
 
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_sheet->row_count(); }
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_sheet->column_count(); }
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
     virtual RefPtr<Core::MimeData> mime_data(const GUI::ModelSelection&) const override;
     virtual bool is_editable(const GUI::ModelIndex&) const override;

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -43,17 +43,17 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
         m_adapter_table_view = adapters_group_box.add<GUI::TableView>();
 
         Vector<GUI::JsonArrayModel::FieldSpec> net_adapters_fields;
-        net_adapters_fields.empend("", Gfx::TextAlignment::CenterLeft,
+        net_adapters_fields.empend(String(), Gfx::TextAlignment::CenterLeft,
             [this](JsonObject const& object) -> GUI::Variant {
                 if (!object.get_bool("link_up"sv).value_or(false))
                     return *m_network_link_down_bitmap;
                 else
                     return object.get_deprecated_string("ipv4_address"sv).value_or("").is_empty() ? *m_network_disconnected_bitmap : *m_network_connected_bitmap;
             });
-        net_adapters_fields.empend("name", "Name", Gfx::TextAlignment::CenterLeft);
-        net_adapters_fields.empend("class_name", "Class", Gfx::TextAlignment::CenterLeft);
-        net_adapters_fields.empend("mac_address", "MAC", Gfx::TextAlignment::CenterLeft);
-        net_adapters_fields.empend("Link status", Gfx::TextAlignment::CenterLeft,
+        net_adapters_fields.empend("name", "Name"_short_string, Gfx::TextAlignment::CenterLeft);
+        net_adapters_fields.empend("class_name", "Class"_short_string, Gfx::TextAlignment::CenterLeft);
+        net_adapters_fields.empend("mac_address", "MAC"_short_string, Gfx::TextAlignment::CenterLeft);
+        net_adapters_fields.empend("Link status"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterLeft,
             [](JsonObject const& object) -> DeprecatedString {
                 if (!object.get_bool("link_up"sv).value_or(false))
                     return "Down";
@@ -61,14 +61,14 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
                 return DeprecatedString::formatted("{} Mb/s {}-duplex", object.get_i32("link_speed"sv).value_or(0),
                     object.get_bool("link_full_duplex"sv).value_or(false) ? "full"sv : "half"sv);
             });
-        net_adapters_fields.empend("IPv4", Gfx::TextAlignment::CenterLeft,
+        net_adapters_fields.empend("IPv4"_short_string, Gfx::TextAlignment::CenterLeft,
             [](JsonObject const& object) -> DeprecatedString {
                 return object.get_deprecated_string("ipv4_address"sv).value_or(""sv);
             });
-        net_adapters_fields.empend("packets_in", "Pkt In", Gfx::TextAlignment::CenterRight);
-        net_adapters_fields.empend("packets_out", "Pkt Out", Gfx::TextAlignment::CenterRight);
-        net_adapters_fields.empend("bytes_in", "Bytes In", Gfx::TextAlignment::CenterRight);
-        net_adapters_fields.empend("bytes_out", "Bytes Out", Gfx::TextAlignment::CenterRight);
+        net_adapters_fields.empend("packets_in", "Pkt In"_short_string, Gfx::TextAlignment::CenterRight);
+        net_adapters_fields.empend("packets_out", "Pkt Out"_short_string, Gfx::TextAlignment::CenterRight);
+        net_adapters_fields.empend("bytes_in", "Bytes In"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterRight);
+        net_adapters_fields.empend("bytes_out", "Bytes Out"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterRight);
         m_adapter_model = GUI::JsonArrayModel::create("/sys/kernel/net/adapters", move(net_adapters_fields));
         m_adapter_table_view->set_model(MUST(GUI::SortingProxyModel::create(*m_adapter_model)));
         m_adapter_context_menu = MUST(GUI::Menu::try_create());
@@ -97,17 +97,17 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
         m_tcp_socket_table_view = tcp_sockets_group_box.add<GUI::TableView>();
 
         Vector<GUI::JsonArrayModel::FieldSpec> net_tcp_fields;
-        net_tcp_fields.empend("peer_address", "Peer", Gfx::TextAlignment::CenterLeft);
-        net_tcp_fields.empend("peer_port", "Port", Gfx::TextAlignment::CenterRight);
-        net_tcp_fields.empend("local_address", "Local", Gfx::TextAlignment::CenterLeft);
-        net_tcp_fields.empend("local_port", "Port", Gfx::TextAlignment::CenterRight);
-        net_tcp_fields.empend("state", "State", Gfx::TextAlignment::CenterLeft);
-        net_tcp_fields.empend("ack_number", "Ack#", Gfx::TextAlignment::CenterRight);
-        net_tcp_fields.empend("sequence_number", "Seq#", Gfx::TextAlignment::CenterRight);
-        net_tcp_fields.empend("packets_in", "Pkt In", Gfx::TextAlignment::CenterRight);
-        net_tcp_fields.empend("packets_out", "Pkt Out", Gfx::TextAlignment::CenterRight);
-        net_tcp_fields.empend("bytes_in", "Bytes In", Gfx::TextAlignment::CenterRight);
-        net_tcp_fields.empend("bytes_out", "Bytes Out", Gfx::TextAlignment::CenterRight);
+        net_tcp_fields.empend("peer_address", "Peer"_short_string, Gfx::TextAlignment::CenterLeft);
+        net_tcp_fields.empend("peer_port", "Port"_short_string, Gfx::TextAlignment::CenterRight);
+        net_tcp_fields.empend("local_address", "Local"_short_string, Gfx::TextAlignment::CenterLeft);
+        net_tcp_fields.empend("local_port", "Port"_short_string, Gfx::TextAlignment::CenterRight);
+        net_tcp_fields.empend("state", "State"_short_string, Gfx::TextAlignment::CenterLeft);
+        net_tcp_fields.empend("ack_number", "Ack#"_short_string, Gfx::TextAlignment::CenterRight);
+        net_tcp_fields.empend("sequence_number", "Seq#"_short_string, Gfx::TextAlignment::CenterRight);
+        net_tcp_fields.empend("packets_in", "Pkt In"_short_string, Gfx::TextAlignment::CenterRight);
+        net_tcp_fields.empend("packets_out", "Pkt Out"_short_string, Gfx::TextAlignment::CenterRight);
+        net_tcp_fields.empend("bytes_in", "Bytes In"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterRight);
+        net_tcp_fields.empend("bytes_out", "Bytes Out"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterRight);
         m_tcp_socket_model = GUI::JsonArrayModel::create("/sys/kernel/net/tcp", move(net_tcp_fields));
         m_tcp_socket_table_view->set_model(MUST(GUI::SortingProxyModel::create(*m_tcp_socket_model)));
 
@@ -117,10 +117,10 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
         m_udp_socket_table_view = udp_sockets_group_box.add<GUI::TableView>();
 
         Vector<GUI::JsonArrayModel::FieldSpec> net_udp_fields;
-        net_udp_fields.empend("peer_address", "Peer", Gfx::TextAlignment::CenterLeft);
-        net_udp_fields.empend("peer_port", "Port", Gfx::TextAlignment::CenterRight);
-        net_udp_fields.empend("local_address", "Local", Gfx::TextAlignment::CenterLeft);
-        net_udp_fields.empend("local_port", "Port", Gfx::TextAlignment::CenterRight);
+        net_udp_fields.empend("peer_address", "Peer"_short_string, Gfx::TextAlignment::CenterLeft);
+        net_udp_fields.empend("peer_port", "Port"_short_string, Gfx::TextAlignment::CenterRight);
+        net_udp_fields.empend("local_address", "Local"_short_string, Gfx::TextAlignment::CenterLeft);
+        net_udp_fields.empend("local_port", "Port"_short_string, Gfx::TextAlignment::CenterRight);
         m_udp_socket_model = GUI::JsonArrayModel::create("/sys/kernel/net/udp", move(net_udp_fields));
         m_udp_socket_table_view->set_model(MUST(GUI::SortingProxyModel::create(*m_udp_socket_model)));
 

--- a/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
@@ -21,23 +21,23 @@ ProcessFileDescriptorMapWidget::ProcessFileDescriptorMapWidget()
     m_table_view = add<GUI::TableView>();
 
     Vector<GUI::JsonArrayModel::FieldSpec> pid_fds_fields;
-    pid_fds_fields.empend("fd", "FD", Gfx::TextAlignment::CenterRight);
-    pid_fds_fields.empend("class", "Class", Gfx::TextAlignment::CenterLeft);
-    pid_fds_fields.empend("offset", "Offset", Gfx::TextAlignment::CenterRight);
-    pid_fds_fields.empend("absolute_path", "Path", Gfx::TextAlignment::CenterLeft);
-    pid_fds_fields.empend("Access", Gfx::TextAlignment::CenterLeft, [](auto& object) {
+    pid_fds_fields.empend("fd", "FD"_short_string, Gfx::TextAlignment::CenterRight);
+    pid_fds_fields.empend("class", "Class"_short_string, Gfx::TextAlignment::CenterLeft);
+    pid_fds_fields.empend("offset", "Offset"_short_string, Gfx::TextAlignment::CenterRight);
+    pid_fds_fields.empend("absolute_path", "Path"_short_string, Gfx::TextAlignment::CenterLeft);
+    pid_fds_fields.empend("Access"_short_string, Gfx::TextAlignment::CenterLeft, [](auto& object) {
         return object.get_bool("seekable"sv).value_or(false) ? "Seekable" : "Sequential";
     });
-    pid_fds_fields.empend("Blocking", Gfx::TextAlignment::CenterLeft, [](auto& object) {
+    pid_fds_fields.empend("Blocking"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterLeft, [](auto& object) {
         return object.get_bool("blocking"sv).value_or(false) ? "Blocking" : "Nonblocking";
     });
-    pid_fds_fields.empend("On exec", Gfx::TextAlignment::CenterLeft, [](auto& object) {
+    pid_fds_fields.empend("On exec"_short_string, Gfx::TextAlignment::CenterLeft, [](auto& object) {
         return object.get_bool("cloexec"sv).value_or(false) ? "Close" : "Keep";
     });
-    pid_fds_fields.empend("Can read", Gfx::TextAlignment::CenterLeft, [](auto& object) {
+    pid_fds_fields.empend("Can read"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterLeft, [](auto& object) {
         return object.get_bool("can_read"sv).value_or(false) ? "Yes" : "No";
     });
-    pid_fds_fields.empend("Can write", Gfx::TextAlignment::CenterLeft, [](auto& object) {
+    pid_fds_fields.empend("Can write"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterLeft, [](auto& object) {
         return object.get_bool("can_write"sv).value_or(false) ? "Yes" : "No";
     });
 

--- a/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
@@ -55,13 +55,13 @@ ProcessMemoryMapWidget::ProcessMemoryMapWidget()
     m_table_view = add<GUI::TableView>();
     Vector<GUI::JsonArrayModel::FieldSpec> pid_vm_fields;
     pid_vm_fields.empend(
-        "Address", Gfx::TextAlignment::CenterLeft,
+        "Address"_short_string, Gfx::TextAlignment::CenterLeft,
         [](auto& object) { return DeprecatedString::formatted("{:p}", object.get_u64("address"sv).value_or(0)); },
         [](auto& object) { return object.get_u64("address"sv).value_or(0); });
-    pid_vm_fields.empend("size", "Size", Gfx::TextAlignment::CenterRight);
-    pid_vm_fields.empend("amount_resident", "Resident", Gfx::TextAlignment::CenterRight);
-    pid_vm_fields.empend("amount_dirty", "Dirty", Gfx::TextAlignment::CenterRight);
-    pid_vm_fields.empend("Access", Gfx::TextAlignment::CenterLeft, [](auto& object) {
+    pid_vm_fields.empend("size", "Size"_short_string, Gfx::TextAlignment::CenterRight);
+    pid_vm_fields.empend("amount_resident", "Resident"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterRight);
+    pid_vm_fields.empend("amount_dirty", "Dirty"_short_string, Gfx::TextAlignment::CenterRight);
+    pid_vm_fields.empend("Access"_short_string, Gfx::TextAlignment::CenterLeft, [](auto& object) {
         StringBuilder builder;
         if (object.get_bool("readable"sv).value_or(false))
             builder.append('R');
@@ -77,19 +77,19 @@ ProcessMemoryMapWidget::ProcessMemoryMapWidget()
             builder.append('T');
         return builder.to_deprecated_string();
     });
-    pid_vm_fields.empend("VMObject type", Gfx::TextAlignment::CenterLeft, [](auto& object) {
+    pid_vm_fields.empend("VMObject type"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterLeft, [](auto& object) {
         auto type = object.get_deprecated_string("vmobject"sv).value_or({});
         if (type.ends_with("VMObject"sv))
             type = type.substring(0, type.length() - 8);
         return type;
     });
-    pid_vm_fields.empend("Purgeable", Gfx::TextAlignment::CenterLeft, [](auto& object) {
+    pid_vm_fields.empend("Purgeable"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterLeft, [](auto& object) {
         if (object.get_bool("volatile"sv).value_or(false))
             return "Volatile";
         return "Non-volatile";
     });
     pid_vm_fields.empend(
-        "Page map", Gfx::TextAlignment::CenterLeft,
+        "Page map"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterLeft,
         [](auto&) {
             return GUI::Variant();
         },
@@ -100,8 +100,8 @@ ProcessMemoryMapWidget::ProcessMemoryMapWidget()
             auto pagemap = object.get_deprecated_string("pagemap"sv).value_or({});
             return pagemap;
         });
-    pid_vm_fields.empend("cow_pages", "# CoW", Gfx::TextAlignment::CenterRight);
-    pid_vm_fields.empend("name", "Name", Gfx::TextAlignment::CenterLeft);
+    pid_vm_fields.empend("cow_pages", "# CoW"_short_string, Gfx::TextAlignment::CenterRight);
+    pid_vm_fields.empend("name", "Name"_short_string, Gfx::TextAlignment::CenterLeft);
     m_json_model = GUI::JsonArrayModel::create({}, move(pid_vm_fields));
     m_table_view->set_model(MUST(GUI::SortingProxyModel::create(*m_json_model)));
 

--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -71,71 +71,71 @@ int ProcessModel::column_count(GUI::ModelIndex const&) const
     return Column::__Count;
 }
 
-DeprecatedString ProcessModel::column_name(int column) const
+String ProcessModel::column_name(int column) const
 {
     switch (column) {
     case Column::Icon:
-        return "";
+        return {};
     case Column::PID:
-        return "PID";
+        return "PID"_short_string;
     case Column::TID:
-        return "TID";
+        return "TID"_short_string;
     case Column::PPID:
-        return "PPID";
+        return "PPID"_short_string;
     case Column::PGID:
-        return "PGID";
+        return "PGID"_short_string;
     case Column::SID:
-        return "SID";
+        return "SID"_short_string;
     case Column::State:
-        return "State";
+        return "State"_short_string;
     case Column::User:
-        return "User";
+        return "User"_short_string;
     case Column::Priority:
-        return "Pr";
+        return "Pr"_short_string;
     case Column::Virtual:
-        return "Virtual";
+        return "Virtual"_short_string;
     case Column::Physical:
-        return "Physical";
+        return "Physical"_string.release_value_but_fixme_should_propagate_errors();
     case Column::DirtyPrivate:
-        return "Private";
+        return "Private"_short_string;
     case Column::CleanInode:
-        return "CleanI";
+        return "CleanI"_short_string;
     case Column::PurgeableVolatile:
-        return "Purg:V";
+        return "Purg:V"_short_string;
     case Column::PurgeableNonvolatile:
-        return "Purg:N";
+        return "Purg:N"_short_string;
     case Column::CPU:
-        return "CPU";
+        return "CPU"_short_string;
     case Column::Processor:
-        return "Processor";
+        return "Processor"_string.release_value_but_fixme_should_propagate_errors();
     case Column::Name:
-        return "Name";
+        return "Name"_short_string;
     case Column::Syscalls:
-        return "Syscalls";
+        return "Syscalls"_string.release_value_but_fixme_should_propagate_errors();
     case Column::InodeFaults:
-        return "F:Inode";
+        return "F:Inode"_short_string;
     case Column::ZeroFaults:
-        return "F:Zero";
+        return "F:Zero"_short_string;
     case Column::CowFaults:
-        return "F:CoW";
+        return "F:CoW"_short_string;
     case Column::IPv4SocketReadBytes:
-        return "IPv4 In";
+        return "IPv4 In"_short_string;
     case Column::IPv4SocketWriteBytes:
-        return "IPv4 Out";
+        return "IPv4 Out"_string.release_value_but_fixme_should_propagate_errors();
     case Column::UnixSocketReadBytes:
-        return "Unix In";
+        return "Unix In"_short_string;
     case Column::UnixSocketWriteBytes:
-        return "Unix Out";
+        return "Unix Out"_string.release_value_but_fixme_should_propagate_errors();
     case Column::FileReadBytes:
-        return "File In";
+        return "File In"_short_string;
     case Column::FileWriteBytes:
-        return "File Out";
+        return "File Out"_string.release_value_but_fixme_should_propagate_errors();
     case Column::Pledge:
-        return "Pledge";
+        return "Pledge"_short_string;
     case Column::Veil:
-        return "Veil";
+        return "Veil"_short_string;
     case Column::Command:
-        return "Command";
+        return "Command"_short_string;
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Applications/SystemMonitor/ProcessModel.h
+++ b/Userland/Applications/SystemMonitor/ProcessModel.h
@@ -63,7 +63,7 @@ public:
     virtual int tree_column() const override { return Column::Name; }
     virtual int row_count(GUI::ModelIndex const&) const override;
     virtual int column_count(GUI::ModelIndex const&) const override;
-    virtual DeprecatedString column_name(int column) const override;
+    virtual String column_name(int column) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual GUI::ModelIndex index(int row, int column, GUI::ModelIndex const& parent = {}) const override;
     virtual GUI::ModelIndex parent_index(GUI::ModelIndex const&) const override;

--- a/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.cpp
@@ -22,8 +22,8 @@ ProcessUnveiledPathsWidget::ProcessUnveiledPathsWidget()
     m_table_view = add<GUI::TableView>();
 
     Vector<GUI::JsonArrayModel::FieldSpec> pid_unveil_fields;
-    pid_unveil_fields.empend("path", "Path", Gfx::TextAlignment::CenterLeft);
-    pid_unveil_fields.empend("permissions", "Permissions", Gfx::TextAlignment::CenterLeft);
+    pid_unveil_fields.empend("path", "Path"_short_string, Gfx::TextAlignment::CenterLeft);
+    pid_unveil_fields.empend("permissions", "Permissions"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterLeft);
 
     m_model = GUI::JsonArrayModel::create({}, move(pid_unveil_fields));
     m_table_view->set_model(MUST(GUI::SortingProxyModel::create(*m_model)));

--- a/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
@@ -30,15 +30,15 @@ public:
     int row_count(GUI::ModelIndex const&) const override { return m_symbols.size(); };
     bool is_column_sortable(int) const override { return false; }
 
-    DeprecatedString column_name(int column) const override
+    String column_name(int column) const override
     {
         switch (column) {
         case Column::Address:
-            return "Address";
+            return "Address"_short_string;
         case Column::Object:
-            return "Object";
+            return "Object"_short_string;
         case Column::Symbol:
-            return "Symbol";
+            return "Symbol"_short_string;
         default:
             VERIFY_NOT_REACHED();
         }

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -123,11 +123,11 @@ public:
             auto& fs_table_view = *self.find_child_of_type_named<GUI::TableView>("storage_table");
 
             Vector<GUI::JsonArrayModel::FieldSpec> df_fields;
-            df_fields.empend("mount_point", "Mount point", Gfx::TextAlignment::CenterLeft);
-            df_fields.empend("class_name", "Class", Gfx::TextAlignment::CenterLeft);
-            df_fields.empend("source", "Source", Gfx::TextAlignment::CenterLeft);
+            df_fields.empend("mount_point", "Mount point"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterLeft);
+            df_fields.empend("class_name", "Class"_short_string, Gfx::TextAlignment::CenterLeft);
+            df_fields.empend("source", "Source"_short_string, Gfx::TextAlignment::CenterLeft);
             df_fields.empend(
-                "Size", Gfx::TextAlignment::CenterRight,
+                "Size"_short_string, Gfx::TextAlignment::CenterRight,
                 [](JsonObject const& object) {
                     StringBuilder size_builder;
                     size_builder.append(' ');
@@ -148,7 +148,7 @@ public:
                     return percentage;
                 });
             df_fields.empend(
-                "Used", Gfx::TextAlignment::CenterRight,
+                "Used"_short_string, Gfx::TextAlignment::CenterRight,
                 [](JsonObject const& object) {
             auto total_blocks = object.get_u64("total_block_count"sv).value_or(0);
             auto free_blocks = object.get_u64("free_block_count"sv).value_or(0);
@@ -161,19 +161,19 @@ public:
                     return used_blocks * object.get_u64("block_size"sv).value_or(0);
                 });
             df_fields.empend(
-                "Available", Gfx::TextAlignment::CenterRight,
+                "Available"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterRight,
                 [](JsonObject const& object) {
                     return human_readable_size(object.get_u64("free_block_count"sv).value_or(0) * object.get_u64("block_size"sv).value_or(0));
                 },
                 [](JsonObject const& object) {
                     return object.get_u64("free_block_count"sv).value_or(0) * object.get_u64("block_size"sv).value_or(0);
                 });
-            df_fields.empend("Access", Gfx::TextAlignment::CenterLeft, [](JsonObject const& object) {
+            df_fields.empend("Access"_short_string, Gfx::TextAlignment::CenterLeft, [](JsonObject const& object) {
                 bool readonly = object.get_bool("readonly"sv).value_or(false);
                 int mount_flags = object.get_i32("mount_flags"sv).value_or(0);
                 return readonly || (mount_flags & MS_RDONLY) ? "Read-only" : "Read/Write";
             });
-            df_fields.empend("Mount flags", Gfx::TextAlignment::CenterLeft, [](JsonObject const& object) {
+            df_fields.empend("Mount flags"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterLeft, [](JsonObject const& object) {
                 int mount_flags = object.get_i32("mount_flags"sv).value_or(0);
                 StringBuilder builder;
                 bool first = true;
@@ -197,11 +197,11 @@ public:
                     return DeprecatedString("defaults");
                 return builder.to_deprecated_string();
             });
-            df_fields.empend("free_block_count", "Free blocks", Gfx::TextAlignment::CenterRight);
-            df_fields.empend("total_block_count", "Total blocks", Gfx::TextAlignment::CenterRight);
-            df_fields.empend("free_inode_count", "Free inodes", Gfx::TextAlignment::CenterRight);
-            df_fields.empend("total_inode_count", "Total inodes", Gfx::TextAlignment::CenterRight);
-            df_fields.empend("block_size", "Block size", Gfx::TextAlignment::CenterRight);
+            df_fields.empend("free_block_count", "Free blocks"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterRight);
+            df_fields.empend("total_block_count", "Total blocks"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterRight);
+            df_fields.empend("free_inode_count", "Free inodes"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterRight);
+            df_fields.empend("total_inode_count", "Total inodes"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterRight);
+            df_fields.empend("block_size", "Block size"_string.release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterRight);
 
             fs_table_view.set_model(MUST(GUI::SortingProxyModel::create(GUI::JsonArrayModel::create("/sys/kernel/df", move(df_fields)))));
 

--- a/Userland/Demos/ModelGallery/BasicModel.h
+++ b/Userland/Demos/ModelGallery/BasicModel.h
@@ -20,7 +20,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return m_items.size(); }
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return 1; }
-    virtual DeprecatedString column_name(int) const override { return "Item"; }
+    virtual String column_name(int) const override { return "Item"_short_string; }
 
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole = GUI::ModelRole::Display) const override;
     virtual TriState data_matches(GUI::ModelIndex const&, GUI::Variant const&) const override;

--- a/Userland/Demos/WidgetGallery/GalleryModels.h
+++ b/Userland/Demos/WidgetGallery/GalleryModels.h
@@ -27,13 +27,13 @@ public:
 
     virtual int row_count(const GUI::ModelIndex&) const override { return m_cursors.size(); }
     virtual int column_count(const GUI::ModelIndex&) const override { return Column::__Count; }
-    virtual DeprecatedString column_name(int column_index) const override
+    virtual String column_name(int column_index) const override
     {
         switch (column_index) {
         case Column::Bitmap:
             return {};
         case Column::Name:
-            return "Name";
+            return "Name"_short_string;
         }
         VERIFY_NOT_REACHED();
     }
@@ -112,7 +112,7 @@ public:
 
     virtual int row_count(const GUI::ModelIndex&) const override { return m_icon_sets.size(); }
     virtual int column_count(const GUI::ModelIndex&) const override { return Column::__Count; }
-    virtual DeprecatedString column_name(int column_index) const override
+    virtual String column_name(int column_index) const override
     {
         switch (column_index) {
         case Column::BigIcon:
@@ -120,7 +120,7 @@ public:
         case Column::LittleIcon:
             return {};
         case Column::Name:
-            return "Name";
+            return "Name"_short_string;
         }
         VERIFY_NOT_REACHED();
     }

--- a/Userland/DevTools/HackStudio/Debugger/BacktraceModel.h
+++ b/Userland/DevTools/HackStudio/Debugger/BacktraceModel.h
@@ -27,10 +27,7 @@ public:
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_frames.size(); }
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return 1; }
 
-    virtual DeprecatedString column_name(int) const override
-    {
-        return "";
-    }
+    virtual String column_name(int) const override { return {}; }
 
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 

--- a/Userland/DevTools/HackStudio/Debugger/DisassemblyModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/DisassemblyModel.cpp
@@ -73,15 +73,15 @@ int DisassemblyModel::row_count(const GUI::ModelIndex&) const
     return m_instructions.size();
 }
 
-DeprecatedString DisassemblyModel::column_name(int column) const
+String DisassemblyModel::column_name(int column) const
 {
     switch (column) {
     case Column::Address:
-        return "Address";
+        return "Address"_short_string;
     case Column::InstructionBytes:
-        return "Insn Bytes";
+        return "Insn Bytes"_string.release_value_but_fixme_should_propagate_errors();
     case Column::Disassembly:
-        return "Disassembly";
+        return "Disassembly"_string.release_value_but_fixme_should_propagate_errors();
     default:
         VERIFY_NOT_REACHED();
         return {};

--- a/Userland/DevTools/HackStudio/Debugger/DisassemblyModel.h
+++ b/Userland/DevTools/HackStudio/Debugger/DisassemblyModel.h
@@ -45,7 +45,7 @@ public:
 
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
 private:

--- a/Userland/DevTools/HackStudio/Debugger/RegistersModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/RegistersModel.cpp
@@ -86,13 +86,13 @@ int RegistersModel::row_count(const GUI::ModelIndex&) const
     return m_registers.size();
 }
 
-DeprecatedString RegistersModel::column_name(int column) const
+String RegistersModel::column_name(int column) const
 {
     switch (column) {
     case Column::Register:
-        return "Register";
+        return "Register"_string.release_value_but_fixme_should_propagate_errors();
     case Column::Value:
-        return "Value";
+        return "Value"_short_string;
     default:
         VERIFY_NOT_REACHED();
         return {};

--- a/Userland/DevTools/HackStudio/Debugger/RegistersModel.h
+++ b/Userland/DevTools/HackStudio/Debugger/RegistersModel.h
@@ -41,7 +41,7 @@ public:
 
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
     PtraceRegisters const& raw_registers() const { return m_raw_registers; }

--- a/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.cpp
@@ -53,15 +53,15 @@ int ProjectTemplatesModel::column_count(const GUI::ModelIndex&) const
     return Column::__Count;
 }
 
-DeprecatedString ProjectTemplatesModel::column_name(int column) const
+String ProjectTemplatesModel::column_name(int column) const
 {
     switch (column) {
     case Column::Icon:
-        return "Icon";
+        return "Icon"_short_string;
     case Column::Id:
-        return "ID";
+        return "ID"_short_string;
     case Column::Name:
-        return "Name";
+        return "Name"_short_string;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.h
+++ b/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.h
@@ -35,7 +35,7 @@ public:
 
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
     void update();

--- a/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
+++ b/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
@@ -39,15 +39,15 @@ public:
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_matches.size(); }
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
 
-    virtual DeprecatedString column_name(int column) const override
+    virtual String column_name(int column) const override
     {
         switch (column) {
         case Column::Filename:
-            return "Filename";
+            return "Filename"_string.release_value_but_fixme_should_propagate_errors();
         case Column::Location:
-            return "#";
+            return "#"_short_string;
         case Column::MatchedText:
-            return "Text";
+            return "Text"_short_string;
         default:
             VERIFY_NOT_REACHED();
         }

--- a/Userland/DevTools/HackStudio/Git/GitFilesModel.h
+++ b/Userland/DevTools/HackStudio/Git/GitFilesModel.h
@@ -19,10 +19,7 @@ public:
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_files.size(); }
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return 1; }
 
-    virtual DeprecatedString column_name(int) const override
-    {
-        return "";
-    }
+    virtual String column_name(int) const override { return {}; }
 
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 

--- a/Userland/DevTools/HackStudio/ToDoEntriesWidget.cpp
+++ b/Userland/DevTools/HackStudio/ToDoEntriesWidget.cpp
@@ -30,17 +30,17 @@ public:
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return m_matches.size(); }
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
 
-    virtual DeprecatedString column_name(int column) const override
+    virtual String column_name(int column) const override
     {
         switch (column) {
         case Column::Filename:
-            return "Filename";
+            return "Filename"_string.release_value_but_fixme_should_propagate_errors();
         case Column::Text:
-            return "Text";
+            return "Text"_short_string;
         case Column::Line:
-            return "Line";
+            return "Line"_short_string;
         case Column::Column:
-            return "Col";
+            return "Col"_short_string;
         default:
             VERIFY_NOT_REACHED();
         }

--- a/Userland/DevTools/Profiler/DisassemblyModel.cpp
+++ b/Userland/DevTools/Profiler/DisassemblyModel.cpp
@@ -131,19 +131,19 @@ int DisassemblyModel::row_count(GUI::ModelIndex const&) const
     return m_instructions.size();
 }
 
-DeprecatedString DisassemblyModel::column_name(int column) const
+String DisassemblyModel::column_name(int column) const
 {
     switch (column) {
     case Column::SampleCount:
-        return m_profile.show_percentages() ? "% Samples" : "# Samples";
+        return m_profile.show_percentages() ? "% Samples"_string.release_value_but_fixme_should_propagate_errors() : "# Samples"_string.release_value_but_fixme_should_propagate_errors();
     case Column::Address:
-        return "Address";
+        return "Address"_short_string;
     case Column::InstructionBytes:
-        return "Insn Bytes";
+        return "Insn Bytes"_string.release_value_but_fixme_should_propagate_errors();
     case Column::Disassembly:
-        return "Disassembly";
+        return "Disassembly"_string.release_value_but_fixme_should_propagate_errors();
     case Column::SourceLocation:
-        return "Source Location";
+        return "Source Location"_string.release_value_but_fixme_should_propagate_errors();
     default:
         VERIFY_NOT_REACHED();
         return {};

--- a/Userland/DevTools/Profiler/DisassemblyModel.h
+++ b/Userland/DevTools/Profiler/DisassemblyModel.h
@@ -46,7 +46,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual bool is_column_sortable(int) const override { return false; }
 

--- a/Userland/DevTools/Profiler/FilesystemEventModel.cpp
+++ b/Userland/DevTools/Profiler/FilesystemEventModel.cpp
@@ -142,15 +142,15 @@ int FileEventModel::column_count(GUI::ModelIndex const&) const
     return Column::__Count;
 }
 
-DeprecatedString FileEventModel::column_name(int column) const
+String FileEventModel::column_name(int column) const
 {
     switch (column) {
     case Column::Path:
-        return "Path";
+        return "Path"_short_string;
     case Column::Count:
-        return "Event Count";
+        return "Event Count"_string.release_value_but_fixme_should_propagate_errors();
     case Column::Duration:
-        return "Duration [ms]";
+        return "Duration [ms]"_string.release_value_but_fixme_should_propagate_errors();
     default:
         VERIFY_NOT_REACHED();
         return {};

--- a/Userland/DevTools/Profiler/FilesystemEventModel.h
+++ b/Userland/DevTools/Profiler/FilesystemEventModel.h
@@ -74,7 +74,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual GUI::ModelIndex index(int row, int column, GUI::ModelIndex const& parent = GUI::ModelIndex()) const override;
     virtual GUI::ModelIndex parent_index(GUI::ModelIndex const&) const override;

--- a/Userland/DevTools/Profiler/IndividualSampleModel.cpp
+++ b/Userland/DevTools/Profiler/IndividualSampleModel.cpp
@@ -29,15 +29,15 @@ int IndividualSampleModel::column_count(GUI::ModelIndex const&) const
     return Column::__Count;
 }
 
-DeprecatedString IndividualSampleModel::column_name(int column) const
+String IndividualSampleModel::column_name(int column) const
 {
     switch (column) {
     case Column::Address:
-        return "Address";
+        return "Address"_short_string;
     case Column::ObjectName:
-        return "Object";
+        return "Object"_short_string;
     case Column::Symbol:
-        return "Symbol";
+        return "Symbol"_short_string;
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/DevTools/Profiler/IndividualSampleModel.h
+++ b/Userland/DevTools/Profiler/IndividualSampleModel.h
@@ -31,7 +31,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
 
 private:

--- a/Userland/DevTools/Profiler/ProfileModel.cpp
+++ b/Userland/DevTools/Profiler/ProfileModel.cpp
@@ -74,19 +74,19 @@ int ProfileModel::column_count(GUI::ModelIndex const&) const
     return Column::__Count;
 }
 
-DeprecatedString ProfileModel::column_name(int column) const
+String ProfileModel::column_name(int column) const
 {
     switch (column) {
     case Column::SampleCount:
-        return m_profile.show_percentages() ? "% Samples" : "# Samples";
+        return m_profile.show_percentages() ? "% Samples"_string.release_value_but_fixme_should_propagate_errors() : "# Samples"_string.release_value_but_fixme_should_propagate_errors();
     case Column::SelfCount:
-        return m_profile.show_percentages() ? "% Self" : "# Self";
+        return m_profile.show_percentages() ? "% Self"_short_string : "# Self"_short_string;
     case Column::ObjectName:
-        return "Object";
+        return "Object"_short_string;
     case Column::StackFrame:
-        return "Stack Frame";
+        return "Stack Frame"_string.release_value_but_fixme_should_propagate_errors();
     case Column::SymbolAddress:
-        return "Symbol Address";
+        return "Symbol Address"_string.release_value_but_fixme_should_propagate_errors();
     default:
         VERIFY_NOT_REACHED();
         return {};

--- a/Userland/DevTools/Profiler/ProfileModel.h
+++ b/Userland/DevTools/Profiler/ProfileModel.h
@@ -34,7 +34,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual GUI::ModelIndex index(int row, int column, GUI::ModelIndex const& parent = GUI::ModelIndex()) const override;
     virtual GUI::ModelIndex parent_index(GUI::ModelIndex const&) const override;

--- a/Userland/DevTools/Profiler/SamplesModel.cpp
+++ b/Userland/DevTools/Profiler/SamplesModel.cpp
@@ -28,25 +28,25 @@ int SamplesModel::column_count(GUI::ModelIndex const&) const
     return Column::__Count;
 }
 
-DeprecatedString SamplesModel::column_name(int column) const
+String SamplesModel::column_name(int column) const
 {
     switch (column) {
     case Column::SampleIndex:
-        return "#";
+        return "#"_short_string;
     case Column::Timestamp:
-        return "Timestamp";
+        return "Timestamp"_string.release_value_but_fixme_should_propagate_errors();
     case Column::ProcessID:
-        return "PID";
+        return "PID"_short_string;
     case Column::ThreadID:
-        return "TID";
+        return "TID"_short_string;
     case Column::ExecutableName:
-        return "Executable";
+        return "Executable"_string.release_value_but_fixme_should_propagate_errors();
     case Column::LostSamples:
-        return "Lost Samples";
+        return "Lost Samples"_string.release_value_but_fixme_should_propagate_errors();
     case Column::InnermostStackFrame:
-        return "Innermost Frame";
+        return "Innermost Frame"_string.release_value_but_fixme_should_propagate_errors();
     case Column::Path:
-        return "Path";
+        return "Path"_short_string;
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/DevTools/Profiler/SamplesModel.h
+++ b/Userland/DevTools/Profiler/SamplesModel.h
@@ -36,7 +36,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual bool is_column_sortable(int) const override { return false; }
 

--- a/Userland/DevTools/Profiler/SignpostsModel.cpp
+++ b/Userland/DevTools/Profiler/SignpostsModel.cpp
@@ -26,23 +26,23 @@ int SignpostsModel::column_count(GUI::ModelIndex const&) const
     return Column::__Count;
 }
 
-DeprecatedString SignpostsModel::column_name(int column) const
+String SignpostsModel::column_name(int column) const
 {
     switch (column) {
     case Column::SignpostIndex:
-        return "#";
+        return "#"_short_string;
     case Column::Timestamp:
-        return "Timestamp";
+        return "Timestamp"_string.release_value_but_fixme_should_propagate_errors();
     case Column::ProcessID:
-        return "PID";
+        return "PID"_short_string;
     case Column::ThreadID:
-        return "TID";
+        return "TID"_short_string;
     case Column::ExecutableName:
-        return "Executable";
+        return "Executable"_string.release_value_but_fixme_should_propagate_errors();
     case Column::SignpostString:
-        return "String";
+        return "String"_short_string;
     case Column::SignpostArgument:
-        return "Argument";
+        return "Argument"_string.release_value_but_fixme_should_propagate_errors();
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/DevTools/Profiler/SignpostsModel.h
+++ b/Userland/DevTools/Profiler/SignpostsModel.h
@@ -35,7 +35,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual bool is_column_sortable(int) const override { return false; }
 

--- a/Userland/DevTools/Profiler/SourceModel.cpp
+++ b/Userland/DevTools/Profiler/SourceModel.cpp
@@ -122,17 +122,17 @@ int SourceModel::row_count(GUI::ModelIndex const&) const
     return m_source_lines.size();
 }
 
-DeprecatedString SourceModel::column_name(int column) const
+String SourceModel::column_name(int column) const
 {
     switch (column) {
     case Column::SampleCount:
-        return m_profile.show_percentages() ? "% Samples" : "# Samples";
+        return m_profile.show_percentages() ? "% Samples"_string.release_value_but_fixme_should_propagate_errors() : "# Samples"_string.release_value_but_fixme_should_propagate_errors();
     case Column::SourceCode:
-        return "Source Code";
+        return "Source Code"_string.release_value_but_fixme_should_propagate_errors();
     case Column::Location:
-        return "Location";
+        return "Location"_string.release_value_but_fixme_should_propagate_errors();
     case Column::LineNumber:
-        return "Line";
+        return "Line"_short_string;
     default:
         VERIFY_NOT_REACHED();
         return {};

--- a/Userland/DevTools/Profiler/SourceModel.h
+++ b/Userland/DevTools/Profiler/SourceModel.h
@@ -38,7 +38,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual bool is_column_sortable(int) const override { return false; }
 

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -286,7 +286,7 @@ ErrorOr<void> MainWidget::setup()
 
         Vector<GUI::JsonArrayModel::FieldSpec> query_result_fields;
         for (auto& column_name : m_result_column_names)
-            query_result_fields.empend(column_name, column_name, Gfx::TextAlignment::CenterLeft);
+            query_result_fields.empend(column_name, String::from_deprecated_string(column_name).release_value_but_fixme_should_propagate_errors(), Gfx::TextAlignment::CenterLeft);
 
         auto query_results_model = GUI::JsonArrayModel::create("{}", move(query_result_fields));
         m_query_results_table_view->set_model(MUST(GUI::SortingProxyModel::create(*query_results_model)));

--- a/Userland/Libraries/LibGUI/CommandPalette.cpp
+++ b/Userland/Libraries/LibGUI/CommandPalette.cpp
@@ -92,7 +92,7 @@ public:
         return Column::__Count;
     }
 
-    virtual DeprecatedString column_name(int) const override { return {}; }
+    virtual String column_name(int) const override { return {}; }
 
     virtual ModelIndex index(int row, int column = 0, ModelIndex const& = ModelIndex()) const override
     {

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -761,27 +761,27 @@ int FileSystemModel::column_count(ModelIndex const&) const
     return Column::__Count;
 }
 
-DeprecatedString FileSystemModel::column_name(int column) const
+String FileSystemModel::column_name(int column) const
 {
     switch (column) {
     case Column::Icon:
-        return "";
+        return {};
     case Column::Name:
-        return "Name";
+        return "Name"_short_string;
     case Column::Size:
-        return "Size";
+        return "Size"_short_string;
     case Column::User:
-        return "User";
+        return "User"_short_string;
     case Column::Group:
-        return "Group";
+        return "Group"_short_string;
     case Column::Permissions:
-        return "Mode";
+        return "Mode"_short_string;
     case Column::ModificationTime:
-        return "Modified";
+        return "Modified"_string.release_value_but_fixme_should_propagate_errors();
     case Column::Inode:
-        return "Inode";
+        return "Inode"_short_string;
     case Column::SymlinkTarget:
-        return "Symlink target";
+        return "Symlink target"_string.release_value_but_fixme_should_propagate_errors();
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibGUI/FileSystemModel.h
+++ b/Userland/Libraries/LibGUI/FileSystemModel.h
@@ -127,7 +127,7 @@ public:
     virtual int tree_column() const override { return Column::Name; }
     virtual int row_count(ModelIndex const& = ModelIndex()) const override;
     virtual int column_count(ModelIndex const& = ModelIndex()) const override;
-    virtual DeprecatedString column_name(int column) const override;
+    virtual String column_name(int column) const override;
     virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const override;
     virtual ModelIndex parent_index(ModelIndex const&) const override;
     virtual ModelIndex index(int row, int column = 0, ModelIndex const& parent = ModelIndex()) const override;

--- a/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
@@ -33,7 +33,7 @@ int FilteringProxyModel::column_count(ModelIndex const& index) const
     return m_model->column_count(m_matching_indices[index.row()]);
 }
 
-DeprecatedString FilteringProxyModel::column_name(int column) const
+String FilteringProxyModel::column_name(int column) const
 {
     return m_model->column_name(column);
 }

--- a/Userland/Libraries/LibGUI/FilteringProxyModel.h
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.h
@@ -29,7 +29,7 @@ public:
 
     virtual int row_count(ModelIndex const& = ModelIndex()) const override;
     virtual int column_count(ModelIndex const& = ModelIndex()) const override;
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const override;
     virtual void invalidate() override;
     virtual ModelIndex index(int row, int column = 0, ModelIndex const& parent = ModelIndex()) const override;

--- a/Userland/Libraries/LibGUI/HeaderView.cpp
+++ b/Userland/Libraries/LibGUI/HeaderView.cpp
@@ -358,7 +358,7 @@ Menu& HeaderView::ensure_context_menu()
         int section_count = this->section_count();
         for (int section = 0; section < section_count; ++section) {
             auto& column_data = this->section_data(section);
-            auto name = model()->column_name(section);
+            auto name = model()->column_name(section).to_deprecated_string();
             column_data.visibility_action = Action::create_checkable(name, [this, section](auto& action) {
                 set_section_visible(section, action.is_checked());
             });

--- a/Userland/Libraries/LibGUI/ItemListModel.h
+++ b/Userland/Libraries/LibGUI/ItemListModel.h
@@ -71,11 +71,11 @@ public:
         return 1;
     }
 
-    virtual DeprecatedString column_name(int index) const override
+    virtual String column_name(int index) const override
     {
         if constexpr (IsTwoDimensional)
             return m_column_names[index];
-        return "Data";
+        return "Data"_short_string;
     }
 
     virtual Variant data(ModelIndex const& index, ModelRole role) const override

--- a/Userland/Libraries/LibGUI/JsonArrayModel.h
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.h
@@ -16,7 +16,7 @@ namespace GUI {
 class JsonArrayModel final : public Model {
 public:
     struct FieldSpec {
-        FieldSpec(DeprecatedString const& a_column_name, Gfx::TextAlignment a_text_alignment, Function<Variant(JsonObject const&)>&& a_massage_for_display, Function<Variant(JsonObject const&)>&& a_massage_for_sort = {}, Function<Variant(JsonObject const&)>&& a_massage_for_custom = {})
+        FieldSpec(String const& a_column_name, Gfx::TextAlignment a_text_alignment, Function<Variant(JsonObject const&)>&& a_massage_for_display, Function<Variant(JsonObject const&)>&& a_massage_for_sort = {}, Function<Variant(JsonObject const&)>&& a_massage_for_custom = {})
             : column_name(a_column_name)
             , text_alignment(a_text_alignment)
             , massage_for_display(move(a_massage_for_display))
@@ -25,7 +25,7 @@ public:
         {
         }
 
-        FieldSpec(DeprecatedString const& a_json_field_name, DeprecatedString const& a_column_name, Gfx::TextAlignment a_text_alignment)
+        FieldSpec(DeprecatedString const& a_json_field_name, String const& a_column_name, Gfx::TextAlignment a_text_alignment)
             : json_field_name(a_json_field_name)
             , column_name(a_column_name)
             , text_alignment(a_text_alignment)
@@ -33,7 +33,7 @@ public:
         }
 
         DeprecatedString json_field_name;
-        DeprecatedString column_name;
+        String column_name;
         Gfx::TextAlignment text_alignment;
         Function<Variant(JsonObject const&)> massage_for_display;
         Function<Variant(JsonObject const&)> massage_for_sort;
@@ -49,7 +49,7 @@ public:
 
     virtual int row_count(ModelIndex const& = ModelIndex()) const override { return m_array.size(); }
     virtual int column_count(ModelIndex const& = ModelIndex()) const override { return m_fields.size(); }
-    virtual String column_name(int column) const override { return String::from_deprecated_string(m_fields[column].column_name).release_value_but_fixme_should_propagate_errors(); }
+    virtual String column_name(int column) const override { return m_fields[column].column_name; }
     virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const override;
     virtual void invalidate() override;
     virtual void update();

--- a/Userland/Libraries/LibGUI/JsonArrayModel.h
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.h
@@ -49,7 +49,7 @@ public:
 
     virtual int row_count(ModelIndex const& = ModelIndex()) const override { return m_array.size(); }
     virtual int column_count(ModelIndex const& = ModelIndex()) const override { return m_fields.size(); }
-    virtual DeprecatedString column_name(int column) const override { return m_fields[column].column_name; }
+    virtual String column_name(int column) const override { return String::from_deprecated_string(m_fields[column].column_name).release_value_but_fixme_should_propagate_errors(); }
     virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const override;
     virtual void invalidate() override;
     virtual void update();

--- a/Userland/Libraries/LibGUI/Model.h
+++ b/Userland/Libraries/LibGUI/Model.h
@@ -9,11 +9,11 @@
 #pragma once
 
 #include <AK/Badge.h>
-#include <AK/DeprecatedString.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/HashTable.h>
 #include <AK/RefCounted.h>
+#include <AK/String.h>
 #include <AK/WeakPtr.h>
 #include <LibCore/MimeData.h>
 #include <LibGUI/Forward.h>
@@ -66,7 +66,7 @@ public:
 
     virtual int row_count(ModelIndex const& = ModelIndex()) const = 0;
     virtual int column_count(ModelIndex const& = ModelIndex()) const = 0;
-    virtual DeprecatedString column_name(int) const { return {}; }
+    virtual String column_name(int) const { return {}; }
     virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const = 0;
     virtual TriState data_matches(ModelIndex const&, Variant const&) const { return TriState::Unknown; }
     virtual void invalidate();

--- a/Userland/Libraries/LibGUI/RunningProcessesModel.cpp
+++ b/Userland/Libraries/LibGUI/RunningProcessesModel.cpp
@@ -45,17 +45,17 @@ int RunningProcessesModel::column_count(const GUI::ModelIndex&) const
     return Column::__Count;
 }
 
-DeprecatedString RunningProcessesModel::column_name(int column_index) const
+String RunningProcessesModel::column_name(int column_index) const
 {
     switch (column_index) {
     case Column::Icon:
         return {};
     case Column::PID:
-        return "PID";
+        return "PID"_short_string;
     case Column::UID:
-        return "UID";
+        return "UID"_short_string;
     case Column::Name:
-        return "Name";
+        return "Name"_short_string;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibGUI/RunningProcessesModel.h
+++ b/Userland/Libraries/LibGUI/RunningProcessesModel.h
@@ -27,7 +27,7 @@ public:
 
     virtual int row_count(const GUI::ModelIndex&) const override;
     virtual int column_count(const GUI::ModelIndex&) const override;
-    virtual DeprecatedString column_name(int column_index) const override;
+    virtual String column_name(int column_index) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
     void update();

--- a/Userland/Libraries/LibGUI/SortingProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/SortingProxyModel.cpp
@@ -106,7 +106,7 @@ ModelIndex SortingProxyModel::map_to_proxy(ModelIndex const& source_index) const
     return create_index(proxy_row, proxy_column, &mapping);
 }
 
-DeprecatedString SortingProxyModel::column_name(int column) const
+String SortingProxyModel::column_name(int column) const
 {
     return source().column_name(column);
 }

--- a/Userland/Libraries/LibGUI/SortingProxyModel.h
+++ b/Userland/Libraries/LibGUI/SortingProxyModel.h
@@ -24,7 +24,7 @@ public:
     virtual int tree_column() const override { return m_source->tree_column(); }
     virtual int row_count(ModelIndex const& = ModelIndex()) const override;
     virtual int column_count(ModelIndex const& = ModelIndex()) const override;
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const override;
     virtual void invalidate() override;
     virtual StringView drag_data_type() const override;

--- a/Userland/Libraries/LibWebView/StylePropertiesModel.cpp
+++ b/Userland/Libraries/LibWebView/StylePropertiesModel.cpp
@@ -30,13 +30,13 @@ int StylePropertiesModel::row_count(GUI::ModelIndex const&) const
     return m_values.size();
 }
 
-DeprecatedString StylePropertiesModel::column_name(int column_index) const
+String StylePropertiesModel::column_name(int column_index) const
 {
     switch (column_index) {
     case Column::PropertyName:
-        return "Name";
+        return "Name"_short_string;
     case Column::PropertyValue:
-        return "Value";
+        return "Value"_short_string;
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibWebView/StylePropertiesModel.h
+++ b/Userland/Libraries/LibWebView/StylePropertiesModel.h
@@ -31,7 +31,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual DeprecatedString column_name(int) const override;
+    virtual String column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual bool is_searchable() const override { return true; }
     virtual Vector<GUI::ModelIndex> matches(StringView, unsigned flags, GUI::ModelIndex const&) override;


### PR DESCRIPTION
This PR doesn't introduce any error propagation. It either adds `_short_string` or `_string.release_value_but_fixme_should_propagate_errors()` suffix to string literals.

code change:
- `"_short_string`: +135
- `TRY(`: +1
- `release_value_but_fixme_should_propagate_errors`: +73 :neutral_face: 
- `String::from_deprecated_string`: +3
- `to_deprecated_string`: +1

Advances: https://github.com/SerenityOS/serenity/issues/17128