### PR TITLE
Shell: Add a "." builtin that aliases to "source"

### DIFF
--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -1328,6 +1328,8 @@ ErrorOr<bool> Shell::run_builtin(const AST::Command& command, Vector<NonnullRefP
 
     if (name == ":"sv)
         name = "noop"sv;
+    else if (m_in_posix_mode && name == "."sv)
+        name = "source"sv;
 
 #define __ENUMERATE_SHELL_BUILTIN(builtin, _mode)                        \
     if (name == #builtin) {                                              \
@@ -1921,7 +1923,7 @@ ErrorOr<int> Shell::builtin_run_with_env(Main::Arguments arguments)
 
 bool Shell::has_builtin(StringView name) const
 {
-    if (name == ":"sv)
+    if (name == ":"sv || (m_in_posix_mode && name == "."sv))
         return true;
 
 #define __ENUMERATE_SHELL_BUILTIN(builtin, mode)                            \

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -462,7 +462,11 @@ private:
 
 #undef __ENUMERATE_SHELL_BUILTIN
 
+            "."sv, // Needs to be aliased to "source" in POSIX mode.
+        // clang-format off
+        // Clang-format does not properly indent this, it gives it 4 spaces too few.
             ":"sv, // POSIX-y name for "noop".
+        // clang-format on
     };
 
     bool m_should_ignore_jobs_on_next_exit { false };


### PR DESCRIPTION
This patch adds an alias to the source builtin when an user types ".". We cannot just add an enumeration entry using `__ENUMERATE_SHELL_BUILTIN` because "." is not a valid name in a function.
This patch adds handling similarly to the name rewriting of ":".

Note that this adds the alias in non-posix mode as well, not sure if that is wanted?

Fixes #19089 

First contribution to serenity :^)