### PR TITLE
Browser+Ladybird: Context menu goodies

### DIFF
--- a/Ladybird/BrowserWindow.cpp
+++ b/Ladybird/BrowserWindow.cpp
@@ -418,6 +418,8 @@ Tab& BrowserWindow::new_tab(QString const& url, Web::HTML::ActivateTab activate_
             m_current_tab->view().on_tab_open_request(url, Web::HTML::ActivateTab::No);
         } else if (target == "_blank") {
             m_current_tab->view().on_tab_open_request(url, Web::HTML::ActivateTab::Yes);
+        } else {
+            m_current_tab->view().load(url);
         }
     };
 

--- a/Ladybird/BrowserWindow.h
+++ b/Ladybird/BrowserWindow.h
@@ -47,6 +47,26 @@ public:
         return *m_reload_action;
     }
 
+    QAction& copy_selection_action()
+    {
+        return *m_copy_selection_action;
+    }
+
+    QAction& select_all_action()
+    {
+        return *m_select_all_action;
+    }
+
+    QAction& view_source_action()
+    {
+        return *m_view_source_action;
+    }
+
+    QAction& inspect_dom_node_action()
+    {
+        return *m_inspect_dom_node_action;
+    }
+
 public slots:
     void tab_title_changed(int index, QString const&);
     void tab_favicon_changed(int index, QIcon icon);
@@ -64,7 +84,6 @@ public slots:
     void reset_zoom();
     void select_all();
     void copy_selected_text();
-    void show_context_menu(QPoint const&);
 
 protected:
     bool eventFilter(QObject* obj, QEvent* event) override;
@@ -83,10 +102,13 @@ private:
     Tab* m_current_tab { nullptr };
     QMenu* m_zoom_menu { nullptr };
 
-    OwnPtr<QMenu> m_context_menu {};
     OwnPtr<QAction> m_go_back_action {};
     OwnPtr<QAction> m_go_forward_action {};
     OwnPtr<QAction> m_reload_action {};
+    OwnPtr<QAction> m_copy_selection_action {};
+    OwnPtr<QAction> m_select_all_action {};
+    OwnPtr<QAction> m_view_source_action {};
+    OwnPtr<QAction> m_inspect_dom_node_action {};
 
     Browser::CookieJar& m_cookie_jar;
 

--- a/Ladybird/Tab.cpp
+++ b/Ladybird/Tab.cpp
@@ -13,6 +13,7 @@
 #include <QCoreApplication>
 #include <QFont>
 #include <QFontMetrics>
+#include <QMenu>
 #include <QPainter>
 #include <QPlainTextEdit>
 #include <QPoint>
@@ -177,6 +178,22 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
         m_window->showFullScreen();
         return Gfx::IntRect { m_window->x(), m_window->y(), m_window->width(), m_window->height() };
     });
+
+    m_page_context_menu = make<QMenu>("Context menu", this);
+    m_page_context_menu->addAction(&m_window->go_back_action());
+    m_page_context_menu->addAction(&m_window->go_forward_action());
+    m_page_context_menu->addAction(&m_window->reload_action());
+    m_page_context_menu->addSeparator();
+    m_page_context_menu->addAction(&m_window->copy_selection_action());
+    m_page_context_menu->addAction(&m_window->select_all_action());
+    m_page_context_menu->addSeparator();
+    m_page_context_menu->addAction(&m_window->view_source_action());
+    m_page_context_menu->addAction(&m_window->inspect_dom_node_action());
+
+    view().on_context_menu_request = [this](auto widget_position) {
+        auto screen_position = mapToGlobal(QPoint { widget_position.x(), widget_position.y() });
+        m_page_context_menu->exec(screen_position);
+    };
 }
 
 void Tab::update_reset_zoom_button()

--- a/Ladybird/Tab.cpp
+++ b/Ladybird/Tab.cpp
@@ -197,6 +197,39 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
         m_page_context_menu->exec(screen_position);
     };
 
