### PR TITLE
LibWeb: Honor the `opacity` attribute on SVG graphics elements

### DIFF
--- a/Userland/Libraries/LibWeb/SVG/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/SVG/AttributeNames.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -49,6 +49,7 @@ namespace Web::SVG::AttributeNames {
     E(maskUnits)                    \
     E(numOctaves)                   \
     E(offset)                       \
+    E(opacity)                      \
     E(pathLength)                   \
     E(patternContentUnits)          \
     E(patternTransform)             \

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2020, Matthew Olsson <mattco@serenityos.org>
  * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,6 +11,7 @@
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGGradientElement.h>
 #include <LibWeb/SVG/SVGGraphicsElement.h>
@@ -138,6 +140,9 @@ void SVGGraphicsElement::apply_presentational_hints(CSS::StyleProperties& style)
         } else if (name.equals_ignoring_ascii_case("stroke-opacity"sv)) {
             if (auto stroke_opacity_value = parse_css_value(parsing_context, value, CSS::PropertyID::FillOpacity).release_value_but_fixme_should_propagate_errors())
                 style.set_property(CSS::PropertyID::StrokeOpacity, stroke_opacity_value.release_nonnull());
+        } else if (name.equals_ignoring_ascii_case(SVG::AttributeNames::opacity)) {
+            if (auto stroke_opacity_value = parse_css_value(parsing_context, value, CSS::PropertyID::Opacity).release_value_but_fixme_should_propagate_errors())
+                style.set_property(CSS::PropertyID::Opacity, stroke_opacity_value.release_nonnull());
         }
     });
 }


### PR DESCRIPTION
This is simply converted to an equivalent CSS `opacity` property value.

Note the icons in the screenshots below:

Before:
![Screenshot at 2023-06-20 12-56-26](https://github.com/SerenityOS/serenity/assets/5954907/eeab58bb-6251-4569-820d-e2a2fe3a06e8)

After:
![Screenshot at 2023-06-20 12-56-33](https://github.com/SerenityOS/serenity/assets/5954907/5bed7eae-0537-413a-8694-d8e388718c4c)
