### PR TITLE
LibWeb: Do the CORS cross-origin workaround to find MIME type for images

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.h
@@ -40,6 +40,7 @@ public:
     using Vector::begin;
     using Vector::clear;
     using Vector::end;
+    using Vector::is_empty;
 
     [[nodiscard]] static JS::NonnullGCPtr<HeaderList> create(JS::VM&);
 


### PR DESCRIPTION
This makes cross-origin image loads actually see the MIME type the server tells us. :^)
