### PR TITLE
CI: Enable KVM for faster qemu

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -49,6 +49,13 @@ jobs:
 
       # === OS SETUP ===
 
+      # Enable KVM for faster QEMU
+      - name: "Enable KVM group perms"
+        run: |
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
+
       # Do we need to update the package cache first?
       # sudo apt-get update -qq
       - name: "Install Ubuntu dependencies"


### PR DESCRIPTION
Testing to see if this will work for QEMU too. [Hardware accelerated Android virtualization on Actions Linux larger hosted runners](https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/)