### PR TITLE
AK+LibUnicode+Ladybird+Browser: Handle converting domains from Unicode to ASCII

### DIFF
--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -603,7 +603,8 @@ static Optional<URL::Host> parse_host(StringView input, bool is_opaque = false)
     // FIXME: 4. Let domain be the result of running UTF-8 decode without BOM on the percent-decoding of input.
     auto domain = URL::percent_decode(input);
 
-    // FIXME: 5. Let asciiDomain be the result of running domain to ASCII on domain.
+    // NOTE: This is handled in Unicode::create_unicode_url, to work around the fact that we can't call into LibUnicode here
+    // FIXME: 5. Let asciiDomain be the result of running domain to ASCII with domain and false.
     // FIXME: 6. If asciiDomain is failure, then return failure.
     auto ascii_domain_or_error = String::from_deprecated_string(domain);
     if (ascii_domain_or_error.is_error())

--- a/Meta/CMake/unicode_data.cmake
+++ b/Meta/CMake/unicode_data.cmake
@@ -68,6 +68,9 @@ set(EMOJI_RES_PATH "${SerenityOS_SOURCE_DIR}/Base/res/emoji")
 set(EMOJI_SERENITY_PATH "${SerenityOS_SOURCE_DIR}/Base/home/anon/Documents/emoji-serenity.txt")
 set(EMOJI_INSTALL_PATH "${CMAKE_BINARY_DIR}/Root/home/anon/Documents/emoji.txt")
 
+set(IDNA_MAPPING_TABLE_URL "https://www.unicode.org/Public/idna/${UCD_VERSION}/IdnaMappingTable.txt")
+set(IDNA_MAPPING_TABLE_PATH "${UCD_PATH}/IdnaMappingTable.txt")
+
 if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
     remove_path_if_version_changed("${UCD_VERSION}" "${UCD_VERSION_FILE}" "${UCD_PATH}")
 
@@ -98,11 +101,16 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
         message(STATUS "Skipping download of ${EMOJI_TEST_URL}, expecting the archive to have been extracted to ${EMOJI_TEST_PATH}")
     endif()
 
+    download_file("${IDNA_MAPPING_TABLE_URL}" "${IDNA_MAPPING_TABLE_PATH}")
+
     set(UNICODE_DATA_HEADER UnicodeData.h)
     set(UNICODE_DATA_IMPLEMENTATION UnicodeData.cpp)
 
     set(EMOJI_DATA_HEADER EmojiData.h)
     set(EMOJI_DATA_IMPLEMENTATION EmojiData.cpp)
+
+    set(IDNA_DATA_HEADER IDNAData.h)
+    set(IDNA_DATA_IMPLEMENTATION IDNAData.cpp)
 
     if (SERENITYOS)
         set(EMOJI_INSTALL_ARG -i "${EMOJI_INSTALL_PATH}")
@@ -130,11 +138,21 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
         # the generated emoji.txt file.
         dependencies "${EMOJI_RES_PATH}" "${EMOJI_SERENITY_PATH}"
     )
+    invoke_generator(
+        "IDNAData"
+        Lagom::GenerateIDNAData
+        "${UCD_VERSION_FILE}"
+        "${IDNA_DATA_HEADER}"
+        "${IDNA_DATA_IMPLEMENTATION}"
+        arguments -m "${IDNA_MAPPING_TABLE_PATH}"
+    )
 
     set(UNICODE_DATA_SOURCES
         ${UNICODE_DATA_HEADER}
         ${UNICODE_DATA_IMPLEMENTATION}
         ${EMOJI_DATA_HEADER}
         ${EMOJI_DATA_IMPLEMENTATION}
+        ${IDNA_DATA_HEADER}
+        ${IDNA_DATA_IMPLEMENTATION}
     )
 endif()

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/CMakeLists.txt
@@ -1,2 +1,3 @@
 lagom_tool(GenerateUnicodeData SOURCES GenerateUnicodeData.cpp LIBS LibMain)
 lagom_tool(GenerateEmojiData SOURCES GenerateEmojiData.cpp LIBS LibMain)
