### PR TITLE
Add ElapsedTimer::elapsed_milliseconds(), call it in a few places

### DIFF
--- a/Userland/Libraries/LibCore/ElapsedTimer.cpp
+++ b/Userland/Libraries/LibCore/ElapsedTimer.cpp
@@ -29,7 +29,7 @@ void ElapsedTimer::reset()
     m_origin_time = {};
 }
 
-i64 ElapsedTimer::elapsed() const
+i64 ElapsedTimer::elapsed_milliseconds() const
 {
     return elapsed_time().to_milliseconds();
 }

--- a/Userland/Libraries/LibCore/ElapsedTimer.h
+++ b/Userland/Libraries/LibCore/ElapsedTimer.h
@@ -23,8 +23,14 @@ public:
     void start();
     void reset();
 
-    i64 elapsed() const; // milliseconds
+    i64 elapsed_milliseconds() const;
     Time elapsed_time() const;
+
+    // FIXME: Move callers to elapsed_milliseconds(), remove this.
+    i64 elapsed() const // milliseconds
+    {
+        return elapsed_milliseconds();
+    }
 
     Time const& origin_time() const { return m_origin_time; }
 

--- a/Userland/Utilities/abench.cpp
+++ b/Userland/Utilities/abench.cpp
@@ -48,7 +48,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         if (remaining_samples > 0) {
             sample_timer = sample_timer.start_new();
             auto samples = loader->get_more_samples(min(MAX_CHUNK_SIZE, remaining_samples));
-            total_loader_time += sample_timer.elapsed();
+            total_loader_time += sample_timer.elapsed_milliseconds();
             if (!samples.is_error()) {
                 remaining_samples -= samples.value().size();
                 total_loaded_samples += samples.value().size();

--- a/Userland/Utilities/allocate.cpp
+++ b/Userland/Utilities/allocate.cpp
@@ -64,7 +64,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         outln("failed.");
         return 1;
     }
-    outln("done in {}ms", timer.elapsed());
+    outln("done in {}ms", timer.elapsed_milliseconds());
 
     auto pages = count / PAGE_SIZE;
     auto step = pages / 10;
@@ -76,7 +76,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         ptr[i * PAGE_SIZE] = 1;
 
         if (i != 0 && (i % step) == 0) {
-            auto ms = timer2.elapsed();
+            auto ms = timer2.elapsed_milliseconds();
             if (ms == 0)
                 ms = 1;
 
@@ -87,7 +87,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             timer2.start();
         }
     }
-    outln("done in {}ms", timer.elapsed());
+    outln("done in {}ms", timer.elapsed_milliseconds());
 
     outln("sleeping for ten seconds...");
     for (int i = 0; i < 10; i++) {
@@ -99,7 +99,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     outln("freeing memory...");
     timer.start();
     free(ptr);
-    outln("done in {}ms", timer.elapsed());
+    outln("done in {}ms", timer.elapsed_milliseconds());
 
     return 0;
 }

--- a/Userland/Utilities/disk_benchmark.cpp
+++ b/Userland/Utilities/disk_benchmark.cpp
@@ -92,7 +92,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 usleep(100);
             }
             auto average = average_result(results);
-            outln("Finished: runs={} time={}ms write_bps={} read_bps={}", results.size(), timer.elapsed(), average.write_bps, average.read_bps);
+            outln("Finished: runs={} time={}ms write_bps={} read_bps={}", results.size(), timer.elapsed_milliseconds(), average.write_bps, average.read_bps);
 
             sleep(1);
         }
@@ -129,7 +129,7 @@ ErrorOr<Result> benchmark(DeprecatedString const& filename, int file_size, ByteB
         total_written += nwritten;
     }
 
-    result.write_bps = (u64)(timer.elapsed() ? (file_size / timer.elapsed()) : file_size) * 1000;
+    result.write_bps = (u64)(timer.elapsed_milliseconds() ? (file_size / timer.elapsed_milliseconds()) : file_size) * 1000;
 
     TRY(Core::System::lseek(fd, 0, SEEK_SET));
 
@@ -140,6 +140,6 @@ ErrorOr<Result> benchmark(DeprecatedString const& filename, int file_size, ByteB
         total_read += nread;
     }
 
-    result.read_bps = (u64)(timer.elapsed() ? (file_size / timer.elapsed()) : file_size) * 1000;
+    result.read_bps = (u64)(timer.elapsed_milliseconds() ? (file_size / timer.elapsed_milliseconds()) : file_size) * 1000;
     return result;
 }


### PR DESCRIPTION
No behavior change, this is just a clearer name. An example of "replace a comment with a better name" technique Mr Kling advertised on Twitter :)

No behavior change.

(js.cpp also calls `elapsed()`, but on a different object, and that different object apparently returns microseconds instead.)