### PR TITLE
LibWeb: Start fleshing out support for width: fit-content

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width-constraints.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width-constraints.txt
@@ -1,0 +1,15 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x56.9375 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x38.9375 children: not-inline
+      BlockContainer <div.box> at (11,11) content-size 138.28125x17.46875 children: inline
+        line 0 width: 138.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 18, rect: [11,11 138.28125x17.46875]
+            "Well hello friends"
+        TextNode <#text>
+      BlockContainer <div.box2> at (11,30.46875) content-size 138.28125x17.46875 children: inline
+        line 0 width: 138.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 18, rect: [11,30.46875 138.28125x17.46875]
+            "Well hello friends"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (10,48.9375) content-size 780x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width.txt
@@ -1,0 +1,10 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x37.46875 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x19.46875 children: not-inline
+      BlockContainer <div.box> at (11,11) content-size 138.28125x17.46875 children: inline
+        line 0 width: 138.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 18, rect: [11,11 138.28125x17.46875]
+            "Well hello friends"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (10,29.46875) content-size 780x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-with-fit-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-with-fit-content-width.txt
@@ -1,0 +1,8 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x37.46875 [BFC] children: not-inline
+    Box <body> at (10,10) content-size 780x19.46875 [GFC] children: not-inline
+      BlockContainer <div.inner> at (11,11) content-size 132.828125x17.46875 [BFC] children: inline
+        line 0 width: 132.828125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 15, rect: [11,11 132.828125x17.46875]
+            "Press and Media"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-with-fit-content-width-constraints.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-with-fit-content-width-constraints.html
@@ -1,0 +1,13 @@
+<!doctype html><style>
+* { border: 1px solid black; }
+.box {
+    background: orange;
+    min-width: fit-content;
+    width: 10px;
+}
+.box2 {
+    background: pink;
+    max-width: fit-content;
+    width: 1000px;
+}
+</style><div class="box">Well hello friends</div><div class="box2">Well hello friends</div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-with-fit-content-width.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-with-fit-content-width.html
@@ -1,0 +1,8 @@
+<!doctype html><style>
+* { border: 1px solid black; }
+.box {
+    background: pink;
+    display: block;
+    width: fit-content;
+}
+</style><div class="box">Well hello friends</div>

--- a/Tests/LibWeb/Layout/input/grid/grid-item-with-fit-content-width.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-item-with-fit-content-width.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html><style>
+    * { border: 1px solid black; }
+    body { display: grid; }
+    .inner { width: fit-content; }
+</style><body><div class="inner">Press and Media

--- a/Userland/Libraries/LibWeb/CSS/Identifiers.json
+++ b/Userland/Libraries/LibWeb/CSS/Identifiers.json
@@ -118,6 +118,7 @@
   "fantasy",
   "fast",
   "fine",
+  "fit-content",
   "fixed",
   "flex",
   "flex-end",

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1648,7 +1648,8 @@
       "percentage [0,∞]"
     ],
     "valid-identifiers": [
-      "auto"
+      "auto",
+      "fit-content"
     ],
     "quirks": [
       "unitless-length"

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1220,6 +1220,7 @@
       "percentage [0,∞]"
     ],
     "valid-identifiers": [
+      "fit-content",
       "none"
     ],
     "quirks": [
@@ -1250,6 +1251,7 @@
     ],
     "valid-identifiers": [
       "auto",
+      "fit-content",
       "none"
     ],
     "quirks": [

--- a/Userland/Libraries/LibWeb/CSS/Size.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Size.cpp
@@ -64,6 +64,12 @@ Size Size::make_fit_content(Length available_space)
     return Size { Type::FitContent, move(available_space) };
 }
 
