### PR TITLE
LibWebView: Unbreak content-scales-to-viewport mode for Presenter

### DIFF
--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -68,10 +68,17 @@ void OutOfProcessWebView::paint_event(GUI::PaintEvent& event)
     if (auto* bitmap = m_client_state.has_usable_bitmap ? m_client_state.front_bitmap.bitmap.ptr() : m_backup_bitmap.ptr()) {
         painter.add_clip_rect(frame_inner_rect());
         painter.translate(frame_thickness(), frame_thickness());
-        if (m_content_scales_to_viewport)
-            painter.draw_scaled_bitmap(rect(), *bitmap, bitmap->rect());
-        else
+        if (m_content_scales_to_viewport) {
+            auto bitmap_rect = Gfx::IntRect {
+                {},
+                m_client_state.has_usable_bitmap
+                    ? m_client_state.front_bitmap.last_painted_size
+                    : m_backup_bitmap_size
+            };
+            painter.draw_scaled_bitmap(rect(), *bitmap, bitmap_rect);
+        } else {
             painter.blit({ 0, 0 }, *bitmap, bitmap->rect());
+        }
         return;
     }
 


### PR DESCRIPTION
Now that we allocate an oversized backing store during resizing of the viewport, we need to constrain the source rect used when drawing a scaled version of the content in the special mode used by Presenter.

Regressed with 85c542ab009ca7aea95f7a7503990c26ed27a123.

cc @GMTA @AtkinsSJ 
