### PR TITLE
LibGfx/PortableFormat: Reject images with a maximum value of 0

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
@@ -153,6 +153,11 @@ static ErrorOr<void> read_max_val(TContext& context)
 {
     context.format_details.max_val = TRY(read_number(*context.stream));
 
+    if (context.format_details.max_val == 0) {
+        context.state = TContext::State::Error;
+        return Error::from_string_literal("The image has a maximum value of 0");
+    }
+
     if (context.format_details.max_val > 255) {
         dbgln_if(PORTABLE_IMAGE_LOADER_DEBUG, "We can't parse 2 byte color for {}", TContext::FormatDetails::image_type);
         context.state = TContext::State::Error;


### PR DESCRIPTION
These images can't contain any meaningful information, so no need to try to decode them. Doing so result in a `SIGFPE`, as we divide by this value later on.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57434&sort=-opened&can=1&q=proj%3Aserenity