### PR TITLE
AK: Forbid calling `from_utf8` and `from_deprecated_{fly_|}string` with unintended types

### DIFF
--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -21,6 +21,10 @@ public:
     ~FlyString();
 
     static ErrorOr<FlyString> from_utf8(StringView);
+    template<typename T>
+    requires(IsOneOf<RemoveCVReference<T>, DeprecatedString, DeprecatedFlyString>)
+    static ErrorOr<String> from_utf8(T&&) = delete;
+
     FlyString(String const&);
     FlyString& operator=(String const&);
 
@@ -54,6 +58,9 @@ public:
     // FIXME: Remove these once all code has been ported to FlyString
     [[nodiscard]] DeprecatedFlyString to_deprecated_fly_string() const;
     static ErrorOr<FlyString> from_deprecated_fly_string(DeprecatedFlyString const&);
+    template<typename T>
+    requires(IsSame<RemoveCVReference<T>, StringView>)
+    static ErrorOr<String> from_deprecated_fly_string(T&&) = delete;
 
     // Compare this FlyString against another string with ASCII caseless matching.
     [[nodiscard]] bool equals_ignoring_ascii_case(FlyString const&) const;

--- a/AK/String.h
+++ b/AK/String.h
@@ -64,6 +64,9 @@ public:
 
     // Creates a new String from a sequence of UTF-8 encoded code points.
     static ErrorOr<String> from_utf8(StringView);
+    template<typename T>
+    requires(IsOneOf<RemoveCVReference<T>, DeprecatedString, DeprecatedFlyString>)
+    static ErrorOr<String> from_utf8(T&&) = delete;
 
     // Creates a new String by reading byte_count bytes from a UTF-8 encoded Stream.
     static ErrorOr<String> from_stream(Stream&, size_t byte_count);
@@ -225,6 +228,9 @@ public:
     // FIXME: Remove these once all code has been ported to String
     [[nodiscard]] DeprecatedString to_deprecated_string() const;
     static ErrorOr<String> from_deprecated_string(DeprecatedString const&);
+    template<typename T>
+    requires(IsSame<RemoveCVReference<T>, StringView>)
+    static ErrorOr<String> from_deprecated_string(T&&) = delete;
 
 private:
     // NOTE: If the least significant bit of the pointer is set, this is a short string.

--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
@@ -97,7 +97,7 @@ public:
         if (m_piece_set_name == piece_set_name.view())
             return {};
 
-        m_piece_set_name = TRY(String::from_utf8(piece_set_name));
+        m_piece_set_name = TRY(String::from_deprecated_string(piece_set_name));
         m_piece_images.clear();
 
         m_piece_images.set({ Chess::Color::White, Chess::Type::Pawn }, TRY(load_piece_image(m_piece_set_name, "white-pawn.png"sv)));

--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -110,7 +110,7 @@ MainWidget::MainWidget()
                 return;
             }
             m_history.push(path.string());
-            auto string_path = String::from_utf8(path.string());
+            auto string_path = String::from_deprecated_string(path.string());
             if (string_path.is_error())
                 return;
             open_page(string_path.value());

--- a/Userland/Applications/HexEditor/FindDialog.cpp
+++ b/Userland/Applications/HexEditor/FindDialog.cpp
@@ -112,7 +112,7 @@ FindDialog::FindDialog()
         auto action = options[i];
         auto& radio = radio_container.add<GUI::RadioButton>();
         radio.set_enabled(action.enabled);
