### PR TITLE
Userland: Avoid some unnecessary copies, repair cycle detection in LibJS value printing

### DIFF
--- a/Userland/Libraries/LibGUI/Action.h
+++ b/Userland/Libraries/LibGUI/Action.h
@@ -134,7 +134,7 @@ public:
     ActionGroup const* group() const { return m_action_group.ptr(); }
     void set_group(Badge<ActionGroup>, ActionGroup*);
 
-    HashTable<MenuItem*> menu_items() const { return m_menu_items; }
+    HashTable<MenuItem*> const& menu_items() const { return m_menu_items; }
 
 private:
     Action(DeprecatedString, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);

--- a/Userland/Libraries/LibIDL/IDLParser.cpp
+++ b/Userland/Libraries/LibIDL/IDLParser.cpp
@@ -942,21 +942,23 @@ Interface& Parser::parse()
     top_level_resolved_imports().set(this_module, &interface);
 
     Vector<Interface&> imports;
-    HashTable<DeprecatedString> required_imported_paths;
-    while (lexer.consume_specific("#import")) {
-        consume_whitespace();
-        assert_specific('<');
-        auto path = lexer.consume_until('>');
-        lexer.ignore();
-        auto maybe_interface = resolve_import(path);
-        if (maybe_interface.has_value()) {
-            for (auto& entry : maybe_interface.value().required_imported_paths)
-                required_imported_paths.set(entry);
-            imports.append(maybe_interface.release_value());
+    {
+        HashTable<DeprecatedString> required_imported_paths;
+        while (lexer.consume_specific("#import")) {
+            consume_whitespace();
+            assert_specific('<');
+            auto path = lexer.consume_until('>');
+            lexer.ignore();
+            auto maybe_interface = resolve_import(path);
+            if (maybe_interface.has_value()) {
+                for (auto& entry : maybe_interface.value().required_imported_paths)
+                    required_imported_paths.set(entry);
+                imports.append(maybe_interface.release_value());
+            }
+            consume_whitespace();
         }
-        consume_whitespace();
+        interface.required_imported_paths = move(required_imported_paths);
     }
-    interface.required_imported_paths = required_imported_paths;
 
     parse_non_interface_entities(true, interface);
 

--- a/Userland/Libraries/LibJS/MarkupGenerator.cpp
+++ b/Userland/Libraries/LibJS/MarkupGenerator.cpp
@@ -32,7 +32,8 @@ ErrorOr<String> MarkupGenerator::html_from_source(StringView source)
 ErrorOr<String> MarkupGenerator::html_from_value(Value value)
 {
     StringBuilder output_html;
-    TRY(value_to_html(value, output_html));
+    HashTable<Object*> seen_objects;
+    TRY(value_to_html(value, output_html, seen_objects));
     return output_html.to_string();
 }
 
@@ -43,7 +44,7 @@ ErrorOr<String> MarkupGenerator::html_from_error(Error const& object, bool in_pr
     return output_html.to_string();
 }
 
-ErrorOr<void> MarkupGenerator::value_to_html(Value value, StringBuilder& output_html, HashTable<Object*> seen_objects)
+ErrorOr<void> MarkupGenerator::value_to_html(Value value, StringBuilder& output_html, HashTable<Object*>& seen_objects)
 {
     if (value.is_empty()) {
         TRY(output_html.try_append("&lt;empty&gt;"sv));

--- a/Userland/Libraries/LibJS/MarkupGenerator.h
+++ b/Userland/Libraries/LibJS/MarkupGenerator.h
@@ -33,7 +33,7 @@ private:
         ObjectType,
     };
 
-    static ErrorOr<void> value_to_html(Value, StringBuilder& output_html, HashTable<Object*> seen_objects = {});
+    static ErrorOr<void> value_to_html(Value, StringBuilder& output_html, HashTable<Object*>& seen_objects);
     static ErrorOr<void> array_to_html(Array const&, StringBuilder& output_html, HashTable<Object*>&);
     static ErrorOr<void> object_to_html(Object const&, StringBuilder& output_html, HashTable<Object*>&);
     static ErrorOr<void> function_to_html(Object const&, StringBuilder& output_html, HashTable<Object*>&);

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1762,7 +1762,7 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                 TRY(Node::append_without_space(total_accumulated_text, after->computed_values().content().data));
 
             // iii. For each child node of the current node:
-            element->for_each_child([&total_accumulated_text, current_node, target, &document, visited_nodes](
+            element->for_each_child([&total_accumulated_text, current_node, target, &document, &visited_nodes](
                                         DOM::Node const& child_node) mutable {
                 if (visited_nodes.contains(child_node.id()))
                     return;


### PR DESCRIPTION
This PR, removes some places where copy-construct and copy-assign is unnecessary, and probably even unintentional.

My long-term quest is to make HashTable/HashMap OOM-safe, by removing infallible copy-construct and copy-assign. (`HashMap::clone` already exists, `HashTable::clone` comes in a future PR.) For this, I want to reduce the callers to copy-construct and copy-assign.

For example, printing cyclic or redundant values in the Browser JS Console. Before:
![before](https://github.com/SerenityOS/serenity/assets/2690845/e1ce8be8-1783-4e1a-87cd-834e44dc07eb)

After:
![after](https://github.com/SerenityOS/serenity/assets/2690845/c657992b-7a03-4736-99be-e79c90490438)