### PR TITLE
AK+LibIDL: Implement fallible "clone()" for most containers; stress-test via LibIDL

### DIFF
--- a/AK/CopyMethod.h
+++ b/AK/CopyMethod.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2023, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+// Because this interacts with ErrorOr and includes Error.h, this cannot go into TypedTransfer.h.
+
+#include <AK/Error.h>
+#include <AK/Format.h>
+#include <AK/Platform.h>
+
+namespace AK {
+
+// TODO:
+// - return decltype of clone() in FallibleCopyHelper
+// - Allow passing template arguments to FallibleCopyHelper
+// - Check that it works for clone-only types
+
+template<typename T>
+concept HasFallibleClone = requires(T&& t) {
+                               t.clone().is_error();
+                               t.clone().release_error();
+                               t.clone().release_value();
+                           };
+
+template<typename Cloner, typename T>
+concept IsCloner = VoidFunction<Cloner, T const&> || FallibleFunction<Cloner, T const&>;
+
+template<typename T>
+class CloneCaller;
+
+template<typename T>
+requires(!HasFallibleClone<T>)
+class CloneCaller<T> {
+public:
+    void operator()(T const&)
+    {
+        // void as a return type indicates that this function shall not be called,
+        // and instead the copy constructor shall be used.
+        VERIFY_NOT_REACHED();
+    }
+};
+
+template<typename T>
+requires(HasFallibleClone<T>)
+class CloneCaller<T> {
+public:
+    auto operator()(T const& source)
+    {
+        return source.clone();
+    }
+};
+
+template<typename T, typename NewT, typename Cloner>
+// Cannot use IsCloner here because C++ template specialization is not clever enough for that.
+requires(VoidFunction<Cloner, T const&> || FallibleFunction<Cloner, T const&>)
+class FallibleCopyHelper;
+
+template<typename T, typename NewT, typename Cloner>
+requires(VoidFunction<Cloner, T const&>)
+class FallibleCopyHelper<T, NewT, Cloner> {
+public:
+    FallibleCopyHelper(Cloner)
+    {
+    }
+
+    void operator()(NewT* destination, T const* source)
+    {
+        new (destination) NewT(*source);
+    }
+};
+
+template<typename T, typename NewT, typename Cloner>
+requires(FallibleFunction<Cloner, T const&>)
+class FallibleCopyHelper<T, NewT, Cloner> {
+public:
+    FallibleCopyHelper(Cloner cloner)
+        : m_cloner(move(cloner))
+    {
+    }
+
+    ErrorOr<void> operator()(NewT* destination, T const* source)
+    {
+        new (destination) NewT(TRY(m_cloner(*source)));
+        return {};
+    }
+
+private:
+    Cloner m_cloner;
+};
+
+// ======
+
+/*
+
+template<typename OldType, typename NewType = OldType>
+class InfallibleCopyConstruct {
+public:
+    void operator()(NewType* destination, OldType const* source)
+    {
+        new (destination) NewType(*source);
+    }
+};
+
+template<typename OldType, typename NewType = OldType, typename... CloneArgs>
+class FallibleClone {
+public:
+    ErrorOr<void> operator()(NewType* destination, OldType const* source, CloneArgs... clone_args)
+    {
+        new (destination) NewType(TRY(source->clone(clone_args...)));
+        return {};
+    }
+};
+
+// We would like to use CopyMethod::ImplicitInfallible() and CopyMethod::FallibleClone() as parameter,
+// but might also want to expose these only when `USING_AK_GLOBALLY` is set.
+// This can only be achieved with classes, not namespaces.
+class CopyMethod {
+public:
+    template<typename OldType, typename NewType = OldType>
+    using InfallibleCopyConstruct = InfallibleCopyConstruct<NewType, OldType>;
+    template<typename OldType, typename NewType = OldType, typename... CloneArgs>
+    using FallibleClone = FallibleClone<NewType, OldType, CloneArgs...>;
+
+    // template<typename T, typename TraitsForT = Traits<T>, bool IsOrdered = false>
+    // class HashTable;
+    // template<typename K, typename V, typename KeyTraits = Traits<K>, typename ValueTraits = Traits<V>, bool IsOrdered = false>
+    // class HashMap;
+    // template<typename T, size_t inline_capacity = 0>
+    // requires(!IsRvalueReference<T>) class Vector;
+};
+
+*/
+
+}
+
+#if USING_AK_GLOBALLY
+// using AK::CopyMethod;
+using AK::HasFallibleClone;
+#endif

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
@@ -89,7 +89,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto output_file = TRY(Core::File::open_file_or_standard_stream(output_path, Core::File::OpenMode::Write));
 
     IDL::Parser parser(path, data, import_base_path);
