### PR TITLE
LibWeb: Support calc(...) in box-shadow's values of type Length

### DIFF
--- a/Tests/LibWeb/Text/expected/css/box-shadow-resolves-length-functions.txt
+++ b/Tests/LibWeb/Text/expected/css/box-shadow-resolves-length-functions.txt
@@ -1,0 +1,1 @@
+0 calc(5px - 10px) 0 calc(2px + 3px) => #000000ff 0px calc(5px + (0 - 10px)) 0px calc(2px + 3px)

--- a/Tests/LibWeb/Text/input/css/box-shadow-resolves-length-functions.html
+++ b/Tests/LibWeb/Text/input/css/box-shadow-resolves-length-functions.html
@@ -1,0 +1,13 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const e = document.createElement("div");
+        document.body.appendChild(e);
+        const definition = "0 calc(5px - 10px) 0 calc(2px + 3px)";
+        e.style.boxShadow = definition;
+        const computedStyle = getComputedStyle(e);
+        const serialized = computedStyle.boxShadow;
+        println(definition + " => " + serialized);
+        e.remove();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -523,8 +523,12 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         if (box_shadow_layers.is_empty())
             return nullptr;
 
-        auto make_box_shadow_style_value = [](ShadowData const& data) {
-            return ShadowStyleValue::create(data.color, data.offset_x, data.offset_y, data.blur_radius, data.spread_distance, data.placement);
+        auto make_box_shadow_style_value = [](ShadowData const& data) -> ErrorOr<NonnullRefPtr<ShadowStyleValue>> {
+            auto offset_x = TRY(LengthStyleValue::create(data.offset_x));
+            auto offset_y = TRY(LengthStyleValue::create(data.offset_y));
+            auto blur_radius = TRY(LengthStyleValue::create(data.blur_radius));
+            auto spread_distance = TRY(LengthStyleValue::create(data.spread_distance));
+            return ShadowStyleValue::create(data.color, offset_x, offset_y, blur_radius, spread_distance, data.placement);
         };
 
         if (box_shadow_layers.size() == 1)

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -64,7 +64,7 @@ public:
     Vector<CSS::TextDecorationLine> text_decoration_line() const;
     Optional<CSS::TextDecorationStyle> text_decoration_style() const;
     Optional<CSS::TextTransform> text_transform() const;
-    Vector<CSS::ShadowData> text_shadow() const;
+    Vector<CSS::ShadowData> text_shadow(Layout::Node const&) const;
     Optional<CSS::ListStyleType> list_style_type() const;
     Optional<CSS::ListStylePosition> list_style_position() const;
     Optional<CSS::FlexDirection> flex_direction() const;
@@ -85,7 +85,7 @@ public:
     Optional<CSS::JustifyContent> justify_content() const;
     Optional<CSS::Overflow> overflow_x() const;
     Optional<CSS::Overflow> overflow_y() const;
-    Vector<CSS::ShadowData> box_shadow() const;
+    Vector<CSS::ShadowData> box_shadow(Layout::Node const&) const;
     Optional<CSS::BoxSizing> box_sizing() const;
     Optional<CSS::PointerEvents> pointer_events() const;
     Variant<CSS::VerticalAlign, CSS::LengthPercentage> vertical_align() const;
@@ -141,7 +141,7 @@ private:
     };
     Array<Optional<StyleAndSourceDeclaration>, to_underlying(CSS::last_property_id) + 1> m_property_values;
     Optional<CSS::Overflow> overflow(CSS::PropertyID) const;
