### PR TITLE
LibWeb: Consume sign in `SVG::parse_elliptical_arg_argument`

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/svg-negative-elliptical-arg-number.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-negative-elliptical-arg-number.txt
@@ -1,0 +1,7 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: inline
+      line 0 width: 100, height: 100, bottom: 100, baseline: 48
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100]
+      SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: not-inline
+        SVGGeometryBox <path> at (8,9.999999) content-size 100x48 children: not-inline

--- a/Tests/LibWeb/Layout/input/svg/svg-negative-elliptical-arg-number.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-negative-elliptical-arg-number.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html><html><body><svg 
+	xmlns="http://www.w3.org/2000/svg"
+	width="100"
+	height="100"
+	viewBox="0 0 10 10"><path d="M0,5 10,5 5.5,.5 a 1,-1 0 0 0 -.5,-.3 1,-1 0 0 0 -.5, .2">

--- a/Userland/Libraries/LibWeb/SVG/AttributeParser.cpp
+++ b/Userland/Libraries/LibWeb/SVG/AttributeParser.cpp
@@ -343,10 +343,10 @@ Vector<float> AttributeParser::parse_coordinate_pair_triplet()
 Vector<float> AttributeParser::parse_elliptical_arg_argument()
 {
     Vector<float> numbers;
-    numbers.append(parse_nonnegative_number());
+    numbers.append(parse_number());
     if (match_comma_whitespace())
         parse_comma_whitespace();
-    numbers.append(parse_nonnegative_number());
+    numbers.append(parse_number());
     if (match_comma_whitespace())
         parse_comma_whitespace();
     numbers.append(parse_number());


### PR DESCRIPTION
This was crashing on google.com with the Linux Chrome user agent. Interestingly it seems like this behavior may have been accidental as only two of the three `parse_number()`'s were changed in f7dbcb6

Crash:
> WebContent: Userland/Libraries/LibWeb/SVG/AttributeParser.cpp:401: float Web::SVG::AttributeParser::parse_nonnegative_number(): Assertion `!match('+') && !match('-')' failed.

After, looks the same as firefox:
![Firefox](https://github.com/SerenityOS/serenity/assets/36214028/7f52d3c7-5c5b-4711-980e-c957d8eb8e3f)
![Ladybird](https://github.com/SerenityOS/serenity/assets/36214028/dff5dd3d-216c-4850-98e0-8c9b08753123)