### PR TITLE
LibWeb: Don't assume response object isn't null in fetch abort algorithm

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
@@ -143,7 +143,7 @@ JS::NonnullGCPtr<JS::Promise> fetch(JS::VM& vm, RequestInfo const& input, Reques
 
         auto& promise_capability = *promise_capability_handle;
         auto& request_object = *request_object_handle;
-        auto& response_object = *response_object_handle;
+        JS::GCPtr<Response> response_object = response_object_handle.ptr();
 
         // 1. Set locallyAborted to true.
         locally_aborted->set_value(true);


### PR DESCRIPTION
The callee that we're passing it to expects a GCPtr anyway, so there's no need to explicitly dereference this.

Fixes a crash when loading https://spotify.com/