### PR TITLE
LibWeb: Support {min,max}-content for {,min-,max-}width

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-max-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-max-content-width.txt
@@ -1,0 +1,24 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x76.40625 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x58.40625 children: not-inline
+      BlockContainer <div.foo> at (11,11) content-size 150.21875x17.46875 children: inline
+        line 0 width: 150.21875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 18, rect: [11,11 150.21875x17.46875]
+            "width: max-content"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (10,29.46875) content-size 780x0 children: inline
+        TextNode <#text>
+      BlockContainer <div.bar> at (11,30.46875) content-size 187.953125x17.46875 children: inline
+        line 0 width: 187.953125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 22, rect: [11,30.46875 187.953125x17.46875]
+            "max-width: max-content"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (10,48.9375) content-size 780x0 children: inline
+        TextNode <#text>
+      BlockContainer <div.baz> at (11,49.9375) content-size 183.078125x17.46875 children: inline
+        line 0 width: 183.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 22, rect: [11,49.9375 183.078125x17.46875]
+            "min-width: max-content"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (10,68.40625) content-size 780x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-min-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-min-content-width.txt
@@ -1,0 +1,33 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x130.21875 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x112.21875 children: not-inline
+      BlockContainer <div.foo> at (11,11) content-size 93.765625x35.40625 children: inline
+        line 0 width: 43.578125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 6, rect: [11,11 43.578125x17.46875]
+            "width:"
+        line 1 width: 93.765625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+          frag 0 from TextNode start: 7, length: 11, rect: [11,28 93.765625x17.46875]
+            "min-content"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (10,47.40625) content-size 780x0 children: inline
+        TextNode <#text>
+      BlockContainer <div.bar> at (11,48.40625) content-size 93.765625x35.40625 children: inline
+        line 0 width: 81.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 10, rect: [11,48.40625 81.3125x17.46875]
+            "max-width:"
+        line 1 width: 93.765625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+          frag 0 from TextNode start: 11, length: 11, rect: [11,65.40625 93.765625x17.46875]
+            "min-content"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (10,84.8125) content-size 780x0 children: inline
+        TextNode <#text>
+      BlockContainer <div.baz> at (11,85.8125) content-size 93.765625x35.40625 children: inline
+        line 0 width: 76.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 10, rect: [11,85.8125 76.4375x17.46875]
+            "min-width:"
+        line 1 width: 93.765625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+          frag 0 from TextNode start: 11, length: 11, rect: [11,102.8125 93.765625x17.46875]
+            "min-content"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (10,122.21875) content-size 780x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-with-max-content-width.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-with-max-content-width.html
@@ -1,0 +1,22 @@
+<!doctype html><style>
+* {
+    border: 1px solid black;
+}
+.foo {
+    background: pink;
+    width: max-content;
+}
+.bar {
+    background: orange;
+    width: 50%;
+    max-width: max-content;
+}
+.baz {
+    background: magenta;
+    width: 1%;
+    min-width: max-content;
+}
+</style>
+<div class="foo">width: max-content</div>
+<div class="bar">max-width: max-content</div>
+<div class="baz">min-width: max-content</div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-with-min-content-width.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-with-min-content-width.html
@@ -1,0 +1,22 @@
+<!doctype html><style>
+* {
+    border: 1px solid black;
+}
+.foo {
+    background: pink;
+    width: min-content;
+}
+.bar {
+    background: orange;
+    width: 50%;
+    max-width: min-content;
+}
+.baz {
+    background: magenta;
+    width: 1%;
+    min-width: min-content;
+}
+</style>
+<div class="foo">width: min-content</div>
+<div class="bar">max-width: min-content</div>
+<div class="baz">min-width: min-content</div>

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1338,6 +1338,7 @@
     ],
     "valid-identifiers": [
       "fit-content",
+      "max-content",
       "none"
     ],
     "quirks": [
@@ -1374,6 +1375,7 @@
     "valid-identifiers": [
       "auto",
       "fit-content",
+      "max-content",
       "none"
     ],
     "quirks": [
@@ -1773,7 +1775,8 @@
     ],
     "valid-identifiers": [
       "auto",
-      "fit-content"
+      "fit-content",
+      "max-content"
     ],
     "quirks": [
       "unitless-length"

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1339,6 +1339,7 @@
     "valid-identifiers": [
       "fit-content",
       "max-content",
+      "min-content",
       "none"
     ],
     "quirks": [
@@ -1376,6 +1377,7 @@
       "auto",
       "fit-content",
       "max-content",
+      "min-content",
       "none"
     ],
     "quirks": [
@@ -1776,7 +1778,8 @@
     "valid-identifiers": [
       "auto",
       "fit-content",
-      "max-content"
+      "max-content",
+      "min-content"
     ],
     "quirks": [
       "unitless-length"

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1349,6 +1349,9 @@ CSS::Length FormattingContext::calculate_inner_width(Layout::Box const& box, Ava
     if (width.is_fit_content()) {
         return CSS::Length::make_px(calculate_fit_content_width(box, AvailableSpace { available_width, AvailableSize::make_indefinite() }));
     }
+    if (width.is_max_content()) {
+        return CSS::Length::make_px(calculate_max_content_width(box));
+    }
 
     auto& computed_values = box.computed_values();
     if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox) {

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1352,6 +1352,9 @@ CSS::Length FormattingContext::calculate_inner_width(Layout::Box const& box, Ava
     if (width.is_max_content()) {
         return CSS::Length::make_px(calculate_max_content_width(box));
     }
+    if (width.is_min_content()) {
+        return CSS::Length::make_px(calculate_min_content_width(box));
+    }
 
     auto& computed_values = box.computed_values();
     if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox) {


### PR DESCRIPTION
We're gonna need to handle this in many more places, these patches only
add it to calculate_inner_width() which covers block and inline layout.