### PR TITLE
LibWeb: Use PaintContext::would_be_fully_clipped_by_painter() everywhere

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -316,7 +316,7 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
             while (image_x < css_clip_rect.right()) {
                 image_rect.set_x(image_x);
                 auto image_device_rect = context.rounded_device_rect(image_rect);
-                if (image_device_rect != last_image_device_rect && image_device_rect.intersects(context.device_viewport_rect()))
+                if (image_device_rect != last_image_device_rect && !context.would_be_fully_clipped_by_painter(image_device_rect))
                     image.paint(context, image_device_rect, image_rendering);
                 last_image_device_rect = image_device_rect;
                 if (!repeat_x)

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -45,10 +45,7 @@ void PaintableBox::invalidate_stacking_context()
 
 bool PaintableBox::is_out_of_view(PaintContext& context) const
 {
-    return !context.enclosing_device_rect(absolute_paint_rect())
-                .to_type<int>()
-                .translated(context.painter().translation())
-                .intersects(context.painter().clip_rect());
+    return context.would_be_fully_clipped_by_painter(context.enclosing_device_rect(absolute_paint_rect()));
 }
 
 PaintableWithLines::PaintableWithLines(Layout::BlockContainer const& layout_box)


### PR DESCRIPTION
Always use `would_be_fully_clipped_by_painter` to check painting can be avoided.

This allows to quickly find all the places where this check happens and also removes incosistency that before we checked for intersection with viewport rect in some places and for intersection with painter clip rect in other places.