### PR TITLE
LibGfx: Improve glyph rendering speed for vector fonts

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1432,7 +1432,7 @@ FLATTEN void Painter::draw_glyph(FloatPoint point, u32 code_point, Font const& f
         draw_scaled_bitmap(rect.to_rounded<int>(), *glyph.bitmap(), glyph.bitmap()->rect(), 1.0f, ScalingMode::BilinearBlend);
     } else {
         blit_filtered(glyph_position.blit_position, *glyph.bitmap(), glyph.bitmap()->rect(), [color](Color pixel) -> Color {
-            return pixel.multiply(color);
+            return color.with_alpha(pixel.alpha());
         });
     }
 }


### PR DESCRIPTION
The glyph bitmap is a grayscale image that is multiplied with the requested color provided to `Gfx::Painter::draw_glyph()` to get the final glyph bitmap that can be blitted.

Using `Gfx::Color::multiply()` is unnecessary however: by simply taking the destination color and copying over the glyph bitmap's alpha value, we can prevent four multiplications and divisions per pixel.

In an artifical benchmark I wrote, this improved glyph rendering performance by ~9%.

<details>
<summary>The benchmark in question</summary>

```cpp
    auto bitmap = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { 800, 600 }));
    Gfx::Painter painter { bitmap };

    String text = TRY(String::from_utf8("This is a test"sv));
    auto text_view = text.code_points();

    auto font = Gfx::FontDatabase::the().get_by_name("Arial 14 400 0"sv);
    VERIFY(!font.is_null());
    auto color = Gfx::Color::from_named_css_color_string("red"sv).release_value();

    for (int i = 0; i < 250000; ++i)
        painter.draw_text_run(Gfx::IntPoint { 40, 40 }, text_view, *font, color);
```
</details>