### PR TITLE
LibWeb: Support SVG vertical/horizontal lineto with multiple parameters

### DIFF
--- a/Userland/Libraries/LibWeb/SVG/AttributeParser.cpp
+++ b/Userland/Libraries/LibWeb/SVG/AttributeParser.cpp
@@ -188,14 +188,16 @@ void AttributeParser::parse_horizontal_lineto()
 {
     bool absolute = consume() == 'H';
     parse_whitespace();
-    m_instructions.append({ PathInstructionType::HorizontalLine, absolute, parse_coordinate_sequence() });
+    for (auto coordinate : parse_coordinate_sequence())
+        m_instructions.append({ PathInstructionType::HorizontalLine, absolute, { coordinate } });
 }
 
 void AttributeParser::parse_vertical_lineto()
 {
     bool absolute = consume() == 'V';
     parse_whitespace();
-    m_instructions.append({ PathInstructionType::VerticalLine, absolute, parse_coordinate_sequence() });
+    for (auto coordinate : parse_coordinate_sequence())
+        m_instructions.append({ PathInstructionType::VerticalLine, absolute, { coordinate } });
 }
 
 void AttributeParser::parse_curveto()


### PR DESCRIPTION
This now allows `v 1 2 3` or `h 1 2 3`, which are treated like `v 1 v 2 v 3` and `h 1 h 2 h 3` respectively. This fixes the freeCodeCamp SVG logo.

| Before                                                                                                                              | After                                                                                                                               |
|-------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
| ![Screenshot from 2023-06-14 21-30-22](https://github.com/SerenityOS/serenity/assets/11597044/5049812d-403a-4794-b386-1cb92e14fc27) | ![Screenshot from 2023-06-14 21-29-06](https://github.com/SerenityOS/serenity/assets/11597044/88369b44-2391-4e59-a00d-30baa307c427) |

(Noticed this in  #19396, thought it was a rasterizer bug, so had to investigate :sweat_smile:)  