-        radio.set_text(String::from_deprecated_string(action.title).release_value_but_fixme_should_propagate_errors());
+        radio.set_text(String::from_utf8(action.title).release_value_but_fixme_should_propagate_errors());
 
         radio.on_checked = [this, i](auto) {
             m_selected_option = options[i].opt;

--- a/Userland/DevTools/SQLStudio/MainWidget.cpp
+++ b/Userland/DevTools/SQLStudio/MainWidget.cpp
@@ -351,7 +351,7 @@ void MainWidget::open_new_script()
 
 void MainWidget::open_script_from_file(LexicalPath const& file_path)
 {
-    auto& editor = m_tab_widget->add_tab<ScriptEditor>(String::from_deprecated_string(file_path.title()).release_value_but_fixme_should_propagate_errors());
+    auto& editor = m_tab_widget->add_tab<ScriptEditor>(String::from_utf8(file_path.title()).release_value_but_fixme_should_propagate_errors());
 
     if (auto result = editor.open_script_from_file(file_path); result.is_error()) {
         GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Failed to open {}\n{}", file_path, result.error()));

--- a/Userland/DevTools/SQLStudio/ScriptEditor.cpp
+++ b/Userland/DevTools/SQLStudio/ScriptEditor.cpp
@@ -72,7 +72,7 @@ ErrorOr<bool> ScriptEditor::save_as()
 
     auto parent = static_cast<GUI::TabWidget*>(parent_widget());
     if (parent)
-        parent->set_tab_title(*this, String::from_deprecated_string(lexical_path.title()).release_value_but_fixme_should_propagate_errors());
+        parent->set_tab_title(*this, String::from_utf8(lexical_path.title()).release_value_but_fixme_should_propagate_errors());
 
     document().set_unmodified();
     return true;

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1047,7 +1047,7 @@ ErrorOr<String> mkdtemp(Span<char> pattern)
         return Error::from_errno(errno);
     }
 
-    return String::from_utf8({ path, strlen(path) });
+    return String::from_utf8(StringView { path, strlen(path) });
 }
 
 ErrorOr<void> rename(StringView old_path, StringView new_path)

--- a/Userland/Libraries/LibGUI/CommonActions.cpp
+++ b/Userland/Libraries/LibGUI/CommonActions.cpp
@@ -22,7 +22,7 @@ NonnullRefPtr<Action> make_about_action(DeprecatedString const& app_name, Icon c
     auto weak_parent = AK::make_weak_ptr_if_nonnull<Window>(parent);
     auto action = Action::create(DeprecatedString::formatted("&About {}", app_name), app_icon.bitmap_for_size(16), [=](auto&) {
         AboutDialog::show(
-            String::from_utf8(app_name).release_value_but_fixme_should_propagate_errors(),
+            String::from_deprecated_string(app_name).release_value_but_fixme_should_propagate_errors(),
             Core::Version::read_long_version_string().release_value_but_fixme_should_propagate_errors(),
             app_icon.bitmap_for_size(32),
             weak_parent)

--- a/Userland/Libraries/LibGUI/Statusbar.cpp
+++ b/Userland/Libraries/LibGUI/Statusbar.cpp
@@ -84,7 +84,7 @@ void Statusbar::update_segment(size_t index)
             if (!text(i).is_empty())
                 m_segments[i]->set_visible(true);
         }
-        segment->set_text(String::from_utf8(segment->restored_text()).release_value_but_fixme_should_propagate_errors());
+        segment->set_text(String::from_deprecated_string(segment->restored_text()).release_value_but_fixme_should_propagate_errors());
         segment->set_frame_style(Gfx::FrameStyle::SunkenPanel);
         if (segment->mode() != Segment::Mode::Proportional)
             segment->set_fixed_width(segment->restored_width());
@@ -93,7 +93,7 @@ void Statusbar::update_segment(size_t index)
             if (!m_segments[i]->is_clickable())
                 m_segments[i]->set_visible(false);
         }
-        segment->set_text(String::from_utf8(segment->override_text()).release_value_but_fixme_should_propagate_errors());
+        segment->set_text(String::from_deprecated_string(segment->override_text()).release_value_but_fixme_should_propagate_errors());
         segment->set_frame_style(Gfx::FrameStyle::NoFrame);
         if (segment->mode() != Segment::Mode::Proportional)
             segment->set_fixed_width(SpecialDimension::Grow);

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -81,7 +81,7 @@ ThrowCompletionOr<String> PrimitiveString::utf8_string() const
 
     if (!has_utf8_string()) {
         if (has_deprecated_string())
-            m_utf8_string = TRY_OR_THROW_OOM(vm, String::from_utf8(*m_deprecated_string));
+            m_utf8_string = TRY_OR_THROW_OOM(vm, String::from_deprecated_string(*m_deprecated_string));
         else if (has_utf16_string())
             m_utf8_string = TRY(m_utf16_string->to_utf8(vm));
         else

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -722,7 +722,7 @@ Parser::ParseErrorOr<Optional<Selector::SimpleSelector>> Parser::parse_simple_se
         return Selector::SimpleSelector {
             .type = Selector::SimpleSelector::Type::TagName,
             // FIXME: XML requires case-sensitivity for identifiers, while HTML does not. As such, this should be reworked if XML support is added.
-            .value = Selector::SimpleSelector::Name { FlyString::from_utf8(first_value.token().ident().to_lowercase_string()).release_value_but_fixme_should_propagate_errors() }
+            .value = Selector::SimpleSelector::Name { FlyString::from_deprecated_fly_string(first_value.token().ident().to_lowercase_string()).release_value_but_fixme_should_propagate_errors() }
         };
     }
     if (first_value.is_block() && first_value.block().is_square())

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1971,7 +1971,7 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
         default:
             return {};
         }
-        return find_font(String::from_utf8(Platform::FontPlugin::the().generic_font_name(generic_font)).release_value_but_fixme_should_propagate_errors());
+        return find_font(String::from_deprecated_string(Platform::FontPlugin::the().generic_font_name(generic_font)).release_value_but_fixme_should_propagate_errors());
     };
 
     RefPtr<Gfx::Font const> found_font;

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1323,7 +1323,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> Document::create_element(Deprecat
     if (options.has<ElementCreationOptions>()) {
         auto const& element_creation_options = options.get<ElementCreationOptions>();
         if (!element_creation_options.is.is_null())
-            is_value = TRY_OR_THROW_OOM(vm, String::from_utf8(element_creation_options.is));
+            is_value = TRY_OR_THROW_OOM(vm, String::from_deprecated_string(element_creation_options.is));
     }
 
     // 5. Let namespace be the HTML namespace, if this is an HTML document or this’s content type is "application/xhtml+xml"; otherwise null.
@@ -1351,7 +1351,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> Document::create_element_ns(Depre
     if (options.has<ElementCreationOptions>()) {
         auto const& element_creation_options = options.get<ElementCreationOptions>();
         if (!element_creation_options.is.is_null())
-            is_value = TRY_OR_THROW_OOM(vm, String::from_utf8(element_creation_options.is));
+            is_value = TRY_OR_THROW_OOM(vm, String::from_deprecated_string(element_creation_options.is));
     }
 
     // 4. Return the result of creating an element given document, localName, namespace, prefix, is, and with the synchronous custom elements flag set.
@@ -2237,7 +2237,7 @@ JS::GCPtr<HTML::CustomElementDefinition> Document::lookup_custom_element_definit
     auto registry = window().custom_elements().release_value_but_fixme_should_propagate_errors();
 
     // 4. If there is custom element definition in registry with name and local name both equal to localName, return that custom element definition.
-    auto converted_local_name = String::from_utf8(local_name).release_value_but_fixme_should_propagate_errors();
+    auto converted_local_name = String::from_deprecated_string(local_name).release_value_but_fixme_should_propagate_errors();
     auto maybe_definition = registry->get_definition_with_name_and_local_name(converted_local_name, converted_local_name);
     if (maybe_definition)
         return maybe_definition;

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -957,7 +957,7 @@ BrowsingContext::ChosenBrowsingContext BrowsingContext::choose_a_browsing_contex
 
             // 6. If name is not an ASCII case-insensitive match for "_blank", then set chosen's name to name.
             if (!Infra::is_ascii_case_insensitive_match(name, "_blank"sv))
-                chosen->set_name(String::from_deprecated_string(name).release_value_but_fixme_should_propagate_errors());
+                chosen->set_name(String::from_utf8(name).release_value_but_fixme_should_propagate_errors());
         }
 
         // --> If the user agent has been configured such that in this instance t will reuse current

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -463,7 +463,7 @@ public:
         //    empty string, then end the synchronous section, and jump down to the failed with elements step below.
         String candiate_src;
         if (m_candidate->has_attribute(HTML::AttributeNames::src))
-            candiate_src = TRY_OR_THROW_OOM(vm, String::from_utf8(m_candidate->attribute(HTML::AttributeNames::src)));
+            candiate_src = TRY_OR_THROW_OOM(vm, String::from_deprecated_string(m_candidate->attribute(HTML::AttributeNames::src)));
 
         if (candiate_src.is_empty()) {
             TRY(failed_with_elements());

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -3796,7 +3796,7 @@ ErrorOr<Vector<String>> GlobValue::resolve_as_list(RefPtr<Shell> shell)
     Vector<String> strings;
     TRY(strings.try_ensure_capacity(results.size()));
     for (auto& entry : results) {
-        TRY(strings.try_append(TRY(String::from_utf8(entry))));
+        TRY(strings.try_append(TRY(String::from_deprecated_string(entry))));
     }
 
     return resolve_slices(shell, move(strings), m_slices);
@@ -3927,7 +3927,7 @@ ErrorOr<Vector<String>> TildeValue::resolve_as_list(RefPtr<Shell> shell)
     if (!shell)
         return { resolve_slices(shell, Vector { TRY(builder.to_string()) }, m_slices) };
 
-    return { resolve_slices(shell, Vector { TRY(String::from_utf8(shell->expand_tilde(builder.to_deprecated_string()))) }, m_slices) };
+    return { resolve_slices(shell, Vector { TRY(String::from_deprecated_string(shell->expand_tilde(builder.to_deprecated_string()))) }, m_slices) };
 }
 
 ErrorOr<NonnullRefPtr<Rewiring>> CloseRedirection::apply() const

--- a/Userland/Shell/Formatter.cpp
+++ b/Userland/Shell/Formatter.cpp
@@ -598,7 +598,7 @@ void Formatter::visit(const AST::MatchExpr* node)
                         if (!first)
                             current_builder().append(" | "sv);
                         first = false;
-                        auto node = make_ref_counted<AST::BarewordLiteral>(AST::Position {}, String::from_utf8(option.pattern_value).release_value_but_fixme_should_propagate_errors());
+                        auto node = make_ref_counted<AST::BarewordLiteral>(AST::Position {}, String::from_deprecated_string(option.pattern_value).release_value_but_fixme_should_propagate_errors());
                         node->visit(*this);
                     }
                 });

