### PR TITLE
LibWeb: Two CSS grid fixes

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/grid-row-height-affected-by-item-margins.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-row-height-affected-by-item-margins.txt
@@ -1,0 +1,8 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x97.817501 [BFC] children: not-inline
+    Box <body> at (10,10) content-size 780x79.817501 [GFC] children: not-inline
+      BlockContainer <h1> at (55.5,32.440000) content-size 689x34.9375 [BFC] children: inline
+        line 0 width: 492.96875, height: 34.9375, bottom: 34.9375, baseline: 27.0625
+          frag 0 from TextNode start: 0, length: 31, rect: [55.5,32.440000 492.96875x34.9375]
+            "Null publishes fine indie games"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/grid-template-columns-with-min-css-function.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-template-columns-with-min-css-function.txt
@@ -1,0 +1,8 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x54.9375 [BFC] children: not-inline
+    Box <body> at (10,10) content-size 780x36.9375 [GFC] children: not-inline
+      BlockContainer <h1> at (55.5,11) content-size 689x34.9375 [BFC] children: inline
+        line 0 width: 200.40625, height: 34.9375, bottom: 34.9375, baseline: 27.0625
+          frag 0 from TextNode start: 0, length: 13, rect: [55.5,11 200.40625x34.9375]
+            "hello friends"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/grid/grid-row-height-affected-by-item-margins.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-row-height-affected-by-item-margins.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html><style>
+    * { border: 1px solid black; }
+    body {
+        display: grid;
+        grid-template-columns: 1fr min(89ch, 100% - 89px) 1fr;
+    }
+    h1 {
+        grid-column: 2 / auto;
+    }
+</style><body><h1>Null publishes fine indie games</h1>

--- a/Tests/LibWeb/Layout/input/grid/grid-template-columns-with-min-css-function.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-template-columns-with-min-css-function.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html><style>
+    * { border: 1px solid black; }
+    body {
+        display: grid;
+        grid-template-columns: 1fr min(89ch, 100% - 89px) 1fr;
+    }
+    h1 {
+        grid-column: 2 / auto;
+        margin: 0;
+    }
+</style><body><h1>hello friends</h1>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -6900,11 +6900,8 @@ Optional<CSS::ExplicitGridTrack> Parser::parse_track_sizing_function(ComponentVa
                 return CSS::ExplicitGridTrack(maybe_min_max_value.value());
             else
                 return {};
-        } else if (function_token.name().equals_ignoring_ascii_case("calc"sv)) {
-            auto grid_size = parse_grid_size(token);
-            if (!grid_size.has_value())
-                return {};
-            return CSS::ExplicitGridTrack(grid_size.value());
+        } else if (auto maybe_dynamic = parse_dynamic_value(token); !maybe_dynamic.is_error() && maybe_dynamic.value()) {
+            return CSS::ExplicitGridTrack(GridSize(LengthPercentage(maybe_dynamic.release_value()->as_calculated())));
         }
         return {};
     } else if (token.is(Token::Type::Ident) && token.token().ident().equals_ignoring_ascii_case("auto"sv)) {

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -45,14 +45,12 @@ public:
         return dimension == GridDimension::Column ? m_column : m_row;
     }
 
-    CSSPixels add_border_box_sizes(CSSPixels content_size, GridDimension dimension, LayoutState const& state) const
+    [[nodiscard]] CSSPixels add_margin_box_sizes(CSSPixels content_size, GridDimension dimension, LayoutState const& state) const
     {
-        auto& box_state = state.get(box());
-        if (dimension == GridDimension::Column) {
-            return box_state.border_left + box_state.padding_left + content_size + box_state.padding_right + box_state.border_right;
-        } else {
-            return box_state.border_top + box_state.padding_top + content_size + box_state.padding_bottom + box_state.border_bottom;
-        }
+        auto const& box_state = state.get(box());
+        if (dimension == GridDimension::Column)
+            return box_state.margin_box_left() + content_size + box_state.margin_box_right();
+        return box_state.margin_box_top() + content_size + box_state.margin_box_bottom();
     }
 
     int raw_row() const { return m_row; }


### PR DESCRIPTION
* **LibWeb: Support more CSS functions in grid track size lists**
    
  Instead of hard-coding a check for `"calc"`, we now call out to `parse_dynamic_value()` which allows use of other functions like `min()`, `max()`, `clamp()`, etc.

* **LibWeb: Use grid item *outer* size when calculating minimum contribution**

  Previously we used the border box, which meant that tracks did not grow to accommodate item margins.