+    auto* open_link_action = new QAction("&Open", this);
+    open_link_action->setIcon(QIcon(QString("%1/res/icons/16x16/go-forward.png").arg(s_serenity_resource_root.characters())));
+    QObject::connect(open_link_action, &QAction::triggered, this, [this]() {
+        open_link(m_link_context_menu_url);
+    });
+
+    auto* open_link_in_new_tab_action = new QAction("&Open in New &Tab", this);
+    open_link_in_new_tab_action->setIcon(QIcon(QString("%1/res/icons/16x16/new-tab.png").arg(s_serenity_resource_root.characters())));
+    QObject::connect(open_link_in_new_tab_action, &QAction::triggered, this, [this]() {
+        open_link_in_new_tab(m_link_context_menu_url);
+    });
+
+    auto* copy_url_action = new QAction("Copy &URL", this);
+    copy_url_action->setIcon(QIcon(QString("%1/res/icons/16x16/edit-copy.png").arg(s_serenity_resource_root.characters())));
+    QObject::connect(copy_url_action, &QAction::triggered, this, [this]() {
+        copy_link_url(m_link_context_menu_url);
+    });
+
+    m_link_context_menu = make<QMenu>("Link context menu", this);
+    m_link_context_menu->addAction(open_link_action);
+    m_link_context_menu->addAction(open_link_in_new_tab_action);
+    m_link_context_menu->addSeparator();
+    m_link_context_menu->addAction(copy_url_action);
+    m_link_context_menu->addSeparator();
+    m_link_context_menu->addAction(&m_window->inspect_dom_node_action());
+
+    view().on_link_context_menu_request = [this](auto const& url, auto widget_position) {
+        m_link_context_menu_url = url;
+
+        auto screen_position = mapToGlobal(QPoint { widget_position.x(), widget_position.y() });
+        m_link_context_menu->exec(screen_position);
+    };
+
     m_video_context_menu_play_icon = make<QIcon>(QString("%1/res/icons/16x16/play.png").arg(s_serenity_resource_root.characters()));
     m_video_context_menu_pause_icon = make<QIcon>(QString("%1/res/icons/16x16/pause.png").arg(s_serenity_resource_root.characters()));
 

--- a/Ladybird/Tab.h
+++ b/Ladybird/Tab.h
@@ -76,6 +76,10 @@ private:
     OwnPtr<QMenu> m_link_context_menu;
     URL m_link_context_menu_url;
 
+    OwnPtr<QMenu> m_image_context_menu;
+    Gfx::ShareableBitmap m_image_context_menu_bitmap;
+    URL m_image_context_menu_url;
+
     OwnPtr<QMenu> m_video_context_menu;
     OwnPtr<QIcon> m_video_context_menu_play_icon;
     OwnPtr<QIcon> m_video_context_menu_pause_icon;

--- a/Ladybird/Tab.h
+++ b/Ladybird/Tab.h
@@ -67,6 +67,8 @@ private:
     QString m_title;
     QLabel* m_hover_label { nullptr };
 
+    OwnPtr<QMenu> m_page_context_menu;
+
     int tab_index();
 
     bool m_is_history_navigation { false };

--- a/Ladybird/Tab.h
+++ b/Ladybird/Tab.h
@@ -73,6 +73,9 @@ private:
 
     OwnPtr<QMenu> m_page_context_menu;
 
+    OwnPtr<QMenu> m_link_context_menu;
+    URL m_link_context_menu_url;
+
     OwnPtr<QMenu> m_video_context_menu;
     OwnPtr<QIcon> m_video_context_menu_play_icon;
     OwnPtr<QIcon> m_video_context_menu_pause_icon;

--- a/Ladybird/Tab.h
+++ b/Ladybird/Tab.h
@@ -56,6 +56,10 @@ private:
     void rerender_toolbar_icons();
     void update_hover_label();
 
+    void open_link(URL const&);
+    void open_link_in_new_tab(URL const&);
+    void copy_link_url(URL const&);
+
     QBoxLayout* m_layout;
     QToolBar* m_toolbar { nullptr };
     QToolButton* m_reset_zoom_button { nullptr };
@@ -68,6 +72,14 @@ private:
     QLabel* m_hover_label { nullptr };
 
     OwnPtr<QMenu> m_page_context_menu;
+
+    OwnPtr<QMenu> m_video_context_menu;
+    OwnPtr<QIcon> m_video_context_menu_play_icon;
+    OwnPtr<QIcon> m_video_context_menu_pause_icon;
+    OwnPtr<QAction> m_video_context_menu_play_pause_action;
+    OwnPtr<QAction> m_video_context_menu_controls_action;
+    OwnPtr<QAction> m_video_context_menu_loop_action;
+    URL m_video_context_menu_url;
 
     int tab_index();
 

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -878,10 +878,8 @@ void WebContentView::notify_server_did_request_link_context_menu(Badge<WebConten
 
 void WebContentView::notify_server_did_request_image_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, AK::URL const& url, DeprecatedString const&, unsigned, Gfx::ShareableBitmap const& bitmap)
 {
-    // FIXME
-    (void)content_position;
-    (void)url;
-    (void)bitmap;
+    if (on_image_context_menu_request)
+        on_image_context_menu_request(url, to_widget(content_position), bitmap);
 }
 
 void WebContentView::notify_server_did_request_video_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, AK::URL const& url, DeprecatedString const&, unsigned, bool is_playing, bool has_user_agent_controls, bool is_looping)

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -885,6 +885,12 @@ void WebContentView::notify_server_did_request_image_context_menu(Badge<WebConte
     (void)bitmap;
 }
 
