### PR TITLE
LibWeb+LibJS: Don't lazily construct web prototypes in cell constructors

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -187,6 +187,8 @@ public:
     template<typename T>
     bool fast_is() const = delete;
 
+    void set_prototype(Object*);
+
 protected:
     enum class GlobalObjectTag { Tag };
     enum class ConstructWithoutPrototypeTag { Tag };
@@ -197,8 +199,6 @@ protected:
     Object(Realm&, Object* prototype);
     Object(ConstructWithPrototypeTag, Object& prototype);
     explicit Object(Shape&);
-
-    void set_prototype(Object*);
 
     // [[Extensible]]
     bool m_is_extensible { true };

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -16,8 +16,15 @@
 namespace Web::CSS {
 
 CSSStyleDeclaration::CSSStyleDeclaration(JS::Realm& realm)
-    : PlatformObject(Bindings::ensure_web_prototype<Bindings::CSSStyleDeclarationPrototype>(realm, "CSSStyleDeclaration"))
+    : PlatformObject(realm)
 {
+}
+
+JS::ThrowCompletionOr<void> CSSStyleDeclaration::initialize(JS::Realm& realm)
+{
+    MUST_OR_THROW_OOM(Base::initialize(realm));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::CSSStyleDeclarationPrototype>(realm, "CSSStyleDeclaration"));
+    return {};
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PropertyOwningCSSStyleDeclaration>> PropertyOwningCSSStyleDeclaration::create(JS::Realm& realm, Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties)

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -19,6 +19,7 @@ class CSSStyleDeclaration : public Bindings::PlatformObject {
 
 public:
     virtual ~CSSStyleDeclaration() = default;
+    virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
     virtual size_t length() const = 0;
     virtual DeprecatedString item(size_t index) const = 0;


### PR DESCRIPTION
It's not safe to allocate from the GC heap while in the constructor of a GC heap cell. (Because if this ends up triggering a collection, we may end up trying to call through an uninitialized vtable).

This was already done safely in the initialize() virtual in much of LibJS and LibWeb. This patch moves the logic for prototypes and mixins as well.

Fixes a long-standing GC crash that was pretty easy to reproduce by refreshing https://vercel.com/