### PR TITLE
LibGUI+Userland: Remember visible columns in FileManager table DirectoryView

### DIFF
--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -23,7 +23,7 @@ ClipboardHistoryModel::ClipboardHistoryModel()
 {
 }
 
-String ClipboardHistoryModel::column_name(int column) const
+ErrorOr<String> ClipboardHistoryModel::column_name(int column) const
 {
     switch (column) {
     case Column::Data:

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
@@ -60,7 +60,7 @@ private:
 
     // ^GUI::Model
     virtual int row_count(const GUI::ModelIndex&) const override { return m_history_items.size(); }
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual int column_count(const GUI::ModelIndex&) const override { return Column::__Count; }
 
     // ^GUI::Clipboard::ClipboardClient

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -190,7 +190,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     };
 
-    text_box.on_change = Core::debounce([&]() {
+    text_box.on_change = Core::debounce(5, [&]() {
         {
             Threading::MutexLocker locker(app_state.lock);
             if (app_state.last_query == text_box.text())
@@ -200,8 +200,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
         db.search(text_box.text());
-    },
-        5);
+    });
     text_box.on_return_pressed = [&]() {
         if (!app_state.selected_index.has_value())
             return;

--- a/Userland/Applications/Browser/CookiesModel.cpp
+++ b/Userland/Applications/Browser/CookiesModel.cpp
@@ -34,7 +34,7 @@ int CookiesModel::row_count(GUI::ModelIndex const& index) const
     return 0;
 }
 
-String CookiesModel::column_name(int column) const
+ErrorOr<String> CookiesModel::column_name(int column) const
 {
     switch (column) {
     case Column::Domain:
@@ -46,14 +46,14 @@ String CookiesModel::column_name(int column) const
     case Column::Value:
         return "Value"_short_string;
     case Column::ExpiryTime:
-        return "Expiry time"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Expiry time"_string);
     case Column::SameSite:
-        return "SameSite"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("SameSite"_string);
     case Column::__Count:
-        return {};
+        return String {};
     }
 
-    return {};
+    return String {};
 }
 
 GUI::ModelIndex CookiesModel::index(int row, int column, GUI::ModelIndex const&) const

--- a/Userland/Applications/Browser/CookiesModel.h
+++ b/Userland/Applications/Browser/CookiesModel.h
@@ -30,7 +30,7 @@ public:
     void clear_items();
     virtual int row_count(GUI::ModelIndex const&) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual String column_name(int column) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::ModelIndex index(int row, int column = 0, GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role = GUI::ModelRole::Display) const override;
     virtual GUI::Model::MatchResult data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const override;

--- a/Userland/Applications/Browser/History/HistoryModel.cpp
+++ b/Userland/Applications/Browser/History/HistoryModel.cpp
@@ -34,7 +34,7 @@ int HistoryModel::row_count(GUI::ModelIndex const& index) const
     return 0;
 }
 
-String HistoryModel::column_name(int column) const
+ErrorOr<String> HistoryModel::column_name(int column) const
 {
     switch (column) {
     case Column::Title:
@@ -45,7 +45,7 @@ String HistoryModel::column_name(int column) const
         VERIFY_NOT_REACHED();
     }
 
-    return {};
+    return String {};
 }
 
 GUI::ModelIndex HistoryModel::index(int row, int column, GUI::ModelIndex const&) const

--- a/Userland/Applications/Browser/History/HistoryModel.h
+++ b/Userland/Applications/Browser/History/HistoryModel.h
@@ -25,7 +25,7 @@ public:
     void clear_items();
     virtual int row_count(GUI::ModelIndex const&) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual String column_name(int column) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::ModelIndex index(int row, int column = 0, GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role = GUI::ModelRole::Display) const override;
     virtual GUI::Model::MatchResult data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const override;

--- a/Userland/Applications/Browser/StorageModel.cpp
+++ b/Userland/Applications/Browser/StorageModel.cpp
@@ -35,7 +35,7 @@ int StorageModel::row_count(GUI::ModelIndex const& index) const
     return 0;
 }
 
-String StorageModel::column_name(int column) const
+ErrorOr<String> StorageModel::column_name(int column) const
 {
     switch (column) {
     case Column::Key:
@@ -43,10 +43,10 @@ String StorageModel::column_name(int column) const
     case Column::Value:
         return "Value"_short_string;
     case Column::__Count:
-        return {};
+        return String {};
     }
 
-    return {};
+    return String {};
 }
 
 GUI::ModelIndex StorageModel::index(int row, int column, GUI::ModelIndex const&) const

--- a/Userland/Applications/Browser/StorageModel.h
+++ b/Userland/Applications/Browser/StorageModel.h
@@ -22,7 +22,7 @@ public:
     void clear_items();
     virtual int row_count(GUI::ModelIndex const&) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual String column_name(int column) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::ModelIndex index(int row, int column = 0, GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role = GUI::ModelRole::Display) const override;
     virtual GUI::Model::MatchResult data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const override;

--- a/Userland/Applications/Calendar/AddEventDialog.cpp
+++ b/Userland/Applications/Calendar/AddEventDialog.cpp
@@ -120,7 +120,7 @@ int AddEventDialog::MeridiemListModel::row_count(const GUI::ModelIndex&) const
     return 2;
 }
 
-String AddEventDialog::MonthListModel::column_name(int column) const
+ErrorOr<String> AddEventDialog::MonthListModel::column_name(int column) const
 {
     switch (column) {
     case Column::Month:
@@ -130,11 +130,11 @@ String AddEventDialog::MonthListModel::column_name(int column) const
     }
 }
 
