### PR TITLE
LibAudio: Calculate and verify FLAC frame header CRC

### DIFF
--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -109,7 +109,7 @@ public:
     }
 
     /// Whether we are (accidentally or intentionally) at a byte boundary right now.
-    ALWAYS_INLINE bool is_aligned_to_byte_boundary() const { return m_bit_offset == 0; }
+    ALWAYS_INLINE bool is_aligned_to_byte_boundary() const { return m_bit_offset % 8 == 0; }
 
 private:
     Optional<u8> m_current_byte;

--- a/Userland/Libraries/LibAudio/CMakeLists.txt
+++ b/Userland/Libraries/LibAudio/CMakeLists.txt
@@ -22,4 +22,4 @@ if (SERENITYOS)
 endif()
 
 serenity_lib(LibAudio audio)
-target_link_libraries(LibAudio PRIVATE LibCore LibIPC LibThreading LibUnicode)
+target_link_libraries(LibAudio PRIVATE LibCore LibIPC LibThreading LibUnicode LibCrypto)

--- a/Userland/Libraries/LibAudio/FlacTypes.h
+++ b/Userland/Libraries/LibAudio/FlacTypes.h
@@ -11,6 +11,7 @@
 #include <AK/ByteBuffer.h>
 #include <AK/Types.h>
 #include <AK/Variant.h>
