### PR TITLE
Browser: Implent the ARIA Role Model

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/CMakeLists.txt
@@ -6,5 +6,6 @@ lagom_tool(GenerateCSSPropertyID           SOURCES GenerateCSSPropertyID.cpp LIB
 lagom_tool(GenerateCSSTransformFunctions   SOURCES GenerateCSSTransformFunctions.cpp LIBS LibMain)
 lagom_tool(GenerateCSSValueID              SOURCES GenerateCSSValueID.cpp LIBS LibMain)
 lagom_tool(GenerateWindowOrWorkerInterfaces SOURCES GenerateWindowOrWorkerInterfaces.cpp LIBS LibMain LibIDL)
+lagom_tool(GenerateAriaRoles                SOURCES GenerateAriaRoles.cpp LIBS LibMain)
 
 add_subdirectory(BindingsGenerator)

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateAriaRoles.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateAriaRoles.cpp
@@ -1,0 +1,398 @@
+/*
+ * Copyright (c) 2023, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GeneratorUtil.h"
+#include <AK/SourceGenerator.h>
+#include <AK/String.h>
+#include <LibCore/ArgsParser.h>
+#include <LibMain/Main.h>
+
+ErrorOr<void> generate_header_file(JsonObject& roles_data, Core::File& file);
+ErrorOr<void> generate_implementation_file(JsonObject& roles_data, Core::File& file);
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    StringView generated_header_path;
+    StringView generated_implementation_path;
+    StringView identifiers_json_path;
+
+    Core::ArgsParser args_parser;
+    args_parser.add_option(generated_header_path, "Path to the TransformFunctions header file to generate", "generated-header-path", 'h', "generated-header-path");
+    args_parser.add_option(generated_implementation_path, "Path to the TransformFunctions implementation file to generate", "generated-implementation-path", 'c', "generated-implementation-path");
+    args_parser.add_option(identifiers_json_path, "Path to the JSON file to read from", "json-path", 'j', "json-path");
+    args_parser.parse(arguments);
+
+    auto json = TRY(read_entire_file_as_json(identifiers_json_path));
+    VERIFY(json.is_object());
+    auto roles_data = json.as_object();
+
+    auto generated_header_file = TRY(Core::File::open(generated_header_path, Core::File::OpenMode::Write));
+    auto generated_implementation_file = TRY(Core::File::open(generated_implementation_path, Core::File::OpenMode::Write));
+
+    TRY(generate_header_file(roles_data, *generated_header_file));
+    TRY(generate_implementation_file(roles_data, *generated_implementation_file));
+
+    return 0;
+}
+
+ErrorOr<void> generate_header_file(JsonObject& roles_data, Core::File& file)
+{
+    StringBuilder builder;
+    SourceGenerator generator { builder };
+
+    generator.append(R"~~~(
+#pragma once
+
+#include <LibWeb/ARIA/RoleType.h>
+
+namespace Web::ARIA {
+)~~~");
+
+    TRY(roles_data.try_for_each_member([&](auto& name, auto& value) -> ErrorOr<void> {
+        VERIFY(value.is_object());
+        JsonObject const& value_object = value.as_object();
+
+        auto class_definition_generator = TRY(generator.fork());
+        class_definition_generator.set("spec_link"sv, value_object.get_deprecated_string("specLink"sv).value());
+        class_definition_generator.set("description"sv, value_object.get_deprecated_string("description"sv).value());
+        class_definition_generator.set("name"sv, name);
+        class_definition_generator.append(R"~~~(
+// @spec_link@
+// @description@
+class @name@ :
+)~~~");
+
+        JsonArray const& super_classes = value_object.get_array("superClassRoles"sv).value();
+        bool first = true;
+        TRY(super_classes.try_for_each([&](JsonValue const& value) -> ErrorOr<void> {
+            VERIFY(value.is_string());
+
+            class_definition_generator.append(first ? " "sv : ", "sv);
+            class_definition_generator.append(TRY(String::formatted("public {}", value.as_string())));
+            first = false;
+            return {};
+        }));
+
+        class_definition_generator.append(R"~~~(
+{
+public:
+    @name@(AriaData const&);
+
+    virtual HashTable<StateAndProperties> const& supported_states() const override;
+    virtual HashTable<StateAndProperties> const& supported_properties() const override;
+
+    virtual HashTable<StateAndProperties> const& required_states() const override;
+    virtual HashTable<StateAndProperties> const& required_properties() const override;
+
+    virtual HashTable<StateAndProperties> const& prohibited_properties() const override;
+    virtual HashTable<StateAndProperties> const& prohibited_states() const override;
+
+    virtual HashTable<Role> const& required_context_roles() const override;
+    virtual HashTable<Role> const& required_owned_elements() const override;
+    virtual bool accessible_name_required() const override;
+    virtual bool children_are_presentational() const override;
+    virtual DefaultValueType default_value_for_property_or_state(StateAndProperties) const override;
+protected:
+    @name@();
+)~~~");
+
+        auto name_from_source = value.as_object().get("nameFromSource"sv).value();
+        if (!name_from_source.is_null())
+            class_definition_generator.append(R"~~~(
+public:
+    virtual NameFromSource name_from_source() const override;
+)~~~");
+        class_definition_generator.appendln("};");
+        return {};
+    }));
+
+    generator.appendln("}");
+
+    TRY(file.write_until_depleted((generator.as_string_view().bytes())));
+    return {};
+}
+
+ErrorOr<String> generate_hash_table_population(JsonArray const& values, StringView hash_table_name, StringView enum_class)
+{
+    StringBuilder builder;
+    TRY(values.try_for_each([&](auto& value) -> ErrorOr<void> {
+        VERIFY(value.is_string());
+        TRY(builder.try_appendff("        {}.set({}::{});\n", hash_table_name, enum_class, value.as_string()));
+        return {};
+    }));
+
+    return builder.to_string();
+}
+
+ErrorOr<void> generate_hash_table_member(SourceGenerator& generator, StringView member_name, StringView hash_table_name, StringView enum_class, JsonArray const& values)
+{
+    auto member_generator = TRY(generator.fork());
+    member_generator.set("member_name"sv, member_name);
+    member_generator.set("hash_table_name"sv, hash_table_name);
+    member_generator.set("enum_class"sv, enum_class);
+    TRY(member_generator.set("hash_table_size"sv, TRY(String::number(values.size()))));
+
+    if (values.size() == 0) {
+        member_generator.append(R"~~~(
+HashTable<@enum_class@> const& @name@::@member_name@() const
+{
+    static HashTable<@enum_class@> @hash_table_name@;
+    return @hash_table_name@;
+}
+)~~~");
+        return {};
+    }
+
+    member_generator.append(R"~~~(
+HashTable<@enum_class@> const& @name@::@member_name@() const
+{
+    static HashTable<@enum_class@> @hash_table_name@;
+    if (@hash_table_name@.is_empty()) {
+        @hash_table_name@.ensure_capacity(@hash_table_size@);
+)~~~");
+    member_generator.append(TRY(generate_hash_table_population(values, hash_table_name, enum_class)));
+    member_generator.append(R"~~~(
+    }
+    return @hash_table_name@;
+}
+)~~~");
+
+    return {};
+}
+
+StringView aria_name_to_enum_name(StringView name)
+{
+    if (name == "aria-activedescendant"sv) {
+        return "AriaActiveDescendant"sv;
+    } else if (name == "aria-atomic"sv) {
+        return "AriaAtomic"sv;
+    } else if (name == "aria-autocomplete"sv) {
+        return "AriaAutoComplete"sv;
+    } else if (name == "aria-busy"sv) {
+        return "AriaBusy"sv;
+    } else if (name == "aria-checked"sv) {
+        return "AriaChecked"sv;
+    } else if (name == "aria-colcount"sv) {
+        return "AriaColCount"sv;
+    } else if (name == "aria-colindex"sv) {
+        return "AriaColIndex"sv;
+    } else if (name == "aria-colspan"sv) {
+        return "AriaColSpan"sv;
+    } else if (name == "aria-controls"sv) {
+        return "AriaControls"sv;
+    } else if (name == "aria-current"sv) {
+        return "AriaCurrent"sv;
+    } else if (name == "aria-describedby"sv) {
+        return "AriaDescribedBy"sv;
+    } else if (name == "aria-details"sv) {
+        return "AriaDetails"sv;
+    } else if (name == "aria-disabled"sv) {
+        return "AriaDisabled"sv;
+    } else if (name == "aria-dropeffect"sv) {
+        return "AriaDropEffect"sv;
+    } else if (name == "aria-errormessage"sv) {
+        return "AriaErrorMessage"sv;
+    } else if (name == "aria-expanded"sv) {
+        return "AriaExpanded"sv;
+    } else if (name == "aria-flowto"sv) {
+        return "AriaFlowTo"sv;
+    } else if (name == "aria-grabbed"sv) {
+        return "AriaGrabbed"sv;
+    } else if (name == "aria-haspopup"sv) {
+        return "AriaHasPopup"sv;
+    } else if (name == "aria-hidden"sv) {
+        return "AriaHidden"sv;
+    } else if (name == "aria-invalid"sv) {
+        return "AriaInvalid"sv;
+    } else if (name == "aria-keyshortcuts"sv) {
+        return "AriaKeyShortcuts"sv;
+    } else if (name == "aria-label"sv) {
+        return "AriaLabel"sv;
+    } else if (name == "aria-labelledby"sv) {
+        return "AriaLabelledBy"sv;
+    } else if (name == "aria-level"sv) {
+        return "AriaLevel"sv;
+    } else if (name == "aria-live"sv) {
+        return "AriaLive"sv;
+    } else if (name == "aria-modal"sv) {
+        return "AriaModal"sv;
+    } else if (name == "aria-multiline"sv) {
+        return "AriaMultiLine"sv;
+    } else if (name == "aria-multiselectable"sv) {
+        return "AriaMultiSelectable"sv;
+    } else if (name == "aria-orientation"sv) {
+        return "AriaOrientation"sv;
+    } else if (name == "aria-owns"sv) {
+        return "AriaOwns"sv;
+    } else if (name == "aria-placeholder"sv) {
+        return "AriaPlaceholder"sv;
+    } else if (name == "aria-posinset"sv) {
+        return "AriaPosInSet"sv;
+    } else if (name == "aria-pressed"sv) {
+        return "AriaPressed"sv;
+    } else if (name == "aria-readonly"sv) {
+        return "AriaReadOnly"sv;
+    } else if (name == "aria-relevant"sv) {
+        return "AriaRelevant"sv;
+    } else if (name == "aria-required"sv) {
+        return "AriaRequired"sv;
+    } else if (name == "aria-roledescription"sv) {
+        return "AriaRoleDescription"sv;
+    } else if (name == "aria-rowcount"sv) {
+        return "AriaRowCount"sv;
+    } else if (name == "aria-rowindex"sv) {
+        return "AriaRowIndex"sv;
+    } else if (name == "aria-rowspan"sv) {
+        return "AriaRowSpan"sv;
+    } else if (name == "aria-selected"sv) {
+        return "AriaSelected"sv;
+    } else if (name == "aria-setsize"sv) {
+        return "AriaSetSize"sv;
+    } else if (name == "aria-sort"sv) {
+        return "AriaSort"sv;
+    } else if (name == "aria-valuemax"sv) {
+        return "AriaValueMax"sv;
+    } else if (name == "aria-valuemin"sv) {
+        return "AriaValueMin"sv;
+    } else if (name == "aria-valuenow"sv) {
+        return "AriaValueNow"sv;
+    } else if (name == "aria-valuetext"sv) {
+        return "AriaValueText"sv;
+    } else {
+        VERIFY_NOT_REACHED();
+    }
+}
+
+ErrorOr<JsonArray> translate_aria_names_to_enum(JsonArray const& names)
+{
+    JsonArray translated_names;
+    TRY(names.try_for_each([&](JsonValue const& value) -> ErrorOr<void> {
+        VERIFY(value.is_string());
+        auto name = value.as_string();
+        TRY(translated_names.append(aria_name_to_enum_name(name)));
+        return {};
+    }));
+    return translated_names;
+}
+
+ErrorOr<void> generate_implementation_file(JsonObject& roles_data, Core::File& file)
+{
+    StringBuilder builder;
+    SourceGenerator generator { builder };
+
+    generator.append(R"~~~(
+#include <LibWeb/ARIA/AriaRoles.h>
+
+namespace Web::ARIA {
+)~~~");
+
+    TRY(roles_data.try_for_each_member([&](auto& name, auto& value) -> ErrorOr<void> {
+        VERIFY(value.is_object());
+
+        auto member_generator = TRY(generator.fork());
+        member_generator.set("name"sv, name);
+
+        JsonObject const& value_object = value.as_object();
+
+        JsonArray const& supported_states = TRY(translate_aria_names_to_enum(value_object.get_array("supportedStates"sv).value()));
+        TRY(generate_hash_table_member(member_generator, "supported_states"sv, "states"sv, "StateAndProperties"sv, supported_states));
+        JsonArray const& supported_properties = TRY(translate_aria_names_to_enum(value_object.get_array("supportedProperties"sv).value()));
+        TRY(generate_hash_table_member(member_generator, "supported_properties"sv, "properties"sv, "StateAndProperties"sv, supported_properties));
+
+        JsonArray const& required_states = TRY(translate_aria_names_to_enum(value_object.get_array("requiredStates"sv).value()));
+        TRY(generate_hash_table_member(member_generator, "required_states"sv, "states"sv, "StateAndProperties"sv, required_states));
+        JsonArray const& required_properties = TRY(translate_aria_names_to_enum(value_object.get_array("requiredProperties"sv).value()));
+        TRY(generate_hash_table_member(member_generator, "required_properties"sv, "properties"sv, "StateAndProperties"sv, required_properties));
+
+        JsonArray const& prohibited_states = TRY(translate_aria_names_to_enum(value_object.get_array("prohibitedStates"sv).value()));
+        TRY(generate_hash_table_member(member_generator, "prohibited_states"sv, "states"sv, "StateAndProperties"sv, prohibited_states));
+        JsonArray const& prohibited_properties = TRY(translate_aria_names_to_enum(value_object.get_array("prohibitedProperties"sv).value()));
+        TRY(generate_hash_table_member(member_generator, "prohibited_properties"sv, "properties"sv, "StateAndProperties"sv, prohibited_properties));
+
+        JsonArray const& required_context_roles = value_object.get_array("requiredContextRoles"sv).value();
+        TRY(generate_hash_table_member(member_generator, "required_context_roles"sv, "roles"sv, "Role"sv, required_context_roles));
+        JsonArray const& required_owned_elements = value_object.get_array("requiredOwnedElements"sv).value();
+        TRY(generate_hash_table_member(member_generator, "required_owned_elements"sv, "roles"sv, "Role"sv, required_owned_elements));
+
+        bool accessible_name_required = value_object.get_bool("accessibleNameRequired"sv).value();
+        member_generator.set("accessible_name_required"sv, accessible_name_required ? "true"sv : "false"sv);
+        bool children_are_presentational = value_object.get_bool("childrenArePresentational"sv).value();
+        member_generator.set("children_are_presentational", children_are_presentational ? "true"sv : "false"sv);
+
+        JsonArray const& super_classes = value.as_object().get_array("superClassRoles"sv).value();
+        member_generator.set("parent", super_classes.at(0).as_string());
+
+        member_generator.append(R"~~~(
+@name@::@name@() { }
+
+@name@::@name@(AriaData const& data)
+    : @parent@(data)
+{
+}
+
+bool @name@::accessible_name_required() const
+{
+    return @accessible_name_required@;
+}
+
+bool @name@::children_are_presentational() const
+{
+    return @children_are_presentational@;
+}
+)~~~");
+
+        JsonObject const& implicit_value_for_role = value_object.get_object("implicitValueForRole"sv).value();
+        if (implicit_value_for_role.size() == 0) {
+            member_generator.append(R"~~~(
+DefaultValueType @name@::default_value_for_property_or_state(StateAndProperties) const
+{
+    return {};
+}
+)~~~");
+        } else {
+            member_generator.append(R"~~~(
+DefaultValueType @name@::default_value_for_property_or_state(StateAndProperties state_or_property) const
+{
+    switch (state_or_property) {
+)~~~");
+            TRY(implicit_value_for_role.try_for_each_member([&](auto& name, auto& value) -> ErrorOr<void> {
+                auto case_generator = TRY(member_generator.fork());
+                VERIFY(value.is_string());
+                case_generator.set("state_or_property"sv, aria_name_to_enum_name(name));
+                case_generator.set("implicit_value"sv, value.as_string());
+                case_generator.append(R"~~~(
+    case StateAndProperties::@state_or_property@:
+        return @implicit_value@;
+)~~~");
+                return {};
+            }));
+            member_generator.append(R"~~~(
+    default:
+        return {};
+    }
+}
+)~~~");
+        }
+
+        JsonValue const& name_from_source = value.as_object().get("nameFromSource"sv).value();
+        if (!name_from_source.is_null()) {
+            member_generator.set("name_from_source"sv, name_from_source.as_string());
+            member_generator.append(R"~~~(
+NameFromSource @name@::name_from_source() const
+{
+    return NameFromSource::@name_from_source@;
+}
+)~~~");
+        }
+
+        return {};
+    }));
+
+    generator.append("}");
+
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
+    return {};
+}

--- a/Userland/Applications/Browser/InspectorWidget.h
+++ b/Userland/Applications/Browser/InspectorWidget.h
@@ -44,7 +44,7 @@ public:
     void set_web_view(NonnullRefPtr<WebView::OutOfProcessWebView> web_view) { m_web_view = web_view; }
     void set_dom_json(StringView);
     void clear_dom_json();
-    void set_dom_node_properties_json(Selection, StringView computed_values_json, StringView resolved_values_json, StringView custom_properties_json, StringView node_box_sizing_json);
+    void set_dom_node_properties_json(Selection, StringView computed_values_json, StringView resolved_values_json, StringView custom_properties_json, StringView node_box_sizing_json, StringView aria_properties_state_json);
     void set_accessibility_json(StringView);
 
     void set_selection(Selection);
@@ -56,6 +56,7 @@ private:
     void set_selection(GUI::ModelIndex);
     void load_style_json(StringView computed_values_json, StringView resolved_values_json, StringView custom_properties_json);
     void update_node_box_model(StringView node_box_sizing_json);
+    void update_aria_properties_state_model(StringView aria_properties_state_json);
     void clear_style_json();
     void clear_node_box_model();
 
@@ -66,6 +67,7 @@ private:
     RefPtr<GUI::TableView> m_computed_style_table_view;
     RefPtr<GUI::TableView> m_resolved_style_table_view;
     RefPtr<GUI::TableView> m_custom_properties_table_view;
+    RefPtr<GUI::TableView> m_aria_properties_state_view;
     RefPtr<ElementSizePreviewWidget> m_element_size_view;
 
     Web::Layout::BoxModelMetrics m_node_box_sizing;

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -519,8 +519,8 @@ Tab::Tab(BrowserWindow& window)
             m_dom_inspector_widget->set_dom_json(dom_tree);
     };
 
-    view().on_get_dom_node_properties = [this](auto node_id, auto& specified, auto& computed, auto& custom_properties, auto& node_box_sizing) {
-        m_dom_inspector_widget->set_dom_node_properties_json({ node_id }, specified, computed, custom_properties, node_box_sizing);
+    view().on_get_dom_node_properties = [this](auto node_id, auto& specified, auto& computed, auto& custom_properties, auto& node_box_sizing, auto& aria_properties_state) {
+        m_dom_inspector_widget->set_dom_node_properties_json({ node_id }, specified, computed, custom_properties, node_box_sizing, aria_properties_state);
     };
 
     view().on_get_accessibility_tree = [this](auto& accessibility_tree) {
@@ -821,7 +821,7 @@ void Tab::show_inspector_window(Browser::Tab::InspectorTarget inspector_target)
     if (!m_dom_inspector_widget) {
         auto window = GUI::Window::construct(&this->window());
         window->set_window_mode(GUI::WindowMode::Modeless);
-        window->resize(300, 500);
+        window->resize(325, 500);
         window->set_title("Inspector");
         window->set_icon(g_icon_bag.inspector_object);
         window->on_close = [&]() {

--- a/Userland/Libraries/LibWeb/ARIA/ARIAMixin.cpp
+++ b/Userland/Libraries/LibWeb/ARIA/ARIAMixin.cpp
@@ -61,4 +61,22 @@ bool ARIAMixin::has_global_aria_attribute() const
         || !aria_role_description().is_null();
 }
 
+Optional<DeprecatedString> ARIAMixin::parse_id_reference(DeprecatedString const& id_reference) const
+{
+    if (id_reference_exists(id_reference))
+        return id_reference;
+    return {};
+}
+
+Vector<DeprecatedString> ARIAMixin::parse_id_reference_list(DeprecatedString const& id_list) const
+{
+    Vector<DeprecatedString> result;
+    auto id_references = id_list.split_view(Infra::is_ascii_whitespace);
+    for (auto const id_reference : id_references) {
+        if (id_reference_exists(id_reference))
+            result.append(id_reference);
+    }
+    return result;
+}
+
 }

--- a/Userland/Libraries/LibWeb/ARIA/ARIAMixin.h
+++ b/Userland/Libraries/LibWeb/ARIA/ARIAMixin.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
-#include <AK/Forward.h>
+#include <AK/DeprecatedString.h>
+#include <AK/Vector.h>
+#include <LibWeb/ARIA/AriaData.h>
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -22,16 +24,22 @@ public:
 
     virtual DeprecatedString aria_active_descendant() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_active_descendant(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_atomic() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_atomic(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_auto_complete() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_auto_complete(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_busy() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_busy(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_checked() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_checked(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_col_count() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_col_count(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_col_index() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_col_index(DeprecatedString const&) = 0;
 
@@ -46,32 +54,40 @@ public:
 
     virtual DeprecatedString aria_described_by() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_described_by(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_details() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_details(DeprecatedString const&) = 0;
-    virtual DeprecatedString aria_drop_effect() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_drop_effect(DeprecatedString const&) = 0;
-    virtual DeprecatedString aria_error_message() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_error_message(DeprecatedString const&) = 0;
 
     virtual DeprecatedString aria_disabled() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_disabled(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_drop_effect() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_drop_effect(DeprecatedString const&) = 0;
+
+    virtual DeprecatedString aria_error_message() const = 0;
+    virtual WebIDL::ExceptionOr<void> set_aria_error_message(DeprecatedString const&) = 0;
 
     virtual DeprecatedString aria_expanded() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_expanded(DeprecatedString const&) = 0;
 
     virtual DeprecatedString aria_flow_to() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_flow_to(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_grabbed() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_grabbed(DeprecatedString const&) = 0;
 
     virtual DeprecatedString aria_has_popup() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_has_popup(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_hidden() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_hidden(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_invalid() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_invalid(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_key_shortcuts() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_key_shortcuts(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_label() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_label(DeprecatedString const&) = 0;
 
@@ -80,14 +96,19 @@ public:
 
     virtual DeprecatedString aria_level() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_level(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_live() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_live(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_modal() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_modal(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_multi_line() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_multi_line(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_multi_selectable() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_multi_selectable(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_orientation() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_orientation(DeprecatedString const&) = 0;
 
@@ -96,10 +117,13 @@ public:
 
     virtual DeprecatedString aria_placeholder() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_placeholder(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_pos_in_set() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_pos_in_set(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_pressed() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_pressed(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_read_only() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_read_only(DeprecatedString const&) = 0;
 
@@ -108,27 +132,37 @@ public:
 
     virtual DeprecatedString aria_required() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_required(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_role_description() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_role_description(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_row_count() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_row_count(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_row_index() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_row_index(DeprecatedString const&) = 0;
 
     virtual DeprecatedString aria_row_span() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_row_span(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_selected() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_selected(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_set_size() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_set_size(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_sort() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_sort(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_value_max() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_value_max(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_value_min() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_value_min(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_value_now() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_value_now(DeprecatedString const&) = 0;
+
     virtual DeprecatedString aria_value_text() const = 0;
     virtual WebIDL::ExceptionOr<void> set_aria_value_text(DeprecatedString const&) = 0;
 
@@ -145,8 +179,16 @@ public:
 
     bool has_global_aria_attribute() const;
 
+    // https://www.w3.org/TR/wai-aria-1.2/#valuetype_idref
+    Optional<DeprecatedString> parse_id_reference(DeprecatedString const&) const;
+
+    // https://www.w3.org/TR/wai-aria-1.2/#valuetype_idref_list
+    Vector<DeprecatedString> parse_id_reference_list(DeprecatedString const&) const;
+
 protected:
     ARIAMixin() = default;
+
+    virtual bool id_reference_exists(DeprecatedString const&) const = 0;
 };
 
 }

--- a/Userland/Libraries/LibWeb/ARIA/AriaData.cpp
+++ b/Userland/Libraries/LibWeb/ARIA/AriaData.cpp
@@ -1,0 +1,529 @@
+/*
+ * Copyright (c) 2023, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/ARIA/AriaData.h>
+#include <LibWeb/Infra/CharacterTypes.h>
+
+namespace Web::ARIA {
+
+AriaData::AriaData(Web::ARIA::ARIAMixin const& source)
+{
+    m_aria_active_descendant = source.aria_active_descendant();
+    m_aria_atomic = AriaData::parse_optional_true_false(source.aria_atomic());
+    m_aria_auto_complete = AriaData::parse_aria_autocomplete(source.aria_auto_complete());
+    m_aria_busy = AriaData::parse_true_false(source.aria_busy());
+    m_aria_checked = AriaData::parse_tristate(source.aria_checked());
+    m_aria_col_count = AriaData::parse_integer(source.aria_col_count());
+    m_aria_col_index = AriaData::parse_integer(source.aria_col_index());
+    m_aria_col_span = AriaData::parse_integer(source.aria_col_span());
+    m_aria_controls = source.parse_id_reference_list(source.aria_controls());
+    m_aria_current = AriaData::parse_aria_current(source.aria_current());
+    m_aria_described_by = source.parse_id_reference_list(source.aria_described_by());
+    m_aria_details = source.parse_id_reference(source.aria_details());
+    m_aria_disabled = AriaData::parse_true_false(source.aria_disabled());
+    m_aria_drop_effect = AriaData::parse_aria_drop_effect(source.aria_drop_effect());
+    m_aria_error_message = source.parse_id_reference(source.aria_error_message());
+    m_aria_expanded = AriaData::parse_true_false_undefined(source.aria_expanded());
+    m_aria_flow_to = source.parse_id_reference_list(source.aria_flow_to());
+    m_aria_grabbed = AriaData::parse_true_false_undefined(source.aria_grabbed());
+    m_aria_has_popup = AriaData::parse_aria_has_popup(source.aria_has_popup());
+    m_aria_hidden = AriaData::parse_true_false_undefined(source.aria_hidden());
+    m_aria_invalid = AriaData::parse_aria_invalid(source.aria_invalid());
+    m_aria_key_shortcuts = source.aria_key_shortcuts();
+    m_aria_label = source.aria_label();
+    m_aria_labelled_by = source.parse_id_reference_list(source.aria_labelled_by());
+    m_aria_level = AriaData::parse_integer(source.aria_level());
+    m_aria_live = AriaData::parse_aria_live(source.aria_live());
+    m_aria_modal = AriaData::parse_true_false(source.aria_modal());
+    m_aria_multi_line = AriaData::parse_true_false(source.aria_multi_line());
+    m_aria_multi_selectable = AriaData::parse_true_false(source.aria_multi_selectable());
+    m_aria_orientation = AriaData::parse_aria_orientation(source.aria_orientation());
+    m_aria_owns = source.parse_id_reference_list(source.aria_owns());
+    m_aria_placeholder = source.aria_placeholder();
+    m_aria_pos_in_set = AriaData::parse_integer(source.aria_pos_in_set());
+    m_aria_pressed = AriaData::parse_tristate(source.aria_pressed());
+    m_aria_read_only = AriaData::parse_true_false(source.aria_read_only());
+    m_aria_relevant = AriaData::parse_aria_relevant(source.aria_relevant());
+    m_aria_required = AriaData::parse_true_false(source.aria_required());
+    m_aria_role_description = source.aria_role_description();
+    m_aria_row_count = AriaData::parse_integer(source.aria_row_count());
+    m_aria_row_index = AriaData::parse_integer(source.aria_row_index());
+    m_aria_row_span = AriaData::parse_integer(source.aria_row_span());
+    m_aria_selected = AriaData::parse_true_false_undefined(source.aria_selected());
+    m_aria_set_size = AriaData::parse_integer(source.aria_set_size());
+    m_aria_sort = AriaData::parse_aria_sort(source.aria_sort());
+    m_aria_value_max = AriaData::parse_number(source.aria_value_max());
+    m_aria_value_min = AriaData::parse_number(source.aria_value_min());
+    m_aria_value_now = AriaData::parse_number(source.aria_value_now());
+    m_aria_value_text = source.aria_value_text();
+}
+
+bool AriaData::parse_true_false(StringView value)
+{
+    if (value == "true"sv)
+        return true;
+    if (value == "false"sv)
+        return false;
+    return false;
+}
+
+Tristate AriaData::parse_tristate(StringView value)
+{
+    if (value == "true"sv)
+        return Tristate::True;
+    if (value == "false"sv)
+        return Tristate::False;
+    if (value == "mixed"sv)
+        return Tristate::Mixed;
+    if (value == "undefined"sv)
+        return Tristate::Undefined;
+    return Tristate::Undefined;
+}
+
+Optional<bool> AriaData::parse_true_false_undefined(StringView value)
+{
+    if (value == "true"sv)
+        return true;
+    if (value == "false"sv)
+        return false;
+    if (value == "undefined"sv)
+        return {};
+    return {};
+}
+
+Optional<i32> AriaData::parse_integer(StringView value)
+{
+    return value.to_int();
+}
+
+Optional<f64> AriaData::parse_number(StringView value)
+{
+    return value.to_double(TrimWhitespace::Yes);
+}
+
+Optional<DeprecatedString> AriaData::aria_active_descendant_or_default() const
+{
+    return m_aria_active_descendant;
+}
+
+bool AriaData::aria_atomic_or_default(bool default_value) const
+{
+    auto value = m_aria_atomic;
+    if (!value.has_value())
+        return default_value;
+    return value.value();
+}
+
+AriaAutocomplete AriaData::aria_auto_complete_or_default() const
+{
+    return m_aria_auto_complete;
+}
+
+bool AriaData::aria_busy_or_default() const
+{
+    return m_aria_busy;
+}
+
+Tristate AriaData::aria_checked_or_default() const
+{
+    return m_aria_checked;
+}
+
+Optional<i32> AriaData::aria_col_count_or_default() const
+{
+    return m_aria_col_count;
+}
+
+Optional<i32> AriaData::aria_col_index_or_default() const
+{
+    return m_aria_col_index;
+}
+
+Optional<i32> AriaData::aria_col_span_or_default() const
+{
+    return m_aria_col_span;
+}
+
+Vector<DeprecatedString> AriaData::aria_controls_or_default() const
+{
+    return m_aria_controls;
+}
+
+AriaCurrent AriaData::aria_current_or_default() const
+{
+    return m_aria_current;
+}
+
+Vector<DeprecatedString> AriaData::aria_described_by_or_default() const
+{
+    return m_aria_described_by;
+}
+
+Optional<DeprecatedString> AriaData::aria_details_or_default() const
+{
+    return m_aria_details;
+}
+
+bool AriaData::aria_disabled_or_default() const
+{
+    return m_aria_disabled;
+}
+
+Vector<AriaDropEffect> AriaData::aria_drop_effect_or_default() const
+{
+    return m_aria_drop_effect;
+}
+
+Optional<DeprecatedString> AriaData::aria_error_message_or_default() const
+{
+    return m_aria_error_message;
+}
+
+Optional<bool> AriaData::aria_expanded_or_default() const
+{
+    return m_aria_expanded;
+}
+
+Vector<DeprecatedString> AriaData::aria_flow_to_or_default() const
+{
+    return m_aria_flow_to;
+}
+
+Optional<bool> AriaData::aria_grabbed_or_default() const
+{
+    return m_aria_grabbed;
+}
+
+AriaHasPopup AriaData::aria_has_popup_or_default() const
+{
+    return m_aria_has_popup;
+}
+
+Optional<bool> AriaData::aria_hidden_or_default() const
+{
+    return m_aria_hidden;
+}
+
+AriaInvalid AriaData::aria_invalid_or_default() const
+{
+    return m_aria_invalid;
+}
+
+DeprecatedString AriaData::aria_key_shortcuts_or_default() const
+{
+    return m_aria_key_shortcuts;
+}
+
+DeprecatedString AriaData::aria_label_or_default() const
+{
+    return m_aria_label;
+}
+
+Vector<DeprecatedString> AriaData::aria_labelled_by_or_default() const
+{
+    return m_aria_labelled_by;
+}
+
+Optional<i32> AriaData::aria_level_or_default() const
+{
+    return m_aria_level;
+}
+
+AriaLive AriaData::aria_live_or_default(AriaLive default_value) const
+{
+    auto value = m_aria_live;
+    if (!value.has_value())
+        return default_value;
+
+    return value.value();
+}
+
+bool AriaData::aria_modal_or_default() const
+{
+    return m_aria_modal;
+}
+
+bool AriaData::aria_multi_line_or_default() const
+{
+    return m_aria_multi_line;
+}
+
+bool AriaData::aria_multi_selectable_or_default() const
+{
+    return m_aria_multi_selectable;
+}
+
+AriaOrientation AriaData::aria_orientation_or_default(AriaOrientation default_value) const
+{
+    auto value = m_aria_orientation;
+    if (!value.has_value())
+        return default_value;
+
+    return value.value();
+}
+
+Vector<DeprecatedString> AriaData::aria_owns_or_default() const
+{
+    return m_aria_owns;
+}
+
+DeprecatedString AriaData::aria_placeholder_or_default() const
+{
+    return m_aria_placeholder;
+}
+
+Optional<i32> AriaData::aria_pos_in_set_or_default() const
+{
+    return m_aria_pos_in_set;
+}
+
+Tristate AriaData::aria_pressed_or_default() const
+{
+    return m_aria_pressed;
+}
+
+bool AriaData::aria_read_only_or_default() const
+{
+    return m_aria_read_only;
+}
+
+Vector<AriaRelevant> AriaData::aria_relevant_or_default() const
+{
+    return m_aria_relevant;
+}
+
+bool AriaData::aria_required_or_default() const
+{
+    return m_aria_required;
+}
+
+DeprecatedString AriaData::aria_role_description_or_default() const
+{
+    return m_aria_role_description;
+}
+
+Optional<i32> AriaData::aria_row_count_or_default() const
+{
+    return m_aria_row_count;
+}
+
+Optional<i32> AriaData::aria_row_index_or_default() const
+{
+    return m_aria_row_index;
+}
+
+Optional<i32> AriaData::aria_row_span_or_default() const
+{
+    return m_aria_row_span;
+}
+
+Optional<bool> AriaData::aria_selected_or_default() const
+{
+    return m_aria_selected;
+}
+
+Optional<i32> AriaData::aria_set_size_or_default() const
+{
+    return m_aria_set_size;
+}
+
+AriaSort AriaData::aria_sort_or_default() const
+{
+    return m_aria_sort;
+}
+
+Optional<f64> AriaData::aria_value_max_or_default(Optional<f64> default_value) const
+{
+    auto value = m_aria_value_max;
+    if (!value.has_value())
+        return default_value;
+    return value;
+}
+
+Optional<f64> AriaData::aria_value_min_or_default(Optional<f64> default_value) const
+{
+    auto value = m_aria_value_min;
+    if (!value.has_value())
+        return default_value;
+    return value;
+}
+
+Optional<f64> AriaData::aria_value_now_or_default() const
+{
+    return m_aria_value_now;
+}
+
+DeprecatedString AriaData::aria_value_text_or_default() const
+{
+    return m_aria_value_text;
+}
+
+AriaAutocomplete AriaData::parse_aria_autocomplete(StringView value)
+{
+    if (value == "inline"sv)
+        return AriaAutocomplete::Inline;
+    if (value == "list"sv)
+        return AriaAutocomplete::List;
+    if (value == "both"sv)
+        return AriaAutocomplete::Both;
+    if (value == "none"sv)
+        return AriaAutocomplete::None;
+    return AriaAutocomplete::None;
+}
+
+AriaCurrent AriaData::parse_aria_current(StringView value)
+{
+    if (value == "page"sv)
+        return AriaCurrent::Page;
+    if (value == "step"sv)
+        return AriaCurrent::Step;
+    if (value == "location"sv)
+        return AriaCurrent::Location;
+    if (value == "date"sv)
+        return AriaCurrent::Date;
+    if (value == "time"sv)
+        return AriaCurrent::Time;
+    if (value == "true"sv)
+        return AriaCurrent::True;
+    if (value == "false"sv)
+        return AriaCurrent::False;
+    return AriaCurrent::False;
+}
+
+Vector<AriaDropEffect> AriaData::parse_aria_drop_effect(StringView value)
+{
+    Vector<AriaDropEffect> result;
+
+    for (auto token : value.split_view_if(Infra::is_ascii_whitespace)) {
+        if (token == "copy"sv)
+            result.append(AriaDropEffect::Copy);
+        else if (token == "execute"sv)
+            result.append(AriaDropEffect::Execute);
+        else if (token == "link"sv)
+            result.append(AriaDropEffect::Link);
+        else if (token == "move"sv)
+            result.append(AriaDropEffect::Move);
+        else if (token == "popup"sv)
+            result.append(AriaDropEffect::Popup);
+    }
+
+    // None combined with any other token value is ignored
+    if (result.is_empty())
+        result.append(AriaDropEffect::None);
+
+    return result;
+}
+
+AriaHasPopup AriaData::parse_aria_has_popup(StringView value)
+{
+    if (value == "false"sv)
+        return AriaHasPopup::False;
+    if (value == "true"sv)
+        return AriaHasPopup::True;
+    if (value == "menu"sv)
+        return AriaHasPopup::Menu;
+    if (value == "listbox"sv)
+        return AriaHasPopup::Listbox;
+    if (value == "tree"sv)
+        return AriaHasPopup::Tree;
+    if (value == "grid"sv)
+        return AriaHasPopup::Grid;
+    if (value == "dialog"sv)
+        return AriaHasPopup::Dialog;
+    return AriaHasPopup::False;
+}
+
+AriaInvalid AriaData::parse_aria_invalid(StringView value)
+{
+    if (value == "grammar"sv)
+        return AriaInvalid::Grammar;
+    if (value == "false"sv)
+        return AriaInvalid::False;
+    if (value == "spelling"sv)
+        return AriaInvalid::Spelling;
+    if (value == "true"sv)
+        return AriaInvalid::True;
+    return AriaInvalid::False;
+}
+
+Optional<AriaLive> AriaData::parse_aria_live(StringView value)
+{
+    if (value == "assertive"sv)
+        return AriaLive::Assertive;
+    if (value == "off"sv)
+        return AriaLive::Off;
+    if (value == "polite"sv)
+        return AriaLive::Polite;
+    return {};
+}
+
+Optional<AriaOrientation> AriaData::parse_aria_orientation(StringView value)
+{
+    if (value == "horizontal"sv)
+        return AriaOrientation::Horizontal;
+    if (value == "undefined"sv)
+        return AriaOrientation::Undefined;
+    if (value == "vertical"sv)
+        return AriaOrientation::Vertical;
+    return {};
+}
+
+Vector<AriaRelevant> AriaData::parse_aria_relevant(StringView value)
+{
+    Vector<AriaRelevant> result;
+    auto tokens = value.split_view_if(Infra::is_ascii_whitespace);
+    for (size_t i = 0; i < tokens.size(); i++) {
+        if (tokens[i] == "additions"sv) {
+            if (i + 1 < tokens.size()) {
+                if (tokens[i + 1] == "text"sv) {
+                    result.append(AriaRelevant::AdditionsText);
+                    ++i;
+                    continue;
+                }
+                if (tokens[i + 1] == "removals"sv && i + 2 < tokens.size() && tokens[i + 2] == "text"sv) {
+                    result.append(AriaRelevant::All);
+                    i += 2;
+                    continue;
+                }
+            }
+            result.append(AriaRelevant::Additions);
+        } else if (tokens[i] == "all"sv)
+            result.append(AriaRelevant::All);
+        else if (tokens[i] == "removals"sv)
+            result.append(AriaRelevant::Removals);
+        else if (tokens[i] == "text"sv)
+            result.append(AriaRelevant::Text);
+    }
+
+    if (result.is_empty())
+        result.append(AriaRelevant::AdditionsText);
+
+    return result;
+}
+
+AriaSort AriaData::parse_aria_sort(StringView value)
+{
+    if (value == "ascending"sv)
+        return AriaSort::Ascending;
+    if (value == "descending"sv)
+        return AriaSort::Descending;
+    if (value == "none"sv)
+        return AriaSort::None;
+    if (value == "other"sv)
+        return AriaSort::Other;
+    return AriaSort::None;
+}
+
+Optional<bool> AriaData::parse_optional_true_false(StringView value)
+{
+    if (value == "true"sv)
+        return true;
+    if (value == "false"sv)
+        return false;
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibWeb/ARIA/AriaData.h
+++ b/Userland/Libraries/LibWeb/ARIA/AriaData.h
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2023, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullOwnPtr.h>
+#include <AK/Vector.h>
+#include <LibWeb/ARIA/ARIAMixin.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::ARIA {
+
+// https://www.w3.org/TR/wai-aria-1.2/#valuetype_tristate
+enum class Tristate {
+    True,
+    False,
+    Mixed,
+    Undefined
+};
+
+// https://www.w3.org/TR/wai-aria-1.2/#aria-autocomplete
+enum class AriaAutocomplete {
+    // When a user is providing input, text suggesting one way to complete the provided input may be dynamically inserted after the caret.
+    Inline,
+    // When a user is providing input, an element containing a collection of values that could complete the provided input may be displayed.
+    List,
+    // When a user is providing input, an element containing a collection of values that could complete the provided input may be displayed.
+    // If displayed, one value in the collection is automatically selected, and the text needed to complete the automatically selected value appears after the caret in the input
+    Both,
+    // When a user is providing input, an automatic suggestion that attempts to predict how the user intends to complete the input is not displayed.
+    None
+};
+
+// https://www.w3.org/TR/wai-aria-1.2/#aria-current
+enum class AriaCurrent {
+    // Represents the current page within a set of pages.
+    Page,
+    // Represents the current step within a process.
+    Step,
+    // Represents the current location within an environment or context.
+    Location,
+    // Represents the current date within a collection of dates.
+    Date,
+    // Represents the current time within a set of times.
+    Time,
+    // Represents the current item within a set.
+    True,
+    // Does not represent the current item within a set.
+    False
+};
+
+// https://www.w3.org/TR/wai-aria-1.2/#aria-dropeffect
+enum class AriaDropEffect {
+    // A duplicate of the source object will be dropped into the target.
+    Copy,
+    // A function supported by the drop target is executed, using the drag source as an input.
+    Execute,
+    // A reference or shortcut to the dragged object will be created in the target object.
+    Link,
+    // The source object will be removed from its current location and dropped into the target.
+    Move,
+    // No operation can be performed; effectively cancels the drag operation if an attempt is made to drop on this object.
+    // Ignored if combined with any other token value. e.g., 'none copy' is equivalent to a 'copy' value.
+    None,
+    // There is a popup menu or dialog that allows the user to choose one of the drag operations (copy, move, link, execute) and any other drag functionality, such as cancel.
+    Popup
+};
+
+// https://www.w3.org/TR/wai-aria-1.2/#aria-haspopup
+enum class AriaHasPopup {
+    // Indicates the element does not have a popup.
+    False,
+    // Indicates the popup is a menu.
+    True,
+    // Indicates the popup is a menu.
+    Menu,
+    // Indicates the popup is a listbox.
+    Listbox,
+    // Indicates the popup is a tree.
+    Tree,
+    // Indicates the popup is a grid.
+    Grid,
+    // Indicates the popup is a dialog.
+    Dialog
+};
+
+// https://www.w3.org/TR/wai-aria-1.2/#aria-invalid
+enum class AriaInvalid {
+    // A grammatical error was detected.
+    Grammar,
+    // There are no detected errors in the value.
+    False,
+    // A spelling error was detected.
+    Spelling,
+    // The value entered by the user has failed validation.
+    True
+};
+
+// https://www.w3.org/TR/wai-aria-1.2/#aria-live
+enum class AriaLive {
+    // Indicates that updates to the region have the highest priority and should be presented the user immediately.
+    Assertive,
+    // Indicates that updates to the region should not be presented to the user unless the user is currently focused on that region.
+    Off,
+    // Indicates that updates to the region should be presented at the next graceful opportunity, such as at the end of speaking the current sentence or when the user pauses typing.
+    Polite
+};
+
+// https://www.w3.org/TR/wai-aria-1.2/#aria-orientation
+enum class AriaOrientation {
+    // The element is oriented horizontally.
+    Horizontal,
+    // The element's orientation is unknown/ambiguous.
+    Undefined,
+    // The element is oriented vertically.
+    Vertical
+};
+
+// https://www.w3.org/TR/wai-aria-1.2/#aria-relevant
+enum class AriaRelevant {
+    // Element nodes are added to the accessibility tree within the live region.
+    Additions,
+    // Equivalent to the combination of values, "additions text".
+    AdditionsText,
+    // Equivalent to the combination of all values, "additions removals text".
+    All,
+    // Text content, a text alternative, or an element node within the live region is removed from the accessibility tree.
+    Removals,
+    // Text content or a text alternative is added to any descendant in the accessibility tree of the live region.
+    Text
+};
+
+// https://www.w3.org/TR/wai-aria-1.2/#aria-sort
+enum class AriaSort {
+    // Items are sorted in ascending order by this column.
+    Ascending,
+    // Items are sorted in descending order by this column.
+    Descending,
+    // There is no defined sort applied to the column.
+    None,
+    // A sort algorithm other than ascending or descending has been applied.
+    Other
+};
+
+class AriaData {
+public:
+    AriaData() { }
+
+    static ErrorOr<NonnullOwnPtr<AriaData>> build_data(ARIAMixin const& mixin) { return adopt_nonnull_own_or_enomem(new (nothrow) AriaData(mixin)); }
+
+    Optional<DeprecatedString> aria_active_descendant_or_default() const;
+    bool aria_atomic_or_default(bool default_value = false) const;
+    AriaAutocomplete aria_auto_complete_or_default() const;
+    bool aria_busy_or_default() const;
+    Tristate aria_checked_or_default() const;
+    Optional<i32> aria_col_count_or_default() const;
+    Optional<i32> aria_col_index_or_default() const;
+    Optional<i32> aria_col_span_or_default() const;
+    Vector<DeprecatedString> aria_controls_or_default() const;
+    AriaCurrent aria_current_or_default() const;
+    Vector<DeprecatedString> aria_described_by_or_default() const;
+    Optional<DeprecatedString> aria_details_or_default() const;
+    bool aria_disabled_or_default() const;
+    Vector<AriaDropEffect> aria_drop_effect_or_default() const;
+    Optional<DeprecatedString> aria_error_message_or_default() const;
+    Optional<bool> aria_expanded_or_default() const;
+    Vector<DeprecatedString> aria_flow_to_or_default() const;
+    Optional<bool> aria_grabbed_or_default() const;
+    AriaHasPopup aria_has_popup_or_default() const;
+    Optional<bool> aria_hidden_or_default() const;
+    AriaInvalid aria_invalid_or_default() const;
+    DeprecatedString aria_key_shortcuts_or_default() const;
+    DeprecatedString aria_label_or_default() const;
+    Vector<DeprecatedString> aria_labelled_by_or_default() const;
+    Optional<i32> aria_level_or_default() const;
+    AriaLive aria_live_or_default(AriaLive default_value = AriaLive::Off) const;
+    bool aria_modal_or_default() const;
+    bool aria_multi_line_or_default() const;
+    bool aria_multi_selectable_or_default() const;
+    AriaOrientation aria_orientation_or_default(AriaOrientation default_value = AriaOrientation::Undefined) const;
+    Vector<DeprecatedString> aria_owns_or_default() const;
+    DeprecatedString aria_placeholder_or_default() const;
+    Optional<i32> aria_pos_in_set_or_default() const;
+    Tristate aria_pressed_or_default() const;
+    bool aria_read_only_or_default() const;
+    Vector<AriaRelevant> aria_relevant_or_default() const;
+    bool aria_required_or_default() const;
+    DeprecatedString aria_role_description_or_default() const;
+    Optional<i32> aria_row_count_or_default() const;
+    Optional<i32> aria_row_index_or_default() const;
+    Optional<i32> aria_row_span_or_default() const;
+    Optional<bool> aria_selected_or_default() const;
+    Optional<i32> aria_set_size_or_default() const;
+    AriaSort aria_sort_or_default() const;
+    Optional<f64> aria_value_max_or_default(Optional<f64> default_value = {}) const;
+    Optional<f64> aria_value_min_or_default(Optional<f64> default_value = {}) const;
+    Optional<f64> aria_value_now_or_default() const;
+    DeprecatedString aria_value_text_or_default() const;
+
+private:
+    explicit AriaData(ARIAMixin const&);
+
+    // https://www.w3.org/TR/wai-aria-1.2/#valuetype_true-false
+    // The default value for this value type is false unless otherwise specified.
+    static bool parse_true_false(StringView);
+
+    // https://www.w3.org/TR/wai-aria-1.2/#valuetype_tristate
+    // The default value for this value type is undefined unless otherwise specified.
+    static Tristate parse_tristate(StringView);
+
+    // https://www.w3.org/TR/wai-aria-1.2/#valuetype_true-false-undefined
+    // The default value for this value type is undefined unless otherwise specified.
+    static Optional<bool> parse_true_false_undefined(StringView);
+
+    // https://www.w3.org/TR/wai-aria-1.2/#valuetype_integer
+    static Optional<i32> parse_integer(StringView);
+
+    // https://www.w3.org/TR/wai-aria-1.2/#valuetype_number
+    static Optional<f64> parse_number(StringView);
+
+    static AriaAutocomplete parse_aria_autocomplete(StringView);
+    static AriaCurrent parse_aria_current(StringView);
+    static Vector<AriaDropEffect> parse_aria_drop_effect(StringView);
+    static AriaHasPopup parse_aria_has_popup(StringView);
+    static AriaInvalid parse_aria_invalid(StringView);
+    static Optional<AriaLive> parse_aria_live(StringView);
+    static Optional<AriaOrientation> parse_aria_orientation(StringView);
+    static Vector<AriaRelevant> parse_aria_relevant(StringView);
+    static AriaSort parse_aria_sort(StringView);
+    static Optional<bool> parse_optional_true_false(StringView);
+
+    Optional<DeprecatedString> m_aria_active_descendant;
+    Optional<bool> m_aria_atomic;
+    AriaAutocomplete m_aria_auto_complete;
+    bool m_aria_busy;
+    Tristate m_aria_checked;
+    Optional<i32> m_aria_col_count;
+    Optional<i32> m_aria_col_index;
+    Optional<i32> m_aria_col_span;
+    Vector<DeprecatedString> m_aria_controls;
+    AriaCurrent m_aria_current;
+    Vector<DeprecatedString> m_aria_described_by;
+    Optional<DeprecatedString> m_aria_details;
+    bool m_aria_disabled;
+    Vector<AriaDropEffect> m_aria_drop_effect;
+    Optional<DeprecatedString> m_aria_error_message;
+    Optional<bool> m_aria_expanded;
+    Vector<DeprecatedString> m_aria_flow_to;
+    Optional<bool> m_aria_grabbed;
+    AriaHasPopup m_aria_has_popup;
+    Optional<bool> m_aria_hidden;
+    AriaInvalid m_aria_invalid;
+    DeprecatedString m_aria_key_shortcuts;
+    DeprecatedString m_aria_label;
+    Vector<DeprecatedString> m_aria_labelled_by;
+    Optional<i32> m_aria_level;
+    Optional<AriaLive> m_aria_live;
+    bool m_aria_modal;
+    bool m_aria_multi_line;
+    bool m_aria_multi_selectable;
+    Optional<AriaOrientation> m_aria_orientation;
+    Vector<DeprecatedString> m_aria_owns;
+    DeprecatedString m_aria_placeholder;
+    Optional<i32> m_aria_pos_in_set;
+    Tristate m_aria_pressed;
+    bool m_aria_read_only;
+    Vector<AriaRelevant> m_aria_relevant;
+    bool m_aria_required;
+    DeprecatedString m_aria_role_description;
+    Optional<i32> m_aria_row_count;
+    Optional<i32> m_aria_row_index;
+    Optional<i32> m_aria_row_span;
+    Optional<bool> m_aria_selected;
+    Optional<i32> m_aria_set_size;
+    AriaSort m_aria_sort;
+    Optional<f64> m_aria_value_max;
+    Optional<f64> m_aria_value_min;
+    Optional<f64> m_aria_value_now;
+    DeprecatedString m_aria_value_text;
+};
+
+}

--- a/Userland/Libraries/LibWeb/ARIA/AriaRoles.json
+++ b/Userland/Libraries/LibWeb/ARIA/AriaRoles.json
@@ -1,0 +1,4165 @@
+{
+  "Structure": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#structure",
+    "description": "A document structural element.",
+    "superClassRoles": [
+      "RoleType"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": null,
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Widget": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#widget",
+    "description": "An interactive component of a graphical user interface (GUI).",
+    "superClassRoles": [
+      "RoleType"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": null,
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Window": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#window",
+    "description": "A browser or application window.",
+    "superClassRoles": [
+      "RoleType"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-modal",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Composite": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#composite",
+    "description": "A widget that may contain navigable descendants or owned children.",
+    "superClassRoles": [
+      "Widget"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Application": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#application",
+    "description": "A structure containing one or more focusable elements requiring user input, such as keyboard or gesture events, that do not follow a standard interaction pattern supported by a widget role.",
+    "superClassRoles": [
+      "Structure"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-expanded",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Document": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#document",
+    "description": "An element containing content that assistive technology users may want to browse in a reading mode.",
+    "superClassRoles": [
+      "Structure"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Generic": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#generic",
+    "description": "A nameless container element that has no semantic meaning on its own.",
+    "superClassRoles": [
+      "Structure"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [
+      "aria-label",
+      "aria-labelledby",
+      "aria-roledescription"
+    ],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Prohibited",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Presentation": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#presentation",
+    "description": "An element whose implicit native role semantics will not be mapped to the accessibility API. See synonym none.",
+    "superClassRoles": [
+      "Structure"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [
+      "aria-label",
+      "aria-labelledby"
+    ],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Prohibited",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Range": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#range",
+    "description": "An element representing a range of values.",
+    "superClassRoles": [
+      "Structure"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid",
+      "aria-valuemax",
+      "aria-valuemin",
+      "aria-valuenow",
+      "aria-valuetext"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "RowGroup": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#rowgroup",
+    "description": "A structure containing one or more row elements in a tabular container.",
+    "superClassRoles": [
+      "Structure"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [
+      "grid",
+      "table",
+      "treegrid"
+    ],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Section": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#section",
+    "description": "A renderable structural containment unit in a document or application.",
+    "superClassRoles": [
+      "Structure"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": null,
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Input": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#input",
+    "description": "A generic type of widget that allows user input.",
+    "superClassRoles": [
+      "Widget"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "SectionHead": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#sectionhead",
+    "description": "A structure that labels or summarizes the topic of its related section.",
+    "superClassRoles": [
+      "Structure"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "FocusableSeparator": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#separator",
+    "description": "A divider that separates and distinguishes sections of content or groups of menuitems.\n// NOTE: This is not an actual aria role, but Separator has distinct behavior and inheritance\n//       depending on if it is focusable or not, so it is implemented as two classes.\n//       Also see NonFocusableSeparator.",
+    "superClassRoles": [
+      "Widget"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-orientation",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-valuemax",
+      "aria-valuemin",
+      "aria-valuetext"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [
+      "aria-valuenow"
+    ],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": true,
+    "implicitValueForRole": {
+      "aria-orientation": "AriaOrientation::Horizontal",
+      "aria-valuemin": "0.0",
+      "aria-valuemax": "100.0"
+    }
+  },
+  "NonFocusableSeparator": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#separator",
+    "description": "A divider that separates and distinguishes sections of content or groups of menuitems.\n// NOTE: This is not an actual aria role, but Separator has distinct behavior and inheritance\n//       depending on if it is focusable or not, so it is implemented as two classes.\n//       Also see FocusableSeparator.",
+    "superClassRoles": [
+      "Structure"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid",
+      "aria-orientation"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": true,
+    "implicitValueForRole": {
+      "aria-orientation": "AriaOrientation::Horizontal"
+    }
+  },
+  "Article": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#article",
+    "description": "A section of a page that consists of a composition that forms an independent part of a document, page, or site.",
+    "superClassRoles": [
+      "Document"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-posinset",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-setsize"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Meter": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#meter",
+    "description": "An element that represents a scalar measurement within a known range, or a fractional value. See related progressbar.",
+    "superClassRoles": [
+      "Range"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-valuemax",
+      "aria-valuemin",
+      "aria-valuenow",
+      "aria-valuetext"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [
+      "aria-valuenow"
+    ],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": true,
+    "implicitValueForRole": {
+      "aria-valuemin": "0.0",
+      "aria-valuemax": "100.0"
+    }
+  },
+  "Progressbar": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#progressbar",
+    "description": "An element that displays the progress status for tasks that take a long time.\n// NOTE: Progresbar also inherits from Widgetfrom Cell, but we can't do that in C++ due to Progressbar already inheriting from Widget\n//       This is fine because behavior is still correct and is() will still work as expected.",
+    "superClassRoles": [
+      "Range"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-valuemax",
+      "aria-valuemin",
+      "aria-valuenow",
+      "aria-valuetext"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": true,
+    "implicitValueForRole": {
+      "aria-valuemin": "0.0",
+      "aria-valuemax": "100.0"
+    }
+  },
+  "Scrollbar": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#scrollbar",
+    "description": "A graphical object that controls the scrolling of content within a viewing area, regardless of whether the content is fully displayed within the viewing area.",
+    "superClassRoles": [
+      "Range",
+      "Widget"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-orientation",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-valuemax",
+      "aria-valuemin",
+      "aria-valuetext"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [
+      "aria-controls",
+      "aria-valuenow"
+    ],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": true,
+    "implicitValueForRole": {
+      "aria-orientation": "AriaOrientation::Vertical",
+      "aria-valuemin": "0.0",
+      "aria-valuemax": "100.0"
+    }
+  },
+  "Slider": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#slider",
+    "description": "An input where the user selects a value from within a given range.",
+    "superClassRoles": [
+      "Input",
+      "Range"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-orientation",
+      "aria-owns",
+      "aria-relevant",
+      "aria-readonly",
+      "aria-roledescription",
+      "aria-valuemax",
+      "aria-valuemin"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [
+      "aria-valuenow"
+    ],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": true,
+    "implicitValueForRole": {
+      "aria-orientation": "AriaOrientation::Horizontal",
+      "aria-valuemin": "0.0",
+      "aria-valuemax": "100.0"
+    }
+  },
+  "SpinButton": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#spinbutton",
+    "description": "A form of range that expects the user to select from among discrete choices.",
+    "superClassRoles": [
+      "Composite",
+      "Input",
+      "Range"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-readonly",
+      "aria-required",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-valuemax",
+      "aria-valuemin",
+      "aria-valuenow",
+      "aria-valuetext"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {
+      "aria-valuenow": "0.0"
+    }
+  },
+  "Alert": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#alert",
+    "description": "A type of live region with important, and usually time-sensitive, information. See related alertdialog and status.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-invalid",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-modal",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {
+      "aria-live": "AriaLive::Assertive",
+      "aria-atomic": "true"
+    }
+  },
+  "BlockQuote": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#blockquote",
+    "description": "A section of content that is quoted from another source.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Caption": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#caption",
+    "description": "Visible content that names, and may also describe, a figure, table, grid, or treegrid.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [
+      "aria-label",
+      "aria-labelledby"
+    ],
+    "requiredContextRoles": [
+      "figure",
+      "grid",
+      "table",
+      "treegrid"
+    ],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Prohibited",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Cell": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#cell",
+    "description": "A cell in a tabular container. See related gridcell.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-colindex",
+      "aria-colspan",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-rowindex",
+      "aria-rowspan"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [
+      "row"
+    ],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Code": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#code",
+    "description": "A section whose content represents a fragment of computer code.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [
+      "aria-label",
+      "aria-labelledby"
+    ],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Prohibited",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Definition": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#definition",
+    "description": "A definition of a term or concept. See related term.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Deletion": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#deletion",
+    "description": "A deletion contains content that is marked as removed or content that is being suggested for removal. See related insertion.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [
+      "aria-label",
+      "aria-labelledby"
+    ],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Prohibited",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Emphasis": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#emphasis",
+    "description": "One or more emphasized characters. See related strong.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [
+      "aria-label",
+      "aria-labelledby"
+    ],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Prohibited",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Figure": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#figure",
+    "description": "A perceivable section of content that typically contains a graphical document, images, code snippets, or example text. The parts of a figure MAY be user-navigable.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Group": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#group",
+    "description": "A set of user interface objects that is not intended to be included in a page summary or table of contents by assistive technologies.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Img": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#img",
+    "description": "A container for a collection of elements that form an image.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": true,
+    "implicitValueForRole": {}
+  },
+  "Insertion": {
+    "specLink": "",
+    "description": "",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [
+      "aria-label",
+      "aria-labelledby"
+    ],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Prohibited",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Landmark": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#landmark",
+    "description": "A perceivable section containing content that is relevant to a specific, author-specified purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "List": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#list",
+    "description": "A section containing listitem elements. See related listbox.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [
+      "listitem"
+    ],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "ListItem": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#listitem",
+    "description": "A single item in a list or directory.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-level",
+      "aria-live",
+      "aria-owns",
+      "aria-posinset",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-setsize"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [
+      "directory",
+      "list"
+    ],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Log": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#log",
+    "description": "A type of live region where new information is added in meaningful order and old information may disappear. See related marquee.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {
+      "aria-live": "AriaLive::Polite"
+    }
+  },
+  "Marquee": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#marquee",
+    "description": "A type of live region where non-essential information changes frequently. See related log.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Math": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#math",
+    "description": "Content that represents a mathematical expression.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Note": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#note",
+    "description": "A section whose content is parenthetic or ancillary to the main content of the resource.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Paragraph": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#paragraph",
+    "description": "A paragraph of content.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [
+      "aria-label",
+      "aria-labelledby"
+    ],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Prohibited",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Status": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#status",
+    "description": "A type of live region whose content is advisory information for the user but is not important enough to justify an alert, often but not necessarily presented as a status bar.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {
+      "aria-live": "AriaLive::Polite",
+      "aria-atomic": "true"
+    }
+  },
+  "Strong": {
+    "specLink": "",
+    "description": "",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [
+      "aria-label",
+      "aria-labelledby"
+    ],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Prohibited",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Subscript": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#subscript",
+    "description": "One or more subscripted characters. See related superscript.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [
+      "aria-label",
+      "aria-labelledby"
+    ],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Prohibited",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Superscript": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#superscript",
+    "description": "One or more superscripted characters. See related superscript.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [
+      "aria-label",
+      "aria-labelledby"
+    ],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Prohibited",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Table": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#table",
+    "description": "A section containing data arranged in rows and columns. See related grid.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-colcount",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-rowcount"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [
+      "row"
+    ],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "TabPanel": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#tabpanel",
+    "description": "A container for the resources associated with a tab, where each tab is contained in a tablist.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Term": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#term",
+    "description": "A word or phrase with a corresponding definition. See related definition.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Time": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#time",
+    "description": "An element that represents a specific point in time.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Tooltip": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#tooltip",
+    "description": "A contextual popup that displays a description for an element.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Dialog": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#dialog",
+    "description": "A dialog is a descendant window of the primary window of a web application. For HTML pages, the primary application window is the entire web document, i.e., the body element.",
+    "superClassRoles": [
+      "Window"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-modal",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "AlertDialog": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#alertdialog",
+    "description": "A type of dialog that contains an alert message, where initial focus goes to an element within the dialog. See related alert and dialog.",
+    "superClassRoles": [
+      "Alert",
+      "Dialog"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "GridCell": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#gridcell",
+    "description": "A cell in a grid or treegrid.",
+    "superClassRoles": [
+      "Cell",
+      "Widget"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-expanded",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid",
+      "aria-selected"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-colindex",
+      "aria-colspan",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-readonly",
+      "aria-relevant",
+      "aria-required",
+      "aria-roledescription",
+      "aria-rowindex",
+      "aria-rowspan"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [
+      "row"
+    ],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "ColumnHeader": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#columnheader",
+    "description": "A cell containing header information for a column.\n// NOTE: ColumnHeader also inherits from Cell, but we can't do that in C++ due to GridCell already inheriting from Cell\n//       This is fine because behavior is still correct and is() will still work as expected.",
+    "superClassRoles": [
+      "GridCell",
+      "SectionHead"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-expanded",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid",
+      "aria-selected"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-colindex",
+      "aria-colspan",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-required",
+      "aria-roledescription",
+      "aria-rowindex",
+      "aria-rowspan",
+      "aria-sort"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [
+      "row"
+    ],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "RowHeader": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#rowheader",
+    "description": "A cell containing header information for a row.\n// NOTE: RowHeader also inherits from Cell, but we can't do that in C++ due to GridCell already inheriting from Cell\n//       This is fine because behavior is still correct and is() will still work as expected.",
+    "superClassRoles": [
+      "GridCell",
+      "SectionHead"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-expanded",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid",
+      "aria-selected"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-colindex",
+      "aria-colspan",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-required",
+      "aria-roledescription",
+      "aria-rowindex",
+      "aria-rowspan",
+      "aria-sort"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [
+      "row"
+    ],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Row": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#row",
+    "description": "A row of cells in a tabular container.",
+    "superClassRoles": [
+      "Group",
+      "Widget"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-expanded",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid",
+      "aria-selected"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-controls",
+      "aria-colindex",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-expanded",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-level",
+      "aria-live",
+      "aria-owns",
+      "aria-posinset",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-rowindex",
+      "aria-setsize"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [
+      "grid",
+      "rowgroup",
+      "table",
+      "treegrid"
+    ],
+    "requiredOwnedElements": [
+      "cell",
+      "columnheader",
+      "gridcell",
+      "rowheader"
+    ],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Select": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#select",
+    "description": "A form widget that allows the user to make selections from a set of choices.",
+    "superClassRoles": [
+      "Composite",
+      "Group"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-orientation",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Toolbar": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#toolbar",
+    "description": "A collection of commonly used function buttons or controls represented in compact visual form.",
+    "superClassRoles": [
+      "Group"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-orientation",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {
+      "aria-orientation": "AriaOrientation::Horizontal"
+    }
+  },
+  "ListBox": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#listbox",
+    "description": "A widget that allows the user to select one or more items from a list of choices. See related combobox and list.",
+    "superClassRoles": [
+      "Select"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-expanded",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-expanded",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-multiselectable",
+      "aria-orientation",
+      "aria-owns",
+      "aria-readonly",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-required"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [
+      "option"
+    ],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {
+      "aria-orientation": "AriaOrientation::Vertical"
+    }
+  },
+  "Menu": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#menu",
+    "description": "A type of widget that offers a list of choices to the user.",
+    "superClassRoles": [
+      "Select"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-orientation",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [
+      "menuitem",
+      "menuitemradio",
+      "menuitemcheckbox"
+    ],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {
+      "aria-orientation": "AriaOrientation::Vertical"
+    }
+  },
+  "RadioGroup": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#radiogroup",
+    "description": "A group of radio buttons.",
+    "superClassRoles": [
+      "Select"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-orientation",
+      "aria-owns",
+      "aria-readonly",
+      "aria-relevant",
+      "aria-required",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [
+      "radio"
+    ],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Tree": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#tree",
+    "description": "A widget that allows the user to select one or more items from a hierarchically organized collection.",
+    "superClassRoles": [
+      "Select"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-multiselectable",
+      "aria-orientation",
+      "aria-owns",
+      "aria-relevant",
+      "aria-required",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [
+      "treeitem"
+    ],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {
+      "aria-orientation": "AriaOrientation::Vertical"
+    }
+  },
+  "MenuBar": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#menubar",
+    "description": "A presentation of menu that usually remains visible and is usually presented horizontally.",
+    "superClassRoles": [
+      "Menu"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [
+      "menuitem",
+      "menuitemcheckbox",
+      "menuitemradio"
+    ],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {
+      "aria-orientation": "AriaOrientation::Horizontal"
+    }
+  },
+  "TreeGrid": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#treegrid",
+    "description": "A grid whose rows can be expanded and collapsed in the same manner as for a tree.",
+    "superClassRoles": [
+      "Row"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-colcount",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-multiselectable",
+      "aria-orientation",
+      "aria-owns",
+      "aria-readonly",
+      "aria-relevant",
+      "aria-required",
+      "aria-roledescription",
+      "aria-rowcount"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Banner": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#banner",
+    "description": "https://www.w3.org/TR/wai-aria-1.2/#banner",
+    "superClassRoles": [
+      "Landmark"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Complementary": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#complementary",
+    "description": "A landmark that is designed to be complementary to the main content at a similar level in the DOM hierarchy, but remaining meaningful when separated from the main content.",
+    "superClassRoles": [
+      "Landmark"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "ContentInfo": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#contentinfo",
+    "description": "A landmark that contains information about the parent document.",
+    "superClassRoles": [
+      "Landmark"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Form": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#form",
+    "description": "A landmark region that contains a collection of items and objects that, as a whole, combine to create a form. See related search.",
+    "superClassRoles": [
+      "Landmark"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Main": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#main",
+    "description": "A landmark containing the main content of a document.",
+    "superClassRoles": [
+      "Landmark"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Navigation": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#navigation",
+    "description": "A landmark containing a collection of navigational elements (usually links) for navigating the document or related documents.",
+    "superClassRoles": [
+      "Landmark"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Region": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#region",
+    "description": "A landmark containing content that is relevant to a specific, author-specified purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.",
+    "superClassRoles": [
+      "Landmark"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Search": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#search",
+    "description": "A landmark region that contains a collection of items and objects that, as a whole, combine to create a search facility. See related form and searchbox.",
+    "superClassRoles": [
+      "Landmark"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Directory": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#directory",
+    "description": "[Deprecated in ARIA 1.2] A list of references to members of a group, such as a static table of contents.",
+    "superClassRoles": [
+      "List"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Feed": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#feed",
+    "description": "A scrollable list of articles where scrolling may cause articles to be added to or removed from either end of the list.",
+    "superClassRoles": [
+      "List"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [
+      "article"
+    ],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+
+  "Option": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#option",
+    "description": "A selectable item in a listbox.",
+    "superClassRoles": [
+      "Input"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-checked",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-posinset",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-setsize"
+    ],
+    "requiredStates": [
+      "aria-selected"
+    ],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [
+      "group",
+      "listbox"
+    ],
+    "requiredOwnedElements": [],
+    "nameFromSource": null,
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "TreeItem": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#treeitem",
+    "description": "An option item of a tree. This is an element within a tree that may be expanded or collapsed if it contains a sub-level group of tree item elements.",
+    "superClassRoles": [
+      "ListItem",
+      "Option"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-checked",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid",
+      "aria-selected"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-level",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-setsize"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Timer": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#timer",
+    "description": "A type of live region containing a numerical counter which indicates an amount of elapsed time from a start point, or the time remaining until an end point.",
+    "superClassRoles": [
+      "Status"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {
+      "aria-live": "AriaLive::Off"
+    }
+  },
+  "Grid": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#grid",
+    "description": "A composite widget containing a collection of one or more rows with one or more cells where some or all cells in the grid are focusable by using methods of two-dimensional navigation, such as directional arrow keys.",
+    "superClassRoles": [
+      "Composite",
+      "Table"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-colcount",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-multiselectable",
+      "aria-owns",
+      "aria-readonly",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [
+      "row"
+    ],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Heading": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#heading",
+    "description": "A heading for a section of the page.",
+    "superClassRoles": [
+      "SectionHead"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-level",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Tab": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#tab",
+    "description": "A grouping label providing a mechanism for selecting the tab content that is to be rendered to the user.",
+    "superClassRoles": [
+      "SectionHead",
+      "Widget"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-expanded",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid",
+      "aria-selected"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-posinset",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-setsize"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [
+      "tablist"
+    ],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": true,
+    "implicitValueForRole": {
+      "aria-selected": "false"
+    }
+  },
+
+  "Command": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#command",
+    "description": "A form of widget that performs an action but does not receive input data.",
+    "superClassRoles": [
+      "Widget"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Button": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#button",
+    "description": "An input that allows for user-triggered actions when clicked or pressed. See related link.",
+    "superClassRoles": [
+      "Command"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-expanded",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-pressed",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": true,
+    "implicitValueForRole": {}
+  },
+  "Link": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#link",
+    "description": "An interactive reference to an internal or external resource that, when activated, causes the user agent to navigate to that resource. See related button.",
+    "superClassRoles": [
+      "Command"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-expanded",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-errormessage",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "MenuItem": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#menuitem",
+    "description": "An option in a set of choices contained by a menu or menubar.",
+    "superClassRoles": [
+      "Command"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-expanded",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-posinset",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-setsize"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [
+      "group",
+      "menu",
+      "menubar"
+    ],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "MenuItemCheckBox": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#menuitemcheckbox",
+    "description": "A menuitem with a checkable state whose possible values are true, false, or mixed.",
+    "superClassRoles": [
+      "MenuItem"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-posinset",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-setsize"
+    ],
+    "requiredStates": [
+      "aria-checked"
+    ],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [
+      "group",
+      "menu",
+      "menubar"
+    ],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": true,
+    "implicitValueForRole": {}
+  },
+  "MenuItemRadio": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#menuitemradio",
+    "description": "A checkable menuitem in a set of elements with the same role, only one of which can be checked at a time.",
+    "superClassRoles": [
+      "MenuItemCheckBox"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-checked",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-posinset",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-setsize"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [
+      "group",
+      "menu",
+      "menubar"
+    ],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": true,
+    "implicitValueForRole": {}
+  },
+  "CheckBox": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#checkbox",
+    "description": "A checkable input that has three possible values: true, false, or mixed.",
+    "superClassRoles": [
+      "Input"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-expanded",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-readonly",
+      "aria-relevant",
+      "aria-required",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": true,
+    "implicitValueForRole": {}
+  },
+  "ComboBox": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#combobox",
+    "description": "An input that controls another element, such as a listbox or grid, that can dynamically pop up to help the user set the value of the input.",
+    "superClassRoles": [
+      "Input"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-autocomplete",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-readonly",
+      "aria-relevant",
+      "aria-required",
+      "aria-roledescription"
+    ],
+    "requiredStates": [
+      "aria-expanded"
+    ],
+    "requiredProperties": [
+      "aria-controls"
+    ],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {
+      "aria-haspopup": "AriaHasPopup::Listbox"
+    }
+  },
+  "Radio": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#radio",
+    "description": "A checkable input in a group of elements with the same role, only one of which can be checked at a time.",
+    "superClassRoles": [
+      "Input"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-posinset",
+      "aria-relevant",
+      "aria-roledescription",
+      "aria-setsize"
+    ],
+    "requiredStates": [
+      "aria-checked"
+    ],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": true,
+    "implicitValueForRole": {}
+  },
+  "TextBox": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#textbox",
+    "description": "A type of input that allows free-form text as its value.",
+    "superClassRoles": [
+      "Input"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-autocomplete",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-multiline",
+      "aria-owns",
+      "aria-placeholder",
+      "aria-readonly",
+      "aria-relevant",
+      "aria-required",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "Switch": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#switch",
+    "description": "A type of checkbox that represents on/off values, as opposed to checked/unchecked values. See related checkbox.",
+    "superClassRoles": [
+      "CheckBox"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-expanded",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-required",
+      "aria-roledescription"
+    ],
+    "requiredStates": [
+      "aria-checked"
+    ],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": true,
+    "implicitValueForRole": {}
+  },
+  "SearchBox": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#searchbox",
+    "description": "A type of textbox intended for specifying search criteria. See related textbox and search.",
+    "superClassRoles": [
+      "TextBox"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-autocomplete",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-multiline",
+      "aria-owns",
+      "aria-placeholder",
+      "aria-readonly",
+      "aria-relevant",
+      "aria-required",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "TabList": {
+    "specLink": "https://www.w3.org/TR/wai-aria-1.2/#tablist",
+    "description": "A list of tab elements, which are references to tabpanel elements.",
+    "superClassRoles": [
+      "Composite"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-controls",
+      "aria-describedby",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-multiselectable",
+      "aria-orientation",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [
+      "tab"
+    ],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {
+      "aria-orientation": "AriaOrientation::Horizontal"
+    }
+  }
+}

--- a/Userland/Libraries/LibWeb/ARIA/RoleType.cpp
+++ b/Userland/Libraries/LibWeb/ARIA/RoleType.cpp
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) 2023, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/ARIA/ARIAMixin.h>
+#include <LibWeb/ARIA/AriaRoles.h>
+#include <LibWeb/ARIA/RoleType.h>
+
+namespace Web::ARIA {
+
+RoleType::RoleType(AriaData const& data)
+    : m_data(data)
+{
+}
+
+constexpr StateAndProperties supported_state_array[] = {
+    StateAndProperties::AriaBusy,
+    StateAndProperties::AriaCurrent,
+    StateAndProperties::AriaDisabled,
+    StateAndProperties::AriaGrabbed,
+    StateAndProperties::AriaHidden,
+    StateAndProperties::AriaInvalid
+};
+constexpr StateAndProperties supported_properties_array[] = {
+    StateAndProperties::AriaAtomic,
+    StateAndProperties::AriaControls,
+    StateAndProperties::AriaDescribedBy,
+    StateAndProperties::AriaDetails,
+    StateAndProperties::AriaDropEffect,
+    StateAndProperties::AriaFlowTo,
+    StateAndProperties::AriaHasPopup,
+    StateAndProperties::AriaKeyShortcuts,
+    StateAndProperties::AriaLabel,
+    StateAndProperties::AriaLabelledBy,
+    StateAndProperties::AriaLive,
+    StateAndProperties::AriaOwns,
+    StateAndProperties::AriaRelevant,
+    StateAndProperties::AriaRoleDescription
+};
+
+HashTable<StateAndProperties> const& RoleType::supported_states() const
+{
+    static HashTable<StateAndProperties> states;
+    if (states.is_empty())
+        states.set_from(supported_state_array);
+    return states;
+}
+
+HashTable<StateAndProperties> const& RoleType::supported_properties() const
+{
+    static HashTable<StateAndProperties> properties;
+    if (properties.is_empty())
+        properties.set_from(supported_properties_array);
+    return properties;
+}
+
+HashTable<StateAndProperties> const& RoleType::required_states() const
+{
+    static HashTable<StateAndProperties> states;
+    return states;
+}
+
+HashTable<StateAndProperties> const& RoleType::required_properties() const
+{
+    static HashTable<StateAndProperties> properties;
+    return properties;
+}
+
+HashTable<StateAndProperties> const& RoleType::prohibited_properties() const
+{
+    static HashTable<StateAndProperties> properties;
+    return properties;
+}
+
+HashTable<StateAndProperties> const& RoleType::prohibited_states() const
+{
+    static HashTable<StateAndProperties> states;
+    return states;
+}
+
+HashTable<Role> const& RoleType::required_context_roles() const
+{
+    static HashTable<Role> roles;
+    return roles;
+}
+
+HashTable<Role> const& RoleType::required_owned_elements() const
+{
+    static HashTable<Role> roles;
+    return roles;
+}
+
+ErrorOr<void> RoleType::serialize_as_json(JsonObjectSerializer<StringBuilder>& object) const
+{
+    auto state_object = TRY(object.add_object("state"sv));
+    for (auto const state : supported_states()) {
+        auto value = TRY(ARIA::state_or_property_to_string_value(state, m_data, default_value_for_property_or_state(state)));
+        TRY(state_object.add(ARIA::state_or_property_to_string(state), value));
+    }
+    TRY(state_object.finish());
+
+    auto properties_object = TRY(object.add_object("properties"sv));
+    for (auto const property : supported_properties()) {
+        auto value = TRY(ARIA::state_or_property_to_string_value(property, m_data, default_value_for_property_or_state(property)));
+        TRY(properties_object.add(ARIA::state_or_property_to_string(property), value));
+    }
+    TRY(properties_object.finish());
+
+    auto required_states_object = TRY(object.add_object("required_state"sv));
+    for (auto const state : required_states()) {
+        auto value = TRY(ARIA::state_or_property_to_string_value(state, m_data, default_value_for_property_or_state(state)));
+        TRY(required_states_object.add(ARIA::state_or_property_to_string(state), value));
+    }
+    TRY(required_states_object.finish());
+
+    auto required_properties_object = TRY(object.add_object("required_properties"sv));
+    for (auto const property : required_properties()) {
+        auto value = TRY(ARIA::state_or_property_to_string_value(property, m_data, default_value_for_property_or_state(property)));
+        TRY(required_properties_object.add(ARIA::state_or_property_to_string(property), value));
+    }
+    TRY(required_properties_object.finish());
+
+    auto prohibited_states_object = TRY(object.add_object("prohibited_state"sv));
+    for (auto const state : prohibited_states()) {
+        auto value = TRY(ARIA::state_or_property_to_string_value(state, m_data, default_value_for_property_or_state(state)));
+        TRY(prohibited_states_object.add(ARIA::state_or_property_to_string(state), value));
+    }
+    TRY(prohibited_states_object.finish());
+
+    auto prohibited_properties_object = TRY(object.add_object("prohibited_properties"sv));
+    for (auto const property : required_properties()) {
+        auto value = TRY(ARIA::state_or_property_to_string_value(property, m_data, default_value_for_property_or_state(property)));
+        TRY(prohibited_properties_object.add(ARIA::state_or_property_to_string(property), value));
+    }
+    TRY(prohibited_properties_object.finish());
+
+    return {};
+}
+
+ErrorOr<NonnullOwnPtr<RoleType>> RoleType::build_role_object(Role role, bool focusable, AriaData const& data)
+{
+    if (is_abstract_role(role))
+        return Error::from_string_view("Cannot construct a role object for an abstract role."sv);
+
+    switch (role) {
+    case Role::alert:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Alert(data));
+    case Role::alertdialog:
+        return adopt_nonnull_own_or_enomem(static_cast<Alert*>((new (nothrow) AlertDialog(data))));
+    case Role::application:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Application(data));
+    case Role::article:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Article(data));
+    case Role::banner:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Banner(data));
+    case Role::blockquote:
+        return adopt_nonnull_own_or_enomem(new (nothrow) BlockQuote(data));
+    case Role::button:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Button(data));
+    case Role::caption:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Caption(data));
+    case Role::cell:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Cell(data));
+    case Role::checkbox:
+        return adopt_nonnull_own_or_enomem(new (nothrow) CheckBox(data));
+    case Role::code:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Code(data));
+    case Role::columnheader:
+        return adopt_nonnull_own_or_enomem(static_cast<Cell*>(new (nothrow) ColumnHeader(data)));
+    case Role::combobox:
+        return adopt_nonnull_own_or_enomem(new (nothrow) ComboBox(data));
+    case Role::complementary:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Complementary(data));
+    case Role::composite:
+        return adopt_nonnull_own_or_enomem(new (nothrow) ContentInfo(data));
+    case Role::definition:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Definition(data));
+    case Role::deletion:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Deletion(data));
+    case Role::dialog:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Dialog(data));
+    case Role::directory:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Directory(data));
+    case Role::document:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Document(data));
+    case Role::emphasis:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Emphasis(data));
+    case Role::feed:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Feed(data));
+    case Role::figure:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Figure(data));
+    case Role::form:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Form(data));
+    case Role::generic:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Generic(data));
+    case Role::grid:
+        return adopt_nonnull_own_or_enomem(static_cast<Composite*>(new (nothrow) Grid(data)));
+    case Role::gridcell:
+        return adopt_nonnull_own_or_enomem(static_cast<Cell*>(new (nothrow) GridCell(data)));
+    case Role::group:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Group(data));
+    case Role::heading:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Heading(data));
+    case Role::img:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Img(data));
+    case Role::input:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Input(data));
+    case Role::insertion:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Insertion(data));
+    case Role::landmark:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Landmark(data));
+    case Role::link:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Link(data));
+    case Role::list:
+        return adopt_nonnull_own_or_enomem(new (nothrow) List(data));
+    case Role::listbox:
+        return adopt_nonnull_own_or_enomem(static_cast<Composite*>(new (nothrow) ListBox(data)));
+    case Role::listitem:
+        return adopt_nonnull_own_or_enomem(new (nothrow) ListItem(data));
+    case Role::log:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Log(data));
+    case Role::main:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Main(data));
+    case Role::marquee:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Marquee(data));
+    case Role::math:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Math(data));
+    case Role::meter:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Meter(data));
+    case Role::menu:
+        return adopt_nonnull_own_or_enomem(static_cast<Composite*>(new (nothrow) Menu(data)));
+    case Role::menubar:
+        return adopt_nonnull_own_or_enomem(static_cast<Composite*>(new (nothrow) MenuBar(data)));
+    case Role::menuitem:
+        return adopt_nonnull_own_or_enomem(new (nothrow) MenuItem(data));
+    case Role::menuitemcheckbox:
+        return adopt_nonnull_own_or_enomem(new (nothrow) MenuItemCheckBox(data));
+    case Role::menuitemradio:
+        return adopt_nonnull_own_or_enomem(new (nothrow) MenuItemRadio(data));
+    case Role::navigation:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Navigation(data));
+    case Role::note:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Note(data));
+    case Role::option:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Option(data));
+    case Role::paragraph:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Paragraph(data));
+    case Role::presentation:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Presentation(data));
+    case Role::progressbar:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Progressbar(data));
+    case Role::radio:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Radio(data));
+    case Role::radiogroup:
+        return adopt_nonnull_own_or_enomem(static_cast<Composite*>(new (nothrow) RadioGroup(data)));
+    case Role::region:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Region(data));
+    case Role::row:
+        return adopt_nonnull_own_or_enomem(static_cast<Group*>(new (nothrow) Row(data)));
+    case Role::rowgroup:
+        return adopt_nonnull_own_or_enomem(new (nothrow) RowGroup(data));
+    case Role::rowheader:
+        return adopt_nonnull_own_or_enomem(static_cast<Cell*>(new (nothrow) RowHeader(data)));
+    case Role::scrollbar:
+        return adopt_nonnull_own_or_enomem(static_cast<Range*>(new (nothrow) Scrollbar(data)));
+    case Role::search:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Search(data));
+    case Role::searchbox:
+        return adopt_nonnull_own_or_enomem(new (nothrow) SearchBox(data));
+    case Role::separator:
+        if (focusable)
+            return adopt_nonnull_own_or_enomem(new (nothrow) FocusableSeparator(data));
+        else
+            return adopt_nonnull_own_or_enomem(new (nothrow) NonFocusableSeparator(data));
+    case Role::slider:
+        return adopt_nonnull_own_or_enomem(static_cast<Input*>(new (nothrow) Slider(data)));
+    case Role::spinbutton:
+        return adopt_nonnull_own_or_enomem(static_cast<Composite*>(new (nothrow) SpinButton(data)));
+    case Role::status:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Status(data));
+    case Role::strong:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Strong(data));
+    case Role::switch_:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Switch(data));
+    case Role::tab:
+        return adopt_nonnull_own_or_enomem(static_cast<SectionHead*>(new (nothrow) Tab(data)));
+    case Role::table:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Table(data));
+    case Role::tablist:
+        return adopt_nonnull_own_or_enomem(new (nothrow) TabList(data));
+    case Role::tabpanel:
+        return adopt_nonnull_own_or_enomem(new (nothrow) TabPanel(data));
+    case Role::term:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Term(data));
+    case Role::textbox:
+        return adopt_nonnull_own_or_enomem(new (nothrow) TextBox(data));
+    case Role::time:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Time(data));
+    case Role::timer:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Timer(data));
+    case Role::toolbar:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Toolbar(data));
+    case Role::tooltip:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Tooltip(data));
+    case Role::tree:
+        return adopt_nonnull_own_or_enomem(static_cast<Composite*>(new (nothrow) Tree(data)));
+    case Role::treegrid:
+        return adopt_nonnull_own_or_enomem(static_cast<Group*>(new (nothrow) TreeGrid(data)));
+    case Role::treeitem:
+        return adopt_nonnull_own_or_enomem(static_cast<ListItem*>(new (nothrow) TreeItem(data)));
+    case Role::window:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Window(data));
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+}

--- a/Userland/Libraries/LibWeb/ARIA/RoleType.h
+++ b/Userland/Libraries/LibWeb/ARIA/RoleType.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonObjectSerializer.h>
+#include <LibWeb/ARIA/AriaData.h>
+#include <LibWeb/ARIA/Roles.h>
+#include <LibWeb/ARIA/StateAndProperties.h>
+
+namespace Web::ARIA {
+
+enum class NameFromSource {
+    Author,
+    Content,
+    AuthorContent,
+    Prohibited
+};
+
+// https://www.w3.org/TR/wai-aria-1.2/#roletype
+// The base role from which all other roles inherit.
+class RoleType {
+public:
+    static ErrorOr<NonnullOwnPtr<RoleType>> build_role_object(Role, bool, AriaData const&);
+
+    virtual ~RoleType() = default;
+    // https://www.w3.org/TR/wai-aria-1.2/#supportedState
+    virtual HashTable<StateAndProperties> const& supported_states() const;
+    virtual HashTable<StateAndProperties> const& supported_properties() const;
+    // https://www.w3.org/TR/wai-aria-1.2/#requiredState
+    virtual HashTable<StateAndProperties> const& required_states() const;
+    virtual HashTable<StateAndProperties> const& required_properties() const;
+    // https://www.w3.org/TR/wai-aria-1.2/#prohibitedattributes
+    virtual HashTable<StateAndProperties> const& prohibited_properties() const;
+    virtual HashTable<StateAndProperties> const& prohibited_states() const;
+    // https://www.w3.org/TR/wai-aria-1.2/#scope
+    virtual HashTable<Role> const& required_context_roles() const;
+    // https://www.w3.org/TR/wai-aria-1.2/#mustContain
+    virtual HashTable<Role> const& required_owned_elements() const;
+    // https://www.w3.org/TR/wai-aria-1.2/#namecalculation
+    virtual NameFromSource name_from_source() const = 0;
+    virtual bool accessible_name_required() const { return false; }
+    // https://www.w3.org/TR/wai-aria-1.2/#childrenArePresentational
+    virtual bool children_are_presentational() const { return false; }
+    // https://www.w3.org/TR/wai-aria-1.2/#implictValueForRole
+    using DefaultValueType = Variant<Empty, f64, AriaOrientation, AriaLive, bool, AriaHasPopup>;
+    virtual DefaultValueType default_value_for_property_or_state(StateAndProperties) const { return {}; };
+    ErrorOr<void> serialize_as_json(JsonObjectSerializer<StringBuilder>& object) const;
+
+protected:
+    RoleType(AriaData const&);
+    RoleType() { }
+
+private:
+    AriaData m_data;
+};
+
+}

--- a/Userland/Libraries/LibWeb/ARIA/StateAndProperties.cpp
+++ b/Userland/Libraries/LibWeb/ARIA/StateAndProperties.cpp
@@ -1,0 +1,450 @@
+/*
+ * Copyright (c) 2023, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Variant.h>
+#include <LibWeb/ARIA/StateAndProperties.h>
+
+namespace Web::ARIA {
+
+ErrorOr<String> state_or_property_to_string_value(StateAndProperties state_or_property, AriaData const& aria_data, DefaultValueType default_value)
+{
+    switch (state_or_property) {
+    case StateAndProperties::AriaActiveDescendant: {
+        auto value = aria_data.aria_active_descendant_or_default();
+        return value.has_value() ? String::from_deprecated_string(value.value()) : String::from_utf8(""sv);
+    }
+    case StateAndProperties::AriaAtomic: {
+        bool value;
+        if (default_value.has<bool>())
+            value = aria_data.aria_atomic_or_default(default_value.get<bool>());
+        else
+            value = aria_data.aria_atomic_or_default();
+        return value ? "true"_short_string : "false"_short_string;
+    }
+    case StateAndProperties::AriaAutoComplete: {
+        auto value = aria_data.aria_auto_complete_or_default();
+        switch (value) {
+        case AriaAutocomplete::None:
+            return "none"_short_string;
+        case AriaAutocomplete::List:
+            return "list"_short_string;
+        case AriaAutocomplete::Both:
+            return "both"_short_string;
+        case AriaAutocomplete::Inline:
+            return "inline"_short_string;
+        }
+        VERIFY_NOT_REACHED();
+    }
+    case StateAndProperties::AriaBusy:
+        return String::from_utf8(aria_data.aria_busy_or_default() ? "true"sv : "false"sv);
+    case StateAndProperties::AriaChecked:
+        return ARIA::tristate_to_string(aria_data.aria_checked_or_default());
+    case StateAndProperties::AriaColCount:
+        return ARIA::optional_integer_to_string(aria_data.aria_col_count_or_default());
+    case StateAndProperties::AriaColIndex:
+        return ARIA::optional_integer_to_string(aria_data.aria_col_index_or_default());
+    case StateAndProperties::AriaColSpan:
+        return ARIA::optional_integer_to_string(aria_data.aria_col_span_or_default());
+    case StateAndProperties::AriaControls:
+        return id_reference_list_to_string(aria_data.aria_controls_or_default());
+    case StateAndProperties::AriaCurrent: {
+        auto value = aria_data.aria_current_or_default();
+        switch (value) {
+        case AriaCurrent::False:
+            return "false"_short_string;
+        case AriaCurrent::True:
+            return "true"_short_string;
+        case AriaCurrent::Date:
+            return "date"_short_string;
+        case AriaCurrent::Location:
+            return "location"_string;
+        case AriaCurrent::Page:
+            return "page"_short_string;
+        case AriaCurrent::Step:
+            return "step"_short_string;
+        case AriaCurrent::Time:
+            return "time"_short_string;
+        }
+        VERIFY_NOT_REACHED();
+    }
+    case StateAndProperties::AriaDescribedBy:
+        return id_reference_list_to_string(aria_data.aria_described_by_or_default());
+    case StateAndProperties::AriaDetails: {
+        auto value = aria_data.aria_details_or_default();
+        return value.has_value() ? String::from_deprecated_string(value.value()) : String::from_utf8(""sv);
+    }
+    case StateAndProperties::AriaDisabled:
+        return aria_data.aria_disabled_or_default() ? "true"_short_string : "false"_short_string;
+    case StateAndProperties::AriaDropEffect: {
+        StringBuilder builder;
+        auto value = aria_data.aria_drop_effect_or_default();
+        for (auto const drop_effect : value) {
+            StringView to_add;
+            switch (drop_effect) {
+            case AriaDropEffect::Copy:
+                to_add = "copy"sv;
+                break;
+            case AriaDropEffect::Execute:
+                to_add = "execute"sv;
+                break;
+            case AriaDropEffect::Link:
+                to_add = "link"sv;
+                break;
+            case AriaDropEffect::Move:
+                to_add = "move"sv;
+                break;
+            case AriaDropEffect::None:
+                to_add = "none"sv;
+                break;
+            case AriaDropEffect::Popup:
+                to_add = "popup"sv;
+                break;
+            }
+            if (builder.is_empty())
+                builder.append(to_add);
+            else {
+                builder.append(" "sv);
+                builder.append(to_add);
+            }
+        }
+        return builder.to_string();
+    }
+    case StateAndProperties::AriaErrorMessage: {
+        auto value = aria_data.aria_error_message_or_default();
+        return value.has_value() ? String::from_deprecated_string(value.value()) : String {};
+    }
+    case StateAndProperties::AriaExpanded:
+        return ARIA::optional_bool_to_string(aria_data.aria_expanded_or_default());
+    case StateAndProperties::AriaFlowTo:
+        return id_reference_list_to_string(aria_data.aria_flow_to_or_default());
+    case StateAndProperties::AriaGrabbed:
+        return ARIA::optional_bool_to_string(aria_data.aria_grabbed_or_default());
+    case StateAndProperties::AriaHasPopup: {
+        auto value = aria_data.aria_has_popup_or_default();
+        switch (value) {
+        case AriaHasPopup::False:
+            return "false"_short_string;
+        case AriaHasPopup::True:
+            return "true"_short_string;
+        case AriaHasPopup::Menu:
+            return "menu"_short_string;
+        case AriaHasPopup::Listbox:
+            return "listbox"_string;
+        case AriaHasPopup::Tree:
+            return "tree"_short_string;
+        case AriaHasPopup::Grid:
+            return "grid"_short_string;
+        case AriaHasPopup::Dialog:
+            return "dialog"_short_string;
+        }
+        VERIFY_NOT_REACHED();
+    }
+    case StateAndProperties::AriaHidden:
+        return ARIA::optional_bool_to_string(aria_data.aria_hidden_or_default());
+    case StateAndProperties::AriaInvalid: {
+        auto value = aria_data.aria_invalid_or_default();
+        switch (value) {
+        case AriaInvalid::Grammar:
+            return "grammar"_short_string;
+        case AriaInvalid::False:
+            return "false"_short_string;
+        case AriaInvalid::Spelling:
+            return "spelling"_string;
+        case AriaInvalid::True:
+            return "true"_short_string;
+        }
+        VERIFY_NOT_REACHED();
+    }
+    case StateAndProperties::AriaKeyShortcuts:
+        return String::from_deprecated_string(aria_data.aria_key_shortcuts_or_default());
+    case StateAndProperties::AriaLabel:
+        return String::from_deprecated_string(aria_data.aria_label_or_default());
+    case StateAndProperties::AriaLabelledBy:
+        return id_reference_list_to_string(aria_data.aria_labelled_by_or_default());
+    case StateAndProperties::AriaLevel:
+        return ARIA::optional_integer_to_string(aria_data.aria_level_or_default());
+    case StateAndProperties::AriaLive: {
+        AriaLive value;
+        if (default_value.has<AriaLive>())
+            value = aria_data.aria_live_or_default(default_value.get<AriaLive>());
+        else
+            value = aria_data.aria_live_or_default();
+
+        switch (value) {
+        case AriaLive::Assertive:
+            return "assertive"_string;
+        case AriaLive::Off:
+            return "off"_short_string;
+        case AriaLive::Polite:
+            return "polite"_short_string;
+        }
+        VERIFY_NOT_REACHED();
+    }
+    case StateAndProperties::AriaModal:
+        return aria_data.aria_modal_or_default() ? "true"_short_string : "false"_short_string;
+    case StateAndProperties::AriaMultiLine:
+        return aria_data.aria_multi_line_or_default() ? "true"_short_string : "false"_short_string;
+    case StateAndProperties::AriaMultiSelectable:
+        return aria_data.aria_multi_selectable_or_default() ? "true"_short_string : "false"_short_string;
+    case StateAndProperties::AriaOrientation: {
+        AriaOrientation value;
+        if (default_value.has<AriaOrientation>())
+            value = aria_data.aria_orientation_or_default(default_value.get<AriaOrientation>());
+        else
+            value = aria_data.aria_orientation_or_default();
+
+        switch (value) {
+        case AriaOrientation::Horizontal:
+            return "horizontal"_string;
+        case AriaOrientation::Undefined:
+            return "undefined"_string;
+        case AriaOrientation::Vertical:
+            return "vertical"_string;
+        }
+        VERIFY_NOT_REACHED();
+    }
+    case StateAndProperties::AriaOwns:
+        return id_reference_list_to_string(aria_data.aria_owns_or_default());
+    case StateAndProperties::AriaPlaceholder:
+        return String::from_deprecated_string(aria_data.aria_placeholder_or_default());
+    case StateAndProperties::AriaPosInSet:
+        return ARIA::optional_integer_to_string(aria_data.aria_pos_in_set_or_default());
+    case StateAndProperties::AriaPressed:
+        return ARIA::tristate_to_string(aria_data.aria_pressed_or_default());
+    case StateAndProperties::AriaReadOnly:
+        return aria_data.aria_read_only_or_default() ? "true"_short_string : "false"_short_string;
+    case StateAndProperties::AriaRelevant: {
+        StringBuilder builder;
+        auto value = aria_data.aria_relevant_or_default();
+        for (auto const relevant : value) {
+            StringView to_add;
+            switch (relevant) {
+            case AriaRelevant::Additions:
+                to_add = "additions"sv;
+                break;
+            case AriaRelevant::AdditionsText:
+                to_add = "additions text"sv;
+                break;
+            case AriaRelevant::All:
+                to_add = "all"sv;
+                break;
+            case AriaRelevant::Removals:
+                to_add = "removals"sv;
+                break;
+            case AriaRelevant::Text:
+                to_add = "text"sv;
+                break;
+            }
+            if (builder.is_empty())
+                builder.append(to_add);
+            else {
+                builder.append(" "sv);
+                builder.append(to_add);
+            }
+        }
+        return builder.to_string();
+    }
+    case StateAndProperties::AriaRequired:
+        return String::from_utf8(aria_data.aria_required_or_default() ? "true"sv : "false"sv);
+    case StateAndProperties::AriaRoleDescription:
+        return String::from_deprecated_string(aria_data.aria_role_description_or_default());
+    case StateAndProperties::AriaRowCount:
+        return ARIA::optional_integer_to_string(aria_data.aria_row_count_or_default());
+    case StateAndProperties::AriaRowIndex:
+        return ARIA::optional_integer_to_string(aria_data.aria_row_index_or_default());
+    case StateAndProperties::AriaRowSpan:
+        return ARIA::optional_integer_to_string(aria_data.aria_row_span_or_default());
+    case StateAndProperties::AriaSelected:
+        return ARIA::optional_bool_to_string(aria_data.aria_selected_or_default());
+    case StateAndProperties::AriaSetSize:
+        return ARIA::optional_integer_to_string(aria_data.aria_set_size_or_default());
+    case StateAndProperties::AriaSort: {
+        auto value = aria_data.aria_sort_or_default();
+        switch (value) {
+        case AriaSort::Ascending:
+            return "ascending"_string;
+        case AriaSort::Descending:
+            return "descending"_string;
+        case AriaSort::None:
+            return "none"_short_string;
+        case AriaSort::Other:
+            return "other"_short_string;
+        }
+        VERIFY_NOT_REACHED();
+    }
+    case StateAndProperties::AriaValueMax:
+        if (default_value.has<f64>())
+            return ARIA::optional_number_to_string(aria_data.aria_value_max_or_default(default_value.get<f64>()));
+        else
+            return ARIA::optional_number_to_string(aria_data.aria_value_max_or_default());
+    case StateAndProperties::AriaValueMin:
+        if (default_value.has<f64>())
+            return ARIA::optional_number_to_string(aria_data.aria_value_min_or_default(default_value.get<f64>()));
+        else
+            return ARIA::optional_number_to_string(aria_data.aria_value_min_or_default());
+    case StateAndProperties::AriaValueNow:
+        return ARIA::optional_number_to_string(aria_data.aria_value_now_or_default());
+    case StateAndProperties::AriaValueText:
+        return String::from_deprecated_string(aria_data.aria_value_text_or_default());
+    }
+    VERIFY_NOT_REACHED();
+}
+
+ErrorOr<String> tristate_to_string(Tristate value)
+{
+    switch (value) {
+    case Tristate::False:
+        return "false"_short_string;
+    case Tristate::True:
+        return "true"_short_string;
+    case Tristate::Undefined:
+        return "undefined"_string;
+    case Tristate::Mixed:
+        return "mixed"_short_string;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+ErrorOr<String> optional_integer_to_string(Optional<i32> value)
+{
+    if (value.has_value())
+        return String::number(value.value());
+    return String {};
+}
+
+ErrorOr<String> optional_bool_to_string(Optional<bool> value)
+{
+    if (!value.has_value())
+        return "undefined"_string;
+    if (value.value())
+        return "true"_short_string;
+    return "false"_short_string;
+}
+
+ErrorOr<String> optional_number_to_string(Optional<f64> value)
+{
+    if (!value.has_value())
+        return "undefined"_string;
+    return String::number(value.value());
+}
+ErrorOr<String> id_reference_list_to_string(Vector<DeprecatedString> const& value)
+{
+    StringBuilder builder;
+    for (auto const& id : value) {
+        if (builder.is_empty()) {
+            builder.append(id);
+        } else {
+            builder.append(" "sv);
+            builder.append(id);
+        }
+    }
+    return builder.to_string();
+}
+
+StringView state_or_property_to_string(StateAndProperties value)
+{
+    switch (value) {
+    case StateAndProperties::AriaActiveDescendant:
+        return "aria-activedescendant"sv;
+    case StateAndProperties::AriaAtomic:
+        return "aria-atomic"sv;
+    case StateAndProperties::AriaAutoComplete:
+        return "aria-autocomplete"sv;
+    case StateAndProperties::AriaBusy:
+        return "aria-busy"sv;
+    case StateAndProperties::AriaChecked:
+        return "aria-checked"sv;
+    case StateAndProperties::AriaColCount:
+        return "aria-colcount"sv;
+    case StateAndProperties::AriaColIndex:
+        return "aria-colindex"sv;
+    case StateAndProperties::AriaColSpan:
+        return "aria-colspan"sv;
+    case StateAndProperties::AriaControls:
+        return "aria-controls"sv;
+    case StateAndProperties::AriaCurrent:
+        return "aria-current"sv;
+    case StateAndProperties::AriaDescribedBy:
+        return "aria-describedby"sv;
+    case StateAndProperties::AriaDetails:
+        return "aria-details"sv;
+    case StateAndProperties::AriaDisabled:
+        return "aria-disabled"sv;
+    case StateAndProperties::AriaDropEffect:
+        return "aria-dropeffect"sv;
+    case StateAndProperties::AriaErrorMessage:
+        return "aria-errormessage"sv;
+    case StateAndProperties::AriaExpanded:
+        return "aria-expanded"sv;
+    case StateAndProperties::AriaFlowTo:
+        return "aria-flowto"sv;
+    case StateAndProperties::AriaGrabbed:
+        return "aria-grabbed"sv;
+    case StateAndProperties::AriaHasPopup:
+        return "aria-haspopup"sv;
+    case StateAndProperties::AriaHidden:
+        return "aria-hidden"sv;
+    case StateAndProperties::AriaInvalid:
+        return "aria-invalid"sv;
+    case StateAndProperties::AriaKeyShortcuts:
+        return "aria-keyshortcuts"sv;
+    case StateAndProperties::AriaLabel:
+        return "aria-label"sv;
+    case StateAndProperties::AriaLabelledBy:
+        return "aria-labelledby"sv;
+    case StateAndProperties::AriaLevel:
+        return "aria-level"sv;
+    case StateAndProperties::AriaLive:
+        return "aria-live"sv;
+    case StateAndProperties::AriaModal:
+        return "aria-modal"sv;
+    case StateAndProperties::AriaMultiLine:
+        return "aria-multiline"sv;
+    case StateAndProperties::AriaMultiSelectable:
+        return "aria-multiselectable"sv;
+    case StateAndProperties::AriaOrientation:
+        return "aria-orientation"sv;
+    case StateAndProperties::AriaOwns:
+        return "aria-owns"sv;
+    case StateAndProperties::AriaPlaceholder:
+        return "aria-placeholder"sv;
+    case StateAndProperties::AriaPosInSet:
+        return "aria-posinset"sv;
+    case StateAndProperties::AriaPressed:
+        return "aria-pressed"sv;
+    case StateAndProperties::AriaReadOnly:
+        return "aria-readonly"sv;
+    case StateAndProperties::AriaRelevant:
+        return "aria-relevant"sv;
+    case StateAndProperties::AriaRequired:
+        return "aria-required"sv;
+    case StateAndProperties::AriaRoleDescription:
+        return "aria-roledescription"sv;
+    case StateAndProperties::AriaRowCount:
+        return "aria-rowcount"sv;
+    case StateAndProperties::AriaRowIndex:
+        return "aria-rowindex"sv;
+    case StateAndProperties::AriaRowSpan:
+        return "aria-rowspan"sv;
+    case StateAndProperties::AriaSelected:
+        return "aria-selected"sv;
+    case StateAndProperties::AriaSetSize:
+        return "aria-setsize"sv;
+    case StateAndProperties::AriaSort:
+        return "aria-sort"sv;
+    case StateAndProperties::AriaValueMax:
+        return "aria-valuemax"sv;
+    case StateAndProperties::AriaValueMin:
+        return "aria-valuemin"sv;
+    case StateAndProperties::AriaValueNow:
+        return "aria-valuenow"sv;
+    case StateAndProperties::AriaValueText:
+        return "aria-valuetext"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+}

--- a/Userland/Libraries/LibWeb/ARIA/StateAndProperties.h
+++ b/Userland/Libraries/LibWeb/ARIA/StateAndProperties.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <LibWeb/ARIA/ARIAMixin.h>
+#include <LibWeb/ARIA/RoleType.h>
+
+namespace Web::ARIA {
+
+enum class StateAndProperties {
+    AriaActiveDescendant,
+    AriaAtomic,
+    AriaAutoComplete,
+    AriaBusy,
+    AriaChecked,
+    AriaColCount,
+    AriaColIndex,
+    AriaColSpan,
+    AriaControls,
+    AriaCurrent,
+    AriaDescribedBy,
+    AriaDetails,
+    AriaDisabled,
+    AriaDropEffect,
+    AriaErrorMessage,
+    AriaExpanded,
+    AriaFlowTo,
+    AriaGrabbed,
+    AriaHasPopup,
+    AriaHidden,
+    AriaInvalid,
+    AriaKeyShortcuts,
+    AriaLabel,
+    AriaLabelledBy,
+    AriaLevel,
+    AriaLive,
+    AriaModal,
+    AriaMultiLine,
+    AriaMultiSelectable,
+    AriaOrientation,
+    AriaOwns,
+    AriaPlaceholder,
+    AriaPosInSet,
+    AriaPressed,
+    AriaReadOnly,
+    AriaRelevant,
+    AriaRequired,
+    AriaRoleDescription,
+    AriaRowCount,
+    AriaRowIndex,
+    AriaRowSpan,
+    AriaSelected,
+    AriaSetSize,
+    AriaSort,
+    AriaValueMax,
+    AriaValueMin,
+    AriaValueNow,
+    AriaValueText
+};
+
+using DefaultValueType = Variant<Empty, f64, AriaOrientation, AriaLive, bool, AriaHasPopup>;
+ErrorOr<String> state_or_property_to_string_value(StateAndProperties, AriaData const&, DefaultValueType = {});
+ErrorOr<String> tristate_to_string(Tristate);
+ErrorOr<String> optional_integer_to_string(Optional<i32>);
+ErrorOr<String> optional_bool_to_string(Optional<bool>);
+ErrorOr<String> optional_number_to_string(Optional<f64>);
+ErrorOr<String> id_reference_list_to_string(Vector<DeprecatedString> const&);
+StringView state_or_property_to_string(StateAndProperties);
+
+}

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(libweb_generators)
 
 set(SOURCES
+    ARIA/AriaData.cpp
     ARIA/ARIAMixin.cpp
     ARIA/ARIAMixin.idl
     ARIA/Roles.cpp

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     ARIA/ARIAMixin.cpp
     ARIA/ARIAMixin.idl
     ARIA/Roles.cpp
+    ARIA/StateAndProperties.cpp
     Bindings/AudioConstructor.cpp
     Bindings/HostDefined.cpp
     Bindings/ImageConstructor.cpp

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     ARIA/ARIAMixin.cpp
     ARIA/ARIAMixin.idl
     ARIA/Roles.cpp
+    ARIA/RoleType.cpp
     ARIA/StateAndProperties.cpp
     Bindings/AudioConstructor.cpp
     Bindings/HostDefined.cpp
@@ -591,9 +592,19 @@ set(SOURCES
     XML/XMLDocumentBuilder.cpp
 )
 
+invoke_generator(
+        "AriaRoles.cpp"
+        Lagom::GenerateAriaRoles
+        "${CMAKE_CURRENT_SOURCE_DIR}/ARIA/AriaRoles.json"
+        "ARIA/AriaRoles.h"
+        "ARIA/AriaRoles.cpp"
+        arguments -j "${CMAKE_CURRENT_SOURCE_DIR}/ARIA/AriaRoles.json"
+)
+
 generate_css_implementation()
 
 set(GENERATED_SOURCES
+    ARIA/AriaRoles.cpp
     CSS/DefaultStyleSheetSource.cpp
     CSS/Enums.cpp
     CSS/MediaFeatureID.cpp

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1779,4 +1779,9 @@ void Element::scroll(HTML::ScrollToOptions const&)
     dbgln("FIXME: Implement Element::scroll(ScrollToOptions)");
 }
 
+bool Element::id_reference_exists(DeprecatedString const& id_reference) const
+{
+    return document().get_element_by_id(id_reference);
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -318,6 +318,8 @@ protected:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
+    virtual bool id_reference_exists(DeprecatedString const&) const override;
+
 private:
     void make_html_uppercased_qualified_name();
 

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -23,6 +23,12 @@ class ResourceLoader;
 class XMLDocumentBuilder;
 }
 
+namespace Web::ARIA {
+class AriaData;
+class ARIAMixin;
+enum class StateAndProperties;
+}
+
 namespace Web::Bindings {
 class Intrinsics;
 class OptionConstructor;

--- a/Userland/Libraries/LibWebView/AriaPropertiesStateModel.cpp
+++ b/Userland/Libraries/LibWebView/AriaPropertiesStateModel.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "AriaPropertiesStateModel.h"
+
+namespace WebView {
+
+AriaPropertiesStateModel::AriaPropertiesStateModel(JsonObject properties_state)
+    : m_properties_state(move(properties_state))
+{
+    m_properties_state.for_each_member([&](auto property_name, JsonValue const& values) {
+        Value value;
+        value.name = property_name;
+        value.value = "";
+        m_values.append(value);
+        values.as_object().for_each_member([&](auto property_name, auto& property_value) {
+            Value value;
+            value.name = property_name;
+            value.value = property_value.to_deprecated_string();
+            m_values.append(value);
+        });
+    });
+}
+
+AriaPropertiesStateModel::~AriaPropertiesStateModel() = default;
+
+int AriaPropertiesStateModel::row_count(GUI::ModelIndex const&) const
+{
+    return m_values.size();
+}
+
+ErrorOr<String> AriaPropertiesStateModel::column_name(int column_index) const
+{
+    switch (column_index) {
+    case Column::PropertyName:
+        return "Name"_short_string;
+    case Column::PropertyValue:
+        return "Value"_short_string;
+    default:
+        return Error::from_string_view("Unexpected column index"sv);
+    }
+}
+
+GUI::Variant AriaPropertiesStateModel::data(GUI::ModelIndex const& index, GUI::ModelRole role) const
+{
+    auto& value = m_values[index.row()];
+    if (role == GUI::ModelRole::Display) {
+        if (index.column() == Column::PropertyName)
+            return value.name;
+        if (index.column() == Column::PropertyValue)
+            return value.value;
+    }
+
+    return {};
+}
+
+Vector<GUI::ModelIndex> AriaPropertiesStateModel::matches(AK::StringView searching, unsigned int flags, GUI::ModelIndex const& parent)
+{
+    if (m_values.is_empty())
+        return {};
+    Vector<GUI::ModelIndex> found_indices;
+    for (auto it = m_values.begin(); !it.is_end(); ++it) {
+        GUI::ModelIndex index = this->index(it.index(), Column::PropertyName, parent);
+        if (!string_matches(data(index, GUI::ModelRole::Display).as_string(), searching, flags))
+            continue;
+
+        found_indices.append(index);
+        if (flags & FirstMatchOnly)
+            break;
+    }
+    return found_indices;
+}
+
+}

--- a/Userland/Libraries/LibWebView/AriaPropertiesStateModel.h
+++ b/Userland/Libraries/LibWebView/AriaPropertiesStateModel.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023, Jonah Shafran <jonahshafran@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonObject.h>
+#include <LibGUI/Model.h>
+
+namespace WebView {
+
+class AriaPropertiesStateModel final : public GUI::Model {
+public:
+    enum Column {
+        PropertyName,
+        PropertyValue,
+        __Count
+    };
+
+    static ErrorOr<NonnullRefPtr<AriaPropertiesStateModel>> create(StringView properties_state)
+    {
+        auto json_or_error = TRY(JsonValue::from_string(properties_state));
+        return adopt_nonnull_ref_or_enomem(new AriaPropertiesStateModel(json_or_error.as_object()));
+    }
+
+    virtual ~AriaPropertiesStateModel() override;
+
+    virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
+    virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
+    virtual ErrorOr<String> column_name(int) const override;
+    virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
+    virtual bool is_searchable() const override { return true; }
+    virtual Vector<GUI::ModelIndex> matches(StringView, unsigned flags, GUI::ModelIndex const&) override;
+
+private:
+    explicit AriaPropertiesStateModel(JsonObject);
+
+    JsonObject m_properties_state;
+
+    struct Value {
+        DeprecatedString name;
+        DeprecatedString value;
+    };
+    Vector<Value> m_values;
+};
+
+}

--- a/Userland/Libraries/LibWebView/CMakeLists.txt
+++ b/Userland/Libraries/LibWebView/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     AccessibilityTreeModel.cpp
+    AriaPropertiesStateModel.cpp
     DOMTreeModel.cpp
     OutOfProcessWebView.cpp
     RequestServerAdapter.cpp

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -118,6 +118,7 @@ ErrorOr<ViewImplementation::DOMNodeProperties> ViewImplementation::inspect_dom_n
         .resolved_style_json = TRY(String::from_deprecated_string(response.take_resolved_style())),
         .custom_properties_json = TRY(String::from_deprecated_string(response.take_custom_properties())),
         .node_box_sizing_json = TRY(String::from_deprecated_string(response.take_node_box_sizing())),
+        .aria_properties_state_json = TRY(String::from_deprecated_string(response.take_aria_properties_state())),
     };
 }
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -44,6 +44,7 @@ public:
         String resolved_style_json;
         String custom_properties_json;
         String node_box_sizing_json;
+        String aria_properties_state_json;
     };
 
     void set_url(Badge<WebContentClient>, AK::URL url) { m_url = move(url); }
@@ -110,7 +111,7 @@ public:
     Function<void(Gfx::Bitmap const&)> on_favicon_change;
     Function<void(const AK::URL&, DeprecatedString const&)> on_get_source;
     Function<void(DeprecatedString const&)> on_get_dom_tree;
-    Function<void(i32 node_id, DeprecatedString const& computed_style, DeprecatedString const& resolved_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing)> on_get_dom_node_properties;
+    Function<void(i32 node_id, DeprecatedString const& computed_style, DeprecatedString const& resolved_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing, DeprecatedString const& aria_properties_state)> on_get_dom_node_properties;
     Function<void(DeprecatedString const&)> on_get_accessibility_tree;
     Function<void(i32 message_id)> on_js_console_new_message;
     Function<void(i32 start_index, Vector<DeprecatedString> const& message_types, Vector<DeprecatedString> const& messages)> on_get_js_console_messages;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -194,10 +194,10 @@ void WebContentClient::did_get_dom_tree(DeprecatedString const& dom_tree)
         m_view.on_get_dom_tree(dom_tree);
 }
 
-void WebContentClient::did_get_dom_node_properties(i32 node_id, DeprecatedString const& computed_style, DeprecatedString const& resolved_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing)
+void WebContentClient::did_get_dom_node_properties(i32 node_id, DeprecatedString const& computed_style, DeprecatedString const& resolved_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing, DeprecatedString const& aria_properties_state)
 {
     if (m_view.on_get_dom_node_properties)
-        m_view.on_get_dom_node_properties(node_id, computed_style, resolved_style, custom_properties, node_box_sizing);
+        m_view.on_get_dom_node_properties(node_id, computed_style, resolved_style, custom_properties, node_box_sizing, aria_properties_state);
 }
 
 void WebContentClient::did_get_accessibility_tree(DeprecatedString const& accessibility_tree)

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -55,7 +55,7 @@ private:
     virtual void did_request_media_context_menu(Gfx::IntPoint, DeprecatedString const&, unsigned, Web::Page::MediaContextMenu const&) override;
     virtual void did_get_source(AK::URL const&, DeprecatedString const&) override;
     virtual void did_get_dom_tree(DeprecatedString const&) override;
-    virtual void did_get_dom_node_properties(i32 node_id, DeprecatedString const& computed_style, DeprecatedString const& resolved_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing) override;
+    virtual void did_get_dom_node_properties(i32 node_id, DeprecatedString const& computed_style, DeprecatedString const& resolved_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing, DeprecatedString const& aria_properties_stae) override;
     virtual void did_get_accessibility_tree(DeprecatedString const&) override;
     virtual void did_output_js_console_message(i32 message_index) override;
     virtual void did_get_js_console_messages(i32 start_index, Vector<DeprecatedString> const& message_types, Vector<DeprecatedString> const& messages) override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -40,7 +40,7 @@ endpoint WebContentClient
     did_request_dismiss_dialog() =|
     did_get_source(URL url, DeprecatedString source) =|
     did_get_dom_tree(DeprecatedString dom_tree) =|
-    did_get_dom_node_properties(i32 node_id, DeprecatedString computed_style, DeprecatedString resolved_style, DeprecatedString custom_properties, DeprecatedString node_box_sizing_json) =|
+    did_get_dom_node_properties(i32 node_id, DeprecatedString computed_style, DeprecatedString resolved_style, DeprecatedString custom_properties, DeprecatedString node_box_sizing_json, DeprecatedString aria_properties_state) =|
     did_get_accessibility_tree(DeprecatedString accessibility_tree) =|
     did_change_favicon(Gfx::ShareableBitmap favicon) =|
     did_request_all_cookies(URL url) => (Vector<Web::Cookie::Cookie> cookies)

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -39,7 +39,7 @@ endpoint WebContentServer
     debug_request(DeprecatedString request, DeprecatedString argument) =|
     get_source() =|
     inspect_dom_tree() =|
-    inspect_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> pseudo_element) => (bool has_style, DeprecatedString computed_style,  DeprecatedString resolved_style,  DeprecatedString custom_properties, DeprecatedString node_box_sizing)
+    inspect_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> pseudo_element) => (bool has_style, DeprecatedString computed_style,  DeprecatedString resolved_style,  DeprecatedString custom_properties, DeprecatedString node_box_sizing, DeprecatedString aria_properties_state)
     inspect_accessibility_tree() =|
     get_hovered_node_id() => (i32 node_id)
     js_console_input(DeprecatedString js_source) =|


### PR DESCRIPTION
This PR adds support for the WAI-ARIA role model. This allows us to determine what state and properties are supported/required/prohibited on a given element, as well as providing default values for some properties and state. You can view this information in the new ARIA tab on the widget inspector:
![image](https://github.com/SerenityOS/serenity/assets/9423342/661cce25-b3c6-4ec9-96dd-27e92ddc782a)
By doing this, we have now implemented the last major piece of the ARIA standards suite before we can start thinking about using this data outside the browser :^)