### PR TITLE
WindowServer+LibGUI: Remove rendundant global opacity facilities from Window and WindowFrame

### DIFF
--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -159,7 +159,6 @@ void Window::show()
         m_fullscreen,
         m_frameless,
         m_forced_shadow,
-        m_opacity_when_windowless,
         m_alpha_hit_threshold,
         m_base_size,
         m_size_increment,
@@ -893,14 +892,6 @@ void Window::set_double_buffering_enabled(bool value)
 {
     VERIFY(!is_visible());
     m_double_buffering_enabled = value;
-}
-
-void Window::set_opacity(float opacity)
-{
-    m_opacity_when_windowless = opacity;
-    if (!is_visible())
-        return;
-    ConnectionToWindowServer::the().async_set_window_opacity(m_window_id, opacity);
 }
 
 void Window::set_alpha_hit_threshold(float threshold)

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -75,8 +75,6 @@ public:
     void set_double_buffering_enabled(bool);
     void set_has_alpha_channel(bool);
     bool has_alpha_channel() const { return m_has_alpha_channel; }
-    void set_opacity(float);
-    float opacity() const { return m_opacity_when_windowless; }
 
     void set_alpha_hit_threshold(float);
     float alpha_hit_threshold() const { return m_alpha_hit_threshold; }
@@ -291,7 +289,6 @@ private:
 
     RefPtr<Gfx::Bitmap const> m_icon;
     int m_window_id { 0 };
-    float m_opacity_when_windowless { 1.0f };
     float m_alpha_hit_threshold { 0.0f };
     RefPtr<Widget> m_main_widget;
     WeakPtr<Widget> m_default_return_key_widget;

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -393,10 +393,7 @@ void Compositor::compose()
                 return;
 
             auto clear_window_rect = [&](const Gfx::IntRect& clear_rect) {
-                auto fill_color = wm.palette().window();
-                if (!window.is_opaque())
-                    fill_color.set_alpha(255 * window.opacity());
-                painter.fill_rect(clear_rect, fill_color);
+                painter.fill_rect(clear_rect, wm.palette().window());
             };
 
             if (!backing_store) {
@@ -447,20 +444,11 @@ void Compositor::compose()
                 auto dst = backing_rect.location().translated(dirty_rect_in_backing_coordinates.location());
 
                 if (window.client() && window.client()->is_unresponsive()) {
-                    if (window.is_opaque()) {
-                        painter.blit_filtered(dst, *backing_store, dirty_rect_in_backing_coordinates, [](Color src) {
-                            return src.to_grayscale().darkened(0.75f);
-                        });
-                    } else {
-                        u8 alpha = 255 * window.opacity();
-                        painter.blit_filtered(dst, *backing_store, dirty_rect_in_backing_coordinates, [&](Color src) {
-                            auto color = src.to_grayscale().darkened(0.75f);
-                            color.set_alpha(alpha);
-                            return color;
-                        });
-                    }
+                    painter.blit_filtered(dst, *backing_store, dirty_rect_in_backing_coordinates, [](Color src) {
+                        return src.to_grayscale().darkened(0.75f);
+                    });
                 } else {
-                    painter.blit(dst, *backing_store, dirty_rect_in_backing_coordinates, window.opacity());
+                    painter.blit(dst, *backing_store, dirty_rect_in_backing_coordinates);
                 }
             }
 

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -322,16 +322,6 @@ void ConnectionFromClient::set_forced_shadow(i32 window_id, bool shadow)
     Compositor::the().invalidate_occlusions();
 }
 
