### PR TITLE
userdel: Removal of files does not require creation rights

### DIFF
--- a/Userland/Utilities/userdel.cpp
+++ b/Userland/Utilities/userdel.cpp
@@ -35,7 +35,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& target_account = account_or_error.value();
 
     if (remove_home)
-        TRY(Core::System::unveil(target_account.home_directory(), "c"sv));
+        TRY(Core::System::unveil(target_account.home_directory(), "r"sv));
 
     TRY(Core::System::unveil(nullptr, nullptr));
 


### PR DESCRIPTION
`userdel -r nona` used to fail with the following error:

```
19.242 [#0 userdel(49:49)]: Rejecting path '/home/nona' because it hasn't been unveiled with 'r' or 'b' permissions
19.242 [#0 userdel(49:49)]: Kernel + 0x0000000000ab1381  Kernel::VirtualFileSystem::validate_path_against_process_veil(Kernel::Process const&, AK::StringView, int) [clone .localalias] +0x611
…
```

This PR fixes that.

We don't really have much use for userdel in the moment, but if we keep it then it should also be kept working, so that's what this PR does.