+lagom_tool(GenerateIDNAData SOURCES GenerateIDNAData.cpp LIBS LibMain)

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateIDNAData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateIDNAData.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2023, Simon Wanner <simon@skyrising.xyz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GeneratorUtil.h"
+#include <AK/Error.h>
+#include <AK/SourceGenerator.h>
+#include <AK/Types.h>
+#include <LibCore/ArgsParser.h>
+
+enum class MappingStatus : u8 {
+    Valid,
+    Ignored,
+    Mapped,
+    Deviation,
+    Disallowed,
+    DisallowedStd3Valid,
+    DisallowedStd3Mapped,
+};
+
+static constexpr Array<StringView, 7> mapping_status_names { "Valid"sv, "Ignored"sv, "Mapped"sv, "Deviation"sv, "Disallowed"sv, "DisallowedStd3Valid"sv, "DisallowedStd3Mapped"sv };
+
+enum class IDNA2008Status : u8 {
+    NV8,
+    XV8,
+};
+
+static constexpr Array<StringView, 2> idna_2008_status_names { "NV8"sv, "XV8"sv };
+
+struct IDNAMapping {
+    Unicode::CodePointRange code_points;
+    MappingStatus status;
+    IDNA2008Status idna_2008_status;
+    Vector<u32> mapped_to {};
+};
+
+struct IDNAData {
+    Vector<IDNAMapping> mapping_table;
+};
+
+static MappingStatus parse_mapping_status(StringView status)
+{
+    if (status == "valid"sv)
+        return MappingStatus::Valid;
+    if (status == "ignored"sv)
+        return MappingStatus::Ignored;
+    if (status == "mapped"sv)
+        return MappingStatus::Mapped;
+    if (status == "deviation"sv)
+        return MappingStatus::Deviation;
+    if (status == "disallowed"sv)
+        return MappingStatus::Disallowed;
+    if (status == "disallowed_STD3_valid"sv)
+        return MappingStatus::DisallowedStd3Valid;
+    if (status == "disallowed_STD3_mapped"sv)
+        return MappingStatus::DisallowedStd3Mapped;
+    VERIFY_NOT_REACHED();
+}
+
+static ErrorOr<void> parse_idna_mapping_table(Core::InputBufferedFile& file, Vector<IDNAMapping>& mapping_table)
+{
+    Array<u8, 1024> buffer;
+
+    while (TRY(file.can_read_line())) {
+        auto line = TRY(file.read_line(buffer));
+
+        if (line.is_empty() || line.starts_with('#'))
+            continue;
+
+        if (auto index = line.find('#'); index.has_value())
+            line = line.substring_view(0, *index);
+
+        auto segments = line.split_view(';', SplitBehavior::KeepEmpty);
+        VERIFY(segments.size() >= 2);
+
+        IDNAMapping idna_mapping {};
+        idna_mapping.code_points = parse_code_point_range(segments[0].trim_whitespace());
+        idna_mapping.status = parse_mapping_status(segments[1].trim_whitespace());
+
+        if (segments.size() >= 3)
+            idna_mapping.mapped_to = parse_code_point_list(segments[2].trim_whitespace());
+
+        if (segments.size() >= 4) {
+            auto trimmed = segments[3].trim_whitespace();
+            if (trimmed == "NV8"sv) {
+                idna_mapping.idna_2008_status = IDNA2008Status::NV8;
+            } else {
+                VERIFY(trimmed == "XV8"sv);
+                idna_mapping.idna_2008_status = IDNA2008Status::XV8;
+            }
+        }
+
+        TRY(mapping_table.try_append(move(idna_mapping)));
+    }
+
+    return {};
+}
+
+static ErrorOr<void> generate_idna_data_header(Core::InputBufferedFile& file, IDNAData&)
+{
+    StringBuilder builder;
+    SourceGenerator generator { builder };
+
+    generator.append(R"~~~(
+#pragma once
+
+#include <AK/Optional.h>
+#include <LibUnicode/IDNA.h>
+
+namespace Unicode::IDNA {
+
+Optional<Mapping> get_idna_mapping(u32 code_point);
+
+}
+)~~~");
+
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
+    return {};
+}
+
+static ErrorOr<void> generate_idna_data_implementation(Core::InputBufferedFile& file, IDNAData& idna_data)
+{
+    StringBuilder builder;
+    SourceGenerator generator { builder };
+
+    generator.set("idna_table_size", TRY(String::number(idna_data.mapping_table.size())));
+
+    generator.append(R"~~~(
+
+#include <AK/BinarySearch.h>
+#include <AK/Utf32View.h>
+#include <LibUnicode/IDNAData.h>
+#include <LibUnicode/CharacterTypes.h>
+
+namespace Unicode::IDNA {
+
+struct MappingEntry {
+    CodePointRange code_points {};
+    MappingStatus status : 3 { MappingStatus::Valid };
+    IDNA2008Status idna_2008_status : 1 { IDNA2008Status::NV8 };
+    size_t mapping_offset : 20 { 0 };
+    size_t mapping_length : 8 { 0 };
+};
+
+static constexpr Array<MappingEntry, @idna_table_size@> s_idna_mapping_table { {)~~~");
+
+    {
+        size_t mapping_offset = 0;
+        for (auto const& mapping : idna_data.mapping_table) {
+            generator.set("code_points", TRY(String::formatted("{:#x}, {:#x}", mapping.code_points.first, mapping.code_points.last)));
+            generator.set("status", mapping_status_names[to_underlying(mapping.status)]);
+            generator.set("idna_2008_status", idna_2008_status_names[to_underlying(mapping.idna_2008_status)]);
+
+            if (mapping.mapped_to.is_empty()) {
+                generator.set("mapping_offset", "0"sv);
+                generator.set("mapping_length", "0"sv);
+            } else {
+                generator.set("mapping_offset", TRY(String::number(mapping_offset)));
+                generator.set("mapping_length", TRY(String::number(mapping.mapped_to.size())));
+                mapping_offset += mapping.mapped_to.size();
+            }
+
+            generator.append(R"~~~(
+    { { @code_points@ }, MappingStatus::@status@, IDNA2008Status::@idna_2008_status@, @mapping_offset@, @mapping_length@ },)~~~");
+        }
+
+        generator.set("mapping_length_total", TRY(String::number(mapping_offset)));
+    }
+
+    generator.append(R"~~~(
+} };
+
+static constexpr Array<u32, @mapping_length_total@> s_mapping_code_points { )~~~");
+
+    {
+        for (auto const& mapping : idna_data.mapping_table) {
+            if (mapping.mapped_to.is_empty())
+                continue;
+
+            for (u32 code_point : mapping.mapped_to)
+                generator.append(TRY(String::formatted("{:#x}, ", code_point)));
+
+            generator.append(R"~~~(
+    )~~~");
+        }
+    }
+
+    generator.append(R"~~~(
+};
+
+Optional<Mapping> get_idna_mapping(u32 code_point)
+{
+    auto* entry = binary_search(s_idna_mapping_table, code_point, nullptr, [](auto code_point, auto entry) {
+        if (code_point < entry.code_points.first)
+            return -1;
+        if (code_point > entry.code_points.last)
+            return 1;
+        return 0;
+    });
+
+    if (!entry)
+        return {};
+
+    auto mapped_to = Utf32View { entry->mapping_length ?  s_mapping_code_points.data() + entry->mapping_offset : nullptr, entry->mapping_length };
+    return Mapping { entry->status, entry->idna_2008_status, move(mapped_to) };
+}
+
+}
+)~~~");
+
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
+    return {};
+}
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    StringView generated_header_path;
+    StringView generated_implementation_path;
+    StringView idna_mapping_table_path;
+
+    Core::ArgsParser args_parser;
+    args_parser.add_option(generated_header_path, "Path to the IDNA Data header file to generate", "generated-header-path", 'h', "generated-header-path");
+    args_parser.add_option(generated_implementation_path, "Path to the IDNA Data implementation file to generate", "generated-implementation-path", 'c', "generated-implementation-path");
+    args_parser.add_option(idna_mapping_table_path, "Path to IdnaMappingTable.txt file", "idna-mapping-table-path", 'm', "idna-mapping-table-path");
+    args_parser.parse(arguments);
+
+    auto generated_header_file = TRY(open_file(generated_header_path, Core::File::OpenMode::Write));
+    auto generated_implementation_file = TRY(open_file(generated_implementation_path, Core::File::OpenMode::Write));
+    auto idna_mapping_table_file = TRY(open_file(idna_mapping_table_path, Core::File::OpenMode::Read));
+
+    IDNAData idna_data {};
+    TRY(parse_idna_mapping_table(*idna_mapping_table_file, idna_data.mapping_table));
+
+    TRY(generate_idna_data_header(*generated_header_file, idna_data));
+    TRY(generate_idna_data_implementation(*generated_implementation_file, idna_data));
+
+    return 0;
+}

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -212,36 +212,6 @@ static DeprecatedString sanitize_entry(DeprecatedString const& entry)
     return builder.to_deprecated_string();
 }
 
