### PR TITLE
Kernel/Net: SO_ERROR reporting for failed O_NONBLOCK socket connections

### DIFF
--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -485,19 +485,19 @@ void handle_tcp(IPv4Packet const& ipv4_packet, UnixDateTime const& packet_timest
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
             send_delayed_tcp_ack(*socket);
             socket->set_state(TCPSocket::State::Closed);
-            socket->set_error(TCPSocket::Error::FINDuringConnect);
+            socket->set_so_error(ECONNREFUSED);
             socket->set_setup_state(Socket::SetupState::Completed);
             return;
         case TCPFlags::ACK | TCPFlags::RST:
             socket->set_state(TCPSocket::State::Closed);
-            socket->set_error(TCPSocket::Error::RSTDuringConnect);
+            socket->set_so_error(ECONNREFUSED);
             socket->set_setup_state(Socket::SetupState::Completed);
             return;
         default:
             dbgln("handle_tcp: unexpected flags in SynSent state ({:x})", tcp_packet.flags());
             (void)socket->send_tcp_packet(TCPFlags::RST);
             socket->set_state(TCPSocket::State::Closed);
-            socket->set_error(TCPSocket::Error::UnexpectedFlagsDuringConnect);
+            socket->set_so_error(ECONNREFUSED);
             socket->set_setup_state(Socket::SetupState::Completed);
             return;
         }

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -108,6 +108,14 @@ public:
 
     bool wants_timestamp() const { return m_timestamp; }
 
+    Error set_so_error(ErrnoCode error_code)
+    {
+        m_so_error.with([&error_code](auto& so_error) {
+            so_error = error_code;
+        });
+        return Error::from_errno(error_code);
+    }
+
 protected:
     Socket(int domain, int type, int protocol);
 
@@ -124,14 +132,6 @@ protected:
     Role m_role { Role::None };
 
     SpinlockProtected<Optional<ErrnoCode>, LockRank::None>& so_error() { return m_so_error; }
-
-    Error set_so_error(ErrnoCode error_code)
-    {
-        m_so_error.with([&error_code](auto& so_error) {
-            so_error = error_code;
-        });
-        return Error::from_errno(error_code);
-    }
 
     Error set_so_error(Error error)
     {

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -92,38 +92,10 @@ public:
         }
     }
 
-    enum class Error {
-        None,
-        FINDuringConnect,
-        RSTDuringConnect,
-        UnexpectedFlagsDuringConnect,
-        RetransmitTimeout,
-    };
-
-    static StringView to_string(Error error)
-    {
-        switch (error) {
-        case Error::None:
-            return "None"sv;
-        case Error::FINDuringConnect:
-            return "FINDuringConnect"sv;
-        case Error::RSTDuringConnect:
-            return "RSTDuringConnect"sv;
-        case Error::UnexpectedFlagsDuringConnect:
-            return "UnexpectedFlagsDuringConnect"sv;
-        default:
-            return "Invalid"sv;
-        }
-    }
-
     State state() const { return m_state; }
     void set_state(State state);
 
     Direction direction() const { return m_direction; }
-
-    bool has_error() const { return m_error != Error::None; }
-    Error error() const { return m_error; }
-    void set_error(Error error) { m_error = error; }
 
     void set_ack_number(u32 n) { m_ack_number = n; }
     void set_sequence_number(u32 n) { m_sequence_number = n; }
@@ -188,7 +160,6 @@ private:
     LockWeakPtr<TCPSocket> m_originator;
     HashMap<IPv4SocketTuple, NonnullRefPtr<TCPSocket>> m_pending_release_for_accept;
     Direction m_direction { Direction::Unspecified };
-    Error m_error { Error::None };
     SpinlockProtected<RefPtr<NetworkAdapter>, LockRank::None> m_adapter;
     u32 m_sequence_number { 0 };
     u32 m_ack_number { 0 };


### PR DESCRIPTION
When using `getsockopt` with `SO_ERROR` to get the state of a connecting non-blocking socket, the result always stayed `EINPROGRESS` no matter if the connection got explicitly refused (RST) or timed out (too many retransmits).

The removed `TCPSocket::m_error` code was an abstraction solely used to  set `SO_ERRORs` for blocking socket connect attempts. The  `SO_ERROR` assigning logic was moved upstream and now works for both blocking and non-blocking sockets.

`Socket::set_so_error()` moved from protected to public which didn't feel good but it does seems like `NetworkTask::handle_tcp()` has the right context and is the right place to make that call.