### PR TITLE
Documentation+Kernel/aarch64: Add proper support for the Raspberry Pi 4B

### DIFF
--- a/Documentation/RunningOnRaspberryPi.md
+++ b/Documentation/RunningOnRaspberryPi.md
@@ -48,6 +48,13 @@ This step is needed because the original firmware files need to be present on th
 
 Please follow one of the existing guides (for example [here](https://scribles.net/setting-up-serial-communication-between-raspberry-pi-and-pc)) and make sure UART is working on Raspberry Pi OS before proceeding.
 
+If you're using a Raspberry Pi 4B and want to test if the UART is working correctly, you need to do a few extra steps.
+UART0 (the one that SerenityOS uses) is used for bluetooth on these models, so for the OS to use it instead, ensure that you disable Bluetooth inside the `config.txt`:
+
+```
+dtoverlay=disable-bt
+```
+
 ### Step 2: Mount SD Card
 
 If you use a Raspberry Pi 4, and your serenity kernel is called `kernel8.img`
@@ -70,7 +77,7 @@ enable_uart=1
 
 ### Step 3: Copy Serenity kernel to SD Card
 
-`kernel8.img` can be found in `Build/aarch64/Kernel/Prekernel/`. Copy it to the main directory on the `Boot/` partition, next to `config.txt`. You can either replace the original file or use another name (see above).
+`kernel8.img` can be found in `Build/aarch64/Kernel/`. Copy it to the main directory on the `Boot/` partition, next to `config.txt`. You can either replace the original file or use another name (see above).
 
 ### Step 4: Put the SD Card in the Raspberry Pi and power on
 
@@ -84,7 +91,7 @@ There are multiple ways to set up your network. The easiest way is a direct conn
 
 Here's the [Raspberry Pi Documentation](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#debugging-network-boot-mode) on booting from the network.
 
-### Step 1: Make sure OTP mode is enabled on the board 
+### Step 1: Make sure OTP mode is enabled on the board
 
 This is enabled by default on Raspberry Pi 3+. For the previous boards please see the section [Debugging Network Boot Mode](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#debugging-network-boot-mode) of the Raspberry Pi documentation.
 


### PR DESCRIPTION
We kind-of supported the Raspberry Pi 4B already, but there was just a change to the MMU that was needed.

With these changes, we reach the same stage as the 3 :)
<img width="941" alt="image" src="https://github.com/SerenityOS/serenity/assets/71222289/43dfa629-7bb2-499d-8893-177abbfc989a">
