### PR TITLE
AK: Steps towards more general Math, starting with fmod/remainder

### DIFF
--- a/AK/Math.h
+++ b/AK/Math.h
@@ -81,6 +81,214 @@ constexpr size_t product_odd() { return value * product_odd<value - 2>(); }
         return res;                           \
     }
 
+namespace Rounding {
+template<FloatingPoint T>
+constexpr T ceil(T num)
+{
+    if (is_constant_evaluated()) {
+        if (num < NumericLimits<i64>::min() || num > NumericLimits<i64>::max())
+            return num;
+        return (static_cast<T>(static_cast<i64>(num)) == num)
+            ? static_cast<i64>(num)
+            : static_cast<i64>(num) + ((num > 0) ? 1 : 0);
+    }
+#if ARCH(AARCH64)
+    AARCH64_INSTRUCTION(frintp, num);
+#else
+    return __builtin_ceil(num);
+#endif
+}
+
+template<FloatingPoint T>
+constexpr T floor(T num)
+{
+    if (is_constant_evaluated()) {
+        if (num < NumericLimits<i64>::min() || num > NumericLimits<i64>::max())
+            return num;
+        return (static_cast<T>(static_cast<i64>(num)) == num)
+            ? static_cast<i64>(num)
+            : static_cast<i64>(num) - ((num > 0) ? 0 : 1);
+    }
+#if ARCH(AARCH64)
+    AARCH64_INSTRUCTION(frintm, num);
+#else
+    return __builtin_floor(num);
+#endif
+}
+
+template<FloatingPoint T>
+constexpr T round(T x)
+{
+    CONSTEXPR_STATE(round, x);
+    // Note: This is break-tie-away-from-zero, so not the hw's understanding of
+    //       "nearest", which would be towards even.
+    if (x == 0.)
+        return x;
+    if (x > 0.)
+        return floor(x + .5);
+    return ceil(x - .5);
+}
+
+template<Integral I, FloatingPoint P>
+ALWAYS_INLINE I round_to(P value);
+
+#if ARCH(X86_64)
+template<Integral I>
+ALWAYS_INLINE I round_to(long double value)
+{
+    // Note: fistps outputs into a signed integer location (i16, i32, i64),
+    //       so lets be nice and tell the compiler that.
+    Conditional<sizeof(I) >= sizeof(i16), MakeSigned<I>, i16> ret;
+    if constexpr (sizeof(I) == sizeof(i64)) {
+        asm("fistpll %0"
+            : "=m"(ret)
+            : "t"(value)
+            : "st");
+    } else if constexpr (sizeof(I) == sizeof(i32)) {
+        asm("fistpl %0"
+            : "=m"(ret)
+            : "t"(value)
+            : "st");
+    } else {
+        asm("fistps %0"
+            : "=m"(ret)
+            : "t"(value)
+            : "st");
+    }
+    return static_cast<I>(ret);
+}
+
+template<Integral I>
+ALWAYS_INLINE I round_to(float value)
+{
+    // FIXME: round_to<u64> might will cause issues, aka the indefinite value being set,
+    //        if the value surpasses the i64 limit, even if the result could fit into an u64
+    //        To solve this we would either need to detect that value or do a range check and
+    //        then do a more specialized conversion, which might include a division (which is expensive)
+    if constexpr (sizeof(I) == sizeof(i64) || IsSame<I, u32>) {
+        i64 ret;
+        asm("cvtss2si %1, %0"
+            : "=r"(ret)
+            : "xm"(value));
+        return static_cast<I>(ret);
+    }
+    i32 ret;
+    asm("cvtss2si %1, %0"
+        : "=r"(ret)
+        : "xm"(value));
+    return static_cast<I>(ret);
+}
+
+template<Integral I>
+ALWAYS_INLINE I round_to(double value)
+{
+    // FIXME: round_to<u64> might will cause issues, aka the indefinite value being set,
+    //        if the value surpasses the i64 limit, even if the result could fit into an u64
+    //        To solve this we would either need to detect that value or do a range check and
+    //        then do a more specialized conversion, which might include a division (which is expensive)
+    if constexpr (sizeof(I) == sizeof(i64) || IsSame<I, u32>) {
+        i64 ret;
+        asm("cvtsd2si %1, %0"
+            : "=r"(ret)
+            : "xm"(value));
+        return static_cast<I>(ret);
+    }
+    i32 ret;
+    asm("cvtsd2si %1, %0"
+        : "=r"(ret)
+        : "xm"(value));
+    return static_cast<I>(ret);
+}
+
+#elif ARCH(AARCH64)
+template<Signed I>
+ALWAYS_INLINE I round_to(float value)
+{
+    if constexpr (sizeof(I) <= sizeof(u32)) {
+        i32 res;
+        asm("fcvtns %w0, %s1"
+            : "=r"(res)
+            : "w"(value));
+        return static_cast<I>(res);
+    }
+    i64 res;
+    asm("fcvtns %0, %s1"
+        : "=r"(res)
+        : "w"(value));
+    return static_cast<I>(res);
+}
+
+template<Signed I>
+ALWAYS_INLINE I round_to(double value)
+{
+    if constexpr (sizeof(I) <= sizeof(u32)) {
+        i32 res;
+        asm("fcvtns %w0, %d1"
+            : "=r"(res)
+            : "w"(value));
+        return static_cast<I>(res);
+    }
+    i64 res;
+    asm("fcvtns %0, %d1"
+        : "=r"(res)
+        : "w"(value));
+    return static_cast<I>(res);
+}
+
+template<Unsigned U>
+ALWAYS_INLINE U round_to(float value)
+{
+    if constexpr (sizeof(U) <= sizeof(u32)) {
+        u32 res;
+        asm("fcvtnu %w0, %s1"
+            : "=r"(res)
+            : "w"(value));
+        return static_cast<U>(res);
+    }
+    i64 res;
+    asm("fcvtnu %0, %s1"
+        : "=r"(res)
+        : "w"(value));
+    return static_cast<U>(res);
+}
+
+template<Unsigned U>
+ALWAYS_INLINE U round_to(double value)
+{
+    if constexpr (sizeof(U) <= sizeof(u32)) {
+        u32 res;
+        asm("fcvtns %w0, %d1"
+            : "=r"(res)
+            : "w"(value));
+        return static_cast<U>(res);
+    }
+    i64 res;
+    asm("fcvtns %0, %d1"
+        : "=r"(res)
+        : "w"(value));
+    return static_cast<U>(res);
+}
+
+#else
+template<Integral I, FloatingPoint P>
+ALWAYS_INLINE I round_to(P value)
+{
+    if constexpr (IsSame<P, long double>)
+        return static_cast<I>(__builtin_llrintl(value));
+    if constexpr (IsSame<P, double>)
+        return static_cast<I>(__builtin_llrint(value));
+    if constexpr (IsSame<P, float>)
+        return static_cast<I>(__builtin_llrintf(value));
+}
+#endif
+
+}
+
+using Rounding::ceil;
+using Rounding::floor;
+using Rounding::round;
+using Rounding::round_to;
+
 namespace Division {
 template<FloatingPoint T>
 constexpr T fmod(T x, T y)
@@ -680,159 +888,6 @@ using Hyperbolic::cosh;
 using Hyperbolic::sinh;
 using Hyperbolic::tanh;
 
-template<Integral I, FloatingPoint P>
-ALWAYS_INLINE I round_to(P value);
-
-#if ARCH(X86_64)
-template<Integral I>
-ALWAYS_INLINE I round_to(long double value)
-{
-    // Note: fistps outputs into a signed integer location (i16, i32, i64),
-    //       so lets be nice and tell the compiler that.
-    Conditional<sizeof(I) >= sizeof(i16), MakeSigned<I>, i16> ret;
-    if constexpr (sizeof(I) == sizeof(i64)) {
-        asm("fistpll %0"
-            : "=m"(ret)
-            : "t"(value)
-            : "st");
-    } else if constexpr (sizeof(I) == sizeof(i32)) {
-        asm("fistpl %0"
-            : "=m"(ret)
-            : "t"(value)
-            : "st");
-    } else {
-        asm("fistps %0"
-            : "=m"(ret)
-            : "t"(value)
-            : "st");
-    }
-    return static_cast<I>(ret);
-}
-
-template<Integral I>
-ALWAYS_INLINE I round_to(float value)
-{
-    // FIXME: round_to<u64> might will cause issues, aka the indefinite value being set,
-    //        if the value surpasses the i64 limit, even if the result could fit into an u64
-    //        To solve this we would either need to detect that value or do a range check and
-    //        then do a more specialized conversion, which might include a division (which is expensive)
-    if constexpr (sizeof(I) == sizeof(i64) || IsSame<I, u32>) {
-        i64 ret;
-        asm("cvtss2si %1, %0"
-            : "=r"(ret)
-            : "xm"(value));
-        return static_cast<I>(ret);
-    }
-    i32 ret;
-    asm("cvtss2si %1, %0"
-        : "=r"(ret)
-        : "xm"(value));
-    return static_cast<I>(ret);
-}
-
-template<Integral I>
-ALWAYS_INLINE I round_to(double value)
-{
-    // FIXME: round_to<u64> might will cause issues, aka the indefinite value being set,
-    //        if the value surpasses the i64 limit, even if the result could fit into an u64
-    //        To solve this we would either need to detect that value or do a range check and
-    //        then do a more specialized conversion, which might include a division (which is expensive)
-    if constexpr (sizeof(I) == sizeof(i64) || IsSame<I, u32>) {
-        i64 ret;
-        asm("cvtsd2si %1, %0"
-            : "=r"(ret)
-            : "xm"(value));
-        return static_cast<I>(ret);
-    }
-    i32 ret;
-    asm("cvtsd2si %1, %0"
-        : "=r"(ret)
-        : "xm"(value));
-    return static_cast<I>(ret);
-}
-
-#elif ARCH(AARCH64)
-template<Signed I>
-ALWAYS_INLINE I round_to(float value)
-{
-    if constexpr (sizeof(I) <= sizeof(u32)) {
-        i32 res;
-        asm("fcvtns %w0, %s1"
-            : "=r"(res)
-            : "w"(value));
-        return static_cast<I>(res);
-    }
-    i64 res;
-    asm("fcvtns %0, %s1"
-        : "=r"(res)
-        : "w"(value));
-    return static_cast<I>(res);
-}
-
-template<Signed I>
-ALWAYS_INLINE I round_to(double value)
-{
-    if constexpr (sizeof(I) <= sizeof(u32)) {
-        i32 res;
-        asm("fcvtns %w0, %d1"
-            : "=r"(res)
-            : "w"(value));
-        return static_cast<I>(res);
-    }
-    i64 res;
-    asm("fcvtns %0, %d1"
-        : "=r"(res)
-        : "w"(value));
-    return static_cast<I>(res);
-}
-
-template<Unsigned U>
-ALWAYS_INLINE U round_to(float value)
-{
-    if constexpr (sizeof(U) <= sizeof(u32)) {
-        u32 res;
-        asm("fcvtnu %w0, %s1"
-            : "=r"(res)
-            : "w"(value));
-        return static_cast<U>(res);
-    }
-    i64 res;
-    asm("fcvtnu %0, %s1"
-        : "=r"(res)
-        : "w"(value));
-    return static_cast<U>(res);
-}
-
-template<Unsigned U>
-ALWAYS_INLINE U round_to(double value)
-{
-    if constexpr (sizeof(U) <= sizeof(u32)) {
-        u32 res;
-        asm("fcvtns %w0, %d1"
-            : "=r"(res)
-            : "w"(value));
-        return static_cast<U>(res);
-    }
-    i64 res;
-    asm("fcvtns %0, %d1"
-        : "=r"(res)
-        : "w"(value));
-    return static_cast<U>(res);
-}
-
-#else
-template<Integral I, FloatingPoint P>
-ALWAYS_INLINE I round_to(P value)
-{
-    if constexpr (IsSame<P, long double>)
-        return static_cast<I>(__builtin_llrintl(value));
-    if constexpr (IsSame<P, double>)
-        return static_cast<I>(__builtin_llrint(value));
-    if constexpr (IsSame<P, float>)
-        return static_cast<I>(__builtin_llrintf(value));
-}
-#endif
-
 template<FloatingPoint T>
 constexpr T pow(T x, T y)
 {
@@ -857,53 +912,6 @@ constexpr T pow(T x, T y)
     }
 
     return exp2<T>(y * log2<T>(x));
-}
-
-template<FloatingPoint T>
-constexpr T ceil(T num)
-{
-    if (is_constant_evaluated()) {
-        if (num < NumericLimits<i64>::min() || num > NumericLimits<i64>::max())
-            return num;
-        return (static_cast<T>(static_cast<i64>(num)) == num)
-            ? static_cast<i64>(num)
-            : static_cast<i64>(num) + ((num > 0) ? 1 : 0);
-    }
-#if ARCH(AARCH64)
-    AARCH64_INSTRUCTION(frintp, num);
-#else
-    return __builtin_ceil(num);
-#endif
-}
-
-template<FloatingPoint T>
-constexpr T floor(T num)
-{
-    if (is_constant_evaluated()) {
-        if (num < NumericLimits<i64>::min() || num > NumericLimits<i64>::max())
-            return num;
-        return (static_cast<T>(static_cast<i64>(num)) == num)
-            ? static_cast<i64>(num)
-            : static_cast<i64>(num) - ((num > 0) ? 0 : 1);
-    }
-#if ARCH(AARCH64)
-    AARCH64_INSTRUCTION(frintm, num);
-#else
-    return __builtin_floor(num);
-#endif
-}
-
-template<FloatingPoint T>
-constexpr T round(T x)
-{
-    CONSTEXPR_STATE(round, x);
-    // Note: This is break-tie-away-from-zero, so not the hw's understanding of
-    //       "nearest", which would be towards even.
-    if (x == 0.)
-        return x;
-    if (x > 0.)
-        return floor(x + .5);
-    return ceil(x - .5);
 }
 
 template<typename T>

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -81,6 +81,18 @@ constexpr size_t product_odd() { return value * product_odd<value - 2>(); }
         return res;                           \
     }
 
