### PR TITLE
WebContent: Wait for Resource to load in wait_for_navigation_to_complete

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.h
@@ -35,6 +35,8 @@ public:
 
     void load_html(StringView, const AK::URL&);
 
+    bool is_pending() const { return resource()->is_pending(); }
+
     HTML::BrowsingContext& browsing_context() { return m_browsing_context; }
     HTML::BrowsingContext const& browsing_context() const { return m_browsing_context; }
 

--- a/Userland/Libraries/LibWeb/Loader/Resource.h
+++ b/Userland/Libraries/LibWeb/Loader/Resource.h
@@ -37,9 +37,16 @@ public:
 
     Type type() const { return m_type; }
 
-    bool is_loaded() const { return m_loaded; }
+    enum class State {
+        Pending,
+        Loaded,
+        Failed,
+    };
 
-    bool is_failed() const { return m_failed; }
+    bool is_pending() const { return m_state == State::Pending; }
+    bool is_loaded() const { return m_state == State::Loaded; }
+    bool is_failed() const { return m_state == State::Failed; }
+
     DeprecatedString const& error() const { return m_error; }
 
     bool has_encoded_data() const { return !m_encoded_data.is_empty(); }
@@ -71,8 +78,7 @@ private:
     LoadRequest m_request;
     ByteBuffer m_encoded_data;
     Type m_type { Type::Generic };
-    bool m_loaded { false };
-    bool m_failed { false };
+    State m_state { State::Pending };
     DeprecatedString m_error;
     Optional<DeprecatedString> m_encoding;
 

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -52,6 +52,11 @@ void Page::load_html(StringView html, const AK::URL& url)
     top_level_browsing_context().loader().load_html(html, url);
 }
 
+bool Page::has_ongoing_navigation() const
+{
+    return top_level_browsing_context().loader().is_pending();
+}
+
 Gfx::Palette Page::palette() const
 {
     return m_client.palette();

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -60,6 +60,8 @@ public:
 
     void load_html(StringView, const AK::URL&);
 
+    bool has_ongoing_navigation() const;
+
     CSSPixelPoint device_to_css_point(DevicePixelPoint) const;
     DevicePixelPoint css_to_device_point(CSSPixelPoint) const;
     CSSPixelRect device_to_css_rect(DevicePixelRect) const;

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1888,7 +1888,11 @@ ErrorOr<void, Web::WebDriver::Error> WebDriverConnection::wait_for_navigation_to
         return {};
 
     // FIXME: 3. Start a timer. If this algorithm has not completed before timer reaches the session’s session page load timeout in milliseconds, return an error with error code timeout.
-    // FIXME: 4. If there is an ongoing attempt to navigate the current browsing context that has not yet matured, wait for navigation to mature.
+
+    // 4. If there is an ongoing attempt to navigate the current browsing context that has not yet matured, wait for navigation to mature.
+    Web::Platform::EventLoopPlugin::the().spin_until([&] {
+        return !m_page_client.page().has_ongoing_navigation();
+    });
 
     // 5. Let readiness target be the document readiness state associated with the current session’s page loading strategy, which can be found in the table of page load strategies.
     auto readiness_target = [this]() {


### PR DESCRIPTION
This fixes the timeout while running WPT tests that was caused by requestAnimationFrame() that queued callbacks on page that is navigated from which in turn was caused by wait_for_navigation_to_complete() that doesn't actually wait for page to load.