### PR TITLE
shuf: Add `-r` option to allow output lines to be repeated

### DIFF
--- a/Base/usr/share/man/man1/shuf.md
+++ b/Base/usr/share/man/man1/shuf.md
@@ -1,0 +1,19 @@
+## Name
+
+shuf - shuffle input lines randomly
+
+## Synopsis
+
+```sh
+$ shuf [--head-count count] [--repeat] [--zero-terminated] [file]
+```
+
+## Options
+
+* `-n count`, `--head-count count`: Output at most "count" lines
+* `-r`, `--repeat`: Pick lines at random rather than shuffling. The program will continue indefinitely if no `-n` option is specified
+* `-z`, `--zero-terminated`: Split input on \0, not newline
+
+## Arguments
+
+* `file`: File


### PR DESCRIPTION
This PR adds the `-r` option to `shuf`, which choses selects random lines from the input rather than shuffling it. This is useful for situations where you may want lines to be repeated. Using `-r` without the `-n` option will cause the program to 

I also replaced usages of `Core::System::Write()` with `outln`. In addition to being more concise, I was also able to induce a kernel panic when testing shuf with the `-r` option and no line limit. Using `outln()` instead resolves the issue, ~~although I haven't been able to replicate the crash in a standalone program :confused:.~~ EDIT: I've been able to reproduce this and have created an issue.

Example usage:
![shuf_allow_repeats](https://github.com/SerenityOS/serenity/assets/2817754/19149a13-1105-4422-898b-af557518a247)

