### PR TITLE
LibWeb: Support `line-height: calc(...)` values that resolve to number

### DIFF
--- a/Tests/LibWeb/Layout/expected/line-height-calc-number.txt
+++ b/Tests/LibWeb/Layout/expected/line-height-calc-number.txt
@@ -1,0 +1,8 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x80 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x64 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x64 children: inline
+        line 0 width: 100.203125, height: 64, bottom: 64, baseline: 36.796875
+          frag 0 from TextNode start: 0, length: 13, rect: [8,8 100.203125x64]
+            "hello friends"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/line-height-calc-number.html
+++ b/Tests/LibWeb/Layout/input/line-height-calc-number.html
@@ -1,0 +1,6 @@
+<!doctype html><style>
+div {
+    line-height: calc(2 + 2);
+    background: pink;
+}
+</style><div>hello friends

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -219,6 +219,15 @@ CSSPixels StyleProperties::line_height(Layout::Node const& layout_node) const
     }
 
     if (line_height->is_calculated()) {
+        if (line_height->as_calculated().resolves_to_number()) {
+            auto resolved = line_height->as_calculated().resolve_number();
+            if (!resolved.has_value()) {
+                dbgln("FIXME: Failed to resolve calc() line-height (number): {}", line_height->as_calculated().to_string().release_value_but_fixme_should_propagate_errors());
+                return layout_node.font().pixel_metrics().line_spacing();
+            }
+            return Length(resolved.value(), Length::Type::Em).to_px(layout_node);
+        }
+
         auto resolved = line_height->as_calculated().resolve_length(layout_node);
         if (!resolved.has_value()) {
             dbgln("FIXME: Failed to resolve calc() line-height: {}", line_height->as_calculated().to_string().release_value_but_fixme_should_propagate_errors());


### PR DESCRIPTION
This is used on GitHub and many other websites.