### PR TITLE
LibWeb: Handle leading whitespace in grid-template-* block components

### DIFF
--- a/Tests/LibWeb/Layout/expected/misc/grid-template-block-components-whitespace-crash.txt
+++ b/Tests/LibWeb/Layout/expected/misc/grid-template-block-components-whitespace-crash.txt
@@ -1,0 +1,3 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline

--- a/Tests/LibWeb/Layout/input/misc/grid-template-block-components-whitespace-crash.html
+++ b/Tests/LibWeb/Layout/input/misc/grid-template-block-components-whitespace-crash.html
@@ -1,0 +1,7 @@
+<style>
+    test {
+        display: grid;
+        width: 100%;
+        grid-template-columns: 50px [  first second ] 1fr;
+    }
+</style>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -7565,6 +7565,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_grid_track_size_list(Vector<ComponentV
             if (!token.block().is_square())
                 return GridTrackSizeListStyleValue::make_auto();
             TokenStream block_tokens { token.block().values() };
+            block_tokens.skip_whitespace();
             while (block_tokens.has_next_token()) {
                 auto current_block_token = block_tokens.next_token();
                 auto maybe_string = String::from_utf8(current_block_token.token().ident());


### PR DESCRIPTION
We're already handling whitespace between components, do the same for leading whitespace. Fixes crash on https://distill.pub/2021/gnn-intro.