### PR TITLE
LibC+Tests: Reduce fuzz iteration in TestMemalign to speed up CI

### DIFF
--- a/Tests/LibC/TestMemalign.cpp
+++ b/Tests/LibC/TestMemalign.cpp
@@ -9,7 +9,7 @@
 #include <mallocdefs.h>
 #include <stdlib.h>
 
-static constexpr size_t runs = 5000;
+static constexpr size_t runs = 500;
 static constexpr size_t ptrs_per_run = 20;
 
 static size_t random_alignment()


### PR DESCRIPTION
In AArch CI, this test alone takes up 110.6 seconds. In x86_64 CI, it takes up 68.4 seconds. There is no reason to spend this much time and this many trials on this.

Let's reduce the number of iterations to 500. This should still surface any misalignment with high probability, and should speed up the CI time from minutes to seconds.