### PR TITLE
LibWasm: Change dir_fd to auto instead of int

### DIFF
--- a/Userland/Libraries/LibWasm/WASI/Wasi.cpp
+++ b/Userland/Libraries/LibWasm/WASI/Wasi.cpp
@@ -511,7 +511,7 @@ ErrorOr<Result<void>> Implementation::impl$fd_prestat_dir_name(Configuration& co
 
 ErrorOr<Result<FileStat>> Implementation::impl$path_filestat_get(Configuration& configuration, FD fd, LookupFlags flags, ConstPointer<u8> path, Size path_len)
 {
-    int dir_fd = AT_FDCWD;
+    auto dir_fd = AT_FDCWD;
 
     auto mapped_fd = map_fd(fd);
     if (mapped_fd.has<PreopenedDirectoryDescriptor>()) {
@@ -569,7 +569,7 @@ ErrorOr<Result<FileStat>> Implementation::impl$path_filestat_get(Configuration& 
 
 ErrorOr<Result<void>> Implementation::impl$path_create_directory(Configuration& configuration, FD fd, Pointer<u8> path, Size path_len)
 {
-    int dir_fd = AT_FDCWD;
+    auto dir_fd = AT_FDCWD;
 
     auto mapped_fd = map_fd(fd);
     if (mapped_fd.has<PreopenedDirectoryDescriptor>()) {
@@ -595,7 +595,7 @@ ErrorOr<Result<void>> Implementation::impl$path_create_directory(Configuration& 
 
 ErrorOr<Result<FD>> Implementation::impl$path_open(Configuration& configuration, FD fd, LookupFlags lookup_flags, Pointer<u8> path, Size path_len, OFlags o_flags, Rights, Rights, FDFlags fd_flags)
 {
-    int dir_fd = AT_FDCWD;
+    auto dir_fd = AT_FDCWD;
 
     auto mapped_fd = map_fd(fd);
     if (mapped_fd.has<PreopenedDirectoryDescriptor>()) {


### PR DESCRIPTION
Solaris defines AT_FDCWD as 0xffd19553, which makes it an unsigned int.
Defining dir_fd as int makes it complain about comparing an int with an unsigned int later when AT_FDCWD and dir_fd are compared.
Defining dir_fd as auto makes it an unsigned int on Solaris and solves the issue.
On other platforms, I don't expect any noticeable change by this, so I decided to just replace it and not use an ifdef.
Solaris' AT_FDCWD definition seems quite unusual, which causes problems also in other projects, see https://bugs.python.org/issue15965 for example.