### PR TITLE
LibWeb: Return DOMException instead of crashing when setting attributes

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -42,9 +42,9 @@ DeprecatedString HTMLAnchorElement::hyperlink_element_utils_href() const
     return attribute(HTML::AttributeNames::href);
 }
 
-void HTMLAnchorElement::set_hyperlink_element_utils_href(DeprecatedString href)
+WebIDL::ExceptionOr<void> HTMLAnchorElement::set_hyperlink_element_utils_href(DeprecatedString href)
 {
-    MUST(set_attribute(HTML::AttributeNames::href, move(href)));
+    return set_attribute(HTML::AttributeNames::href, move(href));
 }
 
 void HTMLAnchorElement::run_activation_behavior(Web::DOM::Event const&)

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -49,7 +49,7 @@ private:
     // ^HTML::HTMLHyperlinkElementUtils
     virtual DOM::Document& hyperlink_element_utils_document() override { return document(); }
     virtual DeprecatedString hyperlink_element_utils_href() const override;
-    virtual void set_hyperlink_element_utils_href(DeprecatedString) override;
+    virtual WebIDL::ExceptionOr<void> set_hyperlink_element_utils_href(DeprecatedString) override;
     virtual bool hyperlink_element_utils_is_html_anchor_element() const final { return true; }
     virtual bool hyperlink_element_utils_is_connected() const final { return is_connected(); }
     virtual DeprecatedString hyperlink_element_utils_target() const final { return target(); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -38,9 +38,9 @@ DeprecatedString HTMLAreaElement::hyperlink_element_utils_href() const
     return attribute(HTML::AttributeNames::href);
 }
 
-void HTMLAreaElement::set_hyperlink_element_utils_href(DeprecatedString href)
+WebIDL::ExceptionOr<void> HTMLAreaElement::set_hyperlink_element_utils_href(DeprecatedString href)
 {
-    MUST(set_attribute(HTML::AttributeNames::href, move(href)));
+    return set_attribute(HTML::AttributeNames::href, move(href));
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
@@ -32,7 +32,7 @@ private:
     // ^HTML::HTMLHyperlinkElementUtils
     virtual DOM::Document& hyperlink_element_utils_document() override { return document(); }
     virtual DeprecatedString hyperlink_element_utils_href() const override;
-    virtual void set_hyperlink_element_utils_href(DeprecatedString) override;
+    virtual WebIDL::ExceptionOr<void> set_hyperlink_element_utils_href(DeprecatedString) override;
     virtual bool hyperlink_element_utils_is_html_anchor_element() const override { return false; }
     virtual bool hyperlink_element_utils_is_connected() const override { return is_connected(); }
     virtual DeprecatedString hyperlink_element_utils_target() const override { return ""; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -105,10 +105,10 @@ DeprecatedString HTMLBaseElement::href() const
 }
 
 // https://html.spec.whatwg.org/multipage/semantics.html#dom-base-href
-void HTMLBaseElement::set_href(DeprecatedString const& href)
+WebIDL::ExceptionOr<void> HTMLBaseElement::set_href(DeprecatedString const& href)
 {
     // The href IDL attribute, on setting, must set the href content attribute to the given new value.
-    MUST(set_attribute(AttributeNames::href, href));
+    return set_attribute(AttributeNames::href, href);
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.h
@@ -17,7 +17,7 @@ public:
     virtual ~HTMLBaseElement() override;
 
     DeprecatedString href() const;
-    void set_href(DeprecatedString const& href);
+    WebIDL::ExceptionOr<void> set_href(DeprecatedString const& href);
 
     AK::URL const& frozen_base_url() const { return m_frozen_base_url; }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -87,9 +87,9 @@ HTMLButtonElement::TypeAttributeState HTMLButtonElement::type_state() const
     return HTMLButtonElement::TypeAttributeState::Submit;
 }
 
-void HTMLButtonElement::set_type(DeprecatedString const& type)
+WebIDL::ExceptionOr<void> HTMLButtonElement::set_type(DeprecatedString const& type)
 {
-    MUST(set_attribute(HTML::AttributeNames::type, type));
+    return set_attribute(HTML::AttributeNames::type, type);
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -36,7 +36,7 @@ public:
 
     DeprecatedString type() const;
     TypeAttributeState type_state() const;
-    void set_type(DeprecatedString const&);
+    WebIDL::ExceptionOr<void> set_type(DeprecatedString const&);
 
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-button-element

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -71,18 +71,20 @@ void HTMLCanvasElement::reset_context_to_default_state()
         });
 }
 
-void HTMLCanvasElement::set_width(unsigned value)
+WebIDL::ExceptionOr<void> HTMLCanvasElement::set_width(unsigned value)
 {
-    MUST(set_attribute(HTML::AttributeNames::width, DeprecatedString::number(value)));
+    TRY(set_attribute(HTML::AttributeNames::width, DeprecatedString::number(value)));
     m_bitmap = nullptr;
     reset_context_to_default_state();
+    return {};
 }
 
