### PR TITLE
LibXML: Fix parser not leaving self-closing tags

### DIFF
--- a/Userland/Libraries/LibXML/Parser/Parser.cpp
+++ b/Userland/Libraries/LibXML/Parser/Parser.cpp
@@ -614,6 +614,7 @@ ErrorOr<void, ParseError> Parser::parse_element()
     //           | STag content ETag
     if (auto result = parse_empty_element_tag(); !result.is_error()) {
         append_node(result.release_value());
+        leave_node();
         rollback.disarm();
         return {};
     }


### PR DESCRIPTION
This fixes parsing for example https://wpt.live/css/reference/ref-filled-green-100px-square.xht