### PR TITLE
LibWeb+LibGfx: Allow filling/stroking with a paint style and opacity

### DIFF
--- a/Base/res/html/misc/svg-gradients.html
+++ b/Base/res/html/misc/svg-gradients.html
@@ -133,6 +133,17 @@
   <rect x="115" y="15" width="170" height="110" fill="url(#grad7)" transform="rotate(45 200 70)" />
 </svg>
 <br>
+<b>Linear gradient + transform with fill-opacity</b><br>
+<svg height="150" width="400">
+  <defs>
+    <linearGradient id="grad7" x1="0" y1="0" x2="70%" y2="0">
+      <stop offset="0" stop-color="blue"/>
+      <stop offset="1" stop-color="magenta"/>
+    </linearGradient>
+  </defs>
+  <rect x="115" y="15" width="170" height="110" fill="url(#grad7)" fill-opacity="0.5" transform="rotate(5 200 70)" />
+</svg>
+<br>
 <b>Stroke linear gradient + transform</b><br>
 <svg height="150" width="400">
   <defs>

--- a/Base/res/html/misc/svg-gradients.html
+++ b/Base/res/html/misc/svg-gradients.html
@@ -154,3 +154,14 @@
   </defs>
   <rect x="115" y="15" width="170" height="110" stroke="url(#grad7)" fill="none" transform="rotate(45 200 70)" />
 </svg>
+<br>
+<b>Stroke linear gradient + transform with stroke-opacity</b><br>
+<svg height="150" width="400">
+  <defs>
+    <linearGradient id="grad7" x1="0" y1="0" x2="70%" y2="0">
+      <stop offset="0" stop-color="blue"/>
+      <stop offset="1" stop-color="magenta"/>
+    </linearGradient>
+  </defs>
+  <rect x="115" y="15" width="170" height="110" stroke="url(#grad7)" stroke-opacity="0.5" stroke-width="10" fill="none" transform="rotate(5 200 70)" />
+</svg>

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -198,10 +198,10 @@ void AntiAliasingPainter::stroke_path(Path const& path, Color color, float thick
     fill_path(path.stroke_to_fill(thickness), color);
 }
 
-void AntiAliasingPainter::stroke_path(Path const& path, Gfx::PaintStyle const& paint_style, float thickness)
+void AntiAliasingPainter::stroke_path(Path const& path, Gfx::PaintStyle const& paint_style, float thickness, float opacity)
 {
     // FIXME: Cache this? Probably at a higher level such as in LibWeb?
-    fill_path(path.stroke_to_fill(thickness), paint_style);
+    fill_path(path.stroke_to_fill(thickness), paint_style, opacity);
 }
 
 void AntiAliasingPainter::fill_rect(FloatRect const& float_rect, Color color)

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -37,7 +37,7 @@ public:
     void fill_path(Path const&, PaintStyle const& paint_style, float opacity = 1.0f, Painter::WindingRule rule = Painter::WindingRule::Nonzero);
 
     void stroke_path(Path const&, Color, float thickness);
-    void stroke_path(Path const&, PaintStyle const& paint_style, float thickness);
+    void stroke_path(Path const&, PaintStyle const& paint_style, float thickness, float opacity = 1.0f);
 
     void translate(float dx, float dy) { m_transform.translate(dx, dy); }
     void translate(FloatPoint delta) { m_transform.translate(delta); }

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -34,7 +34,7 @@ public:
     }
 
     void fill_path(Path const&, Color, Painter::WindingRule rule = Painter::WindingRule::Nonzero);
-    void fill_path(Path const&, PaintStyle const& paint_style, Painter::WindingRule rule = Painter::WindingRule::Nonzero);
+    void fill_path(Path const&, PaintStyle const& paint_style, float opacity = 1.0f, Painter::WindingRule rule = Painter::WindingRule::Nonzero);
 
     void stroke_path(Path const&, Color, float thickness);
     void stroke_path(Path const&, PaintStyle const& paint_style, float thickness);

