### PR TITLE
LibWeb: Implement remaining CSS math functions

### DIFF
--- a/Tests/LibWeb/Layout/expected/acid1.txt
+++ b/Tests/LibWeb/Layout/expected/acid1.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <dl> at (25,25) content-size 470x0 children: inline
         TextNode <#text>
-        BlockContainer <dt> at (40,40) content-size 49.998596x280 floating [BFC] children: inline
+        BlockContainer <dt> at (40,40) content-size 49.998597x280 floating [BFC] children: inline
           line 0 width: 28.310546, height: 10, bottom: 10, baseline: 7.998046
             frag 0 from TextNode start: 0, length: 6, rect: [40,40 28.310546x10]
               "toggle"

--- a/Tests/LibWeb/Layout/expected/flex-item-vertical-padding-relative-to-flex-container-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-vertical-padding-relative-to-flex-container-width.txt
@@ -6,9 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.flex-container> at (11,11) content-size 600x10 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> at (11,11) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.flex-item> at (12,71.999996) content-size 27.15625x18.000010 flex-item [BFC] children: inline
+        BlockContainer <div.flex-item> at (12,72) content-size 27.15625x18 flex-item [BFC] children: inline
           line 0 width: 27.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [12,71.999996 27.15625x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [12,72 27.15625x17.46875]
               "foo"
           TextNode <#text>
         BlockContainer <(anonymous)> at (11,11) content-size 0x0 [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-shrink-2.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-2.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.container> at (9,9) content-size 500x102 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 47.000011x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,10) content-size 47x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (59.000011,10) content-size 164.666666x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (59,10) content-size 164.666666x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [59.000011,10 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [59,10 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (225.666678,10) content-size 282.333321x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (225.666666,10) content-size 282.333333x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [225.666678,10 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [225.666666,10 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/borders.txt
+++ b/Tests/LibWeb/Layout/expected/grid/borders.txt
@@ -103,14 +103,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,275.34375) content-size 784x90.9375 [GFC] children: not-inline
         BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (444.199997,285.34375) content-size 337.800002x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (444.2,285.34375) content-size 337.8x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [444.199997,285.34375 6.34375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [444.2,285.34375 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (18,338.8125) content-size 337.800002x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (18,338.8125) content-size 337.8x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [18,338.8125 8.8125x17.46875]
               "2"

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
@@ -2,12 +2,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x50.9375 children: not-inline
       Box <div.container> at (8,8) content-size 784x50.9375 [GFC] children: not-inline
-        BlockContainer <div.item> at (434.199997,8) content-size 357.800002x17.46875 [BFC] children: inline
+        BlockContainer <div.item> at (434.2,8) content-size 357.8x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [434.199997,8 6.34375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [434.2,8 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <div.item> at (8,41.46875) content-size 357.800002x17.46875 [BFC] children: inline
+        BlockContainer <div.item> at (8,41.46875) content-size 357.8x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,41.46875 8.8125x17.46875]
               "2"

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width.txt
@@ -2,12 +2,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
-        BlockContainer <div.first> at (8,8) content-size 313.599981x17.46875 [BFC] children: inline
+        BlockContainer <div.first> at (8,8) content-size 313.6x17.46875 [BFC] children: inline
           line 0 width: 42.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 5, rect: [8,8 42.140625x17.46875]
               "First"
           TextNode <#text>
-        BlockContainer <div.second> at (400,8) content-size 78.399995x17.46875 [BFC] children: inline
+        BlockContainer <div.second> at (400,8) content-size 78.4x17.46875 [BFC] children: inline
           line 0 width: 57.40625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 6, rect: [400,8 57.40625x17.46875]
               "Second"

--- a/Tests/LibWeb/Layout/expected/vertical-padding-relative-to-cb-width.txt
+++ b/Tests/LibWeb/Layout/expected/vertical-padding-relative-to-cb-width.txt
@@ -6,9 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.cb> at (11,11) content-size 600x10 children: not-inline
         BlockContainer <(anonymous)> at (11,11) content-size 600x0 children: inline
           TextNode <#text>
-        BlockContainer <div.foo> at (12,71.999996) content-size 598x18.000010 children: inline
+        BlockContainer <div.foo> at (12,72) content-size 598x18 children: inline
           line 0 width: 27.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [12,71.999996 27.15625x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [12,72 27.15625x17.46875]
               "foo"
           TextNode <#text>
         BlockContainer <(anonymous)> at (11,211) content-size 600x17.46875 children: inline

--- a/Userland/Libraries/LibWeb/CSS/Angle.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Angle.cpp
@@ -52,6 +52,11 @@ double Angle::to_degrees() const
     VERIFY_NOT_REACHED();
 }
 
+double Angle::to_radians() const
+{
+    return to_degrees() * (AK::Pi<double> / 180.0);
+}
+
 StringView Angle::unit_name() const
 {
     switch (m_type) {

--- a/Userland/Libraries/LibWeb/CSS/Angle.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Angle.cpp
@@ -34,7 +34,7 @@ Angle Angle::percentage_of(Percentage const& percentage) const
 
 ErrorOr<String> Angle::to_string() const
 {
-    return String::formatted("{}{}", m_value, unit_name());
+    return String::formatted("{}deg", to_degrees());
 }
 
 double Angle::to_degrees() const

--- a/Userland/Libraries/LibWeb/CSS/Angle.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Angle.cpp
@@ -16,13 +16,13 @@ Angle::Angle(int value, Type type)
 {
 }
 
-Angle::Angle(float value, Type type)
+Angle::Angle(double value, Type type)
     : m_type(type)
     , m_value(value)
 {
 }
 
-Angle Angle::make_degrees(float value)
+Angle Angle::make_degrees(double value)
 {
     return { value, Type::Deg };
 }
@@ -37,17 +37,17 @@ ErrorOr<String> Angle::to_string() const
     return String::formatted("{}{}", m_value, unit_name());
 }
 
-float Angle::to_degrees() const
+double Angle::to_degrees() const
 {
     switch (m_type) {
     case Type::Deg:
         return m_value;
     case Type::Grad:
-        return m_value * (360.0f / 400.0f);
+        return m_value * (360.0 / 400.0);
     case Type::Rad:
-        return m_value * (180.0f / AK::Pi<float>);
+        return m_value * (180.0 / AK::Pi<double>);
     case Type::Turn:
-        return m_value * 360.0f;
+        return m_value * 360.0;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/Angle.h
+++ b/Userland/Libraries/LibWeb/CSS/Angle.h
@@ -23,15 +23,15 @@ public:
     static Optional<Type> unit_from_name(StringView);
 
     Angle(int value, Type type);
-    Angle(float value, Type type);
-    static Angle make_degrees(float);
+    Angle(double value, Type type);
+    static Angle make_degrees(double);
     Angle percentage_of(Percentage const&) const;
 
     ErrorOr<String> to_string() const;
-    float to_degrees() const;
+    double to_degrees() const;
 
     Type type() const { return m_type; }
-    float raw_value() const { return m_value; }
+    double raw_value() const { return m_value; }
 
     bool operator==(Angle const& other) const
     {
@@ -42,7 +42,7 @@ private:
     StringView unit_name() const;
 
     Type m_type;
-    float m_value { 0 };
+    double m_value { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Angle.h
+++ b/Userland/Libraries/LibWeb/CSS/Angle.h
@@ -29,6 +29,7 @@ public:
 
     ErrorOr<String> to_string() const;
     double to_degrees() const;
+    double to_radians() const;
 
     Type type() const { return m_type; }
     double raw_value() const { return m_value; }

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -86,6 +86,7 @@ public:
     static CSS::Size row_gap() { return CSS::Size::make_auto(); }
     static CSS::BorderCollapse border_collapse() { return CSS::BorderCollapse::Separate; }
     static Vector<Vector<String>> grid_template_areas() { return {}; }
+    static CSS::LengthPercentage letter_spacing() { return CSS::Length::make_px(0); }
 };
 
 enum class BackgroundSize {
@@ -304,6 +305,8 @@ public:
     int font_weight() const { return m_inherited.font_weight; }
     CSS::FontVariant font_variant() const { return m_inherited.font_variant; }
 
+    CSS::LengthPercentage letter_spacing() const { return m_inherited.letter_spacing; }
+
     ComputedValues clone_inherited_values() const
     {
         ComputedValues clone;
@@ -334,6 +337,7 @@ protected:
         float fill_opacity { InitialValues::fill_opacity() };
         float stroke_opacity { InitialValues::stroke_opacity() };
         Optional<LengthPercentage> stroke_width;
+        CSS::LengthPercentage letter_spacing { InitialValues::letter_spacing() };
     } m_inherited;
 
     struct {
@@ -447,6 +451,7 @@ public:
     void set_padding(const CSS::LengthBox& padding) { m_noninherited.padding = padding; }
     void set_overflow_x(CSS::Overflow value) { m_noninherited.overflow_x = value; }
     void set_overflow_y(CSS::Overflow value) { m_noninherited.overflow_y = value; }
+    void set_letter_spacing(CSS::LengthPercentage value) { m_inherited.letter_spacing = value; }
     void set_list_style_type(CSS::ListStyleType value) { m_inherited.list_style_type = value; }
     void set_display(CSS::Display value) { m_noninherited.display = value; }
     void set_backdrop_filter(CSS::BackdropFilter backdrop_filter) { m_noninherited.backdrop_filter = move(backdrop_filter); }

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -87,6 +87,7 @@ public:
     static CSS::BorderCollapse border_collapse() { return CSS::BorderCollapse::Separate; }
     static Vector<Vector<String>> grid_template_areas() { return {}; }
     static CSS::LengthPercentage letter_spacing() { return CSS::Length::make_px(0); }
+    static CSS::Time transition_delay() { return CSS::Time::make_seconds(0); }
 };
 
 enum class BackgroundSize {
@@ -306,6 +307,7 @@ public:
     CSS::FontVariant font_variant() const { return m_inherited.font_variant; }
 
     CSS::LengthPercentage letter_spacing() const { return m_inherited.letter_spacing; }
+    CSS::Time transition_delay() const { return m_noninherited.transition_delay; }
 
     ComputedValues clone_inherited_values() const
     {
@@ -407,6 +409,7 @@ protected:
         Vector<Vector<String>> grid_template_areas { InitialValues::grid_template_areas() };
         Gfx::Color stop_color { InitialValues::stop_color() };
         float stop_opacity { InitialValues::stop_opacity() };
+        CSS::Time transition_delay { InitialValues::transition_delay() };
     } m_noninherited;
 };
 
@@ -494,6 +497,7 @@ public:
     void set_row_gap(CSS::Size const& row_gap) { m_noninherited.row_gap = row_gap; }
     void set_border_collapse(CSS::BorderCollapse const& border_collapse) { m_noninherited.border_collapse = border_collapse; }
     void set_grid_template_areas(Vector<Vector<String>> const& grid_template_areas) { m_noninherited.grid_template_areas = grid_template_areas; }
+    void set_transition_delay(CSS::Time const& transition_delay) { m_noninherited.transition_delay = transition_delay; }
 
     void set_fill(SVGPaint value) { m_inherited.fill = value; }
     void set_stroke(SVGPaint value) { m_inherited.stroke = value; }

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -141,7 +141,7 @@ public:
     bool operator==(BorderData const&) const = default;
 };
 
-using TransformValue = Variant<CSS::AngleOrCalculated, CSS::LengthPercentage, float>;
+using TransformValue = Variant<CSS::AngleOrCalculated, CSS::LengthPercentage, double>;
 
 struct Transformation {
     CSS::TransformFunction function;

--- a/Userland/Libraries/LibWeb/CSS/Frequency.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Frequency.cpp
@@ -33,7 +33,7 @@ Frequency Frequency::percentage_of(Percentage const& percentage) const
 
 ErrorOr<String> Frequency::to_string() const
 {
-    return String::formatted("{}{}", m_value, unit_name());
+    return String::formatted("{}hz", to_hertz());
 }
 
 double Frequency::to_hertz() const

--- a/Userland/Libraries/LibWeb/CSS/Frequency.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Frequency.cpp
@@ -15,13 +15,13 @@ Frequency::Frequency(int value, Type type)
 {
 }
 
-Frequency::Frequency(float value, Type type)
+Frequency::Frequency(double value, Type type)
     : m_type(type)
     , m_value(value)
 {
 }
 
-Frequency Frequency::make_hertz(float value)
+Frequency Frequency::make_hertz(double value)
 {
     return { value, Type::Hz };
 }
@@ -36,7 +36,7 @@ ErrorOr<String> Frequency::to_string() const
     return String::formatted("{}{}", m_value, unit_name());
 }
 
-float Frequency::to_hertz() const
+double Frequency::to_hertz() const
 {
     switch (m_type) {
     case Type::Hz:

--- a/Userland/Libraries/LibWeb/CSS/Frequency.h
+++ b/Userland/Libraries/LibWeb/CSS/Frequency.h
@@ -20,15 +20,15 @@ public:
     static Optional<Type> unit_from_name(StringView);
 
     Frequency(int value, Type type);
-    Frequency(float value, Type type);
-    static Frequency make_hertz(float);
+    Frequency(double value, Type type);
+    static Frequency make_hertz(double);
     Frequency percentage_of(Percentage const&) const;
 
     ErrorOr<String> to_string() const;
-    float to_hertz() const;
+    double to_hertz() const;
 
     Type type() const { return m_type; }
-    float raw_value() const { return m_value; }
+    double raw_value() const { return m_value; }
 
     bool operator==(Frequency const& other) const
     {
@@ -39,7 +39,7 @@ private:
     StringView unit_name() const;
 
     Type m_type;
-    float m_value { 0 };
+    double m_value { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Number.h
+++ b/Userland/Libraries/LibWeb/CSS/Number.h
@@ -25,21 +25,21 @@ public:
         , m_type(Type::Number)
     {
     }
-    Number(Type type, float value)
+    Number(Type type, double value)
         : m_value(value)
         , m_type(type)
     {
     }
 
     Type type() const { return m_type; }
-    float value() const { return m_value; }
+    double value() const { return m_value; }
     i64 integer_value() const
     {
         // https://www.w3.org/TR/css-values-4/#numeric-types
         // When a value cannot be explicitly supported due to range/precision limitations, it must be converted
         // to the closest value supported by the implementation, but how the implementation defines "closest"
         // is explicitly undefined as well.
-        return llroundf(m_value);
+        return llround(m_value);
     }
     bool is_integer() const { return m_type == Type::Integer || m_type == Type::IntegerWithExplicitSign; }
     bool is_integer_with_explicit_sign() const { return m_type == Type::IntegerWithExplicitSign; }
@@ -83,7 +83,7 @@ public:
     }
 
 private:
-    float m_value { 0 };
+    double m_value { 0 };
     Type m_type;
 };
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -6426,12 +6426,14 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_transform_value(Vector<ComponentValue>
 
             auto const& value = argument_tokens.next_token();
             RefPtr<CalculatedStyleValue> maybe_calc_value;
-            if (auto maybe_dynamic_value = TRY(parse_dynamic_value(value))) {
+            auto maybe_dynamic_value = parse_dynamic_value(value);
+            if (!maybe_dynamic_value.is_error()) {
                 // TODO: calc() is the only dynamic value we support for now, but more will come later.
                 // FIXME: Actually, calc() should probably be parsed inside parse_dimension_value() etc,
                 //        so that it affects every use instead of us having to manually implement it.
-                VERIFY(maybe_dynamic_value->is_calculated());
-                maybe_calc_value = maybe_dynamic_value->as_calculated();
+                auto dynamic_value = maybe_dynamic_value.release_value();
+                VERIFY(dynamic_value->is_calculated());
+                maybe_calc_value = dynamic_value->as_calculated();
             }
 
             switch (function_metadata.parameters[argument_index].type) {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -7687,8 +7687,10 @@ ErrorOr<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readonl
                 break;
             case CalculatedStyleValue::ResolvedType::Integer:
             case CalculatedStyleValue::ResolvedType::Number:
-                if (property_accepts_numeric)
-                    return PropertyAndValue { property_accepting_integer.value_or(property_accepting_number.value()), calculated };
+                if (property_accepts_numeric) {
+                    auto property_or_resolved = property_accepting_integer.value_or_lazy_evaluated([property_accepting_number]() { return property_accepting_number.value(); });
+                    return PropertyAndValue { property_or_resolved, calculated };
+                }
                 break;
             case CalculatedStyleValue::ResolvedType::Length:
                 if (auto property = any_property_accepts_type(property_ids, ValueType::Length); property.has_value())

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3713,6 +3713,24 @@ ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_acos_function(Function con
     return TRY(AcosCalculationNode::create(move(node_a)));
 }
 
+ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_atan_function(Function const& function)
+{
+    TokenStream stream { function.values() };
+    auto parameters = parse_a_comma_separated_list_of_component_values(stream);
+
+    if (parameters.size() != 1) {
+        return Error::from_string_view("atan() must have exactly one parameter"sv);
+    }
+
+    auto node_a = TRY(parse_a_calculation(parameters[0]));
+    auto resolved_type = node_a->resolved_type().value();
+
+    if (resolved_type != CalculatedStyleValue::ResolvedType::Number)
+        return Error::from_string_view("atan() parameter must be a number"sv);
+
+    return TRY(AtanCalculationNode::create(move(node_a)));
+}
+
 ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_a_function_node(Function const& function)
 {
     if (function.name().equals_ignoring_ascii_case("calc"sv))
@@ -3756,6 +3774,9 @@ ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_a_function_node(Function c
 
     if (function.name().equals_ignoring_ascii_case("acos"sv))
         return TRY(parse_acos_function(function));
+
+    if (function.name().equals_ignoring_ascii_case("atan"sv))
+        return TRY(parse_atan_function(function));
 
     dbgln_if(CSS_PARSER_DEBUG, "We didn't implement `{}` function yet", function.name());
     return Error::from_string_view("Unknown function"sv);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3610,6 +3610,19 @@ ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_abs_function(Function cons
     return TRY(AbsCalculationNode::create(move(node_a)));
 }
 
+ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_sign_function(Function const& function)
+{
+    TokenStream stream { function.values() };
+    auto parameters = parse_a_comma_separated_list_of_component_values(stream);
+
+    if (parameters.size() != 1) {
+        return Error::from_string_view("sign() must have exactly one parameter"sv);
+    }
+
+    auto node_a = TRY(parse_a_calculation(parameters[0]));
+    return TRY(SignCalculationNode::create(move(node_a)));
+}
+
 ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_a_function_node(Function const& function)
 {
     if (function.name().equals_ignoring_ascii_case("calc"sv))
@@ -3635,6 +3648,9 @@ ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_a_function_node(Function c
 
     if (function.name().equals_ignoring_ascii_case("abs"sv))
         return TRY(parse_abs_function(function));
+
+    if (function.name().equals_ignoring_ascii_case("sign"sv))
+        return TRY(parse_sign_function(function));
 
     dbgln_if(CSS_PARSER_DEBUG, "We didn't implement `{}` function yet", function.name());
     return Error::from_string_view("Unknown function"sv);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3695,6 +3695,24 @@ ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_asin_function(Function con
     return TRY(AsinCalculationNode::create(move(node_a)));
 }
 
+ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_acos_function(Function const& function)
+{
+    TokenStream stream { function.values() };
+    auto parameters = parse_a_comma_separated_list_of_component_values(stream);
+
+    if (parameters.size() != 1) {
+        return Error::from_string_view("acos() must have exactly one parameter"sv);
+    }
+
+    auto node_a = TRY(parse_a_calculation(parameters[0]));
+    auto resolved_type = node_a->resolved_type().value();
+
+    if (resolved_type != CalculatedStyleValue::ResolvedType::Number)
+        return Error::from_string_view("acos() parameter must be a number"sv);
+
+    return TRY(AcosCalculationNode::create(move(node_a)));
+}
+
 ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_a_function_node(Function const& function)
 {
     if (function.name().equals_ignoring_ascii_case("calc"sv))
@@ -3735,6 +3753,9 @@ ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_a_function_node(Function c
 
     if (function.name().equals_ignoring_ascii_case("asin"sv))
         return TRY(parse_asin_function(function));
+
+    if (function.name().equals_ignoring_ascii_case("acos"sv))
+        return TRY(parse_acos_function(function));
 
     dbgln_if(CSS_PARSER_DEBUG, "We didn't implement `{}` function yet", function.name());
     return Error::from_string_view("Unknown function"sv);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -7973,6 +7973,34 @@ ErrorOr<OwnPtr<CalculationNode>> Parser::parse_a_calculation(Vector<ComponentVal
             }
         }
 
+        if (value.is(Token::Type::Ident)) {
+            if (value.token().ident().equals_ignoring_ascii_case("e"sv)) {
+                TRY(values.try_append({ TRY(ConstantCalculationNode::create(CalculationNode::ConstantType::E)) }));
+                continue;
+            }
+
+            if (value.token().ident().equals_ignoring_ascii_case("pi"sv)) {
+                TRY(values.try_append({ TRY(ConstantCalculationNode::create(CalculationNode::ConstantType::PI)) }));
+                continue;
+            }
+
+            if (value.token().ident().equals_ignoring_ascii_case("infinity"sv)) {
+                TRY(values.try_append({ TRY(ConstantCalculationNode::create(CalculationNode::ConstantType::Infinity)) }));
+                continue;
+            }
+
+            if (value.token().ident().equals_ignoring_ascii_case("-infinity"sv)) {
+                TRY(values.try_append({ TRY(ConstantCalculationNode::create(CalculationNode::ConstantType::MinusInfinity)) }));
+                continue;
+            }
+
+            // Note: NaN is case sensitive.
+            if (value.token().ident() == "NaN"sv) {
+                TRY(values.try_append({ TRY(ConstantCalculationNode::create(CalculationNode::ConstantType::NaN)) }));
+                continue;
+            }
+        }
+
         if (value.is(Token::Type::Number)) {
             TRY(values.try_append({ TRY(NumericCalculationNode::create(value.token().number())) }));
             continue;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3623,6 +3623,24 @@ ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_sign_function(Function con
     return TRY(SignCalculationNode::create(move(node_a)));
 }
 
+ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_sin_function(Function const& function)
+{
+    TokenStream stream { function.values() };
+    auto parameters = parse_a_comma_separated_list_of_component_values(stream);
+
+    if (parameters.size() != 1) {
+        return Error::from_string_view("sin() must have exactly one parameter"sv);
+    }
+
+    auto node_a = TRY(parse_a_calculation(parameters[0]));
+    auto resolved_type = node_a->resolved_type().value();
+
+    if (resolved_type != CalculatedStyleValue::ResolvedType::Number && resolved_type != CalculatedStyleValue::ResolvedType::Angle)
+        return Error::from_string_view("sin() parameter must be a number or angle"sv);
+
+    return TRY(SinCalculationNode::create(move(node_a)));
+}
+
 ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_a_function_node(Function const& function)
 {
     if (function.name().equals_ignoring_ascii_case("calc"sv))
@@ -3651,6 +3669,9 @@ ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_a_function_node(Function c
 
     if (function.name().equals_ignoring_ascii_case("sign"sv))
         return TRY(parse_sign_function(function));
+
+    if (function.name().equals_ignoring_ascii_case("sin"sv))
+        return TRY(parse_sin_function(function));
 
     dbgln_if(CSS_PARSER_DEBUG, "We didn't implement `{}` function yet", function.name());
     return Error::from_string_view("Unknown function"sv);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3677,6 +3677,24 @@ ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_tan_function(Function cons
     return TRY(TanCalculationNode::create(move(node_a)));
 }
 
+ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_asin_function(Function const& function)
+{
+    TokenStream stream { function.values() };
+    auto parameters = parse_a_comma_separated_list_of_component_values(stream);
+
+    if (parameters.size() != 1) {
+        return Error::from_string_view("asin() must have exactly one parameter"sv);
+    }
+
+    auto node_a = TRY(parse_a_calculation(parameters[0]));
+    auto resolved_type = node_a->resolved_type().value();
+
+    if (resolved_type != CalculatedStyleValue::ResolvedType::Number)
+        return Error::from_string_view("asin() parameter must be a number"sv);
+
+    return TRY(AsinCalculationNode::create(move(node_a)));
+}
+
 ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_a_function_node(Function const& function)
 {
     if (function.name().equals_ignoring_ascii_case("calc"sv))
@@ -3714,6 +3732,9 @@ ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_a_function_node(Function c
 
     if (function.name().equals_ignoring_ascii_case("tan"sv))
         return TRY(parse_tan_function(function));
+
+    if (function.name().equals_ignoring_ascii_case("asin"sv))
+        return TRY(parse_asin_function(function));
 
     dbgln_if(CSS_PARSER_DEBUG, "We didn't implement `{}` function yet", function.name());
     return Error::from_string_view("Unknown function"sv);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3597,6 +3597,19 @@ ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_rem_function(Function cons
     return TRY(RemCalculationNode::create(move(node_a), move(node_b)));
 }
 
+ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_abs_function(Function const& function)
+{
+    TokenStream stream { function.values() };
+    auto parameters = parse_a_comma_separated_list_of_component_values(stream);
+
+    if (parameters.size() != 1) {
+        return Error::from_string_view("abs() must have exactly one parameter"sv);
+    }
+
+    auto node_a = TRY(parse_a_calculation(parameters[0]));
+    return TRY(AbsCalculationNode::create(move(node_a)));
+}
+
 ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_a_function_node(Function const& function)
 {
     if (function.name().equals_ignoring_ascii_case("calc"sv))
@@ -3619,6 +3632,9 @@ ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::parse_a_function_node(Function c
 
     if (function.name().equals_ignoring_ascii_case("rem"sv))
         return TRY(parse_rem_function(function));
+
+    if (function.name().equals_ignoring_ascii_case("abs"sv))
+        return TRY(parse_abs_function(function));
 
     dbgln_if(CSS_PARSER_DEBUG, "We didn't implement `{}` function yet", function.name());
     return Error::from_string_view("Unknown function"sv);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -8048,8 +8048,108 @@ ErrorOr<OwnPtr<CalculationNode>> Parser::parse_a_calculation(Vector<ComponentVal
     if (parsing_failed_for_child_node)
         return nullptr;
 
-    // FIXME: 6. Return the result of simplifying a calculation tree from values.
-    return single_value.release_value();
+    // 6. Return the result of simplifying a calculation tree from values.
+    return simplify_a_calculation(single_value.release_value());
+}
+
+// https://drafts.csswg.org/css-values-4/#calc-simplification
+ErrorOr<NonnullOwnPtr<CalculationNode>> Parser::simplify_a_calculation(NonnullOwnPtr<CalculationNode> root)
+{
+    // 1. If root is a numeric value:
+    if (root->type() == CalculationNode::Type::Numeric) {
+        // FIXME: 1. If root is a percentage that will be resolved against another value,
+        //    and there is enough information available to resolve it, do so,
+        //    and express the resulting numeric value in the appropriate canonical unit.
+        //    Return the value.
+
+        // FIXME: 2. If root is a dimension that is not expressed in its canonical unit,
+        //           and there is enough information available to convert it to the canonical unit,
+        //           do so, and return the value.
+
+        // FIXME: 3. If root is a <calc-constant>, return its numeric value.
+
+        // FIXME: 4. Otherwise, return root.
+        return root;
+    }
+
+    // 2. If root is any other leaf node (not an operator node):
+    if (!root->is_operator_node()) {
+        // FIXME: 1. If there is enough information available to determine its numeric value,
+        //           return its value, expressed in the value’s canonical unit.
+
+        // 2. Otherwise, return root.
+        return root;
+    }
+
+    // FIXME: 3. At this point, root is an operator node. Simplify all the calculation children of root.
+
+    // FIXME: 4. If root is an operator node that’s not one of the calc-operator nodes,
+    //    and all of its calculation children are numeric values with enough information
+    //    to compute the operation root represents, return the result of running root’s operation using its children,
+    //    expressed in the result’s canonical unit.
+
+    // 5. If root is a Min or Max node, attempt to partially simplify it:
+    if (root->type() == CalculationNode::Type::Min || root->type() == CalculationNode::Type::Max) {
+        // FIXME: 1. For each node child of root’s children:
+        // If child is a numeric value with enough information to compare magnitudes with another child of the same unit
+        // (see note in previous step), and there are other children of root that are numeric values with the same unit,
+        // combine all such children with the appropriate operator per root, and replace child with the result,
+        // removing all other child nodes involved.
+
+        // 2. Return root.
+        return root;
+    }
+
+    // 6. If root is a Negate node:
+    if (root->type() == CalculationNode::Type::Negate) {
+        // FIXME: 1. If root’s child is a numeric value, return an equivalent numeric value, but with the value negated (0 - value).
+        // FIXME: 2. If root’s child is a Negate node, return the child’s child.
+
+        // 3. Return root.
+        return root;
+    }
+
+    // 7. If root is an Invert node:
+    if (root->type() == CalculationNode::Type::Invert) {
+        // FIXME: 1. If root’s child is a number (not a percentage or dimension) return the reciprocal of the child’s value.
+        // FIXME: 2. If root’s child is an Invert node, return the child’s child.
+
+        // 3. Return root.
+        return root;
+    }
+
+    // 8. If root is a Sum node:
+    if (root->type() == CalculationNode::Type::Sum) {
+        // FIXME: 1. For each of root’s children that are Sum nodes, replace them with their children.
+        // FIXME: 2. For each set of root’s children that are numeric values with identical units,
+        //           remove those children and replace them with a single numeric value containing the sum of the removed nodes,
+        //           and with the same unit. (E.g. combine numbers, combine percentages, combine px values, etc.)
+
+        // FIXME: 3. If root has only a single child at this point, return the child. Otherwise, return root.
+        return root;
+    }
+
+    // 9. If root is a Product node:
+    if (root->type() == CalculationNode::Type::Product) {
+        // FIXME: 1. For each of root’s children that are Product nodes, replace them with their children.
+        // FIXME: 2. If root has multiple children that are numbers (not percentages or dimensions),
+        //           remove them and replace them with a single number containing the product of the removed nodes.
+        // FIXME: 3. If root contains only two children, one of which is a number (not a percentage or dimension)
+        // and the other of which is a Sum whose children are all numeric values, multiply all of the Sum’s children by the number,
+        // then return the Sum.
+        // FIXME: 4. If root contains only numeric values and/or Invert nodes containing numeric values,
+        //           and multiplying the types of all the children (noting that the type of an Invert node is the inverse of its child’s type)
+        //           results in a type that matches any of the types that a math function can resolve to,
+        //           return the result of multiplying all the values of the children
+        //           (noting that the value of an Invert node is the reciprocal of its child’s value),
+        //           expressed in the result’s canonical unit.
+
+        // 5. Return root
+        return root;
+    }
+
+    // NOTE: The spec stops here, so lets assume this is an invalid state
+    VERIFY_NOT_REACHED();
 }
 
 bool Parser::has_ignored_vendor_prefix(StringView string)

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3432,6 +3432,35 @@ ErrorOr<RefPtr<CalculatedStyleValue>> Parser::parse_calculated_value(Vector<Comp
     return CalculatedStyleValue::create(calculation_tree.release_nonnull(), calc_type.release_value());
 }
 
+ErrorOr<RefPtr<StyleValue>> Parser::parse_min_function(Function const& function)
+{
+    TokenStream stream { function.values() };
+    auto parameters = parse_a_comma_separated_list_of_component_values(stream);
+
+    Vector<NonnullOwnPtr<CalculationNode>> calculated_parameters;
+    calculated_parameters.ensure_capacity(parameters.size());
+
+    CalculatedStyleValue::ResolvedType type;
+    bool first = true;
+    for (auto& parameter : parameters) {
+        auto calculation_node = TRY(parse_a_calculation(parameter));
+
+        if (first) {
+            type = calculation_node->resolved_type().value();
+            first = false;
+        }
+
+        if (calculation_node->resolved_type().value() != type) {
+            return Error::from_string_view("min() parameters must all be of the same type"sv);
+        }
+
+        calculated_parameters.append(calculation_node.release_nonnull());
+    }
+
+    NonnullOwnPtr<CalculationNode> node = TRY(MinCalculationNode::create(move(calculated_parameters)));
+    return CalculatedStyleValue::create(move(node), type);
+}
+
 ErrorOr<RefPtr<StyleValue>> Parser::parse_dynamic_value(ComponentValue const& component_value)
 {
     if (component_value.is_function()) {
@@ -3443,6 +3472,10 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_dynamic_value(ComponentValue const& co
         if (function.name().equals_ignoring_ascii_case("var"sv)) {
             // Declarations using `var()` should already be parsed as an UnresolvedStyleValue before this point.
             VERIFY_NOT_REACHED();
+        }
+
+        if (function.name().equals_ignoring_ascii_case("min"sv)) {
+            return parse_min_function(function);
         }
     }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3490,6 +3490,39 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_max_function(Function const& function)
     return CalculatedStyleValue::create(move(node), type);
 }
 
+ErrorOr<RefPtr<StyleValue>> Parser::parse_clamp_function(Function const& function)
+{
+    TokenStream stream { function.values() };
+    auto parameters = parse_a_comma_separated_list_of_component_values(stream);
+
+    if (parameters.size() != 3) {
+        return Error::from_string_view("clamp() must have exactly three parameters"sv);
+    }
+
+    Vector<NonnullOwnPtr<CalculationNode>> calculated_parameters;
+    calculated_parameters.ensure_capacity(parameters.size());
+
+    CalculatedStyleValue::ResolvedType type;
+    bool first = true;
+    for (auto& parameter : parameters) {
+        auto calculation_node = TRY(parse_a_calculation(parameter));
+
+        if (first) {
+            type = calculation_node->resolved_type().value();
+            first = false;
+        }
+
+        if (calculation_node->resolved_type().value() != type) {
+            return Error::from_string_view("clamp() parameters must all be of the same type"sv);
+        }
+
+        calculated_parameters.append(calculation_node.release_nonnull());
+    }
+
+    NonnullOwnPtr<CalculationNode> node = TRY(ClampCalculationNode::create(move(calculated_parameters[0]), move(calculated_parameters[1]), move(calculated_parameters[2])));
+    return CalculatedStyleValue::create(move(node), type);
+}
+
 ErrorOr<RefPtr<StyleValue>> Parser::parse_dynamic_value(ComponentValue const& component_value)
 {
     if (component_value.is_function()) {
@@ -3508,6 +3541,9 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_dynamic_value(ComponentValue const& co
 
         if (function.name().equals_ignoring_ascii_case("max"sv))
             return parse_max_function(function);
+
+        if (function.name().equals_ignoring_ascii_case("clamp"sv))
+            return parse_clamp_function(function);
     }
 
     return nullptr;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3539,9 +3539,12 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_dynamic_value(ComponentValue const& co
 
         if (function.name().equals_ignoring_ascii_case("clamp"sv))
             return parse_clamp_function(function);
+
+        dbgln_if(CSS_PARSER_DEBUG, "We didn't implement `{}` function yet", function.name());
+        return Error::from_string_view("Unknown function"sv);
     }
 
-    return nullptr;
+    return Error::from_string_view("Component was not a function"sv);
 }
 
 Optional<Parser::Dimension> Parser::parse_dimension(ComponentValue const& component_value)

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -299,6 +299,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_sign_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_sin_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_cos_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_tan_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -308,6 +308,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_sqrt_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_hypot_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_log_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_exp_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -289,6 +289,7 @@ private:
     ErrorOr<RefPtr<StyleValue>> parse_builtin_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_dynamic_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_min_function(Function const&);
+    ErrorOr<RefPtr<StyleValue>> parse_max_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -295,6 +295,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_round_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_mod_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_rem_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_abs_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -302,6 +302,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_tan_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_asin_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_acos_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_atan_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -290,6 +290,7 @@ private:
     ErrorOr<RefPtr<StyleValue>> parse_dynamic_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_min_function(Function const&);
     ErrorOr<RefPtr<StyleValue>> parse_max_function(Function const&);
+    ErrorOr<RefPtr<StyleValue>> parse_clamp_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -337,6 +337,7 @@ private:
     ErrorOr<RefPtr<StyleValue>> parse_grid_shorthand_value(Vector<ComponentValue> const&);
 
     ErrorOr<OwnPtr<CalculationNode>> parse_a_calculation(Vector<ComponentValue> const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> simplify_a_calculation(NonnullOwnPtr<CalculationNode>);
 
     ParseErrorOr<NonnullRefPtr<Selector>> parse_complex_selector(TokenStream<ComponentValue>&, SelectorType);
     ParseErrorOr<Optional<Selector::CompoundSelector>> parse_compound_selector(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -300,6 +300,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_sin_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_cos_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_tan_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_asin_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -294,6 +294,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_clamp_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_round_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_mod_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_rem_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -288,6 +288,7 @@ private:
     ErrorOr<PropertyAndValue> parse_css_value_for_properties(ReadonlySpan<PropertyID>, TokenStream<ComponentValue>&);
     ErrorOr<RefPtr<StyleValue>> parse_builtin_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_dynamic_value(ComponentValue const&);
+    ErrorOr<RefPtr<StyleValue>> parse_min_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -304,6 +304,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_acos_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_atan_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_atan2_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_pow_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -293,6 +293,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_max_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_clamp_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_round_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_mod_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -307,6 +307,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_pow_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_sqrt_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_hypot_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_log_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -339,7 +339,7 @@ private:
     ErrorOr<RefPtr<StyleValue>> parse_grid_area_shorthand_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_grid_shorthand_value(Vector<ComponentValue> const&);
 
-    ErrorOr<OwnPtr<CalculationNode>> parse_a_calculation(Vector<ComponentValue> const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_a_calculation(Vector<ComponentValue> const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> simplify_a_calculation(NonnullOwnPtr<CalculationNode>);
 
     ParseErrorOr<NonnullRefPtr<Selector>> parse_complex_selector(TokenStream<ComponentValue>&, SelectorType);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -298,6 +298,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_abs_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_sign_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_sin_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_cos_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -303,6 +303,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_asin_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_acos_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_atan_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_atan2_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -306,6 +306,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_atan2_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_pow_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_sqrt_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_hypot_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -288,9 +288,10 @@ private:
     ErrorOr<PropertyAndValue> parse_css_value_for_properties(ReadonlySpan<PropertyID>, TokenStream<ComponentValue>&);
     ErrorOr<RefPtr<StyleValue>> parse_builtin_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_dynamic_value(ComponentValue const&);
-    ErrorOr<RefPtr<StyleValue>> parse_min_function(Function const&);
-    ErrorOr<RefPtr<StyleValue>> parse_max_function(Function const&);
-    ErrorOr<RefPtr<StyleValue>> parse_clamp_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_a_function_node(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_min_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_max_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_clamp_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -301,6 +301,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_cos_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_tan_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_asin_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_acos_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -296,6 +296,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_mod_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_rem_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_abs_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_sign_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -292,6 +292,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_min_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_max_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_clamp_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_round_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -297,6 +297,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_rem_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_abs_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_sign_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_sin_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -305,6 +305,7 @@ private:
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_atan_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_atan2_function(Function const&);
     ErrorOr<NonnullOwnPtr<CalculationNode>> parse_pow_function(Function const&);
+    ErrorOr<NonnullOwnPtr<CalculationNode>> parse_sqrt_function(Function const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/Percentage.h
+++ b/Userland/Libraries/LibWeb/CSS/Percentage.h
@@ -23,13 +23,13 @@ public:
     {
     }
 
-    explicit Percentage(float value)
+    explicit Percentage(double value)
         : m_value(value)
     {
     }
 
-    float value() const { return m_value; }
-    float as_fraction() const { return m_value * 0.01f; }
+    double value() const { return m_value; }
+    double as_fraction() const { return m_value * 0.01; }
 
     ErrorOr<String> to_string() const
     {
@@ -39,7 +39,7 @@ public:
     bool operator==(Percentage const& other) const { return m_value == other.m_value; }
 
 private:
-    float m_value;
+    double m_value;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1755,6 +1755,13 @@
       "top"
     ]
   },
+  "transition-delay": {
+    "inherited": false,
+    "initial": "0s",
+    "valid-types": [
+        "time"
+    ]
+  },
   "user-select": {
     "affects-layout": false,
     "inherited": false,

--- a/Userland/Libraries/LibWeb/CSS/Resolution.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Resolution.cpp
@@ -22,7 +22,7 @@ Resolution::Resolution(float value, Type type)
 
 ErrorOr<String> Resolution::to_string() const
 {
-    return String::formatted("{}{}", m_value, unit_name());
+    return String::formatted("{}dppx", to_dots_per_pixel());
 }
 
 float Resolution::to_dots_per_pixel() const

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -653,7 +653,12 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().justify_content()));
     case PropertyID::Left:
         return style_value_for_length_percentage(layout_node.computed_values().inset().left());
-    case PropertyID::LineHeight:
+    case CSS::PropertyID::LetterSpacing: {
+        auto length_node = layout_node.computed_values().letter_spacing();
+        // FIXME: Return "normal" if the value resolves to 0px.
+        return style_value_for_length_percentage(length_node);
+    }
+    case CSS::PropertyID::LineHeight:
         return LengthStyleValue::create(Length::make_px(layout_node.line_height()));
     case PropertyID::ListStyleType:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().list_style_type()));

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -35,6 +35,7 @@
 #include <LibWeb/CSS/StyleValues/RectStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ShadowStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
+#include <LibWeb/CSS/StyleValues/TimeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/TransformationStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
@@ -771,8 +772,10 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         StyleValueVector matrix_functions { matrix_function };
         return StyleValueList::create(move(matrix_functions), StyleValueList::Separator::Space);
     }
-    case PropertyID::VerticalAlign:
-        if (auto const* length_percentage = layout_node.computed_values().vertical_align().get_pointer<LengthPercentage>()) {
+    case CSS::PropertyID::TransitionDelay:
+        return TimeStyleValue::create(layout_node.computed_values().transition_delay());
+    case CSS::PropertyID::VerticalAlign:
+        if (auto const* length_percentage = layout_node.computed_values().vertical_align().get_pointer<CSS::LengthPercentage>()) {
             return style_value_for_length_percentage(*length_percentage);
         }
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().vertical_align().get<VerticalAlign>()));

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1015,7 +1015,7 @@ StyleComputer::AnimationStepTransition StyleComputer::Animation::step(CSS::Time 
     remaining_delay = CSS::Time { 0, CSS::Time::Type::Ms };
     time_step_ms -= delay_ms;
 
-    float added_progress = static_cast<float>(time_step_ms / duration.to_milliseconds());
+    auto added_progress = time_step_ms / duration.to_milliseconds();
     auto new_progress = progress.as_fraction() + added_progress;
     auto changed_iteration = false;
     if (new_progress >= 1) {
@@ -1250,7 +1250,7 @@ ErrorOr<void> StyleComputer::Animation::collect_into(StyleProperties& style_prop
 
 bool StyleComputer::Animation::is_done() const
 {
-    return progress.as_fraction() >= 0.9999f && iteration_count.has_value() && iteration_count.value() == 0;
+    return progress.as_fraction() >= 0.9999 && iteration_count.has_value() && iteration_count.value() == 0;
 }
 
 float StyleComputer::Animation::compute_output_progress(float input_progress) const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -478,6 +478,94 @@ ErrorOr<void> MinCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
+ErrorOr<NonnullOwnPtr<MaxCalculationNode>> MaxCalculationNode::create(Vector<NonnullOwnPtr<Web::CSS::CalculationNode>> values)
+{
+    return adopt_nonnull_own_or_enomem(new (nothrow) MaxCalculationNode(move(values)));
+}
+
+MaxCalculationNode::MaxCalculationNode(Vector<NonnullOwnPtr<CalculationNode>> values)
+    : CalculationNode(Type::Max)
+    , m_values(move(values))
+{
+}
+
+MaxCalculationNode::~MaxCalculationNode() = default;
+
+ErrorOr<String> MaxCalculationNode::to_string() const
+{
+    StringBuilder builder;
+    TRY(builder.try_append("max("sv));
+    for (size_t i = 0; i < m_values.size(); ++i) {
+        if (i != 0)
+            TRY(builder.try_append(", "sv));
+        TRY(builder.try_append(TRY(m_values[i]->to_string())));
+    }
+    TRY(builder.try_append(")"sv));
+    return builder.to_string();
+}
+
+Optional<CalculatedStyleValue::ResolvedType> MaxCalculationNode::resolved_type() const
+{
+    // NOTE: We check during parsing that all values have the same type.
+    return m_values[0]->resolved_type();
+}
+
+bool MaxCalculationNode::contains_percentage() const
+{
+    for (auto const& value : m_values) {
+        if (value->contains_percentage())
+            return true;
+    }
+
+    return false;
+}
+
+CalculatedStyleValue::CalculationResult MaxCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
+{
+    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) {
+        return value.visit(
+            [](Number const& number) { return number.value(); },
+            [](Angle const& angle) { return angle.to_degrees(); },
+            [](Frequency const& frequency) { return frequency.to_hertz(); },
+            [layout_node](Length const& length) { return static_cast<float>(length.to_px(*layout_node).value()); },
+            [](Percentage const& percentage) { return percentage.value(); },
+            [](Time const& time) { return time.to_seconds(); });
+    };
+
+    CalculatedStyleValue::CalculationResult largest_node = m_values.first()->resolve(layout_node, percentage_basis);
+    auto largest_value = resolve_value(largest_node.value());
+
+    for (size_t i = 1; i < m_values.size(); i++) {
+        auto child_resolved = m_values[i]->resolve(layout_node, percentage_basis);
+        auto child_value = resolve_value(child_resolved.value());
+
+        if (child_value > largest_value) {
+            largest_value = child_value;
+            largest_node = child_resolved;
+        }
+    }
+
+    return largest_node;
+}
+
+ErrorOr<void> MaxCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+{
+    for (auto& value : m_values) {
+        TRY(value->for_each_child_node(callback));
+        TRY(callback(value));
+    }
+
+    return {};
+}
+
+ErrorOr<void> MaxCalculationNode::dump(StringBuilder& builder, int indent) const
+{
+    TRY(builder.try_appendff("{: >{}}MAX:\n", "", indent));
+    for (auto const& value : m_values)
+        TRY(value->dump(builder, indent + 2));
+    return {};
+}
+
 void CalculatedStyleValue::CalculationResult::add(CalculationResult const& other, Layout::Node const* layout_node, PercentageBasis const& percentage_basis)
 {
     add_or_subtract_internal(SumOperation::Add, other, layout_node, percentage_basis);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -39,6 +39,28 @@ static double resolve_value(CalculatedStyleValue::CalculationResult::Value value
         [](Time const& time) { return time.to_seconds(); });
 }
 
+static CalculatedStyleValue::CalculationResult to_resolved_type(CalculatedStyleValue::ResolvedType type, double value)
+{
+    switch (type) {
+    case CalculatedStyleValue::ResolvedType::Integer:
+        return { Number(Number::Type::Integer, value) };
+    case CalculatedStyleValue::ResolvedType::Number:
+        return { Number(Number::Type::Number, value) };
+    case CalculatedStyleValue::ResolvedType::Angle:
+        return { Angle::make_degrees(value) };
+    case CalculatedStyleValue::ResolvedType::Frequency:
+        return { Frequency::make_hertz(value) };
+    case CalculatedStyleValue::ResolvedType::Length:
+        return { Length::make_px(value) };
+    case CalculatedStyleValue::ResolvedType::Percentage:
+        return { Percentage(value) };
+    case CalculatedStyleValue::ResolvedType::Time:
+        return { Time::make_seconds(value) };
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
 CalculationNode::CalculationNode(Type type)
     : m_type(type)
 {
@@ -757,27 +779,6 @@ Optional<CalculatedStyleValue::ResolvedType> RoundCalculationNode::resolved_type
 
 CalculatedStyleValue::CalculationResult RoundCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
 {
-    auto to_resolved_type = [](CalculatedStyleValue::ResolvedType type, double value) -> CalculatedStyleValue::CalculationResult {
-        switch (type) {
-        case CalculatedStyleValue::ResolvedType::Integer:
-            return { Number(Number::Type::Integer, value) };
-        case CalculatedStyleValue::ResolvedType::Number:
-            return { Number(Number::Type::Number, value) };
-        case CalculatedStyleValue::ResolvedType::Angle:
-            return { Angle::make_degrees(value) };
-        case CalculatedStyleValue::ResolvedType::Frequency:
-            return { Frequency::make_hertz(value) };
-        case CalculatedStyleValue::ResolvedType::Length:
-            return { Length::make_px(value) };
-        case CalculatedStyleValue::ResolvedType::Percentage:
-            return { Percentage(value) };
-        case CalculatedStyleValue::ResolvedType::Time:
-            return { Time::make_seconds(value) };
-        }
-
-        VERIFY_NOT_REACHED();
-    };
-
     auto resolved_type = m_a->resolved_type().value();
     auto node_a = m_a->resolve(layout_node, percentage_basis);
     auto node_b = m_b->resolve(layout_node, percentage_basis);
@@ -861,27 +862,6 @@ Optional<CalculatedStyleValue::ResolvedType> ModCalculationNode::resolved_type()
 
 CalculatedStyleValue::CalculationResult ModCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
 {
-    auto to_resolved_type = [](CalculatedStyleValue::ResolvedType type, double value) -> CalculatedStyleValue::CalculationResult {
-        switch (type) {
-        case CalculatedStyleValue::ResolvedType::Integer:
-            return { Number(Number::Type::Integer, value) };
-        case CalculatedStyleValue::ResolvedType::Number:
-            return { Number(Number::Type::Number, value) };
-        case CalculatedStyleValue::ResolvedType::Angle:
-            return { Angle::make_degrees(value) };
-        case CalculatedStyleValue::ResolvedType::Frequency:
-            return { Frequency::make_hertz(value) };
-        case CalculatedStyleValue::ResolvedType::Length:
-            return { Length::make_px(value) };
-        case CalculatedStyleValue::ResolvedType::Percentage:
-            return { Percentage(value) };
-        case CalculatedStyleValue::ResolvedType::Time:
-            return { Time::make_seconds(value) };
-        }
-
-        VERIFY_NOT_REACHED();
-    };
-
     auto resolved_type = m_a->resolved_type().value();
     auto node_a = m_a->resolve(layout_node, percentage_basis);
     auto node_b = m_b->resolve(layout_node, percentage_basis);
@@ -942,27 +922,6 @@ Optional<CalculatedStyleValue::ResolvedType> RemCalculationNode::resolved_type()
 
 CalculatedStyleValue::CalculationResult RemCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
 {
-    auto to_resolved_type = [](CalculatedStyleValue::ResolvedType type, double value) -> CalculatedStyleValue::CalculationResult {
-        switch (type) {
-        case CalculatedStyleValue::ResolvedType::Integer:
-            return { Number(Number::Type::Integer, value) };
-        case CalculatedStyleValue::ResolvedType::Number:
-            return { Number(Number::Type::Number, value) };
-        case CalculatedStyleValue::ResolvedType::Angle:
-            return { Angle::make_degrees(value) };
-        case CalculatedStyleValue::ResolvedType::Frequency:
-            return { Frequency::make_hertz(value) };
-        case CalculatedStyleValue::ResolvedType::Length:
-            return { Length::make_px(value) };
-        case CalculatedStyleValue::ResolvedType::Percentage:
-            return { Percentage(value) };
-        case CalculatedStyleValue::ResolvedType::Time:
-            return { Time::make_seconds(value) };
-        }
-
-        VERIFY_NOT_REACHED();
-    };
-
     auto resolved_type = m_a->resolved_type().value();
     auto node_a = m_a->resolve(layout_node, percentage_basis);
     auto node_b = m_b->resolve(layout_node, percentage_basis);
@@ -1018,27 +977,6 @@ Optional<CalculatedStyleValue::ResolvedType> AbsCalculationNode::resolved_type()
 
 CalculatedStyleValue::CalculationResult AbsCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
 {
-    auto to_resolved_type = [](CalculatedStyleValue::ResolvedType type, double value) -> CalculatedStyleValue::CalculationResult {
-        switch (type) {
-        case CalculatedStyleValue::ResolvedType::Integer:
-            return { Number(Number::Type::Integer, value) };
-        case CalculatedStyleValue::ResolvedType::Number:
-            return { Number(Number::Type::Number, value) };
-        case CalculatedStyleValue::ResolvedType::Angle:
-            return { Angle::make_degrees(value) };
-        case CalculatedStyleValue::ResolvedType::Frequency:
-            return { Frequency::make_hertz(value) };
-        case CalculatedStyleValue::ResolvedType::Length:
-            return { Length::make_px(value) };
-        case CalculatedStyleValue::ResolvedType::Percentage:
-            return { Percentage(value) };
-        case CalculatedStyleValue::ResolvedType::Time:
-            return { Time::make_seconds(value) };
-        }
-
-        VERIFY_NOT_REACHED();
-    };
-
     auto resolved_type = m_a->resolved_type().value();
     auto node_a = m_a->resolve(layout_node, percentage_basis);
     auto node_a_value = resolve_value(node_a.value(), layout_node);
@@ -1640,27 +1578,6 @@ bool HypotCalculationNode::contains_percentage() const
 
 CalculatedStyleValue::CalculationResult HypotCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
 {
-    auto to_resolved_type = [](CalculatedStyleValue::ResolvedType type, double value) -> CalculatedStyleValue::CalculationResult {
-        switch (type) {
-        case CalculatedStyleValue::ResolvedType::Integer:
-            return { Number(Number::Type::Integer, value) };
-        case CalculatedStyleValue::ResolvedType::Number:
-            return { Number(Number::Type::Number, value) };
-        case CalculatedStyleValue::ResolvedType::Angle:
-            return { Angle::make_degrees(value) };
-        case CalculatedStyleValue::ResolvedType::Frequency:
-            return { Frequency::make_hertz(value) };
-        case CalculatedStyleValue::ResolvedType::Length:
-            return { Length::make_px(value) };
-        case CalculatedStyleValue::ResolvedType::Percentage:
-            return { Percentage(value) };
-        case CalculatedStyleValue::ResolvedType::Time:
-            return { Time::make_seconds(value) };
-        }
-
-        VERIFY_NOT_REACHED();
-    };
-
     double square_sum = 0.0;
 
     for (auto const& value : m_values) {

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -566,6 +566,98 @@ ErrorOr<void> MaxCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
+ErrorOr<NonnullOwnPtr<ClampCalculationNode>> ClampCalculationNode::create(NonnullOwnPtr<CalculationNode> min, NonnullOwnPtr<CalculationNode> center, NonnullOwnPtr<CalculationNode> max)
+{
+    return adopt_nonnull_own_or_enomem(new (nothrow) ClampCalculationNode(move(min), move(center), move(max)));
+}
+
+ClampCalculationNode::ClampCalculationNode(NonnullOwnPtr<CalculationNode> min, NonnullOwnPtr<CalculationNode> center, NonnullOwnPtr<CalculationNode> max)
+    : CalculationNode(Type::Clamp)
+    , m_min_value(move(min))
+    , m_center_value(move(center))
+    , m_max_value(move(max))
+{
+}
+
+ClampCalculationNode::~ClampCalculationNode() = default;
+
+ErrorOr<String> ClampCalculationNode::to_string() const
+{
+    StringBuilder builder;
+    TRY(builder.try_append("clamp("sv));
+    TRY(builder.try_append(TRY(m_min_value->to_string())));
+    TRY(builder.try_append(", "sv));
+    TRY(builder.try_append(TRY(m_center_value->to_string())));
+    TRY(builder.try_append(", "sv));
+    TRY(builder.try_append(TRY(m_max_value->to_string())));
+    TRY(builder.try_append(")"sv));
+    return builder.to_string();
+}
+
+Optional<CalculatedStyleValue::ResolvedType> ClampCalculationNode::resolved_type() const
+{
+    // NOTE: We check during parsing that all values have the same type.
+    return m_min_value->resolved_type();
+}
+
+bool ClampCalculationNode::contains_percentage() const
+{
+    return m_min_value->contains_percentage() || m_center_value->contains_percentage() || m_max_value->contains_percentage();
+}
+
+CalculatedStyleValue::CalculationResult ClampCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
+{
+    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) {
+        return value.visit(
+            [](Number const& number) { return number.value(); },
+            [](Angle const& angle) { return angle.to_degrees(); },
+            [](Frequency const& frequency) { return frequency.to_hertz(); },
+            [layout_node](Length const& length) { return static_cast<float>(length.to_px(*layout_node).value()); },
+            [](Percentage const& percentage) { return percentage.value(); },
+            [](Time const& time) { return time.to_seconds(); });
+    };
+
+    auto min_node = m_min_value->resolve(layout_node, percentage_basis);
+    auto center_node = m_center_value->resolve(layout_node, percentage_basis);
+    auto max_node = m_max_value->resolve(layout_node, percentage_basis);
+
+    auto min_value = resolve_value(min_node.value());
+    auto center_value = resolve_value(center_node.value());
+    auto max_value = resolve_value(max_node.value());
+
+    // NOTE: The value should be returned as "max(MIN, min(VAL, MAX))"
+    auto correct_value = max(min_value, min(center_value, max_value));
+    if (correct_value == min_value)
+        return min_node;
+    if (correct_value == center_value)
+        return center_node;
+    if (correct_value == max_value)
+        return max_node;
+
+    VERIFY_NOT_REACHED();
+}
+
+ErrorOr<void> ClampCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+{
+    TRY(m_min_value->for_each_child_node(callback));
+    TRY(m_center_value->for_each_child_node(callback));
+    TRY(m_max_value->for_each_child_node(callback));
+    TRY(callback(m_min_value));
+    TRY(callback(m_center_value));
+    TRY(callback(m_max_value));
+
+    return {};
+}
+
+ErrorOr<void> ClampCalculationNode::dump(StringBuilder& builder, int indent) const
+{
+    TRY(builder.try_appendff("{: >{}}CLAMP:\n", "", indent));
+    TRY(m_min_value->dump(builder, indent + 2));
+    TRY(m_center_value->dump(builder, indent + 2));
+    TRY(m_max_value->dump(builder, indent + 2));
+    return {};
+}
+
 void CalculatedStyleValue::CalculationResult::add(CalculationResult const& other, Layout::Node const* layout_node, PercentageBasis const& percentage_basis)
 {
     add_or_subtract_internal(SumOperation::Add, other, layout_node, percentage_basis);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -1172,6 +1172,62 @@ ErrorOr<void> SinCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
+ErrorOr<NonnullOwnPtr<CosCalculationNode>> CosCalculationNode::create(NonnullOwnPtr<CalculationNode> a)
+{
+    return adopt_nonnull_own_or_enomem(new (nothrow) CosCalculationNode(move(a)));
+}
+
+CosCalculationNode::CosCalculationNode(NonnullOwnPtr<CalculationNode> a)
+    : CalculationNode(Type::Cos)
+    , m_a(move(a))
+{
+}
+
+CosCalculationNode::~CosCalculationNode() = default;
+
+ErrorOr<String> CosCalculationNode::to_string() const
+{
+    StringBuilder builder;
+    builder.append("cos("sv);
+    builder.append(TRY(m_a->to_string()));
+    builder.append(")"sv);
+    return builder.to_string();
+}
+
+Optional<CalculatedStyleValue::ResolvedType> CosCalculationNode::resolved_type() const
+{
+    return CalculatedStyleValue::ResolvedType::Number;
+}
+
+CalculatedStyleValue::CalculationResult CosCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
+{
+    auto resolve_value_radians = [](CalculatedStyleValue::CalculationResult::Value value) -> double {
+        return value.visit(
+            [](Number const& number) { return number.value(); },
+            [](Angle const& angle) { return angle.to_radians(); },
+            [](auto const&) { VERIFY_NOT_REACHED(); return 0.0; });
+    };
+
+    auto node_a = m_a->resolve(layout_node, percentage_basis);
+    auto node_a_value = resolve_value_radians(node_a.value());
+    auto result = cos(node_a_value);
+
+    return { Number(Number::Type::Number, result) };
+}
+
+ErrorOr<void> CosCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+{
+    TRY(m_a->for_each_child_node(callback));
+    TRY(callback(m_a));
+    return {};
+}
+
+ErrorOr<void> CosCalculationNode::dump(StringBuilder& builder, int indent) const
+{
+    TRY(builder.try_appendff("{: >{}}COS: {}\n", "", indent, TRY(to_string())));
+    return {};
+}
+
 void CalculatedStyleValue::CalculationResult::add(CalculationResult const& other, Layout::Node const* layout_node, PercentageBasis const& percentage_basis)
 {
     add_or_subtract_internal(SumOperation::Add, other, layout_node, percentage_basis);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -434,12 +434,12 @@ bool MinCalculationNode::contains_percentage() const
 
 CalculatedStyleValue::CalculationResult MinCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
 {
-    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) {
+    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) -> double {
         return value.visit(
             [](Number const& number) { return number.value(); },
             [](Angle const& angle) { return angle.to_degrees(); },
             [](Frequency const& frequency) { return frequency.to_hertz(); },
-            [layout_node](Length const& length) { return static_cast<float>(length.to_px(*layout_node).value()); },
+            [layout_node](Length const& length) { return length.to_px(*layout_node).value(); },
             [](Percentage const& percentage) { return percentage.value(); },
             [](Time const& time) { return time.to_seconds(); });
     };
@@ -522,12 +522,12 @@ bool MaxCalculationNode::contains_percentage() const
 
 CalculatedStyleValue::CalculationResult MaxCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
 {
-    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) {
+    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) -> double {
         return value.visit(
             [](Number const& number) { return number.value(); },
             [](Angle const& angle) { return angle.to_degrees(); },
             [](Frequency const& frequency) { return frequency.to_hertz(); },
-            [layout_node](Length const& length) { return static_cast<float>(length.to_px(*layout_node).value()); },
+            [layout_node](Length const& length) { return length.to_px(*layout_node).value(); },
             [](Percentage const& percentage) { return percentage.value(); },
             [](Time const& time) { return time.to_seconds(); });
     };
@@ -607,12 +607,12 @@ bool ClampCalculationNode::contains_percentage() const
 
 CalculatedStyleValue::CalculationResult ClampCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
 {
-    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) {
+    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) -> double {
         return value.visit(
             [](Number const& number) { return number.value(); },
             [](Angle const& angle) { return angle.to_degrees(); },
             [](Frequency const& frequency) { return frequency.to_hertz(); },
-            [layout_node](Length const& length) { return static_cast<float>(length.to_px(*layout_node).value()); },
+            [layout_node](Length const& length) { return length.to_px(*layout_node).value(); },
             [](Percentage const& percentage) { return percentage.value(); },
             [](Time const& time) { return time.to_seconds(); });
     };
@@ -702,9 +702,9 @@ CalculatedStyleValue::CalculationResult ConstantCalculationNode::resolve([[maybe
     case CalculationNode::ConstantType::PI:
         return { Number(Number::Type::Number, M_PI) };
     case CalculationNode::ConstantType::Infinity:
-        return { Number(Number::Type::Number, NumericLimits<float>::max()) };
+        return { Number(Number::Type::Number, NumericLimits<double>::max()) };
     case CalculationNode::ConstantType::MinusInfinity:
-        return { Number(Number::Type::Number, NumericLimits<float>::lowest()) };
+        return { Number(Number::Type::Number, NumericLimits<double>::lowest()) };
     case CalculationNode::ConstantType::NaN:
         return { Number(Number::Type::Number, NAN) };
     }
@@ -772,17 +772,17 @@ Optional<CalculatedStyleValue::ResolvedType> RoundCalculationNode::resolved_type
 
 CalculatedStyleValue::CalculationResult RoundCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
 {
-    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) -> float {
+    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) -> double {
         return value.visit(
             [](Number const& number) { return number.value(); },
             [](Angle const& angle) { return angle.to_degrees(); },
             [](Frequency const& frequency) { return frequency.to_hertz(); },
-            [layout_node](Length const& length) { return static_cast<float>(length.to_px(*layout_node).value()); },
+            [layout_node](Length const& length) { return length.to_px(*layout_node).value(); },
             [](Percentage const& percentage) { return percentage.value(); },
             [](Time const& time) { return time.to_seconds(); });
     };
 
-    auto to_resolved_type = [](CalculatedStyleValue::ResolvedType type, float value) -> CalculatedStyleValue::CalculationResult {
+    auto to_resolved_type = [](CalculatedStyleValue::ResolvedType type, double value) -> CalculatedStyleValue::CalculationResult {
         switch (type) {
         case CalculatedStyleValue::ResolvedType::Integer:
             return { Number(Number::Type::Integer, value) };
@@ -810,12 +810,12 @@ CalculatedStyleValue::CalculationResult RoundCalculationNode::resolve(Layout::No
     auto node_a_value = resolve_value(node_a.value());
     auto node_b_value = resolve_value(node_b.value());
 
-    float upper_b = ceilf(node_a_value / node_b_value) * node_b_value;
-    float lower_b = floorf(node_a_value / node_b_value) * node_b_value;
+    auto upper_b = ceil(node_a_value / node_b_value) * node_b_value;
+    auto lower_b = floor(node_a_value / node_b_value) * node_b_value;
 
     if (m_mode == RoundingMode::Nearest) {
-        auto upper_diff = fabsf(upper_b - node_a_value);
-        auto lower_diff = fabsf(node_a_value - lower_b);
+        auto upper_diff = fabs(upper_b - node_a_value);
+        auto lower_diff = fabs(node_a_value - lower_b);
         auto rounded_value = upper_diff < lower_diff ? upper_b : lower_b;
         return to_resolved_type(resolved_type, rounded_value);
     }
@@ -829,8 +829,8 @@ CalculatedStyleValue::CalculationResult RoundCalculationNode::resolve(Layout::No
     }
 
     if (m_mode == RoundingMode::TowardZero) {
-        auto upper_diff = fabsf(upper_b);
-        auto lower_diff = fabsf(lower_b);
+        auto upper_diff = fabs(upper_b);
+        auto lower_diff = fabs(lower_b);
         auto rounded_value = upper_diff < lower_diff ? upper_b : lower_b;
         return to_resolved_type(resolved_type, rounded_value);
     }
@@ -886,17 +886,17 @@ Optional<CalculatedStyleValue::ResolvedType> ModCalculationNode::resolved_type()
 
 CalculatedStyleValue::CalculationResult ModCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
 {
-    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) -> float {
+    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) -> double {
         return value.visit(
             [](Number const& number) { return number.value(); },
             [](Angle const& angle) { return angle.to_degrees(); },
             [](Frequency const& frequency) { return frequency.to_hertz(); },
-            [layout_node](Length const& length) { return static_cast<float>(length.to_px(*layout_node).value()); },
+            [layout_node](Length const& length) { return length.to_px(*layout_node).value(); },
             [](Percentage const& percentage) { return percentage.value(); },
             [](Time const& time) { return time.to_seconds(); });
     };
 
-    auto to_resolved_type = [](CalculatedStyleValue::ResolvedType type, float value) -> CalculatedStyleValue::CalculationResult {
+    auto to_resolved_type = [](CalculatedStyleValue::ResolvedType type, double value) -> CalculatedStyleValue::CalculationResult {
         switch (type) {
         case CalculatedStyleValue::ResolvedType::Integer:
             return { Number(Number::Type::Integer, value) };
@@ -924,7 +924,7 @@ CalculatedStyleValue::CalculationResult ModCalculationNode::resolve(Layout::Node
     auto node_a_value = resolve_value(node_a.value());
     auto node_b_value = resolve_value(node_b.value());
 
-    auto quotient = floorf(node_a_value / node_b_value);
+    auto quotient = floor(node_a_value / node_b_value);
     auto value = node_a_value - (node_b_value * quotient);
     return to_resolved_type(resolved_type, value);
 }
@@ -977,17 +977,17 @@ Optional<CalculatedStyleValue::ResolvedType> RemCalculationNode::resolved_type()
 
 CalculatedStyleValue::CalculationResult RemCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
 {
-    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) -> float {
+    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) -> double {
         return value.visit(
             [](Number const& number) { return number.value(); },
             [](Angle const& angle) { return angle.to_degrees(); },
             [](Frequency const& frequency) { return frequency.to_hertz(); },
-            [layout_node](Length const& length) { return static_cast<float>(length.to_px(*layout_node).value()); },
+            [layout_node](Length const& length) { return length.to_px(*layout_node).value(); },
             [](Percentage const& percentage) { return percentage.value(); },
             [](Time const& time) { return time.to_seconds(); });
     };
 
-    auto to_resolved_type = [](CalculatedStyleValue::ResolvedType type, float value) -> CalculatedStyleValue::CalculationResult {
+    auto to_resolved_type = [](CalculatedStyleValue::ResolvedType type, double value) -> CalculatedStyleValue::CalculationResult {
         switch (type) {
         case CalculatedStyleValue::ResolvedType::Integer:
             return { Number(Number::Type::Integer, value) };
@@ -1015,7 +1015,7 @@ CalculatedStyleValue::CalculationResult RemCalculationNode::resolve(Layout::Node
     auto node_a_value = resolve_value(node_a.value());
     auto node_b_value = resolve_value(node_b.value());
 
-    auto value = fmodf(node_a_value, node_b_value);
+    auto value = fmod(node_a_value, node_b_value);
     return to_resolved_type(resolved_type, value);
 }
 
@@ -1157,7 +1157,7 @@ void CalculatedStyleValue::CalculationResult::add_or_subtract_internal(SumOperat
 void CalculatedStyleValue::CalculationResult::multiply_by(CalculationResult const& other, Layout::Node const* layout_node)
 {
     // We know from validation when resolving the type, that at least one side must be a <number> or <integer>.
-    // Both of these are represented as a float.
+    // Both of these are represented as a double.
     VERIFY(m_value.has<Number>() || other.m_value.has<Number>());
     bool other_is_number = other.m_value.has<Number>();
 
@@ -1196,7 +1196,7 @@ void CalculatedStyleValue::CalculationResult::divide_by(CalculationResult const&
     // Both of these are represented as a Number.
     auto denominator = other.m_value.get<Number>().value();
     // FIXME: Dividing by 0 is invalid, and should be caught during parsing.
-    VERIFY(denominator != 0.0f);
+    VERIFY(denominator != 0.0);
 
     m_value.visit(
         [&](Number const& number) {
@@ -1389,7 +1389,7 @@ Optional<Time> CalculatedStyleValue::resolve_time_percentage(Time const& percent
         });
 }
 
-Optional<float> CalculatedStyleValue::resolve_number() const
+Optional<double> CalculatedStyleValue::resolve_number() const
 {
     auto result = m_calculation->resolve(nullptr, {});
     if (result.value().has<Number>())

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -1389,7 +1389,7 @@ Optional<Time> CalculatedStyleValue::resolve_time_percentage(Time const& percent
         });
 }
 
-Optional<float> CalculatedStyleValue::resolve_number()
+Optional<float> CalculatedStyleValue::resolve_number() const
 {
     auto result = m_calculation->resolve(nullptr, {});
     if (result.value().has<Number>())

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -1116,6 +1116,62 @@ ErrorOr<void> SignCalculationNode::dump(StringBuilder& builder, int indent) cons
     return {};
 }
 
+ErrorOr<NonnullOwnPtr<SinCalculationNode>> SinCalculationNode::create(NonnullOwnPtr<CalculationNode> a)
+{
+    return adopt_nonnull_own_or_enomem(new (nothrow) SinCalculationNode(move(a)));
+}
+
+SinCalculationNode::SinCalculationNode(NonnullOwnPtr<CalculationNode> a)
+    : CalculationNode(Type::Sin)
+    , m_a(move(a))
+{
+}
+
+SinCalculationNode::~SinCalculationNode() = default;
+
+ErrorOr<String> SinCalculationNode::to_string() const
+{
+    StringBuilder builder;
+    builder.append("sin("sv);
+    builder.append(TRY(m_a->to_string()));
+    builder.append(")"sv);
+    return builder.to_string();
+}
+
+Optional<CalculatedStyleValue::ResolvedType> SinCalculationNode::resolved_type() const
+{
+    return CalculatedStyleValue::ResolvedType::Number;
+}
+
+CalculatedStyleValue::CalculationResult SinCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
+{
+    auto resolve_value_radians = [](CalculatedStyleValue::CalculationResult::Value value) -> double {
+        return value.visit(
+            [](Number const& number) { return number.value(); },
+            [](Angle const& angle) { return angle.to_radians(); },
+            [](auto const&) { VERIFY_NOT_REACHED(); return 0.0; });
+    };
+
+    auto node_a = m_a->resolve(layout_node, percentage_basis);
+    auto node_a_value = resolve_value_radians(node_a.value());
+    auto result = sin(node_a_value);
+
+    return { Number(Number::Type::Number, result) };
+}
+
+ErrorOr<void> SinCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+{
+    TRY(m_a->for_each_child_node(callback));
+    TRY(callback(m_a));
+    return {};
+}
+
+ErrorOr<void> SinCalculationNode::dump(StringBuilder& builder, int indent) const
+{
+    TRY(builder.try_appendff("{: >{}}SIN: {}\n", "", indent, TRY(to_string())));
+    return {};
+}
+
 void CalculatedStyleValue::CalculationResult::add(CalculationResult const& other, Layout::Node const* layout_node, PercentageBasis const& percentage_basis)
 {
     add_or_subtract_internal(SumOperation::Add, other, layout_node, percentage_basis);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -1382,6 +1382,55 @@ ErrorOr<void> AcosCalculationNode::dump(StringBuilder& builder, int indent) cons
     return {};
 }
 
+ErrorOr<NonnullOwnPtr<AtanCalculationNode>> AtanCalculationNode::create(NonnullOwnPtr<CalculationNode> a)
+{
+    return adopt_nonnull_own_or_enomem(new (nothrow) AtanCalculationNode(move(a)));
+}
+
+AtanCalculationNode::AtanCalculationNode(NonnullOwnPtr<CalculationNode> a)
+    : CalculationNode(Type::Atan)
+    , m_a(move(a))
+{
+}
+
+AtanCalculationNode::~AtanCalculationNode() = default;
+
+ErrorOr<String> AtanCalculationNode::to_string() const
+{
+    StringBuilder builder;
+    builder.append("atan("sv);
+    builder.append(TRY(m_a->to_string()));
+    builder.append(")"sv);
+    return builder.to_string();
+}
+
+Optional<CalculatedStyleValue::ResolvedType> AtanCalculationNode::resolved_type() const
+{
+    return CalculatedStyleValue::ResolvedType::Angle;
+}
+
+CalculatedStyleValue::CalculationResult AtanCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
+{
+    auto node_a = m_a->resolve(layout_node, percentage_basis);
+    auto node_a_value = resolve_value(node_a.value(), layout_node);
+    auto result = atan(node_a_value);
+
+    return { Angle(result, Angle::Type::Rad) };
+}
+
+ErrorOr<void> AtanCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+{
+    TRY(m_a->for_each_child_node(callback));
+    TRY(callback(m_a));
+    return {};
+}
+
+ErrorOr<void> AtanCalculationNode::dump(StringBuilder& builder, int indent) const
+{
+    TRY(builder.try_appendff("{: >{}}ATAN: {}\n", "", indent, TRY(to_string())));
+    return {};
+}
+
 void CalculatedStyleValue::CalculationResult::add(CalculationResult const& other, Layout::Node const* layout_node, PercentageBasis const& percentage_basis)
 {
     add_or_subtract_internal(SumOperation::Add, other, layout_node, percentage_basis);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -944,6 +944,96 @@ ErrorOr<void> ModCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
+ErrorOr<NonnullOwnPtr<RemCalculationNode>> RemCalculationNode::create(NonnullOwnPtr<CalculationNode> a, NonnullOwnPtr<CalculationNode> b)
+{
+    return adopt_nonnull_own_or_enomem(new (nothrow) RemCalculationNode(move(a), move(b)));
+}
+
+RemCalculationNode::RemCalculationNode(NonnullOwnPtr<CalculationNode> a, NonnullOwnPtr<CalculationNode> b)
+    : CalculationNode(Type::Rem)
+    , m_a(move(a))
+    , m_b(move(b))
+{
+}
+
+RemCalculationNode::~RemCalculationNode() = default;
+
+ErrorOr<String> RemCalculationNode::to_string() const
+{
+    StringBuilder builder;
+    builder.append("rem("sv);
+    builder.append(TRY(m_a->to_string()));
+    builder.append(", "sv);
+    builder.append(TRY(m_b->to_string()));
+    builder.append(")"sv);
+    return builder.to_string();
+}
+
+Optional<CalculatedStyleValue::ResolvedType> RemCalculationNode::resolved_type() const
+{
+    // Note: We check during parsing that all values have the same type
+    return m_a->resolved_type();
+}
+
+CalculatedStyleValue::CalculationResult RemCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
+{
+    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) -> float {
+        return value.visit(
+            [](Number const& number) { return number.value(); },
+            [](Angle const& angle) { return angle.to_degrees(); },
+            [](Frequency const& frequency) { return frequency.to_hertz(); },
+            [layout_node](Length const& length) { return static_cast<float>(length.to_px(*layout_node).value()); },
+            [](Percentage const& percentage) { return percentage.value(); },
+            [](Time const& time) { return time.to_seconds(); });
+    };
+
+    auto to_resolved_type = [](CalculatedStyleValue::ResolvedType type, float value) -> CalculatedStyleValue::CalculationResult {
+        switch (type) {
+        case CalculatedStyleValue::ResolvedType::Integer:
+            return { Number(Number::Type::Integer, value) };
+        case CalculatedStyleValue::ResolvedType::Number:
+            return { Number(Number::Type::Number, value) };
+        case CalculatedStyleValue::ResolvedType::Angle:
+            return { Angle::make_degrees(value) };
+        case CalculatedStyleValue::ResolvedType::Frequency:
+            return { Frequency::make_hertz(value) };
+        case CalculatedStyleValue::ResolvedType::Length:
+            return { Length::make_px(value) };
+        case CalculatedStyleValue::ResolvedType::Percentage:
+            return { Percentage(value) };
+        case CalculatedStyleValue::ResolvedType::Time:
+            return { Time::make_seconds(value) };
+        }
+
+        VERIFY_NOT_REACHED();
+    };
+
+    auto resolved_type = m_a->resolved_type().value();
+    auto node_a = m_a->resolve(layout_node, percentage_basis);
+    auto node_b = m_b->resolve(layout_node, percentage_basis);
+
+    auto node_a_value = resolve_value(node_a.value());
+    auto node_b_value = resolve_value(node_b.value());
+
+    auto value = fmodf(node_a_value, node_b_value);
+    return to_resolved_type(resolved_type, value);
+}
+
+ErrorOr<void> RemCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+{
+    TRY(m_a->for_each_child_node(callback));
+    TRY(m_b->for_each_child_node(callback));
+    TRY(callback(m_a));
+    TRY(callback(m_b));
+    return {};
+}
+
+ErrorOr<void> RemCalculationNode::dump(StringBuilder& builder, int indent) const
+{
+    TRY(builder.try_appendff("{: >{}}REM: {}\n", "", indent, TRY(to_string())));
+    return {};
+}
+
 void CalculatedStyleValue::CalculationResult::add(CalculationResult const& other, Layout::Node const* layout_node, PercentageBasis const& percentage_basis)
 {
     add_or_subtract_internal(SumOperation::Add, other, layout_node, percentage_basis);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -1489,6 +1489,64 @@ ErrorOr<void> Atan2CalculationNode::dump(StringBuilder& builder, int indent) con
     return {};
 }
 
+ErrorOr<NonnullOwnPtr<PowCalculationNode>> PowCalculationNode::create(NonnullOwnPtr<CalculationNode> a, NonnullOwnPtr<CalculationNode> b)
+{
+    return adopt_nonnull_own_or_enomem(new (nothrow) PowCalculationNode(move(a), move(b)));
+}
+
+PowCalculationNode::PowCalculationNode(NonnullOwnPtr<CalculationNode> a, NonnullOwnPtr<CalculationNode> b)
+    : CalculationNode(Type::Pow)
+    , m_a(move(a))
+    , m_b(move(b))
+{
+}
+
+PowCalculationNode::~PowCalculationNode() = default;
+
+ErrorOr<String> PowCalculationNode::to_string() const
+{
+    StringBuilder builder;
+    builder.append("pow("sv);
+    builder.append(TRY(m_a->to_string()));
+    builder.append(", "sv);
+    builder.append(TRY(m_b->to_string()));
+    builder.append(")"sv);
+    return builder.to_string();
+}
+
+Optional<CalculatedStyleValue::ResolvedType> PowCalculationNode::resolved_type() const
+{
+    return CalculatedStyleValue::ResolvedType::Number;
+}
+
+CalculatedStyleValue::CalculationResult PowCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
+{
+    auto node_a = m_a->resolve(layout_node, percentage_basis);
+    auto node_a_value = resolve_value(node_a.value(), layout_node);
+
+    auto node_b = m_b->resolve(layout_node, percentage_basis);
+    auto node_b_value = resolve_value(node_b.value(), layout_node);
+
+    auto result = pow(node_a_value, node_b_value);
+
+    return { Number(Number::Type::Number, result) };
+}
+
+ErrorOr<void> PowCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+{
+    TRY(m_a->for_each_child_node(callback));
+    TRY(m_b->for_each_child_node(callback));
+    TRY(callback(m_a));
+    TRY(callback(m_b));
+    return {};
+}
+
+ErrorOr<void> PowCalculationNode::dump(StringBuilder& builder, int indent) const
+{
+    TRY(builder.try_appendff("{: >{}}POW: {}\n", "", indent, TRY(to_string())));
+    return {};
+}
+
 void CalculatedStyleValue::CalculationResult::add(CalculationResult const& other, Layout::Node const* layout_node, PercentageBasis const& percentage_basis)
 {
     add_or_subtract_internal(SumOperation::Add, other, layout_node, percentage_basis);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -1333,6 +1333,55 @@ ErrorOr<void> AsinCalculationNode::dump(StringBuilder& builder, int indent) cons
     return {};
 }
 
+ErrorOr<NonnullOwnPtr<AcosCalculationNode>> AcosCalculationNode::create(NonnullOwnPtr<CalculationNode> a)
+{
+    return adopt_nonnull_own_or_enomem(new (nothrow) AcosCalculationNode(move(a)));
+}
+
+AcosCalculationNode::AcosCalculationNode(NonnullOwnPtr<CalculationNode> a)
+    : CalculationNode(Type::Acos)
+    , m_a(move(a))
+{
+}
+
+AcosCalculationNode::~AcosCalculationNode() = default;
+
+ErrorOr<String> AcosCalculationNode::to_string() const
+{
+    StringBuilder builder;
+    builder.append("acos("sv);
+    builder.append(TRY(m_a->to_string()));
+    builder.append(")"sv);
+    return builder.to_string();
+}
+
+Optional<CalculatedStyleValue::ResolvedType> AcosCalculationNode::resolved_type() const
+{
+    return CalculatedStyleValue::ResolvedType::Angle;
+}
+
+CalculatedStyleValue::CalculationResult AcosCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
+{
+    auto node_a = m_a->resolve(layout_node, percentage_basis);
+    auto node_a_value = resolve_value(node_a.value(), layout_node);
+    auto result = acos(node_a_value);
+
+    return { Angle(result, Angle::Type::Rad) };
+}
+
+ErrorOr<void> AcosCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+{
+    TRY(m_a->for_each_child_node(callback));
+    TRY(callback(m_a));
+    return {};
+}
+
+ErrorOr<void> AcosCalculationNode::dump(StringBuilder& builder, int indent) const
+{
+    TRY(builder.try_appendff("{: >{}}ACOS: {}\n", "", indent, TRY(to_string())));
+    return {};
+}
+
 void CalculatedStyleValue::CalculationResult::add(CalculationResult const& other, Layout::Node const* layout_node, PercentageBasis const& percentage_basis)
 {
     add_or_subtract_internal(SumOperation::Add, other, layout_node, percentage_basis);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -1284,6 +1284,55 @@ ErrorOr<void> TanCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
+ErrorOr<NonnullOwnPtr<AsinCalculationNode>> AsinCalculationNode::create(NonnullOwnPtr<CalculationNode> a)
+{
+    return adopt_nonnull_own_or_enomem(new (nothrow) AsinCalculationNode(move(a)));
+}
+
+AsinCalculationNode::AsinCalculationNode(NonnullOwnPtr<CalculationNode> a)
+    : CalculationNode(Type::Asin)
+    , m_a(move(a))
+{
+}
+
+AsinCalculationNode::~AsinCalculationNode() = default;
+
+ErrorOr<String> AsinCalculationNode::to_string() const
+{
+    StringBuilder builder;
+    builder.append("asin("sv);
+    builder.append(TRY(m_a->to_string()));
+    builder.append(")"sv);
+    return builder.to_string();
+}
+
+Optional<CalculatedStyleValue::ResolvedType> AsinCalculationNode::resolved_type() const
+{
+    return CalculatedStyleValue::ResolvedType::Angle;
+}
+
+CalculatedStyleValue::CalculationResult AsinCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
+{
+    auto node_a = m_a->resolve(layout_node, percentage_basis);
+    auto node_a_value = resolve_value(node_a.value(), layout_node);
+    auto result = asin(node_a_value);
+
+    return { Angle(result, Angle::Type::Rad) };
+}
+
+ErrorOr<void> AsinCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+{
+    TRY(m_a->for_each_child_node(callback));
+    TRY(callback(m_a));
+    return {};
+}
+
+ErrorOr<void> AsinCalculationNode::dump(StringBuilder& builder, int indent) const
+{
+    TRY(builder.try_appendff("{: >{}}ASIN: {}\n", "", indent, TRY(to_string())));
+    return {};
+}
+
 void CalculatedStyleValue::CalculationResult::add(CalculationResult const& other, Layout::Node const* layout_node, PercentageBasis const& percentage_basis)
 {
     add_or_subtract_internal(SumOperation::Add, other, layout_node, percentage_basis);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -853,6 +853,97 @@ ErrorOr<void> RoundCalculationNode::dump(StringBuilder& builder, int indent) con
     return {};
 }
 
+ErrorOr<NonnullOwnPtr<ModCalculationNode>> ModCalculationNode::create(NonnullOwnPtr<CalculationNode> a, NonnullOwnPtr<CalculationNode> b)
+{
+    return adopt_nonnull_own_or_enomem(new (nothrow) ModCalculationNode(move(a), move(b)));
+}
+
+ModCalculationNode::ModCalculationNode(NonnullOwnPtr<CalculationNode> a, NonnullOwnPtr<CalculationNode> b)
+    : CalculationNode(Type::Mod)
+    , m_a(move(a))
+    , m_b(move(b))
+{
+}
+
+ModCalculationNode::~ModCalculationNode() = default;
+
+ErrorOr<String> ModCalculationNode::to_string() const
+{
+    StringBuilder builder;
+    builder.append("mod("sv);
+    builder.append(TRY(m_a->to_string()));
+    builder.append(", "sv);
+    builder.append(TRY(m_b->to_string()));
+    builder.append(")"sv);
+    return builder.to_string();
+}
+
+Optional<CalculatedStyleValue::ResolvedType> ModCalculationNode::resolved_type() const
+{
+    // Note: We check during parsing that all values have the same type
+    return m_a->resolved_type();
+}
+
+CalculatedStyleValue::CalculationResult ModCalculationNode::resolve(Layout::Node const* layout_node, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
+{
+    auto resolve_value = [layout_node](CalculatedStyleValue::CalculationResult::Value value) -> float {
+        return value.visit(
+            [](Number const& number) { return number.value(); },
+            [](Angle const& angle) { return angle.to_degrees(); },
+            [](Frequency const& frequency) { return frequency.to_hertz(); },
+            [layout_node](Length const& length) { return static_cast<float>(length.to_px(*layout_node).value()); },
+            [](Percentage const& percentage) { return percentage.value(); },
+            [](Time const& time) { return time.to_seconds(); });
+    };
+
+    auto to_resolved_type = [](CalculatedStyleValue::ResolvedType type, float value) -> CalculatedStyleValue::CalculationResult {
+        switch (type) {
+        case CalculatedStyleValue::ResolvedType::Integer:
+            return { Number(Number::Type::Integer, value) };
+        case CalculatedStyleValue::ResolvedType::Number:
+            return { Number(Number::Type::Number, value) };
+        case CalculatedStyleValue::ResolvedType::Angle:
+            return { Angle::make_degrees(value) };
+        case CalculatedStyleValue::ResolvedType::Frequency:
+            return { Frequency::make_hertz(value) };
+        case CalculatedStyleValue::ResolvedType::Length:
+            return { Length::make_px(value) };
+        case CalculatedStyleValue::ResolvedType::Percentage:
+            return { Percentage(value) };
+        case CalculatedStyleValue::ResolvedType::Time:
+            return { Time::make_seconds(value) };
+        }
+
+        VERIFY_NOT_REACHED();
+    };
+
+    auto resolved_type = m_a->resolved_type().value();
+    auto node_a = m_a->resolve(layout_node, percentage_basis);
+    auto node_b = m_b->resolve(layout_node, percentage_basis);
+
+    auto node_a_value = resolve_value(node_a.value());
+    auto node_b_value = resolve_value(node_b.value());
+
+    auto quotient = floorf(node_a_value / node_b_value);
+    auto value = node_a_value - (node_b_value * quotient);
+    return to_resolved_type(resolved_type, value);
+}
+
+ErrorOr<void> ModCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+{
+    TRY(m_a->for_each_child_node(callback));
+    TRY(m_b->for_each_child_node(callback));
+    TRY(callback(m_a));
+    TRY(callback(m_b));
+    return {};
+}
+
+ErrorOr<void> ModCalculationNode::dump(StringBuilder& builder, int indent) const
+{
+    TRY(builder.try_appendff("{: >{}}MOD: {}\n", "", indent, TRY(to_string())));
+    return {};
+}
+
 void CalculatedStyleValue::CalculationResult::add(CalculationResult const& other, Layout::Node const* layout_node, PercentageBasis const& percentage_basis)
 {
     add_or_subtract_internal(SumOperation::Add, other, layout_node, percentage_basis);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -94,7 +94,7 @@ public:
 
     bool resolves_to_integer() const { return m_resolved_type == ResolvedType::Integer; }
     bool resolves_to_number() const { return resolves_to_integer() || m_resolved_type == ResolvedType::Number; }
-    Optional<float> resolve_number();
+    Optional<float> resolve_number() const;
     Optional<i64> resolve_integer();
 
     bool contains_percentage() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -94,7 +94,7 @@ public:
 
     bool resolves_to_integer() const { return m_resolved_type == ResolvedType::Integer; }
     bool resolves_to_number() const { return resolves_to_integer() || m_resolved_type == ResolvedType::Number; }
-    Optional<float> resolve_number() const;
+    Optional<double> resolve_number() const;
     Optional<i64> resolve_integer();
 
     bool contains_percentage() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -259,4 +259,22 @@ private:
     NonnullOwnPtr<CalculationNode> m_value;
 };
 
+class MinCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<MinCalculationNode>> create(Vector<NonnullOwnPtr<CalculationNode>>);
+    ~MinCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override;
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    explicit MinCalculationNode(Vector<NonnullOwnPtr<CalculationNode>>);
+    Vector<NonnullOwnPtr<CalculationNode>> m_values;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -660,4 +660,23 @@ private:
     Vector<NonnullOwnPtr<CalculationNode>> m_values;
 };
 
+class LogCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<LogCalculationNode>> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    ~LogCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    LogCalculationNode(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_a;
+    NonnullOwnPtr<CalculationNode> m_b;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -400,4 +400,23 @@ private:
     NonnullOwnPtr<CalculationNode> m_b;
 };
 
+class RemCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<RemCalculationNode>> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    ~RemCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    RemCalculationNode(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_a;
+    NonnullOwnPtr<CalculationNode> m_b;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -506,4 +506,22 @@ private:
     NonnullOwnPtr<CalculationNode> m_a;
 };
 
+class TanCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<TanCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    ~TanCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    TanCalculationNode(NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_a;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -159,6 +159,16 @@ public:
         Mod,
         Rem,
 
+        // Trigonometric functions, a sub-type of operator node
+        // https://drafts.csswg.org/css-values-4/#trig-funcs
+        Sin,
+        Cos,
+        Tan,
+        Asin,
+        Acos,
+        Atan,
+        Atan2,
+
         // Sign-Related Functions, a sub-type of operator node
         // https://drafts.csswg.org/css-values-4/#sign-funcs
         Abs,
@@ -457,6 +467,24 @@ public:
 
 private:
     SignCalculationNode(NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_a;
+};
+
+class SinCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<SinCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    ~SinCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    SinCalculationNode(NonnullOwnPtr<CalculationNode>);
     NonnullOwnPtr<CalculationNode> m_a;
 };
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -114,6 +114,16 @@ private:
 // https://www.w3.org/TR/css-values-4/#calculation-tree
 class CalculationNode {
 public:
+    // https://drafts.csswg.org/css-values-4/#calc-constants
+    // https://drafts.csswg.org/css-values-4/#calc-error-constants
+    enum class ConstantType {
+        E,
+        PI,
+        NaN,
+        Infinity,
+        MinusInfinity,
+    };
+
     enum class Type {
         Numeric,
         // NOTE: Currently, any value with a `var()` or `attr()` function in it is always an
@@ -134,6 +144,10 @@ public:
         Min,
         Max,
         Clamp,
+
+        // Constant Nodes
+        // https://drafts.csswg.org/css-values-4/#calc-constants
+        Constant,
 
         // This only exists during parsing.
         Unparsed,
@@ -313,6 +327,24 @@ private:
     NonnullOwnPtr<CalculationNode> m_min_value;
     NonnullOwnPtr<CalculationNode> m_center_value;
     NonnullOwnPtr<CalculationNode> m_max_value;
+};
+
+class ConstantCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<ConstantCalculationNode>> create(CalculationNode::ConstantType);
+    ~ConstantCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    ConstantCalculationNode(ConstantType);
+    CalculationNode::ConstantType m_constant;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -679,4 +679,22 @@ private:
     NonnullOwnPtr<CalculationNode> m_b;
 };
 
+class ExpCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<ExpCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    ~ExpCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    ExpCalculationNode(NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_a;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -624,4 +624,22 @@ private:
     NonnullOwnPtr<CalculationNode> m_b;
 };
 
+class SqrtCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<SqrtCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    ~SqrtCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    SqrtCalculationNode(NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_a;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -169,6 +169,14 @@ public:
         Atan,
         Atan2,
 
+        // Exponential functions, a sub-type of operator node
+        // https://drafts.csswg.org/css-values-4/#exponent-funcs
+        Pow,
+        Sqrt,
+        Hypot,
+        Log,
+        Exp,
+
         // Sign-Related Functions, a sub-type of operator node
         // https://drafts.csswg.org/css-values-4/#sign-funcs
         Abs,
@@ -593,6 +601,25 @@ public:
 
 private:
     Atan2CalculationNode(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_a;
+    NonnullOwnPtr<CalculationNode> m_b;
+};
+
+class PowCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<PowCalculationNode>> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    ~PowCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    PowCalculationNode(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
     NonnullOwnPtr<CalculationNode> m_a;
     NonnullOwnPtr<CalculationNode> m_b;
 };

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -277,4 +277,22 @@ private:
     Vector<NonnullOwnPtr<CalculationNode>> m_values;
 };
 
+class MaxCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<MaxCalculationNode>> create(Vector<NonnullOwnPtr<CalculationNode>>);
+    ~MaxCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override;
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    explicit MaxCalculationNode(Vector<NonnullOwnPtr<CalculationNode>>);
+    Vector<NonnullOwnPtr<CalculationNode>> m_values;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -381,4 +381,23 @@ private:
     NonnullOwnPtr<CalculationNode> m_b;
 };
 
+class ModCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<ModCalculationNode>> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    ~ModCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    ModCalculationNode(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_a;
+    NonnullOwnPtr<CalculationNode> m_b;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -295,4 +295,24 @@ private:
     Vector<NonnullOwnPtr<CalculationNode>> m_values;
 };
 
+class ClampCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<ClampCalculationNode>> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    ~ClampCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override;
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    explicit ClampCalculationNode(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_min_value;
+    NonnullOwnPtr<CalculationNode> m_center_value;
+    NonnullOwnPtr<CalculationNode> m_max_value;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -560,4 +560,22 @@ private:
     NonnullOwnPtr<CalculationNode> m_a;
 };
 
+class AtanCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<AtanCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    ~AtanCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    AtanCalculationNode(NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_a;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -159,6 +159,11 @@ public:
         Mod,
         Rem,
 
+        // Sign-Related Functions, a sub-type of operator node
+        // https://drafts.csswg.org/css-values-4/#sign-funcs
+        Abs,
+        Sign,
+
         // Constant Nodes
         // https://drafts.csswg.org/css-values-4/#calc-constants
         Constant,
@@ -417,6 +422,24 @@ private:
     RemCalculationNode(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
     NonnullOwnPtr<CalculationNode> m_a;
     NonnullOwnPtr<CalculationNode> m_b;
+};
+
+class AbsCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<AbsCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    ~AbsCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    AbsCalculationNode(NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_a;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -578,4 +578,23 @@ private:
     NonnullOwnPtr<CalculationNode> m_a;
 };
 
+class Atan2CalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<Atan2CalculationNode>> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    ~Atan2CalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    Atan2CalculationNode(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_a;
+    NonnullOwnPtr<CalculationNode> m_b;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -642,4 +642,22 @@ private:
     NonnullOwnPtr<CalculationNode> m_a;
 };
 
+class HypotCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<HypotCalculationNode>> create(Vector<NonnullOwnPtr<CalculationNode>>);
+    ~HypotCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override;
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    explicit HypotCalculationNode(Vector<NonnullOwnPtr<CalculationNode>>);
+    Vector<NonnullOwnPtr<CalculationNode>> m_values;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -129,6 +129,12 @@ public:
         Negate,
         Invert,
 
+        // Comparison function nodes, a sub-type of operator node
+        // https://drafts.csswg.org/css-values-4/#comp-func
+        Min,
+        Max,
+        Clamp,
+
         // This only exists during parsing.
         Unparsed,
     };

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -542,4 +542,22 @@ private:
     NonnullOwnPtr<CalculationNode> m_a;
 };
 
+class AcosCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<AcosCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    ~AcosCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    AcosCalculationNode(NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_a;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -442,4 +442,22 @@ private:
     NonnullOwnPtr<CalculationNode> m_a;
 };
 
+class SignCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<SignCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    ~SignCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    SignCalculationNode(NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_a;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -524,4 +524,22 @@ private:
     NonnullOwnPtr<CalculationNode> m_a;
 };
 
+class AsinCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<AsinCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    ~AsinCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    AsinCalculationNode(NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_a;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -488,4 +488,22 @@ private:
     NonnullOwnPtr<CalculationNode> m_a;
 };
 
+class CosCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<CosCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    ~CosCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    CosCalculationNode(NonnullOwnPtr<CalculationNode>);
+    NonnullOwnPtr<CalculationNode> m_a;
+};
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -114,6 +114,14 @@ private:
 // https://www.w3.org/TR/css-values-4/#calculation-tree
 class CalculationNode {
 public:
+    // https://drafts.csswg.org/css-values-4/#round-func
+    enum class RoundingMode {
+        Nearest,
+        Up,
+        Down,
+        TowardZero
+    };
+
     // https://drafts.csswg.org/css-values-4/#calc-constants
     // https://drafts.csswg.org/css-values-4/#calc-error-constants
     enum class ConstantType {
@@ -144,6 +152,12 @@ public:
         Min,
         Max,
         Clamp,
+
+        // Stepped value functions, a sub-type of operator node
+        // https://drafts.csswg.org/css-values-4/#round-func
+        Round,
+        Mod,
+        Rem,
 
         // Constant Nodes
         // https://drafts.csswg.org/css-values-4/#calc-constants
@@ -345,6 +359,26 @@ public:
 private:
     ConstantCalculationNode(ConstantType);
     CalculationNode::ConstantType m_constant;
+};
+
+class RoundCalculationNode final : public CalculationNode {
+public:
+    static ErrorOr<NonnullOwnPtr<RoundCalculationNode>> create(CalculationNode::RoundingMode, NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    ~RoundCalculationNode();
+
+    virtual ErrorOr<String> to_string() const override;
+    virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual bool contains_percentage() const override { return false; };
+    virtual CalculatedStyleValue::CalculationResult resolve(Layout::Node const*, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+
+    virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
+
+private:
+    RoundCalculationNode(RoundingMode, NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    CalculationNode::RoundingMode m_mode;
+    NonnullOwnPtr<CalculationNode> m_a;
+    NonnullOwnPtr<CalculationNode> m_b;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
@@ -40,7 +40,7 @@ float Filter::HueRotate::angle_degrees() const
     // Default value when omitted is 0deg.
     if (!angle.has_value())
         return 0.0f;
-    return angle->visit([&](Angle const& a) { return a.to_degrees(); }, [&](auto) { return 0.0f; });
+    return angle->visit([&](Angle const& a) { return a.to_degrees(); }, [&](auto) { return 0.0; });
 }
 
 float Filter::Color::resolved_amount() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
@@ -66,35 +66,35 @@ bool LinearGradientStyleValue::equals(StyleValue const& other_) const
 float LinearGradientStyleValue::angle_degrees(CSSPixelSize gradient_size) const
 {
     auto corner_angle_degrees = [&] {
-        return static_cast<float>(atan2(gradient_size.height().value(), gradient_size.width().value())) * 180 / AK::Pi<float>;
+        return atan2(gradient_size.height().value(), gradient_size.width().value()) * 180 / AK::Pi<double>;
     };
     return m_properties.direction.visit(
         [&](SideOrCorner side_or_corner) {
             auto angle = [&] {
                 switch (side_or_corner) {
                 case SideOrCorner::Top:
-                    return 0.0f;
+                    return 0.0;
                 case SideOrCorner::Bottom:
-                    return 180.0f;
+                    return 180.0;
                 case SideOrCorner::Left:
-                    return 270.0f;
+                    return 270.0;
                 case SideOrCorner::Right:
-                    return 90.0f;
+                    return 90.0;
                 case SideOrCorner::TopRight:
                     return corner_angle_degrees();
                 case SideOrCorner::BottomLeft:
-                    return corner_angle_degrees() + 180.0f;
+                    return corner_angle_degrees() + 180.0;
                 case SideOrCorner::TopLeft:
                     return -corner_angle_degrees();
                 case SideOrCorner::BottomRight:
-                    return -(corner_angle_degrees() + 180.0f);
+                    return -(corner_angle_degrees() + 180.0);
                 default:
                     VERIFY_NOT_REACHED();
                 }
             }();
             // Note: For unknowable reasons the angles are opposite on the -webkit- version
             if (m_properties.gradient_type == GradientType::WebKit)
-                return angle + 180.0f;
+                return angle + 180.0;
             return angle;
         },
         [&](Angle const& angle) {

--- a/Userland/Libraries/LibWeb/CSS/Time.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Time.cpp
@@ -15,13 +15,13 @@ Time::Time(int value, Type type)
 {
 }
 
-Time::Time(float value, Type type)
+Time::Time(double value, Type type)
     : m_type(type)
     , m_value(value)
 {
 }
 
-Time Time::make_seconds(float value)
+Time Time::make_seconds(double value)
 {
     return { value, Type::S };
 }
@@ -36,13 +36,13 @@ ErrorOr<String> Time::to_string() const
     return String::formatted("{}{}", m_value, unit_name());
 }
 
-float Time::to_seconds() const
+double Time::to_seconds() const
 {
     switch (m_type) {
     case Type::S:
         return m_value;
     case Type::Ms:
-        return m_value / 1000.0f;
+        return m_value / 1000.0;
     }
     VERIFY_NOT_REACHED();
 }
@@ -51,9 +51,9 @@ double Time::to_milliseconds() const
 {
     switch (m_type) {
     case Type::S:
-        return static_cast<double>(m_value) * 1000.0;
+        return m_value * 1000.0;
     case Type::Ms:
-        return static_cast<double>(m_value);
+        return m_value;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/Time.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Time.cpp
@@ -33,7 +33,7 @@ Time Time::percentage_of(Percentage const& percentage) const
 
 ErrorOr<String> Time::to_string() const
 {
-    return String::formatted("{}{}", m_value, unit_name());
+    return String::formatted("{}s", to_seconds());
 }
 
 double Time::to_seconds() const

--- a/Userland/Libraries/LibWeb/CSS/Time.h
+++ b/Userland/Libraries/LibWeb/CSS/Time.h
@@ -21,16 +21,16 @@ public:
     static Optional<Type> unit_from_name(StringView);
 
     Time(int value, Type type);
-    Time(float value, Type type);
-    static Time make_seconds(float);
+    Time(double value, Type type);
+    static Time make_seconds(double);
     Time percentage_of(Percentage const&) const;
 
     ErrorOr<String> to_string() const;
-    float to_seconds() const;
     double to_milliseconds() const;
+    double to_seconds() const;
 
     Type type() const { return m_type; }
-    float raw_value() const { return m_value; }
+    double raw_value() const { return m_value; }
 
     bool operator==(Time const& other) const
     {
@@ -41,7 +41,7 @@ private:
     StringView unit_name() const;
 
     Type m_type;
-    float m_value { 0 };
+    double m_value { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -563,6 +563,10 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     if (text_transform.has_value())
         computed_values.set_text_transform(text_transform.value());
 
+    auto letter_spacing = computed_style.length_percentage(CSS::PropertyID::LetterSpacing);
+    if (letter_spacing.has_value())
+        computed_values.set_letter_spacing(letter_spacing.value());
+
     if (auto list_style_type = computed_style.list_style_type(); list_style_type.has_value())
         computed_values.set_list_style_type(list_style_type.value());
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/CSS/StyleValues/NumericStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
+#include <LibWeb/CSS/StyleValues/TimeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/URLStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Dump.h>
@@ -609,6 +610,15 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
 
     computed_values.set_transformations(computed_style.transformations());
     computed_values.set_transform_origin(computed_style.transform_origin());
+
+    auto transition_delay_property = computed_style.property(CSS::PropertyID::TransitionDelay);
+    if (transition_delay_property->is_time()) {
+        auto& transition_delay = transition_delay_property->as_time();
+        computed_values.set_transition_delay(transition_delay.time());
+    } else if (transition_delay_property->is_calculated()) {
+        auto& transition_delay = transition_delay_property->as_calculated();
+        computed_values.set_transition_delay(transition_delay.resolve_time().value());
+    }
 
     auto do_border_style = [&](CSS::BorderData& border, CSS::PropertyID width_property, CSS::PropertyID color_property, CSS::PropertyID style_property) {
         // FIXME: The default border color value is `currentcolor`, but since we can't resolve that easily,

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -232,7 +232,7 @@ Gfx::FloatMatrix4x4 StackingContext::get_transformation_matrix(CSS::Transformati
     auto count = transformation.values.size();
     auto value = [this, transformation](size_t index, Optional<CSS::Length const&> reference_length = {}) -> float {
         return transformation.values[index].visit(
-            [this, reference_length](CSS::LengthPercentage const& value) -> float {
+            [this, reference_length](CSS::LengthPercentage const& value) -> double {
                 if (reference_length.has_value()) {
                     return value.resolved(m_box, reference_length.value()).to_px(m_box).value();
                 }
@@ -240,9 +240,9 @@ Gfx::FloatMatrix4x4 StackingContext::get_transformation_matrix(CSS::Transformati
                 return value.length().to_px(m_box).value();
             },
             [this](CSS::AngleOrCalculated const& value) {
-                return value.resolved(m_box).to_degrees() * static_cast<float>(M_DEG2RAD);
+                return value.resolved(m_box).to_degrees() * M_DEG2RAD;
             },
-            [](float value) {
+            [](double value) {
                 return value;
             });
     };


### PR DESCRIPTION
A chonker :^)

* Implements all functions listed under https://drafts.csswg.org/css-values-4/#math
* Implements `letter-spacing` and `transition-delay` due to wpt tests depending on them
* Allow `calc()` values in `transform` due to wpt tests depending on them
* Fix how some values are serialized
* Change the internal representation of `CalculationNode`s from float to double to fix precision issues
* Return a `NonnullOwnPtr` from `parse_a_calculation`
* Minor fix to variable resolving to avoid a crash