### PR TITLE
IPCCompiler: Nicer error message for invalid template spelling

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -135,6 +135,11 @@ Vector<Endpoint> parse(ByteBuffer const& file_contents)
             // FIXME: This is not entirely correct. Types can have spaces, for example `HashMap<int, DeprecatedString>`.
             //        Maybe we should use LibCpp::Parser for parsing types.
             parameter.type = lexer.consume_until([](char ch) { return isspace(ch); });
+            if (parameter.type.ends_with(',')) {
+                warnln("Parameter type '{}' looks invalid!", parameter.type);
+                warnln("Note that templates must not include spaces.");
+                VERIFY_NOT_REACHED();
+            }
             VERIFY(!lexer.is_eof());
             consume_whitespace();
             parameter.name = lexer.consume_until([](char ch) { return isspace(ch) || ch == ',' || ch == ')'; });


### PR DESCRIPTION
The IPCCompiler generates very weird error messages (if at all) when an IPC type "accidentally" includes a space.

The "correct" thing to do would be to implement correct parsing of template types during compilation, but instead this PR improves the situation by detecting this kind of error very early, and providing a reminder that spaces in template types are not supported.