### PR TITLE
LibGfx+LibWeb: Make the browser book (browser.engineering) a bit more browsable

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-ex-unit.txt
+++ b/Tests/LibWeb/Layout/expected/css-ex-unit.txt
@@ -1,0 +1,4 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x177.132812 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x161.132812 children: not-inline
+      BlockContainer <div> at (8,8) content-size 107.421875x161.132812 children: not-inline

--- a/Tests/LibWeb/Layout/expected/text-align-justify-with-forced-break.txt
+++ b/Tests/LibWeb/Layout/expected/text-align-justify-with-forced-break.txt
@@ -1,0 +1,75 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x118 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x102 children: not-inline
+      BlockContainer <div> at (9,9) content-size 100x100 children: inline
+        line 0 width: 98, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 1, length: 3, rect: [9,9 27.15625x17.46875]
+            "foo"
+          frag 1 from TextNode start: 4, length: 1, rect: [36,9 9x17.46875]
+            " "
+          frag 2 from TextNode start: 5, length: 3, rect: [45,9 27.640625x17.46875]
+            "bar"
+          frag 3 from TextNode start: 8, length: 1, rect: [73,9 9x17.46875]
+            " "
+          frag 4 from TextNode start: 9, length: 3, rect: [82,9 27.203125x17.46875]
+            "baz"
+        line 1 width: 98, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+          frag 0 from TextNode start: 13, length: 3, rect: [9,26 27.15625x17.46875]
+            "foo"
+          frag 1 from TextNode start: 16, length: 1, rect: [36,26 8x17.46875]
+            " "
+          frag 2 from TextNode start: 17, length: 3, rect: [44,26 27.640625x17.46875]
+            "bar"
+          frag 3 from TextNode start: 20, length: 1, rect: [72,26 8x17.46875]
+            " "
+          frag 4 from TextNode start: 21, length: 3, rect: [80,26 27.203125x17.46875]
+            "baz"
+        line 2 width: 98, height: 18.40625, bottom: 53.34375, baseline: 13.53125
+          frag 0 from TextNode start: 1, length: 3, rect: [9,43 27.15625x17.46875]
+            "foo"
+          frag 1 from TextNode start: 4, length: 1, rect: [36,43 9x17.46875]
+            " "
+          frag 2 from TextNode start: 5, length: 3, rect: [45,43 27.640625x17.46875]
+            "bar"
+          frag 3 from TextNode start: 8, length: 1, rect: [73,43 9x17.46875]
+            " "
+          frag 4 from TextNode start: 9, length: 3, rect: [82,43 27.203125x17.46875]
+            "baz"
+        line 3 width: 98, height: 17.875, bottom: 70.28125, baseline: 13.53125
+          frag 0 from TextNode start: 13, length: 3, rect: [9,61 27.15625x17.46875]
+            "foo"
+          frag 1 from TextNode start: 16, length: 1, rect: [36,61 9x17.46875]
+            " "
+          frag 2 from TextNode start: 17, length: 3, rect: [45,61 27.640625x17.46875]
+            "bar"
+          frag 3 from TextNode start: 20, length: 1, rect: [73,61 9x17.46875]
+            " "
+          frag 4 from TextNode start: 21, length: 3, rect: [82,61 27.203125x17.46875]
+            "baz"
+        line 4 width: 98, height: 18.34375, bottom: 88.21875, baseline: 13.53125
+          frag 0 from TextNode start: 25, length: 3, rect: [9,78 27.15625x17.46875]
+            "foo"
+          frag 1 from TextNode start: 28, length: 1, rect: [36,78 8x17.46875]
+            " "
+          frag 2 from TextNode start: 29, length: 3, rect: [44,78 27.640625x17.46875]
+            "bar"
+          frag 3 from TextNode start: 32, length: 1, rect: [72,78 8x17.46875]
+            " "
+          frag 4 from TextNode start: 33, length: 3, rect: [80,78 27.203125x17.46875]
+            "baz"
+        line 5 width: 98, height: 17.8125, bottom: 105.15625, baseline: 13.53125
+          frag 0 from TextNode start: 1, length: 3, rect: [9,96 27.15625x17.46875]
+            "foo"
+          frag 1 from TextNode start: 4, length: 1, rect: [36,96 8x17.46875]
+            " "
+          frag 2 from TextNode start: 5, length: 3, rect: [44,96 27.640625x17.46875]
+            "bar"
+          frag 3 from TextNode start: 8, length: 1, rect: [72,96 8x17.46875]
+            " "
+          frag 4 from TextNode start: 9, length: 3, rect: [80,96 27.203125x17.46875]
+            "baz"
+        TextNode <#text>
+        BreakNode <br>
+        TextNode <#text>
+        BreakNode <br>
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/css-ex-unit.html
+++ b/Tests/LibWeb/Layout/input/css-ex-unit.html
@@ -1,0 +1,8 @@
+<!doctype html><style>
+div {
+    font: 20px SerenitySans;
+    width: 10ex;
+    height: 15ex;
+    background: red;
+}
+</style><div>

