### PR TITLE
LibWeb: Don't use BFC automatic height algorithm for abspos elements that don't form a BFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/abspos-flex-container-with-auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-flex-container-with-auto-height.txt
@@ -1,0 +1,8 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x0 [BFC] children: not-inline
+    Box <body> at (9,9) content-size 512.859375x19.46875 positioned flex-container(column) [FFC] children: not-inline
+      BlockContainer <div> at (10,10) content-size 510.859375x17.46875 flex-item [BFC] children: inline
+        line 0 width: 510.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 60, rect: [10,10 510.859375x17.46875]
+            "Diese Website nutzt Cookies und vergleichbare Funktionen zur"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/abspos-flex-container-with-auto-height.html
+++ b/Tests/LibWeb/Layout/input/abspos-flex-container-with-auto-height.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html><style>
+    * {
+        border: 1px solid black;
+    }
+    html {
+        background: white;
+    }
+    body {
+        display: flex;
+        flex-flow: column nowrap;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+        background: pink;
+    }
+    div {
+        min-height: 0px;
+        background: orange;
+    }
+</style><body><div>Diese Website nutzt Cookies und vergleichbare Funktionen zur

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -146,6 +146,8 @@ protected:
     void compute_height_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&, BeforeOrAfterInsideLayout);
     void compute_height_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&, BeforeOrAfterInsideLayout);
 
+    [[nodiscard]] Optional<CSSPixels> compute_auto_height_for_absolutely_positioned_element(Box const&, AvailableSpace const&, BeforeOrAfterInsideLayout) const;
+
     Type m_type {};
 
     FormattingContext* m_parent { nullptr };


### PR DESCRIPTION
While CSS 2.2 does tell us to use the "auto height for BFC roots"
calculation when resolving auto heights for abspos elements, that
doesn't make sense for other formatting context roots, e.g flex.
    
In lieu of implementing the entire new absolute positioning model from
CSS-POSITION-3, this patch borrows one small nugget from it: using
fit-content height as the auto height for non-BFC-root abspos elements.

Fixes the cookie popup on https://www.ohne-makler.net/

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/f3b48af9-507d-4c31-90a3-4084f4ab4be2)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/ac45b473-702d-4ab8-a571-68981647755b)
