### PR TITLE
LibCompress/Gzip: Replace usage of DeprecatedString

### DIFF
--- a/Userland/Libraries/LibCompress/Gzip.h
+++ b/Userland/Libraries/LibCompress/Gzip.h
@@ -54,7 +54,7 @@ public:
     static ErrorOr<ByteBuffer> decompress_all(ReadonlyBytes);
     static ErrorOr<void> decompress_file(StringView input_file, NonnullOwnPtr<Stream> output_stream);
 
-    static Optional<DeprecatedString> describe_header(ReadonlyBytes);
+    static ErrorOr<Optional<String>> describe_header(ReadonlyBytes);
     static bool is_likely_compressed(ReadonlyBytes bytes);
 
 private:

--- a/Userland/Utilities/file.cpp
+++ b/Userland/Utilities/file.cpp
@@ -97,7 +97,7 @@ static ErrorOr<Optional<String>> gzip_details(StringView description, StringView
     if (!Compress::GzipDecompressor::is_likely_compressed(mapped_file->bytes()))
         return OptionalNone {};
 
-    auto gzip_details = Compress::GzipDecompressor::describe_header(mapped_file->bytes());
+    auto gzip_details = TRY(Compress::GzipDecompressor::describe_header(mapped_file->bytes()));
     if (!gzip_details.has_value())
         return OptionalNone {};
 


### PR DESCRIPTION
Contributes to #17128.