### PR TITLE
LibWeb: Fix iframes flickering on window resize

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -38,7 +38,7 @@ public:
 
     virtual ~Box() override;
 
-    virtual void did_set_rect() { }
+    virtual void did_set_content_size() { }
 
     virtual JS::GCPtr<Painting::Paintable> create_paintable() const override;
 

--- a/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
@@ -28,9 +28,9 @@ void FrameBox::prepare_for_replaced_layout()
     set_intrinsic_height(dom_node().attribute(HTML::AttributeNames::height).to_int().value_or(150));
 }
 
-void FrameBox::did_set_rect()
+void FrameBox::did_set_content_size()
 {
-    ReplacedBox::did_set_rect();
+    ReplacedBox::did_set_content_size();
 
     VERIFY(dom_node().nested_browsing_context());
     dom_node().nested_browsing_context()->set_size(paintable_box()->content_size());

--- a/Userland/Libraries/LibWeb/Layout/FrameBox.h
+++ b/Userland/Libraries/LibWeb/Layout/FrameBox.h
@@ -26,7 +26,7 @@ public:
     virtual JS::GCPtr<Painting::Paintable> create_paintable() const override;
 
 private:
-    virtual void did_set_rect() override;
+    virtual void did_set_content_size() override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -63,13 +63,12 @@ PaintableWithLines::~PaintableWithLines()
 void PaintableBox::set_offset(CSSPixelPoint offset)
 {
     m_offset = offset;
-    layout_box().did_set_rect();
 }
 
 void PaintableBox::set_content_size(CSSPixelSize size)
 {
     m_content_size = size;
-    layout_box().did_set_rect();
+    layout_box().did_set_content_size();
 }
 
 CSSPixelPoint PaintableBox::effective_offset() const


### PR DESCRIPTION
After finishing layout, iframe layout boxes (FrameBox) get notified about their new size by LayoutState::commit(). This information is forwarded to the nested browsing context, where it can be used for layout of the nested document.

The problem here was that we notified the FrameBox twice. Once when assigning the used offset to its paintable, and once when assigning its size. Because the offset was assigned first, we ended up telling the FrameBox "btw, your size is 0x0". This caused us to throw away all the layout information we had for the nested document.

We'd then say "actually, your size is 300x200" (or something) but by then it was already too late, and we had to do a full relayout. This caused iframes to flicker as every time their containing document was laid out, we'd nuke the iframe layout and redo it (on a zero timer).

The fix is pleasantly simple: we didn't need to inform the nested document of its offset in the containing document's layout anyway. Only its size is relevant. So we can simply remove the first call, which removes the bogus 0x0 temporary size.

Note that iframes may still flicker if they change size in the containing document. That's a separate issue that will require more finesse to solve. However, this fixes a very noticeable common case.

Before:
[iframe-before.webm](https://github.com/SerenityOS/serenity/assets/5954907/27d2d4ad-032c-4c40-96be-4c0c4f628685)

After:
[iframe-after.webm](https://github.com/SerenityOS/serenity/assets/5954907/48ded59a-fc5f-443a-827c-e06d4d76fa84)