### PR TITLE
LibLine: Defer handling SIGWINCH and SIGINT

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -582,11 +582,11 @@ void Editor::initialize()
 
     if (m_configuration.m_signal_mode == Configuration::WithSignalHandlers) {
         m_signal_handlers.append(Core::EventLoop::register_signal(SIGINT, [this](int) {
-            interrupted().release_value_but_fixme_should_propagate_errors();
+            Core::EventLoop::current().deferred_invoke([this] { interrupted().release_value_but_fixme_should_propagate_errors(); });
         }));
 
         m_signal_handlers.append(Core::EventLoop::register_signal(SIGWINCH, [this](int) {
-            resized().release_value_but_fixme_should_propagate_errors();
+            Core::EventLoop::current().deferred_invoke([this] { resized().release_value_but_fixme_should_propagate_errors(); });
         }));
     }
 


### PR DESCRIPTION
Previously we were mashing all the registered signal handlers into a global map and invoking them all immediately, which could lead to inconsistencies with how EventLoops block each other. This commit runs signals' handlers whenever the event loop itself is capable of processing events, which fixes a crash in LibLine when Shell is in the middle of executing a process and has given away the ownership of stdin/stdout to the process.

cc @awesomekling - your boog report.