-void HTMLCanvasElement::set_height(unsigned value)
+WebIDL::ExceptionOr<void> HTMLCanvasElement::set_height(unsigned value)
 {
-    MUST(set_attribute(HTML::AttributeNames::height, DeprecatedString::number(value)));
+    TRY(set_attribute(HTML::AttributeNames::height, DeprecatedString::number(value)));
     m_bitmap = nullptr;
     reset_context_to_default_state();
+    return {};
 }
 
 JS::GCPtr<Layout::Node> HTMLCanvasElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.h
@@ -30,8 +30,8 @@ public:
     unsigned width() const;
     unsigned height() const;
 
-    void set_width(unsigned);
-    void set_height(unsigned);
+    WebIDL::ExceptionOr<void> set_width(unsigned);
+    WebIDL::ExceptionOr<void> set_height(unsigned);
 
     DeprecatedString to_data_url(DeprecatedString const& type, Optional<double> quality) const;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -440,10 +440,10 @@ DeprecatedString HTMLHyperlinkElementUtils::href() const
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-href
-void HTMLHyperlinkElementUtils::set_href(DeprecatedString href)
+WebIDL::ExceptionOr<void> HTMLHyperlinkElementUtils::set_href(DeprecatedString href)
 {
     // The href attribute's setter must set this element's href content attribute's value to the given value.
-    set_hyperlink_element_utils_href(move(href));
+    return set_hyperlink_element_utils_href(move(href));
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#update-href

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
@@ -20,7 +20,7 @@ public:
     DeprecatedString origin() const;
 
     DeprecatedString href() const;
-    void set_href(DeprecatedString);
+    WebIDL::ExceptionOr<void> set_href(DeprecatedString);
 
     DeprecatedString protocol() const;
     void set_protocol(DeprecatedString);
@@ -52,7 +52,7 @@ public:
 protected:
     virtual DOM::Document& hyperlink_element_utils_document() = 0;
     virtual DeprecatedString hyperlink_element_utils_href() const = 0;
-    virtual void set_hyperlink_element_utils_href(DeprecatedString) = 0;
+    virtual WebIDL::ExceptionOr<void> set_hyperlink_element_utils_href(DeprecatedString) = 0;
     virtual bool hyperlink_element_utils_is_html_anchor_element() const = 0;
     virtual bool hyperlink_element_utils_is_connected() const = 0;
     virtual DeprecatedString hyperlink_element_utils_target() const = 0;

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -168,9 +168,9 @@ unsigned HTMLImageElement::width() const
     return 0;
 }
 
-void HTMLImageElement::set_width(unsigned width)
+WebIDL::ExceptionOr<void> HTMLImageElement::set_width(unsigned width)
 {
-    MUST(set_attribute(HTML::AttributeNames::width, DeprecatedString::number(width)));
+    return set_attribute(HTML::AttributeNames::width, DeprecatedString::number(width));
 }
 
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-height
@@ -196,9 +196,9 @@ unsigned HTMLImageElement::height() const
     return 0;
 }
 
-void HTMLImageElement::set_height(unsigned height)
+WebIDL::ExceptionOr<void> HTMLImageElement::set_height(unsigned height)
 {
-    MUST(set_attribute(HTML::AttributeNames::height, DeprecatedString::number(height)));
+    return set_attribute(HTML::AttributeNames::height, DeprecatedString::number(height));
 }
 
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-naturalwidth

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -37,10 +37,10 @@ public:
     RefPtr<Gfx::Bitmap const> bitmap() const;
 
     unsigned width() const;
-    void set_width(unsigned);
+    WebIDL::ExceptionOr<void> set_width(unsigned);
 
     unsigned height() const;
-    void set_height(unsigned);
+    WebIDL::ExceptionOr<void> set_height(unsigned);
 
     unsigned natural_width() const;
     unsigned natural_height() const;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -554,9 +554,9 @@ DeprecatedString HTMLInputElement::type() const
     VERIFY_NOT_REACHED();
 }
 
-void HTMLInputElement::set_type(DeprecatedString const& type)
+WebIDL::ExceptionOr<void> HTMLInputElement::set_type(DeprecatedString const& type)
 {
-    MUST(set_attribute(HTML::AttributeNames::type, type));
+    return set_attribute(HTML::AttributeNames::type, type);
 }
 
 // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-simple-colour

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -58,7 +58,7 @@ public:
 
     DeprecatedString type() const;
     TypeAttributeState type_state() const { return m_type; }
-    void set_type(DeprecatedString const&);
+    WebIDL::ExceptionOr<void> set_type(DeprecatedString const&);
 
     DeprecatedString default_value() const { return attribute(HTML::AttributeNames::value); }
     DeprecatedString name() const { return attribute(HTML::AttributeNames::name); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -78,9 +78,9 @@ DeprecatedString HTMLOptionElement::value() const
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-value
-void HTMLOptionElement::set_value(DeprecatedString value)
+WebIDL::ExceptionOr<void> HTMLOptionElement::set_value(DeprecatedString value)
 {
-    MUST(set_attribute(HTML::AttributeNames::value, value));
+    return set_attribute(HTML::AttributeNames::value, value);
 }
 
 static void concatenate_descendants_text_content(DOM::Node const* node, StringBuilder& builder)

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -21,7 +21,7 @@ public:
     void set_selected(bool);
 
     DeprecatedString value() const;
-    void set_value(DeprecatedString);
+    WebIDL::ExceptionOr<void> set_value(DeprecatedString);
 
     DeprecatedString text() const;
     void set_text(DeprecatedString);

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -68,13 +68,14 @@ double HTMLProgressElement::value() const
     return min(maybe_double.value(), max());
 }
 
