### PR TITLE
HackStudio: Migrate from DeprecatedFile to File and FileSystem

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1868,7 +1868,7 @@ void HackStudioWidget::change_editor_font(RefPtr<Gfx::Font const> font)
     Config::write_i32("HackStudio"sv, "EditorFont"sv, "Size"sv, m_editor_font->presentation_size());
 }
 
-void HackStudioWidget::open_coredump(DeprecatedString const& coredump_path)
+void HackStudioWidget::open_coredump(StringView coredump_path)
 {
     open_project("/usr/src/serenity");
     m_mode = Mode::Coredump;

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -75,7 +75,7 @@ public:
         Coredump
     };
 
-    void open_coredump(DeprecatedString const& coredump_path);
+    void open_coredump(StringView coredump_path);
     void debug_process(pid_t pid);
     void for_each_open_file(Function<void(ProjectFile const&)>);
     bool semantic_syntax_highlighting_is_enabled() const;

--- a/Userland/Libraries/LibCoredump/Inspector.cpp
+++ b/Userland/Libraries/LibCoredump/Inspector.cpp
@@ -8,7 +8,7 @@
 
 namespace Coredump {
 
-OwnPtr<Inspector> Inspector::create(DeprecatedString const& coredump_path, Function<void(float)> on_progress)
+OwnPtr<Inspector> Inspector::create(StringView coredump_path, Function<void(float)> on_progress)
 {
     auto reader = Reader::create(coredump_path);
     if (!reader)

--- a/Userland/Libraries/LibCoredump/Inspector.h
+++ b/Userland/Libraries/LibCoredump/Inspector.h
@@ -17,7 +17,7 @@ class Inspector : public Debug::ProcessInspector {
     AK_MAKE_NONMOVABLE(Inspector);
 
 public:
-    static OwnPtr<Inspector> create(DeprecatedString const& coredump_path, Function<void(float)> on_progress = {});
+    static OwnPtr<Inspector> create(StringView coredump_path, Function<void(float)> on_progress = {});
     virtual ~Inspector() override = default;
 
     // ^Debug::ProcessInspector


### PR DESCRIPTION
This also avoids an unnecessary `realpath` call in some cases, so perhaps HackStudio starts a nanosecond faster now.

Advances https://github.com/SerenityOS/serenity/issues/17129.

Please note that after my PRs, there are only one to four callers to DeprecatedFile left :partying_face: 

Please also review and merge #18529.