### PR TITLE
LibJS: Align MathObject::atan2 (ever so slightly) closer to spec

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -303,7 +303,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::atan2)
     }
 
     // 10. If ny < -0𝔽, then
-    if (y.as_double() < 0) {
+    if (y.as_double() < -0) {
         // a. If nx is +∞𝔽, return -0𝔽.
         if (x.is_positive_infinity())
             return Value(-0.0);


### PR DESCRIPTION
I somehow noticed this very very slight difference when looking at this file
to the spec.

This is not an observable difference. Nonetheless, it seems like a good idea
to be as close to the spec as possible, so let's do that (and add some
spec comments while at it)