### PR TITLE
LibGfx: Fix partial loading of tall and interlaced PNG files

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -850,7 +850,7 @@ static ErrorOr<void> decode_adam7_pass(PNGLoadingContext& context, Streamer& str
 
     // Copy the subimage data into the main image according to the pass pattern
     for (int y = 0, dy = adam7_starty[pass]; y < subimage_context.height && dy < context.height; ++y, dy += adam7_stepy[pass]) {
-        for (int x = 0, dx = adam7_startx[pass]; x < subimage_context.width && dy < context.width; ++x, dx += adam7_stepx[pass]) {
+        for (int x = 0, dx = adam7_startx[pass]; x < subimage_context.width && dx < context.width; ++x, dx += adam7_stepx[pass]) {
             context.bitmap->set_pixel(dx, dy, subimage_context.bitmap->get_pixel(x, y));
         }
     }


### PR DESCRIPTION
The function stopped copying data from a subimage when the _y_ value exceeded the image _width_ value, resulting in an incomplete image.

test image: https://images.videolan.org/images/icons/platform-sprite.png

before | after
---|---
![image](https://github.com/SerenityOS/serenity/assets/16520278/f918a5a7-10db-4c99-abcd-6053e8c65edd) | ![image](https://github.com/SerenityOS/serenity/assets/16520278/361c10ba-e143-420c-9a23-3e7797790445)
