### PR TITLE
LibWeb: Resolve auto margins on abspos elements in more cases

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-with-auto-margins-in-inline-axis.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-with-auto-margins-in-inline-axis.txt
@@ -1,0 +1,6 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x18 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x0 children: not-inline
+      BlockContainer <div#foo> at (350,1) content-size 100x100 positioned [BFC] children: not-inline
+      BlockContainer <div#bar> at (699,101) content-size 100x100 positioned [BFC] children: not-inline
+      BlockContainer <div#baz> at (1,201) content-size 100x100 positioned [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/input/block-and-inline/abspos-with-auto-margins-in-inline-axis.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/abspos-with-auto-margins-in-inline-axis.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html><style>
+    * {
+        border: 1px solid black;
+    }
+    div {
+        height: 100px;
+        width: 100px;
+        position: absolute;
+        height: 100px;
+    }
+    #foo {
+        margin: auto;
+        left: 0px;
+        right: 0px;
+        top: 0px;
+    }
+    #bar {
+        margin-left: auto;
+        margin-right: 0px;
+        left: 0px;
+        right: 0px;
+        top: 100px;
+    }
+    #baz {
+        margin-left: 0px;
+        margin-right: auto;
+        left: 0px;
+        right: 0px;
+        top: 200px;
+    }
+</style><div id=foo></div><div id=bar></div><div id=baz></div>


### PR DESCRIPTION
Specifically, we now handle cases where all three of `left`, `width` and `right` are non-`auto`.

Fixes the misaligned search box on https://bing.com/

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/068480ab-0b20-4ef8-b535-b0e1bc698758)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/fd53d6e6-0ccc-402f-a35e-92d28ce3a19d)
