### PR TITLE
Kernel: Make IPv4 TTL configurable

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -203,6 +203,7 @@ set(KERNEL_SOURCES
     FileSystem/SysFS/Subsystems/Kernel/Variables/CoredumpDirectory.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/Directory.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/DumpKmallocStack.cpp
+    FileSystem/SysFS/Subsystems/Kernel/Variables/IntegerVariable.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/StringVariable.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/UBSANDeadly.cpp
     FileSystem/VirtualFileSystem.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -201,6 +201,7 @@ set(KERNEL_SOURCES
     FileSystem/SysFS/Subsystems/Kernel/Variables/BooleanVariable.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/CapsLockRemap.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/CoredumpDirectory.cpp
+    FileSystem/SysFS/Subsystems/Kernel/Variables/DefaultTTL.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/Directory.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/DumpKmallocStack.cpp
     FileSystem/SysFS/Subsystems/Kernel/Variables/IntegerVariable.cpp

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/DefaultTTL.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/DefaultTTL.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023, Mark Douglas <dmarkd@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/DefaultTTL.h>
+#include <Kernel/Net/NetworkingManagement.h>
+#include <Kernel/Sections.h>
+
+namespace Kernel {
+
+UNMAP_AFTER_INIT SysFSDefaultTTL::SysFSDefaultTTL(SysFSDirectory const& parent_directory)
+    : SysFSSystemIntegerVariable(parent_directory)
+{
+}
+
+UNMAP_AFTER_INIT NonnullRefPtr<SysFSDefaultTTL> SysFSDefaultTTL::must_create(SysFSDirectory const& parent_directory)
+{
+    return adopt_ref_if_nonnull(new (nothrow) SysFSDefaultTTL(parent_directory)).release_nonnull();
+}
+
+int32_t SysFSDefaultTTL::value() const
+{
+    return NetworkingManagement::default_ttl();
+}
+void SysFSDefaultTTL::set_value(i32 new_value)
+{
+    dbgln("DefaultTTL new value: {}", new_value);
+    u8 const clamped_value = clamp(new_value, 1, 255);
+    NetworkingManagement::set_default_ttl(clamped_value);
+}
+
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/DefaultTTL.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/DefaultTTL.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, Mark Douglas <dmarkd@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefPtr.h>
+#include <AK/Types.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/IntegerVariable.h>
+#include <Kernel/Library/UserOrKernelBuffer.h>
+
+namespace Kernel {
+
+class SysFSDefaultTTL final : public SysFSSystemIntegerVariable {
+public:
+    virtual StringView name() const override { return "default_ttl"sv; }
+    static NonnullRefPtr<SysFSDefaultTTL> must_create(SysFSDirectory const&);
+
+private:
+    virtual i32 value() const override;
+    virtual void set_value(i32 new_value) override;
+
+    explicit SysFSDefaultTTL(SysFSDirectory const&);
+};
+
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/Directory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/Directory.cpp
@@ -9,6 +9,7 @@
 #include <Kernel/FileSystem/SysFS/Component.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/CapsLockRemap.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/CoredumpDirectory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/DefaultTTL.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/Directory.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/DumpKmallocStack.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/UBSANDeadly.h>
@@ -23,6 +24,7 @@ UNMAP_AFTER_INIT NonnullRefPtr<SysFSGlobalKernelVariablesDirectory> SysFSGlobalK
         list.append(SysFSDumpKmallocStacks::must_create(*global_variables_directory));
         list.append(SysFSUBSANDeadly::must_create(*global_variables_directory));
         list.append(SysFSCoredumpDirectory::must_create(*global_variables_directory));
+        list.append(SysFSDefaultTTL::must_create(*global_variables_directory));
         return {};
     }));
     return global_variables_directory;

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/IntegerVariable.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/IntegerVariable.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, Mark Douglas <dmarkd@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/IntegerVariable.h>
+#include <Kernel/Sections.h>
+#include <Kernel/Tasks/Process.h>
+
+namespace Kernel {
+
+ErrorOr<void> SysFSSystemIntegerVariable::try_generate(KBufferBuilder& builder)
+{
+    return builder.appendff("{}\n", value());
+}
+
+ErrorOr<size_t> SysFSSystemIntegerVariable::write_bytes(off_t, size_t count, UserOrKernelBuffer const& buffer, OpenFileDescription*)
+{
+    MutexLocker locker(m_refresh_lock);
+    // Note: We do all of this code before taking the spinlock because then we disable
+    // interrupts so page faults will not work.
+
+    char* value = nullptr;
+    i32 result = 0;
+    i32 sign = 1;
+    auto new_value = TRY(KString::try_create_uninitialized(count, value));
+    TRY(buffer.read(value, count));
+
+    if (*value == '-') {
+        sign = -1;
+        value++;
+    }
+
+    while (*value != '\0') {
+        if (*value >= '0' && *value <= '9') {
+            result = result * 10 + (*value - '0');
+        } else {
+            break;
+        }
+        value++;
+    }
+
+    result *= sign;
+
+    // NOTE: If we are in a jail, don't let the current process to change the variable.
+    if (Process::current().is_currently_in_jail())
+        return Error::from_errno(EPERM);
+    dbgln("Setting value: {}", result);
+    set_value(result);
+    return count;
+}
+
+ErrorOr<void> SysFSSystemIntegerVariable::truncate(u64 size)
+{
+    if (size != 0)
+        return EPERM;
+    return {};
+}
+
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/IntegerVariable.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Variables/IntegerVariable.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, Mark Douglas <dmarkd@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/AtomicRefCounted.h>
+#include <AK/Error.h>
+#include <AK/Function.h>
+#include <AK/RefPtr.h>
+#include <AK/Types.h>
+#include <Kernel/FileSystem/File.h>
+#include <Kernel/FileSystem/FileSystem.h>
+#include <Kernel/FileSystem/OpenFileDescription.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Kernel/GlobalInformation.h>
+#include <Kernel/Library/KBufferBuilder.h>
+#include <Kernel/Library/UserOrKernelBuffer.h>
+#include <Kernel/Locking/Mutex.h>
+#include <Kernel/Time/TimeManagement.h>
+
+namespace Kernel {
+
+class SysFSSystemIntegerVariable : public SysFSGlobalInformation {
+protected:
+    explicit SysFSSystemIntegerVariable(SysFSDirectory const& parent_directory)
+        : SysFSGlobalInformation(parent_directory)
+    {
+    }
+    virtual i32 value() const = 0;
+    virtual void set_value(i32 new_value) = 0;
+
+private:
+    // ^SysFSGlobalInformation
+    virtual ErrorOr<void> try_generate(KBufferBuilder&) override final;
+
+    // ^SysFSExposedComponent
+    virtual ErrorOr<size_t> write_bytes(off_t, size_t, UserOrKernelBuffer const&, OpenFileDescription*) override final;
+    virtual mode_t permissions() const override final { return 0644; }
+    virtual ErrorOr<void> truncate(u64) override final;
+};
+
+}

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -69,6 +69,8 @@ IPv4Socket::IPv4Socket(int type, int protocol, NonnullOwnPtr<DoubleBuffer> recei
         VERIFY(m_scratch_buffer);
     }
 
+    m_ttl = NetworkingManagement::default_ttl();
+
     all_sockets().with_exclusive([&](auto& table) {
         table.append(*this);
     });

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -126,7 +126,7 @@ private:
     u32 m_bytes_received { 0 };
 
     u8 m_type_of_service { IPTOS_LOWDELAY };
-    u8 m_ttl { 64 };
+    u8 m_ttl {};
 
     bool m_can_read { false };
 

--- a/Kernel/Net/NetworkingManagement.cpp
+++ b/Kernel/Net/NetworkingManagement.cpp
@@ -20,6 +20,8 @@
 namespace Kernel {
 
 static Singleton<NetworkingManagement> s_the;
+// This configurable value is used as the default TTL for all packets sent by the kernel.
+u8 NetworkingManagement::m_default_ttl = 64;
 
 NetworkingManagement& NetworkingManagement::the()
 {

--- a/Kernel/Net/NetworkingManagement.h
+++ b/Kernel/Net/NetworkingManagement.h
@@ -38,11 +38,16 @@ public:
 
     NonnullRefPtr<NetworkAdapter> loopback_adapter() const;
 
+    static u8 default_ttl() { return NetworkingManagement::m_default_ttl; }
+    static void set_default_ttl(u8 ttl) { NetworkingManagement::m_default_ttl = ttl; }
+
 private:
     ErrorOr<NonnullRefPtr<NetworkAdapter>> determine_network_device(PCI::DeviceIdentifier const&) const;
 
     SpinlockProtected<Vector<NonnullRefPtr<NetworkAdapter>>, LockRank::None> m_adapters {};
     RefPtr<NetworkAdapter> m_loopback_adapter;
+
+    static u8 m_default_ttl;
 };
 
 }


### PR DESCRIPTION
This change adds default_ttl to /sys/kernel/variables and links the
functionality through NetworkingManagement to IPv4 sockets.

DefaultTTL is an IntegerVariable type for retrieving the TTL value from
the SysFS file.

NetworkingManagement has a new static variable to store the TTL. This
becomes the single point for configuring default TCP/IP TTL on the
system.

IPv4Socket and NetworkTask reference the value from NetworkingManagement
rather than using their previously hard-coded values. This removes one
FIXME from NetworkTask.

This PR is dependent on #19543 