### PR TITLE
Kernel+pgrep: Add `-n`, `-o` and `-O` options to filter processes by age

### DIFF
--- a/Base/usr/share/man/man1/pgrep.md
+++ b/Base/usr/share/man/man1/pgrep.md
@@ -5,7 +5,7 @@ pgrep - look up processes based on name
 ## Synopsis
 
 ```sh
-$ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--uid uid-list] [--invert-match] [--exact] <process-name>
+$ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--newest] [--uid uid-list] [--invert-match] [--exact] <process-name>
 ```
 
 ## Options
@@ -14,6 +14,7 @@ $ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--uid uid-list] 
 * `-d`, `--delimiter`: Set the string used to delimit multiple pids
 * `-i`, `--ignore-case`: Make matches case-insensitive
 * `-l`, `--list-name`: List the process name in addition to its pid
+* `-n`, `--newest`: Select the most recently created process only
 * `-U uid-list`, `--uid uid-list`: Select only processes whose UID is in the given comma-separated list. Login name or numerical user ID may be used
 * `-x`, `--exact`: Select only processes whose names match the given pattern exactly
 * `-v`, `--invert-match`: Select non-matching lines

--- a/Base/usr/share/man/man1/pgrep.md
+++ b/Base/usr/share/man/man1/pgrep.md
@@ -5,7 +5,7 @@ pgrep - look up processes based on name
 ## Synopsis
 
 ```sh
-$ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--newest] [--uid uid-list] [--invert-match] [--exact] <process-name>
+$ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--newest] [--oldest] [--uid uid-list] [--invert-match] [--exact] <process-name>
 ```
 
 ## Options
@@ -15,6 +15,7 @@ $ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--newest] [--uid
 * `-i`, `--ignore-case`: Make matches case-insensitive
 * `-l`, `--list-name`: List the process name in addition to its pid
 * `-n`, `--newest`: Select the most recently created process only
+* `-o`, `--oldest`: Select the least recently created process only
 * `-U uid-list`, `--uid uid-list`: Select only processes whose UID is in the given comma-separated list. Login name or numerical user ID may be used
 * `-x`, `--exact`: Select only processes whose names match the given pattern exactly
 * `-v`, `--invert-match`: Select non-matching lines

--- a/Base/usr/share/man/man1/pgrep.md
+++ b/Base/usr/share/man/man1/pgrep.md
@@ -5,7 +5,7 @@ pgrep - look up processes based on name
 ## Synopsis
 
 ```sh
-$ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--newest] [--oldest] [--uid uid-list] [--invert-match] [--exact] <process-name>
+$ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--newest] [--oldest] [--older seconds] [--uid uid-list] [--invert-match] [--exact] <process-name>
 ```
 
 ## Options
@@ -16,6 +16,7 @@ $ pgrep [--count] [-d delimiter] [--ignore-case] [--list-name] [--newest] [--old
 * `-l`, `--list-name`: List the process name in addition to its pid
 * `-n`, `--newest`: Select the most recently created process only
 * `-o`, `--oldest`: Select the least recently created process only
+* `-O`, `--older`: Select only processes older than the specified number of seconds
 * `-U uid-list`, `--uid uid-list`: Select only processes whose UID is in the given comma-separated list. Login name or numerical user ID may be used
 * `-x`, `--exact`: Select only processes whose names match the given pattern exactly
 * `-v`, `--invert-match`: Select non-matching lines

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Processes.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Processes.cpp
@@ -83,6 +83,7 @@ ErrorOr<void> SysFSOverallProcesses::try_generate(KBufferBuilder& builder)
         }
         TRY(process.name().with([&](auto& process_name) { return process_object.add("name"sv, process_name->view()); }));
         TRY(process_object.add("executable"sv, process.executable() ? TRY(process.executable()->try_serialize_absolute_path())->view() : ""sv));
+        TRY(process_object.add("creation_time"sv, process.creation_time().nanoseconds_since_epoch()));
 
         size_t amount_virtual = 0;
         size_t amount_resident = 0;

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -42,6 +42,7 @@ ErrorOr<AllProcessesStatistics> ProcessStatisticsReader::get_all(SeekableStream&
         process.tty = process_object.get_deprecated_string("tty"sv).value_or("");
         process.pledge = process_object.get_deprecated_string("pledge"sv).value_or("");
         process.veil = process_object.get_deprecated_string("veil"sv).value_or("");
+        process.creation_time = UnixDateTime::from_nanoseconds_since_epoch(process_object.get_i64("creation_time"sv).value_or(0));
         process.amount_virtual = process_object.get_u32("amount_virtual"sv).value_or(0);
         process.amount_resident = process_object.get_u32("amount_resident"sv).value_or(0);
         process.amount_shared = process_object.get_u32("amount_shared"sv).value_or(0);

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.h
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
+#include <AK/Time.h>
 #include <AK/Vector.h>
 #include <unistd.h>
 
@@ -49,6 +50,7 @@ struct ProcessStatistics {
     DeprecatedString tty;
     DeprecatedString pledge;
     DeprecatedString veil;
+    UnixDateTime creation_time;
     size_t amount_virtual;
     size_t amount_resident;
     size_t amount_shared;


### PR DESCRIPTION
This PR adds the following options to `pgrep`:
* `-n`: Select the newest matching process.
* `-o`: Select the oldest matching process.
* `-O`: Select processes older than the given number of seconds.

The `creation_time` field was added to `/sys/kernel/processes` to support this.

Example usage: 
![pgrep_filter_by_age](https://github.com/SerenityOS/serenity/assets/2817754/17adef80-1558-4b7b-aa01-a13e92d200ec)

