### PR TITLE
LibWeb: Treat % max-height as none when containing block size indefinite

### DIFF
--- a/Tests/LibWeb/Layout/expected/percentage-max-height-when-containing-block-has-indefinite-height.txt
+++ b/Tests/LibWeb/Layout/expected/percentage-max-height-when-containing-block-has-indefinite-height.txt
@@ -1,0 +1,46 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x123.34375 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x105.34375 children: not-inline
+      BlockContainer <div.block.formatting-context> at (11,11) content-size 778x19.46875 [BFC] children: not-inline
+        BlockContainer <div> at (12,12) content-size 776x17.46875 children: inline
+          line 0 width: 40.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [12,12 40.671875x17.46875]
+              "block"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,31.46875) content-size 780x0 children: inline
+        TextNode <#text>
+      BlockContainer <div.inline.formatting-context> at (11,32.46875) content-size 778x17.46875 [BFC] children: inline
+        line 0 width: 43.296875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 6, rect: [12,32.46875 41.296875x17.46875]
+            "inline"
+        InlineNode <div>
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,50.9375) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.flex.formatting-context> at (11,51.9375) content-size 778x19.46875 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (12,52.9375) content-size 29.09375x17.46875 flex-item [BFC] children: inline
+          line 0 width: 29.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 4, rect: [12,52.9375 29.09375x17.46875]
+              "flex"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,72.40625) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.grid.formatting-context> at (11,73.40625) content-size 778x19.46875 [GFC] children: not-inline
+        BlockContainer <div> at (12,74.40625) content-size 776x17.46875 [BFC] children: inline
+          line 0 width: 28.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 4, rect: [12,74.40625 28.8125x17.46875]
+              "grid"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,93.875) content-size 780x0 children: inline
+        TextNode <#text>
+      TableWrapper <(anonymous)> at (10,93.875) content-size 38.625x21.46875 [BFC] children: not-inline
+        Box <div.table.formatting-context> at (11,94.875) content-size 38.625x19.46875 table-box [TFC] children: not-inline
+          Box <(anonymous)> at (11,94.875) content-size 40.625x19.46875 table-row children: not-inline
+            BlockContainer <(anonymous)> at (11,94.875) content-size 40.625x19.46875 table-cell [BFC] children: not-inline
+              BlockContainer <div> at (12,95.875) content-size 38.625x17.46875 children: inline
+                line 0 width: 38.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 5, rect: [12,95.875 38.625x17.46875]
+                    "table"
+                TextNode <#text>
+      BlockContainer <(anonymous)> at (10,115.34375) content-size 780x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/percentage-max-height-when-containing-block-has-indefinite-height.html
+++ b/Tests/LibWeb/Layout/input/percentage-max-height-when-containing-block-has-indefinite-height.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html><style>
+* {
+    border: 1px solid black;
+}
+.formatting-context > div {
+    max-height: 100%;
+    background-color: orange;
+}
+.inline.formatting-context > div {
+    display: inline;
+}
+.block {
+    display: block flow-root;
+}
+.inline {
+    display: block flow-root;
+}
+.flex {
+    display: block flex;
+}
+.grid {
+    display: block grid;
+}
+.table {
+    display: block table;
+}
+</style>
+<div class="block formatting-context"><div>block</div></div>
+<div class="inline formatting-context"><div>inline</div></div>
+<div class="flex formatting-context"><div>flex</div></div>
+<div class="grid formatting-context"><div>grid</div></div>
+<div class="table formatting-context"><div>table</div></div>

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -458,7 +458,7 @@ void BlockFormattingContext::compute_height(Box const& box, AvailableSpace const
         }
     }
 
