### PR TITLE
WebP/Lossy: Add a missing clamp() in `TM_PRED` prediction

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossy.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossy.cpp
@@ -924,7 +924,7 @@ void predict_macroblock(Span<i16> prediction, IntraMacroblockMode mode, int mb_x
         VERIFY(mode == TM_PRED);
         for (int y = 0; y < N; ++y)
             for (int x = 0; x < N; ++x)
-                prediction[y * N + x] = left[y] + above[mb_x * N + x] - truemotion_corner;
+                prediction[y * N + x] = clamp(left[y] + above[mb_x * N + x] - truemotion_corner, 0, 255);
     }
 }
 


### PR DESCRIPTION
The spec has that clamp at the end of
https://datatracker.ietf.org/doc/html/rfc6386#section-12.2:

    The exact algorithm is as follows:
    [...]
               b[r][c] = clamp255(L[r]+ A[c] - P);

For the test images I'm looking at, it doesn't seem to make a dramatic difference, but omitting it in `B_TM_PRED` did make a dramatic difference, so add it. (Also, the spec demands it.)