### PR TITLE
LibWeb: Add initial implementation of CRC2D.globalAlpha

### DIFF
--- a/Base/res/html/misc/canvas-global-alpha.html
+++ b/Base/res/html/misc/canvas-global-alpha.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Canvas 2D global alpha test</title>
+<style type="text/css">
+body {
+    color: #fff;
+}
+canvas {
+    border-width: 1px;
+    border-style: solid;
+    border-color: #fff;
+}
+</style>
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        ctx = document.getElementById("foo").getContext("2d");
+
+        image = new Image(100, 100);
+        image.onload = drawImage;
+        image.src = "car.png";
+
+        function drawImage() {
+
+            ctx.drawImage(image, 0, 0, 400, 400);
+
+        }
+
+        var width = 200;
+        var height = 100;
+
+        ctx.globalAlpha = 0.4;
+        ctx.font = "100px serif";
+        ctx.fillText("hello friends", 50, 90);
+
+
+        for (var i = 0; i < 2; i++)
+        {
+            ctx.globalAlpha = 0.5;
+            ctx.fillStyle = 'red';
+            ctx.fillRect(10, 10, width, height);
+
+            ctx.globalAlpha = 0.6;
+            ctx.strokeStyle = 'blue';
+            ctx.strokeRect(10, 10, width, height);
+
+            ctx.scale(0.5, 0.5);
+            ctx.translate(10 + width * 2, 10 + height * 2);
+        }
+
+    });
+</script>
+</head>
+<body>
+    <canvas id="foo" width="1000" height="1000"></canvas>
+</body>
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -201,6 +201,7 @@
             <li><a href="canvas-path.html">canvas path house!</a></li>
             <li><a href="canvas-clip-path.html">canvas clip paths</a></li>
             <li><a href="trigonometry.html">canvas + trigonometry functions</a></li>
