### PR TITLE
Ladybird+Tests/LibWeb: Add very basic text-only test harness

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -170,4 +170,10 @@ if (BUILD_TESTING)
         COMMAND ${SERENITY_SOURCE_DIR}/Tests/LibWeb/Layout/layout_test.sh ${CMAKE_CURRENT_BINARY_DIR}
     )
     set_tests_properties(Layout PROPERTIES ENVIRONMENT QT_QPA_PLATFORM=offscreen)
+
+    add_test(
+        NAME LibWebText
+        COMMAND ${SERENITY_SOURCE_DIR}/Tests/LibWeb/Text/text_test.sh ${CMAKE_CURRENT_BINARY_DIR}
+    )
+set_tests_properties(LibWebText PROPERTIES ENVIRONMENT QT_QPA_PLATFORM=offscreen)
 endif()

--- a/Tests/LibWeb/Text/expected/basic.txt
+++ b/Tests/LibWeb/Text/expected/basic.txt
@@ -1,0 +1,2 @@
+Well hello
+friends!

--- a/Tests/LibWeb/Text/input/basic.html
+++ b/Tests/LibWeb/Text/input/basic.html
@@ -1,0 +1,9 @@
+<div id="out"></div><script>
+    function println(s) {
+        const out = document.getElementById("out");
+        out.appendChild(document.createTextNode(s + "\n"))
+    }
+
+    println("Well hello")
+    println("friends!")
+</script>

--- a/Tests/LibWeb/Text/text_test.sh
+++ b/Tests/LibWeb/Text/text_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd -P -- "$(dirname -- "${0}")" && pwd -P)"
+LADYBIRD_BUILD_DIR="${1}"
+
+if [[ -z "${LADYBIRD_BUILD_DIR}" ]] ; then
+    echo "Provide path to the Ladybird build directory"
+    exit 1
+fi
+
+BROWSER_BINARY="./headless-browser"
+
+find "${SCRIPT_DIR}/input/" -type f -name "*.html" -print0 | while IFS= read -r -d '' input_html_path; do
+    input_html_file=${input_html_path/${SCRIPT_DIR}"/input/"/}
+    input_html_file=${input_html_file/".html"/}
+
+    output_text_dump=$(cd "${LADYBIRD_BUILD_DIR}"; timeout 300s "${BROWSER_BINARY}" --dump-text "${input_html_path}")
+    expected_text_dump_path="${SCRIPT_DIR}/expected/${input_html_file}.txt"
+
+    if cmp <(echo "${output_text_dump}") "${expected_text_dump_path}"; then
+        echo "${input_html_file} PASSED"
+    else
+        echo "${input_html_file} FAILED"
+        diff -u "${expected_text_dump_path}" <(echo "${output_text_dump}")
+    fi
+done

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -174,12 +174,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto resources_folder = "/res"sv;
     StringView web_driver_ipc_path;
     bool dump_layout_tree = false;
+    bool dump_text = false;
     bool is_layout_test_mode = false;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("This utility runs the Browser in headless mode.");
     args_parser.add_option(screenshot_timeout, "Take a screenshot after [n] seconds (default: 1)", "screenshot", 's', "n");
     args_parser.add_option(dump_layout_tree, "Dump layout tree and exit", "dump-layout-tree", 'd');
+    args_parser.add_option(dump_text, "Dump text and exit", "dump-text", 'T');
     args_parser.add_option(resources_folder, "Path of the base resources folder (defaults to /res)", "resources", 'r', "resources-root-path");
     args_parser.add_option(web_driver_ipc_path, "Path to the WebDriver IPC socket", "webdriver-ipc-path", 0, "path");
     args_parser.add_option(is_layout_test_mode, "Enable layout test mode", "layout-test-mode", 0);
@@ -207,6 +209,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto layout_tree = view->dump_layout_tree().release_value_but_fixme_should_propagate_errors();
 
             out("{}", layout_tree);
+            fflush(stdout);
+
+            event_loop.quit(0);
+        };
+    } else if (dump_text) {
+        view->on_load_finish = [&](auto const&) {
+            view->select_all();
+            auto text = view->selected_text();
+
+            out("{}", text);
             fflush(stdout);
 
             event_loop.quit(0);


### PR DESCRIPTION
This allows us to create "text tests" in addition to "layout tests".
Text tests work the same as layout tests, but dump the document content
as text and exit upon receiving the window "load" event.