### PR TITLE
AK+Everywhere: Introduce AK_MAKE_DEFAULT_MOVABLE to simplify default-move implementations

### DIFF
--- a/AK/BufferedStream.h
+++ b/AK/BufferedStream.h
@@ -21,6 +21,7 @@ concept SeekableStreamLike = IsBaseOf<SeekableStream, T>;
 template<typename T>
 class BufferedHelper {
     AK_MAKE_NONCOPYABLE(BufferedHelper);
+    AK_MAKE_DEFAULT_MOVABLE(BufferedHelper);
 
 public:
     template<StreamLike U>
@@ -28,19 +29,6 @@ public:
         : m_stream(move(stream))
         , m_buffer(move(buffer))
     {
-    }
-
-    BufferedHelper(BufferedHelper&& other)
-        : m_stream(move(other.m_stream))
-        , m_buffer(move(other.m_buffer))
-    {
-    }
-
-    BufferedHelper& operator=(BufferedHelper&& other)
-    {
-        m_stream = move(other.m_stream);
-        m_buffer = move(other.m_buffer);
-        return *this;
     }
 
     template<template<typename> typename BufferedType>

--- a/AK/CircularBuffer.h
+++ b/AK/CircularBuffer.h
@@ -15,13 +15,11 @@ namespace AK {
 
 class CircularBuffer {
     AK_MAKE_NONCOPYABLE(CircularBuffer);
+    AK_MAKE_DEFAULT_MOVABLE(CircularBuffer);
 
 public:
     static ErrorOr<CircularBuffer> create_empty(size_t size);
     static ErrorOr<CircularBuffer> create_initialized(ByteBuffer);
-
-    CircularBuffer(CircularBuffer&& other) = default;
-    CircularBuffer& operator=(CircularBuffer&& other) = default;
 
     ~CircularBuffer() = default;
 

--- a/AK/Noncopyable.h
+++ b/AK/Noncopyable.h
@@ -15,3 +15,8 @@ private:                       \
 private:                      \
     c(c&&) = delete;          \
     c& operator=(c&&) = delete
+
+#define AK_MAKE_DEFAULT_MOVABLE(c) \
+public:                            \
+    c(c&&) = default;              \
+    c& operator=(c&&) = default

--- a/AK/SourceGenerator.h
+++ b/AK/SourceGenerator.h
@@ -34,6 +34,8 @@ public:
     }
 
     SourceGenerator(SourceGenerator&&) = default;
+    // Move-assign is undefinable due to 'StringBuilder& m_builder;'
+    SourceGenerator& operator=(SourceGenerator&&) = delete;
 
     SourceGenerator fork() { return SourceGenerator { m_builder, m_mapping, m_opening, m_closing }; }
 

--- a/Kernel/Library/KBufferBuilder.h
+++ b/Kernel/Library/KBufferBuilder.h
@@ -14,14 +14,13 @@ namespace Kernel {
 
 class KBufferBuilder {
     AK_MAKE_NONCOPYABLE(KBufferBuilder);
+    AK_MAKE_DEFAULT_MOVABLE(KBufferBuilder);
 
 public:
     using OutputType = KBuffer;
 
     static ErrorOr<KBufferBuilder> try_create();
 
-    KBufferBuilder(KBufferBuilder&&) = default;
-    KBufferBuilder& operator=(KBufferBuilder&&) = default;
     ~KBufferBuilder() = default;
 
     ErrorOr<void> append(StringView);

--- a/Tests/AK/TestQuickSort.cpp
+++ b/Tests/AK/TestQuickSort.cpp
@@ -14,12 +14,10 @@ TEST_CASE(sorts_without_copy)
 {
     struct NoCopy {
         AK_MAKE_NONCOPYABLE(NoCopy);
+        AK_MAKE_DEFAULT_MOVABLE(NoCopy);
 
     public:
         NoCopy() = default;
-        NoCopy(NoCopy&&) = default;
-
-        NoCopy& operator=(NoCopy&&) = default;
 
         int value { 0 };
     };

--- a/Tests/AK/TestTuple.cpp
+++ b/Tests/AK/TestTuple.cpp
@@ -53,9 +53,9 @@ TEST_CASE(no_copy)
 {
     struct NoCopy {
         AK_MAKE_NONCOPYABLE(NoCopy);
+        AK_MAKE_DEFAULT_MOVABLE(NoCopy);
 
     public:
-        NoCopy(NoCopy&&) = default;
         NoCopy() = default;
     };
 

--- a/Tests/AK/TestVariant.cpp
+++ b/Tests/AK/TestVariant.cpp
@@ -96,10 +96,10 @@ TEST_CASE(move_moves)
 {
     struct NoCopy {
         AK_MAKE_NONCOPYABLE(NoCopy);
+        AK_MAKE_DEFAULT_MOVABLE(NoCopy);
 
     public:
         NoCopy() = default;
-        NoCopy(NoCopy&&) = default;
     };
 
     Variant<NoCopy, int> first_variant { 42 };

--- a/Userland/Libraries/LibCore/SecretString.h
+++ b/Userland/Libraries/LibCore/SecretString.h
@@ -14,6 +14,7 @@ namespace Core {
 
 class SecretString {
     AK_MAKE_NONCOPYABLE(SecretString);
+    AK_MAKE_DEFAULT_MOVABLE(SecretString);
 
 public:
     [[nodiscard]] static ErrorOr<SecretString> take_ownership(char*&, size_t);
@@ -26,8 +27,6 @@ public:
 
     SecretString() = default;
     ~SecretString();
-    SecretString(SecretString&&) = default;
-    SecretString& operator=(SecretString&&) = default;
 
 private:
     explicit SecretString(ByteBuffer&&);

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -237,9 +237,9 @@ ErrorOr<int> poll(Span<struct pollfd>, int timeout);
 
 class AddressInfoVector {
     AK_MAKE_NONCOPYABLE(AddressInfoVector);
+    AK_MAKE_DEFAULT_MOVABLE(AddressInfoVector);
 
 public:
-    AddressInfoVector(AddressInfoVector&&) = default;
     ~AddressInfoVector() = default;
 
     ReadonlySpan<struct addrinfo> addresses() const { return m_addresses; }

--- a/Userland/Libraries/LibCore/ThreadEventQueue.cpp
+++ b/Userland/Libraries/LibCore/ThreadEventQueue.cpp
@@ -18,17 +18,12 @@ namespace Core {
 struct ThreadEventQueue::Private {
     struct QueuedEvent {
         AK_MAKE_NONCOPYABLE(QueuedEvent);
+        AK_MAKE_DEFAULT_MOVABLE(QueuedEvent);
 
     public:
         QueuedEvent(Object& receiver, NonnullOwnPtr<Event> event)
             : receiver(receiver)
             , event(move(event))
-        {
-        }
-
-        QueuedEvent(QueuedEvent&& other)
-            : receiver(other.receiver)
-            , event(move(other.event))
         {
         }
 

--- a/Userland/Libraries/LibDSP/Music.h
+++ b/Userland/Libraries/LibDSP/Music.h
@@ -202,11 +202,9 @@ constexpr double const middle_c = note_frequencies[36];
 struct Signal : public Variant<FixedArray<Sample>, RollNotes> {
     using Variant::Variant;
     AK_MAKE_NONCOPYABLE(Signal);
+    AK_MAKE_DEFAULT_MOVABLE(Signal);
 
 public:
-    Signal& operator=(Signal&&) = default;
-    Signal(Signal&&) = default;
-
     ALWAYS_INLINE SignalType type() const
     {
         if (has<FixedArray<Sample>>())

--- a/Userland/Libraries/LibSQL/Result.h
+++ b/Userland/Libraries/LibSQL/Result.h
@@ -75,6 +75,9 @@ enum class SQLErrorCode {
 };
 
 class [[nodiscard]] Result {
+    AK_MAKE_NONCOPYABLE(Result);
+    AK_MAKE_DEFAULT_MOVABLE(Result);
+
 public:
     ALWAYS_INLINE Result(SQLCommand command)
         : m_command(command)
@@ -100,9 +103,6 @@ public:
     {
     }
 
-    Result(Result&&) = default;
-    Result& operator=(Result&&) = default;
-
     SQLCommand command() const { return m_command; }
     SQLErrorCode error() const { return m_error; }
     DeprecatedString error_string() const;
@@ -120,8 +120,6 @@ public:
     }
 
 private:
-    AK_MAKE_NONCOPYABLE(Result);
-
     SQLCommand m_command { SQLCommand::Unknown };
 
     SQLErrorCode m_error { SQLErrorCode::NoError };

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -21,6 +21,7 @@ class HTMLTokenizer;
 
 class HTMLToken {
     AK_MAKE_NONCOPYABLE(HTMLToken);
+    AK_MAKE_DEFAULT_MOVABLE(HTMLToken);
 
 public:
     enum class Type : u8 {
@@ -94,9 +95,6 @@ public:
             break;
         }
     }
-
-    HTMLToken(HTMLToken&&) = default;
-    HTMLToken& operator=(HTMLToken&&) = default;
 
     bool is_doctype() const { return m_type == Type::DOCTYPE; }
     bool is_start_tag() const { return m_type == Type::StartTag; }

--- a/Userland/Utilities/sed.cpp
+++ b/Userland/Utilities/sed.cpp
@@ -612,14 +612,7 @@ enum class CycleDecision {
 // In most cases, just an input to sed. However, files are also written to when the -i option is used.
 class File {
     AK_MAKE_NONCOPYABLE(File);
-
-    File(LexicalPath input_file_path, NonnullOwnPtr<Core::InputBufferedFile>&& file, OwnPtr<Core::File>&& output, OwnPtr<FileSystem::TempFile>&& temp_file)
-        : m_input_file_path(move(input_file_path))
-        , m_file(move(file))
-        , m_output(move(output))
-        , m_output_temp_file(move(temp_file))
-    {
-    }
+    AK_MAKE_DEFAULT_MOVABLE(File);
 
 public:
     // Used for -i mode.
@@ -655,9 +648,6 @@ public:
             nullptr,
         };
     }
-
-    File(File&&) = default;
-    File& operator=(File&&) = default;
 
     ErrorOr<bool> has_next() const
     {
@@ -696,6 +686,14 @@ public:
     }
 
 private:
+    File(LexicalPath input_file_path, NonnullOwnPtr<Core::InputBufferedFile>&& file, OwnPtr<Core::File>&& output, OwnPtr<FileSystem::TempFile>&& temp_file)
+        : m_input_file_path(move(input_file_path))
+        , m_file(move(file))
+        , m_output(move(output))
+        , m_output_temp_file(move(temp_file))
+    {
+    }
+
     LexicalPath m_input_file_path;
     NonnullOwnPtr<Core::InputBufferedFile> m_file;
 


### PR DESCRIPTION
There were a couple of incomplete or manually-written default (re-)implementations of move-constructors and move-assigns. This PR fixes them, and offers a new macro `AK_MAKE_DEFAULT_MOVABLE` that solves this problem.

I found these instances by looking for `AK_MAKE_NON*`, and taking a close look at all classes that use `NONCOPYABLE` but not `NONMOVABLE`. A bunch of classes has a good reason to use non-default move-semantics, and I left these alone. If in doubt, I didn't change anything. In particular, I only touched classes where move-semantics were already mentioned in some form, *and* `NONCOPYABLE` is used. (I don't see a point in touching the countless cases where we have perfectly fine default move-semantics like e.g. in InputBufferedSeekable.)

Let me know if you wish the commits to be grouped differently. I don't want to smash them all into a single commit, but it also seems silly to split the last commit ("Everywhere") into four commits.