### PR TITLE
CI: Disable ASAN's use-after-return check

### DIFF
--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -147,7 +147,7 @@ jobs:
           SERENITY_SOURCE_DIR: '$(Build.SourcesDirectory)'
           CTEST_OUTPUT_ON_FAILURE: 1
           # FIXME: enable detect_stack_use_after_return=1 #7420
-          ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1'
+          ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=0'
           UBSAN_OPTIONS: 'print_stacktrace=1:print_summary=1:halt_on_error=1'
 
     - ${{ if eq(parameters.lagom_lints, true) }}:
@@ -162,7 +162,7 @@ jobs:
           MARKDOWN_CHECK_BINARY: ./Meta/Lagom/Build/bin/markdown-check
           GML_FORMAT: ./Meta/Lagom/Build/bin/gml-format
           # FIXME: enable detect_stack_use_after_return=1 #7420
-          ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1'
+          ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=0'
           UBSAN_OPTIONS: 'print_stacktrace=1:print_summary=1:halt_on_error=1'
 
     - script: |


### PR DESCRIPTION
This has apparently started defaulting to "on" at some point, which breaks our conservative stack scan in LibJS.