### PR TITLE
SystemServer: Print useful information when failing to drop privileges

### DIFF
--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -200,8 +200,8 @@ ErrorOr<void> Service::spawn(int socket_fd)
 
         if (m_account.has_value() && m_account.value().uid() != getuid()) {
             auto& account = m_account.value();
-            if (account.login().is_error()) {
-                dbgln("Failed to drop privileges (GID={}, UID={})\n", account.gid(), account.uid());
+            if (auto error_or_void = account.login(); error_or_void.is_error()) {
+                dbgln("Failed to drop privileges (GID={}, UID={}), due to {}\n", account.gid(), account.uid(), error_or_void.error());
                 exit(1);
             }
             TRY(Core::System::setenv("HOME"sv, account.home_directory(), true));


### PR DESCRIPTION
It occurred to me that when trying to running "pls pro SOME_URL" with a subsequent failure (which will be fixed in a future patch), that a small error message was printed to the debug log about "Failed to drop privileges (GID=0, UID=0)".

To actually understand where it failed, I added the actual errno to printed message which helped me with further debugging, but this could easily help others in similar scenarios so let's print the actual error.

Sidenote - This helped me today when I worked on the upcoming _package-manager_ because of a misbehavior during spawning of a RequestServer instance. I figured this could be a patch on its own, so let's have it even now :)