### PR TITLE
LibWeb: Fix specified_size_suggestion to use size of dimension

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1702,7 +1702,7 @@ Optional<CSSPixels> GridFormattingContext::specified_size_suggestion(GridItem co
     if (has_definite_preferred_size) {
         // FIXME: consider margins, padding and borders because it is outer size.
         auto containing_block_size = containing_block_size_for_item(item, dimension);
-        return item.box().computed_values().width().to_px(item.box(), containing_block_size);
+        return get_item_preferred_size(item, dimension).to_px(item.box(), containing_block_size);
     }
 
     return {};


### PR DESCRIPTION
specified_size_suggestion() should use width or height depending on specified dimension.

Unfortunately I haven't done reduced example to add in layout  tests but it fixes GitHub layout.

before/after

![Screenshot 2023-05-15 at 17 00 00](https://github.com/SerenityOS/serenity/assets/45686940/0f6ff63e-3db9-4079-aaed-d4ba9c794378)

![Screenshot 2023-05-15 at 16 55 39](https://github.com/SerenityOS/serenity/assets/45686940/aeb0d2ce-3717-4dc2-a3b5-fdfe09206b62)
6)