+template<FloatingPoint T>
+constexpr T fabs(T x)
+{
+    // Both GCC and Clang inline fabs by default, so this is just a cmath like wrapper
+    if constexpr (IsSame<T, long double>)
+        return __builtin_fabsl(x);
+    if constexpr (IsSame<T, double>)
+        return __builtin_fabs(x);
+    if constexpr (IsSame<T, float>)
+        return __builtin_fabsf(x);
+}
+
 namespace Rounding {
 template<FloatingPoint T>
 constexpr T ceil(T num)
@@ -492,23 +504,6 @@ constexpr T cbrt(T x)
     r = (2.0l / 3.0l) * r + (1.0l / 3.0l) * x / (r * r);
 
     return r;
-}
-
-template<FloatingPoint T>
-constexpr T fabs(T x)
-{
-    if (is_constant_evaluated())
-        return x < 0 ? -x : x;
-#if ARCH(X86_64)
-    asm(
-        "fabs"
-        : "+t"(x));
-    return x;
-#elif ARCH(AARCH64)
-    AARCH64_INSTRUCTION(fabs, x);
-#else
-    return __builtin_fabs(x);
-#endif
 }
 
 namespace Trigonometry {

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -108,7 +108,12 @@ constexpr T ceil(T num)
 #if ARCH(AARCH64)
     AARCH64_INSTRUCTION(frintp, num);
 #else
-    return __builtin_ceil(num);
+    if constexpr (IsSame<T, long double>)
+        return __builtin_ceill(num);
+    if constexpr (IsSame<T, double>)
+        return __builtin_ceil(num);
+    if constexpr (IsSame<T, float>)
+        return __builtin_ceilf(num);
 #endif
 }
 
