### PR TITLE
LibWeb: Resolve padding against 0 and not inf for indefinite width more

### DIFF
--- a/Tests/LibWeb/Layout/expected/floating-non-replaced-element-percentage-padding-against-indefinite-width.txt
+++ b/Tests/LibWeb/Layout/expected/floating-non-replaced-element-percentage-padding-against-indefinite-width.txt
@@ -1,0 +1,6 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      Box <div#box1> at (8,8) content-size 784x0 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (8,8) content-size 0x0 flex-item [BFC] children: not-inline
+          Box <div#box2> at (8,8) content-size 0x0 floating flex-container(row) [FFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/floating-replaced-element-percentage-padding-against-indefinite-width.txt
+++ b/Tests/LibWeb/Layout/expected/floating-replaced-element-percentage-padding-against-indefinite-width.txt
@@ -1,0 +1,6 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x80 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x64 children: not-inline
+      Box <div#box1> at (8,8) content-size 784x64 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (8,8) content-size 16x64 flex-item [BFC] children: not-inline
+          ImageBox <img#box2> at (24,24) content-size 16x32 floating flex-container(row) children: not-inline

--- a/Tests/LibWeb/Layout/expected/non-floating-non-replaced-element-percentage-padding-against-indefinite-width.txt
+++ b/Tests/LibWeb/Layout/expected/non-floating-non-replaced-element-percentage-padding-against-indefinite-width.txt
@@ -1,0 +1,6 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      Box <div#box1> at (8,8) content-size 784x0 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (8,8) content-size 0x0 flex-item [BFC] children: not-inline
+          Box <div#box2> at (8,8) content-size 0x0 flex-container(row) [FFC] children: not-inline

--- a/Tests/LibWeb/Layout/input/floating-non-replaced-element-percentage-padding-against-indefinite-width.html
+++ b/Tests/LibWeb/Layout/input/floating-non-replaced-element-percentage-padding-against-indefinite-width.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html><html><head><style>
+#box1 {
+  display: flex;
+}
+
+#box2 {
+  display: flex;
+  padding: 100%;
+  float: left;
+}
+</style></head><body><div id="box1"><div><div id="box2">

--- a/Tests/LibWeb/Layout/input/floating-replaced-element-percentage-padding-against-indefinite-width.html
+++ b/Tests/LibWeb/Layout/input/floating-replaced-element-percentage-padding-against-indefinite-width.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html><html><head><style>
+#box1 {
+  display: flex;
+}
+
+#box2 {
+  display: flex;
+  padding: 100%;
+  float: left;
+}
+</style></head><body><div id="box1"><div><img id="box2"/>

--- a/Tests/LibWeb/Layout/input/non-floating-non-replaced-element-percentage-padding-against-indefinite-width.html
+++ b/Tests/LibWeb/Layout/input/non-floating-non-replaced-element-percentage-padding-against-indefinite-width.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html><html><head><style>
+#box1 {
+  display: flex;
+}
+
+#box2 {
+  display: flex;
+  padding: 100%;
+}
+</style></head><body><div id="box1"><div><div id="box2">

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -164,8 +164,8 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     auto margin_left = CSS::Length::make_auto();
     auto margin_right = CSS::Length::make_auto();
-    auto const padding_left = computed_values.padding().left().to_px(box, width_of_containing_block);
-    auto const padding_right = computed_values.padding().right().to_px(box, width_of_containing_block);
+    auto const padding_left = computed_values.padding().left().resolved(box, width_of_containing_block_as_length_for_resolve).to_px(box);
+    auto const padding_right = computed_values.padding().right().resolved(box, width_of_containing_block_as_length_for_resolve).to_px(box);
 
     auto& box_state = m_state.get_mutable(box);
     box_state.border_left = computed_values.border_left().width;
@@ -291,8 +291,8 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
 
     auto margin_left = computed_values.margin().left().resolved(box, width_of_containing_block_as_length_for_resolve);
     auto margin_right = computed_values.margin().right().resolved(box, width_of_containing_block_as_length_for_resolve);
-    auto const padding_left = computed_values.padding().left().to_px(box, width_of_containing_block);
-    auto const padding_right = computed_values.padding().right().to_px(box, width_of_containing_block);
+    auto const padding_left = computed_values.padding().left().resolved(box, width_of_containing_block_as_length_for_resolve).to_px(box);
+    auto const padding_right = computed_values.padding().right().resolved(box, width_of_containing_block_as_length_for_resolve).to_px(box);
 
     // If 'margin-left', or 'margin-right' are computed as 'auto', their used value is '0'.
     if (margin_left.is_auto())
@@ -371,8 +371,8 @@ void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_n
     // non-replaced block-level elements are applied to determine the margins.
     auto margin_left = computed_values.margin().left().resolved(box, width_of_containing_block_as_length_for_resolve);
     auto margin_right = computed_values.margin().right().resolved(box, width_of_containing_block_as_length_for_resolve);
-    auto const padding_left = computed_values.padding().left().to_px(box, width_of_containing_block);
-    auto const padding_right = computed_values.padding().right().to_px(box, width_of_containing_block);
+    auto const padding_left = computed_values.padding().left().resolved(box, width_of_containing_block_as_length_for_resolve).to_px(box);
+    auto const padding_right = computed_values.padding().right().resolved(box, width_of_containing_block_as_length_for_resolve).to_px(box);
 
     // If 'margin-left', or 'margin-right' are computed as 'auto', their used value is '0'.
     if (margin_left.is_auto())


### PR DESCRIPTION
In particular, in BFC:
- Non-floating, non-replaced elements
- Floating, non-replaced elements
- Floating, replaced elements

The first two regressed in https://github.com/SerenityOS/serenity/commit/1d76126abe9dd65251bd28a381350f70083b50f7

The third one seems to have been introduced by this regression, as it was seemingly copied from compute_width_for_floating_box in https://github.com/SerenityOS/serenity/commit/7f9ede07bcf287a2b16ff29c1ebbcf64c47a221f