### PR TITLE
LibWeb: Wait for media candidates without endlessly queueing microtasks

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -93,6 +93,7 @@ protected:
     virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
     virtual void did_remove_attribute(DeprecatedFlyString const&) override;
     virtual void removed_from(DOM::Node*) override;
+    virtual void children_changed() override;
 
     // Override in subclasses to handle implementation-specific behavior when the element state changes
     // to playing or paused, e.g. to start/stop play timers.


### PR DESCRIPTION
Rather than queueing microtasks ad nauseam to check if a media element has a new source candidate, let the media element tell us when it might have a new child to inspect. This removes endless CPU churn in cases where there is never a candidate that we can play.