### PR TITLE
LibGfx+Everywhere: Change `Gfx::Rect` to be endpoint exclusive

### DIFF
--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -657,11 +657,10 @@ void WebContentView::notify_server_did_request_scroll_into_view(Badge<WebContent
     if (m_viewport_rect.contains(rect))
         return;
 
-    if (rect.top() < m_viewport_rect.top()) {
+    if (rect.top() < m_viewport_rect.top())
         verticalScrollBar()->setValue(rect.top());
-    } else if (rect.top() > m_viewport_rect.top() && rect.bottom() > m_viewport_rect.bottom()) {
-        verticalScrollBar()->setValue(rect.bottom() - m_viewport_rect.height() + 1);
-    }
+    else if (rect.top() > m_viewport_rect.top() && rect.bottom() > m_viewport_rect.bottom())
+        verticalScrollBar()->setValue(rect.bottom() - m_viewport_rect.height());
 }
 
 void WebContentView::notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint content_position, DeprecatedString const& tooltip)

--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_SOURCES
     TestFontHandling.cpp
     TestICCProfile.cpp
     TestImageDecoder.cpp
+    TestRect.cpp
     TestScalingFunctions.cpp
 )
 

--- a/Tests/LibGfx/TestRect.cpp
+++ b/Tests/LibGfx/TestRect.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, Jelle Raaijmakers <jelle@gmta.nl>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Rect.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(int_rect_right_and_bottom)
+{
+    Gfx::IntRect rect = { 2, 3, 4, 5 };
+    EXPECT_EQ(rect.right(), 6);
+    EXPECT_EQ(rect.bottom(), 8);
+}
+
+TEST_CASE(float_rect_right_and_bottom)
+{
+    Gfx::FloatRect rect = { 1.f, 2.f, 3.5f, 4.5f };
+    EXPECT_APPROXIMATE(rect.right(), 4.5f);
+    EXPECT_APPROXIMATE(rect.bottom(), 6.5f);
+}
+
+TEST_CASE(rect_contains_vertically)
+{
+    Gfx::FloatRect rect = { 0.f, 0.f, 100.f, 100.f };
+    EXPECT(rect.contains_vertically(99.f));
+    EXPECT(!rect.contains_vertically(100.f));
+}
+
+TEST_CASE(rect_shatter)
+{
+    Gfx::IntRect glass_plate = { 0, 0, 100, 100 };
+    Gfx::IntRect hammer = { 30, 40, 40, 10 };
+
+    auto shards = glass_plate.shatter(hammer);
+    EXPECT(!shards.is_empty());
+
+    int total_shard_area = 0;
+    for (auto shard : shards) {
+        EXPECT(glass_plate.contains(shard));
+        EXPECT(!hammer.intersects(shard));
+        total_shard_area += shard.size().area();
+    }
+
+    EXPECT_EQ(glass_plate.size().area() - hammer.size().area(), total_shard_area);
+}

--- a/Tests/LibGfx/TestScalingFunctions.cpp
+++ b/Tests/LibGfx/TestScalingFunctions.cpp
@@ -33,7 +33,7 @@ TEST_CASE(test_painter_scaling_uses_premultiplied_alpha)
         EXPECT(center_pixel.alpha() < 255);
         EXPECT_EQ(center_pixel.with_alpha(0), Color(Color::White).with_alpha(0));
 
-        auto bottom_right_pixel = scaled_bitmap->get_pixel(scaled_bitmap->rect().bottom_right());
+        auto bottom_right_pixel = scaled_bitmap->get_pixel(scaled_bitmap->rect().bottom_right().translated(-1));
         EXPECT_EQ(bottom_right_pixel, Color::Transparent);
     };
 
@@ -61,6 +61,6 @@ TEST_CASE(test_bitmap_scaling_uses_premultiplied_alpha)
     EXPECT(center_pixel.alpha() < 255);
     EXPECT_EQ(center_pixel.with_alpha(0), Color(Color::White).with_alpha(0));
 
-    auto bottom_right_pixel = scaled_bitmap->get_pixel(scaled_bitmap->rect().bottom_right());
+    auto bottom_right_pixel = scaled_bitmap->get_pixel(scaled_bitmap->rect().bottom_right().translated(-1));
     EXPECT_EQ(bottom_right_pixel, Color::Transparent);
 }

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -123,13 +123,13 @@ private:
         for (auto value : m_history) {
             if (value >= 0) {
                 painter.draw_line(
-                    { rect.x() + i, rect.bottom() },
+                    { rect.x() + i, rect.bottom() - 1 },
                     { rect.x() + i, rect.top() + (int)(roundf(rect.height() - (value * rect.height()))) },
                     m_graph_color);
             } else {
                 painter.draw_line(
                     { rect.x() + i, rect.top() },
-                    { rect.x() + i, rect.bottom() },
+                    { rect.x() + i, rect.bottom() - 1 },
                     m_graph_error_color);
             }
             ++i;

--- a/Userland/Applications/AnalogClock/AnalogClock.cpp
+++ b/Userland/Applications/AnalogClock/AnalogClock.cpp
@@ -11,13 +11,13 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/Path.h>
 
-void AnalogClock::draw_graduations(GUI::Painter& painter, Gfx::IntRect& rect, int x, int y)
+void AnalogClock::draw_graduations(GUI::Painter& painter, Gfx::IntRect rect, int x, int y)
 {
-    rect.set_x(x);
-    rect.set_y(y);
+    rect.set_location({ x, y });
 
     painter.fill_rect(rect, palette().active_window_border2());
 
+    rect.shrink(0, 1, 1, 0);
     painter.draw_line(rect.top_left(), rect.top_right(), palette().threed_highlight());
     painter.draw_line(rect.bottom_left(), rect.bottom_right(), palette().active_window_border1().darkened(0.7f));
     painter.draw_line(rect.bottom_right(), rect.top_right(), palette().active_window_border1().darkened(0.7f));

--- a/Userland/Applications/AnalogClock/AnalogClock.h
+++ b/Userland/Applications/AnalogClock/AnalogClock.h
@@ -43,7 +43,7 @@ protected:
     void paint_event(GUI::PaintEvent&) override;
     void draw_face(GUI::Painter&);
     void draw_mirrored_graduations(GUI::Painter&, Gfx::IntRect&, int x, int y, int rect_center_offset);
-    void draw_graduations(GUI::Painter&, Gfx::IntRect&, int x, int y);
+    void draw_graduations(GUI::Painter&, Gfx::IntRect, int x, int y);
     void draw_hand(GUI::Painter&, double angle, double length, Gfx::Color hand_color);
     void draw_seconds_hand(GUI::Painter&, double angle);
     void update_title_date();

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -144,7 +144,7 @@ Tab::Tab(BrowserWindow& window)
             i++;
             m_go_back_context_menu->add_action(GUI::Action::create(url.to_deprecated_string(), g_icon_bag.filetype_html, [this, i](auto&) { go_back(i); }));
         }
-        m_go_back_context_menu->popup(go_back_button.screen_relative_rect().bottom_left());
+        m_go_back_context_menu->popup(go_back_button.screen_relative_rect().bottom_left().moved_up(1));
     };
 
     auto& go_forward_button = toolbar.add_action(window.go_forward_action());
@@ -157,7 +157,7 @@ Tab::Tab(BrowserWindow& window)
             i++;
             m_go_forward_context_menu->add_action(GUI::Action::create(url.to_deprecated_string(), g_icon_bag.filetype_html, [this, i](auto&) { go_forward(i); }));
         }
-        m_go_forward_context_menu->popup(go_forward_button.screen_relative_rect().bottom_left());
+        m_go_forward_context_menu->popup(go_forward_button.screen_relative_rect().bottom_left().moved_up(1));
     };
 
     auto& go_home_button = toolbar.add_action(window.go_home_action());

--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
@@ -167,7 +167,7 @@ private:
         auto rect_for_square = [&](Chess::Square const& square) {
             return Gfx::IntRect {
                 frame_inner_rect().left() + square.file * square_size,
-                frame_inner_rect().bottom() + 1 - (square.rank + 1) * square_size,
+                frame_inner_rect().bottom() - (square.rank + 1) * square_size,
                 square_size,
                 square_size
             };

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -605,7 +605,7 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
         height() - height_occupied_by_horizontal_scrollbar() //(total_rows() * line_height()) + 5
     };
     painter.fill_rect(offset_clip_rect, palette().ruler());
-    painter.draw_line(offset_clip_rect.top_right(), offset_clip_rect.bottom_right(), palette().ruler_border());
+    painter.draw_line(offset_clip_rect.top_right(), offset_clip_rect.bottom_right().translated(-1), palette().ruler_border());
 
     auto margin_and_hex_width = static_cast<int>(offset_margin_width() + m_bytes_per_row * cell_width() + 3 * m_padding);
     painter.draw_line({ margin_and_hex_width, 0 },

--- a/Userland/Applications/Magnifier/MagnifierWidget.cpp
+++ b/Userland/Applications/Magnifier/MagnifierWidget.cpp
@@ -117,11 +117,11 @@ void MagnifierWidget::paint_event(GUI::PaintEvent& event)
         int end_y = bitmap_rect.bottom();
         int end_x = bitmap_rect.right();
 
-        for (int current_y = start_y; current_y <= end_y; current_y += m_scale_factor)
-            painter.draw_line({ start_x, current_y }, { end_x, current_y }, m_grid_color);
+        for (int current_y = start_y; current_y < end_y; current_y += m_scale_factor)
+            painter.draw_line({ start_x, current_y }, { end_x - 1, current_y }, m_grid_color);
 
-        for (int current_x = start_y; current_x <= end_x; current_x += m_scale_factor)
-            painter.draw_line({ current_x, start_y }, { current_x, end_y }, m_grid_color);
+        for (int current_x = start_y; current_x < end_x; current_x += m_scale_factor)
+            painter.draw_line({ current_x, start_y }, { current_x, end_y - 1 }, m_grid_color);
     }
 }
 

--- a/Userland/Applications/MouseSettings/DoubleClickArrowWidget.cpp
+++ b/Userland/Applications/MouseSettings/DoubleClickArrowWidget.cpp
@@ -46,7 +46,7 @@ void DoubleClickArrowWidget::paint_event(GUI::PaintEvent& event)
     });
 
     auto text_rect = rect();
-    text_rect.set_y(bottom_arrow_rect.bottom());
+    text_rect.set_y(bottom_arrow_rect.bottom() - 1);
     text_rect.set_height(font().pixel_size_rounded_up());
 }
 

--- a/Userland/Applications/Piano/RollWidget.cpp
+++ b/Userland/Applications/Piano/RollWidget.cpp
@@ -93,6 +93,7 @@ void RollWidget::paint_event(GUI::PaintEvent& event)
                 else
                     background_painter.fill_rect(rect, Color::White);
 