-    auto& interface = parser.parse();
+    auto& interface = *TRY(parser.parse());
 
     if (IDL::libweb_interface_namespaces.span().contains_slow(namespace_)) {
         StringBuilder builder;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
@@ -389,7 +389,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     for (size_t i = 0; i < paths.size(); ++i) {
         IDL::Parser parser(paths[i], file_contents[i], lexical_base.string());
-        TRY(add_to_interface_sets(parser.parse(), intrinsics, window_exposed, dedicated_worker_exposed, shared_worker_exposed));
+        auto& interface = *TRY(parser.parse());
+        TRY(add_to_interface_sets(interface, intrinsics, window_exposed, dedicated_worker_exposed, shared_worker_exposed));
         parsers.append(move(parser));
     }
 

--- a/Tests/AK/TestHashTable.cpp
+++ b/Tests/AK/TestHashTable.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, thislooksfun <tlf@thislooks.fun>
  * Copyright (c) 2023, Jelle Raaijmakers <jelle@gmta.nl>
+ * Copyright (c) 2023, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,6 +11,7 @@
 #include <AK/DeprecatedString.h>
 #include <AK/HashTable.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/StdLibExtras.h>
 #include <AK/Vector.h>
 
 TEST_CASE(construct)
@@ -450,3 +452,254 @@ TEST_CASE(values)
     EXPECT_EQ(values[1], 30);
     EXPECT_EQ(values[2], 20);
 }
