### PR TITLE
LibCore: Fallback to fstat() on systems without d_type support

### DIFF
--- a/Userland/Libraries/LibCore/DirIterator.cpp
+++ b/Userland/Libraries/LibCore/DirIterator.cpp
@@ -56,7 +56,11 @@ bool DirIterator::advance_next()
             return false;
         }
 
+#ifdef AK_OS_SOLARIS
+        m_next = DirectoryEntry::from_stat(m_dir, *de);
+#else
         m_next = DirectoryEntry::from_dirent(*de);
+#endif
 
         if (m_next->name.is_empty())
             return false;

--- a/Userland/Libraries/LibCore/DirectoryEntry.h
+++ b/Userland/Libraries/LibCore/DirectoryEntry.h
@@ -7,8 +7,7 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
-
-struct dirent;
+#include <dirent.h>
 
 namespace Core {
 
@@ -29,6 +28,7 @@ struct DirectoryEntry {
     DeprecatedString name;
 
     static DirectoryEntry from_dirent(dirent const&);
+    static DirectoryEntry from_stat(DIR*, dirent const&);
 };
 
 }


### PR DESCRIPTION
Solaris/Illumos does not have a d_type in its dirent struct, so building on Solaris was broken since March 5.
See here: https://software.cfht.hawaii.edu/man/solaris/dirent(4)
(I initially thought it would work on Solaris when I submitted a patch only for OpenBSD, but I was wrong)
Now, months after maintaining my ugly local hack that always returns DirectoryEntry::Type::Unknown, I finally wrote a clean solution that falls back to using fstat on Solaris, and possibly other OSes that don't have d_type (are there any?).
I verified that Ladybird builds and runs fine on Solaris with this change.
I also verified that I haven't broken it for other operating systems by building that change on FreeBSD.