### PR TITLE
mkfifo: Don't rely on global errno

### DIFF
--- a/Userland/Utilities/mkfifo.cpp
+++ b/Userland/Utilities/mkfifo.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     for (auto path : paths) {
         auto error_or_void = Core::System::mkfifo(path, mode);
         if (error_or_void.is_error()) {
-            perror("mkfifo");
+            warnln("mkfifo: Couldn't create fifo '{}': {}", path, error_or_void.error());
             exit_code = 1;
         }
     }


### PR DESCRIPTION
Core::System::mkfifo() doesn't rely on POSIX's mkfifo() and sends the syscall directly to our system. This means that the and errno doesn't get updated which ultimately caused the program to display an incorrect message 'mkfifo: Success (not an error)'.

the boog|noboog
---|---
![](https://github.com/SerenityOS/serenity/assets/16520278/bad990a5-aa8b-4051-a604-bce1b1a425fc)|![](https://github.com/SerenityOS/serenity/assets/16520278/61c7423b-8cbe-4fdf-8e76-f57b221eb46b)