### PR TITLE
LibWebView: Unbreak spawning WebContent process with valgrind

### DIFF
--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -200,6 +200,10 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> ViewImplementation::launch_web
         ErrorOr<void> result;
         for (auto const& path : candidate_web_content_paths) {
             constexpr auto callgrind_prefix_length = 3;
+
+            if (Core::System::access(path, X_OK).is_error())
+                continue;
+
             auto arguments = Vector {
                 "valgrind"sv,
                 "--tool=callgrind"sv,


### PR DESCRIPTION
We now check if the WebContent is executable before passing it to the valgrind wrapper. We can't rely on exec() to fail here, since it will always succeed even when passing a bad WebContent path to valgrind.