### PR TITLE
Ladybird: Remove unused IODevice.h include

### DIFF
--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -19,7 +19,6 @@
 #include <Kernel/API/KeyCode.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
-#include <LibCore/IODevice.h>
 #include <LibCore/System.h>
 #include <LibCore/Timer.h>
 #include <LibGfx/Bitmap.h>


### PR DESCRIPTION
I'm not entirely sure why Ladybird includes IODevice.h, but this seems unintentional, especially because this line was unmodified since 26a7ea0e0f15d8b7ec673c453950d2f3c20e4400. In that commit, the entire file was created, with what seems like a lot of copy/paste, so I find it reasonable that this is just a copy/paste error.

However, let's see what the web-people have to say. It definitely compiles without that include, and doesn't seem to use any of the symbols defined therein. :)