### PR TITLE
Ladybird: Run all layout & text tests in the same process

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -166,14 +166,8 @@ endif()
 include(CTest)
 if (BUILD_TESTING)
     add_test(
-        NAME Layout
-        COMMAND ${SERENITY_SOURCE_DIR}/Tests/LibWeb/Layout/layout_test.sh ${CMAKE_CURRENT_BINARY_DIR}
+        NAME LibWeb
+        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/headless-browser --run-tests ${SERENITY_SOURCE_DIR}/Tests/LibWeb
     )
-    set_tests_properties(Layout PROPERTIES ENVIRONMENT QT_QPA_PLATFORM=offscreen)
-
-    add_test(
-        NAME LibWebText
-        COMMAND ${SERENITY_SOURCE_DIR}/Tests/LibWeb/Text/text_test.sh ${CMAKE_CURRENT_BINARY_DIR}
-    )
-set_tests_properties(LibWebText PROPERTIES ENVIRONMENT QT_QPA_PLATFORM=offscreen)
+    set_tests_properties(LibWeb PROPERTIES ENVIRONMENT QT_QPA_PLATFORM=offscreen)
 endif()


### PR DESCRIPTION
Instead of starting a new headless-browser for every layout & text test, headless-browser now gets a mode where it runs all the tests in a single process.

This is massively faster on my machine, taking a full LibWeb test run from 14 seconds to less than 1 second. Hopefully it will be a similarly awesome improvement on CI where it has been soaking up more and more time lately. :^)