### PR TITLE
LibCore+AK+Userland: Prefer String in DirIterator

### DIFF
--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -14,6 +14,11 @@ namespace AK {
 
 char s_single_dot = '.';
 
+LexicalPath::LexicalPath(String path)
+{
+    LexicalPath(path.to_deprecated_string());
+}
+
 LexicalPath::LexicalPath(DeprecatedString path)
     : m_string(canonicalized_path(move(path)))
 {

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 
 // On Linux distros that use mlibc `basename` is defined as a macro that expands to `__mlibc_gnu_basename` or `__mlibc_gnu_basename_c`, so we undefine it.
@@ -19,6 +20,7 @@ namespace AK {
 
 class LexicalPath {
 public:
+    explicit LexicalPath(String);
     explicit LexicalPath(DeprecatedString);
 
     bool is_absolute() const { return !m_string.is_empty() && m_string[0] == '/'; }

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -520,6 +520,11 @@ bool String::ends_with(u32 code_point) const
     return last_code_point == code_point;
 }
 
+bool String::ends_with(StringView str, AK::CaseSensitivity case_sensitivity) const
+{
+    return AK::StringUtils::ends_with(*this, str, case_sensitivity);
+}
+
 bool String::ends_with_bytes(StringView bytes) const
 {
     return bytes_as_string_view().ends_with(bytes);

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -503,6 +503,11 @@ bool String::starts_with(u32 code_point) const
     return *code_points().begin() == code_point;
 }
 
+bool String::starts_with(StringView str, AK::CaseSensitivity case_sensitivity) const
+{
+    return AK::StringUtils::starts_with(*this, str, case_sensitivity);
+}
+
 bool String::starts_with_bytes(StringView bytes) const
 {
     return bytes_as_string_view().starts_with(bytes);

--- a/AK/String.h
+++ b/AK/String.h
@@ -112,6 +112,7 @@ public:
     [[nodiscard]] bool equals_ignoring_case(String const&) const;
 
     [[nodiscard]] bool starts_with(u32 code_point) const;
+    [[nodiscard]] bool starts_with(StringView, AK::CaseSensitivity = AK::CaseSensitivity::CaseSensitive) const;
     [[nodiscard]] bool starts_with_bytes(StringView) const;
 
     [[nodiscard]] bool ends_with(u32 code_point) const;

--- a/AK/String.h
+++ b/AK/String.h
@@ -115,6 +115,7 @@ public:
     [[nodiscard]] bool starts_with_bytes(StringView) const;
 
     [[nodiscard]] bool ends_with(u32 code_point) const;
+    [[nodiscard]] bool ends_with(StringView, AK::CaseSensitivity = AK::CaseSensitivity::CaseSensitive) const;
     [[nodiscard]] bool ends_with_bytes(StringView) const;
 
     // Creates a substring with a deep copy of the specified data window.

--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -201,7 +201,7 @@ void FileProvider::build_filesystem_cache()
                 // FIXME: Propagate errors.
                 (void)Core::Directory::for_each_entry(base_directory, Core::DirIterator::SkipDots, [&](auto const& entry, auto const& directory) -> ErrorOr<IterationDecision> {
                     struct stat st = {};
-                    if (fstatat(directory.fd(), entry.name.characters(), &st, AT_SYMLINK_NOFOLLOW) < 0) {
+                    if (fstatat(directory.fd(), entry.name.to_deprecated_string().characters(), &st, AT_SYMLINK_NOFOLLOW) < 0) {
                         perror("fstatat");
                         return IterationDecision::Continue;
                     }

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -302,7 +302,7 @@ void PropertiesWindow::DirectoryStatisticsCalculator::start()
                         return Error::from_errno(ECANCELED);
 
                     struct stat st = {};
-                    if (fstatat(directory.fd(), entry.name.characters(), &st, AT_SYMLINK_NOFOLLOW) < 0) {
+                    if (fstatat(directory.fd(), entry.name.to_deprecated_string().characters(), &st, AT_SYMLINK_NOFOLLOW) < 0) {
                         perror("fstatat");
                         return IterationDecision::Continue;
                     }

--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
@@ -247,7 +247,7 @@ ErrorOr<void> ChessSettingsWidget::initialize()
 
     m_piece_set_combobox = find_descendant_of_type_named<GUI::ComboBox>("piece_set");
     TRY(Core::Directory::for_each_entry("/res/graphics/chess/sets/"sv, Core::DirIterator::SkipParentAndBaseDir, [&](auto const& entry, auto&) -> ErrorOr<IterationDecision> {
-        TRY(m_piece_sets.try_append(entry.name));
+        TRY(m_piece_sets.try_append(entry.name.to_deprecated_string()));
         return IterationDecision::Continue;
     }));
     auto piece_set_model = GUI::ItemListModel<DeprecatedString>::create(m_piece_sets);

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -61,7 +61,7 @@ private:
         set_icon(parent_window->icon());
 
         auto iterator_result = Core::Directory::for_each_entry("/res/keymaps/"sv, Core::DirIterator::Flags::SkipDots, [&](auto const& entry, auto&) -> ErrorOr<IterationDecision> {
-            auto basename = entry.name.replace(".json"sv, ""sv, ReplaceMode::FirstOnly);
+            auto basename = TRY(entry.name.replace(".json"sv, ""sv, ReplaceMode::FirstOnly)).to_deprecated_string();
             if (selected_keymaps.find(basename).is_end())
                 m_character_map_files.append(basename);
             return IterationDecision::Continue;

--- a/Userland/Applications/MouseSettings/ThemeWidget.cpp
+++ b/Userland/Applications/MouseSettings/ThemeWidget.cpp
@@ -90,7 +90,7 @@ void ThemeModel::invalidate()
     // FIXME: Propagate errors.
     (void)Core::Directory::for_each_entry("/res/cursor-themes"sv, Core::DirIterator::Flags::SkipDots, [&](auto const& entry, auto&) -> ErrorOr<IterationDecision> {
         if (access(DeprecatedString::formatted("/res/cursor-themes/{}/Config.ini", entry.name).characters(), R_OK) == 0)
-            m_themes.append(entry.name);
+            m_themes.append(entry.name.to_deprecated_string());
         return IterationDecision::Continue;
     });
 

--- a/Userland/Applications/SpaceAnalyzer/Tree.cpp
+++ b/Userland/Applications/SpaceAnalyzer/Tree.cpp
@@ -105,7 +105,7 @@ HashMap<int, int> TreeNode::populate_filesize_tree(Vector<MountInfo>& mounts, Fu
             queue_entry.node->m_children = make<Vector<TreeNode>>();
 
             auto iteration_result = Core::Directory::for_each_entry(builder.string_view(), Core::DirIterator::SkipParentAndBaseDir, [&](auto& entry, auto&) -> ErrorOr<IterationDecision> {
-                TRY(queue_entry.node->m_children->try_append(TreeNode(entry.name)));
+                TRY(queue_entry.node->m_children->try_append(TreeNode(entry.name.to_deprecated_string())));
                 return IterationDecision::Continue;
             });
             if (iteration_result.is_error())

--- a/Userland/Demos/WidgetGallery/GalleryModels.h
+++ b/Userland/Demos/WidgetGallery/GalleryModels.h
@@ -63,13 +63,13 @@ public:
         Core::DirIterator iterator(DeprecatedString::formatted("/res/cursor-themes/{}", GUI::ConnectionToWindowServer::the().get_cursor_theme()), Core::DirIterator::Flags::SkipDots);
 
         while (iterator.has_next()) {
-            auto path = iterator.next_full_path();
+            auto path = iterator.next_full_path().release_value_but_fixme_should_propagate_errors();
             if (path.ends_with(".ini"sv))
                 continue;
             if (path.contains("2x"sv))
                 continue;
             Cursor cursor;
-            cursor.path = move(path);
+            cursor.path = path.to_deprecated_string();
             cursor.name = LexicalPath::basename(cursor.path);
 
             // FIXME: Animated cursor bitmaps
@@ -151,29 +151,29 @@ public:
     {
         m_icon_sets.clear();
 
-        Core::DirIterator big_iterator("/res/icons/32x32", Core::DirIterator::Flags::SkipDots);
+        Core::DirIterator big_iterator("/res/icons/32x32"sv, Core::DirIterator::Flags::SkipDots);
 
         while (big_iterator.has_next()) {
-            auto path = big_iterator.next_full_path();
+            auto path = big_iterator.next_full_path().release_value_but_fixme_should_propagate_errors();
             if (!path.contains("filetype-"sv) && !path.contains("app-"sv))
                 continue;
             IconSet icon_set;
             icon_set.big_icon = Gfx::Bitmap::load_from_file(path).release_value_but_fixme_should_propagate_errors();
-            icon_set.name = LexicalPath::basename(path);
+            icon_set.name = LexicalPath::basename(path.to_deprecated_string());
             m_icon_sets.append(move(icon_set));
         }
 
         auto big_icons_found = m_icon_sets.size();
 
-        Core::DirIterator little_iterator("/res/icons/16x16", Core::DirIterator::Flags::SkipDots);
+        Core::DirIterator little_iterator("/res/icons/16x16"sv, Core::DirIterator::Flags::SkipDots);
 
         while (little_iterator.has_next()) {
-            auto path = little_iterator.next_full_path();
+            auto path = little_iterator.next_full_path().release_value_but_fixme_should_propagate_errors();
             if (!path.contains("filetype-"sv) && !path.contains("app-"sv))
                 continue;
             IconSet icon_set;
             icon_set.little_icon = Gfx::Bitmap::load_from_file(path).release_value_but_fixme_should_propagate_errors();
-            icon_set.name = LexicalPath::basename(path);
+            icon_set.name = LexicalPath::basename(path.to_deprecated_string());
             for (size_t i = 0; i < big_icons_found; i++) {
                 if (icon_set.name == m_icon_sets[i].name) {
                     m_icon_sets[i].little_icon = icon_set.little_icon;

--- a/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.cpp
@@ -116,7 +116,7 @@ void ProjectTemplatesModel::rescan_templates()
     }
 
     while (di.has_next()) {
-        auto full_path = LexicalPath(di.next_full_path());
+        auto full_path = LexicalPath(di.next_full_path().release_value_but_fixme_should_propagate_errors());
         if (!full_path.has_extension(".ini"sv))
             continue;
 

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -201,9 +201,9 @@ static HashMap<DeprecatedString, DeprecatedString>& man_paths()
 
             Core::DirIterator it(json_value.as_string(), Core::DirIterator::Flags::SkipDots);
             while (it.has_next()) {
-                auto path = it.next_full_path();
-                auto title = LexicalPath::title(path);
-                paths.set(title, path);
+                auto path = it.next_full_path().release_value_but_fixme_should_propagate_errors();
+                auto title = LexicalPath::title(path.to_deprecated_string());
+                paths.set(title, path.to_deprecated_string());
             }
         }
     }
@@ -408,7 +408,7 @@ static HashMap<DeprecatedString, DeprecatedString>& include_paths()
     auto add_directory = [](DeprecatedString base, Optional<DeprecatedString> recursive, auto handle_directory) -> void {
         Core::DirIterator it(recursive.value_or(base), Core::DirIterator::Flags::SkipDots);
         while (it.has_next()) {
-            auto path = it.next_full_path();
+            auto path = it.next_full_path().release_value_but_fixme_should_propagate_errors().to_deprecated_string();
             if (!FileSystem::is_directory(path)) {
                 auto key = path.substring(base.length() + 1, path.length() - base.length() - 1);
                 dbgln_if(EDITOR_DEBUG, "Adding header \"{}\" in path \"{}\"", key, path);

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -53,7 +53,7 @@ static Vector<DeprecatedString> lookup_database_names()
     Vector<DeprecatedString> database_names;
 
     while (iterator.has_next()) {
-        if (auto database = iterator.next_path(); database.ends_with(database_extension))
+        if (auto database = iterator.next_path().to_deprecated_string(); database.ends_with(database_extension))
             database_names.append(database.substring(0, database.length() - database_extension.length()));
     }
 

--- a/Userland/Libraries/LibCodeComprehension/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/Libraries/LibCodeComprehension/Cpp/CppComprehensionEngine.cpp
@@ -739,12 +739,12 @@ Optional<Vector<CodeComprehension::AutocompleteResultEntry>> CppComprehensionEng
         if (FileSystem::is_directory(LexicalPath::join(full_dir, path).string())) {
             // FIXME: Don't dismiss the autocomplete when filling these suggestions.
             auto completion = DeprecatedString::formatted("{}{}{}/", prefix, include_dir, path);
-            options.empend(completion, include_dir.length() + partial_basename.length() + 1, CodeComprehension::Language::Cpp, path, CodeComprehension::AutocompleteResultEntry::HideAutocompleteAfterApplying::No);
+            options.empend(completion, include_dir.length() + partial_basename.length() + 1, CodeComprehension::Language::Cpp, path.to_deprecated_string(), CodeComprehension::AutocompleteResultEntry::HideAutocompleteAfterApplying::No);
         } else if (path.ends_with(".h"sv)) {
             // FIXME: Place the cursor after the trailing > or ", even if it was
             //        already typed.
             auto completion = DeprecatedString::formatted("{}{}{}{}", prefix, include_dir, path, already_has_suffix ? "" : suffix);
-            options.empend(completion, include_dir.length() + partial_basename.length() + 1, CodeComprehension::Language::Cpp, path);
+            options.empend(completion, include_dir.length() + partial_basename.length() + 1, CodeComprehension::Language::Cpp, path.to_deprecated_string());
         }
     }
 

--- a/Userland/Libraries/LibCore/DirIterator.cpp
+++ b/Userland/Libraries/LibCore/DirIterator.cpp
@@ -56,7 +56,14 @@ bool DirIterator::advance_next()
             return false;
         }
 
-        m_next = DirectoryEntry::from_dirent(*de);
+        auto maybe_next = DirectoryEntry::from_dirent(*de);
+        if (maybe_next.is_error()) {
+            m_error = maybe_next.release_error();
+            m_next.clear();
+            return false;
+        }
+
+        m_next = maybe_next.release_value();
 
         if (m_next->name.is_empty())
             return false;
@@ -93,7 +100,7 @@ DeprecatedString DirIterator::next_path()
 {
     auto entry = next();
     if (entry.has_value())
-        return entry->name;
+        return entry->name.to_deprecated_string();
     return "";
 }
 

--- a/Userland/Libraries/LibCore/DirIterator.h
+++ b/Userland/Libraries/LibCore/DirIterator.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/Error.h>
+#include <AK/String.h>
 #include <LibCore/DirectoryEntry.h>
 #include <dirent.h>
 #include <string.h>
@@ -22,7 +23,7 @@ public:
         SkipParentAndBaseDir = 0x2,
     };
 
-    explicit DirIterator(DeprecatedString path, Flags = Flags::NoFlags);
+    explicit DirIterator(StringView path, Flags = Flags::NoFlags);
     ~DirIterator();
 
     DirIterator(DirIterator&&);
@@ -32,15 +33,15 @@ public:
     Error error() const { return Error::copy(m_error.value()); }
     bool has_next();
     Optional<DirectoryEntry> next();
-    DeprecatedString next_path();
-    DeprecatedString next_full_path();
+    String next_path();
+    ErrorOr<String> next_full_path();
     int fd() const;
 
 private:
     DIR* m_dir = nullptr;
     Optional<Error> m_error;
     Optional<DirectoryEntry> m_next;
-    DeprecatedString m_path;
+    String m_path;
     int m_flags;
 
     bool advance_next();

--- a/Userland/Libraries/LibCore/DirectoryEntry.cpp
+++ b/Userland/Libraries/LibCore/DirectoryEntry.cpp
@@ -36,11 +36,12 @@ static DirectoryEntry::Type directory_entry_type_from_posix(unsigned char dt_con
     VERIFY_NOT_REACHED();
 }
 
-DirectoryEntry DirectoryEntry::from_dirent(dirent const& de)
+ErrorOr<DirectoryEntry> DirectoryEntry::from_dirent(dirent const& de)
 {
+    auto name = TRY(String::from_deprecated_string(de.d_name));
     return DirectoryEntry {
         .type = directory_entry_type_from_posix(de.d_type),
-        .name = de.d_name,
+        .name = name,
     };
 };
 

--- a/Userland/Libraries/LibCore/DirectoryEntry.h
+++ b/Userland/Libraries/LibCore/DirectoryEntry.h
@@ -6,7 +6,8 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/Error.h>
+#include <AK/String.h>
 
 struct dirent;
 
@@ -26,9 +27,9 @@ struct DirectoryEntry {
     };
     Type type;
     // FIXME: Once we have a special Path string class, use that.
-    DeprecatedString name;
+    String name;
 
-    static DirectoryEntry from_dirent(dirent const&);
+    static ErrorOr<DirectoryEntry> from_dirent(dirent const&);
 };
 
 }

--- a/Userland/Libraries/LibFileSystem/FileSystem.cpp
+++ b/Userland/Libraries/LibFileSystem/FileSystem.cpp
@@ -241,7 +241,7 @@ ErrorOr<void> copy_directory(StringView destination_path, StringView source_path
         return di.error();
 
     while (di.has_next()) {
-        auto filename = TRY(String::from_deprecated_string(di.next_path()));
+        auto filename = di.next_path();
         TRY(copy_file_or_directory(
             TRY(String::formatted("{}/{}", destination_path, filename)),
             TRY(String::formatted("{}/{}", source_path, filename)),
@@ -305,8 +305,10 @@ ErrorOr<void> remove(StringView path, RecursionMode mode)
         if (di.has_error())
             return di.error();
 
-        while (di.has_next())
-            TRY(remove(di.next_full_path(), RecursionMode::Allowed));
+        while (di.has_next()) {
+            auto next_full_path = TRY(di.next_full_path());
+            TRY(remove(next_full_path, RecursionMode::Allowed));
+        }
 
         TRY(Core::System::rmdir(path));
     } else {

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -104,7 +104,7 @@ auto EmojiInputDialog::supported_emoji() -> Vector<Emoji>
     static constexpr int button_size = 22;
 
     Vector<Emoji> emojis;
-    Core::DirIterator dt("/res/emoji", Core::DirIterator::SkipDots);
+    Core::DirIterator dt("/res/emoji"sv, Core::DirIterator::SkipDots);
     while (dt.has_next()) {
         auto filename = dt.next_path();
         auto lexical_path = LexicalPath(filename);

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -109,7 +109,7 @@ void FileSystemModel::Node::traverse_if_needed()
 
     Vector<DeprecatedString> child_names;
     while (di.has_next()) {
-        child_names.append(di.next_path());
+        child_names.append(di.next_path().to_deprecated_string());
     }
     quick_sort(child_names);
 

--- a/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -133,15 +133,15 @@ void FontDatabase::load_all_fonts_from_path(DeprecatedString const& root)
             continue;
         }
         while (dir_iterator.has_next()) {
-            auto path = dir_iterator.next_full_path();
+            auto path = dir_iterator.next_full_path().release_value_but_fixme_should_propagate_errors();
 
             if (FileSystem::is_directory(path)) {
-                path_queue.enqueue(path);
+                path_queue.enqueue(path.to_deprecated_string());
                 continue;
             }
 
             if (path.ends_with(".font"sv)) {
-                if (auto font_or_error = Gfx::BitmapFont::try_load_from_file(path); !font_or_error.is_error()) {
+                if (auto font_or_error = Gfx::BitmapFont::try_load_from_file(path.to_deprecated_string()); !font_or_error.is_error()) {
                     auto font = font_or_error.release_value();
                     m_private->full_name_to_font_map.set(font->qualified_name(), *font);
                     auto typeface = get_or_create_typeface(font->family(), font->variant());
@@ -149,13 +149,13 @@ void FontDatabase::load_all_fonts_from_path(DeprecatedString const& root)
                 }
             } else if (path.ends_with(".ttf"sv)) {
                 // FIXME: What about .otf
-                if (auto font_or_error = OpenType::Font::try_load_from_file(path); !font_or_error.is_error()) {
+                if (auto font_or_error = OpenType::Font::try_load_from_file(path.to_deprecated_string()); !font_or_error.is_error()) {
                     auto font = font_or_error.release_value();
                     auto typeface = get_or_create_typeface(font->family(), font->variant());
                     typeface->set_vector_font(move(font));
                 }
             } else if (path.ends_with(".woff"sv)) {
-                if (auto font_or_error = WOFF::Font::try_load_from_file(path); !font_or_error.is_error()) {
+                if (auto font_or_error = WOFF::Font::try_load_from_file(path.to_deprecated_string()); !font_or_error.is_error()) {
                     auto font = font_or_error.release_value();
                     auto typeface = get_or_create_typeface(font->family(), font->variant());
                     typeface->set_vector_font(move(font));

--- a/Userland/Libraries/LibGfx/SystemTheme.cpp
+++ b/Userland/Libraries/LibGfx/SystemTheme.cpp
@@ -200,11 +200,11 @@ ErrorOr<Core::AnonymousBuffer> load_system_theme(DeprecatedString const& path, O
 ErrorOr<Vector<SystemThemeMetaData>> list_installed_system_themes()
 {
     Vector<SystemThemeMetaData> system_themes;
-    Core::DirIterator dt("/res/themes", Core::DirIterator::SkipDots);
+    Core::DirIterator dt("/res/themes"sv, Core::DirIterator::SkipDots);
     while (dt.has_next()) {
         auto theme_name = dt.next_path();
         auto theme_path = DeprecatedString::formatted("/res/themes/{}", theme_name);
-        TRY(system_themes.try_append({ LexicalPath::title(theme_name), theme_path }));
+        TRY(system_themes.try_append({ LexicalPath::title(theme_name.to_deprecated_string()), theme_path }));
     }
     quick_sort(system_themes, [](auto& a, auto& b) { return a.name < b.name; });
     return system_themes;

--- a/Userland/Libraries/LibManual/SectionNode.cpp
+++ b/Userland/Libraries/LibManual/SectionNode.cpp
@@ -45,8 +45,8 @@ ErrorOr<void> SectionNode::reify_if_needed() const
 
     auto own_path = TRY(path());
     Core::DirIterator dir_iterator { own_path.to_deprecated_string(), Core::DirIterator::Flags::SkipDots };
-    Vector<DeprecatedString> directories;
-    HashTable<DeprecatedString> files;
+    Vector<String> directories;
+    HashTable<String> files;
     while (dir_iterator.has_next()) {
         auto entry = dir_iterator.next();
         if (entry->type == Core::DirectoryEntry::Type::Directory)
@@ -64,7 +64,7 @@ ErrorOr<void> SectionNode::reify_if_needed() const
     for (auto const& directory : directories) {
         LexicalPath lexical_path(directory);
         RefPtr<PageNode> associated_page;
-        auto matching_page_name = DeprecatedString::formatted("{}.md", directory);
+        auto matching_page_name = TRY(String::formatted("{}.md", directory));
         if (files.remove(matching_page_name))
             associated_page = TRY(try_make_ref_counted<PageNode>(*this, TRY(String::from_utf8(lexical_path.title()))));
 

--- a/Userland/Libraries/LibTest/TestRunnerUtil.h
+++ b/Userland/Libraries/LibTest/TestRunnerUtil.h
@@ -27,7 +27,7 @@ inline void iterate_directory_recursively(DeprecatedString const& directory_path
     Core::DirIterator directory_iterator(directory_path, Core::DirIterator::Flags::SkipDots);
 
     while (directory_iterator.has_next()) {
-        auto name = directory_iterator.next_path();
+        auto name = directory_iterator.next_path().to_deprecated_string();
         struct stat st = {};
         if (fstatat(directory_iterator.fd(), name.characters(), &st, AT_SYMLINK_NOFOLLOW) < 0)
             continue;

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -273,7 +273,7 @@ ErrorOr<void> Client::handle_directory_listing(String const& requested_path, Str
     TRY(builder.try_append("<code><table>\n"sv));
 
     Core::DirIterator dt(real_path.bytes_as_string_view());
-    Vector<DeprecatedString> names;
+    Vector<String> names;
     while (dt.has_next())
         TRY(names.try_append(dt.next_path()));
     quick_sort(names);

--- a/Userland/Services/WindowServer/main.cpp
+++ b/Userland/Services/WindowServer/main.cpp
@@ -83,7 +83,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
         auto add_unconfigured_display_connector_devices = [&]() -> ErrorOr<void> {
             // Enumerate the /dev/gpu/connectorX devices and try to set up any ones we find that we haven't already used
-            Core::DirIterator di("/dev/gpu", Core::DirIterator::SkipParentAndBaseDir);
+            Core::DirIterator di("/dev/gpu"sv, Core::DirIterator::SkipParentAndBaseDir);
             while (di.has_next()) {
                 auto path = di.next_path();
                 if (!path.starts_with("connector"sv))

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -262,7 +262,7 @@ Vector<DeprecatedString> Shell::expand_globs(Vector<StringView> path_segments, S
             return {};
 
         while (di.has_next()) {
-            DeprecatedString path = di.next_path();
+            DeprecatedString path = di.next_path().to_deprecated_string();
 
             // Dotfiles have to be explicitly requested
             if (path[0] == '.' && first_segment[0] != '.')
@@ -1416,7 +1416,7 @@ void Shell::cache_path()
     if (!path.is_empty()) {
         auto directories = path.split(':');
         for (auto const& directory : directories) {
-            Core::DirIterator programs(directory.characters(), Core::DirIterator::SkipDots);
+            Core::DirIterator programs(directory, Core::DirIterator::SkipDots);
             while (programs.has_next()) {
                 auto program = programs.next_path();
                 auto program_path = DeprecatedString::formatted("{}/{}", directory, program);
@@ -1664,15 +1664,15 @@ Vector<Line::CompletionSuggestion> Shell::complete_user(StringView name, size_t 
     if (m_editor)
         m_editor->transform_suggestion_offsets(invariant_offset, static_offset);
 
-    Core::DirIterator di("/home", Core::DirIterator::SkipParentAndBaseDir);
+    Core::DirIterator di("/home"sv, Core::DirIterator::SkipParentAndBaseDir);
 
     if (di.has_error())
         return suggestions;
 
     while (di.has_next()) {
-        DeprecatedString name = di.next_path();
+        auto name = di.next_path();
         if (name.starts_with(pattern)) {
-            suggestions.append(name);
+            suggestions.append(name.to_deprecated_string());
             auto& suggestion = suggestions.last();
             suggestion.input_offset = offset;
             suggestion.invariant_offset = invariant_offset;

--- a/Userland/Utilities/bt.cpp
+++ b/Userland/Utilities/bt.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     while (iterator.has_next()) {
-        pid_t tid = iterator.next_path().to_int().value();
+        pid_t tid = iterator.next_path().to_number<int>().value();
         outln("thread: {}", tid);
         outln("frames:");
         auto symbols = Symbolication::symbolicate_thread(pid, tid);

--- a/Userland/Utilities/chmod.cpp
+++ b/Userland/Utilities/chmod.cpp
@@ -47,8 +47,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         if (recursive && S_ISDIR(stat.st_mode)) {
             Core::DirIterator it(path, Core::DirIterator::Flags::SkipParentAndBaseDir);
 
-            while (it.has_next())
-                TRY(update_path_permissions(it.next_full_path()));
+            while (it.has_next()) {
+                auto next_full_path = TRY(it.next_full_path());
+                TRY(update_path_permissions(next_full_path));
+            }
         }
 
         return {};

--- a/Userland/Utilities/chown.cpp
+++ b/Userland/Utilities/chown.cpp
@@ -85,8 +85,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         if (recursive && S_ISDIR(stat.st_mode)) {
             Core::DirIterator it(path, Core::DirIterator::Flags::SkipParentAndBaseDir);
 
-            while (it.has_next())
-                TRY(update_path_owner(it.next_full_path()));
+            while (it.has_next()) {
+                auto next_full_path = TRY(it.next_full_path());
+                TRY(update_path_owner(next_full_path));
+            }
         }
 
         return {};

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -154,8 +154,8 @@ u64 print_space_usage(DeprecatedString const& path, DuOption const& du_option, s
         }
 
         while (di.has_next()) {
-            auto const child_path = di.next_full_path();
-            size += print_space_usage(child_path, du_option, current_depth + 1, true);
+            auto const child_path = di.next_full_path().release_value_but_fixme_should_propagate_errors();
+            size += print_space_usage(child_path.to_deprecated_string(), du_option, current_depth + 1, true);
         }
     }
 

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -270,14 +270,14 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         auto add_directory = [&handle_file, user_has_specified_files, suppress_errors](DeprecatedString base, Optional<DeprecatedString> recursive, auto handle_directory) -> void {
             Core::DirIterator it(recursive.value_or(base), Core::DirIterator::Flags::SkipDots);
             while (it.has_next()) {
-                auto path = it.next_full_path();
+                auto path = it.next_full_path().release_value_but_fixme_should_propagate_errors();
                 if (!FileSystem::is_directory(path)) {
-                    auto key = user_has_specified_files ? path.view() : path.substring_view(base.length() + 1, path.length() - base.length() - 1);
+                    StringView key = user_has_specified_files ? path : StringView(path).substring_view(base.length() + 1, path.to_deprecated_string().length() - base.length() - 1);
                     if (auto result = handle_file(key, true); result.is_error() && !suppress_errors)
                         warnln("Failed with file {}: {}", key, result.release_error());
 
                 } else {
-                    handle_directory(base, path, handle_directory);
+                    handle_directory(base, path.to_deprecated_string(), handle_directory);
                 }
             }
         };

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -310,7 +310,7 @@ static ErrorOr<void> collect_tests(Vector<Test>& tests, StringView path, StringV
         }
         if (!name.ends_with(".html"sv))
             continue;
-        auto basename = LexicalPath::title(name);
+        auto basename = LexicalPath::title(name.to_deprecated_string());
         auto expectation_path = TRY(String::formatted("{}/expected/{}/{}.txt", path, trail, basename));
 
         tests.append({ move(input_path), move(expectation_path), mode, {} });

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -174,11 +174,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
 
             while (di.has_next()) {
-                DeprecatedString directory = di.next_full_path();
+                auto directory = TRY(di.next_full_path());
                 if (FileSystem::is_directory(directory) && !FileSystem::is_link(directory)) {
                     ++subdirs;
                     FileMetadata new_file;
-                    new_file.name = move(directory);
+                    new_file.name = directory.to_deprecated_string();
                     files.insert(i + subdirs, move(new_file));
                 }
             }
@@ -415,7 +415,7 @@ static int do_file_system_object_long(DeprecatedString const& path)
     Vector<FileMetadata> files;
     while (di.has_next()) {
         FileMetadata metadata;
-        metadata.name = di.next_path();
+        metadata.name = di.next_path().to_deprecated_string();
         VERIFY(!metadata.name.is_empty());
 
         if (metadata.name.ends_with('~') && flag_ignore_backups && metadata.name != path)
@@ -529,7 +529,7 @@ int do_file_system_object_short(DeprecatedString const& path)
     size_t longest_name = 0;
     while (di.has_next()) {
         FileMetadata metadata;
-        metadata.name = di.next_path();
+        metadata.name = di.next_path().to_deprecated_string();
 
         if (metadata.name.ends_with('~') && flag_ignore_backups && metadata.name != path)
             continue;

--- a/Userland/Utilities/lsblk.cpp
+++ b/Userland/Utilities/lsblk.cpp
@@ -25,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.set_general_help("List Storage (Block) devices.");
     args_parser.parse(arguments);
 
-    Core::DirIterator di("/sys/devices/storage/", Core::DirIterator::SkipParentAndBaseDir);
+    Core::DirIterator di("/sys/devices/storage/"sv, Core::DirIterator::SkipParentAndBaseDir);
     if (di.has_error()) {
         auto error = di.error();
         warnln("Failed to open /sys/devices/storage - {}", error);

--- a/Userland/Utilities/lsusb.cpp
+++ b/Userland/Utilities/lsusb.cpp
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/sys/bus/usb", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    Core::DirIterator usb_devices("/sys/bus/usb", Core::DirIterator::SkipDots);
+    Core::DirIterator usb_devices("/sys/bus/usb"sv, Core::DirIterator::SkipDots);
 
     RefPtr<USBDB::Database> usb_db;
     if (!flag_show_numerical) {
@@ -45,7 +45,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     while (usb_devices.has_next()) {
-        auto full_path = LexicalPath(usb_devices.next_full_path());
+        auto next_full_path = TRY(usb_devices.next_full_path());
+        auto full_path = LexicalPath(next_full_path);
 
         auto proc_usb_device = Core::File::open(full_path.string(), Core::File::OpenMode::Read);
         if (proc_usb_device.is_error()) {

--- a/Userland/Utilities/mount.cpp
+++ b/Userland/Utilities/mount.cpp
@@ -135,13 +135,13 @@ static ErrorOr<void> mount_all()
     if (auto result = process_fstab_entries("/etc/fstab"sv); result.is_error())
         dbgln("Failed to read '/etc/fstab': {}", result.error());
 
-    auto fstab_directory_iterator = Core::DirIterator("/etc/fstab.d", Core::DirIterator::SkipDots);
+    auto fstab_directory_iterator = Core::DirIterator("/etc/fstab.d"sv, Core::DirIterator::SkipDots);
 
     if (fstab_directory_iterator.has_error() && fstab_directory_iterator.error().code() != ENOENT) {
         dbgln("Failed to open /etc/fstab.d: {}", fstab_directory_iterator.error());
     } else if (!fstab_directory_iterator.has_error()) {
         while (fstab_directory_iterator.has_next()) {
-            auto path = fstab_directory_iterator.next_full_path();
+            auto path = TRY(fstab_directory_iterator.next_full_path());
             if (auto result = process_fstab_entries(path); result.is_error())
                 dbgln("Failed to read '{}': {}", path, result.error());
         }

--- a/Userland/Utilities/run-tests.cpp
+++ b/Userland/Utilities/run-tests.cpp
@@ -145,7 +145,7 @@ void TestRunner::do_run_single_test(DeprecatedString const& test_path, size_t cu
             Core::DirIterator iterator("/tmp/coredump"sv);
             if (!iterator.has_error()) {
                 while (iterator.has_next()) {
-                    auto path = iterator.next_full_path();
+                    auto path = iterator.next_full_path().release_value_but_fixme_should_propagate_errors();
                     if (!path.contains(pid_search_string))
                         continue;
 

--- a/Userland/Utilities/sysctl.cpp
+++ b/Userland/Utilities/sysctl.cpp
@@ -80,7 +80,7 @@ static int handle_variables(Vector<StringView> const& variables)
 
 static int handle_show_all()
 {
-    Core::DirIterator di("/sys/kernel/variables", Core::DirIterator::SkipDots);
+    Core::DirIterator di("/sys/kernel/variables"sv, Core::DirIterator::SkipDots);
     if (di.has_error()) {
         outln("DirIterator: {}", di.error());
         return 1;

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -282,7 +282,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
             Core::DirIterator it(path, Core::DirIterator::Flags::SkipParentAndBaseDir);
             while (it.has_next()) {
-                auto child_path = it.next_full_path();
+                auto child_path = TRY(it.next_full_path()).to_deprecated_string();
                 if (!dereference && FileSystem::is_link(child_path)) {
                     TRY(add_link(child_path));
                 } else if (!FileSystem::is_directory(child_path)) {

--- a/Userland/Utilities/tree.cpp
+++ b/Userland/Utilities/tree.cpp
@@ -52,9 +52,9 @@ static void print_directory_tree(DeprecatedString const& root_path, int depth, D
         return;
     }
 
-    Vector<DeprecatedString> names;
+    Vector<String> names;
     while (di.has_next()) {
-        DeprecatedString name = di.next_path();
+        auto name = di.next_path();
         if (di.has_error()) {
             warnln("{}: {}", root_path, di.error());
             continue;
@@ -65,7 +65,7 @@ static void print_directory_tree(DeprecatedString const& root_path, int depth, D
     quick_sort(names);
 
     for (size_t i = 0; i < names.size(); i++) {
-        DeprecatedString name = names[i];
+        auto name = names[i];
 
         StringBuilder builder;
         builder.append(root_path);

--- a/Userland/Utilities/update-cpp-test-results.cpp
+++ b/Userland/Utilities/update-cpp-test-results.cpp
@@ -15,10 +15,10 @@ ErrorOr<int> serenity_main(Main::Arguments)
 {
     Core::DirIterator parser_tests(LexicalPath::join(Core::StandardPaths::home_directory(), "Tests/cpp-tests/parser"sv).string());
     while (parser_tests.has_next()) {
-        auto cpp_full_path = parser_tests.next_full_path();
+        auto cpp_full_path = TRY(parser_tests.next_full_path());
         if (!cpp_full_path.ends_with(".cpp"sv))
             continue;
-        auto ast_full_path = cpp_full_path.replace(".cpp"sv, ".ast"sv, ReplaceMode::FirstOnly);
+        auto ast_full_path = TRY(cpp_full_path.replace(".cpp"sv, ".ast"sv, ReplaceMode::FirstOnly));
         outln("{}", cpp_full_path);
         auto res = Core::command("/bin/sh", { "-c", DeprecatedString::formatted("cpp-parser {} > {}", cpp_full_path, ast_full_path) }, {});
         VERIFY(!res.is_error());
@@ -26,10 +26,10 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     Core::DirIterator preprocessor_tests(LexicalPath::join(Core::StandardPaths::home_directory(), "Tests/cpp-tests/preprocessor"sv).string());
     while (preprocessor_tests.has_next()) {
-        auto cpp_full_path = preprocessor_tests.next_full_path();
+        auto cpp_full_path = TRY(preprocessor_tests.next_full_path());
         if (!cpp_full_path.ends_with(".cpp"sv))
             continue;
-        auto ast_full_path = cpp_full_path.replace(".cpp"sv, ".txt"sv, ReplaceMode::FirstOnly);
+        auto ast_full_path = TRY(cpp_full_path.replace(".cpp"sv, ".txt"sv, ReplaceMode::FirstOnly));
         outln("{}", cpp_full_path);
         auto res = Core::command("/bin/sh", { "-c", DeprecatedString::formatted("cpp-preprocessor {} > {}", cpp_full_path, ast_full_path) }, {});
         VERIFY(!res.is_error());

--- a/Userland/Utilities/wallpaper.cpp
+++ b/Userland/Utilities/wallpaper.cpp
@@ -36,7 +36,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath unix sendfd"));
 
     if (show_all) {
-        Core::DirIterator wallpapers_directory_iterator("/res/wallpapers", Core::DirIterator::SkipDots);
+        Core::DirIterator wallpapers_directory_iterator("/res/wallpapers"sv, Core::DirIterator::SkipDots);
         if (wallpapers_directory_iterator.has_error())
             return Error::from_string_literal("Unable to iterate /res/wallpapers directory");
 
@@ -48,15 +48,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto current_wallpaper_path = GUI::Desktop::the().wallpaper_path();
         outln("{}", current_wallpaper_path);
     } else if (set_random) {
-        Core::DirIterator wallpapers_directory_iterator("/res/wallpapers", Core::DirIterator::SkipDots);
+        Core::DirIterator wallpapers_directory_iterator("/res/wallpapers"sv, Core::DirIterator::SkipDots);
         if (wallpapers_directory_iterator.has_error())
             return Error::from_string_literal("Unable to iterate /res/wallpapers directory");
 
-        Vector<DeprecatedString> wallpaper_paths;
+        Vector<String> wallpaper_paths;
 
-        auto current_wallpaper_path = GUI::Desktop::the().wallpaper_path();
+        auto current_wallpaper_path = TRY(String::from_utf8(GUI::Desktop::the().wallpaper_path()));
         while (wallpapers_directory_iterator.has_next()) {
-            auto next_full_path = wallpapers_directory_iterator.next_full_path();
+            auto next_full_path = TRY(wallpapers_directory_iterator.next_full_path());
             if (next_full_path != current_wallpaper_path)
                 wallpaper_paths.append(move(next_full_path));
         }

--- a/Userland/Utilities/zip.cpp
+++ b/Userland/Utilities/zip.cpp
@@ -106,15 +106,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         Core::DirIterator it(path, Core::DirIterator::Flags::SkipParentAndBaseDir);
         while (it.has_next()) {
-            auto child_path = it.next_full_path();
+            auto child_path = TRY(it.next_full_path());
             if (FileSystem::is_link(child_path))
                 return {};
             if (!FileSystem::is_directory(child_path)) {
-                auto result = add_file(child_path);
+                auto result = add_file(child_path.to_deprecated_string());
                 if (result.is_error())
                     warnln("Couldn't add file '{}': {}", child_path, result.error());
             } else {
-                auto result = handle_directory(child_path, handle_directory);
+                auto result = handle_directory(child_path.to_deprecated_string(), handle_directory);
                 if (result.is_error())
                     warnln("Couldn't add directory '{}': {}", child_path, result.error());
             }


### PR DESCRIPTION
Changed `DirIterator` to use `String` instead of `DeprecatedString`.

First two commits add methods to `LexicalPath` and `String` to make most places which use `DirectoryEntry` seamlessly transition to using `String` without having to touch them.

After `DirectoryEntry` was changed to use `String` I added another method to `String` to reduce the amount of places I'd need to touch after upgrading `DirIterator`.

Hopefully first of many pull requests, as I've seen some `DeprecatedString`s on my way. Assuming my approach is up to scratch :^)