### PR TITLE
LibWeb: Add fast_is<T>() for SVGUseElement

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -75,6 +75,7 @@ public:
     virtual bool is_svg_container() const { return false; }
     virtual bool is_svg_element() const { return false; }
     virtual bool is_svg_svg_element() const { return false; }
+    virtual bool is_svg_use_element() const { return false; }
 
     bool in_a_document_tree() const;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -40,6 +40,8 @@ private:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
+    virtual bool is_svg_use_element() const override { return true; }
+
     Optional<StringView> parse_id_from_href(DeprecatedString const& href);
 
     JS::GCPtr<DOM::Element> referenced_element();
@@ -54,5 +56,12 @@ private:
 
     JS::GCPtr<DOM::DocumentObserver> m_document_observer;
 };
+
+}
+
+namespace Web::DOM {
+
+template<>
+inline bool Node::fast_is<SVG::SVGUseElement>() const { return is_svg_use_element(); }
 
 }


### PR DESCRIPTION
is<SVGUseElement> quite hot in profiles

<img width="833" alt="Screenshot 2023-06-23 at 01 54 35" src="https://github.com/SerenityOS/serenity/assets/45686940/525a4384-0b44-4446-aabf-cce8794f93a2">
