### PR TITLE
LibWeb: Implement the <summary> element behaviour

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -305,6 +305,7 @@ set(SOURCES
     HTML/HTMLSourceElement.cpp
     HTML/HTMLSpanElement.cpp
     HTML/HTMLStyleElement.cpp
+    HTML/HTMLSummaryElement.cpp
     HTML/HTMLTableCaptionElement.cpp
     HTML/HTMLTableCellElement.cpp
     HTML/HTMLTableColElement.cpp

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -89,11 +89,11 @@ public:
     bool has_attributes() const;
     DeprecatedString attribute(DeprecatedFlyString const& name) const { return get_attribute(name); }
     DeprecatedString get_attribute(DeprecatedFlyString const& name) const;
-    WebIDL::ExceptionOr<void> set_attribute(DeprecatedFlyString const& name, DeprecatedString const& value);
+    virtual WebIDL::ExceptionOr<void> set_attribute(DeprecatedFlyString const& name, DeprecatedString const& value);
     WebIDL::ExceptionOr<void> set_attribute_ns(DeprecatedFlyString const& namespace_, DeprecatedFlyString const& qualified_name, DeprecatedString const& value);
     WebIDL::ExceptionOr<JS::GCPtr<Attr>> set_attribute_node(Attr&);
     WebIDL::ExceptionOr<JS::GCPtr<Attr>> set_attribute_node_ns(Attr&);
-    void remove_attribute(DeprecatedFlyString const& name);
+    virtual void remove_attribute(DeprecatedFlyString const& name);
     WebIDL::ExceptionOr<bool> toggle_attribute(DeprecatedFlyString const& name, Optional<bool> force);
     size_t attribute_list_size() const;
     NamedNodeMap const* attributes() const { return m_attributes.ptr(); }

--- a/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
@@ -65,6 +65,7 @@
 #include <LibWeb/HTML/HTMLSourceElement.h>
 #include <LibWeb/HTML/HTMLSpanElement.h>
 #include <LibWeb/HTML/HTMLStyleElement.h>
+#include <LibWeb/HTML/HTMLSummaryElement.h>
 #include <LibWeb/HTML/HTMLTableCaptionElement.h>
 #include <LibWeb/HTML/HTMLTableCellElement.h>
 #include <LibWeb/HTML/HTMLTableColElement.h>
@@ -378,6 +379,8 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_html_element(JS::Re
         return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLSpanElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::style)
         return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLStyleElement>(realm, document, move(qualified_name)));
+    if (lowercase_tag_name == HTML::TagNames::summary)
+        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLSummaryElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name == HTML::TagNames::caption)
         return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTableCaptionElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name.is_one_of(Web::HTML::TagNames::td, Web::HTML::TagNames::th))
@@ -405,7 +408,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_html_element(JS::Re
     if (lowercase_tag_name == HTML::TagNames::video)
         return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLVideoElement>(realm, document, move(qualified_name)));
     if (lowercase_tag_name.is_one_of(
-            HTML::TagNames::article, HTML::TagNames::section, HTML::TagNames::nav, HTML::TagNames::aside, HTML::TagNames::hgroup, HTML::TagNames::header, HTML::TagNames::footer, HTML::TagNames::address, HTML::TagNames::dt, HTML::TagNames::dd, HTML::TagNames::figure, HTML::TagNames::figcaption, HTML::TagNames::main, HTML::TagNames::em, HTML::TagNames::strong, HTML::TagNames::small, HTML::TagNames::s, HTML::TagNames::cite, HTML::TagNames::dfn, HTML::TagNames::abbr, HTML::TagNames::ruby, HTML::TagNames::rt, HTML::TagNames::rp, HTML::TagNames::code, HTML::TagNames::var, HTML::TagNames::samp, HTML::TagNames::kbd, HTML::TagNames::sub, HTML::TagNames::sup, HTML::TagNames::i, HTML::TagNames::b, HTML::TagNames::u, HTML::TagNames::mark, HTML::TagNames::bdi, HTML::TagNames::bdo, HTML::TagNames::wbr, HTML::TagNames::summary, HTML::TagNames::noscript,
+            HTML::TagNames::article, HTML::TagNames::section, HTML::TagNames::nav, HTML::TagNames::aside, HTML::TagNames::hgroup, HTML::TagNames::header, HTML::TagNames::footer, HTML::TagNames::address, HTML::TagNames::dt, HTML::TagNames::dd, HTML::TagNames::figure, HTML::TagNames::figcaption, HTML::TagNames::main, HTML::TagNames::em, HTML::TagNames::strong, HTML::TagNames::small, HTML::TagNames::s, HTML::TagNames::cite, HTML::TagNames::dfn, HTML::TagNames::abbr, HTML::TagNames::ruby, HTML::TagNames::rt, HTML::TagNames::rp, HTML::TagNames::code, HTML::TagNames::var, HTML::TagNames::samp, HTML::TagNames::kbd, HTML::TagNames::sub, HTML::TagNames::sup, HTML::TagNames::i, HTML::TagNames::b, HTML::TagNames::u, HTML::TagNames::mark, HTML::TagNames::bdi, HTML::TagNames::bdo, HTML::TagNames::wbr, HTML::TagNames::noscript,
             // Obsolete
             HTML::TagNames::acronym, HTML::TagNames::basefont, HTML::TagNames::big, HTML::TagNames::center, HTML::TagNames::nobr, HTML::TagNames::noembed, HTML::TagNames::noframes, HTML::TagNames::plaintext, HTML::TagNames::rb, HTML::TagNames::rtc, HTML::TagNames::strike, HTML::TagNames::tt))
         return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLElement>(realm, document, move(qualified_name)));

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -363,6 +363,7 @@ class HTMLSlotElement;
 class HTMLSourceElement;
 class HTMLSpanElement;
 class HTMLStyleElement;
