### PR TITLE
AK+LibJS+Kernel: Fix some (technically) incorrect alignment assumptions 

### DIFF
--- a/AK/Function.h
+++ b/AK/Function.h
@@ -276,11 +276,13 @@ private:
 #ifndef KERNEL
     // Empirically determined to fit most lambdas and functions.
     static constexpr size_t inline_capacity = 4 * sizeof(void*);
+    alignas(__BIGGEST_ALIGNMENT__) u8 m_storage[inline_capacity];
 #else
     // FIXME: Try to decrease this.
     static constexpr size_t inline_capacity = 6 * sizeof(void*);
+    // In the Kernel nothing has an alignment > alignof(void*).
+    alignas(alignof(void*)) u8 m_storage[inline_capacity];
 #endif
-    alignas(max(alignof(CallableWrapperBase), alignof(CallableWrapperBase*))) u8 m_storage[inline_capacity];
 };
 
 }

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -700,10 +700,15 @@ if (NOT "${SERENITY_ARCH}" STREQUAL "aarch64")
         COMMENT "Preprocessing linker.ld"
         VERBATIM
     )
-
     add_custom_target(generate_kernel_linker_script DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/linker.ld)
     target_link_options(Kernel PRIVATE LINKER:-T ${CMAKE_CURRENT_BINARY_DIR}/linker.ld -nostdlib -nodefaultlibs)
     set_target_properties(Kernel PROPERTIES LINK_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/linker.ld")
+
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_compile_options(Kernel PRIVATE -mpreferred-stack-boundary=3)
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+        target_compile_options(Kernel PRIVATE -mstack-alignment=8)
+    endif()
 else()
     target_link_options(Kernel PRIVATE LINKER:-T ${CMAKE_CURRENT_SOURCE_DIR}/Arch/aarch64/linker.ld -nostdlib LINKER:--no-pie)
     set_target_properties(Kernel PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Arch/aarch64/linker.ld)

--- a/Userland/Libraries/LibJS/Heap/HeapBlock.h
+++ b/Userland/Libraries/LibJS/Heap/HeapBlock.h
@@ -111,7 +111,7 @@ private:
     size_t m_cell_size { 0 };
     size_t m_next_lazy_freelist_index { 0 };
     GCPtr<FreelistEntry> m_freelist;
-    alignas(Cell) u8 m_storage[];
+    alignas(__BIGGEST_ALIGNMENT__) u8 m_storage[];
 
 public:
     static constexpr size_t min_possible_cell_size = sizeof(FreelistEntry);


### PR DESCRIPTION
Previously `AK::Function` and `LibJS` were using `alignof(BaseClass)` to align inline storage areas, this would always resolve to 8-bytes regardless of which subclass ended up being stored. This does not fix any issues now, it is possible to break these assumptions (e.g. you could capture by value a `long double` in a `AK::Function`). 

(This is just something that looked fishy to me while perusing AK :smile:) 