### PR TITLE
Documentation: Add Qt6 SVG module to Ladybird build deps on Arch

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -19,7 +19,7 @@ sudo apt install qt6-wayland
 On Arch Linux/Manjaro:
 
 ```
-sudo pacman -S --needed base-devel cmake libgl ninja qt6-base qt6-tools qt6-wayland
+sudo pacman -S --needed base-devel cmake libgl ninja qt6-base qt6-svg qt6-tools qt6-wayland
 ```
 
 On Fedora or derivatives:


### PR DESCRIPTION
Qt6 SVG is required to successfully compile Ladybird.
    
Without this package, a compilation error occurs:
Failed to find required Qt component "Svg".