### PR TITLE
Ladybird+LibWebView: Move backing store management code to LibWebView

### DIFF
--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -198,16 +198,9 @@ private:
     // ^WebView::ViewImplementation
     virtual void create_client(WebView::EnableCallgrindProfiling = WebView::EnableCallgrindProfiling::No) override;
     virtual void update_zoom() override;
+    virtual Gfx::IntRect viewport_rect() const override;
 
-    void request_repaint();
     void update_viewport_rect();
-    void handle_resize();
-
-    enum class WindowResizeInProgress {
-        No,
-        Yes,
-    };
-    void resize_backing_stores_if_needed(WindowResizeInProgress);
 
     void ensure_js_console_widget();
     void ensure_inspector_widget();
@@ -227,10 +220,5 @@ private:
 
     void handle_web_content_process_crash();
 
-    RefPtr<Gfx::Bitmap> m_backup_bitmap;
-    Gfx::IntSize m_backup_bitmap_size;
-
     StringView m_webdriver_content_ipc_path;
-
-    RefPtr<Core::Timer> m_backing_store_shrink_timer;
 };

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -179,8 +179,7 @@ private:
     virtual void notify_server_did_request_file(Badge<WebContentClient>, DeprecatedString const& path, i32) override;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
 
-    void request_repaint();
-    void handle_resize();
+    virtual Gfx::IntRect viewport_rect() const override;
 
     void handle_web_content_process_crash();
 
@@ -188,7 +187,6 @@ private:
     void enqueue_input_event(InputEvent const&);
     void process_next_input_event();
 
-    RefPtr<Gfx::Bitmap> m_backup_bitmap;
     RefPtr<GUI::Dialog> m_dialog;
 
     bool m_is_awaiting_response_for_input_event { false };

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -124,14 +124,27 @@ public:
     virtual void notify_server_did_request_file(Badge<WebContentClient>, DeprecatedString const& path, i32) = 0;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) = 0;
 
+    virtual Gfx::IntRect viewport_rect() const = 0;
+
 protected:
     static constexpr auto ZOOM_MIN_LEVEL = 0.3f;
     static constexpr auto ZOOM_MAX_LEVEL = 5.0f;
     static constexpr auto ZOOM_STEP = 0.1f;
 
+    ViewImplementation();
+
     WebContentClient& client();
     WebContentClient const& client() const;
     virtual void update_zoom() = 0;
+
+    enum class WindowResizeInProgress {
+        No,
+        Yes,
+    };
+    void resize_backing_stores_if_needed(WindowResizeInProgress);
+
+    void request_repaint();
+    void handle_resize();
 
     virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No) {};
 
@@ -160,6 +173,11 @@ protected:
 
     float m_zoom_level { 1.0 };
     float m_device_pixel_ratio { 1.0 };
+
+    RefPtr<Core::Timer> m_backing_store_shrink_timer;
+
+    RefPtr<Gfx::Bitmap> m_backup_bitmap;
+    Gfx::IntSize m_backup_bitmap_size;
 };
 
 }

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -59,7 +59,8 @@ public:
         view->client().async_update_system_theme(move(theme));
         view->client().async_update_system_fonts(Gfx::FontDatabase::default_font_query(), Gfx::FontDatabase::fixed_width_font_query(), Gfx::FontDatabase::window_title_font_query());
 
-        view->client().async_set_viewport_rect({ { 0, 0 }, window_size });
+        view->m_viewport_rect = { { 0, 0 }, window_size };
+        view->client().async_set_viewport_rect(view->m_viewport_rect);
         view->client().async_set_window_size(window_size);
 
         if (!web_driver_ipc_path.is_empty())
@@ -154,6 +155,11 @@ private:
     void notify_server_did_finish_handling_input_event(bool) override { }
     void update_zoom() override { }
     void create_client(WebView::EnableCallgrindProfiling) override { }
+
+    virtual Gfx::IntRect viewport_rect() const override { return m_viewport_rect; }
+
+private:
+    Gfx::IntRect m_viewport_rect;
 };
 
 static ErrorOr<NonnullRefPtr<Core::Timer>> load_page_for_screenshot_and_exit(Core::EventLoop& event_loop, HeadlessWebContentView& view, int screenshot_timeout)


### PR DESCRIPTION
This lets us share this code on all platforms, and makes resizing the window much faster on SerenityOS as well. :^)