### PR TITLE
Kernel: Restore kernel8.img for aarch64 build

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -736,6 +736,14 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel" DESTINATION boot)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel.debug" DESTINATION boot)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/kernel.map" DESTINATION res)
 
+if ("${SERENITY_ARCH}" STREQUAL "aarch64")
+    add_custom_command(
+        TARGET Kernel POST_BUILD
+        COMMAND ${CMAKE_OBJCOPY} -O binary Kernel kernel8.img
+        BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/kernel8.img
+    )
+endif()
+
 serenity_install_headers(Kernel)
 serenity_install_sources(Kernel)
 


### PR DESCRIPTION
This was erroneously deleted in 420952a4334b05d6ac639429e876150c78866963

cc @supercomputer7