### PR TITLE
AK: Modify min/max functions to return by ref or value

### DIFF
--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -90,14 +90,26 @@ constexpr SizeType array_size(T (&)[N])
     return N;
 }
 
-template<typename T>
-constexpr T min(T const& a, IdentityType<T> const& b)
+constexpr auto min(auto&& a, auto&& b)
+requires IsSame<RemoveCVReference<decltype(a)>, RemoveCVReference<decltype(b)>>
+{
+    return b < a ? forward<decltype(b)>(b) : forward<decltype(a)>(a);
+}
+
+constexpr auto min(auto& a, auto& b) -> auto&
+requires IsSame<RemoveCVReference<decltype(a)>, RemoveCVReference<decltype(b)>>
 {
     return b < a ? b : a;
 }
 
-template<typename T>
-constexpr T max(T const& a, IdentityType<T> const& b)
+constexpr auto max(auto&& a, auto&& b)
+requires IsSame<RemoveCVReference<decltype(a)>, RemoveCVReference<decltype(b)>>
+{
+    return a < b ? forward<decltype(b)>(b) : forward<decltype(a)>(a);
+}
+
+constexpr auto max(auto& a, auto& b) -> auto&
+requires IsSame<RemoveCVReference<decltype(a)>, RemoveCVReference<decltype(b)>>
 {
     return a < b ? b : a;
 }

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -50,6 +50,7 @@ set(AK_TEST_SOURCES
     TestMACAddress.cpp
     TestMemory.cpp
     TestMemoryStream.cpp
+    TestMinMax.cpp
     TestNeverDestroyed.cpp
     TestNonnullOwnPtr.cpp
     TestNonnullRefPtr.cpp

--- a/Tests/AK/TestMinMax.cpp
+++ b/Tests/AK/TestMinMax.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023, Muhammad Zahalqa <m@tryfinally.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/StdLibExtras.h>
+
+TEST_CASE(max_returns_correct_type_category)
+{
+    int r = 1;
+    int const c = 42;
+
+    static_assert(IsSame<decltype(min(r, r)), int&>);
+    static_assert(IsSame<decltype(min(c, c)), int const&>);
+    static_assert(IsSame<decltype(min(r, c)), int const&>);
+    static_assert(IsSame<decltype(min(c, r)), int const&>);
+
+    static_assert(IsSame<decltype(min(r, 2)), int>);
+    static_assert(IsSame<decltype(min(2, r)), int>);
+    static_assert(IsSame<decltype(min(c, 2)), int>);
+    static_assert(IsSame<decltype(min(2, c)), int>);
+    static_assert(IsSame<decltype(min(2, 3)), int>);
+}
+
+TEST_CASE(min_returns_correct_type_category)
+{
+    int r = 1;
+    int const c = 42;
+
+    static_assert(IsSame<decltype(max(r, r)), int&>);
+    static_assert(IsSame<decltype(max(c, c)), int const&>);
+    static_assert(IsSame<decltype(max(r, c)), int const&>);
+    static_assert(IsSame<decltype(max(c, r)), int const&>);
+
+    static_assert(IsSame<decltype(max(r, 2)), int>);
+    static_assert(IsSame<decltype(max(2, r)), int>);
+    static_assert(IsSame<decltype(max(c, 2)), int>);
+    static_assert(IsSame<decltype(max(2, c)), int>);
+    static_assert(IsSame<decltype(max(2, 3)), int>);
+}


### PR DESCRIPTION
Current implementations return by value and deviate from C++ standard, where these functions return by ref.

While suboptimal, this avoids the case of returning a dangling ref in calls like ```min(3, 5);```

The fix introduces two variants for each function:
- lvalue variant will return by ref/const ref if both args are lvalues.
- rvalue variant will return by value if at least one arg is a prvalue.