### PR TITLE
killall: Continue killing processes if `kill()` call fails

### DIFF
--- a/Userland/Utilities/killall.cpp
+++ b/Userland/Utilities/killall.cpp
@@ -50,7 +50,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         if (is_ascii_alpha(arguments.argv[1][1])) {
             int value = getsignalbyname(&arguments.argv[1][1]);
-            if (value >= 0 && value < NSIG)
+            if (value > 0 && value < NSIG)
                 number = value;
         }
 

--- a/Userland/Utilities/killall.cpp
+++ b/Userland/Utilities/killall.cpp
@@ -25,7 +25,8 @@ static ErrorOr<int> kill_all(StringView process_name, unsigned const signum)
 
     for (auto& process : all_processes.processes) {
         if (process.name == process_name) {
-            TRY(Core::System::kill(process.pid, signum));
+            if (auto maybe_error = Core::System::kill(process.pid, signum); maybe_error.is_error())
+                warnln("{}", maybe_error.release_error());
         }
     }
 

--- a/Userland/Utilities/killall.cpp
+++ b/Userland/Utilities/killall.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <AK/CharacterTypes.h>
-#include <AK/DeprecatedString.h>
 #include <LibCore/ProcessStatisticsReader.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
@@ -20,7 +19,7 @@ static void print_usage_and_exit()
     exit(1);
 }
 
-static ErrorOr<int> kill_all(DeprecatedString const& process_name, unsigned const signum)
+static ErrorOr<int> kill_all(StringView process_name, unsigned const signum)
 {
     auto all_processes = TRY(Core::ProcessStatisticsReader::get_all());
 
@@ -56,7 +55,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
         if (!number.has_value())
-            number = DeprecatedString(&arguments.argv[1][1]).to_uint();
+            number = arguments.strings[1].substring_view(1).to_uint();
 
         if (!number.has_value()) {
             warnln("'{}' is not a valid signal name or number", &arguments.argv[1][1]);


### PR DESCRIPTION
This PR introduces 2 behavior changes to `killall`

* If a call to `Core::System::kill()` fails, the program no longer stops, but will continue killing matching processes
* Specifying SIGINVAL/INVAL is no longer equivalent to the null signal (signal 0)