### PR TITLE
LibWeb: Allow IFC to size inline-flex boxes midway through flex layout

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/inline-flex-with-main-axis-margin-on-flex-container.txt
+++ b/Tests/LibWeb/Layout/expected/flex/inline-flex-with-main-axis-margin-on-flex-container.txt
@@ -1,0 +1,10 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 500x37.46875 [BFC] children: inline
+    line 0 width: 272.40625, height: 37.46875, bottom: 37.46875, baseline: 15.53125
+      frag 0 from Box start: 0, length: 0, rect: [10,10 162.40625x19.46875]
+    Box <body> at (10,10) content-size 162.40625x19.46875 flex-container(row) [FFC] children: not-inline
+      BlockContainer <div> at (11,11) content-size 160.40625x17.46875 flex-item [BFC] children: inline
+        line 0 width: 160.40625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 20, rect: [11,11 160.40625x17.46875]
+            "Immobilie inserieren"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/flex/inline-flex-with-main-axis-margin-on-flex-container.html
+++ b/Tests/LibWeb/Layout/input/flex/inline-flex-with-main-axis-margin-on-flex-container.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html><style>
+    * {
+        border: 1px solid black;
+    }
+    html {
+        background: white;
+        width: 500px;
+    }
+    body {
+        display: inline-flex;
+        margin-right: 100px;
+        background: pink;
+    }
+    div {
+        background: orange;
+    }
+</style><body><div>Immobilie inserieren

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -348,4 +348,19 @@ bool InlineFormattingContext::can_fit_new_line_at_y(CSSPixels y) const
     return true;
 }
 
+bool InlineFormattingContext::can_determine_size_of_child() const
+{
+    return parent().can_determine_size_of_child();
+}
+
+void InlineFormattingContext::determine_width_of_child(Box const& box, AvailableSpace const& available_space)
+{
+    return parent().determine_width_of_child(box, available_space);
+}
+
+void InlineFormattingContext::determine_height_of_child(Box const& box, AvailableSpace const& available_space)
+{
+    return parent().determine_height_of_child(box, available_space);
+}
+
 }

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.h
@@ -34,6 +34,10 @@ public:
     bool any_floats_intrude_at_y(CSSPixels y) const;
     bool can_fit_new_line_at_y(CSSPixels y) const;
 
+    virtual bool can_determine_size_of_child() const override;
+    virtual void determine_width_of_child(Box const&, AvailableSpace const&) override;
+    virtual void determine_height_of_child(Box const&, AvailableSpace const&) override;
+
 private:
     void generate_line_boxes(LayoutMode);
     void apply_justification_to_fragments(CSS::TextJustify, LineBox&, bool is_last_line);


### PR DESCRIPTION
The part in FFC where we ask the parent formatting context to size the flex container midway through layout is really weird, but let's at least be consistently weird for BFC and IFC. Since IFC always works within its parent BFC, it can simply forward these requests to the BFC.

This fixes an issue where inline-flex containers incorrectly had main axis margins subtracted from their content size.

Visual progression on https://www.ohne-makler.net/

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/f2c3ca81-a1ec-4646-a99b-fb4fe8dc4fa4)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/9d2502e0-c623-4b51-a343-4b523d237a7c)
