### PR TITLE
Libmarkdown to string

### DIFF
--- a/Tests/LibMarkdown/TestCommonmark.cpp
+++ b/Tests/LibMarkdown/TestCommonmark.cpp
@@ -41,7 +41,9 @@ TEST_SETUP
         Test::TestSuite::the().add_case(adopt_ref(*new Test::TestCase(
             name, [markdown, html]() {
                 auto document = Markdown::Document::parse(markdown);
-                EXPECT_EQ(document->render_to_inline_html(), html);
+                EXPECT_EQ(
+                    document->render_to_inline_html().release_value_but_fixme_should_propagate_errors(),
+                    String::from_deprecated_string(html).release_value_but_fixme_should_propagate_errors());
             },
             false)));
     }

--- a/Tests/LibMarkdown/TestImageSizeExtension.cpp
+++ b/Tests/LibMarkdown/TestImageSizeExtension.cpp
@@ -32,8 +32,8 @@ TEST_CASE(test_image_size_markdown_extension)
 {
     for (auto const& test_case : image_size_tests) {
         auto document = Markdown::Document::parse(test_case.markdown);
-        auto raw_rendered_html = document->render_to_inline_html();
-        auto rendered_html = StringView(raw_rendered_html).trim_whitespace();
+        auto raw_rendered_html = document->render_to_inline_html().release_value_but_fixme_should_propagate_errors();
+        StringView rendered_html = raw_rendered_html.bytes_as_string_view().trim_whitespace();
         EXPECT_EQ(rendered_html, test_case.expected_html);
     }
 }

--- a/Userland/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Userland/Applications/Spreadsheet/HelpWindow.cpp
@@ -124,7 +124,8 @@ HelpWindow::HelpWindow(GUI::Window* parent)
             window->show();
         } else if (url.host() == "doc") {
             auto entry = LexicalPath::basename(url.serialize_path());
-            m_webview->load(URL::create_with_data("text/html", render(entry)));
+            auto payload = render(entry).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
+            m_webview->load(URL::create_with_data("text/html", payload));
         } else {
             dbgln("Invalid spreadsheet action domain '{}'", url.host());
         }
@@ -135,11 +136,12 @@ HelpWindow::HelpWindow(GUI::Window* parent)
             return;
 
         auto key = static_cast<HelpListModel*>(m_listview->model())->key(index);
-        m_webview->load(URL::create_with_data("text/html", render(key)));
+        auto payload = render(key).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
+        m_webview->load(URL::create_with_data("text/html", payload));
     };
 }
 
