### PR TITLE
LibAudio: Remove DeprecatedString/DeprecatedFlyString

### DIFF
--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -52,7 +52,7 @@ public:
     virtual int total_samples() override { return static_cast<int>(m_total_samples); }
     virtual u32 sample_rate() override { return m_sample_rate; }
     virtual u16 num_channels() override { return m_num_channels; }
-    virtual DeprecatedString format_name() override { return "FLAC (.flac)"; }
+    virtual StringView format_name() override { return "FLAC (.flac)"sv; }
     virtual PcmSampleFormat pcm_format() override { return m_sample_format; }
 
     bool is_fixed_blocksize_stream() const { return m_min_block_size == m_max_block_size; }

--- a/Userland/Libraries/LibAudio/Loader.cpp
+++ b/Userland/Libraries/LibAudio/Loader.cpp
@@ -63,7 +63,7 @@ ErrorOr<NonnullOwnPtr<LoaderPlugin>, LoaderError> Loader::create_plugin(NonnullO
         TRY(stream->seek(0, SeekMode::SetPosition));
     }
 
-    return LoaderError { "No loader plugin available" };
+    return LoaderError { FlyString::from_utf8("No loader plugin available"sv).release_value() };
 }
 
 LoaderSamples Loader::get_more_samples(size_t samples_to_read_from_input)

--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -70,7 +70,7 @@ public:
     virtual u16 num_channels() = 0;
 
     // Human-readable name of the file format, of the form <full abbreviation> (.<ending>)
-    virtual DeprecatedString format_name() = 0;
+    virtual StringView format_name() = 0;
     virtual PcmSampleFormat pcm_format() = 0;
 
     Metadata const& metadata() const { return m_metadata; }
@@ -102,7 +102,7 @@ public:
     int total_samples() const { return m_plugin->total_samples(); }
     u32 sample_rate() const { return m_plugin->sample_rate(); }
     u16 num_channels() const { return m_plugin->num_channels(); }
-    DeprecatedString format_name() const { return m_plugin->format_name(); }
+    StringView format_name() const { return m_plugin->format_name(); }
     u16 bits_per_sample() const { return pcm_bits_per_sample(m_plugin->pcm_format()); }
     PcmSampleFormat pcm_format() const { return m_plugin->pcm_format(); }
     Metadata const& metadata() const { return m_plugin->metadata(); }

