### PR TITLE
ping: Avoid potential interval overflow and don't wait before exiting

### DIFF
--- a/Userland/Utilities/ping.cpp
+++ b/Userland/Utilities/ping.cpp
@@ -39,7 +39,7 @@ static timespec interval_timespec { .tv_sec = 1, .tv_nsec = 0 };
 static constexpr int max_optional_header_size_in_bytes = 40;
 static constexpr int min_header_size_in_bytes = 5;
 
-static void closing_statistics()
+static void print_closing_statistics()
 {
     int packet_loss = 100;
 
@@ -57,8 +57,6 @@ static void closing_statistics()
     if (successful_pings)
         average_ms = total_ms / successful_pings;
     outln("rtt min/avg/max = {}/{}/{} ms", min_ms, average_ms, max_ms);
-
-    exit(0);
 };
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
@@ -133,7 +131,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     uint16_t seq = 1;
 
     TRY(Core::System::signal(SIGINT, [](int) {
-        closing_statistics();
+        print_closing_statistics();
+        exit(0);
     }));
 
     for (;;) {
@@ -235,9 +234,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
         total_pings++;
-        if (count.has_value() && total_pings == count.value())
-            closing_statistics();
+        if (count.has_value() && total_pings == count.value()) {
+            print_closing_statistics();
+            break;
+        }
 
         clock_nanosleep(CLOCK_MONOTONIC, 0, &interval_timespec, nullptr);
     }
+
+    return 0;
 }

--- a/Userland/Utilities/ping.cpp
+++ b/Userland/Utilities/ping.cpp
@@ -159,11 +159,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         struct timeval tv_send;
         gettimeofday(&tv_send, nullptr);
 
-        if (count.has_value() && total_pings == count.value())
-            closing_statistics();
-        else
-            total_pings++;
-
         TRY(Core::System::sendto(fd, ping_packet.data(), ping_packet.size(), 0, (const struct sockaddr*)&peer_address, sizeof(sockaddr_in)));
 
         for (;;) {
@@ -238,6 +233,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 continue;
             break;
         }
+
+        total_pings++;
+        if (count.has_value() && total_pings == count.value())
+            closing_statistics();
 
         clock_nanosleep(CLOCK_MONOTONIC, 0, &interval_timespec, nullptr);
     }


### PR DESCRIPTION
This PR fixes 2 issues with `ping`:

* Intervals specified with the `-i` option no longer overflow if they are larger than 4294 seconds (it turns out `useconds_t` is `u32` not `u64`, oops...)
* We no longer wait for an extra interval before displaying the closing statistics and exiting.

Before:
![ping_before](https://github.com/SerenityOS/serenity/assets/2817754/48413504-7501-4682-9483-e2e535c49831)


After:
![ping_after](https://github.com/SerenityOS/serenity/assets/2817754/2cb2c782-0d4b-4667-b0c0-66adf19630d2)