@@ -126,7 +131,12 @@ constexpr T floor(T num)
 #if ARCH(AARCH64)
     AARCH64_INSTRUCTION(frintm, num);
 #else
-    return __builtin_floor(num);
+    if constexpr (IsSame<T, long double>)
+        return __builtin_floorl(num);
+    if constexpr (IsSame<T, double>)
+        return __builtin_floor(num);
+    if constexpr (IsSame<T, float>)
+        return __builtin_floorf(num);
 #endif
 }
 
@@ -389,6 +399,7 @@ constexpr T fmod(T x, T y)
     return __builtin_fmod(x, y);
 #endif
 }
+
 template<FloatingPoint T>
 constexpr T remainder(T x, T y)
 {

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -391,12 +391,37 @@ constexpr T fmod(T x, T y)
             : "u"(y));
     } while (fpu_status & 0x400);
     return x;
+    // FIXME: Add a generic implementation of this
+    //        Neither
+    //        ```
+    //        return x - (y * trunc(x/y))
+    //        ```
+    //        nor
+    //        ```
+    //        double result = remainder(std::fabs(x), y = std::fabs(y));
+    //        if (std::signbit(result))
+    //            result += y;
+    //        return std::copysign(result, x);
+    //        ``` from (https://en.cppreference.com/w/cpp/numeric/math/fmod)
+    //        provide enough precision for all cases
+    //        other implementations seem to do this by hand with some fixed point steps in between
+    //        For `remainder` the trivial solution of
+    //        ```
+    //        return x - (y * rint(x/y))
+    //        ```
+    //        might work
+
 #else
 #    if defined(AK_OS_SERENITY)
     // TODO: Add implementation for this function.
     TODO();
 #    endif
