### PR TITLE
groupadd: Add `-U` option for adding members to a new group

### DIFF
--- a/Base/usr/share/man/man8/groupadd.md
+++ b/Base/usr/share/man/man8/groupadd.md
@@ -17,6 +17,7 @@ This program must be run as root.
 ## Options
 
 * `-g`, `--gid` _gid_: The group identifier for the new group. If not specified, an unused GID above `100` will be auto-generated.
+* `-U`, `--users` user-list: A comma-separated list of usernames to add as members of the new group
 
 ## Exit Values
 

--- a/Base/usr/share/man/man8/groupadd.md
+++ b/Base/usr/share/man/man8/groupadd.md
@@ -19,13 +19,6 @@ This program must be run as root.
 * `-g`, `--gid` _gid_: The group identifier for the new group. If not specified, an unused GID above `100` will be auto-generated.
 * `-U`, `--users` user-list: A comma-separated list of usernames to add as members of the new group
 
-## Exit Values
-
-* 0 - Success
-* 1 - Couldn't update the group file
-* 3 - Invalid argument to option
-* 4 - GID already in use
-
 ## Files
 
 * `/etc/group` - new group information (such GID) is appended to this file.

--- a/Userland/Utilities/groupadd.cpp
+++ b/Userland/Utilities/groupadd.cpp
@@ -3,10 +3,13 @@
  * Copyright (c) 2021, Brandon Pruitt  <brapru@pm.me>
  * Copyright (c) 2021, Maxime Friess <M4x1me@pm.me>
  * Copyright (c) 2022, Kenneth Myhra <kennethmyhra@serenityos.org>
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/HashTable.h>
+#include <LibCore/Account.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/Group.h>
 #include <LibCore/System.h>
@@ -18,13 +21,43 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     gid_t gid = 0;
     StringView group_name;
+    Vector<DeprecatedString> group_members;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(gid, "Group ID (gid) for the new group", "gid", 'g', "gid");
+    args_parser.add_option(Core::ArgsParser::Option {
+        .argument_mode = Core::ArgsParser::OptionArgumentMode::Required,
+        .help_string = "A comma-separated list of usernames to add as members of the new group",
+        .long_name = "users",
+        .short_name = 'U',
+        .value_name = "user-list",
+        .accept_value = [&group_members](StringView comma_separated_users) {
+            auto accounts_or_error = Core::Account::all(Core::Account::Read::PasswdOnly);
+            if (accounts_or_error.is_error())
+                return false;
+
+            OrderedHashTable<DeprecatedString> unique_group_members;
+            auto accounts = accounts_or_error.release_value();
+            for (auto const& username : comma_separated_users.split_view(',')) {
+                auto matching_account = accounts.first_matching([&](auto const& account) { return username == account.username(); });
+                if (!matching_account.has_value()) {
+                    warnln("Invalid member username: '{}'", username);
+                    return false;
+                }
+
+                unique_group_members.set(matching_account->username());
+            }
+
+            for (auto const& member : unique_group_members)
+                group_members.append(member);
+
+            return true;
+        },
+    });
     args_parser.add_positional_argument(group_name, "Name of the group (groupname)", "group");
     args_parser.parse(arguments);
 
-    auto group = Core::Group { group_name, gid };
+    Core::Group group { group_name, gid, group_members };
     TRY(Core::Group::add_group(group));
 
     return 0;


### PR DESCRIPTION
This PR adds the `-U` option, which allows the user to specify a comma-separated list of usernames; these are used as the initial members of the new group.

Example usage:
![groupadd_initial_members](https://github.com/SerenityOS/serenity/assets/2817754/52d08ac3-5a2f-4b2b-b711-b085982900e3)