### PR TITLE
du: Continue enumerating directories on error

### DIFF
--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -143,7 +143,7 @@ ErrorOr<u64> print_space_usage(DeprecatedString const& path, DuOption const& du_
         auto di = Core::DirIterator(path, Core::DirIterator::SkipParentAndBaseDir);
         if (di.has_error()) {
             auto error = di.error();
-            outln("du: cannot read directory '{}': {}", path, error);
+            warnln("du: cannot read directory '{}': {}", path, error);
             return error;
         }
 


### PR DESCRIPTION
Previously, the program would exit if a directory couldn't be read. We now write an error message to stderr and continue.

Also, print directory read errors to stderr rather than stdout.

Before:
![du_before](https://github.com/SerenityOS/serenity/assets/2817754/85cdd592-3501-45ee-86f6-5baf61c3556b)

After:
![du_after](https://github.com/SerenityOS/serenity/assets/2817754/8ad10fd4-ace3-4731-af0b-cf0c18239123)


