### PR TITLE
pgrep: Add -d option to specify a pid delimiter

### DIFF
--- a/Base/usr/share/man/man1/pgrep.md
+++ b/Base/usr/share/man/man1/pgrep.md
@@ -1,0 +1,19 @@
+## Name
+
+pgrep - look up processes based on name
+
+## Synopsis
+
+```sh
+$ pgrep [-d delimiter] [-i] [--invert-match] <process-name>
+```
+
+## Options
+
+* `-d`, `--delimiter`: Set the string used to delimit multiple pids
+* `-i`: Make matches case-insensitive
+* `-v`, `--invert-match`: Select non-matching lines
+
+## Arguments
+
+* `process-name`: Process name to search for

--- a/Userland/Utilities/pgrep.cpp
+++ b/Userland/Utilities/pgrep.cpp
@@ -19,11 +19,13 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
+    auto pid_delimiter = "\n"sv;
     bool case_insensitive = false;
     bool invert_match = false;
     StringView pattern;
 
     Core::ArgsParser args_parser;
+    args_parser.add_option(pid_delimiter, "Set the string used to delimit multiple pids", "delimiter", 'd', nullptr);
     args_parser.add_option(case_insensitive, "Make matches case-insensitive", nullptr, 'i');
     args_parser.add_option(invert_match, "Select non-matching lines", "invert-match", 'v');
     args_parser.add_positional_argument(pattern, "Process name to search for", "process-name");
@@ -50,9 +52,18 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     quick_sort(matches);
 
+    auto displayed_at_least_one = false;
     for (auto& match : matches) {
-        outln("{}", match);
+        if (displayed_at_least_one)
+            out("{}{}"sv, pid_delimiter, match);
+        else
+            out("{}"sv, match);
+
+        displayed_at_least_one = true;
     }
+
+    if (displayed_at_least_one)
+        outln();
 
     return 0;
 }


### PR DESCRIPTION
This is useful for commands which expect a comma-separated list of pids.

Example usage (list processes starting with S):

![pgrep_delimiter](https://github.com/SerenityOS/serenity/assets/2817754/69ac3539-c497-4509-b45e-29ad287ef9a5)
