### PR TITLE
LibWeb: Reintroduce bounds-checking of CSS types

### DIFF
--- a/Tests/LibWeb/Layout/expected/negative-max-size.txt
+++ b/Tests/LibWeb/Layout/expected/negative-max-size.txt
@@ -1,0 +1,8 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x35.46875 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x19.46875 children: not-inline
+      BlockContainer <div> at (9,9) content-size 782x17.46875 children: inline
+        line 0 width: 147.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 20, rect: [9,9 147.1875x17.46875]
+            "Well, hello friends!"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/negative-max-size.html
+++ b/Tests/LibWeb/Layout/input/negative-max-size.html
@@ -1,0 +1,9 @@
+<!doctype html><style>
+    * {
+        font: 16px SerenitySans;
+    }
+    div {
+        border: 1px solid black;
+        max-width: -90px;
+    }
+</style><div>Well, hello friends!</div>

--- a/Userland/Libraries/LibWeb/CSS/Angle.h
+++ b/Userland/Libraries/LibWeb/CSS/Angle.h
@@ -38,6 +38,18 @@ public:
         return m_type == other.m_type && m_value == other.m_value;
     }
 
+    int operator<=>(Angle const& other) const
+    {
+        auto this_degrees = to_degrees();
+        auto other_degrees = other.to_degrees();
+
+        if (this_degrees < other_degrees)
+            return -1;
+        if (this_degrees > other_degrees)
+            return 1;
+        return 0;
+    }
+
 private:
     StringView unit_name() const;
 

--- a/Userland/Libraries/LibWeb/CSS/Frequency.h
+++ b/Userland/Libraries/LibWeb/CSS/Frequency.h
@@ -35,6 +35,18 @@ public:
         return m_type == other.m_type && m_value == other.m_value;
     }
 
+    int operator<=>(Frequency const& other) const
+    {
+        auto this_hertz = to_hertz();
+        auto other_hertz = other.to_hertz();
+
+        if (this_hertz < other_hertz)
+            return -1;
+        if (this_hertz > other_hertz)
+            return 1;
+        return 0;
+    }
+
 private:
     StringView unit_name() const;
 

