### PR TITLE
LibWeb: Make input element placeholders be inside the input element

### DIFF
--- a/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
+++ b/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
@@ -1,9 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x45.835937 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x27.835937 children: inline
-      line 0 width: 202, height: 27.835937, bottom: 27.835937, baseline: 25.835937
+      line 0 width: 202, height: 27.835937, bottom: 27.835937, baseline: 23.835937
         frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 200x25.835937]
       BlockContainer <input> at (11,11) content-size 200x25.835937 inline-block [BFC] children: not-inline
-        BlockContainer <#shadow-root> at (11,11) content-size 0x0 children: not-inline
-        BlockContainer <div> at (14,13) content-size 194x21.835937 children: inline
-          TextNode <#text>
+        Box <div> at (13,12) content-size 196x23.835937 flex-container(row) [FFC] children: not-inline
+          BlockContainer <div> at (14,13) content-size 0x21.835937 flex-item [BFC] children: inline
+            TextNode <#text>

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -143,6 +143,8 @@ public:
 
     RequiredInvalidationAfterStyleChange recompute_style();
 
+    virtual Optional<CSS::Selector::PseudoElement> pseudo_element() const { return {}; }
+
     Layout::NodeWithStyle* layout_node();
     Layout::NodeWithStyle const* layout_node() const;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLDivElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDivElement.h
@@ -11,7 +11,7 @@
 
 namespace Web::HTML {
 
-class HTMLDivElement final : public HTMLElement {
+class HTMLDivElement : public HTMLElement {
     WEB_PLATFORM_OBJECT(HTMLDivElement, HTMLElement);
 
 public:
@@ -20,9 +20,10 @@ public:
     // https://www.w3.org/TR/html-aria/#el-div
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::generic; }
 
-private:
+protected:
     HTMLDivElement(DOM::Document&, DOM::QualifiedName);
 
+private:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 };
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -130,6 +130,9 @@ public:
 
     virtual Optional<ARIA::Role> default_role() const override;
 
+    JS::GCPtr<Element> placeholder_element() { return m_placeholder_element; }
+    JS::GCPtr<Element const> placeholder_element() const { return m_placeholder_element; }
+
 private:
     HTMLInputElement(DOM::Document&, DOM::QualifiedName);
 
@@ -156,6 +159,11 @@ private:
     // https://html.spec.whatwg.org/multipage/input.html#value-sanitization-algorithm
     DeprecatedString value_sanitization_algorithm(DeprecatedString) const;
 
+    void update_placeholder_visibility();
+    JS::GCPtr<DOM::Element> m_placeholder_element;
+    JS::GCPtr<DOM::Text> m_placeholder_text_node;
+
+    JS::GCPtr<DOM::Element> m_inner_text_element;
     JS::GCPtr<DOM::Text> m_text_node;
     bool m_checked { false };
 


### PR DESCRIPTION
Let's fix that placeholder visual glitch!

Compare the "search" placeholder on the right:

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/f46971de-c999-4bb2-bf3c-a43cd7fa3c5a)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/6902ce9b-7707-4dec-9774-585d395c7ebd)
