### PR TITLE
Kernel/NetworkTask: Cleanup unnecessary TODO in "Closed" state

### DIFF
--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -435,7 +435,6 @@ void handle_tcp(IPv4Packet const& ipv4_packet, UnixDateTime const& packet_timest
     switch (socket->state()) {
     case TCPSocket::State::Closed:
         dbgln("handle_tcp: unexpected flags in Closed state ({:x})", tcp_packet.flags());
-        // TODO: we may want to send an RST here, maybe as a configurable option
         return;
     case TCPSocket::State::TimeWait:
         dbgln("handle_tcp: unexpected flags in TimeWait state ({:x})", tcp_packet.flags());


### PR DESCRIPTION
A TODO suggested that sending an RST may be desirable from the Closed state. Per the RFC, Closed is a fictional state representing no connection at all, and there is nowhere to send a reset from this state. If a socket is receiving packets in a Closed state, something else has gone wrong. Removed TODO.

RFC 9293: https://datatracker.ietf.org/doc/html/rfc9293