### PR TITLE
LibWeb: Use enclosing (rather than rounded) rect for overflow clipping

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -361,7 +361,7 @@ void PaintableBox::apply_clip_overflow_rect(PaintContext& context, PaintPhase ph
 
     if (!m_clipping_overflow) {
         context.painter().save();
-        context.painter().add_clip_rect(context.rounded_device_rect(*clip_rect).to_type<int>());
+        context.painter().add_clip_rect(context.enclosing_device_rect(*clip_rect).to_type<int>());
         m_clipping_overflow = true;
     }
 


### PR DESCRIPTION
If we use a rounded rect we'll clip off subpixels around the edge.

Fixes this icon on GitHub (at certain window sizes):
![Screenshot from 2023-06-19 20-04-34](https://github.com/SerenityOS/serenity/assets/11597044/9cea5446-258b-4f3c-871d-7b2414c50dbd)
![Screenshot from 2023-06-19 20-03-57](https://github.com/SerenityOS/serenity/assets/11597044/fed7f325-363c-4d4c-9f4e-7afb4be0d9ac)
