### PR TITLE
LibWeb: Treat unresolvable percentages as auto to resolve sizes in GFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/unresolvable-percentage-track.txt
+++ b/Tests/LibWeb/Layout/expected/grid/unresolvable-percentage-track.txt
@@ -1,0 +1,10 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
+      Box <div.ipc-page-grid> at (8,8) content-size 784x17.46875 flex-container(row) [FFC] children: not-inline
+        Box <div.ipc-sub-grid> at (8,8) content-size 36.84375x17.46875 flex-item [GFC] children: not-inline
+          BlockContainer <div> at (8,8) content-size 36.84375x17.46875 [BFC] children: inline
+            line 0 width: 36.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17.46875]
+                "hello"
+            TextNode <#text>

--- a/Tests/LibWeb/Layout/input/grid/unresolvable-percentage-track.html
+++ b/Tests/LibWeb/Layout/input/grid/unresolvable-percentage-track.html
@@ -1,0 +1,11 @@
+<style>
+.ipc-page-grid {
+    display: flex;
+}
+
+.ipc-sub-grid {
+    display: grid;
+    grid-template-columns: 100%;
+}
+</style>
+<div class="ipc-page-grid"><div class="ipc-sub-grid"><div>hello</div></div></div>

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
@@ -36,6 +36,33 @@ GridSize::GridSize()
 
 GridSize::~GridSize() = default;
 
+bool GridSize::is_auto(Layout::AvailableSize const& available_size) const
+{
+    if (m_type == Type::LengthPercentage) {
+        if (m_length_percentage.is_percentage())
+            return !available_size.is_definite();
+        return m_length_percentage.is_auto();
+    }
+
+    return false;
+}
+
+bool GridSize::is_fixed(Layout::AvailableSize const& available_size) const
+{
+    if (m_type == Type::LengthPercentage) {
+        if (m_length_percentage.is_percentage())
+            return available_size.is_definite();
+        return !m_length_percentage.is_auto();
+    }
+
+    return false;
+}
+
+bool GridSize::is_intrinsic(Layout::AvailableSize const& available_size) const
+{
+    return is_auto(available_size) || is_max_content() || is_min_content();
+}
+
 GridSize GridSize::make_auto()
 {
     return GridSize(CSS::Length::make_auto());

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
@@ -8,6 +8,7 @@
 
 #include <AK/Vector.h>
 #include <LibWeb/CSS/PercentageOr.h>
+#include <LibWeb/Layout/AvailableSpace.h>
 
 namespace Web::CSS {
 
@@ -30,8 +31,8 @@ public:
 
     Type type() const { return m_type; }
 
-    bool is_auto() const { return m_type == Type::LengthPercentage && m_length_percentage.is_auto(); }
-    bool is_length_percentage() const { return m_type == Type::LengthPercentage; }
+    bool is_auto(Layout::AvailableSize const&) const;
+    bool is_fixed(Layout::AvailableSize const&) const;
     bool is_flexible_length() const { return m_type == Type::FlexibleLength; }
     bool is_max_content() const { return m_type == Type::MaxContent; }
     bool is_min_content() const { return m_type == Type::MinContent; }
@@ -42,10 +43,7 @@ public:
     // https://www.w3.org/TR/css-grid-2/#layout-algorithm
     // An intrinsic sizing function (min-content, max-content, auto, fit-content()).
     // FIXME: Add missing properties once implemented.
-    bool is_intrinsic_track_sizing() const
-    {
-        return is_auto() || is_max_content() || is_min_content();
-    }
+    bool is_intrinsic(Layout::AvailableSize const&) const;
 
     bool is_definite() const
     {

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -201,6 +201,8 @@ private:
     Vector<GridItem> m_grid_items;
     Vector<JS::NonnullGCPtr<Box const>> m_boxes_to_place;
 
+    Optional<AvailableSpace> m_available_space;
+
     void determine_grid_container_height();
     void determine_intrinsic_size_of_grid_container(AvailableSpace const& available_space);
 


### PR DESCRIPTION
Fixes the bug that currently we always consider tracks with percentage size as ones with "fixed" length even when available size is not definite. With this change tracks with percentage size when available size is not definite will be considered as "intrinsic" sized.