### PR TITLE
LibWeb: Adjust change event timing for text input elements

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -140,6 +140,7 @@ private:
     virtual bool is_html_input_element() const final { return true; }
 
     // ^DOM::EventTarget
+    virtual void did_lose_focus() override;
     virtual void did_receive_focus() override;
     virtual void legacy_pre_activation_behavior() override;
     virtual void legacy_cancelled_activation_behavior() override;


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/input.html#common-input-element-events says that 
```
while text input might not have an explicit commit step, selecting a date from the drop down calendar and then dismissing the drop down would be a commit action.
```
So we remove the commit event from the text change listener.

It goes on to say
```
The change event fires when the value is committed, if that makes sense for the control, or else when the control loses focus.
```
So we need to emit an event when we lose focus