### PR TITLE
Kernel: Remove unused Platform.h include in linker script

### DIFF
--- a/Kernel/Arch/x86_64/linker.ld
+++ b/Kernel/Arch/x86_64/linker.ld
@@ -1,5 +1,3 @@
-#include <AK/Platform.h>
-
 ENTRY(init)
 
 #define PF_X 0x1


### PR DESCRIPTION
This had only been in use for architecture detection before the removal of 32 bit x86.