### PR TITLE
Ladybird: Select all text in LocationEdit on click

### DIFF
--- a/Ladybird/LocationEdit.cpp
+++ b/Ladybird/LocationEdit.cpp
@@ -10,6 +10,7 @@
 #include <QCoreApplication>
 #include <QPalette>
 #include <QTextLayout>
+#include <QTimer>
 
 LocationEdit::LocationEdit(QWidget* parent)
     : QLineEdit(parent)
@@ -27,6 +28,7 @@ void LocationEdit::focusInEvent(QFocusEvent* event)
 {
     QLineEdit::focusInEvent(event);
     highlight_location();
+    QTimer::singleShot(0, this, &QLineEdit::selectAll);
 }
 
 void LocationEdit::focusOutEvent(QFocusEvent* event)


### PR DESCRIPTION
I think it's common thing in modern browsers to select all text in location field when user clicks on it.