### PR TITLE
CI+Toolchain: Update to `actions/cache@v3` and simplify `BuildIt.sh`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -83,10 +83,8 @@ jobs:
           message("::set-output name=libc_headers::${{ hashFiles('Userland/Libraries/LibC/**/*.h', 'Userland/Libraries/LibPthread/**/*.h', 'Toolchain/Patches/*.patch', 'Toolchain/Patches/gcc/*.patch', 'Toolchain/BuildIt.sh') }}")
 
       - name: Toolchain cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
-        env:
-          CACHE_SKIP_SAVE: ${{ github.event_name == 'pull_request' }}
+        uses: actions/cache/restore@v3
+        id: toolchain-cache
         with:
           path: ${{ github.workspace }}/Toolchain/Cache/
           # This assumes that *ALL* LibC and LibPthread headers have an impact on the Toolchain.
@@ -97,12 +95,19 @@ jobs:
       - name: Restore or regenerate Toolchain
         run: TRY_USE_LOCAL_TOOLCHAIN=y ARCH="${{ matrix.arch }}" ${{ github.workspace }}/Toolchain/BuildIt.sh
 
+      - name: Update toolchain cache
+        uses: actions/cache/save@v3
+        # Do not waste time and storage space by updating the toolchain cache from a PR,
+        # as it would be discarded after being merged anyway.
+        if: ${{ github.event_name != 'pull_request' && !steps.toolchain-cache.outputs.cache-hit }}
+        with:
+          path: ${{ github.workspace }}/Toolchain/Cache/
+          key: ${{ steps.toolchain-cache.outputs.cache-primary-key }}
+
       - name: ccache(1) cache
         # Pull the ccache *after* building the toolchain, in case building the Toolchain somehow interferes.
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
-        env:
-          CACHE_SKIP_SAVE: ${{ github.event_name == 'pull_request' }}
+        uses: actions/cache/restore@v3
+        id: ccache
         with:
           path: ${{ github.workspace }}/.ccache
           # If you're here because ccache broke (it never should), increment matrix.ccache-mark.
@@ -131,20 +136,17 @@ jobs:
           mkdir -p ${{ github.workspace }}/Build/caches/UCD
           mkdir -p ${{ github.workspace }}/Build/caches/CLDR
       - name: TimeZoneData cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/Build/caches/TZDB
           key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
       - name: UnicodeData cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/Build/caches/UCD
           key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
       - name: UnicodeLocale Cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/Build/caches/CLDR
           key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}
@@ -185,6 +187,14 @@ jobs:
         run: cmake --build .
       - name: Show ccache stats after build
         run: ccache -s
+
+      - name: Update ccache(1) cache
+        uses: actions/cache/save@v3
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ${{ steps.ccache.outputs.cache-primary-key }}
+
       - name: Lint (Phase 2/2)
         working-directory: ${{ github.workspace }}/Meta
         env:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -86,14 +86,15 @@ jobs:
         uses: actions/cache/restore@v3
         id: toolchain-cache
         with:
-          path: ${{ github.workspace }}/Toolchain/Cache/
+          path: ${{ github.workspace }}/Toolchain/Local/${{ matrix.arch }}
           # This assumes that *ALL* LibC and LibPthread headers have an impact on the Toolchain.
           # This is wrong, and causes more Toolchain rebuilds than necessary.
           # However, we want to avoid false cache hits at all costs.
           key: ${{ runner.os }}-toolchain-${{ matrix.arch }}-${{ steps.stamps.outputs.libc_headers }}
 
-      - name: Restore or regenerate Toolchain
-        run: TRY_USE_LOCAL_TOOLCHAIN=y ARCH="${{ matrix.arch }}" ${{ github.workspace }}/Toolchain/BuildIt.sh
+      - name: Build toolchain
+        if: ${{ !steps.toolchain-cache.outputs.cache-hit }}
+        run: ARCH="${{ matrix.arch }}" ${{ github.workspace }}/Toolchain/BuildIt.sh
 
       - name: Update toolchain cache
         uses: actions/cache/save@v3
@@ -101,7 +102,7 @@ jobs:
         # as it would be discarded after being merged anyway.
         if: ${{ github.event_name != 'pull_request' && !steps.toolchain-cache.outputs.cache-hit }}
         with:
-          path: ${{ github.workspace }}/Toolchain/Cache/
+          path: ${{ github.workspace }}/Toolchain/Local/${{ matrix.arch }}
           key: ${{ steps.toolchain-cache.outputs.cache-primary-key }}
 
       - name: ccache(1) cache

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -77,22 +77,19 @@ jobs:
           mkdir -p libjs-test262/Build/CLDR
 
       - name: TimeZoneData cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/libjs-test262/Build/TZDB
           key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
 
       - name: UnicodeData cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/libjs-test262/Build/UCD
           key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
 
       - name: UnicodeLocale cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/libjs-test262/Build/CLDR
           key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}

--- a/.github/workflows/pvs-studio-static-analysis.yml
+++ b/.github/workflows/pvs-studio-static-analysis.yml
@@ -48,15 +48,17 @@ jobs:
       - name: Toolchain cache
         # This job should always read the cache, never populate it.
         uses: actions/cache/restore@v3
+        id: toolchain-cache
         with:
-          path: ${{ github.workspace }}/Toolchain/Cache/
+          path: ${{ github.workspace }}/Toolchain/Local/${{ env.PVS_STUDIO_ANALYSIS_ARCH }}
           # This assumes that *ALL* LibC and LibPthread headers have an impact on the Toolchain.
           # This is wrong, and causes more Toolchain rebuilds than necessary.
           # However, we want to avoid false cache hits at all costs.
-          key: ${{ runner.os }}-toolchain-${{ env.PVS_STUDIO_NALYSIS_ARCH }}-${{ steps.stamps.outputs.libc_headers }}
+          key: ${{ runner.os }}-toolchain-${{ env.PVS_STUDIO_ANALYSIS_ARCH }}-${{ steps.stamps.outputs.libc_headers }}
 
-      - name: Restore or regenerate Toolchain
-        run: TRY_USE_LOCAL_TOOLCHAIN=y ARCH="${{ env.PVS_STUDIO_ANALYSIS_ARCH }}" ${{ github.workspace }}/Toolchain/BuildIt.sh
+      - name: Build toolchain
+        if: ${{ !steps.toolchain-cache.outputs.cache-hit }}
+        run: ARCH="${{ env.PVS_STUDIO_ANALYSIS_ARCH }}" ${{ github.workspace }}/Toolchain/BuildIt.sh
 
       - name: Create build directory
         run: |

--- a/.github/workflows/pvs-studio-static-analysis.yml
+++ b/.github/workflows/pvs-studio-static-analysis.yml
@@ -46,12 +46,8 @@ jobs:
           message("::set-output name=libc_headers::${{ hashFiles('Userland/Libraries/LibC/**/*.h', 'Userland/Libraries/LibPthread/**/*.h', 'Toolchain/Patches/*.patch', 'Toolchain/Patches/gcc/*.patch', 'Toolchain/BuildIt.sh') }}")
 
       - name: Toolchain cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
-        env:
-          # This job should always read the cache, never populate it.
-          CACHE_SKIP_SAVE: true
-
+        # This job should always read the cache, never populate it.
+        uses: actions/cache/restore@v3
         with:
           path: ${{ github.workspace }}/Toolchain/Cache/
           # This assumes that *ALL* LibC and LibPthread headers have an impact on the Toolchain.
@@ -70,20 +66,17 @@ jobs:
           mkdir -p ${{ github.workspace }}/Build/caches/CLDR
 
       - name: TimeZoneData cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/Build/caches/TZDB
           key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
       - name: UnicodeData cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/Build/caches/UCD
           key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
       - name: UnicodeLocale Cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/Build/caches/CLDR
           key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}

--- a/.github/workflows/serenity-js-artifacts.yml
+++ b/.github/workflows/serenity-js-artifacts.yml
@@ -60,22 +60,19 @@ jobs:
           mkdir -p Build/CLDR
 
       - name: TimeZoneData cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/libjs-test262/Build/TZDB
           key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
 
       - name: UnicodeData cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/libjs-test262/Build/UCD
           key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
 
       - name: UnicodeLocale cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/libjs-test262/Build/CLDR
           key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}

