### PR TITLE
LibCore+Userland: Port ConfigFile's group and keys to String

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -358,6 +358,10 @@ install(TARGETS LibTimeZone EXPORT LagomTargets)
 # This is used by the BindingsGenerator so needs to always be built.
 add_serenity_subdirectory(Userland/Libraries/LibIDL)
 
+# LibUnicode
+# This is used by the ConfigureComponents.
+add_serenity_subdirectory(Userland/Libraries/LibUnicode)
+
 # Manually install AK headers
 install(
     DIRECTORY "${SERENITY_PROJECT_ROOT}/AK"
@@ -400,7 +404,6 @@ if (BUILD_LAGOM)
         TextCodec
         Threading
         TLS
-        Unicode
         Video
         Wasm
         WebSocket

--- a/Meta/Lagom/Tools/ConfigureComponents/CMakeLists.txt
+++ b/Meta/Lagom/Tools/ConfigureComponents/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES
     main.cpp
 )
 
-lagom_tool(ConfigureComponents)
+lagom_tool(ConfigureComponents LIBS LibUnicode)

--- a/Meta/Lagom/Tools/ConfigureComponents/main.cpp
+++ b/Meta/Lagom/Tools/ConfigureComponents/main.cpp
@@ -47,7 +47,7 @@ enum class WhiptailMode {
 
 static Vector<ComponentData> read_component_data(Core::ConfigFile const& config_file)
 {
-    VERIFY(!config_file.read_entry("Global", "build_everything", {}).is_empty());
+    VERIFY(!config_file.read_entry("Global"sv, "build_everything"sv, {}).is_empty());
     Vector<ComponentData> components;
 
     auto groups = config_file.groups();
@@ -58,11 +58,11 @@ static Vector<ComponentData> read_component_data(Core::ConfigFile const& config_
     for (auto& component_name : groups) {
         if (component_name == "Global")
             continue;
-        auto description = config_file.read_entry(component_name, "description", "");
-        auto recommended = config_file.read_bool_entry(component_name, "recommended", false);
-        auto required = config_file.read_bool_entry(component_name, "required", false);
-        auto user_selected = config_file.read_bool_entry(component_name, "user_selected", false);
-        auto depends = config_file.read_entry(component_name, "depends", "").split(';');
+        auto description = config_file.read_entry(component_name, "description"sv, "");
+        auto recommended = config_file.read_bool_entry(component_name, "recommended"sv, false);
+        auto required = config_file.read_bool_entry(component_name, "required"sv, false);
+        auto user_selected = config_file.read_bool_entry(component_name, "user_selected"sv, false);
+        auto depends = config_file.read_entry(component_name, "depends"sv, "").split(';');
         // NOTE: Recommended and required shouldn't be set at the same time.
         VERIFY(!recommended || !required);
         ComponentCategory category { ComponentCategory::Optional };
@@ -254,7 +254,7 @@ int main()
         return 1;
     }
 
-    bool build_everything = components_file->read_bool_entry("Global", "build_everything", false);
+    bool build_everything = components_file->read_bool_entry("Global"sv, "build_everything"sv, false);
     auto components = read_component_data(components_file);
     warnln("{} components were read from 'components.ini'.", components.size());
 

--- a/Meta/Lagom/Tools/ConfigureComponents/main.cpp
+++ b/Meta/Lagom/Tools/ConfigureComponents/main.cpp
@@ -52,7 +52,7 @@ static Vector<ComponentData> read_component_data(Core::ConfigFile const& config_
 
     auto groups = config_file.groups();
     quick_sort(groups, [](auto& a, auto& b) {
-        return a.to_lowercase() < b.to_lowercase();
+        return a.to_lowercase().release_value_but_fixme_should_propagate_errors() < b.to_lowercase().release_value_but_fixme_should_propagate_errors();
     });
 
     for (auto& component_name : groups) {
@@ -71,7 +71,7 @@ static Vector<ComponentData> read_component_data(Core::ConfigFile const& config_
         else if (required)
             category = ComponentCategory ::Required;
 
-        components.append(ComponentData { component_name, move(description), category, user_selected, move(depends), false });
+        components.append(ComponentData { component_name.to_deprecated_string(), move(description), category, user_selected, move(depends), false });
     }
 
     return components;

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto clipboard_config = TRY(Core::ConfigFile::open_for_app("ClipboardHistory"));
 
     auto const default_path = DeprecatedString::formatted("{}/{}", Core::StandardPaths::data_directory(), "Clipboard/ClipboardHistory.json"sv);
-    auto const clipboard_file_path = clipboard_config->read_entry("Clipboard", "ClipboardFilePath", default_path);
+    auto const clipboard_file_path = clipboard_config->read_entry("Clipboard"sv, "ClipboardFilePath"sv, default_path);
     auto const parent_path = LexicalPath(clipboard_file_path);
     TRY(Core::Directory::create(parent_path.dirname(), Core::Directory::CreateDirectories::Yes));
 

--- a/Userland/Applets/Keymap/KeymapStatusWidget.cpp
+++ b/Userland/Applets/Keymap/KeymapStatusWidget.cpp
@@ -34,7 +34,7 @@ ErrorOr<void> KeymapStatusWidget::refresh_menu()
     m_context_menu = GUI::Menu::construct();
 
     auto mapper_config = TRY(Core::ConfigFile::open("/etc/Keyboard.ini"));
-    auto keymaps_string = mapper_config->read_entry("Mapping", "Keymaps", "");
+    auto keymaps_string = mapper_config->read_entry("Mapping"sv, "Keymaps"sv, "");
     auto keymaps = keymaps_string.split(',');
 
     for (auto& keymap : keymaps) {

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -147,16 +147,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(load_autoplay_allowlist());
 
     for (auto& group : Config::list_groups("Browser"sv)) {
-        if (!group.starts_with("Proxy:"sv))
+        if (!group.starts_with_bytes("Proxy:"sv))
             continue;
 
         for (auto& key : Config::list_keys("Browser"sv, group)) {
-            auto proxy_spec = group.substring_view(6);
+            auto proxy_spec = group.bytes_as_string_view().substring_view(6);
             auto existing_proxy = Browser::g_proxies.find(proxy_spec);
             if (existing_proxy.is_end())
                 Browser::g_proxies.append(proxy_spec);
 
-            Browser::g_proxy_mappings.set(key, existing_proxy.index());
+            Browser::g_proxy_mappings.set(key.to_deprecated_string(), existing_proxy.index());
         }
     }
 

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -146,7 +146,7 @@ ErrorOr<void> BackgroundSettingsWidget::load_current_settings()
         m_monitor_widget->set_wallpaper(selected_wallpaper);
     }
 
-    auto mode = TRY(String::from_deprecated_string(ws_config->read_entry("Background", "Mode", "Center")));
+    auto mode = TRY(String::from_deprecated_string(ws_config->read_entry("Background"sv, "Mode"sv, "Center")));
     if (!m_modes.contains_slow(mode)) {
         warnln("Invalid background mode '{}' in WindowServer config, falling back to 'Center'", mode);
         mode = TRY(String::from_utf8("Center"sv));
@@ -155,7 +155,7 @@ ErrorOr<void> BackgroundSettingsWidget::load_current_settings()
     m_mode_combo->set_selected_index(m_modes.find_first_index(mode).value_or(0), GUI::AllowCallback::No);
 
     auto palette_desktop_color = palette().desktop_background();
-    auto background_color = ws_config->read_entry("Background", "Color", "");
+    auto background_color = ws_config->read_entry("Background"sv, "Color"sv, "");
 
     if (!background_color.is_empty()) {
         auto opt_color = Color::from_string(background_color);

--- a/Userland/Applications/DisplaySettings/EffectsSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/EffectsSettingsWidget.cpp
@@ -114,19 +114,19 @@ ErrorOr<void> EffectsSettingsWidget::load_settings()
 {
     auto ws_config = TRY(Core::ConfigFile::open("/etc/WindowServer.ini"));
     Vector<bool> effects = {
-        ws_config->read_bool_entry("Effects", "AnimateMenus", true),
-        ws_config->read_bool_entry("Effects", "FlashMenus", true),
-        ws_config->read_bool_entry("Effects", "AnimateWindows", true),
-        ws_config->read_bool_entry("Effects", "SmoothScrolling", true),
-        ws_config->read_bool_entry("Effects", "TabAccents", true),
-        ws_config->read_bool_entry("Effects", "SplitterKnurls", true),
-        ws_config->read_bool_entry("Effects", "Tooltips", true),
-        ws_config->read_bool_entry("Effects", "MenuShadow", true),
-        ws_config->read_bool_entry("Effects", "WindowShadow", true),
-        ws_config->read_bool_entry("Effects", "TooltipShadow", true),
+        ws_config->read_bool_entry("Effects"sv, "AnimateMenus"sv, true),
+        ws_config->read_bool_entry("Effects"sv, "FlashMenus"sv, true),
+        ws_config->read_bool_entry("Effects"sv, "AnimateWindows"sv, true),
+        ws_config->read_bool_entry("Effects"sv, "SmoothScrolling"sv, true),
+        ws_config->read_bool_entry("Effects"sv, "TabAccents"sv, true),
+        ws_config->read_bool_entry("Effects"sv, "SplitterKnurls"sv, true),
+        ws_config->read_bool_entry("Effects"sv, "Tooltips"sv, true),
+        ws_config->read_bool_entry("Effects"sv, "MenuShadow"sv, true),
+        ws_config->read_bool_entry("Effects"sv, "WindowShadow"sv, true),
+        ws_config->read_bool_entry("Effects"sv, "TooltipShadow"sv, true),
     };
-    auto geometry = WindowServer::ShowGeometryTools::string_to_enum(ws_config->read_entry("Effects", "ShowGeometry", "OnMoveAndResize"));
-    auto tile_window = WindowServer::TileWindowTools::string_to_enum(ws_config->read_entry("Effects", "TileWindow", "ShowTileOverlay"));
+    auto geometry = WindowServer::ShowGeometryTools::string_to_enum(ws_config->read_entry("Effects"sv, "ShowGeometry"sv, "OnMoveAndResize"));
+    auto tile_window = WindowServer::TileWindowTools::string_to_enum(ws_config->read_entry("Effects"sv, "TileWindow"sv, "ShowTileOverlay"));
     m_system_effects = { effects, geometry, tile_window };
 
     static constexpr Array geometry_list = {

--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
@@ -91,7 +91,7 @@ ErrorOr<void> ThemesSettingsWidget::setup_interface()
     }
 
     auto theme_config = TRY(Core::ConfigFile::open(m_selected_theme->path));
-    if (!selected_color_scheme_index.has_value() || GUI::Widget::palette().color_scheme_path() != theme_config->read_entry("Paths", "ColorScheme")) {
+    if (!selected_color_scheme_index.has_value() || GUI::Widget::palette().color_scheme_path() != theme_config->read_entry("Paths"sv, "ColorScheme"sv)) {
         if (m_color_scheme_names.size() > 1) {
             color_scheme_combo.set_enabled(true);
             find_descendant_of_type_named<GUI::CheckBox>("custom_color_scheme_checkbox")->set_checked(true);
@@ -187,7 +187,7 @@ void ThemesSettingsWidget::apply_settings()
             GUI::MessageBox::show_error(window(), "Failed to open theme config file"sv);
             return;
         }
-        auto preferred_color_scheme_path = get_color_scheme_name_from_pathname(theme_config.release_value()->read_entry("Paths", "ColorScheme"));
+        auto preferred_color_scheme_path = get_color_scheme_name_from_pathname(theme_config.release_value()->read_entry("Paths"sv, "ColorScheme"sv));
         auto set_theme_result = GUI::ConnectionToWindowServer::the().set_system_theme(m_selected_theme->path, m_selected_theme->name, m_background_settings_changed, OptionalNone());
         if (!set_theme_result || preferred_color_scheme_path.is_error()) {
             GUI::MessageBox::show_error(window(), "Failed to apply theme settings"sv);

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -162,7 +162,7 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
     dbgln("KeyboardSettings thinks the current keymap is: {}", m_initial_active_keymap);
 
     auto mapper_config(Core::ConfigFile::open("/etc/Keyboard.ini").release_value_but_fixme_should_propagate_errors());
-    auto keymaps = mapper_config->read_entry("Mapping", "Keymaps", "");
+    auto keymaps = mapper_config->read_entry("Mapping"sv, "Keymaps"sv, "");
 
     auto keymaps_vector = keymaps.split(',');
 

--- a/Userland/Applications/MouseSettings/HighlightPreviewWidget.cpp
+++ b/Userland/Applications/MouseSettings/HighlightPreviewWidget.cpp
@@ -32,7 +32,7 @@ ErrorOr<void> HighlightPreviewWidget::reload_cursor()
     };
     constexpr auto default_cursor_path = "/res/cursor-themes/Default/arrow.x2y2.png"sv;
     auto cursor_path = DeprecatedString::formatted("/res/cursor-themes/{}/{}",
-        cursor_theme, cursor_theme_config->read_entry("Cursor", "Arrow"));
+        cursor_theme, cursor_theme_config->read_entry("Cursor"sv, "Arrow"sv));
     m_cursor_bitmap = TRY(load_bitmap(cursor_path, default_cursor_path));
     m_cursor_params = Gfx::CursorParams::parse_from_filename(cursor_path, m_cursor_bitmap->rect().center()).constrained(*m_cursor_bitmap);
     // Setup cursor animation:

--- a/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
+++ b/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
@@ -86,17 +86,17 @@ NetworkSettingsWidget::NetworkSettingsWidget()
 
         bool adapter_exists_in_config = config_file->has_group(adapter_name);
 
-        bool enabled = config_file->read_bool_entry(adapter_name, "Enabled", true);
+        bool enabled = config_file->read_bool_entry(adapter_name, "Enabled"sv, true);
         if (enabled)
             selected_adapter_index = index;
 
         NetworkAdapterData adapter_data;
         adapter_data.enabled = enabled;
-        adapter_data.dhcp = config_file->read_bool_entry(adapter_name, "DHCP", !adapter_exists_in_config);
-        adapter_data.ip_address = config_file->read_entry(adapter_name, "IPv4Address");
-        auto netmask = IPv4Address::from_string(config_file->read_entry(adapter_name, "IPv4Netmask"));
+        adapter_data.dhcp = config_file->read_bool_entry(adapter_name, "DHCP"sv, !adapter_exists_in_config);
+        adapter_data.ip_address = config_file->read_entry(adapter_name, "IPv4Address"sv);
+        auto netmask = IPv4Address::from_string(config_file->read_entry(adapter_name, "IPv4Netmask"sv));
         adapter_data.cidr = netmask.has_value() ? netmask_to_cidr(*netmask) : 32;
-        adapter_data.default_gateway = config_file->read_entry(adapter_name, "IPv4Gateway");
+        adapter_data.default_gateway = config_file->read_entry(adapter_name, "IPv4Gateway"sv);
         m_network_adapters.set(adapter_name, move(adapter_data));
         m_adapter_names.append(adapter_name);
         index++;

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -321,31 +321,34 @@ void MainWidget::set_path(DeprecatedString path)
 
 void MainWidget::save_to_file(String const& filename, NonnullOwnPtr<Core::File> file)
 {
-    auto theme = Core::ConfigFile::open(filename.to_deprecated_string(), move(file)).release_value_but_fixme_should_propagate_errors();
+    auto save_result = [&]() -> ErrorOr<void> {
+        auto theme = TRY(Core::ConfigFile::open(filename.to_deprecated_string(), move(file)));
 
-#define __ENUMERATE_ALIGNMENT_ROLE(role) theme->write_entry("Alignments"_string.release_value_but_fixme_should_propagate_errors(), String::from_utf8(to_string(Gfx::AlignmentRole::role)).release_value_but_fixme_should_propagate_errors(), to_string(m_current_palette.alignment(Gfx::AlignmentRole::role)));
-    ENUMERATE_ALIGNMENT_ROLES(__ENUMERATE_ALIGNMENT_ROLE)
+#define __ENUMERATE_ALIGNMENT_ROLE(role) theme->write_entry(TRY("Alignments"_string), TRY(String::from_utf8(to_string(Gfx::AlignmentRole::role))), to_string(m_current_palette.alignment(Gfx::AlignmentRole::role)));
+        ENUMERATE_ALIGNMENT_ROLES(__ENUMERATE_ALIGNMENT_ROLE)
 #undef __ENUMERATE_ALIGNMENT_ROLE
 
-#define __ENUMERATE_COLOR_ROLE(role) theme->write_entry("Colors"_short_string, String::from_utf8(to_string(Gfx::ColorRole::role)).release_value_but_fixme_should_propagate_errors(), m_current_palette.color(Gfx::ColorRole::role).to_deprecated_string());
-    ENUMERATE_COLOR_ROLES(__ENUMERATE_COLOR_ROLE)
+#define __ENUMERATE_COLOR_ROLE(role) theme->write_entry("Colors"_short_string, TRY(String::from_utf8(to_string(Gfx::ColorRole::role))), m_current_palette.color(Gfx::ColorRole::role).to_deprecated_string());
+        ENUMERATE_COLOR_ROLES(__ENUMERATE_COLOR_ROLE)
 #undef __ENUMERATE_COLOR_ROLE
 
-#define __ENUMERATE_FLAG_ROLE(role) theme->write_bool_entry("Flags"_short_string, String::from_utf8(to_string(Gfx::FlagRole::role)).release_value_but_fixme_should_propagate_errors(), m_current_palette.flag(Gfx::FlagRole::role));
-    ENUMERATE_FLAG_ROLES(__ENUMERATE_FLAG_ROLE)
+#define __ENUMERATE_FLAG_ROLE(role) theme->write_bool_entry("Flags"_short_string, TRY(String::from_utf8(to_string(Gfx::FlagRole::role))), m_current_palette.flag(Gfx::FlagRole::role));
+        ENUMERATE_FLAG_ROLES(__ENUMERATE_FLAG_ROLE)
 #undef __ENUMERATE_FLAG_ROLE
 
-#define __ENUMERATE_METRIC_ROLE(role) theme->write_num_entry("Metrics"_short_string, String::from_utf8(to_string(Gfx::MetricRole::role)).release_value_but_fixme_should_propagate_errors(), m_current_palette.metric(Gfx::MetricRole::role));
-    ENUMERATE_METRIC_ROLES(__ENUMERATE_METRIC_ROLE)
+#define __ENUMERATE_METRIC_ROLE(role) theme->write_num_entry("Metrics"_short_string, TRY(String::from_utf8(to_string(Gfx::MetricRole::role))), m_current_palette.metric(Gfx::MetricRole::role));
+        ENUMERATE_METRIC_ROLES(__ENUMERATE_METRIC_ROLE)
 #undef __ENUMERATE_METRIC_ROLE
 
-#define __ENUMERATE_PATH_ROLE(role) theme->write_entry("Paths"_short_string, String::from_utf8(to_string(Gfx::PathRole::role)).release_value_but_fixme_should_propagate_errors(), m_current_palette.path(Gfx::PathRole::role));
-    ENUMERATE_PATH_ROLES(__ENUMERATE_PATH_ROLE)
+#define __ENUMERATE_PATH_ROLE(role) theme->write_entry("Paths"_short_string, TRY(String::from_utf8(to_string(Gfx::PathRole::role))), m_current_palette.path(Gfx::PathRole::role));
+        ENUMERATE_PATH_ROLES(__ENUMERATE_PATH_ROLE)
 #undef __ENUMERATE_PATH_ROLE
 
-    auto sync_result = theme->sync();
-    if (sync_result.is_error()) {
-        GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Failed to save theme file: {}", sync_result.error()));
+        return theme->sync();
+    }();
+
+    if (save_result.is_error()) {
+        GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Failed to save theme file: {}", save_result.error()));
     } else {
         m_last_modified_time = MonotonicTime::now();
         set_path(filename.to_deprecated_string());

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -323,23 +323,23 @@ void MainWidget::save_to_file(String const& filename, NonnullOwnPtr<Core::File> 
 {
     auto theme = Core::ConfigFile::open(filename.to_deprecated_string(), move(file)).release_value_but_fixme_should_propagate_errors();
 
-#define __ENUMERATE_ALIGNMENT_ROLE(role) theme->write_entry("Alignments", to_string(Gfx::AlignmentRole::role), to_string(m_current_palette.alignment(Gfx::AlignmentRole::role)));
+#define __ENUMERATE_ALIGNMENT_ROLE(role) theme->write_entry("Alignments"_string.release_value_but_fixme_should_propagate_errors(), String::from_utf8(to_string(Gfx::AlignmentRole::role)).release_value_but_fixme_should_propagate_errors(), to_string(m_current_palette.alignment(Gfx::AlignmentRole::role)));
     ENUMERATE_ALIGNMENT_ROLES(__ENUMERATE_ALIGNMENT_ROLE)
 #undef __ENUMERATE_ALIGNMENT_ROLE
 
-#define __ENUMERATE_COLOR_ROLE(role) theme->write_entry("Colors", to_string(Gfx::ColorRole::role), m_current_palette.color(Gfx::ColorRole::role).to_deprecated_string());
+#define __ENUMERATE_COLOR_ROLE(role) theme->write_entry("Colors"_short_string, String::from_utf8(to_string(Gfx::ColorRole::role)).release_value_but_fixme_should_propagate_errors(), m_current_palette.color(Gfx::ColorRole::role).to_deprecated_string());
     ENUMERATE_COLOR_ROLES(__ENUMERATE_COLOR_ROLE)
 #undef __ENUMERATE_COLOR_ROLE
 
-#define __ENUMERATE_FLAG_ROLE(role) theme->write_bool_entry("Flags", to_string(Gfx::FlagRole::role), m_current_palette.flag(Gfx::FlagRole::role));
+#define __ENUMERATE_FLAG_ROLE(role) theme->write_bool_entry("Flags"_short_string, String::from_utf8(to_string(Gfx::FlagRole::role)).release_value_but_fixme_should_propagate_errors(), m_current_palette.flag(Gfx::FlagRole::role));
     ENUMERATE_FLAG_ROLES(__ENUMERATE_FLAG_ROLE)
 #undef __ENUMERATE_FLAG_ROLE
 
-#define __ENUMERATE_METRIC_ROLE(role) theme->write_num_entry("Metrics", to_string(Gfx::MetricRole::role), m_current_palette.metric(Gfx::MetricRole::role));
+#define __ENUMERATE_METRIC_ROLE(role) theme->write_num_entry("Metrics"_short_string, String::from_utf8(to_string(Gfx::MetricRole::role)).release_value_but_fixme_should_propagate_errors(), m_current_palette.metric(Gfx::MetricRole::role));
     ENUMERATE_METRIC_ROLES(__ENUMERATE_METRIC_ROLE)
 #undef __ENUMERATE_METRIC_ROLE
 
-#define __ENUMERATE_PATH_ROLE(role) theme->write_entry("Paths", to_string(Gfx::PathRole::role), m_current_palette.path(Gfx::PathRole::role));
+#define __ENUMERATE_PATH_ROLE(role) theme->write_entry("Paths"_short_string, String::from_utf8(to_string(Gfx::PathRole::role)).release_value_but_fixme_should_propagate_errors(), m_current_palette.path(Gfx::PathRole::role));
     ENUMERATE_PATH_ROLES(__ENUMERATE_PATH_ROLE)
 #undef __ENUMERATE_PATH_ROLE
 

--- a/Userland/DevTools/HackStudio/ProjectTemplate.cpp
+++ b/Userland/DevTools/HackStudio/ProjectTemplate.cpp
@@ -35,22 +35,22 @@ RefPtr<ProjectTemplate> ProjectTemplate::load_from_manifest(DeprecatedString con
         return {};
     auto config = maybe_config.release_value();
 
-    if (!config->has_group("HackStudioTemplate")
-        || !config->has_key("HackStudioTemplate", "Name")
-        || !config->has_key("HackStudioTemplate", "Description")
-        || !config->has_key("HackStudioTemplate", "IconName32x"))
+    if (!config->has_group("HackStudioTemplate"sv)
+        || !config->has_key("HackStudioTemplate"sv, "Name"sv)
+        || !config->has_key("HackStudioTemplate"sv, "Description"sv)
+        || !config->has_key("HackStudioTemplate"sv, "IconName32x"sv))
         return {};
 
     auto id = LexicalPath::title(manifest_path);
-    auto name = config->read_entry("HackStudioTemplate", "Name");
-    auto description = config->read_entry("HackStudioTemplate", "Description");
-    int priority = config->read_num_entry("HackStudioTemplate", "Priority", 0);
+    auto name = config->read_entry("HackStudioTemplate"sv, "Name"sv);
+    auto description = config->read_entry("HackStudioTemplate"sv, "Description"sv);
+    int priority = config->read_num_entry("HackStudioTemplate"sv, "Priority"sv, 0);
 
     // Attempt to read in the template icons
     // Fallback to a generic executable icon if one isn't found
     auto icon = GUI::Icon::default_icon("filetype-executable"sv);
 
-    auto bitmap_path_32 = DeprecatedString::formatted("/res/icons/hackstudio/templates-32x32/{}.png", config->read_entry("HackStudioTemplate", "IconName32x"));
+    auto bitmap_path_32 = DeprecatedString::formatted("/res/icons/hackstudio/templates-32x32/{}.png", config->read_entry("HackStudioTemplate"sv, "IconName32x"sv));
 
     if (FileSystem::exists(bitmap_path_32)) {
         auto bitmap_or_error = Gfx::Bitmap::load_from_file(bitmap_path_32);

--- a/Userland/Libraries/LibConfig/Client.cpp
+++ b/Userland/Libraries/LibConfig/Client.cpp
@@ -29,12 +29,12 @@ void Client::monitor_domain(DeprecatedString const& domain)
     async_monitor_domain(domain);
 }
 
-Vector<DeprecatedString> Client::list_keys(StringView domain, StringView group)
+Vector<String> Client::list_keys(StringView domain, StringView group)
 {
     return list_config_keys(domain, group);
 }
 
-Vector<DeprecatedString> Client::list_groups(StringView domain)
+Vector<String> Client::list_groups(StringView domain)
 {
     return list_config_groups(domain);
 }

--- a/Userland/Libraries/LibConfig/Client.h
+++ b/Userland/Libraries/LibConfig/Client.h
@@ -23,8 +23,8 @@ public:
     void pledge_domains(Vector<DeprecatedString> const&);
     void monitor_domain(DeprecatedString const&);
 
-    Vector<DeprecatedString> list_groups(StringView domain);
-    Vector<DeprecatedString> list_keys(StringView domain, StringView group);
+    Vector<String> list_groups(StringView domain);
+    Vector<String> list_keys(StringView domain, StringView group);
 
     DeprecatedString read_string(StringView domain, StringView group, StringView key, StringView fallback);
     i32 read_i32(StringView domain, StringView group, StringView key, i32 fallback);
@@ -56,12 +56,12 @@ private:
     void notify_added_group(DeprecatedString const& domain, DeprecatedString const& group) override;
 };
 
-inline Vector<DeprecatedString> list_groups(StringView domain)
+inline Vector<String> list_groups(StringView domain)
 {
     return Client::the().list_groups(domain);
 }
 
-inline Vector<DeprecatedString> list_keys(StringView domain, StringView group)
+inline Vector<String> list_keys(StringView domain, StringView group)
 {
     return Client::the().list_keys(domain, group);
 }

--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -140,7 +140,7 @@ ErrorOr<void> ConfigFile::reparse()
     return {};
 }
 
-DeprecatedString ConfigFile::read_entry(DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& default_value) const
+DeprecatedString ConfigFile::read_entry(StringView group, StringView key, DeprecatedString const& default_value) const
 {
     if (!has_key(group, key)) {
         return default_value;
@@ -150,7 +150,7 @@ DeprecatedString ConfigFile::read_entry(DeprecatedString const& group, Deprecate
     return jt->value;
 }
 
-bool ConfigFile::read_bool_entry(DeprecatedString const& group, DeprecatedString const& key, bool default_value) const
+bool ConfigFile::read_bool_entry(StringView group, StringView key, bool default_value) const
 {
     auto value = read_entry(group, key, default_value ? "true" : "false");
     return value == "1" || value.equals_ignoring_ascii_case("true"sv);
@@ -204,7 +204,7 @@ Vector<DeprecatedString> ConfigFile::groups() const
     return m_groups.keys();
 }
 
-Vector<DeprecatedString> ConfigFile::keys(DeprecatedString const& group) const
+Vector<DeprecatedString> ConfigFile::keys(StringView group) const
 {
     auto it = m_groups.find(group);
     if (it == m_groups.end())
@@ -212,7 +212,7 @@ Vector<DeprecatedString> ConfigFile::keys(DeprecatedString const& group) const
     return it->value.keys();
 }
 
-bool ConfigFile::has_key(DeprecatedString const& group, DeprecatedString const& key) const
+bool ConfigFile::has_key(StringView group, StringView key) const
 {
     auto it = m_groups.find(group);
     if (it == m_groups.end())
@@ -220,7 +220,7 @@ bool ConfigFile::has_key(DeprecatedString const& group, DeprecatedString const& 
     return it->value.contains(key);
 }
 
-bool ConfigFile::has_group(DeprecatedString const& group) const
+bool ConfigFile::has_group(StringView group) const
 {
     return m_groups.contains(group);
 }
@@ -231,13 +231,13 @@ void ConfigFile::add_group(DeprecatedString const& group)
     m_dirty = true;
 }
 
-void ConfigFile::remove_group(DeprecatedString const& group)
+void ConfigFile::remove_group(StringView group)
 {
     m_groups.remove(group);
     m_dirty = true;
 }
 
-void ConfigFile::remove_entry(DeprecatedString const& group, DeprecatedString const& key)
+void ConfigFile::remove_entry(StringView group, StringView key)
 {
     auto it = m_groups.find(group);
     if (it == m_groups.end())

--- a/Userland/Libraries/LibCore/ConfigFile.h
+++ b/Userland/Libraries/LibCore/ConfigFile.h
@@ -14,6 +14,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibCore/File.h>
 
@@ -37,8 +38,8 @@ public:
     bool has_group(StringView) const;
     bool has_key(StringView group, StringView key) const;
 
-    Vector<DeprecatedString> groups() const;
-    Vector<DeprecatedString> keys(StringView group) const;
+    Vector<String> groups() const;
+    Vector<String> keys(StringView group) const;
 
     size_t num_groups() const { return m_groups.size(); }
 
@@ -57,11 +58,11 @@ public:
             return read_entry(group, key).to_uint<T>().value_or(default_value);
     }
 
-    void write_entry(DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value);
-    void write_bool_entry(DeprecatedString const& group, DeprecatedString const& key, bool value);
+    void write_entry(String const& group, String const& key, DeprecatedString const& value);
+    void write_bool_entry(String const& group, String const& key, bool value);
 
     template<Integral T = int>
-    void write_num_entry(DeprecatedString const& group, DeprecatedString const& key, T value)
+    void write_num_entry(String const& group, String const& key, T value)
     {
         write_entry(group, key, DeprecatedString::number(value));
     }
@@ -72,7 +73,7 @@ public:
 
     ErrorOr<void> sync();
 
-    void add_group(DeprecatedString const& group);
+    void add_group(String const& group);
     void remove_group(StringView group);
     void remove_entry(StringView group, StringView key);
 
@@ -85,7 +86,7 @@ private:
 
     DeprecatedString m_filename;
     OwnPtr<InputBufferedFile> m_file;
-    HashMap<DeprecatedString, HashMap<DeprecatedString, DeprecatedString>> m_groups;
+    HashMap<String, HashMap<String, DeprecatedString>> m_groups;
     bool m_dirty { false };
 };
 

--- a/Userland/Libraries/LibCore/ConfigFile.h
+++ b/Userland/Libraries/LibCore/ConfigFile.h
@@ -34,19 +34,19 @@ public:
     static ErrorOr<NonnullRefPtr<ConfigFile>> open(DeprecatedString const& filename, NonnullOwnPtr<Core::File>);
     ~ConfigFile();
 
-    bool has_group(DeprecatedString const&) const;
-    bool has_key(DeprecatedString const& group, DeprecatedString const& key) const;
+    bool has_group(StringView) const;
+    bool has_key(StringView group, StringView key) const;
 
     Vector<DeprecatedString> groups() const;
-    Vector<DeprecatedString> keys(DeprecatedString const& group) const;
+    Vector<DeprecatedString> keys(StringView group) const;
 
     size_t num_groups() const { return m_groups.size(); }
 
-    DeprecatedString read_entry(DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& default_value = DeprecatedString()) const;
-    bool read_bool_entry(DeprecatedString const& group, DeprecatedString const& key, bool default_value = false) const;
+    DeprecatedString read_entry(StringView group, StringView key, DeprecatedString const& default_value = DeprecatedString()) const;
+    bool read_bool_entry(StringView group, StringView key, bool default_value = false) const;
 
     template<Integral T = int>
-    T read_num_entry(DeprecatedString const& group, DeprecatedString const& key, T default_value = 0) const
+    T read_num_entry(StringView group, StringView key, T default_value = 0) const
     {
         if (!has_key(group, key))
             return default_value;
@@ -73,8 +73,8 @@ public:
     ErrorOr<void> sync();
 
     void add_group(DeprecatedString const& group);
-    void remove_group(DeprecatedString const& group);
-    void remove_entry(DeprecatedString const& group, DeprecatedString const& key);
+    void remove_group(StringView group);
+    void remove_entry(StringView group, StringView key);
 
     DeprecatedString const& filename() const { return m_filename; }
 

--- a/Userland/Libraries/LibDesktop/AppFile.cpp
+++ b/Userland/Libraries/LibDesktop/AppFile.cpp
@@ -51,45 +51,45 @@ AppFile::AppFile(StringView path)
 
 bool AppFile::validate() const
 {
-    if (m_config->read_entry("App", "Name").trim_whitespace().is_empty())
+    if (m_config->read_entry("App"sv, "Name"sv).trim_whitespace().is_empty())
         return false;
-    if (m_config->read_entry("App", "Executable").trim_whitespace().is_empty())
+    if (m_config->read_entry("App"sv, "Executable"sv).trim_whitespace().is_empty())
         return false;
     return true;
 }
 
 DeprecatedString AppFile::name() const
 {
-    auto name = m_config->read_entry("App", "Name").trim_whitespace();
+    auto name = m_config->read_entry("App"sv, "Name"sv).trim_whitespace();
     VERIFY(!name.is_empty());
     return name;
 }
 
 DeprecatedString AppFile::executable() const
 {
-    auto executable = m_config->read_entry("App", "Executable").trim_whitespace();
+    auto executable = m_config->read_entry("App"sv, "Executable"sv).trim_whitespace();
     VERIFY(!executable.is_empty());
     return executable;
 }
 
 DeprecatedString AppFile::description() const
 {
-    return m_config->read_entry("App", "Description").trim_whitespace();
+    return m_config->read_entry("App"sv, "Description"sv).trim_whitespace();
 }
 
 DeprecatedString AppFile::category() const
 {
-    return m_config->read_entry("App", "Category").trim_whitespace();
+    return m_config->read_entry("App"sv, "Category"sv).trim_whitespace();
 }
 
 DeprecatedString AppFile::working_directory() const
 {
-    return m_config->read_entry("App", "WorkingDirectory").trim_whitespace();
+    return m_config->read_entry("App"sv, "WorkingDirectory"sv).trim_whitespace();
 }
 
 DeprecatedString AppFile::icon_path() const
 {
-    return m_config->read_entry("App", "IconPath").trim_whitespace();
+    return m_config->read_entry("App"sv, "IconPath"sv).trim_whitespace();
 }
 
 GUI::Icon AppFile::icon() const
@@ -104,23 +104,23 @@ GUI::Icon AppFile::icon() const
 
 bool AppFile::run_in_terminal() const
 {
-    return m_config->read_bool_entry("App", "RunInTerminal", false);
+    return m_config->read_bool_entry("App"sv, "RunInTerminal"sv, false);
 }
 
 bool AppFile::requires_root() const
 {
-    return m_config->read_bool_entry("App", "RequiresRoot", false);
+    return m_config->read_bool_entry("App"sv, "RequiresRoot"sv, false);
 }
 
 bool AppFile::exclude_from_system_menu() const
 {
-    return m_config->read_bool_entry("App", "ExcludeFromSystemMenu", false);
+    return m_config->read_bool_entry("App"sv, "ExcludeFromSystemMenu"sv, false);
 }
 
 Vector<DeprecatedString> AppFile::launcher_mime_types() const
 {
     Vector<DeprecatedString> mime_types;
-    for (auto& entry : m_config->read_entry("Launcher", "MimeTypes").split(',')) {
+    for (auto& entry : m_config->read_entry("Launcher"sv, "MimeTypes"sv).split(',')) {
         entry = entry.trim_whitespace();
         if (!entry.is_empty())
             mime_types.append(entry);
@@ -131,7 +131,7 @@ Vector<DeprecatedString> AppFile::launcher_mime_types() const
 Vector<DeprecatedString> AppFile::launcher_file_types() const
 {
     Vector<DeprecatedString> file_types;
-    for (auto& entry : m_config->read_entry("Launcher", "FileTypes").split(',')) {
+    for (auto& entry : m_config->read_entry("Launcher"sv, "FileTypes"sv).split(',')) {
         entry = entry.trim_whitespace();
         if (!entry.is_empty())
             file_types.append(entry);
@@ -142,7 +142,7 @@ Vector<DeprecatedString> AppFile::launcher_file_types() const
 Vector<DeprecatedString> AppFile::launcher_protocols() const
 {
     Vector<DeprecatedString> protocols;
-    for (auto& entry : m_config->read_entry("Launcher", "Protocols").split(',')) {
+    for (auto& entry : m_config->read_entry("Launcher"sv, "Protocols"sv).split(',')) {
         entry = entry.trim_whitespace();
         if (!entry.is_empty())
             protocols.append(entry);

--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -90,9 +90,9 @@ static void initialize_if_needed()
     initialize_filetype_image_icon_if_needed();
     initialize_executable_icon_if_needed();
 
-    for (auto& filetype : config->keys("Icons")) {
+    for (auto& filetype : config->keys("Icons"sv)) {
         s_filetype_icons.set(filetype, Icon::default_icon(DeprecatedString::formatted("filetype-{}", filetype)));
-        s_filetype_patterns.set(filetype, config->read_entry("Icons", filetype).split(','));
+        s_filetype_patterns.set(filetype, config->read_entry("Icons"sv, filetype).split(','));
     }
 
     s_initialized = true;

--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -91,8 +91,8 @@ static void initialize_if_needed()
     initialize_executable_icon_if_needed();
 
     for (auto& filetype : config->keys("Icons"sv)) {
-        s_filetype_icons.set(filetype, Icon::default_icon(DeprecatedString::formatted("filetype-{}", filetype)));
-        s_filetype_patterns.set(filetype, config->read_entry("Icons"sv, filetype).split(','));
+        s_filetype_icons.set(filetype.to_deprecated_string(), Icon::default_icon(DeprecatedString::formatted("filetype-{}", filetype)));
+        s_filetype_patterns.set(filetype.to_deprecated_string(), config->read_entry("Icons"sv, filetype).split(','));
     }
 
     s_initialized = true;

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -42,10 +42,10 @@ Configuration Configuration::from_config(StringView libname)
     auto config_file = Core::ConfigFile::open_for_lib(libname).release_value_but_fixme_should_propagate_errors();
 
     // Read behavior options.
-    auto refresh = config_file->read_entry("behavior", "refresh", "lazy");
-    auto operation = config_file->read_entry("behavior", "operation_mode");
-    auto bracketed_paste = config_file->read_bool_entry("behavior", "bracketed_paste", true);
-    auto default_text_editor = config_file->read_entry("behavior", "default_text_editor");
+    auto refresh = config_file->read_entry("behavior"sv, "refresh"sv, "lazy");
+    auto operation = config_file->read_entry("behavior"sv, "operation_mode"sv);
+    auto bracketed_paste = config_file->read_bool_entry("behavior"sv, "bracketed_paste"sv, true);
+    auto default_text_editor = config_file->read_entry("behavior"sv, "default_text_editor"sv);
 
     Configuration::Flags flags { Configuration::Flags::None };
     if (bracketed_paste)
@@ -74,7 +74,7 @@ Configuration Configuration::from_config(StringView libname)
 
     // Read keybinds.
 
-    for (auto& binding_key : config_file->keys("keybinds")) {
+    for (auto& binding_key : config_file->keys("keybinds"sv)) {
         GenericLexer key_lexer(binding_key);
         auto has_ctrl = false;
         auto alt = false;
@@ -118,7 +118,7 @@ Configuration Configuration::from_config(StringView libname)
             has_ctrl = false;
         }
 
-        GenericLexer value_lexer { config_file->read_entry("keybinds", binding_key) };
+        GenericLexer value_lexer { config_file->read_entry("keybinds"sv, binding_key) };
         StringBuilder value_builder;
         while (!value_lexer.is_eof())
             value_builder.append(value_lexer.consume_escaped_character());

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -124,7 +124,7 @@ void Mixer::set_main_volume(double volume)
     else
         m_main_volume = volume;
 
-    m_config->write_num_entry("Master", "Volume", static_cast<int>(volume * 100));
+    m_config->write_num_entry("Master"_short_string, "Volume"_short_string, static_cast<int>(volume * 100));
     request_setting_sync();
 
     ConnectionFromClient::for_each([&](ConnectionFromClient& client) {
@@ -138,7 +138,7 @@ void Mixer::set_muted(bool muted)
         return;
     m_muted = muted;
 
-    m_config->write_bool_entry("Master", "Mute", m_muted);
+    m_config->write_bool_entry("Master"_short_string, "Mute"_short_string, m_muted);
     request_setting_sync();
 
     ConnectionFromClient::for_each([muted](ConnectionFromClient& client) {

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -29,8 +29,8 @@ Mixer::Mixer(NonnullRefPtr<Core::ConfigFile> config, NonnullOwnPtr<Core::File> d
           "AudioServer[mixer]"sv))
     , m_config(move(config))
 {
-    m_muted = m_config->read_bool_entry("Master", "Mute", false);
-    m_main_volume = static_cast<double>(m_config->read_num_entry("Master", "Volume", 100)) / 100.0;
+    m_muted = m_config->read_bool_entry("Master"sv, "Mute"sv, false);
+    m_main_volume = static_cast<double>(m_config->read_num_entry("Master"sv, "Volume"sv, 100)) / 100.0;
 
     m_sound_thread->start();
 }

--- a/Userland/Services/ConfigServer/ConfigServer.ipc
+++ b/Userland/Services/ConfigServer/ConfigServer.ipc
@@ -4,8 +4,8 @@ endpoint ConfigServer
 
     monitor_domain(DeprecatedString domain) =|
 
-    list_config_groups(DeprecatedString domain) => (Vector<DeprecatedString> groups)
-    list_config_keys(DeprecatedString domain, DeprecatedString group) => (Vector<DeprecatedString> keys)
+    list_config_groups(DeprecatedString domain) => (Vector<String> groups)
+    list_config_keys(DeprecatedString domain, DeprecatedString group) => (Vector<String> keys)
 
     read_string_value(DeprecatedString domain, DeprecatedString group, DeprecatedString key) => (Optional<DeprecatedString> value)
     read_i32_value(DeprecatedString domain, DeprecatedString group, DeprecatedString key) => (Optional<i32> value)

--- a/Userland/Services/ConfigServer/ConnectionFromClient.cpp
+++ b/Userland/Services/ConfigServer/ConnectionFromClient.cpp
@@ -138,25 +138,17 @@ void ConnectionFromClient::sync_dirty_domains_to_disk()
 Messages::ConfigServer::ListConfigKeysResponse ConnectionFromClient::list_config_keys(DeprecatedString const& domain, DeprecatedString const& group)
 {
     if (!validate_access(domain, group, ""))
-        return Vector<DeprecatedString> {};
+        return Vector<String> {};
     auto& config = ensure_domain_config(domain);
-
-    Vector<DeprecatedString> list;
-    for (auto const& key : config.keys(group))
-        list.append(key.to_deprecated_string());
-    return list;
+    return { config.keys(group) };
 }
 
 Messages::ConfigServer::ListConfigGroupsResponse ConnectionFromClient::list_config_groups(DeprecatedString const& domain)
 {
     if (!validate_access(domain, "", ""))
-        return Vector<DeprecatedString> {};
+        return Vector<String> {};
     auto& config = ensure_domain_config(domain);
-
-    Vector<DeprecatedString> list;
-    for (auto const& group : config.groups())
-        list.append(group.to_deprecated_string());
-    return list;
+    return { config.groups() };
 }
 
 Messages::ConfigServer::ReadStringValueResponse ConnectionFromClient::read_string_value(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key)

--- a/Userland/Services/KeyboardPreferenceLoader/main.cpp
+++ b/Userland/Services/KeyboardPreferenceLoader/main.cpp
@@ -21,7 +21,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil("/dev/input/keyboard/0", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
     auto mapper_config = TRY(Core::ConfigFile::open("/etc/Keyboard.ini"));
-    auto keymaps = mapper_config->read_entry("Mapping", "Keymaps", "");
+    auto keymaps = mapper_config->read_entry("Mapping"sv, "Keymaps"sv, "");
 
     auto keymaps_vector = keymaps.split(',');
     if (keymaps_vector.size() == 0)
@@ -29,7 +29,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     TRY(Core::Process::spawn("/bin/keymap"sv, Array { "-m", keymaps_vector.first().characters() }, {}, Core::Process::KeepAsChild::Yes));
 
-    bool enable_num_lock = keyboard_settings_config->read_bool_entry("StartupEnable", "NumLock", true);
+    bool enable_num_lock = keyboard_settings_config->read_bool_entry("StartupEnable"sv, "NumLock"sv, true);
     auto keyboard_device = TRY(Core::File::open("/dev/input/keyboard/0"sv, Core::File::OpenMode::Read));
     TRY(Core::System::ioctl(keyboard_device->fd(), KEYBOARD_IOCTL_SET_NUM_LOCK, enable_num_lock));
 

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -101,8 +101,8 @@ void Launcher::load_handlers(DeprecatedString const& af_dir)
 
 void Launcher::load_config(Core::ConfigFile const& cfg)
 {
-    for (auto key : cfg.keys("MimeType")) {
-        auto handler = cfg.read_entry("MimeType", key).trim_whitespace();
+    for (auto key : cfg.keys("MimeType"sv)) {
+        auto handler = cfg.read_entry("MimeType"sv, key).trim_whitespace();
         if (handler.is_empty())
             continue;
         if (access(handler.characters(), X_OK) != 0)
@@ -110,8 +110,8 @@ void Launcher::load_config(Core::ConfigFile const& cfg)
         m_mime_handlers.set(key.to_lowercase(), handler);
     }
 
-    for (auto key : cfg.keys("FileType")) {
-        auto handler = cfg.read_entry("FileType", key).trim_whitespace();
+    for (auto key : cfg.keys("FileType"sv)) {
+        auto handler = cfg.read_entry("FileType"sv, key).trim_whitespace();
         if (handler.is_empty())
             continue;
         if (access(handler.characters(), X_OK) != 0)
@@ -119,8 +119,8 @@ void Launcher::load_config(Core::ConfigFile const& cfg)
         m_file_handlers.set(key.to_lowercase(), handler);
     }
 
-    for (auto key : cfg.keys("Protocol")) {
-        auto handler = cfg.read_entry("Protocol", key).trim_whitespace();
+    for (auto key : cfg.keys("Protocol"sv)) {
+        auto handler = cfg.read_entry("Protocol"sv, key).trim_whitespace();
         if (handler.is_empty())
             continue;
         if (access(handler.characters(), X_OK) != 0)

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -107,7 +107,7 @@ void Launcher::load_config(Core::ConfigFile const& cfg)
             continue;
         if (access(handler.characters(), X_OK) != 0)
             continue;
-        m_mime_handlers.set(key.to_lowercase(), handler);
+        m_mime_handlers.set(key.to_deprecated_string().to_lowercase(), handler);
     }
 
     for (auto key : cfg.keys("FileType"sv)) {
@@ -116,7 +116,7 @@ void Launcher::load_config(Core::ConfigFile const& cfg)
             continue;
         if (access(handler.characters(), X_OK) != 0)
             continue;
-        m_file_handlers.set(key.to_lowercase(), handler);
+        m_file_handlers.set(key.to_deprecated_string().to_lowercase(), handler);
     }
 
     for (auto key : cfg.keys("Protocol"sv)) {
@@ -125,7 +125,7 @@ void Launcher::load_config(Core::ConfigFile const& cfg)
             continue;
         if (access(handler.characters(), X_OK) != 0)
             continue;
-        m_protocol_handlers.set(key.to_lowercase(), handler);
+        m_protocol_handlers.set(key.to_deprecated_string().to_lowercase(), handler);
     }
 }
 

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -41,7 +41,7 @@ LookupServer::LookupServer()
 
     auto config = Core::ConfigFile::open_for_system("LookupServer").release_value_but_fixme_should_propagate_errors();
     dbgln("Using network config file at {}", config->filename());
-    m_nameservers = config->read_entry("DNS", "Nameservers", "1.1.1.1,1.0.0.1").split(',');
+    m_nameservers = config->read_entry("DNS"sv, "Nameservers"sv, "1.1.1.1,1.0.0.1").split(',');
 
     load_etc_hosts();
 
@@ -68,7 +68,7 @@ LookupServer::LookupServer()
         VERIFY_NOT_REACHED();
     }
 
-    if (config->read_bool_entry("DNS", "EnableServer")) {
+    if (config->read_bool_entry("DNS"sv, "EnableServer"sv)) {
         m_dns_server = DNSServer::construct(this);
         // TODO: drop root privileges here.
     }

--- a/Userland/Services/NetworkServer/main.cpp
+++ b/Userland/Services/NetworkServer/main.cpp
@@ -56,7 +56,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
             return;
 
         InterfaceConfig config;
-        if (!groups.contains_slow(ifname)) {
+        if (!groups.contains_slow(String::from_deprecated_string(ifname).release_value_but_fixme_should_propagate_errors())) {
             dbgln("Config for interface {} doesn't exist, enabling DHCP for it", ifname);
             interfaces_with_dhcp_enabled.append(ifname);
         } else {

--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -270,11 +270,11 @@ Service::Service(Core::ConfigFile const& config, StringView name)
     VERIFY(config.has_group(name));
 
     set_name(name);
-    m_executable_path = config.read_entry(name, "Executable", DeprecatedString::formatted("/bin/{}", this->name()));
-    m_extra_arguments = config.read_entry(name, "Arguments", "");
-    m_stdio_file_path = config.read_entry(name, "StdIO");
+    m_executable_path = config.read_entry(name, "Executable"sv, DeprecatedString::formatted("/bin/{}", this->name()));
+    m_extra_arguments = config.read_entry(name, "Arguments"sv, "");
+    m_stdio_file_path = config.read_entry(name, "StdIO"sv);
 
-    DeprecatedString prio = config.read_entry(name, "Priority");
+    DeprecatedString prio = config.read_entry(name, "Priority"sv);
     if (prio == "low")
         m_priority = 10;
     else if (prio == "normal" || prio.is_null())
@@ -284,10 +284,10 @@ Service::Service(Core::ConfigFile const& config, StringView name)
     else
         VERIFY_NOT_REACHED();
 
-    m_keep_alive = config.read_bool_entry(name, "KeepAlive");
-    m_lazy = config.read_bool_entry(name, "Lazy");
+    m_keep_alive = config.read_bool_entry(name, "KeepAlive"sv);
+    m_lazy = config.read_bool_entry(name, "Lazy"sv);
 
-    m_user = config.read_entry(name, "User");
+    m_user = config.read_entry(name, "User"sv);
     if (!m_user.is_null()) {
         auto result = Core::Account::from_name(m_user, Core::Account::Read::PasswdOnly);
         if (result.is_error())
@@ -296,14 +296,14 @@ Service::Service(Core::ConfigFile const& config, StringView name)
             m_account = result.value();
     }
 
-    m_working_directory = config.read_entry(name, "WorkingDirectory");
-    m_environment = config.read_entry(name, "Environment");
-    m_system_modes = config.read_entry(name, "SystemModes", "graphical").split(',');
-    m_multi_instance = config.read_bool_entry(name, "MultiInstance");
-    m_accept_socket_connections = config.read_bool_entry(name, "AcceptSocketConnections");
+    m_working_directory = config.read_entry(name, "WorkingDirectory"sv);
+    m_environment = config.read_entry(name, "Environment"sv);
+    m_system_modes = config.read_entry(name, "SystemModes"sv, "graphical").split(',');
+    m_multi_instance = config.read_bool_entry(name, "MultiInstance"sv);
+    m_accept_socket_connections = config.read_bool_entry(name, "AcceptSocketConnections"sv);
 
-    DeprecatedString socket_entry = config.read_entry(name, "Socket");
-    DeprecatedString socket_permissions_entry = config.read_entry(name, "SocketPermissions", "0600");
+    DeprecatedString socket_entry = config.read_entry(name, "Socket"sv);
+    DeprecatedString socket_permissions_entry = config.read_entry(name, "SocketPermissions"sv, "0600");
 
     if (!socket_entry.is_null()) {
         Vector<DeprecatedString> socket_paths = socket_entry.split(',');

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -152,7 +152,7 @@ ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu(GUI::Window& window)
             }
         }
         auto& category_menu = parent_menu->add_submenu(String::from_deprecated_string(child_category).release_value_but_fixme_should_propagate_errors());
-        auto category_icon_path = category_icons->read_entry("16x16", category);
+        auto category_icon_path = category_icons->read_entry("16x16"sv, category);
         if (!category_icon_path.is_empty()) {
             auto icon_or_error = Gfx::Bitmap::load_from_file(category_icon_path);
             if (!icon_or_error.is_error())

--- a/Userland/Services/WindowServer/AppletManager.cpp
+++ b/Userland/Services/WindowServer/AppletManager.cpp
@@ -20,7 +20,7 @@ AppletManager::AppletManager()
 {
     s_the = this;
 
-    auto order = g_config->read_entry("Applet", "Order");
+    auto order = g_config->read_entry("Applet"sv, "Order"sv);
     order_vector = order.split(',');
 }
 

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -796,7 +796,7 @@ bool Compositor::set_background_color(DeprecatedString const& background_color)
 
     m_custom_background_color = color;
 
-    g_config->write_entry("Background", "Color", background_color);
+    g_config->write_entry("Background"_string.release_value_but_fixme_should_propagate_errors(), "Color"_short_string, background_color);
     bool succeeded = !g_config->sync().is_error();
 
     if (succeeded) {
@@ -809,7 +809,7 @@ bool Compositor::set_background_color(DeprecatedString const& background_color)
 
 bool Compositor::set_wallpaper_mode(DeprecatedString const& mode)
 {
-    g_config->write_entry("Background", "Mode", mode);
+    g_config->write_entry("Background"_string.release_value_but_fixme_should_propagate_errors(), "Mode"_short_string, mode);
     bool succeeded = !g_config->sync().is_error();
 
     if (succeeded) {

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -146,8 +146,8 @@ void Compositor::did_construct_window_manager(Badge<WindowManager>)
 
     m_current_window_stack = &wm.current_window_stack();
 
-    m_wallpaper_mode = mode_to_enum(g_config->read_entry("Background", "Mode", "Center"));
-    m_custom_background_color = Color::from_string(g_config->read_entry("Background", "Color", ""));
+    m_wallpaper_mode = mode_to_enum(g_config->read_entry("Background"sv, "Mode"sv, "Center"));
+    m_custom_background_color = Color::from_string(g_config->read_entry("Background"sv, "Color"sv, ""));
 
     invalidate_screen();
     invalidate_occlusions();

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -898,7 +898,7 @@ Messages::WindowServer::SetSystemThemeResponse ConnectionFromClient::set_system_
 
 Messages::WindowServer::GetSystemThemeResponse ConnectionFromClient::get_system_theme()
 {
-    return g_config->read_entry("Theme", "Name");
+    return g_config->read_entry("Theme"sv, "Name"sv);
 }
 
 Messages::WindowServer::SetSystemThemeOverrideResponse ConnectionFromClient::set_system_theme_override(Core::AnonymousBuffer const& theme_override)
@@ -954,7 +954,7 @@ Messages::WindowServer::GetCursorHighlightColorResponse ConnectionFromClient::ge
 
 Messages::WindowServer::GetCursorThemeResponse ConnectionFromClient::get_cursor_theme()
 {
-    return g_config->read_entry("Mouse", "CursorTheme");
+    return g_config->read_entry("Mouse"sv, "CursorTheme"sv);
 }
 
 Messages::WindowServer::SetSystemFontsResponse ConnectionFromClient::set_system_fonts(DeprecatedString const& default_font_query, DeprecatedString const& fixed_width_font_query, DeprecatedString const& window_title_font_query)

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -977,9 +977,9 @@ Messages::WindowServer::SetSystemFontsResponse ConnectionFromClient::set_system_
 
     WindowManager::the().invalidate_after_theme_or_font_change();
 
-    g_config->write_entry("Fonts", "Default", default_font_query);
-    g_config->write_entry("Fonts", "FixedWidth", fixed_width_font_query);
-    g_config->write_entry("Fonts", "WindowTitle", window_title_font_query);
+    g_config->write_entry("Fonts"_short_string, "Default"_short_string, default_font_query);
+    g_config->write_entry("Fonts"_short_string, "FixedWidth"_string.release_value_but_fixme_should_propagate_errors(), fixed_width_font_query);
+    g_config->write_entry("Fonts"_short_string, "WindowTitle"_string.release_value_but_fixme_should_propagate_errors(), window_title_font_query);
 
     return !g_config->sync().is_error();
 }

--- a/Userland/Services/WindowServer/KeymapSwitcher.cpp
+++ b/Userland/Services/WindowServer/KeymapSwitcher.cpp
@@ -31,7 +31,7 @@ void KeymapSwitcher::refresh()
     m_keymaps.clear();
 
     auto mapper_config(Core::ConfigFile::open(m_keyboard_config).release_value_but_fixme_should_propagate_errors());
-    auto keymaps = mapper_config->read_entry("Mapping", "Keymaps", "");
+    auto keymaps = mapper_config->read_entry("Mapping"sv, "Keymaps"sv, "");
 
     auto keymaps_vector = keymaps.split(',');
 

--- a/Userland/Services/WindowServer/ScreenLayout.ipp
+++ b/Userland/Services/WindowServer/ScreenLayout.ipp
@@ -261,20 +261,20 @@ bool ScreenLayout::load_config(Core::ConfigFile const& config_file, DeprecatedSt
 
 bool ScreenLayout::save_config(Core::ConfigFile& config_file, bool sync) const
 {
-    config_file.write_num_entry("Screens", "MainScreen", main_screen_index);
+    config_file.write_num_entry("Screens"_short_string, "MainScreen"_string.release_value_but_fixme_should_propagate_errors(), main_screen_index);
 
     size_t index = 0;
     while (index < screens.size()) {
         auto& screen = screens[index];
-        auto group_name = DeprecatedString::formatted("Screen{}", index);
-        config_file.write_entry(group_name, "Mode", Screen::mode_to_string(screen.mode));
+        auto group_name = String::formatted("Screen{}", index).release_value_but_fixme_should_propagate_errors();
+        config_file.write_entry(group_name, "Mode"_short_string, Screen::mode_to_string(screen.mode));
         if (screen.mode == Screen::Mode::Device)
-            config_file.write_entry(group_name, "Device", screen.device.value());
-        config_file.write_num_entry(group_name, "Left", screen.location.x());
-        config_file.write_num_entry(group_name, "Top", screen.location.y());
-        config_file.write_num_entry(group_name, "Width", screen.resolution.width());
-        config_file.write_num_entry(group_name, "Height", screen.resolution.height());
-        config_file.write_num_entry(group_name, "ScaleFactor", screen.scale_factor);
+            config_file.write_entry(group_name, "Device"_short_string, screen.device.value());
+        config_file.write_num_entry(group_name, "Left"_short_string, screen.location.x());
+        config_file.write_num_entry(group_name, "Top"_short_string, screen.location.y());
+        config_file.write_num_entry(group_name, "Width"_short_string, screen.resolution.width());
+        config_file.write_num_entry(group_name, "Height"_short_string, screen.resolution.height());
+        config_file.write_num_entry(group_name, "ScaleFactor"_string.release_value_but_fixme_should_propagate_errors(), screen.scale_factor);
         index++;
     }
     // Prune screens no longer in the layout

--- a/Userland/Services/WindowServer/ScreenLayout.ipp
+++ b/Userland/Services/WindowServer/ScreenLayout.ipp
@@ -228,12 +228,12 @@ bool ScreenLayout::normalize()
 bool ScreenLayout::load_config(Core::ConfigFile const& config_file, DeprecatedString* error_msg)
 {
     screens.clear_with_capacity();
-    main_screen_index = config_file.read_num_entry("Screens", "MainScreen", 0);
+    main_screen_index = config_file.read_num_entry("Screens"sv, "MainScreen"sv, 0);
     for (size_t index = 0;; index++) {
         auto group_name = DeprecatedString::formatted("Screen{}", index);
         if (!config_file.has_group(group_name))
             break;
-        auto str_mode = config_file.read_entry(group_name, "Mode");
+        auto str_mode = config_file.read_entry(group_name, "Mode"sv);
         Screen::Mode mode { Screen::Mode::Invalid };
         if (str_mode == "Device") {
             mode = Screen::Mode::Device;
@@ -246,11 +246,11 @@ bool ScreenLayout::load_config(Core::ConfigFile const& config_file, DeprecatedSt
             *this = {};
             return false;
         }
-        auto device = (mode == Screen::Mode::Device) ? config_file.read_entry(group_name, "Device") : Optional<DeprecatedString> {};
+        auto device = (mode == Screen::Mode::Device) ? config_file.read_entry(group_name, "Device"sv) : Optional<DeprecatedString> {};
         screens.append({ mode, device,
-            { config_file.read_num_entry(group_name, "Left"), config_file.read_num_entry(group_name, "Top") },
-            { config_file.read_num_entry(group_name, "Width"), config_file.read_num_entry(group_name, "Height") },
-            config_file.read_num_entry(group_name, "ScaleFactor", 1) });
+            { config_file.read_num_entry(group_name, "Left"sv), config_file.read_num_entry(group_name, "Top"sv) },
+            { config_file.read_num_entry(group_name, "Width"sv), config_file.read_num_entry(group_name, "Height"sv) },
+            config_file.read_num_entry(group_name, "ScaleFactor"sv, 1) });
     }
     if (!is_valid(error_msg)) {
         *this = {};

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -255,8 +255,8 @@ bool WindowManager::apply_workspace_settings(unsigned rows, unsigned columns, bo
     }
 
     if (save) {
-        g_config->write_num_entry("Workspaces", "Rows", window_stack_rows());
-        g_config->write_num_entry("Workspaces", "Columns", window_stack_columns());
+        g_config->write_num_entry("Workspaces"_string.release_value_but_fixme_should_propagate_errors(), "Rows"_short_string, window_stack_rows());
+        g_config->write_num_entry("Workspaces"_string.release_value_but_fixme_should_propagate_errors(), "Columns"_short_string, window_stack_columns());
         return !g_config->sync().is_error();
     }
     return true;
@@ -266,7 +266,7 @@ void WindowManager::set_acceleration_factor(double factor)
 {
     ScreenInput::the().set_acceleration_factor(factor);
     dbgln("Saving acceleration factor {} to config file at {}", factor, g_config->filename());
-    g_config->write_entry("Mouse", "AccelerationFactor", DeprecatedString::formatted("{}", factor));
+    g_config->write_entry("Mouse"_short_string, "AccelerationFactor"_string.release_value_but_fixme_should_propagate_errors(), DeprecatedString::formatted("{}", factor));
     sync_config_to_disk();
 }
 
@@ -274,7 +274,7 @@ void WindowManager::set_scroll_step_size(unsigned step_size)
 {
     ScreenInput::the().set_scroll_step_size(step_size);
     dbgln("Saving scroll step size {} to config file at {}", step_size, g_config->filename());
-    g_config->write_entry("Mouse", "ScrollStepSize", DeprecatedString::number(step_size));
+    g_config->write_entry("Mouse"_short_string, "ScrollStepSize"_string.release_value_but_fixme_should_propagate_errors(), DeprecatedString::number(step_size));
     sync_config_to_disk();
 }
 
@@ -283,7 +283,7 @@ void WindowManager::set_double_click_speed(int speed)
     VERIFY(speed >= double_click_speed_min && speed <= double_click_speed_max);
     m_double_click_speed = speed;
     dbgln("Saving double-click speed {} to config file at {}", speed, g_config->filename());
-    g_config->write_entry("Input", "DoubleClickSpeed", DeprecatedString::number(speed));
+    g_config->write_entry("Input"_short_string, "DoubleClickSpeed"_string.release_value_but_fixme_should_propagate_errors(), DeprecatedString::number(speed));
     sync_config_to_disk();
 }
 
@@ -296,7 +296,7 @@ void WindowManager::set_mouse_buttons_switched(bool switched)
 {
     m_mouse_buttons_switched = switched;
     dbgln("Saving mouse buttons switched state {} to config file at {}", switched, g_config->filename());
-    g_config->write_bool_entry("Mouse", "ButtonsSwitched", switched);
+    g_config->write_bool_entry("Mouse"_short_string, "ButtonsSwitched"_string.release_value_but_fixme_should_propagate_errors(), switched);
     sync_config_to_disk();
 }
 
@@ -309,7 +309,7 @@ void WindowManager::set_natural_scroll(bool inverted)
 {
     m_natural_scroll = inverted;
     dbgln("Saving scroll inverted state {} to config file at {}", inverted, g_config->filename());
-    g_config->write_bool_entry("Mouse", "NaturalScroll", inverted);
+    g_config->write_bool_entry("Mouse"_short_string, "NaturalScroll"_string.release_value_but_fixme_should_propagate_errors(), inverted);
     sync_config_to_disk();
 }
 
@@ -2164,13 +2164,13 @@ bool WindowManager::update_theme(DeprecatedString theme_path, DeprecatedString t
     m_theme_overridden = false;
     Gfx::set_system_theme(new_theme);
     m_palette = Gfx::PaletteImpl::create_with_anonymous_buffer(new_theme);
-    g_config->write_entry("Theme", "Name", theme_name);
+    g_config->write_entry("Theme"_short_string, "Name"_short_string, theme_name);
     if (color_scheme_path.has_value() && color_scheme_path.value() != "Custom"sv) {
-        g_config->write_bool_entry("Theme", "LoadCustomColorScheme", true);
-        g_config->write_entry("Theme", "CustomColorSchemePath", color_scheme_path.value());
+        g_config->write_bool_entry("Theme"_short_string, "LoadCustomColorScheme"_string.release_value_but_fixme_should_propagate_errors(), true);
+        g_config->write_entry("Theme"_short_string, "CustomColorSchemePath"_string.release_value_but_fixme_should_propagate_errors(), color_scheme_path.value());
         m_preferred_color_scheme = color_scheme_path.value();
     } else if (!color_scheme_path.has_value()) {
-        g_config->write_bool_entry("Theme", "LoadCustomColorScheme", false);
+        g_config->write_bool_entry("Theme"_short_string, "LoadCustomColorScheme"_string.release_value_but_fixme_should_propagate_errors(), false);
         g_config->remove_entry("Theme"sv, "CustomColorSchemePath"sv);
         m_preferred_color_scheme = OptionalNone();
     }
@@ -2367,7 +2367,7 @@ void WindowManager::apply_cursor_theme(DeprecatedString const& theme_name)
     reload_cursor(m_zoom_cursor, "Zoom"sv);
 
     Compositor::the().invalidate_cursor();
-    g_config->write_entry("Mouse", "CursorTheme", theme_name);
+    g_config->write_entry("Mouse"_short_string, "CursorTheme"_string.release_value_but_fixme_should_propagate_errors(), theme_name);
     sync_config_to_disk();
 }
 
@@ -2376,7 +2376,7 @@ void WindowManager::set_cursor_highlight_radius(int radius)
     // TODO: Validate radius
     m_cursor_highlight_radius = radius;
     Compositor::the().invalidate_cursor();
-    g_config->write_num_entry("Mouse", "CursorHighlightRadius", radius);
+    g_config->write_num_entry("Mouse"_short_string, "CursorHighlightRadius"_string.release_value_but_fixme_should_propagate_errors(), radius);
     sync_config_to_disk();
 }
 
@@ -2384,7 +2384,7 @@ void WindowManager::set_cursor_highlight_color(Gfx::Color color)
 {
     m_cursor_highlight_color = color;
     Compositor::the().invalidate_cursor();
-    g_config->write_entry("Mouse", "CursorHighlightColor", color.to_deprecated_string());
+    g_config->write_entry("Mouse"_short_string, "CursorHighlightColor"_string.release_value_but_fixme_should_propagate_errors(), color.to_deprecated_string());
     sync_config_to_disk();
 }
 
@@ -2394,18 +2394,18 @@ void WindowManager::apply_system_effects(Vector<bool> effects, ShowGeometry geom
         return;
 
     m_system_effects = { effects, geometry, tile_window };
-    g_config->write_bool_entry("Effects", "AnimateMenus", m_system_effects.animate_menus());
-    g_config->write_bool_entry("Effects", "FlashMenus", m_system_effects.flash_menus());
-    g_config->write_bool_entry("Effects", "AnimateWindows", m_system_effects.animate_windows());
-    g_config->write_bool_entry("Effects", "SmoothScrolling", m_system_effects.smooth_scrolling());
-    g_config->write_bool_entry("Effects", "TabAccents", m_system_effects.tab_accents());
-    g_config->write_bool_entry("Effects", "SplitterKnurls", m_system_effects.splitter_knurls());
-    g_config->write_bool_entry("Effects", "Tooltips", m_system_effects.tooltips());
-    g_config->write_bool_entry("Effects", "MenuShadow", m_system_effects.menu_shadow());
-    g_config->write_bool_entry("Effects", "WindowShadow", m_system_effects.window_shadow());
-    g_config->write_bool_entry("Effects", "TooltipShadow", m_system_effects.tooltip_shadow());
-    g_config->write_entry("Effects", "ShowGeometry", ShowGeometryTools::enum_to_string(geometry));
-    g_config->write_entry("Effects", "TileWindow", TileWindowTools::enum_to_string(tile_window));
+    g_config->write_bool_entry("Effects"_short_string, "AnimateMenus"_string.release_value_but_fixme_should_propagate_errors(), m_system_effects.animate_menus());
+    g_config->write_bool_entry("Effects"_short_string, "FlashMenus"_string.release_value_but_fixme_should_propagate_errors(), m_system_effects.flash_menus());
+    g_config->write_bool_entry("Effects"_short_string, "AnimateWindows"_string.release_value_but_fixme_should_propagate_errors(), m_system_effects.animate_windows());
+    g_config->write_bool_entry("Effects"_short_string, "SmoothScrolling"_string.release_value_but_fixme_should_propagate_errors(), m_system_effects.smooth_scrolling());
+    g_config->write_bool_entry("Effects"_short_string, "TabAccents"_string.release_value_but_fixme_should_propagate_errors(), m_system_effects.tab_accents());
+    g_config->write_bool_entry("Effects"_short_string, "SplitterKnurls"_string.release_value_but_fixme_should_propagate_errors(), m_system_effects.splitter_knurls());
+    g_config->write_bool_entry("Effects"_short_string, "Tooltips"_string.release_value_but_fixme_should_propagate_errors(), m_system_effects.tooltips());
+    g_config->write_bool_entry("Effects"_short_string, "MenuShadow"_string.release_value_but_fixme_should_propagate_errors(), m_system_effects.menu_shadow());
+    g_config->write_bool_entry("Effects"_short_string, "WindowShadow"_string.release_value_but_fixme_should_propagate_errors(), m_system_effects.window_shadow());
+    g_config->write_bool_entry("Effects"_short_string, "TooltipShadow"_string.release_value_but_fixme_should_propagate_errors(), m_system_effects.tooltip_shadow());
+    g_config->write_entry("Effects"_short_string, "ShowGeometry"_string.release_value_but_fixme_should_propagate_errors(), ShowGeometryTools::enum_to_string(geometry));
+    g_config->write_entry("Effects"_short_string, "TileWindow"_string.release_value_but_fixme_should_propagate_errors(), TileWindowTools::enum_to_string(tile_window));
     sync_config_to_disk();
 }
 

--- a/Userland/Services/WindowServer/main.cpp
+++ b/Userland/Services/WindowServer/main.cpp
@@ -140,7 +140,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     if (f < WindowServer::mouse_accel_min || f > WindowServer::mouse_accel_max) {
         dbgln("Mouse.AccelerationFactor out of range resetting to 1.0");
         f = 1.0;
-        WindowServer::g_config->write_entry("Mouse", "AccelerationFactor", "1.0");
+        WindowServer::g_config->write_entry("Mouse"_short_string, TRY("AccelerationFactor"_string), "1.0");
     }
     screen_input.set_acceleration_factor(f);
     screen_input.set_scroll_step_size(WindowServer::g_config->read_num_entry("Mouse"sv, "ScrollStepSize"sv, 4));

--- a/Userland/Services/WindowServer/main.cpp
+++ b/Userland/Services/WindowServer/main.cpp
@@ -45,19 +45,19 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::pledge("stdio video thread sendfd recvfd accept rpath wpath cpath unix proc getkeymap exec tty"));
 
     WindowServer::g_config = TRY(Core::ConfigFile::open("/etc/WindowServer.ini", Core::ConfigFile::AllowWriting::Yes));
-    auto theme_name = WindowServer::g_config->read_entry("Theme", "Name", "Default");
+    auto theme_name = WindowServer::g_config->read_entry("Theme"sv, "Name"sv, "Default");
 
     Optional<DeprecatedString> custom_color_scheme_path = OptionalNone();
-    if (WindowServer::g_config->read_bool_entry("Theme", "LoadCustomColorScheme", false))
-        custom_color_scheme_path = WindowServer::g_config->read_entry("Theme", "CustomColorSchemePath");
+    if (WindowServer::g_config->read_bool_entry("Theme"sv, "LoadCustomColorScheme"sv, false))
+        custom_color_scheme_path = WindowServer::g_config->read_entry("Theme"sv, "CustomColorSchemePath"sv);
 
     auto theme = TRY(Gfx::load_system_theme(DeprecatedString::formatted("/res/themes/{}.ini", theme_name), custom_color_scheme_path));
     Gfx::set_system_theme(theme);
     auto palette = Gfx::PaletteImpl::create_with_anonymous_buffer(theme);
 
-    auto default_font_query = WindowServer::g_config->read_entry("Fonts", "Default", "Katica 10 400 0");
-    auto fixed_width_font_query = WindowServer::g_config->read_entry("Fonts", "FixedWidth", "Csilla 10 400 0");
-    auto window_title_font_query = WindowServer::g_config->read_entry("Fonts", "WindowTitle", "Katica 10 700 0");
+    auto default_font_query = WindowServer::g_config->read_entry("Fonts"sv, "Default"sv, "Katica 10 400 0");
+    auto fixed_width_font_query = WindowServer::g_config->read_entry("Fonts"sv, "FixedWidth"sv, "Csilla 10 400 0");
+    auto window_title_font_query = WindowServer::g_config->read_entry("Fonts"sv, "WindowTitle"sv, "Katica 10 700 0");
 
     Gfx::FontDatabase::set_default_font_query(default_font_query);
     Gfx::FontDatabase::set_fixed_width_font_query(fixed_width_font_query);
@@ -136,14 +136,14 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     auto& screen_input = WindowServer::ScreenInput::the();
     screen_input.set_cursor_location(WindowServer::Screen::main().rect().center());
-    double f = atof(WindowServer::g_config->read_entry("Mouse", "AccelerationFactor", "1.0").characters());
+    double f = atof(WindowServer::g_config->read_entry("Mouse"sv, "AccelerationFactor"sv, "1.0").characters());
     if (f < WindowServer::mouse_accel_min || f > WindowServer::mouse_accel_max) {
         dbgln("Mouse.AccelerationFactor out of range resetting to 1.0");
         f = 1.0;
         WindowServer::g_config->write_entry("Mouse", "AccelerationFactor", "1.0");
     }
     screen_input.set_acceleration_factor(f);
-    screen_input.set_scroll_step_size(WindowServer::g_config->read_num_entry("Mouse", "ScrollStepSize", 4));
+    screen_input.set_scroll_step_size(WindowServer::g_config->read_num_entry("Mouse"sv, "ScrollStepSize"sv, 4));
 
     WindowServer::Compositor::the();
     auto wm = WindowServer::WindowManager::construct(*palette);

--- a/Userland/Utilities/ini.cpp
+++ b/Userland/Utilities/ini.cpp
@@ -15,8 +15,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath wpath cpath"));
 
     StringView path;
-    DeprecatedString group;
-    DeprecatedString key;
+    StringView group;
+    StringView key;
     DeprecatedString value_to_write;
 
     Core::ArgsParser args_parser;
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto config = TRY(Core::ConfigFile::open(path, value_to_write.is_null() ? Core::ConfigFile::AllowWriting::No : Core::ConfigFile::AllowWriting::Yes));
 
     if (!value_to_write.is_null()) {
-        config->write_entry(group, key, value_to_write);
+        config->write_entry(TRY(String::from_utf8(group)), TRY(String::from_utf8(key)), value_to_write);
         TRY(config->sync());
         return 0;
     }

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -347,9 +347,9 @@ static JS::ThrowCompletionOr<JS::Value> load_ini_impl(JS::VM& vm)
         auto group_object = JS::Object::create(realm, realm.intrinsics().object_prototype());
         for (auto const& key : config_file->keys(group)) {
             auto entry = config_file->read_entry(group, key);
-            group_object->define_direct_property(key, JS::PrimitiveString::create(vm, move(entry)), JS::Attribute::Enumerable | JS::Attribute::Configurable | JS::Attribute::Writable);
+            group_object->define_direct_property(key.to_deprecated_string(), JS::PrimitiveString::create(vm, move(entry)), JS::Attribute::Enumerable | JS::Attribute::Configurable | JS::Attribute::Writable);
         }
-        object->define_direct_property(group, group_object, JS::Attribute::Enumerable | JS::Attribute::Configurable | JS::Attribute::Writable);
+        object->define_direct_property(group.to_deprecated_string(), group_object, JS::Attribute::Enumerable | JS::Attribute::Configurable | JS::Attribute::Writable);
     }
     return object;
 }

--- a/Userland/Utilities/keymap.cpp
+++ b/Userland/Utilities/keymap.cpp
@@ -76,7 +76,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         TRY(mapper_config->sync());
     }
 
-    auto keymaps = mapper_config->read_entry("Mapping", "Keymaps");
+    auto keymaps = mapper_config->read_entry("Mapping"sv, "Keymaps"sv);
     auto keymaps_vector = keymaps.split(',');
 
     if (!mapping.is_empty()) {

--- a/Userland/Utilities/keymap.cpp
+++ b/Userland/Utilities/keymap.cpp
@@ -72,7 +72,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
         auto keymaps = DeprecatedString::join(',', mappings_vector);
-        mapper_config->write_entry("Mapping", "Keymaps", keymaps);
+        mapper_config->write_entry("Mapping"_short_string, "Keymaps"_short_string, keymaps);
         TRY(mapper_config->sync());
     }
 
@@ -82,7 +82,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (!mapping.is_empty()) {
         if (keymaps_vector.is_empty()) {
             warnln("No keymaps configured - writing default configurations (en-us)");
-            mapper_config->write_entry("Mapping", "Keymaps", "en-us");
+            mapper_config->write_entry("Mapping"_short_string, "Keymaps"_short_string, "en-us");
             TRY(mapper_config->sync());
             keymaps_vector.append("en-us");
         }

--- a/Userland/Utilities/network-settings.cpp
+++ b/Userland/Utilities/network-settings.cpp
@@ -35,8 +35,10 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto json_object = json.as_object();
 
     auto config_file = TRY(Core::ConfigFile::open_for_system("Network", Core::ConfigFile::AllowWriting::Yes));
-    json_object.for_each_member([&](DeprecatedString const& adapter_name, JsonValue const& adapter_data) {
-        adapter_data.as_object().for_each_member([&](const DeprecatedString& key, const JsonValue& value) {
+    json_object.for_each_member([&](DeprecatedString const& deprecated_adapter_name, JsonValue const& adapter_data) {
+        auto adapter_name = String::from_deprecated_string(deprecated_adapter_name).release_value_but_fixme_should_propagate_errors();
+        adapter_data.as_object().for_each_member([&](const DeprecatedString& deprecated_key, const JsonValue& value) {
+            auto key = String::from_deprecated_string(deprecated_key).release_value_but_fixme_should_propagate_errors();
             switch (value.type()) {
             case JsonValue::Type::String:
                 config_file->write_entry(adapter_name, key, value.as_string());

--- a/Userland/Utilities/run-tests.cpp
+++ b/Userland/Utilities/run-tests.cpp
@@ -47,8 +47,8 @@ public:
         , m_unlink_coredumps(unlink_coredumps)
     {
         if (!run_skipped_tests) {
-            m_skip_directories = m_config->read_entry("Global", "SkipDirectories", "").split(' ');
-            m_skip_files = m_config->read_entry("Global", "SkipTests", "").split(' ');
+            m_skip_directories = m_config->read_entry("Global"sv, "SkipDirectories"sv, "").split(' ');
+            m_skip_files = m_config->read_entry("Global"sv, "SkipTests"sv, "").split(' ');
         }
     }
 
@@ -256,7 +256,7 @@ FileResult TestRunner::run_test_file(DeprecatedString const& test_path)
 
     Vector<char const*, 4> argv;
     argv.append(basename.characters());
-    auto extra_args = m_config->read_entry(path_for_test.basename(), "Arguments", "").split(' ');
+    auto extra_args = m_config->read_entry(path_for_test.basename(), "Arguments"sv, "").split(' ');
     for (auto& arg : extra_args)
         argv.append(arg.characters());
     argv.append(nullptr);
@@ -397,7 +397,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         warnln("Empty configuration file ({}) loaded!", config_file.is_empty() ? "User config for Tests" : config_file.characters());
 
     if (exclude_pattern.is_empty())
-        exclude_pattern = config->read_entry("Global", "NotTestsPattern", "$^"); // default is match nothing (aka match end then beginning)
+        exclude_pattern = config->read_entry("Global"sv, "NotTestsPattern"sv, "$^"); // default is match nothing (aka match end then beginning)
 
     Regex<PosixExtended> exclude_regex(exclude_pattern, {});
     if (exclude_regex.parser_result.error != regex::Error::NoError) {
@@ -407,7 +407,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     // we need to preconfigure this, because we can't autoinitialize Regex types
     // in the Testrunner
-    auto skip_regex_pattern = config->read_entry("Global", "SkipRegex", "$^");
+    auto skip_regex_pattern = config->read_entry("Global"sv, "SkipRegex"sv, "$^");
     Regex<PosixExtended> skip_regex { skip_regex_pattern, {} };
     if (skip_regex.parser_result.error != regex::Error::NoError) {
         warnln("SkipRegex pattern \"{}\" is invalid", skip_regex_pattern);


### PR DESCRIPTION
- Config values are still stored using DeprecatedString. This PR's already quite big and I assume that porting values would require even more work.
- LibConfig functions still use DeprecatedStrings. Porting them to String now would result in so many `release_value_but_fixme_should_propagate_errors()` that I don't feel comfortable with it.
   However I think that encoding messages with StringView might be a better idea (allocating String objects just to be sent to a socket seems wasteful), but LibIPC doesn't support that yet. ![:yakbait:](https://cdn.discordapp.com/emojis/873672505309679758.png?size=20)

stats:
- `"_short_string`: +53
- `TRY(`: +12
- `release_value_but_fixme_should_propagate_errors`: +45
- `String::from_deprecated_string`: +12
- `to_deprecated_string`: +11

Contributes to: https://github.com/SerenityOS/serenity/issues/17128