### PR TITLE
SystemMonitor: Ignore unveil error about unexisting HackStudio binary

### DIFF
--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -265,7 +265,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return result.release_error();
 
     TRY(Core::System::unveil("/bin/Profiler", "rx"));
-    TRY(Core::System::unveil("/bin/HackStudio", "rx"));
+    // HackStudio doesn't exist in the minimal build configuration.
+    if (auto result = Core::System::unveil("/bin/HackStudio", "rx"); result.is_error() && result.error().code() != ENOENT)
+        return result.release_error();
     TRY(Core::System::unveil(nullptr, nullptr));
 
     StringView args_tab = "processes"sv;


### PR DESCRIPTION
The minimal build configuration doesn't include HackStudio and SystemMonitor refused to run after trying to unveil a not exiting file.

This change will just ignore this specific error for this specific file as if nothing really happened.

The ability to quickly debug a process in HackStudio is not the main feature of the application and HackStudio itself is rather heavy to be put in the minimal configuration.

Additionally, I find it unnecessary to disable/hide the 'Debug in HackStudio' action because build configurations are mostly for testing purposes anyway. You will get a 'No such file or directory' error in the console after activating the action though. :^)