### PR TITLE
LibWeb: Implement and add controls for the HTMLMediaElement volume and muted IDL attributes

### DIFF
--- a/Ladybird/AudioCodecPluginLadybird.cpp
+++ b/Ladybird/AudioCodecPluginLadybird.cpp
@@ -86,4 +86,9 @@ void AudioCodecPluginLadybird::playback_ended()
     m_audio_output->suspend();
 }
 
+void AudioCodecPluginLadybird::set_volume(double volume)
+{
+    m_audio_output->setVolume(volume);
+}
+
 }

--- a/Ladybird/AudioCodecPluginLadybird.h
+++ b/Ladybird/AudioCodecPluginLadybird.h
@@ -31,6 +31,8 @@ public:
     virtual void pause_playback() override;
     virtual void playback_ended() override;
 
+    virtual void set_volume(double) override;
+
 private:
     AudioCodecPluginLadybird(NonnullOwnPtr<QMediaDevices>, NonnullOwnPtr<QAudioSink>);
 

--- a/Userland/Libraries/LibWeb/HTML/AudioTrack.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AudioTrack.cpp
@@ -100,6 +100,11 @@ void AudioTrack::seek(double position, MediaSeekMode seek_mode)
     m_loader->seek(position).release_value_but_fixme_should_propagate_errors();
 }
 
+void AudioTrack::update_volume()
+{
+    m_audio_plugin->set_volume(m_media_element->effective_media_volume());
+}
+
 void AudioTrack::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibWeb/HTML/AudioTrack.h
+++ b/Userland/Libraries/LibWeb/HTML/AudioTrack.h
@@ -28,6 +28,8 @@ public:
     Duration duration() const;
     void seek(double, MediaSeekMode);
 
+    void update_volume();
+
     String const& id() const { return m_id; }
     String const& kind() const { return m_kind; }
     String const& label() const { return m_label; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
@@ -63,4 +63,11 @@ void HTMLAudioElement::on_seek(double position, MediaSeekMode seek_mode)
     });
 }
 
+void HTMLAudioElement::on_volume_change()
+{
+    audio_tracks()->for_each_enabled_track([&](auto& audio_track) {
+        audio_track.update_volume();
+    });
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.h
@@ -29,6 +29,7 @@ private:
     virtual void on_playing() override;
     virtual void on_paused() override;
     virtual void on_seek(double, MediaSeekMode) override;
+    virtual void on_volume_change() override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -303,6 +303,9 @@ void HTMLMediaElement::set_duration(double duration)
     }
 
     m_duration = duration;
+
+    if (auto* layout_node = this->layout_node())
+        layout_node->set_needs_display();
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> HTMLMediaElement::play()

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -389,6 +389,9 @@ void HTMLMediaElement::volume_or_muted_attribute_changed()
 
     // FIXME: Then, if the media element is not allowed to play, the user agent must run the internal pause steps for the media element.
 
+    if (auto* layout_node = this->layout_node())
+        layout_node->set_needs_display();
+
     on_volume_change();
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -104,6 +104,7 @@ public:
         Optional<CSSPixelRect> playback_button_rect;
         Optional<CSSPixelRect> timeline_rect;
         Optional<CSSPixelRect> speaker_button_rect;
+        Optional<CSSPixelRect> volume_rect;
     };
     CachedLayoutBoxes& cached_layout_boxes(Badge<Painting::MediaPaintable>) const { return m_layout_boxes; }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -103,6 +103,7 @@ public:
         Optional<CSSPixelRect> control_box_rect;
         Optional<CSSPixelRect> playback_button_rect;
         Optional<CSSPixelRect> timeline_rect;
+        Optional<CSSPixelRect> speaker_button_rect;
     };
     CachedLayoutBoxes& cached_layout_boxes(Badge<Painting::MediaPaintable>) const { return m_layout_boxes; }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -85,6 +85,14 @@ public:
     WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> play();
     WebIDL::ExceptionOr<void> pause();
 
