### PR TITLE
LibWeb: Allow loading of SVGs in ImageResource

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/ImageResource.h
+++ b/Userland/Libraries/LibWeb/Loader/ImageResource.h
@@ -48,6 +48,8 @@ private:
     explicit ImageResource(Resource&);
 
     void decode_if_needed() const;
+    void decode_svg_image() const;
+    void decode_image() const;
 
     mutable bool m_animated { false };
     mutable int m_loop_count { 0 };

--- a/Userland/Libraries/LibWeb/Loader/Resource.h
+++ b/Userland/Libraries/LibWeb/Loader/Resource.h
@@ -74,6 +74,8 @@ protected:
     explicit Resource(Type, LoadRequest const&);
     Resource(Type, Resource&);
 
+    LoadRequest request() const { return m_request; }
+
 private:
     LoadRequest m_request;
     ByteBuffer m_encoded_data;


### PR DESCRIPTION
This will allow for SVGs to be loaded when used in CSS rules.

For example:

```html
  <style>
  .rect {
          background: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100" height="100" /></svg>');                      
          width: 100px;
          height: 100px;
  }
  </style>
  <div class="rect"></div>
```

This PR will allow the square to be displayed as the background image!