### PR TITLE
LibJS: Make Error stack traces lazier

### DIFF
--- a/Userland/Applications/Spreadsheet/CellSyntaxHighlighter.cpp
+++ b/Userland/Applications/Spreadsheet/CellSyntaxHighlighter.cpp
@@ -36,7 +36,7 @@ void CellSyntaxHighlighter::rehighlight(Palette const& palette)
         if (m_cell && m_cell->thrown_value().has_value()) {
             if (auto value = m_cell->thrown_value().value(); value.is_object() && is<JS::Error>(value.as_object())) {
                 auto& error = static_cast<JS::Error const&>(value.as_object());
-                auto& range = error.traceback().first().source_range;
+                auto& range = error.traceback().first().source_range();
 
                 spans.prepend({
                     GUI::TextRange { { range.start.line - 1, range.start.column }, { range.end.line - 1, range.end.column } },

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -70,7 +70,7 @@ Sheet::Sheet(Workbook& workbook)
                     warnln(" with message '{}'", error.get_without_side_effects(interpreter().vm().names.message));
                     for (auto& traceback_frame : error.traceback()) {
                         auto& function_name = traceback_frame.function_name;
-                        auto& source_range = traceback_frame.source_range;
+                        auto& source_range = traceback_frame.source_range();
                         dbgln("  {} at {}:{}:{}", function_name, source_range.filename(), source_range.start.line, source_range.start.column);
                     }
                 } else {

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -122,13 +122,13 @@ GUI::Variant SheetModel::data(const GUI::ModelIndex& index, GUI::ModelRole role)
         StringBuilder builder;
         builder.appendff("{}\n", error.get_without_side_effects(object.vm().names.message).to_string_without_side_effects().release_value_but_fixme_should_propagate_errors());
         for (auto const& frame : trace.in_reverse()) {
-            if (frame.source_range.filename().contains("runtime.js"sv)) {
+            if (frame.source_range().filename().contains("runtime.js"sv)) {
                 if (frame.function_name == "<unknown>")
-                    builder.appendff("  in a builtin function at line {}, column {}\n", frame.source_range.start.line, frame.source_range.start.column);
+                    builder.appendff("  in a builtin function at line {}, column {}\n", frame.source_range().start.line, frame.source_range().start.column);
                 else
                     builder.appendff("  while evaluating builtin '{}'\n", frame.function_name);
-            } else if (frame.source_range.filename().starts_with("cell "sv)) {
-                builder.appendff("  in cell '{}', at line {}, column {}\n", frame.source_range.filename().substring_view(5), frame.source_range.start.line, frame.source_range.start.column);
+            } else if (frame.source_range().filename().starts_with("cell "sv)) {
+                builder.appendff("  in cell '{}', at line {}, column {}\n", frame.source_range().filename().substring_view(5), frame.source_range().start.line, frame.source_range().start.column);
             }
         }
         return builder.to_deprecated_string();

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -58,6 +58,9 @@ public:
 
     [[nodiscard]] SourceRange source_range() const;
     u32 start_offset() const { return m_start_offset; }
+    u32 end_offset() const { return m_end_offset; }
+
+    SourceCode const& source_code() const { return *m_source_code; }
 
     void set_end_offset(Badge<Parser>, u32 end_offset) { m_end_offset = end_offset; }
 

--- a/Userland/Libraries/LibJS/MarkupGenerator.cpp
+++ b/Userland/Libraries/LibJS/MarkupGenerator.cpp
@@ -150,12 +150,12 @@ ErrorOr<void> MarkupGenerator::date_to_html(Object const& date, StringBuilder& h
 ErrorOr<void> MarkupGenerator::trace_to_html(TracebackFrame const& traceback_frame, StringBuilder& html_output)
 {
     auto function_name = escape_html_entities(traceback_frame.function_name);
-    auto [line, column, _] = traceback_frame.source_range.start;
+    auto [line, column, _] = traceback_frame.source_range().start;
     auto get_filename_from_path = [&](StringView filename) -> StringView {
         auto last_slash_index = filename.find_last('/');
         return last_slash_index.has_value() ? filename.substring_view(*last_slash_index + 1) : filename;
     };
-    auto filename = escape_html_entities(get_filename_from_path(traceback_frame.source_range.filename()));
+    auto filename = escape_html_entities(get_filename_from_path(traceback_frame.source_range().filename()));
     auto trace = TRY(String::formatted("at {} ({}:{}:{})", function_name, filename, line, column));
 
     TRY(html_output.try_appendff("&nbsp;&nbsp;{}<br>", trace));

--- a/Userland/Libraries/LibJS/Runtime/Error.h
+++ b/Userland/Libraries/LibJS/Runtime/Error.h
@@ -17,7 +17,14 @@ namespace JS {
 
 struct TracebackFrame {
     DeprecatedFlyString function_name;
-    SourceRange source_range;
+    [[nodiscard]] SourceRange const& source_range() const;
+
+    struct UnrealizedSourceRange {
+        u32 start_offset { 0 };
+        u32 end_offset { 0 };
+        RefPtr<JS::SourceCode const> source_code;
+    };
+    mutable Variant<SourceRange, UnrealizedSourceRange> source_range_storage;
 };
 
 class Error : public Object {

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ExceptionReporter.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ExceptionReporter.cpp
@@ -33,7 +33,7 @@ void report_exception_to_console(JS::Value value, JS::Realm& realm, ErrorInPromi
             auto const& error_value = static_cast<JS::Error const&>(object);
             for (auto& traceback_frame : error_value.traceback()) {
                 auto& function_name = traceback_frame.function_name;
-                auto& source_range = traceback_frame.source_range;
+                auto& source_range = traceback_frame.source_range();
                 dbgln("  {} at {}:{}:{}", function_name, source_range.filename(), source_range.start.line, source_range.start.column);
             }
             console.report_exception(error_value, error_in_promise == ErrorInPromise::Yes);


### PR DESCRIPTION
Instead of eagerly populating the stack trace with a textual representation of every call frame, just store the raw source code range (code, start offset, end offset). From that, we can generate the full rich backtrace when requested, and save ourselves the trouble otherwise.

This makes test-wasm take ~7 seconds on my machine instead of ~60. :^)