### PR TITLE
LibWeb: Implement table rowspan

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/rowspan.txt
@@ -1,0 +1,111 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x93.875 [BFC] children: not-inline
+    BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
+      TextNode <#text>
+    BlockContainer <body> at (8,8) content-size 784x77.875 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+        TextNode <#text>
+      TableWrapper <(anonymous)> at (8,8) content-size 221.359375x77.875 [BFC] children: not-inline
+        TableBox <table> at (8,8) content-size 221.359375x77.875 [TFC] children: not-inline
+          BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+            TextNode <#text>
+          TableRowGroupBox <tbody> at (8,8) content-size 221.359375x77.875 children: not-inline
+            TableRowBox <tr> at (8,8) content-size 221.359375x19.46875 children: not-inline
+              BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+                TextNode <#text>
+              TableCellBox <th> at (9,9) content-size 70.046875x17.46875 [BFC] children: inline
+                line 0 width: 70.046875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 8, rect: [9,9 70.046875x17.46875]
+                    "Header 1"
+                TextNode <#text>
+              BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+                TextNode <#text>
+              TableCellBox <th> at (81.046875,9) content-size 72.515625x17.46875 [BFC] children: inline
+                line 0 width: 72.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 8, rect: [81.046875,9 72.515625x17.46875]
+                    "Header 2"
+                TextNode <#text>
+              BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+                TextNode <#text>
+              TableCellBox <th> at (155.5625,9) content-size 72.796875x17.46875 [BFC] children: inline
+                line 0 width: 72.796875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 8, rect: [155.5625,9 72.796875x17.46875]
+                    "Header 3"
+                TextNode <#text>
+              BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+              TextNode <#text>
+            TableRowBox <tr> at (8,27.46875) content-size 221.359375x19.46875 children: not-inline
+              BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+                TextNode <#text>
+              TableCellBox <td> at (9,38.203125) content-size 70.046875x17.46875 [BFC] children: inline
+                line 0 width: 49.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 5, rect: [9,38.203125 49.609375x17.46875]
+                    "Row 1"
+                TextNode <#text>
+              BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+                TextNode <#text>
+              TableCellBox <td> at (81.046875,28.46875) content-size 72.515625x17.46875 [BFC] children: inline
+                line 0 width: 41.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [81.046875,28.46875 41.84375x17.46875]
+                    "Cell 1"
+                TextNode <#text>
+              BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+                TextNode <#text>
+              TableCellBox <td> at (155.5625,28.46875) content-size 72.796875x17.46875 [BFC] children: inline
+                line 0 width: 44.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [155.5625,28.46875 44.3125x17.46875]
+                    "Cell 2"
+                TextNode <#text>
+              BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+              TextNode <#text>
+            TableRowBox <tr> at (8,46.9375) content-size 221.359375x19.46875 children: not-inline
+              BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+                TextNode <#text>
+              TableCellBox <td> at (81.046875,47.9375) content-size 72.515625x17.46875 [BFC] children: inline
+                line 0 width: 44.59375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [81.046875,47.9375 44.59375x17.46875]
+                    "Cell 3"
+                TextNode <#text>
+              BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+                TextNode <#text>
+              TableCellBox <td> at (155.5625,47.9375) content-size 72.796875x17.46875 [BFC] children: inline
+                line 0 width: 43.25, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [155.5625,47.9375 43.25x17.46875]
+                    "Cell 4"
+                TextNode <#text>
+              BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+              TextNode <#text>
+            TableRowBox <tr> at (8,66.40625) content-size 221.359375x19.46875 children: not-inline
+              BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+                TextNode <#text>
+              TableCellBox <td> at (9,67.40625) content-size 70.046875x17.46875 [BFC] children: inline
+                line 0 width: 52.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 5, rect: [9,67.40625 52.078125x17.46875]
+                    "Row 2"
+                TextNode <#text>
+              BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+                TextNode <#text>
+              TableCellBox <td> at (81.046875,67.40625) content-size 72.515625x17.46875 [BFC] children: inline
+                line 0 width: 43.953125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [81.046875,67.40625 43.953125x17.46875]
+                    "Cell 5"
+                TextNode <#text>
+              BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+                TextNode <#text>
+              TableCellBox <td> at (155.5625,67.40625) content-size 72.796875x17.46875 [BFC] children: inline
+                line 0 width: 44.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [155.5625,67.40625 44.234375x17.46875]
+                    "Cell 6"
+                TextNode <#text>
+              BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> at (8,8) content-size 0x0 children: inline
+              TextNode <#text>
+      BlockContainer <(anonymous)> at (8,85.875) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/table/rowspan.html
+++ b/Tests/LibWeb/Layout/input/table/rowspan.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Table with rowspan</title>
+</head>
+
+<body>
+    <table border="1">
+        <tr>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+        <tr>
+            <td rowspan="2">Row 1</td>
+            <td>Cell 1</td>
+            <td>Cell 2</td>
+        </tr>
+        <tr>
+            <td>Cell 3</td>
+            <td>Cell 4</td>
+        </tr>
+        <tr>
+            <td>Row 2</td>
+            <td>Cell 5</td>
+            <td>Cell 6</td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -78,6 +78,8 @@ private:
         CSSPixels max_width { 0 };
     };
 
+    CSSPixels compute_row_content_height(Cell const& cell) const;
+
     Vector<Cell> m_cells;
     Vector<Column> m_columns;
     Vector<Row> m_rows;


### PR DESCRIPTION
Adjust computing the table height and positioning of cells to account for the rowspan property.

Fixes #18952.