### PR TITLE
LibCore: Ensure `exec()` keeps a reference to the executable path

### DIFF
--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1263,14 +1263,15 @@ ErrorOr<void> exec(StringView filename, ReadonlySpan<StringView> arguments, Sear
     };
 
     StringView exec_filename;
-
+    String resolved_executable_path;
     if (search_in_path == SearchInPath::Yes) {
         auto executable_or_error = resolve_executable_from_environment(filename);
 
         if (executable_or_error.is_error())
             return executable_or_error.release_error();
 
-        exec_filename = executable_or_error.value();
+        resolved_executable_path = executable_or_error.release_value();
+        exec_filename = resolved_executable_path;
     } else {
         exec_filename = filename;
     }


### PR DESCRIPTION
When called with `SearchInPath::Yes`, calls to `Core::System::exec()` would fail. The value returned from
`resolve_executable_from_environment()` was assigned to a StringView, but the original reference was not kept, causing the StringView to appear empty.

This was causing scripts that use `env` to fail.

Tested with the following script:

```sh
#!/usr/bin/env Shell
echo "Hello"
```

Prior to this PR, the above would fail with: `exec: No such file or directory (errno=2)`.