### PR TITLE
AK: Fix two edge-cases in AllocatingMemoryStream

### DIFF
--- a/AK/MemoryStream.cpp
+++ b/AK/MemoryStream.cpp
@@ -198,11 +198,12 @@ ErrorOr<Optional<size_t>> AllocatingMemoryStream::offset_of(ReadonlyBytes needle
     if (m_chunks.size() == 0)
         return Optional<size_t> {};
 
-    // Ensure that we don't have to trim away more than one block.
+    // Ensure that we don't have empty chunks at the beginning of the stream. Our trimming implementation
+    // assumes this to be the case, since this should be held up by `cleanup_unused_chunks()` at all times.
     VERIFY(m_read_offset < CHUNK_SIZE);
-    VERIFY(m_chunks.size() * CHUNK_SIZE - m_write_offset < CHUNK_SIZE);
 
-    auto chunk_count = m_chunks.size();
+    auto empty_chunks_at_end = ((m_chunks.size() * CHUNK_SIZE - m_write_offset) / CHUNK_SIZE);
+    auto chunk_count = m_chunks.size() - empty_chunks_at_end;
     auto search_spans = TRY(FixedArray<ReadonlyBytes>::create(chunk_count));
 
     for (size_t i = 0; i < chunk_count; i++) {

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -45,6 +45,8 @@ private:
 /// and reading back the written data afterwards.
 class AllocatingMemoryStream final : public Stream {
 public:
+    static constexpr size_t CHUNK_SIZE = 4096;
+
     virtual ErrorOr<Bytes> read_some(Bytes) override;
     virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
     virtual ErrorOr<void> discard(size_t) override;
@@ -59,7 +61,6 @@ public:
 private:
     // Note: We set the inline buffer capacity to zero to make moving chunks as efficient as possible.
     using Chunk = AK::Detail::ByteBuffer<0>;
-    static constexpr size_t chunk_size = 4096;
 
     ErrorOr<ReadonlyBytes> next_read_range();
     ErrorOr<Bytes> next_write_range();

--- a/Tests/AK/TestMemoryStream.cpp
+++ b/Tests/AK/TestMemoryStream.cpp
@@ -73,16 +73,15 @@ TEST_CASE(allocating_memory_stream_offset_of_oob)
     AllocatingMemoryStream stream;
     // NOTE: This test is to make sure that offset_of() doesn't read past the end of the "initialized" data.
     //       So we have to assume some things about the behavior of this class:
-    //       - The chunk size is 4096 bytes.
     //       - A chunk is moved to the end when it's fully read from
     //       - A free chunk is used as-is, no new ones are allocated if one exists.
 
-    // First, fill exactly one chunk.
-    for (size_t i = 0; i < 256; ++i)
+    // First, fill exactly one chunk (in groups of 16 bytes).
+    for (size_t i = 0; i < AllocatingMemoryStream::CHUNK_SIZE / 16; ++i)
         MUST(stream.write_until_depleted("AAAAAAAAAAAAAAAA"sv.bytes()));
 
     // Then discard it all.
-    MUST(stream.discard(4096));
+    MUST(stream.discard(AllocatingMemoryStream::CHUNK_SIZE));
     // Now we can write into this chunk again, knowing that it's initialized to all 'A's.
     MUST(stream.write_until_depleted("Well Hello Friends! :^)"sv.bytes()));
 


### PR DESCRIPTION
There are no Shell boogs.