### PR TITLE
LibWeb: Support min-inline-size & max-inline-size

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -11,6 +11,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibMain/Main.h>
 
+ErrorOr<void> replace_logical_aliases(JsonObject& properties);
 ErrorOr<void> generate_header_file(JsonObject& properties, Core::File& file);
 ErrorOr<void> generate_implementation_file(JsonObject& properties, Core::File& file);
 
@@ -30,6 +31,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     VERIFY(json.is_object());
     auto properties = json.as_object();
 
+    TRY(replace_logical_aliases(properties));
+
     auto generated_header_file = TRY(Core::File::open(generated_header_path, Core::File::OpenMode::Write));
     auto generated_implementation_file = TRY(Core::File::open(generated_implementation_path, Core::File::OpenMode::Write));
 
@@ -37,6 +40,37 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(generate_implementation_file(properties, *generated_implementation_file));
 
     return 0;
+}
+
+ErrorOr<void> replace_logical_aliases(JsonObject& properties)
+{
+    AK::HashMap<DeprecatedString, DeprecatedString> logical_aliases;
+    properties.for_each_member([&](auto& name, auto& value) {
+        VERIFY(value.is_object());
+        const auto& value_as_object = value.as_object();
+        const auto logical_alias_for = value_as_object.get_deprecated_string("logical-alias-for"sv);
+        if (logical_alias_for.has_value()) {
+            logical_aliases.set(name, logical_alias_for.value());
+        }
+    });
+
+    for (auto& [name, alias] : logical_aliases) {
+        auto const maybe_alias_object = properties.get_object(alias);
+        if (!maybe_alias_object.has_value()) {
+            dbgln("No property '{}' found for logical alias '{}'", alias, name);
+            VERIFY_NOT_REACHED();
+        }
+        JsonObject alias_object = maybe_alias_object.value();
+
+        // Copy over anything the logical property overrides
+        properties.get_object(name).value().for_each_member([&](auto& key, auto& value) {
+            alias_object.set(key, value);
+        });
+
+        properties.set(name, alias_object);
+    }
+
+    return {};
 }
 
 ErrorOr<void> generate_header_file(JsonObject& properties, Core::File& file)

--- a/Tests/LibWeb/Layout/expected/inline-size.txt
+++ b/Tests/LibWeb/Layout/expected/inline-size.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x570.851562 [BFC] children: not-inline
+    BlockContainer <body> at (8,70) content-size 784x492.851562 children: not-inline
+      BlockContainer <p.min-inline-test> at (8,70) content-size 784x200 children: inline
+        line 0 width: 85.859375, height: 76.425781, bottom: 76.425781, baseline: 59.199218
+          frag 0 from TextNode start: 0, length: 2, rect: [8,70 85.859375x76.425781]
+            "KK"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,340) content-size 784x76.425781 children: inline
+        line 0 width: 0, height: 76.425781, bottom: 76.425781, baseline: 59.199218
+        TextNode <#text>
+        BreakNode <br>
+        TextNode <#text>
+      BlockContainer <p.max-inline-test> at (8,486.425781) content-size 100x76.425781 children: inline
+        line 0 width: 85.859375, height: 76.425781, bottom: 76.425781, baseline: 59.199218
+          frag 0 from TextNode start: 0, length: 2, rect: [8,486.425781 85.859375x76.425781]
+            "KK"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,632.851562) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/inline-size.html
+++ b/Tests/LibWeb/Layout/input/inline-size.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<style>
+* {
+    font: 70px SerenitySans;
+}
+.min-inline-test {
+    background: red;
+    min-width:  400px;
+    min-height: 200px;
+
+    min-inline-size: 700px;
+    writing-mode: horizontal-tb;
+}
+.max-inline-test {
+    background: blue;
+    max-width:  400px;
+    max-height: 200px;
+
+    max-inline-size: 100px;
+    writing-mode: horizontal-tb;
+}
+</style>
+<p class="min-inline-test">KK</p>
+<br>
+<p class="max-inline-test">KK</p>

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1203,6 +1203,11 @@
       "unitless-length"
     ]
   },
+  "max-inline-size": {
+    "logical-alias-for": "max-width",
+    "__comment": "Also a logical alias for max-height",
+    "initial": "none"
+  },
   "max-width": {
     "inherited": false,
     "initial": "none",
@@ -1231,6 +1236,11 @@
     "quirks": [
       "unitless-length"
     ]
+  },
+  "min-inline-size": {
+    "logical-alias-for": "min-width",
+    "__comment": "Also a logical alias for min-height",
+    "initial": "0"
   },
   "min-width": {
     "inherited": false,

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -665,6 +665,26 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         return;
     }
 
+    if (property_id == CSS::PropertyID::MaxInlineSize || property_id == CSS::PropertyID::MinInlineSize) {
+        // FIXME: Use writing-mode to determine if we should set width or height.
+        bool is_horizontal = true;
+
+        if (is_horizontal) {
+            if (property_id == CSS::PropertyID::MaxInlineSize) {
+                style.set_property(CSS::PropertyID::MaxWidth, value);
+            } else {
+                style.set_property(CSS::PropertyID::MinWidth, value);
+            }
+        } else {
+            if (property_id == CSS::PropertyID::MaxInlineSize) {
+                style.set_property(CSS::PropertyID::MaxHeight, value);
+            } else {
+                style.set_property(CSS::PropertyID::MinHeight, value);
+            }
+        }
+        return;
+    }
+
     style.set_property(property_id, value);
 }
 


### PR DESCRIPTION
Adds support for the [CSS logical properties min-inline-size and max-inline-size](https://drafts.csswg.org/css-logical/#propdef-max-inline-size). These properties affect either min/max-width or min/max-height depending on whether the writing-mode is horizontal or vertical. This PR does not include supporting writing-mode, so it defaults to only affecting width.