### PR TITLE
 Kernel: Some cleanup around adding routes

### DIFF
--- a/Kernel/API/POSIX/net/route.h
+++ b/Kernel/API/POSIX/net/route.h
@@ -14,17 +14,31 @@ extern "C" {
 #endif
 
 struct rtentry {
+    unsigned long rt_pad1;
     struct sockaddr rt_dst;     /* the target address */
     struct sockaddr rt_gateway; /* the gateway address */
     struct sockaddr rt_genmask; /* the target network mask */
     unsigned short int rt_flags;
-    char* rt_dev;
-    /* FIXME: complete the struct */
+    short rt_pad2;
+    unsigned long rt_pad3;
+    void* rt_pad4;
+    short rt_metric;         /* route metric */
+    char* rt_dev;            /* tie route to specific device */
+    unsigned long rt_mtu;    /* Define MTU for this route */
+    unsigned long rt_window; /* Window clamping for this route */
+    unsigned short rt_irtt;  /* Initial round trip time */
 };
 
-#define RTF_UP 0x1      /* do not delete the route */
-#define RTF_GATEWAY 0x2 /* the route is a gateway and not an end host */
-#define RTF_HOST 0x4    /* host entry (net otherwise) */
+#define RTF_UP 0x1        /* do not delete the route */
+#define RTF_GATEWAY 0x2   /* the route is a gateway and not an end host */
+#define RTF_HOST 0x4      /* host entry (net otherwise) */
+#define RTF_REINSTATE 0x8 /* Reinstate route after a timeout */
+#define RTF_DYNAMIC 0x10  /* Route created dynamically */
+#define RTF_MODIFIED 0x20 /* Route modified dynamically */
+#define RTF_MTU 0x40      /* Route has specific MTU */
+#define RTF_WINDOW 0x80   /* Route has window clamping */
+#define RTF_IRTT 0x100    /* Initial round trip time */
+#define RTF_REJECT 0x200  /* Reject the route */
 
 #ifdef __cplusplus
 }

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -636,8 +636,10 @@ ErrorOr<void> IPv4Socket::ioctl(OpenFileDescription&, unsigned request, Userspac
                 return EPERM;
             if (route.rt_gateway.sa_family != AF_INET)
                 return EAFNOSUPPORT;
-            if (!(route.rt_flags & RTF_UP))
-                return EINVAL; // FIXME: Find the correct value to return
+            if (!adapter->link_up())
+                return ENETDOWN;
+            if ((adapter->ipv4_address().to_u32() & adapter->ipv4_netmask().to_u32()) != (((sockaddr_in&)route.rt_gateway).sin_addr.s_addr & adapter->ipv4_netmask().to_u32()))
+                return ENETUNREACH;
 
             auto destination = IPv4Address(((sockaddr_in&)route.rt_dst).sin_addr.s_addr);
             auto gateway = IPv4Address(((sockaddr_in&)route.rt_gateway).sin_addr.s_addr);


### PR DESCRIPTION
This change fills in some a standard struct and some defines. It also
removes an error test that wasn't reachable when adding routes, while
adding tests for a few other scenarios which are currently possible.