### PR TITLE
LibWeb: Allow `auto` as `animation-duration` and make that the default

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -67,9 +67,12 @@
   "animation-duration": {
     "affects-layout": true,
     "inherited": false,
-    "initial": "0s",
+    "initial": "auto",
     "valid-types": [
       "time [0,∞]"
+    ],
+    "valid-identifiers": [
+      "auto"
     ]
   },
   "animation-fill-mode": {

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -45,48 +45,12 @@
       "animation-fill-mode"
     ]
   },
-  "animation-name": {
-    "affects-layout": true,
-    "inherited": false,
-    "initial": "none",
-    "valid-types": [
-      "string",
-      "custom-ident"
-    ],
-    "valid-identifiers": [
-      "none"
-    ]
-  },
-  "animation-duration": {
+  "animation-delay": {
     "affects-layout": true,
     "inherited": false,
     "initial": "0s",
     "valid-types": [
-      "time [0,∞]"
-    ]
-  },
-  "animation-timing-function": {
-    "affects-layout": true,
-    "inherited": false,
-    "initial": "ease",
-    "__comment": "FIXME: This is like...wrong.",
-    "valid-identifiers": [
-      "ease",
-      "linear",
-      "ease-in-out",
-      "ease-in",
-      "ease-out"
-    ]
-  },
-  "animation-iteration-count": {
-    "affects-layout": true,
-    "inherited": false,
-    "initial": "1",
-    "valid-types": [
-      "number [0,∞]"
-    ],
-    "valid-identifiers": [
-      "infinite"
+      "time [-∞,∞]"
     ]
   },
   "animation-direction": {
@@ -100,21 +64,12 @@
       "alternate-reverse"
     ]
   },
-  "animation-play-state": {
-    "affects-layout": false,
-    "inherited": false,
-    "initial": "running",
-    "valid-identifiers": [
-      "running",
-      "paused"
-    ]
-  },
-  "animation-delay": {
+  "animation-duration": {
     "affects-layout": true,
     "inherited": false,
     "initial": "0s",
     "valid-types": [
-      "time [-∞,∞]"
+      "time [0,∞]"
     ]
   },
   "animation-fill-mode": {
@@ -126,6 +81,51 @@
       "forwards",
       "backwards",
       "both"
+    ]
+  },
+  "animation-iteration-count": {
+    "affects-layout": true,
+    "inherited": false,
+    "initial": "1",
+    "valid-types": [
+      "number [0,∞]"
+    ],
+    "valid-identifiers": [
+      "infinite"
+    ]
+  },
+  "animation-name": {
+    "affects-layout": true,
+    "inherited": false,
+    "initial": "none",
+    "valid-types": [
+      "string",
+      "custom-ident"
+    ],
+    "valid-identifiers": [
+      "none"
+    ]
+  },
+  "animation-play-state": {
+    "affects-layout": false,
+    "inherited": false,
+    "initial": "running",
+    "valid-identifiers": [
+      "running",
+      "paused"
+    ]
+  },
+  "animation-timing-function": {
+    "affects-layout": true,
+    "inherited": false,
+    "initial": "ease",
+    "__comment": "FIXME: This is like...wrong.",
+    "valid-identifiers": [
+      "ease",
+      "linear",
+      "ease-in-out",
+      "ease-in",
+      "ease-out"
     ]
   },
   "appearance": {

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -199,7 +199,7 @@ private:
 
     struct Animation {
         String name;
-        CSS::Time duration;
+        Optional<CSS::Time> duration; // "auto" if not set.
         CSS::Time delay;
         Optional<size_t> iteration_count; // Infinite if not set.
         CSS::AnimationDirection direction;


### PR DESCRIPTION
This implements a change from the updated 2023-06-02 CSS Animations 2 spec. ([Link](https://www.w3.org/TR/2023/WD-css-animations-2-20230602/#changes-recent)) There are several changes there, and this only implements one, but I think the others don't affect us yet.