### PR TITLE
LibWeb: Add naive support for margin-{block,inline} and padding-{block,inline} properties

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline.txt
@@ -1,0 +1,10 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x119.46875 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 500x101.46875 children: not-inline
+      BlockContainer <div.a> at (31,21) content-size 458x79.46875 children: not-inline
+        BlockContainer <div.b> at (72,52) content-size 376x17.46875 children: inline
+          line 0 width: 41.78125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [73,52 39.78125x17.46875]
+              "Hello"
+          InlineNode <span>
+            TextNode <#text>

--- a/Tests/LibWeb/Layout/input/block-and-inline/margin-padding-block-inline.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/margin-padding-block-inline.html
@@ -1,0 +1,18 @@
+<!doctype html><style>
+* {
+    border: 1px solid black;
+}
+body {
+    width: 500px;
+}
+.a {
+    padding: 100px;
+    padding-block: 10px;
+    padding-inline: 20px;
+}
+.b {
+    margin: 90px;
+    margin-block: 30px;
+    margin-inline: 40px;
+}
+</style><div class="a"><div class="b"><span>Hello</span>

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1265,6 +1265,12 @@
       "unitless-length"
     ]
   },
+  "margin-block": {
+    "logical-alias-for": [
+      "margin"
+    ],
+    "max-values": 2
+  },
   "margin-block-start": {
     "logical-alias-for": [
       "margin-top",
@@ -1294,6 +1300,12 @@
     "quirks": [
       "unitless-length"
     ]
+  },
+  "margin-inline": {
+    "logical-alias-for": [
+      "margin"
+    ],
+    "max-values": 2
   },
   "margin-inline-start": {
     "logical-alias-for": [
@@ -1535,6 +1547,12 @@
       "unitless-length"
     ]
   },
+  "padding-block": {
+    "logical-alias-for": [
+      "padding"
+    ],
+    "max-values": 2
+  },
   "padding-block-start": {
     "logical-alias-for": [
       "padding-top",
@@ -1561,6 +1579,12 @@
     "quirks": [
       "unitless-length"
     ]
+  },
+  "padding-inline": {
+    "logical-alias-for": [
+      "padding"
+    ],
+    "max-values": 2
   },
   "padding-inline-start": {
     "logical-alias-for": [


### PR DESCRIPTION
Like other logical properties, we just alias these to the LTR TB default properties for now.

Nice visual progression on Apple Security blogs.

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/6d48a245-9ffe-425d-ab7f-078e9e80059a)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/4c35454f-ef32-4607-91e3-356bc07a6fac)
