### PR TITLE
LibWeb: Support reverse flex layout with space-around/space-between

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/reverse-flex-layout-with-space-between-and-space-around.txt
+++ b/Tests/LibWeb/Layout/expected/flex/reverse-flex-layout-with-space-between-and-space-around.txt
@@ -1,0 +1,73 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x616 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x600 children: not-inline
+      Box <div.outer.row> at (8,8) content-size 150x150 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div.inner> at (12.619791,8) content-size 30.078125x150 flex-item [BFC] children: inline
+          line 0 width: 30.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 4, rect: [12.619791,8 30.078125x17.46875]
+              "Well"
+          TextNode <#text>
+        BlockContainer <div.inner> at (51.9375,8) content-size 36.84375x150 flex-item [BFC] children: inline
+          line 0 width: 36.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [51.9375,8 36.84375x17.46875]
+              "hello"
+          TextNode <#text>
+        BlockContainer <div.inner> at (98.020833,8) content-size 55.359375x150 flex-item [BFC] children: inline
+          line 0 width: 55.359375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 7, rect: [98.020833,8 55.359375x17.46875]
+              "friends"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,158) content-size 784x0 children: inline
+        TextNode <#text>
+      Box <div.outer.row-reverse> at (8,158) content-size 150x150 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div.inner> at (123.302083,158) content-size 30.078125x150 flex-item [BFC] children: inline
+          line 0 width: 30.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 4, rect: [123.302083,158 30.078125x17.46875]
+              "Well"
+          TextNode <#text>
+        BlockContainer <div.inner> at (77.21875,158) content-size 36.84375x150 flex-item [BFC] children: inline
+          line 0 width: 36.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [77.21875,158 36.84375x17.46875]
+              "hello"
+          TextNode <#text>
+        BlockContainer <div.inner> at (12.619791,158) content-size 55.359375x150 flex-item [BFC] children: inline
+          line 0 width: 55.359375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 7, rect: [12.619791,158 55.359375x17.46875]
+              "friends"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,308) content-size 784x0 children: inline
+        TextNode <#text>
+      Box <div.outer.column> at (8,308) content-size 150x150 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div.inner> at (8,324.265625) content-size 150x17.46875 flex-item [BFC] children: inline
+          line 0 width: 30.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 4, rect: [8,324.265625 30.078125x17.46875]
+              "Well"
+          TextNode <#text>
+        BlockContainer <div.inner> at (8,374.265625) content-size 150x17.46875 flex-item [BFC] children: inline
+          line 0 width: 36.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [8,374.265625 36.84375x17.46875]
+              "hello"
+          TextNode <#text>
+        BlockContainer <div.inner> at (8,424.265625) content-size 150x17.46875 flex-item [BFC] children: inline
+          line 0 width: 55.359375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 7, rect: [8,424.265625 55.359375x17.46875]
+              "friends"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,458) content-size 784x0 children: inline
+        TextNode <#text>
+      Box <div.outer.column-reverse> at (8,458) content-size 150x150 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div.inner> at (8,574.265625) content-size 150x17.46875 flex-item [BFC] children: inline
+          line 0 width: 30.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 4, rect: [8,574.265625 30.078125x17.46875]
+              "Well"
+          TextNode <#text>
+        BlockContainer <div.inner> at (8,524.265625) content-size 150x17.46875 flex-item [BFC] children: inline
+          line 0 width: 36.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [8,524.265625 36.84375x17.46875]
+              "hello"
+          TextNode <#text>
+        BlockContainer <div.inner> at (8,474.265625) content-size 150x17.46875 flex-item [BFC] children: inline
+          line 0 width: 55.359375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 7, rect: [8,474.265625 55.359375x17.46875]
+              "friends"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/flex/reverse-flex-layout-with-space-between-and-space-around.html
+++ b/Tests/LibWeb/Layout/input/flex/reverse-flex-layout-with-space-between-and-space-around.html
@@ -1,0 +1,20 @@
+<!doctype html><style>
+    .outer {
+        display: flex;
+        width: 150px;
+        height: 150px;
+        justify-content: space-around;
+        background: pink;
+    }
+    .row { flex-direction: row; }
+    .row-reverse { flex-direction: row-reverse; }
+    .column { flex-direction: column; }
+    .column-reverse { flex-direction: column-reverse; }
+    .inner {
+        background: orange;
+    }
+</style>
+<div class="outer row"><div class="inner">Well</div><div class="inner">hello</div><div class="inner">friends</div></div>
+<div class="outer row-reverse"><div class="inner">Well</div><div class="inner">hello</div><div class="inner">friends</div></div>
+<div class="outer column"><div class="inner">Well</div><div class="inner">hello</div><div class="inner">friends</div></div>
+<div class="outer column-reverse"><div class="inner">Well</div><div class="inner">hello</div><div class="inner">friends</div></div>

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1323,11 +1323,20 @@ void FlexFormattingContext::distribute_any_remaining_free_space()
                 }
                 break;
             case CSS::JustifyContent::SpaceBetween:
+                if (is_direction_reverse()) {
+                    initial_offset = inner_main_size(flex_container());
+                } else {
+                    initial_offset = 0;
+                }
                 space_between_items = flex_line.remaining_free_space / (number_of_items - 1);
                 break;
             case CSS::JustifyContent::SpaceAround:
                 space_between_items = flex_line.remaining_free_space / number_of_items;
-                initial_offset = space_between_items / 2.0;
+                if (is_direction_reverse()) {
+                    initial_offset = inner_main_size(flex_container()) - space_between_items / 2.0;
+                } else {
+                    initial_offset = space_between_items / 2.0;
+                }
                 break;
             }
         }


### PR DESCRIPTION
We were not taking reverse flex directions into account when choosing the initial offset for flex item placement if justify-content were either space-around or space-between.

Nice visual improvement on https://theverge.com/

Before:
![Screenshot at 2023-05-28 15-47-36](https://github.com/SerenityOS/serenity/assets/5954907/485600ab-17aa-4d1b-8463-ac359669fea6)

After:
![Screenshot at 2023-05-28 15-46-20](https://github.com/SerenityOS/serenity/assets/5954907/22af5f5d-120d-42d3-90db-68771cceaf34)
