### PR TITLE
LibWeb: Support grid-auto-columns and grid-auto-rows properties in GFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/auto-track-sizes.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-track-sizes.txt
@@ -1,0 +1,8 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x60 children: not-inline
+      Box <div.grid> at (8,8) content-size 784x60 [GFC] children: not-inline
+        BlockContainer <div#c1> at (8,8) content-size 23x11 [BFC] children: not-inline
+        BlockContainer <div#c2> at (8,8) content-size 52x24 [BFC] children: not-inline
+        BlockContainer <div#c3> at (8,8) content-size 83x41 [BFC] children: not-inline
+        BlockContainer <div#c4> at (8,8) content-size 120x60 [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/input/grid/auto-track-sizes.html
+++ b/Tests/LibWeb/Layout/input/grid/auto-track-sizes.html
@@ -1,0 +1,27 @@
+<!-- https://wpt.live/css/css-grid/grid-definition/grid-auto-explicit-rows-001.html -->
+<style>
+.grid {
+    display: grid;
+    grid-template-areas: "a b c" "d e f" "g e h";
+    grid-template-rows: 11px 13px;
+    grid-auto-rows: 17px 19px;
+    grid-template-columns: 23px 29px;
+    grid-auto-columns: 31px 37px;
+}
+
+.grid > div {
+    background: rgba(0, 0, 0, 0.2);
+}
+#c1 {
+    grid-area: 1 / 1 / 2 / 2;
+}
+#c2 {
+    grid-area: 1 / 1 / 3 / 3;
+}
+#c3 {
+    grid-area: 1 / 1 / 4 / 4;
+}
+#c4 {
+    grid-area: 1 / 1 / 5 / 5;
+}
+</style><div class="grid"><div id="c1"></div><div id="c2"></div><div id="c3"></div><div id="c4"></div></div>

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -251,6 +251,8 @@ public:
     CSS::Size const& min_height() const { return m_noninherited.min_height; }
     CSS::Size const& max_height() const { return m_noninherited.max_height; }
     Variant<CSS::VerticalAlign, CSS::LengthPercentage> const& vertical_align() const { return m_noninherited.vertical_align; }
+    CSS::GridTrackSizeList const& grid_auto_columns() const { return m_noninherited.grid_auto_columns; }
+    CSS::GridTrackSizeList const& grid_auto_rows() const { return m_noninherited.grid_auto_rows; }
     CSS::GridTrackSizeList const& grid_template_columns() const { return m_noninherited.grid_template_columns; }
     CSS::GridTrackSizeList const& grid_template_rows() const { return m_noninherited.grid_template_rows; }
     CSS::GridTrackPlacement const& grid_column_end() const { return m_noninherited.grid_column_end; }
@@ -385,6 +387,8 @@ protected:
         CSS::BoxSizing box_sizing { InitialValues::box_sizing() };
         CSS::ContentData content;
         Variant<CSS::VerticalAlign, CSS::LengthPercentage> vertical_align { InitialValues::vertical_align() };
+        CSS::GridTrackSizeList grid_auto_columns;
+        CSS::GridTrackSizeList grid_auto_rows;
         CSS::GridTrackSizeList grid_template_columns;
         CSS::GridTrackSizeList grid_template_rows;
         CSS::GridTrackPlacement grid_column_end { InitialValues::grid_column_end() };
@@ -471,6 +475,8 @@ public:
     void set_box_sizing(CSS::BoxSizing value) { m_noninherited.box_sizing = value; }
     void set_vertical_align(Variant<CSS::VerticalAlign, CSS::LengthPercentage> value) { m_noninherited.vertical_align = move(value); }
     void set_visibility(CSS::Visibility value) { m_inherited.visibility = value; }
