### PR TITLE
LibWeb: Parse & honor font-weight and font-style inside @font-face rules

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Userland/Libraries/LibWeb/CSS/FontFace.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,8 +9,10 @@
 
 namespace Web::CSS {
 
-FontFace::FontFace(FlyString font_family, Vector<Source> sources, Vector<UnicodeRange> unicode_ranges)
+FontFace::FontFace(FlyString font_family, Optional<int> weight, Optional<int> slope, Vector<Source> sources, Vector<UnicodeRange> unicode_ranges)
     : m_font_family(move(font_family))
+    , m_weight(weight)
+    , m_slope(slope)
     , m_sources(move(sources))
     , m_unicode_ranges(move(unicode_ranges))
 {

--- a/Userland/Libraries/LibWeb/CSS/FontFace.h
+++ b/Userland/Libraries/LibWeb/CSS/FontFace.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -20,16 +21,20 @@ public:
         Optional<FlyString> format;
     };
 
-    FontFace(FlyString font_family, Vector<Source> sources, Vector<UnicodeRange> unicode_ranges);
+    FontFace(FlyString font_family, Optional<int> weight, Optional<int> slope, Vector<Source> sources, Vector<UnicodeRange> unicode_ranges);
     ~FontFace() = default;
 
     FlyString font_family() const { return m_font_family; }
+    Optional<int> weight() const { return m_weight; }
+    Optional<int> slope() const { return m_slope; }
     Vector<Source> const& sources() const { return m_sources; }
     Vector<UnicodeRange> const& unicode_ranges() const { return m_unicode_ranges; }
-    // FIXME: font-style, font-weight, font-stretch, font-feature-settings
+    // FIXME: font-stretch, font-feature-settings
 
 private:
     FlyString m_font_family;
+    Optional<int> m_weight { 0 };
+    Optional<int> m_slope { 0 };
     Vector<Source> m_sources;
     Vector<UnicodeRange> m_unicode_ranges;
 };

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1171,39 +1171,7 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
         }
     }
 
-    int weight = Gfx::FontWeight::Regular;
-    if (font_weight->is_identifier()) {
-        switch (static_cast<IdentifierStyleValue const&>(*font_weight).id()) {
-        case CSS::ValueID::Normal:
-            weight = Gfx::FontWeight::Regular;
-            break;
-        case CSS::ValueID::Bold:
-            weight = Gfx::FontWeight::Bold;
-            break;
-        case CSS::ValueID::Lighter:
-            // FIXME: This should be relative to the parent.
-            weight = Gfx::FontWeight::Regular;
-            break;
-        case CSS::ValueID::Bolder:
-            // FIXME: This should be relative to the parent.
-            weight = Gfx::FontWeight::Bold;
-            break;
-        default:
-            break;
-        }
-    } else if (font_weight->has_integer()) {
-        int font_weight_integer = font_weight->to_integer();
-        if (font_weight_integer <= Gfx::FontWeight::Regular)
-            weight = Gfx::FontWeight::Regular;
-        else if (font_weight_integer <= Gfx::FontWeight::Bold)
-            weight = Gfx::FontWeight::Bold;
-        else
-            weight = Gfx::FontWeight::Black;
-    } else if (font_weight->is_calculated()) {
-        auto maybe_weight = const_cast<CalculatedStyleValue&>(font_weight->as_calculated()).resolve_integer();
-        if (maybe_weight.has_value())
-            weight = maybe_weight.value();
-    }
+    auto weight = font_weight->to_font_weight();
 
     bool bold = weight > Gfx::FontWeight::Regular;
 
@@ -1282,21 +1250,7 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
         }
     }
 
-    int slope = Gfx::name_to_slope("Normal"sv);
-    // FIXME: Implement oblique <angle>
-    if (font_style->is_identifier()) {
-        switch (static_cast<IdentifierStyleValue const&>(*font_style).id()) {
-        case CSS::ValueID::Italic:
-            slope = Gfx::name_to_slope("Italic"sv);
-            break;
-        case CSS::ValueID::Oblique:
-            slope = Gfx::name_to_slope("Oblique"sv);
-            break;
-        case CSS::ValueID::Normal:
-        default:
-            break;
-        }
-    }
+    auto slope = font_style->to_font_slope();
 
     // FIXME: Implement the full font-matching algorithm: https://www.w3.org/TR/css-fonts-4/#font-matching-algorithm
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -47,6 +47,15 @@ private:
     bool m_marked { false };
 };
 
+struct FontFaceKey {
+    FlyString family_name;
+    int weight { 0 };
+    int slope { 0 };
+
+    [[nodiscard]] u32 hash() const { return pair_int_hash(family_name.hash(), pair_int_hash(weight, slope)); }
+    [[nodiscard]] bool operator==(FontFaceKey const&) const = default;
+};
+
 class StyleComputer {
 public:
     explicit StyleComputer(DOM::Document&);
@@ -132,7 +141,7 @@ private:
     OwnPtr<RuleCache> m_user_agent_rule_cache;
 
     class FontLoader;
-    HashMap<String, NonnullOwnPtr<FontLoader>> m_loaded_fonts;
+    HashMap<FontFaceKey, NonnullOwnPtr<FontLoader>> m_loaded_fonts;
 
     Length::FontMetrics m_default_font_metrics;
     Length::FontMetrics m_root_element_font_metrics;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
  * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2022-2023, MacDue <macdue@dueutil.tech>
@@ -303,6 +303,9 @@ public:
     virtual float to_number() const { return 0; }
     virtual float to_integer() const { return 0; }
     virtual ErrorOr<String> to_string() const = 0;
+
+    [[nodiscard]] int to_font_weight() const;
+    [[nodiscard]] int to_font_slope() const;
 
     virtual bool equals(StyleValue const& other) const = 0;
 


### PR DESCRIPTION
This makes a lot of websites look quite a bit more like they're supposed to :^)

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/30e4ac6c-97f3-4d28-9b51-a707896e348a)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/dac02e67-5c17-4b3a-b58a-da6802c15c96)
