### PR TITLE
LibWeb: Set 0px fixed size to collapsed auto-fit tracks in GFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/auto-fit-collapse-empty-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fit-collapse-empty-tracks.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x97.46875 children: not-inline
+      Box <div.container> at (18,18) content-size 764x77.46875 [GFC] children: not-inline
+        BlockContainer <div.item> at (48,48) content-size 704x17.46875 [BFC] children: inline
+          line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [48,48 6.34375x17.46875]
+              "1"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/grid/auto-fit-collapse-empty-tracks.html
+++ b/Tests/LibWeb/Layout/input/grid/auto-fit-collapse-empty-tracks.html
@@ -1,0 +1,14 @@
+<style>
+.container {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    background-color: lightcyan;
+    border: 10px solid red;
+}
+
+.item {
+    padding: 20px;
+    background-color: lightgreen;
+    border: 10px solid papayawhip;
+}
+</style><div class="container"><div class="item">1</div></div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -240,6 +240,8 @@ private:
     void initialize_grid_tracks_for_columns_and_rows(AvailableSpace const&);
     void initialize_gap_tracks(AvailableSpace const&);
 
+    void collapse_auto_fit_tracks_if_needed(GridDimension const);
+
     template<typename Match>
     void distribute_extra_space_across_spanned_tracks_base_size(CSSPixels item_size_contribution, Vector<GridTrack&>& spanned_tracks, Match matcher);
 


### PR DESCRIPTION
Fixes the issue that before we set base_size and growth_limit of collapsed tracks to 0px which still allowed them to grow by space distribution.