### PR TITLE
LibWeb/WebDriver: Close client connection socket when EOF is reached

### DIFF
--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -219,8 +219,10 @@ ErrorOr<void, Client::WrappedError> Client::on_ready_to_read()
         auto data = TRY(m_socket->read_some(buffer));
         TRY(m_remaining_request.try_append(StringView { data }));
 
-        if (m_socket->is_eof())
+        if (m_socket->is_eof()) {
+            die();
             break;
+        }
     }
 
     if (m_remaining_request.is_empty())


### PR DESCRIPTION
Fixes the bug that currently we don't ever close webdriver client connection socket when header "Connection: keep-alive" is specified.

This allows to run more WPT tests without running out of free file descriptors :)