### PR TITLE
strings: Add `-o` option to display octal offsets and replace `-p` with `-f`

### DIFF
--- a/Base/usr/share/man/man1/strings.md
+++ b/Base/usr/share/man/man1/strings.md
@@ -5,7 +5,7 @@ strings - find printable strings in files
 ## Synopsis
 
 ```**sh
-$ strings [-n NUMBER] [--print-file-name] [-t FORMAT] [PATHS...]  
+$ strings [--bytes NUMBER] [--print-file-name] [--radix FORMAT] [PATHS...]  
 ```
 
 ## Description
@@ -14,9 +14,9 @@ $ strings [-n NUMBER] [--print-file-name] [-t FORMAT] [PATHS...]
 
 ## Options
 
-* `-n NUMBER`: Specify the minimum string length (4 is default).
+* `-n NUMBER`, `--bytes NUMBER`: Specify the minimum string length (4 is default).
 * `-f`, `--print-file-name`: Print the name of the file before each string.
-* `-t FORMAT`: Write each string preceded by its byte offset from the start of the file in the specified `FORMAT`, where `FORMAT` matches one of the following: `d` (decimal), `o` (octal), or `x` (hexidecimal).
+* `-t FORMAT`, `--radix FORMAT`: Write each string preceded by its byte offset from the start of the file in the specified `FORMAT`, where `FORMAT` matches one of the following: `d` (decimal), `o` (octal), or `x` (hexidecimal).
 
 ## Examples
 

--- a/Base/usr/share/man/man1/strings.md
+++ b/Base/usr/share/man/man1/strings.md
@@ -5,7 +5,7 @@ strings - find printable strings in files
 ## Synopsis
 
 ```**sh
-$ strings [--bytes NUMBER] [--print-file-name] [--radix FORMAT] [PATHS...]  
+$ strings [--bytes NUMBER] [--print-file-name] [-o] [--radix FORMAT] [PATHS...]  
 ```
 
 ## Description
@@ -16,6 +16,7 @@ $ strings [--bytes NUMBER] [--print-file-name] [--radix FORMAT] [PATHS...]
 
 * `-n NUMBER`, `--bytes NUMBER`: Specify the minimum string length (4 is default).
 * `-f`, `--print-file-name`: Print the name of the file before each string.
+* `-o`: Equivalent to specifying `-t o`.
 * `-t FORMAT`, `--radix FORMAT`: Write each string preceded by its byte offset from the start of the file in the specified `FORMAT`, where `FORMAT` matches one of the following: `d` (decimal), `o` (octal), or `x` (hexidecimal).
 
 ## Examples

--- a/Base/usr/share/man/man1/strings.md
+++ b/Base/usr/share/man/man1/strings.md
@@ -5,7 +5,7 @@ strings - find printable strings in files
 ## Synopsis
 
 ```**sh
-$ strings [-n NUMBER] [-p] [-t FORMAT] [PATHS...]  
+$ strings [-n NUMBER] [--print-file-name] [-t FORMAT] [PATHS...]  
 ```
 
 ## Description
@@ -15,7 +15,7 @@ $ strings [-n NUMBER] [-p] [-t FORMAT] [PATHS...]
 ## Options
 
 * `-n NUMBER`: Specify the minimum string length (4 is default).
-* `-p`: Write the pathname for each file specified in `PATHS` to standard output.
+* `-f`, `--print-file-name`: Print the name of the file before each string.
 * `-t FORMAT`: Write each string preceded by its byte offset from the start of the file in the specified `FORMAT`, where `FORMAT` matches one of the following: `d` (decimal), `o` (octal), or `x` (hexidecimal).
 
 ## Examples
@@ -35,5 +35,5 @@ $ strings -t x ~/Videos/test.webm
 Display the printable strings in all .txt files in the current directory, preceded by their pathname:
 
 ```sh
-$ strings -p *.txt
+$ strings -f *.txt
 ```

--- a/Userland/Utilities/strings.cpp
+++ b/Userland/Utilities/strings.cpp
@@ -99,11 +99,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringOffsetFormat string_offset_format { StringOffsetFormat::None };
 
     Core::ArgsParser args_parser;
