### PR TITLE
Base: Add/update some application manpages (Part 1)

### DIFF
--- a/Base/usr/share/man/man1/Applications.md
+++ b/Base/usr/share/man/man1/Applications.md
@@ -4,9 +4,9 @@ Applications - SerenityOS GUI applications
 
 ## Description
 
-SerenityOS comes with a suite of GUI applications. The applications are divided into multiple categories, through which they are available in the start menu.
+SerenityOS comes with a suite of GUI applications. The applications are divided into multiple categories, through which they are available in the System Menu.
 
-Note that many applications can be disabled at SerenityOS build time if desired. Therefore, depending on your SerenityOS build configuration, not all applications may be available. 
+Note that many applications can be disabled at SerenityOS build time if desired. Therefore, depending on your SerenityOS build configuration, not all applications will be available. 
 
 ## See also
 
@@ -14,22 +14,27 @@ Note that many applications can be disabled at SerenityOS build time if desired.
 
 ### List of Application manpages
 
+- [3D File Viewer](help://man/1/Applications/3DFileViewer)
 - [About](help://man/1/Applications/About)
 - [Analog Clock](help://man/1/Applications/AnalogClock)
 - [Assistant](help://man/1/Applications/Assistant)
 - [Browser](help://man/1/Applications/Browser)
 - [Calculator](help://man/1/Applications/Calculator)
 - [Calendar](help://man/1/Applications/Calendar)
+- [CatDog](help://man/1/Applications/CatDog)
+- [Certificate Settings](help://man/1/Applications/CertificateSettings)
 - [Character Map](help://man/1/Applications/CharacterMap)
 - [Eyes](help://man/1/Applications/Eyes)
 - [FontEditor](help://man/1/Applications/FontEditor)
 - [GML Playground](help://man/1/Applications/GMLPlayground)
+- [Help](help://man/1/Applications/Help)
 - [Hex Editor](help://man/1/Applications/HexEditor)
 - [Image Viewer](help://man/1/Applications/ImageViewer)
 - [Magnifier](help://man/1/Applications/Magnifier)
 - [Mail](help://man/1/Applications/Mail)
 - [Mouse Settings](help://man/1/Applications/MouseSettings)
 - [Presenter](help://man/1/Applications/Presenter)
+- [Profiler](help://man/1/Applications/Profiler)
 - [SQL Studio](help://man/1/Applications/SQLStudio)
 - [Terminal](help://man/1/Applications/Terminal)
 - [Text Editor](help://man/1/Applications/TextEditor)

--- a/Base/usr/share/man/man1/Applications/3DFileViewer.md
+++ b/Base/usr/share/man/man1/Applications/3DFileViewer.md
@@ -1,0 +1,31 @@
+## Name
+
+![Icon](/res/icons/16x16/app-3d-file-viewer.png) 3D File Viewer
+
+[Open](file:///bin/3DFileViewer)
+
+## Synopsis
+
+```**sh
+$ 3DFileViewer
+```
+
+## Description
+
+`3D File Viewer` is an application for viewing 3D models.
+
+It currently supports opening the Wavefront OBJ file format (`.obj`).
+
+### Features
+
+By default 3D File Viewer will open with a rotating [Utah teapot](https://en.wikipedia.org/wiki/Utah_teapot), a standard 3D test model.
+
+Rotate the model by grabbing it with the cursor. Zoom-in and out with the mouse wheel.
+
+The rotation axis and speed can be adjusted or turned off in the `View` menu.
+
+The model's texture can be adjusted or turned off in the `Texture` menu.
+
+View in Fullscreen by pressing `F11`.
+
+Drag and drop files into 3D File Viewer to open them.

--- a/Base/usr/share/man/man1/Applications/Assistant.md
+++ b/Base/usr/share/man/man1/Applications/Assistant.md
@@ -16,5 +16,7 @@ $ Assistant
 
 ### Features
 
-* Enter a URL to open it in the web browser.
-* Do quick calculations by typing the equal sign (=) followed by a mathematical expression, e.g. `=22*101`. Press Return to copy the result.
+* Enter a URL to open it in the web browser, e.g. `serenityos.org`.
+* Perform quick calculations by typing the equal sign (=) followed by a mathematical expression, e.g. `=22*101`. Press Return to copy the result.
+* Run commands in [Terminal](help://man/1/Applications/Terminal) by prefixing them with a dollar sign ($), e.g. `$ uname -a`.
+* Launch applications with arguments, e.g. launch Pixel Paint with a file: `pp image.png`.

--- a/Base/usr/share/man/man1/Applications/CatDog.md
+++ b/Base/usr/share/man/man1/Applications/CatDog.md
@@ -1,0 +1,38 @@
+## Name
+
+![Icon](/res/icons/16x16/app-catdog.png) CatDog - A helpful companion
+
+[Open](file:///bin/CatDog)
+
+## Synopsis
+
+```**sh
+$ CatDog
+```
+
+## Description
+
+`CatDog` is an animated screenmate application in the form of a virtual pet.
+
+It was inspired by [Neko](https://en.wikipedia.org/wiki/Neko_(software)). The name derives from its ambiguous appearance: is it a cat, a dog, or a hybrid?
+
+Its helpful suggestions evoke the animated assistants popular at the turn of the millennium, such as [Clippy](https://en.wikipedia.org/wiki/Office_Assistant).
+
+Alongside [Buggie](https://en.wikipedia.org/wiki/SerenityOS#History) and the [Yaks](http://yaksplained.org/), CatDog is a much loved member of the SerenityOS family of mascots. As such it has a wider presence in the project’s online community, promotional materials and merchandise.
+
+### Features
+
+By default, CatDog will chase your mouse cursor around the screen. It will always stay on-top of other windows.
+
+Additionally, CatDog offers helpful suggestions depending on the currently active application.
+
+CatDog has multiple states:
+
+- *Sleeping* if the mouse cursor hasn’t moved in some time
+- *Alert* if woken by the mouse cursor or speaking after being idle
+- *Dressed as an Artist* if Pixel Paint or [Font Editor](help://man/1/Applications/FontEditor) are open
+- *Dressed as an Inspector* if [Profiler](help://man/1/Applications/Profiler) or System Monitor are open
+
+To exit, right-click on CatDog and select `Quit` or, if active, press `Alt+F4`.
+
+CatDog brings good luck to those who keep it open.

--- a/Base/usr/share/man/man1/Applications/CertificateSettings.md
+++ b/Base/usr/share/man/man1/Applications/CertificateSettings.md
@@ -1,0 +1,22 @@
+## Name
+
+![Icon](/res/icons/16x16/certificate.png) Certificate Settings
+
+[Open](file:///bin/CertificateSettings)
+
+## Synopsis
+
+```**sh
+$ CertificateSettings
+```
+
+## Description
+`Certificate Settings` is an application for managing digital certificates in SerenityOS.
+
+Certificates are used for establishing a user's credentials when trying to create secure connection between a client and server by matching a public and private key.
+
+The *Certificate Store* lists all of the certificates currently stored in the system, the Trusted Root Certification Authorities (CAs) they were issued by and their expiration dates.
+
+### Features
+
+Import and export CAs as Privacy-Enhanced Mail files (`.pem`).

--- a/Base/usr/share/man/man7/Tips-and-Tricks.md
+++ b/Base/usr/share/man/man7/Tips-and-Tricks.md
@@ -29,8 +29,9 @@ This is a list of useful tips and tricks to help you make the most out of Sereni
 
 ### [Assistant](help://man/1/Applications/Assistant)
 * Assistant can help you to quickly find files and launch applications. Open it with `Super+Space`.
-* Enter a URL to open it in the web browser.
-* Do quick calculations by typing the equal sign (=) followed by a mathematical expression, e.g. `=22*101`. Press Return to copy the result.
+* Enter a URL to open it in the web browser, e.g. `serenityos.org`.
+* Perform quick calculations by typing the equal sign (=) followed by a mathematical expression, e.g. `=22*101`. Press Return to copy the result.
+* Run commands in the terminal by prefixing them with a dollar sign ($), e.g. `$ uname -a`.
 
 ### [Browser](help://man/1/Applications/Browser)
 * Browser has built-in content filtering, which can be used for ad blocking. Update the filters in `~/.config/BrowserContentFiltering.txt`.


### PR DESCRIPTION
Add application manpages for:
- 3D File Viewer
- CatDog
- Certificate Settings

This contributes towards #11311

Also
- Update `Applications.md` to reflect these new pages and add previously missing pages.
- Update `Assistant.md` with instructions for:
  - Running terminal commands. Reflect this in the sister section in `Tips-and-Tricks.md` 
  - Launching applications with arguments.