### PR TITLE
chgrp: Add support for multiple file paths

### DIFF
--- a/Base/usr/share/man/man1/chgrp.md
+++ b/Base/usr/share/man/man1/chgrp.md
@@ -1,12 +1,12 @@
 ## Name
 
-chgrp - change group ownership of file
+chgrp - change group ownership of files
 
 ## Synopsis
 
 ```**sh
-$ chgrp <gid> <path>
-$ chgrp <name> <path>
+$ chgrp <gid> <path...>
+$ chgrp <name> <path...>
 ```
 
 ## Description


### PR DESCRIPTION
Example usage:

![chgrp_multiple_paths](https://github.com/SerenityOS/serenity/assets/2817754/3a5151b7-b131-4e57-9c88-f6b03e2efb98)
