### PR TITLE
LibWeb: Don't cap used width by available width from a constraint

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
@@ -9,10 +9,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 65.828125x114.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 59.828125x108.40625 table-row-group children: not-inline
+          Box <tbody> at (9,9) content-size 61.828125x108.40625 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,11) content-size 59.828125x54.203125 table-row children: not-inline
+            Box <tr> at (11,11) content-size 61.828125x54.203125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (17,29.367187) content-size 11.5625x17.46875 table-cell [BFC] children: inline
@@ -22,10 +22,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (42.5625,17) content-size 24.265625x98.40625 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (42.5625,17) content-size 24.265625x0 children: inline
+              BlockContainer <td> at (42.5625,17) content-size 26.265625x98.40625 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (42.5625,17) content-size 26.265625x0 children: inline
                   TextNode <#text>
-                TableWrapper <(anonymous)> at (42.5625,17) content-size 24.265625x98.40625 [BFC] children: not-inline
+                TableWrapper <(anonymous)> at (42.5625,17) content-size 26.265625x98.40625 [BFC] children: not-inline
                   Box <table> at (43.5625,18) content-size 28.265625x96.40625 table-box [TFC] children: not-inline
                     BlockContainer <(anonymous)> (not painted) children: inline
                       TextNode <#text>
@@ -70,13 +70,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                         TextNode <#text>
                     BlockContainer <(anonymous)> (not painted) children: inline
                       TextNode <#text>
-                BlockContainer <(anonymous)> at (42.5625,115.40625) content-size 24.265625x0 children: inline
+                BlockContainer <(anonymous)> at (42.5625,115.40625) content-size 26.265625x0 children: inline
                   TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,65.203125) content-size 59.828125x54.203125 table-row children: not-inline
+            Box <tr> at (11,65.203125) content-size 61.828125x54.203125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (17,85.570312) content-size 11.5625x17.46875 table-cell [BFC] children: inline

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -438,7 +438,7 @@ CSSPixels BlockFormattingContext::compute_table_box_width_inside_table_wrapper(B
     VERIFY(table_box.has_value());
 
     auto table_used_width = throwaway_state.get(*table_box).content_width();
-    return table_used_width > available_width ? available_width : table_used_width;
+    return available_space.width.is_definite() ? min(table_used_width, available_width) : table_used_width;
 }
 
 void BlockFormattingContext::compute_height(Box const& box, AvailableSpace const& available_space)


### PR DESCRIPTION
In compute_table_box_width_inside_table_wrapper, we should only consider available_width when it's valid. Values which come from {min, max}-content constraints aren't meaningful and shouldn't be considered for the cap.