### PR TITLE
WebServer: Show the correct port when using port 0

### DIFF
--- a/Userland/Services/WebServer/main.cpp
+++ b/Userland/Services/WebServer/main.cpp
@@ -96,8 +96,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(server->listen(ipv4_address.value(), port));
 
     out("Listening on ");
-    out("\033]8;;http://{}:{}\033\\", ipv4_address.value(), port);
-    out("{}:{}", ipv4_address.value(), port);
+    out("\033]8;;http://{}:{}\033\\", ipv4_address.value(), server->local_port());
+    out("{}:{}", ipv4_address.value(), server->local_port());
     outln("\033]8;;\033\\");
 
     TRY(Core::System::unveil("/etc/timezone", "r"));


### PR DESCRIPTION
Specifying port 0 on the command line causes WebServer to select a random available port. We now show the port WebServer is actually using rather than assuming it is the same as the command line argument.

Example:

https://github.com/SerenityOS/serenity/assets/2817754/4dc2edef-aba3-4ede-b071-54c3e4173711