-static Vector<u32> parse_code_point_list(StringView list)
-{
-    Vector<u32> code_points;
-
-    auto segments = list.split_view(' ');
-    for (auto const& code_point : segments)
-        code_points.append(AK::StringUtils::convert_to_uint_from_hex<u32>(code_point).value());
-
-    return code_points;
-}
-
-static Unicode::CodePointRange parse_code_point_range(StringView list)
-{
-    Unicode::CodePointRange code_point_range {};
-
-    if (list.contains(".."sv)) {
-        auto segments = list.split_view(".."sv);
-        VERIFY(segments.size() == 2);
-
-        auto begin = AK::StringUtils::convert_to_uint_from_hex<u32>(segments[0]).value();
-        auto end = AK::StringUtils::convert_to_uint_from_hex<u32>(segments[1]).value();
-        code_point_range = { begin, end };
-    } else {
-        auto code_point = AK::StringUtils::convert_to_uint_from_hex<u32>(list).value();
-        code_point_range = { code_point, code_point };
-    }
-
-    return code_point_range;
-}
-
 static ErrorOr<void> parse_special_casing(Core::InputBufferedFile& file, UnicodeData& unicode_data)
 {
     Array<u8, 1024> buffer;

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
@@ -22,6 +22,7 @@
 #include <AK/Vector.h>
 #include <LibCore/File.h>
 #include <LibLocale/Locale.h>
+#include <LibUnicode/CharacterTypes.h>
 
 template<class T>
 inline constexpr bool StorageTypeIsList = false;
@@ -597,4 +598,34 @@ ReadonlySpan<StringView> @name@()
     return values.span();
 }
 )~~~");
+}
+
+inline Vector<u32> parse_code_point_list(StringView list)
+{
+    Vector<u32> code_points;
+
+    auto segments = list.split_view(' ');
+    for (auto const& code_point : segments)
+        code_points.append(AK::StringUtils::convert_to_uint_from_hex<u32>(code_point).value());
+
+    return code_points;
+}
+
+inline Unicode::CodePointRange parse_code_point_range(StringView list)
+{
+    Unicode::CodePointRange code_point_range {};
+
+    if (list.contains(".."sv)) {
+        auto segments = list.split_view(".."sv);
+        VERIFY(segments.size() == 2);
+
+        auto begin = AK::StringUtils::convert_to_uint_from_hex<u32>(segments[0]).value();
+        auto end = AK::StringUtils::convert_to_uint_from_hex<u32>(segments[1]).value();
+        code_point_range = { begin, end };
+    } else {
+        auto code_point = AK::StringUtils::convert_to_uint_from_hex<u32>(list).value();
+        code_point_range = { code_point, code_point };
+    }
+
+    return code_point_range;
 }

--- a/Tests/LibUnicode/CMakeLists.txt
+++ b/Tests/LibUnicode/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     TestEmoji.cpp
+    TestPunycode.cpp
     TestSegmentation.cpp
     TestUnicodeCharacterTypes.cpp
     TestUnicodeNormalization.cpp

--- a/Tests/LibUnicode/CMakeLists.txt
+++ b/Tests/LibUnicode/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     TestEmoji.cpp
+    TestIDNA.cpp
     TestPunycode.cpp
     TestSegmentation.cpp
     TestUnicodeCharacterTypes.cpp

--- a/Tests/LibUnicode/TestIDNA.cpp
+++ b/Tests/LibUnicode/TestIDNA.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023, Simon Wanner <simon@skyrising.xyz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <LibUnicode/IDNA.h>
+
+namespace Unicode::IDNA {
+
+TEST_CASE(to_ascii)
+{
+#define TEST_TO_ASCII(input, expected, ...) EXPECT_EQ(TRY_OR_FAIL(to_ascii(Utf8View(input), ##__VA_ARGS__)), expected)
+
+    ToAsciiOptions const options_with_transitional_processing {
+        .transitional_processing = TransitionalProcessing::Yes
+    };
+#define TEST_TO_ASCII_T(input, expected) TEST_TO_ASCII(input, expected, options_with_transitional_processing)
+    TEST_TO_ASCII("www.аррӏе.com"sv, "www.xn--80ak6aa92e.com"sv);
+    TEST_TO_ASCII("ö.com"sv, "xn--nda.com"sv);
+    TEST_TO_ASCII("o\u0308.com"sv, "xn--nda.com"sv);
+
+    // Select cases from IdnaTestV2.txt
+    // FIXME: Download, parse and test all cases
+    TEST_TO_ASCII("Faß.de"sv, "xn--fa-hia.de"sv);
+    TEST_TO_ASCII_T("Faß.de"sv, "fass.de"sv);
+    TEST_TO_ASCII("¡"sv, "xn--7a"sv);
+    TEST_TO_ASCII("Bücher.de"sv, "xn--bcher-kva.de");
+    TEST_TO_ASCII("\u0646\u0627\u0645\u0647\u0627\u06CC"sv, "xn--mgba3gch31f"sv);
+    TEST_TO_ASCII("A.b.c。D。"sv, "a.b.c.d."sv);
+    TEST_TO_ASCII("βόλος"sv, "xn--nxasmm1c"sv);
+    TEST_TO_ASCII_T("βόλος"sv, "xn--nxasmq6b"sv);
+#undef TEST_TO_ASCII_T
+#undef TEST_TO_ASCII
+
+    EXPECT(to_ascii(Utf8View("xn--o-ccb.com"sv)).is_error());
+    EXPECT(to_ascii(Utf8View("wh--f.com"sv)).is_error());
+    EXPECT(to_ascii(Utf8View("xn--whf-cec.com"sv)).is_error());
+    EXPECT(to_ascii(Utf8View("-whf.com"sv)).is_error());
+    EXPECT(to_ascii(Utf8View("whf-.com"sv)).is_error());
+}
+
+}

--- a/Tests/LibUnicode/TestPunycode.cpp
+++ b/Tests/LibUnicode/TestPunycode.cpp
@@ -47,4 +47,11 @@ TEST_CASE(decode)
     EXPECT(decode("Nåväl hej vänner"sv).is_error());
 }
 
+TEST_CASE(encode)
+{
+#define CASE(a, b) EXPECT_EQ(TRY_OR_FAIL(encode(a)), b);
+    ENUMERATE_TEST_CASES
+#undef CASE
+}
+
 }

