### PR TITLE
AK+Userland: Introduce custom error payloads and start using them for Streams

### DIFF
--- a/AK/Error.h
+++ b/AK/Error.h
@@ -83,16 +83,16 @@ public:
     bool operator==(Error const& other) const
     {
 #ifdef KERNEL
-        return m_code == other.m_code;
+        return m_payload == other.m_payload;
 #else
-        return m_code == other.m_code && m_string_literal == other.m_string_literal && m_syscall == other.m_syscall;
+        return m_payload == other.m_payload && m_string_literal == other.m_string_literal && m_syscall == other.m_syscall;
 #endif
     }
 
-    int code() const { return m_code; }
+    int code() const { return m_payload.get<int>(); }
     bool is_errno() const
     {
-        return m_code != 0;
+        return m_payload.has<int>();
     }
 #ifndef KERNEL
     bool is_syscall() const
@@ -107,7 +107,7 @@ public:
 
 protected:
     Error(int code)
-        : m_code(code)
+        : m_payload(code)
     {
     }
 
@@ -120,7 +120,7 @@ private:
 
     Error(StringView syscall_name, int rc)
         : m_string_literal(syscall_name)
-        , m_code(-rc)
+        , m_payload(-rc)
         , m_syscall(true)
     {
     }
@@ -133,7 +133,7 @@ private:
     StringView m_string_literal;
 #endif
 
-    int m_code { 0 };
+    Variant<Empty, int> m_payload { Empty {} };
 
 #ifndef KERNEL
     bool m_syscall { false };

