### PR TITLE
LibWeb: Change calc node representation from float to double

### DIFF
--- a/Tests/LibWeb/Layout/expected/acid1.txt
+++ b/Tests/LibWeb/Layout/expected/acid1.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <dl> at (25,25) content-size 470x0 children: inline
         TextNode <#text>
-        BlockContainer <dt> at (40,40) content-size 49.998596x280 floating [BFC] children: inline
+        BlockContainer <dt> at (40,40) content-size 49.998597x280 floating [BFC] children: inline
           line 0 width: 28.310546, height: 10, bottom: 10, baseline: 7.998046
             frag 0 from TextNode start: 0, length: 6, rect: [40,40 28.310546x10]
               "toggle"

--- a/Tests/LibWeb/Layout/expected/flex-item-vertical-padding-relative-to-flex-container-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-vertical-padding-relative-to-flex-container-width.txt
@@ -6,9 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.flex-container> at (11,11) content-size 600x10 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> at (11,11) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.flex-item> at (12,71.999996) content-size 27.15625x18.000010 flex-item [BFC] children: inline
+        BlockContainer <div.flex-item> at (12,72) content-size 27.15625x18 flex-item [BFC] children: inline
           line 0 width: 27.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [12,71.999996 27.15625x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [12,72 27.15625x17.46875]
               "foo"
           TextNode <#text>
         BlockContainer <(anonymous)> at (11,11) content-size 0x0 [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-shrink-2.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-2.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.container> at (9,9) content-size 500x102 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 47.000011x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,10) content-size 47x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (59.000011,10) content-size 164.666666x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (59,10) content-size 164.666666x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [59.000011,10 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [59,10 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (225.666678,10) content-size 282.333321x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (225.666666,10) content-size 282.333333x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [225.666678,10 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [225.666666,10 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> at (9,9) content-size 0x0 [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/borders.txt
+++ b/Tests/LibWeb/Layout/expected/grid/borders.txt
@@ -103,14 +103,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,275.34375) content-size 784x90.9375 [GFC] children: not-inline
         BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (444.199997,285.34375) content-size 337.800002x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (444.2,285.34375) content-size 337.8x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [444.199997,285.34375 6.34375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [444.2,285.34375 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> at (8,275.34375) content-size 0x0 [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (18,338.8125) content-size 337.800002x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (18,338.8125) content-size 337.8x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [18,338.8125 8.8125x17.46875]
               "2"

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
@@ -2,12 +2,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x50.9375 children: not-inline
       Box <div.container> at (8,8) content-size 784x50.9375 [GFC] children: not-inline
-        BlockContainer <div.item> at (434.199997,8) content-size 357.800002x17.46875 [BFC] children: inline
+        BlockContainer <div.item> at (434.2,8) content-size 357.8x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [434.199997,8 6.34375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [434.2,8 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <div.item> at (8,41.46875) content-size 357.800002x17.46875 [BFC] children: inline
+        BlockContainer <div.item> at (8,41.46875) content-size 357.8x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,41.46875 8.8125x17.46875]
               "2"

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width.txt
@@ -2,12 +2,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
-        BlockContainer <div.first> at (8,8) content-size 313.599981x17.46875 [BFC] children: inline
+        BlockContainer <div.first> at (8,8) content-size 313.6x17.46875 [BFC] children: inline
           line 0 width: 42.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 5, rect: [8,8 42.140625x17.46875]
               "First"
           TextNode <#text>
-        BlockContainer <div.second> at (400,8) content-size 78.399995x17.46875 [BFC] children: inline
+        BlockContainer <div.second> at (400,8) content-size 78.4x17.46875 [BFC] children: inline
           line 0 width: 57.40625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 6, rect: [400,8 57.40625x17.46875]
               "Second"

--- a/Tests/LibWeb/Layout/expected/vertical-padding-relative-to-cb-width.txt
+++ b/Tests/LibWeb/Layout/expected/vertical-padding-relative-to-cb-width.txt
@@ -6,9 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.cb> at (11,11) content-size 600x10 children: not-inline
         BlockContainer <(anonymous)> at (11,11) content-size 600x0 children: inline
           TextNode <#text>
-        BlockContainer <div.foo> at (12,71.999996) content-size 598x18.000010 children: inline
+        BlockContainer <div.foo> at (12,72) content-size 598x18 children: inline
           line 0 width: 27.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [12,71.999996 27.15625x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [12,72 27.15625x17.46875]
               "foo"
           TextNode <#text>
         BlockContainer <(anonymous)> at (11,211) content-size 600x17.46875 children: inline

--- a/Userland/Libraries/LibWeb/CSS/Angle.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Angle.cpp
@@ -16,13 +16,13 @@ Angle::Angle(int value, Type type)
 {
 }
 
-Angle::Angle(float value, Type type)
+Angle::Angle(double value, Type type)
     : m_type(type)
     , m_value(value)
 {
 }
 
-Angle Angle::make_degrees(float value)
+Angle Angle::make_degrees(double value)
 {
     return { value, Type::Deg };
 }
@@ -37,17 +37,17 @@ ErrorOr<String> Angle::to_string() const
     return String::formatted("{}deg", to_degrees());
 }
 
-float Angle::to_degrees() const
+double Angle::to_degrees() const
 {
     switch (m_type) {
     case Type::Deg:
         return m_value;
     case Type::Grad:
-        return m_value * (360.0f / 400.0f);
+        return m_value * (360.0 / 400.0);
     case Type::Rad:
-        return m_value * (180.0f / AK::Pi<float>);
+        return m_value * (180.0 / AK::Pi<double>);
     case Type::Turn:
-        return m_value * 360.0f;
+        return m_value * 360.0;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/Angle.h
+++ b/Userland/Libraries/LibWeb/CSS/Angle.h
@@ -23,15 +23,15 @@ public:
     static Optional<Type> unit_from_name(StringView);
 
     Angle(int value, Type type);
-    Angle(float value, Type type);
-    static Angle make_degrees(float);
+    Angle(double value, Type type);
+    static Angle make_degrees(double);
     Angle percentage_of(Percentage const&) const;
 
     ErrorOr<String> to_string() const;
-    float to_degrees() const;
+    double to_degrees() const;
 
     Type type() const { return m_type; }
-    float raw_value() const { return m_value; }
+    double raw_value() const { return m_value; }
 
     bool operator==(Angle const& other) const
     {
@@ -42,7 +42,7 @@ private:
     StringView unit_name() const;
 
     Type m_type;
-    float m_value { 0 };
+    double m_value { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -140,7 +140,7 @@ public:
     bool operator==(BorderData const&) const = default;
 };
 
-using TransformValue = Variant<CSS::AngleOrCalculated, CSS::LengthPercentage, float>;
+using TransformValue = Variant<CSS::AngleOrCalculated, CSS::LengthPercentage, double>;
 
 struct Transformation {
     CSS::TransformFunction function;

--- a/Userland/Libraries/LibWeb/CSS/Frequency.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Frequency.cpp
@@ -15,13 +15,13 @@ Frequency::Frequency(int value, Type type)
 {
 }
 
-Frequency::Frequency(float value, Type type)
+Frequency::Frequency(double value, Type type)
     : m_type(type)
     , m_value(value)
 {
 }
 
-Frequency Frequency::make_hertz(float value)
+Frequency Frequency::make_hertz(double value)
 {
     return { value, Type::Hz };
 }
@@ -36,7 +36,7 @@ ErrorOr<String> Frequency::to_string() const
     return String::formatted("{}hz", to_hertz());
 }
 
-float Frequency::to_hertz() const
+double Frequency::to_hertz() const
 {
     switch (m_type) {
     case Type::Hz:

--- a/Userland/Libraries/LibWeb/CSS/Frequency.h
+++ b/Userland/Libraries/LibWeb/CSS/Frequency.h
@@ -20,15 +20,15 @@ public:
     static Optional<Type> unit_from_name(StringView);
 
     Frequency(int value, Type type);
-    Frequency(float value, Type type);
-    static Frequency make_hertz(float);
+    Frequency(double value, Type type);
+    static Frequency make_hertz(double);
     Frequency percentage_of(Percentage const&) const;
 
     ErrorOr<String> to_string() const;
-    float to_hertz() const;
+    double to_hertz() const;
 
     Type type() const { return m_type; }
-    float raw_value() const { return m_value; }
+    double raw_value() const { return m_value; }
 
     bool operator==(Frequency const& other) const
     {
@@ -39,7 +39,7 @@ private:
     StringView unit_name() const;
 
     Type m_type;
-    float m_value { 0 };
+    double m_value { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Number.h
+++ b/Userland/Libraries/LibWeb/CSS/Number.h
@@ -25,21 +25,21 @@ public:
         , m_type(Type::Number)
     {
     }
-    Number(Type type, float value)
+    Number(Type type, double value)
         : m_value(value)
         , m_type(type)
     {
     }
 
     Type type() const { return m_type; }
-    float value() const { return m_value; }
+    double value() const { return m_value; }
     i64 integer_value() const
     {
         // https://www.w3.org/TR/css-values-4/#numeric-types
         // When a value cannot be explicitly supported due to range/precision limitations, it must be converted
         // to the closest value supported by the implementation, but how the implementation defines "closest"
         // is explicitly undefined as well.
-        return llroundf(m_value);
+        return llround(m_value);
     }
     bool is_integer() const { return m_type == Type::Integer || m_type == Type::IntegerWithExplicitSign; }
     bool is_integer_with_explicit_sign() const { return m_type == Type::IntegerWithExplicitSign; }
@@ -83,7 +83,7 @@ public:
     }
 
 private:
-    float m_value { 0 };
+    double m_value { 0 };
     Type m_type;
 };
 }

--- a/Userland/Libraries/LibWeb/CSS/Percentage.h
+++ b/Userland/Libraries/LibWeb/CSS/Percentage.h
@@ -23,13 +23,13 @@ public:
     {
     }
 
-    explicit Percentage(float value)
+    explicit Percentage(double value)
         : m_value(value)
     {
     }
 
-    float value() const { return m_value; }
-    float as_fraction() const { return m_value * 0.01f; }
+    double value() const { return m_value; }
+    double as_fraction() const { return m_value * 0.01; }
 
     ErrorOr<String> to_string() const
     {
@@ -39,7 +39,7 @@ public:
     bool operator==(Percentage const& other) const { return m_value == other.m_value; }
 
 private:
-    float m_value;
+    double m_value;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1015,7 +1015,7 @@ StyleComputer::AnimationStepTransition StyleComputer::Animation::step(CSS::Time 
     remaining_delay = CSS::Time { 0, CSS::Time::Type::Ms };
     time_step_ms -= delay_ms;
 
-    float added_progress = static_cast<float>(time_step_ms / duration.to_milliseconds());
+    auto added_progress = time_step_ms / duration.to_milliseconds();
     auto new_progress = progress.as_fraction() + added_progress;
     auto changed_iteration = false;
     if (new_progress >= 1) {
@@ -1250,7 +1250,7 @@ ErrorOr<void> StyleComputer::Animation::collect_into(StyleProperties& style_prop
 
 bool StyleComputer::Animation::is_done() const
 {
-    return progress.as_fraction() >= 0.9999f && iteration_count.has_value() && iteration_count.value() == 0;
+    return progress.as_fraction() >= 0.9999 && iteration_count.has_value() && iteration_count.value() == 0;
 }
 
 float StyleComputer::Animation::compute_output_progress(float input_progress) const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -513,7 +513,7 @@ void CalculatedStyleValue::CalculationResult::add_or_subtract_internal(SumOperat
 void CalculatedStyleValue::CalculationResult::multiply_by(CalculationResult const& other, Layout::Node const* layout_node)
 {
     // We know from validation when resolving the type, that at least one side must be a <number> or <integer>.
-    // Both of these are represented as a float.
+    // Both of these are represented as a double.
     VERIFY(m_value.has<Number>() || other.m_value.has<Number>());
     bool other_is_number = other.m_value.has<Number>();
 
@@ -552,7 +552,7 @@ void CalculatedStyleValue::CalculationResult::divide_by(CalculationResult const&
     // Both of these are represented as a Number.
     auto denominator = other.m_value.get<Number>().value();
     // FIXME: Dividing by 0 is invalid, and should be caught during parsing.
-    VERIFY(denominator != 0.0f);
+    VERIFY(denominator != 0.0);
 
     m_value.visit(
         [&](Number const& number) {
@@ -745,7 +745,7 @@ Optional<Time> CalculatedStyleValue::resolve_time_percentage(Time const& percent
         });
 }
 
-Optional<float> CalculatedStyleValue::resolve_number() const
+Optional<double> CalculatedStyleValue::resolve_number() const
 {
     auto result = m_calculation->resolve(nullptr, {});
     if (result.value().has<Number>())

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -94,7 +94,7 @@ public:
 
     bool resolves_to_integer() const { return m_resolved_type == ResolvedType::Integer; }
     bool resolves_to_number() const { return resolves_to_integer() || m_resolved_type == ResolvedType::Number; }
-    Optional<float> resolve_number() const;
+    Optional<double> resolve_number() const;
     Optional<i64> resolve_integer();
 
     bool contains_percentage() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
@@ -40,7 +40,7 @@ float Filter::HueRotate::angle_degrees() const
     // Default value when omitted is 0deg.
     if (!angle.has_value())
         return 0.0f;
-    return angle->visit([&](Angle const& a) { return a.to_degrees(); }, [&](auto) { return 0.0f; });
+    return angle->visit([&](Angle const& a) { return a.to_degrees(); }, [&](auto) { return 0.0; });
 }
 
 float Filter::Color::resolved_amount() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
@@ -66,35 +66,35 @@ bool LinearGradientStyleValue::equals(StyleValue const& other_) const
 float LinearGradientStyleValue::angle_degrees(CSSPixelSize gradient_size) const
 {
     auto corner_angle_degrees = [&] {
-        return static_cast<float>(atan2(gradient_size.height().value(), gradient_size.width().value())) * 180 / AK::Pi<float>;
+        return atan2(gradient_size.height().value(), gradient_size.width().value()) * 180 / AK::Pi<double>;
     };
     return m_properties.direction.visit(
         [&](SideOrCorner side_or_corner) {
             auto angle = [&] {
                 switch (side_or_corner) {
                 case SideOrCorner::Top:
-                    return 0.0f;
+                    return 0.0;
                 case SideOrCorner::Bottom:
-                    return 180.0f;
+                    return 180.0;
                 case SideOrCorner::Left:
-                    return 270.0f;
+                    return 270.0;
                 case SideOrCorner::Right:
-                    return 90.0f;
+                    return 90.0;
                 case SideOrCorner::TopRight:
                     return corner_angle_degrees();
                 case SideOrCorner::BottomLeft:
-                    return corner_angle_degrees() + 180.0f;
+                    return corner_angle_degrees() + 180.0;
                 case SideOrCorner::TopLeft:
                     return -corner_angle_degrees();
                 case SideOrCorner::BottomRight:
-                    return -(corner_angle_degrees() + 180.0f);
+                    return -(corner_angle_degrees() + 180.0);
                 default:
                     VERIFY_NOT_REACHED();
                 }
             }();
             // Note: For unknowable reasons the angles are opposite on the -webkit- version
             if (m_properties.gradient_type == GradientType::WebKit)
-                return angle + 180.0f;
+                return angle + 180.0;
             return angle;
         },
         [&](Angle const& angle) {

--- a/Userland/Libraries/LibWeb/CSS/Time.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Time.cpp
@@ -15,13 +15,13 @@ Time::Time(int value, Type type)
 {
 }
 
-Time::Time(float value, Type type)
+Time::Time(double value, Type type)
     : m_type(type)
     , m_value(value)
 {
 }
 
-Time Time::make_seconds(float value)
+Time Time::make_seconds(double value)
 {
     return { value, Type::S };
 }
@@ -36,13 +36,13 @@ ErrorOr<String> Time::to_string() const
     return String::formatted("{}s", to_seconds());
 }
 
-float Time::to_seconds() const
+double Time::to_seconds() const
 {
     switch (m_type) {
     case Type::S:
         return m_value;
     case Type::Ms:
-        return m_value / 1000.0f;
+        return m_value / 1000.0;
     }
     VERIFY_NOT_REACHED();
 }
@@ -51,9 +51,9 @@ double Time::to_milliseconds() const
 {
     switch (m_type) {
     case Type::S:
-        return static_cast<double>(m_value) * 1000.0;
+        return m_value * 1000.0;
     case Type::Ms:
-        return static_cast<double>(m_value);
+        return m_value;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/Time.h
+++ b/Userland/Libraries/LibWeb/CSS/Time.h
@@ -21,16 +21,16 @@ public:
     static Optional<Type> unit_from_name(StringView);
 
     Time(int value, Type type);
-    Time(float value, Type type);
-    static Time make_seconds(float);
+    Time(double value, Type type);
+    static Time make_seconds(double);
     Time percentage_of(Percentage const&) const;
 
     ErrorOr<String> to_string() const;
-    float to_seconds() const;
     double to_milliseconds() const;
+    double to_seconds() const;
 
     Type type() const { return m_type; }
-    float raw_value() const { return m_value; }
+    double raw_value() const { return m_value; }
 
     bool operator==(Time const& other) const
     {
@@ -41,7 +41,7 @@ private:
     StringView unit_name() const;
 
     Type m_type;
-    float m_value { 0 };
+    double m_value { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -232,7 +232,7 @@ Gfx::FloatMatrix4x4 StackingContext::get_transformation_matrix(CSS::Transformati
     auto count = transformation.values.size();
     auto value = [this, transformation](size_t index, Optional<CSS::Length const&> reference_length = {}) -> float {
         return transformation.values[index].visit(
-            [this, reference_length](CSS::LengthPercentage const& value) -> float {
+            [this, reference_length](CSS::LengthPercentage const& value) -> double {
                 if (reference_length.has_value()) {
                     return value.resolved(m_box, reference_length.value()).to_px(m_box).value();
                 }
@@ -240,9 +240,9 @@ Gfx::FloatMatrix4x4 StackingContext::get_transformation_matrix(CSS::Transformati
                 return value.length().to_px(m_box).value();
             },
             [this](CSS::AngleOrCalculated const& value) {
-                return value.resolved(m_box).to_degrees() * static_cast<float>(M_DEG2RAD);
+                return value.resolved(m_box).to_degrees() * M_DEG2RAD;
             },
-            [](float value) {
+            [](double value) {
                 return value;
             });
     };


### PR DESCRIPTION
The wpt tests need more precision than a float can offer