### PR TITLE
LibWeb: Fix crashing when grid track size is calc() with percentage

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/track-size-calc-with-percentage.txt
+++ b/Tests/LibWeb/Layout/expected/grid/track-size-calc-with-percentage.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x35.40625 children: not-inline
+      Box <div.ipc-page-grid> at (8,8) content-size 784x35.40625 flex-container(row) [FFC] children: not-inline
+        Box <div.ipc-sub-grid> at (8,8) content-size 401.28125x35.40625 flex-item [GFC] children: not-inline
+          BlockContainer <(anonymous)> at (8,8) content-size 401.281x35.40625 [BFC] children: inline
+            line 0 width: 356.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 0, length: 40, rect: [8,8 356.96875x17.46875]
+                "The 10 Most Anticipated Summer Movies of"
+            line 1 width: 36.3125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+              frag 0 from TextNode start: 41, length: 4, rect: [8,25 36.3125x17.46875]
+                "2023"
+            TextNode <#text>

--- a/Tests/LibWeb/Layout/input/grid/track-size-calc-with-percentage.html
+++ b/Tests/LibWeb/Layout/input/grid/track-size-calc-with-percentage.html
@@ -1,0 +1,10 @@
+<style>
+.ipc-page-grid {
+    display: flex;
+}
+.ipc-sub-grid {
+    display: grid;
+    grid-template-columns: calc(100%);
+}
+</style>
+<div class="ipc-page-grid"><div class="ipc-sub-grid">The 10 Most Anticipated Summer Movies of 2023</div></div>

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
@@ -39,7 +39,7 @@ GridSize::~GridSize() = default;
 bool GridSize::is_auto(Layout::AvailableSize const& available_size) const
 {
     if (m_type == Type::LengthPercentage) {
-        if (m_length_percentage.is_percentage())
+        if (m_length_percentage.contains_percentage())
             return !available_size.is_definite();
         return m_length_percentage.is_auto();
     }
@@ -50,7 +50,7 @@ bool GridSize::is_auto(Layout::AvailableSize const& available_size) const
 bool GridSize::is_fixed(Layout::AvailableSize const& available_size) const
 {
     if (m_type == Type::LengthPercentage) {
-        if (m_length_percentage.is_percentage())
+        if (m_length_percentage.contains_percentage())
             return available_size.is_definite();
         return !m_length_percentage.is_auto();
     }


### PR DESCRIPTION
Use contains_percentage() that works for calc() values instead of is_percentage().

This fixes issue when tracks with calc() that has percentages where considered as "fixed" tracks with resolvable size which led to incorrectly resolved infinite final track sizes.

Fixes crash on https://www.imdb.com