### PR TITLE
LibWeb: Make stretch-fit return 0 when the available size is indefinite

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/dont-stretch-fit-svg-with-indefinite-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/svg/dont-stretch-fit-svg-with-indefinite-containing-block-width.txt
@@ -1,0 +1,6 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 0x17.46875 children: inline
+      line 0 width: 0, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,21 0x0]
+      SVGSVGBox <svg> at (8,21) content-size 0x0 [SVG] children: not-inline

--- a/Tests/LibWeb/Layout/input/svg/dont-stretch-fit-svg-with-indefinite-containing-block-width.html
+++ b/Tests/LibWeb/Layout/input/svg/dont-stretch-fit-svg-with-indefinite-containing-block-width.html
@@ -1,0 +1,3 @@
+<!doctype html><style>
+body { width: max-content; }
+</style><body><svg viewBox="0 0 10 10"></svg>

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1436,7 +1436,11 @@ CSSPixels FormattingContext::calculate_stretch_fit_width(Box const& box, Availab
 {
     // The size a box would take if its outer size filled the available space in the given axis;
     // in other words, the stretch fit into the available space, if that is definite.
+
     // Undefined if the available space is indefinite.
+    if (!available_width.is_definite())
+        return 0;
+
     auto const& box_state = m_state.get(box);
     return available_width.to_px()
         - box_state.margin_left


### PR DESCRIPTION
The spec says the result of this algorithm is undefined in such cases, and it appears that other engines yield a zero size.

More importantly, this prevents us from leaking a non-finite value into the layout tree.