### PR TITLE
LibCore+SpiceAgent: Add `Core::File::OpenMode::DontCreate`

### DIFF
--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -87,6 +87,13 @@ int File::open_mode_to_options(OpenMode mode)
         flags |= O_CLOEXEC;
     if (!has_flag(mode, OpenMode::Nonblocking))
         flags |= O_NONBLOCK;
+
+    // Some open modes, like `ReadWrite` imply the ability to create the file if it doesn't exist.
+    // Certain applications may not want this privledge, and for compability reasons, this is
+    // the easiest way to add this option.
+    if (has_flag(mode, OpenMode::DontCreate))
+        flags &= ~O_CREAT;
+
     return flags;
 }
 

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -31,6 +31,7 @@ public:
         MustBeNew = 16,
         KeepOnExec = 32,
         Nonblocking = 64,
+        DontCreate = 128,
     };
 
     enum class ShouldCloseFileDescriptor {

--- a/Userland/Services/SpiceAgent/SpiceAgent.cpp
+++ b/Userland/Services/SpiceAgent/SpiceAgent.cpp
@@ -15,7 +15,7 @@ namespace SpiceAgent {
 
 ErrorOr<NonnullOwnPtr<SpiceAgent>> SpiceAgent::create(StringView device_path)
 {
-    auto device = TRY(Core::File::open(device_path, Core::File::OpenMode::ReadWrite | Core::File::OpenMode::Nonblocking));
+    auto device = TRY(Core::File::open(device_path, Core::File::OpenMode::ReadWrite | Core::File::OpenMode::DontCreate | Core::File::OpenMode::Nonblocking));
     return try_make<SpiceAgent>(move(device), Vector { Capability::ClipboardByDemand });
 }
 

--- a/Userland/Services/SpiceAgent/main.cpp
+++ b/Userland/Services/SpiceAgent/main.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibDesktop/Launcher.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Clipboard.h>
 #include <LibIPC/ConnectionToServer.h>
@@ -20,6 +21,10 @@ static constexpr auto SPICE_DEVICE = "/dev/hvc0p1"sv;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    if (!FileSystem::exists(SPICE_DEVICE)) {
+        return Error::from_string_literal("Failed to find spice device file!");
+    }
+
     // We use the application to be able to easily write to the user's clipboard.
     auto app = TRY(GUI::Application::create(arguments));
 

--- a/Userland/Services/SpiceAgent/main.cpp
+++ b/Userland/Services/SpiceAgent/main.cpp
@@ -26,11 +26,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_url(URL::create_with_file_scheme(Core::StandardPaths::downloads_directory())));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    // FIXME: Make Core::File support reading and writing, but without creating:
-    //        By default, Core::File opens the file descriptor with O_CREAT when using OpenMode::Write (and subsequently, OpenMode::ReadWrite).
-    //        To minimise confusion for people that have already used Core::File, we can probably just do `OpenMode::ReadWrite | OpenMode::DontCreate`.
-    TRY(Core::System::pledge("unix rpath wpath stdio sendfd recvfd cpath"));
-    TRY(Core::System::unveil(SPICE_DEVICE, "rwc"sv));
+    TRY(Core::System::pledge("unix rpath wpath stdio sendfd recvfd"));
+    TRY(Core::System::unveil(SPICE_DEVICE, "rw"sv));
     TRY(Core::System::unveil(Core::StandardPaths::downloads_directory(), "rwc"sv));
     TRY(Core::System::unveil(nullptr, nullptr));
 


### PR DESCRIPTION
SpiceAgent is one of possibly few applications which doesn't need to create files if they don't exist before reading or writing to them. Unfortunately, `OpenMode::ReadWrite` assumes that you want the `O_CREAT` privilege too, which isn't indicated by its name. In order to not break everyone that uses `Core::File` already, I think an opt-out approach might be the best here?

Previous discussion about this on Discord, never exactly got to a definite conclusion:
https://discord.com/channels/830522505605283862/830739873119207426/1106704476443779132