### PR TITLE
pro: Ensure that progress reporting intervals are respected

### DIFF
--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -235,7 +235,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     u64 previous_downloaded_size = 0;
     u64 current_bytes_per_second_speed = 0;
     u32 const report_time_in_ms = 100;
-    u32 const speed_update_time_in_ms = 4000;
+    u32 const speed_update_time_in_ms = 1000;
 
     auto previous_report_time = MonotonicTime::now();
     auto previous_speed_update_time = previous_report_time;


### PR DESCRIPTION
The `report_time_in_ms` and `speed_update_time_in_ms` variables
weren't previously being respected. This was causing the progress
display to update too frequently, making it difficult to read.

The download speed reporting interval has also been reduced from 4000ms to 1000ms.

NB: The downloads in the videos below are a bit stuttery. This is caused by socket receive buffer filling up, writing the output to `/tmp` makes this issue slightly less apparent, but it definitely needs further investigation.

Before:

https://github.com/SerenityOS/serenity/assets/2817754/fe092d8e-1ac8-4111-9ef8-862e6b31e32b

After:

https://github.com/SerenityOS/serenity/assets/2817754/40ed04f5-08b8-4e3f-ae05-94f3065cc86a