-String AddEventDialog::MeridiemListModel::column_name(int column) const
+ErrorOr<String> AddEventDialog::MeridiemListModel::column_name(int column) const
 {
     switch (column) {
     case Column::Meridiem:
-        return "Meridiem"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Meridiem"_string);
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Applications/Calendar/AddEventDialog.h
+++ b/Userland/Applications/Calendar/AddEventDialog.h
@@ -38,7 +38,7 @@ private:
 
         virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
         virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
-        virtual String column_name(int) const override;
+        virtual ErrorOr<String> column_name(int) const override;
         virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
     private:
@@ -57,7 +57,7 @@ private:
 
         virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
         virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
-        virtual String column_name(int) const override;
+        virtual ErrorOr<String> column_name(int) const override;
         virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
     private:

--- a/Userland/Applications/CertificateSettings/CertificateStoreWidget.cpp
+++ b/Userland/Applications/CertificateSettings/CertificateStoreWidget.cpp
@@ -34,15 +34,15 @@ ErrorOr<void> CertificateStoreModel::load()
     return {};
 }
 
-String CertificateStoreModel::column_name(int column) const
+ErrorOr<String> CertificateStoreModel::column_name(int column) const
 {
     switch (column) {
     case Column::IssuedTo:
-        return "Issued To"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Issued To"_string);
     case Column::IssuedBy:
-        return "Issued By"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Issued By"_string);
     case Column::Expire:
-        return "Expiration Date"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Expiration Date"_string);
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Applications/CertificateSettings/CertificateStoreWidget.h
+++ b/Userland/Applications/CertificateSettings/CertificateStoreWidget.h
@@ -44,7 +44,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return m_certificates.size(); }
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual ErrorOr<void> load();
     virtual ErrorOr<size_t> add(Vector<Certificate> const&);

--- a/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
@@ -62,7 +62,7 @@ CharacterSearchWidget::CharacterSearchWidget()
     m_search_input->on_up_pressed = [this] { m_results_table->move_cursor(GUI::AbstractView::CursorMovement::Up, GUI::AbstractView::SelectionUpdate::Set); };
     m_search_input->on_down_pressed = [this] { m_results_table->move_cursor(GUI::AbstractView::CursorMovement::Down, GUI::AbstractView::SelectionUpdate::Set); };
 
-    m_search_input->on_change = Core::debounce([this] { search(); }, 100);
+    m_search_input->on_change = Core::debounce(100, [this] { search(); });
 
     m_results_table->horizontal_scrollbar().set_visible(false);
     m_results_table->set_column_headers_visible(false);

--- a/Userland/Applications/HexEditor/SearchResultsModel.h
+++ b/Userland/Applications/HexEditor/SearchResultsModel.h
@@ -40,7 +40,7 @@ public:
         return 2;
     }
 
-    String column_name(int column) const override
+    ErrorOr<String> column_name(int column) const override
     {
         switch (column) {
         case Column::Offset:

--- a/Userland/Applications/HexEditor/ValueInspectorModel.h
+++ b/Userland/Applications/HexEditor/ValueInspectorModel.h
@@ -63,13 +63,13 @@ public:
         return 2;
     }
 
-    String column_name(int column) const override
+    ErrorOr<String> column_name(int column) const override
     {
         switch (column) {
         case Column::Type:
             return "Type"_short_string;
         case Column::Value:
-            return m_is_little_endian ? "Value (Little Endian)"_string.release_value_but_fixme_should_propagate_errors() : "Value (Big Endian)"_string.release_value_but_fixme_should_propagate_errors();
+            return m_is_little_endian ? TRY("Value (Little Endian)"_string) : TRY("Value (Big Endian)"_string);
         }
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Applications/Mail/InboxModel.cpp
+++ b/Userland/Applications/Mail/InboxModel.cpp
@@ -17,7 +17,7 @@ int InboxModel::row_count(GUI::ModelIndex const&) const
     return m_entries.size();
 }
 
-String InboxModel::column_name(int column_index) const
+ErrorOr<String> InboxModel::column_name(int column_index) const
 {
     switch (column_index) {
     case Column::From:

--- a/Userland/Applications/Mail/InboxModel.h
+++ b/Userland/Applications/Mail/InboxModel.h
@@ -32,7 +32,7 @@ public:
 
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
 private:

--- a/Userland/Applications/MouseSettings/ThemeWidget.cpp
+++ b/Userland/Applications/MouseSettings/ThemeWidget.cpp
@@ -15,11 +15,11 @@
 #include <LibGUI/SortingProxyModel.h>
 #include <LibGUI/TableView.h>
 
-String MouseCursorModel::column_name(int column_index) const
+ErrorOr<String> MouseCursorModel::column_name(int column_index) const
 {
     switch (column_index) {
     case Column::Bitmap:
-        return {};
+        return String {};
     case Column::Name:
         return "Name"_short_string;
     }

--- a/Userland/Applications/MouseSettings/ThemeWidget.h
+++ b/Userland/Applications/MouseSettings/ThemeWidget.h
@@ -25,7 +25,7 @@ public:
     virtual int row_count(const GUI::ModelIndex&) const override { return m_cursors.size(); }
     virtual int column_count(const GUI::ModelIndex&) const override { return Column::__Count; }
 
-    virtual String column_name(int column_index) const override;
+    virtual ErrorOr<String> column_name(int column_index) const override;
     virtual GUI::Variant data(const GUI::ModelIndex& index, GUI::ModelRole role) const override;
     virtual void invalidate() override;
 

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -64,7 +64,7 @@ public:
         return Columns::Page;
     }
 
-    String column_name(int index) const override
+    ErrorOr<String> column_name(int index) const override
     {
         switch (index) {
         case 0:

--- a/Userland/Applications/PartitionEditor/PartitionModel.cpp
+++ b/Userland/Applications/PartitionEditor/PartitionModel.cpp
@@ -17,17 +17,17 @@ NonnullRefPtr<PartitionModel> PartitionModel::create()
     return adopt_ref(*new PartitionModel);
 }
 
-String PartitionModel::column_name(int column) const
+ErrorOr<String> PartitionModel::column_name(int column) const
 {
     switch (column) {
     case Column::Partition:
-        return "Partition"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Partition"_string);
     case Column::StartBlock:
-        return "Start Block"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Start Block"_string);
     case Column::EndBlock:
-        return "End Block"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("End Block"_string);
     case Column::TotalBlocks:
-        return "Total Blocks"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Total Blocks"_string);
     case Column::Size:
         return "Size"_short_string;
     default:

--- a/Userland/Applications/PartitionEditor/PartitionModel.h
+++ b/Userland/Applications/PartitionEditor/PartitionModel.h
@@ -28,7 +28,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return m_partition_table->partitions_count(); }
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
 
     ErrorOr<void> set_device_path(DeprecatedString const&);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1299,13 +1299,12 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
         m_tab_widget->set_tab_title(image_editor, title);
     };
 
-    image_editor.on_modified_change = Core::debounce([&](auto const modified) {
+    image_editor.on_modified_change = Core::debounce(100, [&](auto const modified) {
         m_tab_widget->set_tab_modified(image_editor, modified);
         update_window_modified();
         m_histogram_widget->image_changed();
         m_vectorscope_widget->image_changed();
-    },
-        100);
+    });
 
     image_editor.on_image_mouse_position_change = [&](auto const& mouse_position) {
         auto const& image_size = current_image_editor()->image().size();
@@ -1340,11 +1339,10 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
         m_show_rulers_action->set_checked(show_rulers);
     };
 
-    image_editor.on_scale_change = Core::debounce([this](float scale) {
+    image_editor.on_scale_change = Core::debounce(100, [this](float scale) {
         m_zoom_combobox->set_text(DeprecatedString::formatted("{}%", roundf(scale * 100)));
         current_image_editor()->update_tool_cursor();
-    },
-        100);
+    });
 
     image_editor.on_primary_color_change = [&](Color color) {
         m_palette_widget->set_primary_color(color);

--- a/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
+++ b/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
@@ -73,13 +73,13 @@ DeprecatedString PlaylistModel::format_duration(u32 duration_in_seconds)
     return DeprecatedString::formatted("{:02}:{:02}:{:02}", duration_in_seconds / 3600, duration_in_seconds / 60, duration_in_seconds % 60);
 }
 
-String PlaylistModel::column_name(int column) const
+ErrorOr<String> PlaylistModel::column_name(int column) const
 {
     switch (column) {
     case 0:
         return "Title"_short_string;
     case 1:
-        return "Duration"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Duration"_string);
     case 2:
         return "Group"_short_string;
     case 3:
@@ -87,7 +87,7 @@ String PlaylistModel::column_name(int column) const
     case 4:
         return "Artist"_short_string;
     case 5:
-        return "Filesize"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Filesize"_string);
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Applications/SoundPlayer/PlaylistWidget.h
+++ b/Userland/Applications/SoundPlayer/PlaylistWidget.h
@@ -24,7 +24,7 @@ public:
     int row_count(const GUI::ModelIndex&) const override { return m_playlist_items.size(); }
     int column_count(const GUI::ModelIndex&) const override { return 6; }
     GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    String column_name(int column) const override;
+    ErrorOr<String> column_name(int column) const override;
     Vector<M3UEntry>& items() { return m_playlist_items; }
 
 private:

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -162,12 +162,12 @@ RefPtr<Core::MimeData> SheetModel::mime_data(const GUI::ModelSelection& selectio
     return mime_data;
 }
 
-String SheetModel::column_name(int index) const
+ErrorOr<String> SheetModel::column_name(int index) const
 {
     if (index < 0)
-        return {};
+        return String {};
 
-    return String::from_deprecated_string(m_sheet->column(index)).release_value_but_fixme_should_propagate_errors();
+    return TRY(String::from_deprecated_string(m_sheet->column(index)));
 }
 
 bool SheetModel::is_editable(const GUI::ModelIndex& index) const

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.h
@@ -23,7 +23,7 @@ public:
 
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_sheet->row_count(); }
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_sheet->column_count(); }
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
     virtual RefPtr<Core::MimeData> mime_data(const GUI::ModelSelection&) const override;
     virtual bool is_editable(const GUI::ModelIndex&) const override;

--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -71,11 +71,11 @@ int ProcessModel::column_count(GUI::ModelIndex const&) const
     return Column::__Count;
 }
 
-String ProcessModel::column_name(int column) const
+ErrorOr<String> ProcessModel::column_name(int column) const
 {
     switch (column) {
     case Column::Icon:
-        return {};
+        return String {};
     case Column::PID:
         return "PID"_short_string;
     case Column::TID:
@@ -95,7 +95,7 @@ String ProcessModel::column_name(int column) const
     case Column::Virtual:
         return "Virtual"_short_string;
     case Column::Physical:
-        return "Physical"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Physical"_string);
     case Column::DirtyPrivate:
         return "Private"_short_string;
     case Column::CleanInode:
@@ -107,11 +107,11 @@ String ProcessModel::column_name(int column) const
     case Column::CPU:
         return "CPU"_short_string;
     case Column::Processor:
-        return "Processor"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Processor"_string);
     case Column::Name:
         return "Name"_short_string;
     case Column::Syscalls:
-        return "Syscalls"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Syscalls"_string);
     case Column::InodeFaults:
         return "F:Inode"_short_string;
     case Column::ZeroFaults:
@@ -121,15 +121,15 @@ String ProcessModel::column_name(int column) const
     case Column::IPv4SocketReadBytes:
         return "IPv4 In"_short_string;
     case Column::IPv4SocketWriteBytes:
-        return "IPv4 Out"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("IPv4 Out"_string);
     case Column::UnixSocketReadBytes:
         return "Unix In"_short_string;
     case Column::UnixSocketWriteBytes:
-        return "Unix Out"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Unix Out"_string);
     case Column::FileReadBytes:
         return "File In"_short_string;
     case Column::FileWriteBytes:
-        return "File Out"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("File Out"_string);
     case Column::Pledge:
         return "Pledge"_short_string;
     case Column::Veil:

--- a/Userland/Applications/SystemMonitor/ProcessModel.h
+++ b/Userland/Applications/SystemMonitor/ProcessModel.h
@@ -63,7 +63,7 @@ public:
     virtual int tree_column() const override { return Column::Name; }
     virtual int row_count(GUI::ModelIndex const&) const override;
     virtual int column_count(GUI::ModelIndex const&) const override;
-    virtual String column_name(int column) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual GUI::ModelIndex index(int row, int column, GUI::ModelIndex const& parent = {}) const override;
     virtual GUI::ModelIndex parent_index(GUI::ModelIndex const&) const override;

--- a/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
@@ -48,7 +48,7 @@ public:
                     // NOTE: The icon column is nameless in ProcessModel, but we want it to have a name here.
                     return "Icon";
                 }
-                return m_target.column_name(index.row());
+                return m_target.column_name(index.row()).release_value_but_fixme_should_propagate_errors();
             }
             return m_target_index.sibling_at_column(index.row()).data();
         }

--- a/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
@@ -30,7 +30,7 @@ public:
     int row_count(GUI::ModelIndex const&) const override { return m_symbols.size(); };
     bool is_column_sortable(int) const override { return false; }
 
-    String column_name(int column) const override
+    ErrorOr<String> column_name(int column) const override
     {
         switch (column) {
         case Column::Address:

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -303,7 +303,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     for (auto column = 0; column < ProcessModel::Column::__Count; ++column) {
         process_table_view.set_column_visible(column,
-            Config::read_bool("SystemMonitor"sv, "ProcessTableColumns"sv, process_model->column_name(column),
+            Config::read_bool("SystemMonitor"sv, "ProcessTableColumns"sv, TRY(process_model->column_name(column)),
                 process_model->is_default_column(column)));
     }
 
@@ -516,7 +516,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // to be loaded the next time the application is opened.
     auto& process_table_header = process_table_view.column_header();
     for (auto column = 0; column < ProcessModel::Column::__Count; ++column)
-        Config::write_bool("SystemMonitor"sv, "ProcessTableColumns"sv, process_model->column_name(column), process_table_header.is_section_visible(column));
+        Config::write_bool("SystemMonitor"sv, "ProcessTableColumns"sv, TRY(process_model->column_name(column)), process_table_header.is_section_visible(column));
 
     return exec;
 }

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -70,10 +70,9 @@ MainWidget::MainWidget()
     if (font_entry != "default")
         m_editor->set_font(Gfx::FontDatabase::the().get_by_name(font_entry));
 
-    m_editor->on_change = Core::debounce([this] {
+    m_editor->on_change = Core::debounce(100, [this] {
         update_preview();
-    },
-        100);
+    });
 
     m_editor->on_modified_change = [this](bool modified) {
         window()->set_modified(modified);

--- a/Userland/Demos/ModelGallery/BasicModel.h
+++ b/Userland/Demos/ModelGallery/BasicModel.h
@@ -20,7 +20,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return m_items.size(); }
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return 1; }
-    virtual String column_name(int) const override { return "Item"_short_string; }
+    virtual ErrorOr<String> column_name(int) const override { return "Item"_short_string; }
 
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole = GUI::ModelRole::Display) const override;
     virtual GUI::Model::MatchResult data_matches(GUI::ModelIndex const&, GUI::Variant const&) const override;

--- a/Userland/Demos/WidgetGallery/GalleryModels.h
+++ b/Userland/Demos/WidgetGallery/GalleryModels.h
@@ -27,11 +27,11 @@ public:
 
     virtual int row_count(const GUI::ModelIndex&) const override { return m_cursors.size(); }
     virtual int column_count(const GUI::ModelIndex&) const override { return Column::__Count; }
-    virtual String column_name(int column_index) const override
+    virtual ErrorOr<String> column_name(int column_index) const override
     {
         switch (column_index) {
         case Column::Bitmap:
-            return {};
+            return String {};
         case Column::Name:
             return "Name"_short_string;
         }
@@ -112,13 +112,13 @@ public:
 
     virtual int row_count(const GUI::ModelIndex&) const override { return m_icon_sets.size(); }
     virtual int column_count(const GUI::ModelIndex&) const override { return Column::__Count; }
-    virtual String column_name(int column_index) const override
+    virtual ErrorOr<String> column_name(int column_index) const override
     {
         switch (column_index) {
         case Column::BigIcon:
-            return {};
+            return String {};
         case Column::LittleIcon:
-            return {};
+            return String {};
         case Column::Name:
             return "Name"_short_string;
         }

--- a/Userland/DevTools/HackStudio/Debugger/BacktraceModel.h
+++ b/Userland/DevTools/HackStudio/Debugger/BacktraceModel.h
@@ -27,7 +27,7 @@ public:
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_frames.size(); }
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return 1; }
 
-    virtual String column_name(int) const override { return {}; }
+    virtual ErrorOr<String> column_name(int) const override { return String {}; }
 
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 

--- a/Userland/DevTools/HackStudio/Debugger/DisassemblyModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/DisassemblyModel.cpp
@@ -73,18 +73,17 @@ int DisassemblyModel::row_count(const GUI::ModelIndex&) const
     return m_instructions.size();
 }
 
-String DisassemblyModel::column_name(int column) const
+ErrorOr<String> DisassemblyModel::column_name(int column) const
 {
     switch (column) {
     case Column::Address:
         return "Address"_short_string;
     case Column::InstructionBytes:
-        return "Insn Bytes"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Insn Bytes"_string);
     case Column::Disassembly:
-        return "Disassembly"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Disassembly"_string);
     default:
         VERIFY_NOT_REACHED();
-        return {};
     }
 }
 

--- a/Userland/DevTools/HackStudio/Debugger/DisassemblyModel.h
+++ b/Userland/DevTools/HackStudio/Debugger/DisassemblyModel.h
@@ -45,7 +45,7 @@ public:
 
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
 private:

--- a/Userland/DevTools/HackStudio/Debugger/RegistersModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/RegistersModel.cpp
@@ -86,16 +86,15 @@ int RegistersModel::row_count(const GUI::ModelIndex&) const
     return m_registers.size();
 }
 
-String RegistersModel::column_name(int column) const
+ErrorOr<String> RegistersModel::column_name(int column) const
 {
     switch (column) {
     case Column::Register:
-        return "Register"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Register"_string);
     case Column::Value:
         return "Value"_short_string;
     default:
         VERIFY_NOT_REACHED();
-        return {};
     }
 }
 

--- a/Userland/DevTools/HackStudio/Debugger/RegistersModel.h
+++ b/Userland/DevTools/HackStudio/Debugger/RegistersModel.h
@@ -41,7 +41,7 @@ public:
 
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
     PtraceRegisters const& raw_registers() const { return m_raw_registers; }

--- a/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.cpp
@@ -53,7 +53,7 @@ int ProjectTemplatesModel::column_count(const GUI::ModelIndex&) const
     return Column::__Count;
 }
 
