### PR TITLE
Chess: Fix stockfish interaction, set I/O as non-blocking on demand

### DIFF
--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -182,4 +182,13 @@ ErrorOr<void> File::truncate(size_t length)
     return System::ftruncate(m_fd, length);
 }
 
+ErrorOr<void> File::set_blocking(bool enabled)
+{
+    // NOTE: This works fine on Serenity, but some systems out there don't support changing the blocking state of certain POSIX objects (message queues, pipes, etc) after their creation.
+    // Therefore, this method shouldn't be used in Lagom.
+    // https://github.com/SerenityOS/serenity/pull/18965#discussion_r1207951840
+    int value = enabled ? 0 : 1;
+    return System::ioctl(fd(), FIONBIO, &value);
+}
+
 }

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -68,6 +68,13 @@ public:
     virtual ErrorOr<size_t> seek(i64 offset, SeekMode) override;
     virtual ErrorOr<void> truncate(size_t length) override;
 
+    // Sets the blocking mode of the file. If blocking mode is disabled, reads
+    // will fail with EAGAIN when there's no data available to read, and writes
+    // will fail with EAGAIN when the data cannot be written without blocking
+    // (due to the send buffer being full, for example).
+    // See also Socket::set_blocking.
+    ErrorOr<void> set_blocking(bool enabled);
+
     template<OneOf<::IPC::File, ::Core::MappedFile> VIP>
     int leak_fd(Badge<VIP>)
     {

--- a/Userland/Services/ChessEngine/main.cpp
+++ b/Userland/Services/ChessEngine/main.cpp
@@ -16,7 +16,11 @@ ErrorOr<int> serenity_main(Main::Arguments)
     Core::EventLoop loop;
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    auto engine = TRY(ChessEngine::try_create(TRY(Core::File::standard_input()), TRY(Core::File::standard_output())));
+    auto infile = TRY(Core::File::standard_input());
+    TRY(infile->set_blocking(false));
+    auto outfile = TRY(Core::File::standard_output());
+    TRY(outfile->set_blocking(false));
+    auto engine = TRY(ChessEngine::try_create(move(infile), move(outfile)));
     engine->on_quit = [&](auto status_code) {
         loop.quit(status_code);
     };


### PR DESCRIPTION
This fixes the behavior of Chess, ChessEngine, and stockfish, as discovered in #18946.

HOWEVER: This causes some other funky issues. 
- Running ChessEngine in the Terminal causes weird behavior, because apparently ChessEngine setting its fd to non-blocking causes some zero-reads in either Shell or Terminal, which makes the Terminal terminate on the second input line. Huh.
- This raises the question why `BufferedFile::can_read_line` insists on populating its entire buffer in the first place. Perhaps that should be fixed, and the `Chess` pipes should always and everywhere be nonblocking?