### PR TITLE
LibWeb: Teach CSS transformed StackingContexts about image-rendering

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -13,6 +13,7 @@
 #include <LibGfx/Matrix4x4.h>
 #include <LibGfx/Painter.h>
 #include <LibGfx/Rect.h>
+#include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/StyleValues/TransformationStyleValue.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/ReplacedBox.h>
@@ -413,10 +414,12 @@ void StackingContext::paint(PaintContext& context) const
         auto paint_context = context.clone(painter);
         paint_internal(paint_context);
 
-        if (destination_rect.size() == bitmap->size())
+        if (destination_rect.size() == bitmap->size()) {
             context.painter().blit(destination_rect.location(), *bitmap, bitmap->rect(), opacity);
-        else
-            context.painter().draw_scaled_bitmap(destination_rect, *bitmap, bitmap->rect(), opacity, Gfx::Painter::ScalingMode::BilinearBlend);
+        } else {
+            auto scaling_mode = CSS::to_gfx_scaling_mode(m_box->computed_values().image_rendering(), bitmap->rect(), destination_rect);
+            context.painter().draw_scaled_bitmap(destination_rect, *bitmap, bitmap->rect(), opacity, scaling_mode);
+        }
     } else {
         Gfx::PainterStateSaver saver(context.painter());
         context.painter().translate(affine_transform.translation().to_rounded<int>());


### PR DESCRIPTION
Previously, the `image-rendering` property was ignored for contexts that were scaled using CSS transforms.

Ignore the unrelated scaling-related goof. The lower example scales the `<img>` element with the usual `width` and `height` properties, and the upper example uses CSS `scale(2)` instead.

Before:
![image](https://github.com/SerenityOS/serenity/assets/20117975/98293838-1544-4a25-b592-5291f5eccf85)

After:
![image](https://github.com/SerenityOS/serenity/assets/20117975/0ec76fa4-9eec-4ebb-8211-efc964d34588)

The difference can be observed well on [pixel.vkoskiv.com](https://pixel.vkoskiv.com), which makes heavy use of dynamic CSS transforms to scale the canvas:

Before:
![image](https://github.com/SerenityOS/serenity/assets/20117975/e5f63760-f021-487a-bc40-22c1437476de)

After:
![image](https://github.com/SerenityOS/serenity/assets/20117975/a7a6cfd9-1f6a-4ac2-94f2-ab870ce092d8)

The test pages are available here:
[img dimension scale](https://gist.github.com/vkoskiv/8e0978a06bcc73f03bbacaa3382e52ba)
[CSS transform scale](https://gist.github.com/vkoskiv/a45d52c0b0731afc64a0ae4fac9eb5bb)

