### PR TITLE
Ladybird+LibWeb+WebConent: Drive audio in Ladybird off the main thread

### DIFF
--- a/Ladybird/AudioCodecPluginLadybird.cpp
+++ b/Ladybird/AudioCodecPluginLadybird.cpp
@@ -7,88 +7,258 @@
 #include "AudioCodecPluginLadybird.h"
 #include <AK/Endian.h>
 #include <AK/MemoryStream.h>
+#include <LibAudio/Loader.h>
 #include <LibAudio/Sample.h>
+#include <LibCore/SharedCircularQueue.h>
 #include <QAudioFormat>
 #include <QAudioSink>
-#include <QBuffer>
+#include <QByteArray>
 #include <QMediaDevices>
+#include <QThread>
 
 namespace Ladybird {
 
-ErrorOr<NonnullOwnPtr<AudioCodecPluginLadybird>> AudioCodecPluginLadybird::create()
-{
-    auto devices = TRY(adopt_nonnull_own_or_enomem(new (nothrow) QMediaDevices()));
-    auto const& device_info = devices->defaultAudioOutput();
+static constexpr u32 UPDATE_RATE_MS = 50;
 
-    auto format = device_info.preferredFormat();
-    format.setSampleFormat(QAudioFormat::Int16);
-    format.setChannelCount(2);
+struct AudioTask {
+    enum class Type {
+        Stop,
+        Play,
+        Pause,
+        Seek,
+        Volume,
+    };
 
-    if (!device_info.isFormatSupported(format))
-        return Error::from_string_literal("Audio device format not supported");
+    Type type;
+    Optional<double> data {};
+};
 
-    auto audio_output = TRY(adopt_nonnull_own_or_enomem(new (nothrow) QAudioSink(device_info, format)));
+using AudioTaskQueue = Core::SharedSingleProducerCircularQueue<AudioTask>;
 
-    return adopt_nonnull_own_or_enomem(new (nothrow) AudioCodecPluginLadybird(move(devices), move(audio_output)));
-}
+class AudioThread final : public QThread { // We have to use QThread, otherwise internal Qt media QTimer objects do not work.
+    Q_OBJECT
 
-AudioCodecPluginLadybird::AudioCodecPluginLadybird(NonnullOwnPtr<QMediaDevices> devices, NonnullOwnPtr<QAudioSink> audio_output)
-    : m_devices(move(devices))
-    , m_audio_output(move(audio_output))
-    , m_io_device(m_audio_output->start())
-{
-}
-
-AudioCodecPluginLadybird::~AudioCodecPluginLadybird() = default;
-
-size_t AudioCodecPluginLadybird::device_sample_rate()
-{
-    return m_audio_output->format().sampleRate();
-}
-
-void AudioCodecPluginLadybird::enqueue_samples(FixedArray<Audio::Sample> samples)
-{
-    QByteArray buffer;
-    buffer.resize(samples.size() * 2 * sizeof(u16));
-
-    FixedMemoryStream stream { Bytes { buffer.data(), static_cast<size_t>(buffer.size()) } };
-
-    for (auto& sample : samples) {
-        LittleEndian<i16> pcm;
-
-        pcm = static_cast<i16>(sample.left * NumericLimits<i16>::max());
-        MUST(stream.write_value(pcm));
-
-        pcm = static_cast<i16>(sample.right * NumericLimits<i16>::max());
-        MUST(stream.write_value(pcm));
+public:
+    static ErrorOr<NonnullOwnPtr<AudioThread>> create(NonnullRefPtr<Audio::Loader> loader)
+    {
+        auto task_queue = TRY(AudioTaskQueue::create());
+        return adopt_nonnull_own_or_enomem(new (nothrow) AudioThread(move(loader), move(task_queue)));
     }
 
-    m_io_device->write(buffer.data(), buffer.size());
+    ErrorOr<void> stop()
+    {
+        TRY(queue_task({ AudioTask::Type::Stop }));
+        wait();
+
+        return {};
+    }
+
+    Duration duration() const
+    {
+        return m_duration;
+    }
+
+    ErrorOr<void> queue_task(AudioTask task)
+    {
+        return m_task_queue.blocking_enqueue(move(task), []() {
+            usleep(UPDATE_RATE_MS * 1000);
+        });
+    }
+
+Q_SIGNALS:
+    void playback_position_updated(Duration);
+
+private:
+    AudioThread(NonnullRefPtr<Audio::Loader> loader, AudioTaskQueue task_queue)
+        : m_loader(move(loader))
+        , m_task_queue(move(task_queue))
+    {
+        auto duration = static_cast<double>(m_loader->total_samples()) / static_cast<double>(m_loader->sample_rate());
+        m_duration = Duration::from_milliseconds(static_cast<i64>(duration * 1000.0));
+
+        m_samples_to_load_per_buffer = static_cast<size_t>(UPDATE_RATE_MS / 1000.0 * static_cast<double>(m_loader->sample_rate()));
+    }
+
+    enum class Paused {
+        Yes,
+        No,
+    };
+
+    void run() override
+    {
+        auto devices = make<QMediaDevices>();
+        auto const& device_info = devices->defaultAudioOutput();
+
+        auto format = device_info.preferredFormat();
+        format.setSampleFormat(QAudioFormat::Int16);
+        format.setChannelCount(2);
+
+        auto audio_output = make<QAudioSink>(device_info, format);
+        auto* io_device = audio_output->start();
+
+        auto paused = Paused::Yes;
+
+        while (true) {
+            if (auto result = m_task_queue.dequeue(); result.is_error()) {
+                VERIFY(result.error() == AudioTaskQueue::QueueStatus::Empty);
+            } else {
+                auto task = result.release_value();
+
+                switch (task.type) {
+                case AudioTask::Type::Stop:
+                    return;
+
+                case AudioTask::Type::Play:
+                    audio_output->resume();
+                    paused = Paused::No;
+                    break;
+
+                case AudioTask::Type::Pause:
+                    audio_output->suspend();
+                    paused = Paused::Yes;
+                    break;
+
+                case AudioTask::Type::Seek: {
+                    VERIFY(task.data.has_value());
+                    auto position = *task.data;
+
+                    auto duration = static_cast<double>(this->duration().to_milliseconds()) / 1000.0;
+                    position = position / duration * static_cast<double>(m_loader->total_samples());
+
+                    m_loader->seek(static_cast<int>(position)).release_value_but_fixme_should_propagate_errors();
+
+                    if (paused == Paused::Yes) {
+                        m_position = Web::Platform::AudioCodecPlugin::current_loader_position(m_loader, audio_output->format().sampleRate());
+                        Q_EMIT playback_position_updated(m_position);
+                    }
+
+                    break;
+                }
+
+                case AudioTask::Type::Volume:
+                    VERIFY(task.data.has_value());
+                    audio_output->setVolume(*task.data);
+                    break;
+                }
+            }
+
+            if (paused == Paused::No) {
+                if (auto result = play_next_samples(*audio_output, *io_device); result.is_error()) {
+                    // FIXME: Propagate the error to the HTMLMediaElement.
+                } else {
+                    Q_EMIT playback_position_updated(m_position);
+                    paused = result.value();
+                }
+            }
+
+            usleep(UPDATE_RATE_MS * 1000);
+        }
+    }
+
+    ErrorOr<Paused> play_next_samples(QAudioSink& audio_output, QIODevice& io_device)
+    {
+        bool all_samples_loaded = m_loader->loaded_samples() >= m_loader->total_samples();
+
+        if (all_samples_loaded) {
+            audio_output.suspend();
+            (void)m_loader->reset();
+
+            m_position = m_duration;
+            return Paused::Yes;
+        }
+
+        auto samples = TRY(Web::Platform::AudioCodecPlugin::read_samples_from_loader(*m_loader, m_samples_to_load_per_buffer, audio_output.format().sampleRate()));
+        enqueue_samples(io_device, move(samples));
+
+        m_position = Web::Platform::AudioCodecPlugin::current_loader_position(m_loader, audio_output.format().sampleRate());
+        return Paused::No;
+    }
+
+    void enqueue_samples(QIODevice& io_device, FixedArray<Audio::Sample> samples)
+    {
+        auto buffer_size = samples.size() * 2 * sizeof(u16);
+        if (buffer_size > static_cast<size_t>(m_sample_buffer.size()))
+            m_sample_buffer.resize(buffer_size);
+
+        FixedMemoryStream stream { Bytes { m_sample_buffer.data(), buffer_size } };
+
+        for (auto& sample : samples) {
+            LittleEndian<i16> pcm;
+
+            pcm = static_cast<i16>(sample.left * NumericLimits<i16>::max());
+            MUST(stream.write_value(pcm));
+
+            pcm = static_cast<i16>(sample.right * NumericLimits<i16>::max());
+            MUST(stream.write_value(pcm));
+        }
+
+        io_device.write(m_sample_buffer.data(), buffer_size);
+    }
+
+    NonnullRefPtr<Audio::Loader> m_loader;
+    AudioTaskQueue m_task_queue;
+
+    size_t m_samples_to_load_per_buffer { 0 };
+    QByteArray m_sample_buffer;
+
+    Duration m_duration;
+    Duration m_position;
+};
+
+ErrorOr<NonnullOwnPtr<AudioCodecPluginLadybird>> AudioCodecPluginLadybird::create(NonnullRefPtr<Audio::Loader> loader)
+{
+    auto audio_thread = TRY(AudioThread::create(move(loader)));
+    audio_thread->start();
+
+    return adopt_nonnull_own_or_enomem(new (nothrow) AudioCodecPluginLadybird(move(audio_thread)));
 }
 
-size_t AudioCodecPluginLadybird::remaining_samples() const
+AudioCodecPluginLadybird::AudioCodecPluginLadybird(NonnullOwnPtr<AudioThread> audio_thread)
+    : m_audio_thread(move(audio_thread))
 {
-    return 0;
+    connect(m_audio_thread, &AudioThread::playback_position_updated, this, [this](auto position) {
+        if (on_playback_position_updated)
+            on_playback_position_updated(position);
+    });
+}
+
+AudioCodecPluginLadybird::~AudioCodecPluginLadybird()
+{
+    m_audio_thread->stop().release_value_but_fixme_should_propagate_errors();
 }
 
 void AudioCodecPluginLadybird::resume_playback()
 {
-    m_audio_output->resume();
+    m_audio_thread->queue_task({ AudioTask::Type::Play }).release_value_but_fixme_should_propagate_errors();
 }
 
 void AudioCodecPluginLadybird::pause_playback()
 {
-    m_audio_output->suspend();
-}
-
-void AudioCodecPluginLadybird::playback_ended()
-{
-    m_audio_output->suspend();
+    m_audio_thread->queue_task({ AudioTask::Type::Pause }).release_value_but_fixme_should_propagate_errors();
 }
 
 void AudioCodecPluginLadybird::set_volume(double volume)
 {
-    m_audio_output->setVolume(volume);
+
+    AudioTask task { AudioTask::Type::Volume };
+    task.data = volume;
+
+    m_audio_thread->queue_task(move(task)).release_value_but_fixme_should_propagate_errors();
+}
+
+void AudioCodecPluginLadybird::seek(double position)
+{
+    AudioTask task { AudioTask::Type::Seek };
+    task.data = position;
+
+    m_audio_thread->queue_task(move(task)).release_value_but_fixme_should_propagate_errors();
+}
+
+Duration AudioCodecPluginLadybird::duration()
+{
+    return m_audio_thread->duration();
 }
 
 }
+
+#include "AudioCodecPluginLadybird.moc"

--- a/Ladybird/AudioCodecPluginLadybird.h
+++ b/Ladybird/AudioCodecPluginLadybird.h
@@ -8,37 +8,35 @@
 
 #include <AK/Error.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/NonnullRefPtr.h>
 #include <LibAudio/Forward.h>
 #include <LibWeb/Platform/AudioCodecPlugin.h>
-
-class QAudioSink;
-class QIODevice;
-class QMediaDevices;
+#include <QObject>
 
 namespace Ladybird {
 
-class AudioCodecPluginLadybird final : public Web::Platform::AudioCodecPlugin {
+class AudioThread;
+
+class AudioCodecPluginLadybird final
+    : public QObject
+    , public Web::Platform::AudioCodecPlugin {
+    Q_OBJECT
+
 public:
-    static ErrorOr<NonnullOwnPtr<AudioCodecPluginLadybird>> create();
+    static ErrorOr<NonnullOwnPtr<AudioCodecPluginLadybird>> create(NonnullRefPtr<Audio::Loader>);
     virtual ~AudioCodecPluginLadybird() override;
-
-    virtual size_t device_sample_rate() override;
-
-    virtual void enqueue_samples(FixedArray<Audio::Sample>) override;
-    virtual size_t remaining_samples() const override;
 
     virtual void resume_playback() override;
     virtual void pause_playback() override;
-    virtual void playback_ended() override;
-
     virtual void set_volume(double) override;
+    virtual void seek(double) override;
+
+    virtual Duration duration() override;
 
 private:
-    AudioCodecPluginLadybird(NonnullOwnPtr<QMediaDevices>, NonnullOwnPtr<QAudioSink>);
+    explicit AudioCodecPluginLadybird(NonnullOwnPtr<AudioThread>);
 
-    NonnullOwnPtr<QMediaDevices> m_devices;
-    NonnullOwnPtr<QAudioSink> m_audio_output;
-    QIODevice* m_io_device { nullptr };
+    NonnullOwnPtr<AudioThread> m_audio_thread;
 };
 
 }

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -13,6 +13,7 @@
 #include "../WebSocketClientManagerLadybird.h"
 #include <AK/LexicalPath.h>
 #include <AK/Platform.h>
+#include <LibAudio/Loader.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/LocalServer.h>
@@ -59,8 +60,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPluginSerenity);
     Web::Platform::ImageCodecPlugin::install(*new Ladybird::ImageCodecPluginLadybird);
 
-    Web::Platform::AudioCodecPlugin::install_creation_hook([] {
-        return Ladybird::AudioCodecPluginLadybird::create();
+    Web::Platform::AudioCodecPlugin::install_creation_hook([](auto loader) {
+        return Ladybird::AudioCodecPluginLadybird::create(move(loader));
     });
 
     Web::ResourceLoader::initialize(RequestManagerQt::create());

--- a/Userland/Libraries/LibWeb/HTML/AudioTrack.h
+++ b/Userland/Libraries/LibWeb/HTML/AudioTrack.h
@@ -24,8 +24,7 @@ public:
     void play(Badge<HTMLAudioElement>);
     void pause(Badge<HTMLAudioElement>);
 
-    Duration position() const;
-    Duration duration() const;
+    Duration duration();
     void seek(double, MediaSeekMode);
 
     void update_volume();
@@ -43,9 +42,6 @@ private:
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
-
-    Optional<FixedArray<Audio::Sample>> get_next_samples();
-    void play_next_samples();
 
     // https://html.spec.whatwg.org/multipage/media.html#dom-audiotrack-id
     String m_id;
@@ -66,8 +62,6 @@ private:
     JS::GCPtr<AudioTrackList> m_audio_track_list;
 
     NonnullOwnPtr<Platform::AudioCodecPlugin> m_audio_plugin;
-    NonnullRefPtr<Audio::Loader> m_loader;
-    NonnullRefPtr<Platform::Timer> m_sample_timer;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Platform/AudioCodecPlugin.cpp
+++ b/Userland/Libraries/LibWeb/Platform/AudioCodecPlugin.cpp
@@ -4,25 +4,51 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibAudio/Loader.h>
+#include <LibAudio/Resampler.h>
+#include <LibAudio/Sample.h>
 #include <LibWeb/Platform/AudioCodecPlugin.h>
 
 namespace Web::Platform {
 
-static Function<ErrorOr<NonnullOwnPtr<AudioCodecPlugin>>()> s_creation_hook;
+static AudioCodecPlugin::AudioCodecPluginCreator s_creation_hook;
 
 AudioCodecPlugin::AudioCodecPlugin() = default;
 AudioCodecPlugin::~AudioCodecPlugin() = default;
 
-void AudioCodecPlugin::install_creation_hook(Function<ErrorOr<NonnullOwnPtr<AudioCodecPlugin>>()> creation_hook)
+void AudioCodecPlugin::install_creation_hook(AudioCodecPluginCreator creation_hook)
 {
     VERIFY(!s_creation_hook);
     s_creation_hook = move(creation_hook);
 }
 
-ErrorOr<NonnullOwnPtr<AudioCodecPlugin>> AudioCodecPlugin::create()
+ErrorOr<NonnullOwnPtr<AudioCodecPlugin>> AudioCodecPlugin::create(NonnullRefPtr<Audio::Loader> loader)
 {
     VERIFY(s_creation_hook);
-    return s_creation_hook();
+    return s_creation_hook(move(loader));
+}
+
+ErrorOr<FixedArray<Audio::Sample>> AudioCodecPlugin::read_samples_from_loader(Audio::Loader& loader, size_t samples_to_load, size_t device_sample_rate)
+{
+    auto buffer_or_error = loader.get_more_samples(samples_to_load);
+    if (buffer_or_error.is_error()) {
+        dbgln("Error while loading samples: {}", buffer_or_error.error().description);
+        return Error::from_string_literal("Error while loading samples");
+    }
+
+    Audio::ResampleHelper<Audio::Sample> resampler(loader.sample_rate(), device_sample_rate);
+    return FixedArray<Audio::Sample>::create(resampler.resample(buffer_or_error.release_value()).span());
+}
+
+Duration AudioCodecPlugin::current_loader_position(Audio::Loader const& loader, size_t device_sample_rate)
+{
+    auto samples_played = static_cast<double>(loader.loaded_samples());
+    auto sample_rate = static_cast<double>(loader.sample_rate());
+
+    auto source_to_device_ratio = sample_rate / static_cast<double>(device_sample_rate);
+    samples_played *= source_to_device_ratio;
+
+    return Duration::from_milliseconds(static_cast<i64>(samples_played / sample_rate * 1000.0));
 }
 
 }

--- a/Userland/Services/WebContent/AudioCodecPluginSerenity.h
+++ b/Userland/Services/WebContent/AudioCodecPluginSerenity.h
@@ -7,34 +7,42 @@
 #pragma once
 
 #include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/NonnullRefPtr.h>
-#include <AK/Optional.h>
+#include <AK/Time.h>
 #include <LibAudio/Forward.h>
+#include <LibWeb/Forward.h>
 #include <LibWeb/Platform/AudioCodecPlugin.h>
 
 namespace WebContent {
 
 class AudioCodecPluginSerenity final : public Web::Platform::AudioCodecPlugin {
 public:
-    static ErrorOr<NonnullOwnPtr<AudioCodecPluginSerenity>> create();
+    static ErrorOr<NonnullOwnPtr<AudioCodecPluginSerenity>> create(NonnullRefPtr<Audio::Loader>);
     virtual ~AudioCodecPluginSerenity() override;
-
-    virtual size_t device_sample_rate() override;
-
-    virtual void enqueue_samples(FixedArray<Audio::Sample>) override;
-    virtual size_t remaining_samples() const override;
 
     virtual void resume_playback() override;
     virtual void pause_playback() override;
-    virtual void playback_ended() override;
-
     virtual void set_volume(double) override;
+    virtual void seek(double) override;
+
+    virtual Duration duration() override;
 
 private:
-    explicit AudioCodecPluginSerenity(NonnullRefPtr<Audio::ConnectionToServer>);
+    AudioCodecPluginSerenity(NonnullRefPtr<Audio::ConnectionToServer>, NonnullRefPtr<Audio::Loader>);
+
+    ErrorOr<void> play_next_samples();
 
     NonnullRefPtr<Audio::ConnectionToServer> m_connection;
-    Optional<size_t> m_device_sample_rate;
+    NonnullRefPtr<Audio::Loader> m_loader;
+    NonnullRefPtr<Web::Platform::Timer> m_sample_timer;
+
+    Duration m_duration;
+    Duration m_position;
+
+    size_t m_device_sample_rate { 0 };
+    size_t m_device_samples_per_buffer { 0 };
+    size_t m_samples_to_load_per_buffer { 0 };
 };
 
 }

--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -6,6 +6,7 @@
 
 #include "AudioCodecPluginSerenity.h"
 #include "ImageCodecPluginSerenity.h"
+#include <LibAudio/Loader.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/LocalServer.h>
 #include <LibCore/StandardPaths.h>
@@ -46,8 +47,8 @@ ErrorOr<int> serenity_main(Main::Arguments)
     Web::Platform::ImageCodecPlugin::install(*new WebContent::ImageCodecPluginSerenity);
     Web::Platform::FontPlugin::install(*new Web::Platform::FontPluginSerenity);
 
-    Web::Platform::AudioCodecPlugin::install_creation_hook([] {
-        return WebContent::AudioCodecPluginSerenity::create();
+    Web::Platform::AudioCodecPlugin::install_creation_hook([](auto loader) {
+        return WebContent::AudioCodecPluginSerenity::create(move(loader));
     });
 
     Web::WebSockets::WebSocketClientManager::initialize(TRY(WebView::WebSocketClientManagerAdapter::try_create()));


### PR DESCRIPTION
The main thread in the WebContent process is often busy with layout and running JavaScript. This can cause audio to sound jittery and crack. To avoid this behavior, we now drive audio on a secondary thread.

Note: Browser on Serenity uses AudioServer, the connection for which is already handled on a secondary thread within LibAudio. So this only applies to Lagom.

Rather than using LibThreading, our hands are tied to QThread for now. Internally, the Qt media objects use a QTimer, which is forbidden from running on a thread that is not a QThread (the debug console is spammed with messages pointing this out). Ideally, in the future AudioServer will be able to run for non-Serenity platforms, and most of this can be aligned with the Serenity implementation.

Here's what bandcamp (which does relayout a *ton*) sounds like before:

https://github.com/SerenityOS/serenity/assets/5600524/b71cfd68-5cbd-45ab-99a2-3be252112494


And after:

https://github.com/SerenityOS/serenity/assets/5600524/5f92642f-bd4b-4290-a13f-4ad28b6ef4b8

