### PR TITLE
LibTimeZone: Move DateTime out of generated header

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
@@ -494,28 +494,6 @@ static ErrorOr<void> generate_time_zone_data_implementation(Core::InputBufferedF
 
 namespace TimeZone {
 
-static constexpr auto max_year_as_time = AK::UnixDateTime::from_unix_time_parts(NumericLimits<u16>::max(), 1, 1, 0, 0, 0, 0);
-
-struct DateTime {
-    AK::UnixDateTime time_since_epoch() const
-    {
-        // FIXME: This implementation does not take last_weekday, after_weekday, or before_weekday into account.
-        return AK::UnixDateTime::from_unix_time_parts(year, month, day, hour, minute, second, 0);
-    }
-
-    u16 year { 0 };
-    u8 month { 1 };
-    u8 day { 1 };
-
-    u8 last_weekday { 0 };
-    u8 after_weekday { 0 };
-    u8 before_weekday { 0 };
-
-    u8 hour { 0 };
-    u8 minute { 0 };
-    u8 second { 0 };
-};
-
 struct TimeZoneOffset {
     i64 offset { 0 };
 

--- a/Userland/Libraries/LibTimeZone/Forward.h
+++ b/Userland/Libraries/LibTimeZone/Forward.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,5 +14,7 @@ namespace TimeZone {
 enum class DaylightSavingsRule : u8;
 enum class Region : u8;
 enum class TimeZone : u16;
+
+struct DateTime;
 
 }

--- a/Userland/Libraries/LibTimeZone/TimeZone.cpp
+++ b/Userland/Libraries/LibTimeZone/TimeZone.cpp
@@ -16,6 +16,12 @@
 
 namespace TimeZone {
 
+AK::UnixDateTime DateTime::time_since_epoch() const
+{
+    // FIXME: This implementation does not take last_weekday, after_weekday, or before_weekday into account.
+    return AK::UnixDateTime::from_unix_time_parts(year, month, day, hour, minute, second, 0);
+}
+
 // NOTE: Without ENABLE_TIME_ZONE_DATA LibTimeZone operates in a UTC-only mode and only recognizes
 //       the 'UTC' time zone, which is slightly more useful than a bunch of dummy functions that
 //       can't do anything. When we build with time zone data, these weakly linked functions are

--- a/Userland/Libraries/LibTimeZone/TimeZone.h
+++ b/Userland/Libraries/LibTimeZone/TimeZone.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -18,6 +19,24 @@
 #include <LibTimeZone/Forward.h>
 
 namespace TimeZone {
+
+static constexpr auto max_year_as_time = AK::UnixDateTime::from_unix_time_parts(NumericLimits<u16>::max(), 1, 1, 0, 0, 0, 0);
+
+struct DateTime {
+    AK::UnixDateTime time_since_epoch() const;
+
+    u16 year { 0 };
+    u8 month { 1 };
+    u8 day { 1 };
+
+    u8 last_weekday { 0 };
+    u8 after_weekday { 0 };
+    u8 before_weekday { 0 };
+
+    u8 hour { 0 };
+    u8 minute { 0 };
+    u8 second { 0 };
+};
 
 enum class InDST {
     No,


### PR DESCRIPTION
This struct is not dependent on timezone data, unlike the other ones, which may change their index types depending on the size of the database. Therefore, we can move it to the static part of LibTimeZone.

@trflynn