### PR TITLE
AK: Two small fixes to MaybeOwned

### DIFF
--- a/AK/MaybeOwned.h
+++ b/AK/MaybeOwned.h
@@ -18,7 +18,7 @@ class MaybeOwned {
 public:
     template<DerivedFrom<T> U>
     MaybeOwned(NonnullOwnPtr<U> handle)
-        : m_handle(adopt_own<T>(*handle.leak_ptr()))
+        : m_handle(static_cast<NonnullOwnPtr<T>&&>(move(handle)))
     {
     }
 

--- a/AK/MaybeOwned.h
+++ b/AK/MaybeOwned.h
@@ -13,6 +13,8 @@ namespace AK {
 
 template<typename T>
 class MaybeOwned {
+    AK_MAKE_NONCOPYABLE(MaybeOwned);
+
 public:
     template<DerivedFrom<T> U>
     MaybeOwned(NonnullOwnPtr<U> handle)
@@ -26,6 +28,9 @@ public:
         : m_handle(&handle)
     {
     }
+
+    MaybeOwned(MaybeOwned&&) = default;
+    MaybeOwned& operator=(MaybeOwned&&) = default;
 
     T* ptr()
     {


### PR DESCRIPTION
- Explicitly delete copy constructors (@nico just tripped over this)
- Simplify and optimize NonNullOwnPtr constructor