+class HTMLSummaryElement;
 class HTMLTableCaptionElement;
 class HTMLTableCellElement;
 class HTMLTableColElement;

--- a/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -5,7 +5,9 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/DOM/Event.h>
 #include <LibWeb/HTML/HTMLDetailsElement.h>
+#include <LibWeb/HTML/HTMLSummaryElement.h>
 
 namespace Web::HTML {
 
@@ -15,6 +17,40 @@ HTMLDetailsElement::HTMLDetailsElement(DOM::Document& document, DOM::QualifiedNa
 }
 
 HTMLDetailsElement::~HTMLDetailsElement() = default;
+
+WebIDL::ExceptionOr<void> HTMLDetailsElement::set_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+{
+    auto result = HTMLElement::set_attribute(name, value);
+    if (result.is_exception())
+        return result.exception();
+
+    if (name == HTML::AttributeNames::open)
+        run_details_notification_task_steps();
+
+    return result;
+}
+
+void HTMLDetailsElement::remove_attribute(DeprecatedFlyString const& name)
+{
+    HTMLElement::remove_attribute(name);
+
+    if (name == HTML::AttributeNames::open)
+        run_details_notification_task_steps();
+}
+
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element:details-notification-task-steps
+void HTMLDetailsElement::run_details_notification_task_steps()
+{
+    // Whenever the open attribute is added to or removed from a details element,
+    // the user agent must queue an element task on the DOM manipulation task source given then details element that runs the following steps,
+    // which are known as the details notification task steps, for this details element:
+    queue_an_element_task(HTML::Task::Source::DOMManipulation, [this] {
+        // 1. FIXME: If another task has been queued to run the details notification task steps for this details element, then return.
+
+        // 2. Fire an event named toggle at the details element.
+        dispatch_event(Web::DOM::Event::create(realm(), HTML::EventNames::toggle).release_value_but_fixme_should_propagate_errors());
+    });
+}
 
 JS::ThrowCompletionOr<void> HTMLDetailsElement::initialize(JS::Realm& realm)
 {

--- a/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.h
@@ -20,6 +20,12 @@ public:
     // https://www.w3.org/TR/html-aria/#el-details
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::group; };
 
+    // ^Element
+    WebIDL::ExceptionOr<void> set_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    void remove_attribute(DeprecatedFlyString const& name) override;
+
+    void run_details_notification_task_steps();
+
 private:
     HTMLDetailsElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLSummaryElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSummaryElement.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/HTML/HTMLDetailsElement.h>
+#include <LibWeb/HTML/HTMLSummaryElement.h>
+
+namespace Web::HTML {
+
+HTMLSummaryElement::HTMLSummaryElement(DOM::Document& document, DOM::QualifiedName qualified_name)
+    : HTMLElement(document, move(qualified_name))
+{
+    activation_behavior = [this](auto&) {
+        // The activation behavior of summary elements is to run the following steps:
+
+        // 1. If this summary element is not the summary for its parent details, then return.
+        if (!is_summary_for_its_parent_details())
+            return;
+
+        // 2. Let parent be this summary element's parent.
+        auto* parent = this->parent_element();
+
+        // 3. If the open attribute is present on parent, then remove it. Otherwise, set parent's open attribute to the empty string.
+        if (parent->has_attribute(HTML::AttributeNames::open))
+            parent->remove_attribute(HTML::AttributeNames::open);
+        else
+            parent->set_attribute(HTML::AttributeNames::open, "").release_value_but_fixme_should_propagate_errors();
+    };
+}
+
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#summary-for-its-parent-details
+bool HTMLSummaryElement::is_summary_for_its_parent_details()
+{
+    // A summary element is a summary for its parent details if the following algorithm returns true:
+
+    // 1. If this summary element has no parent, then return false.
+    if (!parent_element())
+        return false;
+
+    // 2. Let parent be this summary element's parent.
+    auto* parent = this->parent_element();
+
+    // 3. If parent is not a details element, then return false.
+    if (!is<HTMLDetailsElement>(*parent))
+        return false;
+
+    // 4. If parent's first summary element child is not this summary element, then return false.
+    if (parent->first_child_of_type<HTMLSummaryElement>() != this)
+        return false;
+
+    // 5. Return true.
+    return true;
+}
+
+HTMLSummaryElement::~HTMLSummaryElement() = default;
+
+JS::ThrowCompletionOr<void> HTMLSummaryElement::initialize(JS::Realm& realm)
+{
+    MUST_OR_THROW_OOM(Base::initialize(realm));
+
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibWeb/HTML/HTMLSummaryElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSummaryElement.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/ARIA/Roles.h>
+#include <LibWeb/HTML/HTMLElement.h>
+
+namespace Web::HTML {
+
+class HTMLSummaryElement final : public HTMLElement {
+    WEB_PLATFORM_OBJECT(HTMLSummaryElement, HTMLElement);
+
+public:
+    virtual ~HTMLSummaryElement() override;
+
+    // https://www.w3.org/TR/html-aria/#el-details
+    virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::button; };
+
+    bool is_summary_for_its_parent_details();
+
+private:
+    HTMLSummaryElement(DOM::Document&, DOM::QualifiedName);
+
+    virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
+};
+
+}


### PR DESCRIPTION
This does not make the \<details> element display as it should, only implement its behaviour