### PR TITLE
Userland+FileSystemAccessServer: Improved error messages

### DIFF
--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -55,9 +55,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (arguments.argc > 1) {
         // FIXME: Using `try_request_file_read_only_approved` doesn't work here since the file stored in the editor is only readable.
         auto response = FileSystemAccessClient::Client::the().request_file(window, arguments.strings[1], Core::File::OpenMode::ReadWrite);
-        if (response.is_error())
-            return 1;
-        hex_editor_widget->open_file(response.value().filename(), response.value().release_stream());
+        if (!response.is_error())
+            hex_editor_widget->open_file(response.value().filename(), response.value().release_stream());
     }
 
     return app->exec();

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -75,9 +75,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (!image_file.is_empty()) {
         auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window, image_file);
-        if (response.is_error())
-            return 1;
-        main_widget->open_image(response.release_value());
+        if (!response.is_error())
+            main_widget->open_image(response.release_value());
+        else
+            TRY(main_widget->create_default_image());
     } else {
         TRY(main_widget->create_default_image());
     }

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -76,19 +76,20 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (!file_to_edit.is_empty()) {
         auto filename = TRY(String::from_utf8(file_to_edit));
         FileArgument parsed_argument(filename);
+
+        FileSystemAccessClient::Client::the().set_silence_errors(FileSystemAccessClient::ErrorFlag::NoEntries);
         auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window, parsed_argument.filename().to_deprecated_string());
 
         if (response.is_error()) {
             if (response.error().code() == ENOENT)
                 text_widget->open_nonexistent_file(parsed_argument.filename().to_deprecated_string());
-            else
-                return 1;
         } else {
             TRY(text_widget->read_file(response.value().filename(), response.value().stream()));
             text_widget->editor().set_cursor_and_focus_line(parsed_argument.line().value_or(1) - 1, parsed_argument.column().value_or(0));
         }
 
         text_widget->update_title();
+        FileSystemAccessClient::Client::the().set_silence_errors(FileSystemAccessClient::ErrorFlag::None);
     }
     text_widget->update_statusbar();
 

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -53,9 +53,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         app->event_loop().deferred_invoke(
             [&window, &path, &main_widget]() {
                 auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window, path.value().to_deprecated_string());
-                if (response.is_error())
-                    GUI::MessageBox::show_error(window, DeprecatedString::formatted("Opening \"{}\" failed: {}", path.value(), response.error()));
-                else {
+                if (!response.is_error()) {
                     auto load_from_file_result = main_widget->load_from_file(response.value().filename(), response.value().release_stream());
                     if (load_from_file_result.is_error())
                         GUI::MessageBox::show_error(window, DeprecatedString::formatted("Loading theme from file has failed: {}", load_from_file_result.error()));

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -221,9 +221,6 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
             m_filename_textbox->select_all();
         }
     }
-    m_filename_textbox->on_return_pressed = [&] {
-        on_file_return();
-    };
 
     m_context_menu = GUI::Menu::construct();
 
@@ -254,6 +251,11 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
         on_file_return();
     };
     ok_button.set_enabled(m_mode == Mode::OpenFolder || !m_filename_textbox->text().is_empty());
+    ok_button.set_default(true);
+
+    m_location_textbox->on_focus_change = [&ok_button](auto focused, auto) {
+        ok_button.set_default(!focused);
+    };
 
     auto& cancel_button = *widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
     cancel_button.set_text("Cancel"_short_string);

--- a/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
+++ b/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
@@ -83,7 +83,7 @@ void ConnectionFromClient::request_file_handler(i32 request_id, i32 window_serve
             async_handle_prompt_end(request_id, 0, IPC::File(*file.release_value(), IPC::File::CloseAfterSending), path);
         }
     } else {
-        async_handle_prompt_end(request_id, -1, Optional<IPC::File> {}, path);
+        async_handle_prompt_end(request_id, EPERM, Optional<IPC::File> {}, path);
     }
 }
 


### PR DESCRIPTION
Adds options to toggle file/directory/device errors in FSAC.
Fixes some unhelpful, missing, or duplicate messages:
![connreset](https://github.com/SerenityOS/serenity/assets/66646555/7c15b728-ace9-486e-851d-a2dcf6b46f15)
![unknown](https://github.com/SerenityOS/serenity/assets/66646555/f26620a9-11ad-48b6-b182-99636b045bd9)
![double](https://github.com/SerenityOS/serenity/assets/66646555/d3877d0f-c7c3-4cbf-b8ab-188a448e7f58)

