### PR TITLE
LibWeb: Allow infinitely long flex lines when sizing under max-content

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/flex-container-intrinsic-cross-size-with-max-content-main-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-container-intrinsic-cross-size-with-max-content-main-size.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x53.46875 [BFC] children: not-inline
+    BlockContainer <body.outer> at (18,18) content-size 280.84375x17.46875 children: not-inline
+      Box <div.inner> at (18,18) content-size 280.84375x17.46875 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (18,18) content-size 280.84375x17.46875 flex-item [BFC] children: inline
+          line 0 width: 280.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 35, rect: [18,18 280.84375x17.46875]
+              "this text should be all on one line"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/flex/flex-container-intrinsic-cross-size-with-max-content-main-size.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-container-intrinsic-cross-size-with-max-content-main-size.html
@@ -1,0 +1,12 @@
+<!doctype html><style>
+    html { background: white; }
+    .outer {
+        width: max-content;
+        padding: 10px;
+        background: pink;
+    }
+    .inner {
+        display: flex;
+        background: orange;
+    }
+</style><body class="outer"><div class="inner">this text should be all on one line


### PR DESCRIPTION
If the flex container is being sized under a max-content main size constraint, there is effectively infinite space available for flex items. Thus, flex lines should be allowed to be infinitely long.

This is a little awkward, because the spec doesn't mention specifics about how to resolve flexible lengths during intrninsic sizing. I've marked the spec deviations with big "AD-HOC" comments.

Nice progression on the GitHub front page:

Before:
![Screenshot at 2023-06-01 14-25-13](https://github.com/SerenityOS/serenity/assets/5954907/e57ff383-51c3-4c28-a721-29c46cbe10d8)

After:
![Screenshot at 2023-06-01 14-25-21](https://github.com/SerenityOS/serenity/assets/5954907/5268719d-0542-45b2-9217-dc6e7aeaef0b)

