### PR TITLE
LibWeb: Add basic parsing of grid shorthand CSS property

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/grid-shorthand-property.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-shorthand-property.txt
@@ -1,0 +1,5 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
+      Box <div.container> at (8,8) content-size 784x100 [GFC] children: not-inline
+        BlockContainer <div.item> at (8,8) content-size 200x100 [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/input/grid/grid-shorthand-property.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-shorthand-property.html
@@ -1,0 +1,10 @@
+<style>
+.container {
+    display: grid;
+    grid: 100px / 200px;
+}
+
+.item {
+    background-color: navy;
+}
+</style><div class="container"><div class="item"></div></div>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -6869,6 +6869,14 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_grid_area_shorthand_value(Vector<Compo
     return GridAreaShorthandStyleValue::create(row_start, column_start, row_end, column_end);
 }
 
+ErrorOr<RefPtr<StyleValue>> Parser::parse_grid_shorthand_value(Vector<ComponentValue> const& component_value)
+{
+    // <'grid-template'> |
+    // FIXME: <'grid-template-rows'> / [ auto-flow && dense? ] <'grid-auto-columns'>? |
+    // FIXME: [ auto-flow && dense? ] <'grid-auto-rows'>? / <'grid-template-columns'>
+    return parse_grid_track_size_list_shorthand_value(component_value);
+}
+
 ErrorOr<RefPtr<StyleValue>> Parser::parse_grid_template_areas_value(Vector<ComponentValue> const& component_values)
 {
     Vector<Vector<String>> grid_area_rows;
@@ -7074,6 +7082,10 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
         return ParseError::SyntaxError;
     case PropertyID::GridRowStart:
         if (auto parsed_value = FIXME_TRY(parse_grid_track_placement(component_values)))
+            return parsed_value.release_nonnull();
+        return ParseError::SyntaxError;
+    case PropertyID::Grid:
+        if (auto parsed_value = FIXME_TRY(parse_grid_shorthand_value(component_values)))
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
     case PropertyID::GridTemplate:

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -334,6 +334,7 @@ private:
     ErrorOr<RefPtr<StyleValue>> parse_grid_track_placement_shorthand_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_grid_template_areas_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_grid_area_shorthand_value(Vector<ComponentValue> const&);
+    ErrorOr<RefPtr<StyleValue>> parse_grid_shorthand_value(Vector<ComponentValue> const&);
 
     ErrorOr<OwnPtr<CalculationNode>> parse_a_calculation(Vector<ComponentValue> const&);
 

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -940,6 +940,21 @@
       "string"
     ]
   },
+  "grid": {
+    "inherited": false,
+    "initial": "auto",
+    "valid-identifiers": [
+      "auto"
+    ],
+    "valid-types": [
+      "length",
+      "percentage",
+      "string"
+    ],
+    "longhands": [
+      "grid-template"
+    ]
+  },
   "grid-template": {
     "inherited": false,
     "initial": "auto",

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -639,7 +639,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         return;
     }
 
-    if (property_id == CSS::PropertyID::GridTemplate) {
+    if (property_id == CSS::PropertyID::GridTemplate || property_id == CSS::PropertyID::Grid) {
         if (value.is_grid_track_size_list_shorthand()) {
             auto const& shorthand = value.as_grid_track_size_list_shorthand();
             style.set_property(CSS::PropertyID::GridTemplateAreas, shorthand.areas());


### PR DESCRIPTION
Introduces incomplete parsing of grid shorthand property. Only <grid-template> part of syntax is supported for now but it is enough to significantly improve rendering of websites that use this shorthand to define grid :)

Before:
<img width="500" alt="Screenshot 2023-05-27 at 03 11 22" src="https://github.com/SerenityOS/serenity/assets/45686940/50ed7f90-ff9c-459c-a0ba-5f24ebacdac7">

After:
<img width="500" alt="Screenshot 2023-05-27 at 03 10 48" src="https://github.com/SerenityOS/serenity/assets/45686940/da50cb26-a419-418c-96f6-3b038851efd1">

