### PR TITLE
AK+Browser+Ladybird: Fix relative file URL completion

### DIFF
--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -553,7 +553,8 @@ URL URLParser::parse(StringView raw_input, Optional<URL> const& base_url, Option
                     report_validation_error();
                 state = State::FileHost;
             } else if (base_url.has_value() && base_url->m_scheme == "file") {
-                url->m_host = base_url->m_host;
+                url->m_paths = base_url->m_paths;
+                url->m_paths.remove(url->m_paths.size() - 1);
                 auto substring_from_pointer = input.substring_view(iterator - input.begin()).as_string();
                 if (!starts_with_windows_drive_letter(substring_from_pointer) && is_normalized_windows_drive_letter(base_url->m_paths[0]))
                     url->append_path(base_url->m_paths[0], URL::ApplyPercentEncoding::No);

--- a/Tests/AK/TestURL.cpp
+++ b/Tests/AK/TestURL.cpp
@@ -184,6 +184,12 @@ TEST_CASE(file_url_serialization)
     EXPECT_EQ(URL("file:///my/file#fragment"sv).serialize(), "file:///my/file#fragment");
 }
 
+TEST_CASE(file_url_relative)
+{
+    EXPECT_EQ(URL("https://vkoskiv.com/index.html"sv).complete_url("/static/foo.js"sv).serialize(), "https://vkoskiv.com/static/foo.js");
+    EXPECT_EQ(URL("file:///home/vkoskiv/test/index.html"sv).complete_url("/static/foo.js"sv).serialize(), "file:///home/vkoskiv/test/static/foo.js");
+}
+
 TEST_CASE(about_url)
 {
     URL url("about:blank"sv);


### PR DESCRIPTION
The added test case illustrates the issue pretty well. Basically, before this fix, all assets that had a relative URL in a document loaded from a `file://` failed to load.