-    return __builtin_fmod(x, y);
+    if constexpr (IsSame<T, long double>)
+        return __builtin_fmodl(x, y);
+    if constexpr (IsSame<T, double>)
+        return __builtin_fmod(x, y);
+    if constexpr (IsSame<T, float>)
+        return __builtin_fmodf(x, y);
 #endif
 }
 
@@ -420,7 +445,12 @@ constexpr T remainder(T x, T y)
     // TODO: Add implementation for this function.
     TODO();
 #    endif
-    return __builtin_fmod(x, y);
+    if constexpr (IsSame<T, long double>)
+        return __builtin_remainderl(x, y);
+    if constexpr (IsSame<T, double>)
+        return __builtin_remainder(x, y);
+    if constexpr (IsSame<T, float>)
+        return __builtin_remainderf(x, y);
 #endif
 }
 }


### PR DESCRIPTION
### AK: Move rounding function to the top of AK/Math.h
These are useful in other algorithms, so lets move them up

### AK: Add trunc and rint to AK/Math.h
These are useful in some algorithms, which require specific rounding.

### AK: Add generic implementations for remainder and fmod

### AK: Use builtins in fabs implementation

Both GCC and Clang inline this function to use bit-wise logic and/or
appropriate instructions even on -O0 and allow their use in a constexpr
context, see
<https://godbolt.org/z/de1393vha>

### AK: Use correct builtins for floor and ceil

We were using the double ones, forcing casts to and from them for floats