### PR TITLE
Solve some AArch64 CI flakes (and make debugging them slightly nicer)

### DIFF
--- a/Base/home/anon/Tests/run-tests-and-shutdown.sh
+++ b/Base/home/anon/Tests/run-tests-and-shutdown.sh
@@ -5,7 +5,7 @@ echo "==== Running Tests on SerenityOS ===="
 
 export LLVM_PROFILE_FILE="$HOME/profiles/%p-profile.profraw"
 
-run-tests --show-progress=false
+run-tests --show-progress=false --unlink-coredumps
 fail_count=$?
 
 unset LLVM_PROFILE_FILE

--- a/Userland/Libraries/LibC/crt0.cpp
+++ b/Userland/Libraries/LibC/crt0.cpp
@@ -27,6 +27,8 @@ NAKED void _start(int, char**, char**)
 {
 #    if ARCH(AARCH64)
     asm(
+        "mov x29, 0\n"
+        "mov x30, 0\n"
         "bl _entry\n");
 #    else
     asm(

--- a/Userland/Libraries/LibELF/Image.cpp
+++ b/Userland/Libraries/LibELF/Image.cpp
@@ -421,7 +421,16 @@ Optional<Image::Symbol> Image::find_symbol(FlatPtr address, u32* out_offset) con
 NEVER_INLINE void Image::sort_symbols() const
 {
     m_sorted_symbols.ensure_capacity(symbol_count());
-    for_each_symbol([this](auto const& symbol) {
+    bool const is_aarch64 = header().e_machine == EM_AARCH64;
+    for_each_symbol([this, is_aarch64](auto const& symbol) {
+        // The AArch64 ABI marks the boundaries of literal pools in a function with $x/$d.
+        // https://github.com/ARM-software/abi-aa/blob/2023q1-release/aaelf64/aaelf64.rst#mapping-symbols
+        // Skip them so we don't accidentally print these instead of function names.
+        if (is_aarch64 && (symbol.name().starts_with("$x"sv) || symbol.name().starts_with("$d"sv)))
+            return;
+        // STT_SECTION has the same address as the first function in the section, but shows up as the empty string.
+        if (symbol.type() == STT_SECTION)
+            return;
         m_sorted_symbols.append({ symbol.value(), symbol.name(), {}, symbol });
     });
     quick_sort(m_sorted_symbols, [](auto& a, auto& b) {

--- a/Userland/Utilities/run-tests.cpp
+++ b/Userland/Utilities/run-tests.cpp
@@ -37,13 +37,14 @@ DeprecatedString g_currently_running_test;
 
 class TestRunner : public ::Test::TestRunner {
 public:
-    TestRunner(DeprecatedString test_root, Regex<PosixExtended> exclude_regex, NonnullRefPtr<Core::ConfigFile> config, Regex<PosixExtended> skip_regex, bool run_skipped_tests, bool print_progress, bool print_json, bool print_all_output, bool print_times = true)
+    TestRunner(DeprecatedString test_root, Regex<PosixExtended> exclude_regex, NonnullRefPtr<Core::ConfigFile> config, Regex<PosixExtended> skip_regex, bool run_skipped_tests, bool print_progress, bool print_json, bool print_all_output, bool unlink_coredumps, bool print_times = true)
         : ::Test::TestRunner(move(test_root), print_times, print_progress, print_json)
         , m_exclude_regex(move(exclude_regex))
         , m_config(move(config))
         , m_skip_regex(move(skip_regex))
         , m_run_skipped_tests(run_skipped_tests)
         , m_print_all_output(print_all_output)
+        , m_unlink_coredumps(unlink_coredumps)
     {
         if (!run_skipped_tests) {
             m_skip_directories = m_config->read_entry("Global", "SkipDirectories", "").split(' ');
@@ -70,6 +71,7 @@ protected:
     Regex<PosixExtended> m_skip_regex;
     bool m_run_skipped_tests { false };
     bool m_print_all_output { false };
+    bool m_unlink_coredumps { false };
 };
 
 Vector<DeprecatedString> TestRunner::get_test_paths() const
@@ -142,6 +144,7 @@ void TestRunner::do_run_single_test(DeprecatedString const& test_path, size_t cu
         print_modifiers({ Test::CLEAR });
         if (test_result.result == Test::Result::Crashed) {
             auto pid_search_string = DeprecatedString::formatted("_{}_", test_result.child_pid);
+            Optional<DeprecatedString> coredump_path;
             Core::DirIterator iterator("/tmp/coredump"sv);
             if (!iterator.has_error()) {
                 while (iterator.has_next()) {
@@ -149,6 +152,7 @@ void TestRunner::do_run_single_test(DeprecatedString const& test_path, size_t cu
                     if (!path.contains(pid_search_string))
                         continue;
 
+                    coredump_path = path;
                     auto reader = Coredump::Reader::create(path);
                     if (!reader)
                         break;
@@ -165,6 +169,8 @@ void TestRunner::do_run_single_test(DeprecatedString const& test_path, size_t cu
                     break;
                 }
             }
+            if (m_unlink_coredumps && coredump_path.has_value())
+                (void)Core::System::unlink(coredump_path.value());
         }
     } else {
         print_modifiers({ Test::BG_GREEN, Test::FG_BLACK, Test::FG_BOLD });
@@ -315,6 +321,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool print_all_output = false;
     bool run_benchmarks = false;
     bool run_skipped_tests = false;
+    bool unlink_coredumps = false;
     StringView specified_test_root;
     DeprecatedString test_glob;
     DeprecatedString exclude_pattern;
@@ -340,6 +347,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(print_all_output, "Show all test output", "verbose", 'v');
     args_parser.add_option(run_benchmarks, "Run benchmarks as well", "benchmarks", 'b');
     args_parser.add_option(run_skipped_tests, "Run all matching tests, even those marked as 'skip'", "all", 'a');
+    args_parser.add_option(unlink_coredumps, "Unlink coredumps after printing backtraces", "unlink-coredumps", 0);
     args_parser.add_option(test_glob, "Only run tests matching the given glob", "filter", 'f', "glob");
     args_parser.add_option(exclude_pattern, "Regular expression to use to exclude paths from being considered tests", "exclude-pattern", 'e', "pattern");
     args_parser.add_option(config_file, "Configuration file to use", "config-file", 'c', "filename");
@@ -406,7 +414,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    TestRunner test_runner(test_root, move(exclude_regex), move(config), move(skip_regex), run_skipped_tests, print_progress, print_json, print_all_output);
+    TestRunner test_runner(test_root, move(exclude_regex), move(config), move(skip_regex), run_skipped_tests, print_progress, print_json, print_all_output, unlink_coredumps);
     test_runner.run(test_glob);
 
     return test_runner.counts().tests_failed;


### PR DESCRIPTION
This PR resolves an OOM crash that was caused by us leaking coredumps, stop backtrace collection from reading past `_start`'s stack frame and fixes backtrace symbolication issues. See commit messages and comments for details.