+
+TEST_CASE(clone_pod)
+{
+    HashTable<int> table1;
+    TRY_OR_FAIL(table1.try_set(42));
+    TRY_OR_FAIL(table1.try_set(1337));
+    TRY_OR_FAIL(table1.try_set(123456789));
+    EXPECT_EQ(table1.size(), static_cast<size_t>(3));
+    EXPECT_EQ(table1.contains(42), true);
+    EXPECT_EQ(table1.contains(43), false);
+
+    HashTable<int> table2 = TRY_OR_FAIL(table1.clone());
+    EXPECT_EQ(table1.size(), static_cast<size_t>(3));
+    EXPECT_EQ(table2.size(), static_cast<size_t>(3));
+    EXPECT_EQ(table1.contains(42), true);
+    EXPECT_EQ(table1.contains(43), false);
+    EXPECT_EQ(table2.contains(42), true);
+    EXPECT_EQ(table2.contains(43), false);
+}
+
+struct WeirdIntTraits {
+    using PeekType = int&;
+    using ConstPeekType = int const&;
+    static constexpr bool is_trivial() { return false; }
+    static constexpr bool is_trivially_serializable() { return false; }
+    static constexpr bool equals(int const& a, int const& b) { return a == b; }
+    template<AK::Concepts::HashCompatible<int> U>
+    static bool equals(U const& a, int const& b) { return a == b; }
+    static constexpr unsigned hash(int value)
+    {
+        return value + 42;
+    }
+};
+
+TEST_CASE(clone_pod_nonstandard_template_args)
+{
+    HashTable<int, Traits<int>, true> table1;
+    TRY_OR_FAIL(table1.try_set(42));
+    TRY_OR_FAIL(table1.try_set(1337));
+    TRY_OR_FAIL(table1.try_set(123456789));
+    EXPECT_EQ(table1.size(), static_cast<size_t>(3));
+    EXPECT_EQ(table1.contains(42), true);
+    EXPECT_EQ(table1.contains(43), false);
+
+    auto table2 = TRY_OR_FAIL(
+        (table1.clone<int, WeirdIntTraits, false>()));
+    static_assert(IsSame<decltype(table2), HashTable<int, WeirdIntTraits, false>>);
+    EXPECT_EQ(table1.size(), static_cast<size_t>(3));
+    EXPECT_EQ(table2.size(), static_cast<size_t>(3));
+    EXPECT_EQ(table1.contains(42), true);
+    EXPECT_EQ(table1.contains(43), false);
+    EXPECT_EQ(table2.contains(42), true);
+    EXPECT_EQ(table2.contains(43), false);
+}
+
+template<bool CanClone, bool CanCopyConstruct = true>
+class ObservableConstructor {
+public:
+    ObservableConstructor(int value)
+        : m_value(value)
+    {
+    }
+    ObservableConstructor(ObservableConstructor const& other)
+    requires(CanCopyConstruct)
+        : m_value(other.m_value)
+    {
+        s_observed_copy_constructs += 1;
+    }
+    ObservableConstructor(ObservableConstructor&& other)
+        : m_value(other.m_value)
+    {
+        s_observed_move_constructs += 1;
+    }
+
+    ObservableConstructor& operator=(ObservableConstructor const& other)
+    requires(CanCopyConstruct)
+    {
+        m_value = other.m_value;
+        s_observed_copy_assigns += 1;
+        return *this;
+    }
+    ObservableConstructor& operator=(ObservableConstructor&& other)
+    {
+        m_value = other.m_value;
+        s_observed_move_assigns += 1;
+        return *this;
+    }
+
+    int value() const { return m_value; }
+
+    ErrorOr<ObservableConstructor> clone() const
+    requires(CanClone)
+    {
+        s_observed_clones += 1;
+        return { ObservableConstructor { m_value } };
+    }
+
+    bool operator==(ObservableConstructor const& other) const
+    {
+        return m_value == other.m_value;
+    }
+
+    static int observed_copy_constructs() { return s_observed_copy_constructs; }
+    static int observed_move_constructs() { return s_observed_move_constructs; }
+    static int observed_copy_assigns() { return s_observed_copy_assigns; }
+    static int observed_move_assigns() { return s_observed_move_assigns; }
+    static int observed_clones() { return s_observed_clones; }
+
+private:
+    int m_value;
+
+    static int s_observed_copy_constructs;
+    static int s_observed_move_constructs;
+    static int s_observed_copy_assigns;
+    static int s_observed_move_assigns;
+    static int s_observed_clones;
+};
+
+template<bool CanClone, bool CanCopyConstruct>
+int ObservableConstructor<CanClone, CanCopyConstruct>::s_observed_copy_constructs = 0;
+template<bool CanClone, bool CanCopyConstruct>
+int ObservableConstructor<CanClone, CanCopyConstruct>::s_observed_move_constructs = 0;
+template<bool CanClone, bool CanCopyConstruct>
+int ObservableConstructor<CanClone, CanCopyConstruct>::s_observed_copy_assigns = 0;
+template<bool CanClone, bool CanCopyConstruct>
+int ObservableConstructor<CanClone, CanCopyConstruct>::s_observed_move_assigns = 0;
+template<bool CanClone, bool CanCopyConstruct>
+int ObservableConstructor<CanClone, CanCopyConstruct>::s_observed_clones = 0;
+
+static_assert(HasFallibleClone<ObservableConstructor<true, true>>);
+static_assert(!HasFallibleClone<ObservableConstructor<false, true>>);
+static_assert(HasFallibleClone<ObservableConstructor<true, false>>);
+static_assert(!HasFallibleClone<ObservableConstructor<false, false>>);
+
+template<bool CanClone, bool CanCopyConstruct>
+struct Traits<ObservableConstructor<CanClone, CanCopyConstruct>> : public GenericTraits<ObservableConstructor<CanClone, CanCopyConstruct>> {
+    static constexpr unsigned hash(ObservableConstructor<CanClone, CanCopyConstruct> const& value)
+    {
+        return value.value() + 1;
+    }
+};
+
+TEST_CASE(clone_copy_construct)
+{
+    using TypeUnderTest = ObservableConstructor<false, true>;
+    auto old_copies = TypeUnderTest::observed_copy_constructs();
+    auto old_moves = TypeUnderTest::observed_move_constructs();
+    auto old_copies_a = TypeUnderTest::observed_copy_assigns();
+    auto old_moves_a = TypeUnderTest::observed_move_assigns();
+    auto old_clones = TypeUnderTest::observed_clones();
+
+    HashTable<TypeUnderTest> table1;
+    TRY_OR_FAIL(table1.try_set({ 42 }));
+    TRY_OR_FAIL(table1.try_set({ 1337 }));
+    TRY_OR_FAIL(table1.try_set({ 123456789 }));
+    EXPECT_EQ(table1.size(), static_cast<size_t>(3));
+    EXPECT_EQ(TypeUnderTest::observed_copy_constructs() - old_copies, 0);
+    EXPECT_EQ(TypeUnderTest::observed_move_constructs() - old_moves, 3);
+    EXPECT_EQ(TypeUnderTest::observed_copy_assigns() - old_copies_a, 0);
+    EXPECT_EQ(TypeUnderTest::observed_move_assigns() - old_moves_a, 0);
+    EXPECT_EQ(TypeUnderTest::observed_clones() - old_clones, 0);
+
+    HashTable<TypeUnderTest> table2 = TRY_OR_FAIL(table1.clone());
+    EXPECT_EQ(table1.size(), static_cast<size_t>(3));
+    EXPECT_EQ(table2.size(), static_cast<size_t>(3));
+    EXPECT_EQ(TypeUnderTest::observed_copy_constructs() - old_copies, 3);
+    EXPECT_EQ(TypeUnderTest::observed_move_constructs() - old_moves, 6);
+    EXPECT_EQ(TypeUnderTest::observed_copy_assigns() - old_copies_a, 0);
+    EXPECT_EQ(TypeUnderTest::observed_move_assigns() - old_moves_a, 0);
+    EXPECT_EQ(TypeUnderTest::observed_clones() - old_clones, 0);
+    EXPECT_EQ(table1.contains({ 42 }), true);
+    EXPECT_EQ(table1.contains({ 43 }), false);
+    EXPECT_EQ(table2.contains({ 42 }), true);
+    EXPECT_EQ(table2.contains({ 43 }), false);
+}
+
+TEST_CASE(clone_call)
+{
+    using TypeUnderTest = ObservableConstructor<true, false>;
+    auto old_copies = TypeUnderTest::observed_copy_constructs();
+    auto old_moves = TypeUnderTest::observed_move_constructs();
+    auto old_copies_a = TypeUnderTest::observed_copy_assigns();
+    auto old_moves_a = TypeUnderTest::observed_move_assigns();
+    auto old_clones = TypeUnderTest::observed_clones();
+
+    HashTable<TypeUnderTest> table1;
+    TRY_OR_FAIL(table1.try_set({ 42 }));
+    TRY_OR_FAIL(table1.try_set({ 1337 }));
+    TRY_OR_FAIL(table1.try_set({ 123456789 }));
+    EXPECT_EQ(table1.size(), static_cast<size_t>(3));
+    EXPECT_EQ(TypeUnderTest::observed_copy_constructs() - old_copies, 0);
+    EXPECT_EQ(TypeUnderTest::observed_move_constructs() - old_moves, 3);
+    EXPECT_EQ(TypeUnderTest::observed_copy_assigns() - old_copies_a, 0);
+    EXPECT_EQ(TypeUnderTest::observed_move_assigns() - old_moves_a, 0);
+    EXPECT_EQ(TypeUnderTest::observed_clones() - old_clones, 0);
+
+    HashTable<TypeUnderTest> table2 = TRY_OR_FAIL(table1.clone());
+    EXPECT_EQ(table1.size(), static_cast<size_t>(3));
+    EXPECT_EQ(table2.size(), static_cast<size_t>(3));
+    EXPECT_EQ(TypeUnderTest::observed_copy_constructs() - old_copies, 0);
+    // We should cut down the number of moves, but for now it suffices that we don't copy-construct or copy-assign.
+    EXPECT_EQ(TypeUnderTest::observed_move_constructs() - old_moves, 12);
+    EXPECT_EQ(TypeUnderTest::observed_copy_assigns() - old_copies_a, 0);
+    EXPECT_EQ(TypeUnderTest::observed_move_assigns() - old_moves_a, 0);
+    EXPECT_EQ(TypeUnderTest::observed_clones() - old_clones, 3);
+    EXPECT_EQ(table1.contains({ 42 }), true);
+    EXPECT_EQ(table1.contains({ 43 }), false);
+    EXPECT_EQ(table2.contains({ 42 }), true);
+    EXPECT_EQ(table2.contains({ 43 }), false);
+}
+
+TEST_CASE(clone_lambda)
+{
+    using TypeUnderTest = ObservableConstructor<true, false>;
+    auto old_copies = TypeUnderTest::observed_copy_constructs();
+    auto old_moves = TypeUnderTest::observed_move_constructs();
+    auto old_copies_a = TypeUnderTest::observed_copy_assigns();
+    auto old_moves_a = TypeUnderTest::observed_move_assigns();
+    auto old_clones = TypeUnderTest::observed_clones();
+
+    HashTable<TypeUnderTest> table1;
+    TRY_OR_FAIL(table1.try_set({ 42 }));
+    TRY_OR_FAIL(table1.try_set({ 1337 }));
+    TRY_OR_FAIL(table1.try_set({ 123456789 }));
+    EXPECT_EQ(table1.size(), static_cast<size_t>(3));
+    EXPECT_EQ(TypeUnderTest::observed_copy_constructs() - old_copies, 0);
+    EXPECT_EQ(TypeUnderTest::observed_move_constructs() - old_moves, 3);
+    EXPECT_EQ(TypeUnderTest::observed_copy_assigns() - old_copies_a, 0);
+    EXPECT_EQ(TypeUnderTest::observed_move_assigns() - old_moves_a, 0);
+    EXPECT_EQ(TypeUnderTest::observed_clones() - old_clones, 0);
+
+    HashTable<TypeUnderTest> table2 = TRY_OR_FAIL(table1.clone(
+        [](TypeUnderTest const& source) -> ErrorOr<TypeUnderTest> {
+            return TypeUnderTest(source.value() + 1);
+        }));
+    EXPECT_EQ(table1.size(), static_cast<size_t>(3));
+    EXPECT_EQ(table2.size(), static_cast<size_t>(3));
+    EXPECT_EQ(TypeUnderTest::observed_copy_constructs() - old_copies, 0);
+    // We should cut down the number of moves, but for now it suffices that we don't copy-construct or copy-assign.
+    EXPECT_EQ(TypeUnderTest::observed_move_constructs() - old_moves, 12);
+    EXPECT_EQ(TypeUnderTest::observed_copy_assigns() - old_copies_a, 0);
+    EXPECT_EQ(TypeUnderTest::observed_move_assigns() - old_moves_a, 0);
+    EXPECT_EQ(TypeUnderTest::observed_clones() - old_clones, 0);
+    EXPECT_EQ(table1.contains({ 42 }), true);
+    EXPECT_EQ(table1.contains({ 43 }), false);
+    EXPECT_EQ(table2.contains({ 42 }), false);
+    EXPECT_EQ(table2.contains({ 43 }), true);
+}
+
+// clone() of recursive HashTables can't be easily tested, because the containers in AK don't implement hash().
+// This functionality will be tested through HashMap instead.

