### PR TITLE
Remove uses of DeprecatedString in file utility. (Attempt 2)

### DIFF
--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -119,58 +119,58 @@ StringView guess_mime_type_based_on_filename(StringView path)
     return "application/octet-stream"sv;
 }
 
-#define ENUMERATE_HEADER_CONTENTS                                                                                                                \
-    __ENUMERATE_MIME_TYPE_HEADER(blend, "extra/blender", 0, 7, 'B', 'L', 'E', 'N', 'D', 'E', 'R')                                                \
-    __ENUMERATE_MIME_TYPE_HEADER(bmp, "image/bmp", 0, 2, 'B', 'M')                                                                               \
-    __ENUMERATE_MIME_TYPE_HEADER(bzip2, "application/x-bzip2", 0, 3, 'B', 'Z', 'h')                                                              \
-    __ENUMERATE_MIME_TYPE_HEADER(compressed_iso, "extra/isz", 0, 4, 'I', 's', 'Z', '!')                                                          \
-    __ENUMERATE_MIME_TYPE_HEADER(elf, "extra/elf", 0, 4, 0x7F, 'E', 'L', 'F')                                                                    \
-    __ENUMERATE_MIME_TYPE_HEADER(ext, "extra/ext", 0x438, 2, 0x53, 0xEF)                                                                         \
-    __ENUMERATE_MIME_TYPE_HEADER(flac, "audio/flac", 0, 4, 'f', 'L', 'a', 'C')                                                                   \
-    __ENUMERATE_MIME_TYPE_HEADER(gif_87, "image/gif", 0, 6, 'G', 'I', 'F', '8', '7', 'a')                                                        \
-    __ENUMERATE_MIME_TYPE_HEADER(gif_89, "image/gif", 0, 6, 'G', 'I', 'F', '8', '9', 'a')                                                        \
-    __ENUMERATE_MIME_TYPE_HEADER(gzip, "application/gzip", 0, 2, 0x1F, 0x8B)                                                                     \
-    __ENUMERATE_MIME_TYPE_HEADER(icc, "application/vnd.iccprofile", 36, 4, 'a', 'c', 's', 'p')                                                   \
-    __ENUMERATE_MIME_TYPE_HEADER(iso9660_0, "extra/iso-9660", 0x8001, 5, 0x43, 0x44, 0x30, 0x30, 0x31)                                           \
-    __ENUMERATE_MIME_TYPE_HEADER(iso9660_1, "extra/iso-9660", 0x8801, 5, 0x43, 0x44, 0x30, 0x30, 0x31)                                           \
-    __ENUMERATE_MIME_TYPE_HEADER(iso9660_2, "extra/iso-9660", 0x9001, 5, 0x43, 0x44, 0x30, 0x30, 0x31)                                           \
-    __ENUMERATE_MIME_TYPE_HEADER(jpeg, "image/jpeg", 0, 4, 0xFF, 0xD8, 0xFF, 0xDB)                                                               \
-    __ENUMERATE_MIME_TYPE_HEADER(jpeg_huh, "image/jpeg", 0, 4, 0xFF, 0xD8, 0xFF, 0xEE)                                                           \
-    __ENUMERATE_MIME_TYPE_HEADER(jpeg_jfif, "image/jpeg", 0, 12, 0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F', 0x00, 0x01)             \
-    __ENUMERATE_MIME_TYPE_HEADER(lua_bytecode, "extra/lua-bytecode", 0, 4, 0x1B, 'L', 'u', 'a')                                                  \
-    __ENUMERATE_MIME_TYPE_HEADER(midi, "audio/midi", 0, 4, 0x4D, 0x54, 0x68, 0x64)                                                               \
-    __ENUMERATE_MIME_TYPE_HEADER(mkv, "extra/matroska", 0, 4, 0x1A, 0x45, 0xDF, 0xA3)                                                            \
-    __ENUMERATE_MIME_TYPE_HEADER(mp3, "audio/mpeg", 0, 2, 0xFF, 0xFB)                                                                            \
-    __ENUMERATE_MIME_TYPE_HEADER(nesrom, "extra/nes-rom", 0, 4, 'N', 'E', 'S', 0x1A)                                                             \
-    __ENUMERATE_MIME_TYPE_HEADER(pbm, "image/x-portable-bitmap", 0, 3, 0x50, 0x31, 0x0A)                                                         \
-    __ENUMERATE_MIME_TYPE_HEADER(pdf, "application/pdf", 0, 5, 0x25, 'P', 'D', 'F', 0x2D)                                                        \
-    __ENUMERATE_MIME_TYPE_HEADER(pgm, "image/x-portable-graymap", 0, 3, 0x50, 0x32, 0x0A)                                                        \
-    __ENUMERATE_MIME_TYPE_HEADER(png, "image/png", 0, 8, 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A)                                            \
-    __ENUMERATE_MIME_TYPE_HEADER(ppm, "image/x-portable-pixmap", 0, 3, 0x50, 0x33, 0x0A)                                                         \
-    __ENUMERATE_MIME_TYPE_HEADER(qcow, "extra/qcow", 0, 3, 'Q', 'F', 'I')                                                                        \
-    __ENUMERATE_MIME_TYPE_HEADER(qoa, "audio/qoa", 0, 4, 'q', 'o', 'a', 'f')                                                                     \
-    __ENUMERATE_MIME_TYPE_HEADER(qoi, "image/x-qoi", 0, 4, 'q', 'o', 'i', 'f')                                                                   \
-    __ENUMERATE_MIME_TYPE_HEADER(rtf, "application/rtf", 0, 6, 0x7B, 0x5C, 0x72, 0x74, 0x66, 0x31)                                               \
-    __ENUMERATE_MIME_TYPE_HEADER(sevenzip, "application/x-7z-compressed", 0, 6, 0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C)                              \
-    __ENUMERATE_MIME_TYPE_HEADER(shell, "text/x-shellscript", 0, 10, '#', '!', '/', 'b', 'i', 'n', '/', 's', 'h', '\n')                          \
-    __ENUMERATE_MIME_TYPE_HEADER(sqlite, "extra/sqlite", 0, 16, 'S', 'Q', 'L', 'i', 't', 'e', ' ', 'f', 'o', 'r', 'm', 'a', 't', ' ', '3', 0x00) \
-    __ENUMERATE_MIME_TYPE_HEADER(tar, "application/tar", 0x101, 5, 0x75, 0x73, 0x74, 0x61, 0x72)                                                 \
-    __ENUMERATE_MIME_TYPE_HEADER(zip, "application/zip", 0, 2, 0x50, 0x4B)                                                                       \
-    __ENUMERATE_MIME_TYPE_HEADER(tiff, "image/tiff", 0, 4, 'I', 'I', '*', 0x00)                                                                  \
-    __ENUMERATE_MIME_TYPE_HEADER(tiff_bigendian, "image/tiff", 0, 4, 'M', 'M', 0x00, '*')                                                        \
-    __ENUMERATE_MIME_TYPE_HEADER(wasm, "application/wasm", 0, 4, 0x00, 'a', 's', 'm')                                                            \
-    __ENUMERATE_MIME_TYPE_HEADER(wav, "audio/wav", 8, 4, 'W', 'A', 'V', 'E')                                                                     \
-    __ENUMERATE_MIME_TYPE_HEADER(webp, "image/webp", 8, 4, 'W', 'E', 'B', 'P')                                                                   \
-    __ENUMERATE_MIME_TYPE_HEADER(win_31x_archive, "extra/win-31x-compressed", 0, 4, 'K', 'W', 'A', 'J')                                          \
-    __ENUMERATE_MIME_TYPE_HEADER(win_95_archive, "extra/win-95-compressed", 0, 4, 'S', 'Z', 'D', 'D')                                            \
-    __ENUMERATE_MIME_TYPE_HEADER(zlib_0, "extra/raw-zlib", 0, 2, 0x78, 0x01)                                                                     \
-    __ENUMERATE_MIME_TYPE_HEADER(zlib_1, "extra/raw-zlib", 0, 2, 0x78, 0x5E)                                                                     \
-    __ENUMERATE_MIME_TYPE_HEADER(zlib_2, "extra/raw-zlib", 0, 2, 0x78, 0x9C)                                                                     \
-    __ENUMERATE_MIME_TYPE_HEADER(zlib_3, "extra/raw-zlib", 0, 2, 0x78, 0xDA)                                                                     \
-    __ENUMERATE_MIME_TYPE_HEADER(zlib_4, "extra/raw-zlib", 0, 2, 0x78, 0x20)                                                                     \
-    __ENUMERATE_MIME_TYPE_HEADER(zlib_5, "extra/raw-zlib", 0, 2, 0x78, 0x7D)                                                                     \
-    __ENUMERATE_MIME_TYPE_HEADER(zlib_6, "extra/raw-zlib", 0, 2, 0x78, 0xBB)                                                                     \
-    __ENUMERATE_MIME_TYPE_HEADER(zlib_7, "extra/raw-zlib", 0, 2, 0x78, 0xF9)
+#define ENUMERATE_HEADER_CONTENTS                                                                                                                  \
+    __ENUMERATE_MIME_TYPE_HEADER(blend, "extra/blender"sv, 0, 7, 'B', 'L', 'E', 'N', 'D', 'E', 'R')                                                \
+    __ENUMERATE_MIME_TYPE_HEADER(bmp, "image/bmp"sv, 0, 2, 'B', 'M')                                                                               \
+    __ENUMERATE_MIME_TYPE_HEADER(bzip2, "application/x-bzip2"sv, 0, 3, 'B', 'Z', 'h')                                                              \
+    __ENUMERATE_MIME_TYPE_HEADER(compressed_iso, "extra/isz"sv, 0, 4, 'I', 's', 'Z', '!')                                                          \
+    __ENUMERATE_MIME_TYPE_HEADER(elf, "extra/elf"sv, 0, 4, 0x7F, 'E', 'L', 'F')                                                                    \
+    __ENUMERATE_MIME_TYPE_HEADER(ext, "extra/ext"sv, 0x438, 2, 0x53, 0xEF)                                                                         \
+    __ENUMERATE_MIME_TYPE_HEADER(flac, "audio/flac"sv, 0, 4, 'f', 'L', 'a', 'C')                                                                   \
+    __ENUMERATE_MIME_TYPE_HEADER(gif_87, "image/gif"sv, 0, 6, 'G', 'I', 'F', '8', '7', 'a')                                                        \
+    __ENUMERATE_MIME_TYPE_HEADER(gif_89, "image/gif"sv, 0, 6, 'G', 'I', 'F', '8', '9', 'a')                                                        \
+    __ENUMERATE_MIME_TYPE_HEADER(gzip, "application/gzip"sv, 0, 2, 0x1F, 0x8B)                                                                     \
+    __ENUMERATE_MIME_TYPE_HEADER(icc, "application/vnd.iccprofile"sv, 36, 4, 'a', 'c', 's', 'p')                                                   \
+    __ENUMERATE_MIME_TYPE_HEADER(iso9660_0, "extra/iso-9660"sv, 0x8001, 5, 0x43, 0x44, 0x30, 0x30, 0x31)                                           \
+    __ENUMERATE_MIME_TYPE_HEADER(iso9660_1, "extra/iso-9660"sv, 0x8801, 5, 0x43, 0x44, 0x30, 0x30, 0x31)                                           \
+    __ENUMERATE_MIME_TYPE_HEADER(iso9660_2, "extra/iso-9660"sv, 0x9001, 5, 0x43, 0x44, 0x30, 0x30, 0x31)                                           \
+    __ENUMERATE_MIME_TYPE_HEADER(jpeg, "image/jpeg"sv, 0, 4, 0xFF, 0xD8, 0xFF, 0xDB)                                                               \
+    __ENUMERATE_MIME_TYPE_HEADER(jpeg_huh, "image/jpeg"sv, 0, 4, 0xFF, 0xD8, 0xFF, 0xEE)                                                           \
+    __ENUMERATE_MIME_TYPE_HEADER(jpeg_jfif, "image/jpeg"sv, 0, 12, 0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F', 0x00, 0x01)             \
+    __ENUMERATE_MIME_TYPE_HEADER(lua_bytecode, "extra/lua-bytecode"sv, 0, 4, 0x1B, 'L', 'u', 'a')                                                  \
+    __ENUMERATE_MIME_TYPE_HEADER(midi, "audio/midi"sv, 0, 4, 0x4D, 0x54, 0x68, 0x64)                                                               \
+    __ENUMERATE_MIME_TYPE_HEADER(mkv, "extra/matroska"sv, 0, 4, 0x1A, 0x45, 0xDF, 0xA3)                                                            \
+    __ENUMERATE_MIME_TYPE_HEADER(mp3, "audio/mpeg"sv, 0, 2, 0xFF, 0xFB)                                                                            \
+    __ENUMERATE_MIME_TYPE_HEADER(nesrom, "extra/nes-rom"sv, 0, 4, 'N', 'E', 'S', 0x1A)                                                             \
+    __ENUMERATE_MIME_TYPE_HEADER(pbm, "image/x-portable-bitmap"sv, 0, 3, 0x50, 0x31, 0x0A)                                                         \
+    __ENUMERATE_MIME_TYPE_HEADER(pdf, "application/pdf"sv, 0, 5, 0x25, 'P', 'D', 'F', 0x2D)                                                        \
+    __ENUMERATE_MIME_TYPE_HEADER(pgm, "image/x-portable-graymap"sv, 0, 3, 0x50, 0x32, 0x0A)                                                        \
+    __ENUMERATE_MIME_TYPE_HEADER(png, "image/png"sv, 0, 8, 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A)                                            \
+    __ENUMERATE_MIME_TYPE_HEADER(ppm, "image/x-portable-pixmap"sv, 0, 3, 0x50, 0x33, 0x0A)                                                         \
+    __ENUMERATE_MIME_TYPE_HEADER(qcow, "extra/qcow"sv, 0, 3, 'Q', 'F', 'I')                                                                        \
+    __ENUMERATE_MIME_TYPE_HEADER(qoa, "audio/qoa"sv, 0, 4, 'q', 'o', 'a', 'f')                                                                     \
+    __ENUMERATE_MIME_TYPE_HEADER(qoi, "image/x-qoi"sv, 0, 4, 'q', 'o', 'i', 'f')                                                                   \
+    __ENUMERATE_MIME_TYPE_HEADER(rtf, "application/rtf"sv, 0, 6, 0x7B, 0x5C, 0x72, 0x74, 0x66, 0x31)                                               \
+    __ENUMERATE_MIME_TYPE_HEADER(sevenzip, "application/x-7z-compressed"sv, 0, 6, 0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C)                              \
+    __ENUMERATE_MIME_TYPE_HEADER(shell, "text/x-shellscript"sv, 0, 10, '#', '!', '/', 'b', 'i', 'n', '/', 's', 'h', '\n')                          \
+    __ENUMERATE_MIME_TYPE_HEADER(sqlite, "extra/sqlite"sv, 0, 16, 'S', 'Q', 'L', 'i', 't', 'e', ' ', 'f', 'o', 'r', 'm', 'a', 't', ' ', '3', 0x00) \
+    __ENUMERATE_MIME_TYPE_HEADER(tar, "application/tar"sv, 0x101, 5, 0x75, 0x73, 0x74, 0x61, 0x72)                                                 \
+    __ENUMERATE_MIME_TYPE_HEADER(zip, "application/zip"sv, 0, 2, 0x50, 0x4B)                                                                       \
+    __ENUMERATE_MIME_TYPE_HEADER(tiff, "image/tiff"sv, 0, 4, 'I', 'I', '*', 0x00)                                                                  \
+    __ENUMERATE_MIME_TYPE_HEADER(tiff_bigendian, "image/tiff"sv, 0, 4, 'M', 'M', 0x00, '*')                                                        \
+    __ENUMERATE_MIME_TYPE_HEADER(wasm, "application/wasm"sv, 0, 4, 0x00, 'a', 's', 'm')                                                            \
+    __ENUMERATE_MIME_TYPE_HEADER(wav, "audio/wav"sv, 8, 4, 'W', 'A', 'V', 'E')                                                                     \
+    __ENUMERATE_MIME_TYPE_HEADER(webp, "image/webp"sv, 8, 4, 'W', 'E', 'B', 'P')                                                                   \
+    __ENUMERATE_MIME_TYPE_HEADER(win_31x_archive, "extra/win-31x-compressed"sv, 0, 4, 'K', 'W', 'A', 'J')                                          \
+    __ENUMERATE_MIME_TYPE_HEADER(win_95_archive, "extra/win-95-compressed"sv, 0, 4, 'S', 'Z', 'D', 'D')                                            \
+    __ENUMERATE_MIME_TYPE_HEADER(zlib_0, "extra/raw-zlib"sv, 0, 2, 0x78, 0x01)                                                                     \
+    __ENUMERATE_MIME_TYPE_HEADER(zlib_1, "extra/raw-zlib"sv, 0, 2, 0x78, 0x5E)                                                                     \
+    __ENUMERATE_MIME_TYPE_HEADER(zlib_2, "extra/raw-zlib"sv, 0, 2, 0x78, 0x9C)                                                                     \
+    __ENUMERATE_MIME_TYPE_HEADER(zlib_3, "extra/raw-zlib"sv, 0, 2, 0x78, 0xDA)                                                                     \
+    __ENUMERATE_MIME_TYPE_HEADER(zlib_4, "extra/raw-zlib"sv, 0, 2, 0x78, 0x20)                                                                     \
+    __ENUMERATE_MIME_TYPE_HEADER(zlib_5, "extra/raw-zlib"sv, 0, 2, 0x78, 0x7D)                                                                     \
+    __ENUMERATE_MIME_TYPE_HEADER(zlib_6, "extra/raw-zlib"sv, 0, 2, 0x78, 0xBB)                                                                     \
+    __ENUMERATE_MIME_TYPE_HEADER(zlib_7, "extra/raw-zlib"sv, 0, 2, 0x78, 0xF9)
 
 #define __ENUMERATE_MIME_TYPE_HEADER(var_name, mime_type, pattern_offset, pattern_size, ...) \
     static const u8 var_name##_arr[pattern_size] = { __VA_ARGS__ };                          \
@@ -178,7 +178,7 @@ StringView guess_mime_type_based_on_filename(StringView path)
 ENUMERATE_HEADER_CONTENTS
 #undef __ENUMERATE_MIME_TYPE_HEADER
 
-Optional<DeprecatedString> guess_mime_type_based_on_sniffed_bytes(ReadonlyBytes bytes)
+Optional<StringView> guess_mime_type_based_on_sniffed_bytes(ReadonlyBytes bytes)
 {
 #define __ENUMERATE_MIME_TYPE_HEADER(var_name, mime_type, pattern_offset, pattern_size, ...)                       \
     if (static_cast<ssize_t>(bytes.size()) >= pattern_offset && bytes.slice(pattern_offset).starts_with(var_name)) \
@@ -188,7 +188,7 @@ Optional<DeprecatedString> guess_mime_type_based_on_sniffed_bytes(ReadonlyBytes 
     return {};
 }
 
-Optional<DeprecatedString> guess_mime_type_based_on_sniffed_bytes(Core::File& file)
+Optional<StringView> guess_mime_type_based_on_sniffed_bytes(Core::File& file)
 {
     // Read accounts for longest possible offset + signature we currently match against (extra/iso-9660)
     auto maybe_buffer = ByteBuffer::create_uninitialized(0x9006);

--- a/Userland/Libraries/LibCore/MimeData.h
+++ b/Userland/Libraries/LibCore/MimeData.h
@@ -50,7 +50,7 @@ private:
 
 StringView guess_mime_type_based_on_filename(StringView);
 
-Optional<DeprecatedString> guess_mime_type_based_on_sniffed_bytes(ReadonlyBytes);
-Optional<DeprecatedString> guess_mime_type_based_on_sniffed_bytes(Core::File&);
+Optional<StringView> guess_mime_type_based_on_sniffed_bytes(ReadonlyBytes);
+Optional<StringView> guess_mime_type_based_on_sniffed_bytes(Core::File&);
 
 }

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -177,7 +177,7 @@ Vector<DeprecatedString> Launcher::handlers_with_details_for_url(const URL& url)
     return handlers;
 }
 
-Optional<DeprecatedString> Launcher::mime_type_for_file(DeprecatedString path)
+Optional<StringView> Launcher::mime_type_for_file(DeprecatedString path)
 {
     auto file_or_error = Core::File::open(path, Core::File::OpenMode::Read);
     if (file_or_error.is_error())

--- a/Userland/Services/LaunchServer/Launcher.h
+++ b/Userland/Services/LaunchServer/Launcher.h
@@ -51,7 +51,7 @@ private:
     HashMap<DeprecatedString, DeprecatedString> m_mime_handlers;
 
     bool has_mime_handlers(DeprecatedString const&);
-    Optional<DeprecatedString> mime_type_for_file(DeprecatedString path);
+    Optional<StringView> mime_type_for_file(DeprecatedString path);
     Handler get_handler_for_executable(Handler::Type, DeprecatedString const&) const;
     size_t for_each_handler(DeprecatedString const& key, HashMap<DeprecatedString, DeprecatedString> const& user_preferences, Function<bool(Handler const&)> f);
     void for_each_handler_for_path(DeprecatedString const&, Function<bool(Handler const&)> f);


### PR DESCRIPTION
This is just #17266 rebased on `master`. It was blocked at the time, but the issue was resolved by f31bd190b0f746a8e304a4eeb79ce9c002e656d0