### PR TITLE
LibGUI: Fix crooked close button on active tabs in the TabWidget

### DIFF
--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -366,7 +366,7 @@ void TabWidget::paint_event(PaintEvent& event)
             painter.draw_line(icon_rect.top_right().moved_left(1), icon_rect.bottom_left().moved_up(1), palette().button_text());
         } else {
             painter.draw_line(icon_rect.top_left().moved_right(1), icon_rect.bottom_right().translated(-2, -2), palette().button_text());
-            painter.draw_line(icon_rect.top_right().moved_left(2), icon_rect.bottom_left().moved_right(1), palette().button_text());
+            painter.draw_line(icon_rect.top_right().moved_left(2), icon_rect.bottom_left().translated(1, -2), palette().button_text());
             painter.draw_line(icon_rect.bottom_left(), icon_rect.bottom_right().moved_left(1), palette().button_text(), 1, Painter::LineStyle::Dotted);
         }
     }


### PR DESCRIPTION
This is a regression from f391ccfe53e18395842d0d6b743d08d23b9108e5. The bug didn't appear on inactive tabs, as they already use `translated(1, -2)`.

cc @gmta <sub><sup>(*is it okay to ping people when I find bugs in their code?*)</sup></sub>

before | after
---|---
![](https://github.com/SerenityOS/serenity/assets/16520278/cf363309-f8f9-489d-aed8-c02b103c7b63) | ![](https://github.com/SerenityOS/serenity/assets/16520278/c13e1a80-451f-43ae-b360-a674fdfd74be)
