### PR TITLE
Userland: Show "Ladybird Browser" in taskbar title and and start menu

### DIFF
--- a/Base/res/apps/Browser.af
+++ b/Base/res/apps/Browser.af
@@ -1,5 +1,5 @@
 [App]
-Name=Ladybird
+Name=Ladybird Browser
 Executable=/bin/Browser
 Category=Internet
 


### PR DESCRIPTION
Let's make clear what Ladybird is for system consistency by making the Ladybird name less consistent. :^)

Did not change the name in build-root-filesystem.sh because it didn't look great when truncated.

I assume after opening the browser there is less of a need to indicate that it is an... browser.

I prefer the "things are named what they are"-approach so this is a compromise PR.

![image](https://github.com/SerenityOS/serenity/assets/93391300/6d14568d-2d8e-4014-9707-4fdfd22a2e4a)
