### PR TITLE
CatDog: Stop recognizing name of deleted program

### DIFF
--- a/Userland/Demos/CatDog/CatDog.cpp
+++ b/Userland/Demos/CatDog/CatDog.cpp
@@ -81,7 +81,7 @@ CatDog::State CatDog::special_application_states() const
         return State::Artist;
 
     auto maybe_inspector_program = proc_info.processes.first_matching([](auto& process) {
-        return process.name.equals_ignoring_ascii_case("inspector"sv) || process.name.equals_ignoring_ascii_case("systemmonitor"sv) || process.name.equals_ignoring_ascii_case("profiler"sv);
+        return process.name.equals_ignoring_ascii_case("systemmonitor"sv) || process.name.equals_ignoring_ascii_case("profiler"sv);
     });
     if (maybe_inspector_program.has_value())
         return State::Inspector;


### PR DESCRIPTION
Inspector was deleted a long time ago in commit 16c47ccff632f520422c81d96681e3cdff358ddf, and likely isn't coming back any time soon.