### PR TITLE
AK+CodeGenerators: Migrate to String and propagate errors

### DIFF
--- a/AK/SourceGenerator.h
+++ b/AK/SourceGenerator.h
@@ -27,9 +27,9 @@ public:
         , m_closing(closing)
     {
     }
-    explicit SourceGenerator(StringBuilder& builder, MappingType const& mapping, char opening = '@', char closing = '@')
+    explicit SourceGenerator(StringBuilder& builder, MappingType&& mapping, char opening = '@', char closing = '@')
         : m_builder(builder)
-        , m_mapping(mapping.clone().release_value_but_fixme_should_propagate_errors())
+        , m_mapping(move(mapping))
         , m_opening(opening)
         , m_closing(closing)
     {
@@ -37,7 +37,10 @@ public:
 
     SourceGenerator(SourceGenerator&&) = default;
 
-    SourceGenerator fork() { return SourceGenerator { m_builder, m_mapping, m_opening, m_closing }; }
+    ErrorOr<SourceGenerator> fork()
+    {
+        return SourceGenerator { m_builder, TRY(m_mapping.clone()), m_opening, m_closing };
+    }
 
     ErrorOr<void> set(StringView key, String value)
     {

--- a/AK/SourceGenerator.h
+++ b/AK/SourceGenerator.h
@@ -57,7 +57,6 @@ public:
     }
 
     StringView as_string_view() const { return m_builder.string_view(); }
-    DeprecatedString as_string() const { return m_builder.to_deprecated_string(); }
 
     void append(StringView pattern)
     {

--- a/AK/SourceGenerator.h
+++ b/AK/SourceGenerator.h
@@ -63,16 +63,10 @@ public:
         GenericLexer lexer { pattern };
 
         while (!lexer.is_eof()) {
-            // FIXME: It is a bit inconvenient, that 'consume_until' also consumes the 'stop' character, this makes
-            //        the method less generic because there is no way to check if the 'stop' character ever appeared.
-            auto const consume_until_without_consuming_stop_character = [&](char stop) {
-                return lexer.consume_while([&](char ch) { return ch != stop; });
-            };
-
-            m_builder.append(consume_until_without_consuming_stop_character(m_opening));
+            m_builder.append(lexer.consume_until(m_opening));
 
             if (lexer.consume_specific(m_opening)) {
-                auto const placeholder = consume_until_without_consuming_stop_character(m_closing);
+                auto const placeholder = lexer.consume_until(m_closing);
 
                 if (!lexer.consume_specific(m_closing))
                     VERIFY_NOT_REACHED();

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -348,7 +348,7 @@ public:)~~~");
         IPC::Decoder decoder { stream, socket };)~~~");
 
     for (auto const& parameter : parameters) {
-        auto parameter_generator = message_generator.fork();
+        auto parameter_generator = message_generator.fork().release_value_but_fixme_should_propagate_errors();
 
         parameter_generator.set("parameter.type", parameter.type);
         parameter_generator.set("parameter.name", parameter.name);
@@ -394,7 +394,7 @@ public:)~~~");
         TRY(stream.encode((int)MessageID::@message.pascal_name@));)~~~");
 
     for (auto const& parameter : parameters) {
-        auto parameter_generator = message_generator.fork();
+        auto parameter_generator = message_generator.fork().release_value_but_fixme_should_propagate_errors();
 
         parameter_generator.set("parameter.name", parameter.name);
         parameter_generator.appendln(R"~~~(
@@ -406,7 +406,7 @@ public:)~~~");
     })~~~");
 
     for (auto const& parameter : parameters) {
-        auto parameter_generator = message_generator.fork();
+        auto parameter_generator = message_generator.fork().release_value_but_fixme_should_propagate_errors();
         parameter_generator.set("parameter.type", parameter.type);
         parameter_generator.set("parameter.name", parameter.name);
         parameter_generator.appendln(R"~~~(
@@ -419,7 +419,7 @@ private:
     bool m_ipc_message_valid { true };)~~~");
 
     for (auto const& parameter : parameters) {
-        auto parameter_generator = message_generator.fork();
+        auto parameter_generator = message_generator.fork().release_value_but_fixme_should_propagate_errors();
         parameter_generator.set("parameter.type", parameter.type);
         parameter_generator.set("parameter.name", parameter.name);
         parameter_generator.appendln(R"~~~(
@@ -455,7 +455,7 @@ void do_message_for_proxy(SourceGenerator message_generator, Endpoint const& end
 
         for (size_t i = 0; i < parameters.size(); ++i) {
             auto const& parameter = parameters[i];
-            auto argument_generator = message_generator.fork();
+            auto argument_generator = message_generator.fork().release_value_but_fixme_should_propagate_errors();
             argument_generator.set("argument.type", parameter.type);
             argument_generator.set("argument.name", parameter.name);
             argument_generator.append("@argument.type@ @argument.name@");
@@ -488,7 +488,7 @@ void do_message_for_proxy(SourceGenerator message_generator, Endpoint const& end
 
         for (size_t i = 0; i < parameters.size(); ++i) {
             auto const& parameter = parameters[i];
-            auto argument_generator = message_generator.fork();
+            auto argument_generator = message_generator.fork().release_value_but_fixme_should_propagate_errors();
             argument_generator.set("argument.name", parameter.name);
             if (is_primitive_or_simple_type(parameters[i].type))
                 argument_generator.append("@argument.name@");
@@ -544,15 +544,15 @@ void build_endpoint(SourceGenerator generator, Endpoint const& endpoint)
 
     generator.appendln("\nnamespace Messages::@endpoint.name@ {");
 
-    HashMap<DeprecatedString, int> message_ids = build_message_ids_for_endpoint(generator.fork(), endpoint);
+    HashMap<DeprecatedString, int> message_ids = build_message_ids_for_endpoint(generator.fork().release_value_but_fixme_should_propagate_errors(), endpoint);
 
     for (auto const& message : endpoint.messages) {
         DeprecatedString response_name;
         if (message.is_synchronous) {
             response_name = message.response_name();
-            do_message(generator.fork(), response_name, message.outputs);
+            do_message(generator.fork().release_value_but_fixme_should_propagate_errors(), response_name, message.outputs);
         }
-        do_message(generator.fork(), message.name, message.inputs, response_name);
+        do_message(generator.fork().release_value_but_fixme_should_propagate_errors(), message.name, message.inputs, response_name);
     }
 
     generator.appendln(R"~~~(
@@ -569,7 +569,7 @@ public:
     { })~~~");
 
     for (auto const& message : endpoint.messages)
-        do_message_for_proxy(generator.fork(), endpoint, message);
+        do_message_for_proxy(generator.fork().release_value_but_fixme_should_propagate_errors(), endpoint, message);
 
     generator.appendln(R"~~~(
 private:
@@ -611,7 +611,7 @@ public:
 
     for (auto const& message : endpoint.messages) {
         auto do_decode_message = [&](DeprecatedString const& name) {
-            auto message_generator = generator.fork();
+            auto message_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
 
             message_generator.set("message.name", name);
             message_generator.set("message.pascal_name", pascal_case(name));
@@ -655,7 +655,7 @@ public:
         switch (message.message_id()) {)~~~");
     for (auto const& message : endpoint.messages) {
         auto do_handle_message = [&](DeprecatedString const& name, Vector<Parameter> const& parameters, bool returns_something) {
-            auto message_generator = generator.fork();
+            auto message_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
 
             StringBuilder argument_generator;
             for (size_t i = 0; i < parameters.size(); ++i) {
@@ -706,7 +706,7 @@ public:
     })~~~");
 
     for (auto const& message : endpoint.messages) {
-        auto message_generator = generator.fork();
+        auto message_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
 
         auto do_handle_message_decl = [&](DeprecatedString const& name, Vector<Parameter> const& parameters, bool is_response) {
             DeprecatedString return_type = "void";
@@ -732,7 +732,7 @@ public:
 
             for (size_t i = 0; i < parameters.size(); ++i) {
                 auto const& parameter = parameters[i];
-                auto argument_generator = message_generator.fork();
+                auto argument_generator = message_generator.fork().release_value_but_fixme_should_propagate_errors();
                 argument_generator.set("argument.type", make_argument_type(parameter.type));
                 argument_generator.set("argument.name", parameter.name);
                 argument_generator.append("[[maybe_unused]] @argument.type@ @argument.name@");
@@ -790,7 +790,7 @@ void build(StringBuilder& builder, Vector<Endpoint> const& endpoints)
 #endif)~~~");
 
     for (auto const& endpoint : endpoints)
-        build_endpoint(generator.fork(), endpoint);
+        build_endpoint(generator.fork().release_value_but_fixme_should_propagate_errors(), endpoint);
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)

--- a/Meta/Lagom/Tools/CodeGenerators/LibGL/GenerateGLAPIWrapper.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibGL/GenerateGLAPIWrapper.cpp
@@ -375,7 +375,7 @@ ErrorOr<void> generate_header_file(JsonObject& api_data, Core::File& file)
         auto function_definitions = create_function_definitions(function_name, function);
 
         for (auto const& function_definition : function_definitions) {
-            auto function_generator = generator.fork();
+            auto function_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
 
             function_generator.set("name", function_definition.name);
             function_generator.set("return_type", function_definition.return_type);
@@ -387,7 +387,7 @@ ErrorOr<void> generate_header_file(JsonObject& api_data, Core::File& file)
                 if (!argument_definition.name.has_value() || !argument_definition.cpp_type.has_value())
                     continue;
 
-                auto argument_generator = function_generator.fork();
+                auto argument_generator = function_generator.fork().release_value_but_fixme_should_propagate_errors();
                 argument_generator.set("argument_type", argument_definition.cpp_type.value());
                 argument_generator.set("argument_name", argument_definition.name.value());
 
@@ -426,7 +426,7 @@ ErrorOr<void> generate_implementation_file(JsonObject& api_data, Core::File& fil
         auto function_definitions = create_function_definitions(function_name, function);
 
         for (auto const& function_definition : function_definitions) {
-            auto function_generator = generator.fork();
+            auto function_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
             auto return_type = function_definition.return_type;
 
             function_generator.set("name"sv, function_definition.name);
@@ -441,7 +441,7 @@ ErrorOr<void> generate_implementation_file(JsonObject& api_data, Core::File& fil
                 if (!argument_definition.name.has_value() || !argument_definition.cpp_type.has_value())
                     continue;
 
-                auto argument_generator = function_generator.fork();
+                auto argument_generator = function_generator.fork().release_value_but_fixme_should_propagate_errors();
                 argument_generator.set("argument_type", argument_definition.cpp_type.value());
                 argument_generator.set("argument_name", argument_definition.name.value());
 
@@ -504,7 +504,7 @@ ErrorOr<void> generate_implementation_file(JsonObject& api_data, Core::File& fil
 
                 first = true;
                 for (auto const& argument_definition : function_definition.arguments) {
-                    auto argument_generator = function_generator.fork();
+                    auto argument_generator = function_generator.fork().release_value_but_fixme_should_propagate_errors();
 
                     auto cast_to = argument_definition.cast_to;
                     argument_generator.set("argument_name", argument_definition.name.value_or(""));

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -228,7 +228,7 @@ static DeprecatedString make_input_acceptable_cpp(DeprecatedString const& input)
 
 static void generate_include_for_iterator(auto& generator, auto& iterator_path)
 {
-    auto iterator_generator = generator.fork();
+    auto iterator_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
     iterator_generator.set("iterator_class.path", iterator_path);
     // FIXME: These may or may not exist, because REASONS.
     iterator_generator.append(R"~~~(
@@ -240,7 +240,7 @@ static void generate_include_for_iterator(auto& generator, auto& iterator_path)
 
 static void generate_include_for(auto& generator, auto& path)
 {
-    auto forked_generator = generator.fork();
+    auto forked_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
     auto path_string = path;
     for (auto& search_path : s_header_search_paths) {
         if (!path.starts_with(search_path))
@@ -394,7 +394,7 @@ static void generate_to_new_string(SourceGenerator& scoped_generator, ParameterT
 template<typename ParameterType>
 static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter, DeprecatedString const& js_name, DeprecatedString const& js_suffix, DeprecatedString const& cpp_name, IDL::Interface const& interface, bool legacy_null_to_empty_string = false, bool optional = false, Optional<DeprecatedString> optional_default_value = {}, bool variadic = false, size_t recursion_depth = 0)
 {
-    auto scoped_generator = generator.fork();
+    auto scoped_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
     auto acceptable_cpp_name = make_input_acceptable_cpp(cpp_name);
     scoped_generator.set("cpp_name", acceptable_cpp_name);
     scoped_generator.set("js_name", js_name);
@@ -706,7 +706,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
             }
         }
     } else if (interface.enumerations.contains(parameter.type->name())) {
-        auto enum_generator = scoped_generator.fork();
+        auto enum_generator = scoped_generator.fork().release_value_but_fixme_should_propagate_errors();
         auto& enumeration = interface.enumerations.find(parameter.type->name())->value;
         StringView enum_member_name;
         if (optional_default_value.has_value()) {
@@ -767,7 +767,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
     } else if (interface.dictionaries.contains(parameter.type->name())) {
         if (optional_default_value.has_value() && optional_default_value != "{}")
             TODO();
-        auto dictionary_generator = scoped_generator.fork();
+        auto dictionary_generator = scoped_generator.fork().release_value_but_fixme_should_propagate_errors();
         dictionary_generator.append(R"~~~(
     if (!@js_name@@js_suffix@.is_nullish() && !@js_name@@js_suffix@.is_object())
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "@parameter.type.name@");
@@ -829,7 +829,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
     } else if (interface.callback_functions.contains(parameter.type->name())) {
         // https://webidl.spec.whatwg.org/#es-callback-function
 
-        auto callback_function_generator = scoped_generator.fork();
+        auto callback_function_generator = scoped_generator.fork().release_value_but_fixme_should_propagate_errors();
         auto& callback_function = interface.callback_functions.find(parameter.type->name())->value;
 
         if (callback_function.return_type->is_object() && callback_function.return_type->name() == "Promise")
@@ -860,7 +860,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
     } else if (parameter.type->name() == "sequence") {
         // https://webidl.spec.whatwg.org/#es-sequence
 
-        auto sequence_generator = scoped_generator.fork();
+        auto sequence_generator = scoped_generator.fork().release_value_but_fixme_should_propagate_errors();
         auto& parameterized_type = verify_cast<IDL::ParameterizedType>(*parameter.type);
         sequence_generator.set("recursion_depth", DeprecatedString::number(recursion_depth));
 
@@ -925,7 +925,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
     } else if (parameter.type->name() == "record") {
         // https://webidl.spec.whatwg.org/#es-record
 
-        auto record_generator = scoped_generator.fork();
+        auto record_generator = scoped_generator.fork().release_value_but_fixme_should_propagate_errors();
         auto& parameterized_type = verify_cast<IDL::ParameterizedType>(*parameter.type);
         record_generator.set("recursion_depth", DeprecatedString::number(recursion_depth));
 
@@ -994,7 +994,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
     } else if (is<IDL::UnionType>(*parameter.type)) {
         // https://webidl.spec.whatwg.org/#es-union
 
-        auto union_generator = scoped_generator.fork();
+        auto union_generator = scoped_generator.fork().release_value_but_fixme_should_propagate_errors();
 
         auto& union_type = verify_cast<IDL::UnionType>(*parameter.type);
         union_generator.set("union_type", union_type_to_variant(union_type, interface));
@@ -1018,7 +1018,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
         }
 
         if (dictionary_type) {
-            auto dictionary_generator = union_generator.fork();
+            auto dictionary_generator = union_generator.fork().release_value_but_fixme_should_propagate_errors();
             dictionary_generator.set("dictionary.type", dictionary_type->name());
 
             // The lambda must take the JS::Value to convert as a parameter instead of capturing it in order to support union types being variadic.
@@ -1116,7 +1116,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
                 if (!IDL::is_platform_object(type))
                     continue;
 
-                auto union_platform_object_type_generator = union_generator.fork();
+                auto union_platform_object_type_generator = union_generator.fork().release_value_but_fixme_should_propagate_errors();
                 union_platform_object_type_generator.set("platform_object_type", type->name());
 
                 union_platform_object_type_generator.append(R"~~~(
@@ -1344,7 +1344,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
             // 3. Assert: Type(x) is Number.
             // 4. Return the result of converting x to T.
 
-            auto union_numeric_type_generator = union_generator.fork();
+            auto union_numeric_type_generator = union_generator.fork().release_value_but_fixme_should_propagate_errors();
             auto cpp_type = IDL::idl_type_name_to_cpp_type(*numeric_type, interface);
             union_numeric_type_generator.set("numeric_type", cpp_type.name);
 
@@ -1459,7 +1459,7 @@ static void generate_argument_count_check(SourceGenerator& generator, Deprecated
     if (argument_count == 0)
         return;
 
-    auto argument_count_check_generator = generator.fork();
+    auto argument_count_check_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
     argument_count_check_generator.set("function.name", function_name);
     argument_count_check_generator.set("function.nargs", DeprecatedString::number(argument_count));
 
@@ -1479,7 +1479,7 @@ static void generate_argument_count_check(SourceGenerator& generator, Deprecated
 
 static void generate_arguments(SourceGenerator& generator, Vector<IDL::Parameter> const& parameters, StringBuilder& arguments_builder, IDL::Interface const& interface)
 {
-    auto arguments_generator = generator.fork();
+    auto arguments_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
 
     Vector<DeprecatedString> parameter_names;
     size_t argument_index = 0;
@@ -1510,7 +1510,7 @@ static void generate_arguments(SourceGenerator& generator, Vector<IDL::Parameter
 // https://webidl.spec.whatwg.org/#create-sequence-from-iterable
 void IDL::ParameterizedType::generate_sequence_from_iterable(SourceGenerator& generator, DeprecatedString const& cpp_name, DeprecatedString const& iterable_cpp_name, DeprecatedString const& iterator_method_cpp_name, IDL::Interface const& interface, size_t recursion_depth) const
 {
-    auto sequence_generator = generator.fork();
+    auto sequence_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
     sequence_generator.set("cpp_name", cpp_name);
     sequence_generator.set("iterable_cpp_name", iterable_cpp_name);
     sequence_generator.set("iterator_method_cpp_name", iterator_method_cpp_name);
@@ -1569,7 +1569,7 @@ enum class WrappingReference {
 
 static void generate_wrap_statement(SourceGenerator& generator, DeprecatedString const& value, IDL::Type const& type, IDL::Interface const& interface, StringView result_expression, WrappingReference wrapping_reference = WrappingReference::No, size_t recursion_depth = 0)
 {
-    auto scoped_generator = generator.fork();
+    auto scoped_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
     scoped_generator.set("value", value);
     if (!libweb_interface_namespaces.span().contains_slow(type.name())) {
         if (is_javascript_builtin(type))
@@ -1712,7 +1712,7 @@ static void generate_wrap_statement(SourceGenerator& generator, DeprecatedString
     } else if (is<IDL::UnionType>(type)) {
         auto& union_type = verify_cast<IDL::UnionType>(type);
         auto union_types = union_type.flattened_member_types();
-        auto union_generator = scoped_generator.fork();
+        auto union_generator = scoped_generator.fork().release_value_but_fixme_should_propagate_errors();
 
         union_generator.append(R"~~~(
     @result_expression@ @value@.visit(
@@ -1789,7 +1789,7 @@ static void generate_wrap_statement(SourceGenerator& generator, DeprecatedString
         }
     } else if (interface.dictionaries.contains(type.name())) {
         // https://webidl.spec.whatwg.org/#es-dictionary
-        auto dictionary_generator = scoped_generator.fork();
+        auto dictionary_generator = scoped_generator.fork().release_value_but_fixme_should_propagate_errors();
 
         dictionary_generator.append(R"~~~(
     auto dictionary_object@recursion_depth@ = JS::Object::create(realm, realm.intrinsics().object_prototype());
@@ -1857,7 +1857,7 @@ static void generate_return_statement(SourceGenerator& generator, IDL::Type cons
 
 static void generate_variable_statement(SourceGenerator& generator, DeprecatedString const& variable_name, IDL::Type const& value_type, DeprecatedString const& value_name, IDL::Interface const& interface)
 {
-    auto variable_generator = generator.fork();
+    auto variable_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
     variable_generator.set("variable_name", variable_name);
     variable_generator.append(R"~~~(
     JS::Value @variable_name@;
@@ -1867,7 +1867,7 @@ static void generate_variable_statement(SourceGenerator& generator, DeprecatedSt
 
 static void generate_function(SourceGenerator& generator, IDL::Function const& function, StaticFunction is_static_function, DeprecatedString const& class_name, DeprecatedString const& interface_fully_qualified_name, IDL::Interface const& interface)
 {
-    auto function_generator = generator.fork();
+    auto function_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
     function_generator.set("class_name", class_name);
     function_generator.set("interface_fully_qualified_name", interface_fully_qualified_name);
     function_generator.set("function.name:snakecase", make_input_acceptable_cpp(function.name.to_snakecase()));
@@ -2122,7 +2122,7 @@ static DeprecatedString generate_constructor_for_idl_type(Type const& type)
 
 static void generate_overload_arbiter(SourceGenerator& generator, auto const& overload_set, DeprecatedString const& class_name)
 {
-    auto function_generator = generator.fork();
+    auto function_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
     function_generator.set("class_name", class_name);
     function_generator.set("function.name:snakecase", make_input_acceptable_cpp(overload_set.key.to_snakecase()));
 
@@ -2243,7 +2243,7 @@ static void generate_prototype_or_global_mixin_declarations(IDL::Interface const
     SourceGenerator generator { builder };
 
     for (auto const& overload_set : interface.overload_sets) {
-        auto function_generator = generator.fork();
+        auto function_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         function_generator.set("function.name:snakecase", make_input_acceptable_cpp(overload_set.key.to_snakecase()));
         function_generator.append(R"~~~(
     JS_DECLARE_NATIVE_FUNCTION(@function.name:snakecase@);
@@ -2259,14 +2259,14 @@ static void generate_prototype_or_global_mixin_declarations(IDL::Interface const
     }
 
     if (interface.has_stringifier) {
-        auto stringifier_generator = generator.fork();
+        auto stringifier_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         stringifier_generator.append(R"~~~(
     JS_DECLARE_NATIVE_FUNCTION(to_string);
         )~~~");
     }
 
     if (interface.pair_iterator_types.has_value()) {
-        auto iterator_generator = generator.fork();
+        auto iterator_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         iterator_generator.append(R"~~~(
     JS_DECLARE_NATIVE_FUNCTION(entries);
     JS_DECLARE_NATIVE_FUNCTION(for_each);
@@ -2276,7 +2276,7 @@ static void generate_prototype_or_global_mixin_declarations(IDL::Interface const
     }
 
     for (auto& attribute : interface.attributes) {
-        auto attribute_generator = generator.fork();
+        auto attribute_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         attribute_generator.set("attribute.name:snakecase", attribute.name.to_snakecase());
         attribute_generator.append(R"~~~(
     JS_DECLARE_NATIVE_FUNCTION(@attribute.name:snakecase@_getter);
@@ -2298,7 +2298,7 @@ static void generate_prototype_or_global_mixin_declarations(IDL::Interface const
     for (auto& it : interface.enumerations) {
         if (!it.value.is_original_definition)
             continue;
-        auto enum_generator = generator.fork();
+        auto enum_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         enum_generator.set("enum.type.name", it.key);
         enum_generator.append(R"~~~(
 enum class @enum.type.name@ {
@@ -2414,7 +2414,7 @@ static void collect_attribute_values_of_an_inheritance_stack(SourceGenerator& fu
             if (!attribute.type->is_json(interface_in_chain))
                 continue;
 
-            auto attribute_generator = function_generator.fork();
+            auto attribute_generator = function_generator.fork().release_value_but_fixme_should_propagate_errors();
             auto return_value_name = DeprecatedString::formatted("{}_retval", attribute.name.to_snakecase());
 
             attribute_generator.set("attribute.name", attribute.name);
@@ -2462,7 +2462,7 @@ static void collect_attribute_values_of_an_inheritance_stack(SourceGenerator& fu
         }
 
         for (auto& constant : interface_in_chain.constants) {
-            auto constant_generator = function_generator.fork();
+            auto constant_generator = function_generator.fork().release_value_but_fixme_should_propagate_errors();
             constant_generator.set("constant.name", constant.name);
 
             generate_wrap_statement(constant_generator, constant.value, constant.type, interface_in_chain, DeprecatedString::formatted("auto constant_{}_value =", constant.name));
@@ -2479,7 +2479,7 @@ static void generate_default_to_json_function(SourceGenerator& generator, Deprec
 {
     // NOTE: This is done heavily out of order since the spec mixes parse time and run time type information together.
 
-    auto function_generator = generator.fork();
+    auto function_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
     function_generator.set("class_name", class_name);
 
     // 4. Let result be OrdinaryObjectCreate(%Object.prototype%).
@@ -2576,7 +2576,7 @@ JS::ThrowCompletionOr<void> @class_name@::initialize(JS::Realm& realm)
 
     // https://webidl.spec.whatwg.org/#es-attributes
     for (auto& attribute : interface.attributes) {
-        auto attribute_generator = generator.fork();
+        auto attribute_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         attribute_generator.set("attribute.name", attribute.name);
         attribute_generator.set("attribute.getter_callback", attribute.getter_callback_name);
 
@@ -2600,7 +2600,7 @@ JS::ThrowCompletionOr<void> @class_name@::initialize(JS::Realm& realm)
     for (auto& constant : interface.constants) {
         // FIXME: Do constants need to be added to the unscopable list?
 
-        auto constant_generator = generator.fork();
+        auto constant_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         constant_generator.set("constant.name", constant.name);
 
         generate_wrap_statement(constant_generator, constant.value, constant.type, interface, DeprecatedString::formatted("auto constant_{}_value =", constant.name));
@@ -2612,7 +2612,7 @@ JS::ThrowCompletionOr<void> @class_name@::initialize(JS::Realm& realm)
 
     // https://webidl.spec.whatwg.org/#es-operations
     for (auto const& overload_set : interface.overload_sets) {
-        auto function_generator = generator.fork();
+        auto function_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         function_generator.set("function.name", overload_set.key);
         function_generator.set("function.name:snakecase", make_input_acceptable_cpp(overload_set.key.to_snakecase()));
         function_generator.set("function.length", DeprecatedString::number(get_shortest_function_length(overload_set.value)));
@@ -2632,7 +2632,7 @@ JS::ThrowCompletionOr<void> @class_name@::initialize(JS::Realm& realm)
     if (interface.has_stringifier) {
         // FIXME: Do stringifiers need to be added to the unscopable list?
 
-        auto stringifier_generator = generator.fork();
+        auto stringifier_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         stringifier_generator.append(R"~~~(
     define_native_function(realm, "toString", to_string, 0, default_attributes);
 )~~~");
@@ -2641,7 +2641,7 @@ JS::ThrowCompletionOr<void> @class_name@::initialize(JS::Realm& realm)
     // https://webidl.spec.whatwg.org/#define-the-iteration-methods
     // This applies to this if block and the following if block.
     if (interface.indexed_property_getter.has_value()) {
-        auto iterator_generator = generator.fork();
+        auto iterator_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         iterator_generator.append(R"~~~(
     define_direct_property(vm.well_known_symbol_iterator(), realm.intrinsics().array_prototype()->get_without_side_effects(vm.names.values), JS::Attribute::Configurable | JS::Attribute::Writable);
 )~~~");
@@ -2659,7 +2659,7 @@ JS::ThrowCompletionOr<void> @class_name@::initialize(JS::Realm& realm)
     if (interface.pair_iterator_types.has_value()) {
         // FIXME: Do pair iterators need to be added to the unscopable list?
 
-        auto iterator_generator = generator.fork();
+        auto iterator_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         iterator_generator.append(R"~~~(
     define_native_function(realm, vm.names.entries, entries, 0, default_attributes);
     define_native_function(realm, vm.names.forEach, for_each, 1, default_attributes);
@@ -2723,7 +2723,7 @@ static JS::ThrowCompletionOr<@fully_qualified_name@*> impl_from(JS::VM& vm)
     }
 
     for (auto& attribute : interface.attributes) {
-        auto attribute_generator = generator.fork();
+        auto attribute_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         attribute_generator.set("attribute.name", attribute.name);
         attribute_generator.set("attribute.getter_callback", attribute.getter_callback_name);
         attribute_generator.set("attribute.setter_callback", attribute.setter_callback_name);
@@ -2945,7 +2945,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.setter_callback@)
     }
 
     if (interface.has_stringifier) {
-        auto stringifier_generator = generator.fork();
+        auto stringifier_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         stringifier_generator.set("class_name", class_name);
         if (interface.stringifier_attribute.has_value())
             stringifier_generator.set("attribute.cpp_getter_name", interface.stringifier_attribute->to_snakecase());
@@ -2980,7 +2980,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::to_string)
     }
 
     if (interface.pair_iterator_types.has_value()) {
-        auto iterator_generator = generator.fork();
+        auto iterator_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         iterator_generator.append(R"~~~(
 JS_DEFINE_NATIVE_FUNCTION(@class_name@::entries)
 {
@@ -3059,7 +3059,7 @@ private:
     }
 
     for (auto const& overload_set : interface.overload_sets) {
-        auto function_generator = generator.fork();
+        auto function_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         function_generator.set("function.name:snakecase", make_input_acceptable_cpp(overload_set.key.to_snakecase()));
         function_generator.append(R"~~~(
     JS_DECLARE_NATIVE_FUNCTION(@function.name:snakecase@);
@@ -3156,7 +3156,7 @@ JS::ThrowCompletionOr<void> @namespace_class@::initialize(JS::Realm& realm)
 
     // https://webidl.spec.whatwg.org/#es-operations
     for (auto const& overload_set : interface.overload_sets) {
-        auto function_generator = generator.fork();
+        auto function_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         function_generator.set("function.name", overload_set.key);
         function_generator.set("function.name:snakecase", make_input_acceptable_cpp(overload_set.key.to_snakecase()));
         function_generator.set("function.length", DeprecatedString::number(get_shortest_function_length(overload_set.value)));
@@ -3222,7 +3222,7 @@ private:
 )~~~");
 
     for (auto const& overload_set : interface.static_overload_sets) {
-        auto function_generator = generator.fork();
+        auto function_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         function_generator.set("function.name:snakecase", make_input_acceptable_cpp(overload_set.key.to_snakecase()));
         function_generator.append(R"~~~(
     JS_DECLARE_NATIVE_FUNCTION(@function.name:snakecase@);
@@ -3551,7 +3551,7 @@ JS::ThrowCompletionOr<void> @constructor_class@::initialize(JS::Realm& realm)
 )~~~");
 
     for (auto& constant : interface.constants) {
-        auto constant_generator = generator.fork();
+        auto constant_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         constant_generator.set("constant.name", constant.name);
 
         generate_wrap_statement(constant_generator, constant.value, constant.type, interface, DeprecatedString::formatted("auto constant_{}_value =", constant.name));
@@ -3563,7 +3563,7 @@ JS::ThrowCompletionOr<void> @constructor_class@::initialize(JS::Realm& realm)
 
     // https://webidl.spec.whatwg.org/#es-operations
     for (auto const& overload_set : interface.static_overload_sets) {
-        auto function_generator = generator.fork();
+        auto function_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         function_generator.set("function.name", overload_set.key);
         function_generator.set("function.name:snakecase", make_input_acceptable_cpp(overload_set.key.to_snakecase()));
         function_generator.set("function.length", DeprecatedString::number(get_shortest_function_length(overload_set.value)));

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
@@ -58,7 +58,7 @@ enum class ValueID;
         VERIFY(value.is_array());
         auto& members = value.as_array();
 
-        auto enum_generator = generator.fork();
+        auto enum_generator = TRY(generator.fork());
         TRY(enum_generator.set("name:titlecase", TRY(title_casify(name))));
         TRY(enum_generator.set("name:snakecase", TRY(snake_casify(name))));
 
@@ -81,7 +81,7 @@ enum class ValueID;
             // Don't include aliases in the enum.
             if (member_name.contains('='))
                 continue;
-            auto member_generator = enum_generator.fork();
+            auto member_generator = TRY(enum_generator.fork());
             TRY(member_generator.set("member:titlecase", TRY(title_casify(member_name))));
             member_generator.appendln("    @member:titlecase@,");
         }
@@ -117,7 +117,7 @@ namespace Web::CSS {
         VERIFY(value.is_array());
         auto& members = value.as_array();
 
-        auto enum_generator = generator.fork();
+        auto enum_generator = TRY(generator.fork());
         TRY(enum_generator.set("name:titlecase", TRY(title_casify(name))));
         TRY(enum_generator.set("name:snakecase", TRY(snake_casify(name))));
 
@@ -127,7 +127,7 @@ Optional<@name:titlecase@> value_id_to_@name:snakecase@(ValueID value_id)
     switch (value_id) {)~~~");
 
         for (auto& member : members.values()) {
-            auto member_generator = enum_generator.fork();
+            auto member_generator = TRY(enum_generator.fork());
             auto member_name = member.to_deprecated_string();
             if (member_name.contains('=')) {
                 auto parts = member_name.split_view('=');
@@ -155,7 +155,7 @@ ValueID to_value_id(@name:titlecase@ @name:snakecase@_value)
     switch (@name:snakecase@_value) {)~~~");
 
         for (auto& member : members.values()) {
-            auto member_generator = enum_generator.fork();
+            auto member_generator = TRY(enum_generator.fork());
             auto member_name = member.to_deprecated_string();
             if (member_name.contains('='))
                 continue;
@@ -179,7 +179,7 @@ StringView to_string(@name:titlecase@ value)
     switch (value) {)~~~");
 
         for (auto& member : members.values()) {
-            auto member_generator = enum_generator.fork();
+            auto member_generator = TRY(enum_generator.fork());
             auto member_name = member.to_deprecated_string();
             if (member_name.contains('='))
                 continue;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
@@ -54,13 +54,13 @@ enum class ValueID;
 
 )~~~");
 
-    enums_data.for_each_member([&](auto& name, auto& value) {
+    TRY(enums_data.try_for_each_member([&](auto& name, auto& value) -> ErrorOr<void> {
         VERIFY(value.is_array());
         auto& members = value.as_array();
 
         auto enum_generator = generator.fork();
-        enum_generator.set("name:titlecase", title_casify(name));
-        enum_generator.set("name:snakecase", snake_casify(name));
+        TRY(enum_generator.set("name:titlecase", TRY(title_casify(name))));
+        TRY(enum_generator.set("name:snakecase", TRY(snake_casify(name))));
 
         // Find the smallest possible type to use.
         auto member_max_value = members.size() - 1;
@@ -82,7 +82,7 @@ enum class ValueID;
             if (member_name.contains('='))
                 continue;
             auto member_generator = enum_generator.fork();
-            member_generator.set("member:titlecase", title_casify(member_name));
+            TRY(member_generator.set("member:titlecase", TRY(title_casify(member_name))));
             member_generator.appendln("    @member:titlecase@,");
         }
 
@@ -91,7 +91,9 @@ enum class ValueID;
         enum_generator.appendln("ValueID to_value_id(@name:titlecase@);");
         enum_generator.appendln("StringView to_string(@name:titlecase@);");
         enum_generator.append("\n");
-    });
+
+        return {};
+    }));
 
     generator.appendln("}");
 
@@ -111,13 +113,13 @@ ErrorOr<void> generate_implementation_file(JsonObject& enums_data, Core::File& f
 namespace Web::CSS {
 )~~~");
 
-    enums_data.for_each_member([&](auto& name, auto& value) {
+    TRY(enums_data.try_for_each_member([&](auto& name, auto& value) -> ErrorOr<void> {
         VERIFY(value.is_array());
         auto& members = value.as_array();
 
         auto enum_generator = generator.fork();
-        enum_generator.set("name:titlecase", title_casify(name));
-        enum_generator.set("name:snakecase", snake_casify(name));
+        TRY(enum_generator.set("name:titlecase", TRY(title_casify(name))));
+        TRY(enum_generator.set("name:snakecase", TRY(snake_casify(name))));
 
         enum_generator.append(R"~~~(
 Optional<@name:titlecase@> value_id_to_@name:snakecase@(ValueID value_id)
@@ -129,11 +131,11 @@ Optional<@name:titlecase@> value_id_to_@name:snakecase@(ValueID value_id)
             auto member_name = member.to_deprecated_string();
             if (member_name.contains('=')) {
                 auto parts = member_name.split_view('=');
-                member_generator.set("valueid:titlecase", title_casify(parts[0]));
-                member_generator.set("member:titlecase", title_casify(parts[1]));
+                TRY(member_generator.set("valueid:titlecase", TRY(title_casify(parts[0]))));
+                TRY(member_generator.set("member:titlecase", TRY(title_casify(parts[1]))));
             } else {
-                member_generator.set("valueid:titlecase", title_casify(member_name));
-                member_generator.set("member:titlecase", title_casify(member_name));
+                TRY(member_generator.set("valueid:titlecase", TRY(title_casify(member_name))));
+                TRY(member_generator.set("member:titlecase", TRY(title_casify(member_name))));
             }
             member_generator.append(R"~~~(
     case ValueID::@valueid:titlecase@:
@@ -157,7 +159,7 @@ ValueID to_value_id(@name:titlecase@ @name:snakecase@_value)
             auto member_name = member.to_deprecated_string();
             if (member_name.contains('='))
                 continue;
-            member_generator.set("member:titlecase", title_casify(member_name));
+            TRY(member_generator.set("member:titlecase", TRY(title_casify(member_name))));
 
             member_generator.append(R"~~~(
     case @name:titlecase@::@member:titlecase@:
@@ -182,7 +184,7 @@ StringView to_string(@name:titlecase@ value)
             if (member_name.contains('='))
                 continue;
             member_generator.set("member:css", member_name);
-            member_generator.set("member:titlecase", title_casify(member_name));
+            TRY(member_generator.set("member:titlecase", TRY(title_casify(member_name))));
 
             member_generator.append(R"~~~(
     case @name:titlecase@::@member:titlecase@:
@@ -195,7 +197,8 @@ StringView to_string(@name:titlecase@ value)
     }
 }
 )~~~");
-    });
+        return {};
+    }));
 
     generator.appendln("}");
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
@@ -61,7 +61,7 @@ enum class MediaFeatureValueType {
 enum class MediaFeatureID {)~~~");
 
     TRY(media_feature_data.try_for_each_member([&](auto& name, auto&) -> ErrorOr<void> {
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         member_generator.append(R"~~~(
     @name:titlecase@,)~~~");
@@ -99,7 +99,7 @@ Optional<MediaFeatureID> media_feature_id_from_string(StringView string)
 {)~~~");
 
     TRY(media_feature_data.try_for_each_member([&](auto& name, auto&) -> ErrorOr<void> {
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         member_generator.set("name", name);
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         member_generator.append(R"~~~(
@@ -118,7 +118,7 @@ StringView string_from_media_feature_id(MediaFeatureID media_feature_id)
     switch (media_feature_id) {)~~~");
 
     TRY(media_feature_data.try_for_each_member([&](auto& name, auto&) -> ErrorOr<void> {
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         member_generator.set("name", name);
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         member_generator.append(R"~~~(
@@ -140,7 +140,7 @@ bool media_feature_type_is_range(MediaFeatureID media_feature_id)
         VERIFY(value.is_object());
         auto& feature = value.as_object();
 
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         VERIFY(feature.has("type"sv));
         auto feature_type = feature.get_deprecated_string("type"sv);
@@ -165,7 +165,7 @@ bool media_feature_accepts_type(MediaFeatureID media_feature_id, MediaFeatureVal
         VERIFY(member.is_object());
         auto& feature = member.as_object();
 
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         member_generator.append(R"~~~(
     case MediaFeatureID::@name:titlecase@:)~~~");
@@ -244,7 +244,7 @@ bool media_feature_accepts_identifier(MediaFeatureID media_feature_id, ValueID i
         VERIFY(member.is_object());
         auto& feature = member.as_object();
 
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         member_generator.append(R"~~~(
     case MediaFeatureID::@name:titlecase@:)~~~");
@@ -269,7 +269,7 @@ bool media_feature_accepts_identifier(MediaFeatureID media_feature_id, ValueID i
                     continue;
                 append_identifier_switch_if_needed();
 
-                auto ident_generator = member_generator.fork();
+                auto ident_generator = TRY(member_generator.fork());
                 TRY(ident_generator.set("identifier:titlecase", TRY(title_casify(identifier_name))));
                 ident_generator.append(R"~~~(
         case ValueID::@identifier:titlecase@:

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
@@ -60,12 +60,13 @@ enum class MediaFeatureValueType {
 
 enum class MediaFeatureID {)~~~");
 
-    media_feature_data.for_each_member([&](auto& name, auto&) {
+    TRY(media_feature_data.try_for_each_member([&](auto& name, auto&) -> ErrorOr<void> {
         auto member_generator = generator.fork();
-        member_generator.set("name:titlecase", title_casify(name));
+        TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         member_generator.append(R"~~~(
     @name:titlecase@,)~~~");
-    });
+        return {};
+    }));
 
     generator.append(R"~~~(
 };
@@ -97,15 +98,16 @@ namespace Web::CSS {
 Optional<MediaFeatureID> media_feature_id_from_string(StringView string)
 {)~~~");
 
-    media_feature_data.for_each_member([&](auto& name, auto&) {
+    TRY(media_feature_data.try_for_each_member([&](auto& name, auto&) -> ErrorOr<void> {
         auto member_generator = generator.fork();
         member_generator.set("name", name);
-        member_generator.set("name:titlecase", title_casify(name));
+        TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         member_generator.append(R"~~~(
     if (Infra::is_ascii_case_insensitive_match(string, "@name@"sv))
         return MediaFeatureID::@name:titlecase@;
 )~~~");
-    });
+        return {};
+    }));
 
     generator.append(R"~~~(
     return {};
@@ -115,14 +117,15 @@ StringView string_from_media_feature_id(MediaFeatureID media_feature_id)
 {
     switch (media_feature_id) {)~~~");
 
-    media_feature_data.for_each_member([&](auto& name, auto&) {
+    TRY(media_feature_data.try_for_each_member([&](auto& name, auto&) -> ErrorOr<void> {
         auto member_generator = generator.fork();
         member_generator.set("name", name);
-        member_generator.set("name:titlecase", title_casify(name));
+        TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         member_generator.append(R"~~~(
     case MediaFeatureID::@name:titlecase@:
         return "@name@"sv;)~~~");
-    });
+        return {};
+    }));
 
     generator.append(R"~~~(
     }
@@ -133,12 +136,12 @@ bool media_feature_type_is_range(MediaFeatureID media_feature_id)
 {
     switch (media_feature_id) {)~~~");
 
-    media_feature_data.for_each_member([&](auto& name, auto& value) {
+    TRY(media_feature_data.try_for_each_member([&](auto& name, auto& value) -> ErrorOr<void> {
         VERIFY(value.is_object());
         auto& feature = value.as_object();
 
         auto member_generator = generator.fork();
-        member_generator.set("name:titlecase", title_casify(name));
+        TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         VERIFY(feature.has("type"sv));
         auto feature_type = feature.get_deprecated_string("type"sv);
         VERIFY(feature_type.has_value());
@@ -146,7 +149,8 @@ bool media_feature_type_is_range(MediaFeatureID media_feature_id)
         member_generator.append(R"~~~(
     case MediaFeatureID::@name:titlecase@:
         return @is_range@;)~~~");
-    });
+        return {};
+    }));
 
     generator.append(R"~~~(
     }
@@ -157,12 +161,12 @@ bool media_feature_accepts_type(MediaFeatureID media_feature_id, MediaFeatureVal
 {
     switch (media_feature_id) {)~~~");
 
-    media_feature_data.for_each_member([&](auto& name, auto& member) {
+    TRY(media_feature_data.try_for_each_member([&](auto& name, auto& member) -> ErrorOr<void> {
         VERIFY(member.is_object());
         auto& feature = member.as_object();
 
         auto member_generator = generator.fork();
-        member_generator.set("name:titlecase", title_casify(name));
+        TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         member_generator.append(R"~~~(
     case MediaFeatureID::@name:titlecase@:)~~~");
 
@@ -224,7 +228,8 @@ bool media_feature_accepts_type(MediaFeatureID media_feature_id, MediaFeatureVal
             member_generator.append(R"~~~(
         return false;)~~~");
         }
-    });
+        return {};
+    }));
 
     generator.append(R"~~~(
     }
@@ -235,12 +240,12 @@ bool media_feature_accepts_identifier(MediaFeatureID media_feature_id, ValueID i
 {
     switch (media_feature_id) {)~~~");
 
-    media_feature_data.for_each_member([&](auto& name, auto& member) {
+    TRY(media_feature_data.try_for_each_member([&](auto& name, auto& member) -> ErrorOr<void> {
         VERIFY(member.is_object());
         auto& feature = member.as_object();
 
         auto member_generator = generator.fork();
-        member_generator.set("name:titlecase", title_casify(name));
+        TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         member_generator.append(R"~~~(
     case MediaFeatureID::@name:titlecase@:)~~~");
 
@@ -265,7 +270,7 @@ bool media_feature_accepts_identifier(MediaFeatureID media_feature_id, ValueID i
                 append_identifier_switch_if_needed();
 
                 auto ident_generator = member_generator.fork();
-                ident_generator.set("identifier:titlecase", title_casify(identifier_name));
+                TRY(ident_generator.set("identifier:titlecase", TRY(title_casify(identifier_name))));
                 ident_generator.append(R"~~~(
         case ValueID::@identifier:titlecase@:
             return true;)~~~");
@@ -280,7 +285,8 @@ bool media_feature_accepts_identifier(MediaFeatureID media_feature_id, ValueID i
             member_generator.append(R"~~~(
         return false;)~~~");
         }
-    });
+        return {};
+    }));
 
     generator.append(R"~~~(
     }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -119,7 +119,7 @@ enum class PropertyID {
     auto last_property_id = longhand_property_ids.last();
 
     for (auto& name : shorthand_property_ids) {
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
 
         member_generator.append(R"~~~(
@@ -128,7 +128,7 @@ enum class PropertyID {
     }
 
     for (auto& name : longhand_property_ids) {
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
 
         member_generator.append(R"~~~(
@@ -225,7 +225,7 @@ struct Traits<Web::CSS::PropertyID> : public GenericTraits<Web::CSS::PropertyID>
 
 ErrorOr<void> generate_bounds_checking_function(JsonObject& properties, SourceGenerator& parent_generator, StringView css_type_name, StringView type_name, Optional<StringView> default_unit_name, Optional<StringView> value_getter)
 {
-    auto generator = parent_generator.fork();
+    auto generator = TRY(parent_generator.fork());
     generator.set("css_type_name", css_type_name);
     generator.set("type_name", type_name);
 
@@ -243,7 +243,7 @@ bool property_accepts_@css_type_name@(PropertyID property_id, [[maybe_unused]] @
                 if (type_and_range.first() != css_type_name)
                     continue;
 
-                auto property_generator = generator.fork();
+                auto property_generator = TRY(generator.fork());
                 TRY(property_generator.set("property_name:titlecase", TRY(title_casify(name))));
 
                 property_generator.append(R"~~~(
@@ -339,7 +339,7 @@ Optional<PropertyID> property_id_from_camel_case_string(StringView string)
     TRY(properties.try_for_each_member([&](auto& name, auto& value) -> ErrorOr<void> {
         VERIFY(value.is_object());
 
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         member_generator.set("name", name);
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         TRY(member_generator.set("name:camelcase", TRY(camel_casify(name))));
@@ -361,7 +361,7 @@ Optional<PropertyID> property_id_from_string(StringView string)
     TRY(properties.try_for_each_member([&](auto& name, auto& value) -> ErrorOr<void> {
         VERIFY(value.is_object());
 
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         member_generator.set("name", name);
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         member_generator.append(R"~~~(
@@ -382,7 +382,7 @@ StringView string_from_property_id(PropertyID property_id) {
     TRY(properties.try_for_each_member([&](auto& name, auto& value) -> ErrorOr<void> {
         VERIFY(value.is_object());
 
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         member_generator.set("name", name);
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         member_generator.append(R"~~~(
@@ -414,7 +414,7 @@ bool is_inherited_property(PropertyID property_id)
         }
 
         if (inherited) {
-            auto member_generator = generator.fork();
+            auto member_generator = TRY(generator.fork());
             TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
             member_generator.append(R"~~~(
     case PropertyID::@name:titlecase@:
@@ -443,7 +443,7 @@ bool property_affects_layout(PropertyID property_id)
             affects_layout = value.as_object().get_bool("affects-layout"sv).value_or(false);
 
         if (affects_layout) {
-            auto member_generator = generator.fork();
+            auto member_generator = TRY(generator.fork());
             TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
             member_generator.append(R"~~~(
     case PropertyID::@name:titlecase@:
@@ -472,7 +472,7 @@ bool property_affects_stacking_context(PropertyID property_id)
             affects_stacking_context = value.as_object().get_bool("affects-stacking-context"sv).value_or(false);
 
         if (affects_stacking_context) {
-            auto member_generator = generator.fork();
+            auto member_generator = TRY(generator.fork());
             TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
             member_generator.append(R"~~~(
     case PropertyID::@name:titlecase@:
@@ -511,7 +511,7 @@ ErrorOr<NonnullRefPtr<StyleValue>> property_initial_value(JS::Realm& context_rea
         VERIFY(initial_value.has_value());
         auto& initial_value_string = initial_value.value();
 
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
         member_generator.set("initial_value_string", initial_value_string);
         member_generator.append(
@@ -552,7 +552,7 @@ bool property_has_quirk(PropertyID property_id, Quirk quirk)
             auto& quirks = quirks_value.value();
 
             if (!quirks.is_empty()) {
-                auto property_generator = generator.fork();
+                auto property_generator = TRY(generator.fork());
                 TRY(property_generator.set("name:titlecase", TRY(title_casify(name))));
                 property_generator.append(R"~~~(
     case PropertyID::@name:titlecase@: {
@@ -560,7 +560,7 @@ bool property_has_quirk(PropertyID property_id, Quirk quirk)
 )~~~");
                 for (auto& quirk : quirks.values()) {
                     VERIFY(quirk.is_string());
-                    auto quirk_generator = property_generator.fork();
+                    auto quirk_generator = TRY(property_generator.fork());
                     TRY(quirk_generator.set("quirk:titlecase", TRY(title_casify(quirk.as_string()))));
                     quirk_generator.append(R"~~~(
         case Quirk::@quirk:titlecase@:
@@ -593,7 +593,7 @@ bool property_accepts_type(PropertyID property_id, ValueType value_type)
         auto& object = value.as_object();
         if (auto maybe_valid_types = object.get_array("valid-types"sv); maybe_valid_types.has_value() && !maybe_valid_types->is_empty()) {
             auto& valid_types = maybe_valid_types.value();
-            auto property_generator = generator.fork();
+            auto property_generator = TRY(generator.fork());
             TRY(property_generator.set("name:titlecase", TRY(title_casify(name))));
             property_generator.append(R"~~~(
     case PropertyID::@name:titlecase@: {
@@ -671,7 +671,7 @@ bool property_accepts_identifier(PropertyID property_id, ValueID identifier)
         VERIFY(value.is_object());
         auto& object = value.as_object();
 
-        auto property_generator = generator.fork();
+        auto property_generator = TRY(generator.fork());
         TRY(property_generator.set("name:titlecase", TRY(title_casify(name))));
         property_generator.appendln("    case PropertyID::@name:titlecase@: {");
 
@@ -679,7 +679,7 @@ bool property_accepts_identifier(PropertyID property_id, ValueID identifier)
             property_generator.appendln("        switch (identifier) {");
             auto& valid_identifiers = maybe_valid_identifiers.value();
             for (auto& identifier : valid_identifiers.values()) {
-                auto identifier_generator = generator.fork();
+                auto identifier_generator = TRY(generator.fork());
                 TRY(identifier_generator.set("identifier:titlecase", TRY(title_casify(identifier.as_string()))));
                 identifier_generator.appendln("        case ValueID::@identifier:titlecase@:");
             }
@@ -698,7 +698,7 @@ bool property_accepts_identifier(PropertyID property_id, ValueID identifier)
                 if (!type_name_is_enum(type_name))
                     continue;
 
-                auto type_generator = generator.fork();
+                auto type_generator = TRY(generator.fork());
                 TRY(type_generator.set("type_name:snakecase", TRY(snake_casify(type_name))));
                 type_generator.append(R"~~~(
         if (value_id_to_@type_name:snakecase@(identifier).has_value())
@@ -728,7 +728,7 @@ size_t property_maximum_value_count(PropertyID property_id)
         if (value.as_object().has("max-values"sv)) {
             auto max_values = value.as_object().get("max-values"sv);
             VERIFY(max_values.has_value() && max_values->is_number() && !max_values->is_double());
-            auto property_generator = generator.fork();
+            auto property_generator = TRY(generator.fork());
             TRY(property_generator.set("name:titlecase", TRY(title_casify(name))));
             property_generator.set("max_values", max_values->to_deprecated_string());
             property_generator.append(R"~~~(
@@ -764,7 +764,7 @@ Vector<PropertyID> longhands_for_shorthand(PropertyID property_id)
             auto longhands = value.as_object().get("longhands"sv);
             VERIFY(longhands.has_value() && longhands->is_array());
             auto longhand_values = longhands->as_array();
-            auto property_generator = generator.fork();
+            auto property_generator = TRY(generator.fork());
             TRY(property_generator.set("name:titlecase", TRY(title_casify(name))));
             StringBuilder builder;
             bool first = true;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -39,13 +39,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     return 0;
 }
 
-static DeprecatedString title_casify_transform_function(StringView input)
+static ErrorOr<String> title_casify_transform_function(StringView input)
 {
     // Transform function names look like `fooBar`, so we just have to make the first character uppercase.
     StringBuilder builder;
-    builder.append(toupper(input[0]));
-    builder.append(input.substring_view(1));
-    return builder.to_deprecated_string();
+    TRY(builder.try_append(toupper(input[0])));
+    TRY(builder.try_append(input.substring_view(1)));
+    return builder.to_string();
 }
 
 ErrorOr<void> generate_header_file(JsonObject& transforms_data, Core::File& file)
@@ -53,7 +53,7 @@ ErrorOr<void> generate_header_file(JsonObject& transforms_data, Core::File& file
     StringBuilder builder;
     SourceGenerator generator { builder };
 
-    generator.append(R"~~~(
+    TRY(generator.try_append(R"~~~(
 #pragma once
 
 #include <AK/Optional.h>
@@ -62,21 +62,21 @@ ErrorOr<void> generate_header_file(JsonObject& transforms_data, Core::File& file
 
 namespace Web::CSS {
 
-)~~~");
+)~~~"));
 
-    generator.appendln("enum class TransformFunction {");
+    TRY(generator.try_appendln("enum class TransformFunction {"));
     TRY(transforms_data.try_for_each_member([&](auto& name, auto&) -> ErrorOr<void> {
         auto member_generator = TRY(generator.fork());
-        member_generator.set("name:titlecase", title_casify_transform_function(name));
-        member_generator.appendln("    @name:titlecase@,");
+        TRY(member_generator.set("name:titlecase", TRY(title_casify_transform_function(name))));
+        TRY(member_generator.try_appendln("    @name:titlecase@,"));
         return {};
     }));
-    generator.appendln("};");
+    TRY(generator.try_appendln("};"));
 
-    generator.appendln("Optional<TransformFunction> transform_function_from_string(StringView);");
-    generator.appendln("StringView to_string(TransformFunction);");
+    TRY(generator.try_appendln("Optional<TransformFunction> transform_function_from_string(StringView);"));
+    TRY(generator.try_appendln("StringView to_string(TransformFunction);"));
 
-    generator.append(R"~~~(
+    TRY(generator.try_append(R"~~~(
 enum class TransformFunctionParameterType {
     Angle,
     Length,
@@ -93,9 +93,9 @@ struct TransformFunctionMetadata {
     Vector<TransformFunctionParameter> parameters;
 };
 TransformFunctionMetadata transform_function_metadata(TransformFunction);
-)~~~");
+)~~~"));
 
-    generator.appendln("\n}");
+    TRY(generator.try_appendln("\n}"));
 
     TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
@@ -106,72 +106,72 @@ ErrorOr<void> generate_implementation_file(JsonObject& transforms_data, Core::Fi
     StringBuilder builder;
     SourceGenerator generator { builder };
 
-    generator.append(R"~~~(
+    TRY(generator.try_append(R"~~~(
 #include <LibWeb/CSS/TransformFunctions.h>
 #include <AK/Assertions.h>
 
 namespace Web::CSS {
-)~~~");
+)~~~"));
 
-    generator.append(R"~~~(
+    TRY(generator.try_append(R"~~~(
 Optional<TransformFunction> transform_function_from_string(StringView name)
 {
-)~~~");
+)~~~"));
     TRY(transforms_data.try_for_each_member([&](auto& name, auto&) -> ErrorOr<void> {
         auto member_generator = TRY(generator.fork());
-        member_generator.set("name", name);
-        member_generator.set("name:titlecase", title_casify_transform_function(name));
-        member_generator.append(R"~~~(
+        TRY(member_generator.set("name", TRY(String::from_deprecated_string(name))));
+        TRY(member_generator.set("name:titlecase", TRY(title_casify_transform_function(name))));
+        TRY(member_generator.try_append(R"~~~(
     if (name.equals_ignoring_ascii_case("@name@"sv))
         return TransformFunction::@name:titlecase@;
-)~~~");
+)~~~"));
         return {};
     }));
-    generator.append(R"~~~(
+    TRY(generator.try_append(R"~~~(
     return {};
 }
-)~~~");
+)~~~"));
 
-    generator.append(R"~~~(
+    TRY(generator.try_append(R"~~~(
 StringView to_string(TransformFunction transform_function)
 {
     switch (transform_function) {
-)~~~");
+)~~~"));
     TRY(transforms_data.try_for_each_member([&](auto& name, auto&) -> ErrorOr<void> {
         auto member_generator = TRY(generator.fork());
-        member_generator.set("name", name);
-        member_generator.set("name:titlecase", title_casify_transform_function(name));
-        member_generator.append(R"~~~(
+        TRY(member_generator.set("name", TRY(String::from_deprecated_string(name))));
+        TRY(member_generator.set("name:titlecase", TRY(title_casify_transform_function(name))));
+        TRY(member_generator.try_append(R"~~~(
     case TransformFunction::@name:titlecase@:
         return "@name@"sv;
-)~~~");
+)~~~"));
         return {};
     }));
-    generator.append(R"~~~(
+    TRY(generator.try_append(R"~~~(
     default:
         VERIFY_NOT_REACHED();
     }
 }
-)~~~");
+)~~~"));
 
-    generator.append(R"~~~(
+    TRY(generator.try_append(R"~~~(
 TransformFunctionMetadata transform_function_metadata(TransformFunction transform_function)
 {
     switch (transform_function) {
-)~~~");
+)~~~"));
     TRY(transforms_data.try_for_each_member([&](auto& name, auto& value) -> ErrorOr<void> {
         VERIFY(value.is_object());
 
         auto member_generator = TRY(generator.fork());
-        member_generator.set("name:titlecase", title_casify_transform_function(name));
-        member_generator.append(R"~~~(
+        TRY(member_generator.set("name:titlecase", TRY(title_casify_transform_function(name))));
+        TRY(member_generator.try_append(R"~~~(
     case TransformFunction::@name:titlecase@:
         return TransformFunctionMetadata {
-            .parameters = {)~~~");
+            .parameters = {)~~~"));
 
         JsonArray const& parameters = value.as_object().get_array("parameters"sv).value();
         bool first = true;
-        parameters.for_each([&](JsonValue const& value) {
+        TRY(parameters.try_for_each([&](JsonValue const& value) -> ErrorOr<void> {
             GenericLexer lexer { value.as_object().get_deprecated_string("type"sv).value() };
             VERIFY(lexer.consume_specific('<'));
             auto parameter_type_name = lexer.consume_until('>');
@@ -189,25 +189,26 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction transfor
             else
                 VERIFY_NOT_REACHED();
 
-            member_generator.append(first ? " "sv : ", "sv);
+            TRY(member_generator.try_append(first ? " "sv : ", "sv));
             first = false;
 
-            member_generator.append(DeprecatedString::formatted("{{ TransformFunctionParameterType::{}, {}}}", parameter_type, value.as_object().get("required"sv)->to_deprecated_string()));
-        });
+            TRY(member_generator.try_append(TRY(String::formatted("{{ TransformFunctionParameterType::{}, {}}}", parameter_type, value.as_object().get("required"sv)->to_deprecated_string()))));
+            return {};
+        }));
 
-        member_generator.append(R"~~~( }
+        TRY(member_generator.try_append(R"~~~( }
     };
-)~~~");
+)~~~"));
         return {};
     }));
-    generator.append(R"~~~(
+    TRY(generator.try_append(R"~~~(
     default:
         VERIFY_NOT_REACHED();
     }
 }
-)~~~");
+)~~~"));
 
-    generator.appendln("\n}");
+    TRY(generator.try_appendln("\n}"));
 
     TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
@@ -65,11 +65,12 @@ namespace Web::CSS {
 )~~~");
 
     generator.appendln("enum class TransformFunction {");
-    transforms_data.for_each_member([&](auto& name, auto&) {
-        auto member_generator = generator.fork();
+    TRY(transforms_data.try_for_each_member([&](auto& name, auto&) -> ErrorOr<void> {
+        auto member_generator = TRY(generator.fork());
         member_generator.set("name:titlecase", title_casify_transform_function(name));
         member_generator.appendln("    @name:titlecase@,");
-    });
+        return {};
+    }));
     generator.appendln("};");
 
     generator.appendln("Optional<TransformFunction> transform_function_from_string(StringView);");
@@ -116,15 +117,16 @@ namespace Web::CSS {
 Optional<TransformFunction> transform_function_from_string(StringView name)
 {
 )~~~");
-    transforms_data.for_each_member([&](auto& name, auto&) {
-        auto member_generator = generator.fork();
+    TRY(transforms_data.try_for_each_member([&](auto& name, auto&) -> ErrorOr<void> {
+        auto member_generator = TRY(generator.fork());
         member_generator.set("name", name);
         member_generator.set("name:titlecase", title_casify_transform_function(name));
         member_generator.append(R"~~~(
     if (name.equals_ignoring_ascii_case("@name@"sv))
         return TransformFunction::@name:titlecase@;
 )~~~");
-    });
+        return {};
+    }));
     generator.append(R"~~~(
     return {};
 }
@@ -135,15 +137,16 @@ StringView to_string(TransformFunction transform_function)
 {
     switch (transform_function) {
 )~~~");
-    transforms_data.for_each_member([&](auto& name, auto&) {
-        auto member_generator = generator.fork();
+    TRY(transforms_data.try_for_each_member([&](auto& name, auto&) -> ErrorOr<void> {
+        auto member_generator = TRY(generator.fork());
         member_generator.set("name", name);
         member_generator.set("name:titlecase", title_casify_transform_function(name));
         member_generator.append(R"~~~(
     case TransformFunction::@name:titlecase@:
         return "@name@"sv;
 )~~~");
-    });
+        return {};
+    }));
     generator.append(R"~~~(
     default:
         VERIFY_NOT_REACHED();
@@ -156,10 +159,10 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction transfor
 {
     switch (transform_function) {
 )~~~");
-    transforms_data.for_each_member([&](auto& name, auto& value) {
+    TRY(transforms_data.try_for_each_member([&](auto& name, auto& value) -> ErrorOr<void> {
         VERIFY(value.is_object());
 
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         member_generator.set("name:titlecase", title_casify_transform_function(name));
         member_generator.append(R"~~~(
     case TransformFunction::@name:titlecase@:
@@ -195,7 +198,8 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction transfor
         member_generator.append(R"~~~( }
     };
 )~~~");
-    });
+        return {};
+    }));
     generator.append(R"~~~(
     default:
         VERIFY_NOT_REACHED();

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -43,7 +43,7 @@ ErrorOr<void> generate_header_file(JsonArray& identifier_data, Core::File& file)
 {
     StringBuilder builder;
     SourceGenerator generator { builder };
-    generator.append(R"~~~(
+    TRY(generator.try_append(R"~~~(
 #pragma once
 
 #include <AK/StringView.h>
@@ -53,19 +53,19 @@ namespace Web::CSS {
 
 enum class ValueID {
     Invalid,
-)~~~");
+)~~~"));
 
     TRY(identifier_data.try_for_each([&](auto& name) -> ErrorOr<void> {
         auto member_generator = TRY(generator.fork());
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name.to_deprecated_string()))));
 
-        member_generator.append(R"~~~(
+        TRY(member_generator.try_append(R"~~~(
     @name:titlecase@,
-)~~~");
+)~~~"));
         return {};
     }));
 
-    generator.append(R"~~~(
+    TRY(generator.try_append(R"~~~(
 };
 
 Optional<ValueID> value_id_from_string(StringView);
@@ -73,7 +73,7 @@ StringView string_from_value_id(ValueID);
 
 }
 
-)~~~");
+)~~~"));
 
     TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};
@@ -84,7 +84,7 @@ ErrorOr<void> generate_implementation_file(JsonArray& identifier_data, Core::Fil
     StringBuilder builder;
     SourceGenerator generator { builder };
 
-    generator.append(R"~~~(
+    TRY(generator.try_append(R"~~~(
 #include <AK/Assertions.h>
 #include <AK/HashMap.h>
 #include <LibWeb/CSS/ValueID.h>
@@ -92,19 +92,19 @@ ErrorOr<void> generate_implementation_file(JsonArray& identifier_data, Core::Fil
 namespace Web::CSS {
 
 HashMap<StringView, ValueID, AK::CaseInsensitiveASCIIStringViewTraits> g_stringview_to_value_id_map {
-)~~~");
+)~~~"));
 
     TRY(identifier_data.try_for_each([&](auto& name) -> ErrorOr<void> {
         auto member_generator = TRY(generator.fork());
-        member_generator.set("name", name.to_deprecated_string());
+        TRY(member_generator.set("name", TRY(String::from_deprecated_string(name.to_deprecated_string()))));
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name.to_deprecated_string()))));
-        member_generator.append(R"~~~(
+        TRY(member_generator.try_append(R"~~~(
     {"@name@"sv, ValueID::@name:titlecase@},
-)~~~");
+)~~~"));
         return {};
     }));
 
-    generator.append(R"~~~(
+    TRY(generator.try_append(R"~~~(
 };
 
 Optional<ValueID> value_id_from_string(StringView string)
@@ -114,27 +114,27 @@ Optional<ValueID> value_id_from_string(StringView string)
 
 StringView string_from_value_id(ValueID value_id) {
     switch (value_id) {
-)~~~");
+)~~~"));
 
     TRY(identifier_data.try_for_each([&](auto& name) -> ErrorOr<void> {
         auto member_generator = TRY(generator.fork());
-        member_generator.set("name", name.to_deprecated_string());
+        TRY(member_generator.set("name", TRY(String::from_deprecated_string(name.to_deprecated_string()))));
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name.to_deprecated_string()))));
-        member_generator.append(R"~~~(
+        TRY(member_generator.try_append(R"~~~(
     case ValueID::@name:titlecase@:
         return "@name@"sv;
-        )~~~");
+        )~~~"));
         return {};
     }));
 
-    generator.append(R"~~~(
+    TRY(generator.try_append(R"~~~(
     default:
         return "(invalid CSS::ValueID)"sv;
     }
 }
 
 } // namespace Web::CSS
-)~~~");
+)~~~"));
 
     TRY(file.write_until_depleted(generator.as_string_view().bytes()));
     return {};

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
@@ -56,7 +56,7 @@ enum class ValueID {
 )~~~");
 
     TRY(identifier_data.try_for_each([&](auto& name) -> ErrorOr<void> {
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name.to_deprecated_string()))));
 
         member_generator.append(R"~~~(
@@ -95,7 +95,7 @@ HashMap<StringView, ValueID, AK::CaseInsensitiveASCIIStringViewTraits> g_stringv
 )~~~");
 
     TRY(identifier_data.try_for_each([&](auto& name) -> ErrorOr<void> {
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         member_generator.set("name", name.to_deprecated_string());
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name.to_deprecated_string()))));
         member_generator.append(R"~~~(
@@ -117,7 +117,7 @@ StringView string_from_value_id(ValueID value_id) {
 )~~~");
 
     TRY(identifier_data.try_for_each([&](auto& name) -> ErrorOr<void> {
-        auto member_generator = generator.fork();
+        auto member_generator = TRY(generator.fork());
         member_generator.set("name", name.to_deprecated_string());
         TRY(member_generator.set("name:titlecase", TRY(title_casify(name.to_deprecated_string()))));
         member_generator.append(R"~~~(

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
@@ -55,14 +55,15 @@ enum class ValueID {
     Invalid,
 )~~~");
 
-    identifier_data.for_each([&](auto& name) {
+    TRY(identifier_data.try_for_each([&](auto& name) -> ErrorOr<void> {
         auto member_generator = generator.fork();
-        member_generator.set("name:titlecase", title_casify(name.to_deprecated_string()));
+        TRY(member_generator.set("name:titlecase", TRY(title_casify(name.to_deprecated_string()))));
 
         member_generator.append(R"~~~(
     @name:titlecase@,
 )~~~");
-    });
+        return {};
+    }));
 
     generator.append(R"~~~(
 };
@@ -93,14 +94,15 @@ namespace Web::CSS {
 HashMap<StringView, ValueID, AK::CaseInsensitiveASCIIStringViewTraits> g_stringview_to_value_id_map {
 )~~~");
 
-    identifier_data.for_each([&](auto& name) {
+    TRY(identifier_data.try_for_each([&](auto& name) -> ErrorOr<void> {
         auto member_generator = generator.fork();
         member_generator.set("name", name.to_deprecated_string());
-        member_generator.set("name:titlecase", title_casify(name.to_deprecated_string()));
+        TRY(member_generator.set("name:titlecase", TRY(title_casify(name.to_deprecated_string()))));
         member_generator.append(R"~~~(
     {"@name@"sv, ValueID::@name:titlecase@},
 )~~~");
-    });
+        return {};
+    }));
 
     generator.append(R"~~~(
 };
@@ -114,15 +116,16 @@ StringView string_from_value_id(ValueID value_id) {
     switch (value_id) {
 )~~~");
 
-    identifier_data.for_each([&](auto& name) {
+    TRY(identifier_data.try_for_each([&](auto& name) -> ErrorOr<void> {
         auto member_generator = generator.fork();
         member_generator.set("name", name.to_deprecated_string());
-        member_generator.set("name:titlecase", title_casify(name.to_deprecated_string()));
+        TRY(member_generator.set("name:titlecase", TRY(title_casify(name.to_deprecated_string()))));
         member_generator.append(R"~~~(
     case ValueID::@name:titlecase@:
         return "@name@"sv;
         )~~~");
-    });
+        return {};
+    }));
 
     generator.append(R"~~~(
     default:

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
@@ -92,7 +92,7 @@ class @legacy_constructor_class@;)~~~");
     };
 
     for (auto& interface : exposed_interfaces) {
-        auto gen = generator.fork();
+        auto gen = TRY(generator.fork());
 
         if (interface.is_namespace)
             add_namespace(gen, interface.namespace_class);
@@ -123,7 +123,7 @@ static ErrorOr<void> generate_intrinsic_definitions(StringView output_path, Vect
 #include <LibWeb/Bindings/Intrinsics.h>)~~~");
 
     for (auto& interface : exposed_interfaces) {
-        auto gen = generator.fork();
+        auto gen = TRY(generator.fork());
         gen.set("namespace_class", interface.namespace_class);
         gen.set("prototype_class", interface.prototype_class);
         gen.set("constructor_class", interface.constructor_class);
@@ -215,7 +215,7 @@ void Intrinsics::create_web_prototype_and_constructor<@prototype_class@>(JS::Rea
     };
 
     for (auto& interface : exposed_interfaces) {
-        auto gen = generator.fork();
+        auto gen = TRY(generator.fork());
 
         if (interface.is_namespace)
             add_namespace(gen, interface.name, interface.namespace_class);
@@ -274,7 +274,7 @@ static ErrorOr<void> generate_exposed_interface_implementation(StringView class_
 #include <LibWeb/Bindings/@global_object_name@ExposedInterfaces.h>
 )~~~");
     for (auto& interface : exposed_interfaces) {
-        auto gen = generator.fork();
+        auto gen = TRY(generator.fork());
         gen.set("namespace_class", interface.namespace_class);
         gen.set("prototype_class", interface.prototype_class);
         gen.set("constructor_class", interface.constructor_class);
@@ -327,7 +327,7 @@ void add_@global_object_snake_name@_exposed_interfaces(JS::Object& global)
     };
 
     for (auto& interface : exposed_interfaces) {
-        auto gen = generator.fork();
+        auto gen = TRY(generator.fork());
 
         if (interface.is_namespace)
             add_namespace(gen, interface.name, interface.namespace_class);

--- a/Meta/Lagom/Tools/CodeGenerators/StateMachineGenerator/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/StateMachineGenerator/main.cpp
@@ -261,7 +261,7 @@ void generate_lookup_table(StateMachine const& machine, SourceGenerator& generat
 )~~~");
 
     auto generate_for_state = [&](State const& s) {
-        auto table_generator = generator.fork();
+        auto table_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         table_generator.set("active_state", s.name);
         table_generator.append("/* @active_state@ */ { ");
         VERIFY(!s.name.is_empty());
@@ -274,7 +274,7 @@ void generate_lookup_table(StateMachine const& machine, SourceGenerator& generat
             }
         }
         for (int i = 0; i < 256; ++i) {
-            auto cell_generator = table_generator.fork();
+            auto cell_generator = table_generator.fork().release_value_but_fixme_should_propagate_errors();
             cell_generator.set("cell_new_state", row[i].new_state.value_or(s.name));
             cell_generator.set("cell_action", row[i].action.value_or("_Ignore"));
             cell_generator.append(" {State::@cell_new_state@, Action::@cell_action@}, ");
@@ -320,7 +320,7 @@ public:
     for (auto a : actions(machine)) {
         if (a.is_empty())
             continue;
-        auto action_generator = generator.fork();
+        auto action_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         action_generator.set("action.name", a);
         action_generator.append(R"~~~(
         @action.name@,
@@ -347,7 +347,7 @@ public:
             switch (m_state) {
 )~~~");
     for (auto s : machine.states) {
-        auto state_generator = generator.fork();
+        auto state_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         if (s.exit_action.has_value()) {
             state_generator.set("state_name", s.name);
             state_generator.set("action", s.exit_action.value());
@@ -375,7 +375,7 @@ public:
             {
 )~~~");
     for (auto state : machine.states) {
-        auto state_generator = generator.fork();
+        auto state_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         if (state.entry_action.has_value()) {
             state_generator.set("state_name", state.name);
             state_generator.set("action", state.entry_action.value());
@@ -399,7 +399,7 @@ private:
 )~~~");
 
     for (auto s : machine.states) {
-        auto state_generator = generator.fork();
+        auto state_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
         state_generator.set("state.name", s.name);
         state_generator.append(R"~~~(
         @state.name@,
@@ -434,7 +434,7 @@ private:
     }
 )~~~");
 
-    auto table_generator = generator.fork();
+    auto table_generator = generator.fork().release_value_but_fixme_should_propagate_errors();
     generate_lookup_table(machine, table_generator);
     generator.append(R"~~~(
 }; // end @class_name@

--- a/Tests/AK/TestSourceGenerator.cpp
+++ b/Tests/AK/TestSourceGenerator.cpp
@@ -41,7 +41,7 @@ TEST_CASE(scoped)
     global_generator.append("@foo@ @bar@\n"); // foo-0 bar-0
 
     {
-        auto scoped_generator_1 = global_generator.fork();
+        auto scoped_generator_1 = MUST(global_generator.fork());
         scoped_generator_1.set("bar", "bar-1");
         global_generator.append("@foo@ @bar@\n"); // foo-0 bar-0
     }
@@ -49,18 +49,18 @@ TEST_CASE(scoped)
     global_generator.append("@foo@ @bar@\n"); // foo-0 bar-0
 
     {
-        auto scoped_generator_2 = global_generator.fork();
+        auto scoped_generator_2 = MUST(global_generator.fork());
         scoped_generator_2.set("foo", "foo-2");
         scoped_generator_2.append("@foo@ @bar@\n"); // foo-2 bar-0
 
         {
-            auto scoped_generator_3 = scoped_generator_2.fork();
+            auto scoped_generator_3 = MUST(scoped_generator_2.fork());
             scoped_generator_3.set("bar", "bar-3");
             scoped_generator_3.append("@foo@ @bar@\n"); // foo-2 bar-3
         }
 
         {
-            auto scoped_generator_4 = global_generator.fork();
+            auto scoped_generator_4 = MUST(global_generator.fork());
             scoped_generator_4.append("@foo@ @bar@\n"); // foo-0 bar-0
         }
 


### PR DESCRIPTION
This only fully migrates the CSS code generators because they're the ones I'm familiar with, and CLion's code comprehension is currently refusing to work on `Meta/Lagom` code files for some reason, so it's a bit unpleasant to work on. :upside_down_face:

You would not believe how many TRYs you can fit in this bad boy!