### PR TITLE
Documentation: Configure cache dir in CMake settings for CLion

### DIFF
--- a/Documentation/CLionConfiguration.md
+++ b/Documentation/CLionConfiguration.md
@@ -12,10 +12,11 @@ After opening the `serenity` repository in CLion as a new project, the "`Open Pr
 
 `CMake Options`:
 ```
--GNinja
--DCMAKE_TOOLCHAIN_FILE=$CMakeProjectDir$/Build/x86_64/CMakeToolchain.txt
 -DCMAKE_PREFIX_PATH=$CMakeProjectDir$/Build/lagom-install
+-DCMAKE_TOOLCHAIN_FILE=$CMakeProjectDir$/Build/x86_64/CMakeToolchain.txt
 -DSERENITY_ARCH=x86_64
+-DSERENITY_CACHE_DIR=$CMakeProjectDir$/Build/caches
+-GNinja
 ```
 
 > CLion will complain that the toolchain file doesn't exist yet, if you haven't `cmake` for the SuperBuild step before. The SuperBuild configure step creates the Toolchain file.


### PR DESCRIPTION
Without this, CMake would err out on a missing `/CLDR/version.txt`.

@trflynn89 noted that the superbuild sets the variable here:
https://github.com/SerenityOS/serenity/blob/10ceacf5fb6ef8cea7c90958470515d5b386c50b/Meta/CMake/Superbuild/CMakeLists.txt#L47-L48

But CLion seems to fail to pick it up. Until it does, let's include this in the instructions.