### PR TITLE
LibGUI: Fix wrong cursor position after undoing `RemoveTextCommand`

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -963,10 +963,11 @@ void InsertTextCommand::undo()
     m_document.set_all_cursors(m_range.start());
 }
 
-RemoveTextCommand::RemoveTextCommand(TextDocument& document, DeprecatedString const& text, TextRange const& range)
+RemoveTextCommand::RemoveTextCommand(TextDocument& document, DeprecatedString const& text, TextRange const& range, TextPosition const& original_cursor_position)
     : TextDocumentUndoCommand(document)
     , m_text(text)
     , m_range(range)
+    , m_original_cursor_position(original_cursor_position)
 {
 }
 
@@ -1006,8 +1007,8 @@ void RemoveTextCommand::redo()
 
 void RemoveTextCommand::undo()
 {
-    auto new_cursor = m_document.insert_at(m_range.start(), m_text);
-    m_document.set_all_cursors(new_cursor);
+    m_document.insert_at(m_range.start(), m_text);
+    m_document.set_all_cursors(m_original_cursor_position);
 }
 
 InsertLineCommand::InsertLineCommand(TextDocument& document, TextPosition cursor, DeprecatedString&& text, InsertPosition pos)

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -254,7 +254,7 @@ private:
 
 class RemoveTextCommand : public TextDocumentUndoCommand {
 public:
-    RemoveTextCommand(TextDocument&, DeprecatedString const&, TextRange const&);
+    RemoveTextCommand(TextDocument&, DeprecatedString const&, TextRange const&, TextPosition const&);
     virtual ~RemoveTextCommand() = default;
     virtual void undo() override;
     virtual void redo() override;
@@ -265,6 +265,7 @@ public:
 private:
     DeprecatedString m_text;
     TextRange m_range;
+    TextPosition m_original_cursor_position;
 };
 
 class InsertLineCommand : public TextDocumentUndoCommand {


### PR DESCRIPTION
When you undo some forward delete shortcuts like `<Del>` or `<Ctrl-Del>`, the cursor will be put at the end of the text deleted, while the right position should be the start of those text.
Before:

https://github.com/SerenityOS/serenity/assets/57862491/c8d4de0c-d522-4aad-b569-ba468c7fe152

After:

https://github.com/SerenityOS/serenity/assets/57862491/c22d1aa1-c200-4ddc-a6f0-a4177fece62d

