### PR TITLE
LibWeb: Some row span fixes when combined with nested tables

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
@@ -1,0 +1,94 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x120.40625 [BFC] children: not-inline
+    BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
+      TextNode <#text>
+    BlockContainer <body> at (8,8) content-size 784x104.40625 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+        TextNode <#text>
+      TableWrapper <(anonymous)> at (8,8) content-size 59.828125x104.40625 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 57.828125x102.40625 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (9,9) content-size 57.828125x102.40625 table-row-group children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (9,9) content-size 57.828125x51.203125 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (15,25.867187) content-size 11.5625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 11.5625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [15,25.867187 11.5625x17.46875]
+                    "X"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (38.5625,15) content-size 22.265625x90.40625 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (38.5625,15) content-size 22.265625x0 children: inline
+                  TextNode <#text>
+                TableWrapper <(anonymous)> at (38.5625,15) content-size 22.265625x90.40625 [BFC] children: not-inline
+                  Box <table> at (39.5625,16) content-size 24.265625x88.40625 table-box [TFC] children: not-inline
+                    BlockContainer <(anonymous)> (not painted) children: inline
+                      TextNode <#text>
+                    Box <tbody> at (39.5625,16) content-size 26.265625x88.40625 table-row-group children: not-inline
+                      BlockContainer <(anonymous)> (not painted) children: inline
+                        TextNode <#text>
+                      Box <tr> at (39.5625,16) content-size 26.265625x29.46875 table-row children: not-inline
+                        BlockContainer <(anonymous)> (not painted) children: inline
+                          TextNode <#text>
+                        BlockContainer <td> at (45.5625,22) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                          line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                            frag 0 from TextNode start: 0, length: 1, rect: [45.5625,22 14.265625x17.46875]
+                              "A"
+                          TextNode <#text>
+                        BlockContainer <(anonymous)> (not painted) children: inline
+                          TextNode <#text>
+                      BlockContainer <(anonymous)> (not painted) children: inline
+                        TextNode <#text>
+                      Box <tr> at (39.5625,45.46875) content-size 26.265625x29.46875 table-row children: not-inline
+                        BlockContainer <(anonymous)> (not painted) children: inline
+                          TextNode <#text>
+                        BlockContainer <td> at (45.5625,51.46875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                            frag 0 from TextNode start: 0, length: 1, rect: [45.5625,51.46875 9.34375x17.46875]
+                              "B"
+                          TextNode <#text>
+                        BlockContainer <(anonymous)> (not painted) children: inline
+                          TextNode <#text>
+                      BlockContainer <(anonymous)> (not painted) children: inline
+                        TextNode <#text>
+                      Box <tr> at (39.5625,74.9375) content-size 26.265625x29.46875 table-row children: not-inline
+                        BlockContainer <(anonymous)> (not painted) children: inline
+                          TextNode <#text>
+                        BlockContainer <td> at (45.5625,80.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                          line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                            frag 0 from TextNode start: 0, length: 1, rect: [45.5625,80.9375 10.3125x17.46875]
+                              "C"
+                          TextNode <#text>
+                        BlockContainer <(anonymous)> (not painted) children: inline
+                          TextNode <#text>
+                      BlockContainer <(anonymous)> (not painted) children: inline
+                        TextNode <#text>
+                    BlockContainer <(anonymous)> (not painted) children: inline
+                      TextNode <#text>
+                BlockContainer <(anonymous)> at (38.5625,105.40625) content-size 22.265625x0 children: inline
+                  TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (9,60.203125) content-size 57.828125x51.203125 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (15,77.070312) content-size 11.5625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 11.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [15,77.070312 11.09375x17.46875]
+                    "Y"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+      BlockContainer <(anonymous)> at (8,112.40625) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/table/row-span-and-nested-tables.html
+++ b/Tests/LibWeb/Layout/input/table/row-span-and-nested-tables.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<title>Rowspan interaction with nested tables</title>
+
+	<style>
+		table {
+			border: 1px solid black;
+		}
+
+		td {
+			border: 1px solid blue;
+			padding: 5px;
+		}
+	</style>
+</head>
+
+<body>
+	<table>
+		<tbody>
+			<tr>
+				<td>X</td>
+				<td rowspan="2">
+					<table>
+						<tbody>
+							<tr>
+								<td>A</td>
+							</tr>
+							<tr>
+								<td>B</td>
+							</tr>
+							<tr>
+								<td>C</td>
+							</tr>
+						</tbody>
+					</table>
+				</td>
+			</tr>
+			<tr>
+				<td>Y</td>
+			</tr>
+		</tbody>
+	</table>
+</body>
+
+</html>

--- a/Userland/Libraries/LibWeb/Layout/AvailableSpace.cpp
+++ b/Userland/Libraries/LibWeb/Layout/AvailableSpace.cpp
@@ -11,6 +11,7 @@ namespace Web::Layout {
 
 AvailableSize AvailableSize::make_definite(CSSPixels value)
 {
+    VERIFY(isfinite(value.value()));
     return AvailableSize { Type::Definite, value };
 }
 

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -415,7 +415,14 @@ CSSPixels BlockFormattingContext::compute_table_box_width_inside_table_wrapper(B
     auto available_width = width_of_containing_block - margin_left.to_px(box) - margin_right.to_px(box);
 
     LayoutState throwaway_state(&m_state);
-    throwaway_state.get_mutable(box).set_content_width(available_width);
+    if (available_space.width.is_definite())
+        throwaway_state.get_mutable(box).set_content_width(available_width);
+    else if (available_space.width.is_min_content())
+        throwaway_state.get_mutable(box).set_min_content_width();
+    else {
+        VERIFY(available_space.width.is_max_content());
+        throwaway_state.get_mutable(box).set_max_content_width();
+    }
     auto context = create_independent_formatting_context_if_needed(throwaway_state, box);
     VERIFY(context);
     context->run(box, LayoutMode::IntrinsicSizing, m_state.get(box).available_inner_space_or_constraints_from(available_space));

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -297,6 +297,7 @@ void LayoutState::UsedValues::set_node(NodeWithStyleAndBoxModelMetrics& node, Us
 
 void LayoutState::UsedValues::set_content_width(CSSPixels width)
 {
+    VERIFY(isfinite(width.value()));
     if (width < 0) {
         // Negative widths are not allowed in CSS. We have a bug somewhere! Clamp to 0 to avoid doing too much damage.
         dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Layout calculated a negative width for {}: {}", m_node->debug_description(), width);
@@ -308,6 +309,7 @@ void LayoutState::UsedValues::set_content_width(CSSPixels width)
 
 void LayoutState::UsedValues::set_content_height(CSSPixels height)
 {
+    VERIFY(isfinite(height.value()));
     if (height < 0) {
         // Negative heights are not allowed in CSS. We have a bug somewhere! Clamp to 0 to avoid doing too much damage.
         dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Layout calculated a negative height for {}: {}", m_node->debug_description(), height);
@@ -384,6 +386,20 @@ void LayoutState::UsedValues::set_indefinite_content_width()
 
 void LayoutState::UsedValues::set_indefinite_content_height()
 {
+    m_has_definite_height = false;
+}
+
+void LayoutState::UsedValues::set_min_content_width()
+{
+    width_constraint = SizeConstraint::MinContent;
+    m_content_width = 0;
+    m_has_definite_height = false;
+}
+
+void LayoutState::UsedValues::set_max_content_width()
+{
+    width_constraint = SizeConstraint::MaxContent;
+    m_content_width = INFINITY;
     m_has_definite_height = false;
 }
 

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -51,6 +51,8 @@ struct LayoutState {
 
         void set_indefinite_content_width();
         void set_indefinite_content_height();
+        void set_min_content_width();
+        void set_max_content_width();
 
         // NOTE: These are used by FlexFormattingContext to assign a temporary main size to items
         //       early on, so that descendants have something to resolve percentages against.

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -12,6 +12,11 @@
 
 namespace Web::Layout {
 
+enum class TableDimension {
+    Row,
+    Column
+};
+
 class TableFormattingContext final : public FormattingContext {
 public:
     explicit TableFormattingContext(LayoutState&, Box const&, FormattingContext* parent);
@@ -31,6 +36,8 @@ private:
     CSSPixels run_caption_layout(LayoutMode, CSS::CaptionSide);
     CSSPixels compute_capmin();
     void calculate_row_column_grid(Box const&);
+    void compute_cell_measures(AvailableSpace const& available_space);
+    template<class RowOrColumn>
     void compute_table_measures();
     void compute_table_width();
     void distribute_width_to_columns();
@@ -46,17 +53,17 @@ private:
 
     Optional<AvailableSpace> m_available_space;
 
-    enum class ColumnType {
+    enum class SizeType {
         Percent,
         Pixel,
         Auto
     };
 
     struct Column {
-        ColumnType type { ColumnType::Auto };
+        SizeType type { SizeType::Auto };
         CSSPixels left_offset { 0 };
-        CSSPixels min_width { 0 };
-        CSSPixels max_width { 0 };
+        CSSPixels min_size { 0 };
+        CSSPixels max_size { 0 };
         CSSPixels used_width { 0 };
         double percentage_width { 0 };
     };
@@ -67,6 +74,10 @@ private:
         CSSPixels reference_height { 0 };
         CSSPixels final_height { 0 };
         CSSPixels baseline { 0 };
+        SizeType type { SizeType::Auto };
+        CSSPixels min_size { 0 };
+        CSSPixels max_size { 0 };
+        double percentage_height { 0 };
     };
 
     struct Cell {
@@ -78,7 +89,26 @@ private:
         CSSPixels baseline { 0 };
         CSSPixels min_width { 0 };
         CSSPixels max_width { 0 };
+        CSSPixels min_height { 0 };
+        CSSPixels max_height { 0 };
     };
+
+    // Accessors to enable direction-agnostic table measurement.
+
+    template<class RowOrColumn>
+    static size_t cell_span(Cell const& cell);
+
+    template<class RowOrColumn>
+    static size_t cell_index(Cell const& cell);
+
+    template<class RowOrColumn>
+    static CSSPixels cell_min_size(Cell const& cell);
+
+    template<class RowOrColumn>
+    static CSSPixels cell_max_size(Cell const& cell);
+
+    template<class RowOrColumn>
+    Vector<RowOrColumn>& table_rows_or_columns();
 
     CSSPixels compute_row_content_height(Cell const& cell) const;
 


### PR DESCRIPTION
1. Add logic to compute {min, max}-height.
2. Use min-height when calculating table height, per specifications.
3. Fix table width algorithm when available space is a constraint.

Fixes some issues with phylogenetic tree visualizations on Wikipedia.