### PR TITLE
LibGUI: Add support for jumping to a line and column in TextEditor

### DIFF
--- a/Userland/DevTools/GMLPlayground/MainWidget.cpp
+++ b/Userland/DevTools/GMLPlayground/MainWidget.cpp
@@ -200,7 +200,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
     TRY(edit_menu->try_add_action(m_editor->paste_action()));
     TRY(edit_menu->try_add_separator());
     TRY(edit_menu->try_add_action(m_editor->select_all_action()));
-    TRY(edit_menu->try_add_action(m_editor->go_to_line_action()));
+    TRY(edit_menu->try_add_action(m_editor->go_to_line_or_column_action()));
     TRY(edit_menu->try_add_separator());
 
     auto format_gml_action = GUI::Action::create("&Format GML", { Mod_Ctrl | Mod_Shift, Key_I }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/reformat.png"sv)), [&](auto&) {

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -190,7 +190,7 @@ public:
     Action& cut_action() { return *m_cut_action; }
     Action& copy_action() { return *m_copy_action; }
     Action& paste_action() { return *m_paste_action; }
-    Action& go_to_line_action() { return *m_go_to_line_action; }
+    Action& go_to_line_or_column_action() { return *m_go_to_line_or_column_action; }
     Action& select_all_action() { return *m_select_all_action; }
     Action& insert_emoji_action() { return *m_insert_emoji_action; }
 
@@ -426,7 +426,7 @@ private:
     RefPtr<Action> m_cut_action;
     RefPtr<Action> m_copy_action;
     RefPtr<Action> m_paste_action;
-    RefPtr<Action> m_go_to_line_action;
+    RefPtr<Action> m_go_to_line_or_column_action;
     RefPtr<Action> m_select_all_action;
     RefPtr<Action> m_insert_emoji_action;
     Core::ElapsedTimer m_triple_click_timer;


### PR DESCRIPTION
We had support for going to a specific line before, but now we support jumping around using the `line:column` format :^)

![screenshot-2023-05-31-17-23-55](https://github.com/SerenityOS/serenity/assets/71222289/d6c3c7dc-adfb-4cae-884d-4fa9b99aec37)
