### PR TITLE
CI: Don't run known-failing tests on Aarch

### DIFF
--- a/Base/home/anon/Tests/run-tests-and-shutdown.sh
+++ b/Base/home/anon/Tests/run-tests-and-shutdown.sh
@@ -1,11 +1,19 @@
 #!/bin/Shell
+# shellcheck disable=all
 
 echo
 echo "==== Running Tests on SerenityOS ===="
 
 export LLVM_PROFILE_FILE="$HOME/profiles/%p-profile.profraw"
 
-run-tests --show-progress=false --unlink-coredumps
+echo "architecture is: >>$(uname -m)<<"
+skip_args=()
+if [ "$(uname -m)" = "AArch64" ] {
+    # FIXME: This is just temporary. Without this, Aarch64 breaks CI for everyone.
+    skip_args=("-e" "^/usr/Tests/(AK/TestSIMD|Kernel/TestMemoryDeviceMmap|Kernel/crash|LibC/TestAbort|LibC/TestLibCSetjmp|LibC/TestLibCTime|LibC/TestMath|LibGfx/TestDeltaE|LibGfx/TestICCProfile|LibTLS/TestTLSHandshake|LibVideo/TestVP9Decode|LibWeb/TestCSSIDSpeed|LibWeb/TestHTMLTokenizer|test-js/test-js|test-spreadsheet/test-spreadsheet|test-wasm/test-wasm)\$")
+}
+echo "Skip args is" $skip_args
+run-tests $skip_args --show-progress=false --unlink-coredumps
 fail_count=$?
 
 unset LLVM_PROFILE_FILE


### PR DESCRIPTION
These might be the cause of CI failures.