-String ProjectTemplatesModel::column_name(int column) const
+ErrorOr<String> ProjectTemplatesModel::column_name(int column) const
 {
     switch (column) {
     case Column::Icon:

--- a/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.h
+++ b/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.h
@@ -35,7 +35,7 @@ public:
 
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
     void update();

--- a/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
+++ b/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
@@ -39,11 +39,11 @@ public:
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_matches.size(); }
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
 
-    virtual String column_name(int column) const override
+    virtual ErrorOr<String> column_name(int column) const override
     {
         switch (column) {
         case Column::Filename:
-            return "Filename"_string.release_value_but_fixme_should_propagate_errors();
+            return TRY("Filename"_string);
         case Column::Location:
             return "#"_short_string;
         case Column::MatchedText:

--- a/Userland/DevTools/HackStudio/Git/GitFilesModel.h
+++ b/Userland/DevTools/HackStudio/Git/GitFilesModel.h
@@ -19,7 +19,7 @@ public:
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_files.size(); }
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return 1; }
 
-    virtual String column_name(int) const override { return {}; }
+    virtual ErrorOr<String> column_name(int) const override { return String {}; }
 
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 

--- a/Userland/DevTools/HackStudio/ToDoEntriesWidget.cpp
+++ b/Userland/DevTools/HackStudio/ToDoEntriesWidget.cpp
@@ -30,11 +30,11 @@ public:
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return m_matches.size(); }
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
 
