### PR TITLE
LibWeb: Paint the media timeline above the other media controls

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -288,10 +288,13 @@ MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mousedown(Badge<E
     auto& media_element = *verify_cast<HTML::HTMLMediaElement>(layout_box().dom_node());
     auto const& cached_layout_boxes = media_element.cached_layout_boxes({});
 
-    if (cached_layout_boxes.timeline_rect.has_value() && cached_layout_boxes.timeline_rect->contains(position))
+    if (cached_layout_boxes.timeline_rect.has_value() && cached_layout_boxes.timeline_rect->contains(position)) {
         media_element.set_layout_mouse_tracking_component({}, HTML::HTMLMediaElement::MouseTrackingComponent::Timeline);
-    else if (cached_layout_boxes.volume_rect.has_value() && cached_layout_boxes.volume_rect->contains(position))
+        set_current_time(media_element, *cached_layout_boxes.timeline_rect, position, Temporary::Yes);
+    } else if (cached_layout_boxes.volume_rect.has_value() && cached_layout_boxes.volume_rect->contains(position)) {
         media_element.set_layout_mouse_tracking_component({}, HTML::HTMLMediaElement::MouseTrackingComponent::Volume);
+        set_volume(media_element, *cached_layout_boxes.volume_rect, position);
+    }
 
     if (media_element.layout_mouse_tracking_component({}).has_value())
         const_cast<HTML::BrowsingContext&>(browsing_context()).event_handler().set_mouse_event_tracking_layout_node(&layout_node());
@@ -342,18 +345,8 @@ MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mouseup(Badge<Eve
             return DispatchEventOfSameName::Yes;
         }
 
-        if (cached_layout_boxes.timeline_rect.has_value() && cached_layout_boxes.timeline_rect->contains(position)) {
-            set_current_time(media_element, *cached_layout_boxes.timeline_rect, position, Temporary::No);
-            return DispatchEventOfSameName::Yes;
-        }
-
         if (cached_layout_boxes.speaker_button_rect.has_value() && cached_layout_boxes.speaker_button_rect->contains(position)) {
             media_element.set_muted(!media_element.muted());
-            return DispatchEventOfSameName::Yes;
-        }
-
-        if (cached_layout_boxes.volume_rect.has_value() && cached_layout_boxes.volume_rect->contains(position)) {
-            set_volume(media_element, *cached_layout_boxes.volume_rect, position);
             return DispatchEventOfSameName::Yes;
         }
 

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.h
@@ -28,9 +28,7 @@ private:
     struct Components {
         DevicePixelRect control_box_rect;
         DevicePixelRect playback_button_rect;
-
         DevicePixelRect timeline_rect;
-        DevicePixels timeline_button_size;
 
         String timestamp;
         RefPtr<Gfx::Font> timestamp_font;
@@ -50,7 +48,7 @@ private:
 
     Components compute_control_bar_components(PaintContext&, HTML::HTMLMediaElement const&, DevicePixelRect media_rect) const;
     static void paint_control_bar_playback_button(PaintContext&, HTML::HTMLMediaElement const&, Components const&, Optional<DevicePixelPoint> const& mouse_position);
-    static void paint_control_bar_timeline(PaintContext&, HTML::HTMLMediaElement const&, Components const&, Optional<DevicePixelPoint> const& mouse_position);
+    static void paint_control_bar_timeline(PaintContext&, HTML::HTMLMediaElement const&, Components const&);
     static void paint_control_bar_timestamp(PaintContext&, Components const&);
     static void paint_control_bar_speaker(PaintContext&, HTML::HTMLMediaElement const&, Components const& components, Optional<DevicePixelPoint> const& mouse_position);
     static void paint_control_bar_volume(PaintContext&, HTML::HTMLMediaElement const&, Components const&, Optional<DevicePixelPoint> const& mouse_position);


### PR DESCRIPTION
It's a little bit of a battle to fit all of the media controls in the
available width of the media element. We currently cram everything on
one horizontal line. We've made adjustments to be able to fit it all,
but the controls (in particular the media timeline) are rather squished.

This paints the timeline above the other media controls now. This
provides much more granular control over the playback position when
scrubbing, and makes it much more likely for the timeline to render at
all.

Audio:
![audio](https://github.com/SerenityOS/serenity/assets/5600524/e5fe9fb4-8caa-4e93-aa19-c95a365d03b6)

Video:
![video](https://github.com/SerenityOS/serenity/assets/5600524/b7859952-899e-48e3-afd8-0b3ce53feb0f)
