### PR TITLE
LibWeb: Do not crash inside SVGDecodedImageData on invalid SVG input

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/svg-as-image-invalid.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-as-image-invalid.txt
@@ -1,0 +1,4 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x48 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x32 children: not-inline
+      ImageBox <img> at (8,8) content-size 16x32 children: not-inline

--- a/Tests/LibWeb/Layout/input/svg/svg-as-image-invalid.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-as-image-invalid.html
@@ -1,0 +1,1 @@
+<!doctype html><img src="data:image/svg+xml;,some-garbage" style="display: block">

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -70,6 +70,9 @@ ErrorOr<NonnullRefPtr<SVGDecodedImageData>> SVGDecodedImageData::create(Page& ho
     // Perform some DOM surgery to make the SVG root element be the first child of the Document.
     // FIXME: This is a huge hack until we figure out how to actually parse separate SVG files.
     auto* svg_root = document->body()->first_child_of_type<SVG::SVGSVGElement>();
+    if (!svg_root)
+        return Error::from_string_literal("SVGDecodedImageData: Invalid SVG input");
+
     svg_root->remove();
     document->remove_all_children();
 


### PR DESCRIPTION
Return error when input svg is not valid and SVGSVGElement is not present in the tree instead of doing svg_root nullptr dereference.

Fixes crash on https://apps.kde.org/en-gb/