--- a/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h
+++ b/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h
@@ -146,7 +146,7 @@ public:
     EdgeFlagPathRasterizer(IntSize);
 
     void fill(Painter&, Path const&, Color, Painter::WindingRule, FloatPoint offset = {});
-    void fill(Painter&, Path const&, PaintStyle const&, Painter::WindingRule, FloatPoint offset = {});
+    void fill(Painter&, Path const&, PaintStyle const&, float opacity, Painter::WindingRule, FloatPoint offset = {});
 
 private:
     using SubpixelSample = Detail::Sample<SamplesPerPixel>;

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -145,7 +145,7 @@ public:
     };
 
     void fill_path(Path const&, Color, WindingRule rule = WindingRule::Nonzero);
-    void fill_path(Path const&, PaintStyle const& paint_style, WindingRule rule = WindingRule::Nonzero);
+    void fill_path(Path const&, PaintStyle const& paint_style, float opacity = 1.0f, WindingRule rule = WindingRule::Nonzero);
 
     Font const& font() const
     {

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPathClipper.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPathClipper.cpp
@@ -40,7 +40,7 @@ ErrorOr<void> CanvasPathClipper::apply_clip(Gfx::Painter& painter)
     painter.blit(actual_save_rect.location(), *m_saved_clip_region, m_saved_clip_region->rect(), 1.0f, false);
     Gfx::AntiAliasingPainter aa_painter { painter };
     auto fill_offset = m_bounding_box.location() - actual_save_rect.location();
-    aa_painter.fill_path(m_canvas_clip.path, TRY(Gfx::BitmapPaintStyle::create(clip_area, fill_offset)), m_canvas_clip.winding_rule);
+    aa_painter.fill_path(m_canvas_clip.path, TRY(Gfx::BitmapPaintStyle::create(clip_area, fill_offset)), 1.0f, m_canvas_clip.winding_rule);
     return {};
 }
 }

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -272,7 +272,7 @@ void CanvasRenderingContext2D::fill_internal(Gfx::Path& path, StringView fill_ru
         if (auto color = drawing_state.fill_style.as_color(); color.has_value()) {
             painter.fill_path(path, *color, fill_rule);
         } else {
-            painter.fill_path(path, drawing_state.fill_style.to_gfx_paint_style(), fill_rule);
+            painter.fill_path(path, drawing_state.fill_style.to_gfx_paint_style(), 1.0f, fill_rule);
         }
         return path.bounding_box();
     });

--- a/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
@@ -99,12 +99,12 @@ void SVGGeometryPaintable::paint(PaintContext& context, PaintPhase phase) const
         .transform = paint_transform
     };
 
-    // FIXME: Apply fill opacity to paint styles?
     auto fill_opacity = geometry_element.fill_opacity().value_or(svg_context.fill_opacity());
     if (auto paint_style = geometry_element.fill_paint_style(paint_context); paint_style.has_value()) {
         painter.fill_path(
             closed_path(),
             *paint_style,
+            fill_opacity,
             Gfx::Painter::WindingRule::EvenOdd);
     } else if (auto fill_color = geometry_element.fill_color().value_or(svg_context.fill_color()).with_opacity(fill_opacity); fill_color.alpha() > 0) {
         painter.fill_path(

--- a/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
@@ -122,7 +122,8 @@ void SVGGeometryPaintable::paint(PaintContext& context, PaintPhase phase) const
         painter.stroke_path(
             path,
             *paint_style,
-            stroke_thickness);
+            stroke_thickness,
+            stroke_opacity);
     } else if (auto stroke_color = geometry_element.stroke_color().value_or(svg_context.stroke_color()).with_opacity(stroke_opacity); stroke_color.alpha() > 0) {
         painter.stroke_path(
             path,


### PR DESCRIPTION
This allows filling/stroking paths with a paint style and apply an opacity (and hooks it up for SVG paintables): 

![Screenshot from 2023-06-11 14-11-55](https://github.com/SerenityOS/serenity/assets/11597044/252b15fc-5108-4f74-a565-d351cdbb382e)
