### PR TITLE
LibGfx: Add basic support for dashes in stroke_to_fill

### DIFF
--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -12,6 +12,7 @@
 
 #include <AK/Function.h>
 #include <AK/NumericLimits.h>
+#include <AK/Tuple.h>
 #include <LibGfx/AntiAliasingPainter.h>
 #include <LibGfx/Line.h>
 
@@ -194,14 +195,26 @@ void AntiAliasingPainter::draw_line(FloatPoint actual_from, FloatPoint actual_to
 
 void AntiAliasingPainter::stroke_path(Path const& path, Color color, float thickness)
 {
+    StrokeProperties stroke_properties(thickness);
+    stroke_path(path, color, stroke_properties);
+}
+
+void AntiAliasingPainter::stroke_path(Path const& path, Color color, StrokeProperties const& stroke_properties)
+{
     // FIXME: Cache this? Probably at a higher level such as in LibWeb?
-    fill_path(path.stroke_to_fill(thickness), color);
+    fill_path(path.stroke_to_fill(stroke_properties), color);
 }
 
 void AntiAliasingPainter::stroke_path(Path const& path, Gfx::PaintStyle const& paint_style, float thickness)
 {
+    StrokeProperties stroke_properties(thickness);
+    stroke_path(path, paint_style, stroke_properties);
+}
+
+void AntiAliasingPainter::stroke_path(Path const& path, Gfx::PaintStyle const& paint_style, StrokeProperties const& stroke_properties)
+{
     // FIXME: Cache this? Probably at a higher level such as in LibWeb?
-    fill_path(path.stroke_to_fill(thickness), paint_style);
+    fill_path(path.stroke_to_fill(stroke_properties), paint_style);
 }
 
 void AntiAliasingPainter::fill_rect(FloatRect const& float_rect, Color color)

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -38,6 +38,8 @@ public:
 
     void stroke_path(Path const&, Color, float thickness);
     void stroke_path(Path const&, PaintStyle const& paint_style, float thickness);
+    void stroke_path(Path const&, Color, StrokeProperties const&);
+    void stroke_path(Path const&, PaintStyle const& paint_style, StrokeProperties const&);
 
     void translate(float dx, float dy) { m_transform.translate(dx, dy); }
     void translate(FloatPoint delta) { m_transform.translate(delta); }

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -12,6 +12,7 @@
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Orientation.h>
+#include <LibGfx/Vector2.h>
 #include <LibIPC/Forward.h>
 #include <math.h>
 
@@ -132,6 +133,7 @@ public:
     }
 
     [[nodiscard]] Point<T> operator+(Point<T> const& other) const { return { m_x + other.m_x, m_y + other.m_y }; }
+    [[nodiscard]] Point<T> operator+(Vector2<T> const& other) const { return { m_x + other.x(), m_y + other.y() }; }
 
     Point<T>& operator+=(Point<T> const& other)
     {
@@ -143,6 +145,7 @@ public:
     [[nodiscard]] Point<T> operator-() const { return { -m_x, -m_y }; }
 
     [[nodiscard]] Point<T> operator-(Point<T> const& other) const { return { m_x - other.m_x, m_y - other.m_y }; }
+    [[nodiscard]] Point<T> operator-(Vector2<T> const& other) const { return { m_x - other.x(), m_y - other.y() }; }
 
     Point<T>& operator-=(Point<T> const& other)
     {


### PR DESCRIPTION
Add basic support for different dashed strokes when performing strokes to fill conversion. Most of the options are not implemented yet, but the infrastructure for them is added anyway.

Only `stroke-dasharray`, `stroke-offset` and `stroke-linecap` are implemented.

Here are some screenshots of the results.

![image](https://github.com/SerenityOS/serenity/assets/8083073/ce8507d8-9085-4f5d-a286-0c8026b33439)
![image](https://github.com/SerenityOS/serenity/assets/8083073/60f964d4-50b0-4857-8195-88b9c29a0ee3)
![image](https://github.com/SerenityOS/serenity/assets/8083073/78f1b49f-99db-41cb-a001-f2708ecb6d1e)