+void WebContentView::notify_server_did_request_video_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, AK::URL const& url, DeprecatedString const&, unsigned, bool is_playing, bool has_user_agent_controls, bool is_looping)
+{
+    if (on_video_context_menu_request)
+        on_video_context_menu_request(url, to_widget(content_position), is_playing, has_user_agent_controls, is_looping);
+}
+
 void WebContentView::notify_server_did_request_alert(Badge<WebContentClient>, String const& message)
 {
     m_dialog = new QMessageBox(QMessageBox::Icon::Warning, "Ladybird", qstring_from_ak_string(message), QMessageBox::StandardButton::Ok, this);

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -872,9 +872,8 @@ void WebContentView::notify_server_did_request_context_menu(Badge<WebContentClie
 
 void WebContentView::notify_server_did_request_link_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, AK::URL const& url, DeprecatedString const&, unsigned)
 {
-    // FIXME
-    (void)content_position;
-    (void)url;
+    if (on_link_context_menu_request)
+        on_link_context_menu_request(url, to_widget(content_position));
 }
 
 void WebContentView::notify_server_did_request_image_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, AK::URL const& url, DeprecatedString const&, unsigned, Gfx::ShareableBitmap const& bitmap)

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -866,8 +866,8 @@ void WebContentView::notify_server_did_request_refresh(Badge<WebContentClient>)
 
 void WebContentView::notify_server_did_request_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position)
 {
-    // FIXME
-    (void)content_position;
+    if (on_context_menu_request)
+        on_context_menu_request(to_widget(content_position));
 }
 
 void WebContentView::notify_server_did_request_link_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, AK::URL const& url, DeprecatedString const&, unsigned)

--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -54,6 +54,7 @@ public:
     Function<void(const AK::URL&, DeprecatedString const& target, unsigned modifiers)> on_link_click;
     Function<void(const AK::URL&, Gfx::IntPoint screen_position)> on_link_context_menu_request;
     Function<void(const AK::URL&, Gfx::IntPoint screen_position, Gfx::ShareableBitmap const&)> on_image_context_menu_request;
+    Function<void(const AK::URL&, Gfx::IntPoint screen_position, bool, bool, bool)> on_video_context_menu_request;
     Function<void(const AK::URL&, DeprecatedString const& target, unsigned modifiers)> on_link_middle_click;
     Function<void(const AK::URL&)> on_link_hover;
     Function<void(DeprecatedString const&)> on_title_change;
@@ -141,6 +142,7 @@ public:
     virtual void notify_server_did_request_context_menu(Badge<WebContentClient>, Gfx::IntPoint) override;
     virtual void notify_server_did_request_link_context_menu(Badge<WebContentClient>, Gfx::IntPoint, const AK::URL&, DeprecatedString const& target, unsigned modifiers) override;
     virtual void notify_server_did_request_image_context_menu(Badge<WebContentClient>, Gfx::IntPoint, const AK::URL&, DeprecatedString const& target, unsigned modifiers, Gfx::ShareableBitmap const&) override;
+    virtual void notify_server_did_request_video_context_menu(Badge<WebContentClient>, Gfx::IntPoint, const AK::URL&, DeprecatedString const& target, unsigned modifiers, bool is_playing, bool has_user_agent_controls, bool is_looping) override;
     virtual void notify_server_did_request_alert(Badge<WebContentClient>, String const& message) override;
     virtual void notify_server_did_request_confirm(Badge<WebContentClient>, String const& message) override;
     virtual void notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_) override;

--- a/Userland/Applications/Browser/IconBag.cpp
+++ b/Userland/Applications/Browser/IconBag.cpp
@@ -15,6 +15,7 @@ ErrorOr<IconBag> IconBag::try_create()
     icon_bag.filetype_text = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-text.png"sv));
     icon_bag.filetype_javascript = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-javascript.png"sv));
     icon_bag.filetype_image = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-image.png"sv));
+    icon_bag.filetype_video = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-video.png"sv));
     icon_bag.bookmark_contour = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/bookmark-contour.png"sv));
     icon_bag.bookmark_filled = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/bookmark-filled.png"sv));
     icon_bag.inspector_object = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/inspector-object.png"sv));
@@ -42,6 +43,8 @@ ErrorOr<IconBag> IconBag::try_create()
     icon_bag.download = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/download.png"sv));
     icon_bag.copy = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/edit-copy.png"sv));
     icon_bag.rename = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/rename.png"sv));
+    icon_bag.play = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/play.png"sv));
+    icon_bag.pause = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/pause.png"sv));
 
     return icon_bag;
 }

