### PR TITLE
LibWeb: Implement the document title attribute closer to the spec

### DIFF
--- a/Ladybird/BrowserWindow.cpp
+++ b/Ladybird/BrowserWindow.cpp
@@ -516,15 +516,9 @@ int BrowserWindow::tab_index(Tab* tab)
 
 void BrowserWindow::tab_title_changed(int index, QString const& title)
 {
-    if (title.isEmpty()) {
-        m_tabs_container->setTabText(index, "...");
-        if (m_tabs_container->currentIndex() == index)
-            setWindowTitle("Ladybird");
-    } else {
-        m_tabs_container->setTabText(index, title);
-        if (m_tabs_container->currentIndex() == index)
-            setWindowTitle(QString("%1 - Ladybird").arg(title));
-    }
+    m_tabs_container->setTabText(index, title);
+    if (m_tabs_container->currentIndex() == index)
+        setWindowTitle(QString("%1 - Ladybird").arg(title));
 }
 
 void BrowserWindow::tab_favicon_changed(int index, QIcon icon)

--- a/Tests/LibWeb/Text/expected/title.txt
+++ b/Tests/LibWeb/Text/expected/title.txt
@@ -1,0 +1,14 @@
+1: ""
+2a: 0
+2b: 1
+2c: "This is a title!"
+2d: "This is a title!"
+3: ""
+4a: 3
+4b: ""
+4c: ""
+4d: ""
+4e: 3
+4f: "This is another title!"
+4g: ""
+4h: ""

--- a/Tests/LibWeb/Text/input/title.html
+++ b/Tests/LibWeb/Text/input/title.html
@@ -1,0 +1,42 @@
+<script src="include.js"></script>
+<script>
+    test(() => {
+        // The title is the empty string by default.
+        println(`1: "${document.title}"`);
+
+        // When the title is set, and a title element does not exist, one is added to to head element.
+        let titleElements = document.getElementsByTagName('title');
+        println(`2a: ${titleElements.length}`)
+
+        document.title = 'This is a title!';
+
+        titleElements = document.getElementsByTagName('title');
+        println(`2b: ${titleElements.length}`)
+        println(`2c: "${titleElements[0].innerText}"`);
+        println(`2d: "${document.title}"`);
+
+        // Removing the title element sets the title back to default.
+        titleElements[0].remove();
+        println(`3: "${document.title}"`);
+
+        // After adding several title elements to the body, setting the title updates the text
+        // content of only the first title element.
+        document.body.appendChild(document.createElement('title'));
+        document.body.appendChild(document.createElement('title'));
+        document.body.appendChild(document.createElement('title'));
+
+        titleElements = document.getElementsByTagName('title');
+        println(`4a: ${titleElements.length}`)
+        println(`4b: "${titleElements[0].innerText}"`);
+        println(`4c: "${titleElements[1].innerText}"`);
+        println(`4d: "${titleElements[2].innerText}"`);
+
+        document.title = 'This is another title!';
+
+        titleElements = document.getElementsByTagName('title');
+        println(`4e: ${titleElements.length}`)
+        println(`4f: "${titleElements[0].innerText}"`);
+        println(`4g: "${titleElements[1].innerText}"`);
+        println(`4h: "${titleElements[2].innerText}"`);
+    });
+</script>

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -428,14 +428,10 @@ Tab::Tab(BrowserWindow& window)
         view().on_link_click(href, "_blank", 0);
     };
 
-    view().on_title_change = [this](auto& title) {
-        if (title.is_null()) {
-            m_history.update_title(url().to_deprecated_string());
-            m_title = url().to_deprecated_string();
-        } else {
-            m_history.update_title(title);
-            m_title = title;
-        }
+    view().on_title_change = [this](auto const& title) {
+        m_history.update_title(title);
+        m_title = title;
+
         if (on_title_change)
             on_title_change(m_title);
     };

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -631,6 +631,21 @@ HTML::HTMLHeadElement* Document::head()
     return html->first_child_of_type<HTML::HTMLHeadElement>();
 }
 
