### PR TITLE
LibWeb: Add parsing for CSS <paint> values

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -20,7 +20,7 @@ void generate_bounds_checking_function(JsonObject& properties, SourceGenerator& 
 
 static bool type_name_is_enum(StringView type_name)
 {
-    return !AK::first_is_one_of(type_name, "angle"sv, "color"sv, "custom-ident"sv, "frequency"sv, "image"sv, "integer"sv, "length"sv, "number"sv, "percentage"sv, "ratio"sv, "rect"sv, "resolution"sv, "string"sv, "time"sv, "url"sv);
+    return !AK::first_is_one_of(type_name, "angle"sv, "color"sv, "custom-ident"sv, "frequency"sv, "image"sv, "integer"sv, "length"sv, "number"sv, "paint"sv, "percentage"sv, "ratio"sv, "rect"sv, "resolution"sv, "string"sv, "time"sv, "url"sv);
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
@@ -611,6 +611,8 @@ bool property_accepts_type(PropertyID property_id, ValueType value_type)
                     property_generator.appendln("        case ValueType::Length:");
                 } else if (type_name == "number") {
                     property_generator.appendln("        case ValueType::Number:");
+                } else if (type_name == "paint") {
+                    property_generator.appendln("        case ValueType::Paint:");
                 } else if (type_name == "percentage") {
                     property_generator.appendln("        case ValueType::Percentage:");
                 } else if (type_name == "ratio") {

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -308,7 +308,7 @@ public:
     Optional<SVGPaint> const& stroke() const { return m_inherited.stroke; }
     float fill_opacity() const { return m_inherited.fill_opacity; }
     float stroke_opacity() const { return m_inherited.stroke_opacity; }
-    Optional<LengthPercentage> const& stroke_width() const { return m_inherited.stroke_width; }
+    LengthPercentage const& stroke_width() const { return m_inherited.stroke_width; }
     Color stop_color() const { return m_noninherited.stop_color; }
     float stop_opacity() const { return m_noninherited.stop_opacity; }
 
@@ -352,7 +352,7 @@ protected:
         Optional<SVGPaint> stroke;
         float fill_opacity { InitialValues::fill_opacity() };
         float stroke_opacity { InitialValues::stroke_opacity() };
-        Optional<LengthPercentage> stroke_width;
+        LengthPercentage stroke_width { Length::make_px(1) };
 
         Vector<ShadowData> text_shadow;
     } m_inherited;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4447,6 +4447,39 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_image_value(ComponentValue const& comp
     return parse_radial_gradient_function(component_value);
 }
 
+// https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint
+ErrorOr<RefPtr<StyleValue>> Parser::parse_paint_value(TokenStream<ComponentValue>& tokens)
+{
+    // `<paint> = none | <color> | <url> [none | <color>]? | context-fill | context-stroke`
+
+    if (tokens.peek_token().is(Token::Type::Ident)) {
+        auto maybe_ident = value_id_from_string(tokens.peek_token().token().ident());
+        if (maybe_ident.has_value()) {
+            // FIXME: Accept `context-fill` and `context-stroke`
+            switch (*maybe_ident) {
+            case ValueID::None:
+                (void)tokens.next_token();
+                return IdentifierStyleValue::create(*maybe_ident);
+            default:
+                return nullptr;
+            }
+        }
+    }
+
+    if (auto color = TRY(parse_color_value(tokens.peek_token()))) {
+        (void)tokens.next_token();
+        return color;
+    }
+
+    if (auto url = TRY(parse_url_value(tokens.peek_token(), AllowedDataUrlType::Image))) {
+        // FIXME: Accept `[none | <color>]?`
+        (void)tokens.next_token();
+        return url;
+    }
+
+    return nullptr;
+}
+
 template<typename ParseFunction>
 ErrorOr<RefPtr<StyleValue>> Parser::parse_comma_separated_value_list(Vector<ComponentValue> const& component_values, ParseFunction parse_one_value)
 {
@@ -7555,15 +7588,6 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
         if (auto parsed_value = FIXME_TRY(parse_transform_origin_value(component_values)))
             return parsed_value.release_nonnull();
         return ParseError ::SyntaxError;
-    case PropertyID::Fill:
-    case PropertyID::Stroke:
-        if (component_values.size() == 1) {
-            if (auto parsed_url = FIXME_TRY(parse_url_value(component_values.first())))
-                return parsed_url.release_nonnull();
-        }
-        // Allow normal value parsing to continue.
-        // URL is done here to avoid ambiguity with images.
-        break;
     default:
         break;
     }
@@ -7848,6 +7872,11 @@ ErrorOr<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readonl
                 break;
             }
         }
