### PR TITLE
WindowServer: Don't crash when trying to set invalid effects

### DIFF
--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -986,6 +986,10 @@ Messages::WindowServer::SetSystemFontsResponse ConnectionFromClient::set_system_
 
 void ConnectionFromClient::set_system_effects(Vector<bool> const& effects, u8 geometry, u8 tile_window)
 {
+    if (effects.size() != to_underlying(Effects::__Count) || geometry >= to_underlying(ShowGeometry::__Count) || tile_window >= to_underlying(TileWindow::__Count)) {
+        did_misbehave("SetSystemEffects: Bad values");
+        return;
+    }
     WindowManager::the().apply_system_effects(effects, static_cast<ShowGeometry>(geometry), static_cast<TileWindow>(tile_window));
     ConnectionFromClient::for_each_client([&](auto& client) {
         client.async_update_system_effects(effects);

--- a/Userland/Services/WindowServer/SystemEffects.h
+++ b/Userland/Services/WindowServer/SystemEffects.h
@@ -15,14 +15,16 @@ namespace WindowServer {
 enum class TileWindow : u8 {
     TileImmediately,
     ShowTileOverlay,
-    Never
+    Never,
+    __Count
 };
 
 enum class ShowGeometry : u8 {
     OnMoveAndResize,
     OnMoveOnly,
     OnResizeOnly,
-    Never
+    Never,
+    __Count
 };
 
 enum class Effects : size_t {


### PR DESCRIPTION
We used to trust user-provided values blindly, technically leading to UB when `static_cast<ShowGeometry>(geometry)` runs, and in practice crashing in `WindowManager::apply_system_effects` when a too short vector is provided.

Let's be more resilient than that: WindowManager now kicks any client trying to misbehave using this IPC call.