### PR TITLE
LibGfx: Do not use divisions when calculating font subpixel offsets

### DIFF
--- a/Userland/Libraries/LibGfx/Font/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/Font.cpp
@@ -13,7 +13,7 @@ GlyphRasterPosition GlyphRasterPosition::get_nearest_fit_for(FloatPoint position
     constexpr auto subpixel_divisions = GlyphSubpixelOffset::subpixel_divisions();
     auto fit = [](float pos, int& blit_pos, u8& subpixel_offset) {
         blit_pos = floorf(pos);
-        subpixel_offset = round_to<u8>((pos - blit_pos) / (1.0f / subpixel_divisions));
+        subpixel_offset = round_to<u8>((pos - blit_pos) * subpixel_divisions);
         if (subpixel_offset >= subpixel_divisions) {
             blit_pos += 1;
             subpixel_offset = 0;


### PR DESCRIPTION
No functional or performance changes; they were probably already optimized away by the compiler.