### PR TITLE
Fuzzers: Unbreak FuzzHttpRequest

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzHttpRequest.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzHttpRequest.cpp
@@ -11,7 +11,7 @@
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     auto request_wrapper = HTTP::HttpRequest::from_raw_request(ReadonlyBytes { data, size });
-    if (!request_wrapper.is_error())
+    if (request_wrapper.is_error())
         return 0;
 
     auto& request = request_wrapper.value();


### PR DESCRIPTION
Previously, the exit condition was inverted, causing the fuzzer to try to read the value of an error.