### PR TITLE
LibWeb: Disambiguate (some) StyleValues

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5392,9 +5392,10 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_flex_value(Vector<ComponentValue> cons
         case PropertyID::FlexGrow: {
             // NOTE: The spec says that flex-basis should be 0 here, but other engines currently use 0%.
             // https://github.com/w3c/csswg-drafts/issues/5742
-            auto zero_percent = TRY(NumericStyleValue::create_integer(0));
+            // (flex-basis takes `<length>`, not `<number>`, so the 0 is a Length.)
+            auto flex_basis = TRY(LengthStyleValue::create(Length::make_px(0)));
             auto one = TRY(NumericStyleValue::create_integer(1));
-            return FlexStyleValue::create(*value, one, zero_percent);
+            return FlexStyleValue::create(*value, one, flex_basis);
         }
         case PropertyID::FlexBasis: {
             auto one = TRY(NumericStyleValue::create_integer(1));

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4405,8 +4405,8 @@ static Optional<LengthPercentage> style_value_to_length_percentage(auto value)
 {
     if (value->is_percentage())
         return LengthPercentage { value->as_percentage().percentage() };
-    if (value->has_length())
-        return LengthPercentage { value->to_length() };
+    if (value->is_length())
+        return LengthPercentage { value->as_length().length() };
     if (value->is_calculated())
         return LengthPercentage { value->as_calculated() };
     return {};
@@ -4674,8 +4674,8 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_single_background_size_value(TokenStre
             return LengthPercentage { Length::make_auto() };
         if (style_value.is_percentage())
             return LengthPercentage { style_value.as_percentage().percentage() };
-        if (style_value.has_length())
-            return LengthPercentage { style_value.to_length() };
+        if (style_value.is_length())
+            return LengthPercentage { style_value.as_length().length() };
         return {};
     };
 
@@ -6239,8 +6239,6 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_transform_origin_value(Vector<Componen
             return AxisOffset { Axis::None, value->as_percentage() };
         if (value->is_length())
             return AxisOffset { Axis::None, value->as_length() };
-        if (value->has_length())
-            return AxisOffset { Axis::None, TRY(LengthStyleValue::create(value->to_length())) };
         if (value->is_identifier()) {
             switch (value->to_identifier()) {
             case ValueID::Top:

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1101,7 +1101,7 @@ Length::FontMetrics StyleComputer::calculate_root_element_font_metrics(StyleProp
 
     auto font_pixel_metrics = style.computed_font().pixel_metrics();
     Length::FontMetrics font_metrics { m_default_font_metrics.font_size, font_pixel_metrics, font_pixel_metrics.line_spacing() };
-    font_metrics.font_size = root_value->to_length().to_px(viewport_rect(), font_metrics, font_metrics);
+    font_metrics.font_size = root_value->as_length().length().to_px(viewport_rect(), font_metrics, font_metrics);
     font_metrics.line_height = style.line_height(viewport_rect(), font_metrics, font_metrics);
 
     return font_metrics;
@@ -1229,7 +1229,7 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
                 return font_size_in_px;
             auto value = parent_element->computed_css_values()->property(CSS::PropertyID::FontSize);
             if (value->is_length()) {
-                auto length = static_cast<LengthStyleValue const&>(*value).to_length();
+                auto length = value->as_length().length();
                 auto parent_line_height = parent_or_root_element_line_height(parent_element, {});
                 if (length.is_absolute() || length.is_relative()) {
                     Length::FontMetrics font_metrics { font_size_in_px, font_pixel_metrics, parent_line_height };
@@ -1245,7 +1245,7 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
             maybe_length = Length::make_px(static_cast<double>(font_size->as_percentage().percentage().as_fraction()) * parent_font_size());
 
         } else if (font_size->is_length()) {
-            maybe_length = font_size->to_length();
+            maybe_length = font_size->as_length().length();
 
         } else if (font_size->is_calculated()) {
             // FIXME: Support font-size: calc(...)
@@ -1392,7 +1392,7 @@ CSSPixels StyleComputer::parent_or_root_element_line_height(DOM::Element const* 
         return m_root_element_font_metrics.line_height;
     auto const* computed_values = parent_element->computed_css_values();
     auto parent_font_pixel_metrics = computed_values->computed_font().pixel_metrics();
-    auto parent_font_size = computed_values->property(CSS::PropertyID::FontSize)->to_length();
+    auto parent_font_size = computed_values->property(CSS::PropertyID::FontSize)->as_length().length();
     // FIXME: Can the parent font size be non-absolute here?
     auto parent_font_size_value = parent_font_size.is_absolute() ? parent_font_size.absolute_length_to_px() : m_root_element_font_metrics.font_size;
     auto parent_parent_line_height = parent_or_root_element_line_height(parent_element, {});
@@ -1408,7 +1408,7 @@ ErrorOr<void> StyleComputer::absolutize_values(StyleProperties& style, DOM::Elem
 
     Length::FontMetrics font_metrics { m_root_element_font_metrics.font_size, font_pixel_metrics, parent_or_root_line_height };
 
-    auto font_size = style.property(CSS::PropertyID::FontSize)->to_length().to_px(viewport_rect(), font_metrics, m_root_element_font_metrics);
+    auto font_size = style.property(CSS::PropertyID::FontSize)->as_length().length().to_px(viewport_rect(), font_metrics, m_root_element_font_metrics);
     font_metrics.font_size = font_size;
 
     // NOTE: Percentage line-height values are relative to the font-size of the element.

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h>
+#include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumericStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RectStyleValue.h>
@@ -86,11 +87,11 @@ CSS::Size StyleProperties::size_value(CSS::PropertyID id) const
     if (value->is_percentage())
         return CSS::Size::make_percentage(value->as_percentage().percentage());
 
-    if (value->has_length()) {
-        auto length = value->to_length();
+    if (value->is_length()) {
+        auto length = value->as_length().length();
         if (length.is_auto())
             return CSS::Size::make_auto();
-        return CSS::Size::make_length(value->to_length());
+        return CSS::Size::make_length(length);
     }
 
     // FIXME: Support `fit-content(<length>)`
@@ -113,8 +114,8 @@ Optional<LengthPercentage> StyleProperties::length_percentage(CSS::PropertyID id
     if (value->is_percentage())
         return value->as_percentage().percentage();
 
-    if (value->has_length())
-        return value->to_length();
+    if (value->is_length())
+        return value->as_length().length();
 
     if (value->has_auto())
         return LengthPercentage { Length::make_auto() };
@@ -163,7 +164,7 @@ CSSPixels StyleProperties::line_height(CSSPixelRect const& viewport_rect, Length
         return font_metrics.line_height;
 
     if (line_height->is_length()) {
-        auto line_height_length = line_height->to_length();
+        auto line_height_length = line_height->as_length().length();
         if (!line_height_length.is_auto())
             return line_height_length.to_px(viewport_rect, font_metrics, root_font_metrics);
     }
@@ -193,7 +194,7 @@ CSSPixels StyleProperties::line_height(Layout::Node const& layout_node) const
         return layout_node.font().pixel_metrics().line_spacing();
 
     if (line_height->is_length()) {
-        auto line_height_length = line_height->to_length();
+        auto line_height_length = line_height->as_length().length();
         if (!line_height_length.is_auto())
             return line_height_length.to_px(layout_node);
     }
@@ -314,8 +315,8 @@ Optional<CSS::FlexBasisData> StyleProperties::flex_basis() const
     if (value->is_percentage())
         return { { CSS::FlexBasis::LengthPercentage, value->as_percentage().percentage() } };
 
-    if (value->has_length())
-        return { { CSS::FlexBasis::LengthPercentage, value->to_length() } };
+    if (value->is_length())
+        return { { CSS::FlexBasis::LengthPercentage, value->as_length().length() } };
 
     if (value->is_calculated())
         return { { CSS::FlexBasis::LengthPercentage, CSS::LengthPercentage { value->as_calculated() } } };
@@ -390,7 +391,7 @@ Vector<CSS::Transformation> StyleProperties::transformations() const
         Vector<TransformValue> values;
         for (auto& transformation_value : transformation_style_value.values()) {
             if (transformation_value->is_length()) {
-                values.append({ transformation_value->to_length() });
+                values.append({ transformation_value->as_length().length() });
             } else if (transformation_value->is_percentage()) {
                 values.append({ transformation_value->as_percentage().percentage() });
             } else if (transformation_value->is_numeric()) {
@@ -410,7 +411,7 @@ Vector<CSS::Transformation> StyleProperties::transformations() const
 static Optional<LengthPercentage> length_percentage_for_style_value(StyleValue const& value)
 {
     if (value.is_length())
-        return value.to_length();
+        return value.as_length().length();
     if (value.is_percentage())
         return value.as_percentage().percentage();
     return {};
@@ -745,7 +746,7 @@ Variant<CSS::VerticalAlign, CSS::LengthPercentage> StyleProperties::vertical_ali
         return value_id_to_vertical_align(value->to_identifier()).release_value();
 
     if (value->is_length())
-        return CSS::LengthPercentage(value->to_length());
+        return CSS::LengthPercentage(value->as_length().length());
 
     if (value->is_percentage())
         return CSS::LengthPercentage(value->as_percentage().percentage());

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h>
+#include <LibWeb/CSS/StyleValues/NumericStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RectStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ShadowStyleValue.h>
@@ -168,7 +169,7 @@ CSSPixels StyleProperties::line_height(CSSPixelRect const& viewport_rect, Length
     }
 
     if (line_height->is_numeric())
-        return Length(line_height->to_number(), Length::Type::Em).to_px(viewport_rect, font_metrics, root_font_metrics);
+        return Length(line_height->as_numeric().number(), Length::Type::Em).to_px(viewport_rect, font_metrics, root_font_metrics);
 
     if (line_height->is_percentage()) {
         // Percentages are relative to 1em. https://www.w3.org/TR/css-inline-3/#valdef-line-height-percentage
@@ -198,7 +199,7 @@ CSSPixels StyleProperties::line_height(Layout::Node const& layout_node) const
     }
 
     if (line_height->is_numeric())
-        return Length(line_height->to_number(), Length::Type::Em).to_px(layout_node);
+        return Length(line_height->as_numeric().number(), Length::Type::Em).to_px(layout_node);
 
     if (line_height->is_percentage()) {
         // Percentages are relative to 1em. https://www.w3.org/TR/css-inline-3/#valdef-line-height-percentage
@@ -240,8 +241,8 @@ static float resolve_opacity_value(CSS::StyleValue const& value)
 {
     float unclamped_opacity = 1.0f;
 
-    if (value.has_number()) {
-        unclamped_opacity = value.to_number();
+    if (value.is_numeric()) {
+        unclamped_opacity = value.as_numeric().number();
     } else if (value.is_calculated()) {
         auto& calculated = value.as_calculated();
         if (calculated.resolved_type() == CalculatedStyleValue::ResolvedType::Percentage) {
@@ -325,17 +326,17 @@ Optional<CSS::FlexBasisData> StyleProperties::flex_basis() const
 float StyleProperties::flex_grow() const
 {
     auto value = property(CSS::PropertyID::FlexGrow);
-    if (!value->has_number())
+    if (!value->is_numeric())
         return 0;
-    return value->to_number();
+    return value->as_numeric().number();
 }
 
 float StyleProperties::flex_shrink() const
 {
     auto value = property(CSS::PropertyID::FlexShrink);
-    if (!value->has_number())
+    if (!value->is_numeric())
         return 1;
-    return value->to_number();
+    return value->as_numeric().number();
 }
 
 int StyleProperties::order() const
@@ -393,7 +394,7 @@ Vector<CSS::Transformation> StyleProperties::transformations() const
             } else if (transformation_value->is_percentage()) {
                 values.append({ transformation_value->as_percentage().percentage() });
             } else if (transformation_value->is_numeric()) {
-                values.append({ transformation_value->to_number() });
+                values.append({ transformation_value->as_numeric().number() });
             } else if (transformation_value->is_angle()) {
                 values.append({ transformation_value->as_angle().angle() });
             } else {

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -355,7 +355,7 @@ Optional<CSS::ImageRendering> StyleProperties::image_rendering() const
 CSS::Clip StyleProperties::clip() const
 {
     auto value = property(CSS::PropertyID::Clip);
-    if (!value->has_rect())
+    if (!value->is_rect())
         return CSS::Clip::make_auto();
     return CSS::Clip(value->as_rect().rect());
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -224,10 +224,10 @@ Optional<int> StyleProperties::z_index() const
     auto value = property(CSS::PropertyID::ZIndex);
     if (value->has_auto())
         return {};
-    if (value->has_integer()) {
+    if (value->is_numeric() && value->as_numeric().has_integer()) {
         // Clamp z-index to the range of a signed 32-bit integer for consistency with other engines.
         // NOTE: Casting between 32-bit float and 32-bit integer is finicky here, since INT32_MAX is not representable as a 32-bit float!
-        auto integer = value->to_integer();
+        auto integer = value->as_numeric().integer();
         if (integer >= static_cast<float>(NumericLimits<int>::max()))
             return NumericLimits<int>::max();
         if (integer <= static_cast<float>(NumericLimits<int>::min()))
@@ -342,9 +342,9 @@ float StyleProperties::flex_shrink() const
 int StyleProperties::order() const
 {
     auto value = property(CSS::PropertyID::Order);
-    if (!value->has_integer())
+    if (!value->is_numeric() || !value->as_numeric().has_integer())
         return 0;
-    return value->to_integer();
+    return value->as_numeric().integer();
 }
 
 Optional<CSS::ImageRendering> StyleProperties::image_rendering() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -395,8 +395,8 @@ int StyleValue::to_font_weight() const
             return Gfx::FontWeight::Regular;
         }
     }
-    if (has_integer()) {
-        return to_integer();
+    if (is_numeric() && as_numeric().has_integer()) {
+        return as_numeric().integer();
     }
     if (is_calculated()) {
         auto maybe_weight = const_cast<CalculatedStyleValue&>(as_calculated()).resolve_integer();

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -293,13 +293,11 @@ public:
 
     bool has_auto() const;
     virtual bool has_color() const { return false; }
-    virtual bool has_length() const { return false; }
 
     virtual ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const;
 
     virtual Color to_color(Optional<Layout::NodeWithStyle const&>) const { return {}; }
     ValueID to_identifier() const;
-    virtual Length to_length() const { VERIFY_NOT_REACHED(); }
     virtual ErrorOr<String> to_string() const = 0;
 
     [[nodiscard]] int to_font_weight() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -294,14 +294,12 @@ public:
     bool has_auto() const;
     virtual bool has_color() const { return false; }
     virtual bool has_length() const { return false; }
-    virtual bool has_integer() const { return false; }
 
     virtual ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const;
 
     virtual Color to_color(Optional<Layout::NodeWithStyle const&>) const { return {}; }
     ValueID to_identifier() const;
     virtual Length to_length() const { VERIFY_NOT_REACHED(); }
-    virtual float to_integer() const { return 0; }
     virtual ErrorOr<String> to_string() const = 0;
 
     [[nodiscard]] int to_font_weight() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -294,7 +294,6 @@ public:
     bool has_auto() const;
     virtual bool has_color() const { return false; }
     virtual bool has_length() const { return false; }
-    virtual bool has_number() const { return false; }
     virtual bool has_integer() const { return false; }
 
     virtual ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const;
@@ -302,7 +301,6 @@ public:
     virtual Color to_color(Optional<Layout::NodeWithStyle const&>) const { return {}; }
     ValueID to_identifier() const;
     virtual Length to_length() const { VERIFY_NOT_REACHED(); }
-    virtual float to_number() const { return 0; }
     virtual float to_integer() const { return 0; }
     virtual ErrorOr<String> to_string() const = 0;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -294,7 +294,6 @@ public:
     bool has_auto() const;
     virtual bool has_color() const { return false; }
     virtual bool has_length() const { return false; }
-    virtual bool has_rect() const { return false; }
     virtual bool has_number() const { return false; }
     virtual bool has_integer() const { return false; }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
@@ -20,9 +20,7 @@ public:
 
     Length const& length() const { return m_length; }
 
-    virtual bool has_length() const override { return true; }
     virtual ErrorOr<String> to_string() const override { return m_length.to_string(); }
-    virtual Length to_length() const override { return m_length; }
     virtual ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
 
     bool properties_equal(LengthStyleValue const& other) const { return m_length == other.m_length; }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/NumericStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/NumericStyleValue.h
@@ -25,11 +25,10 @@ public:
         return adopt_nonnull_ref_or_enomem(new (nothrow) NumericStyleValue(value));
     }
 
-    virtual bool has_length() const override { return to_number() == 0; }
+    virtual bool has_length() const override { return number() == 0; }
     virtual Length to_length() const override { return Length::make_px(0); }
 
-    virtual bool has_number() const override { return true; }
-    virtual float to_number() const override
+    float number() const
     {
         return m_value.visit(
             [](float value) { return value; },

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/NumericStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/NumericStyleValue.h
@@ -25,9 +25,6 @@ public:
         return adopt_nonnull_ref_or_enomem(new (nothrow) NumericStyleValue(value));
     }
 
-    virtual bool has_length() const override { return number() == 0; }
-    virtual Length to_length() const override { return Length::make_px(0); }
-
     float number() const
     {
         return m_value.visit(

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/NumericStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/NumericStyleValue.h
@@ -35,8 +35,8 @@ public:
             [](i64 value) { return (float)value; });
     }
 
-    virtual bool has_integer() const override { return m_value.has<i64>(); }
-    virtual float to_integer() const override { return m_value.get<i64>(); }
+    bool has_integer() const { return m_value.has<i64>(); }
+    float integer() const { return m_value.get<i64>(); }
 
     virtual ErrorOr<String> to_string() const override;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/RectStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/RectStyleValue.h
@@ -21,7 +21,6 @@ public:
 
     EdgeRect rect() const { return m_rect; }
     virtual ErrorOr<String> to_string() const override;
-    virtual bool has_rect() const override { return true; }
 
     bool properties_equal(RectStyleValue const& other) const { return m_rect == other.m_rect; }
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EdgeStyleValue.h>
+#include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumericStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
@@ -294,7 +295,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     //       m_font is used by Length::to_px() when resolving sizes against this layout node.
     //       That's why it has to be set before everything else.
     m_font = computed_style.computed_font();
-    computed_values.set_font_size(computed_style.property(CSS::PropertyID::FontSize)->to_length().to_px(*this).value());
+    computed_values.set_font_size(computed_style.property(CSS::PropertyID::FontSize)->as_length().length().to_px(*this).value());
     computed_values.set_font_weight(computed_style.property(CSS::PropertyID::FontWeight)->as_numeric().integer());
     m_line_height = computed_style.line_height(*this);
 
@@ -625,8 +626,8 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
                 auto value = computed_style.property(width_property);
                 if (value->is_calculated())
                     return value->as_calculated().resolve_length(*this)->to_px(*this).value();
-                if (value->has_length())
-                    return value->to_length().to_px(*this).value();
+                if (value->is_length())
+                    return value->as_length().length().to_px(*this).value();
                 if (value->is_identifier()) {
                     // https://www.w3.org/TR/css-backgrounds-3/#valdef-line-width-thin
                     switch (value->to_identifier()) {
@@ -679,7 +680,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     if (stroke_width->is_numeric())
         computed_values.set_stroke_width(CSS::Length::make_px(stroke_width->as_numeric().number()));
     else if (stroke_width->is_length())
-        computed_values.set_stroke_width(stroke_width->to_length());
+        computed_values.set_stroke_width(stroke_width->as_length().length());
     else if (stroke_width->is_percentage())
         computed_values.set_stroke_width(CSS::LengthPercentage { stroke_width->as_percentage().percentage() });
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EdgeStyleValue.h>
+#include <LibWeb/CSS/StyleValues/NumericStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
 #include <LibWeb/CSS/StyleValues/URLStyleValue.h>
@@ -676,7 +677,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     // FIXME: Converting to pixels isn't really correct - values should be in "user units"
     //        https://svgwg.org/svg2-draft/coords.html#TermUserUnits
     if (stroke_width->is_numeric())
-        computed_values.set_stroke_width(CSS::Length::make_px(stroke_width->to_number()));
+        computed_values.set_stroke_width(CSS::Length::make_px(stroke_width->as_numeric().number()));
     else if (stroke_width->is_length())
         computed_values.set_stroke_width(stroke_width->to_length());
     else if (stroke_width->is_percentage())

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -295,7 +295,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     //       That's why it has to be set before everything else.
     m_font = computed_style.computed_font();
     computed_values.set_font_size(computed_style.property(CSS::PropertyID::FontSize)->to_length().to_px(*this).value());
-    computed_values.set_font_weight(computed_style.property(CSS::PropertyID::FontWeight)->to_integer());
+    computed_values.set_font_weight(computed_style.property(CSS::PropertyID::FontWeight)->as_numeric().integer());
     m_line_height = computed_style.line_height(*this);
 
     computed_values.set_vertical_align(computed_style.vertical_align());


### PR DESCRIPTION
Now that the Parser only creates StyleValues that a property accepts, we don't need StyleValues to pretend to be other kinds of StyleValue for situations where the grammar is ambiguous.

This does make the code slightly more verbose, but I think that's still an improvement.

I would like to also move the color-related code out of IdentifierStyleValue, but that requires a bit more thought.