-    args_parser.add_option(minimum_string_length, "Specify the minimum string length.", nullptr, 'n', "number");
+    args_parser.add_option(minimum_string_length, "Specify the minimum string length.", "bytes", 'n', "number");
     args_parser.add_option(show_paths, "Print the name of the file before each string.", "print-file-name", 'f');
     args_parser.add_option({ Core::ArgsParser::OptionArgumentMode::Required,
         "Write offset relative to start of each file in (d)ec, (o)ct, or he(x) format.",
-        nullptr,
+        "radix",
         't',
         "format",
         [&string_offset_format](StringView value) {

--- a/Userland/Utilities/strings.cpp
+++ b/Userland/Utilities/strings.cpp
@@ -70,17 +70,15 @@ static ErrorOr<void> process_strings_in_file(StringView path, bool show_paths, S
     auto file = TRY(Core::File::open_file_or_standard_stream(path, Core::File::OpenMode::Read));
     size_t processed_characters = 0;
     size_t string_offset_position = 0;
-    bool did_show_path = false;
     while (!file->is_eof()) {
         auto buffer_span = TRY(file->read_some(buffer));
         while (!buffer_span.is_empty()) {
             string_offset_position += processed_characters;
             processed_characters = process_characters_in_span(output_characters, buffer_span);
-            if (show_paths && !did_show_path) {
-                outln("path {}:", path);
-                did_show_path = true;
-            }
             if (output_characters.size() >= minimum_string_length && should_print_characters(output_characters)) {
+                if (show_paths)
+                    out("{}:", path);
+
                 print_characters(output_characters, string_offset_format, string_offset_position);
             }
             buffer_span = buffer_span.slice(processed_characters);
@@ -102,7 +100,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::ArgsParser args_parser;
     args_parser.add_option(minimum_string_length, "Specify the minimum string length.", nullptr, 'n', "number");
-    args_parser.add_option(show_paths, "Display the path for each matched file.", nullptr, 'p');
+    args_parser.add_option(show_paths, "Print the name of the file before each string.", "print-file-name", 'f');
     args_parser.add_option({ Core::ArgsParser::OptionArgumentMode::Required,
         "Write offset relative to start of each file in (d)ec, (o)ct, or he(x) format.",
         nullptr,

--- a/Userland/Utilities/strings.cpp
+++ b/Userland/Utilities/strings.cpp
@@ -139,8 +139,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (paths.is_empty())
         paths.append("-"sv);
 
-    for (auto const& path : paths)
-        TRY(process_strings_in_file(path, show_paths, string_offset_format, minimum_string_length));
+    bool has_errors = false;
+    for (auto const& path : paths) {
+        auto maybe_error = process_strings_in_file(path, show_paths, string_offset_format, minimum_string_length);
+        if (maybe_error.is_error()) {
+            warnln("strings: '{}'. {}", path, strerror(maybe_error.error().code()));
+            has_errors = true;
+        }
+    }
 
-    return 0;
+    return has_errors ? 1 : 0;
 }

--- a/Userland/Utilities/strings.cpp
+++ b/Userland/Utilities/strings.cpp
@@ -118,6 +118,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
             return true;
         } });
+    args_parser.add_option({ Core::ArgsParser::OptionArgumentMode::None,
+        "Equivalent to specifying -t o.",
+        nullptr,
+        'o',
+        nullptr,
+        [&string_offset_format](auto) {
+            string_offset_format = StringOffsetFormat::Octal;
+            return true;
+        } });
     args_parser.set_general_help("Write the sequences of printable characters in files or pipes to stdout.");
     args_parser.add_positional_argument(paths, "File path", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);


### PR DESCRIPTION
This PR makes the following changes to the `strings` utility:

* Add the `o` option: This is an alias for `-t o`, which prepend each string with an offset in octal.
* Add `--bytes` and `--radix` as aliases for `-n` and `-t` respectively.
* Replace `-p` option with `-f`: This prepends each string with the file name, rather than showing the file name before any strings.
* Continue if an error is encountered processing a file.

These changes make `strings` behave more like the implementation on Linux and FreeBSD.

Example usage:
![strings_tweaks](https://github.com/SerenityOS/serenity/assets/2817754/4ea9dab0-9416-428b-bf32-74b1691c4e68)