### PR TITLE
Ladybird: Look for helper processes at `{app_dir}/{helper}/{helper}`.

### DIFF
--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -25,9 +25,12 @@ ErrorOr<void> spawn_helper_process(StringView process_name, ReadonlySpan<StringV
 
 ErrorOr<Vector<String>> get_paths_for_helper_process(StringView process_name)
 {
+    auto application_path = TRY(ak_string_from_qstring(QCoreApplication::applicationDirPath()));
     Vector<String> paths;
+
     TRY(paths.try_append(TRY(String::formatted("./{}/{}", process_name, process_name))));
-    TRY(paths.try_append(TRY(String::formatted("{}/{}", TRY(ak_string_from_qstring(QCoreApplication::applicationDirPath())), process_name))));
+    TRY(paths.try_append(TRY(String::formatted("{}/{}/{}", application_path, process_name, process_name))));
+    TRY(paths.try_append(TRY(String::formatted("{}/{}", application_path, process_name))));
     TRY(paths.try_append(TRY(String::formatted("./{}", process_name))));
     // NOTE: Add platform-specific paths here
     return paths;


### PR DESCRIPTION
Currently, we only look at the relative path `./{helper}/{helper}`, which fails if the working directory is not the same as the directory where the ladybird binary lives.

Don't know if we actually need the first/third checks here at all.
The relative `./{helper}/{helper}` seems to be unnecessary, since we now check the absolute path.
Not sure when `./{helper}` will ever find anything?