### PR TITLE
"Download finished" dialog layout somewhat busted 

### DIFF
--- a/Userland/Applications/Browser/DownloadWidget.cpp
+++ b/Userland/Applications/Browser/DownloadWidget.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "DownloadWidget.h"
+#include <AK/LexicalPath.h>
 #include <AK/NumberFormat.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/Proxy.h>
@@ -69,9 +70,10 @@ DownloadWidget::DownloadWidget(const URL& url)
     m_browser_image->load_from_file("/res/graphics/download-animation.gif"sv);
     animation_container.add_spacer().release_value_but_fixme_should_propagate_errors();
 
-    auto& source_label = add<GUI::Label>(String::formatted("From: {}", url).release_value_but_fixme_should_propagate_errors());
+    auto& source_label = add<GUI::Label>(String::formatted("File: {}", m_url.basename()).release_value_but_fixme_should_propagate_errors());
     source_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
     source_label.set_fixed_height(16);
+    source_label.set_text_wrapping(Gfx::TextWrapping::DontWrap);
 
     m_progressbar = add<GUI::Progressbar>();
     m_progressbar->set_fixed_height(20);
@@ -79,10 +81,14 @@ DownloadWidget::DownloadWidget(const URL& url)
     m_progress_label = add<GUI::Label>();
     m_progress_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
     m_progress_label->set_fixed_height(16);
+    m_progress_label->set_text_wrapping(Gfx::TextWrapping::DontWrap);
 
-    auto& destination_label = add<GUI::Label>(String::formatted("To: {}", m_destination_path).release_value_but_fixme_should_propagate_errors());
+    auto destination_label_path = LexicalPath(m_destination_path).dirname().to_deprecated_string();
+
+    auto& destination_label = add<GUI::Label>(String::formatted("To: {}", destination_label_path).release_value_but_fixme_should_propagate_errors());
     destination_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
     destination_label.set_fixed_height(16);
+    destination_label.set_text_wrapping(Gfx::TextWrapping::DontWrap);
 
     m_close_on_finish_checkbox = add<GUI::CheckBox>("Close when finished"_string.release_value_but_fixme_should_propagate_errors());
     m_close_on_finish_checkbox->set_checked(close_on_finish);


### PR DESCRIPTION
The previous download dialog had a broken layout:
![](https://user-images.githubusercontent.com/3487/236627305-e2e1883d-1809-40d5-a15f-c7399bd691c9.png)

With these changes the layout becomes:
![](https://user-images.githubusercontent.com/58738123/240032820-04d26665-0d1a-4991-96a5-36ffa27a6947.png)

These changes first fix the text wrapping problems making the original dialog illegible. Secondly they streamline the information given in the "From:" and "To:" sections of the previous dialog. These sections are now called "File:" and "To:" which the former gives the file name without the URL base name and the latter gives the directory that the file is being downloaded to without the file name at the end. This change was made because often the URL or the path would be too long and float off the screen of the dialog. Generally, we only care about the file and where it is going, so the other information is removed for the sake of clarity. 