--- a/Userland/Libraries/LibAudio/LoaderError.h
+++ b/Userland/Libraries/LibAudio/LoaderError.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/Error.h>
+#include <AK/FlyString.h>
 #include <errno.h>
 
 namespace Audio {
@@ -28,20 +28,20 @@ struct LoaderError {
     Category category { Category::Unknown };
     // Binary index: where in the file the error occurred.
     size_t index { 0 };
-    DeprecatedFlyString description { DeprecatedString::empty() };
+    FlyString description { String::from_utf8_short_string(""sv) };
 
     constexpr LoaderError() = default;
-    LoaderError(Category category, size_t index, DeprecatedFlyString description)
+    LoaderError(Category category, size_t index, FlyString description)
         : category(category)
         , index(index)
         , description(move(description))
     {
     }
-    LoaderError(DeprecatedFlyString description)
+    LoaderError(FlyString description)
         : description(move(description))
     {
     }
-    LoaderError(Category category, DeprecatedFlyString description)
+    LoaderError(Category category, FlyString description)
         : category(category)
         , description(move(description))
     {
@@ -54,11 +54,11 @@ struct LoaderError {
     {
         if (error.is_errno()) {
             auto code = error.code();
-            description = DeprecatedString::formatted("{} ({})", strerror(code), code);
+            description = String::formatted("{} ({})", strerror(code), code).release_value();
             if (code == EBADF || code == EBUSY || code == EEXIST || code == EIO || code == EISDIR || code == ENOENT || code == ENOMEM || code == EPIPE)
                 category = Category::IO;
         } else {
-            description = error.string_literal();
+            description = FlyString::from_utf8(error.string_literal()).release_value();
         }
     }
 };

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -37,7 +37,7 @@ public:
     virtual u32 sample_rate() override { return m_sample_rate; }
     virtual u16 num_channels() override { return m_num_channels; }
     virtual PcmSampleFormat pcm_format() override { return m_sample_format; }
-    virtual DeprecatedString format_name() override { return "MP3 (.mp3)"; }
+    virtual StringView format_name() override { return "MP3 (.mp3)"sv; }
 
 private:
     MaybeLoaderError initialize();

--- a/Userland/Libraries/LibAudio/QOALoader.cpp
+++ b/Userland/Libraries/LibAudio/QOALoader.cpp
@@ -48,7 +48,7 @@ MaybeLoaderError QOALoaderPlugin::parse_header()
 {
     u32 header_magic = TRY(m_stream->read_value<BigEndian<u32>>());
     if (header_magic != QOA::magic)
-        return LoaderError { LoaderError::Category::Format, 0, "QOA header: Magic number must be 'qoaf'" };
+        return LoaderError { LoaderError::Category::Format, 0, TRY(FlyString::from_utf8("QOA header: Magic number must be 'qoaf'"sv)) };
 
     m_total_samples = TRY(m_stream->read_value<BigEndian<u32>>());
 
@@ -62,9 +62,9 @@ MaybeLoaderError QOALoaderPlugin::load_one_frame(Span<Sample>& target, IsFirstFr
     if (header.num_channels > 8)
         dbgln("QOALoader: Warning: QOA frame at {} has more than 8 channels ({}), this is not supported by the reference implementation.", TRY(m_stream->tell()) - sizeof(QOA::FrameHeader), header.num_channels);
     if (header.num_channels == 0)
-        return LoaderError { LoaderError::Category::Format, TRY(m_stream->tell()), "QOA frame: Number of channels must be greater than 0" };
+        return LoaderError { LoaderError::Category::Format, TRY(m_stream->tell()), TRY(FlyString::from_utf8("QOA frame: Number of channels must be greater than 0"sv)) };
     if (header.sample_count > QOA::max_frame_samples)
-        return LoaderError { LoaderError::Category::Format, TRY(m_stream->tell()), "QOA frame: Too many samples in frame" };
+        return LoaderError { LoaderError::Category::Format, TRY(m_stream->tell()), TRY(FlyString::from_utf8("QOA frame: Too many samples in frame"sv)) };
 
     // We weren't given a large enough buffer; signal that we didn't write anything and return.
     if (header.sample_count > target.size()) {
@@ -105,7 +105,7 @@ MaybeLoaderError QOALoaderPlugin::load_one_frame(Span<Sample>& target, IsFirstFr
         m_sample_rate = header.sample_rate;
     } else {
         if (m_sample_rate != header.sample_rate)
-            return LoaderError { LoaderError::Category::Unimplemented, TRY(m_stream->tell()), "QOA: Differing sample rate in non-initial frame" };
+            return LoaderError { LoaderError::Category::Unimplemented, TRY(m_stream->tell()), TRY(FlyString::from_utf8("QOA: Differing sample rate in non-initial frame"sv)) };
         if (m_num_channels != header.num_channels)
             m_has_uniform_channel_count = false;
     }
@@ -189,7 +189,7 @@ MaybeLoaderError QOALoaderPlugin::seek(int sample_index)
     // A QOA file consists of 8 bytes header followed by a number of usually fixed-size frames.
     // This fixed bitrate allows us to seek in constant time.
     if (!m_has_uniform_channel_count)
-        return LoaderError { LoaderError::Category::Unimplemented, TRY(m_stream->tell()), "QOA with non-uniform channel count is currently not seekable"sv };
+        return LoaderError { LoaderError::Category::Unimplemented, TRY(m_stream->tell()), TRY(FlyString::from_utf8("QOA with non-uniform channel count is currently not seekable"sv)) };
     /// FIXME: Change the Loader API to use size_t.
     VERIFY(sample_index >= 0);
     // We seek to the frame "before"; i.e. the frame that contains that sample.

--- a/Userland/Libraries/LibAudio/QOALoader.h
+++ b/Userland/Libraries/LibAudio/QOALoader.h
@@ -37,7 +37,7 @@ public:
     virtual int total_samples() override { return static_cast<int>(m_total_samples); }
     virtual u32 sample_rate() override { return m_sample_rate; }
     virtual u16 num_channels() override { return m_num_channels; }
-    virtual DeprecatedString format_name() override { return "Quite Okay Audio (.qoa)"; }
+    virtual StringView format_name() override { return "Quite Okay Audio (.qoa)"sv; }
     virtual PcmSampleFormat pcm_format() override { return PcmSampleFormat::Int16; }
 
 private:

--- a/Userland/Libraries/LibAudio/SampleFormats.cpp
+++ b/Userland/Libraries/LibAudio/SampleFormats.cpp
@@ -27,10 +27,10 @@ u16 pcm_bits_per_sample(PcmSampleFormat format)
     }
 }
 
-DeprecatedString sample_format_name(PcmSampleFormat format)
+ErrorOr<String> sample_format_name(PcmSampleFormat format)
 {
     bool is_float = format == PcmSampleFormat::Float32 || format == PcmSampleFormat::Float64;
-    return DeprecatedString::formatted("PCM {}bit {}", pcm_bits_per_sample(format), is_float ? "Float" : "LE");
+    return String::formatted("PCM {}bit {}", pcm_bits_per_sample(format), is_float ? "Float" : "LE");
 }
 
 }

--- a/Userland/Libraries/LibAudio/SampleFormats.h
+++ b/Userland/Libraries/LibAudio/SampleFormats.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <AK/Types.h>
 
 namespace Audio {
@@ -23,5 +23,5 @@ enum class PcmSampleFormat : u8 {
 
 // Most of the read code only cares about how many bits to read or write
 u16 pcm_bits_per_sample(PcmSampleFormat format);
-DeprecatedString sample_format_name(PcmSampleFormat format);
+ErrorOr<String> sample_format_name(PcmSampleFormat format);
 }

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -165,7 +165,7 @@ MaybeLoaderError WavLoaderPlugin::seek(int sample_index)
 {
     dbgln_if(AWAVLOADER_DEBUG, "seek sample_index {}", sample_index);
     if (sample_index < 0 || sample_index >= static_cast<int>(m_total_samples))
-        return LoaderError { LoaderError::Category::Internal, m_loaded_samples, "Seek outside the sample range" };
+        return LoaderError { LoaderError::Category::Internal, m_loaded_samples, TRY(FlyString::from_utf8("Seek outside the sample range"sv)) };
 
     size_t sample_offset = m_byte_offset_of_data_samples + static_cast<size_t>(sample_index * m_num_channels * (pcm_bits_per_sample(m_sample_format) / 8));
 
@@ -178,11 +178,11 @@ MaybeLoaderError WavLoaderPlugin::seek(int sample_index)
 // Specification reference: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
 MaybeLoaderError WavLoaderPlugin::parse_header()
 {
-#define CHECK(check, category, msg)                                                                                                          \
-    do {                                                                                                                                     \
-        if (!(check)) {                                                                                                                      \
-            return LoaderError { category, static_cast<size_t>(TRY(m_stream->tell())), DeprecatedString::formatted("WAV header: {}", msg) }; \
-        }                                                                                                                                    \
+#define CHECK(check, category, msg)                                                                                                     \
+    do {                                                                                                                                \
+        if (!(check)) {                                                                                                                 \
+            return LoaderError { category, static_cast<size_t>(TRY(m_stream->tell())), TRY(String::formatted("WAV header: {}", msg)) }; \
+        }                                                                                                                               \
     } while (0)
 
     auto riff = TRY(m_stream->read_value<RIFF::ChunkID>());

--- a/Userland/Libraries/LibAudio/WavLoader.h
+++ b/Userland/Libraries/LibAudio/WavLoader.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/FixedArray.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
@@ -41,7 +40,7 @@ public:
     virtual int total_samples() override { return static_cast<int>(m_total_samples); }
     virtual u32 sample_rate() override { return m_sample_rate; }
     virtual u16 num_channels() override { return m_num_channels; }
-    virtual DeprecatedString format_name() override { return "RIFF WAVE (.wav)"; }
+    virtual StringView format_name() override { return "RIFF WAVE (.wav)"sv; }
     virtual PcmSampleFormat pcm_format() override { return m_sample_format; }
 
 private:

--- a/Userland/Libraries/LibAudio/WavWriter.h
+++ b/Userland/Libraries/LibAudio/WavWriter.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/Noncopyable.h>
 #include <AK/RefPtr.h>
 #include <AK/StringView.h>


### PR DESCRIPTION
Contributes to https://github.com/SerenityOS/serenity/issues/17128 and removes all remaining instances of DeprecatedString and DeprecatedFlyString. I tested some of the codepaths manually (since many are loader errors for specific file formats) and the strings still display properly, but if there are any glaring issues with how I've done anything I'm happy to correct.

Last PR was closed unintentionally while trying to rebase, apologies.