### PR TITLE
AK: Define `NAKED` more resiliently for AArch64

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -145,10 +145,14 @@
 #ifdef NAKED
 #    undef NAKED
 #endif
-#if !ARCH(AARCH64)
+#if !ARCH(AARCH64) || defined(AK_COMPILER_CLANG)
 #    define NAKED __attribute__((naked))
 #else
-#    define NAKED
+// GCC doesn't support __attribute__((naked)) on AArch64. We use NAKED to mark functions
+// that are entirely written in inline assembly; having these be inlined would cause
+// various problems, such as explicit `ret` instructions accidentally exiting the caller
+// function or GCC discarding function arguments as they appear "dead".
+#    define NAKED NEVER_INLINE
 #endif
 
 #ifdef DISALLOW


### PR DESCRIPTION
This attribute is used for functions in the kernel that are entirely written in assembly, yet defined in C++ source files.

Without `__attribute__((naked))`, Clang might decide to inline these functions, making any `ret` instructions within them actually exit the caller, or discard argument values as they appear "dead". This issue caused a kernel panic when using the `execve` syscall in AArch64 SerenityOS built by Clang.

While the empty definition so far appears to work fine with GCC, simpler test cases do similarly suffer from unintended inlining, so define `NAKED` as a synonym of `NEVER_INLINE` to avert future issues.

Perhaps we should move users of `NAKED` to plain assembly files?

This makes aarch64Clang builds boot :^)