### PR TITLE
Kernel/ScatterGatherList: Improve error propagation

### DIFF
--- a/Kernel/Memory/ScatterGatherList.cpp
+++ b/Kernel/Memory/ScatterGatherList.cpp
@@ -11,16 +11,16 @@ namespace Kernel::Memory {
 ErrorOr<LockRefPtr<ScatterGatherList>> ScatterGatherList::try_create(AsyncBlockDeviceRequest& request, Span<NonnullRefPtr<PhysicalPage>> allocated_pages, size_t device_block_size)
 {
     auto vm_object = TRY(AnonymousVMObject::try_create_with_physical_pages(allocated_pages));
-    return adopt_lock_ref_if_nonnull(new (nothrow) ScatterGatherList(vm_object, request, device_block_size));
+    auto size = TRY(page_round_up((request.block_count() * device_block_size)));
+    auto region = TRY(MM.allocate_kernel_region_with_vmobject(vm_object, size, "AHCI Scattered DMA"sv, Region::Access::Read | Region::Access::Write, Region::Cacheable::Yes));
+
+    return adopt_lock_ref_if_nonnull(new (nothrow) ScatterGatherList(vm_object, move(region)));
 }
 
-ScatterGatherList::ScatterGatherList(NonnullLockRefPtr<AnonymousVMObject> vm_object, AsyncBlockDeviceRequest& request, size_t device_block_size)
+ScatterGatherList::ScatterGatherList(NonnullLockRefPtr<AnonymousVMObject> vm_object, NonnullOwnPtr<Region> dma_region)
     : m_vm_object(move(vm_object))
+    , m_dma_region(move(dma_region))
 {
-    auto region_or_error = MM.allocate_kernel_region_with_vmobject(m_vm_object, page_round_up((request.block_count() * device_block_size)).release_value_but_fixme_should_propagate_errors(), "AHCI Scattered DMA"sv, Region::Access::Read | Region::Access::Write, Region::Cacheable::Yes);
-    if (region_or_error.is_error())
-        TODO();
-    m_dma_region = region_or_error.release_value();
 }
 
 }

--- a/Kernel/Memory/ScatterGatherList.cpp
+++ b/Kernel/Memory/ScatterGatherList.cpp
@@ -8,14 +8,10 @@
 
 namespace Kernel::Memory {
 
-LockRefPtr<ScatterGatherList> ScatterGatherList::try_create(AsyncBlockDeviceRequest& request, Span<NonnullRefPtr<PhysicalPage>> allocated_pages, size_t device_block_size)
+ErrorOr<LockRefPtr<ScatterGatherList>> ScatterGatherList::try_create(AsyncBlockDeviceRequest& request, Span<NonnullRefPtr<PhysicalPage>> allocated_pages, size_t device_block_size)
 {
-    auto maybe_vm_object = AnonymousVMObject::try_create_with_physical_pages(allocated_pages);
-    if (maybe_vm_object.is_error()) {
-        // FIXME: Would be nice to be able to return a ErrorOr here.
-        return {};
-    }
-    return adopt_lock_ref_if_nonnull(new (nothrow) ScatterGatherList(maybe_vm_object.release_value(), request, device_block_size));
+    auto vm_object = TRY(AnonymousVMObject::try_create_with_physical_pages(allocated_pages));
+    return adopt_lock_ref_if_nonnull(new (nothrow) ScatterGatherList(vm_object, request, device_block_size));
 }
 
 ScatterGatherList::ScatterGatherList(NonnullLockRefPtr<AnonymousVMObject> vm_object, AsyncBlockDeviceRequest& request, size_t device_block_size)

--- a/Kernel/Memory/ScatterGatherList.cpp
+++ b/Kernel/Memory/ScatterGatherList.cpp
@@ -8,11 +8,11 @@
 
 namespace Kernel::Memory {
 
-ErrorOr<LockRefPtr<ScatterGatherList>> ScatterGatherList::try_create(AsyncBlockDeviceRequest& request, Span<NonnullRefPtr<PhysicalPage>> allocated_pages, size_t device_block_size)
+ErrorOr<LockRefPtr<ScatterGatherList>> ScatterGatherList::try_create(AsyncBlockDeviceRequest& request, Span<NonnullRefPtr<PhysicalPage>> allocated_pages, size_t device_block_size, StringView region_name)
 {
     auto vm_object = TRY(AnonymousVMObject::try_create_with_physical_pages(allocated_pages));
     auto size = TRY(page_round_up((request.block_count() * device_block_size)));
-    auto region = TRY(MM.allocate_kernel_region_with_vmobject(vm_object, size, "AHCI Scattered DMA"sv, Region::Access::Read | Region::Access::Write, Region::Cacheable::Yes));
+    auto region = TRY(MM.allocate_kernel_region_with_vmobject(vm_object, size, region_name, Region::Access::Read | Region::Access::Write, Region::Cacheable::Yes));
 
     return adopt_lock_ref_if_nonnull(new (nothrow) ScatterGatherList(vm_object, move(region)));
 }

--- a/Kernel/Memory/ScatterGatherList.h
+++ b/Kernel/Memory/ScatterGatherList.h
@@ -25,9 +25,9 @@ public:
     size_t scatters_count() const { return m_vm_object->physical_pages().size(); }
 
 private:
-    ScatterGatherList(NonnullLockRefPtr<AnonymousVMObject>, AsyncBlockDeviceRequest&, size_t device_block_size);
+    ScatterGatherList(NonnullLockRefPtr<AnonymousVMObject>, NonnullOwnPtr<Region> dma_region);
     NonnullLockRefPtr<AnonymousVMObject> m_vm_object;
-    OwnPtr<Region> m_dma_region;
+    NonnullOwnPtr<Region> m_dma_region;
 };
 
 }

