### PR TITLE
DeprecatedFile: Migrate Services

### DIFF
--- a/Userland/Libraries/LibCodeComprehension/Cpp/Tests.cpp
+++ b/Userland/Libraries/LibCodeComprehension/Cpp/Tests.cpp
@@ -8,7 +8,6 @@
 #include "../FileDB.h"
 #include "CppComprehensionEngine.h"
 #include <AK/LexicalPath.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibMain/Main.h>
 
 static bool s_some_test_failed = false;

--- a/Userland/Services/FileSystemAccessServer/CMakeLists.txt
+++ b/Userland/Services/FileSystemAccessServer/CMakeLists.txt
@@ -18,5 +18,5 @@ set(GENERATED_SOURCES
 )
 
 serenity_bin(FileSystemAccessServer)
-target_link_libraries(FileSystemAccessServer PRIVATE LibCore LibIPC LibGfx LibGUI LibMain)
+target_link_libraries(FileSystemAccessServer PRIVATE LibCore LibFileSystem LibGfx LibGUI LibIPC LibMain)
 add_dependencies(FileSystemAccessServer WindowServer)

--- a/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
+++ b/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <FileSystemAccessServer/ConnectionFromClient.h>
-#include <LibCore/DeprecatedFile.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/ConnectionToWindowServer.h>
 #include <LibGUI/FilePicker.h>
@@ -52,10 +52,10 @@ void ConnectionFromClient::request_file_handler(i32 request_id, i32 window_serve
 
         auto pid = this->socket().peer_pid().release_value_but_fixme_should_propagate_errors();
         auto exe_link = LexicalPath("/proc").append(DeprecatedString::number(pid)).append("exe"sv).string();
-        auto exe_path = Core::DeprecatedFile::real_path_for(exe_link);
+        auto exe_path = FileSystem::real_path(exe_link).release_value_but_fixme_should_propagate_errors();
 
         if (prompt == ShouldPrompt::Yes) {
-            auto exe_name = LexicalPath::basename(exe_path);
+            auto exe_name = LexicalPath::basename(exe_path.to_deprecated_string());
             auto text = String::formatted("Allow {} ({}) to {} \"{}\"?", exe_name, pid, access_string, path).release_value_but_fixme_should_propagate_errors();
             auto result = GUI::MessageBox::try_show({}, window_server_client_id, parent_window_id, text, "File Permissions Requested"sv).release_value_but_fixme_should_propagate_errors();
             approved = result == GUI::MessageBox::ExecResult::Yes;

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -14,7 +14,6 @@
 #include <AK/StringBuilder.h>
 #include <AK/URL.h>
 #include <LibCore/DateTime.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/File.h>
 #include <LibCore/MappedFile.h>
@@ -144,13 +143,12 @@ ErrorOr<bool> Client::handle_request(HTTP::HttpRequest const& request)
         real_path = index_html_path;
     }
 
-    auto file = Core::DeprecatedFile::construct(real_path.bytes_as_string_view());
-    if (!file->open(Core::OpenMode::ReadOnly)) {
+    if (!FileSystem::exists(real_path.bytes_as_string_view())) {
         TRY(send_error_response(404, request));
         return false;
     }
 
-    if (file->is_device()) {
+    if (FileSystem::is_device(real_path.bytes_as_string_view())) {
         TRY(send_error_response(403, request));
         return false;
     }

--- a/Userland/Services/WebServer/Configuration.cpp
+++ b/Userland/Services/WebServer/Configuration.cpp
@@ -11,7 +11,7 @@ namespace WebServer {
 
 static Configuration* s_configuration = nullptr;
 
-Configuration::Configuration(DeprecatedString document_root_path, Optional<HTTP::HttpRequest::BasicAuthenticationCredentials> credentials)
+Configuration::Configuration(String document_root_path, Optional<HTTP::HttpRequest::BasicAuthenticationCredentials> credentials)
     : m_document_root_path(move(document_root_path))
     , m_credentials(move(credentials))
 {

--- a/Userland/Services/WebServer/Configuration.h
+++ b/Userland/Services/WebServer/Configuration.h
@@ -15,15 +15,15 @@ namespace WebServer {
 
 class Configuration {
 public:
-    Configuration(DeprecatedString document_root_path, Optional<HTTP::HttpRequest::BasicAuthenticationCredentials> credentials = {});
+    Configuration(String document_root_path, Optional<HTTP::HttpRequest::BasicAuthenticationCredentials> credentials = {});
 
-    DeprecatedString const& document_root_path() const { return m_document_root_path; }
+    String const& document_root_path() const { return m_document_root_path; }
     Optional<HTTP::HttpRequest::BasicAuthenticationCredentials> const& credentials() const { return m_credentials; }
 
     static Configuration const& the();
 
 private:
-    DeprecatedString m_document_root_path;
+    String m_document_root_path;
     Optional<HTTP::HttpRequest::BasicAuthenticationCredentials> m_credentials;
 };
 

--- a/Userland/Services/WebServer/main.cpp
+++ b/Userland/Services/WebServer/main.cpp
@@ -8,7 +8,6 @@
 
 #include <AK/String.h>
 #include <LibCore/ArgsParser.h>
-#include <LibCore/DeprecatedFile.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/MappedFile.h>
 #include <LibCore/System.h>
@@ -57,7 +56,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    auto real_document_root_path = Core::DeprecatedFile::real_path_for(document_root_path);
+    auto real_document_root_path = TRY(FileSystem::real_path(document_root_path));
     if (!FileSystem::exists(real_document_root_path)) {
         warnln("Root path does not exist: '{}'", document_root_path);
         return 1;
@@ -69,7 +68,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (!username.is_empty() && !password.is_empty())
         credentials = HTTP::HttpRequest::BasicAuthenticationCredentials { username, password };
 
-    WebServer::Configuration configuration(real_document_root_path, credentials);
+    WebServer::Configuration configuration(real_document_root_path.to_deprecated_string(), credentials);
 
     Core::EventLoop loop;
 

--- a/Userland/Services/WebServer/main.cpp
+++ b/Userland/Services/WebServer/main.cpp
@@ -68,7 +68,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (!username.is_empty() && !password.is_empty())
         credentials = HTTP::HttpRequest::BasicAuthenticationCredentials { username, password };
 
-    WebServer::Configuration configuration(real_document_root_path.to_deprecated_string(), credentials);
+    WebServer::Configuration configuration(real_document_root_path, credentials);
 
     Core::EventLoop loop;
 


### PR DESCRIPTION
This PR:
- migrates FileSystemAccessServer and WebServer to use DeprecatedFile
- migrates WebServer in one place from DeprecatedString to String, where it becomes especially easy due to the previous point
- removes a `#include <LibCore/DeprecatedFile.h>` that should have been deleted earlier but I overlooked it in 07dd719e3eb77df96ec574dfbe988932a77bd001 (#18844)

With this, `Userland/Services/` is completely free of DeprecatedFile, hooray! :D

Let me know if the is too much of a mixed bag, then I'll split up the PR.