### PR TITLE
diff+headless-browser+LibDiff: Extract out a common hunk normal diff print function

### DIFF
--- a/Userland/Libraries/LibDiff/Format.cpp
+++ b/Userland/Libraries/LibDiff/Format.cpp
@@ -1,11 +1,14 @@
 /*
  * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@serenityos.org>
+ * Copyright (c) 2023, Shannon Booth <shannon.ml.booth@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "Format.h"
 #include <AK/DeprecatedString.h>
+#include <AK/Stream.h>
 #include <AK/StringBuilder.h>
 #include <AK/Vector.h>
 
@@ -20,4 +23,53 @@ DeprecatedString generate_only_additions(StringView text)
     }
     return builder.to_deprecated_string();
 }
-};
+
+ErrorOr<void> write_normal(Hunk const& hunk, Stream& stream, ColorOutput color_output)
+{
+    auto original_start = hunk.original_start_line;
+    auto target_start = hunk.target_start_line;
+    auto num_added = hunk.added_lines.size();
+    auto num_removed = hunk.removed_lines.size();
+
+    // Source line(s)
+    TRY(stream.write_formatted("{}", original_start));
+
+    if (num_removed > 1)
+        TRY(stream.write_formatted(",{}", original_start + num_removed - 1));
+
+    // Action
+    if (num_added > 0 && num_removed > 0)
+        TRY(stream.write_formatted("c"));
+    else if (num_added > 0)
+        TRY(stream.write_formatted("a"));
+    else
+        TRY(stream.write_formatted("d"));
+
+    // Target line(s)
+    TRY(stream.write_formatted("{}", target_start));
+    if (num_added > 1)
+        TRY(stream.write_formatted(",{}", target_start + num_added - 1));
+
+    TRY(stream.write_formatted("\n"));
+
+    for (auto const& line : hunk.removed_lines) {
+        if (color_output == ColorOutput::Yes)
+            TRY(stream.write_formatted("\033[31;1m< {}\033[0m\n", line));
+        else
+            TRY(stream.write_formatted("< {}\n", line));
+    }
+
+    if (num_added > 0 && num_removed > 0)
+        TRY(stream.write_formatted("---\n"));
+
+    for (auto const& line : hunk.added_lines) {
+        if (color_output == ColorOutput::Yes)
+            TRY(stream.write_formatted("\033[32;1m> {}\033[0m\n", line));
+        else
+            TRY(stream.write_formatted("> {}\n", line));
+    }
+
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibDiff/Format.h
+++ b/Userland/Libraries/LibDiff/Format.h
@@ -1,13 +1,25 @@
 /*
  * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
+ * Copyright (c) 2023, Shannon Booth <shannon.ml.booth@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/Error.h>
+#include <AK/Forward.h>
+#include <LibDiff/Hunks.h>
 
 namespace Diff {
+
 DeprecatedString generate_only_additions(StringView);
+
+enum class ColorOutput {
+    Yes,
+    No,
 };
+
+ErrorOr<void> write_normal(Hunk const& hunk, Stream& stream, ColorOutput color_output = ColorOutput::No);
+
+}

--- a/Userland/Utilities/diff.cpp
+++ b/Userland/Utilities/diff.cpp
@@ -54,7 +54,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         if (num_added > 1)
             sb.appendff(",{}", target_start + num_added - 1);
 
-        outln("Hunk: {}", sb.to_deprecated_string());
+        outln("{}", sb.to_deprecated_string());
         for (auto const& line : hunk.removed_lines) {
             if (color_output)
                 outln("\033[31;1m< {}\033[0m", line);


### PR DESCRIPTION
Apart from reducing duplication, this should also make it easier in the future to change what the underlying representation of a hunk is.