+    double volume() const { return m_volume; }
+    WebIDL::ExceptionOr<void> set_volume(double);
+
+    bool muted() const { return m_muted; }
+    void set_muted(bool);
+
+    double effective_media_volume() const;
+
     JS::NonnullGCPtr<AudioTrackList> audio_tracks() const { return *m_audio_tracks; }
     JS::NonnullGCPtr<VideoTrackList> video_tracks() const { return *m_video_tracks; }
 
@@ -118,6 +126,8 @@ protected:
     // subclasses must invoke set_current_playback_position() to unblock the user agent.
     virtual void on_seek(double, MediaSeekMode) { m_seek_in_progress = false; }
 
+    virtual void on_volume_change() { }
+
 private:
     friend SourceElementSelector;
 
@@ -141,6 +151,8 @@ private:
     void set_show_poster(bool);
     void set_paused(bool);
     void set_duration(double);
+
+    void volume_or_muted_attribute_changed();
 
     bool blocked() const;
     bool is_eligible_for_autoplay() const;
@@ -211,6 +223,12 @@ private:
 
     // https://html.spec.whatwg.org/multipage/media.html#dom-media-paused
     bool m_paused { true };
+
+    // https://html.spec.whatwg.org/multipage/media.html#dom-media-volume
+    double m_volume { 1.0 };
+
+    // https://html.spec.whatwg.org/multipage/media.html#dom-media-muted
+    bool m_muted { false };
 
     // https://html.spec.whatwg.org/multipage/media.html#dom-media-audiotracks
     JS::GCPtr<AudioTrackList> m_audio_tracks;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.idl
