### PR TITLE
LibWeb: Only abort current image request if different from pending

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -487,7 +487,10 @@ after_step_7:
                 //    upgrade the pending request to the current request
                 //    and prepare image request for presentation given the img element.
                 if (image_request == m_pending_request) {
-                    abort_the_image_request(realm(), m_current_request);
+                    // AD-HOC: Account for image sharing. On this branch, the current request is already available and has the same URL
+                    //         as the pending request. Clearing its data through abort_the_image_request would break future reuses.
+                    if (image_request != m_current_request)
+                        abort_the_image_request(realm(), m_current_request);
                     upgrade_pending_request_to_current_request();
                     image_request->prepare_for_presentation(*this);
                 }


### PR DESCRIPTION
Due to sharing of image requests, we can end up in a situation where the current request is already available but we abort it if the image request is the pending request for the same URL as the current image request. This forgets the data, which triggers a crash once we reuse that image request from the cache and it's marked as available.

Fixes a crash on the comments section of https://lobste.rs, which is reusing avatar pictures.