+            <li><a href="canvas-global-alpha.html">canvas globalAlpha</a></li>
             <li><a href="canvas-path2d.html">Path2D</a></li>
             <li><a href="webgl-clear-color-and-multiple-contexts.html">WebGL Demo - Multiple Contexts and glClear(Color)</a></li>
             <li><h3>Wasm</h3></li>

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2596,6 +2596,9 @@ void Painter::draw_scaled_bitmap_with_transform(IntRect const& dst_rect, Bitmap 
 
         // FIXME: Painter should have an affine transform as part of its state and handle all of this instead.
 
+        if (opacity == 0.0f)
+            return;
+
         auto inverse_transform = transform.inverse();
         if (!inverse_transform.has_value())
             return;
@@ -2626,6 +2629,8 @@ void Painter::draw_scaled_bitmap_with_transform(IntRect const& dst_rect, Bitmap 
                 auto source_color = bitmap.get_pixel(source_point);
                 if (source_color.alpha() == 0)
                     continue;
+                if (opacity != 1.0f)
+                    source_color = source_color.with_opacity(opacity);
                 set_physical_pixel(point + clipped_bounding_rect.location(), source_color, true);
             }
         }

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasCompositing.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasCompositing.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/HTML/ImageData.h>
+
+namespace Web::HTML {
+
+// https://html.spec.whatwg.org/multipage/canvas.html#canvascompositing
+class CanvasCompositing {
+public:
+    virtual ~CanvasCompositing() = default;
+
+    virtual float global_alpha() const = 0;
+    virtual void set_global_alpha(float) = 0;
+
+protected:
+    CanvasCompositing() = default;
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasCompositing.idl
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasCompositing.idl
@@ -1,0 +1,6 @@
+// https://html.spec.whatwg.org/multipage/canvas.html#canvascompositing
+interface mixin CanvasCompositing {
+  // compositing
+  attribute unrestricted double globalAlpha; // (default 1.0)
+// FIXME:  attribute DOMString globalCompositeOperation; // (default "source-over")
+};

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
@@ -78,6 +78,7 @@ public:
         float line_width { 1 };
         bool image_smoothing_enabled { true };
         Bindings::ImageSmoothingQuality image_smoothing_quality { Bindings::ImageSmoothingQuality::Low };
+        float global_alpha = { 1 };
         Optional<CanvasClip> clip;
     };
     DrawingState& drawing_state() { return m_drawing_state; }

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -16,6 +16,7 @@
 #include <LibGfx/Painter.h>
 #include <LibGfx/Path.h>
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/HTML/Canvas/CanvasCompositing.h>
 #include <LibWeb/HTML/Canvas/CanvasDrawImage.h>
 #include <LibWeb/HTML/Canvas/CanvasDrawPath.h>
 #include <LibWeb/HTML/Canvas/CanvasFillStrokeStyles.h>
@@ -51,6 +52,7 @@ class CanvasRenderingContext2D
     , public CanvasDrawImage
     , public CanvasImageData
     , public CanvasImageSmoothing
+    , public CanvasCompositing
     , public CanvasPathDrawingStyles<CanvasRenderingContext2D> {
 
     WEB_PLATFORM_OBJECT(CanvasRenderingContext2D, Bindings::PlatformObject);
@@ -93,6 +95,9 @@ public:
     virtual Bindings::ImageSmoothingQuality image_smoothing_quality() const override;
     virtual void set_image_smoothing_quality(Bindings::ImageSmoothingQuality) override;
 
+    virtual float global_alpha() const override;
+    virtual void set_global_alpha(float) override;
+
 private:
     explicit CanvasRenderingContext2D(JS::Realm&, HTMLCanvasElement&);
 
@@ -133,9 +138,11 @@ private:
     HTMLCanvasElement& canvas_element();
     HTMLCanvasElement const& canvas_element() const;
 
+    Gfx::Path rect_path(float x, float y, float width, float height);
+
     void stroke_internal(Gfx::Path const&);
-    void fill_internal(Gfx::Path&, Gfx::Painter::WindingRule winding_rule);
-    void clip_internal(Gfx::Path&, Gfx::Painter::WindingRule winding_rule);
+    void fill_internal(Gfx::Path const&, Gfx::Painter::WindingRule);
+    void clip_internal(Gfx::Path&, Gfx::Painter::WindingRule);
 
     JS::NonnullGCPtr<HTMLCanvasElement> m_element;
     OwnPtr<Gfx::Painter> m_painter;

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -134,8 +134,8 @@ private:
     HTMLCanvasElement const& canvas_element() const;
 
     void stroke_internal(Gfx::Path const&);
-    void fill_internal(Gfx::Path&, StringView fill_rule);
-    void clip_internal(Gfx::Path&, StringView fill_rule);
+    void fill_internal(Gfx::Path&, Gfx::Painter::WindingRule winding_rule);
+    void clip_internal(Gfx::Path&, Gfx::Painter::WindingRule winding_rule);
 
     JS::NonnullGCPtr<HTMLCanvasElement> m_element;
     OwnPtr<Gfx::Painter> m_painter;

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
@@ -1,4 +1,5 @@
 #import <HTML/HTMLCanvasElement.idl>
+#import <HTML/Canvas/CanvasCompositing.idl>
 #import <HTML/Canvas/CanvasDrawImage.idl>
 #import <HTML/Canvas/CanvasDrawPath.idl>
 #import <HTML/Canvas/CanvasFillStrokeStyles.idl>
@@ -21,7 +22,7 @@ interface CanvasRenderingContext2D {
 
 CanvasRenderingContext2D includes CanvasState;
 CanvasRenderingContext2D includes CanvasTransform;
-// FIXME: CanvasRenderingContext2D includes CanvasCompositing;
+CanvasRenderingContext2D includes CanvasCompositing;
 CanvasRenderingContext2D includes CanvasImageSmoothing;
 CanvasRenderingContext2D includes CanvasFillStrokeStyles;
 // FIXME: CanvasRenderingContext2D includes CanvasShadowStyles;


### PR DESCRIPTION
![image](https://github.com/SerenityOS/serenity/assets/11597044/a4c6ccbf-172c-4e1c-88c3-3ce7b1318fd3)

This resurrects #18924 and fixes up the changes so `globalAlpha` works for images, gradients, and patterns too.