### PR TITLE
LibWeb: Add support for grid items with negative column-start in GFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/negative-grid-item-column-index.txt
+++ b/Tests/LibWeb/Layout/expected/grid/negative-grid-item-column-index.txt
@@ -1,0 +1,71 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x69.875 children: not-inline
+      Box <div.grid> at (8,8) content-size 784x69.875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.a> at (8,8) content-size 196x17.46875 [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.c> at (204,8) content-size 196x17.46875 [BFC] children: inline
+          line 0 width: 8.890625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [204,8 8.890625x17.46875]
+              "c"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.b> at (400,8) content-size 196x17.46875 [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [400,8 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.b> at (400,25.46875) content-size 196x17.46875 [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [400,25.46875 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.d> at (596,25.46875) content-size 196x17.46875 [BFC] children: inline
+          line 0 width: 7.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [596,25.46875 7.859375x17.46875]
+              "d"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.c> at (204,42.9375) content-size 196x17.46875 [BFC] children: inline
+          line 0 width: 8.890625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [204,42.9375 8.890625x17.46875]
+              "c"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.d> at (596,42.9375) content-size 196x17.46875 [BFC] children: inline
+          line 0 width: 7.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [596,42.9375 7.859375x17.46875]
+              "d"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.e> at (8,60.40625) content-size 196x17.46875 [BFC] children: inline
+          line 0 width: 8.71875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [8,60.40625 8.71875x17.46875]
+              "e"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.f> at (204,60.40625) content-size 196x17.46875 [BFC] children: inline
+          line 0 width: 6.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [204,60.40625 6.4375x17.46875]
+              "f"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,77.875) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/grid/negative-grid-item-column-index.html
+++ b/Tests/LibWeb/Layout/input/grid/negative-grid-item-column-index.html
@@ -1,0 +1,38 @@
+<style>
+.grid {
+display: grid;
+grid-template-columns: auto;
+}
+
+.a {
+grid-column: -3;
+background-color: lightblue;
+}
+
+.b {
+grid-column-start: -1;
+background-color: lightcoral;
+}
+
+.c {
+grid-column: 1;
+background-color: lightsalmon;
+}
+
+.d {
+grid-column: 3;
+background-color: lightgreen;
+}
+</style>
+<div class="grid">
+<div class="a">a</div>
+<div class="c">c</div>
+<div class="b">b</div>
+<div class="b">b</div>
+<div class="d">d</div>
+<div class="c">c</div>
+<div class="d">d</div>
+<div class="e">e</div>
+<div class="f">f</div>
+</div>
+  

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -17,29 +17,9 @@ enum class GridDimension {
 };
 
 struct GridPosition {
-    size_t row;
-    size_t column;
+    int row;
+    int column;
     inline bool operator==(GridPosition const&) const = default;
-};
-
-class OccupationGrid {
-public:
-    OccupationGrid(size_t columns_count, size_t rows_count)
-        : m_columns_count(columns_count)
-        , m_rows_count(rows_count) {};
-    OccupationGrid() {};
-
-    void set_occupied(size_t column_start, size_t column_end, size_t row_start, size_t row_end);
-    void set_occupied(size_t column_index, size_t row_index);
-
-    size_t column_count() const { return m_columns_count; }
-    size_t row_count() const { return m_rows_count; }
-    bool is_occupied(size_t column_index, size_t row_index) const;
-
-private:
-    HashTable<GridPosition> m_occupation_grid;
-    size_t m_columns_count { 0 };
-    size_t m_rows_count { 0 };
 };
 
 class GridItem {
@@ -60,7 +40,7 @@ public:
         return dimension == GridDimension::Column ? m_column_span : m_row_span;
     }
 
-    size_t raw_position(GridDimension const dimension) const
+    int raw_position(GridDimension const dimension) const
     {
         return dimension == GridDimension::Column ? m_column : m_row;
     }
@@ -75,21 +55,61 @@ public:
         }
     }
 
-    size_t raw_row() const { return m_row; }
-    size_t raw_column() const { return m_column; }
+    int raw_row() const { return m_row; }
+    void set_raw_row(int row) { m_row = row; }
+
+    int raw_column() const { return m_column; }
+    void set_raw_column(int column) { m_column = column; }
 
     size_t raw_row_span() const { return m_row_span; }
     size_t raw_column_span() const { return m_column_span; }
 
-    size_t gap_adjusted_row(Box const& grid_box) const;
-    size_t gap_adjusted_column(Box const& grid_box) const;
+    int gap_adjusted_row(Box const& grid_box) const;
+    int gap_adjusted_column(Box const& grid_box) const;
 
 private:
     JS::NonnullGCPtr<Box const> m_box;
-    size_t m_row { 0 };
+    int m_row { 0 };
     size_t m_row_span { 1 };
-    size_t m_column { 0 };
+    int m_column { 0 };
     size_t m_column_span { 1 };
+};
+
+class OccupationGrid {
+public:
+    OccupationGrid(size_t columns_count, size_t rows_count)
+    {
+        m_max_column_index = max(0, columns_count - 1);
+        m_max_row_index = max(0, rows_count - 1);
+    };
+    OccupationGrid() {};
+
+    void set_occupied(int column_start, int column_end, int row_start, int row_end);
+
+    size_t column_count() const
+    {
+        return abs(m_min_column_index) + m_max_column_index + 1;
+    }
+
+    size_t row_count() const
+    {
+        return abs(m_min_row_index) + m_max_row_index + 1;
+    }
+
+    int min_column_index() const { return m_min_column_index; }
+    int max_column_index() const { return m_max_column_index; };
+    int min_row_index() const { return m_min_row_index; };
+    int max_row_index() const { return m_max_row_index; };
+
+    bool is_occupied(int column_index, int row_index) const;
+
+private:
+    HashTable<GridPosition> m_occupation_grid;
+
+    int m_min_column_index { 0 };
+    int m_max_column_index { 0 };
+    int m_min_row_index { 0 };
+    int m_max_row_index { 0 };
 };
 
 class GridFormattingContext final : public FormattingContext {
@@ -197,6 +217,9 @@ private:
 
     Vector<TemporaryTrack&> m_grid_rows_and_gaps;
     Vector<TemporaryTrack&> m_grid_columns_and_gaps;
+
+    size_t m_explicit_rows_line_count { 0 };
+    size_t m_explicit_columns_line_count { 0 };
 
     OccupationGrid m_occupation_grid;
     Vector<GridItem> m_grid_items;


### PR DESCRIPTION
This changes grid items position storage type from unsigned to signed integer so it can represent negative offsets and also updates placement for grid items with specified column to correctly handle negative offsets.