### PR TITLE
LibWeb: Don't crash when throwing due to failed JS module load

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
@@ -43,7 +43,6 @@ private:
 
     JS::GCPtr<JS::Script> m_script_record;
     MutedErrors m_muted_errors { MutedErrors::No };
-    Optional<JS::ParserError> m_error_to_rethrow;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -619,9 +619,10 @@ void fetch_descendants_of_and_link_a_module_script(JavaScriptModuleScript& modul
             // 2. Perform record.Link().
             auto linking_result = const_cast<JS::SourceTextModule&>(record).link(result->vm());
 
-            // TODO: If this throws an exception, set result's error to rethrow to that exception.
-            if (linking_result.is_error())
-                TODO();
+            // If this throws an exception, set result's error to rethrow to that exception.
+            if (linking_result.is_throw_completion()) {
+                result->set_error_to_rethrow(linking_result.release_error().value().value());
+            }
         } else {
             // FIXME: 4. Otherwise, set result's error to rethrow to parse error.
             TODO();

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Script.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Script.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -21,6 +21,14 @@ Script::~Script() = default;
 void Script::visit_host_defined_self(JS::Cell::Visitor& visitor)
 {
     visitor.visit(this);
+}
+
+void Script::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_settings_object);
+    visitor.visit(m_parse_error);
+    visitor.visit(m_error_to_rethrow);
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Script.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Script.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -27,8 +27,16 @@ public:
 
     EnvironmentSettingsObject& settings_object() { return m_settings_object; }
 
+    [[nodiscard]] JS::Value error_to_rethrow() const { return m_error_to_rethrow; }
+    void set_error_to_rethrow(JS::Value value) { m_error_to_rethrow = value; }
+
+    [[nodiscard]] JS::Value parse_error() const { return m_parse_error; }
+    void set_parse_error(JS::Value value) { m_parse_error = value; }
+
 protected:
     Script(AK::URL base_url, DeprecatedString filename, EnvironmentSettingsObject& environment_settings_object);
+
+    virtual void visit_edges(Visitor&) override;
 
 private:
     virtual void visit_host_defined_self(JS::Cell::Visitor&) override;
@@ -36,6 +44,12 @@ private:
     AK::URL m_base_url;
     DeprecatedString m_filename;
     JS::NonnullGCPtr<EnvironmentSettingsObject> m_settings_object;
+
+    // https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-parse-error
+    JS::Value m_parse_error;
+
+    // https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-error-to-rethrow
+    JS::Value m_error_to_rethrow;
 };
 
 }


### PR DESCRIPTION
* **LibWeb: Implement the "error to rethrow" mechanism in HTML::Script**
    
    This allows JS module loads to fail and throw without crashing the
    WebContent process due to a TODO() assertion.

* **LibWeb: Push the realm execution context while linking modules**

    If linking fails, we throw a JS exception, and if there's no execution
    context on the VM stack at that time, we assert in VM::current_realm().
    
    This is a hack to prevent crashing on failed module loads. Long term we
    need to rewrite module loading since it has been refactored to share
    code differently between HTML and ECMA262.