### PR TITLE
LibWeb: Implement FileAPI::Blob::stream()

### DIFF
--- a/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
@@ -252,6 +252,13 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> Blob::slice(Optional<i64> start, Opt
     return MUST_OR_THROW_OOM(heap().allocate<Blob>(realm(), realm(), move(byte_buffer), move(relative_content_type)));
 }
 
+// https://w3c.github.io/FileAPI/#dom-blob-stream
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Streams::ReadableStream>> Blob::stream()
+{
+    // The stream() method, when invoked, must return the result of calling get stream on this.
+    return this->get_stream();
+}
+
 // https://w3c.github.io/FileAPI/#blob-get-stream
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Streams::ReadableStream>> Blob::get_stream()
 {

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -43,6 +43,7 @@ public:
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> slice(Optional<i64> start = {}, Optional<i64> end = {}, Optional<String> const& content_type = {});
 
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<Streams::ReadableStream>> stream();
     WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> text();
     JS::Promise* array_buffer();
 

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -55,6 +55,8 @@ protected:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
 private:
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<Streams::ReadableStream>> get_stream();
+
     explicit Blob(JS::Realm&);
 
     ByteBuffer m_byte_buffer {};

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.idl
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.idl
@@ -9,6 +9,7 @@ interface Blob {
     Blob slice(optional long long start, optional long long end, optional DOMString contentType);
 
     // read from the Blob.
+    [NewObject] ReadableStream stream();
     [NewObject] Promise<USVString> text();
     [NewObject] Promise<ArrayBuffer> arrayBuffer();
 };

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -540,6 +540,7 @@ class WritableStream;
 class WritableStreamDefaultController;
 class WritableStreamDefaultWriter;
 
+struct PullIntoDescriptor;
 struct UnderlyingSink;
 struct UnderlyingSource;
 }

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/Task.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/Task.h
@@ -38,6 +38,9 @@ public:
 
         // https://html.spec.whatwg.org/multipage/webappapis.html#navigation-and-traversal-task-source
         NavigationAndTraversal,
+
+        // https://w3c.github.io/FileAPI/#fileReadingTaskSource
+        FileReading,
     };
 
     static NonnullOwnPtr<Task> create(Source source, DOM::Document const* document, JS::SafeFunction<void()> steps)

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>
+ * Copyright (c) 2023, Shannon Booth <shannon.ml.booth@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -58,6 +59,15 @@ WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller(ReadableStre
 WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller_from_underlying_source(ReadableStream&, JS::Value underlying_source_value, UnderlyingSource, double high_water_mark, SizeAlgorithm&&);
 WebIDL::ExceptionOr<void> set_up_readable_stream_controller_with_byte_reading_support(ReadableStream&, Optional<PullAlgorithm>&& = {}, Optional<CancelAlgorithm>&& = {}, double high_water_mark = 0);
 WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller(ReadableStream&, ReadableByteStreamController&, StartAlgorithm&&, PullAlgorithm&&, CancelAlgorithm&&, double high_water_mark, JS::Value auto_allocate_chunk_size);
+
+WebIDL::ExceptionOr<void> readable_stream_enqueue(ReadableStreamController& controller, JS::Value chunk);
+WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue(ReadableByteStreamController& controller, JS::Value chunk);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> transfer_array_buffer(JS::Realm& realm, JS::ArrayBuffer& buffer);
+WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue_detached_pull_into_queue(ReadableByteStreamController& controller, PullIntoDescriptor& pull_into_descriptor);
+WebIDL::ExceptionOr<void> readable_byte_stream_controller_process_read_requests_using_queue(ReadableByteStreamController& controller);
+void readable_byte_stream_controller_enqueue_chunk_to_queue(ReadableByteStreamController& controller, JS::NonnullGCPtr<JS::ArrayBuffer> buffer, u32 byte_offset, u32 byte_length);
+WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue_cloned_chunk_to_queue(ReadableByteStreamController& controller, JS::ArrayBuffer& buffer, u64 byte_offset, u64 byte_length);
+PullIntoDescriptor readable_byte_stream_controller_shift_pending_pull_into(ReadableByteStreamController& controller);
 
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_call_pull_if_needed(ReadableByteStreamController&);
 void readable_byte_stream_controller_clear_algorithms(ReadableByteStreamController&);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -56,6 +56,8 @@ Optional<double> readable_stream_default_controller_get_desired_size(ReadableStr
 bool readable_stream_default_controller_can_close_or_enqueue(ReadableStreamDefaultController&);
 WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller(ReadableStream&, ReadableStreamDefaultController&, StartAlgorithm&&, PullAlgorithm&&, CancelAlgorithm&&, double high_water_mark, SizeAlgorithm&&);
 WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller_from_underlying_source(ReadableStream&, JS::Value underlying_source_value, UnderlyingSource, double high_water_mark, SizeAlgorithm&&);
+WebIDL::ExceptionOr<void> set_up_readable_stream_controller_with_byte_reading_support(ReadableStream&, Optional<PullAlgorithm>&& = {}, Optional<CancelAlgorithm>&& = {}, double high_water_mark = 0);
+WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller(ReadableStream&, ReadableByteStreamController&, StartAlgorithm&&, PullAlgorithm&&, CancelAlgorithm&&, double high_water_mark, JS::Value auto_allocate_chunk_size);
 
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_call_pull_if_needed(ReadableByteStreamController&);
 void readable_byte_stream_controller_clear_algorithms(ReadableByteStreamController&);


### PR DESCRIPTION
There are still plenty more cases to handle, but this does allow us to
handle the basic scenario of getting a readable stream from a blob, and
reading all of the data from that stream until it is done.

I've tried adding tests to go along with these changes, but ran into: https://github.com/SerenityOS/serenity/issues/19359

Ideas to fix my above problem appreciated!