### PR TITLE
LibGfx: Remove unneeded TODO in BMPLoader

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
@@ -438,7 +438,6 @@ static bool check_for_invalid_bitmask_combinations(BMPLoadingContext& context)
                 return false;
             break;
         case Compression::RLE4:
-            // TODO: This is a guess
             if (bpp > 4)
                 return false;
             break;


### PR DESCRIPTION
There was a TODO questioning whether breaking on >4bpp images was the correct behaviour when RLE4 was detected. There is no indication in the spec that RLE4 can be used with anything >4bpp, so I believe this doesn't require additional follow-up.

MS Spec:
https://learn.microsoft.com/en-us/windows/win32/gdi/bitmap-compression