### PR TITLE
LibWeb: Wrap child text sequences of grid container in anonymous blocks

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/anonymous-inline-child.txt
+++ b/Tests/LibWeb/Layout/expected/grid/anonymous-inline-child.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
+      Box <div.grid> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 784x17.46875 [BFC] children: inline
+          line 0 width: 36.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17.46875]
+              "hello"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/grid/anonymous-inline-child.html
+++ b/Tests/LibWeb/Layout/input/grid/anonymous-inline-child.html
@@ -1,0 +1,3 @@
+<style>
+.grid { display: grid; }
+</style><div class="grid">hello</div>

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -69,7 +69,7 @@ static Layout::Node& insertion_parent_for_inline_node(Layout::NodeWithStyle& lay
     if (layout_parent.display().is_inline_outside() && layout_parent.display().is_flow_inside())
         return layout_parent;
 
-    if (layout_parent.display().is_flex_inside()) {
+    if (layout_parent.display().is_flex_inside() || layout_parent.display().is_grid_inside()) {
         layout_parent.append_child(layout_parent.create_anonymous_wrapper());
         return *layout_parent.last_child();
     }


### PR DESCRIPTION
From spec https://drafts.csswg.org/css-grid/#grid-items: "Each in-flow child of a grid container becomes a grid item, and each child text sequence is wrapped in an anonymous block container grid item."

Fixes the problem that text sequences inside grid containers are ignored and not displayed.