### PR TITLE
LibWeb: Stop aggressively quantizing font-weight values

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -1,10 +1,11 @@
 /*
  * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
- * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGfx/Font/FontStyleMapping.h>
 #include <LibWeb/Bindings/CSSFontFaceRulePrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSFontFaceRule.h>
@@ -102,15 +103,39 @@ DeprecatedString CSSFontFaceRule::serialized() const
     // followed by the result of performing serialize a <'font-stretch'>,
     // followed by the string ";", i.e., SEMICOLON (U+003B).
 
-    // FIXME: 10. If rule’s associated font-weight descriptor is present, a single SPACE (U+0020),
-    // followed by the string "font-weight:", followed by a single SPACE (U+0020),
-    // followed by the result of performing serialize a <'font-weight'>,
-    // followed by the string ";", i.e., SEMICOLON (U+003B).
+    // 10. If rule’s associated font-weight descriptor is present, a single SPACE (U+0020),
+    //     followed by the string "font-weight:", followed by a single SPACE (U+0020),
+    //     followed by the result of performing serialize a <'font-weight'>,
+    //     followed by the string ";", i.e., SEMICOLON (U+003B).
+    if (m_font_face.weight().has_value()) {
+        auto weight = m_font_face.weight().value();
+        builder.append(" font-weight: "sv);
+        if (weight == 400)
+            builder.append("normal"sv);
+        else if (weight == 700)
+            builder.append("bold"sv);
+        else
+            builder.appendff("{}", weight);
+        builder.append(";"sv);
+    }
 
-    // FIXME: 11. If rule’s associated font-style descriptor is present, a single SPACE (U+0020),
-    // followed by the string "font-style:", followed by a single SPACE (U+0020),
-    // followed by the result of performing serialize a <'font-style'>,
-    // followed by the string ";", i.e., SEMICOLON (U+003B).
+    // 11. If rule’s associated font-style descriptor is present, a single SPACE (U+0020),
+    //     followed by the string "font-style:", followed by a single SPACE (U+0020),
+    //     followed by the result of performing serialize a <'font-style'>,
+    //     followed by the string ";", i.e., SEMICOLON (U+003B).
+    if (m_font_face.slope().has_value()) {
+        auto slope = m_font_face.slope().value();
+        builder.append(" font-style: "sv);
+        if (slope == Gfx::name_to_slope("Normal"sv))
+            builder.append("normal"sv);
+        else if (slope == Gfx::name_to_slope("Italic"sv))
+            builder.append("italic"sv);
+        else {
+            dbgln("FIXME: CSSFontFaceRule::serialized() does not support slope {}", slope);
+            builder.append("italic"sv);
+        }
+        builder.append(";"sv);
+    }
 
     // 12. A single SPACE (U+0020), followed by the string "}", i.e., RIGHT CURLY BRACKET (U+007D).
     builder.append(" }"sv);

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -389,12 +389,7 @@ int StyleValue::to_font_weight() const
         }
     }
     if (has_integer()) {
-        int font_weight_integer = to_integer();
-        if (font_weight_integer <= Gfx::FontWeight::Regular)
-            return Gfx::FontWeight::Regular;
-        if (font_weight_integer <= Gfx::FontWeight::Bold)
-            return Gfx::FontWeight::Bold;
-        return Gfx::FontWeight::Black;
+        return to_integer();
     }
     if (is_calculated()) {
         auto maybe_weight = const_cast<CalculatedStyleValue&>(as_calculated()).resolve_integer();

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -662,6 +662,16 @@ void dump_font_face_rule(StringBuilder& builder, CSS::CSSFontFaceRule const& rul
     indent(builder, indent_levels + 1);
     builder.appendff("font-family: {}\n", font_face.font_family());
 
+    if (font_face.weight().has_value()) {
+        indent(builder, indent_levels + 1);
+        builder.appendff("weight: {}\n", font_face.weight().value());
+    }
+
+    if (font_face.slope().has_value()) {
+        indent(builder, indent_levels + 1);
+        builder.appendff("slope: {}\n", font_face.slope().value());
+    }
+
     indent(builder, indent_levels + 1);
     builder.append("sources:\n"sv);
     for (auto const& source : font_face.sources()) {


### PR DESCRIPTION
Stop snapping font-weights to 400/700/900.

This fixes a long-standing issue where downloaded fonts with other weights were used as if they were 400/700/900.

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/b918426a-0802-4236-bef1-e5b2141699e0)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/4ee527c2-7ff3-439d-aae4-5890b04c6285)
