### PR TITLE
LibWeb: Forward media attribute from link element to loaded style sheet

### DIFF
--- a/Tests/LibWeb/Text/expected/link-element-media-attribute.txt
+++ b/Tests/LibWeb/Text/expected/link-element-media-attribute.txt
@@ -1,0 +1,1 @@
+document background: rgb(0, 128, 0)

--- a/Tests/LibWeb/Text/input/body-background-color-red.css
+++ b/Tests/LibWeb/Text/input/body-background-color-red.css
@@ -1,0 +1,3 @@
+body {
+    background-color: red;
+}

--- a/Tests/LibWeb/Text/input/link-element-media-attribute.html
+++ b/Tests/LibWeb/Text/input/link-element-media-attribute.html
@@ -1,0 +1,17 @@
+<style>
+body {
+    background: green;
+}
+</style>
+<script src="include.js"></script>
+<script>
+    let link = document.createElement("link");
+    link.setAttribute("rel", "stylesheet");
+    link.setAttribute("href", "body-background-color-red.css");
+    link.setAttribute("media", "print")
+    document.head.appendChild(link)
+
+    window.onload = function() {
+        println("document background: " + getComputedStyle(document.body).backgroundColor)
+    }
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -364,6 +364,7 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
 
         if (m_loaded_style_sheet) {
             m_loaded_style_sheet->set_owner_node(this);
+            m_loaded_style_sheet->set_media(attribute(HTML::AttributeNames::media));
             document().style_sheets().add_sheet(*m_loaded_style_sheet);
         } else {
             dbgln_if(CSS_LOADER_DEBUG, "HTMLLinkElement: Failed to parse stylesheet: {}", resource()->url());


### PR DESCRIPTION
Otherwise, we will treat the loaded style sheet as if it had media="all" which is not always appropriate.

Nice progression on https://w3.org/

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/7b3d8692-8ce3-4b95-8b11-0b55a52d658b)


After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/b1c033c8-b935-4998-8a70-1713b58a2a34)
