### PR TITLE
LibWasm: Create AK::StackInfo once per AbstractMachine

### DIFF
--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
@@ -162,7 +162,7 @@ InstantiationResult AbstractMachine::instantiate(Module const& module, Vector<Ex
             auxiliary_instance.globals().append(*ptr);
     }
 
-    BytecodeInterpreter interpreter;
+    BytecodeInterpreter interpreter(m_stack_info);
 
     module.for_each_section_of_type<GlobalSection>([&](auto& global_section) {
         for (auto& entry : global_section.entries()) {
@@ -491,7 +491,7 @@ Optional<InstantiationError> AbstractMachine::allocate_all_final_phase(Module co
 
 Result AbstractMachine::invoke(FunctionAddress address, Vector<Value> arguments)
 {
-    BytecodeInterpreter interpreter;
+    BytecodeInterpreter interpreter(m_stack_info);
     return invoke(interpreter, address, move(arguments));
 }
 

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -11,6 +11,7 @@
 #include <AK/HashTable.h>
 #include <AK/OwnPtr.h>
 #include <AK/Result.h>
+#include <AK/StackInfo.h>
 #include <LibWasm/Types.h>
 
 // NOTE: Special case for Wasm::Result.
@@ -607,6 +608,7 @@ private:
     Optional<InstantiationError> allocate_all_initial_phase(Module const&, ModuleInstance&, Vector<ExternValue>&, Vector<Value>& global_values);
     Optional<InstantiationError> allocate_all_final_phase(Module const&, ModuleInstance&, Vector<Vector<Reference>>& elements);
     Store m_store;
+    StackInfo m_stack_info;
     bool m_should_limit_instruction_count { false };
 };
 

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
@@ -13,6 +13,11 @@
 namespace Wasm {
 
 struct BytecodeInterpreter : public Interpreter {
+    explicit BytecodeInterpreter(StackInfo const& stack_info)
+        : m_stack_info(stack_info)
+    {
+    }
+
     virtual void interpret(Configuration&) override;
     virtual ~BytecodeInterpreter() override = default;
     virtual bool did_trap() const override { return !m_trap.has<Empty>(); }
@@ -72,10 +77,14 @@ protected:
     }
 
     Variant<Trap, JS::Completion, Empty> m_trap;
-    StackInfo m_stack_info;
+    StackInfo const& m_stack_info;
 };
 
 struct DebuggerBytecodeInterpreter : public BytecodeInterpreter {
+    DebuggerBytecodeInterpreter(StackInfo const& stack_info)
+        : BytecodeInterpreter(stack_info)
+    {
+    }
     virtual ~DebuggerBytecodeInterpreter() override = default;
 
     Function<bool(Configuration&, InstructionPointer&, Instruction const&)> pre_interpret_hook;

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/MemoryStream.h>
+#include <AK/StackInfo.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <LibCore/MappedFile.h>
@@ -25,7 +26,8 @@ static OwnPtr<Stream> g_stdout {};
 static OwnPtr<Wasm::Printer> g_printer {};
 static bool g_continue { false };
 static void (*old_signal)(int);
-static Wasm::DebuggerBytecodeInterpreter g_interpreter;
+static StackInfo g_stack_info;
+static Wasm::DebuggerBytecodeInterpreter g_interpreter(g_stack_info);
 
 static void sigint_handler(int)
 {


### PR DESCRIPTION
This makes test-wasm about 20% faster on my Linux machine :^)