+    }
+
+    if (auto property = any_property_accepts_type(property_ids, ValueType::Paint); property.has_value()) {
+        if (auto value = TRY(parse_paint_value(tokens)))
+            return PropertyAndValue { *property, value.release_nonnull() };
     }
 
     return PropertyAndValue { property_ids.first(), nullptr };

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -304,6 +304,7 @@ private:
     ErrorOr<RefPtr<StyleValue>> parse_ratio_value(TokenStream<ComponentValue>&);
     ErrorOr<RefPtr<StyleValue>> parse_string_value(ComponentValue const&);
     ErrorOr<RefPtr<StyleValue>> parse_image_value(ComponentValue const&);
+    ErrorOr<RefPtr<StyleValue>> parse_paint_value(TokenStream<ComponentValue>&);
     template<typename ParseFunction>
     ErrorOr<RefPtr<StyleValue>> parse_comma_separated_value_list(Vector<ComponentValue> const&, ParseFunction);
     ErrorOr<RefPtr<StyleValue>> parse_simple_comma_separated_value_list(PropertyID, Vector<ComponentValue> const&);

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -737,13 +737,8 @@
     "affects-layout": false,
     "inherited": true,
     "initial": "black",
-    "__comment": "FIXME: Use `paint` as the type, once we have a PaintStyleValue and generic parsing for it.",
     "valid-types": [
-      "color",
-      "url"
-    ],
-    "valid-identifiers": [
-      "none"
+      "paint"
     ]
   },
   "fill-opacity": {
@@ -1709,13 +1704,8 @@
     "affects-layout": false,
     "inherited": true,
     "initial": "none",
-    "__comment": "FIXME: Use `paint` as the type, once we have a PaintStyleValue and generic parsing for it.",
     "valid-types": [
-      "color",
-      "url"
-    ],
-    "valid-identifiers": [
-      "none"
+      "paint"
     ]
   },
   "stroke-opacity": {

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -202,21 +202,19 @@ Optional<float> SVGGraphicsElement::stroke_width() const
         return {};
     // FIXME: Converting to pixels isn't really correct - values should be in "user units"
     //        https://svgwg.org/svg2-draft/coords.html#TermUserUnits
-    if (auto width = layout_node()->computed_values().stroke_width(); width.has_value()) {
-        // Resolved relative to the "Scaled viewport size": https://www.w3.org/TR/2017/WD-fill-stroke-3-20170413/#scaled-viewport-size
-        // FIXME: This isn't right, but it's something.
-        CSSPixels viewport_width = 0;
-        CSSPixels viewport_height = 0;
-        if (auto* svg_svg_element = shadow_including_first_ancestor_of_type<SVGSVGElement>()) {
-            if (auto* svg_svg_layout_node = svg_svg_element->layout_node()) {
-                viewport_width = svg_svg_layout_node->computed_values().width().to_px(*svg_svg_layout_node, 0);
-                viewport_height = svg_svg_layout_node->computed_values().height().to_px(*svg_svg_layout_node, 0);
-            }
+    auto width = layout_node()->computed_values().stroke_width();
+    // Resolved relative to the "Scaled viewport size": https://www.w3.org/TR/2017/WD-fill-stroke-3-20170413/#scaled-viewport-size
+    // FIXME: This isn't right, but it's something.
+    CSSPixels viewport_width = 0;
+    CSSPixels viewport_height = 0;
+    if (auto* svg_svg_element = shadow_including_first_ancestor_of_type<SVGSVGElement>()) {
+        if (auto* svg_svg_layout_node = svg_svg_element->layout_node()) {
+            viewport_width = svg_svg_layout_node->computed_values().width().to_px(*svg_svg_layout_node, 0);
+            viewport_height = svg_svg_layout_node->computed_values().height().to_px(*svg_svg_layout_node, 0);
         }
-        auto scaled_viewport_size = (viewport_width + viewport_height) * 0.5;
-        return width->to_px(*layout_node(), scaled_viewport_size).to_double();
     }
-    return {};
+    auto scaled_viewport_size = (viewport_width + viewport_height) * 0.5;
+    return width.to_px(*layout_node(), scaled_viewport_size).to_double();
 }
 
 }


### PR DESCRIPTION
This gets rid of a couple of FIXMEs in Properties.json :^)

Also, resolve the fill and stroke properties so I could more easily check that they're working.