+#include <LibCrypto/Checksum/CRC8.h>
 
 namespace Audio {
 
@@ -22,6 +23,11 @@ namespace Audio {
 #define FLAC_SAMPLERATE_AT_END_OF_HEADER_8 0xffffffff
 #define FLAC_SAMPLERATE_AT_END_OF_HEADER_16 0xfffffffe
 #define FLAC_SAMPLERATE_AT_END_OF_HEADER_16X10 0xfffffffd
+
+// 11.22.11. FRAME CRC
+// The polynomial used here is known as CRC-8-CCITT.
+static constexpr u8 flac_polynomial = 0x07;
+using FlacFrameHeaderCRC = Crypto::Checksum::CRC8<flac_polynomial>;
 
 // 11.8 BLOCK_TYPE (7 bits)
 enum class FlacMetadataBlockType : u8 {
@@ -80,6 +86,7 @@ struct FlacFrameHeader {
     u32 sample_rate;
     FlacFrameChannelType channels;
     u8 bit_depth;
+    u8 checksum;
 };
 
 // 11.25. SUBFRAME_HEADER

--- a/Userland/Libraries/LibCrypto/Checksum/CRC8.h
+++ b/Userland/Libraries/LibCrypto/Checksum/CRC8.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <LibCrypto/Checksum/ChecksumFunction.h>
+
+namespace Crypto::Checksum {
+
+// A generic 8-bit Cyclic Redundancy Check.
+// Note that as opposed to CRC32, this class operates with MSB first, so the polynomial must not be reversed.
+// For example, the polynomial x⁸ + x² + x + 1 is represented as 0x07 and not 0xE0.
+template<u8 polynomial>
+class CRC8 : public ChecksumFunction<u8> {
+public:
+    // This is a big endian table, while CRC-32 uses a little endian table.
+    static constexpr auto generate_table()
+    {
+        Array<u8, 256> data {};
+        u8 value = 0x80;
+        auto i = 1u;
+        do {
+            if ((value & 0x80) != 0) {
+                value = polynomial ^ (value << 1);
+            } else {
+                value = value << 1;
+            }
+
+            for (auto j = 0u; j < i; ++j) {
+                data[i + j] = value ^ data[j];
+            }
+            i <<= 1;
+        } while (i < 256);
+        return data;
+    }
+
+    static constexpr auto table = generate_table();
+
+    virtual ~CRC8() = default;
+
+    CRC8() = default;
+    CRC8(ReadonlyBytes data)
+    {
+        update(data);
+    }
+
+    CRC8(u8 initial_state, ReadonlyBytes data)
+        : m_state(initial_state)
+    {
+        update(data);
+    }
+
+    // FIXME: This implementation is naive and slow.
+    //        Figure out how to adopt the slicing-by-8 algorithm (see CRC32) for 8 bit polynomials.
+    virtual void update(ReadonlyBytes data) override
+    {
+        for (size_t i = 0; i < data.size(); i++) {
+            size_t table_index = (m_state ^ data.at(i)) & 0xFF;
+            m_state = (table[table_index] ^ (static_cast<u32>(m_state) << 8)) & 0xFF;
+        }
+    }
+
+    virtual u8 digest() override
+    {
+        return m_state;
+    }
+
+private:
+    u8 m_state { 0 };
+};
+
+}

--- a/Userland/Libraries/LibCrypto/Checksum/ChecksumFunction.h
+++ b/Userland/Libraries/LibCrypto/Checksum/ChecksumFunction.h
@@ -10,9 +10,11 @@
 
 namespace Crypto::Checksum {
 
-template<typename ChecksumType>
+template<typename ChecksumT>
 class ChecksumFunction {
 public:
+    using ChecksumType = ChecksumT;
+
     virtual void update(ReadonlyBytes data) = 0;
     virtual ChecksumType digest() = 0;
 

--- a/Userland/Libraries/LibCrypto/Checksum/ChecksummingStream.h
+++ b/Userland/Libraries/LibCrypto/Checksum/ChecksummingStream.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/Concepts.h>
+#include <AK/MaybeOwned.h>
+#include <AK/Stream.h>
+#include <LibCrypto/Checksum/ChecksumFunction.h>
+
+namespace Crypto::Checksum {
+
+// A stream wrapper type which passes all read and written data through a checksum function.
+template<typename ChecksumFunctionType, typename ChecksumType = typename ChecksumFunctionType::ChecksumType>
+requires(
+    IsBaseOf<ChecksumFunction<ChecksumType>, ChecksumFunctionType>,
+    // Require checksum function to be constructible without arguments, since we have no initial data.
+    requires() {
+        ChecksumFunctionType {};
+    })
+class ChecksummingStream : public Stream {
+public:
+    virtual ~ChecksummingStream() = default;
+
+    ChecksummingStream(MaybeOwned<Stream> stream)
+        : m_stream(move(stream))
+    {
+    }
+
+    virtual ErrorOr<Bytes> read_some(Bytes bytes) override
+    {
+        auto const written_bytes = TRY(m_stream->read_some(bytes));
+        update(written_bytes);
+        return written_bytes;
+    }
+
+    virtual ErrorOr<void> read_until_filled(Bytes bytes) override
+    {
+        TRY(m_stream->read_until_filled(bytes));
+        update(bytes);
+        return {};
+    }
+
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes bytes) override
+    {
+        auto bytes_written = TRY(m_stream->write_some(bytes));
+        // Only update with the bytes that were actually written
+        update(bytes.trim(bytes_written));
+        return bytes_written;
+    }
+
+    virtual ErrorOr<void> write_until_depleted(ReadonlyBytes bytes) override
+    {
+        update(bytes);
+        return m_stream->write_until_depleted(bytes);
+    }
+
+    virtual bool is_eof() const override { return m_stream->is_eof(); }
+    virtual bool is_open() const override { return m_stream->is_open(); }
+    virtual void close() override { m_stream->close(); }
+
+    ChecksumType digest()
+    {
+        return m_checksum.digest();
+    }
+
+private:
+    ALWAYS_INLINE void update(ReadonlyBytes bytes)
+    {
+        m_checksum.update(bytes);
+    }
+
+    MaybeOwned<Stream> m_stream;
+    ChecksumFunctionType m_checksum {};
+};
+
+}


### PR DESCRIPTION
A FIXME removed, and FLAC frame header integrity verified.

This contains two necessary pieces of underlying library framework:
- A stream wrapper which checksums all read/written stream data. This is both good abstraction and useful practically, since it requires no knowledge of data size, no "simple" data layout that can later be checksummed easily, no seekabililty, and no buffer.
- A generic CRC-8 checksum. The implementation is table-based MSB-first calculation, which means it's not exactly terrible, but in lieu of hardware support it's still worse than the slicing-by-8 we use for CRC32. A yak for someone else to shave :^)

The speed decrease is from 17x to 16x on Linux, which is tolerable given the still significant distance to realtime and the optimization potential elsewhere.