### PR TITLE
pkill: Add -n, -o and -O options to filter processes by age

### DIFF
--- a/Base/usr/share/man/man1/pkill.md
+++ b/Base/usr/share/man/man1/pkill.md
@@ -5,7 +5,7 @@ pkill - Signal processes based on name
 ## Synopsis
 
 ```sh
-$ pkill [--count] [--ignore-case] [--echo] [--newest] [--oldest] [--signal signame] [--uid uid-list] [--exact] <process-name>
+$ pkill [--count] [--ignore-case] [--echo] [--newest] [--oldest] [--older seconds] [--signal signame] [--uid uid-list] [--exact] <process-name>
 ```
 
 ## Options
@@ -15,6 +15,7 @@ $ pkill [--count] [--ignore-case] [--echo] [--newest] [--oldest] [--signal signa
 * `-e`, `--echo`: Display what is killed
 * `-n`, `--newest`: Kill the most recently created process only
 * `-o`, `--oldest`: Select the least recently created process only
+* `-O`, `--older`: Select only processes older than the specified number of seconds
 * `-s signame`, `--signal signame`: Signal to send. The signal name or number may be used
 * `-U uid-list`, `--uid uid-list`: Select only processes whose UID is in the given comma-separated list. Login name or numerical user ID may be used
 * `-x`, `--exact`: Select only processes whose names match the given pattern exactly

--- a/Base/usr/share/man/man1/pkill.md
+++ b/Base/usr/share/man/man1/pkill.md
@@ -5,7 +5,7 @@ pkill - Signal processes based on name
 ## Synopsis
 
 ```sh
-$ pkill [--count] [--ignore-case] [--echo] [--signal signame] [--uid uid-list] [--exact] <process-name>
+$ pkill [--count] [--ignore-case] [--echo] [--newest] [--signal signame] [--uid uid-list] [--exact] <process-name>
 ```
 
 ## Options
@@ -13,6 +13,7 @@ $ pkill [--count] [--ignore-case] [--echo] [--signal signame] [--uid uid-list] [
 * `-c`, `--count`: Display the number of matching processes
 * `-i`, `--ignore-case`: Make matches case-insensitive
 * `-e`, `--echo`: Display what is killed
+* `-n`, `--newest`: Kill the most recently created process only
 * `-s signame`, `--signal signame`: Signal to send. The signal name or number may be used
 * `-U uid-list`, `--uid uid-list`: Select only processes whose UID is in the given comma-separated list. Login name or numerical user ID may be used
 * `-x`, `--exact`: Select only processes whose names match the given pattern exactly

--- a/Base/usr/share/man/man1/pkill.md
+++ b/Base/usr/share/man/man1/pkill.md
@@ -5,7 +5,7 @@ pkill - Signal processes based on name
 ## Synopsis
 
 ```sh
-$ pkill [--count] [--ignore-case] [--echo] [--signal number] [--uid uid-list] [--exact] <process-name>
+$ pkill [--count] [--ignore-case] [--echo] [--signal signame] [--uid uid-list] [--exact] <process-name>
 ```
 
 ## Options
@@ -13,7 +13,7 @@ $ pkill [--count] [--ignore-case] [--echo] [--signal number] [--uid uid-list] [-
 * `-c`, `--count`: Display the number of matching processes
 * `-i`, `--ignore-case`: Make matches case-insensitive
 * `-e`, `--echo`: Display what is killed
-* `-s number`, `--signal number`: Signal number to send
+* `-s signame`, `--signal signame`: Signal to send. The signal name or number may be used
 * `-U uid-list`, `--uid uid-list`: Select only processes whose UID is in the given comma-separated list. Login name or numerical user ID may be used
 * `-x`, `--exact`: Select only processes whose names match the given pattern exactly
 

--- a/Base/usr/share/man/man1/pkill.md
+++ b/Base/usr/share/man/man1/pkill.md
@@ -5,7 +5,7 @@ pkill - Signal processes based on name
 ## Synopsis
 
 ```sh
-$ pkill [--count] [--ignore-case] [--echo] [--newest] [--signal signame] [--uid uid-list] [--exact] <process-name>
+$ pkill [--count] [--ignore-case] [--echo] [--newest] [--oldest] [--signal signame] [--uid uid-list] [--exact] <process-name>
 ```
 
 ## Options
@@ -14,6 +14,7 @@ $ pkill [--count] [--ignore-case] [--echo] [--newest] [--signal signame] [--uid 
 * `-i`, `--ignore-case`: Make matches case-insensitive
 * `-e`, `--echo`: Display what is killed
 * `-n`, `--newest`: Kill the most recently created process only
+* `-o`, `--oldest`: Select the least recently created process only
 * `-s signame`, `--signal signame`: Signal to send. The signal name or number may be used
 * `-U uid-list`, `--uid uid-list`: Select only processes whose UID is in the given comma-separated list. Login name or numerical user ID may be used
 * `-x`, `--exact`: Select only processes whose names match the given pattern exactly

--- a/Userland/Utilities/pkill.cpp
+++ b/Userland/Utilities/pkill.cpp
@@ -25,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    bool display_number_of_matches;
+    bool display_number_of_matches = false;
     bool case_insensitive = false;
     bool echo = false;
     bool exact_match = false;


### PR DESCRIPTION
This PR adds the following options to `pkill`:
* `-n`: Select the newest matching process.
* `-o`: Select the oldest matching process.
* `-O`: Select processes older than the given number of seconds.

Signals can now also be specified by name as well as number (e.g: `-sKILL` or `-sSIGKILL`, as well as `-s9`)

I also fixed a silly issue where I didn't initialize the `display_number_of_matches` variable. Causing the option to always be enabled :man_facepalming:.

Example:

https://github.com/SerenityOS/serenity/assets/2817754/a658b754-4e61-415b-aaab-f58f36862cbb