--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -78,12 +78,8 @@ jobs:
           message("::set-output name=libc_headers::${{ hashFiles('Userland/Libraries/LibC/**/*.h', 'Userland/Libraries/LibPthread/**/*.h', 'Toolchain/Patches/*.patch', 'Toolchain/Patches/gcc/*.patch', 'Toolchain/BuildIt.sh') }}")
 
       - name: Toolchain cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
-        env:
-          # This job should always read the cache, never populate it.
-          CACHE_SKIP_SAVE: true
-
+        # This job should always read the cache, never populate it.
+        uses: actions/cache/restore@v3
         with:
           path: ${{ github.workspace }}/Toolchain/Cache/
           # This assumes that *ALL* LibC and LibPthread headers have an impact on the Toolchain.
@@ -102,20 +98,17 @@ jobs:
           mkdir -p ${{ github.workspace }}/Build/caches/CLDR
 
       - name: TimeZoneData cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/Build/caches/TZDB
           key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
       - name: UnicodeData cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/Build/caches/UCD
           key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
       - name: UnicodeLocale Cache
-        # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/Build/caches/CLDR
           key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}

--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -80,15 +80,17 @@ jobs:
       - name: Toolchain cache
         # This job should always read the cache, never populate it.
         uses: actions/cache/restore@v3
+        id: toolchain-cache
         with:
-          path: ${{ github.workspace }}/Toolchain/Cache/
+          path: ${{ github.workspace }}/Toolchain/Local/${{ env.SONAR_ANALYSIS_ARCH }}
           # This assumes that *ALL* LibC and LibPthread headers have an impact on the Toolchain.
           # This is wrong, and causes more Toolchain rebuilds than necessary.
           # However, we want to avoid false cache hits at all costs.
           key: ${{ runner.os }}-toolchain-${{ env.SONAR_ANALYSIS_ARCH }}-${{ steps.stamps.outputs.libc_headers }}
 
-      - name: Restore or regenerate Toolchain
-        run: TRY_USE_LOCAL_TOOLCHAIN=y ARCH="${{ env.SONAR_ANALYSIS_ARCH }}" ${{ github.workspace }}/Toolchain/BuildIt.sh
+      - name: Build toolchain
+        if: ${{ !steps.toolchain-cache.outputs.cache-hit }}
+        run: ARCH="${{ env.SONAR_ANALYSIS_ARCH }}" ${{ github.workspace }}/Toolchain/BuildIt.sh
 
       - name: Create build directory
         run: |

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -37,17 +37,17 @@ jobs:
           mkdir -p ${{ github.workspace }}/Build/caches/UCD
           mkdir -p ${{ github.workspace }}/Build/caches/CLDR
       - name: "TimeZoneData cache"
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/Build/caches/TZDB
           key: TimeZoneData-${{ hashFiles('Meta/CMake/time_zone_data.cmake') }}
       - name: "UnicodeData cache"
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/Build/caches/UCD
           key: UnicodeData-${{ hashFiles('Meta/CMake/unicode_data.cmake') }}
       - name: "UnicodeLocale cache"
-        uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/Build/caches/CLDR
           key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}


### PR DESCRIPTION
**CI: Update `actions/cache` to v3**

This version now natively supports read-only caches (`cache/restore@v3`)
so we no longer need to pin the version to a commit in https://github.com/actions/cache/pull/489
which is an unmerged PR.

The update is mostly mechanical:
- Steps with `CACHE_SKIP_SAVE` not set can use the plain `cache@v3`
  action.
- Steps with `CACHE_SKIP_SAVE` set to a constant `true` are changed to
  `cache/restore@v3`.
- Steps with saving disabled when running on a pull request are changed
  to a pair of `cache/restore@v3` and `cache/save@v3`. This setup is
  used for the large (100s of MB) ccache and Toolchain caches. As caches
  saved in pull requests can only be utilized from within the same PR,
  uploading these would only waste time and our storage quote.
  Therefore, we skip the `save` steps if running on a PR.

**Toolchain+CI: Remove cache handling logic from BuildIt.sh**

Instead of manually compressing/decompressing a toolchain tarball if
`TRY_USE_LOCAL_TOOLCHAIN` is set, let's use the cache action's automatic
built-in compression (which is zstd, I believe).