### PR TITLE
LibEDID: Ignore duplicate PNP IDs

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibEDID/GeneratePnpIDs.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibEDID/GeneratePnpIDs.cpp
@@ -168,9 +168,7 @@ static ErrorOr<HashMap<DeprecatedString, PnpIdData>> parse_pnp_ids_database(Core
 
         auto approval_date = TRY(parse_approval_date(columns[(size_t)PnpIdColumns::ApprovalDate]));
         auto decoded_manufacturer_name = TRY(decode_html_entities(columns[(size_t)PnpIdColumns::ManufacturerName]));
-        auto hash_set_result = pnp_id_data.set(columns[(size_t)PnpIdColumns::ManufacturerId], PnpIdData { .manufacturer_name = decoded_manufacturer_name, .approval_date = move(approval_date) });
-        if (hash_set_result != AK::HashSetResult::InsertedNewEntry)
-            return Error::from_string_literal("Duplicate manufacturer ID encountered");
+        pnp_id_data.set(columns[(size_t)PnpIdColumns::ManufacturerId], PnpIdData { .manufacturer_name = decoded_manufacturer_name, .approval_date = move(approval_date) });
 
         row_content_offset = row_end.value() + row_end_tag.length();
     }


### PR DESCRIPTION
The PNP IDs data file was recently updated with an accidental duplicate entry (HONOR Device Co., Ltd.). Rather than breaking everyone's build, let's just ignore duplicates.