### PR TITLE
LibWeb: Apply rules for parsing a legacy color value where applicable

### DIFF
--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2019-2023, Shannon Booth <shannon.ml.booth@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -78,7 +79,7 @@ static Optional<Color> parse_rgba_color(StringView string)
     return Color(r, g, b, a);
 }
 
-Optional<Color> Color::from_string(StringView string)
+Optional<Color> Color::from_named_css_color_string(StringView string)
 {
     if (string.is_empty())
         return {};
@@ -243,13 +244,24 @@ Optional<Color> Color::from_string(StringView string)
         WebColor { 0x663399, "rebeccapurple"sv },
     };
 
-    if (string.equals_ignoring_ascii_case("transparent"sv))
-        return Color::from_argb(0x00000000);
-
     for (auto const& web_color : web_colors) {
         if (string.equals_ignoring_ascii_case(web_color.name))
             return Color::from_rgb(web_color.color);
     }
+
+    return {};
+}
+
+Optional<Color> Color::from_string(StringView string)
+{
+    if (string.is_empty())
+        return {};
+
+    if (string.equals_ignoring_ascii_case("transparent"sv))
+        return Color::from_argb(0x00000000);
+
+    if (auto const color = from_named_css_color_string(string); color.has_value())
+        return color;
 
     if (string.starts_with("rgb("sv, CaseSensitivity::CaseInsensitive) && string.ends_with(')'))
         return parse_rgb_color(string);

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -378,6 +378,7 @@ public:
     DeprecatedString to_deprecated_string() const;
     DeprecatedString to_deprecated_string_without_alpha() const;
     static Optional<Color> from_string(StringView);
+    static Optional<Color> from_named_css_color_string(StringView);
 
     constexpr HSV to_hsv() const
     {

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLBodyElement.h>
+#include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Node.h>
 
@@ -33,11 +34,13 @@ void HTMLBodyElement::apply_presentational_hints(CSS::StyleProperties& style) co
 {
     for_each_attribute([&](auto& name, auto& value) {
         if (name.equals_ignoring_ascii_case("bgcolor"sv)) {
-            auto color = Color::from_string(value);
+            // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value
+            auto color = parse_legacy_color_value(value);
             if (color.has_value())
                 style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()).release_value_but_fixme_should_propagate_errors());
         } else if (name.equals_ignoring_ascii_case("text"sv)) {
-            auto color = Color::from_string(value);
+            // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-2
+            auto color = parse_legacy_color_value(value);
             if (color.has_value())
                 style.set_property(CSS::PropertyID::Color, CSS::ColorStyleValue::create(color.value()).release_value_but_fixme_should_propagate_errors());
         } else if (name.equals_ignoring_ascii_case("background"sv)) {
@@ -51,15 +54,18 @@ void HTMLBodyElement::parse_attribute(DeprecatedFlyString const& name, Deprecate
 {
     HTMLElement::parse_attribute(name, value);
     if (name.equals_ignoring_ascii_case("link"sv)) {
-        auto color = Color::from_string(value);
+        // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-3
+        auto color = parse_legacy_color_value(value);
         if (color.has_value())
             document().set_link_color(color.value());
     } else if (name.equals_ignoring_ascii_case("alink"sv)) {
-        auto color = Color::from_string(value);
+        // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-5
+        auto color = parse_legacy_color_value(value);
         if (color.has_value())
             document().set_active_link_color(color.value());
     } else if (name.equals_ignoring_ascii_case("vlink"sv)) {
-        auto color = Color::from_string(value);
+        // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-4
+        auto color = parse_legacy_color_value(value);
         if (color.has_value())
             document().set_visited_link_color(color.value());
     } else if (name.equals_ignoring_ascii_case("background"sv)) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLFontElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFontElement.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/HTML/HTMLFontElement.h>
+#include <LibWeb/HTML/Parser/HTMLParser.h>
 
 namespace Web::HTML {
 
@@ -30,7 +31,8 @@ void HTMLFontElement::apply_presentational_hints(CSS::StyleProperties& style) co
 {
     for_each_attribute([&](auto& name, auto& value) {
         if (name.equals_ignoring_ascii_case("color"sv)) {
-            auto color = Color::from_string(value);
+            // https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3:rules-for-parsing-a-legacy-colour-value
+            auto color = parse_legacy_color_value(value);
             if (color.has_value())
                 style.set_property(CSS::PropertyID::Color, CSS::ColorStyleValue::create(color.value()).release_value_but_fixme_should_propagate_errors());
         }

--- a/Userland/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/HTML/HTMLMarqueeElement.h>
+#include <LibWeb/HTML/Parser/HTMLParser.h>
 
 namespace Web::HTML {
 
@@ -31,7 +32,8 @@ void HTMLMarqueeElement::apply_presentational_hints(CSS::StyleProperties& style)
     HTMLElement::apply_presentational_hints(style);
     for_each_attribute([&](auto& name, auto& value) {
         if (name == HTML::AttributeNames::bgcolor) {
-            auto color = Color::from_string(value);
+            // https://html.spec.whatwg.org/multipage/rendering.html#the-marquee-element-2:rules-for-parsing-a-legacy-colour-value
+            auto color = parse_legacy_color_value(value);
             if (color.has_value())
                 style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()).release_value_but_fixme_should_propagate_errors());
         }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -33,7 +33,8 @@ void HTMLTableCellElement::apply_presentational_hints(CSS::StyleProperties& styl
 {
     for_each_attribute([&](auto& name, auto& value) {
         if (name == HTML::AttributeNames::bgcolor) {
-            auto color = Color::from_string(value);
+            // https://html.spec.whatwg.org/multipage/rendering.html#tables-2:rules-for-parsing-a-legacy-colour-value
+            auto color = parse_legacy_color_value(value);
             if (color.has_value())
                 style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()).release_value_but_fixme_should_propagate_errors());
             return;

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -55,7 +55,8 @@ void HTMLTableElement::apply_presentational_hints(CSS::StyleProperties& style) c
             return;
         }
         if (name == HTML::AttributeNames::bgcolor) {
-            auto color = Color::from_string(value);
+            // https://html.spec.whatwg.org/multipage/rendering.html#tables-2:rules-for-parsing-a-legacy-colour-value
+            auto color = parse_legacy_color_value(value);
             if (color.has_value())
                 style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()).release_value_but_fixme_should_propagate_errors());
             return;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/Color.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/HTML/Parser/HTMLTokenizer.h>
@@ -200,5 +201,6 @@ private:
 
 RefPtr<CSS::StyleValue> parse_dimension_value(StringView);
 RefPtr<CSS::StyleValue> parse_nonzero_dimension_value(StringView);
+Optional<Color> parse_legacy_color_value(DeprecatedString input);
 
 }


### PR DESCRIPTION
Some legacy attributes, such as 'bgcolor' in the body element parse colors following the "rules for parsing a legacy color value". Implement this set of rules, and apply them where applicable.

My first contribution to Serenity OS for a long time now! Github is telling me this was 3 years ago, back in 2020. Figured it would be fitting working on something like this. 
