### PR TITLE
aplay: Determine absolute path before raising the veil

### DIFF
--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -35,8 +35,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(show_sample_progress, "Show playback progress in samples", "sample-progress", 's');
     args_parser.parse(arguments);
 
+    // Note: We must determine the absolute path *before* beginning to raise the veil.
+    auto absolute_path = TRY(FileSystem::absolute_path(path));
+
     TRY(Core::System::unveil("/tmp/session/%sid/portal/audio", "rw"));
-    TRY(Core::System::unveil(TRY(FileSystem::absolute_path(path)), "r"sv));
+    TRY(Core::System::unveil(absolute_path, "r"sv));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     Core::EventLoop loop;


### PR DESCRIPTION
This was a regression introduced in 25d2828e, #18807. In that commit, I forgot to investigate why the order of operations was so "weird", so I added a comment this time to prevent future regressions.

Ping @GMTA and @kleinesfilmroellchen 