### PR TITLE
Meta: Always use the default host compiler for the toolchain on macOS

### DIFF
--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -303,10 +303,16 @@ build_cmake() {
 
 build_toolchain() {
     echo "build_toolchain: $TOOLCHAIN_DIR"
+
     if [ "$TOOLCHAIN_TYPE" = "Clang" ]; then
         ( cd "$SERENITY_SOURCE_DIR/Toolchain" && ./BuildClang.sh )
     else
-        ( cd "$SERENITY_SOURCE_DIR/Toolchain" && ARCH="$TARGET" ./BuildGNU.sh )
+        (
+            # HACK: ISL's configure fails with "Link Time Optimisation is not supported" if CC is
+            #       Homebrew Clang due to incompatibility with Xcode's ranlib.
+            [ "$(uname -s)" = "Darwin" ] && unset CC CXX
+            cd "$SERENITY_SOURCE_DIR/Toolchain" && ARCH="$TARGET" ./BuildGNU.sh
+        )
     fi
 }
 


### PR DESCRIPTION
GCC's build fails in `libisl`'s configure step if `CC` is set to Homebrew Clang with the message "Link Time Optimisation is not supported". This is likely due to the fact that it tries to use ranlib from Xcode, which is not compatible with the newer LLVM version's bitcode format.

The toolchain build runs after `pick_host_compiler` is called, which selects Homebrew Clang if the installed Xcode version is too old. We need to unset `CC` and `CXX` for the toolchain build to sidestep the issue.