### PR TITLE
unzip: Add option to list files of an archive

### DIFF
--- a/Userland/Utilities/unzip.cpp
+++ b/Userland/Utilities/unzip.cpp
@@ -104,10 +104,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     StringView zip_file_path;
     bool quiet { false };
+    bool list_files { false };
     StringView output_directory_path;
     Vector<StringView> file_filters;
 
     Core::ArgsParser args_parser;
+    args_parser.add_option(list_files, "Only list files in the archive", "list", 'l');
     args_parser.add_option(output_directory_path, "Directory to receive the archive content", "output-directory", 'd', "path");
     args_parser.add_option(quiet, "Be less verbose", "quiet", 'q');
     args_parser.add_positional_argument(zip_file_path, "File to unzip", "path", Core::ArgsParser::Required::Yes);
@@ -138,6 +140,24 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (!output_directory_path.is_null()) {
         TRY(Core::Directory::create(output_directory_path, Core::Directory::CreateDirectories::Yes));
         TRY(Core::System::chdir(output_directory_path));
+    }
+
+    if (list_files) {
+        outln("Name");
+        outln("----");
+
+        u16 members_count = 0;
+        TRY(zip_file->for_each_member([&](auto zip_member) {
+            members_count++;
+
+            outln("{}", zip_member.name);
+
+            return IterationDecision::Continue;
+        }));
+
+        outln("----");
+        outln("{} files", members_count);
+        return 0;
     }
 
     Vector<Archive::ZipMember> zip_directories;


### PR DESCRIPTION
I tried to replicate the behavior of the `unzip -l` command from Linux. Lines 147-148 and 167-168 are ugly but I don't know how to do otherwise. There might be better ways to format the timestamp as well.

Linux:
![image](https://github.com/SerenityOS/serenity/assets/38137329/f07c92ac-74ac-4e1f-b408-45e030f6e077)
Serenity:
![image](https://github.com/SerenityOS/serenity/assets/38137329/0fcf2123-9697-4d6f-b77b-8864eea731b0)
