### PR TITLE
LibWeb: Support flex-basis: calc(...) and fix a sneaky calc() bug

### DIFF
--- a/Tests/LibWeb/Layout/expected/calc-negate-length.txt
+++ b/Tests/LibWeb/Layout/expected/calc-negate-length.txt
@@ -1,0 +1,5 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x66 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x50 children: not-inline
+      BlockContainer <div.container> at (8,8) content-size 100x50 children: not-inline
+        BlockContainer <div.foo> at (8,8) content-size 99x50 children: not-inline

--- a/Tests/LibWeb/Layout/expected/flex/calc-flex-basis.txt
+++ b/Tests/LibWeb/Layout/expected/flex/calc-flex-basis.txt
@@ -1,0 +1,24 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x80 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x62 children: not-inline
+      Box <div.flex-container> at (11,11) content-size 778x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div.flex-item> at (12,12) content-size 386x28 flex-item [BFC] children: inline
+          line 0 width: 58.398437, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+            frag 0 from TextNode start: 0, length: 6, rect: [12,12 58.398437x21.835937]
+              "Item 1"
+          TextNode <#text>
+        BlockContainer <div.flex-item> at (401,12) content-size 386x28 flex-item [BFC] children: inline
+          line 0 width: 61.484375, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+            frag 0 from TextNode start: 0, length: 6, rect: [401,12 61.484375x21.835937]
+              "Item 2"
+          TextNode <#text>
+        BlockContainer <div.flex-item> at (12,42) content-size 386x28 flex-item [BFC] children: inline
+          line 0 width: 61.835937, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+            frag 0 from TextNode start: 0, length: 6, rect: [12,42 61.835937x21.835937]
+              "Item 3"
+          TextNode <#text>
+        BlockContainer <div.flex-item> at (401,42) content-size 386x28 flex-item [BFC] children: inline
+          line 0 width: 60.15625, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+            frag 0 from TextNode start: 0, length: 6, rect: [401,42 60.15625x21.835937]
+              "Item 4"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/borders.txt
+++ b/Tests/LibWeb/Layout/expected/grid/borders.txt
@@ -103,14 +103,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,275.34375) content-size 784x90.9375 [GFC] children: not-inline
         BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (444.699981,285.34375) content-size 337.300018x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (444.199981,285.34375) content-size 337.800018x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [444.699981,285.34375 6.34375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [444.199981,285.34375 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (18,338.8125) content-size 337.299987x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (18,338.8125) content-size 337.799987x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [18,338.8125 8.8125x17.46875]
               "2"

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
@@ -2,12 +2,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x50.9375 children: not-inline
       Box <div.container> at (8,8) content-size 784x50.9375 [GFC] children: not-inline
-        BlockContainer <div.item> at (434.699981,8) content-size 357.300018x17.46875 [BFC] children: inline
+        BlockContainer <div.item> at (434.199981,8) content-size 357.800018x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [434.699981,8 6.34375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [434.199981,8 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <div.item> at (8,41.46875) content-size 357.299987x17.46875 [BFC] children: inline
+        BlockContainer <div.item> at (8,41.46875) content-size 357.799987x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,41.46875 8.8125x17.46875]
               "2"

--- a/Tests/LibWeb/Layout/input/calc-negate-length.html
+++ b/Tests/LibWeb/Layout/input/calc-negate-length.html
@@ -1,0 +1,15 @@
+<!doctype html><style>
+body {
+    background: #444;
+}
+.container {
+    width: 100px; 
+    background: green;
+    height: 50px;
+}
+.foo {
+    width: calc(100% - 1px);
+    background: black;
+    height: 50px;
+}
+</style><div class=container><div class=foo>

--- a/Tests/LibWeb/Layout/input/flex/calc-flex-basis.html
+++ b/Tests/LibWeb/Layout/input/flex/calc-flex-basis.html
@@ -1,0 +1,18 @@
+<!doctype html><style>
+* {
+    border: 1px solid black;
+    box-sizing: border-box;
+    font: 20px SerenitySans;
+}
+.flex-container {
+    display: flex;
+    flex-wrap: wrap;
+    background: pink;
+    column-gap: 1px;
+}
+.flex-item {
+    flex-basis: calc(50% - 1px);
+    background: orange;
+    height: 30px;
+}
+</style><div class="flex-container"><div class="flex-item">Item 1</div><div class="flex-item">Item 2</div><div class="flex-item">Item 3</div><div class="flex-item">Item 4</div></div>

--- a/Tests/LibWeb/Layout/input/grid/borders.html
+++ b/Tests/LibWeb/Layout/input/grid/borders.html
@@ -1,4 +1,7 @@
 <style>
+* {
+    font: 16px SerenitySans;
+}
   .grid-container {
     display: grid;
     background-color: lightsalmon;

--- a/Tests/LibWeb/Layout/input/grid/grid-gap-2.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-gap-2.html
@@ -1,4 +1,7 @@
 <style>
+* {
+    font: 16px SerenitySans;
+}
 .container {
     display: grid;
     background-color: lightsalmon;

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -294,6 +294,9 @@ Optional<CSS::FlexBasisData> StyleProperties::flex_basis() const
     if (value->has_length())
         return { { CSS::FlexBasis::LengthPercentage, value->to_length() } };
 
+    if (value->is_calculated())
+        return { { CSS::FlexBasis::LengthPercentage, CSS::LengthPercentage { value->as_calculated() } } };
+
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -583,22 +583,22 @@ void CalculatedStyleValue::CalculationResult::negate()
 {
     m_value.visit(
         [&](Number const& number) {
-            m_value = Number { number.type(), 1 - number.value() };
+            m_value = Number { number.type(), 0 - number.value() };
         },
         [&](Angle const& angle) {
-            m_value = Angle { 1 - angle.raw_value(), angle.type() };
+            m_value = Angle { 0 - angle.raw_value(), angle.type() };
         },
         [&](Frequency const& frequency) {
-            m_value = Frequency { 1 - frequency.raw_value(), frequency.type() };
+            m_value = Frequency { 0 - frequency.raw_value(), frequency.type() };
         },
         [&](Length const& length) {
-            m_value = Length { 1 - length.raw_value(), length.type() };
+            m_value = Length { 0 - length.raw_value(), length.type() };
         },
         [&](Time const& time) {
-            m_value = Time { 1 - time.raw_value(), time.type() };
+            m_value = Time { 0 - time.raw_value(), time.type() };
         },
         [&](Percentage const& percentage) {
-            m_value = Percentage { 1 - percentage.value() };
+            m_value = Percentage { 0 - percentage.value() };
         });
 }
 


### PR DESCRIPTION
Makes this 4x4 grid appear correctly on https://shopify.com/

![image](https://github.com/SerenityOS/serenity/assets/5954907/e8b2e0bb-750d-4cbf-a61b-1c8747936d4e)