+// https://html.spec.whatwg.org/multipage/dom.html#the-title-element-2
+JS::GCPtr<HTML::HTMLTitleElement> Document::title_element()
+{
+    // The title element of a document is the first title element in the document (in tree order), if there is one, or
+    // null otherwise.
+    JS::GCPtr<HTML::HTMLTitleElement> title_element = nullptr;
+
+    for_each_in_subtree_of_type<HTML::HTMLTitleElement>([&](auto& title_element_in_tree) {
+        title_element = title_element_in_tree;
+        return IterationDecision::Break;
+    });
+
+    return title_element;
+}
+
 HTML::HTMLElement* Document::body()
 {
     auto* html = html_element();

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -610,16 +610,21 @@ Element const* Document::document_element() const
     return first_child_of_type<Element>();
 }
 
+// https://html.spec.whatwg.org/multipage/dom.html#the-html-element-2
 HTML::HTMLHtmlElement* Document::html_element()
 {
+    // The html element of a document is its document element, if it's an html element, and null otherwise.
     auto* html = document_element();
     if (is<HTML::HTMLHtmlElement>(html))
         return verify_cast<HTML::HTMLHtmlElement>(html);
     return nullptr;
 }
 
+// https://html.spec.whatwg.org/multipage/dom.html#the-head-element-2
 HTML::HTMLHeadElement* Document::head()
 {
+    // The head element of a document is the first head element that is a child of the html element, if there is one,
+    // or null otherwise.
     auto* html = html_element();
     if (!html)
         return nullptr;

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -173,7 +173,7 @@ public:
     WebIDL::ExceptionOr<void> set_body(HTML::HTMLElement* new_body);
 
     DeprecatedString title() const;
-    void set_title(DeprecatedString const&);
+    WebIDL::ExceptionOr<void> set_title(DeprecatedString const&);
 
     HTML::BrowsingContext* browsing_context() { return m_browsing_context.ptr(); }
     HTML::BrowsingContext const* browsing_context() const { return m_browsing_context.ptr(); }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -147,6 +147,7 @@ public:
 
     HTML::HTMLHtmlElement* html_element();
     HTML::HTMLHeadElement* head();
+    JS::GCPtr<HTML::HTMLTitleElement> title_element();
     HTML::HTMLElement* body();
 
     HTML::HTMLHtmlElement const* html_element() const
@@ -157,6 +158,11 @@ public:
     HTML::HTMLHeadElement const* head() const
     {
         return const_cast<Document*>(this)->head();
+    }
+
+    JS::GCPtr<HTML::HTMLTitleElement const> title_element() const
+    {
+        return const_cast<Document*>(this)->title_element();
     }
 
     HTML::HTMLElement const* body() const

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -149,17 +149,17 @@ public:
     HTML::HTMLHeadElement* head();
     HTML::HTMLElement* body();
 
-    const HTML::HTMLHtmlElement* html_element() const
+    HTML::HTMLHtmlElement const* html_element() const
     {
         return const_cast<Document*>(this)->html_element();
     }
 
-    const HTML::HTMLHeadElement* head() const
+    HTML::HTMLHeadElement const* head() const
     {
         return const_cast<Document*>(this)->head();
     }
 
-    const HTML::HTMLElement* body() const
+    HTML::HTMLElement const* body() const
     {
         return const_cast<Document*>(this)->body();
     }

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -95,7 +95,12 @@ void WebContentClient::did_change_title(DeprecatedString const& title)
 {
     dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidChangeTitle! title={}", title);
 
-    if (m_view.on_title_change)
+    if (!m_view.on_title_change)
+        return;
+
+    if (title.is_empty())
+        m_view.on_title_change(m_view.url().to_deprecated_string());
+    else
         m_view.on_title_change(title);
 }
 


### PR DESCRIPTION
The main differences between our current implementation and the spec
are:

* The title element need not be a child of the head element.

* If the title element does not exist, the default value should be the empty string - we currently return a null string.

* We've since added AOs for several of the spec steps here, so we do not need to implement those steps inline.