### PR TITLE
AK: Add dbg()

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -906,7 +906,7 @@ void set_debug_enabled(bool value)
     is_debug_enabled = value;
 }
 
-void vdbgln(StringView fmtstr, TypeErasedFormatParams& params)
+void vdbg(StringView fmtstr, TypeErasedFormatParams& params, bool newline)
 {
     if (!is_debug_enabled)
         return;
@@ -946,7 +946,8 @@ void vdbgln(StringView fmtstr, TypeErasedFormatParams& params)
 #endif
 
     MUST(vformat(builder, fmtstr, params));
-    builder.append('\n');
+    if (newline)
+        builder.append('\n');
 
     auto const string = builder.string_view();
 

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -605,13 +605,20 @@ inline void warnln() { outln(stderr); }
 
 #endif
 
-void vdbgln(StringView fmtstr, TypeErasedFormatParams&);
+void vdbg(StringView fmtstr, TypeErasedFormatParams&, bool newline = false);
+
+template<typename... Parameters>
+void dbg(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
+{
+    VariadicFormatParams<AllowDebugOnlyFormatters::Yes, Parameters...> variadic_format_params { parameters... };
+    vdbg(fmtstr.view(), variadic_format_params, false);
+}
 
 template<typename... Parameters>
 void dbgln(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
 {
     VariadicFormatParams<AllowDebugOnlyFormatters::Yes, Parameters...> variadic_format_params { parameters... };
-    vdbgln(fmtstr.view(), variadic_format_params);
+    vdbg(fmtstr.view(), variadic_format_params, true);
 }
 
 inline void dbgln() { dbgln(""); }
@@ -739,6 +746,7 @@ using AK::warn;
 using AK::warnln;
 #    endif
 
+using AK::dbg;
 using AK::dbgln;
 
 using AK::CheckedFormatString;


### PR DESCRIPTION
We have outln() and out(), warnln() and warn(),
now we have dbgln() and dbg().

This is useful for printing arrays element-by-element while still only printing one line per array.