### PR TITLE
Shell: Reset the custom Shell keybinds before calling Editor::get_line()

### DIFF
--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -109,6 +109,7 @@ public:
     void set_live_formatting(bool value) { m_should_format_live = value; }
 
     void setup_signals();
+    void setup_keybinds();
 
     struct SourcePosition {
         DeprecatedString source_file;


### PR DESCRIPTION
Fixes #19301.