### PR TITLE
Tests/LibWeb: Add some text tests for 'parsing a legacy color value'

### DIFF
--- a/Tests/LibWeb/Text/expected/css/legacy-color-value.txt
+++ b/Tests/LibWeb/Text/expected/css/legacy-color-value.txt
@@ -1,0 +1,8 @@
+'red' => rgb(255, 0, 0)
+'#408080' => rgb(64, 128, 128)
+'transparent' => rgba(0, 0, 0, 0)
+' GreeN 	' => rgb(0, 128, 0)
+'cafe' => rgb(202, 254, 0)
+'' => rgba(0, 0, 0, 0)
+'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' => rgb(219, 239, 234)
+'#emoji above U+FFFF 🙃' => rgb(224, 176, 255)

--- a/Tests/LibWeb/Text/input/css/legacy-color-value.html
+++ b/Tests/LibWeb/Text/input/css/legacy-color-value.html
@@ -1,0 +1,24 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        function checkColor(color) {
+            document.body.bgColor = color;
+            const computedStyle = getComputedStyle(document.body);
+            const bgcolor = computedStyle.backgroundColor;
+            println(`'${color}' => ${bgcolor}`);
+        }
+
+        for (color of [
+            "red",
+            "#408080",
+            "transparent",
+            " GreeN 	",
+            "cafe",
+            "",
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", // longer than 128 chars of hex
+            "#emoji above U+FFFF 🙃",
+        ]) {
+            checkColor(color);
+        }
+    });
+</script>


### PR DESCRIPTION
I was not aware of this framework back when implementing this back in bc54560e5942c9ff4b9049c034ad09a9f8446fb6. Add in some basic tests for this now that we are compliant with the specification.