+                rect.shrink(0, 1, 1, 0);
                 background_painter.draw_line(rect.top_right(), rect.bottom_right(), Color::Black);
                 background_painter.draw_line(rect.bottom_left(), rect.bottom_right(), Color::Black);
             }

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -690,7 +690,7 @@ ErrorOr<void> Image::resize(Gfx::IntSize new_size, Gfx::Painter::ScalingMode sca
 
             auto layer_rect = layer->relative_rect().to_type<float>();
             auto scaled_top_left = layer_rect.top_left().scaled(scale_x, scale_y).to_rounded<int>();
-            auto scaled_bottom_right = layer_rect.bottom_right().translated(1).scaled(scale_x, scale_y).to_rounded<int>();
+            auto scaled_bottom_right = layer_rect.bottom_right().scaled(scale_x, scale_y).to_rounded<int>();
             auto scaled_layer_rect = Gfx::IntRect::from_two_points(scaled_top_left, scaled_bottom_right);
             TRY(new_layer->scale(scaled_layer_rect, scaling_mode, Layer::NotifyClients::No));
 

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -172,15 +172,15 @@ void ImageEditor::paint_event(GUI::PaintEvent& event)
         auto event_image_rect = enclosing_int_rect(frame_to_content_rect(event.rect())).inflated(1, 1);
         auto image_rect = m_image->rect().inflated(1, 1).intersected(event_image_rect);
 
-        for (auto i = image_rect.left(); i < image_rect.right(); i++) {
+        for (auto i = image_rect.left(); i < image_rect.right() - 1; i++) {
             auto start_point = content_to_frame_position({ i, image_rect.top() }).to_type<int>();
-            auto end_point = content_to_frame_position({ i, image_rect.bottom() }).to_type<int>();
+            auto end_point = content_to_frame_position({ i, image_rect.bottom() - 1 }).to_type<int>();
             painter.draw_line(start_point, end_point, Color::LightGray);
         }
 
-        for (auto i = image_rect.top(); i < image_rect.bottom(); i++) {
+        for (auto i = image_rect.top(); i < image_rect.bottom() - 1; i++) {
             auto start_point = content_to_frame_position({ image_rect.left(), i }).to_type<int>();
-            auto end_point = content_to_frame_position({ image_rect.right(), i }).to_type<int>();
+            auto end_point = content_to_frame_position({ image_rect.right() - 1, i }).to_type<int>();
             painter.draw_line(start_point, end_point, Color::LightGray);
         }
     }
@@ -822,19 +822,19 @@ void ImageEditor::paint_selection(Gfx::Painter& painter)
 void ImageEditor::draw_marching_ants(Gfx::Painter& painter, Gfx::IntRect const& rect) const
 {
     // Top line
-    for (int x = rect.left(); x <= rect.right(); ++x)
+    for (int x = rect.left(); x < rect.right(); ++x)
         draw_marching_ants_pixel(painter, x, rect.top());
 
     // Right line
-    for (int y = rect.top() + 1; y <= rect.bottom(); ++y)
-        draw_marching_ants_pixel(painter, rect.right(), y);
+    for (int y = rect.top() + 1; y < rect.bottom(); ++y)
+        draw_marching_ants_pixel(painter, rect.right() - 1, y);
 
     // Bottom line
-    for (int x = rect.right() - 1; x >= rect.left(); --x)
-        draw_marching_ants_pixel(painter, x, rect.bottom());
+    for (int x = rect.right() - 2; x >= rect.left(); --x)
+        draw_marching_ants_pixel(painter, x, rect.bottom() - 1);
 
     // Left line
-    for (int y = rect.bottom() - 1; y > rect.top(); --y)
+    for (int y = rect.bottom() - 2; y > rect.top(); --y)
         draw_marching_ants_pixel(painter, rect.left(), y);
 }
 
@@ -849,18 +849,17 @@ void ImageEditor::draw_marching_ants(Gfx::Painter& painter, Mask const& mask) co
     rect.inflate(step * 2, step * 2); // prevent borders from having visible ants if the selection extends beyond it
 
     // Scan the image horizontally to find vertical borders
-    for (int y = rect.top(); y <= rect.bottom(); y += step) {
-
+    for (int y = rect.top(); y < rect.bottom(); y += step) {
         bool previous_selected = false;
-        for (int x = rect.left(); x <= rect.right(); x += step) {
+        for (int x = rect.left(); x < rect.right(); x += step) {
             bool this_selected = mask.get(x, y) > 0;
 
             if (this_selected != previous_selected) {
                 Gfx::IntRect image_pixel { x, y, 1, 1 };
                 auto pixel = content_to_frame_rect(image_pixel).to_type<int>();
-                auto end = max(pixel.top(), pixel.bottom()); // for when the zoom is < 100%
+                auto end = max(pixel.top() + 1, pixel.bottom()); // for when the zoom is < 100%
 
-                for (int pixel_y = pixel.top(); pixel_y <= end; pixel_y++) {
+                for (int pixel_y = pixel.top(); pixel_y < end; pixel_y++) {
                     draw_marching_ants_pixel(painter, pixel.left(), pixel_y);
                 }
             }
@@ -870,20 +869,19 @@ void ImageEditor::draw_marching_ants(Gfx::Painter& painter, Mask const& mask) co
     }
 
     // Scan the image vertically to find horizontal borders
-    for (int x = rect.left(); x <= rect.right(); x += step) {
+    for (int x = rect.left(); x < rect.right(); x += step) {
 
         bool previous_selected = false;
-        for (int y = rect.top(); y <= rect.bottom(); y += step) {
+        for (int y = rect.top(); y < rect.bottom(); y += step) {
             bool this_selected = mask.get(x, y) > 0;
 
             if (this_selected != previous_selected) {
                 Gfx::IntRect image_pixel { x, y, 1, 1 };
                 auto pixel = content_to_frame_rect(image_pixel).to_type<int>();
-                auto end = max(pixel.left(), pixel.right()); // for when the zoom is < 100%
+                auto end = max(pixel.left() + 1, pixel.right()); // for when the zoom is < 100%
 
-                for (int pixel_x = pixel.left(); pixel_x <= end; pixel_x++) {
+                for (int pixel_x = pixel.left(); pixel_x < end; pixel_x++)
                     draw_marching_ants_pixel(painter, pixel_x, pixel.top());
-                }
             }
 
             previous_selected = this_selected;

--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -133,9 +133,8 @@ Gfx::Bitmap& Layer::get_scratch_edited_bitmap()
 
 RefPtr<Gfx::Bitmap> Layer::copy_bitmap(Selection const& selection) const
 {
-    if (selection.is_empty()) {
+    if (selection.is_empty())
         return {};
-    }
     auto selection_rect = selection.bounding_rect();
 
     auto bitmap_or_error = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, selection_rect.size());
@@ -144,9 +143,8 @@ RefPtr<Gfx::Bitmap> Layer::copy_bitmap(Selection const& selection) const
     auto result = bitmap_or_error.release_value_but_fixme_should_propagate_errors();
     VERIFY(result->has_alpha_channel());
 
-    for (int y = selection_rect.top(); y <= selection_rect.bottom(); y++) {
-        for (int x = selection_rect.left(); x <= selection_rect.right(); x++) {
-
+    for (int y = selection_rect.top(); y < selection_rect.bottom(); y++) {
+        for (int x = selection_rect.left(); x < selection_rect.right(); x++) {
             Gfx::IntPoint image_point { x, y };
             auto layer_point = image_point - m_location;
             auto result_point = image_point - selection_rect.top_left();
@@ -180,9 +178,8 @@ void Layer::erase_selection(Selection const& selection)
         for (int x = translated_to_layer_space.left(); x < translated_to_layer_space.left() + translated_to_layer_space.width(); ++x) {
 
             // Selection is still in pre-translated coordinates, account for this by adding the layer's relative location
-            if (content_bitmap().rect().contains(x, y) && selection.is_selected(x + location().x(), y + location().y())) {
+            if (content_bitmap().rect().contains(x, y) && selection.is_selected(x + location().x(), y + location().y()))
                 content_bitmap().set_pixel(x, y, Color::Transparent);
-            }
         }
     }
 

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -98,7 +98,7 @@ void LayerListWidget::get_gadget_rects(Gadget const& gadget, bool is_masked, Gfx
     inner_thumbnail_rect.center_within(outer_thumbnail_rect);
 
     if (is_masked) {
-        outer_mask_thumbnail_rect = { outer_thumbnail_rect.top_right().x() + 5, outer_thumbnail_rect.y(), outer_thumbnail_rect.width(), outer_thumbnail_rect.height() };
+        outer_mask_thumbnail_rect = { outer_thumbnail_rect.right() + 4, outer_thumbnail_rect.y(), outer_thumbnail_rect.width(), outer_thumbnail_rect.height() };
         inner_mask_thumbnail_rect = { 0, 0, thumbnail_size.width(), thumbnail_size.height() };
         inner_mask_thumbnail_rect.center_within(outer_mask_thumbnail_rect);
     } else {
@@ -106,7 +106,7 @@ void LayerListWidget::get_gadget_rects(Gadget const& gadget, bool is_masked, Gfx
         inner_mask_thumbnail_rect = inner_thumbnail_rect;
     }
 
-    text_rect = { outer_mask_thumbnail_rect.right() + 10, outer_rect.y(), outer_rect.width(), outer_rect.height() };
+    text_rect = { outer_mask_thumbnail_rect.right() + 9, outer_rect.y(), outer_rect.width(), outer_rect.height() };
     text_rect.intersect(outer_rect);
 }
 
@@ -279,7 +279,7 @@ void LayerListWidget::mousemove_event(GUI::MouseEvent& event)
     VERIFY(gadget.is_moving);
 
     gadget.movement_delta.set_y(delta.y());
-    auto inner_rect_max_height = widget_inner_rect().height() - 2 + vertical_scrollbar().max();
+    auto inner_rect_max_height = widget_inner_rect().height() - 1 + vertical_scrollbar().max();
 
     if (delta.y() < 0 && gadget.rect.y() < -delta.y())
         gadget.movement_delta.set_y(-gadget.rect.y());
@@ -346,12 +346,12 @@ void LayerListWidget::automatic_scrolling_timer_did_fire()
     vertical_scrollbar().increase_slider_by(m_automatic_scroll_delta.y());
     gadget.movement_delta.set_y(gadget.movement_delta.y() + m_automatic_scroll_delta.y());
 
-    auto inner_rect_max_height = widget_inner_rect().height() - 2 + vertical_scrollbar().max();
+    auto inner_rect_max_height = widget_inner_rect().height() - 1 + vertical_scrollbar().max();
     auto gadget_absolute_position = gadget.rect.y() + gadget.movement_delta.y();
 
     if (gadget_absolute_position < 0)
         gadget.movement_delta.set_y(-gadget.rect.y());
-    else if (gadget_absolute_position + gadget.rect.height() >= inner_rect_max_height)
+    else if (gadget_absolute_position + gadget.rect.height() >= inner_rect_max_height - 1)
         gadget.movement_delta.set_y(inner_rect_max_height - gadget.rect.bottom());
     else
         relayout_gadgets();

--- a/Userland/Applications/PixelPaint/Mask.h
+++ b/Userland/Applications/PixelPaint/Mask.h
@@ -61,10 +61,9 @@ public:
     template<typename Func>
     void for_each_pixel(Func func) const
     {
-        for (int x = m_bounding_rect.left(); x <= m_bounding_rect.right(); x++) {
-            for (int y = m_bounding_rect.top(); y <= m_bounding_rect.bottom(); y++) {
+        for (int x = m_bounding_rect.left(); x < m_bounding_rect.right(); x++) {
+            for (int y = m_bounding_rect.top(); y < m_bounding_rect.bottom(); y++)
                 func(x, y);
-            }
         }
     }
 

--- a/Userland/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Userland/Applications/PixelPaint/PaletteWidget.cpp
@@ -115,7 +115,7 @@ PaletteWidget::PaletteWidget()
     m_primary_color_widget->set_fill_with_background_color(true);
 
     m_color_container = add<GUI::Widget>();
-    m_color_container->set_relative_rect(m_secondary_color_widget->relative_rect().right() + 2, 2, 500, 33);
+    m_color_container->set_relative_rect(m_secondary_color_widget->relative_rect().right() + 1, 2, 500, 33);
     m_color_container->set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 1);
 
     auto& top_color_container = m_color_container->add<GUI::Widget>();

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -78,19 +78,19 @@ void MoveTool::on_mousemove(Layer* layer, MouseEvent& event)
         switch (m_resize_anchor_location.value()) {
         case ResizeAnchorLocation::TopLeft:
             scaling_origin = rect_being_moved.top_left();
-            opposite_corner = rect_being_moved.bottom_right().translated(1, 1);
+            opposite_corner = rect_being_moved.bottom_right();
             break;
         case ResizeAnchorLocation::BottomRight:
-            scaling_origin = rect_being_moved.bottom_right().translated(1, 1);
+            scaling_origin = rect_being_moved.bottom_right();
             opposite_corner = rect_being_moved.top_left();
             break;
         case ResizeAnchorLocation::BottomLeft:
-            scaling_origin = rect_being_moved.bottom_left().translated(0, 1);
-            opposite_corner = rect_being_moved.top_right().translated(1, 0);
+            scaling_origin = rect_being_moved.bottom_left();
+            opposite_corner = rect_being_moved.top_right();
             break;
         case ResizeAnchorLocation::TopRight:
-            scaling_origin = rect_being_moved.top_right().translated(1, 0);
-            opposite_corner = rect_being_moved.bottom_left().translated(0, 1);
+            scaling_origin = rect_being_moved.top_right();
+            opposite_corner = rect_being_moved.bottom_left();
             break;
         }
         scaling_origin.translate_by(delta);
@@ -233,9 +233,9 @@ Array<Gfx::IntRect, 4> MoveTool::resize_anchor_rects(Gfx::IntRect layer_rect_in_
 {
     return Array {
         resize_anchor_rect_from_position(layer_rect_in_frame_coordinates.top_left(), resize_anchor_size),
-        resize_anchor_rect_from_position(layer_rect_in_frame_coordinates.top_right().translated(1, 0), resize_anchor_size),
-        resize_anchor_rect_from_position(layer_rect_in_frame_coordinates.bottom_left().translated(0, 1), resize_anchor_size),
-        resize_anchor_rect_from_position(layer_rect_in_frame_coordinates.bottom_right().translated(1), resize_anchor_size)
+        resize_anchor_rect_from_position(layer_rect_in_frame_coordinates.top_right(), resize_anchor_size),
+        resize_anchor_rect_from_position(layer_rect_in_frame_coordinates.bottom_left(), resize_anchor_size),
+        resize_anchor_rect_from_position(layer_rect_in_frame_coordinates.bottom_right(), resize_anchor_size)
     };
 }
 
@@ -265,11 +265,11 @@ Optional<ResizeAnchorLocation const> MoveTool::resize_anchor_location_from_curso
 
     if (cursor_within_resize_anchor_rect(layer_rect.top_left()))
         return ResizeAnchorLocation::TopLeft;
-    if (cursor_within_resize_anchor_rect(layer_rect.top_right().translated(1, 0)))
+    if (cursor_within_resize_anchor_rect(layer_rect.top_right()))
         return ResizeAnchorLocation::TopRight;
-    if (cursor_within_resize_anchor_rect(layer_rect.bottom_left().translated(0, 1)))
+    if (cursor_within_resize_anchor_rect(layer_rect.bottom_left()))
         return ResizeAnchorLocation::BottomLeft;
-    if (cursor_within_resize_anchor_rect(layer_rect.bottom_right().translated(1)))
+    if (cursor_within_resize_anchor_rect(layer_rect.bottom_right()))
         return ResizeAnchorLocation::BottomRight;
     return {};
 }

--- a/Userland/Applications/Run/main.cpp
+++ b/Userland/Applications/Run/main.cpp
@@ -17,7 +17,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::create(arguments));
     auto window = TRY(RunWindow::try_create());
 
-    window->move_to(16, GUI::Desktop::the().rect().bottom() - GUI::Desktop::the().taskbar_height() - 16 - window->height());
+    constexpr int margin = 16;
+    window->move_to(margin, GUI::Desktop::the().rect().bottom() - 1 - GUI::Desktop::the().taskbar_height() - margin - window->height());
     window->show();
 
     return app->exec();

--- a/Userland/Applications/SystemMonitor/GraphWidget.cpp
+++ b/Userland/Applications/SystemMonitor/GraphWidget.cpp
@@ -59,7 +59,7 @@ void GraphWidget::paint_event(GUI::PaintEvent& event)
             auto const& background_color = line_color.with_alpha(0x7f);
             m_calculated_points.clear_with_capacity();
             for (size_t i = 0; i < m_values.size(); i++) {
-                int x = inner_rect.right() - (i * 2) + 1;
+                int x = inner_rect.right() - i * 2;
                 if (x < 0)
                     break;
                 auto const& current_values = m_values.at(m_values.size() - i - 1);
@@ -74,7 +74,7 @@ void GraphWidget::paint_event(GUI::PaintEvent& event)
                         value += current_values[l];
                 }
                 float scaled_value = value * scale;
-                Gfx::IntPoint current_point { x, inner_rect.bottom() - (int)scaled_value };
+                Gfx::IntPoint current_point { x, inner_rect.bottom() - 1 - (int)scaled_value };
                 m_calculated_points.append(current_point);
             }
             VERIFY(m_calculated_points.size() <= m_values.size());
@@ -91,14 +91,14 @@ void GraphWidget::paint_event(GUI::PaintEvent& event)
                     if (points_in_path > 1) {
                         VERIFY(current_point);
                         VERIFY(first_point);
-                        path.line_to({ current_point->x() - 1, inner_rect.bottom() + 1 });
-                        path.line_to({ first_point->x() + 1, inner_rect.bottom() + 1 });
+                        path.line_to({ current_point->x() - 1, inner_rect.bottom() });
+                        path.line_to({ first_point->x() + 1, inner_rect.bottom() });
                         path.close();
                         painter.fill_path(path, background_color, Gfx::Painter::WindingRule::EvenOdd);
                     } else if (points_in_path == 1 && current_point) {
                         // Can't fill any area, we only have one data point.
                         // Just draw a vertical line as a "fill"...
-                        painter.draw_line(*current_point, { current_point->x(), inner_rect.bottom() }, background_color);
+                        painter.draw_line(*current_point, { current_point->x(), inner_rect.bottom() - 1 }, background_color);
                     }
                     path = {};
                     points_in_path = 0;

--- a/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
@@ -42,7 +42,7 @@ public:
             else
                 VERIFY_NOT_REACHED();
 
-            painter.draw_line({ x, rect.top() }, { x, rect.bottom() }, color);
+            painter.draw_line({ x, rect.top() }, { x, rect.bottom() - 1 }, color);
         }
 
         painter.draw_rect(rect, Color::Black);

--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -48,9 +48,9 @@ public:
     {
         set_view(
             rect.left() * (m_x_end - m_x_start) / m_bitmap->width() + m_x_start,
-            rect.right() * (m_x_end - m_x_start) / m_bitmap->width() + m_x_start,
+            (rect.right() - 1) * (m_x_end - m_x_start) / m_bitmap->width() + m_x_start,
             rect.top() * (m_y_end - m_y_start) / m_bitmap->height() + m_y_start,
-            rect.bottom() * (m_y_end - m_y_start) / m_bitmap->height() + m_y_start);
+            (rect.bottom() - 1) * (m_y_end - m_y_start) / m_bitmap->height() + m_y_start);
         correct_aspect();
         calculate();
     }
@@ -146,8 +146,8 @@ public:
         if (rect.is_empty())
             return;
 
-        for (int py = rect.top(); py <= rect.bottom(); py++)
-            for (int px = rect.left(); px <= rect.right(); px++)
+        for (int py = rect.top(); py < rect.bottom(); py++)
+            for (int px = rect.left(); px < rect.right(); px++)
                 calculate_pixel(px, py, max_iterations);
     }
 

--- a/Userland/DevTools/HackStudio/Git/GitFilesView.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitFilesView.cpp
@@ -40,7 +40,7 @@ void GitFilesView::mousedown_event(GUI::MouseEvent& event)
         return;
     }
 
-    if (event.x() < action_icon_rect(0).x() || event.x() > action_icon_rect(0).top_right().x()) {
+    if (event.x() < action_icon_rect(0).x() || event.x() >= action_icon_rect(0).right()) {
         ListView::mousedown_event(event);
         return;
     }

--- a/Userland/DevTools/Profiler/TimelineHeader.cpp
+++ b/Userland/DevTools/Profiler/TimelineHeader.cpp
@@ -42,7 +42,7 @@ void TimelineHeader::paint_event(GUI::PaintEvent& event)
         painter.blit(icon_rect.location(), *m_icon, m_icon->rect());
 
     Gfx::IntRect text_rect {
-        icon_rect.right() + 6,
+        icon_rect.right() + 5,
         icon_rect.y(),
         width() - 32,
         32

--- a/Userland/Games/BrickGame/BrickGame.cpp
+++ b/Userland/Games/BrickGame/BrickGame.cpp
@@ -570,9 +570,9 @@ void BrickGame::paint_cell(GUI::Painter& painter, Gfx::IntRect rect, BrickGame::
     rect.inflate(-1, -1, -1, -1);
     painter.draw_rect(rect, outside_color);
     painter.set_pixel(rect.top_left(), m_back_color);
-    painter.set_pixel(rect.bottom_left(), m_back_color);
-    painter.set_pixel(rect.top_right(), m_back_color);
-    painter.set_pixel(rect.bottom_right(), m_back_color);
+    painter.set_pixel(rect.bottom_left().moved_up(1), m_back_color);
+    painter.set_pixel(rect.top_right().moved_left(1), m_back_color);
+    painter.set_pixel(rect.bottom_right().translated(-1), m_back_color);
     rect.inflate(-2, -2);
     painter.draw_rect(rect, outside_color);
     rect.inflate(-2, -2);

--- a/Userland/Games/ColorLines/ColorLines.cpp
+++ b/Userland/Games/ColorLines/ColorLines.cpp
@@ -179,7 +179,7 @@ void ColorLines::paint_event(GUI::PaintEvent& event)
 
     auto paint_cell = [&](GUI::Painter& painter, Gfx::IntRect rect, int color, int animation_frame) {
         painter.draw_rect(rect, Color::Black);
-        rect.shrink(0, 1, 1, 0);
+        rect.shrink(0, 2, 2, 0);
         painter.draw_line(rect.bottom_left(), rect.top_left(), Color::White);
         painter.draw_line(rect.top_left(), rect.top_right(), Color::White);
         painter.draw_line(rect.top_right(), rect.bottom_right(), Color::DarkGray);
@@ -189,7 +189,6 @@ void ColorLines::paint_event(GUI::PaintEvent& event)
         painter.draw_line(rect.top_left(), rect.top_right(), Color::LightGray);
         painter.draw_line(rect.top_right(), rect.bottom_right(), Color::MidGray);
         painter.draw_line(rect.bottom_right(), rect.bottom_left(), Color::MidGray);
-        rect.shrink(1, 1, 1, 1);
         painter.fill_rect(rect, tile_color);
         rect.shrink(1, 1, 1, 1);
         if (color >= 0 && color < Marble::number_of_colors) {
@@ -222,7 +221,7 @@ void ColorLines::paint_event(GUI::PaintEvent& event)
     auto const high_score_text = MUST(String::formatted("{:05}"sv, m_high_score));
     text_width = m_score_font->width(high_score_text);
     auto const high_score_text_rect = Gfx::IntRect {
-        frame_inner_rect().top_right().translated(-(text_margin + text_width), text_margin),
+        frame_inner_rect().top_right().translated(-(text_margin + text_width) - 1, text_margin),
         Gfx::IntSize { text_width, font().pixel_size_rounded_up() }
     };
     painter.draw_text(high_score_text_rect, high_score_text, Gfx::TextAlignment::CenterLeft, text_color);

--- a/Userland/Games/Hearts/ScoreCard.cpp
+++ b/Userland/Games/Hearts/ScoreCard.cpp
@@ -75,7 +75,7 @@ void ScoreCard::paint_event(GUI::PaintEvent& event)
             if (score_index != (int)player.scores.size() - 1) {
                 painter.draw_line(
                     { text_rect.left() + text_rect.width() / 2 - score_text_width / 2 - 3, text_rect.top() + font.pixel_size_rounded_up() / 2 },
-                    { text_rect.right() - text_rect.width() / 2 + score_text_width / 2 + 3, text_rect.top() + font.pixel_size_rounded_up() / 2 },
+                    { text_rect.right() - text_rect.width() / 2 + score_text_width / 2 + 2, text_rect.top() + font.pixel_size_rounded_up() / 2 },
                     text_color);
             }
             painter.draw_text(text_rect,

--- a/Userland/Games/Minesweeper/Field.cpp
+++ b/Userland/Games/Minesweeper/Field.cpp
@@ -363,14 +363,14 @@ void Field::paint_event(GUI::PaintEvent& event)
     auto inner_rect = frame_inner_rect();
     painter.add_clip_rect(inner_rect);
 
-    for (int y = inner_rect.top() - 1; y <= inner_rect.bottom(); y += square_size()) {
+    for (int y = inner_rect.top() - 1; y < inner_rect.bottom(); y += square_size()) {
         Gfx::IntPoint a { inner_rect.left(), y };
-        Gfx::IntPoint b { inner_rect.right(), y };
+        Gfx::IntPoint b { inner_rect.right() - 1, y };
         painter.draw_line(a, b, palette().threed_shadow1());
     }
-    for (int x = frame_inner_rect().left() - 1; x <= frame_inner_rect().right(); x += square_size()) {
+    for (int x = frame_inner_rect().left() - 1; x < frame_inner_rect().right(); x += square_size()) {
         Gfx::IntPoint a { x, inner_rect.top() };
-        Gfx::IntPoint b { x, inner_rect.bottom() };
+        Gfx::IntPoint b { x, inner_rect.bottom() - 1 };
         painter.draw_line(a, b, palette().threed_shadow1());
     }
 }

--- a/Userland/Games/Snake/Skins/ClassicSkin.cpp
+++ b/Userland/Games/Snake/Skins/ClassicSkin.cpp
@@ -22,8 +22,8 @@ void ClassicSkin::draw_tile_at(Gfx::Painter& painter, Gfx::IntRect const& rect)
 
     Gfx::IntRect left_side(rect.x(), rect.y(), 2, rect.height());
     Gfx::IntRect top_side(rect.x(), rect.y(), rect.width(), 2);
-    Gfx::IntRect right_side(rect.right() - 1, rect.y(), 2, rect.height());
-    Gfx::IntRect bottom_side(rect.x(), rect.bottom() - 1, rect.width(), 2);
+    Gfx::IntRect right_side(rect.right() - 2, rect.y(), 2, rect.height());
+    Gfx::IntRect bottom_side(rect.x(), rect.bottom() - 2, rect.width(), 2);
     auto top_left_color = m_skin_color.lightened(0.88);
     auto bottom_right_color = m_skin_color.darkened(0.55);
     painter.fill_rect(left_side, top_left_color);

--- a/Userland/Libraries/LibCards/CardPainter.cpp
+++ b/Userland/Libraries/LibCards/CardPainter.cpp
@@ -205,13 +205,12 @@ void CardPainter::paint_card_front(Gfx::Bitmap& bitmap, Cards::Suit suit, Cards:
     painter.draw_text(text_rect, card_rank_label(rank), font, Gfx::TextAlignment::Center, suit_color);
 
     painter.draw_bitmap(
-        { text_rect.x() + (text_rect.width() - suit_symbol.size().width()) / 2, text_rect.bottom() + 5 },
+        { text_rect.x() + (text_rect.width() - suit_symbol.size().width()) / 2, text_rect.bottom() + 4 },
         suit_symbol, suit_color);
 
     for (int y = Card::height / 2; y < Card::height; ++y) {
-        for (int x = 0; x < Card::width; ++x) {
+        for (int x = 0; x < Card::width; ++x)
             bitmap.set_pixel(x, y, bitmap.get_pixel(Card::width - x - 1, Card::height - y - 1));
-        }
     }
 }
 

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
@@ -105,7 +105,7 @@ void AbstractScrollableWidget::custom_layout()
     {
         int vertical_scrollbar_width = m_vertical_scrollbar->effective_min_size().width().as_int();
         m_vertical_scrollbar->set_relative_rect(
-            inner_rect.right() + 1 - vertical_scrollbar_width,
+            inner_rect.right() - vertical_scrollbar_width,
             inner_rect.top() + height_wanted_by_banner_widget,
             vertical_scrollbar_width,
             inner_rect.height() - height_wanted_by_horizontal_scrollbar - height_wanted_by_banner_widget);
@@ -115,14 +115,14 @@ void AbstractScrollableWidget::custom_layout()
         int horizontal_scrollbar_height = m_horizontal_scrollbar->effective_min_size().height().as_int();
         m_horizontal_scrollbar->set_relative_rect(
             inner_rect.left(),
-            inner_rect.bottom() + 1 - horizontal_scrollbar_height,
+            inner_rect.bottom() - horizontal_scrollbar_height,
             inner_rect.width() - width_wanted_by_vertical_scrollbar,
             horizontal_scrollbar_height);
     }
 
     m_corner_widget->set_visible(m_vertical_scrollbar->is_visible() && m_horizontal_scrollbar->is_visible());
     if (m_corner_widget->is_visible()) {
-        Gfx::IntRect corner_rect { m_horizontal_scrollbar->relative_rect().right() + 1, m_vertical_scrollbar->relative_rect().bottom() + 1, width_occupied_by_vertical_scrollbar(), height_occupied_by_horizontal_scrollbar() };
+        Gfx::IntRect corner_rect { m_horizontal_scrollbar->relative_rect().right(), m_vertical_scrollbar->relative_rect().bottom(), width_occupied_by_vertical_scrollbar(), height_occupied_by_horizontal_scrollbar() };
         m_corner_widget->set_relative_rect(corner_rect);
     }
 }
@@ -273,18 +273,16 @@ void AbstractScrollableWidget::scroll_into_view(Gfx::IntRect const& rect, bool s
         return;
 
     if (scroll_vertically) {
-        if (rect.top() < visible_content_rect.top()) {
+        if (rect.top() < visible_content_rect.top())
             m_vertical_scrollbar->set_value(rect.top());
-        } else if (rect.top() > visible_content_rect.top() && rect.bottom() > visible_content_rect.bottom()) {
-            m_vertical_scrollbar->set_value(rect.bottom() - visible_content_rect.height() + 1);
-        }
+        else if (rect.top() > visible_content_rect.top() && rect.bottom() > visible_content_rect.bottom())
+            m_vertical_scrollbar->set_value(rect.bottom() - visible_content_rect.height());
     }
     if (scroll_horizontally) {
-        if (rect.left() < visible_content_rect.left()) {
+        if (rect.left() < visible_content_rect.left())
             m_horizontal_scrollbar->set_value(rect.left());
-        } else if (rect.left() > visible_content_rect.left() && rect.right() > visible_content_rect.right()) {
-            m_horizontal_scrollbar->set_value(rect.right() - visible_content_rect.width() + 1);
-        }
+        else if (rect.left() > visible_content_rect.left() && rect.right() > visible_content_rect.right())
+            m_horizontal_scrollbar->set_value(rect.right() - visible_content_rect.width());
     }
 }
 

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
@@ -106,7 +106,7 @@ void AbstractThemePreview::paint_window(StringView title, Gfx::IntRect const& re
     int window_button_width = m_preview_palette.window_title_button_width();
     int window_button_height = m_preview_palette.window_title_button_height();
     auto titlebar_text_rect = Gfx::WindowTheme::current().titlebar_text_rect(Gfx::WindowTheme::WindowType::Normal, Gfx::WindowTheme::WindowMode::Other, rect, m_preview_palette);
-    int pos = titlebar_text_rect.right() + 1;
+    int pos = titlebar_text_rect.right();
 
     Array possible_buttons {
         Button { {}, m_close_bitmap.is_null() ? m_default_close_bitmap : m_close_bitmap },

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -222,7 +222,7 @@ void Button::set_menu(RefPtr<GUI::Menu> menu)
 void Button::mousedown_event(MouseEvent& event)
 {
     if (m_menu) {
-        m_menu->popup(screen_relative_rect().bottom_left(), {}, rect());
+        m_menu->popup(screen_relative_rect().bottom_left().moved_up(1), {}, rect());
         update();
         return;
     }

--- a/Userland/Libraries/LibGUI/CheckBox.cpp
+++ b/Userland/Libraries/LibGUI/CheckBox.cpp
@@ -64,7 +64,7 @@ void CheckBox::paint_event(PaintEvent& event)
     auto box_rect = this->box_rect();
     auto text_rect = rect();
     if (m_checkbox_position == CheckBoxPosition::Left)
-        text_rect.set_left(box_rect.right() + 1 + gap_between_box_and_rect());
+        text_rect.set_left(box_rect.right() + gap_between_box_and_rect());
     text_rect.set_width(font().width_rounded_up(text()));
     text_rect.set_top(height() / 2 - font().pixel_size_rounded_up() / 2);
     text_rect.set_height(font().pixel_size_rounded_up());

--- a/Userland/Libraries/LibGUI/ColumnsView.cpp
+++ b/Userland/Libraries/LibGUI/ColumnsView.cpp
@@ -80,8 +80,8 @@ void ColumnsView::second_paint_event(PaintEvent& event)
     auto column_right = column_x + m_rubber_band_origin_column.width;
 
     // The rubber band rect always stays inside the widget inner rect, the vertical component is handled by mousemove
-    auto rubber_band_left = clamp(column_left, widget_inner_rect().left(), widget_inner_rect().right() + 1);
-    auto rubber_band_right = clamp(column_right, widget_inner_rect().left(), widget_inner_rect().right() + 1);
+    auto rubber_band_left = clamp(column_left, widget_inner_rect().left(), widget_inner_rect().right());
+    auto rubber_band_right = clamp(column_right, widget_inner_rect().left(), widget_inner_rect().right());
 
     auto rubber_band_rect = Gfx::IntRect::from_two_points({ rubber_band_left, m_rubber_band_origin }, { rubber_band_right, m_rubber_band_current });
 
@@ -155,7 +155,7 @@ void ColumnsView::paint_event(PaintEvent& event)
             }
 
             Gfx::IntRect text_rect = {
-                icon_rect.right() + 1 + icon_spacing(), row * item_height(),
+                icon_rect.right() + icon_spacing(), row * item_height(),
                 column.width - icon_spacing() - icon_size() - icon_spacing() - icon_spacing() - static_cast<int>(s_arrow_bitmap.width()) - icon_spacing(), item_height()
             };
             draw_item_text(painter, index, is_selected_row, text_rect, index.data().to_deprecated_string(), font_for_index(index), Gfx::TextAlignment::CenterLeft, Gfx::TextElision::None);
@@ -172,7 +172,7 @@ void ColumnsView::paint_event(PaintEvent& event)
             bool expandable = model()->row_count(index) > 0;
             if (expandable) {
                 Gfx::IntRect arrow_rect = {
-                    text_rect.right() + 1 + icon_spacing(), 0,
+                    text_rect.right() + icon_spacing(), 0,
                     s_arrow_bitmap.width(), s_arrow_bitmap.height()
                 };
                 arrow_rect.center_vertically_within(row_rect);
@@ -339,7 +339,7 @@ void ColumnsView::mousedown_event(MouseEvent& event)
 void ColumnsView::mousemove_event(MouseEvent& event)
 {
     if (m_rubber_banding) {
-        m_rubber_band_current = clamp(event.position().y(), widget_inner_rect().top(), widget_inner_rect().bottom() + 1);
+        m_rubber_band_current = clamp(event.position().y(), widget_inner_rect().top(), widget_inner_rect().bottom());
 
         auto parent = m_rubber_band_origin_column.parent_index;
         int row_count = model()->row_count(parent);

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -246,11 +246,11 @@ void ComboBox::open()
     auto max_height = min(m_list_view->item_height() * m_max_visible_items, m_list_view->content_height());
     auto min_width = m_list_view->content_width() + frame;
     Gfx::IntSize size { max(width(), min_width), max_height + frame };
-    Gfx::IntRect rect { screen_relative_rect().bottom_left(), size };
+    Gfx::IntRect rect { screen_relative_rect().bottom_left().moved_up(1), size };
 
     auto desktop = Desktop::the().rect();
     auto min_height = 5 * m_list_view->item_height() + frame;
-    auto go_upwards_instead = rect.bottom() >= desktop.height() && rect.intersected(desktop).height() < min_height;
+    auto go_upwards_instead = rect.bottom() - 1 >= desktop.height() && rect.intersected(desktop).height() < min_height;
     if (go_upwards_instead) {
         auto origin = screen_relative_rect().top_left();
         rect = { Gfx::IntPoint { origin.x(), origin.y() - size.height() }, size };

--- a/Userland/Libraries/LibGUI/HeaderView.cpp
+++ b/Userland/Libraries/LibGUI/HeaderView.cpp
@@ -81,8 +81,8 @@ HeaderView::VisibleSectionRange HeaderView::visible_section_range() const
     auto section_count = this->section_count();
     auto is_horizontal = m_orientation == Orientation::Horizontal;
     auto rect = m_table_view.visible_content_rect();
-    auto start = is_horizontal ? rect.top_left().x() : rect.top_left().y();
-    auto end = is_horizontal ? (rect.top_left().x() + m_table_view.content_width()) : rect.bottom_left().y();
+    auto start = is_horizontal ? rect.left() : rect.top();
+    auto end = is_horizontal ? (rect.left() + m_table_view.content_width()) : rect.bottom() - 1;
     auto offset = 0;
     VisibleSectionRange range;
     for (; range.end < section_count; ++range.end) {
@@ -113,7 +113,7 @@ Gfx::IntRect HeaderView::section_resize_grabbable_rect(int section) const
     if (m_orientation == Gfx::Orientation::Vertical)
         return {};
     auto rect = section_rect(section);
-    return { rect.right() - 1, rect.top(), 4, rect.height() };
+    return { rect.right() - 2, rect.top(), 4, rect.height() };
 }
 
 int HeaderView::section_count() const
@@ -250,8 +250,8 @@ void HeaderView::mouseup_event(MouseEvent& event)
 
 void HeaderView::paint_horizontal(Painter& painter)
 {
-    painter.draw_line({ 0, 0 }, { rect().right(), 0 }, palette().threed_highlight());
-    painter.draw_line({ 0, rect().bottom() }, { rect().right(), rect().bottom() }, palette().threed_shadow1());
+    painter.draw_line({ 0, 0 }, { rect().right() - 1, 0 }, palette().threed_highlight());
+    painter.draw_line({ 0, rect().bottom() - 1 }, { rect().right() - 1, rect().bottom() - 1 }, palette().threed_shadow1());
     auto range = visible_section_range();
     int x_offset = range.start_offset;
     for (int section = range.start; section < range.end; ++section) {
@@ -283,7 +283,7 @@ void HeaderView::paint_horizontal(Painter& painter)
         x_offset += section_width + m_table_view.horizontal_padding() * 2;
     }
 
-    if (x_offset < rect().right()) {
+    if (x_offset < rect().right() - 1) {
         Gfx::IntRect cell_rect(x_offset, 0, width() - x_offset, height());
         Gfx::StylePainter::paint_button(painter, cell_rect, palette(), Gfx::ButtonStyle::Normal, false, false);
     }
@@ -291,8 +291,8 @@ void HeaderView::paint_horizontal(Painter& painter)
 
 void HeaderView::paint_vertical(Painter& painter)
 {
-    painter.draw_line(rect().top_left(), rect().bottom_left(), palette().threed_highlight());
-    painter.draw_line(rect().top_right(), rect().bottom_right(), palette().threed_shadow1());
+    painter.draw_line(rect().top_left(), rect().bottom_left().moved_up(1), palette().threed_highlight());
+    painter.draw_line(rect().top_right().moved_left(1), rect().bottom_right().translated(-1), palette().threed_shadow1());
     auto range = visible_section_range();
     int y_offset = range.start_offset;
     for (int section = range.start; section < range.end; ++section) {
@@ -312,7 +312,7 @@ void HeaderView::paint_vertical(Painter& painter)
         y_offset += section_size;
     }
 
-    if (y_offset < rect().bottom()) {
+    if (y_offset < rect().bottom() - 1) {
         Gfx::IntRect cell_rect(0, y_offset, width(), height() - y_offset);
         Gfx::StylePainter::paint_button(painter, cell_rect, palette(), Gfx::ButtonStyle::Normal, false, false);
     }

--- a/Userland/Libraries/LibGUI/IconView.cpp
+++ b/Userland/Libraries/LibGUI/IconView.cpp
@@ -431,7 +431,7 @@ void IconView::get_item_rects(int item_index, ItemData& item_data, Gfx::Font con
     int unwrapped_text_width = font.width_rounded_up(item_data.text);
     int available_width = item_rect.width() - 6;
 
-    item_data.text_rect = { 0, item_data.icon_rect.bottom() + 6 + 1, 0, font.pixel_size_rounded_up() };
+    item_data.text_rect = { 0, item_data.icon_rect.bottom() + 6, 0, font.pixel_size_rounded_up() };
     item_data.wrapped_text_lines.clear();
 
     if ((unwrapped_text_width > available_width) && (item_data.selected || m_hovered_index == item_data.index || cursor_index() == item_data.index || m_always_wrap_item_labels)) {
@@ -789,7 +789,7 @@ inline IterationDecision IconView::for_each_item_intersecting_rect(Gfx::IntRect 
     int begin_row, begin_column;
     column_row_from_content_position(rect.top_left(), begin_row, begin_column);
     int end_row, end_column;
-    column_row_from_content_position(rect.bottom_right(), end_row, end_column);
+    column_row_from_content_position(rect.bottom_right().translated(-1), end_row, end_column);
 
     int items_per_flow_axis_step;
     int item_index;

--- a/Userland/Libraries/LibGUI/IncrementalSearchBanner.cpp
+++ b/Userland/Libraries/LibGUI/IncrementalSearchBanner.cpp
@@ -118,8 +118,8 @@ void IncrementalSearchBanner::paint_event(PaintEvent& event)
 
     Painter painter(*this);
     painter.add_clip_rect(event.rect());
-    painter.draw_line({ 0, rect().bottom() - 1 }, { width(), rect().bottom() - 1 }, palette().threed_shadow1());
-    painter.draw_line({ 0, rect().bottom() }, { width(), rect().bottom() }, palette().threed_shadow2());
+    painter.draw_line({ 0, rect().bottom() - 2 }, { width(), rect().bottom() - 2 }, palette().threed_shadow1());
+    painter.draw_line({ 0, rect().bottom() - 1 }, { width(), rect().bottom() - 1 }, palette().threed_shadow2());
 }
 
 Optional<UISize> IncrementalSearchBanner::calculated_min_size() const

--- a/Userland/Libraries/LibGUI/LinkLabel.cpp
+++ b/Userland/Libraries/LibGUI/LinkLabel.cpp
@@ -98,7 +98,7 @@ void LinkLabel::paint_event(PaintEvent& event)
     GUI::Painter painter(*this);
 
     if (m_hovered)
-        painter.draw_line({ 0, rect().bottom() }, { font().width_rounded_up(text()), rect().bottom() }, palette().link());
+        painter.draw_line({ 0, rect().bottom() - 1 }, { font().width_rounded_up(text()), rect().bottom() - 1 }, palette().link());
 
     if (is_focused())
         painter.draw_focus_rect(text_rect(), palette().focus_outline());

--- a/Userland/Libraries/LibGUI/OpacitySlider.cpp
+++ b/Userland/Libraries/LibGUI/OpacitySlider.cpp
@@ -47,16 +47,15 @@ void OpacitySlider::paint_event(PaintEvent& event)
     constexpr int notch_size = 3;
     if (orientation() == Gfx::Orientation::Horizontal) {
         int notch_y_top = inner_rect.top() + notch_size;
-        int notch_y_bottom = inner_rect.bottom() - notch_size;
+        int notch_y_bottom = inner_rect.bottom() - 1 - notch_size;
         int notch_x = inner_rect.left() + ((float)value() / (float)max() * (float)inner_rect.width());
 
         // Top notch
         painter.set_pixel(notch_x, notch_y_top, palette().threed_shadow2());
         for (int i = notch_size; i >= 0; --i) {
             painter.set_pixel(notch_x - (i + 1), notch_y_top - i - 1, palette().threed_highlight());
-            for (int j = 0; j < i * 2; ++j) {
+            for (int j = 0; j < i * 2; ++j)
                 painter.set_pixel(notch_x - (i + 1) + j + 1, notch_y_top - i - 1, palette().button());
-            }
             painter.set_pixel(notch_x + (i + 0), notch_y_top - i - 1, palette().threed_shadow1());
             painter.set_pixel(notch_x + (i + 1), notch_y_top - i - 1, palette().threed_shadow2());
         }
@@ -65,9 +64,8 @@ void OpacitySlider::paint_event(PaintEvent& event)
         painter.set_pixel(notch_x, notch_y_bottom, palette().threed_shadow2());
         for (int i = 0; i < notch_size; ++i) {
             painter.set_pixel(notch_x - (i + 1), notch_y_bottom + i + 1, palette().threed_highlight());
-            for (int j = 0; j < i * 2; ++j) {
+            for (int j = 0; j < i * 2; ++j)
                 painter.set_pixel(notch_x - (i + 1) + j + 1, notch_y_bottom + i + 1, palette().button());
-            }
             painter.set_pixel(notch_x + (i + 0), notch_y_bottom + i + 1, palette().threed_shadow1());
             painter.set_pixel(notch_x + (i + 1), notch_y_bottom + i + 1, palette().threed_shadow2());
         }
@@ -83,16 +81,15 @@ void OpacitySlider::paint_event(PaintEvent& event)
             painter.draw_line({ notch_x - 1, notch_y_top }, { notch_x - 1, notch_y_bottom }, Color(h, h, h, 255));
     } else {
         int notch_x_left = inner_rect.left() + notch_size;
-        int notch_x_right = inner_rect.right() - notch_size;
+        int notch_x_right = inner_rect.right() - 1 - notch_size;
         int notch_y = inner_rect.top() + ((float)value() / (float)max() * (float)inner_rect.height());
 
         // Left notch
         painter.set_pixel(notch_x_left, notch_y, palette().threed_shadow2());
         for (int i = notch_size; i >= 0; --i) {
             painter.set_pixel(notch_x_left - i - 1, notch_y - (i + 1), palette().threed_highlight());
-            for (int j = 0; j < i * 2; ++j) {
+            for (int j = 0; j < i * 2; ++j)
                 painter.set_pixel(notch_x_left - i - 1, notch_y - (i + 1) + j + 1, palette().button());
-            }
             painter.set_pixel(notch_x_left - i - 1, notch_y + (i + 0), palette().threed_shadow1());
             painter.set_pixel(notch_x_left - i - 1, notch_y + (i + 1), palette().threed_shadow2());
         }
@@ -101,9 +98,8 @@ void OpacitySlider::paint_event(PaintEvent& event)
         painter.set_pixel(notch_x_right, notch_y, palette().threed_shadow2());
         for (int i = 0; i < notch_size; ++i) {
             painter.set_pixel(notch_x_right + i + 1, notch_y - (i + 1), palette().threed_highlight());
-            for (int j = 0; j < i * 2; ++j) {
+            for (int j = 0; j < i * 2; ++j)
                 painter.set_pixel(notch_x_right + i + 1, notch_y - (i + 1) + j + 1, palette().button());
-            }
             painter.set_pixel(notch_x_right + i + 1, notch_y + (i + 0), palette().threed_shadow1());
             painter.set_pixel(notch_x_right + i + 1, notch_y + (i + 1), palette().threed_shadow2());
         }

--- a/Userland/Libraries/LibGUI/RadioButton.cpp
+++ b/Userland/Libraries/LibGUI/RadioButton.cpp
@@ -51,7 +51,7 @@ void RadioButton::paint_event(PaintEvent& event)
 
     Gfx::StylePainter::paint_radio_button(painter, circle_rect, palette(), is_checked(), is_being_pressed());
 
-    Gfx::IntRect text_rect { circle_rect.right() + 5 + horizontal_padding(), 0, font().width_rounded_up(text()), font().pixel_size_rounded_up() };
+    Gfx::IntRect text_rect { circle_rect.right() + 4 + horizontal_padding(), 0, font().width_rounded_up(text()), font().pixel_size_rounded_up() };
     text_rect.center_vertically_within(rect());
     paint_text(painter, text_rect, font(), Gfx::TextAlignment::TopLeft);
 

--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -179,21 +179,21 @@ void Scrollbar::paint_event(PaintEvent& event)
         Gfx::IntRect rect_to_fill = rect();
         if (orientation() == Orientation::Vertical) {
             if (m_gutter_click_state == GutterClickState::BeforeScrubber) {
-                rect_to_fill.set_top(decrement_button_rect().bottom());
-                rect_to_fill.set_bottom(scrubber_rect().top());
+                rect_to_fill.set_top(decrement_button_rect().bottom() - 1);
+                rect_to_fill.set_bottom(scrubber_rect().top() + 1);
             } else {
                 VERIFY(m_gutter_click_state == GutterClickState::AfterScrubber);
-                rect_to_fill.set_top(scrubber_rect().bottom());
-                rect_to_fill.set_bottom(increment_button_rect().top());
+                rect_to_fill.set_top(scrubber_rect().bottom() - 1);
+                rect_to_fill.set_bottom(increment_button_rect().top() + 1);
             }
         } else {
             if (m_gutter_click_state == GutterClickState::BeforeScrubber) {
-                rect_to_fill.set_left(decrement_button_rect().right());
-                rect_to_fill.set_right(scrubber_rect().left());
+                rect_to_fill.set_left(decrement_button_rect().right() - 1);
+                rect_to_fill.set_right(scrubber_rect().left() + 1);
             } else {
                 VERIFY(m_gutter_click_state == GutterClickState::AfterScrubber);
-                rect_to_fill.set_left(scrubber_rect().right());
-                rect_to_fill.set_right(increment_button_rect().left());
+                rect_to_fill.set_left(scrubber_rect().right() - 1);
+                rect_to_fill.set_right(increment_button_rect().left() + 1);
             }
         }
         painter.fill_rect_with_dither_pattern(rect_to_fill, palette().button(), palette().button().lightened(0.77f));

--- a/Userland/Libraries/LibGUI/SeparatorWidget.cpp
+++ b/Userland/Libraries/LibGUI/SeparatorWidget.cpp
@@ -29,12 +29,12 @@ void SeparatorWidget::paint_event(PaintEvent& event)
 
     if (m_orientation == Gfx::Orientation::Vertical) {
         painter.translate(rect().center().x() - 1, 0);
-        painter.draw_line({ 0, 0 }, { 0, rect().bottom() }, palette().threed_shadow1());
-        painter.draw_line({ 1, 0 }, { 1, rect().bottom() }, palette().threed_highlight());
+        painter.draw_line({ 0, 0 }, { 0, rect().bottom() - 1 }, palette().threed_shadow1());
+        painter.draw_line({ 1, 0 }, { 1, rect().bottom() - 1 }, palette().threed_highlight());
     } else {
         painter.translate(0, rect().center().y() - 1);
-        painter.draw_line({ 0, 0 }, { rect().right(), 0 }, palette().threed_shadow1());
-        painter.draw_line({ 0, 1 }, { rect().right(), 1 }, palette().threed_highlight());
+        painter.draw_line({ 0, 0 }, { rect().right() - 1, 0 }, palette().threed_shadow1());
+        painter.draw_line({ 0, 1 }, { rect().right() - 1, 1 }, palette().threed_highlight());
     }
 }
 

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -253,7 +253,7 @@ void TabWidget::paint_event(PaintEvent& event)
         icon_rect.translate_by(4, (button_rect.height() / 2) - (icon_rect.height() / 2));
 
         painter.draw_scaled_bitmap(icon_rect, *icon, icon->rect());
-        text_rect.set_x(icon_rect.right() + 1 + 4);
+        text_rect.set_x(icon_rect.right() + 4);
         text_rect.intersect(button_rect);
     };
 
@@ -288,12 +288,12 @@ void TabWidget::paint_event(PaintEvent& event)
 
             Gfx::IntRect icon_rect { close_button_rect.x() + 3, close_button_rect.y() + 3, 6, 6 };
             if (!m_tabs[i].modified) {
-                painter.draw_line(icon_rect.top_left(), icon_rect.bottom_right(), palette().button_text());
-                painter.draw_line(icon_rect.top_right(), icon_rect.bottom_left(), palette().button_text());
+                painter.draw_line(icon_rect.top_left(), icon_rect.bottom_right().translated(-1), palette().button_text());
+                painter.draw_line(icon_rect.top_right().moved_left(1), icon_rect.bottom_left().moved_up(1), palette().button_text());
             } else {
-                painter.draw_line(icon_rect.top_left().moved_right(1), icon_rect.bottom_right().translated(-1, -1), palette().button_text());
-                painter.draw_line(icon_rect.top_right().moved_left(1), icon_rect.bottom_left().translated(1, -1), palette().button_text());
-                painter.draw_line(icon_rect.bottom_left().moved_down(1), icon_rect.bottom_right().moved_down(1), palette().button_text(), 1, Painter::LineStyle::Dotted);
+                painter.draw_line(icon_rect.top_left().moved_right(1), icon_rect.bottom_right().translated(-2), palette().button_text());
+                painter.draw_line(icon_rect.top_right().moved_left(2), icon_rect.bottom_left().translated(1, -2), palette().button_text());
+                painter.draw_line(icon_rect.bottom_left(), icon_rect.bottom_right().moved_left(1), palette().button_text(), 1, Painter::LineStyle::Dotted);
             }
         }
     }
@@ -329,12 +329,12 @@ void TabWidget::paint_event(PaintEvent& event)
         }
 
         if (m_tab_position == TabPosition::Top) {
-            painter.draw_line(button_rect.bottom_left().translated(1, 1), button_rect.bottom_right().translated(-1, 1), palette().button());
+            painter.draw_line(button_rect.bottom_left().moved_right(1), button_rect.bottom_right().translated(-2, 0), palette().button());
         } else if (m_tab_position == TabPosition::Bottom) {
             painter.set_pixel(button_rect.top_left().translated(0, -1), palette().threed_highlight());
-            painter.set_pixel(button_rect.top_right().translated(-1, -1), palette().threed_shadow1());
-            painter.draw_line(button_rect.top_left().translated(1, -1), button_rect.top_right().translated(-2, -1), palette().button());
-            painter.draw_line(button_rect.top_left().translated(1, -2), button_rect.top_right().translated(-2, -2), palette().button());
+            painter.set_pixel(button_rect.top_right().translated(-2, -1), palette().threed_shadow1());
+            painter.draw_line(button_rect.top_left().translated(1, -1), button_rect.top_right().translated(-3, -1), palette().button());
+            painter.draw_line(button_rect.top_left().translated(1, -2), button_rect.top_right().translated(-3, -2), palette().button());
         }
         break;
     }
@@ -362,12 +362,12 @@ void TabWidget::paint_event(PaintEvent& event)
 
         Gfx::IntRect icon_rect { close_button_rect.x() + 3, close_button_rect.y() + 3, 6, 6 };
         if (!m_tabs[i].modified) {
-            painter.draw_line(icon_rect.top_left(), icon_rect.bottom_right(), palette().button_text());
-            painter.draw_line(icon_rect.top_right(), icon_rect.bottom_left(), palette().button_text());
+            painter.draw_line(icon_rect.top_left(), icon_rect.bottom_right().translated(-1), palette().button_text());
+            painter.draw_line(icon_rect.top_right().moved_left(1), icon_rect.bottom_left().moved_up(1), palette().button_text());
         } else {
-            painter.draw_line(icon_rect.top_left().moved_right(1), icon_rect.bottom_right().translated(-1, -1), palette().button_text());
-            painter.draw_line(icon_rect.top_right().moved_left(1), icon_rect.bottom_left().translated(1, -1), palette().button_text());
-            painter.draw_line(icon_rect.bottom_left().moved_down(1), icon_rect.bottom_right().moved_down(1), palette().button_text(), 1, Painter::LineStyle::Dotted);
+            painter.draw_line(icon_rect.top_left().moved_right(1), icon_rect.bottom_right().translated(-2, -2), palette().button_text());
+            painter.draw_line(icon_rect.top_right().moved_left(2), icon_rect.bottom_left().moved_right(1), palette().button_text());
+            painter.draw_line(icon_rect.bottom_left(), icon_rect.bottom_right().moved_left(1), palette().button_text(), 1, Painter::LineStyle::Dotted);
         }
     }
 }
@@ -444,7 +444,7 @@ Gfx::IntRect TabWidget::close_button_rect(size_t index) const
     auto rect = button_rect(index);
     Gfx::IntRect close_button_rect { 0, 0, 12, 12 };
 
-    close_button_rect.translate_by(rect.right(), rect.top());
+    close_button_rect.translate_by(rect.right() - 1, rect.top());
     close_button_rect.translate_by(-(close_button_rect.width() + 4), (rect.height() / 2) - (close_button_rect.height() / 2));
 
     return close_button_rect;
@@ -459,9 +459,8 @@ int TabWidget::TabData::width(Gfx::Font const& font) const
     //       text and the focus rect has an odd number of pixels, and this
     //       causes the text (and subsequently the focus rect) to not be aligned
     //       to the center perfectly.
-    if (width % 2 == 0) {
+    if (width % 2 == 0)
         width++;
-    }
 
     return width;
 }

--- a/Userland/Libraries/LibGUI/TableView.cpp
+++ b/Userland/Libraries/LibGUI/TableView.cpp
@@ -53,7 +53,7 @@ void TableView::paint_event(PaintEvent& event)
 
     bool dummy;
     int first_visible_row = index_at_event_position(frame_inner_rect().top_left().translated(x_offset, y_offset), dummy).row();
-    int last_visible_row = index_at_event_position(frame_inner_rect().bottom_right().translated(x_offset, y_offset), dummy).row();
+    int last_visible_row = index_at_event_position(frame_inner_rect().bottom_right().translated(-1).translated(x_offset, y_offset), dummy).row();
 
     if (first_visible_row == -1)
         first_visible_row = 0;
@@ -136,9 +136,9 @@ void TableView::paint_event(PaintEvent& event)
             }
 
             if (m_grid_style == GridStyle::Horizontal || m_grid_style == GridStyle::Both)
-                painter.draw_line(cell_rect_for_fill.bottom_left(), cell_rect_for_fill.bottom_right(), palette().ruler());
+                painter.draw_line(cell_rect_for_fill.bottom_left().moved_up(1), cell_rect_for_fill.bottom_right().translated(-1), palette().ruler());
             if (m_grid_style == GridStyle::Vertical || m_grid_style == GridStyle::Both)
-                painter.draw_line(cell_rect_for_fill.top_right(), cell_rect_for_fill.bottom_right(), palette().ruler());
+                painter.draw_line(cell_rect_for_fill.top_right().moved_left(1), cell_rect_for_fill.bottom_right().translated(-1), palette().ruler());
 
             if (selection_behavior() == SelectionBehavior::SelectItems && cell_index == cursor_index())
                 painter.draw_rect(cell_rect_for_fill, palette().text_cursor());
@@ -173,7 +173,7 @@ void TableView::second_paint_event(PaintEvent& event)
 
     // The rubber band rect always borders the widget inner to the left and right
     auto rubber_band_left = widget_inner_rect().left();
-    auto rubber_band_right = widget_inner_rect().right() + 1;
+    auto rubber_band_right = widget_inner_rect().right();
 
     auto rubber_band_rect = Gfx::IntRect::from_two_points({ rubber_band_left, m_rubber_band_origin }, { rubber_band_right, m_rubber_band_current });
 
@@ -250,7 +250,7 @@ void TableView::mousemove_event(MouseEvent& event)
 {
     if (m_rubber_banding) {
         // The rubber band rect cannot go outside the bounds of the rect enclosing all rows
-        m_rubber_band_current = clamp(event.position().y(), widget_inner_rect().top() + column_header().height(), widget_inner_rect().bottom() + 1);
+        m_rubber_band_current = clamp(event.position().y(), widget_inner_rect().top() + column_header().height(), widget_inner_rect().bottom());
 
         int row_count = model()->row_count();
 

--- a/Userland/Libraries/LibGUI/TextBox.cpp
+++ b/Userland/Libraries/LibGUI/TextBox.cpp
@@ -114,7 +114,7 @@ void PasswordBox::paint_event(PaintEvent& event)
         painter.fill_ellipse(dot_indicator_rect, icon_color);
 
         Gfx::IntPoint arc_start_point { dot_indicator_rect.x() - dot_indicator_padding / 2, dot_indicator_rect.y() + dot_indicator_padding / 2 };
-        Gfx::IntPoint arc_end_point = { dot_indicator_rect.top_right().x() + dot_indicator_padding / 2, dot_indicator_rect.top_right().y() + dot_indicator_padding / 2 };
+        Gfx::IntPoint arc_end_point = { dot_indicator_rect.right() - 1 + dot_indicator_padding / 2, dot_indicator_rect.top() + dot_indicator_padding / 2 };
         Gfx::IntPoint arc_center_point = { dot_indicator_rect.center().x(), dot_indicator_rect.top() - dot_indicator_padding };
         painter.draw_quadratic_bezier_curve(arc_center_point, arc_start_point, arc_end_point, icon_color, 1);
     }

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -169,7 +169,7 @@ Optional<UISize> Toolbar::calculated_min_size() const
 ErrorOr<void> Toolbar::create_overflow_objects()
 {
     m_overflow_action = Action::create("Overflow Menu", { Mod_Ctrl | Mod_Shift, Key_O }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/overflow-menu.png"sv)), [&](auto&) {
-        m_overflow_menu->popup(m_overflow_button->screen_relative_rect().bottom_left(), {}, m_overflow_button->rect());
+        m_overflow_menu->popup(m_overflow_button->screen_relative_rect().bottom_left().moved_up(1), {}, m_overflow_button->rect());
     });
     m_overflow_action->set_status_tip("Show hidden toolbar actions");
     m_overflow_action->set_enabled(false);

--- a/Userland/Libraries/LibGUI/ToolbarContainer.cpp
+++ b/Userland/Libraries/LibGUI/ToolbarContainer.cpp
@@ -31,8 +31,8 @@ void ToolbarContainer::paint_event(GUI::PaintEvent& event)
     for_each_child_widget([&](auto& widget) {
         if (widget.is_visible()) {
             auto rect = widget.relative_rect();
-            painter.draw_line(rect.top_left().translated(0, -1), rect.top_right().translated(0, -1), palette().threed_highlight());
-            painter.draw_line(rect.bottom_left().translated(0, 1), rect.bottom_right().translated(0, 1), palette().threed_shadow1());
+            painter.draw_line(rect.top_left().moved_up(1), rect.top_right().translated(-1), palette().threed_highlight());
+            painter.draw_line(rect.bottom_left(), rect.bottom_right().moved_left(1), palette().threed_shadow1());
         }
         return IterationDecision::Continue;
     });

--- a/Userland/Libraries/LibGUI/Tray.cpp
+++ b/Userland/Libraries/LibGUI/Tray.cpp
@@ -82,7 +82,7 @@ void Tray::paint_event(GUI::PaintEvent& event)
         icon_rect.center_vertically_within(rect);
 
         Gfx::IntRect text_rect {
-            icon_rect.right() + 5,
+            icon_rect.right() + 4,
             rect.y(),
             rect.width(),
             rect.height(),

--- a/Userland/Libraries/LibGUI/TreeView.cpp
+++ b/Userland/Libraries/LibGUI/TreeView.cpp
@@ -327,7 +327,7 @@ void TreeView::paint_event(PaintEvent& event)
                 Gfx::IntRect icon_rect = { rect.x(), rect.y(), icon_size(), icon_size() };
                 icon_rect.center_vertically_within(rect);
                 Gfx::IntRect background_rect = {
-                    icon_rect.right() + 1 + icon_spacing(), rect.y(),
+                    icon_rect.right() + icon_spacing(), rect.y(),
                     min(rect.width(), column_width - indent_width) - icon_size() - icon_spacing(), rect.height()
                 };
                 Gfx::IntRect text_rect = background_rect.shrunken(text_padding() * 2, 0);

--- a/Userland/Libraries/LibGUI/ValueSlider.cpp
+++ b/Userland/Libraries/LibGUI/ValueSlider.cpp
@@ -84,7 +84,7 @@ void ValueSlider::paint_event(PaintEvent& event)
         painter.fill_rect_with_gradient(m_orientation, bar_rect(), palette().inactive_window_border1(), palette().inactive_window_border2());
 
     auto unfilled_rect = bar_rect();
-    unfilled_rect.set_left(knob_rect().right());
+    unfilled_rect.set_left(knob_rect().right() - 1);
     painter.fill_rect(unfilled_rect, palette().base());
 
     Gfx::StylePainter::paint_frame(painter, bar_rect(), palette(), Gfx::FrameStyle::SunkenContainer);
@@ -143,7 +143,7 @@ int ValueSlider::value_at(Gfx::IntPoint position) const
     float leftmost_knob_center = (float)bar_rect().left() + (float)knob_thickness / 2;
     if (position.x() < leftmost_knob_center)
         return min();
-    float rightmost_knob_center = (float)bar_rect().right() - (float)knob_thickness / 2;
+    float rightmost_knob_center = (float)(bar_rect().right() - 1) - (float)knob_thickness / 2;
     if (position.x() > rightmost_knob_center)
         return max();
     float relative_offset = (float)(position.x() - leftmost_knob_center) / (rightmost_knob_center - leftmost_knob_center);

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -354,7 +354,7 @@ void Widget::handle_keydown_event(KeyEvent& event)
     }
 
     if (event.key() == KeyCode::Key_Menu) {
-        ContextMenuEvent c_event(window_relative_rect().bottom_right(), screen_relative_rect().bottom_right());
+        ContextMenuEvent c_event(window_relative_rect().bottom_right().translated(-1), screen_relative_rect().bottom_right().translated(-1));
         dispatch_event(c_event);
         return;
     }

--- a/Userland/Libraries/LibGfx/AffineTransform.cpp
+++ b/Userland/Libraries/LibGfx/AffineTransform.cpp
@@ -204,9 +204,9 @@ template<>
 FloatRect AffineTransform::map(FloatRect const& rect) const
 {
     FloatPoint p1 = map(rect.top_left());
-    FloatPoint p2 = map(rect.top_right().translated(1, 0));
-    FloatPoint p3 = map(rect.bottom_right().translated(1, 1));
-    FloatPoint p4 = map(rect.bottom_left().translated(0, 1));
+    FloatPoint p2 = map(rect.top_right());
+    FloatPoint p3 = map(rect.bottom_right());
+    FloatPoint p4 = map(rect.bottom_left());
     float left = smallest_of(p1.x(), p2.x(), p3.x(), p4.x());
     float top = smallest_of(p1.y(), p2.y(), p3.y(), p4.y());
     float right = largest_of(p1.x(), p2.x(), p3.x(), p4.x());

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -683,11 +683,11 @@ void AntiAliasingPainter::fill_rect_with_rounded_corners(IntRect const& a_rect, 
     if (top_left)
         fill_corner(top_left_corner, bounding_rect.top_left(), top_left);
     if (top_right)
-        fill_corner(top_right_corner, bounding_rect.top_right(), top_right);
+        fill_corner(top_right_corner, bounding_rect.top_right().moved_left(1), top_right);
     if (bottom_left)
-        fill_corner(bottom_left_corner, bounding_rect.bottom_left(), bottom_left);
+        fill_corner(bottom_left_corner, bounding_rect.bottom_left().moved_up(1), bottom_left);
     if (bottom_right)
-        fill_corner(bottom_right_corner, bounding_rect.bottom_right(), bottom_right);
+        fill_corner(bottom_right_corner, bounding_rect.bottom_right().translated(-1), bottom_right);
 }
 
 void AntiAliasingPainter::stroke_segment_intersection(FloatPoint current_line_a, FloatPoint current_line_b, FloatLine const& previous_line, Color color, float thickness)

--- a/Userland/Libraries/LibGfx/ClassicStylePainter.cpp
+++ b/Userland/Libraries/LibGfx/ClassicStylePainter.cpp
@@ -280,12 +280,12 @@ void ClassicStylePainter::paint_frame(Painter& painter, IntRect const& rect, Pal
         VERIFY_NOT_REACHED();
     }
 
-    painter.draw_line(rect.top_left(), rect.top_right(), top_left_color);
-    painter.draw_line(rect.bottom_left(), rect.bottom_right(), bottom_right_color);
+    painter.draw_line(rect.top_left(), rect.top_right().moved_left(1), top_left_color);
+    painter.draw_line(rect.bottom_left().moved_up(1), rect.bottom_right().translated(-1), bottom_right_color);
 
     if ((style != FrameStyle::SunkenPanel && style != FrameStyle::RaisedPanel) || !skip_vertical_lines) {
-        painter.draw_line(rect.top_left().translated(0, 1), rect.bottom_left().translated(0, -1), top_left_color);
-        painter.draw_line(rect.top_right(), rect.bottom_right().translated(0, -1), bottom_right_color);
+        painter.draw_line(rect.top_left().moved_down(1), rect.bottom_left().moved_up(2), top_left_color);
+        painter.draw_line(rect.top_right().moved_left(1), rect.bottom_right().translated(-1, -2), bottom_right_color);
     }
 
     if (style == FrameStyle::RaisedContainer || style == FrameStyle::SunkenContainer) {
@@ -302,19 +302,19 @@ void ClassicStylePainter::paint_frame(Painter& painter, IntRect const& rect, Pal
             bottom_right_color = light_shade;
         }
         IntRect inner_container_frame_rect = rect.shrunken(2, 2);
-        painter.draw_line(inner_container_frame_rect.top_left(), inner_container_frame_rect.top_right(), top_left_color);
-        painter.draw_line(inner_container_frame_rect.bottom_left(), inner_container_frame_rect.bottom_right(), bottom_right_color);
-        painter.draw_line(inner_container_frame_rect.top_left().translated(0, 1), inner_container_frame_rect.bottom_left().translated(0, -1), top_left_color);
-        painter.draw_line(inner_container_frame_rect.top_right(), inner_container_frame_rect.bottom_right().translated(0, -1), bottom_right_color);
+        painter.draw_line(inner_container_frame_rect.top_left(), inner_container_frame_rect.top_right().moved_left(1), top_left_color);
+        painter.draw_line(inner_container_frame_rect.bottom_left().moved_up(1), inner_container_frame_rect.bottom_right().translated(-1), bottom_right_color);
+        painter.draw_line(inner_container_frame_rect.top_left().moved_down(1), inner_container_frame_rect.bottom_left().moved_up(2), top_left_color);
+        painter.draw_line(inner_container_frame_rect.top_right().moved_left(1), inner_container_frame_rect.bottom_right().translated(-1, -2), bottom_right_color);
     }
 
     if (style == FrameStyle::RaisedBox || style == FrameStyle::SunkenBox) {
         swap(top_left_color, bottom_right_color);
         IntRect inner_rect = rect.shrunken(2, 2);
-        painter.draw_line(inner_rect.top_left(), inner_rect.top_right(), top_left_color);
-        painter.draw_line(inner_rect.bottom_left(), inner_rect.bottom_right(), bottom_right_color);
-        painter.draw_line(inner_rect.top_left().translated(0, 1), inner_rect.bottom_left().translated(0, -1), top_left_color);
-        painter.draw_line(inner_rect.top_right(), inner_rect.bottom_right().translated(0, -1), bottom_right_color);
+        painter.draw_line(inner_rect.top_left(), inner_rect.top_right().moved_left(1), top_left_color);
+        painter.draw_line(inner_rect.bottom_left().moved_up(1), inner_rect.bottom_right().translated(-1), bottom_right_color);
+        painter.draw_line(inner_rect.top_left().moved_down(1), inner_rect.bottom_left().moved_up(2), top_left_color);
+        painter.draw_line(inner_rect.top_right().moved_left(1), inner_rect.bottom_right().translated(-1, -2), bottom_right_color);
     }
 }
 
@@ -342,22 +342,22 @@ void ClassicStylePainter::paint_window_frame(Painter& painter, IntRect const& re
                                          rect.height() - border_thickness },
         base_color, border_thickness);
 
-    painter.draw_line(rect.top_left().translated(0, 1), rect.bottom_left(), base_color);
-    painter.draw_line(rect.top_left().translated(1, 1), rect.top_right().translated(-1, 1), light_shade);
-    painter.draw_line(rect.top_left().translated(1, 1), rect.bottom_left().translated(1, -1), light_shade);
-    painter.draw_line(rect.top_left().translated(2, 2), rect.top_right().translated(-2, 2), base_color);
-    painter.draw_line(rect.top_left().translated(2, 2), rect.bottom_left().translated(2, -2), base_color);
-    painter.draw_line(rect.top_left().translated(3, 3), rect.top_right().translated(-3, 3), base_color);
-    painter.draw_line(rect.top_left().translated(3, 3), rect.bottom_left().translated(3, -3), base_color);
+    painter.draw_line(rect.top_left().translated(0, 1), rect.bottom_left().translated(0, -1), base_color);
+    painter.draw_line(rect.top_left().translated(1, 1), rect.top_right().translated(-2, 1), light_shade);
+    painter.draw_line(rect.top_left().translated(1, 1), rect.bottom_left().translated(1, -2), light_shade);
+    painter.draw_line(rect.top_left().translated(2, 2), rect.top_right().translated(-3, 2), base_color);
+    painter.draw_line(rect.top_left().translated(2, 2), rect.bottom_left().translated(2, -3), base_color);
+    painter.draw_line(rect.top_left().translated(3, 3), rect.top_right().translated(-4, 3), base_color);
+    painter.draw_line(rect.top_left().translated(3, 3), rect.bottom_left().translated(3, -4), base_color);
 
-    painter.draw_line(rect.top_right(), rect.bottom_right(), dark_shade);
-    painter.draw_line(rect.top_right().translated(-1, 1), rect.bottom_right().translated(-1, -1), mid_shade);
-    painter.draw_line(rect.top_right().translated(-2, 2), rect.bottom_right().translated(-2, -2), base_color);
-    painter.draw_line(rect.top_right().translated(-3, 3), rect.bottom_right().translated(-3, -3), base_color);
-    painter.draw_line(rect.bottom_left(), rect.bottom_right(), dark_shade);
-    painter.draw_line(rect.bottom_left().translated(1, -1), rect.bottom_right().translated(-1, -1), mid_shade);
-    painter.draw_line(rect.bottom_left().translated(2, -2), rect.bottom_right().translated(-2, -2), base_color);
-    painter.draw_line(rect.bottom_left().translated(3, -3), rect.bottom_right().translated(-3, -3), base_color);
+    painter.draw_line(rect.top_right().translated(-1, 0), rect.bottom_right().translated(-1, -1), dark_shade);
+    painter.draw_line(rect.top_right().translated(-2, 1), rect.bottom_right().translated(-2, -2), mid_shade);
+    painter.draw_line(rect.top_right().translated(-3, 2), rect.bottom_right().translated(-3, -3), base_color);
+    painter.draw_line(rect.top_right().translated(-4, 3), rect.bottom_right().translated(-4, -4), base_color);
+    painter.draw_line(rect.bottom_left().translated(0, -1), rect.bottom_right().translated(-1, -1), dark_shade);
+    painter.draw_line(rect.bottom_left().translated(1, -2), rect.bottom_right().translated(-2, -2), mid_shade);
+    painter.draw_line(rect.bottom_left().translated(2, -3), rect.bottom_right().translated(-3, -3), base_color);
+    painter.draw_line(rect.bottom_left().translated(3, -4), rect.bottom_right().translated(-4, -4), base_color);
 }
 
 void ClassicStylePainter::paint_progressbar(Painter& painter, IntRect const& rect, Palette const& palette, int min, int max, int value, StringView text, Orientation orientation)
@@ -624,7 +624,7 @@ void ClassicStylePainter::paint_simple_rect_shadow(Painter& painter, IntRect con
     auto half_width = containing_horizontal_rect.width() / 2;
     int corner_piece_width = min(containing_horizontal_rect.width() / 2, base_size * 2);
     int left_corners_right = containing_horizontal_rect.left() + corner_piece_width;
-    int right_corners_left = max(containing_horizontal_rect.right() - corner_piece_width + 1, left_corners_right + 1);
+    int right_corners_left = max(containing_horizontal_rect.right() - corner_piece_width, left_corners_right + 1);
     auto paint_horizontal = [&](int y, int src_row) {
         if (half_width <= 0)
             return;
@@ -639,7 +639,7 @@ void ClassicStylePainter::paint_simple_rect_shadow(Painter& painter, IntRect con
     };
 
     paint_horizontal(containing_rect.top(), 0);
-    paint_horizontal(containing_rect.bottom() - base_size + 1, 1);
+    paint_horizontal(containing_rect.bottom() - base_size, 1);
 
     int corner_piece_height = min(half_height, base_size);
     int top_corners_bottom = base_size + corner_piece_height;
@@ -658,7 +658,7 @@ void ClassicStylePainter::paint_simple_rect_shadow(Painter& painter, IntRect con
     paint_vertical(containing_rect.left(), 0, horizontal_shift, 0);
     if (shadow_includes_frame)
         horizontal_shift = 0; // TODO: fix off-by-one on rectangles barely wide enough
-    paint_vertical(containing_rect.right() - base_size + 1, 1, 0, horizontal_shift);
+    paint_vertical(containing_rect.right() - base_size, 1, 0, horizontal_shift);
 
     if (fill_content) {
         // Fill the enclosed rectangle with the RGBA color of the right-bottom pixel of the TL tile

--- a/Userland/Libraries/LibGfx/ClassicWindowTheme.cpp
+++ b/Userland/Libraries/LibGfx/ClassicWindowTheme.cpp
@@ -64,8 +64,8 @@ void ClassicWindowTheme::paint_normal_frame(Painter& painter, WindowState window
 
     auto [title_color, border_color, border_color2, stripes_color, shadow_color] = compute_frame_colors(window_state, palette);
 
-    painter.draw_line(titlebar_rect.bottom_left().translated(0, 1), titlebar_rect.bottom_right().translated(0, 1), palette.button());
-    painter.draw_line(titlebar_rect.bottom_left().translated(0, 2), titlebar_rect.bottom_right().translated(0, 2), palette.button());
+    painter.draw_line(titlebar_rect.bottom_left(), titlebar_rect.bottom_right().moved_left(1), palette.button());
+    painter.draw_line(titlebar_rect.bottom_left().moved_down(1), titlebar_rect.bottom_right().translated(-1, 1), palette.button());
 
     painter.fill_rect_with_gradient(titlebar_rect, border_color, border_color2);
 
@@ -87,7 +87,7 @@ void ClassicWindowTheme::paint_normal_frame(Painter& painter, WindowState window
     if (stripes_color.alpha() > 0) {
         switch (title_alignment) {
         case Gfx::TextAlignment::CenterLeft: {
-            int stripe_left = titlebar_title_rect.right() + 5;
+            int stripe_left = titlebar_title_rect.right() + 4;
 
             if (stripe_left && stripe_right && stripe_left < stripe_right) {
                 for (int i = 2; i <= titlebar_inner_rect.height() - 2; i += 2) {
@@ -164,12 +164,11 @@ void ClassicWindowTheme::paint_notification_frame(Painter& painter, WindowMode w
     painter.fill_rect_with_gradient(Gfx::Orientation::Vertical, titlebar_rect, palette.active_window_border1(), palette.active_window_border2());
 
     if (palette.active_window_title_stripes().alpha() > 0) {
-        int stripe_top = close_button_rect.bottom() + 4;
+        int stripe_top = close_button_rect.bottom() + 3;
         int stripe_bottom = window_rect.height() - 3;
         if (stripe_top && stripe_bottom && stripe_top < stripe_bottom) {
-            for (int i = 2; i <= palette.window_title_height() - 2; i += 2) {
+            for (int i = 2; i <= palette.window_title_height() - 2; i += 2)
                 painter.draw_line({ titlebar_rect.x() + i, stripe_top }, { titlebar_rect.x() + i, stripe_bottom }, palette.active_window_title_stripes());
-            }
         }
     }
 }
@@ -208,7 +207,7 @@ Vector<IntRect> ClassicWindowTheme::layout_buttons(WindowType window_type, Windo
     if (window_type == WindowType::Notification)
         pos = titlebar_rect(window_type, window_mode, window_rect, palette).top() + 2;
     else
-        pos = titlebar_text_rect(window_type, window_mode, window_rect, palette).right() + 1;
+        pos = titlebar_text_rect(window_type, window_mode, window_rect, palette).right();
 
     for (size_t i = 0; i < buttons; i++) {
         if (window_type == WindowType::Notification) {

--- a/Userland/Libraries/LibGfx/FillPathImplementation.cpp
+++ b/Userland/Libraries/LibGfx/FillPathImplementation.cpp
@@ -68,7 +68,7 @@ ALWAYS_INLINE void Painter::draw_scanline_for_fill_path(int y, T x_start, T x_en
         if (paint_left_subpixel)
             set_physical_pixel(clipped.top_left(), get_color_with_alpha(0, left_subpixel_alpha), true);
         if (paint_right_subpixel)
-            set_physical_pixel(clipped.top_right(), get_color_with_alpha(scanline.width(), right_subpixel_alpha), true);
+            set_physical_pixel(clipped.top_right().moved_left(1), get_color_with_alpha(scanline.width(), right_subpixel_alpha), true);
         clipped.shrink(0, paint_right_subpixel, 0, paint_left_subpixel);
         if (clipped.is_empty())
             return;
@@ -82,9 +82,8 @@ ALWAYS_INLINE void Painter::draw_scanline_for_fill_path(int y, T x_start, T x_en
         }
     }
 
-    for (int x = clipped.x(); x <= clipped.right(); x++) {
+    for (int x = clipped.x(); x < clipped.right(); x++)
         set_physical_pixel({ x, clipped.y() }, get_color(x - scanline.x()), true);
-    }
 }
 
 [[maybe_unused]] inline void approximately_place_on_int_grid(FloatPoint ffrom, FloatPoint fto, IntPoint& from, IntPoint& to, Optional<IntPoint> previous_to)
@@ -144,8 +143,8 @@ void Painter::fill_path_impl(Path const& path, ColorOrFunction color, Gfx::Paint
     active_list.ensure_capacity(segments.size());
 
     // first, grab the segments for the very first scanline
-    GridCoordinateType first_y = path.bounding_box().bottom_right().y() + 1;
-    GridCoordinateType last_y = path.bounding_box().top_left().y() - 1;
+    GridCoordinateType first_y = path.bounding_box().bottom();
+    GridCoordinateType last_y = path.bounding_box().top() - 1;
     float scanline = first_y;
 
     size_t last_active_segment { 0 };

--- a/Userland/Libraries/LibGfx/Filters/GenericConvolutionFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/GenericConvolutionFilter.h
@@ -110,7 +110,7 @@ public:
                 FloatVector3 value(0, 0, 0);
                 for (auto k = 0l; k < (ssize_t)N; ++k) {
                     auto ki = i + k - offset;
-                    if (ki < source_rect.x() || ki > source_rect.right()) {
+                    if (ki < source_rect.x() || ki >= source_rect.right()) {
                         if (parameters.should_wrap())
                             ki = (ki + source.size().width()) % source.size().width(); // TODO: fix up using source_rect
                         else
@@ -119,7 +119,7 @@ public:
 
                     for (auto l = 0l; l < (ssize_t)N; ++l) {
                         auto lj = j + l - offset;
-                        if (lj < source_rect.y() || lj > source_rect.bottom()) {
+                        if (lj < source_rect.y() || lj >= source_rect.bottom()) {
                             if (parameters.should_wrap())
                                 lj = (lj + source.size().height()) % source.size().height(); // TODO: fix up using source_rect
                             else

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1179,20 +1179,6 @@ ALWAYS_INLINE static void do_draw_box_sampled_scaled_bitmap(Gfx::Bitmap& target,
     float source_pixel_area = source_pixel_width * source_pixel_height;
     FloatRect const pixel_box = { 0.f, 0.f, 1.f, 1.f };
 
-    // FIXME: FloatRect.right() and .bottom() subtract 1 since that is what IntRect does as well.
-    //        This is obviously wrong and causes issues with at least .intersect(). Probably the
-    //        best course of action is to fix Rect's behavior for .right() and .bottom(), and then
-    //        replace this with FloatRect.intersected(...).size().area().
-    auto float_rect_intersection_area_fixme = [](FloatRect const& a, FloatRect const& b) -> float {
-        float intersected_left = max(a.left(), b.left());
-        float intersected_right = min(a.left() + a.width(), b.left() + b.width());
-        float intersected_top = max(a.top(), b.top());
-        float intersected_bottom = min(a.top() + a.height(), b.top() + b.height());
-        if (intersected_left >= intersected_right || intersected_top >= intersected_bottom)
-            return 0.f;
-        return (intersected_right - intersected_left) * (intersected_bottom - intersected_top);
-    };
-
     for (int y = clipped_rect.top(); y < clipped_rect.bottom(); ++y) {
         auto* scanline = reinterpret_cast<Color*>(target.scanline(y));
         for (int x = clipped_rect.left(); x < clipped_rect.right(); ++x) {
@@ -1212,7 +1198,7 @@ ALWAYS_INLINE static void do_draw_box_sampled_scaled_bitmap(Gfx::Bitmap& target,
             float total_area = 0.f;
             for (int sy = enclosing_source_box.y(); sy < enclosing_source_box.bottom(); ++sy) {
                 for (int sx = enclosing_source_box.x(); sx < enclosing_source_box.right(); ++sx) {
-                    float area = float_rect_intersection_area_fixme(source_box, pixel_box.translated(sx, sy));
+                    float area = source_box.intersected(pixel_box.translated(sx, sy)).size().area();
 
                     auto pixel = get_pixel(source, sx, sy);
                     area *= pixel.alpha() / 255.f;

--- a/Userland/Libraries/LibGfx/Point.cpp
+++ b/Userland/Libraries/LibGfx/Point.cpp
@@ -15,8 +15,8 @@ namespace Gfx {
 template<typename T>
 void Point<T>::constrain(Rect<T> const& rect)
 {
-    m_x = AK::clamp<T>(x(), rect.left(), rect.right());
-    m_y = AK::clamp<T>(y(), rect.top(), rect.bottom());
+    m_x = AK::clamp<T>(x(), rect.left(), rect.right() - 1);
+    m_y = AK::clamp<T>(y(), rect.top(), rect.bottom() - 1);
 }
 
 template<typename T>

--- a/Userland/Libraries/LibSoftGPU/Buffer/Typed2DBuffer.h
+++ b/Userland/Libraries/LibSoftGPU/Buffer/Typed2DBuffer.h
@@ -29,7 +29,7 @@ public:
         return adopt_ref(*new Typed2DBuffer(buffer));
     }
 
-    void fill(T value, Gfx::IntRect const& rect) { m_buffer->fill(value, rect.left(), rect.right(), rect.top(), rect.bottom(), 0, 0); }
+    void fill(T value, Gfx::IntRect const& rect) { m_buffer->fill(value, rect.left(), rect.right(), rect.top(), rect.bottom(), 0, 1); }
     ALWAYS_INLINE T* scanline(int y) { return m_buffer->buffer_pointer(0, y, 0); }
     ALWAYS_INLINE T const* scanline(int y) const { return m_buffer->buffer_pointer(0, y, 0); }
 
@@ -40,7 +40,7 @@ public:
         int source_y = 0;
 
         // NOTE: we are flipping the Y-coordinate here, which is OpenGL-specific: (0, 0) is considered the lower-left corner of the window
-        for (int y = target.bottom(); y >= target.top(); --y) {
+        for (int y = target.bottom() - 1; y >= target.top(); --y) {
             auto const* buffer_scanline = scanline(source_y++);
             auto* bitmap_scanline = bitmap.scanline(y);
             memcpy(bitmap_scanline + target.left(), buffer_scanline, sizeof(u32) * target.width());

--- a/Userland/Libraries/LibSoftGPU/Buffer/Typed3DBuffer.h
+++ b/Userland/Libraries/LibSoftGPU/Buffer/Typed3DBuffer.h
@@ -41,10 +41,10 @@ public:
 
     void fill(T value, int x1, int x2, int y1, int y2, int z1, int z2)
     {
-        for (auto z = z1; z <= z2; ++z) {
-            for (auto y = y1; y <= y2; ++y) {
+        for (auto z = z1; z < z2; ++z) {
+            for (auto y = y1; y < y2; ++y) {
                 auto* xline = buffer_pointer(0, y, z);
-                for (auto x = x1; x <= x2; ++x)
+                for (auto x = x1; x < x2; ++x)
                     xline[x] = value;
             }
         }

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -231,9 +231,9 @@ ALWAYS_INLINE void Device::rasterize(Gfx::IntRect& render_bounds, CB1 set_covera
 
     // Quad bounds
     auto const render_bounds_left = render_bounds.left();
-    auto const render_bounds_right = render_bounds.right();
+    auto const render_bounds_right = render_bounds.right() - 1;
     auto const render_bounds_top = render_bounds.top();
-    auto const render_bounds_bottom = render_bounds.bottom();
+    auto const render_bounds_bottom = render_bounds.bottom() - 1;
     auto const qx0 = render_bounds_left & ~1;
     auto const qx1 = render_bounds_right & ~1;
     auto const qy0 = render_bounds_top & ~1;
@@ -678,9 +678,9 @@ void Device::rasterize_triangle(Triangle& triangle)
     // Calculate render bounds based on the triangle's vertices
     Gfx::IntRect render_bounds;
     render_bounds.set_left(min(min(v0.x(), v1.x()), v2.x()) / subpixel_factor);
-    render_bounds.set_right(max(max(v0.x(), v1.x()), v2.x()) / subpixel_factor);
+    render_bounds.set_right(max(max(v0.x(), v1.x()), v2.x()) / subpixel_factor + 1);
     render_bounds.set_top(min(min(v0.y(), v1.y()), v2.y()) / subpixel_factor);
-    render_bounds.set_bottom(max(max(v0.y(), v1.y()), v2.y()) / subpixel_factor);
+    render_bounds.set_bottom(max(max(v0.y(), v1.y()), v2.y()) / subpixel_factor + 1);
 
     // Calculate depth of fragment for fog;
     // OpenGL 1.5 chapter 3.10: "An implementation may choose to approximate the

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -369,12 +369,12 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
             }
 
             if (underline_style == UnderlineStyle::Solid) {
-                painter.draw_line(cell_rect.bottom_left(), cell_rect.bottom_right(), underline_color);
+                painter.draw_line(cell_rect.bottom_left().moved_up(1), cell_rect.bottom_right().translated(-1), underline_color);
             } else if (underline_style == UnderlineStyle::Dotted) {
-                int x1 = cell_rect.bottom_left().x();
-                int x2 = cell_rect.bottom_right().x();
-                int y = cell_rect.bottom_left().y();
-                for (int x = x1; x <= x2; ++x) {
+                int x1 = cell_rect.left();
+                int x2 = cell_rect.right();
+                int y = cell_rect.bottom() - 1;
+                for (int x = x1; x < x2; ++x) {
                     if ((x % 3) == 0)
                         painter.set_pixel({ x, y }, underline_color);
                 }
@@ -439,16 +439,16 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
         auto cursor_color = terminal_color_to_rgb(cursor_line.attribute_at(m_terminal.cursor_column()).effective_foreground_color());
         auto cell_rect = glyph_rect(row_with_cursor, m_terminal.cursor_column()).inflated(0, m_line_spacing);
         if (m_cursor_shape == VT::CursorShape::Underline) {
-            auto x1 = cell_rect.bottom_left().x();
-            auto x2 = cell_rect.bottom_right().x();
-            auto y = cell_rect.bottom_left().y();
-            for (auto x = x1; x <= x2; ++x)
+            auto x1 = cell_rect.left();
+            auto x2 = cell_rect.right();
+            auto y = cell_rect.bottom() - 1;
+            for (auto x = x1; x < x2; ++x)
                 painter.set_pixel({ x, y }, cursor_color);
         } else if (m_cursor_shape == VT::CursorShape::Bar) {
-            auto x = cell_rect.bottom_left().x();
-            auto y1 = cell_rect.top_left().y();
-            auto y2 = cell_rect.bottom_left().y();
-            for (auto y = y1; y <= y2; ++y)
+            auto x = cell_rect.left();
+            auto y1 = cell_rect.top();
+            auto y2 = cell_rect.bottom();
+            for (auto y = y1; y < y2; ++y)
                 painter.set_pixel({ x, y }, cursor_color);
         } else {
             // We fall back to a block if we don't support the selected cursor type.

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
@@ -60,8 +60,8 @@ Gfx::FloatSize RadialGradientStyleValue::resolve_size(Layout::Node const& node, 
         auto const distance_from = [&](float v, float a, float b, auto distance_function) {
             return distance_function(fabs(a - v), fabs(b - v));
         };
-        auto x_dist = distance_from(center.x(), size.left(), size.right(), distance_function);
-        auto y_dist = distance_from(center.y(), size.top(), size.bottom(), distance_function);
+        auto x_dist = distance_from(center.x(), size.left(), size.right() - 1, distance_function);
+        auto y_dist = distance_from(center.y(), size.top(), size.bottom() - 1, distance_function);
         if (m_properties.ending_shape == EndingShape::Circle) {
             auto dist = distance_function(x_dist, y_dist);
             return Gfx::FloatSize { dist, dist };
@@ -80,20 +80,20 @@ Gfx::FloatSize RadialGradientStyleValue::resolve_size(Layout::Node const& node, 
 
     auto const corner_distance = [&](auto distance_compare, Gfx::FloatPoint& corner) {
         auto top_left_distance = size.top_left().distance_from(center);
-        auto top_right_distance = size.top_right().distance_from(center);
-        auto bottom_right_distance = size.bottom_right().distance_from(center);
-        auto bottom_left_distance = size.bottom_left().distance_from(center);
+        auto top_right_distance = size.top_right().moved_left(1).distance_from(center);
+        auto bottom_right_distance = size.bottom_right().translated(-1).distance_from(center);
+        auto bottom_left_distance = size.bottom_left().moved_up(1).distance_from(center);
         auto distance = top_left_distance;
         if (distance_compare(top_right_distance, distance)) {
-            corner = size.top_right();
+            corner = size.top_right().translated(-1, 0);
             distance = top_right_distance;
         }
         if (distance_compare(bottom_right_distance, distance)) {
-            corner = size.top_right();
+            corner = size.top_right().translated(-1, 0);
             distance = bottom_right_distance;
         }
         if (distance_compare(bottom_left_distance, distance)) {
-            corner = size.top_right();
+            corner = size.top_right().translated(-1, 0);
             distance = bottom_left_distance;
         }
         return distance;

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -358,7 +358,7 @@ CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_ro
         // NOTE: Floating box coordinates are relative to their own containing block,
         //       which may or may not be the BFC root.
         auto margin_box = margin_box_rect_in_ancestor_coordinate_space(*floating_box, root, m_state);
-        CSSPixels floating_box_bottom_margin_edge = margin_box.bottom() + 1;
+        CSSPixels floating_box_bottom_margin_edge = margin_box.bottom();
         if (!bottom.has_value() || floating_box_bottom_margin_edge > bottom.value())
             bottom = floating_box_bottom_margin_edge;
     }

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -329,7 +329,6 @@ bool InlineFormattingContext::any_floats_intrude_at_y(CSSPixels y) const
 
 bool InlineFormattingContext::can_fit_new_line_at_y(CSSPixels y) const
 {
-
     auto top_intrusions = parent().intrusion_by_floats_into_box(containing_block(), y);
     auto bottom_intrusions = parent().intrusion_by_floats_into_box(containing_block(), y + containing_block().line_height() - 1);
 

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -145,23 +145,25 @@ CSSPixels box_baseline(LayoutState const& state, Box const& box)
 CSSPixelRect margin_box_rect(Box const& box, LayoutState const& state)
 {
     auto const& box_state = state.get(box);
-    auto rect = CSSPixelRect { box_state.offset, { box_state.content_width(), box_state.content_height() } };
-    rect.set_x(rect.x() - box_state.margin_box_left());
-    rect.set_width(rect.width() + box_state.margin_box_left() + box_state.margin_box_right());
-    rect.set_y(rect.y() - box_state.margin_box_top());
-    rect.set_height(rect.height() + box_state.margin_box_top() + box_state.margin_box_bottom());
-    return rect;
+    return {
+        box_state.offset.translated(-box_state.margin_box_left(), -box_state.margin_box_top()),
+        {
+            box_state.margin_box_left() + box_state.content_width() + box_state.margin_box_right(),
+            box_state.margin_box_top() + box_state.content_height() + box_state.margin_box_bottom(),
+        },
+    };
 }
 
 CSSPixelRect border_box_rect(Box const& box, LayoutState const& state)
 {
     auto const& box_state = state.get(box);
-    auto rect = CSSPixelRect { box_state.offset, { box_state.content_width(), box_state.content_height() } };
-    rect.set_x(rect.x() - box_state.border_box_left());
-    rect.set_width(rect.width() + box_state.border_box_left() + box_state.border_box_right());
-    rect.set_y(rect.y() - box_state.border_box_top());
-    rect.set_height(rect.height() + box_state.border_box_top() + box_state.border_box_bottom());
-    return rect;
+    return {
+        box_state.offset.translated(-box_state.border_box_left(), -box_state.border_box_top()),
+        {
+            box_state.border_box_left() + box_state.content_width() + box_state.border_box_right(),
+            box_state.border_box_top() + box_state.content_height() + box_state.border_box_bottom(),
+        },
+    };
 }
 
 CSSPixelRect border_box_rect_in_ancestor_coordinate_space(Box const& box, Box const& ancestor_box, LayoutState const& state)

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -309,11 +309,11 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
 
         image.resolve_for_size(layout_node, image_rect.size());
 
-        while (image_y <= css_clip_rect.bottom()) {
+        while (image_y < css_clip_rect.bottom()) {
             image_rect.set_y(image_y);
 
             auto image_x = initial_image_x;
-            while (image_x <= css_clip_rect.right()) {
+            while (image_x < css_clip_rect.right()) {
                 image_rect.set_x(image_x);
                 auto image_device_rect = context.rounded_device_rect(image_rect);
                 if (image_device_rect != last_image_device_rect && image_device_rect.intersects(context.device_viewport_rect()))

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -85,13 +85,13 @@ void paint_border(PaintContext& context, BorderEdge edge, DevicePixelRect const&
     auto points_for_edge = [](BorderEdge edge, DevicePixelRect const& rect) -> Points {
         switch (edge) {
         case BorderEdge::Top:
-            return { rect.top_left(), rect.top_right() };
+            return { rect.top_left(), rect.top_right().moved_left(1) };
         case BorderEdge::Right:
-            return { rect.top_right(), rect.bottom_right() };
+            return { rect.top_right().moved_left(1), rect.bottom_right().translated(-1) };
         case BorderEdge::Bottom:
-            return { rect.bottom_left(), rect.bottom_right() };
+            return { rect.bottom_left().moved_up(1), rect.bottom_right().translated(-1) };
         default: // Edge::Left
-            return { rect.top_left(), rect.bottom_left() };
+            return { rect.top_left(), rect.bottom_left().moved_up(1) };
         }
     };
 
@@ -365,13 +365,13 @@ void paint_all_borders(PaintContext& context, CSSPixelRect const& bordered_rect,
         blit_corner(border_rect.top_left().to_type<int>(), top_left.as_rect(), pick_corner_color(borders_data.top, borders_data.left));
 
     if (top_right)
-        blit_corner(border_rect.top_right().to_type<int>().translated(-top_right.horizontal_radius + 1, 0), top_right.as_rect().translated(corner_mask_rect.width().value() - top_right.horizontal_radius, 0), pick_corner_color(borders_data.top, borders_data.right));
+        blit_corner(border_rect.top_right().to_type<int>().translated(-top_right.horizontal_radius, 0), top_right.as_rect().translated(corner_mask_rect.width().value() - top_right.horizontal_radius, 0), pick_corner_color(borders_data.top, borders_data.right));
 
     if (bottom_right)
-        blit_corner(border_rect.bottom_right().to_type<int>().translated(-bottom_right.horizontal_radius + 1, -bottom_right.vertical_radius + 1), bottom_right.as_rect().translated(corner_mask_rect.width().value() - bottom_right.horizontal_radius, corner_mask_rect.height().value() - bottom_right.vertical_radius), pick_corner_color(borders_data.bottom, borders_data.right));
+        blit_corner(border_rect.bottom_right().to_type<int>().translated(-bottom_right.horizontal_radius, -bottom_right.vertical_radius), bottom_right.as_rect().translated(corner_mask_rect.width().value() - bottom_right.horizontal_radius, corner_mask_rect.height().value() - bottom_right.vertical_radius), pick_corner_color(borders_data.bottom, borders_data.right));
 
     if (bottom_left)
-        blit_corner(border_rect.bottom_left().to_type<int>().translated(0, -bottom_left.vertical_radius + 1), bottom_left.as_rect().translated(0, corner_mask_rect.height().value() - bottom_left.vertical_radius), pick_corner_color(borders_data.bottom, borders_data.left));
+        blit_corner(border_rect.bottom_left().to_type<int>().translated(0, -bottom_left.vertical_radius), bottom_left.as_rect().translated(0, corner_mask_rect.height().value() - bottom_left.vertical_radius), pick_corner_color(borders_data.bottom, borders_data.left));
 }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
@@ -43,7 +43,7 @@ ErrorOr<BorderRadiusCornerClipper> BorderRadiusCornerClipper::create(PaintContex
             .top_right = top_right,
             .bottom_right = bottom_right,
             .bottom_left = bottom_left },
-        .page_locations = { .top_left = border_rect.top_left(), .top_right = border_rect.top_right().translated(-top_right.horizontal_radius + 1, 0), .bottom_right = border_rect.bottom_right().translated(-bottom_right.horizontal_radius + 1, -bottom_right.vertical_radius + 1), .bottom_left = border_rect.bottom_left().translated(0, -bottom_left.vertical_radius + 1) },
+        .page_locations = { .top_left = border_rect.top_left(), .top_right = border_rect.top_right().translated(-top_right.horizontal_radius, 0), .bottom_right = border_rect.bottom_right().translated(-bottom_right.horizontal_radius, -bottom_right.vertical_radius), .bottom_left = border_rect.bottom_left().translated(0, -bottom_left.vertical_radius) },
         .bitmap_locations = { .top_left = { 0, 0 }, .top_right = { corners_bitmap_size.width() - top_right.horizontal_radius, 0 }, .bottom_right = { corners_bitmap_size.width() - bottom_right.horizontal_radius, corners_bitmap_size.height() - bottom_right.vertical_radius }, .bottom_left = { 0, corners_bitmap_size.height() - bottom_left.vertical_radius } },
         .corner_bitmap_size = corners_bitmap_size
     };

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -450,16 +450,16 @@ static void paint_text_decoration(PaintContext& context, Gfx::Painter& painter, 
             return;
         case CSS::TextDecorationLine::Underline:
             line_start_point = context.rounded_device_point(fragment_box.top_left().translated(0, baseline + 2));
-            line_end_point = context.rounded_device_point(fragment_box.top_right().translated(0, baseline + 2));
+            line_end_point = context.rounded_device_point(fragment_box.top_right().translated(-1, baseline + 2));
             break;
         case CSS::TextDecorationLine::Overline:
             line_start_point = context.rounded_device_point(fragment_box.top_left().translated(0, baseline - glyph_height));
-            line_end_point = context.rounded_device_point(fragment_box.top_right().translated(0, baseline - glyph_height));
+            line_end_point = context.rounded_device_point(fragment_box.top_right().translated(-1, baseline - glyph_height));
             break;
         case CSS::TextDecorationLine::LineThrough: {
             auto x_height = font.x_height();
             line_start_point = context.rounded_device_point(fragment_box.top_left().translated(0, baseline - x_height * 0.5f));
-            line_end_point = context.rounded_device_point(fragment_box.top_right().translated(0, baseline - x_height * 0.5f));
+            line_end_point = context.rounded_device_point(fragment_box.top_right().translated(-1, baseline - x_height * 0.5f));
             break;
         }
         case CSS::TextDecorationLine::Blink:
@@ -603,7 +603,7 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
                 context.painter().draw_rect(context.enclosing_device_rect(fragment_absolute_rect).to_type<int>(), Color::Green);
                 context.painter().draw_line(
                     context.rounded_device_point(fragment_absolute_rect.top_left().translated(0, fragment.baseline())).to_type<int>(),
-                    context.rounded_device_point(fragment_absolute_rect.top_right().translated(0, fragment.baseline())).to_type<int>(), Color::Red);
+                    context.rounded_device_point(fragment_absolute_rect.top_right().translated(-1, fragment.baseline())).to_type<int>(), Color::Red);
             }
             if (is<Layout::TextNode>(fragment.layout_node()))
                 paint_text_fragment(context, static_cast<Layout::TextNode const&>(fragment.layout_node()), fragment, phase);
@@ -715,7 +715,7 @@ Optional<HitTestResult> PaintableWithLines::hit_test(CSSPixelPoint position, Hit
             // The best candidate is either the end of the line above, the beginning of the line below, or the beginning or end of the current line.
             // We arbitrarily choose to consider the end of the line above and ignore the beginning of the line below.
             // If we knew the direction of selection, we could make a better choice.
-            if (fragment_absolute_rect.bottom() <= position.y()) { // fully below the fragment
+            if (fragment_absolute_rect.bottom() - 1 <= position.y()) { // fully below the fragment
                 last_good_candidate = HitTestResult { const_cast<Paintable&>(*fragment.layout_node().paintable()), fragment.start() + fragment.length() };
             } else if (fragment_absolute_rect.top() <= position.y()) { // vertically within the fragment
                 if (position.x() < fragment_absolute_rect.left()) {    // left of the fragment

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -27,9 +27,9 @@ static void update_notification_window_locations(Gfx::IntRect const& screen_rect
         auto& window = window_entry.value;
         Gfx::IntPoint new_window_location;
         if (last_window_rect.has_value())
-            new_window_location = last_window_rect.value().bottom_left().translated(0, 10);
+            new_window_location = last_window_rect.value().bottom_left().moved_down(9);
         else
-            new_window_location = screen_rect.top_right().translated(-window->rect().width() - 24, 7);
+            new_window_location = screen_rect.top_right().translated(-window->rect().width() - 24 - 1, 7);
         if (window->rect().location() != new_window_location) {
             window->move_to(new_window_location);
             window->set_original_rect(window->rect());
@@ -58,10 +58,10 @@ NotificationWindow::NotificationWindow(i32 client_id, DeprecatedString const& te
     Gfx::IntRect rect;
     rect.set_width(220);
     rect.set_height(40);
-    rect.set_location(GUI::Desktop::the().rect().top_right().translated(-rect.width() - 24, 7));
+    rect.set_location(GUI::Desktop::the().rect().top_right().translated(-rect.width() - 24 - 1, 7));
 
     if (lowest_notification_rect_on_screen.has_value())
-        rect.set_location(lowest_notification_rect_on_screen.value().bottom_left().translated(0, 10));
+        rect.set_location(lowest_notification_rect_on_screen.value().bottom_left().moved_down(9));
 
     set_rect(rect);
 

--- a/Userland/Services/Taskbar/ClockWidget.cpp
+++ b/Userland/Services/Taskbar/ClockWidget.cpp
@@ -219,7 +219,7 @@ void ClockWidget::position_calendar_window()
 {
     constexpr auto taskbar_top_padding { 4 };
     m_calendar_window->set_rect(
-        screen_relative_rect().right() - m_calendar_window->width() + 1,
+        screen_relative_rect().right() - m_calendar_window->width(),
         screen_relative_rect().top() - taskbar_top_padding - m_calendar_window->height(),
         m_window_size.width(),
         m_window_size.height());

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -142,7 +142,7 @@ void TaskbarWindow::toggle_show_desktop()
 void TaskbarWindow::on_screen_rects_change(Vector<Gfx::IntRect, 4> const& rects, size_t main_screen_index)
 {
     auto const& rect = rects[main_screen_index];
-    Gfx::IntRect new_rect { rect.x(), rect.bottom() - taskbar_height() + 1, rect.width(), taskbar_height() };
+    Gfx::IntRect new_rect { rect.x(), rect.bottom() - taskbar_height(), rect.width(), taskbar_height() };
     set_rect(new_rect);
     update_applet_area();
 }

--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -129,7 +129,7 @@ Window& Menu::ensure_menu_window(Gfx::IntPoint position)
     auto calculate_window_rect = [&]() -> Gfx::IntRect {
         int window_height_available = screen.height() - frame_thickness() * 2;
         int max_window_height = (window_height_available / item_height()) * item_height() + frame_thickness() * 2;
-        int content_height = m_items.is_empty() ? 0 : (m_items.last()->rect().bottom() + 1) + frame_thickness();
+        int content_height = m_items.is_empty() ? 0 : m_items.last()->rect().bottom() + frame_thickness();
         int window_height = min(max_window_height, content_height);
         if (window_height < content_height) {
             m_scrollable = true;
@@ -284,7 +284,7 @@ void Menu::draw(MenuItem const& item, bool is_drawing_all)
         painter.set_font(previous_font);
         if (item.is_submenu()) {
             Gfx::IntRect submenu_arrow_rect {
-                item.rect().right() - static_cast<int>(s_submenu_arrow_bitmap.width()) - 2,
+                item.rect().right() - static_cast<int>(s_submenu_arrow_bitmap.width()) - 3,
                 0,
                 s_submenu_arrow_bitmap.width(),
                 s_submenu_arrow_bitmap.height()
@@ -313,7 +313,7 @@ void Menu::update_for_new_hovered_item(bool make_input)
         if (hovered_item->is_submenu()) {
             VERIFY(menu_window());
             MenuManager::the().close_everyone_not_in_lineage(*hovered_item->submenu());
-            hovered_item->submenu()->do_popup(hovered_item->rect().top_right().translated(menu_window()->rect().location()), make_input, true);
+            hovered_item->submenu()->do_popup(hovered_item->rect().top_right().translated(-1, 0).translated(menu_window()->rect().location()), make_input, true);
         } else {
             MenuManager::the().close_everyone_not_in_lineage(*this);
             VERIFY(menu_window());
@@ -620,10 +620,10 @@ void Menu::open_button_menu(Gfx::IntPoint position, Gfx::IntRect const& button_r
     auto& window = ensure_menu_window(position);
     Gfx::IntPoint adjusted_pos = position;
 
-    if (window.rect().right() > screen.width())
-        adjusted_pos = adjusted_pos.translated(-(window.rect().right() - screen.width()) - 1, 0);
+    if (window.rect().right() - 1 > screen.width())
+        adjusted_pos = adjusted_pos.translated(-(window.rect().right() - screen.width()), 0);
 
-    if (window.rect().bottom() > screen.height())
+    if (window.rect().bottom() - 1 > screen.height())
         adjusted_pos = adjusted_pos.translated(0, -window.rect().height() - button_rect.height() + 1);
 
     window.set_rect(adjusted_pos.x(), adjusted_pos.y(), window.rect().width(), window.rect().height());
@@ -651,7 +651,7 @@ void Menu::do_popup(Gfx::IntPoint position, bool make_input, bool as_submenu)
     constexpr auto margin = 10;
     Gfx::IntPoint adjusted_pos = m_unadjusted_position = position;
 
-    if (adjusted_pos.x() + window.width() > screen.rect().right() - margin) {
+    if (adjusted_pos.x() + window.width() >= screen.rect().right() - margin) {
         // Vertically translate the window by its full width, i.e. flip it at its vertical axis.
         adjusted_pos = adjusted_pos.translated(-window.width(), 0);
         // If the window is a submenu, translate to the opposite side of its immediate ancestor
@@ -664,7 +664,7 @@ void Menu::do_popup(Gfx::IntPoint position, bool make_input, bool as_submenu)
         // underneath the cursor and can be closed by another click at the same position.
         adjusted_pos.set_x(adjusted_pos.x() + 1);
     }
-    if (adjusted_pos.y() + window.height() > screen.rect().bottom() - margin) {
+    if (adjusted_pos.y() + window.height() >= screen.rect().bottom() - margin) {
         // Vertically translate the window by its full height, i.e. flip it at its horizontal axis.
         auto offset = window.height();
         // ...but if it's a submenu, go back by one menu item height to keep the menu aligned with

--- a/Userland/Services/WindowServer/MenuManager.cpp
+++ b/Userland/Services/WindowServer/MenuManager.cpp
@@ -98,7 +98,7 @@ void MenuManager::event(Core::Event& event)
                     else {
                         auto* target_menu = previous_menu(m_current_menu);
                         if (target_menu) {
-                            target_menu->ensure_menu_window(target_menu->rect_in_window_menubar().bottom_left().translated(wm.window_with_active_menu()->frame().rect().location()).translated(wm.window_with_active_menu()->frame().menubar_rect().location()));
+                            target_menu->ensure_menu_window(target_menu->rect_in_window_menubar().bottom_left().moved_up(1).translated(wm.window_with_active_menu()->frame().rect().location()).translated(wm.window_with_active_menu()->frame().menubar_rect().location()));
                             open_menu(*target_menu);
                             wm.window_with_active_menu()->invalidate_menubar();
                         }
@@ -115,7 +115,7 @@ void MenuManager::event(Core::Event& event)
                 else if (m_open_menu_stack.size() <= 1 && wm.window_with_active_menu()) {
                     auto* target_menu = next_menu(m_current_menu);
                     if (target_menu) {
-                        target_menu->ensure_menu_window(target_menu->rect_in_window_menubar().bottom_left().translated(wm.window_with_active_menu()->frame().rect().location()).translated(wm.window_with_active_menu()->frame().menubar_rect().location()));
+                        target_menu->ensure_menu_window(target_menu->rect_in_window_menubar().bottom_left().moved_up(1).translated(wm.window_with_active_menu()->frame().rect().location()).translated(wm.window_with_active_menu()->frame().menubar_rect().location()));
                         open_menu(*target_menu);
                         wm.window_with_active_menu()->invalidate_menubar();
                         close_everyone_not_in_lineage(*target_menu);

--- a/Userland/Services/WindowServer/ScreenLayout.ipp
+++ b/Userland/Services/WindowServer/ScreenLayout.ipp
@@ -358,7 +358,7 @@ bool ScreenLayout::try_auto_add_display_connector(DeprecatedString const& device
     for (auto& screen : screens) {
         auto screen_rect = screen.virtual_rect();
         Gfx::IntRect new_screen_rect {
-            screen_rect.right() + 1,
+            screen_rect.right(),
             screen_rect.top(),
             (int)mode_setting.horizontal_active,
             (int)mode_setting.vertical_active

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -512,7 +512,7 @@ void Window::event(Core::Event& event)
 void Window::handle_keydown_event(KeyEvent const& event)
 {
     if (event.modifiers() == Mod_Alt && event.key() == Key_Space && type() == WindowType::Normal && !is_frameless()) {
-        auto position = frame().titlebar_rect().bottom_left().translated(frame().rect().location());
+        auto position = frame().titlebar_rect().bottom_left().moved_up(1).translated(frame().rect().location());
         popup_window_menu(position, WindowMenuDefaultAction::Close);
         return;
     }

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -887,7 +887,7 @@ bool WindowManager::process_ongoing_window_move(MouseEvent& event)
                     apply_window_tile(WindowTileType::Right);
             } else if (allow_tile && event_location_relative_to_screen.y() <= secondary_deadzone + desktop_relative_to_screen.top()) {
                 apply_window_tile(WindowTileType::Top);
-            } else if (allow_tile && event_location_relative_to_screen.y() >= desktop_relative_to_screen.bottom() - secondary_deadzone) {
+            } else if (allow_tile && event_location_relative_to_screen.y() >= desktop_relative_to_screen.bottom() - 1 - secondary_deadzone) {
                 apply_window_tile(WindowTileType::Bottom);
             } else if (!m_move_window->is_tiled()) {
                 apply_window_tile(WindowTileType::None);
@@ -971,12 +971,12 @@ bool WindowManager::process_ongoing_window_resize(MouseEvent const& event)
         constexpr auto hot_zone = 10;
         Gfx::IntRect tiling_rect = desktop_rect(cursor_screen).shrunken({ hot_zone, hot_zone });
         if ((m_resize_direction == ResizeDirection::Up || m_resize_direction == ResizeDirection::Down)
-            && (event.y() >= tiling_rect.bottom() || event.y() <= tiling_rect.top())) {
+            && (event.y() >= tiling_rect.bottom() - 1 || event.y() <= tiling_rect.top())) {
             m_resize_window->set_tiled(WindowTileType::VerticallyMaximized);
             return true;
         }
         if ((m_resize_direction == ResizeDirection::Left || m_resize_direction == ResizeDirection::Right)
-            && (event.x() >= tiling_rect.right() || event.x() <= tiling_rect.left())) {
+            && (event.x() > tiling_rect.right() || event.x() <= tiling_rect.left())) {
             m_resize_window->set_tiled(WindowTileType::HorizontallyMaximized);
             return true;
         }

--- a/Userland/Services/WindowServer/WindowSwitcher.cpp
+++ b/Userland/Services/WindowServer/WindowSwitcher.cpp
@@ -199,9 +199,9 @@ void WindowSwitcher::draw()
         Gfx::IntRect thumbnail_rect = { item_rect.location().translated(0, 5), { thumbnail_width(), thumbnail_height() } };
         if (window.backing_store())
             painter.draw_scaled_bitmap(thumbnail_rect, *window.backing_store(), window.backing_store()->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
-        Gfx::IntRect icon_rect = { thumbnail_rect.bottom_right().translated(-window.icon().width(), -window.icon().height()), { window.icon().width(), window.icon().height() } };
+        Gfx::IntRect icon_rect = { thumbnail_rect.bottom_right().translated(-window.icon().width() - 1, -window.icon().height() - 1), { window.icon().width(), window.icon().height() } };
         painter.blit(icon_rect.location(), window.icon(), window.icon().rect());
-        painter.draw_text(item_rect.translated(thumbnail_width() + 12, 0).translated(1, 1), window.computed_title(), WindowManager::the().window_title_font(), Gfx::TextAlignment::CenterLeft, text_color.inverted());
+        painter.draw_text(item_rect.translated(thumbnail_width() + 12, 0).translated(1), window.computed_title(), WindowManager::the().window_title_font(), Gfx::TextAlignment::CenterLeft, text_color.inverted());
         painter.draw_text(item_rect.translated(thumbnail_width() + 12, 0), window.computed_title(), WindowManager::the().window_title_font(), Gfx::TextAlignment::CenterLeft, text_color);
         auto window_details = m_windows_on_multiple_stacks ? DeprecatedString::formatted("{} on {}:{}", window.rect().to_deprecated_string(), window.window_stack().row() + 1, window.window_stack().column() + 1) : window.rect().to_deprecated_string();
         painter.draw_text(item_rect, window_details, Gfx::TextAlignment::CenterRight, rect_text_color);


### PR DESCRIPTION
Previously, calling `.right()` on a `Gfx::Rect` would return the last column's coordinate still inside the rectangle, or `left + width - 1`. This is called 'endpoint inclusive' and does not make a lot of sense for `Gfx::Rect<float>` where a rectangle of width 5 at position (0, 0) would return 4 as its right side. This same problem exists for `.bottom()`.

This changes `Gfx::Rect` to be endpoint exclusive, which gives us the nice property that `width = right - left` and `height = bottom - top`. It enables us to treat `Gfx::Rect<int>` and `Gfx::Rect<float>` exactly the same.

Note that although this allows us to clean up a lot of `+ 1`s from the code, it approximately adds the same amount of `- 1`s - especially in line drawing code, which tends to follow the inside edges of `IntRect`s.

* All users of `Gfx::Rect` have been updated accordingly.
* A `Gfx::Rect` test suite was introduced to validate this change and prevent regression on a bug I manifested along the way.
* Remove the `FloatRect` workaround I made for the box sampling code in `Gfx::Painter`.
* LibWeb contained some `Gfx::Rect<float>` comparison bugs that are marked with `FIXME` comments. The old, buggy behavior remains intact in this PR as to not include a lot of updated layout test results in this PR.

Visual example:

![image](https://github.com/SerenityOS/serenity/assets/3210731/13d1ceb7-0d72-4c5d-af9b-8bc37b0457b7)

Consider the above rectangle, then its endpoint exclusive properties would be:
* Left or X = 1
* Top or Y = 0
* Right = 3
* Bottom = 3
* Width = Right - Left = 2
* Height = Bottom - Top = 3