### PR TITLE
man: Remove DeprecatedString

### DIFF
--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -430,6 +430,27 @@ void ArgsParser::add_option(DeprecatedString& value, char const* help_string, ch
     add_option(move(option));
 }
 
+void ArgsParser::add_option(String& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode)
+{
+    Option option {
+        OptionArgumentMode::Required,
+        help_string,
+        long_name,
+        short_name,
+        value_name,
+        [&value](StringView s) {
+            auto value_or_error = String::from_utf8(s);
+            if (value_or_error.is_error())
+                return false;
+
+            value = value_or_error.release_value();
+            return true;
+        },
+        hide_mode,
+    };
+    add_option(move(option));
+}
+
 void ArgsParser::add_option(StringView& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode)
 {
     Option option {
@@ -604,6 +625,25 @@ void ArgsParser::add_positional_argument(StringView& value, char const* help_str
         1,
         [&value](StringView s) {
             value = s;
+            return true;
+        }
+    };
+    add_positional_argument(move(arg));
+}
+
+void ArgsParser::add_positional_argument(String& value, char const* help_string, char const* name, Required required)
+{
+    Arg arg {
+        help_string,
+        name,
+        required == Required::Yes ? 1 : 0,
+        1,
+        [&value](StringView s) {
+            auto value_or_error = String::from_utf8(s);
+            if (value_or_error.is_error())
+                return false;
+
+            value = value_or_error.release_value();
             return true;
         }
     };

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -88,6 +88,7 @@ public:
     void add_ignored(char const* long_name, char short_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(bool& value, char const* help_string, char const* long_name, char short_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(DeprecatedString& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
+    void add_option(String& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(StringView& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     template<Integral I>
     void add_option(I& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
@@ -102,6 +103,7 @@ public:
     void add_positional_argument(Arg&&);
     void add_positional_argument(DeprecatedString& value, char const* help_string, char const* name, Required required = Required::Yes);
     void add_positional_argument(StringView& value, char const* help_string, char const* name, Required required = Required::Yes);
+    void add_positional_argument(String& value, char const* help_string, char const* name, Required required = Required::Yes);
     template<Integral I>
     void add_positional_argument(I& value, char const* help_string, char const* name, Required required = Required::Yes);
     void add_positional_argument(double& value, char const* help_string, char const* name, Required required = Required::Yes);

--- a/Userland/Libraries/LibMarkdown/Document.cpp
+++ b/Userland/Libraries/LibMarkdown/Document.cpp
@@ -43,15 +43,15 @@ DeprecatedString Document::render_to_inline_html() const
     return m_container->render_to_html();
 }
 
-DeprecatedString Document::render_for_terminal(size_t view_width) const
+ErrorOr<String> Document::render_for_terminal(size_t view_width) const
 {
     StringBuilder builder;
     for (auto& line : m_container->render_lines_for_terminal(view_width)) {
-        builder.append(line);
-        builder.append("\n"sv);
+        TRY(builder.try_append(line));
+        TRY(builder.try_append("\n"sv));
     }
 
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
 RecursionDecision Document::walk(Visitor& visitor) const

--- a/Userland/Libraries/LibMarkdown/Document.h
+++ b/Userland/Libraries/LibMarkdown/Document.h
@@ -8,6 +8,7 @@
 
 #include <AK/DeprecatedString.h>
 #include <AK/OwnPtr.h>
+#include <AK/String.h>
 #include <LibMarkdown/Block.h>
 #include <LibMarkdown/ContainerBlock.h>
 
@@ -21,7 +22,7 @@ public:
     }
     DeprecatedString render_to_html(StringView extra_head_contents = ""sv) const;
     DeprecatedString render_to_inline_html() const;
-    DeprecatedString render_for_terminal(size_t view_width = 0) const;
+    ErrorOr<String> render_for_terminal(size_t view_width = 0) const;
 
     /*
      * Walk recursively through the document tree. Returning `RecursionDecision::Recurse` from

--- a/Userland/Utilities/man.cpp
+++ b/Userland/Utilities/man.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/Assertions.h>
 #include <AK/ByteBuffer.h>
-#include <AK/DeprecatedString.h>
 #include <AK/String.h>
 #include <AK/Utf8View.h>
 #include <LibCore/ArgsParser.h>
@@ -22,9 +21,14 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-static ErrorOr<pid_t> pipe_to_pager(DeprecatedString const& command)
+static ErrorOr<pid_t> pipe_to_pager(StringView command)
 {
-    char const* argv[] = { "Shell", "-c", command.characters(), nullptr };
+    StringBuilder builder;
+    TRY(builder.try_append(command));
+    TRY(builder.try_append('\0'));
+    auto shell_command = builder.string_view().characters_without_null_termination();
+
+    char const* argv[] = { "Shell", "-c", shell_command, nullptr };
 
     auto stdout_pipe = TRY(Core::System::pipe2(O_CLOEXEC));
 
@@ -58,9 +62,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/bin", "x"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    DeprecatedString section_argument;
-    DeprecatedString name_argument;
-    DeprecatedString pager;
+    StringView section_argument;
+    StringView name_argument;
+    String pager;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Read manual pages. Try 'man man' to get started.");
@@ -80,9 +84,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (pager.is_empty())
         pager = TRY(String::formatted("less -P 'Manual Page {}({}) line %l?e (END):.'",
-                        TRY(page_name.replace("'"sv, "'\\''"sv, ReplaceMode::FirstOnly)),
-                        TRY(section->section_name().replace("'"sv, "'\\''"sv, ReplaceMode::FirstOnly))))
-                    .to_deprecated_string();
+            TRY(page_name.replace("'"sv, "'\\''"sv, ReplaceMode::FirstOnly)),
+            TRY(section->section_name().replace("'"sv, "'\\''"sv, ReplaceMode::FirstOnly))));
     pid_t pager_pid = TRY(pipe_to_pager(pager));
 
     auto file = TRY(Core::File::open(TRY(page->path()), Core::File::OpenMode::Read));
@@ -91,14 +94,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     dbgln("Loading man page from {}", TRY(page->path()));
     auto buffer = TRY(file->read_until_eof());
-    auto source = DeprecatedString::copy(buffer);
 
     auto const title = TRY("SerenityOS manual"_string);
 
     int spaces = max(view_width / 2 - page_name.code_points().length() - section->section_name().code_points().length() - title.code_points().length() / 2 - 4, 0);
-    outln("{}({}){}{}", page_name, section->section_name(), DeprecatedString::repeated(' ', spaces), title);
+    outln("{}({}){}{}", page_name, section->section_name(), String::repeated(' ', spaces), title);
 
-    auto document = Markdown::Document::parse(source);
+    auto document = Markdown::Document::parse(buffer);
     VERIFY(document);
 
     auto rendered = TRY(document->render_for_terminal(view_width));

--- a/Userland/Utilities/man.cpp
+++ b/Userland/Utilities/man.cpp
@@ -7,6 +7,7 @@
 #include <AK/Assertions.h>
 #include <AK/ByteBuffer.h>
 #include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <AK/Utf8View.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
@@ -100,7 +101,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto document = Markdown::Document::parse(source);
     VERIFY(document);
 
-    DeprecatedString rendered = document->render_for_terminal(view_width);
+    auto rendered = TRY(document->render_for_terminal(view_width));
     outln("{}", rendered);
 
     // FIXME: Remove this wait, it shouldn't be necessary but Shell does not

--- a/Userland/Utilities/md.cpp
+++ b/Userland/Utilities/md.cpp
@@ -56,7 +56,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    DeprecatedString res = html ? document->render_to_html() : document->render_for_terminal(view_width);
-    out("{}", res);
+    if (html) {
+        out("{}", document->render_to_html());
+    } else {
+        out("{}", TRY(document->render_for_terminal(view_width)));
+    }
+
     return 0;
 }


### PR DESCRIPTION
Related to #17128

This pull request requires the minimum set of patches that I could think of to remove `DeprecatedString` from the `man` utility.

This includes:
* Adding `String` variants to `add_option` and `add_positional_argument` in the `ArgsParser`
* Converting `render_to_terminal` from `DeprecatedString` to `ErrorOr<String>` (which meant also changing the `md` utility)
* Removing all of the `DeprecatedString` from `man`

When converting `render_to_terminal` to `ErrorOr<String>` I made a conscious decision to ignore the other methods on the class, even if they would have been simple to convert, in order to keep the patch as small as possible.

As discussed on the Discord another possible improvement here would be to have a version of `Core::System::posix_spawnp` that can take `StringView`s instead of `const char*`, but I think that is something best dealt with in another pull request.