### PR TITLE
LibTest: Use the 16 standard ANSI colors in status output

### DIFF
--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -512,7 +512,7 @@ inline JSFileResult TestRunner::run_file_test(DeprecatedString const& test_path)
 inline void TestRunner::print_file_result(JSFileResult const& file_result) const
 {
     if (file_result.most_severe_test_result == Test::Result::Fail || file_result.error.has_value()) {
-        print_modifiers({ BG_RED, FG_BLACK, FG_BOLD });
+        print_modifiers({ BG_RED, FG_BOLD });
         out(" FAIL ");
         print_modifiers({ CLEAR });
     } else {

--- a/Userland/Libraries/LibTest/TestRunner.h
+++ b/Userland/Libraries/LibTest/TestRunner.h
@@ -132,17 +132,17 @@ inline void print_modifiers(Vector<Modifier> modifiers)
         auto code = [&] {
             switch (modifier) {
             case BG_RED:
-                return "\033[48;2;255;0;102m";
+                return "\033[41m";
             case BG_GREEN:
-                return "\033[48;2;102;255;0m";
+                return "\033[42m";
             case FG_RED:
-                return "\033[38;2;255;0;102m";
+                return "\033[31m";
             case FG_GREEN:
-                return "\033[38;2;102;255;0m";
+                return "\033[32m";
             case FG_ORANGE:
-                return "\033[38;2;255;102;0m";
+                return "\033[33m";
             case FG_GRAY:
-                return "\033[38;2;135;139;148m";
+                return "\033[90m";
             case FG_BLACK:
                 return "\033[30m";
             case FG_BOLD:

--- a/Userland/Utilities/run-tests.cpp
+++ b/Userland/Utilities/run-tests.cpp
@@ -137,7 +137,7 @@ void TestRunner::do_run_single_test(DeprecatedString const& test_path, size_t cu
     bool print_stdout_stderr = crashed_or_failed || m_print_all_output;
     if (crashed_or_failed) {
         m_failed_test_names.append(test_path);
-        print_modifiers({ Test::BG_RED, Test::FG_BLACK, Test::FG_BOLD });
+        print_modifiers({ Test::BG_RED, Test::FG_BOLD });
         out("{}", test_result.result == Test::Result::Fail ? " FAIL  " : "CRASHED");
         print_modifiers({ Test::CLEAR });
         if (test_result.result == Test::Result::Crashed) {


### PR DESCRIPTION
Neither Azure Pipelines' log viewer, nor macOS Terminal.app support full 24-bit RGB color codes, causing the text output to be displayed incorrectly. Fix this by using one of the 16 standard colors.

Most terminal emulators use a relatively dark shade for red by default, as seen in the "ANSI escape code" Wikipedia article, so change the foreground color to white to preserve contrast.

| Before | After  |
| - | - |
| ![color_before](https://github.com/SerenityOS/serenity/assets/25866827/9b0de6b5-31de-4f37-838a-1f8f43cd5e4c) | ![color_after](https://github.com/SerenityOS/serenity/assets/25866827/9ffaef15-6816-41e5-87af-e76605bc1c9c) |