--- a/Tests/LibWeb/Layout/input/text-align-justify-with-forced-break.html
+++ b/Tests/LibWeb/Layout/input/text-align-justify-with-forced-break.html
@@ -1,0 +1,14 @@
+<!doctype html><style>
+div {
+    text-align: justify;
+    border: 1px solid black;
+    width: 100px;
+    height: 100px;
+}
+</style><div>
+    foo bar baz
+    foo bar baz<br>
+    foo bar baz
+    foo bar baz
+    foo bar baz<br>
+    foo bar baz

--- a/Tests/LibWeb/rebaseline-libweb-test
+++ b/Tests/LibWeb/rebaseline-libweb-test
@@ -15,6 +15,6 @@ fi
 input_dir=$(dirname $t)
 expected_dir=$(echo $input_dir | sed s/input/expected/)
 test_name=$(basename $t .html)
-cd $SERENITY_SOURCE_DIR/Build/lagom/Ladybird
+cd $SERENITY_SOURCE_DIR/Build/lagom
 mkdir -p $expected_dir
-./headless-browser $mode_flag --layout-test-mode $input_dir/$test_name.html > $expected_dir/$test_name.txt
+./bin/headless-browser $mode_flag --layout-test-mode $input_dir/$test_name.html > $expected_dir/$test_name.txt

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.h
@@ -243,6 +243,8 @@ public:
 
     bool use_typographic_metrics() const;
 
+    [[nodiscard]] Optional<i16> x_height() const;
+
     explicit OS2(ReadonlyBytes slice)
         : m_slice(slice)
     {
@@ -282,7 +284,27 @@ private:
         BigEndian<u16> us_win_descent;
     };
 
+    struct Version1 {
+        Version0 version0;
+        BigEndian<u32> ul_code_page_range1;
+        BigEndian<u32> ul_code_page_range2;
+    };
+
+    struct Version2 {
+        Version1 version1;
+        BigEndian<i16> sx_height;
+        BigEndian<i16> s_cap_height;
+        BigEndian<u16> us_default_char;
+        BigEndian<u16> us_break_char;
+        BigEndian<u16> us_max_context;
+    };
+
     Version0 const& header() const { return *bit_cast<Version0 const*>(m_slice.data()); }
+    Version2 const& header_v2() const
+    {
+        VERIFY(header().version >= 2);
+        return *bit_cast<Version2 const*>(m_slice.data());
+    }
 
     ReadonlyBytes m_slice;
 };

--- a/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
@@ -27,7 +27,7 @@ ScaledFont::ScaledFont(NonnullRefPtr<VectorFont> font, float point_width, float 
 
     m_pixel_metrics = Gfx::FontPixelMetrics {
         .size = (float)pixel_size(),
-        .x_height = (float)x_height(),
+        .x_height = metrics.x_height,
         .advance_of_ascii_zero = (float)glyph_width('0'),
         .glyph_spacing = (float)glyph_spacing(),
         .ascent = metrics.ascender,

--- a/Userland/Libraries/LibGfx/Font/VectorFont.h
+++ b/Userland/Libraries/LibGfx/Font/VectorFont.h
@@ -17,6 +17,7 @@ struct ScaledFontMetrics {
     float ascender { 0 };
     float descender { 0 };
     float line_gap { 0 };
+    float x_height { 0 };
 
     float height() const
     {

--- a/Userland/Libraries/LibWeb/Layout/LineBox.h
+++ b/Userland/Libraries/LibWeb/Layout/LineBox.h
@@ -47,6 +47,7 @@ private:
     CSSPixels m_original_available_width { 0 };
 
     bool m_has_break { false };
+    bool m_has_forced_break { false };
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -25,10 +25,11 @@ LineBuilder::~LineBuilder()
         update_last_line();
 }
 
-void LineBuilder::break_line(Optional<CSSPixels> next_item_width)
+void LineBuilder::break_line(ForcedBreak forced_break, Optional<CSSPixels> next_item_width)
 {
-    auto last_line_box = ensure_last_line_box();
+    auto& last_line_box = ensure_last_line_box();
     last_line_box.m_has_break = true;
+    last_line_box.m_has_forced_break = forced_break == ForcedBreak::Yes;
 
     update_last_line();
     size_t break_count = 0;

--- a/Userland/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Userland/Libraries/LibWeb/Layout/LineBuilder.h
@@ -18,7 +18,12 @@ public:
     LineBuilder(InlineFormattingContext&, LayoutState&);
     ~LineBuilder();
 
-    void break_line(Optional<CSSPixels> next_item_width = {});
+    enum class ForcedBreak {
+        No,
+        Yes,
+    };
+
+    void break_line(ForcedBreak, Optional<CSSPixels> next_item_width = {});
     void append_box(Box const&, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin);
     void append_text_chunk(TextNode const&, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height);
 
@@ -26,7 +31,7 @@ public:
     bool break_if_needed(CSSPixels next_item_width)
     {
         if (should_break(next_item_width)) {
-            break_line(next_item_width);
+            break_line(LineBuilder::ForcedBreak::No, next_item_width);
             return true;
         }
         return false;


### PR DESCRIPTION
Two main fixes here:

- Actually fetch the x-height from OpenType fonts so that CSS `ex` length units work as expected.
- Don't justify text on the last line before a forced break.

Nice progression on https://browser.engineering/

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/b1de1175-08f8-4e42-8c54-621b394c7005)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/df5d4506-9edc-473b-b3d9-91bdc72811e0)
