### PR TITLE
Ladybird: Add context menu items to directly open audio files

### DIFF
--- a/Ladybird/Tab.cpp
+++ b/Ladybird/Tab.cpp
@@ -403,6 +403,18 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
         view().toggle_media_loop_state();
     });
 
+    auto* open_audio_action = new QAction("&Open Audio", this);
+    open_audio_action->setIcon(QIcon(QString("%1/res/icons/16x16/filetype-sound.png").arg(s_serenity_resource_root.characters())));
+    QObject::connect(open_audio_action, &QAction::triggered, this, [this]() {
+        open_link(m_media_context_menu_url);
+    });
+
+    auto* open_audio_in_new_tab_action = new QAction("Open Audio in New &Tab", this);
+    open_audio_in_new_tab_action->setIcon(QIcon(QString("%1/res/icons/16x16/new-tab.png").arg(s_serenity_resource_root.characters())));
+    QObject::connect(open_audio_in_new_tab_action, &QAction::triggered, this, [this]() {
+        open_link_in_new_tab(m_media_context_menu_url);
+    });
+
     auto* copy_audio_url_action = new QAction("Copy Audio &URL", this);
     copy_audio_url_action->setIcon(QIcon(QString("%1/res/icons/16x16/edit-copy.png").arg(s_serenity_resource_root.characters())));
     QObject::connect(copy_audio_url_action, &QAction::triggered, this, [this]() {
@@ -414,6 +426,9 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
     m_audio_context_menu->addAction(m_media_context_menu_mute_unmute_action);
     m_audio_context_menu->addAction(m_media_context_menu_controls_action);
     m_audio_context_menu->addAction(m_media_context_menu_loop_action);
+    m_audio_context_menu->addSeparator();
+    m_audio_context_menu->addAction(open_audio_action);
+    m_audio_context_menu->addAction(open_audio_in_new_tab_action);
     m_audio_context_menu->addSeparator();
     m_audio_context_menu->addAction(copy_audio_url_action);
     m_audio_context_menu->addSeparator();

--- a/Userland/Applications/Browser/IconBag.cpp
+++ b/Userland/Applications/Browser/IconBag.cpp
@@ -14,6 +14,7 @@ ErrorOr<IconBag> IconBag::try_create()
     icon_bag.filetype_html = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-html.png"sv));
     icon_bag.filetype_text = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-text.png"sv));
     icon_bag.filetype_javascript = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-javascript.png"sv));
+    icon_bag.filetype_audio = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-sound.png"sv));
     icon_bag.filetype_image = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-image.png"sv));
     icon_bag.filetype_video = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-video.png"sv));
     icon_bag.bookmark_contour = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/bookmark-contour.png"sv));

--- a/Userland/Applications/Browser/IconBag.h
+++ b/Userland/Applications/Browser/IconBag.h
@@ -16,6 +16,7 @@ struct IconBag final {
     RefPtr<Gfx::Bitmap> filetype_html { nullptr };
     RefPtr<Gfx::Bitmap> filetype_text { nullptr };
     RefPtr<Gfx::Bitmap> filetype_javascript { nullptr };
+    RefPtr<Gfx::Bitmap> filetype_audio { nullptr };
     RefPtr<Gfx::Bitmap> filetype_image { nullptr };
     RefPtr<Gfx::Bitmap> filetype_video { nullptr };
     RefPtr<Gfx::Bitmap> bookmark_contour { nullptr };

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -393,6 +393,13 @@ Tab::Tab(BrowserWindow& window)
     m_audio_context_menu->add_action(*m_media_context_menu_controls_action);
     m_audio_context_menu->add_action(*m_media_context_menu_loop_action);
     m_audio_context_menu->add_separator();
+    m_audio_context_menu->add_action(GUI::Action::create("&Open Audio", g_icon_bag.filetype_audio, [this](auto&) {
+        view().on_link_click(m_media_context_menu_url, "", 0);
+    }));
+    m_audio_context_menu->add_action(GUI::Action::create("Open Audio in New &Tab", g_icon_bag.new_tab, [this](auto&) {
+        view().on_link_click(m_media_context_menu_url, "_blank", 0);
+    }));
+    m_audio_context_menu->add_separator();
     m_audio_context_menu->add_action(GUI::Action::create("Copy Audio &URL", g_icon_bag.copy, [this](auto&) {
         GUI::Clipboard::the().set_plain_text(m_media_context_menu_url.to_deprecated_string());
     }));

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -102,6 +102,16 @@ StringView guess_mime_type_based_on_filename(StringView path)
         return "application/x-sheets+json"sv;
     if (path.ends_with(".webm"sv, CaseSensitivity::CaseInsensitive))
         return "video/webm"sv;
+    if (path.ends_with(".flac"sv, CaseSensitivity::CaseInsensitive))
+        return "audio/flac"sv;
+    if (path.ends_with(".mid"sv, CaseSensitivity::CaseInsensitive) || path.ends_with(".midi"sv, CaseSensitivity::CaseInsensitive))
+        return "audio/midi"sv;
+    if (path.ends_with(".mp3"sv, CaseSensitivity::CaseInsensitive))
+        return "audio/mpeg"sv;
+    if (path.ends_with(".qoa"sv, CaseSensitivity::CaseInsensitive))
+        return "audio/qoa"sv;
+    if (path.ends_with(".wav"sv, CaseSensitivity::CaseInsensitive))
+        return "audio/wav"sv;
     // FIXME: Share this, TextEditor and HackStudio language detection somehow.
     auto basename = LexicalPath::basename(path);
     if (path.ends_with(".cpp"sv, CaseSensitivity::CaseInsensitive)


### PR DESCRIPTION
After commit 7ec7015750a8760c124cba0b4c759f4b08078390, we can open audio documents directly. This adds
content menu items to do so, similar to images and videos.