### PR TITLE
Kernel+SystemMonitor: Make thread statistics human-readable and avoid overflow

### DIFF
--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -896,41 +896,41 @@ public:
     unsigned cow_faults() const { return m_cow_faults; }
     void did_cow_fault() { ++m_cow_faults; }
 
-    unsigned file_read_bytes() const { return m_file_read_bytes; }
-    unsigned file_write_bytes() const { return m_file_write_bytes; }
+    u64 file_read_bytes() const { return m_file_read_bytes; }
+    u64 file_write_bytes() const { return m_file_write_bytes; }
 
-    void did_file_read(unsigned bytes)
+    void did_file_read(u64 bytes)
     {
         m_file_read_bytes += bytes;
     }
 
-    void did_file_write(unsigned bytes)
+    void did_file_write(u64 bytes)
     {
         m_file_write_bytes += bytes;
     }
 
-    unsigned unix_socket_read_bytes() const { return m_unix_socket_read_bytes; }
-    unsigned unix_socket_write_bytes() const { return m_unix_socket_write_bytes; }
+    u64 unix_socket_read_bytes() const { return m_unix_socket_read_bytes; }
+    u64 unix_socket_write_bytes() const { return m_unix_socket_write_bytes; }
 
-    void did_unix_socket_read(unsigned bytes)
+    void did_unix_socket_read(u64 bytes)
     {
         m_unix_socket_read_bytes += bytes;
     }
 
-    void did_unix_socket_write(unsigned bytes)
+    void did_unix_socket_write(u64 bytes)
     {
         m_unix_socket_write_bytes += bytes;
     }
 
-    unsigned ipv4_socket_read_bytes() const { return m_ipv4_socket_read_bytes; }
-    unsigned ipv4_socket_write_bytes() const { return m_ipv4_socket_write_bytes; }
+    u64 ipv4_socket_read_bytes() const { return m_ipv4_socket_read_bytes; }
+    u64 ipv4_socket_write_bytes() const { return m_ipv4_socket_write_bytes; }
 
-    void did_ipv4_socket_read(unsigned bytes)
+    void did_ipv4_socket_read(u64 bytes)
     {
         m_ipv4_socket_read_bytes += bytes;
     }
 
-    void did_ipv4_socket_write(unsigned bytes)
+    void did_ipv4_socket_write(u64 bytes)
     {
         m_ipv4_socket_write_bytes += bytes;
     }
@@ -1210,14 +1210,14 @@ private:
     unsigned m_zero_faults { 0 };
     unsigned m_cow_faults { 0 };
 
-    unsigned m_file_read_bytes { 0 };
-    unsigned m_file_write_bytes { 0 };
+    u64 m_file_read_bytes { 0 };
+    u64 m_file_write_bytes { 0 };
 
-    unsigned m_unix_socket_read_bytes { 0 };
-    unsigned m_unix_socket_write_bytes { 0 };
+    u64 m_unix_socket_read_bytes { 0 };
+    u64 m_unix_socket_write_bytes { 0 };
 
-    unsigned m_ipv4_socket_read_bytes { 0 };
-    unsigned m_ipv4_socket_write_bytes { 0 };
+    u64 m_ipv4_socket_read_bytes { 0 };
+    u64 m_ipv4_socket_write_bytes { 0 };
 
     FPUState m_fpu_state {};
     State m_state { Thread::State::Invalid };

