### PR TITLE
LibWeb: Allow paint style fills for CRC2D strokes (and other tweaks)

### DIFF
--- a/Base/res/html/misc/canvas-gradients.html
+++ b/Base/res/html/misc/canvas-gradients.html
@@ -18,7 +18,7 @@
 <canvas id="conic" width="200" height="200"></canvas>
 <h2>Linear Gradients</h2>
 <em>This time in a path to spice things up!</em><br>
-<canvas id="linear" width="200" height="200"></canvas>
+<canvas id="linear" width="400" height="200"></canvas>
 
 <script>
 {
@@ -137,7 +137,6 @@ makeMouseDemo("radialHell2", (canvas, ctx, mX, mY) => {
   const ctx = canvas.getContext("2d");
 
   const gradient = ctx.createLinearGradient(20, 20, 220, 120);
-  ctx.createLinearGradient(0,0,200,50);
   gradient.addColorStop(0,"red");
   gradient.addColorStop(0.15,"yellow");
   gradient.addColorStop(0.3,"green");
@@ -147,6 +146,12 @@ makeMouseDemo("radialHell2", (canvas, ctx, mX, mY) => {
   gradient.addColorStop(1,"red");
 
   ctx.fillStyle = gradient;
+
+  const gradient2 = ctx.createLinearGradient(200,0,400,50);
+  gradient2.addColorStop(0,"cyan");
+  gradient2.addColorStop(1,"fuchsia");
+
+  ctx.strokeStyle = gradient2;
 
   const starPath = (cx, cy, spikes, outerRadius, innerRadius) => {
     let x = cx;
@@ -171,7 +176,11 @@ makeMouseDemo("radialHell2", (canvas, ctx, mX, mY) => {
     ctx.closePath();
   }
 
-  starPath(canvas.width/2,canvas.height/2,5,100,60);
+  starPath(canvas.width/4,canvas.height/2,5,100,60);
   ctx.fill();
+
+  starPath(canvas.width/4 + 200 ,canvas.height/2,5,80,40);
+  ctx.lineWidth = 5;
+  ctx.stroke();
 }
 </script>

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -97,11 +97,10 @@ void CanvasRenderingContext2D::stroke_rect(float x, float y, float width, float 
 {
     auto& drawing_state = this->drawing_state();
 
-    // We could remove the rounding here, but the lines look better when they have whole number pixel endpoints.
-    auto top_left = drawing_state.transform.map(Gfx::FloatPoint(x, y)).to_rounded<float>();
-    auto top_right = drawing_state.transform.map(Gfx::FloatPoint(x + width - 1, y)).to_rounded<float>();
-    auto bottom_left = drawing_state.transform.map(Gfx::FloatPoint(x, y + height - 1)).to_rounded<float>();
-    auto bottom_right = drawing_state.transform.map(Gfx::FloatPoint(x + width - 1, y + height - 1)).to_rounded<float>();
+    auto top_left = drawing_state.transform.map(Gfx::FloatPoint(x, y));
+    auto top_right = drawing_state.transform.map(Gfx::FloatPoint(x + width - 1, y));
+    auto bottom_left = drawing_state.transform.map(Gfx::FloatPoint(x, y + height - 1));
+    auto bottom_right = drawing_state.transform.map(Gfx::FloatPoint(x + width - 1, y + height - 1));
 
     Gfx::Path path;
     path.move_to(top_left);

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -265,11 +265,17 @@ static Gfx::Painter::WindingRule parse_fill_rule(StringView fill_rule)
     return Gfx::Painter::WindingRule::Nonzero;
 }
 
-void CanvasRenderingContext2D::fill_internal(Gfx::Path& path, StringView fill_rule)
+void CanvasRenderingContext2D::fill_internal(Gfx::Path& path, StringView fill_rule_value)
 {
     draw_clipped([&](auto& painter) {
         path.close_all_subpaths();
-        painter.fill_path(path, *drawing_state().fill_style.to_gfx_paint_style(), parse_fill_rule(fill_rule));
+        auto& drawing_state = this->drawing_state();
+        auto fill_rule = parse_fill_rule(fill_rule_value);
+        if (auto color = drawing_state.fill_style.as_color(); color.has_value()) {
+            painter.fill_path(path, *color, fill_rule);
+        } else {
+            painter.fill_path(path, drawing_state.fill_style.to_gfx_paint_style(), fill_rule);
+        }
         return path.bounding_box();
     });
 }

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -74,11 +74,10 @@ void CanvasRenderingContext2D::fill_rect(float x, float y, float width, float he
     draw_clipped([&](auto& painter) {
         auto& drawing_state = this->drawing_state();
         auto rect = drawing_state.transform.map(Gfx::FloatRect(x, y, width, height));
-        auto color_fill = drawing_state.fill_style.as_color();
-        if (color_fill.has_value()) {
-            painter.fill_rect(rect, *color_fill);
+        if (auto color = drawing_state.fill_style.as_color(); color.has_value()) {
+            painter.fill_rect(rect, *color);
         } else {
-            // FIXME: This should use AntiAliasingPainter::fill_rect() too but that does not support FillPath yet.
+            // FIXME: This should use AntiAliasingPainter::fill_rect() too but that does not support PaintStyle yet.
             painter.underlying_painter().fill_rect(rect.to_rounded<int>(), *drawing_state.fill_style.to_gfx_paint_style());
         }
         return rect;


### PR DESCRIPTION
A gradient stroke:
![Screenshot from 2023-06-07 23-16-04](https://github.com/SerenityOS/serenity/assets/11597044/31d83d7c-019c-456b-85cf-0ec914f663a8)

\+ A few small fixes/tweaks I noticed while adding the above.