### PR TITLE
LibWeb: Implement Blob::text and Blob::array_buffer to spec

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/ExceptionOrUtils.h
+++ b/Userland/Libraries/LibWeb/Bindings/ExceptionOrUtils.h
@@ -56,6 +56,8 @@ struct ExtractExceptionOrValueType<WebIDL::ExceptionOr<void>> {
     using Type = JS::Value;
 };
 
+}
+
 ALWAYS_INLINE JS::Completion dom_exception_to_throw_completion(JS::VM& vm, auto&& exception)
 {
     return exception.visit(
@@ -81,8 +83,6 @@ ALWAYS_INLINE JS::Completion dom_exception_to_throw_completion(JS::VM& vm, auto&
         });
 }
 
-}
-
 template<typename T>
 using ExtractExceptionOrValueType = typename Detail::ExtractExceptionOrValueType<T>::Type;
 
@@ -97,7 +97,7 @@ JS::ThrowCompletionOr<Ret> throw_dom_exception_if_needed(JS::VM& vm, F&& fn)
         auto&& result = fn();
 
         if (result.is_exception())
-            return Detail::dom_exception_to_throw_completion(vm, result.exception());
+            return dom_exception_to_throw_completion(vm, result.exception());
 
         if constexpr (requires(T v) { v.value(); })
             return result.value();

--- a/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
@@ -36,8 +36,7 @@ JS::NonnullGCPtr<JS::Promise> fetch(JS::VM& vm, RequestInfo const& input, Reques
     //    as arguments. If this throws an exception, reject p with it and return p.
     auto exception_or_request_object = Request::construct_impl(realm, input, init);
     if (exception_or_request_object.is_exception()) {
-        // FIXME: We should probably make this a public API?
-        auto throw_completion = Bindings::Detail::dom_exception_to_throw_completion(vm, exception_or_request_object.release_error());
+        auto throw_completion = Bindings::dom_exception_to_throw_completion(vm, exception_or_request_object.exception());
         WebIDL::reject_promise(realm, promise_capability, *throw_completion.value());
         return verify_cast<JS::Promise>(*promise_capability->promise().ptr());
     }

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -45,7 +45,7 @@ public:
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Streams::ReadableStream>> stream();
     WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> text();
-    JS::Promise* array_buffer();
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> array_buffer();
 
     ReadonlyBytes bytes() const { return m_byte_buffer.bytes(); }
 

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
@@ -169,6 +169,22 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> ReadableStreamDefaultReader::
     return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise_capability->promise()) };
 }
 
