### PR TITLE
LibWeb: Resolve CSS custom properties on pseudo elements

### DIFF
--- a/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties-2.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties-2.txt
@@ -1,0 +1,60 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x470.195312 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x454.195312 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x21.835937 children: inline
+        line 0 width: 391.640625, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+          frag 0 from TextNode start: 0, length: 40, rect: [8,8 391.640625x21.835937]
+            "Variable set by inline style of element:"
+        TextNode <#text>
+        BreakNode <br>
+        TextNode <#text>
+      BlockContainer <div.a> at (8,29.835937) content-size 784x100 children: inline
+        line 0 width: 200, height: 100, bottom: 100, baseline: 16.914062
+          frag 0 from BlockContainer start: 0, length: 0, rect: [8,29.835937 200x100]
+        BlockContainer <(anonymous)> at (8,29.835937) content-size 200x100 inline-block [BFC] children: inline
+          line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+            frag 0 from TextNode start: 0, length: 0, rect: [8,29.835937 0x21.835937]
+              ""
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,129.835937) content-size 784x66.179687 children: inline
+        line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+        line 1 width: 0, height: 21.835937, bottom: 43.671875, baseline: 16.914062
+        line 2 width: 441.269531, height: 22.507812, bottom: 66.179687, baseline: 16.914062
+          frag 0 from TextNode start: 1, length: 42, rect: [8,172.835937 441.269531x21.835937]
+            "Variable set by CSS rule matching element:"
+        TextNode <#text>
+        BreakNode <br>
+        BreakNode <br>
+        TextNode <#text>
+        BreakNode <br>
+        TextNode <#text>
+      BlockContainer <div.b> at (8,196.015625) content-size 784x100 children: inline
+        line 0 width: 200, height: 100, bottom: 100, baseline: 16.914062
+          frag 0 from BlockContainer start: 0, length: 0, rect: [8,196.015625 200x100]
+        BlockContainer <(anonymous)> at (8,196.015625) content-size 200x100 inline-block [BFC] children: inline
+          line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+            frag 0 from TextNode start: 0, length: 0, rect: [8,196.015625 0x21.835937]
+              ""
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,296.015625) content-size 784x66.179687 children: inline
+        line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+        line 1 width: 0, height: 21.835937, bottom: 43.671875, baseline: 16.914062
+        line 2 width: 520.605468, height: 22.507812, bottom: 66.179687, baseline: 16.914062
+          frag 0 from TextNode start: 1, length: 49, rect: [8,339.015625 520.605468x21.835937]
+            "Variable set by CSS rule matching pseudo element:"
+        TextNode <#text>
+        BreakNode <br>
+        BreakNode <br>
+        TextNode <#text>
+        BreakNode <br>
+        TextNode <#text>
+      BlockContainer <div.c> at (8,362.195312) content-size 784x100 children: inline
+        line 0 width: 200, height: 100, bottom: 100, baseline: 16.914062
+          frag 0 from BlockContainer start: 0, length: 0, rect: [8,362.195312 200x100]
+        BlockContainer <(anonymous)> at (8,362.195312) content-size 200x100 inline-block [BFC] children: inline
+          line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+            frag 0 from TextNode start: 0, length: 0, rect: [8,362.195312 0x21.835937]
+              ""
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,462.195312) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <div.hello> at (8,8) content-size 784x0 children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 500x100 positioned [BFC] children: inline
+          line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
+            frag 0 from TextNode start: 0, length: 0, rect: [8,8 0x21.835937]
+              ""
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/pseudo-element-with-custom-properties-2.html
+++ b/Tests/LibWeb/Layout/input/pseudo-element-with-custom-properties-2.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html><style>
+* {
+    font: 20px SerenitySans;
+}
+:root {
+    --bg: red;
+    --width: 100px;
+}
+div::before {
+    display: inline-block;
+    height: 100px;
+    content: "";
+    background: var(--bg);
+    width: var(--width);
+}
+.b {
+    --bg: green;
+    --width: 200px;
+}
+.c::before {
+    --bg: green;
+    --width: 200px;
+}
+</style>
+Variable set by inline style of element:<br>
+<div class="a" style="--bg: green; --width: 200px;"></div>
+<br><br>
+Variable set by CSS rule matching element:<br>
+<div class="b"></div>
+<br><br>
+Variable set by CSS rule matching pseudo element:<br>
+<div class="c"></div>

