### PR TITLE
Magnifier: Correct captured bitmap's clipping

### DIFF
--- a/Userland/Applications/Magnifier/MagnifierWidget.cpp
+++ b/Userland/Applications/Magnifier/MagnifierWidget.cpp
@@ -100,36 +100,22 @@ void MagnifierWidget::paint_event(GUI::PaintEvent& event)
         return;
 
     GUI::Painter painter(*this);
+    auto frame_inner_rect = this->frame_inner_rect();
+    auto bitmap_rect = Gfx::IntRect { frame_inner_rect.top_left(), m_grabbed_bitmap->rect().size() * m_scale_factor };
+    painter.add_clip_rect(frame_inner_rect);
 
     if (m_pause_capture)
-        painter.fill_rect(frame_inner_rect(), Gfx::Color::Black);
-
-    // We have to clip the source rect for cases when the currently captured image is larger than the inner_rect
-    int horizontal_clip = (frame_inner_rect().width() + m_scale_factor - 1) / m_scale_factor;
-    int vertical_clip = (frame_inner_rect().height() + m_scale_factor - 1) / m_scale_factor;
+        painter.fill_rect(frame_inner_rect, Gfx::Color::Black);
 
     if (m_grabbed_bitmap)
-        painter.draw_scaled_bitmap(
-            frame_inner_rect().intersected(Gfx::IntRect { { 0, 0 }, m_grabbed_bitmap->rect().size() } * m_scale_factor),
-            *m_grabbed_bitmap,
-            m_grabbed_bitmap->rect().intersected({ 0, 0, horizontal_clip, vertical_clip }),
-            1.0,
-            Gfx::Painter::ScalingMode::NearestFractional);
+        painter.draw_scaled_bitmap(bitmap_rect, *m_grabbed_bitmap, m_grabbed_bitmap->rect(), 1.0, Gfx::Painter::ScalingMode::NearestNeighbor);
 
     if (m_show_grid) {
+        int start_y = bitmap_rect.top();
+        int start_x = bitmap_rect.left();
 
-        auto grid_rect = frame_inner_rect();
-        if (m_grabbed_bitmap)
-            grid_rect = frame_inner_rect().intersected({ 0,
-                0,
-                m_grabbed_bitmap->rect().width() * m_scale_factor,
-                m_grabbed_bitmap->rect().height() * m_scale_factor });
-
-        int start_y = grid_rect.top(),
-            start_x = grid_rect.left();
-
-        int end_y = grid_rect.bottom(),
-            end_x = grid_rect.right();
+        int end_y = bitmap_rect.bottom();
+        int end_x = bitmap_rect.right();
 
         for (int current_y = start_y; current_y <= end_y; current_y += m_scale_factor)
             painter.draw_line({ start_x, current_y }, { end_x, current_y }, m_grid_color);

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -41,7 +41,6 @@ public:
     };
 
     enum class ScalingMode {
-        NearestFractional,
         NearestNeighbor,
         SmoothPixels,
         BilinearBlend,


### PR DESCRIPTION
Previously, we would get a line of junk pixels to the right or bottom of
the captured bitmap.

Two aspects to this:
- Use Painter's clip-rect functionality instead of trying to implement
  it ourselves.
- Switch from ScalingMode::NearestFractional to ::NearestNeighbor.
  Somehow, `draw_scaled_bitmap(NearestFractional)` draws outside of the
  Painter's clip-rect. I can't discern any difference in behavior
  between these two otherwise.

We also now use the same bitmap for drawing the grid as we used for the
bitmap, since this had issues where it wasn't drawn to the edge of the
bitmap.