### PR TITLE
LibWeb: Reset margin collapsing state only if box actually adds clearance

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/box-with-clearance-and-margin-top.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/box-with-clearance-and-margin-top.txt
@@ -1,0 +1,7 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x110 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x110 children: not-inline
+        BlockContainer <div.square.white> at (8,8) content-size 100x100 floating [BFC] children: not-inline
+        BlockContainer <div.clearfix> at (8,108) content-size 10x10 children: not-inline
+        BlockContainer <div.square.black> at (8,218) content-size 49x49 floating [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/clear-both-without-introducing-clearance.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/clear-both-without-introducing-clearance.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x125.9375 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x109.9375 children: not-inline
+      BlockContainer <div.upper> at (8,8) content-size 784x17.46875 children: inline
+        line 0 width: 46.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 5, rect: [8,8 46.15625x17.46875]
+            "upper"
+        TextNode <#text>
+      BlockContainer <div.mystery> at (8,100.46875) content-size 784x0 children: not-inline
+      BlockContainer <div.lower> at (8,100.46875) content-size 784x17.46875 children: inline
+        line 0 width: 43.359375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 5, rect: [8,100.46875 43.359375x17.46875]
+            "lower"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/block-and-inline/box-with-clearance-and-margin-top.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/box-with-clearance-and-margin-top.html
@@ -1,0 +1,24 @@
+<style>
+.clearfix {
+    clear: both;
+    margin-top: 9999px;
+    margin-bottom: 100px;
+    background-color: black;
+    width: 10px;
+    height: 10px;
+}
+.square {
+    float: left;
+    width: 49px;
+    height: 49px;
+}
+.white {
+    background-color: salmon;
+    width: 100px;
+    height: 100px;
+}
+.black {
+    background-color: slateblue;
+}
+</style>
+<div><div class="square white"></div><div class="clearfix"></div><div class="square black"></div></div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/clear-both-without-introducing-clearance.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/clear-both-without-introducing-clearance.html
@@ -1,0 +1,8 @@
+<!doctype html><style>
+.upper {
+    margin-bottom: 75px;
+}
+.mystery {
+    clear: both;
+}
+</style><body><div class="upper">upper</div><div class="mystery"></div><div class="lower">lower

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -72,6 +72,13 @@ private:
 
     void layout_list_item_marker(ListItemBox const&);
 
+    enum class DidIntroduceClearance {
+        Yes,
+        No,
+    };
+
+    [[nodiscard]] DidIntroduceClearance clear_floating_boxes(Box const& child_box);
+
     enum class FloatSide {
         Left,
         Right,


### PR DESCRIPTION
This fixes the issue when margin collapsing state was always reset if a box has clear property not equal to none even if it does not actually introduce clearance.