### PR TITLE
WebContent: Prevent renderer crash on partially invalid image

### DIFF
--- a/Ladybird/ImageCodecPluginLadybird.cpp
+++ b/Ladybird/ImageCodecPluginLadybird.cpp
@@ -21,21 +21,14 @@ Optional<Web::Platform::DecodedImage> ImageCodecPluginLadybird::decode_image(Rea
         return {};
     }
 
-    bool had_errors = false;
     Vector<Web::Platform::Frame> frames;
     for (size_t i = 0; i < decoder->frame_count(); ++i) {
         auto frame_or_error = decoder->frame(i);
-        if (frame_or_error.is_error()) {
-            frames.append({ {}, 0 });
-            had_errors = true;
-        } else {
-            auto frame = frame_or_error.release_value();
-            frames.append({ move(frame.image), static_cast<size_t>(frame.duration) });
-        }
+        if (frame_or_error.is_error())
+            return {};
+        auto frame = frame_or_error.release_value();
+        frames.append({ move(frame.image), static_cast<size_t>(frame.duration) });
     }
-
-    if (had_errors)
-        return {};
 
     return Web::Platform::DecodedImage {
         decoder->is_animated(),

--- a/Userland/Services/WebContent/ImageCodecPluginSerenity.cpp
+++ b/Userland/Services/WebContent/ImageCodecPluginSerenity.cpp
@@ -31,6 +31,8 @@ Optional<Web::Platform::DecodedImage> ImageCodecPluginSerenity::decode_image(Rea
     decoded_image.is_animated = result.is_animated;
     decoded_image.loop_count = result.loop_count;
     for (auto const& frame : result.frames) {
+        if (!frame.bitmap)
+            return {};
         decoded_image.frames.empend(move(frame.bitmap), frame.duration);
     }
 


### PR DESCRIPTION
If an image had a valid header and valid metadata, but decoding the
image frame data failed, the renderer used to crash.

The crash only happened in SerenityOS, because there
ImageCodecPluginSerenity returned nullptr bitmaps.  Instead, return
{} like ImageCodecPluginLadybird already does if there's a nullptr
frame.

Fixes #19141.

Loading #19141 in the browser satisfyingly also serves as a manual
test for the bug.  (No automated test since we don't run layout
tests within SerenityOS on the bots.)