### PR TITLE
LibWeb: Implement QueuingStrategy for WritableStream and ReadableStream

### DIFF
--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -550,6 +550,7 @@ class WritableStreamDefaultController;
 class WritableStreamDefaultWriter;
 
 struct PullIntoDescriptor;
+struct QueuingStrategy;
 struct QueuingStrategyInit;
 struct UnderlyingSink;
 struct UnderlyingSource;

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/DOM/AbortSignal.h>
 #include <LibWeb/Streams/AbstractOperations.h>
+#include <LibWeb/Streams/QueuingStrategy.h>
 #include <LibWeb/Streams/ReadableByteStreamController.h>
 #include <LibWeb/Streams/ReadableStream.h>
 #include <LibWeb/Streams/ReadableStreamBYOBReader.h>
@@ -184,6 +185,24 @@ bool readable_stream_has_default_reader(ReadableStream const& stream)
 
     // 4. Return false.
     return false;
+}
+
+// https://streams.spec.whatwg.org/#validate-and-normalize-high-water-mark
+WebIDL::ExceptionOr<double> extract_high_water_mark(QueuingStrategy const& strategy, double default_hwm)
+{
+    // 1. If strategy["highWaterMark"] does not exist, return defaultHWM.
+    if (!strategy.high_water_mark.has_value())
+        return default_hwm;
+
+    // 2. Let highWaterMark be strategy["highWaterMark"].
+    auto high_water_mark = strategy.high_water_mark.value();
+
+    // 3. If highWaterMark is NaN or highWaterMark < 0, throw a RangeError exception.
+    if (isnan(high_water_mark) || high_water_mark < 0)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::RangeError, "Invalid value for high water mark"sv };
+
+    // 4. Return highWaterMark.
+    return high_water_mark;
 }
 
 // https://streams.spec.whatwg.org/#readable-stream-close

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -2721,4 +2721,64 @@ JS::ThrowCompletionOr<JS::Handle<WebIDL::CallbackType>> property_to_callback(JS:
     return vm.heap().allocate_without_realm<WebIDL::CallbackType>(property.as_object(), HTML::incumbent_settings_object(), operation_returns_promise);
 }
 
+// https://streams.spec.whatwg.org/#set-up-readable-byte-stream-controller-from-underlying-source
+WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller_from_underlying_source(ReadableStream& stream, JS::Value underlying_source, UnderlyingSource const& underlying_source_dict, double high_water_mark)
+{
+    auto& realm = stream.realm();
+
+    // 1. Let controller be a new ReadableByteStreamController.
+    auto controller = MUST_OR_THROW_OOM(stream.heap().allocate<ReadableByteStreamController>(realm, realm));
+
+    // 2. Let startAlgorithm be an algorithm that returns undefined.
+    StartAlgorithm start_algorithm = [] { return JS::js_undefined(); };
+
+    // 3. Let pullAlgorithm be an algorithm that returns a promise resolved with undefined.
+    PullAlgorithm pull_algorithm = [&realm]() {
+        return WebIDL::create_resolved_promise(realm, JS::js_undefined());
+    };
+
+    // 4. Let cancelAlgorithm be an algorithm that returns a promise resolved with undefined.
+    CancelAlgorithm cancel_algorithm = [&realm](auto const&) {
+        return WebIDL::create_resolved_promise(realm, JS::js_undefined());
+    };
+
+    // 5. If underlyingSourceDict["start"] exists, then set startAlgorithm to an algorithm which returns the result of invoking underlyingSourceDict["start"] with argument list « controller » and callback this value underlyingSource.
+    if (underlying_source_dict.start) {
+        start_algorithm = [controller, underlying_source, callback = underlying_source_dict.start]() -> WebIDL::ExceptionOr<JS::Value> {
+            // Note: callback does not return a promise, so invoke_callback may return an abrupt completion
+            return TRY(WebIDL::invoke_callback(*callback, underlying_source, controller)).release_value();
+        };
+    }
+
+    // 6. If underlyingSourceDict["pull"] exists, then set pullAlgorithm to an algorithm which returns the result of invoking underlyingSourceDict["pull"] with argument list « controller » and callback this value underlyingSource.
+    if (underlying_source_dict.pull) {
+        pull_algorithm = [&realm, controller, underlying_source, callback = underlying_source_dict.pull]() -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
+            // Note: callback return a promise, so invoke_callback will never return an abrupt completion
+            auto result = MUST_OR_THROW_OOM(WebIDL::invoke_callback(*callback, underlying_source, controller)).release_value();
+            return WebIDL::create_resolved_promise(realm, result);
+        };
+    }
+
+    // 7. If underlyingSourceDict["cancel"] exists, then set cancelAlgorithm to an algorithm which takes an argument reason and returns the result of invoking underlyingSourceDict["cancel"] with argument list « reason » and callback this value underlyingSource.
+    if (underlying_source_dict.cancel) {
+        cancel_algorithm = [&realm, controller, underlying_source, callback = underlying_source_dict.cancel](auto const& reason) -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
+            // Note: callback return a promise, so invoke_callback will never return an abrupt completion
+            auto result = MUST_OR_THROW_OOM(WebIDL::invoke_callback(*callback, underlying_source, reason)).release_value();
+            return WebIDL::create_resolved_promise(realm, result);
+        };
+    }
+
+    // 8. Let autoAllocateChunkSize be underlyingSourceDict["autoAllocateChunkSize"], if it exists, or undefined otherwise.
+    auto auto_allocate_chunk_size = underlying_source_dict.auto_allocate_chunk_size.has_value()
+        ? JS::Value(underlying_source_dict.auto_allocate_chunk_size.value())
+        : JS::js_undefined();
+
+    // 9. If autoAllocateChunkSize is 0, then throw a TypeError exception.
+    if (auto_allocate_chunk_size.is_integral_number() && auto_allocate_chunk_size.as_double() == 0)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Cannot use an auto allocate chunk size of 0"sv };
+
+    // 10. Perform ? SetUpReadableByteStreamController(stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark, autoAllocateChunkSize).
+    return set_up_readable_byte_stream_controller(stream, controller, move(start_algorithm), move(pull_algorithm), move(cancel_algorithm), high_water_mark, auto_allocate_chunk_size);
+}
+
 }

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -187,6 +187,20 @@ bool readable_stream_has_default_reader(ReadableStream const& stream)
     return false;
 }
 
