### PR TITLE
DeprecatedFile: Eliminate some calls to DeprecatedFile::read_all

### DIFF
--- a/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
@@ -9,7 +9,6 @@
 #include "GraphWidget.h"
 #include <AK/JsonObject.h>
 #include <AK/NumberFormat.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/Object.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Label.h>
@@ -102,11 +101,9 @@ static inline u64 page_count_to_bytes(size_t count)
 
 void MemoryStatsWidget::refresh()
 {
-    auto proc_memstat = Core::DeprecatedFile::construct("/sys/kernel/memstat");
-    if (!proc_memstat->open(Core::OpenMode::ReadOnly))
-        VERIFY_NOT_REACHED();
+    auto proc_memstat = Core::File::open("/sys/kernel/memstat"sv, Core::File::OpenMode::Read).release_value_but_fixme_should_propagate_errors();
 
-    auto file_contents = proc_memstat->read_all();
+    auto file_contents = proc_memstat->read_until_eof().release_value_but_fixme_should_propagate_errors();
     auto json_result = JsonValue::from_string(file_contents).release_value_but_fixme_should_propagate_errors();
     auto const& json = json_result.as_object();
 

--- a/Userland/DevTools/HackStudio/Git/GitRepo.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitRepo.cpp
@@ -80,10 +80,10 @@ DeprecatedString GitRepo::command(Vector<DeprecatedString> const& command_parts)
 
 DeprecatedString GitRepo::command_wrapper(Vector<DeprecatedString> const& command_parts, DeprecatedString const& chdir)
 {
-    auto result = Core::command("git", command_parts, LexicalPath(chdir));
+    auto const result = Core::command("git", command_parts, LexicalPath(chdir));
     if (result.is_error() || result.value().exit_code != 0)
         return {};
-    return result.value().output;
+    return DeprecatedString(result.value().output.bytes());
 }
 
 bool GitRepo::git_is_installed()

--- a/Userland/DevTools/HackStudio/ProjectBuilder.cpp
+++ b/Userland/DevTools/HackStudio/ProjectBuilder.cpp
@@ -209,7 +209,7 @@ void ProjectBuilder::for_each_library_definition(Function<void(DeprecatedString,
     }
 
     static Regex<ECMA262> const parse_library_definition(R"~~~(.+:serenity_lib[c]?\((\w+) (\w+)\).*)~~~");
-    for (auto& line : res.value().output.split('\n')) {
+    for (auto& line : StringView(res.value().output).split_view('\n')) {
         RegexResult result;
         if (!parse_library_definition.search(line, result))
             continue;
@@ -234,10 +234,10 @@ void ProjectBuilder::for_each_library_dependencies(Function<void(DeprecatedStrin
         warnln("{}", res.error());
         return;
     }
+    auto libraries = StringView(res.value().output).split_view('\n');
 
     static Regex<ECMA262> const parse_library_definition(R"~~~(.+:target_link_libraries\((\w+) ([\w\s]+)\).*)~~~");
-    for (auto& line : res.value().output.split('\n')) {
-
+    for (auto& line : libraries) {
         RegexResult result;
         if (!parse_library_definition.search(line, result))
             continue;

--- a/Userland/Libraries/LibCodeComprehension/Cpp/Tests.cpp
+++ b/Userland/Libraries/LibCodeComprehension/Cpp/Tests.cpp
@@ -89,9 +89,8 @@ int run_tests()
 
 static void add_file(FileDB& filedb, DeprecatedString const& name)
 {
-    auto file = Core::DeprecatedFile::open(LexicalPath::join(TESTS_ROOT_DIR, name).string(), Core::OpenMode::ReadOnly);
-    VERIFY(!file.is_error());
-    filedb.add(name, DeprecatedString::copy(file.value()->read_all()));
+    auto file = Core::File::open(LexicalPath::join(TESTS_ROOT_DIR, name).string(), Core::File::OpenMode::Read).release_value_but_fixme_should_propagate_errors();
+    filedb.add(name, DeprecatedString::copy(MUST(file->read_until_eof())));
 }
 
 void test_complete_local_args()

--- a/Userland/Libraries/LibCore/Command.h
+++ b/Userland/Libraries/LibCore/Command.h
@@ -6,19 +6,18 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/ByteBuffer.h>
 #include <AK/LexicalPath.h>
 #include <AK/Optional.h>
+#include <AK/String.h>
 #include <spawn.h>
 
 namespace Core {
 
-// If the executed command fails, the returned String will be in the null state.
-
 struct CommandResult {
     int exit_code { 0 };
-    DeprecatedString output;
-    DeprecatedString error;
+    ByteBuffer output;
+    ByteBuffer error;
 };
 
 ErrorOr<CommandResult> command(DeprecatedString const& program, Vector<DeprecatedString> const& arguments, Optional<LexicalPath> chdir);

--- a/Userland/Libraries/LibDebug/DebugSession.h
+++ b/Userland/Libraries/LibDebug/DebugSession.h
@@ -137,7 +137,7 @@ private:
     // x86 breakpoint instruction "int3"
     static constexpr u8 BREAKPOINT_INSTRUCTION = 0xcc;
 
-    void update_loaded_libs();
+    ErrorOr<void> update_loaded_libs();
 
     int m_debuggee_pid { -1 };
     DeprecatedString m_source_root;


### PR DESCRIPTION
This PR removes some, but not all, instances of `DeprecatedFile::read_all`. (One of the remaining instances is #18529.)

The situation in `MemoryStatsWidget::refresh` is really unfortunate, but if the file is corrupted or we OOM while reading a few bytes, then crashing seems like the only reasonable behavior left anyway. Even with some mechanism to propagate these errors across the EventLoop, I don't see how SystemMonitor could possibly react any better.

Similarly for `MulticastDNS::local_addresses()`: If the Kernel responds with incomplete or broken JSON, all hope is lost. But for LookupServer there is at least some point in trying to stay alive as other processes might depend on it still running, hence my overkil.

Advances #17129.