### PR TITLE
LibVideo/PlaybackManager: Return duration zero when an error occurs

### DIFF
--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -118,8 +118,13 @@ Duration PlaybackManager::duration()
         auto demuxer_locker = Threading::MutexLocker(m_demuxer_mutex);
         m_demuxer->duration();
     });
-    if (duration_result.is_error())
+    if (duration_result.is_error()) {
         dispatch_decoder_error(duration_result.release_error());
+        // FIXME: We should determine the last sample that the demuxer knows is available and
+        //        use that as the current duration. The duration may change if the demuxer doesn't
+        //        know there is a fixed duration.
+        return Duration::zero();
+    }
     return duration_result.release_value();
 }
 


### PR DESCRIPTION
Previously, we would unwrap the duration value even when it contained an error, causing an assertion failure.

Later, we should change it to return the last known sample timestamp in the media data, allowing for example live-streamed video to have a semi-useful duration. In general, though, this is not used by players in the wild, so we can leave it for now.