--- a/Userland/Shell/ImmediateFunctions.cpp
+++ b/Userland/Shell/ImmediateFunctions.cpp
@@ -232,7 +232,7 @@ ErrorOr<RefPtr<AST::Node>> Shell::immediate_regex_replace(AST::ImmediateExpressi
         TRY(replacement->resolve_as_list(this))[0],
         PosixFlags::Global | PosixFlags::Multiline | PosixFlags::Unicode);
 
-    return AST::make_ref_counted<AST::StringLiteral>(invoking_node.position(), TRY(String::from_utf8(result)), AST::StringLiteral::EnclosureType::None);
+    return AST::make_ref_counted<AST::StringLiteral>(invoking_node.position(), TRY(String::from_deprecated_string(result)), AST::StringLiteral::EnclosureType::None);
 }
 
 ErrorOr<RefPtr<AST::Node>> Shell::immediate_remove_suffix(AST::ImmediateExpression& invoking_node, Vector<NonnullRefPtr<AST::Node>> const& arguments)

--- a/Userland/Shell/Parser.cpp
+++ b/Userland/Shell/Parser.cpp
@@ -1023,12 +1023,12 @@ AST::MatchEntry Parser::parse_match_entry()
         for (auto& regex : regexps) {
             if (names.is_empty()) {
                 for (auto& name : regex.parser_result.capture_groups)
-                    names.append(String::from_utf8(name).release_value_but_fixme_should_propagate_errors());
+                    names.append(String::from_deprecated_string(name).release_value_but_fixme_should_propagate_errors());
             } else {
                 size_t index = 0;
                 for (auto& name : regex.parser_result.capture_groups) {
                     if (names.size() <= index) {
-                        names.append(String::from_utf8(name).release_value_but_fixme_should_propagate_errors());
+                        names.append(String::from_deprecated_string(name).release_value_but_fixme_should_propagate_errors());
                         continue;
                     }
 

--- a/Userland/Utilities/cal.cpp
+++ b/Userland/Utilities/cal.cpp
@@ -51,7 +51,7 @@ static ErrorOr<int> weekday_index(StringView weekday_name)
 static ErrorOr<int> default_weekday_start()
 {
     auto calendar_config = TRY(Core::ConfigFile::open_for_app("Calendar"sv));
-    String default_first_day_of_week = TRY(String::from_utf8(calendar_config->read_entry("View"sv, "FirstDayOfWeek"sv, "Sunday"sv)));
+    String default_first_day_of_week = TRY(String::from_deprecated_string(calendar_config->read_entry("View"sv, "FirstDayOfWeek"sv, "Sunday"sv)));
     return TRY(weekday_index(default_first_day_of_week));
 }
 


### PR DESCRIPTION
Let's just stop lying about types, hiding the fact that we are using deprecated APIs,
also this actually removes some falsely marked `from_deprecated_string`s, so:
`from_deprecated_(fly_)?string`: +19-5 = +14
`from_utf8`: +5