### PR TITLE
LibWeb: Add undistributable space to GRID{MIN, MAX} instead of content

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
@@ -2,11 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x124 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x106 children: not-inline
       TableWrapper <(anonymous)> at (10,10) content-size 106x106 [BFC] children: not-inline
-        Box <table> at (11,11) content-size 106x104 table-box [TFC] children: not-inline
-          Box <tbody> at (11,11) content-size 102x100 table-row-group children: not-inline
-            Box <tr> at (13,13) content-size 102x100 table-row children: not-inline
-              BlockContainer <td> at (15,51.082031) content-size 98x23.835937 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (16,52.082031) content-size 96x21.835937 children: inline
+        Box <table> at (11,11) content-size 104x104 table-box [TFC] children: not-inline
+          Box <tbody> at (11,11) content-size 100x100 table-row-group children: not-inline
+            Box <tr> at (13,13) content-size 100x100 table-row children: not-inline
+              BlockContainer <td> at (15,51.082031) content-size 96x23.835937 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (16,52.082031) content-size 94x21.835937 children: inline
                   line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
                     frag 0 from TextNode start: 0, length: 0, rect: [16,52.082031 0x21.835937]
                       ""

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
@@ -1,0 +1,36 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: inline
+      BlockContainer <div.left> at (8,8) content-size 117.599999x17.46875 floating [BFC] children: inline
+        line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17.46875]
+            "A"
+        TextNode <#text>
+      TextNode <#text>
+      TableWrapper <(anonymous)> at (125.599999,8) content-size 478.24x23.46875 floating [BFC] children: not-inline
+        Box <table.middle> at (125.599999,8) content-size 478.24x23.46875 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (125.599999,8) content-size 474.24x19.46875 table-row-group children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (127.599999,10) content-size 474.24x19.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (128.599999,11) content-size 472.24x17.46875 table-cell [BFC] children: inline
+                line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [128.599999,11 9.34375x17.46875]
+                    "B"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+      TextNode <#text>
+      BlockContainer <div.right> at (8,32) content-size 188.159999x17.46875 floating [BFC] children: inline
+        line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 1, length: 1, rect: [8,32 10.3125x17.46875]
+            "C"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
@@ -1,15 +1,15 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x96.21875 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 784x96.21875 [BFC] children: not-inline
-        Box <table.ambox> at (9,9) content-size 788x94.21875 table-box [TFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x113.15625 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 782x113.15625 [BFC] children: not-inline
+        Box <table.ambox> at (9,9) content-size 780x111.15625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 782x90.21875 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 782x90.21875 table-row children: not-inline
-              BlockContainer <td.mbox-image> at (12,31.109375) content-size 50x50 table-cell [BFC] children: not-inline
-                BlockContainer <div.mbox-image-div> at (12,31.109375) content-size 50x50 children: not-inline
-              BlockContainer <td.mbox-text> at (66,12) content-size 728x88.21875 table-cell [BFC] children: inline
+          Box <tbody> at (9,9) content-size 774x107.15625 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 774x107.15625 table-row children: not-inline
+              BlockContainer <td.mbox-image> at (12,39.578125) content-size 50x50 table-cell [BFC] children: not-inline
+                BlockContainer <div.mbox-image-div> at (12,39.578125) content-size 50x50 children: not-inline
+              BlockContainer <td.mbox-text> at (66,12) content-size 720x105.15625 table-cell [BFC] children: inline
                 line 0 width: 689.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 1, length: 84, rect: [66,12 689.640625x17.46875]
                     "In a scene set in a lawyer's office, the lawyer sits alone and bounces a rubber ball"
@@ -22,7 +22,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 line 3 width: 695.90625, height: 17.875, bottom: 70.28125, baseline: 13.53125
                   frag 0 from TextNode start: 257, length: 81, rect: [66,64 695.90625x17.46875]
                     "some papers from a large envelope, which turn out to be divorce papers from their"
-                line 4 width: 725.734375, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-                  frag 0 from TextNode start: 339, length: 92, rect: [66,81 725.734375x17.46875]
-                    "significant other. Finally, the lawyer instructs their assistant to send in the next client."
+                line 4 width: 670.515625, height: 18.34375, bottom: 88.21875, baseline: 13.53125
+                  frag 0 from TextNode start: 339, length: 84, rect: [66,81 670.515625x17.46875]
+                    "significant other. Finally, the lawyer instructs their assistant to send in the next"
+                line 5 width: 47.21875, height: 17.8125, bottom: 105.15625, baseline: 13.53125
+                  frag 0 from TextNode start: 424, length: 7, rect: [66,99 47.21875x17.46875]
+                    "client."
                 TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
@@ -1,38 +1,41 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x127.8125 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x146.21875 [BFC] children: not-inline
     BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
       TextNode <#text>
-    BlockContainer <body> at (8,8) content-size 784x111.8125 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 61.046875x111.8125 [BFC] children: not-inline
-        Box <table#full-table> at (10,43.40625) content-size 61.046875x72.40625 table-box [TFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x130.21875 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 55.046875x130.21875 [BFC] children: not-inline
+        Box <table#full-table> at (10,61.8125) content-size 55.046875x72.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          BlockContainer <caption> at (8,8) content-size 59.046875x35.40625 [BFC] children: inline
-            line 0 width: 54.03125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-              frag 0 from TextNode start: 1, length: 6, rect: [10,8 54.03125x17.46875]
-                "A long"
-            line 1 width: 59.046875, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-              frag 0 from TextNode start: 8, length: 7, rect: [8,25 59.046875x17.46875]
+          BlockContainer <caption> at (8,8) content-size 59.046875x53.8125 [BFC] children: inline
+            line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 1, length: 1, rect: [22,8 14.265625x17.46875]
+                "A"
+            line 1 width: 31.765625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+              frag 0 from TextNode start: 3, length: 4, rect: [14,25 31.765625x17.46875]
+                "long"
+            line 2 width: 59.046875, height: 18.40625, bottom: 53.34375, baseline: 13.53125
+              frag 0 from TextNode start: 8, length: 7, rect: [8,42 59.046875x17.46875]
                 "caption"
             TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <thead> at (10,10) content-size 55.046875x21.46875 table-header-group children: not-inline
+          Box <thead> at (10,10) content-size 51.6875x21.46875 table-header-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (12,45.40625) content-size 55.046875x21.46875 table-row children: not-inline
+            Box <tr> at (12,63.8125) content-size 51.6875x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (14,47.40625) content-size 22.208835x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (14,65.8125) content-size 20.609375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 20.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [14,47.40625 20.609375x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [14,65.8125 20.609375x17.46875]
                     "A1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (42.208835,47.40625) content-size 24.838039x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (40.609375,65.8125) content-size 23.078125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 23.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [42.208835,47.40625 23.078125x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [40.609375,65.8125 23.078125x17.46875]
                     "A2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -41,22 +44,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (10,31.46875) content-size 55.046875x21.46875 table-row-group children: not-inline
+          Box <tbody> at (10,31.46875) content-size 51.6875x21.46875 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (12,66.875) content-size 55.046875x21.46875 table-row children: not-inline
+            Box <tr> at (12,85.28125) content-size 51.6875x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (14,70.875) content-size 22.208835x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (14,89.28125) content-size 20.609375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 15.6875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [14,70.875 15.6875x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [14,89.28125 15.6875x17.46875]
                     "B1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (42.208835,70.875) content-size 24.838039x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (40.609375,89.28125) content-size 23.078125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 18.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [42.208835,70.875 18.15625x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [40.609375,89.28125 18.15625x17.46875]
                     "B2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -65,22 +68,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tfoot> at (10,52.9375) content-size 55.046875x21.46875 table-footer-group children: not-inline
+          Box <tfoot> at (10,52.9375) content-size 51.6875x21.46875 table-footer-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (12,88.34375) content-size 55.046875x21.46875 table-row children: not-inline
+            Box <tr> at (12,106.75) content-size 51.6875x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (14,94.34375) content-size 22.208835x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (14,112.75) content-size 20.609375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 18.890625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [14,94.34375 18.890625x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [14,112.75 18.890625x17.46875]
                     "F1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (42.208835,94.34375) content-size 24.838039x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (40.609375,112.75) content-size 23.078125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 21.359375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [42.208835,94.34375 21.359375x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [40.609375,112.75 21.359375x17.46875]
                     "F2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -89,5 +92,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-      BlockContainer <(anonymous)> at (8,119.8125) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,138.21875) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-width.txt
@@ -1,8 +1,8 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x214 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 588x214 [BFC] children: not-inline
-        Box <table.table> at (108,108) content-size 588x14 table-box [TFC] children: not-inline
-          Box <tbody> at (108,108) content-size 584x10 table-row-group children: not-inline
-            Box <tr> at (110,110) content-size 584x10 table-row children: not-inline
-              BlockContainer <td.cell> at (111,115) content-size 582x0 table-cell [BFC] children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 584x214 [BFC] children: not-inline
+        Box <table.table> at (108,108) content-size 584x14 table-box [TFC] children: not-inline
+          Box <tbody> at (108,108) content-size 580x10 table-row-group children: not-inline
+            Box <tr> at (110,110) content-size 580x10 table-row children: not-inline
+              BlockContainer <td.cell> at (111,115) content-size 578x0 table-cell [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/input/table/border-spacing-with-percentage-width.html
+++ b/Tests/LibWeb/Layout/input/table/border-spacing-with-percentage-width.html
@@ -1,0 +1,31 @@
+<style>
+    .left,
+    .right {
+        float: left;
+    }
+
+    .left {
+        width: 15%;
+    }
+
+    .middle {
+        float: left;
+        width: 61%;
+        border-spacing: 2px;
+    }
+
+    .right {
+        width: 24%
+    }
+</style>
+<div class="left">A</div>
+<table class="middle">
+    <tbody>
+        <tr>
+            <td>B</td>
+        </tr>
+    </tbody>
+</table>
+<div class="right">
+    C
+</div>

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -332,12 +332,16 @@ void TableFormattingContext::compute_table_width()
     // not the table wrapper box itself.
     CSSPixels width_of_table_wrapper_containing_block = m_state.get(*table_wrapper().containing_block()).content_width();
 
+    // Compute undistributable space due to border spacing: https://www.w3.org/TR/css-tables-3/#computing-undistributable-space.
+    auto undistributable_space = (m_columns.size() + 1) * border_spacing_horizontal();
+
     // The row/column-grid width minimum (GRIDMIN) width is the sum of the min-content width
     // of all the columns plus cell spacing or borders.
     CSSPixels grid_min = 0.0f;
     for (auto& column : m_columns) {
         grid_min += column.min_size;
     }
+    grid_min += undistributable_space;
 
     // The row/column-grid width maximum (GRIDMAX) width is the sum of the max-content width
     // of all the columns plus cell spacing or borders.
@@ -345,6 +349,7 @@ void TableFormattingContext::compute_table_width()
     for (auto& column : m_columns) {
         grid_max += column.max_size;
     }
+    grid_max += undistributable_space;
 
     // The used min-width of a table is the greater of the resolved min-width, CAPMIN, and GRIDMIN.
     auto used_min_width = max(grid_min, compute_capmin());
@@ -367,9 +372,7 @@ void TableFormattingContext::compute_table_width()
             used_width = min(used_width, computed_values.max_width().to_px(table_box(), width_of_table_wrapper_containing_block));
     }
 
-    // Compute undistributable space due to border spacing: https://www.w3.org/TR/css-tables-3/#computing-undistributable-space.
-    auto undistributable_space = (m_columns.size() + 1) * border_spacing_horizontal();
-    table_box_state.set_content_width(used_width - table_box_state.border_left - table_box_state.border_right + undistributable_space);
+    table_box_state.set_content_width(used_width - table_box_state.border_left - table_box_state.border_right);
 }
 
 void TableFormattingContext::distribute_width_to_columns()


### PR DESCRIPTION
Adding undistributable space right before setting the content width is incorrect when it's a percentage. Follow the specification and add it to GRIDMIN and GRIDMAX instead.