### PR TITLE
Base: Move user nona from group 200 into existing group users

### DIFF
--- a/Base/etc/passwd
+++ b/Base/etc/passwd
@@ -3,4 +3,4 @@ lookup:!:10:10:LookupServer,,,:/:/bin/false
 window:!:13:13:WindowServer,,,:/:/bin/false
 sshd:!:19:19:OpenSSH privsep,,,:/:/bin/false
 anon:!:100:100:Anonymous,,,:/home/anon:/bin/Shell
-nona:!:200:200:Nona,,,:/home/nona:/bin/Shell
+nona:!:200:100:Nona,,,:/home/nona:/bin/Shell

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -191,7 +191,7 @@ chmod 700 mnt/root
 chmod 700 mnt/home/anon
 chmod 700 mnt/home/nona
 chown -R 100:100 mnt/home/anon
-chown -R 200:200 mnt/home/nona
+chown -R 200:100 mnt/home/nona
 echo "done"
 
 printf "adding some desktop icons... "


### PR DESCRIPTION
It seems that group 200 never existed, and group 100=users always did: 90bab5ea717682d819609e9238ab6785a450b696

This PR turns this silly group ownership:
![Bildschirmfoto_2023-05-20_11-06-58](https://github.com/SerenityOS/serenity/assets/2690845/e89323f6-d61d-4462-892b-f1d6208fc536)

Into this slightly more reasonable group ownership:
![Bildschirmfoto_2023-05-20_11-13-23](https://github.com/SerenityOS/serenity/assets/2690845/7aa71035-2891-478f-beef-bf27bd776a69)