### PR TITLE
Spreadsheet: Don't release the file buffer when importing CSV files

### DIFF
--- a/Userland/Applications/Spreadsheet/ImportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ImportDialog.cpp
@@ -184,7 +184,7 @@ ErrorOr<Vector<NonnullRefPtr<Sheet>>, DeprecatedString> ImportDialog::make_and_r
         auto contents_or_error = file.read_until_eof();
         if (contents_or_error.is_error())
             return DeprecatedString::formatted("{}", contents_or_error.release_error());
-        CSVImportDialogPage page { contents_or_error.release_value() };
+        CSVImportDialogPage page { contents_or_error.value() };
         wizard->replace_page(page.page());
         auto result = wizard->exec();
 


### PR DESCRIPTION
CSVImportDialogPage takes and holds a StringView which meant that the data was dropped instantly and displayed garbage.

![this is what happened when you tried to import README.md](https://github.com/SerenityOS/serenity/assets/16520278/12ee571d-b94d-4e2d-afad-34a4a4541d81)