--- a/Userland/Applications/Browser/IconBag.h
+++ b/Userland/Applications/Browser/IconBag.h
@@ -17,6 +17,7 @@ struct IconBag final {
     RefPtr<Gfx::Bitmap> filetype_text { nullptr };
     RefPtr<Gfx::Bitmap> filetype_javascript { nullptr };
     RefPtr<Gfx::Bitmap> filetype_image { nullptr };
+    RefPtr<Gfx::Bitmap> filetype_video { nullptr };
     RefPtr<Gfx::Bitmap> bookmark_contour { nullptr };
     RefPtr<Gfx::Bitmap> bookmark_filled { nullptr };
     RefPtr<Gfx::Bitmap> inspector_object { nullptr };
@@ -44,5 +45,7 @@ struct IconBag final {
     RefPtr<Gfx::Bitmap> download { nullptr };
     RefPtr<Gfx::Bitmap> copy { nullptr };
     RefPtr<Gfx::Bitmap> rename { nullptr };
+    RefPtr<Gfx::Bitmap> play { nullptr };
+    RefPtr<Gfx::Bitmap> pause { nullptr };
 };
 }

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -369,6 +369,55 @@ Tab::Tab(BrowserWindow& window)
         m_image_context_menu->popup(screen_position);
     };
 
+    m_video_context_menu_play_pause_action = GUI::Action::create("&Play", g_icon_bag.play, [this](auto&) {
+        view().toggle_video_play_state();
+    });
+    m_video_context_menu_controls_action = GUI::Action::create_checkable("Show &Controls", [this](auto&) {
+        view().toggle_video_controls_state();
+    });
+    m_video_context_menu_loop_action = GUI::Action::create_checkable("&Loop Video", [this](auto&) {
+        view().toggle_video_loop_state();
+    });
+
+    m_video_context_menu = GUI::Menu::construct();
+    m_video_context_menu->add_action(*m_video_context_menu_play_pause_action);
+    m_video_context_menu->add_action(*m_video_context_menu_controls_action);
+    m_video_context_menu->add_action(*m_video_context_menu_loop_action);
+    m_video_context_menu->add_separator();
+    m_video_context_menu->add_action(GUI::Action::create("&Open Video", g_icon_bag.filetype_video, [this](auto&) {
+        view().on_link_click(m_video_context_menu_url, "", 0);
+    }));
+    m_video_context_menu->add_action(GUI::Action::create("Open Video in New &Tab", g_icon_bag.new_tab, [this](auto&) {
+        view().on_link_click(m_video_context_menu_url, "_blank", 0);
+    }));
+    m_video_context_menu->add_separator();
+    m_video_context_menu->add_action(GUI::Action::create("Copy Video &URL", g_icon_bag.copy, [this](auto&) {
+        GUI::Clipboard::the().set_plain_text(m_video_context_menu_url.to_deprecated_string());
+    }));
+    m_video_context_menu->add_separator();
+    m_video_context_menu->add_action(GUI::Action::create("&Download", g_icon_bag.download, [this](auto&) {
+        start_download(m_video_context_menu_url);
+    }));
+    m_video_context_menu->add_separator();
+    m_video_context_menu->add_action(window.inspect_dom_node_action());
+
+    view().on_video_context_menu_request = [this](auto& video_url, auto screen_position, bool is_playing, bool has_user_agent_controls, bool is_looping) {
+        m_video_context_menu_url = video_url;
+
+        if (is_playing) {
+            m_video_context_menu_play_pause_action->set_icon(g_icon_bag.play);
+            m_video_context_menu_play_pause_action->set_text("&Play"sv);
+        } else {
+            m_video_context_menu_play_pause_action->set_icon(g_icon_bag.pause);
+            m_video_context_menu_play_pause_action->set_text("&Pause"sv);
+        }
+
+        m_video_context_menu_controls_action->set_checked(has_user_agent_controls);
+        m_video_context_menu_loop_action->set_checked(is_looping);
+
+        m_video_context_menu->popup(screen_position);
+    };
+
     view().on_link_middle_click = [this](auto& href, auto&, auto) {
         view().on_link_click(href, "_blank", 0);
     };

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -144,6 +144,12 @@ private:
     Gfx::ShareableBitmap m_image_context_menu_bitmap;
     URL m_image_context_menu_url;
 
+    RefPtr<GUI::Menu> m_video_context_menu;
+    RefPtr<GUI::Action> m_video_context_menu_play_pause_action;
+    RefPtr<GUI::Action> m_video_context_menu_controls_action;
+    RefPtr<GUI::Action> m_video_context_menu_loop_action;
+    URL m_video_context_menu_url;
+
     RefPtr<GUI::Menu> m_tab_context_menu;
     RefPtr<GUI::Menu> m_page_context_menu;
     RefPtr<GUI::Menu> m_go_back_context_menu;

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -100,6 +100,8 @@ StringView guess_mime_type_based_on_filename(StringView path)
         return "text/csv"sv;
     if (path.ends_with(".sheets"sv, CaseSensitivity::CaseInsensitive))
         return "application/x-sheets+json"sv;