+// https://streams.spec.whatwg.org/#make-size-algorithm-from-size-function
+SizeAlgorithm extract_size_algorithm(QueuingStrategy const& strategy)
+{
+    // 1. If strategy["size"] does not exist, return an algorithm that returns 1.
+    if (!strategy.size)
+        return [](auto const&) { return JS::normal_completion(JS::Value(1)); };
+
+    // 2. Return an algorithm that performs the following steps, taking a chunk argument:
+    return [strategy](auto const& chunk) {
+        // 1. Return the result of invoking strategy["size"] with argument list « chunk ».
+        return WebIDL::invoke_callback(*strategy.size, JS::js_undefined(), chunk);
+    };
+}
+
 // https://streams.spec.whatwg.org/#validate-and-normalize-high-water-mark
 WebIDL::ExceptionOr<double> extract_high_water_mark(QueuingStrategy const& strategy, double default_hwm)
 {

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -61,6 +61,7 @@ WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller(ReadableStre
 WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller_from_underlying_source(ReadableStream&, JS::Value underlying_source_value, UnderlyingSource, double high_water_mark, SizeAlgorithm&&);
 WebIDL::ExceptionOr<void> set_up_readable_stream_controller_with_byte_reading_support(ReadableStream&, Optional<PullAlgorithm>&& = {}, Optional<CancelAlgorithm>&& = {}, double high_water_mark = 0);
 WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller(ReadableStream&, ReadableByteStreamController&, StartAlgorithm&&, PullAlgorithm&&, CancelAlgorithm&&, double high_water_mark, JS::Value auto_allocate_chunk_size);
+WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller_from_underlying_source(ReadableStream&, JS::Value underlying_source, UnderlyingSource const& underlying_source_dict, double high_water_mark);
 
 WebIDL::ExceptionOr<void> readable_stream_enqueue(ReadableStreamController& controller, JS::Value chunk);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue(ReadableByteStreamController& controller, JS::Value chunk);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -28,6 +28,7 @@ using WriteAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<Web
 WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStreamDefaultReader>> acquire_readable_stream_default_reader(ReadableStream&);
 bool is_readable_stream_locked(ReadableStream const&);
 
+SizeAlgorithm extract_size_algorithm(QueuingStrategy const&);
 WebIDL::ExceptionOr<double> extract_high_water_mark(QueuingStrategy const&, double default_hwm);
 
 void readable_stream_close(ReadableStream&);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -28,6 +28,8 @@ using WriteAlgorithm = JS::SafeFunction<WebIDL::ExceptionOr<JS::NonnullGCPtr<Web
 WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStreamDefaultReader>> acquire_readable_stream_default_reader(ReadableStream&);
 bool is_readable_stream_locked(ReadableStream const&);
 
+WebIDL::ExceptionOr<double> extract_high_water_mark(QueuingStrategy const&, double default_hwm);
+
 void readable_stream_close(ReadableStream&);
 void readable_stream_error(ReadableStream&, JS::Value error);
 void readable_stream_add_read_request(ReadableStream&, ReadRequest const&);

--- a/Userland/Libraries/LibWeb/Streams/QueuingStrategy.h
+++ b/Userland/Libraries/LibWeb/Streams/QueuingStrategy.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023, Shannon Booth <shannon.ml.booth@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <LibJS/Heap/GCPtr.h>
+#include <LibWeb/WebIDL/CallbackType.h>
+
+namespace Web::Streams {
+
+// https://streams.spec.whatwg.org/#dictdef-queuingstrategy
+struct QueuingStrategy {
+    Optional<double> high_water_mark;
+    JS::GCPtr<WebIDL::CallbackType> size;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Streams/QueuingStrategy.idl
+++ b/Userland/Libraries/LibWeb/Streams/QueuingStrategy.idl
@@ -1,0 +1,7 @@
+callback QueuingStrategySize = unrestricted double (any chunk);
+
+// https://streams.spec.whatwg.org/#dictdef-queuingstrategy
+dictionary QueuingStrategy {
+    unrestricted double highWaterMark;
+    QueuingStrategySize size;
+};

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -66,7 +66,7 @@ ReadableStream::ReadableStream(JS::Realm& realm)
 ReadableStream::~ReadableStream() = default;
 
 // https://streams.spec.whatwg.org/#rs-locked
-bool ReadableStream::locked()
+bool ReadableStream::locked() const
 {
     // 1. Return ! IsReadableStreamLocked(this).
     return is_readable_stream_locked(*this);

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.h
@@ -35,7 +35,7 @@ public:
     virtual ~ReadableStream() override;
 
     bool locked() const;
-    WebIDL::ExceptionOr<JS::GCPtr<JS::Object>> cancel(JS::Value view);
+    WebIDL::ExceptionOr<JS::GCPtr<JS::Object>> cancel(JS::Value reason);
     WebIDL::ExceptionOr<ReadableStreamReader> get_reader();
 
     Optional<ReadableStreamController>& controller() { return m_controller; }

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.h
@@ -34,7 +34,7 @@ public:
 
     virtual ~ReadableStream() override;
 
-    bool locked();
+    bool locked() const;
     WebIDL::ExceptionOr<JS::GCPtr<JS::Object>> cancel(JS::Value view);
     WebIDL::ExceptionOr<ReadableStreamReader> get_reader();
 

--- a/Userland/Libraries/LibWeb/Streams/WritableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/WritableStream.cpp
@@ -17,7 +17,7 @@
 namespace Web::Streams {
 
 // https://streams.spec.whatwg.org/#ws-constructor
-WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStream>> WritableStream::construct_impl(JS::Realm& realm, Optional<JS::Handle<JS::Object>> const& underlying_sink_object)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStream>> WritableStream::construct_impl(JS::Realm& realm, Optional<JS::Handle<JS::Object>> const& underlying_sink_object, QueuingStrategy const& strategy)
 {
     auto& vm = realm.vm();
 
@@ -36,11 +36,11 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStream>> WritableStream::construct_
     // 4. Perform ! InitializeWritableStream(this).
     // Note: This AO configures slot values which are already specified in the class's field initializers.
 
-    // FIXME: 5. Let sizeAlgorithm be ! ExtractSizeAlgorithm(strategy).
-    SizeAlgorithm size_algorithm = [](auto const&) { return JS::normal_completion(JS::Value(1)); };
+    // 5. Let sizeAlgorithm be ! ExtractSizeAlgorithm(strategy).
+    auto size_algorithm = extract_size_algorithm(strategy);
 
-    // FIXME: 6. Let highWaterMark be ? ExtractHighWaterMark(strategy, 1).
-    auto high_water_mark = 1.0;
+    // 6. Let highWaterMark be ? ExtractHighWaterMark(strategy, 1).
+    auto high_water_mark = TRY(extract_high_water_mark(strategy, 1));
 
     // 7. Perform ? SetUpWritableStreamDefaultControllerFromUnderlyingSink(this, underlyingSink, underlyingSinkDict, highWaterMark, sizeAlgorithm).
     TRY(set_up_writable_stream_default_controller_from_underlying_sink(*writable_stream, underlying_sink, underlying_sink_dict, high_water_mark, move(size_algorithm)));

--- a/Userland/Libraries/LibWeb/Streams/WritableStream.h
+++ b/Userland/Libraries/LibWeb/Streams/WritableStream.h
@@ -11,6 +11,7 @@
 #include <LibJS/Forward.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Streams/QueuingStrategy.h>
 #include <LibWeb/WebIDL/Promise.h>
 
 namespace Web::Streams {
@@ -42,7 +43,7 @@ public:
         Errored,
     };
 
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStream>> construct_impl(JS::Realm& realm, Optional<JS::Handle<JS::Object>> const& underlying_sink);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStream>> construct_impl(JS::Realm& realm, Optional<JS::Handle<JS::Object>> const& underlying_sink, QueuingStrategy const& = {});
 
     virtual ~WritableStream() = default;
 

--- a/Userland/Libraries/LibWeb/Streams/WritableStream.idl
+++ b/Userland/Libraries/LibWeb/Streams/WritableStream.idl
@@ -1,9 +1,9 @@
+#import <Streams/QueuingStrategy.idl>
 #import <Streams/WritableStreamDefaultWriter.idl>
 
 [Exposed=*, Transferable]
 interface WritableStream {
-    // FIXME: optional QueuingStrategy strategy = {}
-    constructor(optional object underlyingSink);
+    constructor(optional object underlyingSink, optional QueuingStrategy strategy = {});
 
     readonly attribute boolean locked;
 


### PR DESCRIPTION
Ready now that https://github.com/SerenityOS/serenity/pull/19455 is merged!

These set of changes aim to implement the `optional QueuingStrategy strategy = {}` argument in the constructor of both ReadableStream and WritableStream - and the AO's required to implement that.