### PR TITLE
LibWeb: Only update style for the element being animated by CSS

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1325,7 +1325,7 @@ void StyleComputer::ensure_animation_timer() const
                 m_active_animations.remove(key);
 
             for (auto* element : owning_elements_to_invalidate)
-                element->invalidate_style();
+                element->set_needs_style_update(true);
         });
     }
 


### PR DESCRIPTION
Unlike DOM mutations, CSS animations don't affect the style of the entire subtree of the element being animated. This means we only have to recompute style for the animating element, which is significantly faster than doing the whole subtree.

This takes idle CPU usage on https://shopify.com/ from 100% to 30% on my (not massively powerful) laptop. :^)