### PR TITLE
Kernel: Enable data and instruction cache on aarch64

### DIFF
--- a/Kernel/Arch/aarch64/MMU.cpp
+++ b/Kernel/Arch/aarch64/MMU.cpp
@@ -214,8 +214,10 @@ static void activate_mmu()
     Aarch64::TCR_EL1::write(tcr_el1);
 
     // Enable MMU in the system control register
-    Aarch64::SCTLR_EL1 sctlr_el1 = Aarch64::SCTLR_EL1::read();
+    Aarch64::SCTLR_EL1 sctlr_el1 = Aarch64::SCTLR_EL1::reset_value();
     sctlr_el1.M = 1; // Enable MMU
+    sctlr_el1.C = 1; // Enable data cache
+    sctlr_el1.I = 1; // Enable instruction cache
     Aarch64::SCTLR_EL1::write(sctlr_el1);
 
     Aarch64::Asm::flush();

--- a/Kernel/Arch/aarch64/Registers.h
+++ b/Kernel/Arch/aarch64/Registers.h
@@ -626,12 +626,12 @@ struct alignas(u64) SCTLR_EL1 {
     int SA : 1;
     int SA0 : 1;
     int CP15BEN : 1;
-    int _reserved6 : 1 = 0;
+    int nAA : 1;
     int ITD : 1;
     int SED : 1;
     int UMA : 1;
-    int _reserved10 : 1 = 0;
-    int _reserved11 : 1 = 1;
+    int EnRCTX : 1;
+    int EOS : 1;
     int I : 1;
     int EnDB : 1;
     int DZE : 1;
@@ -640,9 +640,9 @@ struct alignas(u64) SCTLR_EL1 {
     int _reserved17 : 1 = 0;
     int nTWE : 1;
     int WXN : 1;
-    int _reserved20 : 1 = 1;
+    int TSCXT : 1;
     int IESB : 1;
-    int _reserved22 : 1 = 1;
+    int EIS : 1;
     int SPAN : 1;
     int E0E : 1;
     int EE : 1;
@@ -688,10 +688,17 @@ struct alignas(u64) SCTLR_EL1 {
     static constexpr SCTLR_EL1 reset_value()
     {
         SCTLR_EL1 system_control_register_el1 = {};
+        system_control_register_el1.SA = 1;
+        system_control_register_el1.SA0 = 1;
+        system_control_register_el1.ITD = 1;
+        system_control_register_el1.SED = 1;
+        system_control_register_el1.EOS = 1;
+        system_control_register_el1.TSCXT = 1;
+        system_control_register_el1.IESB = 1;
+        system_control_register_el1.EIS = 1;
+        system_control_register_el1.SPAN = 1;
         system_control_register_el1.LSMAOE = 1;
         system_control_register_el1.nTLSMD = 1;
-        system_control_register_el1.SPAN = 1;
-        system_control_register_el1.IESB = 1;
         return system_control_register_el1;
     }
 };


### PR DESCRIPTION
Enabling these will fix the Unsupported Exclusive or Atomic access data fault we get on bare metal Raspberry Pi 3. However, there's still some issues to fix with our initial MMU configuration and possibly page tables, as we only get to the first mailbox message before things start to fail in new and exciting ways.

The most obvious problem is that we need to initialize the UART before actually setting the cache enabled flags in SCTLR_EL1. This doesn't make much sense, and points to there still being issues with the device memory page tables we set up.

This lets my Pi3B+ boot to the first mailbox message with caches enabled, failing to send/recieve any data in the process and crashing trying to access the frame buffer that it never allocated.

```
[Kernel]: Loading kernel symbol table...
[Kernel]: CPU[0]: Supports DoubleLock CRC32 BBM PMUv3
[Kernel]: CPU[0]: Physical address bit width: 40
[Kernel]: CPU[0]: Virtual address bit width: 48
[Kernel]: CPU[0]: Random number generator not detected, randomness will be poor
[Kernel]: Kernel Commandline: 
[Kernel]: Initialize MMU
[Kernel]: MM: Multiboot mmap: address=0x0000000000000000, length=1056964608, type=1
[Kernel]: MM: boot_pml4t @ P00000000024fa000
[Kernel]: MM: boot_pdpt @ P00000000024fb000
[Kernel]: MM: boot_pd0 @ P0000000000000000
[Kernel]: MM: boot_pd_kernel @ P000000000251c000
[Kernel]: MM: Physical page entries: 0x0000002002e00000 - 0x0000002002ff8fff (size 0x00000000001f9000)
[Kernel]: MM: Kernel range @ P0000000000080000 - P0000000002cf9fff (size 0x2c7a000)
[Kernel]: MM: Physical Pages range @ P0000000002cfb000 - P0000000002ef4fff (size 0x1fa000)
[Kernel]: MM: User physical region: P0000000000000000 - P000000000007efff (size 0x7f000)
[Kernel]: MM: User physical region: P0000000002ef5000 - P000000003effffff (size 0x3c10b000)
[Kernel]:  * 60x PhysicalZone (16 MiB) @ 0000000002ef5000-000000003def4fff
[Kernel]:  * 1x PhysicalZone (1 MiB) @ 000000003eef5000-000000003eef4fff
[Kernel]: RPi: Firmware version: 4294967295
[Kernel]: Framebuffer(): Mailbox send failed.
[Kernel]: BUG! Unexpected NP fault at V0x0000002007018000
[Kernel]:      - Physical page slot pointer: 0x0000002002e005c0
[Kernel]:      - Physical page: P00000000000b8000
[Kernel]:      - Lazy committed: false
[Kernel]:      - Shared zero: false
[Kernel]: ASSERTION FAILED: TODO_AARCH64
[Kernel]: ./Kernel/Arch/aarch64/SafeMem.cpp:64 in bool Kernel::handle_safe_access_fault(RegisterState&, FlatPtr)
```