+    void set_grid_auto_columns(CSS::GridTrackSizeList value) { m_noninherited.grid_auto_columns = move(value); }
+    void set_grid_auto_rows(CSS::GridTrackSizeList value) { m_noninherited.grid_auto_rows = move(value); }
     void set_grid_template_columns(CSS::GridTrackSizeList value) { m_noninherited.grid_template_columns = move(value); }
     void set_grid_template_rows(CSS::GridTrackSizeList value) { m_noninherited.grid_template_rows = move(value); }
     void set_grid_column_end(CSS::GridTrackPlacement value) { m_noninherited.grid_column_end = value; }

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
@@ -189,7 +189,7 @@ ErrorOr<String> GridTrackSizeList::to_string() const
     };
 
     for (size_t i = 0; i < m_track_list.size(); ++i) {
-        if (m_line_names[i].size() > 0) {
+        if (m_line_names.size() > 0 && m_line_names[i].size() > 0) {
             print_line_names(i);
             builder.append(" "sv);
         }
@@ -197,7 +197,7 @@ ErrorOr<String> GridTrackSizeList::to_string() const
         if (i < m_track_list.size() - 1)
             builder.append(" "sv);
     }
-    if (m_line_names[m_track_list.size()].size() > 0) {
+    if (m_line_names.size() > 0 && m_line_names[m_track_list.size()].size() > 0) {
         builder.append(" "sv);
         print_line_names(m_track_list.size());
     }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -323,6 +323,7 @@ private:
     ErrorOr<RefPtr<StyleValue>> parse_transform_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_transform_origin_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_grid_track_size_list(Vector<ComponentValue> const&, bool allow_separate_line_name_blocks = false);
+    ErrorOr<RefPtr<StyleValue>> parse_grid_auto_track_sizes(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_grid_track_size_list_shorthand_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_grid_track_placement(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_grid_track_placement_shorthand_value(Vector<ComponentValue> const&);

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -958,6 +958,30 @@
       "string"
     ]
   },
+  "grid-auto-columns": {
+    "inherited": false,
+    "initial": "auto",
+    "valid-identifiers": [
+      "auto"
+    ],
+    "valid-types": [
+      "length",
+      "percentage",
+      "string"
+    ]
+  },
+  "grid-auto-rows": {
+    "inherited": false,
+    "initial": "auto",
+    "valid-identifiers": [
+      "auto"
+    ],
+    "valid-types": [
+      "length",
+      "percentage",
+      "string"
+    ]
+  },
   "grid-template-columns": {
     "inherited": false,
     "initial": "auto",

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -758,6 +758,18 @@ Optional<CSS::FontVariant> StyleProperties::font_variant() const
     return value_id_to_font_variant(value->to_identifier());
 }
 
+CSS::GridTrackSizeList StyleProperties::grid_auto_columns() const
+{
+    auto value = property(CSS::PropertyID::GridAutoColumns);
+    return value->as_grid_track_size_list().grid_track_size_list();
+}
+
+CSS::GridTrackSizeList StyleProperties::grid_auto_rows() const
+{
+    auto value = property(CSS::PropertyID::GridAutoRows);
+    return value->as_grid_track_size_list().grid_track_size_list();
+}
+
 CSS::GridTrackSizeList StyleProperties::grid_template_columns() const
 {
     auto value = property(CSS::PropertyID::GridTemplateColumns);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -85,6 +85,8 @@ public:
     Optional<CSS::PointerEvents> pointer_events() const;
     Variant<CSS::VerticalAlign, CSS::LengthPercentage> vertical_align() const;
     Optional<CSS::FontVariant> font_variant() const;
+    CSS::GridTrackSizeList grid_auto_columns() const;
+    CSS::GridTrackSizeList grid_auto_rows() const;
     CSS::GridTrackSizeList grid_template_columns() const;
     CSS::GridTrackSizeList grid_template_rows() const;
     CSS::GridTrackPlacement grid_column_end() const;

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -553,13 +553,33 @@ void GridFormattingContext::initialize_grid_tracks_from_definition(AvailableSpac
 
 void GridFormattingContext::initialize_grid_tracks_for_columns_and_rows(AvailableSpace const& available_space)
 {
-    initialize_grid_tracks_from_definition(available_space, grid_container().computed_values().grid_template_columns().track_list(), m_grid_columns);
-    initialize_grid_tracks_from_definition(available_space, grid_container().computed_values().grid_template_rows().track_list(), m_grid_rows);
+    auto const& grid_computed_values = grid_container().computed_values();
+    initialize_grid_tracks_from_definition(available_space, grid_computed_values.grid_template_columns().track_list(), m_grid_columns);
+    initialize_grid_tracks_from_definition(available_space, grid_computed_values.grid_template_rows().track_list(), m_grid_rows);
 
-    for (size_t column_index = m_grid_columns.size(); column_index < m_occupation_grid.column_count(); column_index++)
-        m_grid_columns.append(TemporaryTrack());
-    for (size_t row_index = m_grid_rows.size(); row_index < m_occupation_grid.row_count(); row_index++)
-        m_grid_rows.append(TemporaryTrack());
+    auto const& grid_auto_columns = grid_computed_values.grid_auto_columns().track_list();
+    size_t implicit_column_index = 0;
+    for (size_t column_index = m_grid_columns.size(); column_index < m_occupation_grid.column_count(); column_index++) {
+        if (grid_auto_columns.size() > 0) {
+            auto size = grid_auto_columns[implicit_column_index % grid_auto_columns.size()];
+            m_grid_columns.append(TemporaryTrack(size.grid_size()));
+        } else {
+            m_grid_columns.append(TemporaryTrack());
+        }
+        implicit_column_index++;
+    }
+
+    auto const& grid_auto_rows = grid_computed_values.grid_auto_rows().track_list();
+    size_t implicit_row_index = 0;
+    for (size_t row_index = m_grid_rows.size(); row_index < m_occupation_grid.row_count(); row_index++) {
+        if (grid_auto_rows.size() > 0) {
+            auto size = grid_auto_rows[implicit_row_index % grid_auto_rows.size()];
+            m_grid_rows.append(TemporaryTrack(size.grid_size()));
+        } else {
+            m_grid_rows.append(TemporaryTrack());
+        }
+        implicit_row_index++;
+    }
 }
 
 void GridFormattingContext::initialize_gap_tracks(AvailableSpace const& available_space)


### PR DESCRIPTION
Implements assignment of sizes specified in grid-auto-columns/rows for implicitly created tracks.