### PR TITLE
LibGfx/PortableFormat: Easy optimisations

### DIFF
--- a/AK/MemoryStream.cpp
+++ b/AK/MemoryStream.cpp
@@ -54,6 +54,17 @@ ErrorOr<Bytes> FixedMemoryStream::read_some(Bytes bytes)
     return bytes.trim(to_read);
 }
 
+ErrorOr<void> FixedMemoryStream::read_until_filled(AK::Bytes bytes)
+{
+    if (remaining() < bytes.size())
+        return Error::from_string_view_or_print_error_and_return_errno("Can't read past the end of the stream memory"sv, EINVAL);
+
+    m_bytes.slice(m_offset).copy_trimmed_to(bytes);
+    m_offset += bytes.size();
+
+    return {};
+}
+
 ErrorOr<size_t> FixedMemoryStream::seek(i64 offset, SeekMode seek_mode)
 {
     switch (seek_mode) {

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -24,6 +24,7 @@ public:
     virtual void close() override;
     virtual ErrorOr<void> truncate(size_t) override;
     virtual ErrorOr<Bytes> read_some(Bytes bytes) override;
+    virtual ErrorOr<void> read_until_filled(Bytes bytes) override;
 
     virtual ErrorOr<size_t> seek(i64 offset, SeekMode seek_mode = SeekMode::SetPosition) override;
 

--- a/Userland/Libraries/LibGfx/ImageFormats/PBMLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PBMLoader.cpp
@@ -12,19 +12,19 @@ namespace Gfx {
 
 ErrorOr<void> read_image_data(PBMLoadingContext& context)
 {
+    TRY(create_bitmap(context));
+
     auto& stream = *context.stream;
-    Vector<Gfx::Color> color_data;
 
     auto const context_size = context.width * context.height;
-    color_data.resize(context_size);
 
     if (context.type == PBMLoadingContext::Type::ASCII) {
         for (u64 i = 0; i < context_size; ++i) {
             auto const byte = TRY(stream.read_value<u8>());
             if (byte == '0')
-                color_data[i] = Color::White;
+                context.bitmap->set_pixel(i % context.width, i / context.width, Color::White);
             else if (byte == '1')
-                color_data[i] = Color::Black;
+                context.bitmap->set_pixel(i % context.width, i / context.width, Color::Black);
             else
                 i--;
         }
@@ -35,9 +35,9 @@ ErrorOr<void> read_image_data(PBMLoadingContext& context)
                 auto const val = byte & 0x80;
 
                 if (val == 0)
-                    color_data[color_index] = Color::White;
+                    context.bitmap->set_pixel(color_index % context.width, color_index / context.width, Color::White);
                 else
-                    color_data[color_index] = Color::Black;
+                    context.bitmap->set_pixel(color_index % context.width, color_index / context.width, Color::Black);
 
                 byte = byte << 1;
                 color_index++;
@@ -48,10 +48,6 @@ ErrorOr<void> read_image_data(PBMLoadingContext& context)
             }
         }
     }
-
-    TRY(create_bitmap(context));
-
-    set_pixels(context, color_data);
 
     context.state = PBMLoadingContext::State::Bitmap;
     return {};

--- a/Userland/Libraries/LibGfx/ImageFormats/PPMLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PPMLoader.cpp
@@ -12,9 +12,9 @@ namespace Gfx {
 
 ErrorOr<void> read_image_data(PPMLoadingContext& context)
 {
-    Vector<Gfx::Color> color_data;
     auto const context_size = context.width * context.height;
-    color_data.resize(context_size);
+
+    TRY(create_bitmap(context));
 
     auto& stream = *context.stream;
 
@@ -32,7 +32,7 @@ ErrorOr<void> read_image_data(PPMLoadingContext& context)
             Color color { static_cast<u8>(red), static_cast<u8>(green), static_cast<u8>(blue) };
             if (context.format_details.max_val < 255)
                 color = adjust_color(context.format_details.max_val, color);
-            color_data[i] = color;
+            context.bitmap->set_pixel(i % context.width, i / context.width, color);
         }
     } else if (context.type == PPMLoadingContext::Type::RAWBITS) {
         for (u64 i = 0; i < context_size; ++i) {
@@ -41,13 +41,9 @@ ErrorOr<void> read_image_data(PPMLoadingContext& context)
 
             TRY(stream.read_until_filled(buffer));
 
-            color_data[i] = { pixel[0], pixel[1], pixel[2] };
+            context.bitmap->set_pixel(i % context.width, i / context.width, { pixel[0], pixel[1], pixel[2] });
         }
     }
-
-    TRY(create_bitmap(context));
-
-    set_pixels(context, color_data);
 
     context.state = PPMLoadingContext::State::Bitmap;
     return {};

--- a/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
@@ -171,18 +171,6 @@ static ErrorOr<void> create_bitmap(TContext& context)
 }
 
 template<typename TContext>
-static void set_pixels(TContext& context, Vector<Gfx::Color> const& color_data)
-{
-    size_t index = 0;
-    for (size_t y = 0; y < context.height; ++y) {
-        for (size_t x = 0; x < context.width; ++x) {
-            context.bitmap->set_pixel(x, y, color_data.at(index));
-            index++;
-        }
-    }
-}
-
-template<typename TContext>
 static ErrorOr<void> decode(TContext& context)
 {
     if (context.state >= TContext::State::Decoded)


### PR DESCRIPTION
These two patches already reduce execution time by more than 30%.

Many low-hanging fruits remain tho