### PR TITLE
SpiceAgent: Don't send `ClipboardGrab` if the shared clipboard is disabled

### DIFF
--- a/Userland/Services/SpiceAgent/SpiceAgent.cpp
+++ b/Userland/Services/SpiceAgent/SpiceAgent.cpp
@@ -53,6 +53,12 @@ ErrorOr<void> SpiceAgent::start()
 
 ErrorOr<void> SpiceAgent::on_clipboard_update(String const& mime_type)
 {
+    // NOTE: If we indicate that we don't support clipboard by demand, the spice server will ignore our messages,
+    //       but it will do some ugly debug logging.. so let's just not send anything instead.
+    if (!m_capabilities.contains_slow(Capability::ClipboardByDemand)) {
+        return {};
+    }
+
     // If we just copied something to the clipboard, we shouldn't do anything here.
     if (m_clipboard_dirty) {
         m_clipboard_dirty = false;


### PR DESCRIPTION
The spice server will ignore any clipboard-related messages if we don't have the appropriate capabilities, but I think it's better for us to do less CPU churning whenever the user copies something to their clipboard.

It also stops the spice server from warning in the console about a clipboard grab message being recieved when the capability was never announced.