### PR TITLE
PixelPaint: Add luminosity and color masking for editing masks

### DIFF
--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -10,6 +10,7 @@ compile_gml(EditGuideDialog.gml EditGuideDialogGML.h edit_guide_dialog_gml)
 compile_gml(FilterGallery.gml FilterGalleryGML.h filter_gallery_gml)
 compile_gml(ResizeImageDialog.gml ResizeImageDialogGML.h resize_image_dialog_gml)
 compile_gml(LevelsDialog.gml LevelsDialogGML.h levels_dialog_gml)
+compile_gml(LuminosityMasking.gml LuminosityMaskingGML.h luminosity_masking_gml)
 compile_gml(Filters/MedianSettings.gml Filters/MedianSettingsGML.h median_settings_gml)
 
 set(SOURCES
@@ -38,6 +39,7 @@ set(SOURCES
     IconBag.cpp
     Image.cpp
     ImageEditor.cpp
+    ImageMasking.cpp
     ImageProcessor.cpp
     Layer.cpp
     LayerListWidget.cpp
@@ -81,6 +83,7 @@ set(GENERATED_SOURCES
     FilterGalleryGML.h
     Filters/MedianSettingsGML.h
     LevelsDialogGML.h
+    LuminosityMaskingGML.h
     PixelPaintWindowGML.h
     ResizeImageDialogGML.h
 )

--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -11,6 +11,7 @@ compile_gml(FilterGallery.gml FilterGalleryGML.h filter_gallery_gml)
 compile_gml(ResizeImageDialog.gml ResizeImageDialogGML.h resize_image_dialog_gml)
 compile_gml(LevelsDialog.gml LevelsDialogGML.h levels_dialog_gml)
 compile_gml(LuminosityMasking.gml LuminosityMaskingGML.h luminosity_masking_gml)
+compile_gml(ColorMasking.gml ColorMaskingGML.h color_masking_gml)
 compile_gml(Filters/MedianSettings.gml Filters/MedianSettingsGML.h median_settings_gml)
 
 set(SOURCES
@@ -80,6 +81,7 @@ set(SOURCES
 
 set(GENERATED_SOURCES
     EditGuideDialogGML.h
+    ColorMaskingGML.h
     FilterGalleryGML.h
     Filters/MedianSettingsGML.h
     LevelsDialogGML.h

--- a/Userland/Applications/PixelPaint/ColorMasking.gml
+++ b/Userland/Applications/PixelPaint/ColorMasking.gml
@@ -1,0 +1,77 @@
+@GUI::Frame {
+    fill_with_background_color: true
+    layout: @GUI::VerticalBoxLayout {
+        margins: [4]
+    }
+
+    @GUI::Widget {
+        layout: @GUI::VerticalBoxLayout {}
+
+        @GUI::Label {
+            name: "hint_label"
+            enabled: true
+            fixed_height: 20
+            visible: true
+            text: "Restrict mask to colors:"
+            text_alignment: "CenterLeft"
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {}
+
+            @GUI::VerticalSlider {
+                name: "color_range"
+                max: 180
+                min: 0
+                value: 15
+                page_step: 10
+            }
+
+            @GUI::Widget {
+                name: "color_wheel_container"
+            }
+
+            @GUI::VerticalSlider {
+                name: "hardness"
+                max: 100
+                min: 0
+                value: 50
+                page_step: 10
+            }
+        }
+
+        @GUI::HorizontalRangeSlider {
+            name: "saturation_value"
+            max: 100
+            min: -100
+            lower_range: -100
+            upper_range: 100
+            page_step: 5
+            show_label: false
+        }
+
+        @GUI::CheckBox {
+            name: "mask_visibility"
+            text: "Show layer mask"
+        }
+
+        @GUI::HorizontalSeparator {}
+    }
+
+    @GUI::Widget {
+        layout: @GUI::HorizontalBoxLayout {}
+        fixed_height: 22
+
+        @GUI::Layout::Spacer {}
+
+        @GUI::DialogButton {
+            name: "apply_button"
+            text: "OK"
+        }
+
+        @GUI::DialogButton {
+            name: "cancel_button"
+            text: "Cancel"
+        }
+    }
+}

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -290,6 +290,9 @@ Gfx::IntRect ImageEditor::mouse_indicator_rect_y() const
 
 void ImageEditor::second_paint_event(GUI::PaintEvent& event)
 {
+    if (m_active_layer && m_active_layer->mask_type() != Layer::MaskType::None)
+        m_active_layer->on_second_paint(*this);
+
     if (m_active_tool) {
         if (m_show_rulers) {
             auto clipped_event = GUI::PaintEvent(subtract_rulers_from_rect(event.rect()), event.window_size());
@@ -943,6 +946,17 @@ DeprecatedString ImageEditor::generate_unique_layer_name(DeprecatedString const&
     } while (layer_with_name_exists(new_layer_name.string_view()));
 
     return new_layer_name.to_deprecated_string();
+}
+
+Gfx::IntRect ImageEditor::active_layer_visible_rect()
+{
+    if (!active_layer())
+        return {};
+
+    auto scaled_layer_rect = active_layer()->relative_rect().to_type<float>().scaled(scale(), scale()).to_type<int>().translated(content_rect().location());
+    auto visible_editor_rect = ruler_visibility() ? subtract_rulers_from_rect(rect()) : rect();
+    scaled_layer_rect.intersect(visible_editor_rect);
+    return scaled_layer_rect;
 }
 
 }

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -37,6 +37,7 @@ public:
 
     Layer* active_layer() { return m_active_layer; }
     void set_active_layer(Layer*);
+    Gfx::IntRect active_layer_visible_rect();
 
     ErrorOr<void> add_new_layer_from_selection();
     Tool* active_tool() { return m_active_tool; }

--- a/Userland/Applications/PixelPaint/ImageMasking.cpp
+++ b/Userland/Applications/PixelPaint/ImageMasking.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2023, Torsten Engelmann <engelTorsten@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ImageMasking.h"
+#include <Applications/PixelPaint/LuminosityMaskingGML.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/CheckBox.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/Painter.h>
+#include <LibGUI/RangeSlider.h>
+#include <LibGfx/Palette.h>
+#include <LibGfx/Path.h>
+
+namespace PixelPaint {
+
+ImageMasking::ImageMasking(GUI::Window* parent_window, ImageEditor* editor)
+    : GUI::Dialog(parent_window)
+{
+    set_title("Luminosity Mask");
+    set_icon(parent_window->icon());
+
+    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    main_widget->load_from_gml(luminosity_masking_gml).release_value_but_fixme_should_propagate_errors();
+
+    resize(300, 170);
+    set_resizable(false);
+
+    m_editor = editor;
+
+    m_full_masking_slider = main_widget->find_descendant_of_type_named<GUI::RangeSlider>("full_masking");
+    m_edge_masking_slider = main_widget->find_descendant_of_type_named<GUI::RangeSlider>("edge_masking");
+    auto range_illustration_container = main_widget->find_descendant_of_type_named<GUI::Widget>("range_illustration");
+    auto mask_visibility = main_widget->find_descendant_of_type_named<GUI::CheckBox>("mask_visibility");
+    auto apply_button = main_widget->find_descendant_of_type_named<GUI::Button>("apply_button");
+    auto cancel_button = main_widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
+
+    VERIFY(m_full_masking_slider);
+    VERIFY(m_edge_masking_slider);
+    VERIFY(range_illustration_container);
+    VERIFY(mask_visibility);
+    VERIFY(apply_button);
+    VERIFY(cancel_button);
+    VERIFY(m_editor->active_layer());
+
+    m_full_masking_slider->set_gradient_color(Color(0, 0, 0, 255), Color(255, 255, 255, 255));
+    m_edge_masking_slider->set_gradient_color(Color(0, 0, 0, 255), Color(255, 255, 255, 255));
+
+    auto illustration_widget = range_illustration_container->try_add<RangeIllustrationWidget>(m_edge_masking_slider, m_full_masking_slider).release_value();
+    illustration_widget->set_width(range_illustration_container->width());
+    illustration_widget->set_height(range_illustration_container->height());
+
+    // check that edges of full and edge masking are not intersecting, and refine the mask with the updated values
+    m_full_masking_slider->on_range_change = [this, illustration_widget](int lower, int upper) {
+        if (lower < m_edge_masking_slider->lower_range())
+            m_full_masking_slider->set_lower_range(AK::max(lower, m_edge_masking_slider->lower_range()));
+        if (upper > m_edge_masking_slider->upper_range())
+            m_full_masking_slider->set_upper_range(AK::min(upper, m_edge_masking_slider->upper_range()));
+
+        illustration_widget->update();
+        generate_new_mask();
+    };
+    m_edge_masking_slider->on_range_change = [this, illustration_widget](int lower, int upper) {
+        if (lower > m_full_masking_slider->lower_range())
+            m_edge_masking_slider->set_lower_range(AK::min(lower, m_full_masking_slider->lower_range()));
+        if (upper < m_full_masking_slider->upper_range())
+            m_edge_masking_slider->set_upper_range(AK::max(upper, m_full_masking_slider->upper_range()));
+
+        illustration_widget->update();
+        generate_new_mask();
+    };
+
+    mask_visibility->set_checked(m_editor->active_layer()->mask_visibility());
+    mask_visibility->on_checked = [this](auto checked) {
+        m_editor->active_layer()->set_mask_visibility(checked);
+        m_editor->update();
+    };
+
+    apply_button->on_click = [this](auto) {
+        if (m_did_change)
+            m_editor->did_complete_action("Luminosity Masking"sv);
+
+        cleanup_resources();
+        done(ExecResult::OK);
+    };
+
+    cancel_button->on_click = [this](auto) {
+        done(ExecResult::Cancel);
+    };
+
+    generate_new_mask();
+}
+
+void ImageMasking::revert_possible_changes()
+{
+    if (m_did_change && m_reference_mask) {
+        MUST(m_editor->active_layer()->set_bitmaps(m_editor->active_layer()->content_bitmap(), m_reference_mask.release_nonnull()));
+        m_editor->layers_did_change();
+    }
+    cleanup_resources();
+}
+
+void ImageMasking::generate_new_mask()
+{
+    ensure_reference_mask().release_value_but_fixme_should_propagate_errors();
+
+    if (m_reference_mask.is_null())
+        return;
+
+    int min_luminosity_start = m_edge_masking_slider->lower_range();
+    int min_luminosity_full = m_full_masking_slider->lower_range();
+    int max_luminosity_full = m_full_masking_slider->upper_range();
+    int max_luminosity_end = m_edge_masking_slider->upper_range();
+    int current_content_luminosity, approximation_alpha;
+    bool has_start_range = min_luminosity_start != min_luminosity_full;
+    bool has_end_range = max_luminosity_end != max_luminosity_full;
+    Gfx::Color reference_mask_pixel, content_pixel;
+
+    for (int y = 0; y < m_reference_mask->height(); y++) {
+        for (int x = 0; x < m_reference_mask->width(); x++) {
+            reference_mask_pixel = m_reference_mask->get_pixel(x, y);
+            if (!reference_mask_pixel.alpha())
+                continue;
+
+            content_pixel = m_editor->active_layer()->content_bitmap().get_pixel(x, y);
+            current_content_luminosity = content_pixel.luminosity();
+
+            if (!content_pixel.alpha() || current_content_luminosity < min_luminosity_start || current_content_luminosity > max_luminosity_end) {
+                reference_mask_pixel.set_alpha(0);
+            } else if (current_content_luminosity >= min_luminosity_start && current_content_luminosity < min_luminosity_full && has_start_range) {
+                approximation_alpha = reference_mask_pixel.alpha() * static_cast<float>((current_content_luminosity - min_luminosity_start)) / (min_luminosity_full - min_luminosity_start);
+                reference_mask_pixel.set_alpha(approximation_alpha);
+            } else if (current_content_luminosity > max_luminosity_full && current_content_luminosity <= max_luminosity_end && has_end_range) {
+                approximation_alpha = reference_mask_pixel.alpha() * (1 - static_cast<float>((current_content_luminosity - max_luminosity_full)) / (max_luminosity_end - max_luminosity_full));
+                reference_mask_pixel.set_alpha(approximation_alpha);
+            }
+
+            m_editor->active_layer()->mask_bitmap()->set_pixel(x, y, reference_mask_pixel);
+        }
+    }
+
+    m_editor->active_layer()->did_modify_bitmap();
+    m_did_change = true;
+}
+
+ErrorOr<void> ImageMasking::ensure_reference_mask()
+{
+    if (m_reference_mask.is_null())
+        m_reference_mask = TRY(m_editor->active_layer()->mask_bitmap()->clone());
+
+    return {};
+}
+
+void ImageMasking::cleanup_resources()
+{
+    if (m_reference_mask)
+        m_reference_mask = nullptr;
+}
+
+void RangeIllustrationWidget::paint_event(GUI::PaintEvent&)
+{
+    GUI::Painter painter(*this);
+    painter.fill_rect(Gfx::IntRect(0, 0, width(), height()), palette().color(background_role()));
+    float fraction = width() / 255.0f;
+
+    Gfx::Path illustration;
+    illustration.move_to({ fraction * m_edge_mask_values->lower_range(), static_cast<float>(height()) });
+    illustration.line_to({ fraction * m_full_mask_values->lower_range(), 0 });
+    illustration.line_to({ fraction * m_full_mask_values->upper_range(), 0 });
+    illustration.line_to({ fraction * m_edge_mask_values->upper_range(), static_cast<float>(height()) });
+    illustration.close();
+
+    painter.fill_path(illustration, Color::MidGray);
+}
+}

--- a/Userland/Applications/PixelPaint/ImageMasking.cpp
+++ b/Userland/Applications/PixelPaint/ImageMasking.cpp
@@ -5,72 +5,135 @@
  */
 
 #include "ImageMasking.h"
+#include <Applications/PixelPaint/ColorMaskingGML.h>
 #include <Applications/PixelPaint/LuminosityMaskingGML.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/CheckBox.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/RangeSlider.h>
+#include <LibGfx/AntiAliasingPainter.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/Path.h>
 
 namespace PixelPaint {
 
-ImageMasking::ImageMasking(GUI::Window* parent_window, ImageEditor* editor)
+ImageMasking::ImageMasking(GUI::Window* parent_window, ImageEditor* editor, MaskingType masking_type)
     : GUI::Dialog(parent_window)
+    , m_masking_type(masking_type)
+    , m_editor(editor)
 {
-    set_title("Luminosity Mask");
     set_icon(parent_window->icon());
 
     auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->load_from_gml(luminosity_masking_gml).release_value_but_fixme_should_propagate_errors();
 
-    resize(300, 170);
     set_resizable(false);
+    m_previous_edit_mode = m_editor->active_layer()->edit_mode();
+    m_editor->active_layer()->set_edit_mode(Layer::EditMode::Mask);
 
-    m_editor = editor;
+    if (m_masking_type == MaskingType::Luminosity) {
+        main_widget->load_from_gml(luminosity_masking_gml).release_value_but_fixme_should_propagate_errors();
+        set_title("Luminosity Mask");
+        resize(300, 170);
 
-    m_full_masking_slider = main_widget->find_descendant_of_type_named<GUI::RangeSlider>("full_masking");
-    m_edge_masking_slider = main_widget->find_descendant_of_type_named<GUI::RangeSlider>("edge_masking");
-    auto range_illustration_container = main_widget->find_descendant_of_type_named<GUI::Widget>("range_illustration");
+        m_full_masking_slider = main_widget->find_descendant_of_type_named<GUI::RangeSlider>("full_masking");
+        m_edge_masking_slider = main_widget->find_descendant_of_type_named<GUI::RangeSlider>("edge_masking");
+        auto range_illustration_container = main_widget->find_descendant_of_type_named<GUI::Widget>("range_illustration");
+        VERIFY(m_full_masking_slider);
+        VERIFY(m_edge_masking_slider);
+        VERIFY(range_illustration_container);
+
+        m_full_masking_slider->set_gradient_color(Color(0, 0, 0, 255), Color(255, 255, 255, 255));
+        m_edge_masking_slider->set_gradient_color(Color(0, 0, 0, 255), Color(255, 255, 255, 255));
+
+        auto illustration_widget = range_illustration_container->try_add<RangeIllustrationWidget>(m_edge_masking_slider, m_full_masking_slider).release_value();
+        illustration_widget->set_width(range_illustration_container->width());
+        illustration_widget->set_height(range_illustration_container->height());
+
+        // check that edges of full and edge masking are not intersecting, and refine the mask with the updated values
+        m_full_masking_slider->on_range_change = [this, illustration_widget](int lower, int upper) {
+            if (lower < m_edge_masking_slider->lower_range())
+                m_full_masking_slider->set_lower_range(AK::max(lower, m_edge_masking_slider->lower_range()));
+            if (upper > m_edge_masking_slider->upper_range())
+                m_full_masking_slider->set_upper_range(AK::min(upper, m_edge_masking_slider->upper_range()));
+
+            illustration_widget->update();
+            generate_new_mask();
+        };
+        m_edge_masking_slider->on_range_change = [this, illustration_widget](int lower, int upper) {
+            if (lower > m_full_masking_slider->lower_range())
+                m_edge_masking_slider->set_lower_range(AK::min(lower, m_full_masking_slider->lower_range()));
+            if (upper < m_full_masking_slider->upper_range())
+                m_edge_masking_slider->set_upper_range(AK::max(upper, m_full_masking_slider->upper_range()));
+
+            illustration_widget->update();
+            generate_new_mask();
+        };
+    }
+
+    if (m_masking_type == MaskingType::Color) {
+        main_widget->load_from_gml(color_masking_gml).release_value_but_fixme_should_propagate_errors();
+
+        set_title("Color Mask");
+        resize(300, 250);
+
+        m_saturation_value_masking_slider = main_widget->find_descendant_of_type_named<GUI::RangeSlider>("saturation_value");
+        auto color_range_slider = main_widget->find_descendant_of_type_named<GUI::VerticalSlider>("color_range");
+        auto hardness_slider = main_widget->find_descendant_of_type_named<GUI::VerticalSlider>("hardness");
+        auto color_wheel_container = main_widget->find_descendant_of_type_named<GUI::Widget>("color_wheel_container");
+
+        VERIFY(m_saturation_value_masking_slider);
+        VERIFY(color_wheel_container);
+        VERIFY(color_range_slider);
+        VERIFY(hardness_slider);
+
+        m_color_wheel_widget = color_wheel_container->try_add<ColorWheelWidget>().release_value();
+        m_color_wheel_widget->set_width(color_wheel_container->width());
+        m_color_wheel_widget->set_height(color_wheel_container->height());
+
+        auto update_control_gradients = [this, color_range_slider, hardness_slider]() {
+            auto selected_color = Gfx::Color::from_hsv(m_color_wheel_widget->hue(), 1, 1);
+            m_saturation_value_masking_slider->set_gradient_colors(Vector {
+                Gfx::ColorStop { Color(0, 0, 0, 255), 0 },
+                Gfx::ColorStop { selected_color, 0.5 },
+                Gfx::ColorStop { Color(255, 255, 255, 255), 1 } });
+            color_range_slider->set_value(m_color_wheel_widget->color_range());
+            hardness_slider->set_value(m_color_wheel_widget->hardness());
+        };
+
+        auto hsv = editor->primary_color().to_hsv();
+        m_color_wheel_widget->set_hue(hsv.hue);
+        m_color_wheel_widget->set_color_range(15);
+        update_control_gradients();
+
+        m_saturation_value_masking_slider->on_range_change = [this](int, int) {
+            generate_new_mask();
+        };
+
+        color_range_slider->on_change = [this](int value) {
+            m_color_wheel_widget->set_color_range(value);
+        };
+
+        hardness_slider->on_change = [this](int value) {
+            m_color_wheel_widget->set_hardness(value);
+        };
+
+        m_color_wheel_widget->on_change = [this, update_control_gradients, color_range_slider, hardness_slider](double, double color_range, int hardness) {
+            color_range_slider->set_value(color_range);
+            hardness_slider->set_value(hardness);
+            update_control_gradients();
+            generate_new_mask();
+        };
+    }
+
     auto mask_visibility = main_widget->find_descendant_of_type_named<GUI::CheckBox>("mask_visibility");
     auto apply_button = main_widget->find_descendant_of_type_named<GUI::Button>("apply_button");
     auto cancel_button = main_widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
 
-    VERIFY(m_full_masking_slider);
-    VERIFY(m_edge_masking_slider);
-    VERIFY(range_illustration_container);
     VERIFY(mask_visibility);
     VERIFY(apply_button);
     VERIFY(cancel_button);
     VERIFY(m_editor->active_layer());
-
-    m_full_masking_slider->set_gradient_color(Color(0, 0, 0, 255), Color(255, 255, 255, 255));
-    m_edge_masking_slider->set_gradient_color(Color(0, 0, 0, 255), Color(255, 255, 255, 255));
-
-    auto illustration_widget = range_illustration_container->try_add<RangeIllustrationWidget>(m_edge_masking_slider, m_full_masking_slider).release_value();
-    illustration_widget->set_width(range_illustration_container->width());
-    illustration_widget->set_height(range_illustration_container->height());
-
-    // check that edges of full and edge masking are not intersecting, and refine the mask with the updated values
-    m_full_masking_slider->on_range_change = [this, illustration_widget](int lower, int upper) {
-        if (lower < m_edge_masking_slider->lower_range())
-            m_full_masking_slider->set_lower_range(AK::max(lower, m_edge_masking_slider->lower_range()));
-        if (upper > m_edge_masking_slider->upper_range())
-            m_full_masking_slider->set_upper_range(AK::min(upper, m_edge_masking_slider->upper_range()));
-
-        illustration_widget->update();
-        generate_new_mask();
-    };
-    m_edge_masking_slider->on_range_change = [this, illustration_widget](int lower, int upper) {
-        if (lower > m_full_masking_slider->lower_range())
-            m_edge_masking_slider->set_lower_range(AK::min(lower, m_full_masking_slider->lower_range()));
-        if (upper < m_full_masking_slider->upper_range())
-            m_edge_masking_slider->set_upper_range(AK::max(upper, m_full_masking_slider->upper_range()));
-
-        illustration_widget->update();
-        generate_new_mask();
-    };
 
     mask_visibility->set_checked(m_editor->active_layer()->mask_visibility());
     mask_visibility->on_checked = [this](auto checked) {
@@ -80,9 +143,8 @@ ImageMasking::ImageMasking(GUI::Window* parent_window, ImageEditor* editor)
 
     apply_button->on_click = [this](auto) {
         if (m_did_change)
-            m_editor->did_complete_action("Luminosity Masking"sv);
+            m_editor->did_complete_action("Image Masking"sv);
 
-        cleanup_resources();
         done(ExecResult::OK);
     };
 
@@ -93,15 +155,6 @@ ImageMasking::ImageMasking(GUI::Window* parent_window, ImageEditor* editor)
     generate_new_mask();
 }
 
-void ImageMasking::revert_possible_changes()
-{
-    if (m_did_change && m_reference_mask) {
-        MUST(m_editor->active_layer()->set_bitmaps(m_editor->active_layer()->content_bitmap(), m_reference_mask.release_nonnull()));
-        m_editor->layers_did_change();
-    }
-    cleanup_resources();
-}
-
 void ImageMasking::generate_new_mask()
 {
     ensure_reference_mask().release_value_but_fixme_should_propagate_errors();
@@ -109,35 +162,104 @@ void ImageMasking::generate_new_mask()
     if (m_reference_mask.is_null())
         return;
 
-    int min_luminosity_start = m_edge_masking_slider->lower_range();
-    int min_luminosity_full = m_full_masking_slider->lower_range();
-    int max_luminosity_full = m_full_masking_slider->upper_range();
-    int max_luminosity_end = m_edge_masking_slider->upper_range();
-    int current_content_luminosity, approximation_alpha;
-    bool has_start_range = min_luminosity_start != min_luminosity_full;
-    bool has_end_range = max_luminosity_end != max_luminosity_full;
-    Gfx::Color reference_mask_pixel, content_pixel;
+    if (m_masking_type == MaskingType::Luminosity) {
+        int min_luminosity_start = m_edge_masking_slider->lower_range();
+        int min_luminosity_full = m_full_masking_slider->lower_range();
+        int max_luminosity_full = m_full_masking_slider->upper_range();
+        int max_luminosity_end = m_edge_masking_slider->upper_range();
+        int current_content_luminosity, approximation_alpha;
+        bool has_start_range = min_luminosity_start != min_luminosity_full;
+        bool has_end_range = max_luminosity_end != max_luminosity_full;
+        Gfx::Color reference_mask_pixel, content_pixel;
 
-    for (int y = 0; y < m_reference_mask->height(); y++) {
-        for (int x = 0; x < m_reference_mask->width(); x++) {
-            reference_mask_pixel = m_reference_mask->get_pixel(x, y);
-            if (!reference_mask_pixel.alpha())
-                continue;
+        for (int y = 0; y < m_reference_mask->height(); y++) {
+            for (int x = 0; x < m_reference_mask->width(); x++) {
+                reference_mask_pixel = m_reference_mask->get_pixel(x, y);
+                if (!reference_mask_pixel.alpha())
+                    continue;
 
-            content_pixel = m_editor->active_layer()->content_bitmap().get_pixel(x, y);
-            current_content_luminosity = content_pixel.luminosity();
+                content_pixel = m_editor->active_layer()->content_bitmap().get_pixel(x, y);
+                current_content_luminosity = content_pixel.luminosity();
 
-            if (!content_pixel.alpha() || current_content_luminosity < min_luminosity_start || current_content_luminosity > max_luminosity_end) {
-                reference_mask_pixel.set_alpha(0);
-            } else if (current_content_luminosity >= min_luminosity_start && current_content_luminosity < min_luminosity_full && has_start_range) {
-                approximation_alpha = reference_mask_pixel.alpha() * static_cast<float>((current_content_luminosity - min_luminosity_start)) / (min_luminosity_full - min_luminosity_start);
-                reference_mask_pixel.set_alpha(approximation_alpha);
-            } else if (current_content_luminosity > max_luminosity_full && current_content_luminosity <= max_luminosity_end && has_end_range) {
-                approximation_alpha = reference_mask_pixel.alpha() * (1 - static_cast<float>((current_content_luminosity - max_luminosity_full)) / (max_luminosity_end - max_luminosity_full));
-                reference_mask_pixel.set_alpha(approximation_alpha);
+                if (!content_pixel.alpha() || current_content_luminosity < min_luminosity_start || current_content_luminosity > max_luminosity_end) {
+                    reference_mask_pixel.set_alpha(0);
+                } else if (current_content_luminosity >= min_luminosity_start && current_content_luminosity < min_luminosity_full && has_start_range) {
+                    approximation_alpha = reference_mask_pixel.alpha() * static_cast<float>((current_content_luminosity - min_luminosity_start)) / (min_luminosity_full - min_luminosity_start);
+                    reference_mask_pixel.set_alpha(approximation_alpha);
+                } else if (current_content_luminosity > max_luminosity_full && current_content_luminosity <= max_luminosity_end && has_end_range) {
+                    approximation_alpha = reference_mask_pixel.alpha() * (1 - static_cast<float>((current_content_luminosity - max_luminosity_full)) / (max_luminosity_end - max_luminosity_full));
+                    reference_mask_pixel.set_alpha(approximation_alpha);
+                }
+
+                m_editor->active_layer()->mask_bitmap()->set_pixel(x, y, reference_mask_pixel);
             }
+        }
+    }
 
-            m_editor->active_layer()->mask_bitmap()->set_pixel(x, y, reference_mask_pixel);
+    if (m_masking_type == MaskingType::Color) {
+        double lower_saturation = 1;
+        double upper_saturation = 1;
+        double lower_value = 1;
+        double upper_value = 1;
+
+        // m_saturation_value_masking_slider value description:
+        // - saturation part in the positive range
+        // - value part in the negative range
+        if (m_saturation_value_masking_slider->upper_range() <= 0) {
+            lower_value = (100 + m_saturation_value_masking_slider->lower_range()) / 100.0;
+            upper_value = (100 + m_saturation_value_masking_slider->upper_range()) / 100.0;
+        } else if (m_saturation_value_masking_slider->lower_range() >= 0) {
+            lower_saturation = 1.0 - (m_saturation_value_masking_slider->upper_range() / 100.0);
+            upper_saturation = 1.0 - (m_saturation_value_masking_slider->lower_range() / 100.0);
+        } else {
+            lower_value = (100 + m_saturation_value_masking_slider->lower_range()) / 100.0;
+            upper_value = 1.0;
+            lower_saturation = 1.0 - m_saturation_value_masking_slider->upper_range() / 100.0;
+            upper_saturation = 1;
+        }
+
+        double full_masking_edge = m_color_wheel_widget->hardness();
+        double gradient_masking_length = m_color_wheel_widget->color_range() - m_color_wheel_widget->hardness();
+        double corrected_current_hue;
+        double distance_to_selected_color = 0;
+        Gfx::Color reference_mask_pixel;
+        Gfx::HSV content_pixel_hsv;
+
+        for (int y = 0; y < m_reference_mask->height(); y++) {
+            for (int x = 0; x < m_reference_mask->width(); x++) {
+                reference_mask_pixel = m_reference_mask->get_pixel(x, y);
+                if (!reference_mask_pixel.alpha())
+                    continue;
+
+                content_pixel_hsv = m_editor->active_layer()->content_bitmap().get_pixel(x, y).to_hsv();
+
+                // check against saturation
+                if (!(lower_saturation <= content_pixel_hsv.saturation && upper_saturation >= content_pixel_hsv.saturation)) {
+                    m_editor->active_layer()->mask_bitmap()->set_pixel(x, y, reference_mask_pixel.with_alpha(0));
+                    continue;
+                }
+
+                // check against value
+                if (!(lower_value <= content_pixel_hsv.value && upper_value >= content_pixel_hsv.value)) {
+                    m_editor->active_layer()->mask_bitmap()->set_pixel(x, y, reference_mask_pixel.with_alpha(0));
+                    continue;
+                }
+
+                // check against hue
+                corrected_current_hue = content_pixel_hsv.hue - m_color_wheel_widget->hue();
+                distance_to_selected_color = AK::min(AK::abs(corrected_current_hue), AK::min(AK::abs(corrected_current_hue - 360), AK::abs(corrected_current_hue + 360)));
+                if (distance_to_selected_color > m_color_wheel_widget->color_range()) {
+                    m_editor->active_layer()->mask_bitmap()->set_pixel(x, y, reference_mask_pixel.with_alpha(0));
+                    continue;
+                }
+
+                if (distance_to_selected_color < full_masking_edge) {
+                    m_editor->active_layer()->mask_bitmap()->set_pixel(x, y, reference_mask_pixel);
+                    continue;
+                }
+
+                m_editor->active_layer()->mask_bitmap()->set_pixel(x, y, reference_mask_pixel.with_alpha(reference_mask_pixel.alpha() - (((distance_to_selected_color - full_masking_edge) * reference_mask_pixel.alpha()) / gradient_masking_length)));
+            }
         }
     }
 
@@ -153,10 +275,15 @@ ErrorOr<void> ImageMasking::ensure_reference_mask()
     return {};
 }
 
-void ImageMasking::cleanup_resources()
+void ImageMasking::on_done(GUI::Dialog::ExecResult result)
 {
+    if (result != GUI::Dialog::ExecResult::OK && m_did_change && m_reference_mask)
+        m_editor->active_layer()->set_bitmaps(m_editor->active_layer()->content_bitmap(), m_reference_mask.release_nonnull()).release_value_but_fixme_should_propagate_errors();
+
     if (m_reference_mask)
         m_reference_mask = nullptr;
+
+    m_editor->active_layer()->set_edit_mode(m_previous_edit_mode);
 }
 
 void RangeIllustrationWidget::paint_event(GUI::PaintEvent&)
@@ -174,4 +301,176 @@ void RangeIllustrationWidget::paint_event(GUI::PaintEvent&)
 
     painter.fill_path(illustration, Color::MidGray);
 }
+
+void ColorWheelWidget::paint_event(GUI::PaintEvent&)
+{
+    GUI::Painter painter(*this);
+    painter.save();
+
+    auto wedge_edge = Gfx::FloatPoint(0, -height() / 2);
+
+    float deg_as_radians = 10.0f * (AK::Pi<float> / 180);
+    Gfx::AffineTransform transform;
+    transform.rotate_radians(deg_as_radians);
+
+    painter.translate(width() / 2, height() / 2);
+
+    for (int deg = 0; deg < 360; deg += 10) {
+        auto rotated_edge = wedge_edge.transformed(transform);
+        Gfx::Path wedge;
+        wedge.move_to({
+            0,
+            0,
+        });
+        wedge.line_to(wedge_edge);
+        wedge.line_to(rotated_edge);
+        wedge.line_to({
+            0,
+            0,
+        });
+        wedge.close();
+
+        painter.fill_path(wedge, Color::from_hsv(deg, 1, 1));
+
+        wedge_edge = rotated_edge;
+    }
+
+    transform.rotate_radians(-deg_as_radians);
+    deg_as_radians = static_cast<float>(hue()) * (AK::Pi<float> / 180);
+    transform.rotate_radians(deg_as_radians);
+    auto selected_color = Gfx::FloatPoint(0, -height() / 2);
+    selected_color.transform_by(transform);
+
+    deg_as_radians = static_cast<float>(color_range()) * (AK::Pi<float> / 180);
+
+    auto selected_color_edge_1 = Gfx::FloatPoint(0, -height() / 2);
+    transform.rotate_radians(deg_as_radians);
+    selected_color_edge_1.transform_by(transform);
+
+    auto selected_color_edge_2 = Gfx::FloatPoint(0, -height() / 2);
+    transform.rotate_radians(-deg_as_radians);
+    transform.rotate_radians(-deg_as_radians);
+    selected_color_edge_2.transform_by(transform);
+
+    transform.rotate_radians(deg_as_radians);
+    deg_as_radians = static_cast<float>(color_range() * static_cast<double>(hardness()) / 100.0) * (AK::Pi<float> / 180);
+
+    auto hardness_edge_1 = Gfx::FloatPoint(0, -height() / 2);
+    transform.rotate_radians(deg_as_radians);
+    hardness_edge_1.transform_by(transform);
+
+    auto hardness_edge_2 = Gfx::FloatPoint(0, -height() / 2);
+    transform.rotate_radians(-deg_as_radians);
+    transform.rotate_radians(-deg_as_radians);
+    hardness_edge_2.transform_by(transform);
+
+    Gfx::AntiAliasingPainter aa_painter = Gfx::AntiAliasingPainter(painter);
+
+    aa_painter.draw_line(Gfx::IntPoint(0, 0), selected_color_edge_1.to_type<int>(), Color::White, 2);
+    aa_painter.draw_line(Gfx::IntPoint(0, 0), selected_color_edge_2.to_type<int>(), Color::White, 2);
+    aa_painter.draw_line(Gfx::IntPoint(0, 0), hardness_edge_1.to_type<int>(), Color::LightGray, 1);
+    aa_painter.draw_line(Gfx::IntPoint(0, 0), hardness_edge_2.to_type<int>(), Color::LightGray, 1);
+    aa_painter.draw_line(Gfx::IntPoint(0, 0), selected_color.to_type<int>(), Color::Black, 3);
+    aa_painter.fill_circle({ 0, 0 }, height() / 4, Color(Color::LightGray));
+    aa_painter.fill_circle({ 0, 0 }, (height() - 4) / 4, Color::from_hsv(hue(), 1, 1));
+
+    painter.restore();
+    auto hue_text = DeprecatedString::formatted("hue: {:.0}", hue());
+    painter.draw_text(rect().translated(1, 1), hue_text, Gfx::TextAlignment::Center, Color::Black);
+    painter.draw_text(rect(), hue_text, Gfx::TextAlignment::Center, Color::White);
+}
+
+void ColorWheelWidget::mousedown_event(GUI::MouseEvent& event)
+{
+    if (event.button() == GUI::MouseButton::Primary)
+        m_mouse_pressed = true;
+}
+
+void ColorWheelWidget::mouseup_event(GUI::MouseEvent& event)
+{
+    if (m_mouse_pressed)
+        calc_hue(event.position());
+    m_mouse_pressed = false;
+}
+
+void ColorWheelWidget::mousemove_event(GUI::MouseEvent& event)
+{
+    if (!m_mouse_pressed)
+        return;
+
+    calc_hue(event.position());
+}
+
+void ColorWheelWidget::mousewheel_event(GUI::MouseEvent& event)
+{
+    if (event.ctrl())
+        set_color_range(color_range() + event.wheel_delta_y());
+    else if (event.shift())
+        set_hardness(hardness() + event.wheel_delta_y());
+    else
+        set_hue(hue() + event.wheel_delta_y());
+}
+
+void ColorWheelWidget::set_hue(double value)
+{
+    if (value < 0)
+        value += 360.0;
+
+    value = AK::fmod(value, 360.0);
+    if (m_hue != value) {
+        m_hue = value;
+        update();
+
+        if (on_change)
+            on_change(hue(), color_range(), hardness());
+    }
+}
+
+double ColorWheelWidget::hue()
+{
+    return m_hue;
+}
+
+void ColorWheelWidget::calc_hue(Gfx::IntPoint const& position)
+{
+    auto center = Gfx::IntPoint(width() / 2, height() / 2);
+
+    auto angle = AK::atan2(static_cast<float>(position.y() - center.y()), static_cast<float>(position.x() - center.x())) * 180 / AK::Pi<float>;
+    set_hue(angle + 90);
+}
+
+double ColorWheelWidget::color_range()
+{
+    return m_color_range;
+}
+
+void ColorWheelWidget::set_color_range(double value)
+{
+    value = clamp(value, 0.0, 180.0);
+    if (m_color_range != value) {
+        m_color_range = value;
+        update();
+
+        if (on_change)
+            on_change(hue(), color_range(), hardness());
+    }
+}
+
+void ColorWheelWidget::set_hardness(int value)
+{
+    value = clamp(value, 0, 100);
+    if (m_hardness != value) {
+        m_hardness = value;
+        update();
+
+        if (on_change)
+            on_change(hue(), color_range(), hardness());
+    }
+}
+
+int ColorWheelWidget::hardness()
+{
+    return m_hardness;
+}
+
 }

--- a/Userland/Applications/PixelPaint/ImageMasking.h
+++ b/Userland/Applications/PixelPaint/ImageMasking.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, Torsten Engelmann <engelTorsten@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "ImageEditor.h"
+#include "Layer.h"
+#include <LibGUI/Dialog.h>
+#include <LibGUI/RangeSlider.h>
+#include <LibGUI/Widget.h>
+
+namespace PixelPaint {
+
+class ImageMasking final : public GUI::Dialog {
+    C_OBJECT(ImageMasking);
+
+public:
+    void revert_possible_changes();
+
+private:
+    ImageMasking(GUI::Window* parent_window, ImageEditor*);
+
+    ImageEditor* m_editor { nullptr };
+    RefPtr<Gfx::Bitmap> m_reference_mask { nullptr };
+    bool m_did_change = false;
+
+    RefPtr<GUI::RangeSlider> m_full_masking_slider = { nullptr };
+    RefPtr<GUI::RangeSlider> m_edge_masking_slider = { nullptr };
+
+    ErrorOr<void> ensure_reference_mask();
+    void generate_new_mask();
+    void cleanup_resources();
+};
+
+class RangeIllustrationWidget final : public GUI::Widget {
+    C_OBJECT(RangeIllustrationWidget)
+public:
+    virtual ~RangeIllustrationWidget() override = default;
+
+protected:
+    virtual void paint_event(GUI::PaintEvent&) override;
+
+private:
+    RangeIllustrationWidget(RefPtr<GUI::RangeSlider> edge_mask_values, RefPtr<GUI::RangeSlider> full_mask_values)
+    {
+        m_edge_mask_values = edge_mask_values;
+        m_full_mask_values = full_mask_values;
+    }
+    RefPtr<GUI::RangeSlider> m_edge_mask_values;
+    RefPtr<GUI::RangeSlider> m_full_mask_values;
+};
+
+}

--- a/Userland/Applications/PixelPaint/ImageMasking.h
+++ b/Userland/Applications/PixelPaint/ImageMasking.h
@@ -10,29 +10,41 @@
 #include "Layer.h"
 #include <LibGUI/Dialog.h>
 #include <LibGUI/RangeSlider.h>
+#include <LibGUI/Slider.h>
 #include <LibGUI/Widget.h>
 
 namespace PixelPaint {
+
+class ColorWheelWidget;
 
 class ImageMasking final : public GUI::Dialog {
     C_OBJECT(ImageMasking);
 
 public:
-    void revert_possible_changes();
+    enum class MaskingType {
+        Luminosity,
+        Color,
+    };
+
+protected:
+    void on_done(GUI::Dialog::ExecResult) override;
 
 private:
-    ImageMasking(GUI::Window* parent_window, ImageEditor*);
+    explicit ImageMasking(GUI::Window* parent_window, ImageEditor*, MaskingType masking_type);
 
+    MaskingType m_masking_type;
+    Layer::EditMode m_previous_edit_mode;
     ImageEditor* m_editor { nullptr };
     RefPtr<Gfx::Bitmap> m_reference_mask { nullptr };
     bool m_did_change = false;
 
     RefPtr<GUI::RangeSlider> m_full_masking_slider = { nullptr };
     RefPtr<GUI::RangeSlider> m_edge_masking_slider = { nullptr };
+    RefPtr<ColorWheelWidget> m_color_wheel_widget = { nullptr };
+    RefPtr<GUI::RangeSlider> m_saturation_value_masking_slider = { nullptr };
 
     ErrorOr<void> ensure_reference_mask();
     void generate_new_mask();
-    void cleanup_resources();
 };
 
 class RangeIllustrationWidget final : public GUI::Widget {
@@ -51,6 +63,35 @@ private:
     }
     RefPtr<GUI::RangeSlider> m_edge_mask_values;
     RefPtr<GUI::RangeSlider> m_full_mask_values;
+};
+
+class ColorWheelWidget final : public GUI::Widget {
+    C_OBJECT(ColorWheelWidget)
+public:
+    virtual ~ColorWheelWidget() override = default;
+    double hue();
+    void set_hue(double);
+    double color_range();
+    void set_color_range(double);
+    int hardness();
+    void set_hardness(int);
+    Function<void(double, double, int)> on_change;
+
+protected:
+    virtual void paint_event(GUI::PaintEvent&) override;
+    virtual void mousedown_event(GUI::MouseEvent&) override;
+    virtual void mousemove_event(GUI::MouseEvent&) override;
+    virtual void mouseup_event(GUI::MouseEvent&) override;
+    virtual void mousewheel_event(GUI::MouseEvent&) override;
+
+private:
+    ColorWheelWidget() = default;
+    double m_hue = 0;
+    double m_color_range = 0;
+    int m_hardness = 0;
+    bool m_mouse_pressed = false;
+
+    void calc_hue(Gfx::IntPoint const&);
 };
 
 }

--- a/Userland/Applications/PixelPaint/ImageProcessor.cpp
+++ b/Userland/Applications/PixelPaint/ImageProcessor.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "ImageProcessor.h"
+#include "Layer.h"
 
 namespace PixelPaint {
 
@@ -16,7 +17,18 @@ FilterApplicationCommand::FilterApplicationCommand(NonnullRefPtr<Filter> filter,
 
 void FilterApplicationCommand::execute()
 {
-    m_filter->apply(m_target_layer->get_scratch_edited_bitmap(), m_target_layer->get_scratch_edited_bitmap());
+    if (m_target_layer->mask_type() == Layer::MaskType::EditingMask && m_target_layer->edit_mode() == Layer::EditMode::Content) {
+        auto unchanged_source = m_target_layer->get_scratch_edited_bitmap().clone().release_value_but_fixme_should_propagate_errors();
+
+        m_filter->apply(m_target_layer->get_scratch_edited_bitmap(), m_target_layer->get_scratch_edited_bitmap());
+
+        for (int y = 0; y < m_target_layer->content_bitmap().height(); y++)
+            for (int x = 0; x < m_target_layer->content_bitmap().width(); x++)
+                m_target_layer->content_bitmap().set_pixel(x, y, m_target_layer->modify_pixel_with_editing_mask(x, y, m_target_layer->content_bitmap().get_pixel(x, y), unchanged_source->get_pixel(x, y)));
+    } else {
+        m_filter->apply(m_target_layer->get_scratch_edited_bitmap(), m_target_layer->get_scratch_edited_bitmap());
+    }
+
     m_filter->m_editor->gui_event_loop().deferred_invoke([strong_this = NonnullRefPtr(*this)]() {
         // HACK: we can't tell strong_this to not be const
         (*const_cast<NonnullRefPtr<Layer>*>(&strong_this->m_target_layer))->did_modify_bitmap(strong_this->m_target_layer->rect());

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -13,12 +13,14 @@
 #include <AK/Noncopyable.h>
 #include <AK/RefCounted.h>
 #include <AK/Weakable.h>
+#include <LibGUI/Event.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Painter.h>
 
 namespace PixelPaint {
 
 class Image;
+class ImageEditor;
 class Selection;
 
 class Layer
@@ -56,6 +58,8 @@ public:
     void apply_mask();
     void invert_mask();
     void clear_mask();
+    void set_mask_visibility(bool visible) { m_visible_mask = visible; }
+    bool mask_visibility() { return m_visible_mask; }
 
     Gfx::Bitmap& get_scratch_edited_bitmap();
 
@@ -126,6 +130,8 @@ public:
         return current_color.mixed_with(target_color, mask_intensity);
     }
 
+    void on_second_paint(ImageEditor&);
+
 private:
     Layer(Image&, NonnullRefPtr<Gfx::Bitmap>, DeprecatedString name);
 
@@ -140,6 +146,7 @@ private:
 
     bool m_selected { false };
     bool m_visible { true };
+    bool m_visible_mask { false };
 
     int m_opacity_percent { 100 };
 

--- a/Userland/Applications/PixelPaint/LuminosityMasking.gml
+++ b/Userland/Applications/PixelPaint/LuminosityMasking.gml
@@ -1,0 +1,65 @@
+@GUI::Frame {
+    fill_with_background_color: true
+    layout: @GUI::VerticalBoxLayout {
+        margins: [4]
+    }
+
+    @GUI::Widget {
+        layout: @GUI::VerticalBoxLayout {}
+
+        @GUI::Label {
+            name: "hint_label"
+            enabled: true
+            fixed_height: 20
+            visible: true
+            text: "Restrict mask to luminosity values:"
+            text_alignment: "CenterLeft"
+        }
+
+        @GUI::HorizontalRangeSlider {
+            name: "full_masking"
+            max: 255
+            min: 0
+            lower_range: 25
+            upper_range: 230
+            page_step: 10
+        }
+
+        @GUI::Widget {
+            name: "range_illustration"
+        }
+
+        @GUI::HorizontalRangeSlider {
+            name: "edge_masking"
+            max: 255
+            min: 0
+            lower_range: 0
+            upper_range: 255
+            page_step: 10
+        }
+
+        @GUI::CheckBox {
+            name: "mask_visibility"
+            text: "Show layer mask"
+        }
+
+        @GUI::HorizontalSeparator {}
+    }
+
+    @GUI::Widget {
+        layout: @GUI::HorizontalBoxLayout {}
+        fixed_height: 22
+
+        @GUI::Layout::Spacer {}
+
+        @GUI::DialogButton {
+            name: "apply_button"
+            text: "OK"
+        }
+
+        @GUI::DialogButton {
+            name: "cancel_button"
+            text: "Cancel"
+        }
+    }
+}

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -869,17 +869,32 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
     TRY(m_layer_menu->try_add_action(*m_toggle_mask_visibility_action));
 
     m_open_luminosity_masking_action = GUI::Action::create(
-        "Luminosity Masking", create_layer_mask_callback("Luminosity Masking", [&](Layer* active_layer) {
-            VERIFY(active_layer->mask_type() == Layer::MaskType::EditingMask);
-
+        "Luminosity Masking", [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
-            auto dialog = PixelPaint::ImageMasking::construct(&window, editor);
-            if (dialog->exec() != GUI::Dialog::ExecResult::OK)
-                dialog->revert_possible_changes();
-        }));
+            if (!editor->active_layer())
+                return;
+            VERIFY(editor->active_layer()->mask_type() == Layer::MaskType::EditingMask);
+
+            PixelPaint::ImageMasking::construct(&window, editor, ImageMasking::MaskingType::Luminosity)->exec();
+            m_layer_list_widget->repaint();
+        });
 
     TRY(m_layer_menu->try_add_action(*m_open_luminosity_masking_action));
+
+    m_open_color_masking_action = GUI::Action::create(
+        "Color Masking", [&](auto&) {
+            auto* editor = current_image_editor();
+            VERIFY(editor);
+            if (!editor->active_layer())
+                return;
+            VERIFY(editor->active_layer()->mask_type() == Layer::MaskType::EditingMask);
+
+            PixelPaint::ImageMasking::construct(&window, editor, ImageMasking::MaskingType::Color)->exec();
+            m_layer_list_widget->repaint();
+        });
+
+    TRY(m_layer_menu->try_add_action(*m_open_color_masking_action));
 
     TRY(m_layer_menu->try_add_separator());
 
@@ -1263,6 +1278,7 @@ void MainWidget::set_mask_actions_for_layer(Layer* layer)
     m_toggle_mask_visibility_action->set_visible(layer->mask_type() == Layer::MaskType::EditingMask);
     m_toggle_mask_visibility_action->set_checked(layer->mask_visibility());
     m_open_luminosity_masking_action->set_visible(layer->mask_type() == Layer::MaskType::EditingMask);
+    m_open_color_masking_action->set_visible(layer->mask_type() == Layer::MaskType::EditingMask);
 }
 
 void MainWidget::open_image(FileSystemAccessClient::File file)

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -810,13 +810,15 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         };
     };
 
+    auto mask_submenu = TRY(m_layer_menu->try_add_submenu("&Masks"_short_string));
+
     m_add_mask_action = GUI::Action::create(
         "Add M&ask", { Mod_Ctrl | Mod_Shift, Key_M }, g_icon_bag.add_mask, create_layer_mask_callback("Add Mask", [&](Layer* active_layer) {
             VERIFY(!active_layer->is_masked());
             if (auto maybe_error = active_layer->create_mask(Layer::MaskType::BasicMask); maybe_error.is_error())
                 GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to create layer mask: {}", maybe_error.release_error())));
         }));
-    TRY(m_layer_menu->try_add_action(*m_add_mask_action));
+    TRY(mask_submenu->try_add_action(*m_add_mask_action));
 
     m_add_editing_mask_action = GUI::Action::create(
         "Add E&diting Mask", { Mod_Ctrl | Mod_Alt, Key_E }, g_icon_bag.add_mask, create_layer_mask_callback("Add Editing Mask", [&](Layer* active_layer) {
@@ -824,35 +826,35 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             if (auto maybe_error = active_layer->create_mask(Layer::MaskType::EditingMask); maybe_error.is_error())
                 GUI::MessageBox::show_error(&window, MUST(String::formatted("Failed to create layer mask: {}", maybe_error.release_error())));
         }));
-    TRY(m_layer_menu->try_add_action(*m_add_editing_mask_action));
+    TRY(mask_submenu->try_add_action(*m_add_editing_mask_action));
 
     m_delete_mask_action = GUI::Action::create(
         "Delete Mask", create_layer_mask_callback("Delete Mask", [&](Layer* active_layer) {
             VERIFY(active_layer->is_masked());
             active_layer->delete_mask();
         }));
-    TRY(m_layer_menu->try_add_action(*m_delete_mask_action));
+    TRY(mask_submenu->try_add_action(*m_delete_mask_action));
 
     m_apply_mask_action = GUI::Action::create(
         "Apply Mask", create_layer_mask_callback("Apply Mask", [&](Layer* active_layer) {
             VERIFY(active_layer->is_masked());
             active_layer->apply_mask();
         }));
-    TRY(m_layer_menu->try_add_action(*m_apply_mask_action));
+    TRY(mask_submenu->try_add_action(*m_apply_mask_action));
 
     m_invert_mask_action = GUI::Action::create(
         "Invert Mask", create_layer_mask_callback("Invert Mask", [&](Layer* active_layer) {
             VERIFY(active_layer->is_masked());
             active_layer->invert_mask();
         }));
-    TRY(m_layer_menu->try_add_action(*m_invert_mask_action));
+    TRY(mask_submenu->try_add_action(*m_invert_mask_action));
 
     m_clear_mask_action = GUI::Action::create(
         "Clear Mask", create_layer_mask_callback("Clear Mask", [&](Layer* active_layer) {
             VERIFY(active_layer->is_masked());
             active_layer->clear_mask();
         }));
-    TRY(m_layer_menu->try_add_action(*m_clear_mask_action));
+    TRY(mask_submenu->try_add_action(*m_clear_mask_action));
 
     m_toggle_mask_visibility_action = GUI::Action::create_checkable(
         "Show Mask", [&](auto&) {
@@ -866,7 +868,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             editor->update();
         });
 
-    TRY(m_layer_menu->try_add_action(*m_toggle_mask_visibility_action));
+    TRY(mask_submenu->try_add_action(*m_toggle_mask_visibility_action));
 
     m_open_luminosity_masking_action = GUI::Action::create(
         "Luminosity Masking", [&](auto&) {
@@ -880,7 +882,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             m_layer_list_widget->repaint();
         });
 
-    TRY(m_layer_menu->try_add_action(*m_open_luminosity_masking_action));
+    TRY(mask_submenu->try_add_action(*m_open_luminosity_masking_action));
 
     m_open_color_masking_action = GUI::Action::create(
         "Color Masking", [&](auto&) {
@@ -894,7 +896,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             m_layer_list_widget->repaint();
         });
 
-    TRY(m_layer_menu->try_add_action(*m_open_color_masking_action));
+    TRY(mask_submenu->try_add_action(*m_open_color_masking_action));
 
     TRY(m_layer_menu->try_add_separator());
 
@@ -1260,13 +1262,16 @@ void MainWidget::set_mask_actions_for_layer(Layer* layer)
 {
     if (!layer) {
         m_add_mask_action->set_visible(true);
+        m_add_editing_mask_action->set_visible(true);
         m_delete_mask_action->set_visible(false);
         m_apply_mask_action->set_visible(false);
         m_add_mask_action->set_enabled(false);
+        m_add_editing_mask_action->set_enabled(false);
         return;
     }
 
     m_add_mask_action->set_enabled(true);
+    m_add_editing_mask_action->set_enabled(true);
 
     auto masked = layer->is_masked();
     m_add_mask_action->set_visible(!masked);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -13,6 +13,7 @@
 #include "EditGuideDialog.h"
 #include "FilterGallery.h"
 #include "FilterParams.h"
+#include "ImageMasking.h"
 #include "LevelsDialog.h"
 #include "ResizeImageDialog.h"
 #include <AK/String.h>
@@ -867,6 +868,19 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
 
     TRY(m_layer_menu->try_add_action(*m_toggle_mask_visibility_action));
 
+    m_open_luminosity_masking_action = GUI::Action::create(
+        "Luminosity Masking", create_layer_mask_callback("Luminosity Masking", [&](Layer* active_layer) {
+            VERIFY(active_layer->mask_type() == Layer::MaskType::EditingMask);
+
+            auto* editor = current_image_editor();
+            VERIFY(editor);
+            auto dialog = PixelPaint::ImageMasking::construct(&window, editor);
+            if (dialog->exec() != GUI::Dialog::ExecResult::OK)
+                dialog->revert_possible_changes();
+        }));
+
+    TRY(m_layer_menu->try_add_action(*m_open_luminosity_masking_action));
+
     TRY(m_layer_menu->try_add_separator());
 
     TRY(m_layer_menu->try_add_action(GUI::Action::create(
@@ -1248,6 +1262,7 @@ void MainWidget::set_mask_actions_for_layer(Layer* layer)
     m_apply_mask_action->set_visible(layer->mask_type() == Layer::MaskType::BasicMask);
     m_toggle_mask_visibility_action->set_visible(layer->mask_type() == Layer::MaskType::EditingMask);
     m_toggle_mask_visibility_action->set_checked(layer->mask_visibility());
+    m_open_luminosity_masking_action->set_visible(layer->mask_type() == Layer::MaskType::EditingMask);
 }
 
 void MainWidget::open_image(FileSystemAccessClient::File file)

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -117,6 +117,7 @@ private:
     RefPtr<GUI::Action> m_add_editing_mask_action;
     RefPtr<GUI::Action> m_invert_mask_action;
     RefPtr<GUI::Action> m_clear_mask_action;
+    RefPtr<GUI::Action> m_toggle_mask_visibility_action;
 
     Gfx::IntPoint m_last_image_editor_mouse_position;
 };

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -119,6 +119,7 @@ private:
     RefPtr<GUI::Action> m_clear_mask_action;
     RefPtr<GUI::Action> m_toggle_mask_visibility_action;
     RefPtr<GUI::Action> m_open_luminosity_masking_action;
+    RefPtr<GUI::Action> m_open_color_masking_action;
 
     Gfx::IntPoint m_last_image_editor_mouse_position;
 };

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -118,6 +118,7 @@ private:
     RefPtr<GUI::Action> m_invert_mask_action;
     RefPtr<GUI::Action> m_clear_mask_action;
     RefPtr<GUI::Action> m_toggle_mask_visibility_action;
+    RefPtr<GUI::Action> m_open_luminosity_masking_action;
 
     Gfx::IntPoint m_last_image_editor_mouse_position;
 };

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -88,6 +88,7 @@ set(SOURCES
     ProcessChooser.cpp
     Progressbar.cpp
     RadioButton.cpp
+    RangeSlider.cpp
     RegularEditingEngine.cpp
     ResizeCorner.cpp
     RunningProcessesModel.cpp

--- a/Userland/Libraries/LibGUI/RangeSlider.cpp
+++ b/Userland/Libraries/LibGUI/RangeSlider.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2023, Torsten Engelmann <engelTorsten@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGUI/Painter.h>
+#include <LibGUI/RangeSlider.h>
+#include <LibGfx/Palette.h>
+#include <LibGfx/StylePainter.h>
+
+REGISTER_WIDGET(GUI, RangeSlider)
+REGISTER_WIDGET(GUI, HorizontalRangeSlider)
+
+namespace GUI {
+
+RangeSlider::RangeSlider(Gfx::Orientation orientation)
+    : AbstractSlider(orientation)
+
+{
+    REGISTER_INT_PROPERTY("lower_range", lower_range, set_lower_range);
+    REGISTER_INT_PROPERTY("upper_range", upper_range, set_upper_range);
+    REGISTER_BOOL_PROPERTY("show_label", show_label, set_show_label);
+
+    set_min(0);
+    set_max(100);
+    set_lower_range(0);
+    set_upper_range(100);
+    set_preferred_size(SpecialDimension::Fit);
+}
+
+Gfx::IntRect RangeSlider::frame_inner_rect() const
+{
+    return rect().shrunken(4, 4);
+}
+
+void RangeSlider::paint_event(PaintEvent& event)
+{
+    GUI::Painter painter(*this);
+    painter.add_clip_rect(event.rect());
+
+    auto inner_rect = frame_inner_rect();
+
+    // Grid pattern
+    Gfx::StylePainter::paint_transparency_grid(painter, inner_rect, palette());
+
+    // Alpha gradient
+    painter.fill_rect_with_linear_gradient(inner_rect, m_background_gradient, orientation() == Orientation::Horizontal ? 90.0f : 180.0f);
+
+    Gfx::StylePainter::paint_button(painter, knob_rect_for_value(lower_range()), palette(), Gfx::ButtonStyle::Normal, false, m_hovered_lower_knob);
+    Gfx::StylePainter::paint_button(painter, knob_rect_for_value(upper_range()), palette(), Gfx::ButtonStyle::Normal, false, m_hovered_upper_knob);
+
+    // Text label
+    if (m_show_label) {
+        auto range_text = DeprecatedString::formatted("{} to {}", lower_range(), upper_range());
+        painter.draw_text(inner_rect.translated(1, 1), range_text, Gfx::TextAlignment::Center, Color::Black);
+        painter.draw_text(inner_rect, range_text, Gfx::TextAlignment::Center, Color::White);
+    }
+
+    // Frame
+    Gfx::StylePainter::paint_frame(painter, rect(), palette(), Gfx::FrameStyle::SunkenContainer);
+}
+
+int RangeSlider::value_at(Gfx::IntPoint position) const
+{
+    auto inner_rect = frame_inner_rect();
+    auto relevant_position = position.primary_offset_for_orientation(orientation()),
+         begin_position = inner_rect.first_edge_for_orientation(orientation()),
+         end_position = inner_rect.last_edge_for_orientation(orientation());
+    if (relevant_position < begin_position)
+        return min();
+    if (relevant_position > end_position)
+        return max();
+
+    float relative_offset = static_cast<float>(relevant_position - begin_position) / static_cast<float>(inner_rect.primary_size_for_orientation(orientation()));
+    return min() + (relative_offset * static_cast<float>(max() - min()));
+}
+
+void RangeSlider::set_gradient_color(Gfx::Color from_color, Gfx::Color to_color)
+{
+    m_background_gradient = Vector { Gfx::ColorStop { from_color, 0 }, Gfx::ColorStop { to_color, 1 } };
+    update();
+}
+
+void RangeSlider::set_gradient_colors(Vector<Gfx::ColorStop> colors)
+{
+    VERIFY(colors.size());
+    m_background_gradient = colors;
+    update();
+}
+
+void RangeSlider::mousedown_event(MouseEvent& event)
+{
+    if (event.button() == MouseButton::Primary) {
+        m_dragging = true;
+        int clicked_value = value_at(event.position());
+        if (m_hovered_lower_knob)
+            set_lower_range(clicked_value);
+        if (m_hovered_upper_knob)
+            set_upper_range(clicked_value);
+        if (!m_hovered_lower_knob && !m_hovered_upper_knob) {
+            if (clicked_value < lower_range())
+                set_lower_range(lower_range() - AK::min(page_step(), lower_range() - clicked_value));
+            if (clicked_value > upper_range())
+                set_upper_range(upper_range() + AK::min(page_step(), clicked_value - upper_range()));
+            if (clicked_value > lower_range() && clicked_value < upper_range()) {
+                set_lower_range(lower_range() + page_step());
+                set_upper_range(upper_range() - page_step());
+            }
+        }
+
+        return;
+    }
+    AbstractSlider::mousedown_event(event);
+}
+
+void RangeSlider::mousemove_event(MouseEvent& event)
+{
+    if (m_dragging) {
+        if (m_hovered_lower_knob)
+            set_lower_range(value_at(event.position()));
+        if (m_hovered_upper_knob)
+            set_upper_range(value_at(event.position()));
+
+        return;
+    } else {
+        m_hovered_lower_knob = knob_rect_for_value(lower_range()).contains(event.position());
+        m_hovered_upper_knob = knob_rect_for_value(upper_range()).contains(event.position());
+    }
+    AbstractSlider::mousemove_event(event);
+}
+
+void RangeSlider::mouseup_event(MouseEvent& event)
+{
+    if (event.button() == MouseButton::Primary) {
+        m_dragging = false;
+        m_hovered_lower_knob = false;
+        m_hovered_upper_knob = false;
+        return;
+    }
+    AbstractSlider::mouseup_event(event);
+}
+
+void RangeSlider::mousewheel_event(MouseEvent& event)
+{
+    set_lower_range(lower_range() + event.wheel_delta_y());
+
+    if (event.ctrl())
+        set_upper_range(upper_range() + event.wheel_delta_y());
+    else
+        set_upper_range(upper_range() - event.wheel_delta_y());
+}
+
+Optional<UISize> RangeSlider::calculated_min_size() const
+{
+    if (orientation() == Gfx::Orientation::Vertical)
+        return { { 33, 40 } };
+    return { { 40, 22 } };
+}
+
+Optional<UISize> RangeSlider::calculated_preferred_size() const
+{
+    if (orientation() == Gfx::Orientation::Vertical)
+        return { { SpecialDimension::Shrink, SpecialDimension::OpportunisticGrow } };
+    return { { SpecialDimension::OpportunisticGrow, SpecialDimension::Shrink } };
+}
+
+Gfx::IntRect RangeSlider::knob_rect_for_value(int value) const
+{
+    auto knob_rect = frame_inner_rect();
+    knob_rect.set_left(knob_rect.left() + (static_cast<float>(value + AK::abs(min())) / static_cast<float>((max() - min())) * (knob_rect.width() - c_knob_width)));
+    knob_rect.set_width(c_knob_width);
+
+    return knob_rect;
+}
+
+void RangeSlider::set_lower_range(int value, AllowCallback allow_callback)
+{
+    if (lower_range() == value)
+        return;
+
+    if (value > upper_range())
+        m_lower_range = upper_range();
+    else
+        m_lower_range = clamp(value, min(), max());
+
+    if (on_range_change && allow_callback == AllowCallback::Yes)
+        on_range_change(lower_range(), upper_range());
+
+    update();
+}
+
+int RangeSlider::lower_range()
+{
+    return m_lower_range;
+}
+
+void RangeSlider::set_upper_range(int value, AllowCallback allow_callback)
+{
+    if (upper_range() == value)
+        return;
+    if (value < lower_range())
+        m_upper_range = lower_range();
+    else
+        m_upper_range = clamp(value, min(), max());
+
+    if (on_range_change && allow_callback == AllowCallback::Yes)
+        on_range_change(lower_range(), upper_range());
+
+    update();
+}
+
+int RangeSlider::upper_range()
+{
+    return m_upper_range;
+}
+
+void RangeSlider::set_range(int min, int max)
+{
+    AbstractSlider::set_range(min, max);
+    set_lower_range(clamp(lower_range(), AbstractSlider::min(), AbstractSlider::max()), AllowCallback::No);
+    set_upper_range(clamp(upper_range(), AbstractSlider::min(), AbstractSlider::max()), AllowCallback::No);
+}
+
+void RangeSlider::set_show_label(bool show_label)
+{
+    m_show_label = show_label;
+}
+
+bool RangeSlider::show_label()
+{
+    return m_show_label;
+}
+
+}

--- a/Userland/Libraries/LibGUI/RangeSlider.h
+++ b/Userland/Libraries/LibGUI/RangeSlider.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023, Torsten Engelmann <engelTorsten@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/AbstractSlider.h>
+
+namespace GUI {
+
+class RangeSlider : public AbstractSlider {
+    C_OBJECT(RangeSlider);
+
+public:
+    virtual ~RangeSlider() override = default;
+
+    void set_gradient_color(Gfx::Color, Gfx::Color);
+    void set_gradient_colors(Vector<Gfx::ColorStop>);
+    void set_show_label(bool);
+    bool show_label();
+    void set_lower_range(int value, AllowCallback allow_callback = AllowCallback::Yes);
+    void set_upper_range(int value, AllowCallback allow_callback = AllowCallback::Yes);
+    int lower_range();
+    int upper_range();
+    void set_range(int min, int max);
+    Function<void(int, int)> on_range_change;
+
+protected:
+    explicit RangeSlider(Gfx::Orientation = Gfx::Orientation::Horizontal);
+
+    virtual void paint_event(PaintEvent&) override;
+    virtual void mousedown_event(MouseEvent&) override;
+    virtual void mousemove_event(MouseEvent&) override;
+    virtual void mouseup_event(MouseEvent&) override;
+    virtual void mousewheel_event(MouseEvent&) override;
+
+private:
+    Gfx::IntRect frame_inner_rect() const;
+
+    Vector<Gfx::ColorStop> m_background_gradient = Vector { Gfx::ColorStop { { 0, 0, 0, 0 }, 0 }, Gfx::ColorStop { { 0, 0, 0, 255 }, 1 } };
+
+    virtual Optional<UISize> calculated_min_size() const override;
+    virtual Optional<UISize> calculated_preferred_size() const override;
+
+    int value_at(Gfx::IntPoint) const;
+    Gfx::IntRect knob_rect_for_value(int value) const;
+
+    bool m_show_label { true };
+    bool m_dragging { false };
+    bool m_hovered_lower_knob { false };
+    bool m_hovered_upper_knob { false };
+    int m_lower_range = 0;
+    int m_upper_range = 0;
+    int const c_knob_width = 7;
+};
+
+class HorizontalRangeSlider final : public RangeSlider {
+    C_OBJECT(HorizontalRangeSlider);
+
+public:
+    virtual ~HorizontalRangeSlider() override = default;
+
+private:
+    HorizontalRangeSlider()
+        : RangeSlider(Orientation::Horizontal)
+    {
+    }
+};
+
+}

--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -129,7 +129,14 @@ Window& Menu::ensure_menu_window(Gfx::IntPoint position)
     auto calculate_window_rect = [&]() -> Gfx::IntRect {
         int window_height_available = screen.height() - frame_thickness() * 2;
         int max_window_height = (window_height_available / item_height()) * item_height() + frame_thickness() * 2;
-        int content_height = m_items.is_empty() ? 0 : m_items.last()->rect().bottom() + frame_thickness();
+        int content_height = 0;
+        // find the last visible item to determine the required menu height
+        for (size_t i = m_items.size(); i > 0; i--) {
+            if (m_items[i - 1]->is_visible()) {
+                content_height = m_items[i - 1]->rect().bottom() + frame_thickness();
+                break;
+            }
+        }
         int window_height = min(max_window_height, content_height);
         if (window_height < content_height) {
             m_scrollable = true;


### PR DESCRIPTION
This pr has the following new functions for editing masks:
- adds a option to make editing masks visible so that it's easier to make changes to the masks
- adds a "Luminisity Masking" function that can be used to refine editing masks to certain luminosity values of the content image
- adds a "Color Masking" function that can be used to refine editing masks based in the color of the content pixels
- filter gallery makes changes only to masked regions if a editing mask is defined
- makes image editing with PixelPaint more brrrr

Preview Luminosity Masking:
![PixelPaint_Luminosity_Masking](https://github.com/SerenityOS/serenity/assets/103676658/af10c34b-699f-4f1d-b547-b1ea0c6d8c06)

Preview Color Masking:
![PixelPaint_Color_Masking](https://github.com/SerenityOS/serenity/assets/103676658/9bfb641f-3552-4848-815d-0507fc24fb5b)

