### PR TITLE
LibWeb: Add CustomIdentStyleValue, along with parsing for it

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -17,7 +17,7 @@ ErrorOr<void> generate_implementation_file(JsonObject& properties, Core::File& f
 
 static bool type_name_is_enum(StringView type_name)
 {
-    return !AK::first_is_one_of(type_name, "angle"sv, "color"sv, "frequency"sv, "image"sv, "integer"sv, "length"sv, "number"sv, "percentage"sv, "rect"sv, "resolution"sv, "string"sv, "time"sv, "url"sv);
+    return !AK::first_is_one_of(type_name, "angle"sv, "color"sv, "custom-ident"sv, "frequency"sv, "image"sv, "integer"sv, "length"sv, "number"sv, "percentage"sv, "rect"sv, "resolution"sv, "string"sv, "time"sv, "url"sv);
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
@@ -118,6 +118,7 @@ ErrorOr<NonnullRefPtr<StyleValue>> property_initial_value(JS::Realm&, PropertyID
 enum class ValueType {
     Angle,
     Color,
+    CustomIdent,
     FilterValueList,
     Frequency,
     Image,
@@ -455,6 +456,8 @@ bool property_accepts_type(PropertyID property_id, ValueType value_type)
                     property_generator.appendln("        case ValueType::Angle:");
                 } else if (type_name == "color") {
                     property_generator.appendln("        case ValueType::Color:");
+                } else if (type_name == "custom-ident") {
+                    property_generator.appendln("        case ValueType::CustomIdent:");
                 } else if (type_name == "frequency") {
                     property_generator.appendln("        case ValueType::Frequency:");
                 } else if (type_name == "image") {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -41,6 +41,7 @@
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ConicGradientStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ContentStyleValue.h>
+#include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EdgeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FilterValueListStyleValue.h>
@@ -7205,7 +7206,11 @@ ErrorOr<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readonl
             }
         }
 
-        // FIXME: Custom idents. https://www.w3.org/TR/css-values-4/#identifier-value
+        // Custom idents
+        if (auto property = any_property_accepts_type(property_ids, ValueType::CustomIdent); property.has_value()) {
+            (void)tokens.next_token();
+            return PropertyAndValue { *property, TRY(CustomIdentStyleValue::create(TRY(FlyString::from_utf8(peek_token.token().ident())))) };
+        }
     }
 
     if (auto property = any_property_accepts_type(property_ids, ValueType::Color); property.has_value()) {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -21,6 +21,7 @@
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ConicGradientStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ContentStyleValue.h>
+#include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EdgeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FilterValueListStyleValue.h>
@@ -141,6 +142,12 @@ ContentStyleValue const& StyleValue::as_content() const
 {
     VERIFY(is_content());
     return static_cast<ContentStyleValue const&>(*this);
+}
+
+CustomIdentStyleValue const& StyleValue::as_custom_ident() const
+{
+    VERIFY(is_custom_ident());
+    return static_cast<CustomIdentStyleValue const&>(*this);
 }
 
 DisplayStyleValue const& StyleValue::as_display() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -98,6 +98,7 @@ public:
         Color,
         ConicGradient,
         Content,
+        CustomIdent,
         Display,
         Edge,
         FilterValueList,
@@ -150,6 +151,7 @@ public:
     bool is_color() const { return type() == Type::Color; }
     bool is_conic_gradient() const { return type() == Type::ConicGradient; }
     bool is_content() const { return type() == Type::Content; }
+    bool is_custom_ident() const { return type() == Type::CustomIdent; }
     bool is_display() const { return type() == Type::Display; }
     bool is_edge() const { return type() == Type::Edge; }
     bool is_filter_value_list() const { return type() == Type::FilterValueList; }
@@ -201,6 +203,7 @@ public:
     ColorStyleValue const& as_color() const;
     ConicGradientStyleValue const& as_conic_gradient() const;
     ContentStyleValue const& as_content() const;
+    CustomIdentStyleValue const& as_custom_ident() const;
     DisplayStyleValue const& as_display() const;
     EdgeStyleValue const& as_edge() const;
     FilterValueListStyleValue const& as_filter_value_list() const;
@@ -250,6 +253,7 @@ public:
     ColorStyleValue& as_color() { return const_cast<ColorStyleValue&>(const_cast<StyleValue const&>(*this).as_color()); }
     ConicGradientStyleValue& as_conic_gradient() { return const_cast<ConicGradientStyleValue&>(const_cast<StyleValue const&>(*this).as_conic_gradient()); }
     ContentStyleValue& as_content() { return const_cast<ContentStyleValue&>(const_cast<StyleValue const&>(*this).as_content()); }
+    CustomIdentStyleValue& as_custom_ident() { return const_cast<CustomIdentStyleValue&>(const_cast<StyleValue const&>(*this).as_custom_ident()); }
     DisplayStyleValue& as_display() { return const_cast<DisplayStyleValue&>(const_cast<StyleValue const&>(*this).as_display()); }
     EdgeStyleValue& as_edge() { return const_cast<EdgeStyleValue&>(const_cast<StyleValue const&>(*this).as_edge()); }
     FilterValueListStyleValue& as_filter_value_list() { return const_cast<FilterValueListStyleValue&>(const_cast<StyleValue const&>(*this).as_filter_value_list()); }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+// https://www.w3.org/TR/css-values-4/#custom-idents
+class CustomIdentStyleValue final : public StyleValueWithDefaultOperators<CustomIdentStyleValue> {
+public:
+    static ErrorOr<ValueComparingNonnullRefPtr<CustomIdentStyleValue>> create(FlyString custom_ident)
+    {
+        return adopt_nonnull_ref_or_enomem(new (nothrow) CustomIdentStyleValue(move(custom_ident)));
+    }
+    virtual ~CustomIdentStyleValue() override = default;
+
+    FlyString const& custom_ident() const { return m_custom_ident; }
+
+    virtual ErrorOr<String> to_string() const override { return m_custom_ident.to_string(); }
+
+    bool properties_equal(CustomIdentStyleValue const& other) const { return m_custom_ident == other.m_custom_ident; }
+
+private:
+    explicit CustomIdentStyleValue(FlyString custom_ident)
+        : StyleValueWithDefaultOperators(Type::CustomIdent)
+        , m_custom_ident(move(custom_ident))
+    {
+    }
+
+    FlyString m_custom_ident;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -84,6 +84,7 @@ class CSSStyleDeclaration;
 class CSSStyleRule;
 class CSSStyleSheet;
 class CSSSupportsRule;
+class CustomIdentStyleValue;
 class Display;
 class DisplayStyleValue;
 class EdgeStyleValue;


### PR DESCRIPTION
This corresponds to the `<custom-ident>` type in CSS grammar.