### PR TITLE
LibRegex: One boog fix / Shell: Let's switch to ECMAScript Regex

### DIFF
--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -5,10 +5,7 @@
  */
 
 #include <AK/Error.h>
-
-#ifdef KERNEL
-#    include <AK/Format.h>
-#endif
+#include <AK/Format.h>
 
 namespace AK {
 
@@ -20,6 +17,11 @@ Error Error::from_string_view_or_print_error_and_return_errno(StringView string_
 #else
     return Error::from_string_view(string_literal);
 #endif
+}
+
+void ak_loudly_complain_about_fixmed_error(Error const& e, SourceLocation location)
+{
+    dbgln("Error was caught (in {}) and was not propagated: {}", location, e);
 }
 
 }

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -14,6 +14,7 @@
 #include <AK/Error.h>
 #include <AK/Forward.h>
 #include <AK/Optional.h>
+#include <AK/SourceLocation.h>
 #include <AK/StringView.h>
 
 #ifndef KERNEL
@@ -729,6 +730,14 @@ struct Formatter<Optional<T>> : Formatter<FormatString> {
         if (optional.has_value())
             return Formatter<FormatString>::format(builder, "{}"sv, *optional);
         return builder.put_literal("None"sv);
+    }
+};
+
+template<>
+struct Formatter<SourceLocation> : Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, SourceLocation location)
+    {
+        return Formatter<FormatString>::format(builder, "[\x1b[34m{}\x1b[0m @ {}:{}]"sv, location.function_name(), location.filename(), location.line_number());
     }
 };
 

--- a/AK/SourceLocation.h
+++ b/AK/SourceLocation.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/Format.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
 
@@ -40,14 +39,6 @@ private:
 };
 
 }
-
-template<>
-struct AK::Formatter<AK::SourceLocation> : AK::Formatter<FormatString> {
-    ErrorOr<void> format(FormatBuilder& builder, AK::SourceLocation location)
-    {
-        return AK::Formatter<FormatString>::format(builder, "[\x1b[34m{}\x1b[0m @ {}:{}]"sv, location.function_name(), location.filename(), location.line_number());
-    }
-};
 
 #if USING_AK_GLOBALLY
 using AK::SourceLocation;

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -164,7 +164,7 @@ public:
     }
 
     RegexStringView(String const& string)
-        : m_view(string.bytes_as_string_view())
+        : m_view(string.code_points())
     {
     }
 

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -1765,16 +1765,9 @@ ErrorOr<void> Execute::for_each_entry(RefPtr<Shell> shell, Function<ErrorOr<Iter
                             return Break;
                         }
                 } else {
-                    auto entry_result = ByteBuffer::create_uninitialized(line_end + ifs.length());
-                    if (entry_result.is_error()) {
-                        loop.quit(Break);
-                        notifier->set_enabled(false);
-                        return Break;
-                    }
-                    auto entry = entry_result.release_value();
-                    TRY(stream.read_until_filled(entry));
+                    auto str = TRY(String::from_stream(stream, line_end));
+                    TRY(stream.discard(ifs.length()));
 
-                    auto str = TRY(String::from_utf8(StringView(entry.data(), entry.size() - ifs.length())));
                     if (TRY(callback(make_ref_counted<StringValue>(move(str)))) == IterationDecision::Break) {
                         loop.quit(Break);
                         notifier->set_enabled(false);


### PR DESCRIPTION
TLDR, `${regex_replace '(\[[^\]]*\]) .*' ...}` didn't work right, and made me question why we were using POSIX Extended Regex to begin with.