### PR TITLE
LibJS: Parse slashes after reserved identifiers correctly

### DIFF
--- a/Userland/Libraries/LibJS/Lexer.cpp
+++ b/Userland/Libraries/LibJS/Lexer.cpp
@@ -500,23 +500,18 @@ bool Lexer::is_numeric_literal_start() const
 bool Lexer::slash_means_division() const
 {
     auto type = m_current_token.type();
-    return type == TokenType::BigIntLiteral
-        || type == TokenType::BoolLiteral
+    return m_current_token.is_identifier_name()
+        || type == TokenType::BigIntLiteral
         || type == TokenType::BracketClose
         || type == TokenType::CurlyClose
-        || type == TokenType::Identifier
-        || type == TokenType::In
-        || type == TokenType::Instanceof
         || type == TokenType::MinusMinus
-        || type == TokenType::NullLiteral
         || type == TokenType::NumericLiteral
         || type == TokenType::ParenClose
         || type == TokenType::PlusPlus
         || type == TokenType::PrivateIdentifier
         || type == TokenType::RegexLiteral
         || type == TokenType::StringLiteral
-        || type == TokenType::TemplateLiteralEnd
-        || type == TokenType::This;
+        || type == TokenType::TemplateLiteralEnd;
 }
 
 Token Lexer::next()

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -244,6 +244,7 @@ private:
     void expected(char const* what);
     void syntax_error(DeprecatedString const& message, Optional<Position> = {});
     Token consume();
+    Token consume_and_allow_division();
     Token consume_identifier();
     Token consume_identifier_reference();
     Token consume(TokenType type);

--- a/Userland/Libraries/LibJS/Tests/modules/basic-modules.js
+++ b/Userland/Libraries/LibJS/Tests/modules/basic-modules.js
@@ -210,6 +210,12 @@ describe("in- and exports", () => {
     test("can have top level using declarations which trigger at the end of running a module", () => {
         expectModulePassed("./top-level-dispose.mjs");
     });
+
+    test("can export default a RegExp", () => {
+        const result = expectModulePassed("./default-regexp-export.mjs");
+        expect(result.default).toBeInstanceOf(RegExp);
+        expect(result.default.toString()).toBe(/foo/.toString());
+    });
 });
 
 describe("loops", () => {

--- a/Userland/Libraries/LibJS/Tests/modules/default-regexp-export.mjs
+++ b/Userland/Libraries/LibJS/Tests/modules/default-regexp-export.mjs
@@ -1,0 +1,3 @@
+export default /foo/;
+
+export let passed = true;

--- a/Userland/Libraries/LibJS/Tests/syntax/slash-after-block.js
+++ b/Userland/Libraries/LibJS/Tests/syntax/slash-after-block.js
@@ -19,7 +19,30 @@ test("slash token resolution in lexer", () => {
     expect("a.instanceof / b").toEval();
     expect("class A { #name; d = a.#name / b; }").toEval();
 
-    // FIXME: Even more 'reserved' words are valid however the cases below do still need to pass.
-    //expect("a.void / b").toEval();
+    expect("async / b").toEval();
+    expect("a.delete / b").toEval();
+    expect("delete / b/").toEval();
+    expect("a.in / b").toEval();
+    expect("for (a in / b/) {}").toEval();
+    expect("a.instanceof / b").toEval();
+    expect("a instanceof / b/").toEval();
+    expect("new / b/").toEval();
+    expect("null / b").toEval();
+    expect("for (a of / b/) {}").toEval();
+    expect("a.return / b").toEval();
+    expect("function foo() { return / b/ }").toEval();
+    expect("throw / b/").toEval();
+    expect("a.typeof / b").toEval();
+    expect("a.void / b").toEval();
     expect("void / b/").toEval();
+
+    expect("await / b").toEval();
+    expect("await / b/").not.toEval();
+    expect("async function foo() { await / b }").not.toEval();
+    expect("async function foo() { await / b/ }").toEval();
+
+    expect("yield / b").toEval();
+    expect("yield / b/").not.toEval();
+    expect("function* foo() { yield / b }").not.toEval();
+    expect("function* foo() { yield / b/ }").toEval();
 });


### PR DESCRIPTION
Previously we were unable to parse code like `yield/2` because `/2` was parsed as a regex. At the same time `for (a in / b/)` was parsed as a division.

This is solved by defaulting to division for any IdentifierName and telling the lexer to `force_slash_as_regex()` whenever the name is used as a keyword instead of an identifier.