### PR TITLE
pkill: Add `-c`, `-U` and `-x` options

### DIFF
--- a/Base/usr/share/man/man1/pkill.md
+++ b/Base/usr/share/man/man1/pkill.md
@@ -1,0 +1,22 @@
+## Name
+
+pkill - Signal processes based on name
+
+## Synopsis
+
+```sh
+$ pkill [--count] [--ignore-case] [--echo] [--signal number] [--uid uid-list] [--exact] <process-name>
+```
+
+## Options
+
+* `-c`, `--count`: Display the number of matching processes
+* `-i`, `--ignore-case`: Make matches case-insensitive
+* `-e`, `--echo`: Display what is killed
+* `-s number`, `--signal number`: Signal number to send
+* `-U uid-list`, `--uid uid-list`: Select only processes whose UID is in the given comma-separated list. Login name or numerical user ID may be used
+* `-x`, `--exact`: Select only processes whose names match the given pattern exactly
+
+## Arguments
+
+* `process-name`: Process name to search for

--- a/Userland/Utilities/pkill.cpp
+++ b/Userland/Utilities/pkill.cpp
@@ -28,6 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     bool display_number_of_matches;
     bool case_insensitive = false;
     bool echo = false;
+    bool exact_match = false;
     StringView pattern;
     HashTable<uid_t> uids_to_filter_by;
     int signal = SIGTERM;
@@ -61,6 +62,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
             return true;
         },
     });
+    args_parser.add_option(exact_match, "Select only processes whose names match the given pattern exactly", "exact", 'x');
     args_parser.add_positional_argument(pattern, "Process name to search for", "process-name");
     args_parser.parse(args);
 
@@ -69,6 +71,12 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     PosixOptions options {};
     if (case_insensitive) {
         options |= PosixFlags::Insensitive;
+    }
+
+    StringBuilder exact_pattern_builder;
+    if (exact_match) {
+        exact_pattern_builder.appendff("^({})$", pattern);
+        pattern = exact_pattern_builder.string_view();
     }
 
     Regex<PosixExtended> re(pattern, options);

--- a/Userland/Utilities/pkill.cpp
+++ b/Userland/Utilities/pkill.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Maxwell Trussell <maxtrussell@gmail.com>
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -59,10 +60,11 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     }
 
     for (auto& process : matched_processes) {
-        if (echo) {
+        auto result = Core::System::kill(process.pid, signal);
+        if (result.is_error())
+            warnln("Killing pid {} failed. {}", process.pid, result.release_error());
+        else if (echo)
             outln("{} killed (pid {})", process.name, process.pid);
-        }
-        kill(process.pid, signal);
     }
     return 0;
 }

--- a/Userland/Utilities/pkill.cpp
+++ b/Userland/Utilities/pkill.cpp
@@ -35,7 +35,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     Core::ArgsParser args_parser;
     args_parser.add_option(display_number_of_matches, "Display the number of matching processes", "count", 'c');
-    args_parser.add_option(case_insensitive, "Make matches case-insensitive", nullptr, 'i');
+    args_parser.add_option(case_insensitive, "Make matches case-insensitive", "ignore-case", 'i');
     args_parser.add_option(echo, "Display what is killed", "echo", 'e');
     args_parser.add_option(signal, "Signal number to send", "signal", 's', "number");
     args_parser.add_option(Core::ArgsParser::Option {


### PR DESCRIPTION
This PR adds 3 new options to `pkill`:

* `-c`: Prints a count of the number of matched processes. Note: processes that fail to be killed are counted in this total.
* `-U`: Filter processes by a comma-separated list of UIDs or login names
* `-x`: Match the given pattern exactly

`pkill` will now also output the reason for failure when killing a process fails.

Video showing the new functionality:

https://github.com/SerenityOS/serenity/assets/2817754/413451a4-36e8-4f10-b986-b353240a6dd6


