### PR TITLE
LibGUI+Userland: Give more apps Statusbars, and make Statusbar usage better

### DIFF
--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -272,6 +272,13 @@ HexEditorWidget::HexEditorWidget()
     m_statusbar->segment(0).set_action(*m_goto_offset_action);
 
     m_editor->set_focus(true);
+
+    GUI::Application::the()->on_action_enter = [this](GUI::Action& action) {
+        m_statusbar->set_override_text(action.status_tip());
+    };
+    GUI::Application::the()->on_action_leave = [this](GUI::Action&) {
+        m_statusbar->set_override_text({});
+    };
 }
 
 void HexEditorWidget::update_inspector_values(size_t position)

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -58,6 +58,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& breadcrumbbar = *main_widget->find_descendant_of_type_named<GUI::Breadcrumbbar>("breadcrumbbar");
     auto& tree_map_widget = *main_widget->find_descendant_of_type_named<SpaceAnalyzer::TreeMapWidget>("tree_map");
     auto& statusbar = *main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
+    GUI::Application::the()->on_action_enter = [&statusbar](GUI::Action& action) {
+        statusbar.set_override_text(action.status_tip());
+    };
+    GUI::Application::the()->on_action_leave = [&statusbar](GUI::Action&) {
+        statusbar.set_override_text({});
+    };
 
     tree_map_widget.set_focus(true);
 

--- a/Userland/Applications/ThemeEditor/CMakeLists.txt
+++ b/Userland/Applications/ThemeEditor/CMakeLists.txt
@@ -28,4 +28,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_app(ThemeEditor ICON app-theme-editor)
-target_link_libraries(ThemeEditor PRIVATE LibCore LibGfx LibGUI LibFileSystem LibFileSystemAccessClient LibIPC LibMain)
+target_link_libraries(ThemeEditor PRIVATE LibConfig LibCore LibGfx LibGUI LibFileSystem LibFileSystemAccessClient LibIPC LibMain)

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021-2022, networkException <networkexception@serenityos.org>
- * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2021, Antonio Di Stefano <tonio9681@gmail.com>
  * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
  *
@@ -31,11 +31,11 @@
 #include <LibGUI/Menubar.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/ScrollableContainerWidget.h>
