### PR TITLE
Meta+Documentation: Require Xcode 14.3 or Clang 14 for the host compiler

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -11,9 +11,9 @@ sudo apt install build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2
 ```
 Optional: `fuse2fs` for [building images without root](https://github.com/SerenityOS/serenity/pull/11224).
 
-#### GCC 12 or Clang 13
+#### GCC 12 or Clang 14
 
-A host compiler that supports C++20 features is required for building host tools, the newer the better. Tested versions include gcc-12 and clang-13.
+A host compiler that supports C++20 features is required for building host tools, the newer the better. Tested versions include gcc-12 and clang-14.
 
 On Ubuntu gcc-12 is available in the repositories of 22.04 (Jammy) and later.
 If you are running an older version, you will either need to upgrade, or find an alternative installation source.

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -2,7 +2,7 @@
 
 ## Build Prerequisites
 
-Qt6 development packages and a C++20 capable compiler are required. gcc-12 or clang-13 are required at a minimum for c++20 support.
+Qt6 development packages and a C++20 capable compiler are required. gcc-12 or clang-14 are required at a minimum for c++20 support.
 
 On Debian/Ubuntu required packages include, but are not limited to:
 
@@ -39,7 +39,7 @@ nix-shell ladybird.nix
 
 On macOS:
 
-Note that Xcode 13.x does not have sufficient C++20 support to build ladybird. Xcode 14.x or clang from homebrew may be required to successfully build ladybird.
+Note that Xcode 13.x does not have sufficient C++20 support to build ladybird. Xcode 14 versions before 14.3 might crash while building ladybird. Xcode 14.3 or clang from homebrew may be required to successfully build ladybird.
 
 ```
 xcode-select --install
@@ -103,7 +103,7 @@ The install rules in Ladybird/cmake/InstallRules.cmake define which binaries and
 installed into the configured CMAKE_PREFIX_PATH or path passed to ``cmake --install``.
 
 Note that when using a custom build directory rather than Meta/serenity.sh, the user may need to provide
-a suitable C++ compiler (g++ >= 12, clang >= 13, Apple Clang >= 14) via the CMAKE_CXX_COMPILER and
+a suitable C++ compiler (g++ >= 12, clang >= 14, Apple Clang >= 14.3) via the CMAKE_CXX_COMPILER and
 CMAKE_C_COMPILER cmake options.
 
 ```

--- a/Documentation/BuildInstructionsMacOS.md
+++ b/Documentation/BuildInstructionsMacOS.md
@@ -27,7 +27,7 @@ brew install genext2fs
 brew install x86_64-elf-gdb
 ```
 
-If you have Xcode version 13 or older, also install a newer host compiler from homebrew. Xcode 14 is known to work.
+If you have Xcode version 14.2 or older, also install a newer host compiler from homebrew. Xcode 14.3 is known to work.
 
 ```console
 brew install llvm@15

--- a/Meta/Lagom/BuildFuzzers.sh
+++ b/Meta/Lagom/BuildFuzzers.sh
@@ -14,7 +14,7 @@ die() {
 
 pick_clang() {
     local BEST_VERSION=0
-    for CLANG_CANDIDATE in clang clang-13 clang-14 clang-15 /opt/homebrew/opt/llvm/bin/clang ; do
+    for CLANG_CANDIDATE in clang clang-14 clang-15 /opt/homebrew/opt/llvm/bin/clang ; do
         if ! command -v $CLANG_CANDIDATE >/dev/null 2>&1; then
             continue
         fi
@@ -33,8 +33,8 @@ pick_clang() {
             BEST_CLANG_CANDIDATE="$CLANG_CANDIDATE"
         fi
     done
-    if [ "$BEST_VERSION" -lt 13 ]; then
-        die "Please make sure that Clang version 13 or higher is installed."
+    if [ "$BEST_VERSION" -lt 14 ]; then
+        die "Please make sure that Clang version 14 or higher is installed."
     fi
 }
 

--- a/Meta/Lagom/BuildFuzzers.sh
+++ b/Meta/Lagom/BuildFuzzers.sh
@@ -14,7 +14,7 @@ die() {
 
 pick_clang() {
     local BEST_VERSION=0
-    for CLANG_CANDIDATE in clang clang-14 clang-15 /opt/homebrew/opt/llvm/bin/clang ; do
+    for CLANG_CANDIDATE in clang clang-14 clang-15 clang-16 /opt/homebrew/opt/llvm/bin/clang ; do
         if ! command -v $CLANG_CANDIDATE >/dev/null 2>&1; then
             continue
         fi

--- a/Meta/Lagom/ReadMe.md
+++ b/Meta/Lagom/ReadMe.md
@@ -61,7 +61,7 @@ To build with LLVM's libFuzzer, invoke the ``BuildFuzzers.sh`` script with no ar
 ./Build/lagom-fuzzers/FuzzSomething # The full list can be found in Fuzzers/CMakeLists.txt
 ```
 
