### PR TITLE
LibWeb: Expand CSS var() inside calc() paren blocks

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-var-in-calc-block.txt
+++ b/Tests/LibWeb/Layout/expected/css-var-in-calc-block.txt
@@ -1,0 +1,4 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x270 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x252 children: not-inline
+      BlockContainer <div> at (11,11) content-size 250x250 children: not-inline

--- a/Tests/LibWeb/Layout/input/css-var-in-calc-block.html
+++ b/Tests/LibWeb/Layout/input/css-var-in-calc-block.html
@@ -1,0 +1,10 @@
+<!doctype html><style>
+* {
+    border: 1px solid black;
+}
+div {
+    --five: 5;
+    width: calc(50px * (var(--five)));
+    height: calc(50px * (0 + var(--five)));
+}
+</style><div>

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -836,6 +836,16 @@ bool StyleComputer::expand_variables(DOM::Element& element, Optional<CSS::Select
 
     while (source.has_next_token()) {
         auto const& value = source.next_token();
+        if (value.is_block()) {
+            auto const& source_block = value.block();
+            Vector<Parser::ComponentValue> block_values;
+            Parser::TokenStream source_block_contents { source_block.values() };
+            if (!expand_variables(element, pseudo_element, property_name, dependencies, source_block_contents, block_values))
+                return false;
+            NonnullRefPtr<Parser::Block> block = Parser::Block::create(source_block.token(), move(block_values));
+            dest.empend(block);
+            continue;
+        }
         if (!value.is_function()) {
             dest.empend(value);
             continue;


### PR DESCRIPTION
Before this change, this var() would get expanded:

    calc(10px * var(--one))

But this one would not:

    calc(10px * (var(--one))

Visual progression on https://www.ohne-makler.net/

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/5d587fb5-c307-4281-ad08-600cbba91aa5)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/2a138fb2-809d-4403-aed4-7e4c29879653)
