### PR TITLE
LibWeb: Add support for parsing 'inset' shorthand CSS property

### DIFF
--- a/Tests/LibWeb/Layout/expected/inset-shorthand-property.txt
+++ b/Tests/LibWeb/Layout/expected/inset-shorthand-property.txt
@@ -1,0 +1,15 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x200 children: not-inline
+      BlockContainer <div.parent> at (8,8) content-size 200x200 positioned children: inline
+        TextNode <#text>
+        BlockContainer <div.bad> at (38,18) content-size 150x150 positioned [BFC] children: inline
+          line 0 width: 26.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 3, rect: [38,18 26.546875x17.46875]
+              "Bad"
+          TextNode <#text>
+        TextNode <#text>
+        BlockContainer <div.good> at (38,18) content-size 150x150 positioned [BFC] children: not-inline
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,208) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/inset-shorthand-property.html
+++ b/Tests/LibWeb/Layout/input/inset-shorthand-property.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html><style>
+.parent {
+    width: 200px;
+    height: 200px;
+    background: grey;
+    position: relative;
+}
+.bad {
+    position: absolute;
+    background-color: red;
+    top: 10px;
+    right: 20px;
+    bottom: 40px;
+    left: 30px;
+}
+.good {
+    position: absolute;
+    inset: 10px 20px 40px 30px;
+    background-color: green;
+}
+</style>
+<div class="parent">
+    <div class="bad">Bad</div>
+    <div class="good"></div>
+</div>

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1151,6 +1151,24 @@
       "image-rendering"
     ]
   },
+  "inset": {
+    "inherited": false,
+    "initial": "auto",
+    "longhands": [
+      "top",
+      "right",
+      "bottom",
+      "left"
+    ],
+    "max-values": 4,
+    "valid-types": [
+      "length",
+      "percentage"
+    ],
+    "valid-identifiers": [
+      "auto"
+    ]
+  },
   "justify-content": {
     "inherited": false,
     "initial": "flex-start",

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -516,6 +516,20 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         return;
     }
 
+    if (property_id == CSS::PropertyID::Inset) {
+        if (value.is_value_list()) {
+            auto const& values_list = value.as_value_list();
+            assign_edge_values(PropertyID::Top, PropertyID::Right, PropertyID::Bottom, PropertyID::Left, values_list.values());
+            return;
+        }
+
+        style.set_property(CSS::PropertyID::Top, value, declaration);
+        style.set_property(CSS::PropertyID::Right, value, declaration);
+        style.set_property(CSS::PropertyID::Bottom, value, declaration);
+        style.set_property(CSS::PropertyID::Left, value, declaration);
+        return;
+    }
+
     if (property_id == CSS::PropertyID::Margin) {
         if (value.is_value_list()) {
             auto const& values_list = value.as_value_list();


### PR DESCRIPTION
This adds another shorthand property that was missing in a website I was testing!

Before:
![image](https://github.com/SerenityOS/serenity/assets/20765494/1dd4f30b-fbf0-49e9-9154-a2122c026eb5)

After:
![image](https://github.com/SerenityOS/serenity/assets/20765494/f3479577-8b2f-4ceb-aebb-b93588f7da0e)
