### PR TITLE
Ladybird+LibJS: Add CLI option to run browser with LibJS bytecode VM

### DIFF
--- a/Ladybird/BrowserWindow.cpp
+++ b/Ladybird/BrowserWindow.cpp
@@ -39,10 +39,11 @@ static QIcon const& app_icon()
     return icon;
 }
 
-BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling)
+BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling, WebView::UseJavaScriptBytecode use_javascript_bytecode)
     : m_cookie_jar(cookie_jar)
     , m_webdriver_content_ipc_path(webdriver_content_ipc_path)
     , m_enable_callgrind_profiling(enable_callgrind_profiling)
+    , m_use_javascript_bytecode(use_javascript_bytecode)
 {
     setWindowIcon(app_icon());
     m_tabs_container = new QTabWidget(this);
@@ -415,7 +416,7 @@ void BrowserWindow::debug_request(DeprecatedString const& request, DeprecatedStr
 
 Tab& BrowserWindow::new_tab(QString const& url, Web::HTML::ActivateTab activate_tab)
 {
-    auto tab = make<Tab>(this, m_webdriver_content_ipc_path, m_enable_callgrind_profiling);
+    auto tab = make<Tab>(this, m_webdriver_content_ipc_path, m_enable_callgrind_profiling, m_use_javascript_bytecode);
     auto tab_ptr = tab.ptr();
     m_tabs.append(std::move(tab));
 

--- a/Ladybird/BrowserWindow.h
+++ b/Ladybird/BrowserWindow.h
@@ -26,7 +26,7 @@ class CookieJar;
 class BrowserWindow : public QMainWindow {
     Q_OBJECT
 public:
-    explicit BrowserWindow(Browser::CookieJar&, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling);
+    explicit BrowserWindow(Browser::CookieJar&, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling, WebView::UseJavaScriptBytecode);
 
     WebContentView& view() const { return m_current_tab->view(); }
 
@@ -115,4 +115,5 @@ private:
 
     StringView m_webdriver_content_ipc_path;
     WebView::EnableCallgrindProfiling m_enable_callgrind_profiling;
+    WebView::UseJavaScriptBytecode m_use_javascript_bytecode;
 };

--- a/Ladybird/ConsoleWidget.cpp
+++ b/Ladybird/ConsoleWidget.cpp
@@ -27,7 +27,7 @@ ConsoleWidget::ConsoleWidget()
 {
     setLayout(new QVBoxLayout);
 
-    m_output_view = new WebContentView({}, WebView::EnableCallgrindProfiling::No);
+    m_output_view = new WebContentView({}, WebView::EnableCallgrindProfiling::No, WebView::UseJavaScriptBytecode::No);
     if (is_using_dark_system_theme(*this))
         m_output_view->update_palette(WebContentView::PaletteMode::Dark);
 

--- a/Ladybird/Tab.cpp
+++ b/Ladybird/Tab.cpp
@@ -59,7 +59,7 @@ static QIcon render_svg_icon_with_theme_colors(QString name, QPalette const& pal
     return icon;
 }
 
-Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling)
+Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling, WebView::UseJavaScriptBytecode use_javascript_bytecode)
     : QWidget(window)
     , m_window(window)
 {
@@ -67,7 +67,7 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
     m_layout->setSpacing(0);
     m_layout->setContentsMargins(0, 0, 0, 0);
 
-    m_view = new WebContentView(webdriver_content_ipc_path, enable_callgrind_profiling);
+    m_view = new WebContentView(webdriver_content_ipc_path, enable_callgrind_profiling, use_javascript_bytecode);
     m_toolbar = new QToolBar(this);
     m_location_edit = new LocationEdit(this);
     m_reset_zoom_button = new QToolButton(m_toolbar);

--- a/Ladybird/Tab.h
+++ b/Ladybird/Tab.h
@@ -27,7 +27,7 @@ class InspectorWidget;
 class Tab final : public QWidget {
     Q_OBJECT
 public:
-    Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling);
+    Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling, WebView::UseJavaScriptBytecode);
     virtual ~Tab() override;
 
     WebContentView& view() { return *m_view; }

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -19,6 +19,7 @@
 #include <LibCore/System.h>
 #include <LibCore/SystemServerTakeover.h>
 #include <LibIPC/ConnectionFromClient.h>
+#include <LibJS/Bytecode/Interpreter.h>
 #include <LibMain/Main.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Loader/ContentFilter.h>
@@ -69,11 +70,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     int webcontent_fd_passing_socket { -1 };
     bool is_layout_test_mode = false;
+    bool use_javascript_bytecode = false;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(webcontent_fd_passing_socket, "File descriptor of the passing socket for the WebContent connection", "webcontent-fd-passing-socket", 'c', "webcontent_fd_passing_socket");
     args_parser.add_option(is_layout_test_mode, "Is layout test mode", "layout-test-mode", 0);
+    args_parser.add_option(use_javascript_bytecode, "Enable JavaScript bytecode VM", "use-bytecode", 0);
     args_parser.parse(arguments);
+
+    JS::Bytecode::Interpreter::set_enabled(use_javascript_bytecode);
 
     VERIFY(webcontent_fd_passing_socket >= 0);
 

--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -51,7 +51,7 @@
 
 bool is_using_dark_system_theme(QWidget&);
 
-WebContentView::WebContentView(StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling)
+WebContentView::WebContentView(StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling, WebView::UseJavaScriptBytecode use_javascript_bytecode)
     : m_webdriver_content_ipc_path(webdriver_content_ipc_path)
 {
     setMouseTracking(true);
@@ -72,7 +72,7 @@ WebContentView::WebContentView(StringView webdriver_content_ipc_path, WebView::E
         update_viewport_rect();
     });
 
-    create_client(enable_callgrind_profiling);
+    create_client(enable_callgrind_profiling, use_javascript_bytecode);
 }
 
 WebContentView::~WebContentView() = default;
@@ -512,12 +512,12 @@ void WebContentView::update_palette(PaletteMode mode)
     client().async_update_system_theme(make_system_theme_from_qt_palette(*this, mode));
 }
 
