### PR TITLE
LibWeb: Resolve % min-sizes against 0 while under min-content constraint

### DIFF
--- a/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-indefinite-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-indefinite-containing-block-width.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x136 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x120 children: not-inline
-      BlockContainer <div> at (8,8) content-size 784x120 children: inline
+    BlockContainer <body> at (8,8) content-size 120x120 children: not-inline
+      BlockContainer <div> at (8,8) content-size 120x120 children: inline
         line 0 width: 120, height: 120, bottom: 120, baseline: 120
           frag 0 from ImageBox start: 0, length: 0, rect: [8,8 120x120]
         ImageBox <img> at (8,8) content-size 120x120 children: not-inline

--- a/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-min-content-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-min-content-containing-block-width.txt
@@ -1,0 +1,6 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 0x17.46875 children: inline
+      line 0 width: 0, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,21 0x0]
+      ImageBox <img> at (8,21) content-size 0x0 children: not-inline

--- a/Tests/LibWeb/Layout/input/img-with-percentage-max-width-and-indefinite-containing-block-width.html
+++ b/Tests/LibWeb/Layout/input/img-with-percentage-max-width-and-indefinite-containing-block-width.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html><style>
-body { display: max-content; }
+body { width: max-content; }
 img { max-width: 100%; }
 </style><body><div><img src="120.png">

--- a/Tests/LibWeb/Layout/input/img-with-percentage-max-width-and-min-content-containing-block-width.html
+++ b/Tests/LibWeb/Layout/input/img-with-percentage-max-width-and-min-content-containing-block-width.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html><style>
+body { width: min-content; }
+img { max-width: 100%; }
+</style><body><img src="120.png">

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -253,7 +253,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!should_treat_max_width_as_none(box)) {
+    if (!should_treat_max_width_as_none(box, available_space.width)) {
         auto max_width = calculate_inner_width(box, remaining_available_space.width, computed_values.max_width());
         auto used_width_px = used_width.is_auto() ? remaining_available_space.width.to_px() : used_width.to_px(box);
         if (used_width_px > max_width.to_px(box)) {
@@ -331,7 +331,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!should_treat_max_width_as_none(box)) {
+    if (!should_treat_max_width_as_none(box, available_space.width)) {
         auto max_width = calculate_inner_width(box, available_space.width, computed_values.max_width());
         if (width.to_px(box) > max_width.to_px(box))
             width = compute_width(max_width);
@@ -458,7 +458,7 @@ void BlockFormattingContext::compute_height(Box const& box, AvailableSpace const
         }
     }
 
-    if (!should_treat_max_height_as_none(box)) {
+    if (!should_treat_max_height_as_none(box, available_space.height)) {
         auto max_height = calculate_inner_height(box, available_space.height, computed_values.max_height());
         if (!max_height.is_auto())
             height = min(height, max_height.to_px(box));

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -99,8 +99,8 @@ protected:
     static bool should_treat_width_as_auto(Box const&, AvailableSpace const&);
     static bool should_treat_height_as_auto(Box const&, AvailableSpace const&);
 
-    [[nodiscard]] bool should_treat_max_width_as_none(Box const&) const;
-    [[nodiscard]] bool should_treat_max_height_as_none(Box const&) const;
+    [[nodiscard]] bool should_treat_max_width_as_none(Box const&, AvailableSize const&) const;
+    [[nodiscard]] bool should_treat_max_height_as_none(Box const&, AvailableSize const&) const;
 
     OwnPtr<FormattingContext> layout_inside(Box const&, LayoutMode, AvailableSpace const&);
     void compute_inset(Box const& box);
@@ -129,7 +129,7 @@ protected:
     CSSPixels tentative_height_for_replaced_element(Box const&, CSS::Size const& computed_height, AvailableSpace const&) const;
     CSSPixels compute_auto_height_for_block_formatting_context_root(Box const&) const;
 
-    [[nodiscard]] CSSPixelSize solve_replaced_size_constraint(CSSPixels input_width, CSSPixels input_height, Box const&) const;
+    [[nodiscard]] CSSPixelSize solve_replaced_size_constraint(CSSPixels input_width, CSSPixels input_height, Box const&, AvailableSpace const&) const;
 
     ShrinkToFitResult calculate_shrink_to_fit_widths(Box const&);
 

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -149,7 +149,7 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     }
 
     CSSPixels width = unconstrained_width;
-    if (!should_treat_max_width_as_none(box)) {
+    if (!should_treat_max_width_as_none(box, m_available_space->width)) {
         auto max_width = box.computed_values().max_width().to_px(box, width_of_containing_block);
         width = min(width, max_width);
     }

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -186,9 +186,9 @@ void TableFormattingContext::compute_cell_measures(AvailableSpace const& availab
 
         CSSPixels max_height = computed_values.height().is_auto() ? max_content_height : height;
         CSSPixels max_width = computed_values.width().is_auto() ? max_content_width : width;
-        if (!should_treat_max_height_as_none(cell.box))
+        if (!should_treat_max_height_as_none(cell.box, available_space.height))
             max_height = min(max_height, computed_values.max_height().to_px(cell.box, containing_block.content_height()));
-        if (!should_treat_max_width_as_none(cell.box))
+        if (!should_treat_max_width_as_none(cell.box, available_space.width))
             max_width = min(max_width, computed_values.max_width().to_px(cell.box, containing_block.content_width()));
 
         if (computed_values.height().is_percentage()) {
@@ -350,7 +350,7 @@ void TableFormattingContext::compute_table_width()
         // of resolved-table-width, and the used min-width of the table.
         CSSPixels resolved_table_width = computed_values.width().to_px(table_box(), width_of_table_wrapper_containing_block);
         used_width = max(resolved_table_width, used_min_width);
-        if (!should_treat_max_width_as_none(table_box()))
+        if (!should_treat_max_width_as_none(table_box(), m_available_space->width))
             used_width = min(used_width, computed_values.max_width().to_px(table_box(), width_of_table_wrapper_containing_block));
     }
 


### PR DESCRIPTION
When resolving a percentage `min-width` or `min-height` size against a containing block currently under a `min-content` constraint, we should act as if the containing block has zero size in that axis.

Visual progression on https://null.com/

Before:
![Screenshot at 2023-06-16 13-52-15](https://github.com/SerenityOS/serenity/assets/5954907/f320dba8-a47a-4478-be57-d226742314ee)

After:
![Screenshot at 2023-06-16 13-52-02](https://github.com/SerenityOS/serenity/assets/5954907/38dac0c8-f837-4bf1-ab95-5419377eee50)

