### PR TITLE
Kernel/aarch64: Flush data cache when updating page tables

### DIFF
--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -109,8 +109,12 @@ void Processor::initialize(u32)
         asm volatile("wfi");
 }
 
-void Processor::flush_tlb_local(VirtualAddress, size_t)
+void Processor::flush_tlb_local(VirtualAddress vaddr, size_t page_count)
 {
+    // We must flush the data cache here, such that the updated page tables actually
+    // end up in main memory, and thus actually get used by the MMU.
+    Aarch64::Asm::flush_data_cache(vaddr.get(), PAGE_SIZE * page_count);
+
     // FIXME: Figure out how to flush a single page
     asm volatile("dsb ishst");
     asm volatile("tlbi vmalle1");

--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -265,7 +265,9 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init([[maybe_unused]] BootInfo con
         (*ctor)();
 
     InterruptManagement::initialize();
+#if ARCH(X86_64)
     ACPI::initialize();
+#endif
 
     // Initialize TimeManagement before using randomness!
     TimeManagement::initialize(0);

--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -349,6 +349,8 @@ struct KmallocGlobalData {
             if (cpu_supports_nx)
                 pte->set_execute_disabled(true);
             pte->set_present(true);
+
+            Processor::flush_tlb_local(VirtualAddress((FlatPtr)pte), 1);
         }
 
         add_subheap(new_subheap_base.as_ptr(), new_subheap_size);

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -225,6 +225,8 @@ bool Region::map_individual_page_impl(size_t page_index, RefPtr<PhysicalPage> pa
     if (!pte)
         return false;
 
+    ScopeGuard flush_tlb_guard = [pte] { Processor::flush_tlb_local(VirtualAddress((FlatPtr)pte), 1); };
+
     if (!page || (!is_readable() && !is_writable())) {
         pte->clear();
         return true;


### PR DESCRIPTION
This is currently a draft as it relies on `Aarch64::Asm::flush_data_cache` present in #18876.

Found by running the aarch64 kernel bare metal on a Raspberry Pi 3B.

With these two commits, we now get to the point where the Scheduler starts, and we hang indefinitely.