### PR TITLE
LibArchive+zip: Add helper functions for adding members to a `ZipOutputStream`

### DIFF
--- a/Userland/Libraries/LibArchive/CMakeLists.txt
+++ b/Userland/Libraries/LibArchive/CMakeLists.txt
@@ -5,4 +5,4 @@ set(SOURCES
         )
 
 serenity_lib(LibArchive archive)
-target_link_libraries(LibArchive PRIVATE LibCore)
+target_link_libraries(LibArchive PRIVATE LibCompress LibCore LibCrypto)

--- a/Userland/Libraries/LibArchive/Zip.h
+++ b/Userland/Libraries/LibArchive/Zip.h
@@ -15,6 +15,7 @@
 #include <AK/Stream.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <LibCore/DateTime.h>
 #include <string.h>
 
 namespace Archive {
@@ -271,9 +272,20 @@ private:
 
 class ZipOutputStream {
 public:
+    struct MemberInformation {
+        float compression_ratio;
+        size_t compressed_size;
+    };
+
     ZipOutputStream(NonnullOwnPtr<Stream>);
 
     ErrorOr<void> add_member(ZipMember const&);
+    ErrorOr<MemberInformation> add_member_from_stream(StringView, Stream&, Optional<Core::DateTime> const& = {});
+
+    // NOTE: This does not add any of the files within the directory,
+    //       it just adds an entry for it.
+    ErrorOr<void> add_directory(StringView, Optional<Core::DateTime> const& = {});
+
     ErrorOr<void> finish();
 
 private:

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -155,7 +155,7 @@ target_link_libraries(watch PRIVATE LibFileSystem)
 target_link_libraries(wsctl PRIVATE LibGUI LibIPC)
 target_link_libraries(xml PRIVATE LibFileSystem LibXML)
 target_link_libraries(xzcat PRIVATE LibCompress)
-target_link_libraries(zip PRIVATE LibArchive LibCompress LibCrypto LibFileSystem)
+target_link_libraries(zip PRIVATE LibArchive LibFileSystem)
 
 # FIXME: Link this file into headless-browser without compiling it again.
 target_sources(headless-browser PRIVATE "${SerenityOS_SOURCE_DIR}/Userland/Services/WebContent/WebDriverConnection.cpp")

--- a/Userland/Utilities/zip.cpp
+++ b/Userland/Utilities/zip.cpp
@@ -4,16 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DOSPackedTime.h>
 #include <AK/LexicalPath.h>
 #include <LibArchive/Zip.h>
-#include <LibCompress/Deflate.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DateTime.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/File.h>
 #include <LibCore/System.h>
-#include <LibCrypto/Checksum/CRC32.h>
 #include <LibFileSystem/FileSystem.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
@@ -54,52 +51,28 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Archive::ZipOutputStream zip_stream(move(file_stream));
 
     auto add_file = [&](DeprecatedString path) -> ErrorOr<void> {
-        auto canonicalized_path = LexicalPath::canonicalized_path(path);
-        auto file = TRY(Core::File::open(path, Core::File::OpenMode::Read));
-        auto file_buffer = TRY(file->read_until_eof());
-        Archive::ZipMember member {};
-        member.name = TRY(String::from_deprecated_string(canonicalized_path));
+        auto canonicalized_path = TRY(String::from_deprecated_string(LexicalPath::canonicalized_path(path)));
 
+        auto file = TRY(Core::File::open(path, Core::File::OpenMode::Read));
         auto stat = TRY(Core::System::fstat(file->fd()));
         auto date = Core::DateTime::from_timestamp(stat.st_mtim.tv_sec);
-        member.modification_date = to_packed_dos_date(date.year(), date.month(), date.day());
-        member.modification_time = to_packed_dos_time(date.hour(), date.minute(), date.second());
 
-        auto deflate_buffer = Compress::DeflateCompressor::compress_all(file_buffer);
-        if (!deflate_buffer.is_error() && deflate_buffer.value().size() < file_buffer.size()) {
-            member.compressed_data = deflate_buffer.value().bytes();
-            member.compression_method = Archive::ZipCompressionMethod::Deflate;
-            auto compression_ratio = (double)deflate_buffer.value().size() / file_buffer.size();
-            outln("  adding: {} (deflated {}%)", canonicalized_path, (int)(compression_ratio * 100));
+        auto information = TRY(zip_stream.add_member_from_stream(canonicalized_path, *file, date));
+        if (information.compression_ratio < 1.f) {
+            outln("  adding: {} (deflated {}%)", canonicalized_path, (int)(information.compression_ratio * 100));
         } else {
-            member.compressed_data = file_buffer.bytes();
-            member.compression_method = Archive::ZipCompressionMethod::Store;
-            outln("  adding: {} (stored 0%)", canonicalized_path);
+            outln("  adding: {} (stored)", canonicalized_path);
         }
-        member.uncompressed_size = file_buffer.size();
-        Crypto::Checksum::CRC32 checksum { file_buffer.bytes() };
-        member.crc32 = checksum.digest();
-        member.is_directory = false;
-        return zip_stream.add_member(member);
+
+        return {};
     };
 
     auto add_directory = [&](DeprecatedString path, auto handle_directory) -> ErrorOr<void> {
-        auto canonicalized_path = DeprecatedString::formatted("{}/", LexicalPath::canonicalized_path(path));
-        Archive::ZipMember member {};
-        member.name = TRY(String::from_deprecated_string(canonicalized_path));
-        member.compressed_data = {};
-        member.compression_method = Archive::ZipCompressionMethod::Store;
-        member.uncompressed_size = 0;
-        member.crc32 = 0;
-        member.is_directory = true;
+        auto canonicalized_path = TRY(String::formatted("{}/", LexicalPath::canonicalized_path(path)));
 
-        auto stat = TRY(Core::System::stat(canonicalized_path));
+        auto stat = TRY(Core::System::stat(path));
         auto date = Core::DateTime::from_timestamp(stat.st_mtim.tv_sec);
-        member.modification_date = to_packed_dos_date(date.year(), date.month(), date.day());
-        member.modification_time = to_packed_dos_time(date.hour(), date.minute(), date.second());
-
-        TRY(zip_stream.add_member(member));
-        outln("  adding: {} (stored 0%)", canonicalized_path);
+        TRY(zip_stream.add_directory(canonicalized_path, date));
 
         if (!recurse)
             return {};

--- a/Userland/Utilities/zip.cpp
+++ b/Userland/Utilities/zip.cpp
@@ -36,21 +36,20 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    DeprecatedString zip_file_path { zip_path };
-    if (FileSystem::exists(zip_file_path)) {
+    if (FileSystem::exists(zip_path)) {
         if (force) {
-            outln("{} already exists, overwriting...", zip_file_path);
+            outln("{} already exists, overwriting...", zip_path);
         } else {
-            warnln("{} already exists, aborting!", zip_file_path);
+            warnln("{} already exists, aborting!", zip_path);
             return 1;
         }
     }
 
-    outln("Archive: {}", zip_file_path);
-    auto file_stream = TRY(Core::File::open(zip_file_path, Core::File::OpenMode::Write));
+    outln("Archive: {}", zip_path);
+    auto file_stream = TRY(Core::File::open(zip_path, Core::File::OpenMode::Write));
     Archive::ZipOutputStream zip_stream(move(file_stream));
 
-    auto add_file = [&](DeprecatedString path) -> ErrorOr<void> {
+    auto add_file = [&](StringView path) -> ErrorOr<void> {
         auto canonicalized_path = TRY(String::from_deprecated_string(LexicalPath::canonicalized_path(path)));
 
         auto file = TRY(Core::File::open(path, Core::File::OpenMode::Read));
@@ -67,7 +66,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return {};
     };
 
-    auto add_directory = [&](DeprecatedString path, auto handle_directory) -> ErrorOr<void> {
+    auto add_directory = [&](StringView path, auto handle_directory) -> ErrorOr<void> {
         auto canonicalized_path = TRY(String::formatted("{}/", LexicalPath::canonicalized_path(path)));
 
         auto stat = TRY(Core::System::stat(path));


### PR DESCRIPTION
*This is a re-do of #18107.*

We now have helper functions in `ZipOutputStream` for adding files (via `AK::Stream`) to a zip. This should allow other applications to add files to a zip archive with ease (and not have to invoke `zip` when doing so).

The `zip` utility has been updated to use these new helpers.