### PR TITLE
Meta: Enable NVME by default

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -240,18 +240,14 @@ if [ -z "$SERENITY_QEMU_DISPLAY_DEVICE" ]; then
     fi
 fi
 
-# Check if SERENITY_NVME_ENABLE is unset
-if [ -z ${SERENITY_NVME_ENABLE+x} ]; then
-    SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk,id=disk"
+# NVME is enabled by default; disable by setting SERENITY_NVME_ENABLE=0
+if [ -z "${SERENITY_NVME_ENABLE}" ] || [ "${SERENITY_NVME_ENABLE}" -eq 1 ]; then
+    SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk,if=none,id=disk"
+    SERENITY_BOOT_DRIVE="${SERENITY_BOOT_DRIVE} -device i82801b11-bridge,id=bridge4 -device sdhci-pci,bus=bridge4"
+    SERENITY_BOOT_DRIVE="${SERENITY_BOOT_DRIVE} -device nvme,serial=deadbeef,drive=disk,bus=bridge4,logical_block_size=4096,physical_block_size=4096"
+    SERENITY_KERNEL_CMDLINE="${SERENITY_KERNEL_CMDLINE} root=nvme0:1:0"
 else
-    if [ "$SERENITY_NVME_ENABLE" -eq 1 ]; then
-        SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk,if=none,id=disk"
-        SERENITY_BOOT_DRIVE="$SERENITY_BOOT_DRIVE -device i82801b11-bridge,id=bridge4 -device sdhci-pci,bus=bridge4"
-        SERENITY_BOOT_DRIVE="$SERENITY_BOOT_DRIVE -device nvme,serial=deadbeef,drive=disk,bus=bridge4,logical_block_size=4096,physical_block_size=4096"
-        SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE root=nvme0:1:0"
-    else
-        SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk,id=disk"
-    fi
+    SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk,id=disk"
 fi
 
 if [ -n "${SERENITY_USE_SDCARD}" ] && [ "${SERENITY_USE_SDCARD}" -eq 1 ]; then
@@ -532,12 +528,12 @@ elif [ "$SERENITY_RUN" = "ci" ]; then
         "$SERENITY_QEMU_BIN" \
             $SERENITY_EXTRA_QEMU_ARGS \
             $SERENITY_VIRT_TECH_ARG \
+            $SERENITY_BOOT_DRIVE \
             -m $SERENITY_RAM_SIZE \
             -cpu $SERENITY_QEMU_CPU \
             -d guest_errors \
             -no-reboot \
             -smp ${SERENITY_CPUS} \
-            -drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk \
             -device ich9-ahci \
             -nographic \
             -display none \

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -240,8 +240,10 @@ if [ -z "$SERENITY_QEMU_DISPLAY_DEVICE" ]; then
     fi
 fi
 
-# NVME is enabled by default; disable by setting SERENITY_NVME_ENABLE=0
-if [ -z "${SERENITY_NVME_ENABLE}" ] || [ "${SERENITY_NVME_ENABLE}" -eq 1 ]; then
+if [ "$SERENITY_ARCH" = 'aarch64' ]; then
+    SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},if=sd,format=raw"
+elif [ -z "${SERENITY_NVME_ENABLE}" ] || [ "${SERENITY_NVME_ENABLE}" -eq 1 ]; then
+    # NVME is enabled by default; disable by setting SERENITY_NVME_ENABLE=0
     SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk,if=none,id=disk"
     SERENITY_BOOT_DRIVE="${SERENITY_BOOT_DRIVE} -device i82801b11-bridge,id=bridge4 -device sdhci-pci,bus=bridge4"
     SERENITY_BOOT_DRIVE="${SERENITY_BOOT_DRIVE} -device nvme,serial=deadbeef,drive=disk,bus=bridge4,logical_block_size=4096,physical_block_size=4096"
@@ -294,7 +296,6 @@ if [ -z "$SERENITY_MACHINE" ]; then
         SERENITY_MACHINE="
         -M raspi3b
         -serial stdio
-        -drive file=${SERENITY_DISK_IMAGE},if=sd,format=raw
         "
     else
         SERENITY_MACHINE="
@@ -513,10 +514,10 @@ elif [ "$SERENITY_RUN" = "ci" ]; then
       "$SERENITY_QEMU_BIN" \
             $SERENITY_EXTRA_QEMU_ARGS \
             $SERENITY_VIRT_TECH_ARG \
+            $SERENITY_BOOT_DRIVE \
             -M raspi3b \
             -d guest_errors \
             -no-reboot \
-            -drive file=${SERENITY_DISK_IMAGE},if=sd,format=raw \
             -nographic \
             -monitor none \
             -display none \


### PR DESCRIPTION
This results in significant performance improvements in both sequential and random disk reading and writing.

Some benchmarks on my machine, all run on a fresh boot of SerenityOS:

|Benchmark|ATA|NVME|
|---|---:|---:|
|`dd if=/dev/zero of=./output.file bs=64k count=1600`|8602 ms|3131 ms (-64%)|
|`dd if=./output.file bs=64k of=/dev/null`|10223 ms|3988 ms (-61%)|
|`find / 2>&1 >/dev/null`|1075 ms|500 ms (-54%)|