-(Note that we require clang >= 13, see the pick_clang() function in the script for the paths that are searched)
+(Note that we require clang >= 14, see the pick_clang() function in the script for the paths that are searched)
 
 To build fuzzers without any kind of default instrumentation, pass the ``--standalone`` flag to ``BuildFuzzers.sh``:
 

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -191,14 +191,14 @@ pick_host_compiler() {
         return
     fi
 
-    find_newest_compiler clang clang-14 clang-15 /opt/homebrew/opt/llvm/bin/clang
+    find_newest_compiler clang clang-14 clang-15 clang-16 /opt/homebrew/opt/llvm/bin/clang
     if is_supported_compiler "$HOST_COMPILER"; then
         export CC="${HOST_COMPILER}"
         export CXX="${HOST_COMPILER/clang/clang++}"
         return
     fi
 
-    find_newest_compiler egcc gcc gcc-12 /usr/local/bin/gcc-12 /opt/homebrew/bin/gcc-12
+    find_newest_compiler egcc gcc gcc-12 gcc-13 /usr/local/bin/gcc-{12,13} /opt/homebrew/bin/gcc-{12,13}
     if is_supported_compiler "$HOST_COMPILER"; then
         export CC="${HOST_COMPILER}"
         export CXX="${HOST_COMPILER/gcc/g++}"

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -152,10 +152,12 @@ is_supported_compiler() {
     MAJOR_VERSION="${VERSION%%.*}"
     if $COMPILER --version 2>&1 | grep "Apple clang" >/dev/null; then
         # Apple Clang version check
-        [ "$MAJOR_VERSION" -ge 14 ] && return 0
+        BUILD_VERSION=$(echo | $COMPILER -dM -E - | grep __apple_build_version__ | cut -d ' ' -f3)
+        # Xcode 14.3, based on upstream LLVM 15
+        [ "$BUILD_VERSION" -ge 14030022 ] && return 0
     elif $COMPILER --version 2>&1 | grep "clang" >/dev/null; then
         # Clang version check
-        [ "$MAJOR_VERSION" -ge 13 ] && return 0
+        [ "$MAJOR_VERSION" -ge 14 ] && return 0
     else
         # GCC version check
         [ "$MAJOR_VERSION" -ge 12 ] && return 0
@@ -189,7 +191,7 @@ pick_host_compiler() {
         return
     fi
 
-    find_newest_compiler clang clang-13 clang-14 clang-15 /opt/homebrew/opt/llvm/bin/clang
+    find_newest_compiler clang clang-14 clang-15 /opt/homebrew/opt/llvm/bin/clang
     if is_supported_compiler "$HOST_COMPILER"; then
         export CC="${HOST_COMPILER}"
         export CXX="${HOST_COMPILER/clang/clang++}"
@@ -203,7 +205,11 @@ pick_host_compiler() {
         return
     fi
 
-    die "Please make sure that GCC version 12, Clang version 13, or higher is installed."
+    if [ "$(uname -s)" = "Darwin" ]; then
+        die "Please make sure that Xcode 14.3, Homebrew Clang 14, or higher is installed."
+    else
+        die "Please make sure that GCC version 12, Clang version 14, or higher is installed."
+    fi
 }
 
 cmd_with_target() {


### PR DESCRIPTION
There have been multiple reports of Xcode 14.0 (based on upstream LLVM 14) segfaulting when compiling `LibCore/Process.cpp`. Let's require Xcode 14.3, which is a known good version based on LLVM 15.

Note that Xcode 14.3 requires macOS Ventura, so users of Monterey or older are expected to get Homebrew Clang instead.

Homebrew Clang 13 also suffers from the same crash. Although I have not tested on Linux, the backtrace points to the middle-end, so x86_64 is also likely to be affected. LLVM 14 was released 14 months ago, so it's not an unreasonable requirement.