--- a/Tests/LibUnicode/TestPunycode.cpp
+++ b/Tests/LibUnicode/TestPunycode.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, Simon Wanner <simon@skyrising.xyz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <LibUnicode/Punycode.h>
+
+namespace Unicode::Punycode {
+
+#define ENUMERATE_TEST_CASES                                                                                                              \
+    CASE(""sv, ""sv)                                                                                                                      \
+    CASE("Well hello friends!"sv, "Well hello friends!-"sv)                                                                               \
+    CASE("Well-hello-friends"sv, "Well-hello-friends-"sv)                                                                                 \
+    CASE("Wгellд-бhellбвo"sv, "Well-hello-friends"sv)                                                                                     \
+    CASE("Hallöchen Freunde!"sv, "Hallchen Freunde!-2zb"sv)                                                                               \
+    CASE("Nåväl hej vänner"sv, "Nvl hej vnner-cfbhg"sv)                                                                                   \
+    CASE("Ну привіт друзі"sv, "  -kjc9flsd9cjetgj5xg"sv)                                                                                  \
+    CASE("ليهمابتكلموشعربي؟"sv, "egbpdaj6bu4bxfgehfvwxn"sv)                                                                               \
+    CASE("他们为什么不说中文"sv, "ihqwcrb4cv8a8dqg056pqjye"sv)                                                                            \
+    CASE("他們爲什麽不說中文"sv, "ihqwctvzc91f659drss3x8bo0yb"sv)                                                                         \
+    CASE("Pročprostěnemluvíčesky"sv, "Proprostnemluvesky-uyb24dma41a"sv)                                                                  \
+    CASE("למההםפשוטלאמדבריםעברית"sv, "4dbcagdahymbxekheh6e0a7fei0b"sv)                                                                    \
+    CASE("यहलोगहिन्दीक्योंनहींबोलसकतेहैं"sv, "i1baa7eci9glrd9b2ae1bj0hfcgg6iyaf8o0a1dig0cd"sv)                                                   \
+    CASE("なぜみんな日本語を話してくれないのか"sv, "n8jok5ay5dzabd5bym9f0cm5685rrjetr6pdxa"sv)                                            \
+    CASE("세계의모든사람들이한국어를이해한다면얼마나좋을까"sv, "989aomsvi5e83db1d2a355cv1e0vak1dwrv93d5xbh15a0dt30a5jpsd879ccm6fea98c"sv) \
+    CASE("почемужеонинеговорятпорусски"sv, "b1abfaaepdrnnbgefbadotcwatmq2g4l"sv)                                                          \
+    CASE("PorquénopuedensimplementehablarenEspañol"sv, "PorqunopuedensimplementehablarenEspaol-fmd56a"sv)                                 \
+    CASE("TạisaohọkhôngthểchỉnóitiếngViệt"sv, "TisaohkhngthchnitingVit-kjcr8268qyxafd2f1b9g"sv)                                           \
+    CASE("3年B組金八先生"sv, "3B-ww4c5e180e575a65lsy2b"sv)                                                                                \
+    CASE("安室奈美恵-with-SUPER-MONKEYS"sv, "-with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n"sv)                                                 \
+    CASE("Hello-Another-Way-それぞれの場所"sv, "Hello-Another-Way--fc4qua05auwb3674vfr0b"sv)                                              \
+    CASE("ひとつ屋根の下2"sv, "2-u9tlzr9756bt3uc0v"sv)                                                                                    \
+    CASE("MajiでKoiする5秒前"sv, "MajiKoi5-783gue6qz075azm5e"sv)                                                                          \
+    CASE("パフィーdeルンバ"sv, "de-jg4avhby1noc0d"sv)                                                                                     \
+    CASE("そのスピードで"sv, "d9juau41awczczp"sv)                                                                                         \
+    CASE("-> $1.00 <-"sv, "-> $1.00 <--"sv)
+
+TEST_CASE(decode)
+{
+#define CASE(a, b) EXPECT_EQ(TRY_OR_FAIL(decode(b)), a);
+    ENUMERATE_TEST_CASES
+#undef CASE
+    EXPECT(decode("Well hello friends!"sv).is_error());
+    EXPECT(decode("Nåväl hej vänner"sv).is_error());
+}
+
+}

--- a/Userland/Libraries/LibUnicode/CMakeLists.txt
+++ b/Userland/Libraries/LibUnicode/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     CurrencyCode.cpp
     Emoji.cpp
     Normalize.cpp
+    Punycode.cpp
     Segmentation.cpp
     String.cpp
     UnicodeUtils.cpp

--- a/Userland/Libraries/LibUnicode/CMakeLists.txt
+++ b/Userland/Libraries/LibUnicode/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
     CharacterTypes.cpp
     CurrencyCode.cpp
     Emoji.cpp
+    IDNA.cpp
     Normalize.cpp
     Punycode.cpp
     Segmentation.cpp

--- a/Userland/Libraries/LibUnicode/CMakeLists.txt
+++ b/Userland/Libraries/LibUnicode/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
     Segmentation.cpp
     String.cpp
     UnicodeUtils.cpp
+    URL.cpp
     ${UNICODE_DATA_SOURCES}
 )
 set(GENERATED_SOURCES ${CURRENT_LIB_GENERATED})

