### PR TITLE
usermod: Add `-r`, `-a` and `-G` options for changing supplementary groups

### DIFF
--- a/Base/usr/share/man/man8/usermod.md
+++ b/Base/usr/share/man/man8/usermod.md
@@ -5,7 +5,7 @@ usermod - modify a user account
 ## Synopsis
 
 ```sh
-$ usermod [--uid uid] [--gid group] [--groups groups] [--lock] [--unlock] [--home new-home] [--move] [--shell path-to-shell] [--gecos general-info] <username>
+$ usermod [--append] [--uid uid] [--gid group] [--groups groups] [--lock] [--remove] [--unlock] [--home new-home] [--move] [--shell path-to-shell] [--gecos general-info] <username>
 ```
 
 ## Description
@@ -17,10 +17,12 @@ This program must be run as root.
 
 * `--help`: Display help message and exit
 * `--version`: Print version
+* `-a`, `--append`: Append the supplementary groups specified with the -G option to the user
 * `-u uid`, `--uid uid`: The new numerical value of the user's ID
 * `-g group`, `--gid group`: The group name or number of the user's new initial login group
 * `-G groups`, `--groups groups`: Set the user's supplementary groups. Groups are specified with a comma-separated list. Group names or numbers may be used
 * `-L`, `--lock`: Lock password
+* `-r`, `--remove`: Remove the supplementary groups specified with the -G option from the user
 * `-U`, `--unlock`: Unlock password
 * `-d new-home`, `--home new-home`: The user's new login directory
 * `-m`, `--move`: Move the content of the user's home directory to the new location

--- a/Base/usr/share/man/man8/usermod.md
+++ b/Base/usr/share/man/man8/usermod.md
@@ -5,7 +5,7 @@ usermod - modify a user account
 ## Synopsis
 
 ```sh
-$ usermod [--uid uid] [--gid gid] [--lock] [--unlock] [--home new-home] [--move] [--shell path-to-shell] [--gecos general-info] <username>
+$ usermod [--uid uid] [--gid group] [--lock] [--unlock] [--home new-home] [--move] [--shell path-to-shell] [--gecos general-info] <username>
 ```
 
 ## Description
@@ -18,7 +18,7 @@ This program must be run as root.
 * `--help`: Display help message and exit
 * `--version`: Print version
 * `-u uid`, `--uid uid`: The new numerical value of the user's ID
-* `-g gid`, `--gid gid`: The group number of the user's new initial login group
+* `-g group`, `--gid group`: The group name or number of the user's new initial login group
 * `-L`, `--lock`: Lock password
 * `-U`, `--unlock`: Unlock password
 * `-d new-home`, `--home new-home`: The user's new login directory

--- a/Base/usr/share/man/man8/usermod.md
+++ b/Base/usr/share/man/man8/usermod.md
@@ -5,7 +5,7 @@ usermod - modify a user account
 ## Synopsis
 
 ```sh
-$ usermod [--uid uid] [--gid group] [--lock] [--unlock] [--home new-home] [--move] [--shell path-to-shell] [--gecos general-info] <username>
+$ usermod [--uid uid] [--gid group] [--groups groups] [--lock] [--unlock] [--home new-home] [--move] [--shell path-to-shell] [--gecos general-info] <username>
 ```
 
 ## Description
@@ -19,6 +19,7 @@ This program must be run as root.
 * `--version`: Print version
 * `-u uid`, `--uid uid`: The new numerical value of the user's ID
 * `-g group`, `--gid group`: The group name or number of the user's new initial login group
+* `-G groups`, `--groups groups`: Set the user's supplementary groups. Groups are specified with a comma-separated list. Group names or numbers may be used
 * `-L`, `--lock`: Lock password
 * `-U`, `--unlock`: Unlock password
 * `-d new-home`, `--home new-home`: The user's new login directory

--- a/Userland/Libraries/LibCore/Account.h
+++ b/Userland/Libraries/LibCore/Account.h
@@ -53,6 +53,7 @@ public:
     void set_shell(StringView shell) { m_shell = shell; }
     void set_gecos(StringView gecos) { m_gecos = gecos; }
     void set_deleted() { m_deleted = true; };
+    void set_extra_gids(Vector<gid_t> extra_gids) { m_extra_gids = move(extra_gids); }
     void delete_password();
 
     // A null password means that this account was missing from /etc/shadow.
@@ -74,6 +75,7 @@ private:
     Account(passwd const& pwd, spwd const& spwd, Vector<gid_t> extra_gids);
 
     ErrorOr<DeprecatedString> generate_passwd_file() const;
+    ErrorOr<DeprecatedString> generate_group_file() const;
 #ifndef AK_OS_BSD_GENERIC
     ErrorOr<DeprecatedString> generate_shadow_file() const;
 #endif

--- a/Userland/Utilities/usermod.cpp
+++ b/Userland/Utilities/usermod.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Brandon Pruitt <brapru@pm.me>
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -49,6 +50,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(username, "Username of the account to modify", "username");
 
     args_parser.parse(arguments);
+
+    if (lock && unlock) {
+        warnln("The -L and -U options are mutually exclusive");
+        args_parser.print_usage(stderr, arguments.strings[0]);
+        return 1;
+    }
 
     auto account_or_error = Core::Account::from_name(username);
 

--- a/Userland/Utilities/usermod.cpp
+++ b/Userland/Utilities/usermod.cpp
@@ -27,7 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio wpath rpath cpath fattr tty"));
     TRY(Core::System::unveil("/etc", "rwc"));
 
-    int uid = 0;
+    uid_t uid = 0;
     int gid = 0;
     bool lock = false;
     bool unlock = false;
@@ -75,12 +75,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     unveil(nullptr, nullptr);
 
     if (uid) {
-        if (uid < 0) {
-            warnln("invalid uid {}", uid);
-            return 1;
-        }
-
-        if (getpwuid(static_cast<uid_t>(uid))) {
+        if (getpwuid(uid)) {
             warnln("uid {} already exists", uid);
             return 1;
         }


### PR DESCRIPTION
This PR adds the following options to `usermod`:

* `-G`: Set the supplementary groups for a given user. By default, the user is removed from any groups they are a part of that are not specified.
* `-a`: Append to the given user's list of supplementary groups.
* `-r`: Remove the user from the given supplementary groups if they are a member of them.

In addition to these changes, group names as well as numbers may be specified with the `-g` option A sanity check has also been added to ensure that the `-L` and `-U` options cannot be used at the same time.

Example usage:
![usermod_supplementary_groups](https://github.com/SerenityOS/serenity/assets/2817754/c197bf81-eb85-4c41-9fc1-f880f81d429d)

