### PR TITLE
wc: Add `-L` option to show the length of the longest line

### DIFF
--- a/Base/usr/share/man/man1/wc.md
+++ b/Base/usr/share/man/man1/wc.md
@@ -5,7 +5,7 @@ wc - word, line, character, and byte count
 ## Synopsis
 
 ```sh
-$ wc [--lines] [--bytes] [--words] [file...]
+$ wc [--lines] [--bytes] [--words] [--max-line-length] [file...]
 ```
 
 ## Options
@@ -15,6 +15,7 @@ $ wc [--lines] [--bytes] [--words] [file...]
 * `-l`, `--lines`: Output line count
 * `-c`, `--bytes`: Output byte count
 * `-w`, `--words`: Output word count
+* `-L`, `--max-line-length`: Output byte count of the longest line
 
 ## Arguments
 


### PR DESCRIPTION
If more than one file is specified on the command line and the `-L` option is used, the totals field will show the longest line encountered; it is not a sum like the other values.

Example usage:

![wc_longest_line](https://github.com/SerenityOS/serenity/assets/2817754/ce57f05b-7a97-400a-8cd6-0bfe58859637)
