### PR TITLE
LibWeb: Add support for parsing place-content shorthand CSS property

### DIFF
--- a/Tests/LibWeb/Layout/expected/place-content-shorthand-property.txt
+++ b/Tests/LibWeb/Layout/expected/place-content-shorthand-property.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x37.46875 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x19.46875 children: not-inline
+      Box <div.container> at (11,11) content-size 800x17.46875 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (392.210937,11) content-size 37.578125x17.46875 flex-item [BFC] children: inline
+          line 0 width: 37.578125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 4, rect: [392.210937,11 37.578125x17.46875]
+              "Text"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/place-content-shorthand-property.html
+++ b/Tests/LibWeb/Layout/input/place-content-shorthand-property.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html><style>
+* { border: 1px solid black; }
+.container {
+    background: pink;
+    display: flex;
+    width: 100vw;
+    place-content: center;
+}
+</style><div class="container">Text

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -101,6 +101,7 @@ set(SOURCES
     CSS/StyleValues/ListStyleStyleValue.cpp
     CSS/StyleValues/NumericStyleValue.cpp
     CSS/StyleValues/OverflowStyleValue.cpp
+    CSS/StyleValues/PlaceContentStyleValue.cpp
     CSS/StyleValues/PositionStyleValue.cpp
     CSS/StyleValues/RadialGradientStyleValue.cpp
     CSS/StyleValues/RectStyleValue.cpp

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -317,6 +317,7 @@ private:
     ErrorOr<RefPtr<StyleValue>> parse_font_family_value(TokenStream<ComponentValue>&);
     ErrorOr<RefPtr<StyleValue>> parse_list_style_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_overflow_value(Vector<ComponentValue> const&);
+    ErrorOr<RefPtr<StyleValue>> parse_place_content_value(Vector<ComponentValue> const&);
     enum class AllowInsetKeyword {
         No,
         Yes,

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1525,6 +1525,14 @@
       "unitless-length"
     ]
   },
+  "place-content": {
+    "inherited": false,
+    "initial": "normal",
+    "longhands": [
+      "align-content",
+      "justify-content"
+    ]
+  },
   "pointer-events": {
     "affects-layout": false,
     "inherited": true,

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -48,6 +48,7 @@
 #include <LibWeb/CSS/StyleValues/NumericStyleValue.h>
 #include <LibWeb/CSS/StyleValues/OverflowStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
+#include <LibWeb/CSS/StyleValues/PlaceContentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RectStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
@@ -338,6 +339,19 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
         style.set_property(CSS::PropertyID::OverflowX, value, declaration);
         style.set_property(CSS::PropertyID::OverflowY, value, declaration);
+        return;
+    }
+
+    if (property_id == CSS::PropertyID::PlaceContent) {
+        if (value.is_place_content()) {
+            auto const& place_content = value.as_place_content();
+            style.set_property(CSS::PropertyID::AlignContent, place_content.align_content());
+            style.set_property(CSS::PropertyID::JustifyContent, place_content.justify_content());
+            return;
+        }
+
+        style.set_property(CSS::PropertyID::AlignContent, value);
+        style.set_property(CSS::PropertyID::JustifyContent, value);
         return;
     }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -46,6 +46,7 @@
 #include <LibWeb/CSS/StyleValues/NumericStyleValue.h>
 #include <LibWeb/CSS/StyleValues/OverflowStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
+#include <LibWeb/CSS/StyleValues/PlaceContentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RadialGradientStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RectStyleValue.h>
@@ -293,6 +294,12 @@ PercentageStyleValue const& StyleValue::as_percentage() const
 {
     VERIFY(is_percentage());
     return static_cast<PercentageStyleValue const&>(*this);
+}
+
+PlaceContentStyleValue const& StyleValue::as_place_content() const
+{
+    VERIFY(is_place_content());
+    return static_cast<PlaceContentStyleValue const&>(*this);
 }
 
 PositionStyleValue const& StyleValue::as_position() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -123,6 +123,7 @@ public:
         Numeric,
         Overflow,
         Percentage,
+        PlaceContent,
         Position,
         RadialGradient,
         Rect,
@@ -177,6 +178,7 @@ public:
     bool is_numeric() const { return type() == Type::Numeric; }
     bool is_overflow() const { return type() == Type::Overflow; }
     bool is_percentage() const { return type() == Type::Percentage; }
