### PR TITLE
lsirq: Restore enumeration of interrupt line

### DIFF
--- a/Userland/Utilities/lsirq.cpp
+++ b/Userland/Utilities/lsirq.cpp
@@ -35,7 +35,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     json.as_array().for_each([cpu_count](JsonValue const& value) {
         auto& handler = value.as_object();
         auto purpose = handler.get_deprecated_string("purpose"sv).value_or({});
-        auto interrupt = handler.get_deprecated_string("interrupt_line"sv).value_or({});
+        auto interrupt = handler.get_u8("interrupt_line"sv).value();
         auto controller = handler.get_deprecated_string("controller"sv).value_or({});
         auto call_counts = handler.get_array("per_cpu_call_counts"sv).value();
 


### PR DESCRIPTION
This was broken by changes to `JsonObject::get_deprecated_string`. Found while testing #18732.