### PR TITLE
Meta: Also run markdown-check on markdown files in each Port subdir

### DIFF
--- a/Meta/check-markdown.sh
+++ b/Meta/check-markdown.sh
@@ -23,4 +23,4 @@ if [ -z "$SERENITY_SOURCE_DIR" ] ; then
     export SERENITY_SOURCE_DIR
 fi
 
-find AK Base Documentation Kernel Meta Ports Tests Userland -path 'Ports/*/*' -prune -o -type f -name '*.md' -print0 | xargs -0 "${MARKDOWN_CHECK_BINARY}" README.md CONTRIBUTING.md
+find AK Base Documentation Kernel Meta Ports Tests Userland -type f -name '*.md' -print0 | xargs -0 "${MARKDOWN_CHECK_BINARY}" README.md CONTRIBUTING.md

--- a/Userland/Utilities/markdown-check.cpp
+++ b/Userland/Utilities/markdown-check.cpp
@@ -6,9 +6,9 @@
 
 /*
  * You may want to invoke the checker like this:
- * $ cd Build/lagom
- * $ ninja
- * $ find ../../AK ../../Base ../../Documentation/ ../../Kernel/ ../../Meta/ ../../Ports/ ../../Tests/ ../../Userland/ -type f -name '*.md' | xargs ./markdown-check ../../README.md
+ * $ ninja -C Build/lagom
+ * $ export SERENITY_SOURCE_DIR=/path/to/serenity
+ * $ find AK Base Documentation Kernel Meta Ports Tests Userland -type f -name '*.md' -print0 | xargs -0 Build/lagom/markdown-check README.md CONTRIBUTING.md
  */
 
 #include <AK/Format.h>


### PR DESCRIPTION
We used to exclude the Ports subdirs because that's where we also extracted the tarballs, and we didn't want to lint any markdown included inside the (extracted) tarballs.

This is no longer the case, so we can safely remove this exception.

While I was at it, I also updated the instructions on how to invoke the binary directly (although using the shell wrapper is much more comfortable).