+    if (path.ends_with(".webm"sv, CaseSensitivity::CaseInsensitive))
+        return "video/webm"sv;
     // FIXME: Share this, TextEditor and HackStudio language detection somehow.
     auto basename = LexicalPath::basename(path);
     if (path.ends_with(".cpp"sv, CaseSensitivity::CaseInsensitive)

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/HTML/HTMLAnchorElement.h>
 #include <LibWeb/HTML/HTMLIFrameElement.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
+#include <LibWeb/HTML/HTMLVideoElement.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Page/Page.h>
@@ -302,6 +303,17 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, unsigned button, unsig
                         auto image_url = image_element.document().parse_url(image_element.src());
                         if (auto* page = m_browsing_context->page())
                             page->client().page_did_request_image_context_menu(m_browsing_context->to_top_level_position(position), image_url, "", modifiers, image_element.bitmap());
+                    } else if (is<HTML::HTMLVideoElement>(*node)) {
+                        auto& video_element = verify_cast<HTML::HTMLVideoElement>(*node);
+
+                        auto video_id = video_element.id();
+                        auto video_url = video_element.document().parse_url(video_element.current_src());
+                        auto is_playing = !video_element.potentially_playing();
+                        auto has_user_agent_controls = video_element.has_attribute(HTML::AttributeNames::controls);
+                        auto is_looping = video_element.has_attribute(HTML::AttributeNames::loop);
+
+                        if (auto* page = m_browsing_context->page())
+                            page->did_request_video_context_menu(video_id, m_browsing_context->to_top_level_position(position), video_url, "", modifiers, is_playing, has_user_agent_controls, is_looping);
                     } else if (auto* page = m_browsing_context->page()) {
                         page->client().page_did_request_context_menu(m_browsing_context->to_top_level_position(position));
                     }

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -275,4 +275,10 @@ void Page::accept_dialog()
     }
 }
 
+void Page::did_request_video_context_menu(i32 video_id, CSSPixelPoint position, AK::URL const& url, DeprecatedString const& target, unsigned modifiers, bool is_playing, bool has_user_agent_controls, bool is_looping)
+{
+    m_video_context_menu_element_id = video_id;
+    client().page_did_request_video_context_menu(position, url, target, modifiers, is_playing, has_user_agent_controls, is_looping);
+}
+
 }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -116,10 +116,15 @@ public:
     void accept_dialog();
 
     void did_request_video_context_menu(i32 video_id, CSSPixelPoint, AK::URL const&, DeprecatedString const& target, unsigned modifiers, bool is_playing, bool has_user_agent_controls, bool is_looping);
+    WebIDL::ExceptionOr<void> toggle_video_play_state();
+    WebIDL::ExceptionOr<void> toggle_video_loop_state();
+    WebIDL::ExceptionOr<void> toggle_video_controls_state();
 
     bool pdf_viewer_supported() const { return m_pdf_viewer_supported; }
 
 private:
+    JS::GCPtr<HTML::HTMLVideoElement> video_context_menu_element();
+
     PageClient& m_client;
 
     JS::Handle<HTML::BrowsingContext> m_top_level_browsing_context;

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -115,6 +115,8 @@ public:
     void dismiss_dialog();
     void accept_dialog();
 
+    void did_request_video_context_menu(i32 video_id, CSSPixelPoint, AK::URL const&, DeprecatedString const& target, unsigned modifiers, bool is_playing, bool has_user_agent_controls, bool is_looping);
+
     bool pdf_viewer_supported() const { return m_pdf_viewer_supported; }
 
 private:
@@ -142,6 +144,8 @@ private:
     Optional<Empty> m_pending_alert_response;
     Optional<bool> m_pending_confirm_response;
     Optional<Optional<String>> m_pending_prompt_response;
+
+    Optional<int> m_video_context_menu_element_id;
 
     // https://html.spec.whatwg.org/multipage/system-state.html#pdf-viewer-supported
     // Each user agent has a PDF viewer supported boolean, whose value is implementation-defined (and might vary according to user preferences).
@@ -178,6 +182,7 @@ public:
     virtual void page_did_request_context_menu(CSSPixelPoint) { }
     virtual void page_did_request_link_context_menu(CSSPixelPoint, AK::URL const&, [[maybe_unused]] DeprecatedString const& target, [[maybe_unused]] unsigned modifiers) { }
     virtual void page_did_request_image_context_menu(CSSPixelPoint, AK::URL const&, [[maybe_unused]] DeprecatedString const& target, [[maybe_unused]] unsigned modifiers, Gfx::Bitmap const*) { }
+    virtual void page_did_request_video_context_menu(CSSPixelPoint, AK::URL const&, [[maybe_unused]] DeprecatedString const& target, [[maybe_unused]] unsigned modifiers, [[maybe_unused]] bool is_playing, [[maybe_unused]] bool has_user_agent_controls, [[maybe_unused]] bool is_looping) { }
     virtual void page_did_click_link(const AK::URL&, [[maybe_unused]] DeprecatedString const& target, [[maybe_unused]] unsigned modifiers) { }
     virtual void page_did_middle_click_link(const AK::URL&, [[maybe_unused]] DeprecatedString const& target, [[maybe_unused]] unsigned modifiers) { }
     virtual void page_did_enter_tooltip_area(CSSPixelPoint, DeprecatedString const&) { }

