### PR TITLE
LibWeb: Parse the `min()` css math function

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -7871,8 +7871,108 @@ ErrorOr<OwnPtr<CalculationNode>> Parser::parse_a_calculation(Vector<ComponentVal
     if (parsing_failed_for_child_node)
         return nullptr;
 
-    // FIXME: 6. Return the result of simplifying a calculation tree from values.
-    return single_value.release_value();
+    // 6. Return the result of simplifying a calculation tree from values.
+    return simplify_a_calculation(single_value.release_value());
+}
+
+// https://drafts.csswg.org/css-values-4/#calc-simplification
+ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::simplify_a_calculation(NonnullOwnPtr<CalculationNode> root)
+{
+    // 1. If root is a numeric value:
+    if (root->type() == CalculationNode::Type::Numeric) {
+        // FIXME: 1. If root is a percentage that will be resolved against another value,
+        //    and there is enough information available to resolve it, do so,
+        //    and express the resulting numeric value in the appropriate canonical unit.
+        //    Return the value.
+
+        // FIXME: 2. If root is a dimension that is not expressed in its canonical unit,
+        //           and there is enough information available to convert it to the canonical unit,
+        //           do so, and return the value.
+
+        // FIXME: 3. If root is a <calc-constant>, return its numeric value.
+
+        // FIXME: 4. Otherwise, return root.
+        return root;
+    }
+
+    // 2. If root is any other leaf node (not an operator node):
+    if (!root->is_operator_node()) {
+        // FIXME: 1. If there is enough information available to determine its numeric value,
+        //           return its value, expressed in the value’s canonical unit.
+
+        // 2. Otherwise, return root.
+        return root;
+    }
+
+    // FIXME: 3. At this point, root is an operator node. Simplify all the calculation children of root.
+
+    // FIXME: 4. If root is an operator node that’s not one of the calc-operator nodes,
+    //    and all of its calculation children are numeric values with enough information
+    //    to compute the operation root represents, return the result of running root’s operation using its children,
+    //    expressed in the result’s canonical unit.
+
+    // 5. If root is a Min or Max node, attempt to partially simplify it:
+    if (root->type() == CalculationNode::Type::Min || root->type() == CalculationNode::Type::Max) {
+        // FIXME: 1. For each node child of root’s children:
+        // If child is a numeric value with enough information to compare magnitudes with another child of the same unit
+        // (see note in previous step), and there are other children of root that are numeric values with the same unit,
+        // combine all such children with the appropriate operator per root, and replace child with the result,
+        // removing all other child nodes involved.
+
+        // 2. Return root.
+        return root;
+    }
+
+    // 6. If root is a Negate node:
+    if (root->type() == CalculationNode::Type::Negate) {
+        // FIXME: 1. If root’s child is a numeric value, return an equivalent numeric value, but with the value negated (0 - value).
+        // FIXME: 2. If root’s child is a Negate node, return the child’s child.
+
+        // 3. Return root.
+        return root;
+    }
+
+    // 7. If root is an Invert node:
+    if (root->type() == CalculationNode::Type::Invert) {
+        // FIXME: 1. If root’s child is a number (not a percentage or dimension) return the reciprocal of the child’s value.
+        // FIXME: 2. If root’s child is an Invert node, return the child’s child.
+
+        // 3. Return root.
+        return root;
+    }
+
+    // 8. If root is a Sum node:
+    if (root->type() == CalculationNode::Type::Sum) {
+        // FIXME: 1. For each of root’s children that are Sum nodes, replace them with their children.
+        // FIXME: 2. For each set of root’s children that are numeric values with identical units,
+        //           remove those children and replace them with a single numeric value containing the sum of the removed nodes,
+        //           and with the same unit. (E.g. combine numbers, combine percentages, combine px values, etc.)
+
+        // FIXME: 3. If root has only a single child at this point, return the child. Otherwise, return root.
+        return root;
+    }
+
+    // 9. If root is a Product node:
+    if (root->type() == CalculationNode::Type::Product) {
+        // FIXME: 1. For each of root’s children that are Product nodes, replace them with their children.
+        // FIXME: 2. If root has multiple children that are numbers (not percentages or dimensions),
+        //           remove them and replace them with a single number containing the product of the removed nodes.
+        // FIXME: 3. If root contains only two children, one of which is a number (not a percentage or dimension)
+        // and the other of which is a Sum whose children are all numeric values, multiply all of the Sum’s children by the number,
+        // then return the Sum.
+        // FIXME: 4. If root contains only numeric values and/or Invert nodes containing numeric values,
+        //           and multiplying the types of all the children (noting that the type of an Invert node is the inverse of its child’s type)
+        //           results in a type that matches any of the types that a math function can resolve to,
+        //           return the result of multiplying all the values of the children
+        //           (noting that the value of an Invert node is the reciprocal of its child’s value),
+        //           expressed in the result’s canonical unit.
+
+        // 5. Return root
+        return root;
+    }
+
+    // NOTE: The spec stops here, so lets assume this is an invalid state
+    VERIFY_NOT_REACHED();
 }
 
 bool Parser::has_ignored_vendor_prefix(StringView string)

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -336,6 +336,7 @@ private:
     ErrorOr<RefPtr<StyleValue>> parse_grid_area_shorthand_value(Vector<ComponentValue> const&);
 
     ErrorOr<OwnPtr<CalculationNode>> parse_a_calculation(Vector<ComponentValue> const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> simplify_a_calculation(NonnullOwnPtr<CalculationNode>);
 
     ParseErrorOr<NonnullRefPtr<Selector>> parse_complex_selector(TokenStream<ComponentValue>&, SelectorType);
     ParseErrorOr<Optional<Selector::CompoundSelector>> parse_compound_selector(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -288,6 +288,7 @@ private:
     ErrorOr<PropertyAndValue> parse_css_value_for_properties(ReadonlySpan<PropertyID>, TokenStream<ComponentValue>&);
     ErrorOr<RefPtr<StyleValue>> parse_builtin_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_dynamic_value(ComponentValue const&);
+    ErrorOr<RefPtr<StyleValue>> parse_min_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -390,6 +390,111 @@ ErrorOr<void> InvertCalculationNode::dump(StringBuilder& builder, int indent) co
     return {};
 }
 
+ErrorOr<NonnullOwnPtr<MinCalculationNode>> MinCalculationNode::create(Vector<NonnullOwnPtr<Web::CSS::CalculationNode>> values)
+{
+    return adopt_nonnull_own_or_enomem(new (nothrow) MinCalculationNode(move(values)));
+}
+
+MinCalculationNode::MinCalculationNode(Vector<NonnullOwnPtr<CalculationNode>> values)
+    : CalculationNode(Type::Min)
+    , m_values(move(values))
+{
+}
+
+MinCalculationNode::~MinCalculationNode() = default;
+
+ErrorOr<String> MinCalculationNode::to_string() const
+{
+    StringBuilder builder;
+    TRY(builder.try_append("min("sv));
+    for (size_t i = 0; i < m_values.size(); ++i) {
+        if (i != 0)
+            TRY(builder.try_append(", "sv));
+        TRY(builder.try_append(TRY(m_values[i]->to_string())));
+    }
+    TRY(builder.try_append(")"sv));
+    return builder.to_string();
+}
+
+Optional<CalculatedStyleValue::ResolvedType> MinCalculationNode::resolved_type() const
+{
+    CalculatedStyleValue::ResolvedType type;
+    bool has_first = false;
+    for (auto const& value : m_values) {
+        auto value_type = value->resolved_type();
+        if (!value_type.has_value())
+            return {};
+
+        auto type_value = value_type.value();
+
+        if (!has_first) {
+            has_first = true;
+            type = type_value;
+        }
+
+        if (type_value != type)
+            return {};
+    }
+
+    return type;
+}
+
+bool MinCalculationNode::contains_percentage() const
+{
+    for (auto const& value : m_values) {
+        if (value->contains_percentage())
+            return true;
+    }
+
+    return false;
+}
+
+CalculatedStyleValue::CalculationResult MinCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
+{
+    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) {
+        return value.visit(
+            [](Number const& number) { return number.value(); },
+            [](Angle const& angle) { return angle.to_degrees(); },
+            [](Frequency const& frequency) { return frequency.to_hertz(); },
+            [layout_node](Length const& length) { return static_cast<float>(length.to_px(*layout_node).value()); },
+            [](Percentage const& percentage) { return percentage.value(); },
+            [](Time const& time) { return time.to_seconds(); });
+    };
+
+    CalculatedStyleValue::CalculationResult smallest_node = m_values.first()->resolve(layout_node, percentage_basis);
+    auto smallest_value = resolve_value(smallest_node.value());
+
+    for (size_t i = 1; i < m_values.size(); i++) {
+        auto child_resolved = m_values[i]->resolve(layout_node, percentage_basis);
+        auto child_value = resolve_value(child_resolved.value());
+
+        if (child_value < smallest_value) {
+            smallest_value = child_value;
+            smallest_node = child_resolved;
+        }
+    }
+
+    return smallest_node;
+}
+
+ErrorOr<void> MinCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+{
+    for (auto& value : m_values) {
+        TRY(value->for_each_child_node(callback));
+        TRY(callback(value));
+    }
+
+    return {};
+}
+
+ErrorOr<void> MinCalculationNode::dump(StringBuilder& builder, int indent) const
+{
+    TRY(builder.try_appendff("{: >{}}MIN:\n", "", indent));
+    for (auto const& value : m_values)
+        TRY(value->dump(builder, indent + 2));
+    return {};
+}
+
 void CalculatedStyleValue::CalculationResult::add(CalculationResult const& other, Layout::Node const* layout_node, PercentageBasis const& percentage_basis)
 {
     add_or_subtract_internal(SumOperation::Add, other, layout_node, percentage_basis);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -418,25 +418,8 @@ ErrorOr<String> MinCalculationNode::to_string() const
 
 Optional<CalculatedStyleValue::ResolvedType> MinCalculationNode::resolved_type() const
 {
-    CalculatedStyleValue::ResolvedType type;
-    bool has_first = false;
-    for (auto const& value : m_values) {
-        auto value_type = value->resolved_type();
-        if (!value_type.has_value())
-            return {};
-
-        auto type_value = value_type.value();
-
-        if (!has_first) {
-            has_first = true;
-            type = type_value;
-        }
-
-        if (type_value != type)
-            return {};
-    }
-
-    return type;
+    // NOTE: We check during parsing that all values have the same type.
+    return m_values[0]->resolved_type();
 }
 
 bool MinCalculationNode::contains_percentage() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -147,12 +147,17 @@ public:
     bool is_operator_node() const
     {
         // FIXME: Check for operator node types once they exist
-        return is_calc_operator_node();
+        return is_calc_operator_node() || is_math_function_node();
     }
 
     bool is_calc_operator_node() const
     {
         return first_is_one_of(m_type, Type::Sum, Type::Product, Type::Negate, Type::Invert);
+    }
+
+    bool is_math_function_node() const
+    {
+        return first_is_one_of(m_type, Type::Min);
     }
 
     virtual ErrorOr<String> to_string() const = 0;
@@ -257,6 +262,24 @@ public:
 private:
     explicit InvertCalculationNode(NonnullOwnPtr<CalculationNode>);
     NonnullOwnPtr<CalculationNode> m_value;
+};
+
+class MinCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<MinCalculationNode>> create(Vector<NonnullOwnPtr<CalculationNode>>);
+    ~MinCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override;
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    explicit MinCalculationNode(Vector<NonnullOwnPtr<CalculationNode>>);
+    Vector<NonnullOwnPtr<CalculationNode>> m_values;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -129,6 +129,12 @@ public:
         Negate,
         Invert,
 
+        // Comparison function nodes, a sub-type of operator node
+        // https://drafts.csswg.org/css-values-4/#comp-func
+        Min,
+        Max,
+        Clamp,
+
         // This only exists during parsing.
         Unparsed,
     };


### PR DESCRIPTION
Fixes https://wpt.live/css/css-values/min-length-percent-001.html


cc @AtkinsSJ 