### PR TITLE
LibWeb: Create an audio document for `audio/` MIME types on navigation

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -178,6 +178,26 @@ static bool build_video_document(DOM::Document& document)
     return true;
 }
 
+static bool build_audio_document(DOM::Document& document)
+{
+    auto html_element = DOM::create_element(document, HTML::TagNames::html, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
+    MUST(document.append_child(html_element));
+
+    auto head_element = DOM::create_element(document, HTML::TagNames::head, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
+    MUST(html_element->append_child(head_element));
+
+    auto body_element = DOM::create_element(document, HTML::TagNames::body, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
+    MUST(html_element->append_child(body_element));
+
+    auto video_element = DOM::create_element(document, HTML::TagNames::audio, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
+    MUST(video_element->set_attribute(HTML::AttributeNames::src, document.url().to_deprecated_string()));
+    MUST(video_element->set_attribute(HTML::AttributeNames::autoplay, DeprecatedString::empty()));
+    MUST(video_element->set_attribute(HTML::AttributeNames::controls, DeprecatedString::empty()));
+    MUST(body_element->append_child(video_element));
+
+    return true;
+}
+
 bool parse_document(DOM::Document& document, ByteBuffer const& data)
 {
     auto& mime_type = document.content_type();
@@ -192,6 +212,8 @@ bool parse_document(DOM::Document& document, ByteBuffer const& data)
         return build_image_document(document, data);
     if (mime_type.starts_with("video/"sv))
         return build_video_document(document);
+    if (mime_type.starts_with("audio/"sv))
+        return build_audio_document(document);
     if (mime_type == "text/plain" || mime_type == "application/json")
         return build_text_document(document, data);
     if (mime_type == "text/markdown")


### PR DESCRIPTION
(Note that GitHub mutes videos by default)

https://github.com/SerenityOS/serenity/assets/25595356/07966d5e-1e44-416b-955f-5cb630ce03b9

