### PR TITLE
LibWeb: Fix for absolutely positioned elements with specified height

### DIFF
--- a/Tests/LibWeb/Layout/expected/height-of-absolute-position-box-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/height-of-absolute-position-box-with-padding.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
+      TextNode <#text>
+    BlockContainer <body> at (8,8) content-size 784x0 children: inline
+      TextNode <#text>
+      BlockContainer <h1> at (76.590553,103.754333) content-size 126x38 positioned [BFC] children: inline
+        line 0 width: 37.21875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 4, rect: [120.590553,103.754333 37.21875x17.46875]
+            "Test"
+        TextNode <#text>
+      TextNode <#text>

--- a/Tests/LibWeb/Layout/input/height-of-absolute-position-box-with-padding.html
+++ b/Tests/LibWeb/Layout/input/height-of-absolute-position-box-with-padding.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+
+<head>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    h1 {
+      position: absolute;
+      top: 12mm;
+      left: 20mm;
+      width: 128px;
+      height: 128px;
+      font-size: 20px;
+      text-align: center;
+      padding: 44px 0;
+      border: 1px solid black;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>Test</h1>
+</body>
+
+</html>


### PR DESCRIPTION
Make absolute_padding_box_rect account for specified height. Padding should not increase the height of the box in such cases.

Fixes #18842.