@@ -52,6 +52,9 @@ interface HTMLMediaElement : HTMLElement {
 
     // controls
     [Reflect, CEReactions] attribute boolean controls;
+    attribute double volume;
+    attribute boolean muted;
+    [Reflect=muted, CEReactions] attribute boolean defaultMuted;
 
     // tracks
     [SameObject] readonly attribute AudioTrackList audioTracks;

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -169,14 +169,14 @@ DevicePixelRect MediaPaintable::paint_control_bar_timestamp(PaintContext& contex
     auto duration = human_readable_digital_time(round(media_element.duration()));
     auto timestamp = String::formatted("{} / {}", current_time, duration).release_value_but_fixme_should_propagate_errors();
 
-    auto timestamp_size = static_cast<DevicePixels::Type>(ceilf(context.painter().font().width(timestamp)));
+    auto const& scaled_font = layout_node().scaled_font(context);
+
+    auto timestamp_size = static_cast<DevicePixels::Type>(ceilf(scaled_font.width(timestamp)));
     if (timestamp_size > control_box_rect.width())
         return control_box_rect;
 
     auto timestamp_rect = control_box_rect;
     timestamp_rect.set_width(timestamp_size);
-
-    auto const& scaled_font = layout_node().scaled_font(context);
     context.painter().draw_text(timestamp_rect.to_type<int>(), timestamp, scaled_font, Gfx::TextAlignment::CenterLeft, Color::White);
 
     control_box_rect.take_from_left(timestamp_rect.width());

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -55,44 +55,69 @@ void MediaPaintable::fill_triangle(Gfx::Painter& painter, Gfx::IntPoint location
 
 void MediaPaintable::paint_media_controls(PaintContext& context, HTML::HTMLMediaElement const& media_element, DevicePixelRect media_rect, Optional<DevicePixelPoint> const& mouse_position) const
 {
-    auto maximum_control_box_size = context.rounded_device_pixels(40);
-    auto playback_padding = context.rounded_device_pixels(5);
+    auto components = compute_control_bar_components(context, media_element, media_rect);
+    context.painter().fill_rect(components.control_box_rect.to_type<int>(), control_box_color.with_alpha(0xd0));
 
-    auto control_box_rect = media_rect;
-    if (control_box_rect.height() > maximum_control_box_size)
-        control_box_rect.take_from_top(control_box_rect.height() - maximum_control_box_size);
-
-    context.painter().fill_rect(control_box_rect.to_type<int>(), control_box_color.with_alpha(0xd0));
-    media_element.cached_layout_boxes({}).control_box_rect = context.scale_to_css_rect(control_box_rect);
-
-    control_box_rect = paint_control_bar_playback_button(context, media_element, control_box_rect, mouse_position);
-    control_box_rect.take_from_left(playback_padding);
-
-    control_box_rect = paint_control_bar_timeline(context, media_element, control_box_rect, mouse_position);
-    control_box_rect.take_from_left(playback_padding);
-
-    control_box_rect = paint_control_bar_timestamp(context, media_element, control_box_rect);
-    control_box_rect.take_from_left(playback_padding);
+    paint_control_bar_playback_button(context, media_element, components, mouse_position);
+    paint_control_bar_timeline(context, media_element, components, mouse_position);
+    paint_control_bar_timestamp(context, components);
 }
 
-DevicePixelRect MediaPaintable::paint_control_bar_playback_button(PaintContext& context, HTML::HTMLMediaElement const& media_element, DevicePixelRect control_box_rect, Optional<DevicePixelPoint> const& mouse_position) const
+MediaPaintable::Components MediaPaintable::compute_control_bar_components(PaintContext& context, HTML::HTMLMediaElement const& media_element, DevicePixelRect media_rect) const
 {
-    auto maximum_playback_button_size = context.rounded_device_pixels(15);
-    auto maximum_playback_button_offset_x = context.rounded_device_pixels(15);
+    auto maximum_control_box_height = context.rounded_device_pixels(40);
+    auto component_padding = context.rounded_device_pixels(5);
 
-    auto playback_button_size = min(maximum_playback_button_size, control_box_rect.height() / 2);
-    auto playback_button_offset_x = min(maximum_playback_button_offset_x, control_box_rect.width());
-    auto playback_button_offset_y = (control_box_rect.height() - playback_button_size) / 2;
+    Components components {};
 
-    auto playback_button_location = control_box_rect.top_left().translated(playback_button_offset_x, playback_button_offset_y);
+    components.control_box_rect = media_rect;
+    if (components.control_box_rect.height() > maximum_control_box_height)
+        components.control_box_rect.take_from_top(components.control_box_rect.height() - maximum_control_box_height);
 
-    auto playback_button_hover_rect = DevicePixelRect {
-        control_box_rect.top_left(),
-        { playback_button_size + playback_button_offset_x * 2, control_box_rect.height() }
-    };
-    media_element.cached_layout_boxes({}).playback_button_rect = context.scale_to_css_rect(playback_button_hover_rect);
+    auto remaining_rect = components.control_box_rect;
+    remaining_rect.shrink(component_padding * 2, 0);
 
-    auto playback_button_is_hovered = mouse_position.has_value() && playback_button_hover_rect.contains(*mouse_position);
+    auto playback_button_rect_width = min(context.rounded_device_pixels(40), remaining_rect.width());
+    components.playback_button_rect = remaining_rect;
+    components.playback_button_rect.set_width(playback_button_rect_width);
+    remaining_rect.take_from_left(playback_button_rect_width);
+
+    auto current_time = human_readable_digital_time(round(media_element.current_time()));
+    auto duration = human_readable_digital_time(isnan(media_element.duration()) ? 0 : round(media_element.duration()));
+    components.timestamp = String::formatted("{} / {}", current_time, duration).release_value_but_fixme_should_propagate_errors();
+
+    auto const& scaled_font = layout_node().scaled_font(context);
+    components.timestamp_font = scaled_font.with_size(10);
+    if (!components.timestamp_font)
+        components.timestamp_font = scaled_font;
+
+    auto timestamp_size = DevicePixels { static_cast<DevicePixels::Type>(ceilf(components.timestamp_font->width(components.timestamp))) };
+    if (timestamp_size <= remaining_rect.width()) {
+        components.timestamp_rect = remaining_rect;
+        components.timestamp_rect.take_from_left(remaining_rect.width() - timestamp_size);
+        remaining_rect.take_from_right(timestamp_size + component_padding);
+    }
+
+    components.timeline_button_size = context.rounded_device_pixels(16);
+    if ((components.timeline_button_size * 3) <= remaining_rect.width())
+        components.timeline_rect = remaining_rect;
+
+    media_element.cached_layout_boxes({}).control_box_rect = context.scale_to_css_rect(components.control_box_rect);
+    media_element.cached_layout_boxes({}).playback_button_rect = context.scale_to_css_rect(components.playback_button_rect);
+    media_element.cached_layout_boxes({}).timeline_rect = context.scale_to_css_rect(components.timeline_rect);
+
+    return components;
+}
+
+void MediaPaintable::paint_control_bar_playback_button(PaintContext& context, HTML::HTMLMediaElement const& media_element, Components const& components, Optional<DevicePixelPoint> const& mouse_position)
+{
+    auto playback_button_size = components.playback_button_rect.width() * 4 / 10;
+
+    auto playback_button_offset_x = (components.playback_button_rect.width() - playback_button_size) / 2;
+    auto playback_button_offset_y = (components.playback_button_rect.height() - playback_button_size) / 2;
+    auto playback_button_location = components.playback_button_rect.top_left().translated(playback_button_offset_x, playback_button_offset_y);
+
+    auto playback_button_is_hovered = mouse_position.has_value() && components.playback_button_rect.contains(*mouse_position);
     auto playback_button_color = control_button_color(playback_button_is_hovered);
 
     if (media_element.paused()) {
@@ -106,85 +131,55 @@ DevicePixelRect MediaPaintable::paint_control_bar_playback_button(PaintContext& 
     } else {
         DevicePixelRect pause_button_left_rect {
             playback_button_location,
-            { maximum_playback_button_size / 3, playback_button_size }
+            { playback_button_size / 3, playback_button_size }
         };
         DevicePixelRect pause_button_right_rect {
-            playback_button_location.translated(maximum_playback_button_size * 2 / 3, 0),
-            { maximum_playback_button_size / 3, playback_button_size }
+            playback_button_location.translated(playback_button_size * 2 / 3, 0),
+            { playback_button_size / 3, playback_button_size }
         };
 
         context.painter().fill_rect(pause_button_left_rect.to_type<int>(), playback_button_color);
         context.painter().fill_rect(pause_button_right_rect.to_type<int>(), playback_button_color);
     }
-
-    control_box_rect.take_from_left(playback_button_hover_rect.width());
-    return control_box_rect;
 }
 
-DevicePixelRect MediaPaintable::paint_control_bar_timeline(PaintContext& context, HTML::HTMLMediaElement const& media_element, DevicePixelRect control_box_rect, Optional<DevicePixelPoint> const& mouse_position) const
+void MediaPaintable::paint_control_bar_timeline(PaintContext& context, HTML::HTMLMediaElement const& media_element, Components const& components, Optional<DevicePixelPoint> const& mouse_position)
 {
-    auto maximum_timeline_button_size = context.rounded_device_pixels(16);
+    if (components.timeline_rect.is_empty())
+        return;
 
-    auto timeline_rect = control_box_rect;
-    if (is<HTML::HTMLAudioElement>(media_element))
-        timeline_rect.set_width(min(control_box_rect.width() * 6 / 10, timeline_rect.width() * 4 / 10));
-    else
-        timeline_rect.set_width(min(control_box_rect.width() * 6 / 10, timeline_rect.width()));
-    media_element.cached_layout_boxes({}).timeline_rect = context.scale_to_css_rect(timeline_rect);
+    auto timelime_scrub_rect = components.timeline_rect;
+    timelime_scrub_rect.shrink(components.timeline_button_size, timelime_scrub_rect.height() - components.timeline_button_size / 2);
 
     auto playback_percentage = isnan(media_element.duration()) ? 0.0 : media_element.current_time() / media_element.duration();
-    auto playback_position = static_cast<double>(static_cast<int>(timeline_rect.width())) * playback_percentage;
-
-    auto timeline_button_size = min(maximum_timeline_button_size, timeline_rect.height() / 2);
+    auto playback_position = static_cast<double>(static_cast<int>(timelime_scrub_rect.width())) * playback_percentage;
     auto timeline_button_offset_x = static_cast<DevicePixels>(round(playback_position));
 
     Gfx::AntiAliasingPainter painter { context.painter() };
 
-    auto playback_timelime_scrub_rect = timeline_rect;
-    playback_timelime_scrub_rect.shrink(0, timeline_rect.height() - timeline_button_size / 2);
-
-    auto timeline_past_rect = playback_timelime_scrub_rect;
+    auto timeline_past_rect = timelime_scrub_rect;
     timeline_past_rect.set_width(timeline_button_offset_x);
     painter.fill_rect_with_rounded_corners(timeline_past_rect.to_type<int>(), control_highlight_color.lightened(), 4);
 
-    auto timeline_future_rect = playback_timelime_scrub_rect;
+    auto timeline_future_rect = timelime_scrub_rect;
     timeline_future_rect.take_from_left(timeline_button_offset_x);
     painter.fill_rect_with_rounded_corners(timeline_future_rect.to_type<int>(), Color::Black, 4);
 
-    auto timeline_button_rect = timeline_rect;
-    timeline_button_rect.shrink(timeline_rect.width() - timeline_button_size, timeline_rect.height() - timeline_button_size);
-    timeline_button_rect.set_x(timeline_rect.x() + timeline_button_offset_x - timeline_button_size / 2);
+    auto timeline_button_rect = timelime_scrub_rect;
+    timeline_button_rect.shrink(timelime_scrub_rect.width() - components.timeline_button_size, timelime_scrub_rect.height() - components.timeline_button_size);
+    timeline_button_rect.set_x(timelime_scrub_rect.x() + timeline_button_offset_x - components.timeline_button_size / 2);
 
-    auto timeline_is_hovered = mouse_position.has_value() && timeline_rect.contains(*mouse_position);
+    auto timeline_is_hovered = mouse_position.has_value() && components.timeline_rect.contains(*mouse_position);
     auto timeline_color = control_button_color(timeline_is_hovered);
     painter.fill_ellipse(timeline_button_rect.to_type<int>(), timeline_color);
-
-    control_box_rect.take_from_left(timeline_rect.width() + timeline_button_size / 2);
-    return control_box_rect;
 }
 
-DevicePixelRect MediaPaintable::paint_control_bar_timestamp(PaintContext& context, HTML::HTMLMediaElement const& media_element, DevicePixelRect control_box_rect) const
+void MediaPaintable::paint_control_bar_timestamp(PaintContext& context, Components const& components)
 {
-    auto current_time = human_readable_digital_time(round(media_element.current_time()));
-    auto duration = human_readable_digital_time(isnan(media_element.duration()) ? 0 : round(media_element.duration()));
+    if (components.timestamp_rect.is_empty())
+        return;
 
-    auto timestamp = String::formatted("{} / {}", current_time, duration).release_value_but_fixme_should_propagate_errors();
-
-    auto const& scaled_font = layout_node().scaled_font(context);
-    auto font = scaled_font.with_size(10);
-    if (!font)
-        font = scaled_font;
-
-    auto timestamp_size = static_cast<DevicePixels::Type>(ceilf(font->width(timestamp)));
-    if (timestamp_size > control_box_rect.width())
-        return control_box_rect;
-
-    auto timestamp_rect = control_box_rect;
-    timestamp_rect.set_width(timestamp_size);
-    context.painter().draw_text(timestamp_rect.to_type<int>(), timestamp, *font, Gfx::TextAlignment::CenterLeft, Color::White);
-
-    control_box_rect.take_from_left(timestamp_rect.width());
-    return control_box_rect;
+    context.painter().draw_text(components.timestamp_rect.to_type<int>(), components.timestamp, *components.timestamp_font, Gfx::TextAlignment::CenterLeft, Color::White);
 }
 
 MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mouseup(Badge<EventHandler>, CSSPixelPoint position, unsigned button, unsigned)

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -132,7 +132,7 @@ DevicePixelRect MediaPaintable::paint_control_bar_timeline(PaintContext& context
         timeline_rect.set_width(min(control_box_rect.width() * 6 / 10, timeline_rect.width()));
     media_element.cached_layout_boxes({}).timeline_rect = context.scale_to_css_rect(timeline_rect);
 
-    auto playback_percentage = media_element.current_time() / media_element.duration();
+    auto playback_percentage = isnan(media_element.duration()) ? 0.0 : media_element.current_time() / media_element.duration();
     auto playback_position = static_cast<double>(static_cast<int>(timeline_rect.width())) * playback_percentage;
 
     auto timeline_button_size = min(maximum_timeline_button_size, timeline_rect.height() / 2);
@@ -166,7 +166,8 @@ DevicePixelRect MediaPaintable::paint_control_bar_timeline(PaintContext& context
 DevicePixelRect MediaPaintable::paint_control_bar_timestamp(PaintContext& context, HTML::HTMLMediaElement const& media_element, DevicePixelRect control_box_rect) const
 {
     auto current_time = human_readable_digital_time(round(media_element.current_time()));
-    auto duration = human_readable_digital_time(round(media_element.duration()));
+    auto duration = human_readable_digital_time(isnan(media_element.duration()) ? 0 : round(media_element.duration()));
+
     auto timestamp = String::formatted("{} / {}", current_time, duration).release_value_but_fixme_should_propagate_errors();
 
     auto const& scaled_font = layout_node().scaled_font(context);

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -170,14 +170,17 @@ DevicePixelRect MediaPaintable::paint_control_bar_timestamp(PaintContext& contex
     auto timestamp = String::formatted("{} / {}", current_time, duration).release_value_but_fixme_should_propagate_errors();
 
     auto const& scaled_font = layout_node().scaled_font(context);
+    auto font = scaled_font.with_size(10);
+    if (!font)
+        font = scaled_font;
 
-    auto timestamp_size = static_cast<DevicePixels::Type>(ceilf(scaled_font.width(timestamp)));
+    auto timestamp_size = static_cast<DevicePixels::Type>(ceilf(font->width(timestamp)));
     if (timestamp_size > control_box_rect.width())
         return control_box_rect;
 
     auto timestamp_rect = control_box_rect;
     timestamp_rect.set_width(timestamp_size);
-    context.painter().draw_text(timestamp_rect.to_type<int>(), timestamp, scaled_font, Gfx::TextAlignment::CenterLeft, Color::White);
+    context.painter().draw_text(timestamp_rect.to_type<int>(), timestamp, *font, Gfx::TextAlignment::CenterLeft, Color::White);
 
     control_box_rect.take_from_left(timestamp_rect.width());
     return control_box_rect;

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.h
@@ -8,6 +8,7 @@
 
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/PaintableBox.h>
+#include <LibWeb/PixelUnits.h>
 
 namespace Web::Painting {
 
@@ -23,13 +24,26 @@ protected:
     void paint_media_controls(PaintContext&, HTML::HTMLMediaElement const&, DevicePixelRect media_rect, Optional<DevicePixelPoint> const& mouse_position) const;
 
 private:
+    struct Components {
+        DevicePixelRect control_box_rect;
+        DevicePixelRect playback_button_rect;
+
+        DevicePixelRect timeline_rect;
+        DevicePixels timeline_button_size;
+
+        String timestamp;
+        RefPtr<Gfx::Font> timestamp_font;
+        DevicePixelRect timestamp_rect;
+    };
+
     virtual bool wants_mouse_events() const override { return true; }
     virtual DispatchEventOfSameName handle_mouseup(Badge<EventHandler>, CSSPixelPoint, unsigned button, unsigned modifiers) override;
     virtual DispatchEventOfSameName handle_mousemove(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers) override;
 
-    DevicePixelRect paint_control_bar_playback_button(PaintContext&, HTML::HTMLMediaElement const&, DevicePixelRect control_box_rect, Optional<DevicePixelPoint> const& mouse_position) const;
-    DevicePixelRect paint_control_bar_timeline(PaintContext&, HTML::HTMLMediaElement const&, DevicePixelRect control_box_rect, Optional<DevicePixelPoint> const& mouse_position) const;
-    DevicePixelRect paint_control_bar_timestamp(PaintContext&, HTML::HTMLMediaElement const&, DevicePixelRect control_box_rect) const;
+    Components compute_control_bar_components(PaintContext&, HTML::HTMLMediaElement const&, DevicePixelRect media_rect) const;
+    static void paint_control_bar_playback_button(PaintContext&, HTML::HTMLMediaElement const&, Components const&, Optional<DevicePixelPoint> const& mouse_position);
+    static void paint_control_bar_timeline(PaintContext&, HTML::HTMLMediaElement const&, Components const&, Optional<DevicePixelPoint> const& mouse_position);
+    static void paint_control_bar_timestamp(PaintContext&, Components const&);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.h
@@ -37,6 +37,9 @@ private:
 
         DevicePixelRect speaker_button_rect;
         DevicePixels speaker_button_size;
+
+        DevicePixelRect volume_rect;
+        DevicePixels volume_button_size;
     };
 
     virtual bool wants_mouse_events() const override { return true; }
@@ -48,6 +51,7 @@ private:
     static void paint_control_bar_timeline(PaintContext&, HTML::HTMLMediaElement const&, Components const&, Optional<DevicePixelPoint> const& mouse_position);
     static void paint_control_bar_timestamp(PaintContext&, Components const&);
     static void paint_control_bar_speaker(PaintContext&, HTML::HTMLMediaElement const&, Components const& components, Optional<DevicePixelPoint> const& mouse_position);
+    static void paint_control_bar_volume(PaintContext&, HTML::HTMLMediaElement const&, Components const&, Optional<DevicePixelPoint> const& mouse_position);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.h
@@ -34,6 +34,9 @@ private:
         String timestamp;
         RefPtr<Gfx::Font> timestamp_font;
         DevicePixelRect timestamp_rect;
+
+        DevicePixelRect speaker_button_rect;
+        DevicePixels speaker_button_size;
     };
 
     virtual bool wants_mouse_events() const override { return true; }
@@ -44,6 +47,7 @@ private:
     static void paint_control_bar_playback_button(PaintContext&, HTML::HTMLMediaElement const&, Components const&, Optional<DevicePixelPoint> const& mouse_position);
     static void paint_control_bar_timeline(PaintContext&, HTML::HTMLMediaElement const&, Components const&, Optional<DevicePixelPoint> const& mouse_position);
     static void paint_control_bar_timestamp(PaintContext&, Components const&);
+    static void paint_control_bar_speaker(PaintContext&, HTML::HTMLMediaElement const&, Components const& components, Optional<DevicePixelPoint> const& mouse_position);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Platform/AudioCodecPlugin.h
+++ b/Userland/Libraries/LibWeb/Platform/AudioCodecPlugin.h
@@ -30,6 +30,8 @@ public:
     virtual void pause_playback() = 0;
     virtual void playback_ended() = 0;
 
+    virtual void set_volume(double) = 0;
+
 protected:
     AudioCodecPlugin();
 };

--- a/Userland/Services/WebContent/AudioCodecPluginSerenity.cpp
+++ b/Userland/Services/WebContent/AudioCodecPluginSerenity.cpp
@@ -56,4 +56,9 @@ void AudioCodecPluginSerenity::playback_ended()
     m_connection->async_clear_buffer();
 }
 
+void AudioCodecPluginSerenity::set_volume(double volume)
+{
+    m_connection->async_set_self_volume(volume);
+}
+
 }

--- a/Userland/Services/WebContent/AudioCodecPluginSerenity.h
+++ b/Userland/Services/WebContent/AudioCodecPluginSerenity.h
@@ -28,6 +28,8 @@ public:
     virtual void pause_playback() override;
     virtual void playback_ended() override;
 
+    virtual void set_volume(double) override;
+
 private:
     explicit AudioCodecPluginSerenity(NonnullRefPtr<Audio::ConnectionToServer>);
 


### PR DESCRIPTION

https://github.com/SerenityOS/serenity/assets/5600524/a34eb5b5-68c3-40d5-b578-160b61f00a06


And how it looks on video elements, which will typically have more width:

![Screenshot_20230615_154447](https://github.com/SerenityOS/serenity/assets/5600524/593ef88e-3838-4953-a6ae-c28999c5fe3d)
