### PR TITLE
LibWeb: Fixes for table width with spanning columns

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
@@ -1,0 +1,45 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x60.9375 [BFC] children: not-inline
+    BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
+      TextNode <#text>
+    BlockContainer <body> at (8,8) content-size 784x44.9375 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+        TextNode <#text>
+      TableWrapper <(anonymous)> at (8,8) content-size 32.904952x44.9375 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 32.904952x42.9375 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (9,9) content-size 34.904952x42.9375 table-row-group children: not-inline
+            Box <tr> at (9,9) content-size 34.904952x21.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 17.561202x17.46875 table-cell [BFC] children: inline
+                line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [13,11 14.265625x17.46875]
+                    "A"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (32.561202,11) content-size 9.34375x17.46875 table-cell [BFC] children: inline
+                line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [32.561202,11 9.34375x17.46875]
+                    "B"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (9,30.46875) content-size 34.904952x21.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,32.46875) content-size 30.904952x17.46875 table-cell [BFC] children: inline
+                line 0 width: 33.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 3, rect: [11,32.46875 33.3125x17.46875]
+                    "CDE"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+      BlockContainer <(anonymous)> at (8,52.9375) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
@@ -5,12 +5,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x44.9375 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
-      TableWrapper <(anonymous)> at (8,8) content-size 32.904952x44.9375 [BFC] children: not-inline
-        Box <table> at (9,9) content-size 32.904952x42.9375 table-box [TFC] children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 41.122404x44.9375 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 41.122404x42.9375 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 34.904952x42.9375 table-row-group children: not-inline
-            Box <tr> at (9,9) content-size 34.904952x21.46875 table-row children: not-inline
+          Box <tbody> at (9,9) content-size 43.122404x42.9375 table-row-group children: not-inline
+            Box <tr> at (9,9) content-size 43.122404x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,11) content-size 17.561202x17.46875 table-cell [BFC] children: inline
@@ -20,21 +20,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (32.561202,11) content-size 9.34375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (32.561202,11) content-size 17.561202x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [32.561202,11 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [36.561202,11 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (9,30.46875) content-size 34.904952x21.46875 table-row children: not-inline
+            Box <tr> at (9,30.46875) content-size 43.122404x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32.46875) content-size 30.904952x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,32.46875) content-size 39.122404x17.46875 table-cell [BFC] children: inline
                 line 0 width: 33.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 3, rect: [11,32.46875 33.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 3, rect: [14,32.46875 33.3125x17.46875]
                     "CDE"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/input/table/colspan-width-distribution.html
+++ b/Tests/LibWeb/Layout/input/table/colspan-width-distribution.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>Computing column measures</title>
+    <style>
+        table, td {
+            border: 1px solid black;
+            border-spacing: 0px;
+            text-align: center;
+        }
+    </style>
+</head>
+
+<body>
+    <table>
+        <tr>
+            <td>A</td>
+            <td>B</td>
+        </tr>
+        <tr>
+            <td colspan="2">CDE</td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -172,7 +172,7 @@ void TableFormattingContext::compute_table_measures()
         }
     }
 
-    for (size_t current_column_span = 2; current_column_span < max_cell_column_span; current_column_span++) {
+    for (size_t current_column_span = 2; current_column_span <= max_cell_column_span; current_column_span++) {
         // https://www.w3.org/TR/css-tables-3/#min-content-width-of-a-column-based-on-cells-of-span-up-to-n-n--1
         Vector<Vector<CSSPixels>> cell_min_contributions_by_column_index;
         cell_min_contributions_by_column_index.resize(m_columns.size());

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -205,8 +205,12 @@ void TableFormattingContext::compute_table_measures()
                 // - the outer max-content width of the cell minus the baseline max-content width and the baseline border spacing, or 0 if this is negative
                 cell_max_contribution += (m_columns[cell.column_index].max_width / baseline_max_content_width) * max(CSSPixels(0), cell.max_width - baseline_max_content_width);
 
-                cell_min_contributions_by_column_index[cell.column_index].append(cell_min_contribution);
-                cell_max_contributions_by_column_index[cell.column_index].append(cell_max_contribution);
+                // Spread contribution to all columns, since we've weighted the gap to the desired spanned width by the the
+                // ratio of the max-content width based on cells of span up to N-1 of the column to the baseline max-content width.
+                for (auto column_index = cell_start_column_index; column_index < cell_end_column_index; column_index++) {
+                    cell_min_contributions_by_column_index[column_index].append(cell_min_contribution);
+                    cell_max_contributions_by_column_index[column_index].append(cell_max_contribution);
+                }
             }
         }
 


### PR DESCRIPTION
* Fix upper limit of span when computing column measures
* Distribute cell contribution to all spanned columns

More details are in the commit messages.