### PR TITLE
LibCore: Fix logic deciding when to open files in non-blocking mode

### DIFF
--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -85,7 +85,7 @@ int File::open_mode_to_options(OpenMode mode)
         flags |= O_EXCL;
     if (!has_flag(mode, OpenMode::KeepOnExec))
         flags |= O_CLOEXEC;
-    if (!has_flag(mode, OpenMode::Nonblocking))
+    if (has_flag(mode, OpenMode::Nonblocking))
         flags |= O_NONBLOCK;
     return flags;
 }


### PR DESCRIPTION
The if statement for setting the O_NONBLOCK flag was written the other way around, causing Core::File to open files in non-blocking mode, when we didn't actually specify it.

---

I did find that this "fixes" reading FIFOs with cat(1), but I'm making it draft anyway because I feel that further investigation should be done on how this affects the system.

Before|After
---|---
![image](https://github.com/SerenityOS/serenity/assets/16520278/b98d1600-ea3b-4d63-a28d-bd8fd6819176) | ![image](https://github.com/SerenityOS/serenity/assets/16520278/6fb5b4cd-aead-44eb-b37f-ca6f90fe0993)
![image](https://github.com/SerenityOS/serenity/assets/16520278/6f8c9094-7163-456f-b6b7-618059782b67) | ![image](https://github.com/SerenityOS/serenity/assets/16520278/b5a3a5ee-eb7a-406a-8d2e-7ded14e1ecb8)
