### PR TITLE
LibWeb: Add audio mime types to HTMLMediaElement.canPlayType

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -191,6 +191,27 @@ WebIDL::ExceptionOr<Bindings::CanPlayTypeResult> HTMLMediaElement::can_play_type
         return Bindings::CanPlayTypeResult::Maybe;
     }
 
+    if (mime_type.has_value() && mime_type->type() == "audio"sv) {
+        // "Maybe" because we support mp3, but "mpeg" can also refer to MP1 and MP2.
+        if (mime_type->subtype() == "mpeg"sv)
+            return Bindings::CanPlayTypeResult::Maybe;
+        if (mime_type->subtype() == "mp3"sv)
+            return Bindings::CanPlayTypeResult::Probably;
+        if (mime_type->subtype() == "wav"sv)
+            return Bindings::CanPlayTypeResult::Probably;
+        if (mime_type->subtype() == "flac"sv)
+            return Bindings::CanPlayTypeResult::Probably;
+        // We don't currently support `ogg`. We'll also have to check parameters, e.g. from Bandcamp:
+        // audio/ogg; codecs="vorbis"
+        // audio/ogg; codecs="opus"
+        if (mime_type->subtype() == "ogg"sv)
+            return Bindings::CanPlayTypeResult::Empty;
+        // Quite OK Audio
+        if (mime_type->subtype() == "qoa"sv)
+            return Bindings::CanPlayTypeResult::Probably;
+        return Bindings::CanPlayTypeResult::Maybe;
+    }
+
     return Bindings::CanPlayTypeResult::Empty;
 }
 


### PR DESCRIPTION
Now that we support audio, we can start correctly reporting we support certain audio mime types!

Required by certain sites like Gartic Phone, which fails to load audio because we didn't return a non-empty string for `audio/mpeg`:
```
"https://garticphone.com/sounds/turnundefined", Error: Load failed: 404
```

```js
(new Audio).canPlayType("audio/mpeg") && (this._extension = ".mp3"),
```