### PR TITLE
LibWeb: Resolve CSS variables if present in SVG presentation attributes

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/svg-with-css-variable-in-presentation-hint.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-css-variable-in-presentation-hint.txt
@@ -1,0 +1,7 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x118 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x102 children: inline
+      line 0 width: 102, height: 102, bottom: 102, baseline: 60
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,9 100x100]
+      SVGSVGBox <svg> at (9,9) content-size 100x100 [SVG] children: not-inline
+        SVGGeometryBox <rect> at (29,29) content-size 60x60 children: not-inline

--- a/Tests/LibWeb/Layout/input/svg/svg-with-css-variable-in-presentation-hint.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-with-css-variable-in-presentation-hint.html
@@ -1,0 +1,10 @@
+<!doctype html><style>
+    :root {
+        --huge: 5px;
+    }
+    svg {
+        width: 100px;
+        height: 100px;
+        border: 1px solid black;
+    }
+</style><svg viewBox="0 0 10 10"><rect x=4.5 y=4.5 width=1 height=1 stroke="green" stroke-width="var(--huge)" />

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -73,6 +73,7 @@ public:
 
     virtual bool requires_svg_container() const { return false; }
     virtual bool is_svg_container() const { return false; }
+    virtual bool is_svg_element() const { return false; }
     virtual bool is_svg_svg_element() const { return false; }
 
     bool in_a_document_tree() const;

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.h
@@ -26,6 +26,16 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
     JS::GCPtr<HTML::DOMStringMap> m_dataset;
+
+private:
+    virtual bool is_svg_element() const final { return true; }
 };
+
+}
+
+namespace Web::DOM {
+
+template<>
+inline bool Node::fast_is<SVG::SVGElement>() const { return is_svg_element(); }
 
 }


### PR DESCRIPTION
This (roughly) matches the behavior of other engines.

It's also used on the web, for example on https://stripe.com/ :^)