-    virtual String column_name(int column) const override
+    virtual ErrorOr<String> column_name(int column) const override
     {
         switch (column) {
         case Column::Filename:
-            return "Filename"_string.release_value_but_fixme_should_propagate_errors();
+            return TRY("Filename"_string);
         case Column::Text:
             return "Text"_short_string;
         case Column::Line:

--- a/Userland/DevTools/Profiler/DisassemblyModel.cpp
+++ b/Userland/DevTools/Profiler/DisassemblyModel.cpp
@@ -131,22 +131,21 @@ int DisassemblyModel::row_count(GUI::ModelIndex const&) const
     return m_instructions.size();
 }
 
-String DisassemblyModel::column_name(int column) const
+ErrorOr<String> DisassemblyModel::column_name(int column) const
 {
     switch (column) {
     case Column::SampleCount:
-        return m_profile.show_percentages() ? "% Samples"_string.release_value_but_fixme_should_propagate_errors() : "# Samples"_string.release_value_but_fixme_should_propagate_errors();
+        return m_profile.show_percentages() ? TRY("% Samples"_string) : TRY("# Samples"_string);
     case Column::Address:
         return "Address"_short_string;
     case Column::InstructionBytes:
-        return "Insn Bytes"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Insn Bytes"_string);
     case Column::Disassembly:
-        return "Disassembly"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Disassembly"_string);
     case Column::SourceLocation:
-        return "Source Location"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Source Location"_string);
     default:
         VERIFY_NOT_REACHED();
-        return {};
     }
 }
 

--- a/Userland/DevTools/Profiler/DisassemblyModel.h
+++ b/Userland/DevTools/Profiler/DisassemblyModel.h
@@ -46,7 +46,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual bool is_column_sortable(int) const override { return false; }
 

--- a/Userland/DevTools/Profiler/FilesystemEventModel.cpp
+++ b/Userland/DevTools/Profiler/FilesystemEventModel.cpp
@@ -142,18 +142,17 @@ int FileEventModel::column_count(GUI::ModelIndex const&) const
     return Column::__Count;
 }
 