-    if (!computed_values.max_height().is_none()) {
+    if (!should_treat_max_height_as_none(box)) {
         auto max_height = calculate_inner_height(box, available_space.height, computed_values.max_height());
         if (!max_height.is_auto())
             height = min(height, max_height.to_px(box));

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -260,7 +260,7 @@ CSSPixelSize FormattingContext::solve_replaced_size_constraint(CSSPixels input_w
 {
     // 10.4 Minimum and maximum widths: 'min-width' and 'max-width'
 
-    auto const& containing_block = *box.non_anyonymous_containing_block();
+    auto const& containing_block = *box.non_anonymous_containing_block();
     auto const& containing_block_state = m_state.get(containing_block);
     auto width_of_containing_block = containing_block_state.content_width();
     auto height_of_containing_block = containing_block_state.content_height();
@@ -507,7 +507,7 @@ CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box,
     // 10.6.6 Floating replaced elements
     // 10.6.10 'inline-block' replaced elements in normal flow
 
-    auto height_of_containing_block = m_state.get(*box.non_anyonymous_containing_block()).content_height();
+    auto height_of_containing_block = m_state.get(*box.non_anonymous_containing_block()).content_height();
     auto computed_width = should_treat_width_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().width();
     auto computed_height = should_treat_height_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().height();
 
@@ -1392,7 +1392,7 @@ CSS::Length FormattingContext::calculate_inner_width(Layout::Box const& box, Ava
 
 CSS::Length FormattingContext::calculate_inner_height(Layout::Box const& box, AvailableSize const&, CSS::Size const& height) const
 {
-    auto height_of_containing_block = m_state.get(*box.non_anyonymous_containing_block()).content_height();
+    auto height_of_containing_block = m_state.get(*box.non_anonymous_containing_block()).content_height();
     auto height_of_containing_block_as_length_for_resolve = CSS::Length::make_px(height_of_containing_block);
     if (height.is_auto()) {
         return height.resolved(box, height_of_containing_block_as_length_for_resolve);

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -99,6 +99,8 @@ protected:
     static bool should_treat_width_as_auto(Box const&, AvailableSpace const&);
     static bool should_treat_height_as_auto(Box const&, AvailableSpace const&);
 
+    [[nodiscard]] bool should_treat_max_height_as_none(Box const&) const;
+
     OwnPtr<FormattingContext> layout_inside(Box const&, LayoutMode, AvailableSpace const&);
     void compute_inset(Box const& box);
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -119,7 +119,7 @@ Box const* Node::containing_block() const
     return nearest_ancestor_capable_of_forming_a_containing_block(*this);
 }
 
-Box const* Node::non_anyonymous_containing_block() const
+Box const* Node::non_anonymous_containing_block() const
 {
     auto nearest_ancestor_box = containing_block();
     VERIFY(nearest_ancestor_box);

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -115,7 +115,7 @@ public:
     // Anonymous block boxes are ignored when resolving percentage values that would refer to it:
     // the closest non-anonymous ancestor box is used instead.
     // https://www.w3.org/TR/CSS22/visuren.html#anonymous-block-level
-    Box const* non_anyonymous_containing_block() const;
+    Box const* non_anonymous_containing_block() const;
 
     bool establishes_stacking_context() const;
 

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -186,7 +186,7 @@ void TableFormattingContext::compute_cell_measures(AvailableSpace const& availab
 
         CSSPixels max_height = computed_values.height().is_auto() ? max_content_height : height;
         CSSPixels max_width = computed_values.width().is_auto() ? max_content_width : width;
-        if (!computed_values.max_height().is_none())
+        if (!should_treat_max_height_as_none(cell.box))
             max_height = min(max_height, computed_values.max_height().to_px(cell.box, containing_block.content_height()));
         if (!computed_values.max_width().is_none())
             max_width = min(max_width, computed_values.max_width().to_px(cell.box, containing_block.content_width()));


### PR DESCRIPTION
Fixes #19371

Nice progression on https://www.freecodecamp.org (the yellow "Get started (it's free)" button)

Before:
![Screenshot at 2023-06-14 15-50-50](https://github.com/SerenityOS/serenity/assets/5954907/2be53522-5e0c-41c8-82c4-6d12203b69ab)

After:
![Screenshot at 2023-06-14 15-51-04](https://github.com/SerenityOS/serenity/assets/5954907/05af803c-fd0e-475d-904b-eb9251df0d3f)

