### PR TITLE
LibWeb: Make LayoutState use HashMap instead of potentially huge Vector

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -859,13 +859,11 @@ void Document::update_layout()
     auto viewport_rect = browsing_context()->viewport_rect();
 
     if (!m_layout_root) {
-        m_next_layout_node_serial_id = 0;
         Layout::TreeBuilder tree_builder;
         m_layout_root = verify_cast<Layout::Viewport>(*tree_builder.build(*this));
     }
 
     Layout::LayoutState layout_state;
-    layout_state.used_values_per_layout_node.resize(layout_node_count());
 
     {
         Layout::BlockFormattingContext root_formatting_context(layout_state, *m_layout_root, nullptr);

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -97,9 +97,6 @@ public:
 
     JS::GCPtr<Selection::Selection> get_selection() const;
 
-    size_t next_layout_node_serial_id(Badge<Layout::Node>) { return m_next_layout_node_serial_id++; }
-    size_t layout_node_count() const { return m_next_layout_node_serial_id; }
-
     DeprecatedString cookie(Cookie::Source = Cookie::Source::NonHttp);
     void set_cookie(DeprecatedString const&, Cookie::Source = Cookie::Source::NonHttp);
 
@@ -492,8 +489,6 @@ private:
     void evaluate_media_rules();
 
     WebIDL::ExceptionOr<void> run_the_document_write_steps(DeprecatedString);
-
-    size_t m_next_layout_node_serial_id { 0 };
 
     OwnPtr<CSS::StyleComputer> m_style_computer;
     JS::GCPtr<CSS::StyleSheetList> m_style_sheets;

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -29,12 +29,8 @@ struct LayoutState {
     {
     }
 
-    explicit LayoutState(LayoutState const* parent)
-        : m_parent(parent)
-        , m_root(find_root())
-    {
-        used_values_per_layout_node.resize(m_root.used_values_per_layout_node.size());
-    }
+    explicit LayoutState(LayoutState const* parent);
+    ~LayoutState();
 
     LayoutState const& find_root() const
     {
@@ -153,7 +149,7 @@ struct LayoutState {
     // NOTE: get() will not CoW the UsedValues.
     UsedValues const& get(NodeWithStyleAndBoxModelMetrics const&) const;
 
-    Vector<OwnPtr<UsedValues>> used_values_per_layout_node;
+    HashMap<Layout::Node const*, NonnullOwnPtr<UsedValues>> used_values_per_layout_node;
 
     // We cache intrinsic sizes once determined, as they will not change over the course of a full layout.
     // This avoids computing them several times while performing flex layout.

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -32,8 +32,6 @@ Node::Node(DOM::Document& document, DOM::Node* node)
     , m_browsing_context(*document.browsing_context())
     , m_anonymous(node == nullptr)
 {
-    m_serial_id = document.next_layout_node_serial_id({});
-
     if (node)
         node->set_layout_node({}, *this);
 }

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -42,8 +42,6 @@ class Node
 public:
     virtual ~Node();
 
-    size_t serial_id() const { return m_serial_id; }
-
     bool is_anonymous() const;
     DOM::Node const* dom_node() const;
     DOM::Node* dom_node();
@@ -164,8 +162,6 @@ private:
     JS::GCPtr<Painting::Paintable> m_paintable;
 
     JS::NonnullGCPtr<HTML::BrowsingContext> m_browsing_context;
-
-    size_t m_serial_id { 0 };
 
     bool m_anonymous { false };
     bool m_has_style { false };


### PR DESCRIPTION
Before this change, LayoutState essentially had a Vector<UsedValues*> resized to the exact number of layout nodes in the current document.

When a nested layout is performed (to calculate the intrinsic size of something), we make a new LayoutState with its own Vector. If an entry is missing in a nested LayoutState, we check the parent chain all the way up to the root.

Because each nested LayoutState had to allocate a new Vector with space for all layout nodes, this could get really nasty on very large pages (such as the ECMA262 specification).

This patch replaces the Vector with a HashMap. There's now a small cost to lookups, but what we get in return is the ability to handle huge layout trees without spending eternity in page faults.