-void WebContentView::create_client(WebView::EnableCallgrindProfiling enable_callgrind_profiling)
+void WebContentView::create_client(WebView::EnableCallgrindProfiling enable_callgrind_profiling, WebView::UseJavaScriptBytecode use_javascript_bytecode)
 {
     m_client_state = {};
 
     auto candidate_web_content_paths = get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
-    auto new_client = launch_web_content_process(candidate_web_content_paths, enable_callgrind_profiling).release_value_but_fixme_should_propagate_errors();
+    auto new_client = launch_web_content_process(candidate_web_content_paths, enable_callgrind_profiling, WebView::IsLayoutTestMode::No, use_javascript_bytecode).release_value_but_fixme_should_propagate_errors();
 
     m_client_state.client = new_client;
     m_client_state.client->on_web_content_process_crash = [this] {

--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -39,7 +39,7 @@ class WebContentView final
     , public WebView::ViewImplementation {
     Q_OBJECT
 public:
-    explicit WebContentView(StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling);
+    explicit WebContentView(StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling, WebView::UseJavaScriptBytecode);
     virtual ~WebContentView() override;
 
     Function<String(const AK::URL&, Web::HTML::ActivateTab)> on_tab_open_request;
@@ -96,7 +96,7 @@ signals:
 
 private:
     // ^WebView::ViewImplementation
-    virtual void create_client(WebView::EnableCallgrindProfiling = WebView::EnableCallgrindProfiling::No) override;
+    virtual void create_client(WebView::EnableCallgrindProfiling = WebView::EnableCallgrindProfiling::No, WebView::UseJavaScriptBytecode = WebView::UseJavaScriptBytecode::No) override;
     virtual void update_zoom() override;
     virtual Gfx::IntRect viewport_rect() const override;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const override;

--- a/Ladybird/main.cpp
+++ b/Ladybird/main.cpp
@@ -70,6 +70,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView webdriver_content_ipc_path;
     bool enable_callgrind_profiling = false;
     bool enable_sql_database = false;
+    bool use_javascript_bytecode = false;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("The Ladybird web browser :^)");
@@ -77,6 +78,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(webdriver_content_ipc_path, "Path to WebDriver IPC for WebContent", "webdriver-content-path", 0, "path");
     args_parser.add_option(enable_callgrind_profiling, "Enable Callgrind profiling", "enable-callgrind-profiling", 'P');
     args_parser.add_option(enable_sql_database, "Enable SQL database", "enable-sql-database", 0);
+    args_parser.add_option(use_javascript_bytecode, "Enable JavaScript bytecode VM", "use-bytecode", 0);
     args_parser.parse(arguments);
 
     auto get_formatted_url = [&](StringView const& raw_url) -> ErrorOr<URL> {
@@ -99,7 +101,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto cookie_jar = database ? TRY(Browser::CookieJar::create(*database)) : Browser::CookieJar::create();
 
     s_settings = adopt_own_if_nonnull(new Browser::Settings());
-    BrowserWindow window(cookie_jar, webdriver_content_ipc_path, enable_callgrind_profiling ? WebView::EnableCallgrindProfiling::Yes : WebView::EnableCallgrindProfiling::No);
+    BrowserWindow window(cookie_jar, webdriver_content_ipc_path, enable_callgrind_profiling ? WebView::EnableCallgrindProfiling::Yes : WebView::EnableCallgrindProfiling::No, use_javascript_bytecode ? WebView::UseJavaScriptBytecode::Yes : WebView::UseJavaScriptBytecode::No);
     window.setWindowTitle("Ladybird");
     window.resize(800, 600);
     window.show();

--- a/Tests/LibJS/test-bytecode-js.cpp
+++ b/Tests/LibJS/test-bytecode-js.cpp
@@ -7,6 +7,7 @@
 #include <LibJS/AST.h>
 #include <LibJS/Bytecode/Generator.h>
 #include <LibJS/Bytecode/Interpreter.h>
+#include <LibJS/Bytecode/PassManager.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibJS/Script.h>

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -8,15 +8,29 @@
 #include <AK/TemporaryChange.h>
 #include <LibJS/AST.h>
 #include <LibJS/Bytecode/BasicBlock.h>
+#include <LibJS/Bytecode/Generator.h>
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Bytecode/Op.h>
+#include <LibJS/Bytecode/PassManager.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/GlobalEnvironment.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Realm.h>
 
 namespace JS::Bytecode {
+
+static bool s_bytecode_interpreter_enabled = false;
+
+bool Interpreter::enabled()
+{
+    return s_bytecode_interpreter_enabled;
+}
+
+void Interpreter::set_enabled(bool enabled)
+{
+    s_bytecode_interpreter_enabled = enabled;
+}
 
 static Interpreter* s_current;
 bool g_dump_bytecode = false;
@@ -423,6 +437,16 @@ Bytecode::PassManager& Interpreter::optimization_pipeline(Interpreter::Optimizat
     entry = move(pm);
 
     return passes;
+}
+
+size_t Interpreter::pc() const
+{
+    return m_pc ? m_pc->offset() : 0;
+}
+
+DeprecatedString Interpreter::debug_position() const
+{
+    return DeprecatedString::formatted("{}:{:2}:{:4x}", m_current_executable->name, m_current_block->name(), pc());
 }
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include "Generator.h"
-#include "PassManager.h"
 #include <LibJS/Bytecode/Label.h>
 #include <LibJS/Bytecode/Register.h>
 #include <LibJS/Forward.h>
@@ -18,6 +16,9 @@
 
 namespace JS::Bytecode {
 
+class InstructionStreamIterator;
+class PassManager;
+
 struct RegisterWindow {
     MarkedVector<Value> registers;
     MarkedVector<GCPtr<Environment>> saved_lexical_environments;
@@ -27,6 +28,9 @@ struct RegisterWindow {
 
 class Interpreter {
 public:
+    [[nodiscard]] static bool enabled();
+    static void set_enabled(bool);
+
     explicit Interpreter(Realm&);
     ~Interpreter();
 
@@ -82,11 +86,8 @@ public:
 
     Executable const& current_executable() { return *m_current_executable; }
     BasicBlock const& current_block() const { return *m_current_block; }
-    size_t pc() const { return m_pc ? m_pc->offset() : 0; }
-    DeprecatedString debug_position()
-    {
-        return DeprecatedString::formatted("{}:{:2}:{:4x}", m_current_executable->name, m_current_block->name(), pc());
-    }
+    size_t pc() const;
+    DeprecatedString debug_position() const;
 
     enum class OptimizationLevel {
         None,

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -12,6 +12,7 @@
 #include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Bytecode/Generator.h>
 #include <LibJS/Bytecode/Interpreter.h>
+#include <LibJS/Bytecode/PassManager.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -35,7 +35,7 @@ OutOfProcessWebView::OutOfProcessWebView()
 
 OutOfProcessWebView::~OutOfProcessWebView() = default;
 
-void OutOfProcessWebView::create_client(EnableCallgrindProfiling)
+void OutOfProcessWebView::create_client(EnableCallgrindProfiling, UseJavaScriptBytecode)
 {
     m_client_state = {};
 

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -78,7 +78,7 @@ private:
     virtual void did_scroll() override;
 
     // ^WebView::ViewImplementation
-    virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No) override;
+    virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No, UseJavaScriptBytecode = UseJavaScriptBytecode::No) override;
     virtual void update_zoom() override;
     virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) override;
     virtual void notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize) override;

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -179,7 +179,7 @@ void ViewImplementation::handle_resize()
 
 #if !defined(AK_OS_SERENITY)
 
-ErrorOr<NonnullRefPtr<WebView::WebContentClient>> ViewImplementation::launch_web_content_process(ReadonlySpan<String> candidate_web_content_paths, EnableCallgrindProfiling enable_callgrind_profiling, IsLayoutTestMode is_layout_test_mode)
+ErrorOr<NonnullRefPtr<WebView::WebContentClient>> ViewImplementation::launch_web_content_process(ReadonlySpan<String> candidate_web_content_paths, EnableCallgrindProfiling enable_callgrind_profiling, IsLayoutTestMode is_layout_test_mode, UseJavaScriptBytecode use_javascript_bytecode)
 {
     int socket_fds[2] {};
     TRY(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, socket_fds));
@@ -221,6 +221,8 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> ViewImplementation::launch_web
                 arguments.remove(0, callgrind_prefix_length);
             if (is_layout_test_mode == IsLayoutTestMode::Yes)
                 arguments.append("--layout-test-mode"sv);
+            if (use_javascript_bytecode == UseJavaScriptBytecode::Yes)
+                arguments.append("--use-bytecode"sv);
 
             result = Core::System::exec(arguments[0], arguments.span(), Core::System::SearchInPath::Yes);
             if (!result.is_error())

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -30,6 +30,11 @@ enum class IsLayoutTestMode {
     Yes
 };
 
+enum class UseJavaScriptBytecode {
+    No,
+    Yes
+};
+
 class ViewImplementation {
 public:
     virtual ~ViewImplementation() { }
@@ -167,10 +172,10 @@ protected:
     void request_repaint();
     void handle_resize();
 
-    virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No) {};
+    virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No, UseJavaScriptBytecode = UseJavaScriptBytecode::No) { }
 
 #if !defined(AK_OS_SERENITY)
-    ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(ReadonlySpan<String> candidate_web_content_paths, EnableCallgrindProfiling = EnableCallgrindProfiling::No, IsLayoutTestMode = IsLayoutTestMode::No);
+    ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(ReadonlySpan<String> candidate_web_content_paths, EnableCallgrindProfiling = EnableCallgrindProfiling::No, IsLayoutTestMode = IsLayoutTestMode::No, UseJavaScriptBytecode = UseJavaScriptBytecode::No);
 #endif
 
     void handle_web_content_process_crash();


### PR DESCRIPTION
This required quite a bit of plumbing, but now you can run

    ladybird --use-bytecode