### PR TITLE
LibWeb: Support SVG-as-image in HTMLImageElement

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/svg-as-image.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-as-image.txt
@@ -2,3 +2,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x1584 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x1568 children: not-inline
       ImageBox <img> at (8,8) content-size 784x1568 children: not-inline
+        (SVG-as-image isolated context)
+        Viewport <#document> at (0,0) content-size 0x0 children: inline
+          SVGSVGBox <svg> at (0,0) content-size 0x0 [SVG] children: inline
+            TextNode <#text>
+            SVGGeometryBox <rect> at (0,0) content-size 0x0 children: not-inline
+            TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/svg/svg-as-image.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-as-image.txt
@@ -1,0 +1,4 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x1584 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x1568 children: not-inline
+      ImageBox <img> at (8,8) content-size 784x1568 children: not-inline

--- a/Tests/LibWeb/Layout/input/svg/rectangle.svg
+++ b/Tests/LibWeb/Layout/input/svg/rectangle.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 200" xmlns="http://www.w3.org/2000/svg">
+    <rect x="0" y="0" width="100" height="200" fill="green" />
+</svg>

--- a/Tests/LibWeb/Layout/input/svg/svg-as-image.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-as-image.html
@@ -1,0 +1,1 @@
+<!doctype html><img src="rectangle.svg" style="display: block">

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -206,6 +206,7 @@ set(SOURCES
     Geometry/DOMRect.cpp
     Geometry/DOMRectList.cpp
     Geometry/DOMRectReadOnly.cpp
+    HTML/AnimatedBitmapDecodedImageData.cpp
     HTML/AttributeNames.cpp
     HTML/BrowsingContext.cpp
     HTML/BrowsingContextGroup.cpp

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -500,6 +500,7 @@ set(SOURCES
     SVG/SVGAnimatedLength.cpp
     SVG/SVGAnimatedNumber.cpp
     SVG/SVGClipPathElement.cpp
+    SVG/SVGDecodedImageData.cpp
     SVG/SVGDefsElement.cpp
     SVG/SVGElement.cpp
     SVG/SVGGElement.cpp

--- a/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
@@ -23,7 +23,7 @@ AnimatedBitmapDecodedImageData::AnimatedBitmapDecodedImageData(Vector<Frame>&& f
 
 AnimatedBitmapDecodedImageData::~AnimatedBitmapDecodedImageData() = default;
 
-RefPtr<Gfx::Bitmap const> AnimatedBitmapDecodedImageData::bitmap(size_t frame_index) const
+RefPtr<Gfx::Bitmap const> AnimatedBitmapDecodedImageData::bitmap(size_t frame_index, Gfx::IntSize) const
 {
     if (frame_index >= m_frames.size())
         return nullptr;

--- a/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Bitmap.h>
+#include <LibWeb/HTML/AnimatedBitmapDecodedImageData.h>
+
+namespace Web::HTML {
+
+ErrorOr<NonnullRefPtr<AnimatedBitmapDecodedImageData>> AnimatedBitmapDecodedImageData::create(Vector<Frame>&& frames, size_t loop_count, bool animated)
+{
+    return adopt_nonnull_ref_or_enomem(new (nothrow) AnimatedBitmapDecodedImageData(move(frames), loop_count, animated));
+}
+
+AnimatedBitmapDecodedImageData::AnimatedBitmapDecodedImageData(Vector<Frame>&& frames, size_t loop_count, bool animated)
+    : m_frames(move(frames))
+    , m_loop_count(loop_count)
+    , m_animated(animated)
+{
+}
+
+AnimatedBitmapDecodedImageData::~AnimatedBitmapDecodedImageData() = default;
+
+RefPtr<Gfx::Bitmap const> AnimatedBitmapDecodedImageData::bitmap(size_t frame_index) const
+{
+    if (frame_index >= m_frames.size())
+        return nullptr;
+    return m_frames[frame_index].bitmap;
+}
+
+int AnimatedBitmapDecodedImageData::frame_duration(size_t frame_index) const
+{
+    if (frame_index >= m_frames.size())
+        return 0;
+    return m_frames[frame_index].duration;
+}
+
+Optional<int> AnimatedBitmapDecodedImageData::natural_width() const
+{
+    return m_frames.first().bitmap->width();
+}
+
+Optional<int> AnimatedBitmapDecodedImageData::natural_height() const
+{
+    return m_frames.first().bitmap->height();
+}
+
+}

--- a/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
@@ -37,14 +37,19 @@ int AnimatedBitmapDecodedImageData::frame_duration(size_t frame_index) const
     return m_frames[frame_index].duration;
 }
 
-Optional<int> AnimatedBitmapDecodedImageData::natural_width() const
+Optional<CSSPixels> AnimatedBitmapDecodedImageData::intrinsic_width() const
 {
     return m_frames.first().bitmap->width();
 }
 
-Optional<int> AnimatedBitmapDecodedImageData::natural_height() const
+Optional<CSSPixels> AnimatedBitmapDecodedImageData::intrinsic_height() const
 {
     return m_frames.first().bitmap->height();
+}
+
+Optional<float> AnimatedBitmapDecodedImageData::intrinsic_aspect_ratio() const
+{
+    return static_cast<float>(m_frames.first().bitmap->width()) / static_cast<float>(m_frames.first().bitmap->height());
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
@@ -20,7 +20,7 @@ public:
     static ErrorOr<NonnullRefPtr<AnimatedBitmapDecodedImageData>> create(Vector<Frame>&&, size_t loop_count, bool animated);
     virtual ~AnimatedBitmapDecodedImageData() override;
 
-    virtual RefPtr<Gfx::Bitmap const> bitmap(size_t frame_index) const override;
+    virtual RefPtr<Gfx::Bitmap const> bitmap(size_t frame_index, Gfx::IntSize = {}) const override;
     virtual int frame_duration(size_t frame_index) const override;
 
     virtual size_t frame_count() const override { return m_frames.size(); }

--- a/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
@@ -27,8 +27,9 @@ public:
     virtual size_t loop_count() const override { return m_loop_count; }
     virtual bool is_animated() const override { return m_animated; }
 
-    virtual Optional<int> natural_width() const override;
-    virtual Optional<int> natural_height() const override;
+    virtual Optional<CSSPixels> intrinsic_width() const override;
+    virtual Optional<CSSPixels> intrinsic_height() const override;
+    virtual Optional<float> intrinsic_aspect_ratio() const override;
 
 private:
     AnimatedBitmapDecodedImageData(Vector<Frame>&&, size_t loop_count, bool animated);

--- a/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/HTML/DecodedImageData.h>
+
+namespace Web::HTML {
+
+class AnimatedBitmapDecodedImageData final : public DecodedImageData {
+public:
+    struct Frame {
+        RefPtr<Gfx::Bitmap const> bitmap;
+        int duration { 0 };
+    };
+
+    static ErrorOr<NonnullRefPtr<AnimatedBitmapDecodedImageData>> create(Vector<Frame>&&, size_t loop_count, bool animated);
+    virtual ~AnimatedBitmapDecodedImageData() override;
+
+    virtual RefPtr<Gfx::Bitmap const> bitmap(size_t frame_index) const override;
+    virtual int frame_duration(size_t frame_index) const override;
+
+    virtual size_t frame_count() const override { return m_frames.size(); }
+    virtual size_t loop_count() const override { return m_loop_count; }
+    virtual bool is_animated() const override { return m_animated; }
+
+    virtual Optional<int> natural_width() const override;
+    virtual Optional<int> natural_height() const override;
+
+private:
+    AnimatedBitmapDecodedImageData(Vector<Frame>&&, size_t loop_count, bool animated);
+
+    Vector<Frame> m_frames;
+    size_t m_loop_count { 0 };
+    bool m_animated { false };
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/DecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DecodedImageData.cpp
@@ -4,47 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGfx/Bitmap.h>
 #include <LibWeb/HTML/DecodedImageData.h>
 
 namespace Web::HTML {
 
-ErrorOr<NonnullRefPtr<DecodedImageData>> DecodedImageData::create(Vector<Frame>&& frames, size_t loop_count, bool animated)
-{
-    return adopt_nonnull_ref_or_enomem(new (nothrow) DecodedImageData(move(frames), loop_count, animated));
-}
-
-DecodedImageData::DecodedImageData(Vector<Frame>&& frames, size_t loop_count, bool animated)
-    : m_frames(move(frames))
-    , m_loop_count(loop_count)
-    , m_animated(animated)
-{
-}
+DecodedImageData::DecodedImageData() = default;
 
 DecodedImageData::~DecodedImageData() = default;
-
-RefPtr<Gfx::Bitmap const> DecodedImageData::bitmap(size_t frame_index) const
-{
-    if (frame_index >= m_frames.size())
-        return nullptr;
-    return m_frames[frame_index].bitmap;
-}
-
-int DecodedImageData::frame_duration(size_t frame_index) const
-{
-    if (frame_index >= m_frames.size())
-        return 0;
-    return m_frames[frame_index].duration;
-}
-
-Optional<int> DecodedImageData::natural_width() const
-{
-    return m_frames.first().bitmap->width();
-}
-
-Optional<int> DecodedImageData::natural_height() const
-{
-    return m_frames.first().bitmap->height();
-}
 
 }

--- a/Userland/Libraries/LibWeb/HTML/DecodedImageData.h
+++ b/Userland/Libraries/LibWeb/HTML/DecodedImageData.h
@@ -13,32 +13,22 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/images.html#img-req-data
-class DecodedImageData final : public RefCounted<DecodedImageData> {
+class DecodedImageData : public RefCounted<DecodedImageData> {
 public:
-    struct Frame {
-        RefPtr<Gfx::Bitmap const> bitmap;
-        int duration { 0 };
-    };
+    virtual ~DecodedImageData();
 
-    static ErrorOr<NonnullRefPtr<DecodedImageData>> create(Vector<Frame>&&, size_t loop_count, bool animated);
-    ~DecodedImageData();
+    virtual RefPtr<Gfx::Bitmap const> bitmap(size_t frame_index) const = 0;
+    virtual int frame_duration(size_t frame_index) const = 0;
 
-    RefPtr<Gfx::Bitmap const> bitmap(size_t frame_index) const;
-    int frame_duration(size_t frame_index) const;
+    virtual size_t frame_count() const = 0;
+    virtual size_t loop_count() const = 0;
+    virtual bool is_animated() const = 0;
 
-    size_t frame_count() const { return m_frames.size(); }
-    size_t loop_count() const { return m_loop_count; }
-    bool is_animated() const { return m_animated; }
+    virtual Optional<int> natural_width() const = 0;
+    virtual Optional<int> natural_height() const = 0;
 
-    Optional<int> natural_width() const;
-    Optional<int> natural_height() const;
-
-private:
-    DecodedImageData(Vector<Frame>&&, size_t loop_count, bool animated);
-
-    Vector<Frame> m_frames;
-    size_t m_loop_count { 0 };
-    bool m_animated { false };
+protected:
+    DecodedImageData();
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/DecodedImageData.h
+++ b/Userland/Libraries/LibWeb/HTML/DecodedImageData.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <AK/RefCounted.h>
-#include <LibGfx/Forward.h>
+#include <LibGfx/Size.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibWeb/PixelUnits.h>
 
@@ -18,7 +18,7 @@ class DecodedImageData : public RefCounted<DecodedImageData> {
 public:
     virtual ~DecodedImageData();
 
-    virtual RefPtr<Gfx::Bitmap const> bitmap(size_t frame_index) const = 0;
+    virtual RefPtr<Gfx::Bitmap const> bitmap(size_t frame_index, Gfx::IntSize = {}) const = 0;
     virtual int frame_duration(size_t frame_index) const = 0;
 
     virtual size_t frame_count() const = 0;

--- a/Userland/Libraries/LibWeb/HTML/DecodedImageData.h
+++ b/Userland/Libraries/LibWeb/HTML/DecodedImageData.h
@@ -9,6 +9,7 @@
 #include <AK/RefCounted.h>
 #include <LibGfx/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibWeb/PixelUnits.h>
 
 namespace Web::HTML {
 
@@ -24,8 +25,9 @@ public:
     virtual size_t loop_count() const = 0;
     virtual bool is_animated() const = 0;
 
-    virtual Optional<int> natural_width() const = 0;
-    virtual Optional<int> natural_height() const = 0;
+    virtual Optional<CSSPixels> intrinsic_width() const = 0;
+    virtual Optional<CSSPixels> intrinsic_height() const = 0;
+    virtual Optional<float> intrinsic_aspect_ratio() const = 0;
 
 protected:
     DecodedImageData();

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -132,10 +132,10 @@ Optional<float> HTMLImageElement::intrinsic_aspect_ratio() const
     return {};
 }
 
-RefPtr<Gfx::Bitmap const> HTMLImageElement::current_image_bitmap() const
+RefPtr<Gfx::Bitmap const> HTMLImageElement::current_image_bitmap(Gfx::IntSize size) const
 {
     if (auto data = m_current_request->image_data())
-        return data->bitmap(m_current_frame_index);
+        return data->bitmap(m_current_frame_index, size);
     return nullptr;
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -14,8 +14,8 @@
 #include <LibWeb/Fetch/Fetching/Fetching.h>
 #include <LibWeb/Fetch/Infrastructure/FetchController.h>
 #include <LibWeb/Fetch/Response.h>
+#include <LibWeb/HTML/AnimatedBitmapDecodedImageData.h>
 #include <LibWeb/HTML/CORSSettingAttribute.h>
-#include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/HTML/HTMLLinkElement.h>
@@ -530,15 +530,15 @@ void HTMLImageElement::handle_successful_fetch(AK::URL const& url_string, ImageR
         return;
     }
 
-    Vector<DecodedImageData::Frame> frames;
+    Vector<AnimatedBitmapDecodedImageData::Frame> frames;
     for (auto& frame : result.value().frames) {
-        frames.append(DecodedImageData::Frame {
+        frames.append(AnimatedBitmapDecodedImageData::Frame {
             .bitmap = frame.bitmap,
             .duration = static_cast<int>(frame.duration),
         });
     }
 
-    auto image_data = DecodedImageData::create(move(frames), result.value().loop_count, result.value().is_animated).release_value_but_fixme_should_propagate_errors();
+    auto image_data = AnimatedBitmapDecodedImageData::create(move(frames), result.value().loop_count, result.value().is_animated).release_value_but_fixme_should_propagate_errors();
     image_request.set_image_data(image_data);
 
     ListOfAvailableImages::Key key;

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -111,6 +111,27 @@ RefPtr<Gfx::Bitmap const> HTMLImageElement::bitmap() const
     return current_image_bitmap();
 }
 
+Optional<CSSPixels> HTMLImageElement::intrinsic_width() const
+{
+    if (auto image_data = m_current_request->image_data())
+        return image_data->intrinsic_width();
+    return {};
+}
+
+Optional<CSSPixels> HTMLImageElement::intrinsic_height() const
+{
+    if (auto image_data = m_current_request->image_data())
+        return image_data->intrinsic_height();
+    return {};
+}
+
+Optional<float> HTMLImageElement::intrinsic_aspect_ratio() const
+{
+    if (auto image_data = m_current_request->image_data())
+        return image_data->intrinsic_aspect_ratio();
+    return {};
+}
+
 RefPtr<Gfx::Bitmap const> HTMLImageElement::current_image_bitmap() const
 {
     if (auto data = m_current_request->image_data())

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -78,6 +78,9 @@ public:
     void upgrade_pending_request_to_current_request();
 
     // ^Layout::ImageProvider
+    virtual Optional<CSSPixels> intrinsic_width() const override;
+    virtual Optional<CSSPixels> intrinsic_height() const override;
+    virtual Optional<float> intrinsic_aspect_ratio() const override;
     virtual RefPtr<Gfx::Bitmap const> current_image_bitmap() const override;
     virtual void set_visible_in_viewport(bool) override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -93,7 +93,7 @@ private:
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 
-    void handle_successful_fetch(AK::URL const&, ImageRequest&, ByteBuffer);
+    void handle_successful_fetch(AK::URL const&, StringView mime_type, ImageRequest&, ByteBuffer);
     void handle_failed_fetch();
 
     void animate();

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -81,7 +81,7 @@ public:
     virtual Optional<CSSPixels> intrinsic_width() const override;
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<float> intrinsic_aspect_ratio() const override;
-    virtual RefPtr<Gfx::Bitmap const> current_image_bitmap() const override;
+    virtual RefPtr<Gfx::Bitmap const> current_image_bitmap(Gfx::IntSize = {}) const override;
     virtual void set_visible_in_viewport(bool) override;
 
 private:

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -371,7 +371,7 @@ Optional<float> HTMLObjectElement::intrinsic_aspect_ratio() const
     return {};
 }
 
-RefPtr<Gfx::Bitmap const> HTMLObjectElement::current_image_bitmap() const
+RefPtr<Gfx::Bitmap const> HTMLObjectElement::current_image_bitmap(Gfx::IntSize) const
 {
     if (m_image_loader.has_value())
         return m_image_loader->bitmap(m_image_loader->current_frame_index());

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -350,6 +350,27 @@ i32 HTMLObjectElement::default_tab_index_value() const
     return 0;
 }
 
+Optional<CSSPixels> HTMLObjectElement::intrinsic_width() const
+{
+    if (m_image_loader.has_value())
+        return m_image_loader->bitmap(0)->width();
+    return {};
+}
+
+Optional<CSSPixels> HTMLObjectElement::intrinsic_height() const
+{
+    if (m_image_loader.has_value())
+        return m_image_loader->bitmap(0)->height();
+    return {};
+}
+
+Optional<float> HTMLObjectElement::intrinsic_aspect_ratio() const
+{
+    if (m_image_loader.has_value())
+        return static_cast<float>(m_image_loader->bitmap(0)->width()) / static_cast<float>(m_image_loader->bitmap(0)->height());
+    return {};
+}
+
 RefPtr<Gfx::Bitmap const> HTMLObjectElement::current_image_bitmap() const
 {
     if (m_image_loader.has_value())

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -70,6 +70,9 @@ private:
     virtual i32 default_tab_index_value() const override;
 
     // ^Layout::ImageProvider
+    virtual Optional<CSSPixels> intrinsic_width() const override;
+    virtual Optional<CSSPixels> intrinsic_height() const override;
+    virtual Optional<float> intrinsic_aspect_ratio() const override;
     virtual RefPtr<Gfx::Bitmap const> current_image_bitmap() const override;
     virtual void set_visible_in_viewport(bool) override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -73,7 +73,7 @@ private:
     virtual Optional<CSSPixels> intrinsic_width() const override;
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<float> intrinsic_aspect_ratio() const override;
-    virtual RefPtr<Gfx::Bitmap const> current_image_bitmap() const override;
+    virtual RefPtr<Gfx::Bitmap const> current_image_bitmap(Gfx::IntSize = {}) const override;
     virtual void set_visible_in_viewport(bool) override;
 
     Representation m_representation { Representation::Unknown };

--- a/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -23,18 +23,9 @@ ImageBox::~ImageBox() = default;
 
 void ImageBox::prepare_for_replaced_layout()
 {
-    auto bitmap = m_image_provider.current_image_bitmap();
-
-    if (!bitmap) {
-        set_intrinsic_width(0);
-        set_intrinsic_height(0);
-    } else {
-        auto width = bitmap->width();
-        auto height = bitmap->height();
-        set_intrinsic_width(width);
-        set_intrinsic_height(height);
-        set_intrinsic_aspect_ratio(static_cast<float>(width) / static_cast<float>(height));
-    }
+    set_intrinsic_width(m_image_provider.intrinsic_width());
+    set_intrinsic_height(m_image_provider.intrinsic_height());
+    set_intrinsic_aspect_ratio(m_image_provider.intrinsic_aspect_ratio());
 
     if (renders_as_alt_text()) {
         auto& image_element = verify_cast<HTML::HTMLImageElement>(dom_node());

--- a/Userland/Libraries/LibWeb/Layout/ImageProvider.h
+++ b/Userland/Libraries/LibWeb/Layout/ImageProvider.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/Size.h>
 #include <LibWeb/PixelUnits.h>
 
 namespace Web::Layout {
@@ -18,7 +19,7 @@ public:
     virtual Optional<CSSPixels> intrinsic_height() const = 0;
     virtual Optional<float> intrinsic_aspect_ratio() const = 0;
 
-    virtual RefPtr<Gfx::Bitmap const> current_image_bitmap() const = 0;
+    virtual RefPtr<Gfx::Bitmap const> current_image_bitmap(Gfx::IntSize) const = 0;
     virtual void set_visible_in_viewport(bool) = 0;
 };
 

--- a/Userland/Libraries/LibWeb/Layout/ImageProvider.h
+++ b/Userland/Libraries/LibWeb/Layout/ImageProvider.h
@@ -6,11 +6,17 @@
 
 #pragma once
 
+#include <LibWeb/PixelUnits.h>
+
 namespace Web::Layout {
 
 class ImageProvider {
 public:
     virtual ~ImageProvider() { }
+
+    virtual Optional<CSSPixels> intrinsic_width() const = 0;
+    virtual Optional<CSSPixels> intrinsic_height() const = 0;
+    virtual Optional<float> intrinsic_aspect_ratio() const = 0;
 
     virtual RefPtr<Gfx::Bitmap const> current_image_bitmap() const = 0;
     virtual void set_visible_in_viewport(bool) = 0;

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -52,6 +52,7 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
     PaintableBox::paint(context, phase);
 
     if (phase == PaintPhase::Foreground) {
+        auto image_rect = context.rounded_device_rect(absolute_rect());
         if (layout_box().renders_as_alt_text()) {
             auto& image_element = verify_cast<HTML::HTMLImageElement>(*dom_node());
             auto enclosing_rect = context.enclosing_device_rect(absolute_rect()).to_type<int>();
@@ -61,8 +62,7 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
             if (alt.is_empty())
                 alt = image_element.src();
             context.painter().draw_text(enclosing_rect, alt, Gfx::TextAlignment::Center, computed_values().color(), Gfx::TextElision::Right);
-        } else if (auto bitmap = layout_box().image_provider().current_image_bitmap()) {
-            auto image_rect = context.rounded_device_rect(absolute_rect());
+        } else if (auto bitmap = layout_box().image_provider().current_image_bitmap(image_rect.size().to_type<int>())) {
             ScopedCornerRadiusClip corner_clip { context, context.painter(), image_rect, normalized_border_radii_data(ShrinkRadiiForBorders::Yes) };
             auto scaling_mode = to_gfx_scaling_mode(computed_values().image_rendering(), bitmap->rect(), image_rect.to_type<int>());
             context.painter().draw_scaled_bitmap(image_rect.to_type<int>(), *bitmap, bitmap->rect(), 1.f, scaling_mode);

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -5,24 +5,114 @@
  */
 
 #include <LibGfx/Bitmap.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/Dump.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
+#include <LibWeb/HTML/BrowsingContext.h>
+#include <LibWeb/HTML/NavigationParams.h>
+#include <LibWeb/HTML/Parser/HTMLParser.h>
+#include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/Painting/PaintContext.h>
 #include <LibWeb/SVG/SVGDecodedImageData.h>
+#include <LibWeb/SVG/SVGSVGElement.h>
 
 namespace Web::SVG {
 
-ErrorOr<NonnullRefPtr<SVGDecodedImageData>> SVGDecodedImageData::create(ByteBuffer)
+class SVGDecodedImageData::SVGPageClient final : public PageClient {
+public:
+    explicit SVGPageClient(Page& host_page)
+        : m_host_page(host_page)
+    {
+    }
+
+    virtual ~SVGPageClient() override = default;
+
+    Page& m_host_page;
+    Page* m_svg_page { nullptr };
+
+    virtual Page& page() override { return *m_svg_page; }
+    virtual Page const& page() const override { return *m_svg_page; }
+    virtual bool is_connection_open() const override { return false; }
+    virtual Gfx::Palette palette() const override { return m_host_page.client().palette(); }
+    virtual DevicePixelRect screen_rect() const override { return {}; }
+    virtual float device_pixels_per_css_pixel() const override { return m_host_page.client().device_pixels_per_css_pixel(); }
+    virtual CSS::PreferredColorScheme preferred_color_scheme() const override { return m_host_page.client().preferred_color_scheme(); }
+    virtual void request_file(FileRequest) override { }
+    virtual void paint(DevicePixelRect const&, Gfx::Bitmap&) override { }
+};
+
+ErrorOr<NonnullRefPtr<SVGDecodedImageData>> SVGDecodedImageData::create(Page& host_page, AK::URL const& url, ByteBuffer data)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) SVGDecodedImageData());
+    auto page_client = make<SVGPageClient>(host_page);
+    auto page = make<Page>(*page_client);
+    page_client->m_svg_page = page.ptr();
+    auto browsing_context = HTML::BrowsingContext::create_a_new_top_level_browsing_context(*page);
+    auto response = Fetch::Infrastructure::Response::create(browsing_context->vm());
+    response->url_list().append(url);
+    HTML::NavigationParams navigation_params {
+        .id = {},
+        .request = nullptr,
+        .response = response,
+        .origin = HTML::Origin {},
+        .policy_container = HTML::PolicyContainer {},
+        .final_sandboxing_flag_set = HTML::SandboxingFlagSet {},
+        .cross_origin_opener_policy = HTML::CrossOriginOpenerPolicy {},
+        .coop_enforcement_result = HTML::CrossOriginOpenerPolicyEnforcementResult {},
+        .reserved_environment = {},
+        .browsing_context = browsing_context,
+        .navigable = nullptr,
+    };
+    auto document = DOM::Document::create_and_initialize(DOM::Document::Type::HTML, "text/html", move(navigation_params)).release_value_but_fixme_should_propagate_errors();
+    browsing_context->set_active_document(document);
+
+    auto parser = HTML::HTMLParser::create_with_uncertain_encoding(document, data);
+    parser->run(document->url());
+
+    // Perform some DOM surgery to make the SVG root element be the first child of the Document.
+    // FIXME: This is a huge hack until we figure out how to actually parse separate SVG files.
+    auto* svg_root = document->body()->first_child_of_type<SVG::SVGSVGElement>();
+    svg_root->remove();
+    document->remove_all_children();
+
+    MUST(document->append_child(*svg_root));
+
+    return adopt_nonnull_ref_or_enomem(new (nothrow) SVGDecodedImageData(move(page), move(page_client), move(document), move(svg_root)));
 }
 
-SVGDecodedImageData::SVGDecodedImageData()
+SVGDecodedImageData::SVGDecodedImageData(NonnullOwnPtr<Page> page, NonnullOwnPtr<SVGPageClient> page_client, JS::Handle<DOM::Document> document, JS::Handle<SVG::SVGSVGElement> root_element)
+    : m_page(move(page))
+    , m_page_client(move(page_client))
+    , m_document(move(document))
+    , m_root_element(move(root_element))
 {
 }
 
 SVGDecodedImageData::~SVGDecodedImageData() = default;
 
-RefPtr<Gfx::Bitmap const> SVGDecodedImageData::bitmap(size_t, Gfx::IntSize) const
+void SVGDecodedImageData::render(Gfx::IntSize size) const
 {
-    return nullptr;
+    m_document->browsing_context()->set_viewport_rect({ 0, 0, size.width(), size.height() });
+    m_document->update_layout();
+
+    dump_tree(*m_document->layout_node());
+
+    Gfx::Painter painter(*m_bitmap);
+    PaintContext context(painter, m_page_client->palette(), m_page_client->device_pixels_per_css_pixel());
+
+    m_document->layout_node()->paint_all_phases(context);
+}
+
+RefPtr<Gfx::Bitmap const> SVGDecodedImageData::bitmap(size_t, Gfx::IntSize size) const
+{
+    if (size.is_empty())
+        return nullptr;
+
+    if (m_bitmap && m_bitmap->size() == size)
+        return m_bitmap;
+
+    m_bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, size).release_value_but_fixme_should_propagate_errors();
+    render(size);
+    return m_bitmap;
 }
 
 Optional<CSSPixels> SVGDecodedImageData::intrinsic_width() const

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -20,7 +20,7 @@ SVGDecodedImageData::SVGDecodedImageData()
 
 SVGDecodedImageData::~SVGDecodedImageData() = default;
 
-RefPtr<Gfx::Bitmap const> SVGDecodedImageData::bitmap(size_t) const
+RefPtr<Gfx::Bitmap const> SVGDecodedImageData::bitmap(size_t, Gfx::IntSize) const
 {
     return nullptr;
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Bitmap.h>
+#include <LibWeb/SVG/SVGDecodedImageData.h>
+
+namespace Web::SVG {
+
+ErrorOr<NonnullRefPtr<SVGDecodedImageData>> SVGDecodedImageData::create(ByteBuffer)
+{
+    return adopt_nonnull_ref_or_enomem(new (nothrow) SVGDecodedImageData());
+}
+
+SVGDecodedImageData::SVGDecodedImageData()
+{
+}
+
+SVGDecodedImageData::~SVGDecodedImageData() = default;
+
+RefPtr<Gfx::Bitmap const> SVGDecodedImageData::bitmap(size_t) const
+{
+    return nullptr;
+}
+
+Optional<CSSPixels> SVGDecodedImageData::intrinsic_width() const
+{
+    return 0;
+}
+
+Optional<CSSPixels> SVGDecodedImageData::intrinsic_height() const
+{
+    return 0;
+}
+
+Optional<float> SVGDecodedImageData::intrinsic_aspect_ratio() const
+{
+    return 1;
+}
+
+}

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -27,6 +27,8 @@ public:
     virtual size_t loop_count() const override { return 0; }
     virtual bool is_animated() const override { return false; }
 
+    DOM::Document const& svg_document() const { return *m_document; }
+
 private:
     class SVGPageClient;
     SVGDecodedImageData(NonnullOwnPtr<Page>, NonnullOwnPtr<SVGPageClient>, JS::Handle<DOM::Document>, JS::Handle<SVG::SVGSVGElement>);

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/HTML/DecodedImageData.h>
+
+namespace Web::SVG {
+
+class SVGDecodedImageData final : public HTML::DecodedImageData {
+public:
+    static ErrorOr<NonnullRefPtr<SVGDecodedImageData>> create(ByteBuffer encoded_svg);
+    virtual ~SVGDecodedImageData() override;
+
+    virtual RefPtr<Gfx::Bitmap const> bitmap(size_t frame_index) const override;
+
+    virtual Optional<CSSPixels> intrinsic_width() const override;
+    virtual Optional<CSSPixels> intrinsic_height() const override;
+    virtual Optional<float> intrinsic_aspect_ratio() const override;
+
+    // FIXME: Support SVG animations. :^)
+    virtual int frame_duration(size_t) const override { return 0; }
+    virtual size_t frame_count() const override { return 1; }
+    virtual size_t loop_count() const override { return 0; }
+    virtual bool is_animated() const override { return false; }
+
+private:
+    SVGDecodedImageData();
+};
+
+}

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -15,7 +15,7 @@ public:
     static ErrorOr<NonnullRefPtr<SVGDecodedImageData>> create(ByteBuffer encoded_svg);
     virtual ~SVGDecodedImageData() override;
 
-    virtual RefPtr<Gfx::Bitmap const> bitmap(size_t frame_index) const override;
+    virtual RefPtr<Gfx::Bitmap const> bitmap(size_t frame_index, Gfx::IntSize) const override;
 
     virtual Optional<CSSPixels> intrinsic_width() const override;
     virtual Optional<CSSPixels> intrinsic_height() const override;

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -12,7 +12,7 @@ namespace Web::SVG {
 
 class SVGDecodedImageData final : public HTML::DecodedImageData {
 public:
-    static ErrorOr<NonnullRefPtr<SVGDecodedImageData>> create(ByteBuffer encoded_svg);
+    static ErrorOr<NonnullRefPtr<SVGDecodedImageData>> create(Page&, AK::URL const&, ByteBuffer encoded_svg);
     virtual ~SVGDecodedImageData() override;
 
     virtual RefPtr<Gfx::Bitmap const> bitmap(size_t frame_index, Gfx::IntSize) const override;
@@ -28,7 +28,17 @@ public:
     virtual bool is_animated() const override { return false; }
 
 private:
-    SVGDecodedImageData();
+    class SVGPageClient;
+    SVGDecodedImageData(NonnullOwnPtr<Page>, NonnullOwnPtr<SVGPageClient>, JS::Handle<DOM::Document>, JS::Handle<SVG::SVGSVGElement>);
+
+    void render(Gfx::IntSize) const;
+    mutable RefPtr<Gfx::Bitmap> m_bitmap;
+
+    NonnullOwnPtr<Page> m_page;
+    NonnullOwnPtr<SVGPageClient> m_page_client;
+
+    JS::Handle<DOM::Document> m_document;
+    JS::Handle<SVG::SVGSVGElement> m_root_element;
 };
 
 }


### PR DESCRIPTION
This PR adds support for `<img src="some.svg">`

See individual commits for details.