### PR TITLE
LibCrypto: Don't return reference to stack frame in PBKDF

### DIFF
--- a/Userland/Libraries/LibCrypto/Hash/PBKDF2.h
+++ b/Userland/Libraries/LibCrypto/Hash/PBKDF2.h
@@ -15,7 +15,7 @@ namespace Crypto::Hash {
 class PBKDF2 {
 public:
     template<typename PRF>
-    static ErrorOr<Bytes> derive_key(ReadonlyBytes password, ReadonlyBytes salt, u32 iterations, u32 key_length_bytes)
+    static ErrorOr<ByteBuffer> derive_key(ReadonlyBytes password, ReadonlyBytes salt, u32 iterations, u32 key_length_bytes)
     requires requires(PRF t) {
                  t.digest_size();
              }


### PR DESCRIPTION
A reference to the current stack frame becomes invalid after returning, so returning Bytes is pointless.

I don't understand why this wasn't discovered earlier, but [it caused some CI problems for me](https://github.com/SerenityOS/serenity/pull/19209#issuecomment-1572599912), so I fixed it.

Don't take this as encouragement to break master! :^)