### PR TITLE
CI: Do not expect `test-results.log` to exist on AArch64

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -246,6 +246,10 @@ jobs:
           echo "::group::ninja run # Qemu output"
           ninja run
           echo "::endgroup::"
+          if ${{ matrix.arch == 'aarch64' }}; then
+            # FIXME: Actually verify test results when all tests are expected to pass.
+            exit 0
+          fi
           echo "::group::Verify Output File"
           mkdir fsmount
           sudo mount -t ext2 -o loop,rw _disk_image fsmount
@@ -253,11 +257,6 @@ jobs:
           sudo cat fsmount/home/anon/test-results.log
           if ! sudo grep -q "Failed: 0" fsmount/home/anon/test-results.log
           then
-            if ${{ matrix.arch == 'aarch64' }}; then
-              # FIXME: Remove this once all tests pass on AArch64
-              echo "::warning:: :^( Some tests failed"
-              exit 0
-            fi
             echo "::error:: :^( Tests failed, failing job"
             exit 1
           fi


### PR DESCRIPTION
The AArch64 port is still unstable, and in some cases, we may encounter a kernel panic or Shell crash that prevents `test-results.log` from being written to disk. The CI job would fail when we tried to print out the contents of this non-existent file. We have been ignoring its contents anyway, so let's not read it at all.