-void ConnectionFromClient::set_window_opacity(i32 window_id, float opacity)
-{
-    auto it = m_windows.find(window_id);
-    if (it == m_windows.end()) {
-        did_misbehave("SetWindowOpacity: Bad window ID");
-        return;
-    }
-    it->value->set_opacity(opacity);
-}
-
 Messages::WindowServer::SetWallpaperResponse ConnectionFromClient::set_wallpaper(Gfx::ShareableBitmap const& bitmap)
 {
     return Compositor::the().set_wallpaper(bitmap.bitmap());
@@ -613,7 +603,7 @@ Window* ConnectionFromClient::window_from_id(i32 window_id)
 
 void ConnectionFromClient::create_window(i32 window_id, Gfx::IntRect const& rect,
     bool auto_position, bool has_alpha_channel, bool minimizable, bool closeable, bool resizable,
-    bool fullscreen, bool frameless, bool forced_shadow, float opacity,
+    bool fullscreen, bool frameless, bool forced_shadow,
     float alpha_hit_threshold, Gfx::IntSize base_size, Gfx::IntSize size_increment,
     Gfx::IntSize minimum_size, Optional<Gfx::IntSize> const& resize_aspect_ratio, i32 type, i32 mode,
     DeprecatedString const& title, i32 parent_window_id, Gfx::IntRect const& launch_origin_rect)
@@ -675,7 +665,6 @@ void ConnectionFromClient::create_window(i32 window_id, Gfx::IntRect const& rect
         window->set_rect(Screen::bounding_rect());
         window->recalculate_rect();
     }
-    window->set_opacity(opacity);
     window->set_alpha_hit_threshold(alpha_hit_threshold);
     window->set_size_increment(size_increment);
     window->set_base_size(base_size);

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -103,7 +103,7 @@ private:
     virtual void remove_menu_item(i32 menu_id, i32 identifier) override;
     virtual void flash_menubar_menu(i32, i32) override;
     virtual void create_window(i32, Gfx::IntRect const&, bool, bool, bool,
-        bool, bool, bool, bool, bool, float, float, Gfx::IntSize, Gfx::IntSize, Gfx::IntSize,
+        bool, bool, bool, bool, bool, float, Gfx::IntSize, Gfx::IntSize, Gfx::IntSize,
         Optional<Gfx::IntSize> const&, i32, i32, DeprecatedString const&, i32, Gfx::IntRect const&) override;
     virtual Messages::WindowServer::DestroyWindowResponse destroy_window(i32) override;
     virtual void set_window_title(i32, DeprecatedString const&) override;
@@ -121,7 +121,6 @@ private:
     virtual void invalidate_rect(i32, Vector<Gfx::IntRect> const&, bool) override;
     virtual void did_finish_painting(i32, Vector<Gfx::IntRect> const&) override;
     virtual void set_global_mouse_tracking(bool) override;
-    virtual void set_window_opacity(i32, float) override;
     virtual void set_window_backing_store(i32, i32, i32, IPC::File const&, i32, bool, Gfx::IntSize, Gfx::IntSize, bool) override;
     virtual void set_window_has_alpha_channel(i32, bool) override;
     virtual void set_window_alpha_hit_threshold(i32, float) override;

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -380,18 +380,6 @@ void Window::start_launch_animation(Gfx::IntRect const& launch_origin_rect)
     m_animation->start();
 }
 
-void Window::set_opacity(float opacity)
-{
-    if (m_opacity == opacity)
-        return;
-    bool was_opaque = is_opaque();
-    m_opacity = opacity;
-    if (was_opaque != is_opaque())
-        Compositor::the().invalidate_occlusions();
-    invalidate(false);
-    WindowManager::the().notify_opacity_changed(*this);
-}
-
 void Window::set_has_alpha_channel(bool value)
 {
     if (m_has_alpha_channel == value)

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -153,9 +153,6 @@ public:
 
     DeprecatedString computed_title() const;
 
-    float opacity() const { return m_opacity; }
-    void set_opacity(float);
-
     void set_hit_testing_enabled(bool value)
     {
         m_hit_testing_enabled = value;
@@ -327,11 +324,7 @@ public:
 
     bool is_opaque() const
     {
-        if (opacity() < 1.0f)
-            return false;
-        if (has_alpha_channel())
-            return false;
-        return true;
+        return !has_alpha_channel();
     }
 
     Gfx::DisjointIntRectSet& opaque_rects() { return m_opaque_rects; }
@@ -444,7 +437,6 @@ private:
     i32 m_last_backing_store_serial { -1 };
     int m_window_id { -1 };
     i32 m_client_id { -1 };
-    float m_opacity { 1 };
     float m_alpha_hit_threshold { 0.0f };
     Gfx::IntSize m_size_increment;
     Gfx::IntSize m_base_size;

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -358,14 +358,14 @@ void WindowFrame::PerScaleRenderedCache::paint(WindowFrame& frame, Gfx::Painter&
             // We have a top piece
             auto src_rect = rect.intersected(Gfx::Rect { frame_rect.location(), { frame_rect.width(), m_bottom_y } });
             if (!src_rect.is_empty())
-                painter.blit(src_rect.location(), *m_top_bottom, src_rect.translated(-frame_rect.location()), frame.opacity());
+                painter.blit(src_rect.location(), *m_top_bottom, src_rect.translated(-frame_rect.location()));
         }
         if (m_bottom_y < top_bottom_height) {
             // We have a bottom piece
             Gfx::IntRect rect_in_frame { frame_rect.x(), window_rect.bottom(), frame_rect.width(), top_bottom_height - m_bottom_y };
             auto src_rect = rect.intersected(rect_in_frame);
             if (!src_rect.is_empty())
-                painter.blit(src_rect.location(), *m_top_bottom, src_rect.translated(-rect_in_frame.x(), -rect_in_frame.y() + m_bottom_y), frame.opacity());
+                painter.blit(src_rect.location(), *m_top_bottom, src_rect.translated(-rect_in_frame.x(), -rect_in_frame.y() + m_bottom_y));
         }
     }
 
@@ -376,14 +376,14 @@ void WindowFrame::PerScaleRenderedCache::paint(WindowFrame& frame, Gfx::Painter&
             Gfx::IntRect rect_in_frame { frame_rect.x(), window_rect.y(), m_right_x, window_rect.height() };
             auto src_rect = rect.intersected(rect_in_frame);
             if (!src_rect.is_empty())
-                painter.blit(src_rect.location(), *m_left_right, src_rect.translated(-rect_in_frame.location()), frame.opacity());
+                painter.blit(src_rect.location(), *m_left_right, src_rect.translated(-rect_in_frame.location()));
         }
         if (m_right_x < left_right_width) {
             // We have a right piece
             Gfx::IntRect rect_in_frame { window_rect.right(), window_rect.y(), left_right_width - m_right_x, window_rect.height() };
             auto src_rect = rect.intersected(rect_in_frame);
             if (!src_rect.is_empty())
-                painter.blit(src_rect.location(), *m_left_right, src_rect.translated(-rect_in_frame.x() + m_right_x, -rect_in_frame.y()), frame.opacity());
+                painter.blit(src_rect.location(), *m_left_right, src_rect.translated(-rect_in_frame.x() + m_right_x, -rect_in_frame.y()));
         }
     }
 }
