### PR TITLE
Settings: Add right-click context menu for manipulating items

### DIFF
--- a/Userland/Applications/Settings/CMakeLists.txt
+++ b/Userland/Applications/Settings/CMakeLists.txt
@@ -9,4 +9,4 @@ set(SOURCES
 )
 
 serenity_app(Settings ICON app-settings)
-target_link_libraries(Settings PRIVATE LibCore LibGfx LibGUI LibDesktop LibMain)
+target_link_libraries(Settings PRIVATE LibCore LibFileSystem LibGfx LibGUI LibDesktop LibMain)


### PR DESCRIPTION
This PR adds a context menu for all items in the Settings app, which allows the user to open the selected item or to create a shortcut to the item on the desktop. This improves the consistency of the design language shared between the Settings app and the FileManager, which should improve the UX.

![screenshot](https://github.com/SerenityOS/serenity/assets/7926283/95cfe7e6-4eee-420b-89b8-2eb036839a93)
