### PR TITLE
LibWeb: Fix null dereference on SVG element with bogus fill URL

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/svg-fill-with-bogus-url.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-fill-with-bogus-url.txt
@@ -1,0 +1,7 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x37.835937 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x21.835937 children: inline
+      line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 100
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 0x0]
+      SVGSVGBox <svg> at (8,8) content-size 0x0 [SVG] children: not-inline
+        SVGGeometryBox <rect> at (8,8) content-size 100x100 children: not-inline

--- a/Tests/LibWeb/Layout/input/svg/svg-fill-with-bogus-url.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-fill-with-bogus-url.html
@@ -1,0 +1,3 @@
+<!doctype html><style>
+* { font: 20px SerenitySans; }
+</style><svg viewBox="0 0 100 100"><rect x=0 y=0 width=100 height=100 fill="url(#bogus)"></svg>

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -51,11 +51,11 @@ Optional<Gfx::PaintStyle const&> SVGGraphicsElement::fill_paint_style(SVGPaintCo
     if (!fill.has_value() || !fill->is_url())
         return {};
     auto& url = fill->as_url();
-    auto maybe_gradient = document().get_element_by_id(url.fragment());
-    if (is<SVG::SVGGradientElement>(*maybe_gradient)) {
-        auto& gradient = verify_cast<SVG::SVGGradientElement>(*maybe_gradient);
-        return gradient.to_gfx_paint_style(paint_context);
-    }
+    auto gradient = document().get_element_by_id(url.fragment());
+    if (!gradient)
+        return {};
+    if (is<SVG::SVGGradientElement>(*gradient))
+        return static_cast<SVG::SVGGradientElement const&>(*gradient).to_gfx_paint_style(paint_context);
     return {};
 }
 


### PR DESCRIPTION
Fixes a crash seen on YouTube channel pages.