### PR TITLE
LibWeb: Make `testharness` WPT tests run and fix some calc-related crashes

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -8351,11 +8351,11 @@ ErrorOr<OwnPtr<CalculationNode>> Parser::parse_a_calculation(Vector<ComponentVal
                 TRY(values.try_append({ TRY(NumericCalculationNode::create(dimension->length())) }));
             else if (dimension->is_percentage())
                 TRY(values.try_append({ TRY(NumericCalculationNode::create(dimension->percentage())) }));
-            // FIXME: Resolutions, once calc() supports them.
             else if (dimension->is_time())
                 TRY(values.try_append({ TRY(NumericCalculationNode::create(dimension->time())) }));
             else
-                VERIFY_NOT_REACHED();
+                dbgln("Unknown dimension type: {}", TRY(dimension->to_string()));
+            // FIXME: Resolutions, once calc() supports them.
             continue;
         }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -249,6 +249,14 @@ private:
         bool is_time_percentage() const;
         TimePercentage time_percentage() const;
 
+        ErrorOr<String> to_string()
+        {
+            return m_value.visit(
+                [](auto& value) -> ErrorOr<String> {
+                    return value.to_string();
+                });
+        }
+
     private:
         Variant<Angle, Frequency, Length, Percentage, Resolution, Time> m_value;
     };

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -813,13 +813,14 @@ CalculatedStyleValue::CalculationResult ClampCalculationNode::resolve(Optional<L
     auto center_value = resolve_value(center_node.value(), context);
     auto max_value = resolve_value(max_node.value(), context);
 
+    // NOTE: Any operation with at least one NaN argument produces NaN.
     // NOTE: The value should be returned as "max(MIN, min(VAL, MAX))"
     auto chosen_value = max(min_value, min(center_value, max_value));
-    if (chosen_value == min_value)
+    if (isnan(min_value) || chosen_value == min_value)
         return min_node;
-    if (chosen_value == center_value)
+    if (isnan(center_value) || chosen_value == center_value)
         return center_node;
-    if (chosen_value == max_value)
+    if (isnan(max_value) || chosen_value == max_value)
         return max_node;
 
     VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -96,6 +96,7 @@ static constexpr auto s_webdriver_endpoints = Array {
     ROUTE(POST, "/session/:session_id/cookie"sv, add_cookie),
     ROUTE(DELETE, "/session/:session_id/cookie/:name"sv, delete_cookie),
     ROUTE(DELETE, "/session/:session_id/cookie"sv, delete_all_cookies),
+    ROUTE(DELETE, "/session/:session_id/actions"sv, release_actions),
     ROUTE(POST, "/session/:session_id/alert/dismiss"sv, dismiss_alert),
     ROUTE(POST, "/session/:session_id/alert/accept"sv, accept_alert),
     ROUTE(GET, "/session/:session_id/alert/text"sv, get_alert_text),

--- a/Userland/Libraries/LibWeb/WebDriver/Client.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.h
@@ -92,6 +92,9 @@ public:
     virtual Response delete_cookie(Parameters parameters, JsonValue payload) = 0;
     virtual Response delete_all_cookies(Parameters parameters, JsonValue payload) = 0;
 
+    // 15. Actions, https://www.w3.org/TR/webdriver/#actions
+    virtual Response release_actions(Parameters parameters, JsonValue payload) = 0;
+
     // 16. User prompts, https://w3c.github.io/webdriver/#user-prompts
     virtual Response dismiss_alert(Parameters parameters, JsonValue payload) = 0;
     virtual Response accept_alert(Parameters parameters, JsonValue payload) = 0;

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -354,8 +354,10 @@ ExecuteScriptResultSerialized execute_async_script(Web::Page& page, DeprecatedSt
         // NOTE: Prior revisions of this specification did not recognize the return value of the provided script.
         //       In order to preserve legacy behavior, the return value only influences the command if it is a
         //       "thenable"  object or if determining this produces an exception.
-        if (script_result.is_throw_completion())
+        if (script_result.is_throw_completion()) {
+            promise->reject(*script_result.throw_completion().value());
             return;
+        }
 
         // 5. If Type(scriptResult.[[Value]]) is not Object, then abort these steps.
         if (!script_result.value().is_object())
@@ -365,8 +367,10 @@ ExecuteScriptResultSerialized execute_async_script(Web::Page& page, DeprecatedSt
         auto then = script_result.value().as_object().get(vm.names.then);
 
         // 7. If then.[[Type]] is not normal, then reject promise with value then.[[Value]], and abort these steps.
-        if (then.is_throw_completion())
+        if (then.is_throw_completion()) {
+            promise->reject(*then.throw_completion().value());
             return;
+        }
 
         // 8. If IsCallable(then.[[Type]]) is false, then abort these steps.
         if (!then.value().is_function())

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -58,5 +58,6 @@ endpoint WebDriverClient {
     take_screenshot() => (Web::WebDriver::Response response)
     take_element_screenshot(String element_id) => (Web::WebDriver::Response response)
     print_page() => (Web::WebDriver::Response response)
+    release_actions() => (Web::WebDriver::Response response)
     ensure_top_level_browsing_context_is_open() => (Web::WebDriver::Response response)
 }

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1654,6 +1654,26 @@ Messages::WebDriverClient::DeleteAllCookiesResponse WebDriverConnection::delete_
     return JsonValue {};
 }
 
+// 15.8 Release Actions, https://www.w3.org/TR/webdriver/#dfn-release-actions
+Messages::WebDriverClient::ReleaseActionsResponse WebDriverConnection::release_actions()
+{
+    // 1. If the current browsing context is no longer open, return error with error code no such window.
+    TRY(ensure_open_top_level_browsing_context());
+
+    // FIXME: 2. Let input state be the result of get the input state with current session and current top-level browsing context.
+
+    // FIXME: 3. Let actions options be a new actions options with the is element origin steps set to represents a web element, and the get element origin steps set to get a WebElement origin.
+
+    // FIXME: 4. Let undo actions be input state’s input cancel list in reverse order.
+
+    // FIXME: 5. Try to dispatch tick actions with arguments undo actions, 0, current browsing context, and actions options.
+
+    // FIXME: 6. Reset the input state with current session and current top-level browsing context.
+
+    // 7. Return success with data null.
+    return JsonValue {};
+}
+
 // 16.1 Dismiss Alert, https://w3c.github.io/webdriver/#dismiss-alert
 Messages::WebDriverClient::DismissAlertResponse WebDriverConnection::dismiss_alert()
 {

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -95,6 +95,7 @@ private:
     virtual Messages::WebDriverClient::TakeScreenshotResponse take_screenshot() override;
     virtual Messages::WebDriverClient::TakeElementScreenshotResponse take_element_screenshot(String const& element_id) override;
     virtual Messages::WebDriverClient::PrintPageResponse print_page() override;
+    virtual Messages::WebDriverClient::ReleaseActionsResponse release_actions() override;
 
     virtual Messages::WebDriverClient::EnsureTopLevelBrowsingContextIsOpenResponse ensure_top_level_browsing_context_is_open() override;
     ErrorOr<void, Web::WebDriver::Error> ensure_open_top_level_browsing_context();

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -632,6 +632,15 @@ Web::WebDriver::Response Client::delete_all_cookies(Web::WebDriver::Parameters p
     return session->web_content_connection().delete_all_cookies();
 }
 
+// 15.8 Release Actions, https://www.w3.org/TR/webdriver/#dfn-release-actions
+// DELETE /session/{session id}/actions
+Web::WebDriver::Response Client::release_actions(Web::WebDriver::Parameters parameters, JsonValue)
+{
+    dbgln_if(WEBDRIVER_DEBUG, "Handling DELETE /session/<session_id>/actions");
+    auto session = TRY(find_session_with_id(parameters[0]));
+    return session->web_content_connection().release_actions();
+}
+
 // 16.1 Dismiss Alert, https://w3c.github.io/webdriver/#dismiss-alert
 // POST /session/{session id}/alert/dismiss
 Web::WebDriver::Response Client::dismiss_alert(Web::WebDriver::Parameters parameters, JsonValue)

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -92,6 +92,7 @@ private:
     virtual Web::WebDriver::Response take_screenshot(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response take_element_screenshot(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response print_page(Web::WebDriver::Parameters parameters, JsonValue payload) override;
+    virtual Web::WebDriver::Response release_actions(Web::WebDriver::Parameters parameters, JsonValue payload) override;
 
     static HashMap<unsigned, NonnullRefPtr<Session>> s_sessions;
     static Atomic<unsigned> s_next_session_id;


### PR DESCRIPTION
It still needs a small hack to manually mark the document readystate as complete before executing an async script, but other than that there is nothing stopping the tests from running