### PR TITLE
Meta: Re-add boot drive to aarch64 run configuration

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -315,7 +315,6 @@ if [ -z "$SERENITY_MACHINE" ]; then
         -device i82801b11-bridge,id=bridge3 -device sdhci-pci,bus=bridge3
         -device ich9-ahci,bus=bridge3
         -chardev stdio,id=stdout,mux=on
-        $SERENITY_BOOT_DRIVE
         "
     fi
 fi
@@ -340,6 +339,7 @@ fi
 [ -z "$SERENITY_COMMON_QEMU_ARGS" ] && SERENITY_COMMON_QEMU_ARGS="
 $SERENITY_EXTRA_QEMU_ARGS
 $SERENITY_MACHINE
+$SERENITY_BOOT_DRIVE
 -cpu $SERENITY_QEMU_CPU
 -name SerenityOS
 -d guest_errors


### PR DESCRIPTION
This broke in c2e24a2fa19f442e6285fc3b96b69cf0f97115e5 where the boot drive was removed from `SERENITY_MACHINE`. We now add the boot drive to the common Qemu arguments, so it gets included in the aarch64 run configuration as well.