-String FileEventModel::column_name(int column) const
+ErrorOr<String> FileEventModel::column_name(int column) const
 {
     switch (column) {
     case Column::Path:
         return "Path"_short_string;
     case Column::Count:
-        return "Event Count"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Event Count"_string);
     case Column::Duration:
-        return "Duration [ms]"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Duration [ms]"_string);
     default:
         VERIFY_NOT_REACHED();
-        return {};
     }
 }
 

--- a/Userland/DevTools/Profiler/FilesystemEventModel.h
+++ b/Userland/DevTools/Profiler/FilesystemEventModel.h
@@ -74,7 +74,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual GUI::ModelIndex index(int row, int column, GUI::ModelIndex const& parent = GUI::ModelIndex()) const override;
     virtual GUI::ModelIndex parent_index(GUI::ModelIndex const&) const override;

--- a/Userland/DevTools/Profiler/IndividualSampleModel.cpp
+++ b/Userland/DevTools/Profiler/IndividualSampleModel.cpp
@@ -29,7 +29,7 @@ int IndividualSampleModel::column_count(GUI::ModelIndex const&) const
     return Column::__Count;
 }
 
-String IndividualSampleModel::column_name(int column) const
+ErrorOr<String> IndividualSampleModel::column_name(int column) const
 {
     switch (column) {
     case Column::Address:

--- a/Userland/DevTools/Profiler/IndividualSampleModel.h
+++ b/Userland/DevTools/Profiler/IndividualSampleModel.h
@@ -31,7 +31,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
 
 private:

--- a/Userland/DevTools/Profiler/ProfileModel.cpp
+++ b/Userland/DevTools/Profiler/ProfileModel.cpp
@@ -74,22 +74,21 @@ int ProfileModel::column_count(GUI::ModelIndex const&) const
     return Column::__Count;
 }
 
-String ProfileModel::column_name(int column) const
+ErrorOr<String> ProfileModel::column_name(int column) const
 {
     switch (column) {
     case Column::SampleCount:
-        return m_profile.show_percentages() ? "% Samples"_string.release_value_but_fixme_should_propagate_errors() : "# Samples"_string.release_value_but_fixme_should_propagate_errors();
+        return m_profile.show_percentages() ? TRY("% Samples"_string) : TRY("# Samples"_string);
     case Column::SelfCount:
         return m_profile.show_percentages() ? "% Self"_short_string : "# Self"_short_string;
     case Column::ObjectName:
         return "Object"_short_string;
     case Column::StackFrame:
-        return "Stack Frame"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Stack Frame"_string);
     case Column::SymbolAddress:
-        return "Symbol Address"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Symbol Address"_string);
     default:
         VERIFY_NOT_REACHED();
-        return {};
     }
 }
 

--- a/Userland/DevTools/Profiler/ProfileModel.h
+++ b/Userland/DevTools/Profiler/ProfileModel.h
@@ -34,7 +34,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual GUI::ModelIndex index(int row, int column, GUI::ModelIndex const& parent = GUI::ModelIndex()) const override;
     virtual GUI::ModelIndex parent_index(GUI::ModelIndex const&) const override;

--- a/Userland/DevTools/Profiler/SamplesModel.cpp
+++ b/Userland/DevTools/Profiler/SamplesModel.cpp
@@ -28,23 +28,23 @@ int SamplesModel::column_count(GUI::ModelIndex const&) const
     return Column::__Count;
 }
 
