### PR TITLE
tail: Don't read past EOF and handle trailing newlines correctly

### DIFF
--- a/Userland/Utilities/tail.cpp
+++ b/Userland/Utilities/tail.cpp
@@ -14,7 +14,7 @@
 
 static ErrorOr<void> tail_from_pos(Core::File& file, off_t startline)
 {
-    TRY(file.seek(startline + 1, SeekMode::SetPosition));
+    TRY(file.seek(startline, SeekMode::SetPosition));
     auto buffer = TRY(file.read_until_eof());
     out("{}", StringView { buffer });
     return {};
@@ -29,11 +29,9 @@ static ErrorOr<off_t> find_seek_pos(Core::File& file, int wanted_lines)
     off_t end = pos;
     int lines = 0;
 
-    for (; pos >= 0; pos--) {
-        TRY(file.seek(pos, SeekMode::SetPosition));
+    for (; pos >= 1; pos--) {
+        TRY(file.seek(pos - 1, SeekMode::SetPosition));
 
-        if (file.is_eof())
-            break;
         auto ch = TRY(file.read_value<u8>());
         if (ch == '\n' && (end - pos) > 1) {
             lines++;

--- a/Userland/Utilities/tail.cpp
+++ b/Userland/Utilities/tail.cpp
@@ -33,7 +33,7 @@ static ErrorOr<off_t> find_seek_pos(Core::File& file, int wanted_lines)
         TRY(file.seek(pos - 1, SeekMode::SetPosition));
 
         auto ch = TRY(file.read_value<u8>());
-        if (ch == '\n' && (end - pos) > 1) {
+        if (ch == '\n' && (end - pos) > 0) {
             lines++;
             if (lines == wanted_lines)
                 break;

--- a/Userland/Utilities/tail.cpp
+++ b/Userland/Utilities/tail.cpp
@@ -70,6 +70,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto buffer = TRY(f->read_until_eof(PAGE_SIZE));
             auto line_count = StringView(buffer).count("\n"sv);
             auto bytes = buffer.bytes();
+            if (bytes.size() > 0 && bytes.last() != '\n')
+                line_count++;
+
             size_t line_index = 0;
             StringBuilder line;
 
@@ -81,7 +84,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             for (size_t i = 0; i < bytes.size(); i++) {
                 auto ch = bytes.at(i);
                 line.append(ch);
-                if (ch == '\n') {
+                if (ch == '\n' || i == bytes.size() - 1) {
                     if (wanted_line_count > line_count || line_index >= line_count - wanted_line_count)
                         out("{}", line.to_deprecated_string());
                     line_index++;


### PR DESCRIPTION
This PR fixes 3 issues in `tail`:
* Previously, we weren't able to use `tail` with files because we would read 1 byte past the end of the file, causing a crash.
* The last line would be ignored if the input had no trailing newline.
* Files ending in more than one newline would display an extra line. (NB: this only affected reading files, not standard input.)

Before:
![tail_before](https://github.com/SerenityOS/serenity/assets/2817754/8774d6aa-465c-48a9-b5de-d9bc603cb72c)

After:
![tail_after](https://github.com/SerenityOS/serenity/assets/2817754/9ecf6268-aad1-4063-b74b-a5d087e71920)