### PR TITLE
Ports: Point to the correct subdirectory for `gettext`

### DIFF
--- a/Ports/gettext/package.sh
+++ b/Ports/gettext/package.sh
@@ -2,7 +2,7 @@
 port='gettext'
 version='0.21.1'
 useconfigure='true'
-files="https://ftpmirror.gnu.org/pub/gnu/gettext/gettext-${version}.tar.gz gettext-${version}.tar.gz e8c3650e1d8cee875c4f355642382c1df83058bd5a11ee8555c0cf276d646d45"
+files="https://ftpmirror.gnu.org/gettext/gettext-${version}.tar.gz gettext-${version}.tar.gz e8c3650e1d8cee875c4f355642382c1df83058bd5a11ee8555c0cf276d646d45"
 auth_type='sha256'
 depends=("libiconv")
 use_fresh_config_sub='true'


### PR DESCRIPTION
`ftpmirror.gnu.org` does not seem to have the `/pub/gnu` folder structure, all files are in `/gnu` instead.

This regressed in 41f7f821f6bc2380e7b4d2db5ee5a8737aea1281.