### PR TITLE
Ports/nhlohmann-json: fix pkgconf install path

### DIFF
--- a/Ports/nlohmann-json/package.sh
+++ b/Ports/nlohmann-json/package.sh
@@ -7,6 +7,7 @@ files="https://github.com/nlohmann/json/archive/refs/tags/v${version}.tar.gz jso
 useconfigure='true'
 configopts=(
     "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"
+    "-DCMAKE_INSTALL_DATADIR=${SERENITY_INSTALL_ROOT}/usr/local/lib"
     "-DJSON_BuildTests=OFF"
 )
 


### PR DESCRIPTION
CMAKE_INSTALL_DATADIR is used to define the install base dir for
pkgconf files. In this case it defaulted to /usr/local/share/pkgconf
which is not a location searched by default.

See https://github.com/nlohmann/json/blob/a0c1318830519eac027a31edec1a99ce1ae5670e/CMakeLists.txt#L69