-void HTMLProgressElement::set_value(double value)
+WebIDL::ExceptionOr<void> HTMLProgressElement::set_value(double value)
 {
     if (value < 0)
-        return;
+        return {};
 
-    MUST(set_attribute(HTML::AttributeNames::value, DeprecatedString::number(value)));
+    TRY(set_attribute(HTML::AttributeNames::value, DeprecatedString::number(value)));
     progress_position_updated();
+    return {};
 }
 
 double HTMLProgressElement::max() const
@@ -94,13 +95,14 @@ double HTMLProgressElement::max() const
     return double_or_none.value();
 }
 
-void HTMLProgressElement::set_max(double value)
+WebIDL::ExceptionOr<void> HTMLProgressElement::set_max(double value)
 {
     if (value <= 0)
-        return;
+        return {};
 
-    MUST(set_attribute(HTML::AttributeNames::max, DeprecatedString::number(value)));
+    TRY(set_attribute(HTML::AttributeNames::max, DeprecatedString::number(value)));
     progress_position_updated();
+    return {};
 }
 
 double HTMLProgressElement::position() const

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.h
@@ -20,10 +20,10 @@ public:
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 
     double value() const;
-    void set_value(double);
+    WebIDL::ExceptionOr<void> set_value(double);
 
     double max() const;
-    void set_max(double value);
+    WebIDL::ExceptionOr<void> set_max(double value);
 
     double position() const;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -64,9 +64,9 @@ unsigned int HTMLTableCellElement::col_span() const
     return attribute(HTML::AttributeNames::colspan).to_uint().value_or(1);
 }
 
-void HTMLTableCellElement::set_col_span(unsigned int value)
+WebIDL::ExceptionOr<void> HTMLTableCellElement::set_col_span(unsigned int value)
 {
-    MUST(set_attribute(HTML::AttributeNames::colspan, DeprecatedString::number(value)));
+    return set_attribute(HTML::AttributeNames::colspan, DeprecatedString::number(value));
 }
 
 unsigned int HTMLTableCellElement::row_span() const
@@ -74,9 +74,9 @@ unsigned int HTMLTableCellElement::row_span() const
     return attribute(HTML::AttributeNames::rowspan).to_uint().value_or(1);
 }
 
-void HTMLTableCellElement::set_row_span(unsigned int value)
+WebIDL::ExceptionOr<void> HTMLTableCellElement::set_row_span(unsigned int value)
 {
-    MUST(set_attribute(HTML::AttributeNames::rowspan, DeprecatedString::number(value)));
+    return set_attribute(HTML::AttributeNames::rowspan, DeprecatedString::number(value));
 }
 
 Optional<ARIA::Role> HTMLTableCellElement::default_role() const

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.h
@@ -19,8 +19,8 @@ public:
     unsigned col_span() const;
     unsigned row_span() const;
 
-    void set_col_span(unsigned);
-    void set_row_span(unsigned);
+    WebIDL::ExceptionOr<void> set_col_span(unsigned);
+    WebIDL::ExceptionOr<void> set_row_span(unsigned);
 
     virtual Optional<ARIA::Role> default_role() const override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -72,14 +72,16 @@ JS::GCPtr<HTMLTableCaptionElement> HTMLTableElement::caption()
 }
 
 // https://html.spec.whatwg.org/multipage/tables.html#dom-table-caption
-void HTMLTableElement::set_caption(HTMLTableCaptionElement* caption)
+WebIDL::ExceptionOr<void> HTMLTableElement::set_caption(HTMLTableCaptionElement* caption)
 {
     // On setting, the first caption element child of the table element, if any, must be removed,
     // and the new value, if not null, must be inserted as the first node of the table element.
     delete_caption();
 
     if (caption)
-        MUST(pre_insert(*caption, first_child()));
+        TRY(pre_insert(*caption, first_child()));
+
+    return {};
 }
 
 // https://html.spec.whatwg.org/multipage/tables.html#dom-table-createcaption

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.h
@@ -21,7 +21,7 @@ public:
     virtual ~HTMLTableElement() override;
 
     JS::GCPtr<HTMLTableCaptionElement> caption();
-    void set_caption(HTMLTableCaptionElement*);
+    WebIDL::ExceptionOr<void> set_caption(HTMLTableCaptionElement*);
     JS::NonnullGCPtr<HTMLTableCaptionElement> create_caption();
     void delete_caption();
 


### PR DESCRIPTION
As mentioned [here](https://github.com/SerenityOS/serenity/pull/19026#discussion_r1205740058) `MUST` shouldn't be used for these situations. 

So instead of crashing, we return the `DOMException` that `set_attribute()` can return.