### PR TITLE
WebP/Lossy+Alpha: Implement filtering_method for ALPH chunk

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -245,27 +245,6 @@ static ErrorOr<void> decode_webp_chunk_ALPH(Chunk const& alph_chunk, Bitmap& bit
         return {};
     }
 
-#if 0
-    dbgln("writing compressed alpha channel to alph.webp");
-    u32 size0 = 1 + 4 + alpha_data.size(); // 1 byte 0x2f, 4 byte width/height, data. doesn't include size of VP8L chunk size field.
-    u32 size = strlen("WEBP") + strlen("VP8L") + sizeof(u32) + size0; // Doesn't include size of "RIFF" and file size field (but does include size of VP8L chunk size field)
-    FILE* f = fopen("alph.webp", "wb");
-    fwrite("RIFF", 1, 4, f);
-    fwrite(&size, 4, 1, f);
-    fwrite("WEBP", 1, 4, f);
-    fwrite("VP8L", 1, 4, f);
-
-    fwrite(&size0, 4, 1, f);
-    u8 signature = 0x2f;
-    fwrite(&signature, 1, 1, f);
-    u32 header_stuff = (bitmap.width() - 1) | ((bitmap.height() - 1) << 14);
-    fwrite(&header_stuff, 4, 1, f);
-
-    fwrite(alpha_data.data(), 1, alpha_data.size(), f);
-
-    fclose(f);
-#endif
-
     // "Lossless format compression: the byte sequence is a compressed image-stream (as described in the WebP Lossless Bitstream Format)
     //  of implicit dimension width x height. That is, this image-stream does NOT contain any headers describing the image dimension.
     //  Once the image-stream is decoded into ARGB color values, following the process described in the lossless format specification,

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -245,6 +245,27 @@ static ErrorOr<void> decode_webp_chunk_ALPH(Chunk const& alph_chunk, Bitmap& bit
         return {};
     }
 
+#if 0
+    dbgln("writing compressed alpha channel to alph.webp");
+    u32 size0 = 1 + 4 + alpha_data.size(); // 1 byte 0x2f, 4 byte width/height, data. doesn't include size of VP8L chunk size field.
+    u32 size = strlen("WEBP") + strlen("VP8L") + sizeof(u32) + size0; // Doesn't include size of "RIFF" and file size field (but does include size of VP8L chunk size field)
+    FILE* f = fopen("alph.webp", "wb");
+    fwrite("RIFF", 1, 4, f);
+    fwrite(&size, 4, 1, f);
+    fwrite("WEBP", 1, 4, f);
+    fwrite("VP8L", 1, 4, f);
+
+    fwrite(&size0, 4, 1, f);
+    u8 signature = 0x2f;
+    fwrite(&signature, 1, 1, f);
+    u32 header_stuff = (bitmap.width() - 1) | ((bitmap.height() - 1) << 14);
+    fwrite(&header_stuff, 4, 1, f);
+
+    fwrite(alpha_data.data(), 1, alpha_data.size(), f);
+
+    fclose(f);
+#endif
+
     // "Lossless format compression: the byte sequence is a compressed image-stream (as described in the WebP Lossless Bitstream Format)
     //  of implicit dimension width x height. That is, this image-stream does NOT contain any headers describing the image dimension.
     //  Once the image-stream is decoded into ARGB color values, following the process described in the lossless format specification,

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -630,6 +630,7 @@ WebPImageDecoderPlugin::~WebPImageDecoderPlugin() = default;
 bool WebPImageDecoderPlugin::set_error(ErrorOr<void> const& error_or)
 {
     if (error_or.is_error()) {
+        dbgln("WebPLoadingContext error: {}", error_or.error());
         m_context->state = WebPLoadingContext::State::Error;
         return true;
     }


### PR DESCRIPTION
For https://fjord.dropboxstatic.com/warp/conversion/dropbox/warp/en-us/dropbox/Integrations_4@2x.png?id=ce8269af-ef1a-460a-8199-65af3dd978a3&output_type=webp :

Before:

![webp-ALPH-borked](https://github.com/SerenityOS/serenity/assets/3487/cc8857e6-0bad-4183-9ce7-05eaafa902f6)

After:

![webp-ALPH-fixed](https://github.com/SerenityOS/serenity/assets/3487/4bddd062-2e47-4ef6-901d-a7b40f17e57f)