@@ -547,18 +547,6 @@ void WindowFrame::PerScaleRenderedCache::render(WindowFrame& frame, Screen& scre
     }
 
     m_shadow_dirty = false;
-}
-
-void WindowFrame::set_opacity(float opacity)
-{
-    if (m_opacity == opacity)
-        return;
-    bool was_opaque = is_opaque();
-    m_opacity = opacity;
-    if (was_opaque != is_opaque())
-        Compositor::the().invalidate_occlusions();
-    Compositor::the().invalidate_screen(render_rect());
-    WindowManager::the().notify_opacity_changed(m_window);
 }
 
 Gfx::IntRect WindowFrame::inflated_for_shadow(Gfx::IntRect const& frame_rect) const

--- a/Userland/Services/WindowServer/WindowFrame.h
+++ b/Userland/Services/WindowServer/WindowFrame.h
@@ -94,16 +94,9 @@ public:
     void set_has_alpha_channel(bool value) { m_has_alpha_channel = value; }
     bool has_shadow() const;
 
-    void set_opacity(float);
-    float opacity() const { return m_opacity; }
-
     bool is_opaque() const
     {
-        if (opacity() < 1.0f)
-            return false;
-        if (has_alpha_channel())
-            return false;
-        return true;
+        return !has_alpha_channel();
     }
 
     void set_dirty(bool re_render_shadow = false)
@@ -148,7 +141,6 @@ private:
 
     RefPtr<Core::Timer> m_flash_timer;
     size_t m_flash_counter { 0 };
-    float m_opacity { 1 };
     bool m_has_alpha_channel { false };
 };
 

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -53,7 +53,6 @@ endpoint WindowServer
         bool fullscreen,
         bool frameless,
         bool forced_shadow,
-        float opacity,
         float alpha_hit_threshold,
         Gfx::IntSize base_size,
         Gfx::IntSize size_increment,
@@ -95,7 +94,6 @@ endpoint WindowServer
     did_finish_painting(i32 window_id, Vector<Gfx::IntRect> rects) =|
 
     set_global_mouse_tracking(bool enabled) =|
-    set_window_opacity(i32 window_id, float opacity) =|
 
     set_window_alpha_hit_threshold(i32 window_id, float threshold) =|
 


### PR DESCRIPTION
I first spotted `WindowServer::Window::opacity()` and the corresponding setter while studying how `WindowServer::Compositor` works. I immediately found it a bit weird that we have special way to set that globally when we already have more fine-grained control over window opacity.
Then I found out the *only* place that actually made use of window-global opacity was... `WindowServer` itself! Specifically, the wonderfully subtle fade-out animation in `WindowServer::Menu::start_activation_animation()` that happens when you select a menu item that makes the menu disappear. You can see a demo of it in #5988 where it was added.
This was also hooked up to `LibGUI::Window::set_opacity()`, but that wasn't used anywhere.
I refactored this animation to blit the fade-out animation directly instead.

Similar case with `WindowServer::WindowFrame::set_opacity()` that was never called anywhere. I thought `AnalogClock` might use it, but that uses `GUI::Window::set_frameless()` instead.

I think cleaning these redundant facilities made `WindowServer` compositing code and the IPC interface a bit easier to grok. If there is still desire to keep these around, at least I had fun seeing if I could tear them out! :^)