### PR TITLE
LibWeb: Don't crash on percentage values for CSS stroke-width

### DIFF
--- a/Tests/LibWeb/Layout/expected/misc/percentage-stroke-width-crash.txt
+++ b/Tests/LibWeb/Layout/expected/misc/percentage-stroke-width-crash.txt
@@ -1,0 +1,3 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline

--- a/Tests/LibWeb/Layout/input/misc/percentage-stroke-width-crash.html
+++ b/Tests/LibWeb/Layout/input/misc/percentage-stroke-width-crash.html
@@ -1,0 +1,3 @@
+<!doctype html><style>
+body { stroke-width: 5%; }
+</style>

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EdgeStyleValue.h>
+#include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
 #include <LibWeb/CSS/StyleValues/URLStyleValue.h>
 #include <LibWeb/DOM/Document.h>
@@ -665,8 +666,10 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     //        https://svgwg.org/svg2-draft/coords.html#TermUserUnits
     if (stroke_width->is_numeric())
         computed_values.set_stroke_width(CSS::Length::make_px(stroke_width->to_number()));
-    else
+    else if (stroke_width->is_length())
         computed_values.set_stroke_width(stroke_width->to_length());
+    else if (stroke_width->is_percentage())
+        computed_values.set_stroke_width(CSS::LengthPercentage { stroke_width->as_percentage().percentage() });
 
     computed_values.set_fill_opacity(computed_style.fill_opacity());
     computed_values.set_stroke_opacity(computed_style.stroke_opacity());


### PR DESCRIPTION
Fixes a crash when loading https://vercel.com/