### PR TITLE
LibWeb: Null-check layout node before dereferencing in HTMLVideoElement

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -109,7 +109,8 @@ void HTMLVideoElement::set_video_track(JS::GCPtr<HTML::VideoTrack> video_track)
 void HTMLVideoElement::set_current_frame(Badge<VideoTrack>, RefPtr<Gfx::Bitmap> frame, double position)
 {
     m_current_frame = { move(frame), position };
-    layout_node()->set_needs_display();
+    if (layout_node())
+        layout_node()->set_needs_display();
 }
 
 void HTMLVideoElement::on_playing()

--- a/Userland/Libraries/LibWeb/HTML/VideoTrack.cpp
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrack.cpp
@@ -83,6 +83,7 @@ JS::ThrowCompletionOr<void> VideoTrack::initialize(JS::Realm& realm)
 
 void VideoTrack::visit_edges(Cell::Visitor& visitor)
 {
+    Base::visit_edges(visitor);
     visitor.visit(m_media_element);
     visitor.visit(m_video_track_list);
 }


### PR DESCRIPTION
DOM elements don't always have a corresponding layout node. This fixes a
crash soon after loading the Steam store.