### PR TITLE
LibWeb: Add initial implementation of CRC2D.globalAlpha()

### DIFF
--- a/Base/res/html/misc/canvas-global-alpha.html
+++ b/Base/res/html/misc/canvas-global-alpha.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Canvas 2D global alpha test</title>
+<style type="text/css">
+body {
+    color: #fff;
+}
+canvas {
+    border-width: 1px;
+    border-style: solid;
+    border-color: #fff;
+}
+</style>
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        ctx = document.getElementById("foo").getContext("2d");
+
+        image = new Image(100, 100);
+        image.onload = drawImage;
+        image.src = "car.png";
+
+        function drawImage() {
+
+            ctx.drawImage(image, 0, 0, 400, 400);
+
+        }
+       
+        var width = 200;
+        var height = 100;
+
+        ctx.globalAlpha = 0.4;
+        ctx.font = "100px serif";
+        ctx.fillText("hello friends", 50, 90);
+
+       
+        for (var i = 0; i < 2; i++)
+        {
+            ctx.globalAlpha = 0.5;
+            ctx.fillStyle = 'red';
+            ctx.fillRect(10, 10, width, height);
+
+            ctx.globalAlpha = 0.6;
+            ctx.strokeStyle = 'blue';
+            ctx.strokeRect(10, 10, width, height);
+
+            ctx.scale(0.5, 0.5);
+            ctx.translate(10 + width * 2, 10 + height * 2);
+        }
+ 
+    });
+</script>
+</head>
+<body>
+    <canvas id="foo" width="1000" height="1000"></canvas>
+</body>
+</html>

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasCompositing.idl
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasCompositing.idl
@@ -1,0 +1,6 @@
+// https://html.spec.whatwg.org/multipage/canvas.html#canvascompositing
+interface mixin CanvasCompositing {
+  // compositing
+  attribute unrestricted double globalAlpha; // (default 1.0)
+// FIXME:  attribute DOMString globalCompositeOperation; // (default "source-over")
+};

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
@@ -78,6 +78,7 @@ public:
         float line_width { 1 };
         bool image_smoothing_enabled { true };
         Bindings::ImageSmoothingQuality image_smoothing_quality { Bindings::ImageSmoothingQuality::Low };
+        double global_alpha = 1.0;
         Optional<CanvasClip> clip;
     };
     DrawingState& drawing_state() { return m_drawing_state; }

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -16,6 +16,7 @@
 #include <LibGfx/Painter.h>
 #include <LibGfx/Path.h>
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/HTML/Canvas/CanvasCompositing.h>
 #include <LibWeb/HTML/Canvas/CanvasDrawImage.h>
 #include <LibWeb/HTML/Canvas/CanvasDrawPath.h>
 #include <LibWeb/HTML/Canvas/CanvasFillStrokeStyles.h>
@@ -51,6 +52,7 @@ class CanvasRenderingContext2D
     , public CanvasDrawImage
     , public CanvasImageData
     , public CanvasImageSmoothing
+    , public CanvasCompositing
     , public CanvasPathDrawingStyles<CanvasRenderingContext2D> {
 
     WEB_PLATFORM_OBJECT(CanvasRenderingContext2D, Bindings::PlatformObject);
@@ -92,6 +94,9 @@ public:
     virtual void set_image_smoothing_enabled(bool) override;
     virtual Bindings::ImageSmoothingQuality image_smoothing_quality() const override;
     virtual void set_image_smoothing_quality(Bindings::ImageSmoothingQuality) override;
+
+    virtual double global_alpha() const override;
+    virtual void set_global_alpha(double) override;
 
 private:
     explicit CanvasRenderingContext2D(JS::Realm&, HTMLCanvasElement&);

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
@@ -1,4 +1,5 @@
 #import <HTML/HTMLCanvasElement.idl>
+#import <HTML/Canvas/CanvasCompositing.idl>
 #import <HTML/Canvas/CanvasDrawImage.idl>
 #import <HTML/Canvas/CanvasDrawPath.idl>
 #import <HTML/Canvas/CanvasFillStrokeStyles.idl>
@@ -21,7 +22,7 @@ interface CanvasRenderingContext2D {
 
 CanvasRenderingContext2D includes CanvasState;
 CanvasRenderingContext2D includes CanvasTransform;
-// FIXME: CanvasRenderingContext2D includes CanvasCompositing;
+CanvasRenderingContext2D includes CanvasCompositing;
 CanvasRenderingContext2D includes CanvasImageSmoothing;
 CanvasRenderingContext2D includes CanvasFillStrokeStyles;
 // FIXME: CanvasRenderingContext2D includes CanvasShadowStyles;


### PR DESCRIPTION
Works for fills, strokes and text, not yet implemented for images.