-DeprecatedString HelpWindow::render(StringView key)
+ErrorOr<String> HelpWindow::render(StringView key)
 {
     VERIFY(m_docs.has_object(key));
     auto& doc = m_docs.get_object(key).value();

--- a/Userland/Applications/Spreadsheet/HelpWindow.h
+++ b/Userland/Applications/Spreadsheet/HelpWindow.h
@@ -32,7 +32,7 @@ public:
 
 private:
     static RefPtr<HelpWindow> s_the;
-    DeprecatedString render(StringView key);
+    ErrorOr<String> render(StringView key);
     HelpWindow(GUI::Window* parent = nullptr);
 
     JsonObject m_docs;

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -907,7 +907,7 @@ void MainWidget::update_markdown_preview()
 {
     auto document = Markdown::Document::parse(m_editor->text());
     if (document) {
-        auto html = document->render_to_html();
+        String html = document->render_to_html().release_value_but_fixme_should_propagate_errors();
         auto current_scroll_pos = m_page_view->visible_content_rect();
         m_page_view->load_html(html, URL::create_with_file_scheme(m_path));
         m_page_view->scroll_into_view(current_scroll_pos, true, true);

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -246,7 +246,8 @@ void Editor::show_documentation_tooltip_if_available(DeprecatedString const& hov
         return;
     }
 
-    s_tooltip_page_view->load_html(man_document->render_to_html("<style>body { background-color: #dac7b5; }</style>"sv), {});
+    String rendered_html = man_document->render_to_html("<style>body { background-color: #dac7b5; }</style>"sv).release_value_but_fixme_should_propagate_errors();
+    s_tooltip_page_view->load_html(rendered_html, {});
 
     s_tooltip_window->set_rect(0, 0, 500, 400);
     s_tooltip_window->move_to(screen_location.translated(4, 4));

--- a/Userland/Libraries/LibMarkdown/Document.cpp
+++ b/Userland/Libraries/LibMarkdown/Document.cpp
@@ -29,7 +29,8 @@ ErrorOr<String> Document::render_to_html(StringView extra_head_contents) const
 <body>
 )~~~"sv));
 
-    TRY(builder.try_append(render_to_inline_html()));
+    auto inline_html = TRY(render_to_inline_html());
+    TRY(builder.try_append(inline_html));
 
     TRY(builder.try_append(R"~~~(
 </body>
@@ -38,9 +39,9 @@ ErrorOr<String> Document::render_to_html(StringView extra_head_contents) const
     return builder.to_string();
 }
 
-DeprecatedString Document::render_to_inline_html() const
+ErrorOr<String> Document::render_to_inline_html() const
 {
-    return m_container->render_to_html();
+    return String::from_deprecated_string(m_container->render_to_html());
 }
 
 ErrorOr<String> Document::render_for_terminal(size_t view_width) const

--- a/Userland/Libraries/LibMarkdown/Document.cpp
+++ b/Userland/Libraries/LibMarkdown/Document.cpp
@@ -12,30 +12,30 @@
 
 namespace Markdown {
 
-DeprecatedString Document::render_to_html(StringView extra_head_contents) const
+ErrorOr<String> Document::render_to_html(StringView extra_head_contents) const
 {
     StringBuilder builder;
-    builder.append(R"~~~(<!DOCTYPE html>
+    TRY(builder.try_append(R"~~~(<!DOCTYPE html>
 <html>
 <head>
     <style>
         code { white-space: pre; }
     </style>
-)~~~"sv);
+)~~~"sv));
     if (!extra_head_contents.is_empty())
-        builder.append(extra_head_contents);
-    builder.append(R"~~~(
+        TRY(builder.try_append(extra_head_contents));
+    TRY(builder.try_append(R"~~~(
 </head>
 <body>
-)~~~"sv);
+)~~~"sv));
 
-    builder.append(render_to_inline_html());
+    TRY(builder.try_append(render_to_inline_html()));
 
-    builder.append(R"~~~(
+    TRY(builder.try_append(R"~~~(
 </body>
-</html>)~~~"sv);
+</html>)~~~"sv));
 
-    return builder.to_deprecated_string();
+    return builder.to_string();
 }
 
 DeprecatedString Document::render_to_inline_html() const

--- a/Userland/Libraries/LibMarkdown/Document.h
+++ b/Userland/Libraries/LibMarkdown/Document.h
@@ -21,7 +21,7 @@ public:
     {
     }
     ErrorOr<String> render_to_html(StringView extra_head_contents = ""sv) const;
-    DeprecatedString render_to_inline_html() const;
+    ErrorOr<String> render_to_inline_html() const;
     ErrorOr<String> render_for_terminal(size_t view_width = 0) const;
 
     /*

--- a/Userland/Libraries/LibMarkdown/Document.h
+++ b/Userland/Libraries/LibMarkdown/Document.h
@@ -20,7 +20,7 @@ public:
         : m_container(move(container))
     {
     }
-    DeprecatedString render_to_html(StringView extra_head_contents = ""sv) const;
+    ErrorOr<String> render_to_html(StringView extra_head_contents = ""sv) const;
     DeprecatedString render_to_inline_html() const;
     ErrorOr<String> render_for_terminal(size_t view_width = 0) const;
 

--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -72,7 +72,8 @@ static bool build_markdown_document(DOM::Document& document, ByteBuffer const& d
 </script>
 )~~~"sv;
 
-    auto parser = HTML::HTMLParser::create(document, markdown_document->render_to_html(extra_head_contents), "utf-8");
+    auto rendered_markdown = markdown_document->render_to_html(extra_head_contents).release_value_but_fixme_should_propagate_errors();
+    auto parser = HTML::HTMLParser::create(document, rendered_markdown, "utf-8");
     parser->run(document.url());
     return true;
 }

--- a/Userland/Utilities/md.cpp
+++ b/Userland/Utilities/md.cpp
@@ -56,11 +56,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    if (html) {
-        out("{}", document->render_to_html());
-    } else {
-        out("{}", TRY(document->render_for_terminal(view_width)));
-    }
+    out("{}", html ? TRY(document->render_to_html()) : TRY(document->render_for_terminal(view_width)));
 
     return 0;
 }


### PR DESCRIPTION
Related to #17128

This PR changes `Document::render_to_html` and `Document::render_to_inline_html` in `LibMarkdown` to return an `ErrorOr<String>` instead of a `DeprecatedString`, as well as changes to all the places that consume this function.

Almost all of the consumers of these functions do not have error propagation, so in the interests of keeping the diff small (and not getting yak baited) I have decided to use `release_allocated_value_but_fixme_should_propagate_errors()`.