### PR TITLE
LibWeb: Split NumericStyleValue into NumberStyleValue and IntegerStyleValue

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -96,6 +96,7 @@ set(SOURCES
     CSS/StyleValues/GridTrackSizeListStyleValue.cpp
     CSS/StyleValues/IdentifierStyleValue.cpp
     CSS/StyleValues/ImageStyleValue.cpp
+    CSS/StyleValues/IntegerStyleValue.cpp
     CSS/StyleValues/LengthStyleValue.cpp
     CSS/StyleValues/LinearGradientStyleValue.cpp
     CSS/StyleValues/ListStyleStyleValue.cpp

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -99,7 +99,7 @@ set(SOURCES
     CSS/StyleValues/LengthStyleValue.cpp
     CSS/StyleValues/LinearGradientStyleValue.cpp
     CSS/StyleValues/ListStyleStyleValue.cpp
-    CSS/StyleValues/NumericStyleValue.cpp
+    CSS/StyleValues/NumberStyleValue.cpp
     CSS/StyleValues/OverflowStyleValue.cpp
     CSS/StyleValues/PlaceContentStyleValue.cpp
     CSS/StyleValues/PositionStyleValue.cpp

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -65,7 +65,7 @@
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LinearGradientStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ListStyleStyleValue.h>
-#include <LibWeb/CSS/StyleValues/NumericStyleValue.h>
+#include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/OverflowStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PlaceContentStyleValue.h>
@@ -3816,8 +3816,8 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_numeric_value(ComponentValue const& co
     if (component_value.is(Token::Type::Number)) {
         auto const& number = component_value.token();
         if (number.number().is_integer())
-            return NumericStyleValue::create_integer(number.to_integer());
-        return NumericStyleValue::create_float(number.number_value());
+            return NumberStyleValue::create_integer(number.to_integer());
+        return NumberStyleValue::create_float(number.number_value());
     }
 
     return nullptr;
@@ -5500,16 +5500,16 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_flex_value(Vector<ComponentValue> cons
             // https://github.com/w3c/csswg-drafts/issues/5742
             // (flex-basis takes `<length>`, not `<number>`, so the 0 is a Length.)
             auto flex_basis = TRY(LengthStyleValue::create(Length::make_px(0)));
-            auto one = TRY(NumericStyleValue::create_integer(1));
+            auto one = TRY(NumberStyleValue::create_integer(1));
             return FlexStyleValue::create(*value, one, flex_basis);
         }
         case PropertyID::FlexBasis: {
-            auto one = TRY(NumericStyleValue::create_integer(1));
+            auto one = TRY(NumberStyleValue::create_integer(1));
             return FlexStyleValue::create(one, one, *value);
         }
         case PropertyID::Flex: {
             if (value->is_identifier() && value->to_identifier() == ValueID::None) {
-                auto zero = TRY(NumericStyleValue::create_integer(0));
+                auto zero = TRY(NumberStyleValue::create_integer(0));
                 return FlexStyleValue::create(zero, zero, TRY(IdentifierStyleValue::create(ValueID::Auto)));
             }
             break;
@@ -7438,7 +7438,7 @@ ErrorOr<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readonl
     if (peek_token.is(Token::Type::Number) && property_accepts_numeric) {
         auto numeric = TRY(parse_numeric_value(peek_token));
         (void)tokens.next_token();
-        if (numeric->as_numeric().has_integer() && property_accepting_integer.has_value())
+        if (numeric->as_number().has_integer() && property_accepting_integer.has_value())
             return PropertyAndValue { *property_accepting_integer, numeric };
         return PropertyAndValue { property_accepting_integer.value_or(property_accepting_number.value()), numeric };
     }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3828,7 +3828,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_number_value(TokenStream<ComponentValu
     auto peek_token = tokens.peek_token();
     if (peek_token.is(Token::Type::Number)) {
         (void)tokens.next_token();
-        return NumberStyleValue::create_float(peek_token.token().number().value());
+        return NumberStyleValue::create(peek_token.token().number().value());
     }
 
     return nullptr;
@@ -5511,16 +5511,16 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_flex_value(Vector<ComponentValue> cons
             // https://github.com/w3c/csswg-drafts/issues/5742
             // (flex-basis takes `<length>`, not `<number>`, so the 0 is a Length.)
             auto flex_basis = TRY(LengthStyleValue::create(Length::make_px(0)));
-            auto one = TRY(NumberStyleValue::create_integer(1));
+            auto one = TRY(NumberStyleValue::create(1));
             return FlexStyleValue::create(*value, one, flex_basis);
         }
         case PropertyID::FlexBasis: {
-            auto one = TRY(NumberStyleValue::create_integer(1));
+            auto one = TRY(NumberStyleValue::create(1));
             return FlexStyleValue::create(one, one, *value);
         }
         case PropertyID::Flex: {
             if (value->is_identifier() && value->to_identifier() == ValueID::None) {
-                auto zero = TRY(NumberStyleValue::create_integer(0));
+                auto zero = TRY(NumberStyleValue::create(0));
                 return FlexStyleValue::create(zero, zero, TRY(IdentifierStyleValue::create(ValueID::Auto)));
             }
             break;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -290,7 +290,8 @@ private:
     ErrorOr<RefPtr<StyleValue>> parse_dynamic_value(ComponentValue const&);
     ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
-    ErrorOr<RefPtr<StyleValue>> parse_numeric_value(ComponentValue const&);
+    ErrorOr<RefPtr<StyleValue>> parse_integer_value(TokenStream<ComponentValue>&);
+    ErrorOr<RefPtr<StyleValue>> parse_number_value(TokenStream<ComponentValue>&);
     ErrorOr<RefPtr<StyleValue>> parse_identifier_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_color_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_rect_value(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -28,6 +28,7 @@
 #include <LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
 #include <LibWeb/CSS/StyleValues/InitialStyleValue.h>
+#include <LibWeb/CSS/StyleValues/IntegerStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
@@ -534,9 +535,9 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     case PropertyID::FlexDirection:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_direction()));
     case PropertyID::FlexGrow:
-        return NumberStyleValue::create_float(layout_node.computed_values().flex_grow());
+        return NumberStyleValue::create(layout_node.computed_values().flex_grow());
     case PropertyID::FlexShrink:
-        return NumberStyleValue::create_float(layout_node.computed_values().flex_shrink());
+        return NumberStyleValue::create(layout_node.computed_values().flex_shrink());
     case PropertyID::FlexWrap:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_wrap()));
     case PropertyID::Float:
@@ -554,7 +555,7 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         VERIFY_NOT_REACHED();
     }
     case PropertyID::FontWeight:
-        return NumberStyleValue::create_integer(layout_node.computed_values().font_weight());
+        return NumberStyleValue::create(layout_node.computed_values().font_weight());
     case PropertyID::GridArea: {
         auto maybe_grid_row_start = property(PropertyID::GridRowStart);
         auto maybe_grid_column_start = property(PropertyID::GridColumnStart);
@@ -682,9 +683,9 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     case PropertyID::MinWidth:
         return style_value_for_size(layout_node.computed_values().min_width());
     case PropertyID::Opacity:
-        return NumberStyleValue::create_float(layout_node.computed_values().opacity());
+        return NumberStyleValue::create(layout_node.computed_values().opacity());
     case PropertyID::Order:
-        return NumberStyleValue::create_integer(layout_node.computed_values().order());
+        return IntegerStyleValue::create(layout_node.computed_values().order());
     case PropertyID::OverflowX:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().overflow_x()));
     case PropertyID::OverflowY:
@@ -753,12 +754,12 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
 
         StyleValueVector parameters;
         TRY(parameters.try_ensure_capacity(6));
-        parameters.unchecked_append(TRY(NumberStyleValue::create_float(affine_matrix.a())));
-        parameters.unchecked_append(TRY(NumberStyleValue::create_float(affine_matrix.b())));
-        parameters.unchecked_append(TRY(NumberStyleValue::create_float(affine_matrix.c())));
-        parameters.unchecked_append(TRY(NumberStyleValue::create_float(affine_matrix.d())));
-        parameters.unchecked_append(TRY(NumberStyleValue::create_float(affine_matrix.e())));
-        parameters.unchecked_append(TRY(NumberStyleValue::create_float(affine_matrix.f())));
+        parameters.unchecked_append(TRY(NumberStyleValue::create(affine_matrix.a())));
+        parameters.unchecked_append(TRY(NumberStyleValue::create(affine_matrix.b())));
+        parameters.unchecked_append(TRY(NumberStyleValue::create(affine_matrix.c())));
+        parameters.unchecked_append(TRY(NumberStyleValue::create(affine_matrix.d())));
+        parameters.unchecked_append(TRY(NumberStyleValue::create(affine_matrix.e())));
+        parameters.unchecked_append(TRY(NumberStyleValue::create(affine_matrix.f())));
 
         NonnullRefPtr<StyleValue> matrix_function = TRY(TransformationStyleValue::create(TransformFunction::Matrix, move(parameters)));
         // Elsewhere we always store the transform property's value as a StyleValueList of TransformationStyleValues,
@@ -779,7 +780,7 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         auto maybe_z_index = layout_node.computed_values().z_index();
         if (!maybe_z_index.has_value())
             return nullptr;
-        return NumberStyleValue::create_integer(maybe_z_index.release_value());
+        return IntegerStyleValue::create(maybe_z_index.release_value());
     }
     case PropertyID::Invalid:
         return IdentifierStyleValue::create(ValueID::Invalid);

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -29,7 +29,7 @@
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
 #include <LibWeb/CSS/StyleValues/InitialStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
