### PR TITLE
KeyboardMapper: Do not drop the `unix` pledge

### DIFF
--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -26,9 +26,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio getkeymap thread rpath cpath wpath recvfd sendfd unix"));
 
     auto app = TRY(GUI::Application::create(arguments));
-
-    TRY(Core::System::pledge("stdio getkeymap thread rpath cpath wpath recvfd sendfd"));
-
     auto app_icon = GUI::Icon::default_icon("app-keyboard-mapper"sv);
 
     auto window = GUI::Window::construct();
@@ -43,7 +40,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     else
         TRY(keyboard_mapper_widget->load_map_from_file(path));
 
-    TRY(Core::System::pledge("stdio thread rpath cpath wpath recvfd sendfd"));
+    TRY(Core::System::pledge("stdio thread rpath cpath wpath recvfd sendfd unix"));
 
     auto open_action = GUI::CommonActions::make_open_action(
         [&](auto&) {


### PR DESCRIPTION
Without it, KeyboardMapper crashes as soon as you try to open a file.