### PR TITLE
LibWeb: Treat % max-width as none when containing block size indefinite

### DIFF
--- a/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-indefinite-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-indefinite-containing-block-width.txt
@@ -1,0 +1,7 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x136 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x120 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x120 children: inline
+        line 0 width: 120, height: 120, bottom: 120, baseline: 120
+          frag 0 from ImageBox start: 0, length: 0, rect: [8,8 120x120]
+        ImageBox <img> at (8,8) content-size 120x120 children: not-inline

--- a/Tests/LibWeb/Layout/input/img-with-percentage-max-width-and-indefinite-containing-block-width.html
+++ b/Tests/LibWeb/Layout/input/img-with-percentage-max-width-and-indefinite-containing-block-width.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html><style>
+body { display: max-content; }
+img { max-width: 100%; }
+</style><body><div><img src="120.png">

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -253,7 +253,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!computed_values.max_width().is_none()) {
+    if (!should_treat_max_width_as_none(box)) {
         auto max_width = calculate_inner_width(box, remaining_available_space.width, computed_values.max_width());
         auto used_width_px = used_width.is_auto() ? remaining_available_space.width.to_px() : used_width.to_px(box);
         if (used_width_px > max_width.to_px(box)) {
@@ -331,7 +331,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!computed_values.max_width().is_none()) {
+    if (!should_treat_max_width_as_none(box)) {
         auto max_width = calculate_inner_width(box, available_space.width, computed_values.max_width());
         if (width.to_px(box) > max_width.to_px(box))
             width = compute_width(max_width);

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -99,6 +99,7 @@ protected:
     static bool should_treat_width_as_auto(Box const&, AvailableSpace const&);
     static bool should_treat_height_as_auto(Box const&, AvailableSpace const&);
 
+    [[nodiscard]] bool should_treat_max_width_as_none(Box const&) const;
     [[nodiscard]] bool should_treat_max_height_as_none(Box const&) const;
 
     OwnPtr<FormattingContext> layout_inside(Box const&, LayoutMode, AvailableSpace const&);

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -149,9 +149,8 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     }
 
     CSSPixels width = unconstrained_width;
-    auto computed_max_width = box.computed_values().max_width();
-    if (!computed_max_width.is_none()) {
-        auto max_width = computed_max_width.to_px(box, width_of_containing_block);
+    if (!should_treat_max_width_as_none(box)) {
+        auto max_width = box.computed_values().max_width().to_px(box, width_of_containing_block);
         width = min(width, max_width);
     }
 

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -188,7 +188,7 @@ void TableFormattingContext::compute_cell_measures(AvailableSpace const& availab
         CSSPixels max_width = computed_values.width().is_auto() ? max_content_width : width;
         if (!should_treat_max_height_as_none(cell.box))
             max_height = min(max_height, computed_values.max_height().to_px(cell.box, containing_block.content_height()));
-        if (!computed_values.max_width().is_none())
+        if (!should_treat_max_width_as_none(cell.box))
             max_width = min(max_width, computed_values.max_width().to_px(cell.box, containing_block.content_width()));
 
         if (computed_values.height().is_percentage()) {
@@ -350,7 +350,7 @@ void TableFormattingContext::compute_table_width()
         // of resolved-table-width, and the used min-width of the table.
         CSSPixels resolved_table_width = computed_values.width().to_px(table_box(), width_of_table_wrapper_containing_block);
         used_width = max(resolved_table_width, used_min_width);
-        if (!computed_values.max_width().is_none())
+        if (!should_treat_max_width_as_none(table_box()))
             used_width = min(used_width, computed_values.max_width().to_px(table_box(), width_of_table_wrapper_containing_block));
     }
 


### PR DESCRIPTION
This is technically "undefined behavior" per CSS 2.2, but it seems sensible to mirror the behavior of max-height in the same situation. It also appears to match how other engines behave.

Fixes #19242