### PR TITLE
w: Filter by username, optionally hide header + bugfixes

### DIFF
--- a/Base/usr/share/man/man1/w.md
+++ b/Base/usr/share/man/man1/w.md
@@ -1,0 +1,17 @@
+## Name
+
+w - Show information about currently logged-in users
+
+## Synopsis
+
+```sh
+$ w [--no-header] [user]
+```
+
+## Options
+
+* `-h`, `--no-header`: Don't show the header
+
+## Arguments
+
+* `user`: Only show information about the specified user

--- a/Userland/Utilities/w.cpp
+++ b/Userland/Utilities/w.cpp
@@ -75,6 +75,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
         StringBuilder builder;
         String idle_string = "n/a"_short_string;
         String what = "n/a"_short_string;
+        StringView tty_display_name = tty;
         auto maybe_stat = Core::System::stat(tty);
         if (!maybe_stat.is_error()) {
             auto stat = maybe_stat.release_value();
@@ -85,6 +86,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
             }
 
             auto tty_pseudo_name = TRY(tty_stat_to_pseudo_name(stat));
+            tty_display_name = tty_pseudo_name;
             for (auto& process : process_statistics.processes) {
                 if (tty_pseudo_name == process.tty.view() && process.pid == process.pgid) {
                     what = TRY(String::from_deprecated_string(process.name));
@@ -93,7 +95,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
             }
         }
 
-        outln("{:10} {:12} {:16} {:6} {}", username, tty, login_at, idle_string, what);
+        outln("{:10} {:12} {:16} {:6} {}", username, tty_display_name, login_at, idle_string, what);
         return {};
     }));
     return 0;

--- a/Userland/Utilities/w.cpp
+++ b/Userland/Utilities/w.cpp
@@ -45,9 +45,11 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     TRY(Core::System::unveil("/sys/kernel/processes", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
+    bool hide_header = false;
     StringView username_to_filter_by;
 
     Core::ArgsParser args_parser;
+    args_parser.add_option(hide_header, "Don't show the header", "no-header", 'h');
     args_parser.add_positional_argument(username_to_filter_by, "Only show information about the specified user", "user", Core::ArgsParser::Required::No);
     args_parser.parse(args);
 
@@ -63,7 +65,9 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     auto now = Time::now_realtime().to_seconds();
 
-    outln("\033[1m{:10} {:12} {:16} {:6} {}\033[0m", "USER", "TTY", "LOGIN@", "IDLE", "WHAT");
+    if (!hide_header)
+        outln("\033[1m{:10} {:12} {:16} {:6} {}\033[0m", "USER", "TTY", "LOGIN@", "IDLE", "WHAT");
+
     TRY(json.as_object().try_for_each_member([&](auto& tty, auto& value) -> ErrorOr<void> {
         const JsonObject& entry = value.as_object();
         auto uid = entry.get_u32("uid"sv).value_or(0);


### PR DESCRIPTION
This PR makes multiple improvements to the `w` command:
* The "WHEN" column now displays the correct information. Previously, it always displayed "n/a".
* The "TTY" column now displays the TTY in the format "[tty|pts]:<number>" rather than the full device name. This matches the format used by `ps`.
* You can now filter by username; `w root` will display only entries for the root user.
* You can now use the `-h` option to hide the header.

Before:
![w_before](https://github.com/SerenityOS/serenity/assets/2817754/3d1909a6-95d8-4d84-9d69-b8d604520862)

After:
![w_after](https://github.com/SerenityOS/serenity/assets/2817754/17e7cd17-b556-4fd8-9e33-6e0040aa4b66)
