### PR TITLE
Userland: Avoid even more unnecessary copies

### DIFF
--- a/Userland/Applications/Browser/StorageWidget.cpp
+++ b/Userland/Applications/Browser/StorageWidget.cpp
@@ -109,7 +109,7 @@ void StorageWidget::clear_cookies()
 
 void StorageWidget::set_local_storage_entries(OrderedHashMap<DeprecatedString, DeprecatedString> entries)
 {
-    m_local_storage_model->set_items(entries);
+    m_local_storage_model->set_items(move(entries));
 }
 
 void StorageWidget::clear_local_storage_entries()
@@ -119,7 +119,7 @@ void StorageWidget::clear_local_storage_entries()
 
 void StorageWidget::set_session_storage_entries(OrderedHashMap<DeprecatedString, DeprecatedString> entries)
 {
-    m_session_storage_model->set_items(entries);
+    m_session_storage_model->set_items(move(entries));
 }
 
 void StorageWidget::clear_session_storage_entries()

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -865,13 +865,13 @@ void Tab::show_storage_inspector()
     if (on_get_local_storage_entries) {
         auto local_storage_entries = on_get_local_storage_entries();
         m_storage_widget->clear_local_storage_entries();
-        m_storage_widget->set_local_storage_entries(local_storage_entries);
+        m_storage_widget->set_local_storage_entries(move(local_storage_entries));
     }
 
     if (on_get_session_storage_entries) {
         auto session_storage_entries = on_get_session_storage_entries();
         m_storage_widget->clear_session_storage_entries();
-        m_storage_widget->set_session_storage_entries(session_storage_entries);
+        m_storage_widget->set_session_storage_entries(move(session_storage_entries));
     }
 
     auto* window = m_storage_widget->window();

--- a/Userland/Libraries/LibGUI/Clipboard.cpp
+++ b/Userland/Libraries/LibGUI/Clipboard.cpp
@@ -59,7 +59,7 @@ Clipboard::DataAndType Clipboard::fetch_data_and_type() const
 {
     auto response = connection().get_clipboard_data();
     auto type = response.mime_type();
-    auto metadata = response.metadata();
+    auto& metadata = response.metadata();
 
     auto metadata_clone_or_error = metadata.clone();
     if (metadata_clone_or_error.is_error())
@@ -71,7 +71,7 @@ Clipboard::DataAndType Clipboard::fetch_data_and_type() const
     if (data.is_error())
         return {};
 
-    return { data.release_value(), type, metadata };
+    return { data.release_value(), type, metadata_clone_or_error.release_value() };
 }
 
 RefPtr<Gfx::Bitmap> Clipboard::DataAndType::as_bitmap() const

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -1409,11 +1409,11 @@ ErrorOr<void> Editor::refresh_display()
     }
 
     auto apply_styles = [&, empty_styles = HashMap<u32, Style> {}](size_t i) -> ErrorOr<void> {
-        auto ends = m_current_spans.m_spans_ending.get(i).value_or(empty_styles);
-        auto starts = m_current_spans.m_spans_starting.get(i).value_or(empty_styles);
+        auto& ends = m_current_spans.m_spans_ending.get(i).value_or<>(empty_styles);
+        auto& starts = m_current_spans.m_spans_starting.get(i).value_or<>(empty_styles);
 
-        auto anchored_ends = m_current_spans.m_anchored_spans_ending.get(i).value_or(empty_styles);
-        auto anchored_starts = m_current_spans.m_anchored_spans_starting.get(i).value_or(empty_styles);
+        auto& anchored_ends = m_current_spans.m_anchored_spans_ending.get(i).value_or<>(empty_styles);
+        auto& anchored_starts = m_current_spans.m_anchored_spans_starting.get(i).value_or<>(empty_styles);
 
         if (ends.size() || anchored_ends.size()) {
             Style style;

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -458,7 +458,8 @@ WebIDL::ExceptionOr<void> ElementInlineCSSStyleDeclaration::set_css_text(StringV
 
     // 3. Parse the given value and, if the return value is not the empty list, insert the items in the list into the declarations, in specified order.
     auto style = parse_css_style_attribute(CSS::Parser::ParsingContext(m_element->document()), css_text, *m_element.ptr());
-    set_the_declarations(style->properties(), style->custom_properties());
+    auto custom_properties = TRY_OR_THROW_OOM(vm(), style->custom_properties().clone());
+    set_the_declarations(style->properties(), move(custom_properties));
 
     // 4. Update style attribute for the CSS declaration block.
     update_style_attribute();


### PR DESCRIPTION
This is similar to #19298 in that we remove another bunch of unnecessary copies.

Unnecessary copies mean unnecessary memory consumption, running time, and risk of OOM. So let's do fewer of those.