### PR TITLE
LibThreading: Improve resiliancy of timed threading tests

### DIFF
--- a/Tests/LibThreading/TestThread.cpp
+++ b/Tests/LibThreading/TestThread.cpp
@@ -4,13 +4,30 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Time.h>
 #include <LibTest/TestCase.h>
 #include <LibThreading/Thread.h>
 #include <unistd.h>
 
+using namespace AK::TimeLiterals;
+
+static void sleep_until_thread_exits(Threading::Thread const& thread)
+{
+    static constexpr auto delay = 20_ms;
+
+    for (auto i = 0; i < 100; ++i) {
+        if (thread.has_exited())
+            return;
+
+        usleep(delay.to_microseconds());
+    }
+
+    FAIL("Timed out waiting for thread to exit");
+}
+
 TEST_CASE(threads_can_detach)
 {
-    int should_be_42 = 0;
+    Atomic<int> should_be_42 = 0;
 
     auto thread = Threading::Thread::construct([&should_be_42]() {
         usleep(10 * 1000);
@@ -19,12 +36,12 @@ TEST_CASE(threads_can_detach)
     });
     thread->start();
     thread->detach();
-    usleep(20 * 1000);
 
+    sleep_until_thread_exits(*thread);
     EXPECT(should_be_42 == 42);
 }
 
-TEST_CASE(joining_detached_thread_errors)
+TEST_CASE(detached_threads_do_not_need_to_be_joined)
 {
     Atomic<bool> should_exit { false };
     auto thread = Threading::Thread::construct([&]() {
@@ -40,15 +57,16 @@ TEST_CASE(joining_detached_thread_errors)
 
     // FIXME: Dropping a running thread crashes because of the Function destructor. For now, force the detached thread to exit.
     should_exit.store(true);
-    usleep(20 * 1000);
+    sleep_until_thread_exits(*thread);
 }
 
 TEST_CASE(join_dead_thread)
 {
     auto thread = Threading::Thread::construct([&]() { return 0 /*nullptr*/; });
     thread->start();
+
     // The thread should have exited by then.
-    usleep(40 * 1000);
+    sleep_until_thread_exits(*thread);
 
     auto join_result = TRY_OR_FAIL(thread->join<int*>());
     EXPECT_EQ(join_result, static_cast<int*>(0));


### PR DESCRIPTION
The threading tests currently wait for a very small amount of time for the expected test condition to be reached, e.g. 20ms. This changes the tests to *check* the condition every 20ms, but allow the test to run for up to 2s until the condition is reached. This should hopefully resolve the failures seen on CI.

This also renames one of the tests to match what it actually does. The test itself was changed in commit 5b335e7, but the name was not updated to reflect that change.