### PR TITLE
Kernel/TCPSocket: Read window size from peer

### DIFF
--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -321,6 +321,9 @@ void TCPSocket::receive_tcp_packet(TCPPacket const& packet, u16 size)
                     if (old_adapter)
                         old_adapter->release_packet_buffer(*packet.buffer);
                     TCPPacket& tcp_packet = *(TCPPacket*)(packet.buffer->buffer->data() + packet.ipv4_payload_offset);
+                    if (m_send_window_size != tcp_packet.window_size()) {
+                        m_send_window_size = tcp_packet.window_size();
+                    }
                     auto payload_size = packet.buffer->buffer->data() + packet.buffer->buffer->size() - (u8*)tcp_packet.payload();
                     unacked_packets.size -= payload_size;
                     evaluate_block_conditions();

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -223,7 +223,8 @@ private:
     UnixDateTime m_last_retransmit_time;
     u32 m_retransmit_attempts { 0 };
 
-    // FIXME: Parse window size TCP option from the peer
+    // Default to maximum window size. receive_tcp_packet() will update from the
+    // peer's advertised window size.
     u32 m_send_window_size { 64 * KiB };
 
     IntrusiveListNode<TCPSocket> m_retransmit_list_node;


### PR DESCRIPTION
During receive_tcp_packet(), we now set m_send_window_size for the socket if it is different from the default.

This removes one FIXME from TCPSocket.h.