-#include <LibWeb/CSS/StyleValues/NumericStyleValue.h>
+#include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RectStyleValue.h>
@@ -534,9 +534,9 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     case PropertyID::FlexDirection:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_direction()));
     case PropertyID::FlexGrow:
-        return NumericStyleValue::create_float(layout_node.computed_values().flex_grow());
+        return NumberStyleValue::create_float(layout_node.computed_values().flex_grow());
     case PropertyID::FlexShrink:
-        return NumericStyleValue::create_float(layout_node.computed_values().flex_shrink());
+        return NumberStyleValue::create_float(layout_node.computed_values().flex_shrink());
     case PropertyID::FlexWrap:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_wrap()));
     case PropertyID::Float:
@@ -554,7 +554,7 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         VERIFY_NOT_REACHED();
     }
     case PropertyID::FontWeight:
-        return NumericStyleValue::create_integer(layout_node.computed_values().font_weight());
+        return NumberStyleValue::create_integer(layout_node.computed_values().font_weight());
     case PropertyID::GridArea: {
         auto maybe_grid_row_start = property(PropertyID::GridRowStart);
         auto maybe_grid_column_start = property(PropertyID::GridColumnStart);
@@ -682,9 +682,9 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     case PropertyID::MinWidth:
         return style_value_for_size(layout_node.computed_values().min_width());
     case PropertyID::Opacity:
-        return NumericStyleValue::create_float(layout_node.computed_values().opacity());
+        return NumberStyleValue::create_float(layout_node.computed_values().opacity());
     case PropertyID::Order:
-        return NumericStyleValue::create_integer(layout_node.computed_values().order());
+        return NumberStyleValue::create_integer(layout_node.computed_values().order());
     case PropertyID::OverflowX:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().overflow_x()));
     case PropertyID::OverflowY:
@@ -753,12 +753,12 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
 
         StyleValueVector parameters;
         TRY(parameters.try_ensure_capacity(6));
-        parameters.unchecked_append(TRY(NumericStyleValue::create_float(affine_matrix.a())));
-        parameters.unchecked_append(TRY(NumericStyleValue::create_float(affine_matrix.b())));
-        parameters.unchecked_append(TRY(NumericStyleValue::create_float(affine_matrix.c())));
-        parameters.unchecked_append(TRY(NumericStyleValue::create_float(affine_matrix.d())));
-        parameters.unchecked_append(TRY(NumericStyleValue::create_float(affine_matrix.e())));
-        parameters.unchecked_append(TRY(NumericStyleValue::create_float(affine_matrix.f())));
+        parameters.unchecked_append(TRY(NumberStyleValue::create_float(affine_matrix.a())));
+        parameters.unchecked_append(TRY(NumberStyleValue::create_float(affine_matrix.b())));
+        parameters.unchecked_append(TRY(NumberStyleValue::create_float(affine_matrix.c())));
+        parameters.unchecked_append(TRY(NumberStyleValue::create_float(affine_matrix.d())));
+        parameters.unchecked_append(TRY(NumberStyleValue::create_float(affine_matrix.e())));
+        parameters.unchecked_append(TRY(NumberStyleValue::create_float(affine_matrix.f())));
 
         NonnullRefPtr<StyleValue> matrix_function = TRY(TransformationStyleValue::create(TransformFunction::Matrix, move(parameters)));
         // Elsewhere we always store the transform property's value as a StyleValueList of TransformationStyleValues,
@@ -779,7 +779,7 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         auto maybe_z_index = layout_node.computed_values().z_index();
         if (!maybe_z_index.has_value())
             return nullptr;
-        return NumericStyleValue::create_integer(maybe_z_index.release_value());
+        return NumberStyleValue::create_integer(maybe_z_index.release_value());
     }
     case PropertyID::Invalid:
         return IdentifierStyleValue::create(ValueID::Invalid);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -47,7 +47,7 @@
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ListStyleStyleValue.h>
-#include <LibWeb/CSS/StyleValues/NumericStyleValue.h>
+#include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/OverflowStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PlaceContentStyleValue.h>
@@ -1086,8 +1086,8 @@ static ErrorOr<NonnullRefPtr<StyleValue>> interpolate_property(StyleValue const&
         auto& to_length = to.as_length().length();
         return LengthStyleValue::create(Length(interpolate_raw(from_length.raw_value(), to_length.raw_value()), from_length.type()));
     }
