### PR TITLE
AK+LibWeb: Migrate WebSockets::WebSocket to String

### DIFF
--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -388,6 +388,11 @@ DeprecatedString URL::serialize_for_display() const
     return builder.to_deprecated_string();
 }
 
+ErrorOr<String> URL::to_string() const
+{
+    return String::from_deprecated_string(serialize());
+}
+
 // https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin
 // https://url.spec.whatwg.org/#concept-url-origin
 DeprecatedString URL::serialize_origin() const

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -99,6 +99,7 @@ public:
     DeprecatedString serialize(ExcludeFragment = ExcludeFragment::No) const;
     DeprecatedString serialize_for_display() const;
     DeprecatedString to_deprecated_string() const { return serialize(); }
+    ErrorOr<String> to_string() const;
 
     // HTML origin
     DeprecatedString serialize_origin() const;

--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.h
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.h
@@ -37,11 +37,11 @@ public:
         Closed = 3,
     };
 
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> construct_impl(JS::Realm&, DeprecatedString const& url, Optional<Variant<DeprecatedString, Vector<DeprecatedString>>> const& protocols);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> construct_impl(JS::Realm&, String const& url, Optional<Variant<String, Vector<String>>> const& protocols);
 
     virtual ~WebSocket() override;
 
-    DeprecatedString url() const { return m_url.to_deprecated_string(); }
+    WebIDL::ExceptionOr<String> url() const { return TRY_OR_THROW_OOM(vm(), m_url.to_string()); }
 
 #undef __ENUMERATE
 #define __ENUMERATE(attribute_name, event_name)       \
@@ -51,22 +51,22 @@ public:
 #undef __ENUMERATE
 
     ReadyState ready_state() const;
-    DeprecatedString extensions() const;
-    DeprecatedString protocol() const;
+    String extensions() const;
+    WebIDL::ExceptionOr<String> protocol() const;
 
-    DeprecatedString const& binary_type() { return m_binary_type; };
-    void set_binary_type(DeprecatedString const& type) { m_binary_type = type; };
+    String const& binary_type() { return m_binary_type; };
+    void set_binary_type(String const& type) { m_binary_type = type; };
 
-    WebIDL::ExceptionOr<void> close(Optional<u16> code, Optional<DeprecatedString> reason);
-    WebIDL::ExceptionOr<void> send(Variant<JS::Handle<JS::Object>, JS::Handle<FileAPI::Blob>, DeprecatedString> const& data);
+    WebIDL::ExceptionOr<void> close(Optional<u16> code, Optional<String> reason);
+    WebIDL::ExceptionOr<void> send(Variant<JS::Handle<JS::Object>, JS::Handle<FileAPI::Blob>, String> const& data);
 
 private:
     void on_open();
     void on_message(ByteBuffer message, bool is_text);
     void on_error();
-    void on_close(u16 code, DeprecatedString reason, bool was_clean);
+    void on_close(u16 code, String reason, bool was_clean);
 
-    WebSocket(HTML::Window&, AK::URL&, Vector<DeprecatedString> const& protocols);
+    WebSocket(HTML::Window&, AK::URL&, Vector<String> const& protocols);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -74,7 +74,7 @@ private:
     JS::NonnullGCPtr<HTML::Window> m_window;
 
     AK::URL m_url;
-    DeprecatedString m_binary_type { "blob" };
+    String m_binary_type { "blob"_string.release_value_but_fixme_should_propagate_errors() };
     RefPtr<WebSocketClientSocket> m_websocket;
 };
 

--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.idl
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.idl
@@ -2,7 +2,7 @@
 #import <DOM/EventHandler.idl>
 
 // https://websockets.spec.whatwg.org/#websocket
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), UseNewAKString]
 interface WebSocket : EventTarget {
 
     constructor(USVString url, optional (DOMString or sequence<DOMString>) protocols);


### PR DESCRIPTION
#### AK: Add URL::to_string() returning a String
For convenience wire up a to_string() method which returns a new String.

#### LibWeb: Migrate WebSockets::WebSocket to String