### PR TITLE
LibWeb: Invalidate layout tree in textContent setter

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -201,7 +201,8 @@ void Node::set_text_content(DeprecatedString const& content)
 
     // Otherwise, do nothing.
 
-    set_needs_style_update(true);
+    document().invalidate_style();
+    document().invalidate_layout();
 }
 
 // https://dom.spec.whatwg.org/#dom-node-nodevalue


### PR DESCRIPTION
The textContent setter changes the structure of the DOM, therefore the layout tree becomes invalid.