### PR TITLE
Meta: Make sure that our includes are properly formatted

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibEDID/GeneratePnpIDs.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibEDID/GeneratePnpIDs.cpp
@@ -221,7 +221,7 @@ static ErrorOr<void> generate_source(Core::File& file, HashMap<DeprecatedString,
     SourceGenerator generator { builder };
 
     generator.append(R"~~~(
-#include "PnpIDs.h"
+#include <LibEDID/PnpIDs.h>
 
 namespace PnpIDs {
 

--- a/Meta/check-style.py
+++ b/Meta/check-style.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import pathlib
 import re
 import subprocess
 import sys
@@ -46,6 +47,16 @@ GOOD_PRAGMA_ONCE_PATTERN = re.compile('(^|\\S\n\n)#pragma once(\n\n\\S.|$)')
 # LibC is supposed to be a system library; don't mention the directory.
 BAD_INCLUDE_LIBC = re.compile("# *include <LibC/")
 
+# Make sure that all includes are either system includes or immediately resolvable local includes
+ANY_INCLUDE_PATTERN = re.compile('^ *# *include\\b.*[>"](?!\\)).*$', re.M)
+SYSTEM_INCLUDE_PATTERN = re.compile("^ *# *include *<([^>]+)>(?: /[*/].*)?$")
+LOCAL_INCLUDE_PATTERN = re.compile('^ *# *include *"([^>]+)"(?: /[*/].*)?$')
+INCLUDE_CHECK_EXCLUDES = {
+    "Userland/Libraries/LibCodeComprehension/Cpp/Tests/",
+    "Userland/Libraries/LibCpp/Tests/parser/",
+    "Userland/Libraries/LibCpp/Tests/preprocessor/",
+}
+
 
 def should_check_file(filename):
     if not filename.endswith('.cpp') and not filename.endswith('.h'):
@@ -67,20 +78,28 @@ def find_files_here_or_argv():
     return filter(should_check_file, raw_list)
 
 
+def is_in_prefix_list(filename, prefix_list):
+    return any(
+        filename.startswith(prefix) for prefix in prefix_list
+    )
+
+
 def run():
     errors_license = []
     errors_pragma_once_bad = []
     errors_pragma_once_missing = []
     errors_include_libc = []
+    errors_include_weird_format = []
+    errors_include_missing_local = []
 
     for filename in find_files_here_or_argv():
         with open(filename, "r") as f:
             file_content = f.read()
-        if not any(filename.startswith(forbidden_prefix) for forbidden_prefix in LICENSE_HEADER_CHECK_EXCLUDES):
+        if not is_in_prefix_list(filename, LICENSE_HEADER_CHECK_EXCLUDES):
             if not GOOD_LICENSE_HEADER_PATTERN.search(file_content):
                 errors_license.append(filename)
         if filename.endswith('.h'):
-            if any(filename.startswith(forbidden_prefix) for forbidden_prefix in PRAGMA_ONCE_CHECK_EXCLUDES):
+            if is_in_prefix_list(filename, PRAGMA_ONCE_CHECK_EXCLUDES):
                 # File was excluded
                 pass
             elif GOOD_PRAGMA_ONCE_PATTERN.search(file_content):
@@ -92,20 +111,58 @@ def run():
             else:
                 # Bad, the '#pragma once' is missing completely.
                 errors_pragma_once_missing.append(filename)
-        if not any(filename.startswith(forbidden_prefix) for forbidden_prefix in LIBC_CHECK_EXCLUDES):
+        if not is_in_prefix_list(filename, LIBC_CHECK_EXCLUDES):
             if BAD_INCLUDE_LIBC.search(file_content):
                 errors_include_libc.append(filename)
+        if not is_in_prefix_list(filename, INCLUDE_CHECK_EXCLUDES):
+            file_directory = pathlib.Path(filename).parent
+            for include_line in ANY_INCLUDE_PATTERN.findall(file_content):
+                if SYSTEM_INCLUDE_PATTERN.match(include_line):
+                    # Don't try to resolve system-style includes, as these might depend on generators.
+                    continue
+                local_match = LOCAL_INCLUDE_PATTERN.match(include_line)
+                if local_match is None:
+                    print(f"Cannot parse include-line '{include_line}' in {filename}")
+                    if filename not in errors_include_weird_format:
+                        errors_include_weird_format.append(filename)
+                    continue
+                relative_filename = local_match.group(1)
+                referenced_file = file_directory.joinpath(relative_filename)
+                if not referenced_file.exists():
+                    print(f"In {filename}: Cannot find {referenced_file}")
+                    if filename not in errors_include_missing_local:
+                        errors_include_missing_local.append(filename)
 
+    have_errors = False
     if errors_license:
         print("Files with bad licenses:", " ".join(errors_license))
+        have_errors = True
     if errors_pragma_once_missing:
         print("Files without #pragma once:", " ".join(errors_pragma_once_missing))
+        have_errors = True
     if errors_pragma_once_bad:
         print("Files with a bad #pragma once:", " ".join(errors_pragma_once_bad))
+        have_errors = True
     if errors_include_libc:
-        print("Files that include a LibC header using #include <LibC/...>:", " ".join(errors_include_libc))
+        print(
+            "Files that include a LibC header using #include <LibC/...>:",
+            " ".join(errors_include_libc),
+        )
+        have_errors = True
+    if errors_include_weird_format:
+        print(
+            "Files that contain badly-formatted #include statements:",
+            " ".join(errors_include_weird_format),
+        )
+        have_errors = True
+    if errors_include_missing_local:
+        print(
+            "Files that #include a missing local file:",
+            " ".join(errors_include_missing_local),
+        )
+        have_errors = True
 
-    if errors_license or errors_pragma_once_missing or errors_pragma_once_bad or errors_include_libc:
+    if have_errors:
         sys.exit(1)
 
 

--- a/Userland/Applications/Piano/RollWidget.cpp
+++ b/Userland/Applications/Piano/RollWidget.cpp
@@ -8,9 +8,9 @@
  */
 
 #include "RollWidget.h"
-#include "LibDSP/Music.h"
 #include "TrackManager.h"
 #include <AK/IntegralMath.h>
+#include <LibDSP/Music.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Scrollbar.h>

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
@@ -8,11 +8,11 @@
 
 #pragma once
 
-#include "AK/Endian.h"
-#include "AK/Forward.h"
 #include <AK/DeprecatedString.h>
+#include <AK/Endian.h>
 #include <AK/Error.h>
 #include <AK/FixedArray.h>
+#include <AK/Forward.h>
 #include <AK/Span.h>
 
 namespace OpenType {

--- a/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.cpp
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "MatroskaDemuxer.h"
-#include "AK/Debug.h"
+#include <AK/Debug.h>
 
 namespace Video::Matroska {
 


### PR DESCRIPTION
This is about the third time we have weirdly-ordered includes, so let's add a lint that prevents these from being introduced. I don't like that we rely on weird "local include but resolve using system include paths" quirks.

While this does introduce significant overhead in terms of percentage, I think that an additional 10ms on huge commits (or less on smaller commits) are acceptable:

```
hyperfine -w1 './Meta/check-style.py AK/*.h AK/*.cpp' # Before this PR
Benchmark 1: ./Meta/check-style.py AK/*.h AK/*.cpp
  Time (mean ± σ):      20.3 ms ±   0.4 ms    [User: 17.1 ms, System: 3.5 ms]
  Range (min … max):    19.5 ms …  21.6 ms    128 runs

hyperfine -w1 './Meta/check-style.py AK/*.h AK/*.cpp' # After this PR
Benchmark 1: ./Meta/check-style.py AK/*.h AK/*.cpp
  Time (mean ± σ):      32.3 ms ±   0.4 ms    [User: 27.9 ms, System: 4.4 ms]
  Range (min … max):    31.4 ms …  34.9 ms    91 runs
```

The new code in `check-style.py` is formatted according to "black", but not the existing untouched code. It didn't seem like a good idea to reformat the entire file without any reason.