### PR TITLE
WebP/Lossy: Implement macroblock coefficient decoding

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossy.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossy.h
@@ -20,7 +20,8 @@ struct VP8Header {
     u8 horizontal_scale;
     u32 height;
     u8 vertical_scale;
-    ReadonlyBytes lossy_data;
+    ReadonlyBytes first_partition;
+    ReadonlyBytes second_partition;
 };
 
 // Parses the header data in a VP8 chunk. Pass the payload of a `VP8 ` chunk, after the tag and after the tag's data size.


### PR DESCRIPTION
This basically adds the line

    u8 token = TRY(
        tree_decode(decoder, COEFFICIENT_TREE,
        header.coefficient_probabilities[plane][band][tricky],
        last_decoded_value == DCT_0 ? 2 : 0));

and calls it once for the 16 coefficients of a discrete cosine transform
that covers a 4x4 pixel subblock.

And then it does this 24 or 25 times per macroblock, for the 4x4 Y
subblocks and the 2x2 each U and V subblocks (plus an optional Y2 block
for some macroblocks).

It then adds a whole bunch of machinery to be able to compute `plane`,
`band`, and in particular `tricky` (which depends on if the
corresponding left or above subblock has non-zero coefficients).

(It also does dequantization, and does an inverse Walsh-Hadamard
transform when needed, to end up with complete DCT coefficients
in all cases.)