### PR TITLE
pgrep: Add `-c`, `-l`, `-U` and `-x` options

### DIFF
--- a/Base/usr/share/man/man1/pgrep.md
+++ b/Base/usr/share/man/man1/pgrep.md
@@ -5,11 +5,12 @@ pgrep - look up processes based on name
 ## Synopsis
 
 ```sh
-$ pgrep [-d delimiter] [--ignore-case] [--invert-match] <process-name>
+$ pgrep [--count] [-d delimiter] [--ignore-case] [--invert-match] <process-name>
 ```
 
 ## Options
 
+* `-c`, `--count`: Suppress normal output and print the number of matching processes
 * `-d`, `--delimiter`: Set the string used to delimit multiple pids
 * `-i`, `--ignore-case`: Make matches case-insensitive
 * `-v`, `--invert-match`: Select non-matching lines

--- a/Base/usr/share/man/man1/pgrep.md
+++ b/Base/usr/share/man/man1/pgrep.md
@@ -5,7 +5,7 @@ pgrep - look up processes based on name
 ## Synopsis
 
 ```sh
-$ pgrep [--count] [-d delimiter] [--ignore-case] [--invert-match] <process-name>
+$ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--invert-match] <process-name>
 ```
 
 ## Options
@@ -13,6 +13,7 @@ $ pgrep [--count] [-d delimiter] [--ignore-case] [--invert-match] <process-name>
 * `-c`, `--count`: Suppress normal output and print the number of matching processes
 * `-d`, `--delimiter`: Set the string used to delimit multiple pids
 * `-i`, `--ignore-case`: Make matches case-insensitive
+* `-l`, `--list-name`: List the process name in addition to its pid
 * `-v`, `--invert-match`: Select non-matching lines
 
 ## Arguments

--- a/Base/usr/share/man/man1/pgrep.md
+++ b/Base/usr/share/man/man1/pgrep.md
@@ -5,13 +5,13 @@ pgrep - look up processes based on name
 ## Synopsis
 
 ```sh
-$ pgrep [-d delimiter] [-i] [--invert-match] <process-name>
+$ pgrep [-d delimiter] [--ignore-case] [--invert-match] <process-name>
 ```
 
 ## Options
 
 * `-d`, `--delimiter`: Set the string used to delimit multiple pids
-* `-i`: Make matches case-insensitive
+* `-i`, `--ignore-case`: Make matches case-insensitive
 * `-v`, `--invert-match`: Select non-matching lines
 
 ## Arguments

--- a/Base/usr/share/man/man1/pgrep.md
+++ b/Base/usr/share/man/man1/pgrep.md
@@ -5,7 +5,7 @@ pgrep - look up processes based on name
 ## Synopsis
 
 ```sh
-$ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--invert-match] <process-name>
+$ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--uid uid-list] [--invert-match] <process-name>
 ```
 
 ## Options
@@ -14,6 +14,8 @@ $ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--invert-match] 
 * `-d`, `--delimiter`: Set the string used to delimit multiple pids
 * `-i`, `--ignore-case`: Make matches case-insensitive
 * `-l`, `--list-name`: List the process name in addition to its pid
+* `-U uid-list`, `--uid uid-list`: Select only processes whose UID is in the given comma-separated list. Login name or numerical user ID may be used
+
 * `-v`, `--invert-match`: Select non-matching lines
 
 ## Arguments

--- a/Base/usr/share/man/man1/pgrep.md
+++ b/Base/usr/share/man/man1/pgrep.md
@@ -5,7 +5,7 @@ pgrep - look up processes based on name
 ## Synopsis
 
 ```sh
-$ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--uid uid-list] [--invert-match] <process-name>
+$ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--uid uid-list] [--invert-match] [--exact] <process-name>
 ```
 
 ## Options
@@ -15,7 +15,7 @@ $ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--uid uid-list] 
 * `-i`, `--ignore-case`: Make matches case-insensitive
 * `-l`, `--list-name`: List the process name in addition to its pid
 * `-U uid-list`, `--uid uid-list`: Select only processes whose UID is in the given comma-separated list. Login name or numerical user ID may be used
-
+* `-x`, `--exact`: Select only processes whose names match the given pattern exactly
 * `-v`, `--invert-match`: Select non-matching lines
 
 ## Arguments

--- a/Userland/Utilities/pgrep.cpp
+++ b/Userland/Utilities/pgrep.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Aziz Berkay Yesilyurt <abyesilyurt@gmail.com>
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -65,5 +66,5 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     if (displayed_at_least_one)
         outln();
 
-    return 0;
+    return matches.size() > 0 ? 0 : 1;
 }

--- a/Userland/Utilities/pgrep.cpp
+++ b/Userland/Utilities/pgrep.cpp
@@ -27,7 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     Core::ArgsParser args_parser;
     args_parser.add_option(pid_delimiter, "Set the string used to delimit multiple pids", "delimiter", 'd', nullptr);
-    args_parser.add_option(case_insensitive, "Make matches case-insensitive", nullptr, 'i');
+    args_parser.add_option(case_insensitive, "Make matches case-insensitive", "ignore-case", 'i');
     args_parser.add_option(invert_match, "Select non-matching lines", "invert-match", 'v');
     args_parser.add_positional_argument(pattern, "Process name to search for", "process-name");
     args_parser.parse(args);

--- a/Userland/Utilities/pgrep.cpp
+++ b/Userland/Utilities/pgrep.cpp
@@ -20,12 +20,14 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
+    bool display_number_of_matches = false;
     auto pid_delimiter = "\n"sv;
     bool case_insensitive = false;
     bool invert_match = false;
     StringView pattern;
 
     Core::ArgsParser args_parser;
+    args_parser.add_option(display_number_of_matches, "Suppress normal output and print the number of matching processes", "count", 'c');
     args_parser.add_option(pid_delimiter, "Set the string used to delimit multiple pids", "delimiter", 'd', nullptr);
     args_parser.add_option(case_insensitive, "Make matches case-insensitive", "ignore-case", 'i');
     args_parser.add_option(invert_match, "Select non-matching lines", "invert-match", 'v');
@@ -51,20 +53,23 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         }
     }
 
-    quick_sort(matches);
+    if (display_number_of_matches) {
+        outln("{}", matches.size());
+    } else {
+        quick_sort(matches);
+        auto displayed_at_least_one = false;
+        for (auto& match : matches) {
+            if (displayed_at_least_one)
+                out("{}{}"sv, pid_delimiter, match);
+            else
+                out("{}"sv, match);
 
-    auto displayed_at_least_one = false;
-    for (auto& match : matches) {
+            displayed_at_least_one = true;
+        }
+
         if (displayed_at_least_one)
-            out("{}{}"sv, pid_delimiter, match);
-        else
-            out("{}"sv, match);
-
-        displayed_at_least_one = true;
+            outln();
     }
-
-    if (displayed_at_least_one)
-        outln();
 
     return matches.size() > 0 ? 0 : 1;
 }


### PR DESCRIPTION
This PR adds the following options to `pgrep`:

* `-c`: Shows the number of matched processes
* `-l`: Shows the name of the matched process in addition to its pid
* `-U`: Filter processes by a list of UIDs / user names
* `-x`: Match the given pattern exactly

Examples of the new functionality:
![pgrep_new_options](https://github.com/SerenityOS/serenity/assets/2817754/d8316ee8-0d77-4754-84bf-2d2d4bb4641c)


