### PR TITLE
image: Add --strip-alpha, --move-alpha-to-rbg flags

### DIFF
--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -546,6 +546,14 @@ Bitmap::~Bitmap()
     delete[] m_palette;
 }
 
+void Bitmap::strip_alpha_channel()
+{
+    VERIFY(m_format == BitmapFormat::BGRA8888 || m_format == BitmapFormat::BGRx8888);
+    for (ARGB32& pixel : *this)
+        pixel = 0xff000000 | (pixel & 0xffffff);
+    m_format = BitmapFormat::BGRx8888;
+}
+
 void Bitmap::set_mmap_name([[maybe_unused]] DeprecatedString const& name)
 {
     VERIFY(m_needs_munmap);

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -66,7 +66,7 @@ enum class StorageFormat {
     RGBA8888,
 };
 
-static StorageFormat determine_storage_format(BitmapFormat format)
+inline StorageFormat determine_storage_format(BitmapFormat format)
 {
     switch (format) {
     case BitmapFormat::BGRx8888:

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -212,6 +212,9 @@ public:
     [[nodiscard]] bool has_alpha_channel() const { return m_format == BitmapFormat::BGRA8888 || m_format == BitmapFormat::RGBA8888; }
     [[nodiscard]] BitmapFormat format() const { return m_format; }
 
+    // Call only for BGRx8888 and BGRA8888 bitmaps.
+    void strip_alpha_channel();
+
     void set_mmap_name(DeprecatedString const&);
 
     [[nodiscard]] static constexpr size_t size_in_bytes(size_t pitch, int physical_height) { return pitch * physical_height; }


### PR DESCRIPTION
Allows running `Build/lagom/image --strip-alpha ~/Downloads/Integrations_4@2x.webp -o tmp-rgb.png` and `Build/lagom/image --move-alpha-to-rgb ~/Downloads/Integrations_4@2x.webp -o tmp-a.png` on this file

![tmp](https://github.com/SerenityOS/serenity/assets/3487/75ebbc06-1378-4405-a8a6-951177e2dd18)

to learn that its RGB looks like

![tmp-rgb](https://github.com/SerenityOS/serenity/assets/3487/132aca60-f67e-428f-9fab-a1f9af580f95)

and its alpha like

![tmp-a](https://github.com/SerenityOS/serenity/assets/3487/db84f3d1-d41a-46aa-be0c-8c75555f8c23)

(It however doesn't tell you that the lossless webp that stores the alpha channel actually looks like

![alph](https://github.com/SerenityOS/serenity/assets/3487/a861e662-3678-4336-95fc-fa648388c654)

since that information is lost during webp decoding.)

(Can be used with any image with an alpha channel of course, not just webps.)