### PR TITLE
LibWeb: Modernize handling of the CSS flex-basis property

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -23,6 +23,9 @@
 
 namespace Web::CSS {
 
+struct FlexBasisContent { };
+using FlexBasis = Variant<FlexBasisContent, Size>;
+
 struct AspectRatio {
     bool use_natural_aspect_ratio_if_available;
     Optional<Ratio> preferred_ratio;
@@ -59,6 +62,7 @@ public:
     static CSS::Visibility visibility() { return CSS::Visibility::Visible; }
     static CSS::FlexDirection flex_direction() { return CSS::FlexDirection::Row; }
     static CSS::FlexWrap flex_wrap() { return CSS::FlexWrap::Nowrap; }
+    static CSS::FlexBasis flex_basis() { return CSS::Size::make_auto(); }
     static CSS::ImageRendering image_rendering() { return CSS::ImageRendering::Auto; }
     static CSS::JustifyContent justify_content() { return CSS::JustifyContent::FlexStart; }
     static CSS::AlignContent align_content() { return CSS::AlignContent::Stretch; }
@@ -164,17 +168,6 @@ struct TransformOrigin {
     CSS::LengthPercentage y { Percentage(50) };
 };
 
-enum class FlexBasis {
-    Content,
-    LengthPercentage,
-    Auto,
-};
-
-struct FlexBasisData {
-    CSS::FlexBasis type { CSS::FlexBasis::Auto };
-    Optional<CSS::LengthPercentage> length_percentage;
-};
-
 struct ShadowData {
     Color color {};
     CSS::Length offset_x { Length::make_px(0) };
@@ -246,7 +239,7 @@ public:
     CSS::WhiteSpace white_space() const { return m_inherited.white_space; }
     CSS::FlexDirection flex_direction() const { return m_noninherited.flex_direction; }
     CSS::FlexWrap flex_wrap() const { return m_noninherited.flex_wrap; }
-    FlexBasisData const& flex_basis() const { return m_noninherited.flex_basis; }
+    FlexBasis const& flex_basis() const { return m_noninherited.flex_basis; }
     float flex_grow() const { return m_noninherited.flex_grow; }
     float flex_shrink() const { return m_noninherited.flex_shrink; }
     int order() const { return m_noninherited.order; }
@@ -398,7 +391,7 @@ protected:
         Vector<BackgroundLayerData> background_layers;
         CSS::FlexDirection flex_direction { InitialValues::flex_direction() };
         CSS::FlexWrap flex_wrap { InitialValues::flex_wrap() };
-        CSS::FlexBasisData flex_basis {};
+        CSS::FlexBasis flex_basis { InitialValues::flex_basis() };
         float flex_grow { InitialValues::flex_grow() };
         float flex_shrink { InitialValues::flex_shrink() };
         int order { InitialValues::order() };
@@ -492,7 +485,7 @@ public:
     BorderData& border_bottom() { return m_noninherited.border_bottom; }
     void set_flex_direction(CSS::FlexDirection value) { m_noninherited.flex_direction = value; }
     void set_flex_wrap(CSS::FlexWrap value) { m_noninherited.flex_wrap = value; }
-    void set_flex_basis(FlexBasisData value) { m_noninherited.flex_basis = move(value); }
+    void set_flex_basis(FlexBasis value) { m_noninherited.flex_basis = move(value); }
     void set_flex_grow(float value) { m_noninherited.flex_grow = value; }
     void set_flex_shrink(float value) { m_noninherited.flex_shrink = value; }
     void set_order(int value) { m_noninherited.order = value; }

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -559,18 +559,14 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         return NumberStyleValue::create(layout_node.computed_values().fill_opacity());
     case PropertyID::FillRule:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().fill_rule()));
-    case PropertyID::FlexBasis: {
-        switch (layout_node.computed_values().flex_basis().type) {
-        case FlexBasis::Content:
-            return IdentifierStyleValue::create(ValueID::Content);
-        case FlexBasis::LengthPercentage:
-            return style_value_for_length_percentage(*layout_node.computed_values().flex_basis().length_percentage);
-        case FlexBasis::Auto:
-            return IdentifierStyleValue::create(ValueID::Auto);
-        default:
-            VERIFY_NOT_REACHED();
-        }
-        break;
+    case PropertyID::FlexBasis:
+        return layout_node.computed_values().flex_basis().visit(
+            [](CSS::FlexBasisContent const&) -> ErrorOr<RefPtr<StyleValue const>> {
+                return IdentifierStyleValue::create(ValueID::Content);
+            },
+            [&](CSS::Size const& size) -> ErrorOr<RefPtr<StyleValue const>> {
+                return style_value_for_size(size);
+            });
     case PropertyID::FlexDirection:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_direction()));
     case PropertyID::FlexGrow:
@@ -837,7 +833,6 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     default:
         dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Computed style for the '{}' property was requested", string_from_property_id(property_id));
         return nullptr;
-    }
     }
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -327,26 +327,14 @@ Optional<CSS::FlexWrap> StyleProperties::flex_wrap() const
     return value_id_to_flex_wrap(value->to_identifier());
 }
 
-Optional<CSS::FlexBasisData> StyleProperties::flex_basis() const
+Optional<CSS::FlexBasis> StyleProperties::flex_basis() const
 {
     auto value = property(CSS::PropertyID::FlexBasis);
 
     if (value->is_identifier() && value->to_identifier() == CSS::ValueID::Content)
-        return { { CSS::FlexBasis::Content, {} } };
+        return CSS::FlexBasisContent {};
 
-    if (value->has_auto())
-        return { { CSS::FlexBasis::Auto, {} } };
-
-    if (value->is_percentage())
-        return { { CSS::FlexBasis::LengthPercentage, value->as_percentage().percentage() } };
-
-    if (value->is_length())
-        return { { CSS::FlexBasis::LengthPercentage, value->as_length().length() } };
-
-    if (value->is_calculated())
-        return { { CSS::FlexBasis::LengthPercentage, CSS::LengthPercentage { value->as_calculated() } } };
-
-    return {};
+    return size_value(CSS::PropertyID::FlexBasis);
 }
 
 float StyleProperties::flex_grow() const

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -69,7 +69,7 @@ public:
     Optional<CSS::ListStylePosition> list_style_position() const;
     Optional<CSS::FlexDirection> flex_direction() const;
     Optional<CSS::FlexWrap> flex_wrap() const;
-    Optional<CSS::FlexBasisData> flex_basis() const;
+    Optional<CSS::FlexBasis> flex_basis() const;
     float flex_grow() const;
     float flex_shrink() const;
     int order() const;

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -53,7 +53,7 @@ private:
 
     struct FlexItem {
         JS::NonnullGCPtr<Box> box;
-        CSS::FlexBasisData used_flex_basis {};
+        Optional<CSS::FlexBasis> used_flex_basis {};
         bool used_flex_basis_is_definite { false };
         CSSPixels flex_base_size { 0 };
         CSSPixels hypothetical_main_size { 0 };
@@ -214,7 +214,7 @@ private:
 
     virtual void parent_context_did_dimension_child_root_box() override;
 
-    CSS::FlexBasisData used_flex_basis_for_item(FlexItem const&) const;
+    CSS::FlexBasis used_flex_basis_for_item(FlexItem const&) const;
 
     LayoutState::UsedValues& m_flex_container_state;
 


### PR DESCRIPTION
Instead of a custom struct, use an AK::Variant for flex-basis. A flex-basis is either `content` or a CSS size value, so we don't need anything custom for that.

By using a CSS size, we also avoid having to convert in and out of size in various places, simplifying the code.

This finally gets rid of the "Unsupported main size for flex-basis" debug spam. :^)