### PR TITLE
LibWeb: Make popup blocker less strict by implementing `has_transient_activation`

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -621,7 +621,23 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Storage>> Window::session_storage()
 // https://html.spec.whatwg.org/multipage/interaction.html#transient-activation
 bool Window::has_transient_activation() const
 {
-    // FIXME: Implement this.
+    // The transient activation duration is expected be at most a few seconds, so that the user can possibly
+    // perceive the link between an interaction with the page and the page calling the activation-gated API.
+    auto transient_activation_duration = 5;
+
+    // When the current high resolution time given W
+    auto unsafe_shared_time = HighResolutionTime::unsafe_shared_current_time();
+    auto current_time = HighResolutionTime::relative_high_resolution_time(unsafe_shared_time, realm().global_object());
+
+    // is greater than or equal to the last activation timestamp in W
+    if (current_time >= m_last_activation_timestamp) {
+        // and less than the last activation timestamp in W plus the transient activation duration
+        if (current_time < m_last_activation_timestamp + transient_activation_duration) {
+            // then W is said to have transient activation.
+            return true;
+        }
+    }
+
     return false;
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -184,6 +184,9 @@ public:
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomElementRegistry>> custom_elements();
 
+    HighResolutionTime::DOMHighResTimeStamp get_last_activation_timestamp() const { return m_last_activation_timestamp; }
+    void set_last_activation_timestamp(HighResolutionTime::DOMHighResTimeStamp timestamp) { m_last_activation_timestamp = timestamp; }
+
 private:
     explicit Window(JS::Realm&);
 
@@ -235,6 +238,9 @@ private:
 
     // [[CrossOriginPropertyDescriptorMap]], https://html.spec.whatwg.org/multipage/browsers.html#crossoriginpropertydescriptormap
     CrossOriginPropertyDescriptorMap m_cross_origin_property_descriptor_map;
+
+    // https://html.spec.whatwg.org/multipage/interaction.html#user-activation-data-model
+    HighResolutionTime::DOMHighResTimeStamp m_last_activation_timestamp { NumericLimits<double>::max() };
 };
 
 void run_animation_frame_callbacks(DOM::Document&, double now);


### PR DESCRIPTION
This fixes an interaction on https://wpt.live/tools/runner/index.html, where you could not open the test runner window due to the popup blocker

Also fixes the fact that we wrongly hit step 7 in `choose_a_browsing_context`, and returned the current window, when we want to open a new window