### PR TITLE
Ladybird: Add open file item to menu...

### DIFF
--- a/Ladybird/BrowserWindow.cpp
+++ b/Ladybird/BrowserWindow.cpp
@@ -54,6 +54,8 @@ BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdrive
     close_current_tab_action->setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::Close));
     menu->addAction(close_current_tab_action);
 
+    menu->addSeparator();
+
     auto* quit_action = new QAction("&Quit", this);
     quit_action->setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::Quit));
     menu->addAction(quit_action);
@@ -71,6 +73,8 @@ BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdrive
     m_select_all_action->setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::SelectAll));
     edit_menu->addAction(m_select_all_action);
     QObject::connect(m_select_all_action, &QAction::triggered, this, &BrowserWindow::select_all);
+
+    edit_menu->addSeparator();
 
     auto* settings_action = new QAction("&Settings", this);
     settings_action->setIcon(QIcon(QString("%1/res/icons/16x16/settings.png").arg(s_serenity_resource_root.characters())));

--- a/Ladybird/BrowserWindow.cpp
+++ b/Ladybird/BrowserWindow.cpp
@@ -54,6 +54,11 @@ BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdrive
     close_current_tab_action->setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::Close));
     menu->addAction(close_current_tab_action);
 
+    auto* open_file_action = new QAction("&Open File...", this);
+    open_file_action->setIcon(QIcon(QString("%1/res/icons/16x16/filetype-folder-open.png").arg(s_serenity_resource_root.characters())));
+    open_file_action->setShortcut(QKeySequence(QKeySequence::StandardKey::Open));
+    menu->addAction(open_file_action);
+
     menu->addSeparator();
 
     auto* quit_action = new QAction("&Quit", this);
@@ -331,6 +336,7 @@ BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdrive
     QObject::connect(new_tab_action, &QAction::triggered, this, [this] {
         new_tab(s_settings->new_tab_page(), Web::HTML::ActivateTab::Yes);
     });
+    QObject::connect(open_file_action, &QAction::triggered, this, &BrowserWindow::open_file);
     QObject::connect(settings_action, &QAction::triggered, this, [this] {
         new SettingsDialog(this);
     });
@@ -485,6 +491,11 @@ void BrowserWindow::close_tab(int index)
     m_tabs.remove_first_matching([&](auto& entry) {
         return entry == tab;
     });
+}
+
+void BrowserWindow::open_file()
+{
+    m_current_tab->open_file();
 }
 
 void BrowserWindow::close_current_tab()

--- a/Ladybird/BrowserWindow.h
+++ b/Ladybird/BrowserWindow.h
@@ -76,6 +76,7 @@ public slots:
     void close_current_tab();
     void open_next_tab();
     void open_previous_tab();
+    void open_file();
     void enable_auto_color_scheme();
     void enable_light_color_scheme();
     void enable_dark_color_scheme();

--- a/Ladybird/Tab.cpp
+++ b/Ladybird/Tab.cpp
@@ -521,6 +521,14 @@ void Tab::location_edit_return_pressed()
     navigate(m_location_edit->text());
 }
 
+void Tab::open_file()
+{
+    auto filename = QFileDialog::getOpenFileName(this, tr("Open file"), QDir::homePath(), tr("All Files (*.*)"));
+
+    if (!filename.isEmpty() && !filename.isNull())
+        navigate("file://" + filename);
+}
+
 int Tab::tab_index()
 {
     return m_window->tab_index(this);

--- a/Ladybird/Tab.h
+++ b/Ladybird/Tab.h
@@ -11,6 +11,7 @@
 #include "WebContentView.h"
 #include <Browser/History.h>
 #include <QBoxLayout>
+#include <QFileDialog>
 #include <QLabel>
 #include <QLineEdit>
 #include <QToolBar>
@@ -43,6 +44,7 @@ public:
 
     void debug_request(DeprecatedString const& request, DeprecatedString const& argument);
 
+    void open_file();
     void update_reset_zoom_button();
 
     enum class InspectorTarget {
@@ -85,6 +87,7 @@ private:
     Browser::History m_history;
     QString m_title;
     QLabel* m_hover_label { nullptr };
+    QString m_open_file;
 
     OwnPtr<QMenu> m_page_context_menu;
 
@@ -101,6 +104,7 @@ private:
     OwnPtr<QAction> m_video_context_menu_play_pause_action;
     OwnPtr<QAction> m_video_context_menu_controls_action;
     OwnPtr<QAction> m_video_context_menu_loop_action;
+    OwnPtr<QAction> m_open_file_action;
     URL m_video_context_menu_url;
 
     int tab_index();


### PR DESCRIPTION
We **do** have drag and drop to open local files but I like the Ctrl+O option to open file dialog.

All my browser have this functionality (Chromium, Firefox, Netsurf, Doodle, Edge, Vivaldi).

This is probably my biggest code contribution so far and I do not have a firm grasp of C++ yet so check the code before a possible merge. :^)

Also added two separators(the "File" separator has the same position as in Ladybird SerenityOS, the "Edit" separator just made sense).