### PR TITLE
LibWeb: Use a default width of 20ch for `<input>` and `<textarea>`

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -30,7 +30,7 @@ input, textarea {
     border: 1px solid -libweb-palette-threed-shadow1;
     min-width: 80px;
     min-height: 16px;
-    width: 120px;
+    width: 20ch;
     cursor: text;
     overflow: hidden;
 }


### PR DESCRIPTION
The spec says that the default width for the `<input>` and `<textarea>` elements should be 20ch.

Relevant `<input>` spec link:
https://html.spec.whatwg.org/#the-size-attribute

Relevant `<textarea>` spec link:
https://html.spec.whatwg.org/#attr-textarea-cols