+Size Size::make_fit_content()
+{
+    // NOTE: We use "auto" as a stand-in for "stretch" here.
+    return Size { Type::FitContent, Length::make_auto() };
+}
+
 Size Size::make_none()
 {
     return Size { Type::None, Length::make_auto() };

--- a/Userland/Libraries/LibWeb/CSS/Size.h
+++ b/Userland/Libraries/LibWeb/CSS/Size.h
@@ -33,6 +33,7 @@ public:
     static Size make_min_content();
     static Size make_max_content();
     static Size make_fit_content(Length available_space);
+    static Size make_fit_content();
     static Size make_none();
 
     bool is_auto() const { return m_type == Type::Auto; }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -72,6 +72,8 @@ CSS::Size StyleProperties::size_value(CSS::PropertyID id) const
             return CSS::Size::make_min_content();
         case ValueID::MaxContent:
             return CSS::Size::make_max_content();
+        case ValueID::FitContent:
+            return CSS::Size::make_fit_content();
         case ValueID::None:
             return CSS::Size::make_none();
         default:

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1347,6 +1347,9 @@ CSS::Length FormattingContext::calculate_inner_width(Layout::Box const& box, Ava
     if (width.is_auto()) {
         return width.resolved(box, width_of_containing_block_as_length_for_resolve);
     }
+    if (width.is_fit_content()) {
+        return CSS::Length::make_px(calculate_fit_content_width(box, AvailableSpace { available_width, AvailableSize::make_indefinite() }));
+    }
 
     auto& computed_values = box.computed_values();
     if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox) {

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1169,7 +1169,9 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
     box_state.set_indefinite_content_height();
 
     auto context = const_cast<FormattingContext*>(this)->create_independent_formatting_context_if_needed(throwaway_state, box);
-    VERIFY(context);
+    if (!context) {
+        context = make<BlockFormattingContext>(throwaway_state, verify_cast<BlockContainer>(box), nullptr);
+    }
 
     auto available_width = AvailableSize::make_min_content();
     auto available_height = AvailableSize::make_indefinite();
@@ -1205,7 +1207,9 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box)
     box_state.set_indefinite_content_height();
 
     auto context = const_cast<FormattingContext*>(this)->create_independent_formatting_context_if_needed(throwaway_state, box);
-    VERIFY(context);
+    if (!context) {
+        context = make<BlockFormattingContext>(throwaway_state, verify_cast<BlockContainer>(box), nullptr);
+    }
 
     auto available_width = AvailableSize::make_max_content();
     auto available_height = AvailableSize::make_indefinite();
@@ -1260,7 +1264,9 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
         box_state.set_content_width(available_width.to_px());
 
     auto context = const_cast<FormattingContext*>(this)->create_independent_formatting_context_if_needed(throwaway_state, box);
-    VERIFY(context);
+    if (!context) {
+        context = make<BlockFormattingContext>(throwaway_state, verify_cast<BlockContainer>(box), nullptr);
+    }
 
     context->run(box, LayoutMode::IntrinsicSizing, AvailableSpace(available_width, AvailableSize::make_min_content()));
 
@@ -1313,7 +1319,9 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
         box_state.set_content_width(available_width.to_px());
 
     auto context = const_cast<FormattingContext*>(this)->create_independent_formatting_context_if_needed(throwaway_state, box);
-    VERIFY(context);
+    if (!context) {
+        context = make<BlockFormattingContext>(throwaway_state, verify_cast<BlockContainer>(box), nullptr);
+    }
 
     context->run(box, LayoutMode::IntrinsicSizing, AvailableSpace(available_width, AvailableSize::make_max_content()));
 

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1393,7 +1393,13 @@ void GridFormattingContext::resolve_grid_item_widths()
         box_state.border_right = border_right;
 
         auto const& computed_width = item.box().computed_values().width();
-        auto used_width = computed_width.is_auto() ? (containing_block_width - box_state.border_left - box_state.border_right - box_state.padding_left - box_state.padding_right) : computed_width.to_px(grid_container(), containing_block_width);
+        CSSPixels used_width;
+        if (computed_width.is_auto())
+            used_width = (containing_block_width - box_state.border_left - box_state.border_right - box_state.padding_left - box_state.padding_right);
+        else if (computed_width.is_fit_content())
+            used_width = calculate_fit_content_width(item.box(), get_available_space_for_item(item));
+        else
+            used_width = computed_width.to_px(grid_container(), containing_block_width);
         box_state.set_content_width(used_width);
     }
 }


### PR DESCRIPTION
This PR adds basic support for `width: fit-content` in block and grid layout. We only support the identifier version for now, and there are many more places to handle this, but we have to start somewhere. :^)