### PR TITLE
LibWeb: Implement CSS `aspect-ratio` property

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -20,7 +20,7 @@ void generate_bounds_checking_function(JsonObject& properties, SourceGenerator& 
 
 static bool type_name_is_enum(StringView type_name)
 {
-    return !AK::first_is_one_of(type_name, "angle"sv, "color"sv, "custom-ident"sv, "frequency"sv, "image"sv, "integer"sv, "length"sv, "number"sv, "percentage"sv, "rect"sv, "resolution"sv, "string"sv, "time"sv, "url"sv);
+    return !AK::first_is_one_of(type_name, "angle"sv, "color"sv, "custom-ident"sv, "frequency"sv, "image"sv, "integer"sv, "length"sv, "number"sv, "percentage"sv, "ratio"sv, "rect"sv, "resolution"sv, "string"sv, "time"sv, "url"sv);
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
@@ -167,6 +167,7 @@ enum class ValueType {
     Paint,
     Percentage,
     Position,
+    Ratio,
     Rect,
     Resolution,
     String,
@@ -612,6 +613,8 @@ bool property_accepts_type(PropertyID property_id, ValueType value_type)
                     property_generator.appendln("        case ValueType::Number:");
                 } else if (type_name == "percentage") {
                     property_generator.appendln("        case ValueType::Percentage:");
+                } else if (type_name == "ratio") {
+                    property_generator.appendln("        case ValueType::Ratio:");
                 } else if (type_name == "rect") {
                     property_generator.appendln("        case ValueType::Rect:");
                 } else if (type_name == "resolution") {

--- a/Tests/LibWeb/Layout/expected/aspect-ratio-auto-and-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/aspect-ratio-auto-and-ratio.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x320 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x304 children: not-inline
+      BlockContainer <div> at (9,9) content-size 200x100 children: not-inline
+      BlockContainer <(anonymous)> at (8,110) content-size 784x202 children: inline
+        line 0 width: 202, height: 202, bottom: 202, baseline: 202
+          frag 0 from ImageBox start: 0, length: 0, rect: [9,111 200x200]
+        ImageBox <img> at (9,111) content-size 200x200 children: not-inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/aspect-ratio-auto.txt
+++ b/Tests/LibWeb/Layout/expected/aspect-ratio-auto.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x220 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x204 children: not-inline
+      BlockContainer <div> at (9,9) content-size 200x0 children: not-inline
+      BlockContainer <(anonymous)> at (8,10) content-size 784x202 children: inline
+        line 0 width: 202, height: 202, bottom: 202, baseline: 202
+          frag 0 from ImageBox start: 0, length: 0, rect: [9,11 200x200]
+        ImageBox <img> at (9,11) content-size 200x200 children: not-inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/aspect-ratio-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/aspect-ratio-ratio.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x220 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x204 children: not-inline
+      BlockContainer <div> at (9,9) content-size 200x100 children: not-inline
+      BlockContainer <(anonymous)> at (8,110) content-size 784x102 children: inline
+        line 0 width: 202, height: 102, bottom: 102, baseline: 102
+          frag 0 from ImageBox start: 0, length: 0, rect: [9,111 200x100]
+        ImageBox <img> at (9,111) content-size 200x100 children: not-inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/aspect-ratio-auto-and-ratio.html
+++ b/Tests/LibWeb/Layout/input/aspect-ratio-auto-and-ratio.html
@@ -1,0 +1,7 @@
+<!doctype html><style>
+    div, img {
+        width: 200px;
+        aspect-ratio: auto 2/1;
+        border: 1px solid black;
+    }
+</style><div></div><img src="120.png"/>

--- a/Tests/LibWeb/Layout/input/aspect-ratio-auto.html
+++ b/Tests/LibWeb/Layout/input/aspect-ratio-auto.html
@@ -1,0 +1,7 @@
+<!doctype html><style>
+    div, img {
+        width: 200px;
+        aspect-ratio: auto;
+        border: 1px solid black;
+    }
+</style><div></div><img src="120.png"/>

--- a/Tests/LibWeb/Layout/input/aspect-ratio-ratio.html
+++ b/Tests/LibWeb/Layout/input/aspect-ratio-ratio.html
@@ -1,0 +1,7 @@
+<!doctype html><style>
+    div, img {
+        width: 200px;
+        aspect-ratio: 2/1;
+        border: 1px solid black;
+    }
+</style><div></div><img src="120.png"/>

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -15,6 +15,7 @@
 #include <LibWeb/CSS/GridTrackSize.h>
 #include <LibWeb/CSS/LengthBox.h>
 #include <LibWeb/CSS/PercentageOr.h>
+#include <LibWeb/CSS/Ratio.h>
 #include <LibWeb/CSS/Size.h>
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ShadowStyleValue.h>
@@ -22,8 +23,14 @@
 
 namespace Web::CSS {
 
+struct AspectRatio {
+    bool use_natural_aspect_ratio_if_available;
+    Optional<Ratio> preferred_ratio;
+};
+
 class InitialValues {
 public:
+    static AspectRatio aspect_ratio() { return AspectRatio { true, {} }; }
     static float font_size() { return 16; }
     static int font_weight() { return 400; }
     static CSS::FontVariant font_variant() { return CSS::FontVariant::Normal; }
@@ -211,6 +218,7 @@ inline Gfx::Painter::ScalingMode to_gfx_scaling_mode(CSS::ImageRendering css_val
 
 class ComputedValues {
 public:
+    AspectRatio aspect_ratio() const { return m_noninherited.aspect_ratio; }
     CSS::Float float_() const { return m_noninherited.float_; }
     CSS::Clear clear() const { return m_noninherited.clear; }
     CSS::Clip clip() const { return m_noninherited.clip; }
@@ -344,6 +352,7 @@ protected:
     } m_inherited;
 
     struct {
+        AspectRatio aspect_ratio { InitialValues::aspect_ratio() };
         CSS::Float float_ { InitialValues::float_() };
         CSS::Clear clear { InitialValues::clear() };
         CSS::Clip clip { InitialValues::clip() };
@@ -418,6 +427,7 @@ class ImmutableComputedValues final : public ComputedValues {
 
 class MutableComputedValues final : public ComputedValues {
 public:
+    void set_aspect_ratio(AspectRatio aspect_ratio) { m_noninherited.aspect_ratio = aspect_ratio; }
     void set_font_size(float font_size) { m_inherited.font_size = font_size; }
     void set_font_weight(int font_weight) { m_inherited.font_weight = font_weight; }
     void set_font_variant(CSS::FontVariant font_variant) { m_inherited.font_variant = font_variant; }

--- a/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.h
@@ -31,6 +31,7 @@ public:
 
     bool is_token() const { return m_value.has<Token>(); }
     bool is(Token::Type type) const { return is_token() && token().is(type); }
+    bool is_delim(u32 delim) const { return is(Token::Type::Delim) && token().delim() == delim; }
     Token const& token() const { return m_value.get<Token>(); }
     operator Token() const { return m_value.get<Token>(); }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -72,6 +72,7 @@
 #include <LibWeb/CSS/StyleValues/PlaceContentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RadialGradientStyleValue.h>
+#include <LibWeb/CSS/StyleValues/RatioStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RectStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ResolutionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ShadowStyleValue.h>
@@ -4387,6 +4388,13 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_color_value(ComponentValue const& comp
     return nullptr;
 }
 
+ErrorOr<RefPtr<StyleValue>> Parser::parse_ratio_value(TokenStream<ComponentValue>& tokens)
+{
+    if (auto ratio = parse_ratio(tokens); ratio.has_value())
+        return RatioStyleValue::create(ratio.release_value());
+    return nullptr;
+}
+
 ErrorOr<RefPtr<StyleValue>> Parser::parse_string_value(ComponentValue const& component_value)
 {
     if (component_value.is(Token::Type::String))
@@ -7624,6 +7632,11 @@ ErrorOr<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readonl
             (void)tokens.next_token();
             return PropertyAndValue { *property, maybe_image };
         }
+    }
+
+    if (auto property = any_property_accepts_type(property_ids, ValueType::Ratio); property.has_value()) {
+        if (auto maybe_ratio = TRY(parse_ratio_value(tokens)))
+            return PropertyAndValue { *property, maybe_ratio };
     }
 
     auto property_accepting_integer = any_property_accepts_type(property_ids, ValueType::Integer);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -299,6 +299,7 @@ private:
     ErrorOr<RefPtr<StyleValue>> parse_identifier_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_color_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_rect_value(ComponentValue const&);
+    ErrorOr<RefPtr<StyleValue>> parse_ratio_value(TokenStream<ComponentValue>&);
     ErrorOr<RefPtr<StyleValue>> parse_string_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_image_value(ComponentValue const&);
     template<typename ParseFunction>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -307,6 +307,7 @@ private:
     ErrorOr<RefPtr<StyleValue>> parse_simple_comma_separated_value_list(PropertyID, Vector<ComponentValue> const&);
 
     ErrorOr<RefPtr<StyleValue>> parse_filter_value_list_value(Vector<ComponentValue> const&);
+    ErrorOr<RefPtr<StyleValue>> parse_aspect_ratio_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_background_value(Vector<ComponentValue> const&);
     ErrorOr<RefPtr<StyleValue>> parse_single_background_position_value(TokenStream<ComponentValue>&);
     ErrorOr<RefPtr<StyleValue>> parse_single_background_position_x_or_y_value(TokenStream<ComponentValue>&, PropertyID);

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -138,6 +138,17 @@
       "appearance"
     ]
   },
+  "aspect-ratio": {
+    "affects-layout": true,
+    "inherited": false,
+    "initial": "auto",
+    "valid-types": [
+      "ratio"
+    ],
+    "valid-identifiers":[
+      "auto"
+    ]
+  },
   "backdrop-filter": {
     "affects-layout": false,
     "affects-stacking-context": true,

--- a/Userland/Libraries/LibWeb/CSS/Ratio.h
+++ b/Userland/Libraries/LibWeb/CSS/Ratio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -18,6 +18,23 @@ public:
     bool is_degenerate() const;
 
     ErrorOr<String> to_string() const;
+
+    bool operator==(Ratio const& other) const
+    {
+        return value() == other.value();
+    }
+
+    int operator<=>(Ratio const& other) const
+    {
+        auto this_value = value();
+        auto other_value = other.value();
+
+        if (this_value < other_value)
+            return -1;
+        if (this_value > other_value)
+            return 1;
+        return 0;
+    }
 
 private:
     float m_first_value { 0 };

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -33,6 +33,7 @@
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
+#include <LibWeb/CSS/StyleValues/RatioStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RectStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ShadowStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
@@ -263,6 +264,19 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         return TRY(IdentifierStyleValue::create(to_value_id(layout_node.computed_values().align_self())));
     case PropertyID::Appearance:
         return TRY(IdentifierStyleValue::create(to_value_id(layout_node.computed_values().appearance())));
+    case PropertyID::AspectRatio: {
+        auto aspect_ratio = layout_node.computed_values().aspect_ratio();
+        if (aspect_ratio.use_natural_aspect_ratio_if_available && aspect_ratio.preferred_ratio.has_value()) {
+            return TRY(StyleValueList::create(
+                StyleValueVector {
+                    TRY(IdentifierStyleValue::create(ValueID::Auto)),
+                    TRY(RatioStyleValue::create(aspect_ratio.preferred_ratio.value())) },
+                StyleValueList::Separator::Space));
+        }
+        if (aspect_ratio.preferred_ratio.has_value())
+            return TRY(RatioStyleValue::create(aspect_ratio.preferred_ratio.value()));
+        return TRY(IdentifierStyleValue::create(ValueID::Auto));
+    }
     case PropertyID::Background: {
         auto maybe_background_color = property(PropertyID::BackgroundColor);
         auto maybe_background_image = property(PropertyID::BackgroundImage);

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -50,6 +50,7 @@
 #include <LibWeb/CSS/StyleValues/PlaceContentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RadialGradientStyleValue.h>
+#include <LibWeb/CSS/StyleValues/RatioStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RectStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ResolutionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ShadowStyleValue.h>
@@ -319,6 +320,12 @@ RadialGradientStyleValue const& StyleValue::as_radial_gradient() const
 {
     VERIFY(is_radial_gradient());
     return static_cast<RadialGradientStyleValue const&>(*this);
+}
+
+RatioStyleValue const& StyleValue::as_ratio() const
+{
+    VERIFY(is_ratio());
+    return static_cast<RatioStyleValue const&>(*this);
 }
 
 RectStyleValue const& StyleValue::as_rect() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -127,6 +127,7 @@ public:
         PlaceContent,
         Position,
         RadialGradient,
+        Ratio,
         Rect,
         Resolution,
         Shadow,
@@ -183,6 +184,7 @@ public:
     bool is_place_content() const { return type() == Type::PlaceContent; }
     bool is_position() const { return type() == Type::Position; }
     bool is_radial_gradient() const { return type() == Type::RadialGradient; }
+    bool is_ratio() const { return type() == Type::Ratio; }
     bool is_rect() const { return type() == Type::Rect; }
     bool is_resolution() const { return type() == Type::Resolution; }
     bool is_shadow() const { return type() == Type::Shadow; }
@@ -238,6 +240,7 @@ public:
     PlaceContentStyleValue const& as_place_content() const;
     PositionStyleValue const& as_position() const;
     RadialGradientStyleValue const& as_radial_gradient() const;
+    RatioStyleValue const& as_ratio() const;
     RectStyleValue const& as_rect() const;
     ResolutionStyleValue const& as_resolution() const;
     ShadowStyleValue const& as_shadow() const;
@@ -290,6 +293,7 @@ public:
     PlaceContentStyleValue& as_place_content() { return const_cast<PlaceContentStyleValue&>(const_cast<StyleValue const&>(*this).as_place_content()); }
     PositionStyleValue& as_position() { return const_cast<PositionStyleValue&>(const_cast<StyleValue const&>(*this).as_position()); }
     RadialGradientStyleValue& as_radial_gradient() { return const_cast<RadialGradientStyleValue&>(const_cast<StyleValue const&>(*this).as_radial_gradient()); }
+    RatioStyleValue& as_ratio() { return const_cast<RatioStyleValue&>(const_cast<StyleValue const&>(*this).as_ratio()); }
     RectStyleValue& as_rect() { return const_cast<RectStyleValue&>(const_cast<StyleValue const&>(*this).as_rect()); }
     ResolutionStyleValue& as_resolution() { return const_cast<ResolutionStyleValue&>(const_cast<StyleValue const&>(*this).as_resolution()); }
     ShadowStyleValue& as_shadow() { return const_cast<ShadowStyleValue&>(const_cast<StyleValue const&>(*this).as_shadow()); }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/RatioStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/RatioStyleValue.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/Ratio.h>
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+class RatioStyleValue final : public StyleValueWithDefaultOperators<RatioStyleValue> {
+public:
+    static ErrorOr<ValueComparingNonnullRefPtr<RatioStyleValue>> create(Ratio ratio)
+    {
+        return adopt_nonnull_ref_or_enomem(new (nothrow) RatioStyleValue(move(ratio)));
+    }
+    virtual ~RatioStyleValue() override = default;
+
+    Ratio const& ratio() const { return m_ratio; }
+    Ratio& ratio() { return m_ratio; }
+
+    virtual ErrorOr<String> to_string() const override { return m_ratio.to_string(); }
+
+    bool properties_equal(RatioStyleValue const& other) const { return m_ratio == other.m_ratio; }
+
+private:
+    RatioStyleValue(Ratio&& ratio)
+        : StyleValueWithDefaultOperators(Type::Ratio)
+        , m_ratio(ratio)
+    {
+    }
+
+    Ratio m_ratio;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -140,6 +140,8 @@ class PlaceContentStyleValue;
 class PositionStyleValue;
 class PropertyOwningCSSStyleDeclaration;
 class RadialGradientStyleValue;
+class Ratio;
+class RatioStyleValue;
 class RectStyleValue;
 class Resolution;
 class ResolutionStyleValue;

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -57,7 +57,7 @@ private:
 
     void compute_width_for_floating_box(Box const&, AvailableSpace const&);
 
-    void compute_width_for_block_level_replaced_element_in_normal_flow(ReplacedBox const&, AvailableSpace const&);
+    void compute_width_for_block_level_replaced_element_in_normal_flow(Box const&, AvailableSpace const&);
 
     CSSPixels compute_table_box_width_inside_table_wrapper(Box const&, AvailableSpace const&);
 

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -91,4 +91,12 @@ Painting::PaintableBox const* Box::paintable_box() const
     return static_cast<Painting::PaintableBox const*>(Node::paintable());
 }
 
+Optional<float> Box::preferred_aspect_ratio() const
+{
+    auto computed_aspect_ratio = computed_values().aspect_ratio();
+    if (computed_aspect_ratio.use_natural_aspect_ratio_if_available && natural_aspect_ratio().has_value())
+        return natural_aspect_ratio();
+    return computed_aspect_ratio.preferred_ratio.map([](CSS::Ratio const& ratio) { return ratio.value(); });
+}
+
 }

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -41,6 +41,10 @@ public:
     void set_natural_height(Optional<CSSPixels> height) { m_natural_height = height; }
     void set_natural_aspect_ratio(Optional<float> ratio) { m_natural_aspect_ratio = ratio; }
 
+    // https://www.w3.org/TR/css-sizing-4/#preferred-aspect-ratio
+    Optional<float> preferred_aspect_ratio() const;
+    bool has_preferred_aspect_ratio() const { return preferred_aspect_ratio().has_value(); }
+
     virtual ~Box() override;
 
     virtual void did_set_content_size() { }

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -28,13 +28,18 @@ public:
 
     bool is_body() const;
 
-    virtual Optional<CSSPixels> intrinsic_width() const { return {}; }
-    virtual Optional<CSSPixels> intrinsic_height() const { return {}; }
-    virtual Optional<float> intrinsic_aspect_ratio() const { return {}; }
+    // https://www.w3.org/TR/css-images-3/#natural-dimensions
+    Optional<CSSPixels> natural_width() const { return m_natural_width; }
+    Optional<CSSPixels> natural_height() const { return m_natural_height; }
+    Optional<float> natural_aspect_ratio() const { return m_natural_aspect_ratio; }
 
-    bool has_intrinsic_width() const { return intrinsic_width().has_value(); }
-    bool has_intrinsic_height() const { return intrinsic_height().has_value(); }
-    bool has_intrinsic_aspect_ratio() const { return intrinsic_aspect_ratio().has_value(); }
+    bool has_natural_width() const { return natural_width().has_value(); }
+    bool has_natural_height() const { return natural_height().has_value(); }
+    bool has_natural_aspect_ratio() const { return natural_aspect_ratio().has_value(); }
+
+    void set_natural_width(Optional<CSSPixels> width) { m_natural_width = width; }
+    void set_natural_height(Optional<CSSPixels> height) { m_natural_height = height; }
+    void set_natural_aspect_ratio(Optional<float> ratio) { m_natural_aspect_ratio = ratio; }
 
     virtual ~Box() override;
 
@@ -56,6 +61,10 @@ private:
     virtual bool is_box() const final { return true; }
 
     CSSPixelPoint m_scroll_offset;
+
+    Optional<CSSPixels> m_natural_width;
+    Optional<CSSPixels> m_natural_height;
+    Optional<float> m_natural_aspect_ratio;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/Layout/ButtonBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ButtonBox.cpp
@@ -25,8 +25,8 @@ void ButtonBox::prepare_for_replaced_layout()
     // value attribute. This is not the case with <button />, which contains
     // its contents normally.
     if (is<HTML::HTMLInputElement>(dom_node())) {
-        set_intrinsic_width(font().width(static_cast<HTML::HTMLInputElement&>(dom_node()).value()));
-        set_intrinsic_height(font().pixel_size_rounded_up());
+        set_natural_width(font().width(static_cast<HTML::HTMLInputElement&>(dom_node()).value()));
+        set_natural_height(font().pixel_size_rounded_up());
     }
 }
 

--- a/Userland/Libraries/LibWeb/Layout/CanvasBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/CanvasBox.cpp
@@ -19,8 +19,8 @@ CanvasBox::~CanvasBox() = default;
 
 void CanvasBox::prepare_for_replaced_layout()
 {
-    set_intrinsic_width(dom_node().width());
-    set_intrinsic_height(dom_node().height());
+    set_natural_width(dom_node().width());
+    set_natural_height(dom_node().height());
 }
 
 JS::GCPtr<Painting::Paintable> CanvasBox::create_paintable() const

--- a/Userland/Libraries/LibWeb/Layout/CheckBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/CheckBox.cpp
@@ -16,8 +16,8 @@ namespace Web::Layout {
 CheckBox::CheckBox(DOM::Document& document, HTML::HTMLInputElement& element, NonnullRefPtr<CSS::StyleProperties> style)
     : FormAssociatedLabelableNode(document, element, move(style))
 {
-    set_intrinsic_width(13);
-    set_intrinsic_height(13);
+    set_natural_width(13);
+    set_natural_height(13);
 }
 
 CheckBox::~CheckBox() = default;

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -590,12 +590,12 @@ CSSPixels FlexFormattingContext::adjust_main_size_through_aspect_ratio_for_cross
 {
     if (!max_cross_size.is_none()) {
         auto max_cross_size_px = max_cross_size.to_px(box, !is_row_layout() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
-        main_size = min(main_size, calculate_main_size_from_cross_size_and_aspect_ratio(max_cross_size_px, box.natural_aspect_ratio().value()));
+        main_size = min(main_size, calculate_main_size_from_cross_size_and_aspect_ratio(max_cross_size_px, box.preferred_aspect_ratio().value()));
     }
 
     if (!min_cross_size.is_auto()) {
         auto min_cross_size_px = min_cross_size.to_px(box, !is_row_layout() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
-        main_size = max(main_size, calculate_main_size_from_cross_size_and_aspect_ratio(min_cross_size_px, box.natural_aspect_ratio().value()));
+        main_size = max(main_size, calculate_main_size_from_cross_size_and_aspect_ratio(min_cross_size_px, box.preferred_aspect_ratio().value()));
     }
 
     return main_size;
@@ -647,13 +647,13 @@ void FlexFormattingContext::determine_flex_base_size_and_hypothetical_main_size(
         //    - an intrinsic aspect ratio,
         //    - a used flex basis of content, and
         //    - a definite cross size,
-        if (item.box->has_natural_aspect_ratio()
+        if (item.box->has_preferred_aspect_ratio()
             && item.used_flex_basis.type == CSS::FlexBasis::Content
             && has_definite_cross_size(item.box)) {
             // flex_base_size is calculated from definite cross size and intrinsic aspect ratio
             return adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(
                 item.box,
-                calculate_main_size_from_cross_size_and_aspect_ratio(inner_cross_size(item.box), item.box->natural_aspect_ratio().value()),
+                calculate_main_size_from_cross_size_and_aspect_ratio(inner_cross_size(item.box), item.box->preferred_aspect_ratio().value()),
                 computed_cross_min_size(item.box),
                 computed_cross_max_size(item.box));
         }
@@ -713,7 +713,7 @@ void FlexFormattingContext::determine_flex_base_size_and_hypothetical_main_size(
 
     // AD-HOC: This is not mentioned in the spec, but if the item has an aspect ratio,
     //         we may need to adjust the main size in response to cross size min/max constraints.
-    if (item.box->has_natural_aspect_ratio()) {
+    if (item.box->has_preferred_aspect_ratio()) {
         item.flex_base_size = adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(child_box, item.flex_base_size, computed_cross_min_size(child_box), computed_cross_max_size(child_box));
     }
 
@@ -762,7 +762,7 @@ CSSPixels FlexFormattingContext::content_size_suggestion(FlexItem const& item) c
 {
     auto suggestion = calculate_min_content_main_size(item);
 
-    if (item.box->has_natural_aspect_ratio()) {
+    if (item.box->has_preferred_aspect_ratio()) {
         suggestion = adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(item.box, suggestion, computed_cross_min_size(item.box), computed_cross_max_size(item.box));
     }
 
@@ -775,8 +775,8 @@ Optional<CSSPixels> FlexFormattingContext::transferred_size_suggestion(FlexItem 
     // If the item has a preferred aspect ratio and its preferred cross size is definite,
     // then the transferred size suggestion is that size
     // (clamped by its minimum and maximum cross sizes if they are definite), converted through the aspect ratio.
-    if (item.box->has_natural_aspect_ratio() && has_definite_cross_size(item.box)) {
-        auto aspect_ratio = item.box->natural_aspect_ratio().value();
+    if (item.box->has_preferred_aspect_ratio() && has_definite_cross_size(item.box)) {
+        auto aspect_ratio = item.box->preferred_aspect_ratio().value();
         return adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(
             item.box,
             calculate_main_size_from_cross_size_and_aspect_ratio(inner_cross_size(item.box), aspect_ratio),

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -590,12 +590,12 @@ CSSPixels FlexFormattingContext::adjust_main_size_through_aspect_ratio_for_cross
 {
     if (!max_cross_size.is_none()) {
         auto max_cross_size_px = max_cross_size.to_px(box, !is_row_layout() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
-        main_size = min(main_size, calculate_main_size_from_cross_size_and_aspect_ratio(max_cross_size_px, box.intrinsic_aspect_ratio().value()));
+        main_size = min(main_size, calculate_main_size_from_cross_size_and_aspect_ratio(max_cross_size_px, box.natural_aspect_ratio().value()));
     }
 
     if (!min_cross_size.is_auto()) {
         auto min_cross_size_px = min_cross_size.to_px(box, !is_row_layout() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
-        main_size = max(main_size, calculate_main_size_from_cross_size_and_aspect_ratio(min_cross_size_px, box.intrinsic_aspect_ratio().value()));
+        main_size = max(main_size, calculate_main_size_from_cross_size_and_aspect_ratio(min_cross_size_px, box.natural_aspect_ratio().value()));
     }
 
     return main_size;
@@ -647,13 +647,13 @@ void FlexFormattingContext::determine_flex_base_size_and_hypothetical_main_size(
         //    - an intrinsic aspect ratio,
         //    - a used flex basis of content, and
         //    - a definite cross size,
-        if (item.box->has_intrinsic_aspect_ratio()
+        if (item.box->has_natural_aspect_ratio()
             && item.used_flex_basis.type == CSS::FlexBasis::Content
             && has_definite_cross_size(item.box)) {
             // flex_base_size is calculated from definite cross size and intrinsic aspect ratio
             return adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(
                 item.box,
-                calculate_main_size_from_cross_size_and_aspect_ratio(inner_cross_size(item.box), item.box->intrinsic_aspect_ratio().value()),
+                calculate_main_size_from_cross_size_and_aspect_ratio(inner_cross_size(item.box), item.box->natural_aspect_ratio().value()),
                 computed_cross_min_size(item.box),
                 computed_cross_max_size(item.box));
         }
@@ -713,7 +713,7 @@ void FlexFormattingContext::determine_flex_base_size_and_hypothetical_main_size(
 
     // AD-HOC: This is not mentioned in the spec, but if the item has an aspect ratio,
     //         we may need to adjust the main size in response to cross size min/max constraints.
-    if (item.box->has_intrinsic_aspect_ratio()) {
+    if (item.box->has_natural_aspect_ratio()) {
         item.flex_base_size = adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(child_box, item.flex_base_size, computed_cross_min_size(child_box), computed_cross_max_size(child_box));
     }
 
@@ -762,7 +762,7 @@ CSSPixels FlexFormattingContext::content_size_suggestion(FlexItem const& item) c
 {
     auto suggestion = calculate_min_content_main_size(item);
 
-    if (item.box->has_intrinsic_aspect_ratio()) {
+    if (item.box->has_natural_aspect_ratio()) {
         suggestion = adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(item.box, suggestion, computed_cross_min_size(item.box), computed_cross_max_size(item.box));
     }
 
@@ -775,8 +775,8 @@ Optional<CSSPixels> FlexFormattingContext::transferred_size_suggestion(FlexItem 
     // If the item has a preferred aspect ratio and its preferred cross size is definite,
     // then the transferred size suggestion is that size
     // (clamped by its minimum and maximum cross sizes if they are definite), converted through the aspect ratio.
-    if (item.box->has_intrinsic_aspect_ratio() && has_definite_cross_size(item.box)) {
-        auto aspect_ratio = item.box->intrinsic_aspect_ratio().value();
+    if (item.box->has_natural_aspect_ratio() && has_definite_cross_size(item.box)) {
+        auto aspect_ratio = item.box->natural_aspect_ratio().value();
         return adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(
             item.box,
             calculate_main_size_from_cross_size_and_aspect_ratio(inner_cross_size(item.box), aspect_ratio),

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -378,8 +378,8 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(ReplacedBox co
 
     // If 'height' and 'width' both have computed values of 'auto' and the element also has an intrinsic width,
     // then that intrinsic width is the used value of 'width'.
-    if (computed_height.is_auto() && computed_width.is_auto() && box.has_intrinsic_width())
-        return box.intrinsic_width().value();
+    if (computed_height.is_auto() && computed_width.is_auto() && box.has_natural_width())
+        return box.natural_width().value();
 
     // If 'height' and 'width' both have computed values of 'auto' and the element has no intrinsic width,
     // but does have an intrinsic height and intrinsic ratio;
@@ -387,22 +387,22 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(ReplacedBox co
     // 'height' has some other computed value, and the element does have an intrinsic ratio; then the used value of 'width' is:
     //
     //     (used height) * (intrinsic ratio)
-    if ((computed_height.is_auto() && computed_width.is_auto() && !box.has_intrinsic_width() && box.has_intrinsic_height() && box.has_intrinsic_aspect_ratio())
-        || (computed_width.is_auto() && !computed_height.is_auto() && box.has_intrinsic_aspect_ratio())) {
-        return compute_height_for_replaced_element(box, available_space) * static_cast<double>(box.intrinsic_aspect_ratio().value());
+    if ((computed_height.is_auto() && computed_width.is_auto() && !box.has_natural_width() && box.has_natural_height() && box.has_natural_aspect_ratio())
+        || (computed_width.is_auto() && !computed_height.is_auto() && box.has_natural_aspect_ratio())) {
+        return compute_height_for_replaced_element(box, available_space) * static_cast<double>(box.natural_aspect_ratio().value());
     }
 
     // If 'height' and 'width' both have computed values of 'auto' and the element has an intrinsic ratio but no intrinsic height or width,
     // then the used value of 'width' is undefined in CSS 2.2. However, it is suggested that, if the containing block's width does not itself
     // depend on the replaced element's width, then the used value of 'width' is calculated from the constraint equation used for block-level,
     // non-replaced elements in normal flow.
-    if (computed_height.is_auto() && computed_width.is_auto() && !box.has_intrinsic_width() && !box.has_intrinsic_height() && box.has_intrinsic_aspect_ratio()) {
+    if (computed_height.is_auto() && computed_width.is_auto() && !box.has_natural_width() && !box.has_natural_height() && box.has_natural_aspect_ratio()) {
         return calculate_stretch_fit_width(box, available_space.width);
     }
 
     // Otherwise, if 'width' has a computed value of 'auto', and the element has an intrinsic width, then that intrinsic width is the used value of 'width'.
-    if (computed_width.is_auto() && box.has_intrinsic_width())
-        return box.intrinsic_width().value();
+    if (computed_width.is_auto() && box.has_natural_width())
+        return box.natural_width().value();
 
     // Otherwise, if 'width' has a computed value of 'auto', but none of the conditions above are met, then the used value of 'width' becomes 300px.
     // If 300px is too wide to fit the device, UAs should use the width of the largest rectangle that has a 2:1 ratio and fits the device instead.
@@ -443,7 +443,7 @@ CSSPixels FormattingContext::compute_width_for_replaced_element(ReplacedBox cons
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
     auto used_width = tentative_width_for_replaced_element(box, computed_width, available_space);
 
-    if (computed_width.is_auto() && computed_height.is_auto() && box.has_intrinsic_aspect_ratio()) {
+    if (computed_width.is_auto() && computed_height.is_auto() && box.has_natural_aspect_ratio()) {
         CSSPixels w = used_width;
         CSSPixels h = tentative_height_for_replaced_element(box, computed_height, available_space);
         used_width = solve_replaced_size_constraint(w, h, box).width();
@@ -477,18 +477,18 @@ CSSPixels FormattingContext::tentative_height_for_replaced_element(ReplacedBox c
 {
     // If 'height' and 'width' both have computed values of 'auto' and the element also has
     // an intrinsic height, then that intrinsic height is the used value of 'height'.
-    if (should_treat_width_as_auto(box, available_space) && should_treat_height_as_auto(box, available_space) && box.has_intrinsic_height())
-        return box.intrinsic_height().value();
+    if (should_treat_width_as_auto(box, available_space) && should_treat_height_as_auto(box, available_space) && box.has_natural_height())
+        return box.natural_height().value();
 
     // Otherwise, if 'height' has a computed value of 'auto', and the element has an intrinsic ratio then the used value of 'height' is:
     //
     //     (used width) / (intrinsic ratio)
-    if (computed_height.is_auto() && box.has_intrinsic_aspect_ratio())
-        return m_state.get(box).content_width() / static_cast<double>(box.intrinsic_aspect_ratio().value());
+    if (computed_height.is_auto() && box.has_natural_aspect_ratio())
+        return m_state.get(box).content_width() / static_cast<double>(box.natural_aspect_ratio().value());
 
     // Otherwise, if 'height' has a computed value of 'auto', and the element has an intrinsic height, then that intrinsic height is the used value of 'height'.
-    if (computed_height.is_auto() && box.has_intrinsic_height())
-        return box.intrinsic_height().value();
+    if (computed_height.is_auto() && box.has_natural_height())
+        return box.natural_height().value();
 
     // Otherwise, if 'height' has a computed value of 'auto', but none of the conditions above are met,
     // then the used value of 'height' must be set to the height of the largest rectangle that has a 2:1 ratio, has a height not greater than 150px,
@@ -518,7 +518,7 @@ CSSPixels FormattingContext::compute_height_for_replaced_element(ReplacedBox con
     // use the algorithm under 'Minimum and maximum widths'
     // https://www.w3.org/TR/CSS22/visudet.html#min-max-widths
     // to find the used width and height.
-    if (computed_width.is_auto() && computed_height.is_auto() && box.has_intrinsic_aspect_ratio()) {
+    if (computed_width.is_auto() && computed_height.is_auto() && box.has_natural_aspect_ratio()) {
         CSSPixels w = tentative_width_for_replaced_element(box, computed_width, available_space);
         CSSPixels h = used_height;
         used_height = solve_replaced_size_constraint(w, h, box).height();
@@ -1150,8 +1150,8 @@ CSSPixels FormattingContext::calculate_fit_content_height(Layout::Box const& box
 
 CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box) const
 {
-    if (box.has_intrinsic_width())
-        return *box.intrinsic_width();
+    if (box.has_natural_width())
+        return *box.natural_width();
 
     auto& root_state = m_state.m_root;
 
@@ -1188,8 +1188,8 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
 
 CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box) const
 {
-    if (box.has_intrinsic_width())
-        return *box.intrinsic_width();
+    if (box.has_natural_width())
+        return *box.natural_width();
 
     auto& root_state = m_state.m_root;
 
@@ -1231,8 +1231,8 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
     if (box.is_block_container() || box.display().is_table_inside())
         return calculate_max_content_height(box, available_width);
 
-    if (box.has_intrinsic_height())
-        return *box.intrinsic_height();
+    if (box.has_natural_height())
+        return *box.natural_height();
 
     bool is_cacheable = available_width.is_definite() || available_width.is_intrinsic_sizing_constraint();
 
@@ -1283,11 +1283,11 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
 
 CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box, AvailableSize const& available_width) const
 {
-    if (box.has_intrinsic_aspect_ratio() && available_width.is_definite())
-        return available_width.to_px() / static_cast<double>(*box.intrinsic_aspect_ratio());
+    if (box.has_natural_aspect_ratio() && available_width.is_definite())
+        return available_width.to_px() / static_cast<double>(*box.natural_aspect_ratio());
 
-    if (box.has_intrinsic_height())
-        return *box.intrinsic_height();
+    if (box.has_natural_height())
+        return *box.natural_height();
 
     bool is_cacheable = available_width.is_definite() || available_width.is_intrinsic_sizing_constraint();
 

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -50,8 +50,8 @@ public:
 
     static bool creates_block_formatting_context(Box const&);
 
-    CSSPixels compute_width_for_replaced_element(ReplacedBox const&, AvailableSpace const&) const;
-    CSSPixels compute_height_for_replaced_element(ReplacedBox const&, AvailableSpace const&) const;
+    CSSPixels compute_width_for_replaced_element(Box const&, AvailableSpace const&) const;
+    CSSPixels compute_height_for_replaced_element(Box const&, AvailableSpace const&) const;
 
     OwnPtr<FormattingContext> create_independent_formatting_context_if_needed(LayoutState&, Box const& child_box);
 
@@ -112,18 +112,18 @@ protected:
         CSSPixels preferred_minimum_width { 0 };
     };
 
-    CSSPixels tentative_width_for_replaced_element(ReplacedBox const&, CSS::Size const& computed_width, AvailableSpace const&) const;
-    CSSPixels tentative_height_for_replaced_element(ReplacedBox const&, CSS::Size const& computed_height, AvailableSpace const&) const;
+    CSSPixels tentative_width_for_replaced_element(Box const&, CSS::Size const& computed_width, AvailableSpace const&) const;
+    CSSPixels tentative_height_for_replaced_element(Box const&, CSS::Size const& computed_height, AvailableSpace const&) const;
     CSSPixels compute_auto_height_for_block_formatting_context_root(Box const&) const;
 
-    [[nodiscard]] CSSPixelSize solve_replaced_size_constraint(CSSPixels input_width, CSSPixels input_height, ReplacedBox const&) const;
+    [[nodiscard]] CSSPixelSize solve_replaced_size_constraint(CSSPixels input_width, CSSPixels input_height, Box const&) const;
 
     ShrinkToFitResult calculate_shrink_to_fit_widths(Box const&);
 
     void layout_absolutely_positioned_element(Box const&, AvailableSpace const&);
     void compute_width_for_absolutely_positioned_element(Box const&, AvailableSpace const&);
     void compute_width_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&);
-    void compute_width_for_absolutely_positioned_replaced_element(ReplacedBox const&, AvailableSpace const&);
+    void compute_width_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&);
 
     enum class BeforeOrAfterInsideLayout {
         Before,
@@ -131,7 +131,7 @@ protected:
     };
     void compute_height_for_absolutely_positioned_element(Box const&, AvailableSpace const&, BeforeOrAfterInsideLayout);
     void compute_height_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&, BeforeOrAfterInsideLayout);
-    void compute_height_for_absolutely_positioned_replaced_element(ReplacedBox const&, AvailableSpace const&, BeforeOrAfterInsideLayout);
+    void compute_height_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&, BeforeOrAfterInsideLayout);
 
     Type m_type {};
 
@@ -140,5 +140,7 @@ protected:
 
     LayoutState& m_state;
 };
+
+bool box_is_sized_as_replaced_element(Box const&);
 
 }

--- a/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
@@ -24,8 +24,8 @@ void FrameBox::prepare_for_replaced_layout()
     VERIFY(dom_node().nested_browsing_context());
 
     // FIXME: Do proper error checking, etc.
-    set_intrinsic_width(dom_node().attribute(HTML::AttributeNames::width).to_int().value_or(300));
-    set_intrinsic_height(dom_node().attribute(HTML::AttributeNames::height).to_int().value_or(150));
+    set_natural_width(dom_node().attribute(HTML::AttributeNames::width).to_int().value_or(300));
+    set_natural_height(dom_node().attribute(HTML::AttributeNames::height).to_int().value_or(150));
 }
 
 void FrameBox::did_set_content_size()

--- a/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -23,9 +23,9 @@ ImageBox::~ImageBox() = default;
 
 void ImageBox::prepare_for_replaced_layout()
 {
-    set_intrinsic_width(m_image_provider.intrinsic_width());
-    set_intrinsic_height(m_image_provider.intrinsic_height());
-    set_intrinsic_aspect_ratio(m_image_provider.intrinsic_aspect_ratio());
+    set_natural_width(m_image_provider.intrinsic_width());
+    set_natural_height(m_image_provider.intrinsic_height());
+    set_natural_aspect_ratio(m_image_provider.intrinsic_aspect_ratio());
 
     if (renders_as_alt_text()) {
         auto& image_element = verify_cast<HTML::HTMLImageElement>(dom_node());
@@ -37,11 +37,11 @@ void ImageBox::prepare_for_replaced_layout()
             m_cached_alt_text_width = font.width(alt);
         alt_text_width = m_cached_alt_text_width.value();
 
-        set_intrinsic_width(alt_text_width + 16);
-        set_intrinsic_height(font.pixel_size() + 16);
+        set_natural_width(alt_text_width + 16);
+        set_natural_height(font.pixel_size() + 16);
     }
 
-    if (!has_intrinsic_width() && !has_intrinsic_height()) {
+    if (!has_natural_width() && !has_natural_height()) {
         // FIXME: Do something.
     }
 }

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -110,14 +110,12 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     box_state.border_bottom = computed_values.border_bottom().width;
     box_state.margin_bottom = computed_values.margin().bottom().to_px(box, width_of_containing_block);
 
-    if (is<ReplacedBox>(box)) {
-        auto& replaced = verify_cast<ReplacedBox>(box);
-
-        box_state.set_content_width(compute_width_for_replaced_element(replaced, *m_available_space));
-        box_state.set_content_height(compute_height_for_replaced_element(replaced, *m_available_space));
+    if (box_is_sized_as_replaced_element(box)) {
+        box_state.set_content_width(compute_width_for_replaced_element(box, *m_available_space));
+        box_state.set_content_height(compute_height_for_replaced_element(box, *m_available_space));
 
         if (is<SVGSVGBox>(box))
-            (void)layout_inside(replaced, layout_mode, box_state.available_inner_space_or_constraints_from(*m_available_space));
+            (void)layout_inside(box, layout_mode, box_state.available_inner_space_or_constraints_from(*m_available_space));
         return;
     }
 

--- a/Userland/Libraries/LibWeb/Layout/Progress.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Progress.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 Progress::Progress(DOM::Document& document, HTML::HTMLProgressElement& element, NonnullRefPtr<CSS::StyleProperties> style)
     : LabelableNode(document, element, move(style))
 {
-    set_intrinsic_height(12);
+    set_natural_height(12);
 }
 
 Progress::~Progress() = default;

--- a/Userland/Libraries/LibWeb/Layout/RadioButton.cpp
+++ b/Userland/Libraries/LibWeb/Layout/RadioButton.cpp
@@ -14,9 +14,9 @@ namespace Web::Layout {
 RadioButton::RadioButton(DOM::Document& document, HTML::HTMLInputElement& element, NonnullRefPtr<CSS::StyleProperties> style)
     : FormAssociatedLabelableNode(document, element, move(style))
 {
-    set_intrinsic_width(12);
-    set_intrinsic_height(12);
-    set_intrinsic_aspect_ratio(1);
+    set_natural_width(12);
+    set_natural_height(12);
+    set_natural_aspect_ratio(1);
 }
 
 RadioButton::~RadioButton() = default;

--- a/Userland/Libraries/LibWeb/Layout/ReplacedBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ReplacedBox.h
@@ -18,16 +18,8 @@ public:
     ReplacedBox(DOM::Document&, DOM::Element&, NonnullRefPtr<CSS::StyleProperties>);
     virtual ~ReplacedBox() override;
 
-    const DOM::Element& dom_node() const { return verify_cast<DOM::Element>(*Node::dom_node()); }
+    DOM::Element const& dom_node() const { return verify_cast<DOM::Element>(*Node::dom_node()); }
     DOM::Element& dom_node() { return verify_cast<DOM::Element>(*Node::dom_node()); }
-
-    virtual Optional<CSSPixels> intrinsic_width() const final { return m_intrinsic_width; }
-    virtual Optional<CSSPixels> intrinsic_height() const final { return m_intrinsic_height; }
-    virtual Optional<float> intrinsic_aspect_ratio() const final { return m_intrinsic_aspect_ratio; }
-
-    void set_intrinsic_width(Optional<CSSPixels> width) { m_intrinsic_width = width; }
-    void set_intrinsic_height(Optional<CSSPixels> height) { m_intrinsic_height = height; }
-    void set_intrinsic_aspect_ratio(Optional<float> ratio) { m_intrinsic_aspect_ratio = ratio; }
 
     virtual void prepare_for_replaced_layout() { }
 

--- a/Userland/Libraries/LibWeb/Layout/SVGSVGBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGSVGBox.cpp
@@ -31,15 +31,15 @@ void SVGSVGBox::prepare_for_replaced_layout()
     // 'auto' and percentage lengths must not be used to determine an intrinsic width or intrinsic height.
     auto const& computed_width = computed_values().width();
     if (computed_width.is_length() && !computed_width.contains_percentage()) {
-        set_intrinsic_width(computed_width.to_px(*this, 0));
+        set_natural_width(computed_width.to_px(*this, 0));
     }
 
     auto const& computed_height = computed_values().height();
     if (computed_height.is_length() && !computed_height.contains_percentage()) {
-        set_intrinsic_height(computed_height.to_px(*this, 0));
+        set_natural_height(computed_height.to_px(*this, 0));
     }
 
-    set_intrinsic_aspect_ratio(calculate_intrinsic_aspect_ratio());
+    set_natural_aspect_ratio(calculate_intrinsic_aspect_ratio());
 }
 
 Optional<float> SVGSVGBox::calculate_intrinsic_aspect_ratio() const

--- a/Userland/Libraries/LibWeb/Layout/VideoBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/VideoBox.cpp
@@ -48,15 +48,15 @@ int VideoBox::preferred_height() const
 void VideoBox::prepare_for_replaced_layout()
 {
     auto width = static_cast<float>(dom_node().video_width());
-    set_intrinsic_width(width);
+    set_natural_width(width);
 
     auto height = static_cast<float>(dom_node().video_height());
-    set_intrinsic_height(height);
+    set_natural_height(height);
 
     if (width != 0 && height != 0)
-        set_intrinsic_aspect_ratio(width / height);
+        set_natural_aspect_ratio(width / height);
     else
-        set_intrinsic_aspect_ratio({});
+        set_natural_aspect_ratio({});
 }
 
 void VideoBox::browsing_context_did_set_viewport_rect(CSSPixelRect const&)


### PR DESCRIPTION
![image](https://github.com/SerenityOS/serenity/assets/222642/537f0b70-a9c5-426e-88d5-0f786e3dbc3e)

This is far from perfect, but:
- All the [parsing tests](https://wpt.live/css/css-sizing/aspect-ratio/parsing/) pass except for a couple related to float precision.
- A bunch:tm: of the other WPT tests for `aspect-ratio` pass.
- Lots of exciting new layout bugs for people to enjoy fixing. :upside_down_face: 