-String SamplesModel::column_name(int column) const
+ErrorOr<String> SamplesModel::column_name(int column) const
 {
     switch (column) {
     case Column::SampleIndex:
         return "#"_short_string;
     case Column::Timestamp:
-        return "Timestamp"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Timestamp"_string);
     case Column::ProcessID:
         return "PID"_short_string;
     case Column::ThreadID:
         return "TID"_short_string;
     case Column::ExecutableName:
-        return "Executable"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Executable"_string);
     case Column::LostSamples:
-        return "Lost Samples"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Lost Samples"_string);
     case Column::InnermostStackFrame:
-        return "Innermost Frame"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Innermost Frame"_string);
     case Column::Path:
         return "Path"_short_string;
     default:

--- a/Userland/DevTools/Profiler/SamplesModel.h
+++ b/Userland/DevTools/Profiler/SamplesModel.h
@@ -36,7 +36,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual bool is_column_sortable(int) const override { return false; }
 

--- a/Userland/DevTools/Profiler/SignpostsModel.cpp
+++ b/Userland/DevTools/Profiler/SignpostsModel.cpp
@@ -26,23 +26,23 @@ int SignpostsModel::column_count(GUI::ModelIndex const&) const
     return Column::__Count;
 }
 
-String SignpostsModel::column_name(int column) const
+ErrorOr<String> SignpostsModel::column_name(int column) const
 {
     switch (column) {
     case Column::SignpostIndex:
         return "#"_short_string;
     case Column::Timestamp:
-        return "Timestamp"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Timestamp"_string);
     case Column::ProcessID:
         return "PID"_short_string;
     case Column::ThreadID:
         return "TID"_short_string;
     case Column::ExecutableName:
-        return "Executable"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Executable"_string);
     case Column::SignpostString:
         return "String"_short_string;
     case Column::SignpostArgument:
-        return "Argument"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Argument"_string);
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/DevTools/Profiler/SignpostsModel.h
+++ b/Userland/DevTools/Profiler/SignpostsModel.h
@@ -35,7 +35,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual bool is_column_sortable(int) const override { return false; }
 

--- a/Userland/DevTools/Profiler/SourceModel.cpp
+++ b/Userland/DevTools/Profiler/SourceModel.cpp
@@ -122,20 +122,19 @@ int SourceModel::row_count(GUI::ModelIndex const&) const
     return m_source_lines.size();
 }
 
-String SourceModel::column_name(int column) const
+ErrorOr<String> SourceModel::column_name(int column) const
 {
     switch (column) {
     case Column::SampleCount:
-        return m_profile.show_percentages() ? "% Samples"_string.release_value_but_fixme_should_propagate_errors() : "# Samples"_string.release_value_but_fixme_should_propagate_errors();
+        return m_profile.show_percentages() ? TRY("% Samples"_string) : TRY("# Samples"_string);
     case Column::SourceCode:
-        return "Source Code"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Source Code"_string);
     case Column::Location:
-        return "Location"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Location"_string);
     case Column::LineNumber:
         return "Line"_short_string;
     default:
         VERIFY_NOT_REACHED();
-        return {};
     }
 }
 

--- a/Userland/DevTools/Profiler/SourceModel.h
+++ b/Userland/DevTools/Profiler/SourceModel.h
@@ -38,7 +38,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual bool is_column_sortable(int) const override { return false; }
 

--- a/Userland/Libraries/LibCore/Debounce.h
+++ b/Userland/Libraries/LibCore/Debounce.h
@@ -11,7 +11,7 @@
 namespace Core {
 
 template<typename TFunction>
-auto debounce(TFunction function, int timeout)
+auto debounce(int timeout, TFunction function)
 {
     RefPtr<Core::Timer> timer;
     return [=]<typename... T>(T... args) mutable {

--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -58,7 +58,7 @@ void AbstractTableView::auto_resize_column(int column)
     auto& model = *this->model();
     int row_count = model.row_count();
 
-    int header_width = m_column_header->font().width(model.column_name(column));
+    int header_width = m_column_header->font().width(model.column_name(column).release_value_but_fixme_should_propagate_errors());
     if (column == m_key_column && model.is_column_sortable(column))
         header_width += HeaderView::sorting_arrow_width + HeaderView::sorting_arrow_offset;
 
@@ -97,7 +97,7 @@ void AbstractTableView::update_column_sizes()
     for (int column = 0; column < column_count; ++column) {
         if (!column_header().is_section_visible(column))
             continue;
-        int header_width = m_column_header->font().width(model.column_name(column));
+        int header_width = m_column_header->font().width(model.column_name(column).release_value_but_fixme_should_propagate_errors());
         if (column == m_key_column && model.is_column_sortable(column))
             header_width += HeaderView::sorting_arrow_width + HeaderView::sorting_arrow_offset;
         int column_width = header_width;

--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -376,6 +376,9 @@ void AbstractTableView::header_did_change_section_visibility(Badge<HeaderView>, 
 {
     update_content_size();
     update();
+
+    if (on_visible_columns_changed)
+        on_visible_columns_changed();
 }
 
 void AbstractTableView::set_default_column_width(int column, int width)

--- a/Userland/Libraries/LibGUI/AbstractTableView.h
+++ b/Userland/Libraries/LibGUI/AbstractTableView.h
@@ -44,6 +44,7 @@ public:
     // These return/accept a comma-separated list of column ids, for storing in a config file.
     ErrorOr<String> get_visible_columns() const;
     void set_visible_columns(StringView column_ids);
+    Function<void()> on_visible_columns_changed;
 
     int column_width(int column) const;
     void set_column_width(int column, int width);

--- a/Userland/Libraries/LibGUI/AbstractTableView.h
+++ b/Userland/Libraries/LibGUI/AbstractTableView.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, networkException <networkexception@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -40,6 +41,9 @@ public:
     void set_column_headers_visible(bool);
 
     void set_column_visible(int, bool);
+    // These return/accept a comma-separated list of column ids, for storing in a config file.
+    ErrorOr<String> get_visible_columns() const;
+    void set_visible_columns(StringView column_ids);
 
     int column_width(int column) const;
     void set_column_width(int column, int width);

--- a/Userland/Libraries/LibGUI/CommandPalette.cpp
+++ b/Userland/Libraries/LibGUI/CommandPalette.cpp
@@ -92,7 +92,7 @@ public:
         return Column::__Count;
     }
 
-    virtual String column_name(int) const override { return {}; }
+    virtual ErrorOr<String> column_name(int) const override { return String {}; }
 
     virtual ModelIndex index(int row, int column = 0, ModelIndex const& = ModelIndex()) const override
     {

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -761,11 +761,11 @@ int FileSystemModel::column_count(ModelIndex const&) const
     return Column::__Count;
 }
 
-String FileSystemModel::column_name(int column) const
+ErrorOr<String> FileSystemModel::column_name(int column) const
 {
     switch (column) {
     case Column::Icon:
-        return {};
+        return String {};
     case Column::Name:
         return "Name"_short_string;
     case Column::Size:
@@ -777,11 +777,11 @@ String FileSystemModel::column_name(int column) const
     case Column::Permissions:
         return "Mode"_short_string;
     case Column::ModificationTime:
-        return "Modified"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Modified"_string);
     case Column::Inode:
         return "Inode"_short_string;
     case Column::SymlinkTarget:
-        return "Symlink target"_string.release_value_but_fixme_should_propagate_errors();
+        return TRY("Symlink target"_string);
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibGUI/FileSystemModel.h
+++ b/Userland/Libraries/LibGUI/FileSystemModel.h
@@ -127,7 +127,7 @@ public:
     virtual int tree_column() const override { return Column::Name; }
     virtual int row_count(ModelIndex const& = ModelIndex()) const override;
     virtual int column_count(ModelIndex const& = ModelIndex()) const override;
-    virtual String column_name(int column) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const override;
     virtual ModelIndex parent_index(ModelIndex const&) const override;
     virtual ModelIndex index(int row, int column = 0, ModelIndex const& parent = ModelIndex()) const override;

--- a/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
@@ -34,7 +34,7 @@ int FilteringProxyModel::column_count(ModelIndex const& index) const
     return m_model->column_count(m_matching_indices[index.row()].index);
 }
 
-String FilteringProxyModel::column_name(int column) const
+ErrorOr<String> FilteringProxyModel::column_name(int column) const
 {
     return m_model->column_name(column);
 }

--- a/Userland/Libraries/LibGUI/FilteringProxyModel.h
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.h
@@ -35,7 +35,7 @@ public:
 
     virtual int row_count(ModelIndex const& = ModelIndex()) const override;
     virtual int column_count(ModelIndex const& = ModelIndex()) const override;
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const override;
     virtual void invalidate() override;
     virtual ModelIndex index(int row, int column = 0, ModelIndex const& parent = ModelIndex()) const override;

--- a/Userland/Libraries/LibGUI/HeaderView.cpp
+++ b/Userland/Libraries/LibGUI/HeaderView.cpp
@@ -265,7 +265,7 @@ void HeaderView::paint_horizontal(Painter& painter)
         bool hovered = section == m_hovered_section && model()->is_column_sortable(section);
         Gfx::StylePainter::paint_button(painter, cell_rect, palette(), Gfx::ButtonStyle::Normal, pressed, hovered);
 
-        auto text = model()->column_name(section);
+        auto text = model()->column_name(section).release_value_but_fixme_should_propagate_errors();
         auto text_rect = cell_rect.shrunken(m_table_view.horizontal_padding() * 2, 0);
         if (pressed)
             text_rect.translate_by(1, 1);
@@ -358,7 +358,7 @@ Menu& HeaderView::ensure_context_menu()
         int section_count = this->section_count();
         for (int section = 0; section < section_count; ++section) {
             auto& column_data = this->section_data(section);
-            auto name = model()->column_name(section).to_deprecated_string();
+            auto name = model()->column_name(section).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
             column_data.visibility_action = Action::create_checkable(name, [this, section](auto& action) {
                 set_section_visible(section, action.is_checked());
             });

--- a/Userland/Libraries/LibGUI/ItemListModel.h
+++ b/Userland/Libraries/LibGUI/ItemListModel.h
@@ -71,7 +71,7 @@ public:
         return 1;
     }
 
-    virtual String column_name(int index) const override
+    virtual ErrorOr<String> column_name(int index) const override
     {
         if constexpr (IsTwoDimensional)
             return m_column_names[index];

--- a/Userland/Libraries/LibGUI/JsonArrayModel.h
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.h
@@ -49,7 +49,7 @@ public:
 
     virtual int row_count(ModelIndex const& = ModelIndex()) const override { return m_array.size(); }
     virtual int column_count(ModelIndex const& = ModelIndex()) const override { return m_fields.size(); }
-    virtual String column_name(int column) const override { return m_fields[column].column_name; }
+    virtual ErrorOr<String> column_name(int column) const override { return m_fields[column].column_name; }
     virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const override;
     virtual void invalidate() override;
     virtual void update();

--- a/Userland/Libraries/LibGUI/Model.h
+++ b/Userland/Libraries/LibGUI/Model.h
@@ -71,7 +71,7 @@ public:
 
     virtual int row_count(ModelIndex const& = ModelIndex()) const = 0;
     virtual int column_count(ModelIndex const& = ModelIndex()) const = 0;
-    virtual String column_name(int) const { return {}; }
+    virtual ErrorOr<String> column_name(int) const { return String {}; }
     virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const = 0;
     virtual MatchResult data_matches(ModelIndex const&, Variant const&) const { return {}; }
     virtual void invalidate();

--- a/Userland/Libraries/LibGUI/RunningProcessesModel.cpp
+++ b/Userland/Libraries/LibGUI/RunningProcessesModel.cpp
@@ -45,11 +45,11 @@ int RunningProcessesModel::column_count(const GUI::ModelIndex&) const
     return Column::__Count;
 }
 
-String RunningProcessesModel::column_name(int column_index) const
+ErrorOr<String> RunningProcessesModel::column_name(int column_index) const
 {
     switch (column_index) {
     case Column::Icon:
-        return {};
+        return String {};
     case Column::PID:
         return "PID"_short_string;
     case Column::UID:

--- a/Userland/Libraries/LibGUI/RunningProcessesModel.h
+++ b/Userland/Libraries/LibGUI/RunningProcessesModel.h
@@ -27,7 +27,7 @@ public:
 
     virtual int row_count(const GUI::ModelIndex&) const override;
     virtual int column_count(const GUI::ModelIndex&) const override;
-    virtual String column_name(int column_index) const override;
+    virtual ErrorOr<String> column_name(int column_index) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
     void update();

--- a/Userland/Libraries/LibGUI/SortingProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/SortingProxyModel.cpp
@@ -106,7 +106,7 @@ ModelIndex SortingProxyModel::map_to_proxy(ModelIndex const& source_index) const
     return create_index(proxy_row, proxy_column, &mapping);
 }
 
-String SortingProxyModel::column_name(int column) const
+ErrorOr<String> SortingProxyModel::column_name(int column) const
 {
     return source().column_name(column);
 }

--- a/Userland/Libraries/LibGUI/SortingProxyModel.h
+++ b/Userland/Libraries/LibGUI/SortingProxyModel.h
@@ -24,7 +24,7 @@ public:
     virtual int tree_column() const override { return m_source->tree_column(); }
     virtual int row_count(ModelIndex const& = ModelIndex()) const override;
     virtual int column_count(ModelIndex const& = ModelIndex()) const override;
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const override;
     virtual void invalidate() override;
     virtual StringView drag_data_type() const override;

--- a/Userland/Libraries/LibGUI/TreeView.cpp
+++ b/Userland/Libraries/LibGUI/TreeView.cpp
@@ -673,7 +673,7 @@ void TreeView::auto_resize_column(int column)
 
     auto& model = *this->model();
 
-    int header_width = column_header().font().width(model.column_name(column));
+    int header_width = column_header().font().width(model.column_name(column).release_value_but_fixme_should_propagate_errors());
     if (column == m_key_column && model.is_column_sortable(column))
         header_width += HeaderView::sorting_arrow_width + HeaderView::sorting_arrow_offset;
     int column_width = header_width;
@@ -718,7 +718,7 @@ void TreeView::update_column_sizes()
             continue;
         if (!column_header().is_section_visible(column))
             continue;
-        int header_width = column_header().font().width(model.column_name(column));
+        int header_width = column_header().font().width(model.column_name(column).release_value_but_fixme_should_propagate_errors());
         if (column == m_key_column && model.is_column_sortable(column))
             header_width += HeaderView::sorting_arrow_width + HeaderView::sorting_arrow_offset;
         int column_width = header_width;
@@ -739,7 +739,7 @@ void TreeView::update_column_sizes()
         set_column_width(column, max(this->column_width(column), column_width));
     }
 
-    int tree_column_header_width = column_header().font().width(model.column_name(tree_column));
+    int tree_column_header_width = column_header().font().width(model.column_name(tree_column).release_value_but_fixme_should_propagate_errors());
     if (tree_column == m_key_column && model.is_column_sortable(tree_column))
         tree_column_header_width += HeaderView::sorting_arrow_width + HeaderView::sorting_arrow_offset;
     int tree_column_width = tree_column_header_width;

--- a/Userland/Libraries/LibWebView/StylePropertiesModel.cpp
+++ b/Userland/Libraries/LibWebView/StylePropertiesModel.cpp
@@ -30,7 +30,7 @@ int StylePropertiesModel::row_count(GUI::ModelIndex const&) const
     return m_values.size();
 }
 
-String StylePropertiesModel::column_name(int column_index) const
+ErrorOr<String> StylePropertiesModel::column_name(int column_index) const
 {
     switch (column_index) {
     case Column::PropertyName:

--- a/Userland/Libraries/LibWebView/StylePropertiesModel.h
+++ b/Userland/Libraries/LibWebView/StylePropertiesModel.h
@@ -31,7 +31,7 @@ public:
 
     virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
-    virtual String column_name(int) const override;
+    virtual ErrorOr<String> column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual bool is_searchable() const override { return true; }
     virtual Vector<GUI::ModelIndex> matches(StringView, unsigned flags, GUI::ModelIndex const&) override;


### PR DESCRIPTION
This is implemented by storing a comma-separated list of the visible columns' IDs. This feels like a nicer solution to me than what was done previously for SystemMonitor. (A whole config section for the table, with one bool for each column being visible). I haven't converted that yet though since I wanted to know if people like this more.

Also not sure about using the IDs instead of names. As noted in the commit, we commonly have columns without names, often for an icon. that gets goofy when you use it as a key, though evidently works fine in SystemMonitor currently. The downside of using ID numbers though is that they're a little meaningless, and modifying the enum in a way that changes the numbers would mess up the value.