--- a/Tests/LibWeb/Layout/input/pseudo-element-with-custom-properties.html
+++ b/Tests/LibWeb/Layout/input/pseudo-element-with-custom-properties.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html><style>
+* {
+    font: 20px SerenitySans;
+}
+.hello::before {
+    position: absolute;
+    height: 100px;
+    width: 100px;
+    --wide: 500px;
+    width: var(--wide);
+    --bg: orange;
+    background: var(--bg);
+    content: "";
+}
+</style><div class="hello">

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -94,8 +94,8 @@ private:
 
     void compute_defaulted_property_value(StyleProperties&, DOM::Element const*, CSS::PropertyID, Optional<CSS::Selector::PseudoElement>) const;
 
-    RefPtr<StyleValue> resolve_unresolved_style_value(DOM::Element&, PropertyID, UnresolvedStyleValue const&) const;
-    bool expand_variables(DOM::Element&, StringView property_name, HashMap<FlyString, NonnullRefPtr<PropertyDependencyNode>>& dependencies, Parser::TokenStream<Parser::ComponentValue>& source, Vector<Parser::ComponentValue>& dest) const;
+    RefPtr<StyleValue> resolve_unresolved_style_value(DOM::Element&, Optional<CSS::Selector::PseudoElement>, PropertyID, UnresolvedStyleValue const&) const;
+    bool expand_variables(DOM::Element&, Optional<CSS::Selector::PseudoElement>, StringView property_name, HashMap<FlyString, NonnullRefPtr<PropertyDependencyNode>>& dependencies, Parser::TokenStream<Parser::ComponentValue>& source, Vector<Parser::ComponentValue>& dest) const;
     bool expand_unresolved_values(DOM::Element&, StringView property_name, Parser::TokenStream<Parser::ComponentValue>& source, Vector<Parser::ComponentValue>& dest) const;
 
     template<typename Callback>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1708,4 +1708,20 @@ void Element::set_computed_css_values(RefPtr<CSS::StyleProperties> style)
     m_computed_css_values = move(style);
 }
 
+void Element::set_custom_properties(Optional<CSS::Selector::PseudoElement> pseudo_element, HashMap<DeprecatedFlyString, CSS::StyleProperty> custom_properties)
+{
+    if (!pseudo_element.has_value()) {
+        m_custom_properties = move(custom_properties);
+        return;
+    }
+    m_pseudo_element_custom_properties[to_underlying(pseudo_element.value())] = move(custom_properties);
+}
+
+HashMap<DeprecatedFlyString, CSS::StyleProperty> const& Element::custom_properties(Optional<CSS::Selector::PseudoElement> pseudo_element) const
+{
+    if (!pseudo_element.has_value())
+        return m_custom_properties;
+    return m_pseudo_element_custom_properties[to_underlying(pseudo_element.value())];
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -158,8 +158,8 @@ public:
     ShadowRoot const* shadow_root_internal() const { return m_shadow_root.ptr(); }
     void set_shadow_root(JS::GCPtr<ShadowRoot>);
 
-    void set_custom_properties(HashMap<DeprecatedFlyString, CSS::StyleProperty> custom_properties) { m_custom_properties = move(custom_properties); }
-    HashMap<DeprecatedFlyString, CSS::StyleProperty> const& custom_properties() const { return m_custom_properties; }
+    void set_custom_properties(Optional<CSS::Selector::PseudoElement>, HashMap<DeprecatedFlyString, CSS::StyleProperty> custom_properties);
+    [[nodiscard]] HashMap<DeprecatedFlyString, CSS::StyleProperty> const& custom_properties(Optional<CSS::Selector::PseudoElement>) const;
 
     void queue_an_element_task(HTML::Task::Source, JS::SafeFunction<void()>);
 
@@ -318,6 +318,7 @@ private:
 
     RefPtr<CSS::StyleProperties> m_computed_css_values;
     HashMap<DeprecatedFlyString, CSS::StyleProperty> m_custom_properties;
+    Array<HashMap<DeprecatedFlyString, CSS::StyleProperty>, to_underlying(CSS::Selector::PseudoElement::PseudoElementCount)> m_pseudo_element_custom_properties;
 
     Vector<FlyString> m_classes;
 


### PR DESCRIPTION
The resolved property sets are stored with the element in a per-pseudo-element array (same as for pseudo element layout nodes).

Longer term, we should stop storing this with elements entirely and make it temporary state in StyleComputer somehow, so we don't waste memory keeping all the resolved properties around.