--- a/Userland/Libraries/LibUnicode/IDNA.cpp
+++ b/Userland/Libraries/LibUnicode/IDNA.cpp
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2023, Simon Wanner <simon@skyrising.xyz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Error.h>
+#include <AK/String.h>
+#include <LibUnicode/CharacterTypes.h>
+#include <LibUnicode/IDNA.h>
+#include <LibUnicode/Normalize.h>
+#include <LibUnicode/Punycode.h>
+
+#if ENABLE_UNICODE_DATA
+#    include <LibUnicode/IDNAData.h>
+#    include <LibUnicode/UnicodeData.h>
+#endif
+
+namespace Unicode::IDNA {
+
+#if not ENABLE_UNICODE_DATA
+
+Optional<Mapping> get_idna_mapping(u32)
+{
+    return {};
+}
+
+#endif
+
+struct ProcessingResult {
+    Vector<String> result {};
+    bool has_error { false };
+};
+
+static MappingStatus translate_status(MappingStatus status, UseStd3AsciiRules use_std3_ascii_rules)
+{
+    switch (status) {
+    case MappingStatus::DisallowedStd3Valid:
+        return use_std3_ascii_rules == UseStd3AsciiRules::Yes ? MappingStatus::Disallowed : MappingStatus::Valid;
+    case MappingStatus::DisallowedStd3Mapped:
+        return use_std3_ascii_rules == UseStd3AsciiRules::Yes ? MappingStatus::Disallowed : MappingStatus::Mapped;
+    default:
+        return status;
+    }
+}
+
+// https://www.unicode.org/reports/tr46/#Validity_Criteria
+static bool is_valid_label(String const& label, CheckHyphens check_hyphens, CheckBidi check_bidi, CheckJoiners check_joiners, UseStd3AsciiRules use_std3_ascii_rules, TransitionalProcessing transitional_processing)
+{
+    // 1. The label must be in Unicode Normalization Form NFC.
+    auto normalized = normalize(label, NormalizationForm::NFC);
+    if (normalized != label)
+        return false;
+
+    size_t position = 0;
+    for (auto code_point : label.code_points()) {
+        // 2. If CheckHyphens, the label must not contain a U+002D HYPHEN-MINUS character in both the third and fourth positions.
+        if (check_hyphens == CheckHyphens::Yes && code_point == '-' && (position == 2 || position == 3))
+            return false;
+
+        // 4. The label must not contain a U+002E ( . ) FULL STOP.
+        if (code_point == '.')
+            return false;
+
+        // 5. The label must not begin with a combining mark, that is: General_Category=Mark.
+        static auto general_category_mark = general_category_from_string("Mark"sv);
+        if (position == 0 && general_category_mark.has_value() && code_point_has_general_category(code_point, general_category_mark.value()))
+            return false;
+
+        // 6. Each code point in the label must only have certain status values according to Section 5, IDNA Mapping Table:
+        Optional<Mapping> mapping = get_idna_mapping(code_point);
+        if (!mapping.has_value())
+            return false;
+
+        auto status = translate_status(mapping->status, use_std3_ascii_rules);
+        if (transitional_processing == TransitionalProcessing::Yes) {
+            // 1. For Transitional Processing, each value must be valid.
+            if (status != MappingStatus::Valid)
+                return false;
+        } else {
+            // 2. For Nontransitional Processing, each value must be either valid or deviation.
+            if (status != MappingStatus::Valid && status != MappingStatus::Deviation)
+                return false;
+        }
+        position++;
+    }
+
+    // 3. If CheckHyphens, the label must neither begin nor end with a U+002D HYPHEN-MINUS character.
+    if (check_hyphens == CheckHyphens::Yes && (label.starts_with('-') || label.ends_with('-')))
+        return false;
+
+    // FIXME: 7. If CheckJoiners, the label must satisify the ContextJ rules from Appendix A, in The Unicode Code Points and Internationalized Domain Names for Applications (IDNA) [IDNA2008].
+    (void)check_joiners;
+
+    // FIXME: 8. If CheckBidi, and if the domain name is a  Bidi domain name, then the label must satisfy all six of the numbered conditions in [IDNA2008] RFC 5893, Section 2.
+    (void)check_bidi;
+
+    return true;
+}
+
+// https://www.unicode.org/reports/tr46/#Processing
+static ErrorOr<ProcessingResult> apply_main_processing_steps(Utf8View domain_name, ToAsciiOptions const& options)
+{
+    bool has_error = false;
+    StringBuilder mapped;
+    // 1. Map. For each code point in the domain_name string, look up the status value in Section 5, IDNA Mapping Table, and take the following actions:
+    for (u32 code_point : domain_name) {
+        Optional<Mapping> mapping = get_idna_mapping(code_point);
+        if (!mapping.has_value()) {
+            has_error = true;
+            continue;
+        }
+        switch (translate_status(mapping->status, options.use_std3_ascii_rules)) {
+        // disallowed: Leave the code point unchanged in the string, and record that there was an error.
+        case MappingStatus::Disallowed:
+            TRY(mapped.try_append_code_point(code_point));
+            has_error = true;
+            break;
+        // ignored: Remove the code point from the string. This is equivalent to mapping the code point to an empty string.
+        case MappingStatus::Ignored:
+            break;
+        // mapped: Replace the code point in the string by the value for the mapping in Section 5, IDNA Mapping Table.
+        case MappingStatus::Mapped:
+            TRY(mapped.try_append(mapping->mapped_to));
+            break;
+        // deviation:
+        case MappingStatus::Deviation:
+            if (options.transitional_processing == TransitionalProcessing::Yes) {
+                // If Transitional_Processing, replace the code point in the string by the value for the mapping in Section 5, IDNA Mapping Table .
+                TRY(mapped.try_append(mapping->mapped_to));
+            } else {
+                TRY(mapped.try_append_code_point(code_point));
+            }
+            break;
+        // valid: Leave the code point unchanged in the string.
+        case MappingStatus::Valid:
+            TRY(mapped.try_append_code_point(code_point));
+            break;
+
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+
+    // 2. Normalize. Normalize the domain_name string to Unicode Normalization Form C.
+    auto normalized = normalize(mapped.string_view(), NormalizationForm::NFC);
+
+    // 3. Break. Break the string into labels at U+002E ( . ) FULL STOP.
+    auto labels = TRY(normalized.split('.', SplitBehavior::KeepEmpty));
+
+    // 4. Convert/Validate. For each label in the domain_name string:
+    for (auto& label : labels) {
+        // If the label starts with “xn--”:
+        if (label.starts_with_bytes("xn--"sv)) {
+            // 1. Attempt to convert the rest of the label to Unicode according to Punycode [RFC3492]. If that conversion fails, record that there was an error, and continue with the next label.
+            //    Otherwise replace the original label in the string by the results of the conversion.
+            auto punycode = Punycode::decode(label.bytes_as_string_view().substring_view(4));
+            if (punycode.is_error()) {
+                has_error = true;
+                continue;
+            }
+
+            label = punycode.release_value();
+
+            // 2. Verify that the label meets the validity criteria in Section 4.1, Validity Criteria for Nontransitional Processing.
+            //    If any of the validity criteria are not satisfied, record that there was an error.
+            if (!is_valid_label(label, options.check_hyphens, options.check_bidi, options.check_joiners, options.use_std3_ascii_rules, TransitionalProcessing::No))
+                has_error = true;
+        }
+        // If the label does not start with “xn--”:
+        else {
+            // Verify that the label meets the validity criteria in Section 4.1, Validity Criteria for the input Processing choice (Transitional or Nontransitional).
+            // If any of the validity criteria are not satisfied, record that there was an error.
+            if (!is_valid_label(label, options.check_hyphens, options.check_bidi, options.check_joiners, options.use_std3_ascii_rules, options.transitional_processing))
+                has_error = true;
+        }
+    }
+
+    return ProcessingResult {
+        .result = move(labels),
+        .has_error = has_error,
+    };
+}
+
+// https://www.unicode.org/reports/tr46/#ToASCII
+ErrorOr<String> to_ascii(Utf8View domain_name, ToAsciiOptions const& options)
+{
+    // 1. To the input domain_name, apply the Processing Steps in Section 4, Processing, using the input boolean flags Transitional_Processing, CheckHyphens, CheckBidi, CheckJoiners, and UseSTD3ASCIIRules. This may record an error.
+    auto processed = TRY(apply_main_processing_steps(domain_name, options));
+    bool has_error = processed.has_error;
+
+    // 2. Break the result into labels at U+002E FULL STOP.
+    auto labels = move(processed.result);
+
+    // 3. Convert each label with non-ASCII characters into Punycode [RFC3492], and prefix by “xn--”. This may record an error.
+    for (auto& label : labels) {
+        auto all_ascii = true;
+        for (auto code_point : label.code_points()) {
+            if (!is_ascii(code_point)) {
+                all_ascii = false;
+                break;
+            }
+        }
+
+        if (!all_ascii) {
+            auto punycode = Punycode::encode(label);
+            if (punycode.is_error()) {
+                has_error = true;
+                continue;
+            }
+            auto punycode_result = punycode.release_value();
+
+            StringBuilder builder;
+            TRY(builder.try_append("xn--"sv));
+            TRY(builder.try_append(punycode_result));
+            label = TRY(builder.to_string());
+        }
+    }
+
+    // 4. If the VerifyDnsLength flag is true, then verify DNS length restrictions. This may record an error. For more information, see [STD13] and [STD3].
+    if (options.verify_dns_length == VerifyDnsLength::Yes) {
+        // 1. The length of the domain name, excluding the root label and its dot, is from 1 to 253.
+        size_t total_length = 0;
+        auto* root_label = !labels.is_empty() && labels.last().is_empty() ? &labels.last() : nullptr;
+        for (auto& label : labels) {
+            // 2. The length of each label is from 1 to 63.
+            auto length = label.bytes().size();
+            if (label.is_empty() && &label != root_label)
+                return Error::from_string_literal("Invalid empty label");
+            if (length > 63)
+                return Error::from_string_literal("Label too long");
+            total_length += length;
+        }
+
+        total_length += labels.size() - (root_label ? 2 : 1);
+        if (total_length == 0 || total_length > 253)
+            return Error::from_string_literal("Domain too long");
+    }
+
+    // 5. If an error was recorded in steps 1-4, then the operation has failed and a failure value is returned. No DNS lookup should be done.
+    if (has_error)
+        return Error::from_string_literal("Invalid domain name");
+
+    // 6. Otherwise join the labels using U+002E FULL STOP as a separator, and return the result.
+    return String::join('.', labels);
+}
+
+}

--- a/Userland/Libraries/LibUnicode/IDNA.h
+++ b/Userland/Libraries/LibUnicode/IDNA.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <AK/Utf32View.h>
+#include <AK/Utf8View.h>
 
 namespace Unicode::IDNA {
 
@@ -30,5 +32,46 @@ struct Mapping {
     IDNA2008Status idna_2008_status;
     Utf32View mapped_to;
 };
+
+enum class CheckHyphens {
+    No,
+    Yes,
+};
+
+enum class CheckBidi {
+    No,
+    Yes,
+};
+
+enum class CheckJoiners {
+    No,
+    Yes,
+};
+
+enum class UseStd3AsciiRules {
+    No,
+    Yes,
+};
+
+enum class TransitionalProcessing {
+    No,
+    Yes,
+};
+
+enum class VerifyDnsLength {
+    No,
+    Yes,
+};
+
+struct ToAsciiOptions {
+    CheckHyphens check_hyphens { CheckHyphens::Yes };
+    CheckBidi check_bidi { CheckBidi::Yes };
+    CheckJoiners check_joiners { CheckJoiners::Yes };
+    UseStd3AsciiRules use_std3_ascii_rules { UseStd3AsciiRules::No };
+    TransitionalProcessing transitional_processing { TransitionalProcessing::No };
+    VerifyDnsLength verify_dns_length { VerifyDnsLength::Yes };
+};
+
+ErrorOr<String> to_ascii(Utf8View domain_name, ToAsciiOptions const& = {});
 
 }

--- a/Userland/Libraries/LibUnicode/IDNA.h
+++ b/Userland/Libraries/LibUnicode/IDNA.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023, Simon Wanner <simon@skyrising.xyz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Utf32View.h>
+
+namespace Unicode::IDNA {
+
+enum class MappingStatus : u8 {
+    Valid,
+    Ignored,
+    Mapped,
+    Deviation,
+    Disallowed,
+    DisallowedStd3Valid,
+    DisallowedStd3Mapped,
+};
+
+enum class IDNA2008Status : u8 {
+    NV8,
+    XV8,
+};
+
+struct Mapping {
+    MappingStatus status;
+    IDNA2008Status idna_2008_status;
+    Utf32View mapped_to;
+};
+
+}

--- a/Userland/Libraries/LibUnicode/Punycode.cpp
+++ b/Userland/Libraries/LibUnicode/Punycode.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2023, Simon Wanner <simon@skyrising.xyz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Utf32View.h>
+#include <LibUnicode/Punycode.h>
+
+namespace Unicode::Punycode {
+
+// https://www.rfc-editor.org/rfc/rfc3492.html#section-5
+static constexpr u32 BASE = 36;
+static constexpr u32 TMIN = 1;
+static constexpr u32 TMAX = 26;
+static constexpr u32 SKEW = 38;
+static constexpr u32 DAMP = 700;
+static constexpr u32 INITIAL_BIAS = 72;
+static constexpr u32 INITIAL_N = 0x80;
+static constexpr u32 DELIMITER = '-';
+
+static Optional<u32> digit_value_of_code_point(u32 code_point)
+{
+    if (code_point >= 'A' && code_point <= 'Z')
+        return code_point - 'A';
+    if (code_point >= 'a' && code_point <= 'z')
+        return code_point - 'a';
+    if (code_point >= '0' && code_point <= '9')
+        return code_point - '0' + 26;
+    return {};
+}
+
+// https://www.rfc-editor.org/rfc/rfc3492.html#section-6.1
+static u32 adapt(u32 delta, u32 num_points, bool first_time)
+{
+    // if firsttime then let delta = delta div damp
+    if (first_time)
+        delta = delta / DAMP;
+    // else let delta = delta div 2
+    else
+        delta = delta / 2;
+
+    // let delta = delta + (delta div numpoints)
+    delta = delta + (delta / num_points);
+
+    // let k = 0
+    u32 k = 0;
+
+    // while delta > ((base - tmin) * tmax) div 2 do begin
+    while (delta > ((BASE - TMIN) * TMAX) / 2) {
+        // let delta = delta div (base - tmin)
+        delta = delta / (BASE - TMIN);
+
+        // let k = k + base
+        k = k + BASE;
+    }
+
+    // return k + (((base - tmin + 1) * delta) div (delta + skew))
+    return k + (((BASE - TMIN + 1) * delta) / (delta + SKEW));
+}
+
+// https://www.rfc-editor.org/rfc/rfc3492.html#section-6.2
+ErrorOr<String> decode(StringView input)
+{
+    size_t consumed = 0;
+
+    // let n = initial_n
+    Checked<size_t> n = INITIAL_N;
+
+    // let i = 0
+    Checked<u32> i = 0;
+
+    // let bias = initial_bias
+    u32 bias = INITIAL_BIAS;
+
+    // let output = an empty string indexed from 0
+    Vector<u32> output;
+
+    // consume all code points before the last delimiter (if there is one)
+    //   and copy them to output, fail on any non-basic code point
+    Optional<size_t> last_delimiter_index = input.find_last(DELIMITER);
+    if (last_delimiter_index.has_value()) {
+        for (; consumed < last_delimiter_index.value(); consumed++) {
+            if (!is_ascii(input[consumed]))
+                return Error::from_string_literal("Unexpected non-basic code point");
+            TRY(output.try_append(input[consumed]));
+        }
+
+        // if more than zero code points were consumed then consume one more
+        //   (which will be the last delimiter)
+        if (last_delimiter_index.value() > 0) {
+            auto next = input[consumed++];
+            VERIFY(next == DELIMITER);
+        }
+    }
+
+    // while the input is not exhausted do begin
+    while (consumed < input.length()) {
+        // let oldi = i
+        Checked<u32> old_i = i;
+
+        // let w = 1
+        Checked<u32> w = 1;
+
+        // for k = base to infinity in steps of base do begin
+        for (size_t k = BASE;; k += BASE) {
+            // consume a code point, or fail if there was none to consume
+            if (consumed >= input.length())
+                return Error::from_string_literal("No more code points to consume");
+            auto code_point = input[consumed++];
+
+            // let digit = the code point's digit-value, fail if it has none
+            auto digit = digit_value_of_code_point(code_point);
+            if (!digit.has_value())
+                return Error::from_string_literal("Invalid base-36 digit");
+
+            // let i = i + digit * w, fail on overflow
+            i = i + Checked(digit.value()) * w;
+            if (i.has_overflow())
+                return Error::from_string_literal("Numeric overflow");
+
+            // let t = tmin if k <= bias {+ tmin}, or
+            //         tmax if k >= bias + tmax, or k - bias otherwise
+            u32 t = k <= bias ? TMIN : (k >= bias + TMAX ? TMAX : k - bias);
+
+            // if digit < t then break
+            if (digit.value() < t)
+                break;
+
+            // let w = w * (base - t), fail on overflow
+            w = w * Checked(BASE - t);
+            if (w.has_overflow())
+                return Error::from_string_literal("Numeric overflow");
+        }
+        // let bias = adapt(i - oldi, length(output) + 1, test oldi is 0?)
+        bias = adapt((i - old_i).value(), output.size() + 1, !old_i);
+
+        // let n = n + i div (length(output) + 1), fail on overflow
+        n = n + Checked(static_cast<size_t>(i.value() / static_cast<u32>(output.size() + 1)));
+        if (n.has_overflow())
+            return Error::from_string_literal("Numeric overflow");
+
+        // let i = i mod (length(output) + 1)
+        i = i % Checked(static_cast<u32>(output.size() + 1));
+
+        // {if n is a basic code point then fail}
+        // NOTE: The full statement enclosed in braces (checking whether n is a basic code point) can be omitted if initial_n exceeds all basic code points
+        //       (which is true for Punycode), because n is never less than initial_n.
+        VERIFY(!is_ascii(n.value()));
+
+        // insert n into output at position i
+        TRY(output.try_insert(i.value(), n.value()));
+
+        // increment i
+        i++;
+    }
+
+    StringBuilder builder;
+    TRY(builder.try_append(Utf32View(output.data(), output.size())));
+    return builder.to_string();
+}
+
+}

--- a/Userland/Libraries/LibUnicode/Punycode.cpp
+++ b/Userland/Libraries/LibUnicode/Punycode.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Utf32View.h>
+#include <AK/Utf8View.h>
 #include <LibUnicode/Punycode.h>
 
 namespace Unicode::Punycode {
@@ -28,6 +29,14 @@ static Optional<u32> digit_value_of_code_point(u32 code_point)
     if (code_point >= '0' && code_point <= '9')
         return code_point - '0' + 26;
     return {};
+}
+
+static u32 code_point_value_of_digit(u32 digit)
+{
+    VERIFY(digit < 36);
+    if (digit <= 25)
+        return 'a' + digit;
+    return '0' + digit - 26;
 }
 
 // https://www.rfc-editor.org/rfc/rfc3492.html#section-6.1
@@ -153,6 +162,120 @@ ErrorOr<String> decode(StringView input)
 
         // increment i
         i++;
+    }
+
+    StringBuilder builder;
+    TRY(builder.try_append(Utf32View(output.data(), output.size())));
+    return builder.to_string();
+}
+
+static Optional<u32> find_smallest_code_point_greater_than_or_equal(Utf32View code_points, u32 threshold)
+{
+    Optional<u32> result;
+    for (auto code_point : code_points) {
+        if (code_point >= threshold && (!result.has_value() || code_point < result.value()))
+            result = code_point;
+    }
+    return result;
+}
+
+ErrorOr<String> encode(StringView input)
+{
+    Vector<u32> code_points;
+    for (auto code_point : Utf8View(input))
+        TRY(code_points.try_append(code_point));
+    return encode(Utf32View(code_points.data(), code_points.size()));
+}
+
+// https://www.rfc-editor.org/rfc/rfc3492.html#section-6.3
+ErrorOr<String> encode(Utf32View input)
+{
+    Vector<u32> output;
+
+    // let n = initial_n
+    Checked<size_t> n = INITIAL_N;
+
+    // let delta = 0
+    Checked<size_t> delta = 0;
+
+    // let bias = initial_bias
+    u32 bias = INITIAL_BIAS;
+
+    // let h = b = the number of basic code points in the input
+    // copy them to the output in order, followed by a delimiter if b > 0
+    size_t b = 0;
+    for (auto code_point : input) {
+        if (is_ascii(code_point)) {
+            TRY(output.try_append(code_point));
+            b++;
+        }
+    }
+    auto h = b;
+    if (b > 0)
+        TRY(output.try_append(DELIMITER));
+
+    // while h < length(input) do begin
+    while (h < input.length()) {
+        // let m = the minimum {non-basic} code point >= n in the input
+        auto m = find_smallest_code_point_greater_than_or_equal(input, n.value());
+        VERIFY(m.has_value());
+
+        // let delta = delta + (m - n) * (h + 1), fail on overflow
+        delta = delta + (Checked(static_cast<size_t>(m.value())) - n) * Checked(h + 1);
+        if (delta.has_overflow())
+            return Error::from_string_literal("Numeric overflow");
+
+        // let n = m
+        n = m.value();
+
+        // for each code point c in the input (in order) do begin
+        for (auto c : input) {
+            // if c < n {or c is basic} then increment delta, fail on overflow
+            if (c < n.value()) {
+                delta++;
+                if (delta.has_overflow())
+                    return Error::from_string_literal("Numeric overflow");
+            }
+
+            // if c == n then begin
+            if (c == n.value()) {
+                // let q = delta
+                auto q = delta.value();
+
+                // for k = base to infinity in steps of base do begin
+                for (size_t k = BASE;; k += BASE) {
+                    // let t = tmin if k <= bias {+ tmin}, or
+                    //         tmax if k >= bias + tmax, or k - bias otherwise
+                    u32 t = k <= bias ? TMIN : (k >= bias + TMAX ? TMAX : k - bias);
+
+                    // if q < t then break
+                    if (q < t)
+                        break;
+
+                    // output the code point for digit t + ((q - t) mod (base - t))
+                    auto digit = t + ((q - t) % (BASE - t));
+                    TRY(output.try_append(code_point_value_of_digit(digit)));
+
+                    // let q = (q - t) div (base - t)
+                    q = (q - t) / (BASE - t);
+                }
+                // output the code point for digit q
+                TRY(output.try_append(code_point_value_of_digit(q)));
+
+                // let bias = adapt(delta, h + 1, test h equals b?)
+                bias = adapt(delta.value(), h + 1, h == b);
+
+                // let delta = 0
+                delta = 0;
+
+                // increment h
+                h++;
+            }
+        }
+
+        // increment delta and n
+        delta++;
+        n++;
     }
 
     StringBuilder builder;

--- a/Userland/Libraries/LibUnicode/Punycode.h
+++ b/Userland/Libraries/LibUnicode/Punycode.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023, Simon Wanner <simon@skyrising.xyz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+
+namespace Unicode::Punycode {
+
+ErrorOr<String> decode(StringView);
+
+}

--- a/Userland/Libraries/LibUnicode/Punycode.h
+++ b/Userland/Libraries/LibUnicode/Punycode.h
@@ -11,5 +11,7 @@
 namespace Unicode::Punycode {
 
 ErrorOr<String> decode(StringView);
+ErrorOr<String> encode(StringView);
+ErrorOr<String> encode(Utf32View);
 
 }

--- a/Userland/Libraries/LibUnicode/URL.cpp
+++ b/Userland/Libraries/LibUnicode/URL.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023, Simon Wanner <simon@skyrising.xyz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibUnicode/IDNA.h>
+#include <LibUnicode/URL.h>
+
+namespace Unicode {
+
+// https://url.spec.whatwg.org/#concept-domain-to-ascii
+static ErrorOr<String> domain_to_ascii(StringView domain, bool be_strict)
+{
+    // 1. Let result be the result of running Unicode ToASCII with domain_name set to domain, UseSTD3ASCIIRules set to beStrict, CheckHyphens set to false, CheckBidi set to true, CheckJoiners set to true, Transitional_Processing set to false, and VerifyDnsLength set to beStrict. [UTS46]
+    // 2. If result is a failure value, domain-to-ASCII validation error, return failure.
+    Unicode::IDNA::ToAsciiOptions const options {
+        Unicode::IDNA::CheckHyphens::No,
+        Unicode::IDNA::CheckBidi::Yes,
+        Unicode::IDNA::CheckJoiners::Yes,
+        be_strict ? Unicode::IDNA::UseStd3AsciiRules::Yes : Unicode::IDNA::UseStd3AsciiRules::No,
+        Unicode::IDNA::TransitionalProcessing::No,
+        be_strict ? Unicode::IDNA::VerifyDnsLength::Yes : Unicode::IDNA::VerifyDnsLength::No
+    };
+    auto result = TRY(Unicode::IDNA::to_ascii(Utf8View(domain), options));
+
+    // 3. If result is the empty string, domain-to-ASCII validation error, return failure.
+    if (result.is_empty())
+        return Error::from_string_literal("Empty domain");
+
+    // 4. Return result.
+    return result;
+}
+
+// https://url.spec.whatwg.org/#concept-host-parser
+ErrorOr<URL> create_unicode_url(String const& url_string)
+{
+    // NOTE: 1.-4. are implemented in URLParser::parse_host
+
+    URL url = url_string;
+    if (!url.is_valid() || !url.host().has<String>())
+        return url;
+
+    auto& domain = url.host().get<String>();
+    if (domain.is_empty())
+        return url;
+
+    // 5. Let asciiDomain be the result of running domain to ASCII with domain and false.
+    // 6. If asciiDomain is failure, then return failure.
+    auto ascii_domain = TRY(domain_to_ascii(domain.bytes_as_string_view(), false));
+
+    // FIXME: Reimplement 7. or call into URLParser::parse_host using ascii_domain (8. & 9. do not apply)
+    url.set_host(ascii_domain);
+    return url;
+}
+
+}

--- a/Userland/Libraries/LibUnicode/URL.h
+++ b/Userland/Libraries/LibUnicode/URL.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, Simon Wanner <simon@skyrising.xyz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <AK/URL.h>
+
+namespace Unicode {
+
+ErrorOr<URL> create_unicode_url(String const&);
+
+}

--- a/Userland/Libraries/LibWebView/CMakeLists.txt
+++ b/Userland/Libraries/LibWebView/CMakeLists.txt
@@ -44,7 +44,7 @@ set(GENERATED_SOURCES
 )
 
 serenity_lib(LibWebView webview)
-target_link_libraries(LibWebView PRIVATE LibCore LibFileSystem LibGfx LibIPC LibProtocol LibJS LibWeb LibSQL)
+target_link_libraries(LibWebView PRIVATE LibCore LibFileSystem LibGfx LibIPC LibProtocol LibJS LibWeb LibSQL LibUnicode)
 target_compile_definitions(LibWebView PRIVATE ENABLE_PUBLIC_SUFFIX=$<BOOL:${ENABLE_PUBLIC_SUFFIX_DOWNLOAD}>)
 
 if (SERENITYOS)


### PR DESCRIPTION
This set of commits implements Punycode conversion as well as the Unicode processing for domain names of UTS 46 and hooks it up to the user URL inputs of Browser & Ladybird (command line and address bar).

The parsing of these URLs is made opt-in through `Unicode::create_unicode_url` because it requires linking with LibUnicode.
Ideally the normal URL parser would handle them directly, but that would require a major overhaul, most likely involving moving `URL` out of AK.
This, while somewhat of a hack, seems to be the least invasive solution for now.