### PR TITLE
AK: Get rid of some DeprecatedStrings — IPv6Address::to_deprecated_string()

### DIFF
--- a/AK/IPv6Address.h
+++ b/AK/IPv6Address.h
@@ -251,6 +251,12 @@ public:
         return {};
     }
 
+    // https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.3
+    [[nodiscard]] static IPv6Address loopback()
+    {
+        return IPv6Address({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 });
+    }
+
 private:
     constexpr u16 group(unsigned i) const
     {

--- a/Tests/AK/TestIPv6Address.cpp
+++ b/Tests/AK/TestIPv6Address.cpp
@@ -55,14 +55,18 @@ TEST_CASE(should_get_groups_by_index)
 
 TEST_CASE(should_convert_to_string)
 {
-    EXPECT_EQ("102:304:506:708:90a:b0c:d0e:f10"sv, IPv6Address({ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }).to_deprecated_string());
-    EXPECT_EQ("::"sv, IPv6Address().to_deprecated_string());
-    EXPECT_EQ("::1"sv, IPv6Address({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }).to_deprecated_string());
-    EXPECT_EQ("1::"sv, IPv6Address({ 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }).to_deprecated_string());
-    EXPECT_EQ("102:0:506:708:900::10"sv, IPv6Address({ 1, 2, 0, 0, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 16 }).to_deprecated_string());
-    EXPECT_EQ("102:0:506:708:900::"sv, IPv6Address({ 1, 2, 0, 0, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0 }).to_deprecated_string());
-    EXPECT_EQ("::304:506:708:90a:b0c:d0e:f10"sv, IPv6Address({ 0, 0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }).to_deprecated_string());
-    EXPECT_EQ("102:304::708:90a:b0c:d0e:f10"sv, IPv6Address({ 1, 2, 3, 4, 0, 0, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }).to_deprecated_string());
+    auto to_string = [&](IPv6Address::in6_addr_t const& data) -> String {
+        return MUST(IPv6Address(data).to_string());
+    };
+
+    EXPECT_EQ("102:304:506:708:90a:b0c:d0e:f10"sv, to_string({ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }));
+    EXPECT_EQ("::"sv, MUST(IPv6Address().to_string()));
+    EXPECT_EQ("::1"sv, to_string({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }));
+    EXPECT_EQ("1::"sv, to_string({ 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }));
+    EXPECT_EQ("102:0:506:708:900::10"sv, to_string({ 1, 2, 0, 0, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 16 }));
+    EXPECT_EQ("102:0:506:708:900::"sv, to_string({ 1, 2, 0, 0, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0 }));
+    EXPECT_EQ("::304:506:708:90a:b0c:d0e:f10"sv, to_string({ 0, 0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }));
+    EXPECT_EQ("102:304::708:90a:b0c:d0e:f10"sv, to_string({ 1, 2, 3, 4, 0, 0, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }));
 }
 
 TEST_CASE(should_make_ipv6_address_from_string)
@@ -86,7 +90,7 @@ TEST_CASE(ipv4_mapped_ipv6)
     IPv6Address mapped_address(ipv4_address_to_map);
     EXPECT(mapped_address.is_ipv4_mapped());
     EXPECT_EQ(ipv4_address_to_map, mapped_address.ipv4_mapped_address().value());
-    EXPECT_EQ("::ffff:192.168.0.1"sv, mapped_address.to_deprecated_string());
+    EXPECT_EQ("::ffff:192.168.0.1"sv, MUST(mapped_address.to_string()));
     EXPECT_EQ(IPv4Address(192, 168, 1, 9), IPv6Address::from_string("::FFFF:192.168.1.9"sv).value().ipv4_mapped_address().value());
     EXPECT(!IPv6Address::from_string("::abcd:192.168.1.9"sv).has_value());
 }

--- a/Tests/AK/TestIPv6Address.cpp
+++ b/Tests/AK/TestIPv6Address.cpp
@@ -105,14 +105,17 @@ TEST_CASE(should_make_empty_optional_from_out_of_range_values)
     EXPECT(!addr.has_value());
 }
 
-TEST_CASE(should_compare)
+TEST_CASE(should_only_compare_bytes_from_address)
 {
     constexpr IPv6Address addr_a({ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
     constexpr IPv6Address addr_b({ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17 });
+    constexpr IPv6Address addr_c({ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17 });
 
     static_assert(addr_a != addr_b);
     static_assert(addr_a == addr_a);
+    static_assert(addr_b == addr_c);
 
     EXPECT(addr_a != addr_b);
     EXPECT(addr_a == addr_a);
+    EXPECT(addr_b == addr_c);
 }

--- a/Userland/Libraries/LibC/arpa/inet.cpp
+++ b/Userland/Libraries/LibC/arpa/inet.cpp
@@ -27,8 +27,13 @@ char const* inet_ntop(int af, void const* src, char* dst, socklen_t len)
             errno = ENOSPC;
             return nullptr;
         }
-        auto str = IPv6Address(((in6_addr const*)src)->s6_addr).to_deprecated_string();
-        if (!str.copy_characters_to_buffer(dst, len)) {
+        auto str_or_error = IPv6Address(((in6_addr const*)src)->s6_addr).to_string();
+        if (str_or_error.is_error()) {
+            errno = ENOMEM;
+            return nullptr;
+        }
+        auto str = str_or_error.release_value();
+        if (!str.bytes_as_string_view().copy_characters_to_buffer(dst, len)) {
             errno = ENOSPC;
             return nullptr;
         }

--- a/Userland/Libraries/LibWeb/SecureContexts/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/SecureContexts/AbstractOperations.cpp
@@ -30,7 +30,7 @@ Trustworthiness is_origin_potentially_trustworthy(HTML::Origin const& origin)
     // 4. If origin’s host matches one of the CIDR notations 127.0.0.0/8 or ::1/128 [RFC4632], return "Potentially Trustworthy".
     if (auto ipv4_address = IPv4Address::from_string(origin.host()); ipv4_address.has_value() && (ipv4_address->to_u32() & 0xff000000) != 0)
         return Trustworthiness::PotentiallyTrustworthy;
-    if (auto ipv6_address = IPv6Address::from_string(origin.host()); ipv6_address.has_value() && ipv6_address->to_deprecated_string() == "::1")
+    if (auto ipv6_address = IPv6Address::from_string(origin.host()); ipv6_address.has_value() && ipv6_address == IPv6Address::loopback())
         return Trustworthiness::PotentiallyTrustworthy;
 
     // 5. If the user agent conforms to the name resolution rules in [let-localhost-be-localhost] and one of the following is true:


### PR DESCRIPTION
Hi!

commit ada1b4a and commit 45ee7dc introduces and uses `IPv6Address::loopback()`, so one can compare against the loopback address without parsing addresses and introducing strings at all.

commit 81d8de7 :
>Change the name and return type of `IPv6Address::to_deprecated_string()` to `IPv6Address::to_string()` with return type `ErrorOr<String>`.
>
> It will now propagate errors that occur when writing to the StringBuilder.
>
> There are two users of `to_deprecated_string()` that now use `to_string()`:
>
> 1. `Formatted<IPv6Address>`: it now propagates errors.
>
> 2. `inet_ntop`: doesn't propgate errors. I first thought about setting `ENOSPC`, but that would be wrong, as that error refers to the buffer provided by the user. Since the user has provided a buffer to write into, ideally, there should be an allocation-free version.

(lambda on Discord)