### PR TITLE
Browser: Store default config values in a single place

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -15,6 +15,7 @@
 #include "InspectorWidget.h"
 #include "Tab.h"
 #include <Applications/Browser/BrowserWindowGML.h>
+#include <Applications/BrowserSettings/Defaults.h>
 #include <LibConfig/Client.h>
 #include <LibCore/StandardPaths.h>
 #include <LibGUI/Application.h>
@@ -131,7 +132,7 @@ BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url)
         Config::write_bool("Browser"sv, "Preferences"sv, "ShowBookmarksBar"sv, action.is_checked());
     };
 
-    bool show_bookmarks_bar = Config::read_bool("Browser"sv, "Preferences"sv, "ShowBookmarksBar"sv, true);
+    bool show_bookmarks_bar = Config::read_bool("Browser"sv, "Preferences"sv, "ShowBookmarksBar"sv, Browser::default_show_bookmarks_bar);
     m_window_actions.show_bookmarks_bar_action().set_checked(show_bookmarks_bar);
     Browser::BookmarksBarWidget::the().set_visible(show_bookmarks_bar);
 
@@ -288,7 +289,7 @@ void BrowserWindow::build_menus()
 
     m_change_homepage_action = GUI::Action::create(
         "Set Homepage URL...", g_icon_bag.go_home, [this](auto&) {
-            String homepage_url = String::from_deprecated_string(Config::read_string("Browser"sv, "Preferences"sv, "Home"sv, "about:blank"sv)).release_value_but_fixme_should_propagate_errors();
+            String homepage_url = String::from_deprecated_string(Config::read_string("Browser"sv, "Preferences"sv, "Home"sv, Browser::default_homepage_url)).release_value_but_fixme_should_propagate_errors();
             if (GUI::InputBox::show(this, homepage_url, "Enter a URL:"sv, "Change Homepage"sv) == GUI::InputBox::ExecResult::OK) {
                 if (URL(homepage_url).is_valid()) {
                     Config::write_string("Browser"sv, "Preferences"sv, "Home"sv, homepage_url);
@@ -310,7 +311,7 @@ void BrowserWindow::build_menus()
     auto& color_scheme_menu = settings_menu.add_submenu("&Color Scheme"_string.release_value_but_fixme_should_propagate_errors());
     color_scheme_menu.set_icon(g_icon_bag.color_chooser);
     {
-        auto current_setting = Web::CSS::preferred_color_scheme_from_string(Config::read_string("Browser"sv, "Preferences"sv, "ColorScheme"sv, "auto"sv));
+        auto current_setting = Web::CSS::preferred_color_scheme_from_string(Config::read_string("Browser"sv, "Preferences"sv, "ColorScheme"sv, Browser::default_color_scheme));
         m_color_scheme_actions.set_exclusive(true);
 
         auto add_color_scheme_action = [&](auto& name, Web::CSS::PreferredColorScheme preference_value) {

--- a/Userland/Applications/Browser/DownloadWidget.cpp
+++ b/Userland/Applications/Browser/DownloadWidget.cpp
@@ -9,6 +9,7 @@
 #include <AK/LexicalPath.h>
 #include <AK/NumberFormat.h>
 #include <AK/StringBuilder.h>
+#include <Applications/BrowserSettings/Defaults.h>
 #include <LibCore/Proxy.h>
 #include <LibCore/StandardPaths.h>
 #include <LibDesktop/Launcher.h>
@@ -37,7 +38,7 @@ DownloadWidget::DownloadWidget(const URL& url)
         m_destination_path = builder.to_deprecated_string();
     }
 
-    auto close_on_finish = Config::read_bool("Browser"sv, "Preferences"sv, "CloseDownloadWidgetOnFinish"sv, false);
+    auto close_on_finish = Config::read_bool("Browser"sv, "Preferences"sv, "CloseDownloadWidgetOnFinish"sv, Browser::default_close_download_widget_on_finish);
 
     m_elapsed_timer.start();
     m_download = Web::ResourceLoader::the().connector().start_request("GET", url);

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -21,6 +21,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/URL.h>
 #include <Applications/Browser/TabGML.h>
+#include <Applications/BrowserSettings/Defaults.h>
 #include <LibConfig/Client.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
@@ -124,7 +125,7 @@ Tab::Tab(BrowserWindow& window)
 
     m_web_content_view = webview_container.add<WebView::OutOfProcessWebView>();
 
-    auto preferred_color_scheme = Web::CSS::preferred_color_scheme_from_string(Config::read_string("Browser"sv, "Preferences"sv, "ColorScheme"sv, "auto"sv));
+    auto preferred_color_scheme = Web::CSS::preferred_color_scheme_from_string(Config::read_string("Browser"sv, "Preferences"sv, "ColorScheme"sv, Browser::default_color_scheme));
     m_web_content_view->set_preferred_color_scheme(preferred_color_scheme);
 
     content_filters_changed();

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -12,6 +12,7 @@
 #include <Applications/Browser/Database.h>
 #include <Applications/Browser/Tab.h>
 #include <Applications/Browser/WindowActions.h>
+#include <Applications/BrowserSettings/Defaults.h>
 #include <LibConfig/Client.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/FileWatcher.h>
@@ -134,11 +135,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = GUI::Icon::default_icon("app-browser"sv);
 
-    Browser::g_home_url = Config::read_string("Browser"sv, "Preferences"sv, "Home"sv, "file:///res/html/misc/welcome.html"sv);
-    Browser::g_new_tab_url = Config::read_string("Browser"sv, "Preferences"sv, "NewTab"sv, "file:///res/html/misc/new-tab.html"sv);
-    Browser::g_search_engine = Config::read_string("Browser"sv, "Preferences"sv, "SearchEngine"sv, {});
-    Browser::g_content_filters_enabled = Config::read_bool("Browser"sv, "Preferences"sv, "EnableContentFilters"sv, true);
-    Browser::g_autoplay_allowed_on_all_websites = Config::read_bool("Browser"sv, "Preferences"sv, "AllowAutoplayOnAllWebsites"sv, false);
+    Browser::g_home_url = Config::read_string("Browser"sv, "Preferences"sv, "Home"sv, Browser::default_homepage_url);
+    Browser::g_new_tab_url = Config::read_string("Browser"sv, "Preferences"sv, "NewTab"sv, Browser::default_new_tab_url);
+    Browser::g_search_engine = Config::read_string("Browser"sv, "Preferences"sv, "SearchEngine"sv, Browser::default_search_engine);
+    Browser::g_content_filters_enabled = Config::read_bool("Browser"sv, "Preferences"sv, "EnableContentFilters"sv, Browser::default_enable_content_filters);
+    Browser::g_autoplay_allowed_on_all_websites = Config::read_bool("Browser"sv, "Preferences"sv, "AllowAutoplayOnAllWebsites"sv, Browser::default_allow_autoplay_on_all_websites);
 
     Browser::g_icon_bag = TRY(Browser::IconBag::try_create());
 

--- a/Userland/Applications/BrowserSettings/AutoplaySettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/AutoplaySettingsWidget.cpp
@@ -6,6 +6,7 @@
 
 #include "AutoplaySettingsWidget.h"
 #include <Applications/BrowserSettings/AutoplaySettingsWidgetGML.h>
+#include <Applications/BrowserSettings/Defaults.h>
 #include <LibConfig/Client.h>
 #include <LibCore/StandardPaths.h>
 #include <LibGUI/Button.h>
@@ -14,8 +15,6 @@
 #include <LibGUI/InputBox.h>
 #include <LibGUI/ListView.h>
 #include <LibGUI/Menu.h>
-
-static constexpr bool default_allow_autoplay_on_all_websites = false;
 
 ErrorOr<String> AutoplayAllowlistModel::filter_list_file_path() const
 {
@@ -38,7 +37,7 @@ ErrorOr<NonnullRefPtr<AutoplaySettingsWidget>> AutoplaySettingsWidget::create()
     TRY(widget->load_from_gml(autoplay_settings_widget_gml));
 
     widget->m_allow_autoplay_on_all_websites_checkbox = widget->find_descendant_of_type_named<GUI::CheckBox>("allow_autoplay_on_all_websites_checkbox");
-    widget->m_allow_autoplay_on_all_websites_checkbox->set_checked(Config::read_bool("Browser"sv, "Preferences"sv, "AllowAutoplayOnAllWebsites"sv, default_allow_autoplay_on_all_websites), GUI::AllowCallback::No);
+    widget->m_allow_autoplay_on_all_websites_checkbox->set_checked(Config::read_bool("Browser"sv, "Preferences"sv, "AllowAutoplayOnAllWebsites"sv, Browser::default_allow_autoplay_on_all_websites), GUI::AllowCallback::No);
     widget->m_allow_autoplay_on_all_websites_checkbox->on_checked = [widget](auto) {
         widget->set_modified(true);
     };
@@ -86,5 +85,5 @@ void AutoplaySettingsWidget::apply_settings()
 void AutoplaySettingsWidget::reset_default_values()
 {
     m_allowlist_model->reset_default_values();
-    m_allow_autoplay_on_all_websites_checkbox->set_checked(default_allow_autoplay_on_all_websites);
+    m_allow_autoplay_on_all_websites_checkbox->set_checked(Browser::default_allow_autoplay_on_all_websites);
 }

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
@@ -7,18 +7,12 @@
 
 #include "BrowserSettingsWidget.h"
 #include <Applications/BrowserSettings/BrowserSettingsWidgetGML.h>
+#include <Applications/BrowserSettings/Defaults.h>
 #include <LibConfig/Client.h>
 #include <LibGUI/JsonArrayModel.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/Model.h>
-
-static DeprecatedString default_homepage_url = "file:///res/html/misc/welcome.html";
-static DeprecatedString default_new_tab_url = "file:///res/html/misc/new-tab.html";
-static DeprecatedString default_search_engine = "";
-static DeprecatedString default_color_scheme = "auto";
-static bool default_show_bookmarks_bar = true;
-static bool default_auto_close_download_windows = false;
 
 struct ColorScheme {
     DeprecatedString title;
@@ -71,22 +65,22 @@ ErrorOr<NonnullRefPtr<BrowserSettingsWidget>> BrowserSettingsWidget::create()
 ErrorOr<void> BrowserSettingsWidget::setup()
 {
     m_homepage_url_textbox = find_descendant_of_type_named<GUI::TextBox>("homepage_url_textbox");
-    m_homepage_url_textbox->set_text(Config::read_string("Browser"sv, "Preferences"sv, "Home"sv, default_homepage_url), GUI::AllowCallback::No);
+    m_homepage_url_textbox->set_text(Config::read_string("Browser"sv, "Preferences"sv, "Home"sv, Browser::default_homepage_url), GUI::AllowCallback::No);
     m_homepage_url_textbox->on_change = [&]() { set_modified(true); };
 
     m_new_tab_url_textbox = find_descendant_of_type_named<GUI::TextBox>("new_tab_url_textbox");
-    m_new_tab_url_textbox->set_text(Config::read_string("Browser"sv, "Preferences"sv, "NewTab"sv, default_new_tab_url), GUI::AllowCallback::No);
+    m_new_tab_url_textbox->set_text(Config::read_string("Browser"sv, "Preferences"sv, "NewTab"sv, Browser::default_new_tab_url), GUI::AllowCallback::No);
     m_new_tab_url_textbox->on_change = [&]() { set_modified(true); };
 
     m_color_scheme_combobox = find_descendant_of_type_named<GUI::ComboBox>("color_scheme_combobox");
     m_color_scheme_combobox->set_only_allow_values_from_model(true);
     m_color_scheme_combobox->set_model(adopt_ref(*new ColorSchemeModel()));
     m_color_scheme_combobox->set_selected_index(0, GUI::AllowCallback::No);
-    set_color_scheme(Config::read_string("Browser"sv, "Preferences"sv, "ColorScheme"sv, default_color_scheme));
+    set_color_scheme(Config::read_string("Browser"sv, "Preferences"sv, "ColorScheme"sv, Browser::default_color_scheme));
     m_color_scheme_combobox->on_change = [&](auto, auto) { set_modified(true); };
 
     m_show_bookmarks_bar_checkbox = find_descendant_of_type_named<GUI::CheckBox>("show_bookmarks_bar_checkbox");
-    m_show_bookmarks_bar_checkbox->set_checked(Config::read_bool("Browser"sv, "Preferences"sv, "ShowBookmarksBar"sv, default_show_bookmarks_bar), GUI::AllowCallback::No);
+    m_show_bookmarks_bar_checkbox->set_checked(Config::read_bool("Browser"sv, "Preferences"sv, "ShowBookmarksBar"sv, Browser::default_show_bookmarks_bar), GUI::AllowCallback::No);
     m_show_bookmarks_bar_checkbox->on_checked = [&](auto) { set_modified(true); };
 
     m_enable_search_engine_checkbox = find_descendant_of_type_named<GUI::CheckBox>("enable_search_engine_checkbox");
@@ -120,10 +114,10 @@ ErrorOr<void> BrowserSettingsWidget::setup()
         m_custom_search_engine_group->set_enabled(m_is_custom_search_engine);
         set_modified(true);
     };
-    set_search_engine_url(Config::read_string("Browser"sv, "Preferences"sv, "SearchEngine"sv, default_search_engine));
+    set_search_engine_url(Config::read_string("Browser"sv, "Preferences"sv, "SearchEngine"sv, Browser::default_search_engine));
 
     m_auto_close_download_windows_checkbox = find_descendant_of_type_named<GUI::CheckBox>("auto_close_download_windows_checkbox");
-    m_auto_close_download_windows_checkbox->set_checked(Config::read_bool("Browser"sv, "Preferences"sv, "CloseDownloadWidgetOnFinish"sv, default_auto_close_download_windows), GUI::AllowCallback::No);
+    m_auto_close_download_windows_checkbox->set_checked(Config::read_bool("Browser"sv, "Preferences"sv, "CloseDownloadWidgetOnFinish"sv, Browser::default_close_download_widget_on_finish), GUI::AllowCallback::No);
     m_auto_close_download_windows_checkbox->on_checked = [&](auto) { set_modified(true); };
 
     return {};
@@ -218,10 +212,10 @@ void BrowserSettingsWidget::apply_settings()
 
 void BrowserSettingsWidget::reset_default_values()
 {
-    m_homepage_url_textbox->set_text(default_homepage_url);
-    m_new_tab_url_textbox->set_text(default_new_tab_url);
-    m_show_bookmarks_bar_checkbox->set_checked(default_show_bookmarks_bar);
-    set_color_scheme(default_color_scheme);
-    m_auto_close_download_windows_checkbox->set_checked(default_auto_close_download_windows);
-    set_search_engine_url(default_search_engine);
+    m_homepage_url_textbox->set_text(Browser::default_homepage_url);
+    m_new_tab_url_textbox->set_text(Browser::default_new_tab_url);
+    m_show_bookmarks_bar_checkbox->set_checked(Browser::default_show_bookmarks_bar);
+    set_color_scheme(Browser::default_color_scheme);
+    m_auto_close_download_windows_checkbox->set_checked(Browser::default_close_download_widget_on_finish);
+    set_search_engine_url(Browser::default_search_engine);
 }

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
@@ -9,6 +9,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/String.h>
 #include <Applications/BrowserSettings/ContentFilterSettingsWidgetGML.h>
+#include <Applications/BrowserSettings/Defaults.h>
 #include <LibConfig/Client.h>
 #include <LibCore/StandardPaths.h>
 #include <LibGUI/CheckBox.h>
@@ -17,8 +18,6 @@
 #include <LibGUI/InputBox.h>
 #include <LibGUI/ListView.h>
 #include <LibGUI/Menu.h>
-
-static constexpr bool s_default_enable_content_filtering = true;
 
 ErrorOr<String> DomainListModel::filter_list_file_path() const
 {
@@ -126,7 +125,7 @@ ErrorOr<NonnullRefPtr<ContentFilterSettingsWidget>> ContentFilterSettingsWidget:
     TRY(widget->load_from_gml(content_filter_settings_widget_gml));
 
     widget->m_enable_content_filtering_checkbox = widget->find_descendant_of_type_named<GUI::CheckBox>("enable_content_filtering_checkbox");
-    widget->m_enable_content_filtering_checkbox->set_checked(Config::read_bool("Browser"sv, "Preferences"sv, "EnableContentFilters"sv, s_default_enable_content_filtering), GUI::AllowCallback::No);
+    widget->m_enable_content_filtering_checkbox->set_checked(Config::read_bool("Browser"sv, "Preferences"sv, "EnableContentFilters"sv, Browser::default_enable_content_filters), GUI::AllowCallback::No);
     widget->m_enable_content_filtering_checkbox->on_checked = [widget](auto) {
         widget->set_modified(true);
     };
@@ -174,5 +173,5 @@ void ContentFilterSettingsWidget::apply_settings()
 void ContentFilterSettingsWidget::reset_default_values()
 {
     m_domain_list_model->reset_default_values();
-    m_enable_content_filtering_checkbox->set_checked(s_default_enable_content_filtering);
+    m_enable_content_filtering_checkbox->set_checked(Browser::default_enable_content_filters);
 }

--- a/Userland/Applications/BrowserSettings/Defaults.h
+++ b/Userland/Applications/BrowserSettings/Defaults.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+
+namespace Browser {
+
+static constexpr StringView default_homepage_url = "file:///res/html/misc/welcome.html"sv;
+static constexpr StringView default_new_tab_url = "file:///res/html/misc/new-tab.html"sv;
+static constexpr StringView default_search_engine = ""sv;
+static constexpr StringView default_color_scheme = "auto"sv;
+static constexpr bool default_enable_content_filters = true;
+static constexpr bool default_show_bookmarks_bar = true;
+static constexpr bool default_close_download_widget_on_finish = false;
+static constexpr bool default_allow_autoplay_on_all_websites = false;
+
+}


### PR DESCRIPTION
Note that this fixes contradictory default values for group "Preferences", key "Home", and unifies the definition of the default value for all other values into a single source of truth. This is exactly the kind of errors I want to prevent with this new style. Here's a screenrecording of the confusion solved in this PR:

https://github.com/SerenityOS/serenity/assets/2690845/b43a21b5-224c-4db6-8a03-c27c14712d63

The hope is that this can later be used to:
- verify that all accesses to the same key use the same default value,
- and extract the default values more easily.

See also: #19080