### PR TITLE
Toolchain+Ports: Use `ftpmirror.gnu.org` for faster downloads

### DIFF
--- a/Ports/cpio/package.sh
+++ b/Ports/cpio/package.sh
@@ -4,5 +4,5 @@ version='2.13'
 useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('build-aux/config.sub')
-files="https://ftp.gnu.org/gnu/cpio/cpio-${version}.tar.gz cpio-${version}.tar.gz e87470d9c984317f658567c03bfefb6b0c829ff17dbf6b0de48d71a4c8f3db88"
+files="https://ftpmirror.gnu.org/gnu/cpio/cpio-${version}.tar.gz cpio-${version}.tar.gz e87470d9c984317f658567c03bfefb6b0c829ff17dbf6b0de48d71a4c8f3db88"
 auth_type='sha256'

--- a/Ports/findutils/package.sh
+++ b/Ports/findutils/package.sh
@@ -4,5 +4,5 @@ version='4.9.0'
 useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('build-aux/config.sub')
-files="https://ftp.gnu.org/gnu/findutils/findutils-${version}.tar.xz findutils-${version}.tar.xz a2bfb8c09d436770edc59f50fa483e785b161a3b7b9d547573cb08065fd462fe"
+files="https://ftpmirror.gnu.org/gnu/findutils/findutils-${version}.tar.xz findutils-${version}.tar.xz a2bfb8c09d436770edc59f50fa483e785b161a3b7b9d547573cb08065fd462fe"
 auth_type='sha256'

--- a/Ports/gettext/package.sh
+++ b/Ports/gettext/package.sh
@@ -2,7 +2,7 @@
 port='gettext'
 version='0.21.1'
 useconfigure='true'
-files="https://ftp.gnu.org/pub/gnu/gettext/gettext-${version}.tar.gz gettext-${version}.tar.gz e8c3650e1d8cee875c4f355642382c1df83058bd5a11ee8555c0cf276d646d45"
+files="https://ftpmirror.gnu.org/pub/gnu/gettext/gettext-${version}.tar.gz gettext-${version}.tar.gz e8c3650e1d8cee875c4f355642382c1df83058bd5a11ee8555c0cf276d646d45"
 auth_type='sha256'
 depends=("libiconv")
 use_fresh_config_sub='true'

--- a/Ports/gsl/package.sh
+++ b/Ports/gsl/package.sh
@@ -3,8 +3,8 @@
 port=gsl
 version=2.7.1
 useconfigure=true
-files="https://ftp.gnu.org/gnu/gsl/gsl-${version}.tar.gz gsl-${version}.tar.gz
-https://ftp.gnu.org/gnu/gsl/gsl-${version}.tar.gz.sig gsl-${version}.tar.gz.sig
+files="https://ftpmirror.gnu.org/gnu/gsl/gsl-${version}.tar.gz gsl-${version}.tar.gz
+https://ftpmirror.gnu.org/gnu/gsl/gsl-${version}.tar.gz.sig gsl-${version}.tar.gz.sig
 https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type=sig
 auth_opts=("--keyring" "./gnu-keyring.gpg" "gsl-${version}.tar.gz.sig")

--- a/Ports/gzip/package.sh
+++ b/Ports/gzip/package.sh
@@ -4,5 +4,5 @@ version='1.12'
 useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('build-aux/config.sub')
-files="https://ftp.gnu.org/gnu/gzip/gzip-${version}.tar.gz gzip-${version}.tar.gz 5b4fb14d38314e09f2fc8a1c510e7cd540a3ea0e3eb9b0420046b82c3bf41085"
+files="https://ftpmirror.gnu.org/gnu/gzip/gzip-${version}.tar.gz gzip-${version}.tar.gz 5b4fb14d38314e09f2fc8a1c510e7cd540a3ea0e3eb9b0420046b82c3bf41085"
 auth_type='sha256'

--- a/Ports/patch/package.sh
+++ b/Ports/patch/package.sh
@@ -4,5 +4,5 @@ version=2.7.6
 useconfigure=true
 use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
-files="https://ftp.gnu.org/gnu/patch/patch-${version}.tar.gz patch-${version}.tar.gz 8cf86e00ad3aaa6d26aca30640e86b0e3e1f395ed99f189b06d4c9f74bc58a4e"
+files="https://ftpmirror.gnu.org/gnu/patch/patch-${version}.tar.gz patch-${version}.tar.gz 8cf86e00ad3aaa6d26aca30640e86b0e3e1f395ed99f189b06d4c9f74bc58a4e"
 auth_type=sha256