--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -306,17 +306,17 @@ GUI::Variant ProcessModel::data(GUI::ModelIndex const& index, GUI::ModelRole rol
         case Column::CowFaults:
             return thread.current_state.cow_faults;
         case Column::IPv4SocketReadBytes:
-            return thread.current_state.ipv4_socket_read_bytes;
+            return human_readable_size_long(thread.current_state.ipv4_socket_read_bytes, UseThousandsSeparator::Yes);
         case Column::IPv4SocketWriteBytes:
-            return thread.current_state.ipv4_socket_write_bytes;
+            return human_readable_size_long(thread.current_state.ipv4_socket_write_bytes, UseThousandsSeparator::Yes);
         case Column::UnixSocketReadBytes:
-            return thread.current_state.unix_socket_read_bytes;
+            return human_readable_size_long(thread.current_state.unix_socket_read_bytes, UseThousandsSeparator::Yes);
         case Column::UnixSocketWriteBytes:
-            return thread.current_state.unix_socket_write_bytes;
+            return human_readable_size_long(thread.current_state.unix_socket_write_bytes, UseThousandsSeparator::Yes);
         case Column::FileReadBytes:
-            return thread.current_state.file_read_bytes;
+            return human_readable_size_long(thread.current_state.file_read_bytes, UseThousandsSeparator::Yes);
         case Column::FileWriteBytes:
-            return thread.current_state.file_write_bytes;
+            return human_readable_size_long(thread.current_state.file_write_bytes, UseThousandsSeparator::Yes);
         case Column::Pledge:
             return thread.current_state.pledge;
         case Column::Veil:

--- a/Userland/Applications/SystemMonitor/ProcessModel.h
+++ b/Userland/Applications/SystemMonitor/ProcessModel.h
@@ -123,12 +123,12 @@ private:
         unsigned inode_faults { 0 };
         unsigned zero_faults { 0 };
         unsigned cow_faults { 0 };
-        unsigned unix_socket_read_bytes { 0 };
-        unsigned unix_socket_write_bytes { 0 };
-        unsigned ipv4_socket_read_bytes { 0 };
-        unsigned ipv4_socket_write_bytes { 0 };
-        unsigned file_read_bytes { 0 };
-        unsigned file_write_bytes { 0 };
+        u64 unix_socket_read_bytes { 0 };
+        u64 unix_socket_write_bytes { 0 };
+        u64 ipv4_socket_read_bytes { 0 };
+        u64 ipv4_socket_write_bytes { 0 };
+        u64 file_read_bytes { 0 };
+        u64 file_write_bytes { 0 };
         float cpu_percent { 0 };
         float cpu_percent_kernel { 0 };
         Process& process;

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -68,12 +68,12 @@ ErrorOr<AllProcessesStatistics> ProcessStatisticsReader::get_all(SeekableStream&
             thread.inode_faults = thread_object.get_u32("inode_faults"sv).value_or(0);
             thread.zero_faults = thread_object.get_u32("zero_faults"sv).value_or(0);
             thread.cow_faults = thread_object.get_u32("cow_faults"sv).value_or(0);
-            thread.unix_socket_read_bytes = thread_object.get_u32("unix_socket_read_bytes"sv).value_or(0);
-            thread.unix_socket_write_bytes = thread_object.get_u32("unix_socket_write_bytes"sv).value_or(0);
-            thread.ipv4_socket_read_bytes = thread_object.get_u32("ipv4_socket_read_bytes"sv).value_or(0);
-            thread.ipv4_socket_write_bytes = thread_object.get_u32("ipv4_socket_write_bytes"sv).value_or(0);
-            thread.file_read_bytes = thread_object.get_u32("file_read_bytes"sv).value_or(0);
-            thread.file_write_bytes = thread_object.get_u32("file_write_bytes"sv).value_or(0);
+            thread.unix_socket_read_bytes = thread_object.get_u64("unix_socket_read_bytes"sv).value_or(0);
+            thread.unix_socket_write_bytes = thread_object.get_u64("unix_socket_write_bytes"sv).value_or(0);
+            thread.ipv4_socket_read_bytes = thread_object.get_u64("ipv4_socket_read_bytes"sv).value_or(0);
+            thread.ipv4_socket_write_bytes = thread_object.get_u64("ipv4_socket_write_bytes"sv).value_or(0);
+            thread.file_read_bytes = thread_object.get_u64("file_read_bytes"sv).value_or(0);
+            thread.file_write_bytes = thread_object.get_u64("file_write_bytes"sv).value_or(0);
             process.threads.append(move(thread));
         });
 

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.h
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.h
@@ -22,12 +22,12 @@ struct ThreadStatistics {
     unsigned inode_faults;
     unsigned zero_faults;
     unsigned cow_faults;
-    unsigned unix_socket_read_bytes;
-    unsigned unix_socket_write_bytes;
-    unsigned ipv4_socket_read_bytes;
-    unsigned ipv4_socket_write_bytes;
-    unsigned file_read_bytes;
-    unsigned file_write_bytes;
+    u64 unix_socket_read_bytes;
+    u64 unix_socket_write_bytes;
+    u64 ipv4_socket_read_bytes;
+    u64 ipv4_socket_write_bytes;
+    u64 file_read_bytes;
+    u64 file_write_bytes;
     DeprecatedString state;
     u32 cpu;
     u32 priority;


### PR DESCRIPTION
This PR changes the byte counts shown in the `ProcessStateWidget` to be 64 bit.
This allows IPv4/Unix sockets and file I/O to exceed 4GiB without overflowing. 
The statistics are now shown in a human-readable format with thousands separators.

Tested with the following command: `dd if=/dev/zero of=/home/anon/large.test bs=8M count=1024`

I also tested with: `pro -O http://speed.hetzner.de/10GB.bin`. I managed to download more than 4GiB, but I didn't wait for the entire file to download.

> **Note**
> You need to create a larger disk image than usual to test this, I used: `export SERENITY_DISK_SIZE_BYTES=20000000000`  to create a 20GB image.

Example `dd` command:

![system_monitor_over_4gb](https://github.com/SerenityOS/serenity/assets/2817754/e78fc50a-7cd5-48d7-9912-ad60c7dee513)

Example RequestServer statistics:
![request_server_over_4gb](https://github.com/SerenityOS/serenity/assets/2817754/3140c56d-96c3-4340-81d5-0e1d8be8ec41)