--- a/AK/ErrorPayloadWithEnum.h
+++ b/AK/ErrorPayloadWithEnum.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, Tim Schumacher <timschumi@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/Format.h>
+
+namespace AK {
+
+template<Enum T>
+class ErrorPayloadWithEnum : public ErrorPayload {
+public:
+    ErrorPayloadWithEnum(T value)
+        : m_value(value)
+    {
+    }
+
+    virtual ErrorOr<void> format(Formatter<FormatString>& formatter, FormatBuilder& builder) const override
+    {
+        return formatter.format(builder, "{}"sv, m_value);
+    }
+
+#ifdef AK_ERROR_SUPPORTS_DYNAMIC
+    virtual bool operator==(ErrorPayload const& other) const override
+    {
+        auto const* other_as_specific_type = dynamic_cast<ErrorPayloadWithEnum<T> const*>(&other);
+
+        // If it isn't the same type, it can't be equal.
+        if (!other_as_specific_type)
+            return false;
+
+        return m_value == other_as_specific_type->m_value;
+    }
+#endif
+
+    bool operator==(T value) const
+    {
+        return m_value == value;
+    }
+
+private:
+    T m_value;
+};
+
+template<Enum T>
+struct Formatter<ErrorPayloadWithEnum<T>> : Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, ErrorPayloadWithEnum<T> const& error)
+    {
+        return Formatter<FormatString>::format(builder, "{}"sv, error);
+    }
+};
+
+}
+
+#if USING_AK_GLOBALLY
+using AK::ErrorPayloadWithEnum;
+#endif

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -701,6 +701,9 @@ template<>
 struct Formatter<Error> : Formatter<FormatString> {
     ErrorOr<void> format(FormatBuilder& builder, Error const& error)
     {
+        if (auto maybe_error_payload = error.generic_error_payload(); maybe_error_payload.has_value())
+            return maybe_error_payload->format(*this, builder);
+
 #if defined(AK_OS_SERENITY) && defined(KERNEL)
         return Formatter<FormatString>::format(builder, "Error(errno={})"sv, error.code());
 #else

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -26,7 +26,7 @@ class TypeErasedFormatParams;
 class FormatParser;
 class FormatBuilder;
 
-template<typename T, typename = void>
+template<typename T, typename>
 struct Formatter {
     using __no_formatter_defined = void;
 };

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -30,6 +30,8 @@ class DeprecatedStringCodePointIterator;
 class Duration;
 class Error;
 class FlyString;
+class FormatBuilder;
+struct FormatString;
 class GenericLexer;
 class IPv4Address;
 class JsonArray;
@@ -105,6 +107,12 @@ class FixedArray;
 template<size_t precision, typename Underlying = i32>
 class FixedPoint;
 
+template<typename T, typename = void>
+struct Formatter;
+
+template<>
+struct Formatter<FormatString>;
+
 template<typename>
 class Function;
 
@@ -171,6 +179,9 @@ using AK::ErrorOr;
 using AK::FixedArray;
 using AK::FixedPoint;
 using AK::FlyString;
+using AK::FormatBuilder;
+using AK::FormatString;
+using AK::Formatter;
 using AK::Function;
 using AK::GenericLexer;
 using AK::HashMap;

--- a/AK/LEB128.h
+++ b/AK/LEB128.h
@@ -31,7 +31,7 @@ public:
         size_t num_bytes = 0;
         while (true) {
             if (stream.is_eof())
-                return Error::from_string_literal("Stream reached end-of-file while reading LEB128 value");
+                return Error::from_error_payload(StreamError(StreamErrorCode::NotEnoughData));
 
             auto byte = TRY(stream.read_value<u8>());
 
@@ -67,7 +67,7 @@ public:
 
         do {
             if (stream.is_eof())
-                return Error::from_string_literal("Stream reached end-of-file while reading LEB128 value");
+                return Error::from_error_payload(StreamError(StreamErrorCode::NotEnoughData));
 
             byte = TRY(stream.read_value<u8>());
 

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -8,11 +8,18 @@
 #pragma once
 
 #include <AK/Error.h>
+#include <AK/ErrorPayloadWithEnum.h>
 #include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/Traits.h>
 
 namespace AK {
+
+enum StreamErrorCode {
+    NotEnoughData,
+};
+
+using StreamError = ErrorPayloadWithEnum<StreamErrorCode>;
 
 /// The base, abstract class for stream operations. This class defines the
 /// operations one can perform on every stream.
@@ -138,8 +145,15 @@ public:
     virtual ErrorOr<void> discard(size_t discarded_bytes) override;
 };
 
+template<>
+struct Formatter<StreamErrorCode> : Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, StreamErrorCode const& error);
+};
+
 }
 
 #if USING_AK_GLOBALLY
 using AK::SeekMode;
+using AK::StreamError;
+using AK::StreamErrorCode;
 #endif

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -25,6 +25,7 @@ set(AK_TEST_SOURCES
     TestDoublyLinkedList.cpp
     TestEndian.cpp
     TestEnumBits.cpp
+    TestError.cpp
     TestFind.cpp
     TestFixedArray.cpp
     TestFixedPoint.cpp

--- a/Tests/AK/TestError.cpp
+++ b/Tests/AK/TestError.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, Tim Schumacher <timschumi@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/Error.h>
+#include <AK/ErrorPayloadWithEnum.h>
+#include <AK/Format.h>
+
+enum TestEnumA {
+    EntryA1,
+};
+
+enum TestEnumB {
+    EntryB1,
+    EntryB2,
+};
+
+template<Enum T>
+struct AK::Formatter<T> : AK::Formatter<AK::FormatString> {
+    ErrorOr<void> format(AK::FormatBuilder& builder, T value)
+    {
+        return Formatter<FormatString>::format(builder, "{}"sv, to_underlying(value));
+    }
+};
+
+TEST_CASE(custom_error_basic)
+{
+    auto error_a1 = Error::from_error_payload(ErrorPayloadWithEnum<TestEnumA>(TestEnumA::EntryA1));
+    auto error_b1 = Error::from_error_payload(ErrorPayloadWithEnum<TestEnumB>(TestEnumB::EntryB1));
+    auto error_b2 = Error::from_error_payload(ErrorPayloadWithEnum<TestEnumB>(TestEnumB::EntryB2));
+    auto error_b2_v2 = Error::from_error_payload(ErrorPayloadWithEnum<TestEnumB>(TestEnumB::EntryB2));
+
+    // Check that everything is convertible to `CustomErrorBase`.
+    // This is needed for any type-agnostic functions to access virtual methods.
+    EXPECT(error_a1.error_payload<ErrorPayload>().has_value());
+    EXPECT(error_b1.error_payload<ErrorPayload>().has_value());
+    EXPECT(error_b2.error_payload<ErrorPayload>().has_value());
+
+    // Check that the error contents are only convertible to their respective types.
+    EXPECT(error_a1.error_payload<ErrorPayloadWithEnum<TestEnumA>>().has_value());
+    EXPECT(!error_a1.error_payload<ErrorPayloadWithEnum<TestEnumB>>().has_value());
+    EXPECT(error_b1.error_payload<ErrorPayloadWithEnum<TestEnumB>>().has_value());
+    EXPECT(!error_b1.error_payload<ErrorPayloadWithEnum<TestEnumA>>().has_value());
+
+    // Check that the error codes get through the conversion unscathed.
+    EXPECT_EQ(error_a1.error_payload<ErrorPayloadWithEnum<TestEnumA>>(), TestEnumA::EntryA1);
+    EXPECT_EQ(error_b1.error_payload<ErrorPayloadWithEnum<TestEnumB>>(), TestEnumB::EntryB1);
+    EXPECT_EQ(error_b2.error_payload<ErrorPayloadWithEnum<TestEnumB>>(), TestEnumB::EntryB2);
+
+    // Ensure that comparing against values from a different error type counts as non-matching.
+    EXPECT_NE(error_a1.error_payload<ErrorPayloadWithEnum<TestEnumB>>(), TestEnumB::EntryB1);
+
+    // Ensure that comparisons of the overarching error type works as expected.
+    // Note: Errors don't allow being copied (which the `EXPECT_*` macros do), so we have to compare them manually.
+    if (error_a1 == error_b1)
+        FAIL("error_a1 and error_b1 are equal according to the comparison function");
+    if (error_b1 == error_b2)
+        FAIL("error_b1 and error_b2 are equal according to the comparison function");
+    if (error_b2 != error_b2_v2)
+        FAIL("error_b2 and error_b2_v2 are not equal according to the comparison function");
+}

--- a/Userland/Libraries/LibCompress/Xz.cpp
+++ b/Userland/Libraries/LibCompress/Xz.cpp
@@ -217,7 +217,7 @@ ErrorOr<bool> XzDecompressor::load_next_stream()
             // Read the first byte until we either get a non-null byte or reach EOF.
             auto byte_or_error = m_stream->read_value<u8>();
 
-            if (byte_or_error.is_error() && m_stream->is_eof())
+            if (byte_or_error.is_error() && byte_or_error.error().error_payload<StreamError>() == StreamErrorCode::NotEnoughData)
                 break;
 
             auto byte = TRY(byte_or_error);


### PR DESCRIPTION
For various file formats, we need to know whether we failed to read a value due to encountering EOF or if it errored due to a different reasons.

Since comparing string literals is not great and we can't easily add a new errno due to portability problems with Lagom, this adds a new, rather generic storage area where users can basically store arbitrary error data. The different types are discerned via vtables and `dynamic_cast`, so we should only have a performance impact (beyond the impact caused by the slightly increased size) whenever we interact with the error payload itself, not when interacting with the surrounding `Error`.

The performance values look like they are reasonably within margin of error, at least to a point where we don't have a measurable performance decrease:

|                                                  | Before  | After   |
|--------------------------------------------------|---------|---------|
| `tar -tf llvm-project-15.0.3.src.tar.xz` (n=10)  | 18920ms | 18275ms |
| `/usr/Tests/LibCompress/TestXz` (n=1000)         | 42ms |  43ms  |
| `test-js` (n=100)                                | 5241ms | 5080ms |

|                                                  | Before  | After   | Difference | Deviation(?) |
|--------------------------------------------------|---------|---------|---------|---------|
| `./bin/tar -tf llvm-project-15.0.3.src.tar.xz` (n=1)         | 153056076473 instructions | 162921936369 instructions | +6.4% | - |
| `./bin/TestXz` (n=5)         |  9211626 instructions | 9524613 instructions | +3.4% | $10^2$ |
| `./bin/test-js` (n=5)                                | 30863526661 instructions | 32203265126 instructions | +4.3% | $10^8$ |

Remaining points of discussion (maybe):
 - Naming of the new classes
 - Have I implemented the formatters correctly
 - ~~What to do in Kernel land~~