### PR TITLE
Kernel: Add new integer variable type to SysFS

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -203,6 +203,7 @@ set(KERNEL_SOURCES
     FileSystem/SysFS/Subsystems/Kernel/Variables/CoredumpDirectory.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/Directory.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/DumpKmallocStack.cpp
+    FileSystem/SysFS/Subsystems/Kernel/Variables/IntegerVariable.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/StringVariable.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/UBSANDeadly.cpp
     FileSystem/VirtualFileSystem.cpp

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/IntegerVariable.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/IntegerVariable.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, Mark Douglas <dmarkd@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/IntegerVariable.h>
+#include <Kernel/Sections.h>
+#include <Kernel/Tasks/Process.h>
+
+namespace Kernel {
+
+ErrorOr<void> SysFSSystemIntegerVariable::try_generate(KBufferBuilder& builder)
+{
+    return builder.appendff("{}\n", value());
+}
+
+ErrorOr<size_t> SysFSSystemIntegerVariable::write_bytes(off_t, size_t count, UserOrKernelBuffer const& buffer, OpenFileDescription*)
+{
+    MutexLocker locker(m_refresh_lock);
+    // Note: We do all of this code before taking the spinlock because then we disable
+    // interrupts so page faults will not work.
+
+    char* value = nullptr;
+    i32 result = 0;
+    i32 sign = 1;
+    auto new_value = TRY(KString::try_create_uninitialized(count, value));
+    TRY(buffer.read(value, count));
+
+    if (*value == '-') {
+        sign = -1;
+        value++;
+    }
+
+    while (*value != '\0') {
+        if (*value >= '0' && *value <= '9') {
+            result = result * 10 + (*value - '0');
+        } else {
+            break;
+        }
+        value++;
+    }
+
+    result *= sign;
+
+    // NOTE: If we are in a jail, don't let the current process to change the variable.
+    if (Process::current().is_currently_in_jail())
+        return Error::from_errno(EPERM);
+    dbgln("Setting value: {}", result);
+    set_value(result);
+    return count;
+}
+
+ErrorOr<void> SysFSSystemIntegerVariable::truncate(u64 size)
+{
+    if (size != 0)
+        return EPERM;
+    return {};
+}
+
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/IntegerVariable.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/IntegerVariable.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, Mark Douglas <dmarkd@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/AtomicRefCounted.h>
+#include <AK/Error.h>
+#include <AK/Function.h>
+#include <AK/RefPtr.h>
+#include <AK/Types.h>
+#include <Kernel/FileSystem/File.h>
+#include <Kernel/FileSystem/FileSystem.h>
+#include <Kernel/FileSystem/OpenFileDescription.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
+#include <Kernel/Library/KBufferBuilder.h>
+#include <Kernel/Library/UserOrKernelBuffer.h>
+#include <Kernel/Locking/Mutex.h>
+#include <Kernel/Time/TimeManagement.h>
+
+namespace Kernel {
+
+class SysFSSystemIntegerVariable : public SysFSGlobalInformation {
+protected:
+    explicit SysFSSystemIntegerVariable(SysFSDirectory const& parent_directory)
+        : SysFSGlobalInformation(parent_directory)
+    {
+    }
+    virtual i32 value() const = 0;
+    virtual void set_value(i32 new_value) = 0;
+
+private:
+    // ^SysFSGlobalInformation
+    virtual ErrorOr<void> try_generate(KBufferBuilder&) override final;
+
+    // ^SysFSExposedComponent
+    virtual ErrorOr<size_t> write_bytes(off_t, size_t, UserOrKernelBuffer const&, OpenFileDescription*) override final;
+    virtual mode_t permissions() const override final { return 0644; }
+    virtual ErrorOr<void> truncate(u64) override final;
+};
+
+}


### PR DESCRIPTION
This change adds an integer variable type to SysFS in preparation for allowing certain features to be configured live, such as network TTL.