### PR TITLE
Chess: Don't ask the engine to make a move if the game is finished 

### DIFF
--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -448,7 +448,7 @@ bool ChessWidget::want_engine_move()
 {
     if (!m_engine)
         return false;
-    if (board().turn() == side())
+    if (board().turn() == side() || board().game_finished())
         return false;
     return true;
 }

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -680,6 +680,10 @@ void ChessWidget::flip_board()
 
 int ChessWidget::resign()
 {
+    // FIXME: Disable the resign checkbox if the game is finished
+    if (board().game_finished())
+        return -1;
+
     if (want_engine_move()) {
         GUI::MessageBox::show(window(), "You can only resign on your turn."sv, "Resign"sv, GUI::MessageBox::Type::Information);
         return -1;


### PR DESCRIPTION
Previously, the engine would attempt to make a move if the engine was 
changed after the game had ended.

To reproduce:

1. With 2 humans playing, set up a checkmate position (easiest is: 1. f3 e6 2. g4 Qh4#)
2. Select ChessEngine from the Engine menu
3. Select Game -> Flip Board
4. :fire:

This PR also ensures that the player is always able to flip the board after the game is finished, and makes the resign button have no effect after the game is finished.