### PR TITLE
LibWeb: Make inline node visibility hidden works

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -132,6 +132,10 @@ void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, 
     if (display.is_inline_outside()) {
         // Inlines can be inserted into the nearest ancestor.
         auto& insertion_point = insertion_parent_for_inline_node(m_ancestor_stack.last());
+        // TextNode's visible follows its parent's visible property.
+        if (is<Layout::TextNode>(node)) {
+            node.set_visible(insertion_point.is_visible());
+        }
         if (mode == AppendOrPrepend::Prepend)
             insertion_point.prepend_child(node);
         else

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -132,10 +132,6 @@ void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, 
     if (display.is_inline_outside()) {
         // Inlines can be inserted into the nearest ancestor.
         auto& insertion_point = insertion_parent_for_inline_node(m_ancestor_stack.last());
-        // TextNode's visible follows its parent's visible property.
-        if (is<Layout::TextNode>(node)) {
-            node.set_visible(insertion_point.is_visible());
-        }
         if (mode == AppendOrPrepend::Prepend)
             insertion_point.prepend_child(node);
         else

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -31,6 +31,9 @@ Layout::InlineNode const& InlinePaintable::layout_node() const
 
 void InlinePaintable::paint(PaintContext& context, PaintPhase phase) const
 {
+    if (!is_visible())
+        return;
+
     auto& painter = context.painter();
 
     if (phase == PaintPhase::Background) {

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
@@ -22,6 +22,8 @@ public:
     Layout::InlineNode const& layout_node() const;
     auto const& box_model() const { return layout_node().box_model(); }
 
+    bool is_visible() const { return layout_node().is_visible(); }
+
 private:
     InlinePaintable(Layout::InlineNode const&);
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -512,7 +512,7 @@ static void paint_text_decoration(PaintContext& context, Gfx::Painter& painter, 
 
 static void paint_text_fragment(PaintContext& context, Layout::TextNode const& text_node, Layout::LineBoxFragment const& fragment, PaintPhase phase)
 {
-    if (!text_node.is_visible())
+    if (!text_node.parent()->is_visible())
         return;
 
     auto& painter = context.painter();

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -512,6 +512,9 @@ static void paint_text_decoration(PaintContext& context, Gfx::Painter& painter, 
 
 static void paint_text_fragment(PaintContext& context, Layout::TextNode const& text_node, Layout::LineBoxFragment const& fragment, PaintPhase phase)
 {
+    if (!text_node.is_visible())
+        return;
+
     auto& painter = context.painter();
 
     if (phase == PaintPhase::Foreground) {


### PR DESCRIPTION
Fix inline node visibility: hidden.
Example:

```
<!DOCTYPE html>
<html>
<head>
  <style>
    span {
      visibility: hidden;
      background-color: #808080;
    }
  </style>
</head>

<body>
  foo
  <span>#</span>
  bar
</body>
</html>
```