### PR TITLE
LibWeb: Add partial implementation of border conflict resolution

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
@@ -1,0 +1,70 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x181.875 [BFC] children: not-inline
+    BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
+      TextNode <#text>
+    BlockContainer <body> at (8,8) content-size 784x165.875 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+        TextNode <#text>
+      TableWrapper <(anonymous)> at (8,8) content-size 64.265625x165.875 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 64.265625x165.875 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          BlockContainer <colgroup> (not painted) table-column-group children: not-inline
+            BlockContainer <col> (not painted) children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (8,8) content-size 64.265625x165.875 table-row-group children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (8,8) content-size 64.265625x43.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (33,23) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [33,23 14.265625x17.46875]
+                    "A"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (8,51.46875) content-size 64.265625x39.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (33,62.46875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [33,62.46875 9.34375x17.46875]
+                    "B"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (8,90.9375) content-size 64.265625x39.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (33,101.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [33,101.9375 10.3125x17.46875]
+                    "C"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (8,130.40625) content-size 64.265625x43.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (33,141.40625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [33,141.40625 11.140625x17.46875]
+                    "D"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+      BlockContainer <(anonymous)> at (8,173.875) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/table/border-conflict-resolution-with-col.html
+++ b/Tests/LibWeb/Layout/input/table/border-conflict-resolution-with-col.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>Table with border conflict resolution with col</title>
+  <style>
+    table {
+      border-collapse: collapse;
+    }
+
+    td {
+      border: 1px solid black;
+      padding: 10px 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <table>
+    <colgroup>
+      <col style="border: 5px solid black">
+    </colgroup>
+    <tbody>
+      <tr>
+        <td>A</td>
+      </tr>
+      <tr>
+        <td>B</td>
+      </tr>
+      <tr>
+        <td>C</td>
+      </tr>
+      <tr>
+        <td>D</td>
+      </tr>
+    </tbody>
+  </table>
+
+
+</body>
+
+</html>

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -230,6 +230,8 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
             builder.appendff(" {}table-box{}", table_color_on, color_off);
         if (box.display().is_table_row_group())
             builder.appendff(" {}table-row-group{}", table_color_on, color_off);
+        if (box.display().is_table_column_group())
+            builder.appendff(" {}table-column-group{}", table_color_on, color_off);
         if (box.display().is_table_header_group())
             builder.appendff(" {}table-header-group{}", table_color_on, color_off);
         if (box.display().is_table_footer_group())

--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.h
@@ -211,6 +211,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(shape)                      \
     __ENUMERATE_HTML_ATTRIBUTE(size)                       \
     __ENUMERATE_HTML_ATTRIBUTE(sizes)                      \
+    __ENUMERATE_HTML_ATTRIBUTE(span)                       \
     __ENUMERATE_HTML_ATTRIBUTE(src)                        \
     __ENUMERATE_HTML_ATTRIBUTE(srcdoc)                     \
     __ENUMERATE_HTML_ATTRIBUTE(srclang)                    \

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -122,6 +122,9 @@ void LayoutState::commit()
             paintable_box.set_offset(used_values.offset);
             paintable_box.set_content_size(used_values.content_width(), used_values.content_height());
             paintable_box.set_containing_line_box_fragment(used_values.containing_line_box_fragment);
+            if (used_values.override_borders_data().has_value()) {
+                paintable_box.set_override_borders_data(used_values.override_borders_data().value());
+            }
 
             if (is<Layout::BlockContainer>(box)) {
                 for (auto& line_box : used_values.line_boxes) {

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -117,6 +117,9 @@ struct LayoutState {
         void add_floating_descendant(Box const& box) { m_floating_descendants.set(&box); }
         auto const& floating_descendants() const { return m_floating_descendants; }
 
+        void set_override_borders_data(Painting::BordersData const& override_borders_data) { m_override_borders_data = override_borders_data; };
+        auto const& override_borders_data() const { return m_override_borders_data; }
+
     private:
         AvailableSize available_width_inside() const;
         AvailableSize available_height_inside() const;
@@ -130,6 +133,8 @@ struct LayoutState {
         bool m_has_definite_height { false };
 
         HashTable<JS::GCPtr<Box const>> m_floating_descendants;
+
+        Optional<Painting::BordersData> m_override_borders_data;
     };
 
     void commit();

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -39,6 +39,7 @@ private:
     void distribute_height_to_rows();
     void position_row_boxes(CSSPixels&);
     void position_cell_boxes();
+    void border_conflict_resolution();
 
     CSSPixels m_table_height { 0 };
     CSSPixels m_automatic_content_height { 0 };
@@ -80,6 +81,25 @@ private:
     };
 
     CSSPixels compute_row_content_height(Cell const& cell) const;
+
+    enum class ConflictingEdge {
+        Top,
+        Right,
+        Bottom,
+        Left,
+    };
+
+    class BorderConflictFinder {
+    public:
+        BorderConflictFinder(TableFormattingContext const* context);
+        Vector<Node const*> conflicting_elements(Cell const&, ConflictingEdge) const;
+
+    private:
+        void collect_conflicting_col_elements();
+
+        Vector<Node const*> m_col_elements_by_index;
+        TableFormattingContext const* m_context;
+    };
 
     Vector<Cell> m_cells;
     Vector<Column> m_columns;

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -382,7 +382,7 @@ void TreeBuilder::remove_irrelevant_boxes(NodeWithStyle& root)
     // Children of a table-column-group which are not a table-column.
     for_each_in_tree_with_internal_display<CSS::Display::Internal::TableColumnGroup>(root, [&](Box& table_column_group) {
         table_column_group.for_each_child([&](auto& child) {
-            if (child.display().is_table_column())
+            if (!child.display().is_table_column())
                 to_remove.append(child);
         });
     });

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -222,7 +222,7 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
 
 void PaintableBox::paint_border(PaintContext& context) const
 {
-    auto borders_data = BordersData {
+    auto borders_data = m_override_borders_data.has_value() ? m_override_borders_data.value() : BordersData {
         .top = box_model().border.top == 0 ? CSS::BorderData() : computed_values().border_top(),
         .right = box_model().border.right == 0 ? CSS::BorderData() : computed_values().border_right(),
         .bottom = box_model().border.bottom == 0 ? CSS::BorderData() : computed_values().border_bottom(),

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -123,6 +123,8 @@ public:
 
     bool is_out_of_view(PaintContext&) const;
 
+    void set_override_borders_data(BordersData const& override_borders_data) { m_override_borders_data = override_borders_data; };
+
 protected:
     explicit PaintableBox(Layout::Box const&);
 
@@ -161,6 +163,8 @@ private:
 
     mutable bool m_clipping_overflow { false };
     Optional<BorderRadiusCornerClipper> mutable m_overflow_corner_radius_clipper;
+
+    Optional<BordersData> m_override_borders_data;
 };
 
 class PaintableWithLines final : public PaintableBox {


### PR DESCRIPTION
Makes the [structuring planet data](https://mdn.github.io/learning-area/html/tables/assessment-finished/planets-data.html) example on MDN a bit closer to correct.

Before:
![before](https://github.com/SerenityOS/serenity/assets/133611595/c9fd8062-6959-469e-9962-08230540582e)

After:
![after](https://github.com/SerenityOS/serenity/assets/133611595/05cc3f93-b79b-47cc-8aa4-ba86e2f844c5)