--- a/Userland/Libraries/LibWeb/Painting/VideoPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/VideoPaintable.cpp
@@ -349,7 +349,7 @@ void VideoPaintable::paint_placeholder_video_controls(PaintContext& context, Dev
 VideoPaintable::DispatchEventOfSameName VideoPaintable::handle_mouseup(Badge<EventHandler>, CSSPixelPoint position, unsigned button, unsigned)
 {
     if (button != GUI::MouseButton::Primary)
-        return DispatchEventOfSameName::No;
+        return DispatchEventOfSameName::Yes;
 
     auto& video_element = layout_box().dom_node();
     auto const& cached_layout_boxes = video_element.cached_layout_boxes({});

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -320,6 +320,12 @@ void OutOfProcessWebView::notify_server_did_request_image_context_menu(Badge<Web
         on_image_context_menu_request(url, screen_relative_rect().location().translated(to_widget_position(content_position)), bitmap);
 }
 
+void OutOfProcessWebView::notify_server_did_request_video_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, const AK::URL& url, DeprecatedString const&, unsigned, bool is_playing, bool has_user_agent_controls, bool is_looping)
+{
+    if (on_video_context_menu_request)
+        on_video_context_menu_request(url, screen_relative_rect().location().translated(to_widget_position(content_position)), is_playing, has_user_agent_controls, is_looping);
+}
+
 void OutOfProcessWebView::notify_server_did_request_alert(Badge<WebContentClient>, String const& message)
 {
     m_dialog = GUI::MessageBox::create(window(), message, "Alert"sv, GUI::MessageBox::Type::Information, GUI::MessageBox::InputType::OK).release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -67,6 +67,7 @@ public:
     Function<void(const AK::URL&, DeprecatedString const& target, unsigned modifiers)> on_link_click;
     Function<void(const AK::URL&, Gfx::IntPoint screen_position)> on_link_context_menu_request;
     Function<void(const AK::URL&, Gfx::IntPoint screen_position, Gfx::ShareableBitmap const&)> on_image_context_menu_request;
+    Function<void(const AK::URL&, Gfx::IntPoint screen_position, bool, bool, bool)> on_video_context_menu_request;
     Function<void(const AK::URL&, DeprecatedString const& target, unsigned modifiers)> on_link_middle_click;
     Function<void(const AK::URL&)> on_link_hover;
     Function<void(DeprecatedString const&)> on_title_change;
@@ -148,6 +149,7 @@ private:
     virtual void notify_server_did_request_context_menu(Badge<WebContentClient>, Gfx::IntPoint) override;
     virtual void notify_server_did_request_link_context_menu(Badge<WebContentClient>, Gfx::IntPoint, const AK::URL&, DeprecatedString const& target, unsigned modifiers) override;
     virtual void notify_server_did_request_image_context_menu(Badge<WebContentClient>, Gfx::IntPoint, const AK::URL&, DeprecatedString const& target, unsigned modifiers, Gfx::ShareableBitmap const&) override;
+    virtual void notify_server_did_request_video_context_menu(Badge<WebContentClient>, Gfx::IntPoint, const AK::URL&, DeprecatedString const& target, unsigned modifiers, bool is_playing, bool has_user_agent_controls, bool is_looping) override;
     virtual void notify_server_did_request_alert(Badge<WebContentClient>, String const& message) override;
     virtual void notify_server_did_request_confirm(Badge<WebContentClient>, String const& message) override;
     virtual void notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_) override;

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -131,6 +131,21 @@ void ViewImplementation::run_javascript(StringView js_source)
     client().async_run_javascript(js_source);
 }
 
+void ViewImplementation::toggle_video_play_state()
+{
+    client().async_toggle_video_play_state();
+}
+
+void ViewImplementation::toggle_video_loop_state()
+{
+    client().async_toggle_video_loop_state();
+}
+
+void ViewImplementation::toggle_video_controls_state()
+{
+    client().async_toggle_video_controls_state();
+}
+
 void ViewImplementation::handle_resize()
 {
     resize_backing_stores_if_needed(WindowResizeInProgress::Yes);

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -93,6 +93,7 @@ public:
     virtual void notify_server_did_request_context_menu(Badge<WebContentClient>, Gfx::IntPoint) = 0;
     virtual void notify_server_did_request_link_context_menu(Badge<WebContentClient>, Gfx::IntPoint, const AK::URL&, DeprecatedString const& target, unsigned modifiers) = 0;
     virtual void notify_server_did_request_image_context_menu(Badge<WebContentClient>, Gfx::IntPoint, const AK::URL&, DeprecatedString const& target, unsigned modifiers, Gfx::ShareableBitmap const&) = 0;
+    virtual void notify_server_did_request_video_context_menu(Badge<WebContentClient>, Gfx::IntPoint, const AK::URL&, DeprecatedString const& target, unsigned modifiers, bool is_playing, bool has_user_agent_controls, bool is_looping) = 0;
     virtual void notify_server_did_request_alert(Badge<WebContentClient>, String const& message) = 0;
     virtual void notify_server_did_request_confirm(Badge<WebContentClient>, String const& message) = 0;
     virtual void notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_) = 0;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -70,6 +70,10 @@ public:
 
     void run_javascript(StringView);
 
