### PR TITLE
LibWeb: Don't skip width computation for intrinsic table width

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
@@ -1,10 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x46.9375 children: inline
-      line 0 width: 131.984375, height: 46.9375, bottom: 46.9375, baseline: 39
-        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 129.984375x44.9375]
-      BlockContainer <table> at (9,9) content-size 129.984375x44.9375 inline-block [BFC] children: not-inline
-        TableWrapper <(anonymous)> at (9,9) content-size 129.984375x44.9375 inline-block [BFC] children: not-inline
+      line 0 width: 137.984375, height: 46.9375, bottom: 46.9375, baseline: 39
+        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 135.984375x44.9375]
+      BlockContainer <table> at (9,9) content-size 135.984375x44.9375 inline-block [BFC] children: not-inline
+        TableWrapper <(anonymous)> at (9,9) content-size 135.984375x44.9375 inline-block [BFC] children: not-inline
           Box <(anonymous)> at (9,9) content-size 135.984375x44.9375 inline-table table-box [TFC] children: not-inline
             Box <tbody> at (9,9) content-size 129.984375x38.9375 table-row-group children: not-inline
               Box <tr> at (11,11) content-size 129.984375x19.46875 table-row children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
@@ -5,14 +5,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x116.40625 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
-      TableWrapper <(anonymous)> at (8,8) content-size 65.828125x116.40625 [BFC] children: not-inline
-        Box <table> at (9,9) content-size 65.828125x114.40625 table-box [TFC] children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 67.828125x116.40625 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 67.828125x114.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 61.828125x108.40625 table-row-group children: not-inline
+          Box <tbody> at (9,9) content-size 63.828125x108.40625 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,11) content-size 61.828125x54.203125 table-row children: not-inline
+            Box <tr> at (11,11) content-size 63.828125x54.203125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (17,29.367187) content-size 11.5625x17.46875 table-cell [BFC] children: inline
@@ -22,10 +22,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (42.5625,17) content-size 26.265625x98.40625 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (42.5625,17) content-size 26.265625x0 children: inline
+              BlockContainer <td> at (42.5625,17) content-size 28.265625x98.40625 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (42.5625,17) content-size 28.265625x0 children: inline
                   TextNode <#text>
-                TableWrapper <(anonymous)> at (42.5625,17) content-size 26.265625x98.40625 [BFC] children: not-inline
+                TableWrapper <(anonymous)> at (42.5625,17) content-size 28.265625x98.40625 [BFC] children: not-inline
                   Box <table> at (43.5625,18) content-size 28.265625x96.40625 table-box [TFC] children: not-inline
                     BlockContainer <(anonymous)> (not painted) children: inline
                       TextNode <#text>
@@ -70,13 +70,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                         TextNode <#text>
                     BlockContainer <(anonymous)> (not painted) children: inline
                       TextNode <#text>
-                BlockContainer <(anonymous)> at (42.5625,115.40625) content-size 26.265625x0 children: inline
+                BlockContainer <(anonymous)> at (42.5625,115.40625) content-size 28.265625x0 children: inline
                   TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,65.203125) content-size 61.828125x54.203125 table-row children: not-inline
+            Box <tr> at (11,65.203125) content-size 63.828125x54.203125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (17,85.570312) content-size 11.5625x17.46875 table-cell [BFC] children: inline

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -500,27 +500,6 @@ void TableFormattingContext::distribute_width_to_columns()
     }
 }
 
-void TableFormattingContext::determine_intrisic_size_of_table_container(AvailableSpace const& available_space)
-{
-    auto& table_box_state = m_state.get_mutable(table_box());
-
-    if (available_space.width.is_min_content()) {
-        // The min-content width of a table is the width required to fit all of its columns min-content widths and its undistributable spaces.
-        CSSPixels grid_min = 0.0f;
-        for (auto& column : m_columns)
-            grid_min += column.min_size;
-        table_box_state.set_content_width(grid_min);
-    }
-
-    if (available_space.width.is_max_content()) {
-        // The max-content width of a table is the width required to fit all of its columns max-content widths and its undistributable spaces.
-        CSSPixels grid_max = 0.0f;
-        for (auto& column : m_columns)
-            grid_max += column.max_size;
-        table_box_state.set_content_width(grid_max);
-    }
-}
-
 void TableFormattingContext::compute_table_height(LayoutMode layout_mode)
 {
     // First pass of row height calculation:
@@ -995,13 +974,12 @@ void TableFormattingContext::run(Box const& box, LayoutMode layout_mode, Availab
     // height specified on cells that span this row only (the algorithm starts by considering cells of span 2 on top of that assignment).
     compute_table_measures<Row>();
 
-    if (available_space.width.is_intrinsic_sizing_constraint() && !available_space.height.is_intrinsic_sizing_constraint()) {
-        determine_intrisic_size_of_table_container(available_space);
-        return;
-    }
-
     // Compute the width of the table.
     compute_table_width();
+
+    if (available_space.width.is_intrinsic_sizing_constraint() && !available_space.height.is_intrinsic_sizing_constraint()) {
+        return;
+    }
 
     // Distribute the width of the table among columns.
     distribute_width_to_columns();

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -41,7 +41,6 @@ private:
     void compute_table_measures();
     void compute_table_width();
     void distribute_width_to_columns();
-    void determine_intrisic_size_of_table_container(AvailableSpace const& available_space);
     void compute_table_height(LayoutMode layout_mode);
     void distribute_height_to_rows();
     void position_row_boxes(CSSPixels&);


### PR DESCRIPTION
The shortcut we put in place didn't resolve percentage widths and ignored border spacing. We can still return early after we compute the width per the specifications.