### PR TITLE
Kernel: Store process creation time and use it in ProcFS

### DIFF
--- a/Kernel/FileSystem/ProcFS/Inode.cpp
+++ b/Kernel/FileSystem/ProcFS/Inode.cpp
@@ -394,7 +394,10 @@ InodeMetadata ProcFSInode::metadata() const
         metadata.uid = credentials->uid();
         metadata.gid = credentials->gid();
         metadata.size = 0;
-        metadata.mtime = TimeManagement::now();
+        auto creation_time = process->creation_time();
+        metadata.atime = creation_time;
+        metadata.ctime = creation_time;
+        metadata.mtime = creation_time;
         break;
     }
     case Type::ProcessDirectory: {
@@ -408,7 +411,10 @@ InodeMetadata ProcFSInode::metadata() const
         metadata.uid = credentials->uid();
         metadata.gid = credentials->gid();
         metadata.size = 0;
-        metadata.mtime = TimeManagement::now();
+        auto creation_time = process->creation_time();
+        metadata.atime = creation_time;
+        metadata.ctime = creation_time;
+        metadata.mtime = creation_time;
         break;
     }
     case Type::ProcessSubdirectory: {
@@ -422,7 +428,10 @@ InodeMetadata ProcFSInode::metadata() const
         metadata.uid = credentials->uid();
         metadata.gid = credentials->gid();
         metadata.size = 0;
-        metadata.mtime = TimeManagement::now();
+        auto creation_time = process->creation_time();
+        metadata.atime = creation_time;
+        metadata.ctime = creation_time;
+        metadata.mtime = creation_time;
         break;
     }
     }

--- a/Kernel/Tasks/Process.cpp
+++ b/Kernel/Tasks/Process.cpp
@@ -291,7 +291,7 @@ ErrorOr<Process::ProcessAndFirstThread> Process::create(NonnullOwnPtr<KString> n
     auto exec_unveil_tree = UnveilNode { TRY(KString::try_create("/"sv)), UnveilMetadata(TRY(KString::try_create("/"sv))) };
     auto credentials = TRY(Credentials::create(uid, gid, uid, gid, uid, gid, {}, fork_parent ? fork_parent->sid() : 0, fork_parent ? fork_parent->pgid() : 0));
 
-    auto process = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) Process(move(name), move(credentials), ppid, is_kernel_process, move(current_directory), move(executable), tty, move(unveil_tree), move(exec_unveil_tree))));
+    auto process = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) Process(move(name), move(credentials), ppid, is_kernel_process, move(current_directory), move(executable), tty, move(unveil_tree), move(exec_unveil_tree), kgettimeofday())));
 
     OwnPtr<Memory::AddressSpace> new_address_space;
     if (fork_parent) {
@@ -308,11 +308,12 @@ ErrorOr<Process::ProcessAndFirstThread> Process::create(NonnullOwnPtr<KString> n
     return ProcessAndFirstThread { move(process), move(first_thread) };
 }
 
-Process::Process(NonnullOwnPtr<KString> name, NonnullRefPtr<Credentials> credentials, ProcessID ppid, bool is_kernel_process, RefPtr<Custody> current_directory, RefPtr<Custody> executable, RefPtr<TTY> tty, UnveilNode unveil_tree, UnveilNode exec_unveil_tree)
+Process::Process(NonnullOwnPtr<KString> name, NonnullRefPtr<Credentials> credentials, ProcessID ppid, bool is_kernel_process, RefPtr<Custody> current_directory, RefPtr<Custody> executable, RefPtr<TTY> tty, UnveilNode unveil_tree, UnveilNode exec_unveil_tree, UnixDateTime creation_time)
     : m_name(move(name))
     , m_is_kernel_process(is_kernel_process)
     , m_executable(move(executable))
     , m_current_directory(move(current_directory))
+    , m_creation_time(creation_time)
     , m_unveil_data(move(unveil_tree))
     , m_exec_unveil_data(move(exec_unveil_tree))
     , m_wait_blocker_set(*this)

--- a/Kernel/Tasks/Process.h
+++ b/Kernel/Tasks/Process.h
@@ -482,6 +482,8 @@ public:
     RefPtr<Custody> executable();
     RefPtr<Custody const> executable() const;
 
+    UnixDateTime creation_time() const { return m_creation_time; };
+
     static constexpr size_t max_arguments_size = Thread::default_userspace_stack_size / 8;
     static constexpr size_t max_environment_size = Thread::default_userspace_stack_size / 8;
     static constexpr size_t max_auxiliary_size = Thread::default_userspace_stack_size / 8;
@@ -608,7 +610,7 @@ private:
     bool add_thread(Thread&);
     bool remove_thread(Thread&);
 
-    Process(NonnullOwnPtr<KString> name, NonnullRefPtr<Credentials>, ProcessID ppid, bool is_kernel_process, RefPtr<Custody> current_directory, RefPtr<Custody> executable, RefPtr<TTY> tty, UnveilNode unveil_tree, UnveilNode exec_unveil_tree);
+    Process(NonnullOwnPtr<KString> name, NonnullRefPtr<Credentials>, ProcessID ppid, bool is_kernel_process, RefPtr<Custody> current_directory, RefPtr<Custody> executable, RefPtr<TTY> tty, UnveilNode unveil_tree, UnveilNode exec_unveil_tree, UnixDateTime creation_time);
     static ErrorOr<ProcessAndFirstThread> create(NonnullOwnPtr<KString> name, UserID, GroupID, ProcessID ppid, bool is_kernel_process, RefPtr<Custody> current_directory = nullptr, RefPtr<Custody> executable = nullptr, RefPtr<TTY> = nullptr, Process* fork_parent = nullptr);
     ErrorOr<NonnullRefPtr<Thread>> attach_resources(NonnullOwnPtr<Memory::AddressSpace>&&, Process* fork_parent);
     static ProcessID allocate_pid();
@@ -855,6 +857,8 @@ private:
     SpinlockProtected<RefPtr<Custody>, LockRank::None> m_executable;
 
     SpinlockProtected<RefPtr<Custody>, LockRank::None> m_current_directory;
+
+    UnixDateTime const m_creation_time;
 
     Vector<NonnullOwnPtr<KString>> m_arguments;
     Vector<NonnullOwnPtr<KString>> m_environment;


### PR DESCRIPTION
With this PR, processes now store their creation time. I have used this to set the ProcFS `atime`, `ctime` and `mtime` initial values to the time the process was created. 

Before:
![proc_stat_before](https://github.com/SerenityOS/serenity/assets/2817754/51496f1d-c6ca-4de1-8f8c-06023ba75eeb)

After:
![proc_stat_after](https://github.com/SerenityOS/serenity/assets/2817754/42b01b08-3033-46ac-a6cc-7e55f9bb8da2)