+    void toggle_video_play_state();
+    void toggle_video_loop_state();
+    void toggle_video_controls_state();
+
     virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) = 0;
     virtual void notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize) = 0;
     virtual void notify_server_did_invalidate_content_rect(Badge<WebContentClient>, Gfx::IntRect const&) = 0;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -151,6 +151,11 @@ void WebContentClient::did_request_image_context_menu(Gfx::IntPoint content_posi
     m_view.notify_server_did_request_image_context_menu({}, content_position, url, target, modifiers, bitmap);
 }
 
+void WebContentClient::did_request_video_context_menu(Gfx::IntPoint content_position, AK::URL const& url, DeprecatedString const& target, unsigned modifiers, bool is_playing, bool has_user_agent_controls, bool is_looping)
+{
+    m_view.notify_server_did_request_video_context_menu({}, content_position, url, target, modifiers, is_playing, has_user_agent_controls, is_looping);
+}
+
 void WebContentClient::did_get_source(AK::URL const& url, DeprecatedString const& source)
 {
     m_view.notify_server_did_get_source(url, source);

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -52,6 +52,7 @@ private:
     virtual void did_request_context_menu(Gfx::IntPoint) override;
     virtual void did_request_link_context_menu(Gfx::IntPoint, AK::URL const&, DeprecatedString const&, unsigned) override;
     virtual void did_request_image_context_menu(Gfx::IntPoint, AK::URL const&, DeprecatedString const&, unsigned, Gfx::ShareableBitmap const&) override;
+    virtual void did_request_video_context_menu(Gfx::IntPoint, AK::URL const&, DeprecatedString const&, unsigned, bool, bool, bool) override;
     virtual void did_get_source(AK::URL const&, DeprecatedString const&) override;
     virtual void did_get_dom_tree(DeprecatedString const&) override;
     virtual void did_get_dom_node_properties(i32 node_id, DeprecatedString const& computed_style, DeprecatedString const& resolved_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -756,6 +756,21 @@ void ConnectionFromClient::prompt_closed(Optional<String> const& response)
     m_page_host->prompt_closed(response);
 }
 
+void ConnectionFromClient::toggle_video_play_state()
+{
+    m_page_host->toggle_video_play_state().release_value_but_fixme_should_propagate_errors();
+}
+
+void ConnectionFromClient::toggle_video_loop_state()
+{
+    m_page_host->toggle_video_loop_state().release_value_but_fixme_should_propagate_errors();
+}
+
+void ConnectionFromClient::toggle_video_controls_state()
+{
+    m_page_host->toggle_video_controls_state().release_value_but_fixme_should_propagate_errors();
+}
+
 void ConnectionFromClient::inspect_accessibility_tree()
 {
     if (auto* doc = page().top_level_browsing_context().active_document()) {

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -95,6 +95,10 @@ private:
     virtual void confirm_closed(bool accepted) override;
     virtual void prompt_closed(Optional<String> const& response) override;
 
+    virtual void toggle_video_play_state() override;
+    virtual void toggle_video_loop_state() override;
+    virtual void toggle_video_controls_state() override;
+
     virtual Messages::WebContentServer::TakeDocumentScreenshotResponse take_document_screenshot() override;
 
     virtual Messages::WebContentServer::GetLocalStorageEntriesResponse get_local_storage_entries() override;

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -334,6 +334,21 @@ void PageHost::prompt_closed(Optional<String> response)
     page().prompt_closed(move(response));
 }
 
+Web::WebIDL::ExceptionOr<void> PageHost::toggle_video_play_state()
+{
+    return page().toggle_video_play_state();
+}
+
+Web::WebIDL::ExceptionOr<void> PageHost::toggle_video_loop_state()
+{
+    return page().toggle_video_loop_state();
+}
+
+Web::WebIDL::ExceptionOr<void> PageHost::toggle_video_controls_state()
+{
+    return page().toggle_video_controls_state();
+}
+
 void PageHost::page_did_request_accept_dialog()
 {
     m_client.async_did_request_accept_dialog();

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -355,6 +355,11 @@ void PageHost::page_did_request_image_context_menu(Web::CSSPixelPoint content_po
     m_client.async_did_request_image_context_menu({ content_position.x().value(), content_position.y().value() }, url, target, modifiers, bitmap);
 }
 
+void PageHost::page_did_request_video_context_menu(Web::CSSPixelPoint content_position, URL const& url, DeprecatedString const& target, unsigned modifiers, bool is_playing, bool has_user_agent_controls, bool is_looping)
+{
+    m_client.async_did_request_video_context_menu({ content_position.x().value(), content_position.y().value() }, url, target, modifiers, is_playing, has_user_agent_controls, is_looping);
+}
+
 Vector<Web::Cookie::Cookie> PageHost::page_did_request_all_cookies(URL const& url)
 {
     return m_client.did_request_all_cookies(url);

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -49,6 +49,10 @@ public:
     void confirm_closed(bool accepted);
     void prompt_closed(Optional<String> response);
 
+    Web::WebIDL::ExceptionOr<void> toggle_video_play_state();
+    Web::WebIDL::ExceptionOr<void> toggle_video_loop_state();
+    Web::WebIDL::ExceptionOr<void> toggle_video_controls_state();
+
     [[nodiscard]] Gfx::Color background_color() const;
 
 private:

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -94,6 +94,7 @@ private:
     virtual void page_did_request_dismiss_dialog() override;
     virtual void page_did_change_favicon(Gfx::Bitmap const&) override;
     virtual void page_did_request_image_context_menu(Web::CSSPixelPoint, const URL&, DeprecatedString const& target, unsigned modifiers, Gfx::Bitmap const*) override;
+    virtual void page_did_request_video_context_menu(Web::CSSPixelPoint, const URL&, DeprecatedString const& target, unsigned modifiers, bool is_playing, bool has_user_agent_controls, bool is_looping) override;
     virtual Vector<Web::Cookie::Cookie> page_did_request_all_cookies(URL const&) override;
     virtual Optional<Web::Cookie::Cookie> page_did_request_named_cookie(URL const&, DeprecatedString const&) override;
     virtual DeprecatedString page_did_request_cookie(const URL&, Web::Cookie::Source) override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -30,6 +30,7 @@ endpoint WebContentClient
     did_request_context_menu(Gfx::IntPoint content_position) =|
     did_request_link_context_menu(Gfx::IntPoint content_position, URL url, DeprecatedString target, unsigned modifiers) =|
     did_request_image_context_menu(Gfx::IntPoint content_position, URL url, DeprecatedString target, unsigned modifiers, Gfx::ShareableBitmap bitmap) =|
+    did_request_video_context_menu(Gfx::IntPoint content_position, URL url, DeprecatedString target, unsigned modifiers, bool is_playing, bool has_user_agent_controls, bool is_looping) =|
     did_request_alert(String message) =|
     did_request_confirm(String message) =|
     did_request_prompt(String message, String default_) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -76,4 +76,8 @@ endpoint WebContentServer
     alert_closed() =|
     confirm_closed(bool accepted) =|
     prompt_closed(Optional<String> response) =|
+
+    toggle_video_play_state() =|
+    toggle_video_loop_state() =|
+    toggle_video_controls_state() =|
 }

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -113,6 +113,7 @@ private:
     void notify_server_did_request_context_menu(Badge<WebView::WebContentClient>, Gfx::IntPoint) override { }
     void notify_server_did_request_link_context_menu(Badge<WebView::WebContentClient>, Gfx::IntPoint, const URL&, DeprecatedString const&, unsigned) override { }
     void notify_server_did_request_image_context_menu(Badge<WebView::WebContentClient>, Gfx::IntPoint, const URL&, DeprecatedString const&, unsigned, Gfx::ShareableBitmap const&) override { }
+    void notify_server_did_request_video_context_menu(Badge<WebView::WebContentClient>, Gfx::IntPoint, const URL&, DeprecatedString const&, unsigned, bool, bool, bool) override { }
     void notify_server_did_request_alert(Badge<WebView::WebContentClient>, String const&) override { }
     void notify_server_did_request_confirm(Badge<WebView::WebContentClient>, String const&) override { }
     void notify_server_did_request_prompt(Badge<WebView::WebContentClient>, String const&, String const&) override { }


### PR DESCRIPTION
Some sites like https://steamcommunity.com/id/egaruoC play a video as the website's background, and neither render controls themselves nor allow the UA to render control. Our autoplay mechanism will block these videos by default. This adds a context menu to video elements to allow controlling playback regardless of what the website provides, similar to how other browsers like Firefox behave:

https://github.com/SerenityOS/serenity/assets/5600524/a43ba699-9e84-4f92-9bfc-a5e0c5d853e2

While in the area, this PR also hooks up all of the context menus (page, link, image, video) for Ladybird:


https://github.com/SerenityOS/serenity/assets/5600524/b83e8b85-40c2-4145-a35b-df2df24db979

