### PR TITLE
dirname: Add `-z` option for null terminated output and support multiple paths

### DIFF
--- a/Base/usr/share/man/man1/dirname.md
+++ b/Base/usr/share/man/man1/dirname.md
@@ -1,0 +1,18 @@
+## Name
+
+dirname - return the directory portion of a path
+
+## Synopsis
+
+```sh
+$ dirname [--zero] <path...>
+```
+
+## Options
+
+* `-z`, `--zero`: End each output line with \0, rather than \n
+
+## Arguments
+
+* `path`: Path
+

--- a/Userland/Utilities/dirname.cpp
+++ b/Userland/Utilities/dirname.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,11 +11,14 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    DeprecatedString path = {};
+    bool null_terminated = false;
+    DeprecatedString path;
     Core::ArgsParser args_parser;
+    args_parser.add_option(null_terminated, "End each output line with \\0, rather than \\n", "zero", 'z');
     args_parser.add_positional_argument(path, "Path", "path");
     args_parser.parse(arguments);
 
-    outln("{}", LexicalPath::dirname(path));
+    auto const delimiter = null_terminated ? '\0' : '\n';
+    out("{}{}", LexicalPath::dirname(path), delimiter);
     return 0;
 }

--- a/Userland/Utilities/dirname.cpp
+++ b/Userland/Utilities/dirname.cpp
@@ -12,13 +12,15 @@
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     bool null_terminated = false;
-    DeprecatedString path;
+    Vector<DeprecatedString> paths;
     Core::ArgsParser args_parser;
     args_parser.add_option(null_terminated, "End each output line with \\0, rather than \\n", "zero", 'z');
-    args_parser.add_positional_argument(path, "Path", "path");
+    args_parser.add_positional_argument(paths, "Path", "path");
     args_parser.parse(arguments);
 
     auto const delimiter = null_terminated ? '\0' : '\n';
-    out("{}{}", LexicalPath::dirname(path), delimiter);
+    for (auto const& path : paths)
+        out("{}{}", LexicalPath::dirname(path), delimiter);
+
     return 0;
 }


### PR DESCRIPTION
This PR adds the following to `dirname`:

* Multiple paths can now be given. Results are separated by a newline unless `-z` is specified.
* The `-z` option separates each result with a `\0` instead of a newline (useful for things like `xargs -0`).

Example usage:

![dirname_multiple_paths](https://github.com/SerenityOS/serenity/assets/2817754/96e4440b-5888-4590-a5db-c9bc005df2e6)
