### PR TITLE
rmdir: Add `-p` to remove parent directories and `-v` to be verbose

### DIFF
--- a/Base/usr/share/man/man1/rmdir.md
+++ b/Base/usr/share/man/man1/rmdir.md
@@ -15,6 +15,7 @@ Remove given `directory(ies)`, if they are empty
 ## Options
 
 * `-p`, `--parents`:  Remove all directories in each given path
+* `-v`, `--verbose`: List each directory as it is removed
 
 ## Arguments
 

--- a/Base/usr/share/man/man1/rmdir.md
+++ b/Base/usr/share/man/man1/rmdir.md
@@ -12,6 +12,10 @@ $ rmdir `[directory...]`
 
 Remove given `directory(ies)`, if they are empty
 
+## Options
+
+* `-p`, `--parents`:  Remove all directories in each given path
+
 ## Arguments
 
 * `directory`: directory(ies) to remove
@@ -31,4 +35,7 @@ $ ls -a example
 $ rmdir example
 $ ls -a example
 example: No such file or directory
+
+# Removes foo/bar/baz/, foo/bar/ and foo/
+$ rmdir -p foo/bar/baz/
 ```

--- a/Userland/Utilities/rmdir.cpp
+++ b/Userland/Utilities/rmdir.cpp
@@ -16,16 +16,21 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio cpath"));
 
     bool remove_parents = false;
+    bool verbose = false;
     Vector<StringView> paths;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(remove_parents, "Remove all directories in each given path", "parents", 'p');
+    args_parser.add_option(verbose, "List each directory as it is removed", "verbose", 'v');
     args_parser.add_positional_argument(paths, "Directories to remove", "paths");
     args_parser.parse(arguments);
 
     int status = 0;
 
     auto remove_directory = [&](StringView path) {
+        if (verbose)
+            outln("rmdir: removing directory '{}'", path);
+
         auto maybe_error = Core::System::rmdir(path);
         if (maybe_error.is_error()) {
             warnln("Failed to remove '{}': {}", path, maybe_error.release_error());

--- a/Userland/Utilities/rmdir.cpp
+++ b/Userland/Utilities/rmdir.cpp
@@ -1,32 +1,54 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/LexicalPath.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
-#include <stdio.h>
-#include <unistd.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio cpath"));
 
-    Vector<DeprecatedString> paths;
+    bool remove_parents = false;
+    Vector<StringView> paths;
 
     Core::ArgsParser args_parser;
+    args_parser.add_option(remove_parents, "Remove all directories in each given path", "parents", 'p');
     args_parser.add_positional_argument(paths, "Directories to remove", "paths");
     args_parser.parse(arguments);
 
     int status = 0;
-    for (auto path : paths) {
-        int rc = rmdir(path.characters());
-        if (rc < 0) {
-            perror("rmdir");
+
+    auto remove_directory = [&](StringView path) {
+        auto maybe_error = Core::System::rmdir(path);
+        if (maybe_error.is_error()) {
+            warnln("Failed to remove '{}': {}", path, maybe_error.release_error());
             status = 1;
+        }
+
+        return !maybe_error.is_error();
+    };
+
+    for (auto path : paths) {
+        if (!remove_directory(path) || !remove_parents)
+            continue;
+
+        LexicalPath lexical_path(path);
+        auto const& path_parts = lexical_path.parts_view();
+        if (path_parts.size() < 2)
+            continue;
+
+        for (size_t i = path_parts.size() - 1; i > 0; --i) {
+            auto current_path_parts = path_parts.span().slice(0, i);
+            LexicalPath current_path { DeprecatedString::join('/', current_path_parts) };
+            if (!remove_directory(current_path.string()))
+                break;
         }
     }
     return status;


### PR DESCRIPTION
This PR adds the following options to `rmdir`:
* `-p`: Remove all directories in each given path. e.g: `rmdir -p foo/bar/baz/` would remove `foo/bar/baz/`, `foo/bar/` and `foo/`
* `-v`: Print a message before removing each directory

Example usage:

![rmdir_parents](https://github.com/SerenityOS/serenity/assets/2817754/b84bd213-dff4-4f75-9f0d-d6f767f1eff5)
