### PR TITLE
ping: Add `-q` for quiet mode and `-i` for a custom interval

### DIFF
--- a/Base/usr/share/man/man8/ping.md
+++ b/Base/usr/share/man/man8/ping.md
@@ -1,0 +1,20 @@
+## Name
+
+ping - send ICMP ECHO_REQUEST packets to network hosts
+
+## Synopsis
+
+```sh
+$ ping [--count count] [-i interval] [--size size] [--quiet] <host>
+```
+
+## Options
+
+* `-c count`, `--count count`: Stop after sending specified number of ECHO_REQUEST packets.
+* `-i interval`: Wait `interval` seconds between sending each packet. Fractional seconds are allowed.
+* `-s size`, `--size size`: Amount of bytes to send as payload in the ECHO_REQUEST packets.
+* `-q`, `--quiet`: Quiet mode. Only display summary when finished.
+
+## Arguments
+
+* `host`: Host to ping


### PR DESCRIPTION
This PR adds two new options to `ping`: 

* The `-q` option suppresses all output except the statistics shown before the program exits. 
* The `-i` option to specify the time to wait between packets in seconds. Fractional values are allowed down to 1 microsecond.*

\* The implementation of the `-i`  option on Linux (and possibly elsewhere) doesn't allow values lower than 2ms unless the user is root. I decided not to implement this, as I couldn't find any other utility that changes its behavior in this way. This feature seems like more of a fat-finger protection than a security measure, as nothing prevents someone from running many instances. I'm happy to add this if people think it is warranted.

Example usage:
![ping_quiet_and_interval](https://github.com/SerenityOS/serenity/assets/2817754/8f430e5d-eeca-4182-8b6e-6ebd4c38ab35)



