### PR TITLE
LibWeb: Remove per path clipping for SVGGeometryPaintable

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
@@ -65,13 +65,11 @@ void SVGGeometryPaintable::paint(PaintContext& context, PaintPhase phase) const
     auto const* svg_element = geometry_element.first_ancestor_of_type<SVG::SVGSVGElement>();
     auto maybe_view_box = svg_element->view_box();
 
-    context.painter().add_clip_rect(context.enclosing_device_rect(absolute_rect()).to_type<int>());
-    auto css_scale = context.device_pixels_per_css_pixel();
-
     auto transform = layout_box().layout_transform();
     if (!transform.has_value())
         return;
 
+    auto css_scale = context.device_pixels_per_css_pixel();
     auto paint_transform = Gfx::AffineTransform {}.scale(css_scale, css_scale).multiply(*transform);
     auto const& original_path = const_cast<SVG::SVGGeometryElement&>(geometry_element).get_path();
     Gfx::Path path = original_path.copy_transformed(paint_transform);


### PR DESCRIPTION
Somewhere the path bounding box in the layout and the actual draw path are getting slightly mismatched. This results in partly clipped bits of SVGs. The paths are already clipped to the containing SVG, and the size of the path in the layout is computed from the bounding box, so it is probably safe just to remove this clipping for now.

**Before**
![image](https://github.com/SerenityOS/serenity/assets/11597044/3ba1e32d-f73d-446f-8d30-b0fbe1d4c913)
**After**
![image](https://github.com/SerenityOS/serenity/assets/11597044/30a3212d-8f9a-4f1b-8123-23b62d4001e3)