-    Vector<CSS::ShadowData> shadow(CSS::PropertyID) const;
+    Vector<CSS::ShadowData> shadow(CSS::PropertyID, Layout::Node const&) const;
 
     mutable RefPtr<Gfx::Font const> m_font;
 };

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.cpp
@@ -14,7 +14,7 @@ namespace Web::CSS {
 ErrorOr<String> ShadowStyleValue::to_string() const
 {
     StringBuilder builder;
-    TRY(builder.try_appendff("{} {} {} {} {}", m_properties.color.to_deprecated_string(), TRY(m_properties.offset_x.to_string()), TRY(m_properties.offset_y.to_string()), TRY(m_properties.blur_radius.to_string()), TRY(m_properties.spread_distance.to_string())));
+    TRY(builder.try_appendff("{} {} {} {} {}", m_properties.color.to_deprecated_string(), TRY(m_properties.offset_x->to_string()), TRY(m_properties.offset_y->to_string()), TRY(m_properties.blur_radius->to_string()), TRY(m_properties.spread_distance->to_string())));
     if (m_properties.placement == ShadowPlacement::Inner)
         TRY(builder.try_append(" inset"sv));
     return builder.to_string();
@@ -22,10 +22,10 @@ ErrorOr<String> ShadowStyleValue::to_string() const
 
 ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> ShadowStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
 {
-    auto absolutized_offset_x = m_properties.offset_x.absolutized(viewport_rect, font_metrics, root_font_metrics);
-    auto absolutized_offset_y = m_properties.offset_y.absolutized(viewport_rect, font_metrics, root_font_metrics);
-    auto absolutized_blur_radius = m_properties.blur_radius.absolutized(viewport_rect, font_metrics, root_font_metrics);
-    auto absolutized_spread_distance = m_properties.spread_distance.absolutized(viewport_rect, font_metrics, root_font_metrics);
+    auto absolutized_offset_x = TRY(m_properties.offset_x->absolutized(viewport_rect, font_metrics, root_font_metrics));
+    auto absolutized_offset_y = TRY(m_properties.offset_y->absolutized(viewport_rect, font_metrics, root_font_metrics));
+    auto absolutized_blur_radius = TRY(m_properties.blur_radius->absolutized(viewport_rect, font_metrics, root_font_metrics));
+    auto absolutized_spread_distance = TRY(m_properties.spread_distance->absolutized(viewport_rect, font_metrics, root_font_metrics));
     return ShadowStyleValue::create(m_properties.color, absolutized_offset_x, absolutized_offset_y, absolutized_blur_radius, absolutized_spread_distance, m_properties.placement);
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.h
@@ -22,17 +22,23 @@ enum class ShadowPlacement {
 
 class ShadowStyleValue final : public StyleValueWithDefaultOperators<ShadowStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<ShadowStyleValue>> create(Color color, Length const& offset_x, Length const& offset_y, Length const& blur_radius, Length const& spread_distance, ShadowPlacement placement)
+    static ErrorOr<ValueComparingNonnullRefPtr<ShadowStyleValue>> create(
+        Color color,
+        ValueComparingNonnullRefPtr<StyleValue const> offset_x,
+        ValueComparingNonnullRefPtr<StyleValue const> offset_y,
+        ValueComparingNonnullRefPtr<StyleValue const> blur_radius,
+        ValueComparingNonnullRefPtr<StyleValue const> spread_distance,
+        ShadowPlacement placement)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) ShadowStyleValue(color, offset_x, offset_y, blur_radius, spread_distance, placement));
+        return adopt_nonnull_ref_or_enomem(new (nothrow) ShadowStyleValue(color, move(offset_x), move(offset_y), move(blur_radius), move(spread_distance), placement));
     }
     virtual ~ShadowStyleValue() override = default;
 
     Color color() const { return m_properties.color; }
-    Length const& offset_x() const { return m_properties.offset_x; }
-    Length const& offset_y() const { return m_properties.offset_y; }
-    Length const& blur_radius() const { return m_properties.blur_radius; }
-    Length const& spread_distance() const { return m_properties.spread_distance; }
+    ValueComparingNonnullRefPtr<StyleValue const> const& offset_x() const { return m_properties.offset_x; }
+    ValueComparingNonnullRefPtr<StyleValue const> const& offset_y() const { return m_properties.offset_y; }
+    ValueComparingNonnullRefPtr<StyleValue const> const& blur_radius() const { return m_properties.blur_radius; }
+    ValueComparingNonnullRefPtr<StyleValue const> const& spread_distance() const { return m_properties.spread_distance; }
     ShadowPlacement placement() const { return m_properties.placement; }
 
     virtual ErrorOr<String> to_string() const override;
@@ -40,9 +46,22 @@ public:
     bool properties_equal(ShadowStyleValue const& other) const { return m_properties == other.m_properties; }
 
 private:
-    explicit ShadowStyleValue(Color color, Length const& offset_x, Length const& offset_y, Length const& blur_radius, Length const& spread_distance, ShadowPlacement placement)
+    ShadowStyleValue(
+        Color color,
+        ValueComparingNonnullRefPtr<StyleValue const> offset_x,
+        ValueComparingNonnullRefPtr<StyleValue const> offset_y,
+        ValueComparingNonnullRefPtr<StyleValue const> blur_radius,
+        ValueComparingNonnullRefPtr<StyleValue const> spread_distance,
+        ShadowPlacement placement)
         : StyleValueWithDefaultOperators(Type::Shadow)
-        , m_properties { .color = color, .offset_x = offset_x, .offset_y = offset_y, .blur_radius = blur_radius, .spread_distance = spread_distance, .placement = placement }
+        , m_properties {
+            .color = color,
+            .offset_x = move(offset_x),
+            .offset_y = move(offset_y),
+            .blur_radius = move(blur_radius),
+            .spread_distance = move(spread_distance),
+            .placement = placement
+        }
     {
     }
 
@@ -50,10 +69,10 @@ private:
 
     struct Properties {
         Color color;
-        Length offset_x;
-        Length offset_y;
-        Length blur_radius;
-        Length spread_distance;
+        ValueComparingNonnullRefPtr<StyleValue const> offset_x;
+        ValueComparingNonnullRefPtr<StyleValue const> offset_y;
+        ValueComparingNonnullRefPtr<StyleValue const> blur_radius;
+        ValueComparingNonnullRefPtr<StyleValue const> spread_distance;
         ShadowPlacement placement;
         bool operator==(Properties const&) const = default;
     } m_properties;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -594,7 +594,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     if (auto maybe_text_decoration_thickness = computed_style.length_percentage(CSS::PropertyID::TextDecorationThickness); maybe_text_decoration_thickness.has_value())
         computed_values.set_text_decoration_thickness(maybe_text_decoration_thickness.release_value());
 
-    computed_values.set_text_shadow(computed_style.text_shadow());
+    computed_values.set_text_shadow(computed_style.text_shadow(*this));
 
     computed_values.set_z_index(computed_style.z_index());
     computed_values.set_opacity(computed_style.opacity());
@@ -616,7 +616,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     computed_values.set_margin(computed_style.length_box(CSS::PropertyID::MarginLeft, CSS::PropertyID::MarginTop, CSS::PropertyID::MarginRight, CSS::PropertyID::MarginBottom, CSS::Length::make_px(0)));
     computed_values.set_padding(computed_style.length_box(CSS::PropertyID::PaddingLeft, CSS::PropertyID::PaddingTop, CSS::PropertyID::PaddingRight, CSS::PropertyID::PaddingBottom, CSS::Length::make_px(0)));
 
-    computed_values.set_box_shadow(computed_style.box_shadow());
+    computed_values.set_box_shadow(computed_style.box_shadow(*this));
 
     computed_values.set_transformations(computed_style.transformations());
     computed_values.set_transform_origin(computed_style.transform_origin());


### PR DESCRIPTION
The CSS box-shadow property takes 2-4 properties that are `<length>`s, those being:
  - offset-x
  - offset-y
  - blur-radius
  - spread-radius

Previously these were resolved directly to concrete Lengths at parse time, but now they will be parsed as LengthStyleValues and/or CalculatedStyleValues and be stored that way until styles are later resolved.

Note: Optimally the test's expected value (`#000000ff 0px calc(5px + (0 - 10px)) 0px calc(2px + 3px)`) would definitely have the `calc(...)`'s resolved, but I'm unsure if this is a flaw in my patch or our current implementation of `getComputedStyle`. If it's the latter, I think this test can simply be updated later with the correctly resolved values.

Before:
![image](https://github.com/SerenityOS/serenity/assets/20765494/dec0464c-f2bf-405b-9e9d-37ac21799d2b)

After:
![image](https://github.com/SerenityOS/serenity/assets/20765494/f1350c68-579f-4e83-9c30-24e818122955)
