### PR TITLE
LibWeb: Allow <input> to use the size attribute for its width

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -28,7 +28,6 @@ label {
 /* FIXME: This is a temporary hack until we can render a native-looking frame for these. */
 input, textarea {
     border: 1px solid -libweb-palette-threed-shadow1;
-    min-width: 80px;
     min-height: 16px;
     width: 120px;
     cursor: text;
@@ -39,6 +38,8 @@ textarea {
     padding: 2px;
     display: inline-block;
     overflow: scroll;
+    /* FIXME: This is temporary until textarea supports the cols attribute */
+    min-width: 80px;
 }
 
 input[type=submit], input[type=button], input[type=reset], input[type=checkbox], input[type=radio] {

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -52,6 +52,11 @@ Length Length::make_px(CSSPixels value)
     return Length(value.value(), Type::Px);
 }
 
+Length Length::make_ch(unsigned value)
+{
+    return Length(static_cast<int>(value), Type::Ch);
+}
+
 Length Length::percentage_of(Percentage const& percentage) const
 {
     if (is_auto()) {

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -88,6 +88,7 @@ public:
 
     static Length make_auto();
     static Length make_px(CSSPixels value);
+    static Length make_ch(unsigned value);
     Length percentage_of(Percentage const&) const;
 
     bool is_auto() const { return m_type == Type::Auto; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -66,6 +66,9 @@ public:
     DeprecatedString value() const;
     WebIDL::ExceptionOr<void> set_value(DeprecatedString);
 
+    unsigned size() const;
+    WebIDL::ExceptionOr<void> set_size(unsigned);
+
     Optional<DeprecatedString> placeholder_value() const;
 
     bool checked() const { return m_checked; }
@@ -147,6 +150,9 @@ private:
 
     // ^DOM::Element
     virtual i32 default_tab_index_value() const override;
+
+    virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
+    bool should_apply_size_attribute() const;
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -37,6 +37,8 @@ interface HTMLInputElement : HTMLElement {
     [CEReactions, Reflect] attribute boolean multiple;
     [CEReactions, Reflect=readonly] attribute boolean readOnly;
     [CEReactions, Reflect] attribute boolean required;
+    // FIXME: Uncomment Reflect when reflect supports number attributes
+    [CEReactions/*, Reflect*/] attribute unsigned long size;
 
     [CEReactions, Reflect] attribute DOMString align;
     [CEReactions, Reflect=usemap] attribute DOMString useMap;


### PR DESCRIPTION
This pr allows for the size attribute to work to work on `<input>` elements as specified by the [spec](https://html.spec.whatwg.org/#the-size-attribute) :^)

Also closes #18989
sorry for the redundant issue :^(