+    bool is_place_content() const { return type() == Type::PlaceContent; }
     bool is_position() const { return type() == Type::Position; }
     bool is_radial_gradient() const { return type() == Type::RadialGradient; }
     bool is_rect() const { return type() == Type::Rect; }
@@ -230,6 +232,7 @@ public:
     NumericStyleValue const& as_numeric() const;
     OverflowStyleValue const& as_overflow() const;
     PercentageStyleValue const& as_percentage() const;
+    PlaceContentStyleValue const& as_place_content() const;
     PositionStyleValue const& as_position() const;
     RadialGradientStyleValue const& as_radial_gradient() const;
     RectStyleValue const& as_rect() const;
@@ -280,6 +283,7 @@ public:
     NumericStyleValue& as_numeric() { return const_cast<NumericStyleValue&>(const_cast<StyleValue const&>(*this).as_numeric()); }
     OverflowStyleValue& as_overflow() { return const_cast<OverflowStyleValue&>(const_cast<StyleValue const&>(*this).as_overflow()); }
     PercentageStyleValue& as_percentage() { return const_cast<PercentageStyleValue&>(const_cast<StyleValue const&>(*this).as_percentage()); }
+    PlaceContentStyleValue& as_place_content() { return const_cast<PlaceContentStyleValue&>(const_cast<StyleValue const&>(*this).as_place_content()); }
     PositionStyleValue& as_position() { return const_cast<PositionStyleValue&>(const_cast<StyleValue const&>(*this).as_position()); }
     RadialGradientStyleValue& as_radial_gradient() { return const_cast<RadialGradientStyleValue&>(const_cast<StyleValue const&>(*this).as_radial_gradient()); }
     RectStyleValue& as_rect() { return const_cast<RectStyleValue&>(const_cast<StyleValue const&>(*this).as_rect()); }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/PlaceContentStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/PlaceContentStyleValue.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, Hunter Salyer <thefalsehonesty@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "PlaceContentStyleValue.h"
+
+namespace Web::CSS {
+
+ErrorOr<String> PlaceContentStyleValue::to_string() const
+{
+    return String::formatted("{} {}", TRY(m_properties.align_content->to_string()), TRY(m_properties.justify_content->to_string()));
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/PlaceContentStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/PlaceContentStyleValue.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023, Hunter Salyer <thefalsehonesty@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+class PlaceContentStyleValue final : public StyleValueWithDefaultOperators<PlaceContentStyleValue> {
+public:
+    static ErrorOr<ValueComparingNonnullRefPtr<PlaceContentStyleValue>> create(ValueComparingNonnullRefPtr<StyleValue> align_content, ValueComparingNonnullRefPtr<StyleValue> justify_content)
+    {
+        return adopt_nonnull_ref_or_enomem(new (nothrow) PlaceContentStyleValue(move(align_content), move(justify_content)));
+    }
+    virtual ~PlaceContentStyleValue() override = default;
+
+    ValueComparingNonnullRefPtr<StyleValue> align_content() const { return m_properties.align_content; }
+    ValueComparingNonnullRefPtr<StyleValue> justify_content() const { return m_properties.justify_content; }
+
+    virtual ErrorOr<String> to_string() const override;
+
+    bool properties_equal(PlaceContentStyleValue const& other) const { return m_properties == other.m_properties; };
+
+private:
+    PlaceContentStyleValue(ValueComparingNonnullRefPtr<StyleValue> align_content, ValueComparingNonnullRefPtr<StyleValue> justify_content)
+        : StyleValueWithDefaultOperators(Type::PlaceContent)
+        , m_properties { .align_content = move(align_content), .justify_content = move(justify_content) }
+    {
+    }
+
+    struct Properties {
+        ValueComparingNonnullRefPtr<StyleValue> align_content;
+        ValueComparingNonnullRefPtr<StyleValue> justify_content;
+        bool operator==(Properties const&) const = default;
+    } m_properties;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -135,6 +135,7 @@ class OverflowStyleValue;
 class Percentage;
 class PercentageOrCalculated;
 class PercentageStyleValue;
+class PlaceContentStyleValue;
 class PositionStyleValue;
 class PropertyOwningCSSStyleDeclaration;
 class RadialGradientStyleValue;


### PR DESCRIPTION
This adds support for expanding the `place-content` shorthand CSS property as seen here: https://www.w3.org/TR/css-align-3/#place-content.

This is my first contribution in a long while and my first CSS-related PR, exciting :^)