### PR TITLE
Kernel/aarch64: Fix misaligned stack pointer exception when getting an exception

### DIFF
--- a/Kernel/Arch/aarch64/Interrupts.cpp
+++ b/Kernel/Arch/aarch64/Interrupts.cpp
@@ -89,6 +89,7 @@ extern "C" void exception_common(Kernel::TrapFrame* trap_frame)
     if (Aarch64::exception_class_is_data_abort(esr_el1.EC) || Aarch64::exception_class_is_instruction_abort(esr_el1.EC)) {
         auto page_fault_or_error = page_fault_from_exception_syndrome_register(VirtualAddress(fault_address), esr_el1);
         if (page_fault_or_error.is_error()) {
+            dump_registers(*trap_frame->regs);
             handle_crash(*trap_frame->regs, "Unknown page fault", SIGSEGV, false);
         } else {
             auto page_fault = page_fault_or_error.release_value();
@@ -97,6 +98,7 @@ extern "C" void exception_common(Kernel::TrapFrame* trap_frame)
     } else if (Aarch64::exception_class_is_svc_instruction_execution(esr_el1.EC)) {
         syscall_handler(trap_frame);
     } else {
+        dump_registers(*trap_frame->regs);
         handle_crash(*trap_frame->regs, "Unexpected exception", SIGSEGV, false);
     }
 

--- a/Kernel/Arch/aarch64/vector_table.S
+++ b/Kernel/Arch/aarch64/vector_table.S
@@ -6,7 +6,13 @@
 
 .section .text.vector_table
 
-#define REGISTER_STATE_SIZE 264
+// NOTE: This size must be a multiple of 16 bytes, to ensure that the stack pointer
+//       stays 16 byte aligned.
+#define REGISTER_STATE_SIZE 272
+#if REGISTER_STATE_SIZE % 16 != 0
+#    error "REGISTER_STATE_SIZE is not a multiple of 16 bytes!"
+#endif
+
 #define SPSR_EL1_SLOT       (31 * 8)
 #define ELR_EL1_SLOT        (32 * 8)
 #define SP_EL0_SLOT         (33 * 8)


### PR DESCRIPTION
Two patches I had laying around when I did the initial testing of the aarch64 port on bare metal.