-    case StyleValue::Type::Numeric:
-        return NumericStyleValue::create_float(interpolate_raw(from.as_numeric().number(), to.as_numeric().number()));
+    case StyleValue::Type::Number:
+        return NumberStyleValue::create_float(interpolate_raw(from.as_number().number(), to.as_number().number()));
     case StyleValue::Type::Percentage:
         return PercentageStyleValue::create(Percentage(interpolate_raw(from.as_percentage().percentage().value(), to.as_percentage().percentage().value())));
     case StyleValue::Type::Position: {
@@ -1447,8 +1447,8 @@ ErrorOr<void> StyleComputer::compute_cascaded_values(StyleProperties& style, DOM
                     if (auto iteration_count_value = style.maybe_null_property(PropertyID::AnimationIterationCount); iteration_count_value) {
                         if (iteration_count_value->is_identifier() && iteration_count_value->to_identifier() == ValueID::Infinite)
                             iteration_count = {};
-                        else if (iteration_count_value->is_numeric())
-                            iteration_count = static_cast<size_t>(iteration_count_value->as_numeric().number());
+                        else if (iteration_count_value->is_number())
+                            iteration_count = static_cast<size_t>(iteration_count_value->as_number().number());
                     }
 
                     CSS::AnimationFillMode fill_mode { CSS::AnimationFillMode::None };
@@ -1929,7 +1929,7 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
     FontCache::the().set(font_selector, *found_font);
 
     style.set_property(CSS::PropertyID::FontSize, LengthStyleValue::create(CSS::Length::make_px(font_size_in_px)).release_value_but_fixme_should_propagate_errors(), nullptr);
-    style.set_property(CSS::PropertyID::FontWeight, NumericStyleValue::create_integer(weight).release_value_but_fixme_should_propagate_errors(), nullptr);
+    style.set_property(CSS::PropertyID::FontWeight, NumberStyleValue::create_integer(weight).release_value_but_fixme_should_propagate_errors(), nullptr);
 
     style.set_computed_font(found_font.release_nonnull());
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -45,6 +45,7 @@
 #include <LibWeb/CSS/StyleValues/GridTrackSizeListShorthandStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h>
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
+#include <LibWeb/CSS/StyleValues/IntegerStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ListStyleStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
@@ -1081,13 +1082,15 @@ static ErrorOr<NonnullRefPtr<StyleValue>> interpolate_property(StyleValue const&
 
         return ColorStyleValue::create(color);
     }
+    case StyleValue::Type::Integer:
+        return IntegerStyleValue::create(interpolate_raw(from.as_integer().integer(), to.as_integer().integer()));
     case StyleValue::Type::Length: {
         auto& from_length = from.as_length().length();
         auto& to_length = to.as_length().length();
         return LengthStyleValue::create(Length(interpolate_raw(from_length.raw_value(), to_length.raw_value()), from_length.type()));
     }
     case StyleValue::Type::Number:
-        return NumberStyleValue::create_float(interpolate_raw(from.as_number().number(), to.as_number().number()));
+        return NumberStyleValue::create(interpolate_raw(from.as_number().number(), to.as_number().number()));
     case StyleValue::Type::Percentage:
         return PercentageStyleValue::create(Percentage(interpolate_raw(from.as_percentage().percentage().value(), to.as_percentage().percentage().value())));
     case StyleValue::Type::Position: {
@@ -1929,7 +1932,7 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
     FontCache::the().set(font_selector, *found_font);
 
     style.set_property(CSS::PropertyID::FontSize, LengthStyleValue::create(CSS::Length::make_px(font_size_in_px)).release_value_but_fixme_should_propagate_errors(), nullptr);
-    style.set_property(CSS::PropertyID::FontWeight, NumberStyleValue::create_integer(weight).release_value_but_fixme_should_propagate_errors(), nullptr);
+    style.set_property(CSS::PropertyID::FontWeight, NumberStyleValue::create(weight).release_value_but_fixme_should_propagate_errors(), nullptr);
 
     style.set_computed_font(found_font.release_nonnull());
 

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h>
+#include <LibWeb/CSS/StyleValues/IntegerStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
@@ -244,13 +245,12 @@ Optional<int> StyleProperties::z_index() const
     auto value = property(CSS::PropertyID::ZIndex);
     if (value->has_auto())
         return {};
-    if (value->is_number() && value->as_number().has_integer()) {
+    if (value->is_integer()) {
         // Clamp z-index to the range of a signed 32-bit integer for consistency with other engines.
-        // NOTE: Casting between 32-bit float and 32-bit integer is finicky here, since INT32_MAX is not representable as a 32-bit float!
-        auto integer = value->as_number().integer();
-        if (integer >= static_cast<float>(NumericLimits<int>::max()))
+        auto integer = value->as_integer().integer();
+        if (integer >= NumericLimits<int>::max())
             return NumericLimits<int>::max();
-        if (integer <= static_cast<float>(NumericLimits<int>::min()))
+        if (integer <= NumericLimits<int>::min())
             return NumericLimits<int>::min();
         return static_cast<int>(integer);
     }
@@ -362,9 +362,9 @@ float StyleProperties::flex_shrink() const
 int StyleProperties::order() const
 {
     auto value = property(CSS::PropertyID::Order);
-    if (!value->is_number() || !value->as_number().has_integer())
+    if (!value->is_integer())
         return 0;
-    return value->as_number().integer();
+    return value->as_integer().integer();
 }
 
 Optional<CSS::ImageRendering> StyleProperties::image_rendering() const

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -16,7 +16,7 @@
 #include <LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
-#include <LibWeb/CSS/StyleValues/NumericStyleValue.h>
+#include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RectStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ShadowStyleValue.h>
@@ -179,8 +179,8 @@ CSSPixels StyleProperties::line_height(CSSPixelRect const& viewport_rect, Length
             return line_height_length.to_px(viewport_rect, font_metrics, root_font_metrics);
     }
 
-    if (line_height->is_numeric())
-        return Length(line_height->as_numeric().number(), Length::Type::Em).to_px(viewport_rect, font_metrics, root_font_metrics);
+    if (line_height->is_number())
+        return Length(line_height->as_number().number(), Length::Type::Em).to_px(viewport_rect, font_metrics, root_font_metrics);
 
     if (line_height->is_percentage()) {
         // Percentages are relative to 1em. https://www.w3.org/TR/css-inline-3/#valdef-line-height-percentage
@@ -209,8 +209,8 @@ CSSPixels StyleProperties::line_height(Layout::Node const& layout_node) const
             return line_height_length.to_px(layout_node);
     }
 
-    if (line_height->is_numeric())
-        return Length(line_height->as_numeric().number(), Length::Type::Em).to_px(layout_node);
+    if (line_height->is_number())
+        return Length(line_height->as_number().number(), Length::Type::Em).to_px(layout_node);
 
     if (line_height->is_percentage()) {
         // Percentages are relative to 1em. https://www.w3.org/TR/css-inline-3/#valdef-line-height-percentage
@@ -244,10 +244,10 @@ Optional<int> StyleProperties::z_index() const
     auto value = property(CSS::PropertyID::ZIndex);
     if (value->has_auto())
         return {};
-    if (value->is_numeric() && value->as_numeric().has_integer()) {
+    if (value->is_number() && value->as_number().has_integer()) {
         // Clamp z-index to the range of a signed 32-bit integer for consistency with other engines.
         // NOTE: Casting between 32-bit float and 32-bit integer is finicky here, since INT32_MAX is not representable as a 32-bit float!
-        auto integer = value->as_numeric().integer();
+        auto integer = value->as_number().integer();
         if (integer >= static_cast<float>(NumericLimits<int>::max()))
             return NumericLimits<int>::max();
         if (integer <= static_cast<float>(NumericLimits<int>::min()))
@@ -261,8 +261,8 @@ static float resolve_opacity_value(CSS::StyleValue const& value)
 {
     float unclamped_opacity = 1.0f;
 
-    if (value.is_numeric()) {
-        unclamped_opacity = value.as_numeric().number();
+    if (value.is_number()) {
+        unclamped_opacity = value.as_number().number();
     } else if (value.is_calculated()) {
         auto& calculated = value.as_calculated();
         if (calculated.resolved_type() == CalculatedStyleValue::ResolvedType::Percentage) {
@@ -346,25 +346,25 @@ Optional<CSS::FlexBasisData> StyleProperties::flex_basis() const
 float StyleProperties::flex_grow() const
 {
     auto value = property(CSS::PropertyID::FlexGrow);
-    if (!value->is_numeric())
+    if (!value->is_number())
         return 0;
-    return value->as_numeric().number();
+    return value->as_number().number();
 }
 
 float StyleProperties::flex_shrink() const
 {
     auto value = property(CSS::PropertyID::FlexShrink);
-    if (!value->is_numeric())
+    if (!value->is_number())
         return 1;
-    return value->as_numeric().number();
+    return value->as_number().number();
 }
 
 int StyleProperties::order() const
 {
     auto value = property(CSS::PropertyID::Order);
-    if (!value->is_numeric() || !value->as_numeric().has_integer())
+    if (!value->is_number() || !value->as_number().has_integer())
         return 0;
-    return value->as_numeric().integer();
+    return value->as_number().integer();
 }
 
 Optional<CSS::ImageRendering> StyleProperties::image_rendering() const
@@ -426,8 +426,8 @@ Vector<CSS::Transformation> StyleProperties::transformations() const
                 values.append({ transformation_value->as_length().length() });
             } else if (transformation_value->is_percentage()) {
                 values.append({ transformation_value->as_percentage().percentage() });
-            } else if (transformation_value->is_numeric()) {
-                values.append({ transformation_value->as_numeric().number() });
+            } else if (transformation_value->is_number()) {
+                values.append({ transformation_value->as_number().number() });
             } else if (transformation_value->is_angle()) {
                 values.append({ transformation_value->as_angle().angle() });
             } else {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -40,6 +40,7 @@
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/InheritStyleValue.h>
 #include <LibWeb/CSS/StyleValues/InitialStyleValue.h>
+#include <LibWeb/CSS/StyleValues/IntegerStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LinearGradientStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ListStyleStyleValue.h>
@@ -248,6 +249,12 @@ InitialStyleValue const& StyleValue::as_initial() const
     return static_cast<InitialStyleValue const&>(*this);
 }
 
+IntegerStyleValue const& StyleValue::as_integer() const
+{
+    VERIFY(is_integer());
+    return static_cast<IntegerStyleValue const&>(*this);
+}
+
 LengthStyleValue const& StyleValue::as_length() const
 {
     VERIFY(is_length());
@@ -409,8 +416,8 @@ int StyleValue::to_font_weight() const
             return Gfx::FontWeight::Regular;
         }
     }
-    if (is_number() && as_number().has_integer()) {
-        return as_number().integer();
+    if (is_number()) {
+        return round_to<int>(as_number().number());
     }
     if (is_calculated()) {
         auto maybe_weight = const_cast<CalculatedStyleValue&>(as_calculated()).resolve_integer();

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -43,7 +43,7 @@
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LinearGradientStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ListStyleStyleValue.h>
-#include <LibWeb/CSS/StyleValues/NumericStyleValue.h>
+#include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/OverflowStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PlaceContentStyleValue.h>
@@ -278,10 +278,10 @@ ListStyleStyleValue const& StyleValue::as_list_style() const
     return static_cast<ListStyleStyleValue const&>(*this);
 }
 
-NumericStyleValue const& StyleValue::as_numeric() const
+NumberStyleValue const& StyleValue::as_number() const
 {
-    VERIFY(is_numeric());
-    return static_cast<NumericStyleValue const&>(*this);
+    VERIFY(is_number());
+    return static_cast<NumberStyleValue const&>(*this);
 }
 
 OverflowStyleValue const& StyleValue::as_overflow() const
@@ -409,8 +409,8 @@ int StyleValue::to_font_weight() const
             return Gfx::FontWeight::Regular;
         }
     }
-    if (is_numeric() && as_numeric().has_integer()) {
-        return as_numeric().integer();
+    if (is_number() && as_number().has_integer()) {
+        return as_number().integer();
     }
     if (is_calculated()) {
         auto maybe_weight = const_cast<CalculatedStyleValue&>(as_calculated()).resolve_integer();

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -117,6 +117,7 @@ public:
         Image,
         Inherit,
         Initial,
+        Integer,
         Length,
         LinearGradient,
         ListStyle,
@@ -172,6 +173,7 @@ public:
     bool is_image() const { return type() == Type::Image; }
     bool is_inherit() const { return type() == Type::Inherit; }
     bool is_initial() const { return type() == Type::Initial; }
+    bool is_integer() const { return type() == Type::Integer; }
     bool is_length() const { return type() == Type::Length; }
     bool is_linear_gradient() const { return type() == Type::LinearGradient; }
     bool is_list_style() const { return type() == Type::ListStyle; }
@@ -226,6 +228,7 @@ public:
     ImageStyleValue const& as_image() const;
     InheritStyleValue const& as_inherit() const;
     InitialStyleValue const& as_initial() const;
+    IntegerStyleValue const& as_integer() const;
     LengthStyleValue const& as_length() const;
     LinearGradientStyleValue const& as_linear_gradient() const;
     ListStyleStyleValue const& as_list_style() const;
@@ -277,6 +280,7 @@ public:
     ImageStyleValue& as_image() { return const_cast<ImageStyleValue&>(const_cast<StyleValue const&>(*this).as_image()); }
     InheritStyleValue& as_inherit() { return const_cast<InheritStyleValue&>(const_cast<StyleValue const&>(*this).as_inherit()); }
     InitialStyleValue& as_initial() { return const_cast<InitialStyleValue&>(const_cast<StyleValue const&>(*this).as_initial()); }
+    IntegerStyleValue& as_integer() { return const_cast<IntegerStyleValue&>(const_cast<StyleValue const&>(*this).as_integer()); }
     LengthStyleValue& as_length() { return const_cast<LengthStyleValue&>(const_cast<StyleValue const&>(*this).as_length()); }
     LinearGradientStyleValue& as_linear_gradient() { return const_cast<LinearGradientStyleValue&>(const_cast<StyleValue const&>(*this).as_linear_gradient()); }
     ListStyleStyleValue& as_list_style() { return const_cast<ListStyleStyleValue&>(const_cast<StyleValue const&>(*this).as_list_style()); }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -120,7 +120,7 @@ public:
         Length,
         LinearGradient,
         ListStyle,
-        Numeric,
+        Number,
         Overflow,
         Percentage,
         PlaceContent,
@@ -175,7 +175,7 @@ public:
     bool is_length() const { return type() == Type::Length; }
     bool is_linear_gradient() const { return type() == Type::LinearGradient; }
     bool is_list_style() const { return type() == Type::ListStyle; }
-    bool is_numeric() const { return type() == Type::Numeric; }
+    bool is_number() const { return type() == Type::Number; }
     bool is_overflow() const { return type() == Type::Overflow; }
     bool is_percentage() const { return type() == Type::Percentage; }
     bool is_place_content() const { return type() == Type::PlaceContent; }
@@ -229,7 +229,7 @@ public:
     LengthStyleValue const& as_length() const;
     LinearGradientStyleValue const& as_linear_gradient() const;
     ListStyleStyleValue const& as_list_style() const;
-    NumericStyleValue const& as_numeric() const;
+    NumberStyleValue const& as_number() const;
     OverflowStyleValue const& as_overflow() const;
     PercentageStyleValue const& as_percentage() const;
     PlaceContentStyleValue const& as_place_content() const;
@@ -280,7 +280,7 @@ public:
     LengthStyleValue& as_length() { return const_cast<LengthStyleValue&>(const_cast<StyleValue const&>(*this).as_length()); }
     LinearGradientStyleValue& as_linear_gradient() { return const_cast<LinearGradientStyleValue&>(const_cast<StyleValue const&>(*this).as_linear_gradient()); }
     ListStyleStyleValue& as_list_style() { return const_cast<ListStyleStyleValue&>(const_cast<StyleValue const&>(*this).as_list_style()); }
-    NumericStyleValue& as_numeric() { return const_cast<NumericStyleValue&>(const_cast<StyleValue const&>(*this).as_numeric()); }
+    NumberStyleValue& as_number() { return const_cast<NumberStyleValue&>(const_cast<StyleValue const&>(*this).as_number()); }
     OverflowStyleValue& as_overflow() { return const_cast<OverflowStyleValue&>(const_cast<StyleValue const&>(*this).as_overflow()); }
     PercentageStyleValue& as_percentage() { return const_cast<PercentageStyleValue&>(const_cast<StyleValue const&>(*this).as_percentage()); }
     PlaceContentStyleValue& as_place_content() { return const_cast<PlaceContentStyleValue&>(const_cast<StyleValue const&>(*this).as_place_content()); }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "IntegerStyleValue.h"
+
+namespace Web::CSS {
+
+ErrorOr<String> IntegerStyleValue::to_string() const
+{
+    return String::number(m_value);
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+class IntegerStyleValue : public StyleValueWithDefaultOperators<IntegerStyleValue> {
+public:
+    static ErrorOr<ValueComparingNonnullRefPtr<IntegerStyleValue>> create(i64 value)
+    {
+        return adopt_nonnull_ref_or_enomem(new (nothrow) IntegerStyleValue(value));
+    }
+
+    i64 integer() const { return m_value; }
+
+    virtual ErrorOr<String> to_string() const override;
+
+    bool properties_equal(IntegerStyleValue const& other) const { return m_value == other.m_value; }
+
+private:
+    explicit IntegerStyleValue(i64 value)
+        : StyleValueWithDefaultOperators(Type::Integer)
+        , m_value(value)
+    {
+    }
+
+    i64 m_value { 0 };
+};
+
+}

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.cpp
@@ -13,10 +13,7 @@ namespace Web::CSS {
 
 ErrorOr<String> NumberStyleValue::to_string() const
 {
-    return m_value.visit(
-        [](auto value) {
-            return String::formatted("{}", value);
-        });
+    return String::number(m_value);
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.cpp
@@ -7,11 +7,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "NumericStyleValue.h"
+#include "NumberStyleValue.h"
 
 namespace Web::CSS {
 
-ErrorOr<String> NumericStyleValue::to_string() const
+ErrorOr<String> NumberStyleValue::to_string() const
 {
     return m_value.visit(
         [](auto value) {

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.h
@@ -15,25 +15,25 @@ namespace Web::CSS {
 
 class NumberStyleValue : public StyleValueWithDefaultOperators<NumberStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<NumberStyleValue>> create(float value)
+    static ErrorOr<ValueComparingNonnullRefPtr<NumberStyleValue>> create(double value)
     {
         return adopt_nonnull_ref_or_enomem(new (nothrow) NumberStyleValue(value));
     }
 
-    float number() const { return m_value; }
+    double number() const { return m_value; }
 
     virtual ErrorOr<String> to_string() const override;
 
     bool properties_equal(NumberStyleValue const& other) const { return m_value == other.m_value; }
 
 private:
-    explicit NumberStyleValue(float value)
+    explicit NumberStyleValue(double value)
         : StyleValueWithDefaultOperators(Type::Number)
         , m_value(value)
     {
     }
 
-    float m_value { 0 };
+    double m_value { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.h
@@ -13,16 +13,16 @@
 
 namespace Web::CSS {
 
-class NumericStyleValue : public StyleValueWithDefaultOperators<NumericStyleValue> {
+class NumberStyleValue : public StyleValueWithDefaultOperators<NumberStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<NumericStyleValue>> create_float(float value)
+    static ErrorOr<ValueComparingNonnullRefPtr<NumberStyleValue>> create_float(float value)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) NumericStyleValue(value));
+        return adopt_nonnull_ref_or_enomem(new (nothrow) NumberStyleValue(value));
     }
 
-    static ErrorOr<ValueComparingNonnullRefPtr<NumericStyleValue>> create_integer(i64 value)
+    static ErrorOr<ValueComparingNonnullRefPtr<NumberStyleValue>> create_integer(i64 value)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) NumericStyleValue(value));
+        return adopt_nonnull_ref_or_enomem(new (nothrow) NumberStyleValue(value));
     }
 
     float number() const
@@ -37,11 +37,11 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
 
-    bool properties_equal(NumericStyleValue const& other) const { return m_value == other.m_value; }
+    bool properties_equal(NumberStyleValue const& other) const { return m_value == other.m_value; }
 
 private:
-    explicit NumericStyleValue(Variant<float, i64> value)
-        : StyleValueWithDefaultOperators(Type::Numeric)
+    explicit NumberStyleValue(Variant<float, i64> value)
+        : StyleValueWithDefaultOperators(Type::Number)
         , m_value(move(value))
     {
     }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.h
@@ -15,38 +15,25 @@ namespace Web::CSS {
 
 class NumberStyleValue : public StyleValueWithDefaultOperators<NumberStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<NumberStyleValue>> create_float(float value)
+    static ErrorOr<ValueComparingNonnullRefPtr<NumberStyleValue>> create(float value)
     {
         return adopt_nonnull_ref_or_enomem(new (nothrow) NumberStyleValue(value));
     }
 
-    static ErrorOr<ValueComparingNonnullRefPtr<NumberStyleValue>> create_integer(i64 value)
-    {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) NumberStyleValue(value));
-    }
-
-    float number() const
-    {
-        return m_value.visit(
-            [](float value) { return value; },
-            [](i64 value) { return (float)value; });
-    }
-
-    bool has_integer() const { return m_value.has<i64>(); }
-    float integer() const { return m_value.get<i64>(); }
+    float number() const { return m_value; }
 
     virtual ErrorOr<String> to_string() const override;
 
     bool properties_equal(NumberStyleValue const& other) const { return m_value == other.m_value; }
 
 private:
-    explicit NumberStyleValue(Variant<float, i64> value)
+    explicit NumberStyleValue(float value)
         : StyleValueWithDefaultOperators(Type::Number)
-        , m_value(move(value))
+        , m_value(value)
     {
     }
 
-    Variant<float, i64> m_value { (i64)0 };
+    float m_value { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -130,7 +130,7 @@ class MediaQuery;
 class MediaQueryList;
 class MediaQueryListEvent;
 class Number;
-class NumericStyleValue;
+class NumberStyleValue;
 class OverflowStyleValue;
 class Percentage;
 class PercentageOrCalculated;

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -117,6 +117,7 @@ class IdentifierStyleValue;
 class ImageStyleValue;
 class InheritStyleValue;
 class InitialStyleValue;
+class IntegerStyleValue;
 class Length;
 class LengthBox;
 class LengthOrCalculated;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -11,7 +11,7 @@
 #include <LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EdgeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
-#include <LibWeb/CSS/StyleValues/NumericStyleValue.h>
+#include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
 #include <LibWeb/CSS/StyleValues/URLStyleValue.h>
@@ -295,7 +295,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     //       That's why it has to be set before everything else.
     m_font = computed_style.computed_font();
     computed_values.set_font_size(computed_style.property(CSS::PropertyID::FontSize)->as_length().length().to_px(*this).value());
-    computed_values.set_font_weight(computed_style.property(CSS::PropertyID::FontWeight)->as_numeric().integer());
+    computed_values.set_font_weight(computed_style.property(CSS::PropertyID::FontWeight)->as_number().integer());
     m_line_height = computed_style.line_height(*this);
 
     computed_values.set_vertical_align(computed_style.vertical_align());
@@ -676,8 +676,8 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     auto stroke_width = computed_style.property(CSS::PropertyID::StrokeWidth);
     // FIXME: Converting to pixels isn't really correct - values should be in "user units"
     //        https://svgwg.org/svg2-draft/coords.html#TermUserUnits
-    if (stroke_width->is_numeric())
-        computed_values.set_stroke_width(CSS::Length::make_px(stroke_width->as_numeric().number()));
+    if (stroke_width->is_number())
+        computed_values.set_stroke_width(CSS::Length::make_px(stroke_width->as_number().number()));
     else if (stroke_width->is_length())
         computed_values.set_stroke_width(stroke_width->as_length().length());
     else if (stroke_width->is_percentage())

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -295,7 +295,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     //       That's why it has to be set before everything else.
     m_font = computed_style.computed_font();
     computed_values.set_font_size(computed_style.property(CSS::PropertyID::FontSize)->as_length().length().to_px(*this).value());
-    computed_values.set_font_weight(computed_style.property(CSS::PropertyID::FontWeight)->as_number().integer());
+    computed_values.set_font_weight(round_to<int>(computed_style.property(CSS::PropertyID::FontWeight)->as_number().number()));
     m_line_height = computed_style.line_height(*this);
 
     computed_values.set_vertical_align(computed_style.vertical_align());


### PR DESCRIPTION
`<integer>` and `<number>` are distinct types in CSS, and we now know which one we want while parsing, so let's use that knowledge to clarify the types we use.

This may or may not exist to make my life easier when reimplementing bounds-checking. :sweat_smile: 

cc @awesomekling: I have a very vague understanding of what the z-index problem was before, is my change there correct?