### PR TITLE
Kernel: Remove DiskCache entirely

### DIFF
--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -11,110 +11,6 @@
 
 namespace Kernel {
 
-struct CacheEntry {
-    IntrusiveListNode<CacheEntry> list_node;
-    BlockBasedFileSystem::BlockIndex block_index { 0 };
-    u8* data { nullptr };
-    bool has_data { false };
-};
-
-class DiskCache {
-public:
-    static constexpr size_t EntryCount = 10000;
-    explicit DiskCache(BlockBasedFileSystem& fs, NonnullOwnPtr<KBuffer> cached_block_data, NonnullOwnPtr<KBuffer> entries_buffer)
-        : m_fs(fs)
-        , m_cached_block_data(move(cached_block_data))
-        , m_entries(move(entries_buffer))
-    {
-        for (size_t i = 0; i < EntryCount; ++i) {
-            entries()[i].data = m_cached_block_data->data() + i * m_fs->block_size();
-            m_clean_list.append(entries()[i]);
-        }
-    }
-
-    ~DiskCache() = default;
-
-    bool is_dirty() const { return !m_dirty_list.is_empty(); }
-    bool entry_is_dirty(CacheEntry const& entry) const { return m_dirty_list.contains(entry); }
-
-    void mark_all_clean()
-    {
-        while (auto* entry = m_dirty_list.first())
-            m_clean_list.prepend(*entry);
-    }
-
-    void mark_dirty(CacheEntry& entry)
-    {
-        m_dirty_list.prepend(entry);
-    }
-
-    void mark_clean(CacheEntry& entry)
-    {
-        m_clean_list.prepend(entry);
-    }
-
-    CacheEntry* get(BlockBasedFileSystem::BlockIndex block_index) const
-    {
-        auto it = m_hash.find(block_index);
-        if (it == m_hash.end())
-            return nullptr;
-        auto& entry = const_cast<CacheEntry&>(*it->value);
-        VERIFY(entry.block_index == block_index);
-        if (!entry_is_dirty(entry) && (m_clean_list.first() != &entry)) {
-            // Cache hit! Promote the entry to the front of the list.
-            m_clean_list.prepend(entry);
-        }
-        return &entry;
-    }
-
-    ErrorOr<CacheEntry*> ensure(BlockBasedFileSystem::BlockIndex block_index) const
-    {
-        if (auto* entry = get(block_index))
-            return entry;
-
-        if (m_clean_list.is_empty()) {
-            // Not a single clean entry! Flush writes and try again.
-            // NOTE: We want to make sure we only call FileBackedFileSystem flush here,
-            //       not some FileBackedFileSystem subclass flush!
-            m_fs->flush_writes_impl();
-            return ensure(block_index);
-        }
-
-        VERIFY(m_clean_list.last());
-        auto& new_entry = *m_clean_list.last();
-        m_clean_list.prepend(new_entry);
-
-        m_hash.remove(new_entry.block_index);
-        TRY(m_hash.try_set(block_index, &new_entry));
-
-        new_entry.block_index = block_index;
-        new_entry.has_data = false;
-
-        return &new_entry;
-    }
-
-    CacheEntry const* entries() const { return (CacheEntry const*)m_entries->data(); }
-    CacheEntry* entries() { return (CacheEntry*)m_entries->data(); }
-
-    template<typename Callback>
-    void for_each_dirty_entry(Callback callback)
-    {
-        for (auto& entry : m_dirty_list)
-            callback(entry);
-    }
-
-private:
-    mutable NonnullRefPtr<BlockBasedFileSystem> m_fs;
-    NonnullOwnPtr<KBuffer> m_cached_block_data;
-
-    // NOTE: m_entries must be declared before m_dirty_list and m_clean_list because their entries are allocated from it.
-    // We need to ensure that the destructors of m_dirty_list and m_clean_list are called before m_entries is destroyed.
-    NonnullOwnPtr<KBuffer> m_entries;
-    mutable IntrusiveList<&CacheEntry::list_node> m_dirty_list;
-    mutable IntrusiveList<&CacheEntry::list_node> m_clean_list;
-    mutable HashMap<BlockBasedFileSystem::BlockIndex, CacheEntry*> m_hash;
-};
-
 BlockBasedFileSystem::BlockBasedFileSystem(OpenFileDescription& file_description)
     : FileBackedFileSystem(file_description)
 {
@@ -123,62 +19,23 @@ BlockBasedFileSystem::BlockBasedFileSystem(OpenFileDescription& file_description
 
 BlockBasedFileSystem::~BlockBasedFileSystem() = default;
 
-void BlockBasedFileSystem::remove_disk_cache_before_last_unmount()
-{
-    VERIFY(m_lock.is_locked());
-    m_cache.with_exclusive([&](auto& cache) {
-        cache.clear();
-    });
-}
-
 ErrorOr<void> BlockBasedFileSystem::initialize_while_locked()
 {
     VERIFY(m_lock.is_locked());
     VERIFY(!is_initialized_while_locked());
-    VERIFY(block_size() != 0);
-    auto cached_block_data = TRY(KBuffer::try_create_with_size("BlockBasedFS: Cache blocks"sv, DiskCache::EntryCount * block_size()));
-    auto entries_data = TRY(KBuffer::try_create_with_size("BlockBasedFS: Cache entries"sv, DiskCache::EntryCount * sizeof(CacheEntry)));
-    auto disk_cache = TRY(adopt_nonnull_own_or_enomem(new (nothrow) DiskCache(*this, move(cached_block_data), move(entries_data))));
-
-    m_cache.with_exclusive([&](auto& cache) {
-        cache = move(disk_cache);
-    });
     return {};
 }
 
-ErrorOr<void> BlockBasedFileSystem::write_block(BlockIndex index, UserOrKernelBuffer const& data, size_t count, u64 offset, bool allow_cache)
+ErrorOr<void> BlockBasedFileSystem::write_block(BlockIndex index, UserOrKernelBuffer const& data, size_t count, u64 offset)
 {
     VERIFY(m_logical_block_size);
     VERIFY(offset + count <= block_size());
     dbgln_if(BBFS_DEBUG, "BlockBasedFileSystem::write_block {}, size={}", index, count);
 
-    // NOTE: We copy the `data` to write into a local buffer before taking the cache lock.
-    //       This makes sure any page faults caused by accessing the data will occur before
-    //       we tie down the cache.
-    auto buffered_data = TRY(ByteBuffer::create_uninitialized(count));
-
-    TRY(data.read(buffered_data.bytes()));
-
-    return m_cache.with_exclusive([&](auto& cache) -> ErrorOr<void> {
-        if (!allow_cache) {
-            flush_specific_block_if_needed(index);
-            u64 base_offset = index.value() * block_size() + offset;
-            auto nwritten = TRY(file_description().write(base_offset, data, count));
-            VERIFY(nwritten == count);
-            return {};
-        }
-
-        auto entry = TRY(cache->ensure(index));
-        if (count < block_size()) {
-            // Fill the cache first.
-            TRY(read_block(index, nullptr, block_size()));
-        }
-        memcpy(entry->data + offset, buffered_data.data(), count);
-
-        cache->mark_dirty(*entry);
-        entry->has_data = true;
-        return {};
-    });
+    u64 base_offset = index.value() * block_size() + offset;
+    auto nwritten = TRY(file_description().write(base_offset, data, count));
+    VERIFY(nwritten == count);
+    return {};
 }
 
 ErrorOr<void> BlockBasedFileSystem::raw_read(BlockIndex index, UserOrKernelBuffer& buffer)
@@ -217,97 +74,42 @@ ErrorOr<void> BlockBasedFileSystem::raw_write_blocks(BlockIndex index, size_t co
     return {};
 }
 
-ErrorOr<void> BlockBasedFileSystem::write_blocks(BlockIndex index, unsigned count, UserOrKernelBuffer const& data, bool allow_cache)
+ErrorOr<void> BlockBasedFileSystem::write_blocks(BlockIndex index, unsigned count, UserOrKernelBuffer const& data)
 {
     VERIFY(m_logical_block_size);
     dbgln_if(BBFS_DEBUG, "BlockBasedFileSystem::write_blocks {}, count={}", index, count);
     for (unsigned i = 0; i < count; ++i) {
-        TRY(write_block(BlockIndex { index.value() + i }, data.offset(i * block_size()), block_size(), 0, allow_cache));
+        TRY(write_block(BlockIndex { index.value() + i }, data.offset(i * block_size()), block_size(), 0));
     }
     return {};
 }
 
-ErrorOr<void> BlockBasedFileSystem::read_block(BlockIndex index, UserOrKernelBuffer* buffer, size_t count, u64 offset, bool allow_cache) const
+ErrorOr<void> BlockBasedFileSystem::read_block(BlockIndex index, UserOrKernelBuffer* buffer, size_t count, u64 offset) const
 {
     VERIFY(m_logical_block_size);
     VERIFY(offset + count <= block_size());
     dbgln_if(BBFS_DEBUG, "BlockBasedFileSystem::read_block {}", index);
 
-    return m_cache.with_exclusive([&](auto& cache) -> ErrorOr<void> {
-        if (!allow_cache) {
-            const_cast<BlockBasedFileSystem*>(this)->flush_specific_block_if_needed(index);
-            u64 base_offset = index.value() * block_size() + offset;
-            auto nread = TRY(file_description().read(*buffer, base_offset, count));
-            VERIFY(nread == count);
-            return {};
-        }
-
-        auto* entry = TRY(cache->ensure(index));
-        if (!entry->has_data) {
-            auto base_offset = index.value() * block_size();
-            auto entry_data_buffer = UserOrKernelBuffer::for_kernel_buffer(entry->data);
-            auto nread = TRY(file_description().read(entry_data_buffer, base_offset, block_size()));
-            VERIFY(nread == block_size());
-            entry->has_data = true;
-        }
-        if (buffer)
-            TRY(buffer->write(entry->data + offset, count));
-        return {};
-    });
+    u64 base_offset = index.value() * block_size() + offset;
+    auto nread = TRY(file_description().read(*buffer, base_offset, count));
+    VERIFY(nread == count);
+    return {};
 }
 
-ErrorOr<void> BlockBasedFileSystem::read_blocks(BlockIndex index, unsigned count, UserOrKernelBuffer& buffer, bool allow_cache) const
+ErrorOr<void> BlockBasedFileSystem::read_blocks(BlockIndex index, unsigned count, UserOrKernelBuffer& buffer) const
 {
     VERIFY(m_logical_block_size);
     if (!count)
         return EINVAL;
     if (count == 1)
-        return read_block(index, &buffer, block_size(), 0, allow_cache);
+        return read_block(index, &buffer, block_size(), 0);
     auto out = buffer;
     for (unsigned i = 0; i < count; ++i) {
-        TRY(read_block(BlockIndex { index.value() + i }, &out, block_size(), 0, allow_cache));
+        TRY(read_block(BlockIndex { index.value() + i }, &out, block_size(), 0));
         out = out.offset(block_size());
     }
 
     return {};
-}
-
-void BlockBasedFileSystem::flush_specific_block_if_needed(BlockIndex index)
-{
-    m_cache.with_exclusive([&](auto& cache) {
-        if (!cache->is_dirty())
-            return;
-        auto* entry = cache->get(index);
-        if (!entry)
-            return;
-        if (!cache->entry_is_dirty(*entry))
-            return;
-        size_t base_offset = entry->block_index.value() * block_size();
-        auto entry_data_buffer = UserOrKernelBuffer::for_kernel_buffer(entry->data);
-        (void)file_description().write(base_offset, entry_data_buffer, block_size());
-    });
-}
-
-void BlockBasedFileSystem::flush_writes_impl()
-{
-    size_t count = 0;
-    m_cache.with_exclusive([&](auto& cache) {
-        if (!cache->is_dirty())
-            return;
-        cache->for_each_dirty_entry([&](CacheEntry& entry) {
-            auto base_offset = entry.block_index.value() * block_size();
-            auto entry_data_buffer = UserOrKernelBuffer::for_kernel_buffer(entry.data);
-            [[maybe_unused]] auto rc = file_description().write(base_offset, entry_data_buffer, block_size());
-            ++count;
-        });
-        cache->mark_all_clean();
-        dbgln("{}: Flushed {} blocks to disk", class_name(), count);
-    });
-}
-
-void BlockBasedFileSystem::flush_writes()
-{
-    flush_writes_impl();
 }
 
 }

--- a/Kernel/FileSystem/BlockBasedFileSystem.h
+++ b/Kernel/FileSystem/BlockBasedFileSystem.h
@@ -19,16 +19,13 @@ public:
 
     u64 logical_block_size() const { return m_logical_block_size; };
 
-    virtual void flush_writes() override;
-    void flush_writes_impl();
-
 protected:
     explicit BlockBasedFileSystem(OpenFileDescription&);
 
     virtual ErrorOr<void> initialize_while_locked() override;
 
-    ErrorOr<void> read_block(BlockIndex, UserOrKernelBuffer*, size_t count, u64 offset = 0, bool allow_cache = true) const;
-    ErrorOr<void> read_blocks(BlockIndex, unsigned count, UserOrKernelBuffer&, bool allow_cache = true) const;
+    ErrorOr<void> read_block(BlockIndex, UserOrKernelBuffer*, size_t count, u64 offset = 0) const;
+    ErrorOr<void> read_blocks(BlockIndex, unsigned count, UserOrKernelBuffer&) const;
 
     ErrorOr<void> raw_read(BlockIndex, UserOrKernelBuffer&);
     ErrorOr<void> raw_write(BlockIndex, UserOrKernelBuffer const&);
@@ -36,17 +33,10 @@ protected:
     ErrorOr<void> raw_read_blocks(BlockIndex index, size_t count, UserOrKernelBuffer&);
     ErrorOr<void> raw_write_blocks(BlockIndex index, size_t count, UserOrKernelBuffer const&);
 
-    ErrorOr<void> write_block(BlockIndex, UserOrKernelBuffer const&, size_t count, u64 offset = 0, bool allow_cache = true);
-    ErrorOr<void> write_blocks(BlockIndex, unsigned count, UserOrKernelBuffer const&, bool allow_cache = true);
+    ErrorOr<void> write_block(BlockIndex, UserOrKernelBuffer const&, size_t count, u64 offset = 0);
+    ErrorOr<void> write_blocks(BlockIndex, unsigned count, UserOrKernelBuffer const&);
 
     u64 m_logical_block_size { 512 };
-
-    void remove_disk_cache_before_last_unmount();
-
-private:
-    void flush_specific_block_if_needed(BlockIndex index);
-
-    mutable MutexProtected<OwnPtr<DiskCache>> m_cache;
 };
 
 }

--- a/Kernel/FileSystem/Ext2FS/FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.cpp
@@ -540,7 +540,6 @@ ErrorOr<void> Ext2FS::prepare_to_clear_last_mount()
             return EBUSY;
     }
 
-    BlockBasedFileSystem::remove_disk_cache_before_last_unmount();
     m_inode_cache.clear();
     m_root_inode = nullptr;
     return {};

--- a/Kernel/FileSystem/ISO9660FS/FileSystem.cpp
+++ b/Kernel/FileSystem/ISO9660FS/FileSystem.cpp
@@ -83,7 +83,6 @@ u8 ISO9660FS::internal_file_type_to_directory_entry_type(DirectoryEntryView cons
 ErrorOr<void> ISO9660FS::prepare_to_clear_last_mount()
 {
     // FIXME: Do proper cleaning here.
-    BlockBasedFileSystem::remove_disk_cache_before_last_unmount();
     return {};
 }
 


### PR DESCRIPTION
We will re-introduce caching, but the DiskCache design is utterly incapable of figuring what are the important things to cache or not.

This decreases boot times by half on my machine (from about 4 seconds to 2 seconds), so this is an actual improvement that we should keep in future filesystem cache design.