--- a/Kernel/Memory/ScatterGatherList.h
+++ b/Kernel/Memory/ScatterGatherList.h
@@ -19,7 +19,7 @@ namespace Kernel::Memory {
 
 class ScatterGatherList final : public AtomicRefCounted<ScatterGatherList> {
 public:
-    static LockRefPtr<ScatterGatherList> try_create(AsyncBlockDeviceRequest&, Span<NonnullRefPtr<PhysicalPage>> allocated_pages, size_t device_block_size);
+    static ErrorOr<LockRefPtr<ScatterGatherList>> try_create(AsyncBlockDeviceRequest&, Span<NonnullRefPtr<PhysicalPage>> allocated_pages, size_t device_block_size);
     VMObject const& vmobject() const { return m_vm_object; }
     VirtualAddress dma_region() const { return m_dma_region->vaddr(); }
     size_t scatters_count() const { return m_vm_object->physical_pages().size(); }

--- a/Kernel/Memory/ScatterGatherList.h
+++ b/Kernel/Memory/ScatterGatherList.h
@@ -19,7 +19,7 @@ namespace Kernel::Memory {
 
 class ScatterGatherList final : public AtomicRefCounted<ScatterGatherList> {
 public:
-    static ErrorOr<LockRefPtr<ScatterGatherList>> try_create(AsyncBlockDeviceRequest&, Span<NonnullRefPtr<PhysicalPage>> allocated_pages, size_t device_block_size);
+    static ErrorOr<LockRefPtr<ScatterGatherList>> try_create(AsyncBlockDeviceRequest&, Span<NonnullRefPtr<PhysicalPage>> allocated_pages, size_t device_block_size, StringView region_name);
     VMObject const& vmobject() const { return m_vm_object; }
     VirtualAddress dma_region() const { return m_dma_region->vaddr(); }
     size_t scatters_count() const { return m_vm_object->physical_pages().size(); }

--- a/Kernel/Storage/ATA/AHCI/Port.cpp
+++ b/Kernel/Storage/ATA/AHCI/Port.cpp
@@ -429,7 +429,7 @@ Optional<AsyncDeviceRequest::RequestResult> AHCIPort::prepare_and_set_scatter_li
         allocated_dma_regions.append(m_dma_buffers.at(index));
     }
 
-    m_current_scatter_list = Memory::ScatterGatherList::try_create(request, allocated_dma_regions.span(), m_connected_device->block_size()).release_value_but_fixme_should_propagate_errors();
+    m_current_scatter_list = Memory::ScatterGatherList::try_create(request, allocated_dma_regions.span(), m_connected_device->block_size(), "AHCI Scattered DMA"sv).release_value_but_fixme_should_propagate_errors();
     if (!m_current_scatter_list)
         return AsyncDeviceRequest::Failure;
     if (request.request_type() == AsyncBlockDeviceRequest::Write) {

--- a/Kernel/Storage/ATA/AHCI/Port.cpp
+++ b/Kernel/Storage/ATA/AHCI/Port.cpp
@@ -429,7 +429,7 @@ Optional<AsyncDeviceRequest::RequestResult> AHCIPort::prepare_and_set_scatter_li
         allocated_dma_regions.append(m_dma_buffers.at(index));
     }
 
-    m_current_scatter_list = Memory::ScatterGatherList::try_create(request, allocated_dma_regions.span(), m_connected_device->block_size());
+    m_current_scatter_list = Memory::ScatterGatherList::try_create(request, allocated_dma_regions.span(), m_connected_device->block_size()).release_value_but_fixme_should_propagate_errors();
     if (!m_current_scatter_list)
         return AsyncDeviceRequest::Failure;
     if (request.request_type() == AsyncBlockDeviceRequest::Write) {


### PR DESCRIPTION
A small cleanup to remove some of the TODOs in the ScatterGatherList for better error propagation.