--- a/Userland/Libraries/LibIDL/IDLParser.h
+++ b/Userland/Libraries/LibIDL/IDLParser.h
@@ -18,7 +18,9 @@ namespace IDL {
 class Parser {
 public:
     Parser(DeprecatedString filename, StringView contents, DeprecatedString import_base_path);
-    Interface& parse();
+    // FIXME: Should return ErrorOr<NonnullRefPtr<Interface>> or something.
+    // However, `Interface` is not sharable yet.
+    ErrorOr<Interface*> parse();
 
     Vector<DeprecatedString> imported_files() const;
 
@@ -38,25 +40,25 @@ private:
     Optional<Interface&> resolve_import(auto path);
 
     HashMap<DeprecatedString, DeprecatedString> parse_extended_attributes();
-    void parse_attribute(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&);
-    void parse_interface(Interface&);
-    void parse_namespace(Interface&);
-    void parse_non_interface_entities(bool allow_interface, Interface&);
-    void parse_enumeration(Interface&);
-    void parse_typedef(Interface&);
-    void parse_interface_mixin(Interface&);
-    void parse_dictionary(Interface&);
-    void parse_callback_function(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&);
-    void parse_constructor(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&);
-    void parse_getter(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&);
-    void parse_setter(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&);
-    void parse_deleter(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&);
-    void parse_stringifier(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&);
-    void parse_iterable(Interface&);
-    Function parse_function(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&, IsSpecialOperation is_special_operation = IsSpecialOperation::No);
+    ErrorOr<void> parse_attribute(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&);
+    ErrorOr<void> parse_interface(Interface&);
+    ErrorOr<void> parse_namespace(Interface&);
+    ErrorOr<void> parse_non_interface_entities(bool allow_interface, Interface&);
+    ErrorOr<void> parse_enumeration(Interface&);
+    ErrorOr<void> parse_typedef(Interface&);
+    ErrorOr<void> parse_interface_mixin(Interface&);
+    ErrorOr<void> parse_dictionary(Interface&);
+    ErrorOr<void> parse_callback_function(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&);
+    ErrorOr<void> parse_constructor(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&);
+    ErrorOr<void> parse_getter(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&);
+    ErrorOr<void> parse_setter(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&);
+    ErrorOr<void> parse_deleter(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&);
+    ErrorOr<void> parse_stringifier(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&);
+    ErrorOr<void> parse_iterable(Interface&);
+    ErrorOr<Function> parse_function(HashMap<DeprecatedString, DeprecatedString>& extended_attributes, Interface&, IsSpecialOperation is_special_operation = IsSpecialOperation::No);
     Vector<Parameter> parse_parameters();
     NonnullRefPtr<Type const> parse_type();
-    void parse_constant(Interface&);
+    ErrorOr<void> parse_constant(Interface&);
 
     DeprecatedString import_base_path;
     DeprecatedString filename;

--- a/Userland/Libraries/LibIDL/Types.cpp
+++ b/Userland/Libraries/LibIDL/Types.cpp
@@ -293,6 +293,98 @@ bool Type::is_json(Interface const& interface) const
     return false;
 }
 
+ErrorOr<Parameter> Parameter::clone() const
+{
+    return Parameter {
+        this->type,
+        this->name,
+        this->optional,
+        this->optional_default_value,
+        TRY(this->extended_attributes.clone()),
+        this->variadic,
+    };
+}
+
+ErrorOr<Function> Function::clone() const
+{
+    return Function {
+        this->return_type,
+        this->name,
+        TRY(this->parameters.clone()),
+        TRY(this->extended_attributes.clone()),
+        this->overload_index,
+        this->is_overloaded,
+    };
+}
+
+ErrorOr<Constructor> Constructor::clone() const
+{
+    return Constructor {
+        this->name,
+        TRY(this->parameters.clone()),
+        TRY(this->extended_attributes.clone()),
+    };
+}
+
+ErrorOr<Attribute> Attribute::clone() const
+{
+    return Attribute {
+        this->inherit,
+        this->readonly,
+        this->type,
+        this->name,
+        TRY(this->extended_attributes.clone()),
+        this->getter_callback_name,
+        this->setter_callback_name,
+    };
+}
+
+ErrorOr<DictionaryMember> DictionaryMember::clone() const
+{
+    return DictionaryMember {
+        this->required,
+        this->type,
+        this->name,
+        TRY(this->extended_attributes.clone()),
+        this->default_value,
+    };
+}
+
+ErrorOr<Dictionary> Dictionary::clone() const
+{
+    return Dictionary {
+        this->parent_name,
+        TRY(this->members.clone()),
+    };
+}
+
+ErrorOr<Typedef> Typedef::clone() const
+{
+    return Typedef {
+        TRY(this->extended_attributes.clone()),
+        this->type,
+    };
+}
+
+ErrorOr<Enumeration> Enumeration::clone() const
+{
+    return Enumeration {
+        TRY(this->values.clone()),
+        TRY(this->translated_cpp_names.clone()),
+        this->first_member,
+        this->is_original_definition,
+    };
+}
+
+ErrorOr<CallbackFunction> CallbackFunction::clone() const
+{
+    return CallbackFunction {
+        this->return_type,
+        TRY(this->parameters.clone()),
+        this->is_legacy_treat_non_object_as_null,
+    };
+}
+
 // https://webidl.spec.whatwg.org/#dfn-distinguishing-argument-index
 int EffectiveOverloadSet::distinguishing_argument_index()
 {

--- a/Userland/Libraries/LibIDL/Types.h
+++ b/Userland/Libraries/LibIDL/Types.h
@@ -144,6 +144,15 @@ private:
     bool m_nullable { false };
 };
 
+struct DummyNoncopyable {
+    AK_MAKE_NONCOPYABLE(DummyNoncopyable);
+
+public:
+    DummyNoncopyable() = default;
+    DummyNoncopyable(DummyNoncopyable&&) = default;
+    DummyNoncopyable& operator=(DummyNoncopyable&&) = default;
+};
+
 struct Parameter {
     NonnullRefPtr<Type const> type;
     DeprecatedString name;
@@ -151,6 +160,9 @@ struct Parameter {
     Optional<DeprecatedString> optional_default_value;
     HashMap<DeprecatedString, DeprecatedString> extended_attributes;
     bool variadic { false };
+    [[no_unique_address]] DummyNoncopyable m_dummy {};
+
+    ErrorOr<Parameter> clone() const;
 };
 
 struct Function {
@@ -160,16 +172,20 @@ struct Function {
     HashMap<DeprecatedString, DeprecatedString> extended_attributes;
     size_t overload_index { 0 };
     bool is_overloaded { false };
+    [[no_unique_address]] DummyNoncopyable m_dummy {};
 
     size_t shortest_length() const { return get_function_shortest_length(*this); }
+    ErrorOr<Function> clone() const;
 };
 
 struct Constructor {
     DeprecatedString name;
     Vector<Parameter> parameters;
     HashMap<DeprecatedString, DeprecatedString> extended_attributes;
+    [[no_unique_address]] DummyNoncopyable m_dummy {};
 
     size_t shortest_length() const { return get_function_shortest_length(*this); }
+    ErrorOr<Constructor> clone() const;
 };
 
 struct Constant {
@@ -188,6 +204,9 @@ struct Attribute {
     // Added for convenience after parsing
     DeprecatedString getter_callback_name;
     DeprecatedString setter_callback_name;
+    [[no_unique_address]] DummyNoncopyable m_dummy {};
+
+    ErrorOr<Attribute> clone() const;
 };
 
 struct DictionaryMember {
@@ -196,16 +215,25 @@ struct DictionaryMember {
     DeprecatedString name;
     HashMap<DeprecatedString, DeprecatedString> extended_attributes;
     Optional<DeprecatedString> default_value;
+    [[no_unique_address]] DummyNoncopyable m_dummy {};
+
+    ErrorOr<DictionaryMember> clone() const;
 };
 
 struct Dictionary {
     DeprecatedString parent_name;
     Vector<DictionaryMember> members;
+    [[no_unique_address]] DummyNoncopyable m_dummy {};
+
+    ErrorOr<Dictionary> clone() const;
 };
 
 struct Typedef {
     HashMap<DeprecatedString, DeprecatedString> extended_attributes;
     NonnullRefPtr<Type const> type;
+    [[no_unique_address]] DummyNoncopyable m_dummy {};
+
+    ErrorOr<Typedef> clone() const;
 };
 
 struct Enumeration {
@@ -213,12 +241,18 @@ struct Enumeration {
     OrderedHashMap<DeprecatedString, DeprecatedString> translated_cpp_names;
     DeprecatedString first_member;
     bool is_original_definition { true };
+    [[no_unique_address]] DummyNoncopyable m_dummy {};
+
+    ErrorOr<Enumeration> clone() const;
 };
 
 struct CallbackFunction {
     NonnullRefPtr<Type const> return_type;
     Vector<Parameter> parameters;
     bool is_legacy_treat_non_object_as_null { false };
+    [[no_unique_address]] DummyNoncopyable m_dummy {};
+
+    ErrorOr<CallbackFunction> clone() const;
 };
 
 class ParameterizedType : public Type {


### PR DESCRIPTION
This PR works towards improving OOM-correctness in serenity:
- Implement a fallible, OOM-safe alternative to copy-construct and copy-assign, specifically `Vector::clone`, `HashMap::clone`, and `HashTable::clone`. These will automatically detect and use `ItemType::clone` if available.
- This feature is tested in new Tests.
- This feature is *also* tested by converting LibIDL entirely to the new `.clone()` thing.
- The `DummyNoncopyable` verifies that no default copy-constructors and copy-assigns survived. (Note that doing e.g. `Parameter(Parameter const&) = delete;` would also disable the default struct-like constructor, which would require unnecessary rewrites.)

My hope is that one day, we can delete the copy-constructors of all containers. That's why I think it's important to have an easy-to-use `.clone()` available. (Also, at that point far in the future, we can also get rid of `IDL::DummyNoncopyable`.)

See also #19298 and #19400.