### PR TITLE
Kernel/aarch64: Account for reserved VideoCore range in the memory map

### DIFF
--- a/Kernel/Arch/aarch64/RPi/Mailbox.h
+++ b/Kernel/Arch/aarch64/RPi/Mailbox.h
@@ -55,6 +55,15 @@ public:
 
     // Returns the kernel command line as a StringView into the given buffer.
     StringView query_kernel_command_line(Bytes buffer);
+
+    struct MemoryRange {
+        u32 base;
+        u32 size;
+    };
+    // Returns the RAM available to the CPU in the first 1GB of the physical address space.
+    // FIXME: Remove in favor of parsing the device tree.
+    MemoryRange query_lower_arm_memory_range();
+    MemoryRange query_videocore_memory_range();
 };
 
 }


### PR DESCRIPTION
Instead of having a single available memory range that encompasses the
whole 0x00000000-0x3EFFFFFF range of physical memory, create a separate
reserved entry for the RAM range used by the VideoCore. This fixes a
crash that happens when we try to allocate physical pages in the GPU's
reserved range.

This will eventually be replaced with parsing the data from the device
tree, but for now, this should solve some of the recurring CI failures.