--- a/Ports/tar/package.sh
+++ b/Ports/tar/package.sh
@@ -4,7 +4,7 @@ version='1.34'
 useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('build-aux/config.sub')
-files="https://ftp.gnu.org/gnu/tar/tar-${version}.tar.gz tar-${version}.tar.gz 03d908cf5768cfe6b7ad588c921c6ed21acabfb2b79b788d1330453507647aed"
+files="https://ftpmirror.gnu.org/gnu/tar/tar-${version}.tar.gz tar-${version}.tar.gz 03d908cf5768cfe6b7ad588c921c6ed21acabfb2b79b788d1330453507647aed"
 auth_type='sha256'
 configopts=(
     "--without-selinux"

--- a/Ports/which/package.sh
+++ b/Ports/which/package.sh
@@ -2,5 +2,5 @@
 port='which'
 version='2.21'
 useconfigure='true'
-files="https://ftp.gnu.org/gnu/which/which-${version}.tar.gz which-${version}.tar.gz f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad"
+files="https://ftpmirror.gnu.org/gnu/which/which-${version}.tar.gz which-${version}.tar.gz f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad"
 auth_type='sha256'

--- a/Toolchain/BuildGDB.sh
+++ b/Toolchain/BuildGDB.sh
@@ -12,7 +12,7 @@ GDB_VERSION="13.1"
 GDB_MD5SUM="4aaad768ff2585464173c091947287ec"
 GDB_NAME="gdb-$GDB_VERSION"
 GDB_PKG="${GDB_NAME}.tar.xz"
-GDB_BASE_URL="https://ftp.gnu.org/gnu/gdb"
+GDB_BASE_URL="https://ftpmirror.gnu.org/gnu/gdb"
 
 ARCH=${1:-"x86_64"}
 TARGET="$ARCH-pc-serenity"
@@ -82,7 +82,7 @@ pushd "$DIR/Tarballs"
         md5="$($MD5SUM "$GDB_PKG" | cut -f1 -d' ')"
     fi
     if [ "$md5" != "$GDB_MD5SUM" ]; then
-        curl -C - -O "$GDB_BASE_URL/$GDB_PKG"
+        curl -C - -LO "$GDB_BASE_URL/$GDB_PKG"
     else
         echo "Skipped downloading $GDB_PKG"
     fi

--- a/Toolchain/BuildGDB.sh
+++ b/Toolchain/BuildGDB.sh
@@ -59,8 +59,9 @@ for lib in gmp isl mpfr mpc; do
         [ "$lib" = "mpc" ] && formula_name="libmpc" || formula_name="$lib"
         config_args+=("--with-$lib=$(brew --prefix --installed "$formula_name")") || missing_lib $lib
     else
+        [ "$lib" = "isl" ] && header="isl/version.h" || header="$lib.h"
         if ! ${CC:-cc} -I /usr/local/include -L /usr/local/lib -l$lib -o /dev/null -xc - >/dev/null <<PROGRAM
-#include <$lib.h>
+#include <$header>
 int main() {}
 PROGRAM
               then

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -78,7 +78,7 @@ BINUTILS_VERSION="2.40"
 BINUTILS_MD5SUM="007b59bd908a737c06e5a8d3d2c737eb"
 BINUTILS_NAME="binutils-$BINUTILS_VERSION"
 BINUTILS_PKG="${BINUTILS_NAME}.tar.xz"
-BINUTILS_BASE_URL="https://ftp.gnu.org/gnu/binutils"
+BINUTILS_BASE_URL="https://ftpmirror.gnu.org/gnu/binutils"
 
 # Note: If you bump the gcc version, you also have to update the matching
 #       GCC_VERSION variable in the project's root CMakeLists.txt
@@ -86,7 +86,7 @@ GCC_VERSION="13.1.0"
 GCC_MD5SUM="43e4de77f2218c83ca675257ea1af9ef"
 GCC_NAME="gcc-$GCC_VERSION"
 GCC_PKG="${GCC_NAME}.tar.xz"
-GCC_BASE_URL="https://ftp.gnu.org/gnu/gcc"
+GCC_BASE_URL="https://ftpmirror.gnu.org/gnu/gcc"
 
 buildstep() {
     NAME=$1


### PR DESCRIPTION
This service automatically redirects to a mirror that's geographically closer, which should make downloading the tarballs faster. The GNU project recommends this instead of bombarding their top-level downloads site.

Also included is a tiny patch to make `BuildGDB.sh` *actually* work on Linux this time :man_facepalming: 

See also: #6341