### PR TITLE
LibWeb: Move function parsing to separate method

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -289,6 +289,7 @@ private:
     ErrorOr<RefPtr<StyleValue>> parse_builtin_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_dynamic_value(ComponentValue const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
+    ErrorOr<OwnPtr<CalculationNode>> parse_a_function_node(Function const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_identifier_value(ComponentValue const&);


### PR DESCRIPTION
This allows us to reuse the functions more easily
