### PR TITLE
LibWeb: Consider all spanned tracks while finding extra space in GFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/distribute-extra-space-across-spanned-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/distribute-extra-space-across-spanned-tracks.txt
@@ -1,0 +1,27 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
+      Box <div.grid> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.right> at (400,8) content-size 392x17.46875 [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [400,8 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.left> at (8,8) content-size 392x17.46875 [BFC] children: not-inline
+          BlockContainer <(anonymous)> at (8,8) content-size 392x0 children: inline
+            TextNode <#text>
+          BlockContainer <div.inner> at (8,8) content-size 392x17.46875 children: inline
+            line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.46875x17.46875]
+                "b"
+            TextNode <#text>
+          BlockContainer <(anonymous)> at (8,25.46875) content-size 392x0 children: inline
+            TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,25.46875) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/grid/distribute-extra-space-across-spanned-tracks.html
+++ b/Tests/LibWeb/Layout/input/grid/distribute-extra-space-across-spanned-tracks.html
@@ -1,0 +1,24 @@
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: min-content auto;
+}
+.right {
+    background-color: lightpink;
+    grid-area: 1 / 2 / auto / -1;
+}
+.left {
+    grid-area: 1 / 1 / -1 / auto;
+    background-color: lightslategrey;
+}
+.inner {
+    background-color: lightskyblue;
+}
+</style>
+<div class="grid">
+<div class="right">a</div>
+<div class="left">
+    <div class="inner">b</div>
+</div>
+</div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -252,10 +252,14 @@ private:
     void initialize_grid_tracks_for_columns_and_rows(AvailableSpace const&);
     void initialize_gap_tracks(AvailableSpace const&);
 
+    template<typename Match>
+    void distribute_extra_space_across_spanned_tracks_base_size(CSSPixels item_size_contribution, Vector<TemporaryTrack&>& spanned_tracks, Match matcher);
+
+    template<typename Match>
+    void distribute_extra_space_across_spanned_tracks_growth_limit(CSSPixels item_size_contribution, Vector<TemporaryTrack&>& spanned_tracks, Match matcher);
+
     void initialize_track_sizes(AvailableSpace const&, GridDimension const);
     void resolve_intrinsic_track_sizes(AvailableSpace const&, GridDimension const);
-    void distribute_extra_space_across_spanned_tracks_base_size(CSSPixels item_size_contribution, Vector<TemporaryTrack&>& spanned_tracks);
-    void distribute_extra_space_across_spanned_tracks_growth_limit(CSSPixels item_size_contribution, Vector<TemporaryTrack&>& spanned_tracks);
     void increase_sizes_to_accommodate_spanning_items_crossing_content_sized_tracks(AvailableSpace const&, GridDimension const, size_t span);
     void increase_sizes_to_accommodate_spanning_items_crossing_flexible_tracks(GridDimension const);
     void maximize_tracks(AvailableSpace const&, GridDimension const);


### PR DESCRIPTION
This fixes the issue when functions that distribute base_size or growth_limit to tracks only considered *affected* spanned tracks while calculating left extra that is available for distribution while indeed it should be just *all* spanned track by specific item that extra space size.