### PR TITLE
LibGfx: Remove SSE version of `Color::blend()`

### DIFF
--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -204,37 +204,18 @@ public:
 
     constexpr Color blend(Color source) const
     {
-        if (!alpha() || source.alpha() == 255)
+        if (alpha() == 0 || source.alpha() == 255)
             return source;
 
-        if (!source.alpha())
+        if (source.alpha() == 0)
             return *this;
 
-#ifdef __SSE__
-        using AK::SIMD::i32x4;
-
-        const i32x4 color = {
-            red(),
-            green(),
-            blue()
-        };
-        const i32x4 source_color = {
-            source.red(),
-            source.green(),
-            source.blue()
-        };
-
         int const d = 255 * (alpha() + source.alpha()) - alpha() * source.alpha();
-        const i32x4 out = (color * alpha() * (255 - source.alpha()) + 255 * source.alpha() * source_color) / d;
-        return Color(out[0], out[1], out[2], d / 255);
-#else
-        int d = 255 * (alpha() + source.alpha()) - alpha() * source.alpha();
-        u8 r = (red() * alpha() * (255 - source.alpha()) + 255 * source.alpha() * source.red()) / d;
-        u8 g = (green() * alpha() * (255 - source.alpha()) + 255 * source.alpha() * source.green()) / d;
-        u8 b = (blue() * alpha() * (255 - source.alpha()) + 255 * source.alpha() * source.blue()) / d;
+        u8 r = (red() * alpha() * (255 - source.alpha()) + source.red() * 255 * source.alpha()) / d;
+        u8 g = (green() * alpha() * (255 - source.alpha()) + source.green() * 255 * source.alpha()) / d;
+        u8 b = (blue() * alpha() * (255 - source.alpha()) + source.blue() * 255 * source.alpha()) / d;
         u8 a = d / 255;
         return Color(r, g, b, a);
-#endif
     }
 
     ALWAYS_INLINE Color mixed_with(Color other, float weight) const


### PR DESCRIPTION
I could not discover proof that this is actually faster than the non-SSE version. In addition, for these relatively simple structures, the compiler is often sufficiently smart to generate SSE code itself.

For a synthetic font benchmark I wrote, this results in a nice 11% decrease in runtime.