### PR TITLE
LibGfx: Convert strokes to fills => Nice stroke rendering for free!

### DIFF
--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -32,15 +32,11 @@ public:
     {
         draw_line(line.a(), line.b(), color, thickness, style, alternate_color, line_length_mode);
     }
-    void draw_line_for_path(FloatPoint, FloatPoint, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid, Color alternate_color = Color::Transparent, LineLengthMode line_length_mode = LineLengthMode::PointToPoint);
 
     void fill_path(Path const&, Color, Painter::WindingRule rule = Painter::WindingRule::Nonzero);
     void fill_path(Path const&, PaintStyle const& paint_style, Painter::WindingRule rule = Painter::WindingRule::Nonzero);
 
     void stroke_path(Path const&, Color, float thickness);
-    void draw_quadratic_bezier_curve(FloatPoint control_point, FloatPoint, FloatPoint, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid);
-    void draw_cubic_bezier_curve(FloatPoint control_point_0, FloatPoint control_point_1, FloatPoint, FloatPoint, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid);
-    void draw_elliptical_arc(FloatPoint p1, FloatPoint p2, FloatPoint center, FloatSize radii, float x_axis_rotation, float theta_1, float theta_delta, Color, float thickness = 1, Painter::LineStyle style = Painter::LineStyle::Solid);
 
     void translate(float dx, float dy) { m_transform.translate(dx, dy); }
     void translate(FloatPoint delta) { m_transform.translate(delta); }
@@ -90,19 +86,10 @@ private:
         }
     };
 
-    Range draw_ellipse_part(IntPoint a_rect, int radius_a, int radius_b, Color, bool flip_x_and_y, Optional<Range> x_clip, BlendMode blend_mode);
+    Range draw_ellipse_part(IntPoint a_rect, int radius_a, int radius_b, Color alternate_color, bool flip_x_and_y, Optional<Range> x_clip, BlendMode blend_mode);
 
+    void draw_anti_aliased_line(FloatPoint, FloatPoint, Color, float thickness, Painter::LineStyle, Color, LineLengthMode);
     void draw_dotted_line(IntPoint, IntPoint, Gfx::Color, int thickness);
-
-    enum class FixmeEnableHacksForBetterPathPainting {
-        Yes,
-        No,
-    };
-
-    template<FixmeEnableHacksForBetterPathPainting path_hacks>
-    void draw_anti_aliased_line(FloatPoint, FloatPoint, Color, float thickness, Painter::LineStyle style, Color alternate_color, LineLengthMode line_length_mode = LineLengthMode::PointToPoint);
-
-    void stroke_segment_intersection(FloatPoint current_line_a, FloatPoint current_line_b, FloatLine const& previous_line, Color, float thickness);
 
     Painter& m_underlying_painter;
     AffineTransform m_transform;

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -365,4 +365,164 @@ void Path::add_path(Path const& other)
     invalidate_split_lines();
 }
 
