### PR TITLE
Audio: Merge config default values into single source of truth

### DIFF
--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -24,6 +24,8 @@
 #include <LibGfx/Palette.h>
 #include <LibMain/Main.h>
 
+static constexpr bool audio_applet_show_percent_default = false;
+
 class AudioWidget final : public GUI::Widget {
     C_OBJECT_ABSTRACT(AudioWidget)
 
@@ -53,7 +55,7 @@ private:
     AudioWidget(NonnullRefPtr<Audio::ConnectionToServer> audio_client, Array<VolumeBitmapPair, 5> volume_level_bitmaps)
         : m_audio_client(move(audio_client))
         , m_volume_level_bitmaps(move(volume_level_bitmaps))
-        , m_show_percent(Config::read_bool("AudioApplet"sv, "Applet"sv, "ShowPercent"sv, false))
+        , m_show_percent(Config::read_bool("AudioApplet"sv, "Applet"sv, "ShowPercent"sv, audio_applet_show_percent_default))
     {
         m_audio_volume = static_cast<int>(m_audio_client->get_main_mix_volume() * 100);
         m_audio_muted = m_audio_client->is_main_mix_muted();
@@ -246,7 +248,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->show();
 
     // This positioning code depends on the window actually existing.
-    static_cast<AudioWidget*>(window->main_widget())->set_audio_widget_size(Config::read_bool("AudioApplet"sv, "Applet"sv, "ShowPercent"sv, false));
+    static_cast<AudioWidget*>(window->main_widget())->set_audio_widget_size(Config::read_bool("AudioApplet"sv, "Applet"sv, "ShowPercent"sv, audio_applet_show_percent_default));
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
 


### PR DESCRIPTION
In Serenity, we have many calls like `Config::read_i32("Foo"sv, "Bar"sv, "baz"sv, 0xC0FFEE)` with inline constants. This can easily lead to conflicting defaults, which already is the case(!) for a handful of places. I want to get to a point where there is exactly one single source of truth for each config value. This PR is a pilot to determine where exactly we want to go, and to avoid conflicting defaults.

The simplest way to store a single source of truth seems in my eyes to be a single `static constexpr` like in this PR, or in those places where it's really necessary, a `FooSettings/Defaults.h` file that is shared by `Foo` and `FooSettings`.

This PR:
- Merges two accesses to the AudioApplet>Applet>ShowPercent into one.
- Instead of having the default value somewhere as a literal in the program, store it in a `static constexpr`.

In the case of AudioApplet we can actually avoid the duplicate IPC call. This doesn't really improve performance, but it's nice.

Feel free to bikeshed the name `DEFAULT_AudioApplet_Applet_ShowPercent`. I hope the name can be done in a way where we can still parse the domain/group/key from it.