### PR TITLE
LibJS: Fix reading cached source ranges

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Error.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Error.cpp
@@ -17,12 +17,15 @@ namespace JS {
 
 SourceRange const& TracebackFrame::source_range() const
 {
-    if (auto* unrealized = source_range_storage.get_pointer<UnrealizedSourceRange>(); unrealized && unrealized->source_code) {
-        auto source_range = unrealized->source_code->range_from_offsets(unrealized->start_offset, unrealized->end_offset);
+    if (auto* unrealized = source_range_storage.get_pointer<UnrealizedSourceRange>()) {
+        auto source_range = [&] {
+            if (!unrealized->source_code) {
+                static auto dummy_source_code = SourceCode::create(String {}, String {});
+                return SourceRange { dummy_source_code, {}, {} };
+            }
+            return unrealized->source_code->range_from_offsets(unrealized->start_offset, unrealized->end_offset);
+        }();
         source_range_storage = move(source_range);
-    } else {
-        static auto dummy_source_range = SourceRange { .code = SourceCode::create(String {}, String {}), .start = {}, .end = {} };
-        return dummy_source_range;
     }
     return source_range_storage.get<SourceRange>();
 }


### PR DESCRIPTION
Made a slight logic error in 95d69fc which meant the dummy range would be returned even if the source_range_storage contained an actual source range. This corrects that by resolving the null unrealized range to a dummy range, and storing that. It then can be treated as a normal source range.