### PR TITLE
Base: Add .mkv file association to Video Player

### DIFF
--- a/Base/res/apps/VideoPlayer.af
+++ b/Base/res/apps/VideoPlayer.af
@@ -4,4 +4,4 @@ Executable=/bin/VideoPlayer
 Category=Media
 
 [Launcher]
-FileTypes=webm
+FileTypes=webm,mkv


### PR DESCRIPTION
Video Player can play VP9 videos inside Matroska. Double-clicking on such files in File Manager will now open this application.