+// https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes
+WebIDL::ExceptionOr<void> ReadableStreamDefaultReader::read_all_bytes(ReadLoopReadRequest::SuccessSteps success_steps, ReadLoopReadRequest::FailureSteps failure_steps)
+{
+    auto& realm = this->realm();
+    auto& vm = realm.vm();
+
+    // 1. Let readRequest be a new read request with the following items:
+    //    NOTE: items and steps in ReadLoopReadRequest.
+    auto read_request = adopt_ref(*new ReadLoopReadRequest(vm, realm, *this, move(success_steps), move(failure_steps)));
+
+    // 2. Perform ! ReadableStreamDefaultReaderRead(this, readRequest).
+    TRY(readable_stream_default_reader_read(*this, read_request));
+
+    return {};
+}
+
 // https://streams.spec.whatwg.org/#default-reader-release-lock
 WebIDL::ExceptionOr<void> ReadableStreamDefaultReader::release_lock()
 {

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
@@ -1,14 +1,18 @@
 /*
  * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>
+ * Copyright (c) 2023, Shannon Booth <shannon.ml.booth@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <LibJS/Heap/Heap.h>
+#include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/IteratorOperations.h>
 #include <LibJS/Runtime/PromiseCapability.h>
 #include <LibJS/Runtime/Realm.h>
+#include <LibJS/Runtime/TypedArray.h>
+#include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/ReadableStreamDefaultReaderPrototype.h>
 #include <LibWeb/Streams/AbstractOperations.h>
@@ -48,6 +52,62 @@ void ReadableStreamDefaultReader::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     ReadableStreamGenericReaderMixin::visit_edges(visitor);
+}
+
+// https://streams.spec.whatwg.org/#read-loop
+ReadLoopReadRequest::ReadLoopReadRequest(JS::VM& vm, JS::Realm& realm, ReadableStreamDefaultReader& reader, SuccessSteps success_steps, FailureSteps failure_steps)
+    : m_vm(vm)
+    , m_realm(realm)
+    , m_reader(reader)
+    , m_success_steps(move(success_steps))
+    , m_failure_steps(move(failure_steps))
+{
+}
+
+// chunk steps, given chunk
+void ReadLoopReadRequest::on_chunk(JS::Value chunk)
+{
+    // 1. If chunk is not a Uint8Array object, call failureSteps with a TypeError and abort these steps.
+    if (!chunk.is_object() || !is<JS::Uint8Array>(chunk.as_object())) {
+        auto exception = JS::TypeError::create(m_realm, "Chunk data is not Uint8Array"sv);
+        if (exception.is_error()) {
+            m_failure_steps(*exception.release_error().value());
+            return;
+        }
+
+        m_failure_steps(exception.value());
+    }
+
+    auto const& array = static_cast<JS::Uint8Array const&>(chunk.as_object());
+    auto const& buffer = array.viewed_array_buffer()->buffer();
+
+    // 2. Append the bytes represented by chunk to bytes.
+    m_bytes.append(buffer);
+
+    // FIXME: As the spec suggests, implement this non-recursively - instead of directly. It is not too big of a deal currently
+    //        as we enqueue the entire blob buffer in one go, meaning that we only recurse a single time. Once we begin queuing
+    //        up more than one chunk at a time, we may run into stack overflow problems.
+    //
+    // 3. Read-loop given reader, bytes, successSteps, and failureSteps.
+    auto maybe_error = readable_stream_default_reader_read(m_reader, *this);
+    if (maybe_error.is_exception()) {
+        auto throw_completion = Bindings::dom_exception_to_throw_completion(m_vm, maybe_error.exception());
+        m_failure_steps(*throw_completion.release_error().value());
+    }
+}
+
+// close steps
+void ReadLoopReadRequest::on_close()
+{
+    // 1. Call successSteps with bytes.
+    m_success_steps(m_bytes);
+}
+
+// error steps, given e
+void ReadLoopReadRequest::on_error(JS::Value error)
+{
+    // 1. Call failureSteps with e.
+    m_failure_steps(error);
 }
 
 class DefaultReaderReadRequest : public ReadRequest {

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
@@ -68,6 +68,8 @@ public:
     WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> read();
 
     WebIDL::ExceptionOr<void> read_all_bytes(ReadLoopReadRequest::SuccessSteps, ReadLoopReadRequest::FailureSteps);
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> read_all_bytes_deprecated();
+
     WebIDL::ExceptionOr<void> release_lock();
 
     SinglyLinkedList<NonnullRefPtr<ReadRequest>>& read_requests() { return m_read_requests; }

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
@@ -66,6 +66,8 @@ public:
     virtual ~ReadableStreamDefaultReader() override = default;
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> read();
+
+    WebIDL::ExceptionOr<void> read_all_bytes(ReadLoopReadRequest::SuccessSteps, ReadLoopReadRequest::FailureSteps);
     WebIDL::ExceptionOr<void> release_lock();
 
     SinglyLinkedList<NonnullRefPtr<ReadRequest>>& read_requests() { return m_read_requests; }

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
@@ -29,6 +29,31 @@ public:
     virtual void on_error(JS::Value error) = 0;
 };
 
+class ReadLoopReadRequest : public ReadRequest {
+public:
+    // successSteps, which is an algorithm accepting a byte sequence
+    using SuccessSteps = JS::SafeFunction<void(ByteBuffer)>;
+
+    // failureSteps, which is an algorithm accepting a JavaScript value
+    using FailureSteps = JS::SafeFunction<void(JS::Value error)>;
+
+    ReadLoopReadRequest(JS::VM& vm, JS::Realm& realm, ReadableStreamDefaultReader& reader, SuccessSteps success_steps, FailureSteps failure_steps);
+
+    virtual void on_chunk(JS::Value chunk) override;
+
+    virtual void on_close() override;
+
+    virtual void on_error(JS::Value error) override;
+
+private:
+    JS::VM& m_vm;
+    JS::Realm& m_realm;
+    ReadableStreamDefaultReader& m_reader;
+    ByteBuffer m_bytes;
+    SuccessSteps m_success_steps;
+    FailureSteps m_failure_steps;
+};
+
 // https://streams.spec.whatwg.org/#readablestreamdefaultreader
 class ReadableStreamDefaultReader final
     : public Bindings::PlatformObject


### PR DESCRIPTION
After adding ReadableStreamDefaultReader::read_all_bytes, all of the
pieces are in place to implement these functions to spec!
