### PR TITLE
DeprecatedFile: Remove all remaining callers to IODevice::read_all

### DIFF
--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -7,7 +7,6 @@
 #include "Shell.h"
 #include <AK/LexicalPath.h>
 #include <LibCore/ArgsParser.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/Event.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/System.h>
@@ -190,12 +189,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         skip_rc_files = true;
 
     if (!format.is_empty()) {
-        auto file = TRY(Core::DeprecatedFile::open(format, Core::OpenMode::ReadOnly));
+        auto file = TRY(Core::File::open(format, Core::File::OpenMode::Read));
 
         initialize(posix_mode);
 
         ssize_t cursor = -1;
-        puts(shell->format(file->read_all(), cursor).characters());
+        puts(shell->format(TRY(file->read_until_eof()), cursor).characters());
         return 0;
     }
 


### PR DESCRIPTION
Together with #18529 and #18844, this PR removes all callers to `IODevice::read_all`, which used to be a reasonably popular method of `DeprecatedFile`.

This method can easily cause OOM conditions and does not provide any ability to reasonably handle it. The plan in the long term is to remove DeprecatedFile and IODevice entirely, so no replacement is necessary; or rather, `Core::File::read_until_eof()` *is* the replacement.

Advances #17129.