### PR TITLE
LibWeb: Skip separate height computation for tables

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
@@ -1,0 +1,29 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x86.8125 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 77.4375x86.8125 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 77.4375x84.8125 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (9,9) content-size 75.4375x78.8125 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 75.4375x21.468749 table-row children: not-inline
+              BlockContainer <td> at (13,12.999999) content-size 71.4375x17.46875 table-cell [BFC] children: inline
+                line 0 width: 7.9375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [13,12.999999 7.9375x17.46875]
+                    "*"
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (11,32.46875) content-size 75.4375x57.34375 table-row children: not-inline
+              BlockContainer <td> at (13,45.4375) content-size 71.4375x35.40625 table-cell [BFC] children: inline
+                line 0 width: 71.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 9, rect: [13,45.4375 71.4375x17.46875]
+                    "*********"
+                line 1 width: 63.5625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+                  frag 0 from TextNode start: 10, length: 8, rect: [13,62.4375 63.5625x17.46875]
+                    "***** **"
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+      BlockContainer <(anonymous)> at (8,94.8125) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/table/multi-line-cell.html
+++ b/Tests/LibWeb/Layout/input/table/multi-line-cell.html
@@ -1,0 +1,14 @@
+<style>
+	table {
+		border: 1px solid black;
+	}
+
+	td {
+		border: 1px solid blue;
+	}
+</style>
+
+<table style="width: 10px;">
+	<tr><td>*</td></tr>
+	<tr><td>********* ***** **</td></tr>
+</table>

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -659,7 +659,11 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         }
     }
 
-    compute_height(box, available_space);
+    // Tables already set their height during the independent formatting context run. When multi-line text cells are involved, using different
+    // available space here than during the independent formatting context run can result in different line breaks and thus a different height.
+    if (!box.display().is_table_inside()) {
+        compute_height(box, available_space);
+    }
 
     if (independent_formatting_context || !margins_collapse_through(box, m_state)) {
         if (!m_margin_state.box_last_in_flow_child_margin_bottom_collapsed) {


### PR DESCRIPTION
With multi-line text cells, we don't reliably know the height would stay the same as the one set by the independent format context run. In such situations, we can end up with a table box which is sized inconsistently with the grid boxes of the table due to differences in line breaks.