--- a/Userland/Libraries/LibWeb/CSS/Number.h
+++ b/Userland/Libraries/LibWeb/CSS/Number.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -80,6 +80,15 @@ public:
     bool operator==(Number const& other) const
     {
         return m_type == other.m_type && m_value == other.m_value;
+    }
+
+    int operator<=>(Number const& other) const
+    {
+        if (m_value < other.m_value)
+            return -1;
+        if (m_value > other.m_value)
+            return 1;
+        return 0;
     }
 
 private:

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -7450,19 +7450,20 @@ ErrorOr<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readonl
 
     if (peek_token.is(Token::Type::Number) && property_accepts_numeric) {
         if (property_accepting_integer.has_value()) {
-            if (auto integer = TRY(parse_integer_value(tokens)))
+            if (auto integer = TRY(parse_integer_value(tokens)); integer && property_accepts_integer(*property_accepting_integer, integer->as_integer().integer()))
                 return PropertyAndValue { *property_accepting_integer, integer };
         }
         if (property_accepting_number.has_value()) {
-            if (auto number = TRY(parse_number_value(tokens)))
+            if (auto number = TRY(parse_number_value(tokens)); number && property_accepts_number(*property_accepting_number, number->as_number().number()))
                 return PropertyAndValue { *property_accepting_number, number };
         }
     }
 
     if (peek_token.is(Token::Type::Percentage)) {
-        if (auto property = any_property_accepts_type(property_ids, ValueType::Percentage); property.has_value()) {
+        auto percentage = Percentage(peek_token.token().percentage());
+        if (auto property = any_property_accepts_type(property_ids, ValueType::Percentage); property.has_value() && property_accepts_percentage(*property, percentage)) {
             (void)tokens.next_token();
-            return PropertyAndValue { *property, TRY(PercentageStyleValue::create(Percentage(peek_token.token().percentage()))) };
+            return PropertyAndValue { *property, TRY(PercentageStyleValue::create(percentage)) };
         }
     }
 
@@ -7496,24 +7497,29 @@ ErrorOr<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readonl
             (void)tokens.next_token();
             auto dimension = maybe_dimension.release_value();
             if (dimension.is_angle()) {
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Angle); property.has_value())
-                    return PropertyAndValue { *property, TRY(AngleStyleValue::create(dimension.angle())) };
+                auto angle = dimension.angle();
+                if (auto property = any_property_accepts_type(property_ids, ValueType::Angle); property.has_value() && property_accepts_angle(*property, angle))
+                    return PropertyAndValue { *property, TRY(AngleStyleValue::create(angle)) };
             }
             if (dimension.is_frequency()) {
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Frequency); property.has_value())
-                    return PropertyAndValue { *property, TRY(FrequencyStyleValue::create(dimension.frequency())) };
+                auto frequency = dimension.frequency();
+                if (auto property = any_property_accepts_type(property_ids, ValueType::Frequency); property.has_value() && property_accepts_frequency(*property, frequency))
+                    return PropertyAndValue { *property, TRY(FrequencyStyleValue::create(frequency)) };
             }
             if (dimension.is_length()) {
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Length); property.has_value())
-                    return PropertyAndValue { *property, TRY(LengthStyleValue::create(dimension.length())) };
+                auto length = dimension.length();
+                if (auto property = any_property_accepts_type(property_ids, ValueType::Length); property.has_value() && property_accepts_length(*property, length))
+                    return PropertyAndValue { *property, TRY(LengthStyleValue::create(length)) };
             }
             if (dimension.is_resolution()) {
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Resolution); property.has_value())
-                    return PropertyAndValue { *property, TRY(ResolutionStyleValue::create(dimension.resolution())) };
+                auto resolution = dimension.resolution();
+                if (auto property = any_property_accepts_type(property_ids, ValueType::Resolution); property.has_value() && property_accepts_resolution(*property, resolution))
+                    return PropertyAndValue { *property, TRY(ResolutionStyleValue::create(resolution)) };
             }
             if (dimension.is_time()) {
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Time); property.has_value())
-                    return PropertyAndValue { *property, TRY(TimeStyleValue::create(dimension.time())) };
+                auto time = dimension.time();
+                if (auto property = any_property_accepts_type(property_ids, ValueType::Time); property.has_value() && property_accepts_time(*property, time))
+                    return PropertyAndValue { *property, TRY(TimeStyleValue::create(time)) };
             }
         }
     }

--- a/Userland/Libraries/LibWeb/CSS/Percentage.h
+++ b/Userland/Libraries/LibWeb/CSS/Percentage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -37,6 +37,15 @@ public:
     }
 
     bool operator==(Percentage const& other) const { return m_value == other.m_value; }
+
+    int operator<=>(Percentage const& other) const
+    {
+        if (m_value < other.m_value)
+            return -1;
+        if (m_value > other.m_value)
+            return 1;
+        return 0;
+    }
 
 private:
     double m_value;

--- a/Userland/Libraries/LibWeb/CSS/Resolution.h
+++ b/Userland/Libraries/LibWeb/CSS/Resolution.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -30,6 +30,18 @@ public:
     bool operator==(Resolution const& other) const
     {
         return m_type == other.m_type && m_value == other.m_value;
+    }
+
+    int operator<=>(Resolution const& other) const
+    {
+        auto this_dots_per_pixel = to_dots_per_pixel();
+        auto other_dots_per_pixel = other.to_dots_per_pixel();
+
+        if (this_dots_per_pixel < other_dots_per_pixel)
+            return -1;
+        if (this_dots_per_pixel > other_dots_per_pixel)
+            return 1;
+        return 0;
     }
 
 private:

--- a/Userland/Libraries/LibWeb/CSS/Time.h
+++ b/Userland/Libraries/LibWeb/CSS/Time.h
@@ -37,6 +37,18 @@ public:
         return m_type == other.m_type && m_value == other.m_value;
     }
 
+    int operator<=>(Time const& other) const
+    {
+        auto this_seconds = to_seconds();
+        auto other_seconds = other.to_seconds();
+
+        if (this_seconds < other_seconds)
+            return -1;
+        if (this_seconds > other_seconds)
+            return 1;
+        return 0;
+    }
+
 private:
     StringView unit_name() const;
 


### PR DESCRIPTION
Now things like `max-width: -999px;` will be properly rejected at parse-time.