### PR TITLE
LibWeb: Cache state of the contenteditable attribute on HTMLElement

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -67,6 +67,7 @@ protected:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
     virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void did_remove_attribute(DeprecatedFlyString const& name) override;
 
     virtual void visit_edges(Cell::Visitor&) override;
 
@@ -81,7 +82,7 @@ private:
         False,
         Inherit,
     };
-    ContentEditableState content_editable_state() const;
+    ContentEditableState m_content_editable_state { ContentEditableState::Inherit };
 
     JS::GCPtr<DOMStringMap> m_dataset;
 


### PR DESCRIPTION
Instead of recomputing the state whenever someone asks for it, we now cache it when the attribute is added/changed/removed.

Before this change, `HTMLElement::is_editable()` was 6.5% of CPU time when furiously resizing Hacker News. After, it's less than 0.5%. :^)