### PR TITLE
AK: Align Function inline storage to __BIGGEST_ALIGNMENT__

### DIFF
--- a/AK/Function.h
+++ b/AK/Function.h
@@ -280,7 +280,7 @@ private:
     // FIXME: Try to decrease this.
     static constexpr size_t inline_capacity = 6 * sizeof(void*);
 #endif
-    alignas(max(alignof(CallableWrapperBase), alignof(CallableWrapperBase*))) u8 m_storage[inline_capacity];
+    alignas(__BIGGEST_ALIGNMENT__) u8 m_storage[inline_capacity];
 };
 
 }


### PR DESCRIPTION
The previous alignment of the maximum of a pointer and a pure virtual class (with no members) would always result in a 8-byte alignment.

This would break functions that capture (by value) types that require 16+ byte alignment, such as in this contrived example:

    long double foo = 923489;
    Vector<Function<void()>> foobar;
    foobar.append([=](){
        dbgln("{}", int(foo));
    });
    for (auto& func: foobar)
        func();

This now uses the maximum alignment defined by the compiler.