-#include <LibGfx/Filters/ColorBlindnessFilter.h>
+#include <LibGUI/Statusbar.h>
 
 namespace ThemeEditor {
 
-static const PropertyTab window_tab {
+static PropertyTab const window_tab {
     "Windows"sv,
     {
         { "General",
@@ -91,7 +91,7 @@ static const PropertyTab window_tab {
     }
 };
 
-static const PropertyTab widgets_tab {
+static PropertyTab const widgets_tab {
     "Widgets"sv,
     {
         { "General",
@@ -160,7 +160,7 @@ static const PropertyTab widgets_tab {
     }
 };
 
-static const PropertyTab syntax_highlighting_tab {
+static PropertyTab const syntax_highlighting_tab {
     "Syntax Highlighting"sv,
     {
         { "General",
@@ -184,7 +184,7 @@ static const PropertyTab syntax_highlighting_tab {
     }
 };
 
-static const PropertyTab color_scheme_tab {
+static PropertyTab const color_scheme_tab {
     "Color Scheme"sv,
     {
         { "General",
@@ -219,6 +219,7 @@ ErrorOr<NonnullRefPtr<MainWidget>> MainWidget::try_create()
     TRY(main_widget->load_from_gml(theme_editor_gml));
     main_widget->m_preview_widget = main_widget->find_descendant_of_type_named<ThemeEditor::PreviewWidget>("preview_widget");
     main_widget->m_property_tabs = main_widget->find_descendant_of_type_named<GUI::TabWidget>("property_tabs");
+    main_widget->m_statusbar = main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
 
     TRY(main_widget->add_property_tab(window_tab));
     TRY(main_widget->add_property_tab(widgets_tab));
@@ -234,6 +235,12 @@ MainWidget::MainWidget(NonnullRefPtr<AlignmentModel> alignment_model)
     : m_current_palette(GUI::Application::the()->palette())
     , m_alignment_model(move(alignment_model))
 {
+    GUI::Application::the()->on_action_enter = [this](GUI::Action& action) {
+        m_statusbar->set_override_text(action.status_tip());
+    };
+    GUI::Application::the()->on_action_leave = [this](GUI::Action&) {
+        m_statusbar->set_override_text({});
+    };
 }
 
 ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)

--- a/Userland/Applications/ThemeEditor/MainWidget.h
+++ b/Userland/Applications/ThemeEditor/MainWidget.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -117,6 +117,7 @@ private:
 
     RefPtr<PreviewWidget> m_preview_widget;
     RefPtr<GUI::TabWidget> m_property_tabs;
+    RefPtr<GUI::Statusbar> m_statusbar;
     RefPtr<GUI::Action> m_save_action;
 
     RefPtr<GUI::Button> m_theme_override_apply;

--- a/Userland/Applications/ThemeEditor/ThemeEditor.gml
+++ b/Userland/Applications/ThemeEditor/ThemeEditor.gml
@@ -1,44 +1,52 @@
 @GUI::Widget {
-    layout: @GUI::VerticalBoxLayout {
-        margins: [0, 4, 4]
-        spacing: 6
-    }
+    layout: @GUI::VerticalBoxLayout {}
     fill_with_background_color: true
 
     @GUI::Widget {
-        layout: @GUI::HorizontalBoxLayout {
-            spacing: 4
+        layout: @GUI::VerticalBoxLayout {
+            margins: [0, 4, 4]
+            spacing: 6
         }
 
-        @ThemeEditor::PreviewWidget {
-            name: "preview_widget"
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 4
+            }
+
+            @ThemeEditor::PreviewWidget {
+                name: "preview_widget"
+            }
+
+            @GUI::TabWidget {
+                name: "property_tabs"
+                container_margins: [5]
+            }
         }
 
-        @GUI::TabWidget {
-            name: "property_tabs"
-            container_margins: [5]
+        @GUI::Widget {
+            name: "theme_override_controls"
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 6
+            }
+            preferred_height: "shrink"
+
+            @GUI::Layout::Spacer {}
+
+            @GUI::DialogButton {
+                name: "reset_button"
+                text: "Reset"
+                enabled: false
+            }
+
+            @GUI::DialogButton {
+                name: "apply_button"
+                text: "Apply"
+                enabled: false
+            }
         }
     }
 
-    @GUI::Widget {
-        name: "theme_override_controls"
-        layout: @GUI::HorizontalBoxLayout {
-            spacing: 6
-        }
-        preferred_height: "shrink"
-
-        @GUI::Layout::Spacer {}
-
-        @GUI::DialogButton {
-            name: "reset_button"
-            text: "Reset"
-            enabled: false
-        }
-
-        @GUI::DialogButton {
-            name: "apply_button"
-            text: "Apply"
-            enabled: false
-        }
+    @GUI::Statusbar {
+        name: "statusbar"
     }
 }

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "MainWidget.h"
+#include <LibConfig/Client.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibFileSystem/FileSystem.h>
@@ -26,6 +27,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath unix"));
 
     auto app = TRY(GUI::Application::create(arguments));
+
+    Config::pledge_domain("ThemeEditor");
+    app->set_config_domain(TRY("ThemeEditor"_string));
 
     StringView file_to_edit;
 

--- a/Userland/DevTools/GMLPlayground/GMLPlaygroundWindow.gml
+++ b/Userland/DevTools/GMLPlayground/GMLPlaygroundWindow.gml
@@ -20,4 +20,8 @@
             name: "preview_frame"
         }
     }
+
+    @GUI::Statusbar {
+        name: "statusbar"
+    }
 }

--- a/Userland/DevTools/GMLPlayground/MainWidget.cpp
+++ b/Userland/DevTools/GMLPlayground/MainWidget.cpp
@@ -24,6 +24,7 @@
 #include <LibGUI/Painter.h>
 #include <LibGUI/RegularEditingEngine.h>
 #include <LibGUI/Splitter.h>
+#include <LibGUI/Statusbar.h>
 #include <LibGUI/TextEditor.h>
 #include <LibGUI/Toolbar.h>
 #include <LibGUI/VimEditingEngine.h>
@@ -62,7 +63,7 @@ void UnregisteredWidget::paint_event(GUI::PaintEvent& event)
 
 ErrorOr<NonnullRefPtr<MainWidget>> MainWidget::try_create(GUI::Icon const& icon)
 {
-    auto main_widget = TRY(try_make_ref_counted<MainWidget>());
+    auto main_widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) MainWidget()));
     TRY(main_widget->load_from_gml(gml_playground_window_gml));
     main_widget->m_icon = icon;
 
@@ -70,6 +71,7 @@ ErrorOr<NonnullRefPtr<MainWidget>> MainWidget::try_create(GUI::Icon const& icon)
     main_widget->m_splitter = main_widget->find_descendant_of_type_named<GUI::HorizontalSplitter>("splitter");
     main_widget->m_editor = main_widget->find_descendant_of_type_named<GUI::TextEditor>("text_editor");
     main_widget->m_preview_frame_widget = main_widget->find_descendant_of_type_named<GUI::Frame>("preview_frame");
+    main_widget->m_statusbar = main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
 
     main_widget->m_preview_window = TRY(GUI::Window::try_create(main_widget));
     main_widget->m_preview_window->set_title("Preview - GML Playground");
@@ -98,6 +100,16 @@ ErrorOr<NonnullRefPtr<MainWidget>> MainWidget::try_create(GUI::Icon const& icon)
     };
 
     return main_widget;
+}
+
+MainWidget::MainWidget()
+{
+    GUI::Application::the()->on_action_enter = [this](GUI::Action& action) {
+        m_statusbar->set_override_text(action.status_tip());
+    };
+    GUI::Application::the()->on_action_leave = [this](GUI::Action&) {
+        m_statusbar->set_override_text({});
+    };
 }
 
 void MainWidget::update_title()

--- a/Userland/DevTools/GMLPlayground/MainWidget.h
+++ b/Userland/DevTools/GMLPlayground/MainWidget.h
@@ -30,6 +30,7 @@ public:
     GUI::TextEditor& editor() const { return *m_editor; }
 
 private:
+    MainWidget();
     virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
@@ -37,6 +38,7 @@ private:
     RefPtr<GUI::TextEditor> m_editor;
     RefPtr<GUI::Toolbar> m_toolbar;
     RefPtr<GUI::Splitter> m_splitter;
+    RefPtr<GUI::Statusbar> m_statusbar;
 
     RefPtr<GUI::Frame> m_preview_frame_widget;
     RefPtr<GUI::Window> m_preview_window;

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -66,6 +66,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto& statusbar = *main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
     statusbar.set_text(click_tip);
+    GUI::Application::the()->on_action_enter = [&statusbar](GUI::Action& action) {
+        statusbar.set_override_text(action.status_tip());
+    };
+    GUI::Application::the()->on_action_leave = [&statusbar](GUI::Action&) {
+        statusbar.set_override_text({});
+    };
 
     auto& columns_spinbox = *main_widget->find_descendant_of_type_named<GUI::SpinBox>("columns_spinbox");
     auto& rows_spinbox = *main_widget->find_descendant_of_type_named<GUI::SpinBox>("rows_spinbox");

--- a/Userland/Games/MasterWord/main.cpp
+++ b/Userland/Games/MasterWord/main.cpp
@@ -51,6 +51,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(main_widget->load_from_gml(master_word_gml));
     auto& game = *main_widget->find_descendant_of_type_named<MasterWord::WordGame>("word_game");
     auto& statusbar = *main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
+    GUI::Application::the()->on_action_enter = [&statusbar](GUI::Action& action) {
+        statusbar.set_override_text(action.status_tip());
+    };
+    GUI::Application::the()->on_action_leave = [&statusbar](GUI::Action&) {
+        statusbar.set_override_text({});
+    };
 
     auto use_system_theme = Config::read_bool("MasterWord"sv, ""sv, "use_system_theme"sv, false);
     game.set_use_system_theme(use_system_theme);

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -64,6 +64,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& statusbar = *widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar"sv);
     statusbar.set_text(0, TRY("Score: 0"_string));
     statusbar.set_text(1, TRY(String::formatted("High Score: {}", high_score)));
+    GUI::Application::the()->on_action_enter = [&statusbar](GUI::Action& action) {
+        statusbar.set_override_text(action.status_tip());
+    };
+    GUI::Application::the()->on_action_leave = [&statusbar](GUI::Action&) {
+        statusbar.set_override_text({});
+    };
 
     game.on_score_update = [&](auto score) {
         statusbar.set_text(0, String::formatted("Score: {}", score).release_value_but_fixme_should_propagate_errors());

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -360,6 +360,7 @@ void Application::update_recent_file_actions()
             action->set_visible(true);
             action->set_enabled(true);
             action->set_text(path);
+            action->set_status_tip(String::formatted("Open {}", path).release_value_but_fixme_should_propagate_errors());
             ++number_of_recently_open_files;
         }
     };


### PR DESCRIPTION
- Show "Open /path/to/file" as the status bar tip for recent-file actions.
- Add Statusbars to GMLPlayground and ThemEditor.
- Show recent files in ThemeEditor.
- Show status tips in the Statusbar for... lots of things that had Statusbars.