### PR TITLE
LibWeb: Fix the x coordinate of a block after a float

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-float.txt
@@ -1,0 +1,25 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
+    BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
+      TextNode <#text>
+    BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <div.ab> at (108,8) content-size 684x17.46875 children: not-inline
+        BlockContainer <(anonymous)> at (108,8) content-size 684x0 children: inline
+          TextNode <#text>
+          BlockContainer <div.a> at (108,8) content-size 14.265625x17.46875 floating [BFC] children: inline
+            line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 0, length: 1, rect: [108,8 14.265625x17.46875]
+                "A"
+            TextNode <#text>
+          TextNode <#text>
+        BlockContainer <div.b> at (122.265625,8) content-size 669.734375x17.46875 [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [122.265625,8 9.34375x17.46875]
+              "B"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (108,25.46875) content-size 684x0 children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,25.46875) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-with-hidden-overflow-after-float.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-with-hidden-overflow-after-float.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>Block with hidden overflow after float</title>
+    <style>
+        .ab {
+            margin-left: 100px;
+        }
+
+        .a {
+            float: left;
+        }
+
+        .b {
+            overflow: hidden;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="ab">
+        <div class="a">A</div>
+        <div class="b">B</div>
+    </div>
+
+</body>
+
+</html>

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -39,7 +39,7 @@ public:
 
     void add_absolutely_positioned_box(Box const& box) { m_absolutely_positioned_boxes.append(box); }
 
-    SpaceUsedByFloats space_used_by_floats(CSSPixels y) const;
+    SpaceUsedAndContainingMarginForFloats space_used_and_containing_margin_for_floats(CSSPixels y) const;
     SpaceUsedByFloats intrusion_by_floats_into_box(Box const&, CSSPixels y_in_box) const;
 
     virtual CSSPixels greatest_child_width(Box const&) const override;

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -107,6 +107,16 @@ protected:
         CSSPixels right { 0 };
     };
 
+    struct SpaceUsedAndContainingMarginForFloats {
+        // Width for left / right floats, including their own margins.
+        CSSPixels left_used_space;
+        CSSPixels right_used_space;
+        // Left / right total margins from the outermost containing block to the floating element.
+        // Each block in the containing chain adds its own margin and we store the total here.
+        CSSPixels left_total_containing_margin;
+        CSSPixels right_total_containing_margin;
+    };
+
     struct ShrinkToFitResult {
         CSSPixels preferred_width { 0 };
         CSSPixels preferred_minimum_width { 0 };

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -41,15 +41,16 @@ CSSPixels InlineFormattingContext::leftmost_x_offset_at(CSSPixels y) const
     // NOTE: Floats are relative to the BFC root box, not necessarily the containing block of this IFC.
     auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(containing_block(), parent().root());
     CSSPixels y_in_root = box_in_root_rect.y() + y;
-    auto space = parent().space_used_by_floats(y_in_root);
-    if (box_in_root_rect.x() >= space.left) {
+    auto space_and_containing_margin = parent().space_used_and_containing_margin_for_floats(y_in_root);
+    auto left_side_floats_limit_to_right = space_and_containing_margin.left_total_containing_margin + space_and_containing_margin.left_used_space;
+    if (box_in_root_rect.x() >= left_side_floats_limit_to_right) {
         // The left edge of the containing block is to the right of the rightmost left-side float.
         // We start placing inline content at the left edge of the containing block.
         return 0;
     }
     // The left edge of the containing block is to the left of the rightmost left-side float.
     // We adjust the inline content insertion point by the overlap between the containing block and the float.
-    return space.left - max(CSSPixels(0), box_in_root_rect.x());
+    return left_side_floats_limit_to_right - max(CSSPixels(0), box_in_root_rect.x());
 }
 
 CSSPixels InlineFormattingContext::available_space_for_line(CSSPixels y) const
@@ -319,8 +320,8 @@ bool InlineFormattingContext::any_floats_intrude_at_y(CSSPixels y) const
 {
     auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(containing_block(), parent().root());
     CSSPixels y_in_root = box_in_root_rect.y() + y;
-    auto space = parent().space_used_by_floats(y_in_root);
-    return space.left > 0 || space.right > 0;
+    auto space_and_containing_margin = parent().space_used_and_containing_margin_for_floats(y_in_root);
+    return space_and_containing_margin.left_used_space > 0 || space_and_containing_margin.right_used_space > 0;
 }
 
 bool InlineFormattingContext::can_fit_new_line_at_y(CSSPixels y) const


### PR DESCRIPTION
The margin from the containing blocks shouldn't be included in the amount by which we increment x after a float was places. That coordinate should be relative to the containing block.

Fixes the comments layout on https://lobste.rs.