### PR TITLE
mkdir: Add `-v` option to print a message for each created directory

### DIFF
--- a/Base/usr/share/man/man1/mkdir.md
+++ b/Base/usr/share/man/man1/mkdir.md
@@ -17,6 +17,7 @@ Create a new empty directory for each of the given *directories*.
 * `-p`, `--parents`: Create parent directories if they don't exist
 * `-m`, `--mode`: Sets the permissions for the final directory (possibly altered by the process umask). The mode argument can be given in any of the formats
 accepted by the chmod(1) command. Addition and removal of permissions is relative to a default permission of 0777.
+* `-v`, `--verbose`: Print a message for each created directory
 
 ## Examples
 

--- a/Userland/Utilities/mkdir.cpp
+++ b/Userland/Utilities/mkdir.cpp
@@ -19,12 +19,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio cpath rpath"));
 
     bool create_parents = false;
+    bool verbose = false;
     StringView mode_string;
     Vector<StringView> directories;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(create_parents, "Create parent directories if they don't exist", "parents", 'p');
     args_parser.add_option(mode_string, "Set new directory permissions", "mode", 'm', "mode");
+    args_parser.add_option(verbose, "Print a message for each created directory", "verbose", 'v');
     args_parser.add_positional_argument(directories, "Directories to create", "directories");
     args_parser.parse(arguments);
 
@@ -41,14 +43,24 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     bool has_errors = false;
 
+    auto create_directory = [&](StringView path, mode_t mode) {
+        auto maybe_error = Core::System::mkdir(path, mode);
+        if (maybe_error.is_error()) {
+            warnln("mkdir: {}", strerror(maybe_error.error().code()));
+            has_errors = true;
+            return false;
+        }
+
+        if (verbose)
+            outln("mkdir: Created directory '{}'", path);
+
+        return true;
+    };
+
     for (auto& directory : directories) {
         LexicalPath lexical_path(directory);
         if (!create_parents) {
-            auto maybe_error = Core::System::mkdir(lexical_path.string(), mask.apply(mask_reference_mode));
-            if (maybe_error.is_error()) {
-                warnln("mkdir: {}", strerror(maybe_error.error().code()));
-                has_errors = true;
-            }
+            create_directory(lexical_path.string(), mask.apply(mask_reference_mode));
             continue;
         }
         StringBuilder path_builder;
@@ -75,12 +87,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 bool is_final = (idx == (num_parts - 1));
                 mode_t mode = is_final ? mask.apply(mask_reference_mode) : default_mode;
 
-                auto maybe_error = Core::System::mkdir(path, mode);
-                if (maybe_error.is_error()) {
-                    warnln("mkdir: {}", strerror(maybe_error.error().code()));
-                    has_errors = true;
+                if (!create_directory(path, mode))
                     break;
-                }
+
             } else {
                 if (!S_ISDIR(stat_or_error.value().st_mode)) {
                     warnln("mkdir: cannot create directory '{}': not a directory", path);

--- a/Userland/Utilities/mkdir.cpp
+++ b/Userland/Utilities/mkdir.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2020-2021, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021, Xavier Defrang <xavier.defrang@gmail.com>
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,17 +13,14 @@
 #include <LibCore/FilePermissionsMask.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
-#include <errno.h>
-#include <sys/stat.h>
-#include <unistd.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio cpath rpath"));
 
     bool create_parents = false;
-    DeprecatedString mode_string;
-    Vector<DeprecatedString> directories;
+    StringView mode_string;
+    Vector<StringView> directories;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(create_parents, "Create parent directories if they don't exist", "parents", 'p');
@@ -46,8 +44,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     for (auto& directory : directories) {
         LexicalPath lexical_path(directory);
         if (!create_parents) {
-            if (mkdir(lexical_path.string().characters(), mask.apply(mask_reference_mode)) < 0) {
-                perror("mkdir");
+            auto maybe_error = Core::System::mkdir(lexical_path.string(), mask.apply(mask_reference_mode));
+            if (maybe_error.is_error()) {
+                warnln("mkdir: {}", strerror(maybe_error.error().code()));
                 has_errors = true;
             }
             continue;
@@ -63,12 +62,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto& part = parts[idx];
 
             path_builder.append(part);
-            auto path = path_builder.to_deprecated_string();
+            auto path = path_builder.string_view();
 
-            struct stat st;
-            if (stat(path.characters(), &st) < 0) {
-                if (errno != ENOENT) {
-                    perror("stat");
+            auto stat_or_error = Core::System::stat(path);
+            if (stat_or_error.is_error()) {
+                if (stat_or_error.error().code() != ENOENT) {
+                    warnln("mkdir: {}", strerror(stat_or_error.error().code()));
                     has_errors = true;
                     break;
                 }
@@ -76,13 +75,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 bool is_final = (idx == (num_parts - 1));
                 mode_t mode = is_final ? mask.apply(mask_reference_mode) : default_mode;
 
-                if (mkdir(path.characters(), mode) < 0) {
-                    perror("mkdir");
+                auto maybe_error = Core::System::mkdir(path, mode);
+                if (maybe_error.is_error()) {
+                    warnln("mkdir: {}", strerror(maybe_error.error().code()));
                     has_errors = true;
                     break;
                 }
             } else {
-                if (!S_ISDIR(st.st_mode)) {
+                if (!S_ISDIR(stat_or_error.value().st_mode)) {
                     warnln("mkdir: cannot create directory '{}': not a directory", path);
                     has_errors = true;
                     break;


### PR DESCRIPTION
Example usage:
![mkdir_verbose](https://github.com/SerenityOS/serenity/assets/2817754/87f27d90-fcd1-465a-b8fa-b61a5e927949)

