### PR TITLE
LibWeb: Don't assert when flex-item has `align-self: end`

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/align-self-end-crash.txt
+++ b/Tests/LibWeb/Layout/expected/flex/align-self-end-crash.txt
@@ -1,0 +1,4 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x0 flex-container(row) [FFC] children: not-inline
+      BlockContainer <div> at (8,8) content-size 0x0 flex-item [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/input/flex/align-self-end-crash.html
+++ b/Tests/LibWeb/Layout/input/flex/align-self-end-crash.html
@@ -1,0 +1,4 @@
+<!doctype html><style>
+body { display: flex; }
+div { align-self: end; }
+</style><div>

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1447,6 +1447,8 @@ CSS::AlignItems FlexFormattingContext::alignment_for_item(Box const& box) const
     switch (box.computed_values().align_self()) {
     case CSS::AlignSelf::Auto:
         return flex_container().computed_values().align_items();
+    case CSS::AlignSelf::End:
+        return CSS::AlignItems::End;
     case CSS::AlignSelf::Normal:
         return CSS::AlignItems::Normal;
     case CSS::AlignSelf::SelfStart:


### PR DESCRIPTION
We were missing the code to convert this to `align-items: end`.

Fixes an assertion failure when resizing the window on https://www.kde.org/