+template<typename T>
+struct RoundTrip {
+    RoundTrip(ReadonlySpan<T> span)
+        : m_span(span)
+    {
+    }
+
+    size_t size() const
+    {
+        return m_span.size() * 2 - 1;
+    }
+
+    T const& operator[](size_t index) const
+    {
+        // Follow the path:
+        if (index < m_span.size())
+            return m_span[index];
+        // Then in reverse:
+        if (index < size())
+            return m_span[size() - index - 1];
+        // Then wrap around again:
+        return m_span[index - size() + 1];
+    }
+
+private:
+    ReadonlySpan<T> m_span;
+};
+
+Path Path::stroke_to_fill(float thickness) const
+{
+    // Note: This convolves a polygon with the path using the algorithm described
+    // in https://keithp.com/~keithp/talks/cairo2003.pdf (3.1 Stroking Splines via Convolution)
+
+    auto& lines = split_lines();
+    if (lines.is_empty())
+        return Path {};
+
+    // Paths can be disconnected, which a pain to deal with, so split it up.
+    Vector<Vector<FloatPoint>> segments;
+    segments.append({ lines.first().a() });
+    for (auto& line : lines) {
+        if (line.a() == segments.last().last()) {
+            segments.last().append(line.b());
+        } else {
+            segments.append({ line.a(), line.b() });
+        }
+    }
+
+    // Note: This is the same as the tolerance from bezier curve splitting.
+    constexpr auto flatness = 0.015f;
+    auto pen_vertex_count = max(
+        static_cast<int>(ceilf(AK::Pi<float> / acosf(1 - (2 * flatness) / thickness))), 4);
+    if (pen_vertex_count % 2 == 1)
+        pen_vertex_count += 1;
+
+    Vector<FloatPoint, 128> pen_vertices;
+    pen_vertices.ensure_capacity(pen_vertex_count);
+
+    // Generate vertices for the pen (going counterclockwise). The pen does not necessarily need
+    // to be a circle (or an approximation of one), but other shapes are untested.
+    float theta = 0;
+    float theta_delta = (AK::Pi<float> * 2) / pen_vertex_count;
+    for (int i = 0; i < pen_vertex_count; i++) {
+        float sin_theta;
+        float cos_theta;
+        AK::sincos(theta, sin_theta, cos_theta);
+        pen_vertices.unchecked_append({ cos_theta * thickness / 2, sin_theta * thickness / 2 });
+        theta -= theta_delta;
+    }
+
+    auto wrapping_index = [](auto& vertices, auto index) {
+        return vertices[(index + vertices.size()) % vertices.size()];
+    };
+
+    auto angle_between = [](auto p1, auto p2) {
+        auto delta = p2 - p1;
+        return atan2f(delta.y(), delta.x());
+    };
+
+    struct ActiveRange {
+        float start;
+        float end;
+
+        bool in_range(float angle) const
+        {
+            // Note: Since active ranges go counterclockwise start > end unless we wrap around at 180 degrees
+            return ((angle <= start && angle >= end)
+                || (start < end && angle <= start)
+                || (start < end && angle >= end));
+        }
+    };
+
+    Vector<ActiveRange, 128> active_ranges;
+    active_ranges.ensure_capacity(pen_vertices.size());
+    for (auto i = 0; i < pen_vertex_count; i++) {
+        active_ranges.unchecked_append({ angle_between(wrapping_index(pen_vertices, i - 1), pen_vertices[i]),
+            angle_between(pen_vertices[i], wrapping_index(pen_vertices, i + 1)) });
+    }
+
+    auto clockwise = [](float current_angle, float target_angle) {
+        if (target_angle < 0)
+            target_angle += AK::Pi<float> * 2;
+        if (current_angle < 0)
+            current_angle += AK::Pi<float> * 2;
+        if (target_angle < current_angle)
+            target_angle += AK::Pi<float> * 2;
+        return (target_angle - current_angle) <= AK::Pi<float>;
+    };
+
+    Path convolution;
+    for (auto& segment : segments) {
+        RoundTrip<FloatPoint> shape { segment };
+
+        bool first = true;
+        auto add_vertex = [&](auto v) {
+            if (first) {
+                convolution.move_to(v);
+                first = false;
+            } else {
+                convolution.line_to(v);
+            }
+        };
+
+        auto shape_idx = 0u;
+
+        auto slope = [&] {
+            return angle_between(shape[shape_idx], shape[shape_idx + 1]);
+        };
+
+        auto start_slope = slope();
+        // Note: At least one range must be active.
+        auto active = *active_ranges.find_first_index_if([&](auto& range) {
+            return range.in_range(start_slope);
+        });
+
+        while (shape_idx < shape.size()) {
+            add_vertex(shape[shape_idx] + pen_vertices[active]);
+            auto slope_now = slope();
+            auto range = active_ranges[active];
+            if (range.in_range(slope_now)) {
+                shape_idx++;
+            } else {
+                if (clockwise(slope_now, range.end)) {
+                    if (active == static_cast<size_t>(pen_vertex_count - 1))
+                        active = 0;
+                    else
+                        active++;
+                } else {
+                    if (active == 0)
+                        active = pen_vertex_count - 1;
+                    else
+                        active--;
+                }
+            }
+        }
+    }
+
+    return convolution;
+}
+
 }

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -248,6 +248,8 @@ public:
 
     DeprecatedString to_deprecated_string() const;
 
+    Path stroke_to_fill(float thickness) const;
+
 private:
     void invalidate_split_lines()
     {


### PR DESCRIPTION
Finally, I can be happy with the SVG rasterization! Note: There's still a bunch of TODOs (e.g. implement line joins other than round, wire up using paint styles with strokes, and probably fix bugs and optimise things).

| Old                                                                                                                                 | New                                                                                                                                 |
|-------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
| ![image](https://github.com/SerenityOS/serenity/assets/11597044/c25e6b80-6cea-4be5-a4b1-17a838e59223)                               | ![image](https://github.com/SerenityOS/serenity/assets/11597044/ba200ec9-8951-442c-b664-0afae9089eac)                               |
| ![Screenshot from 2023-06-05 21-54-05](https://github.com/SerenityOS/serenity/assets/11597044/1a3544d2-b72c-4bfa-bde9-a83d7abbe9d1) | ![Screenshot from 2023-06-05 21-51-21](https://github.com/SerenityOS/serenity/assets/11597044/796d023a-6b38-4d77-b0ea-aaf12121df16) |
| ![Screenshot from 2023-06-05 21-54-39](https://github.com/SerenityOS/serenity/assets/11597044/cc47316b-a625-42a2-a865-bc86aa73fe0e) | ![Screenshot from 2023-06-05 21-51-35](https://github.com/SerenityOS/serenity/assets/11597044/6a51c1a9-4efb-4d8c-8cc5-beb6e68f8b5e) |
| ![Screenshot from 2023-06-05 21-55-13](https://github.com/SerenityOS/serenity/assets/11597044/57c57fa2-ba91-4a93-b598-1fe345fa4bb8) | ![Screenshot from 2023-06-05 21-52-17](https://github.com/SerenityOS/serenity/assets/11597044/e37cded3-5f1f-4d77-93d0-6446c82acc41) |
| ![Screenshot from 2023-06-05 21-55-58](https://github.com/SerenityOS/serenity/assets/11597044/ce2cea16-85e5-4fe3-ab4c-3399e6f755a2) | ![image](https://github.com/SerenityOS/serenity/assets/11597044/d081ccba-c50d-4d87-a94e-9a5269afc988)                               |