### PR TITLE
LibWeb: Take specified height into account for automatic table height

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x122 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 0x122 [BFC] children: not-inline
+        Box <table> at (19,19) content-size 0x100 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (19,19) content-size 0x0 table-row-group children: not-inline
+            Box <tr> at (21,31) content-size 0x0 table-row children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>

--- a/Tests/LibWeb/Layout/input/table/stretch-to-fixed-height.html
+++ b/Tests/LibWeb/Layout/input/table/stretch-to-fixed-height.html
@@ -1,0 +1,10 @@
+<style>
+    table {
+        border: 1px solid black;
+        height: 100px;
+        padding: 10px;
+    }
+</style>
+<table>
+    <tr></tr>
+</table>

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -43,7 +43,7 @@ private:
     void distribute_width_to_columns();
     void compute_table_height(LayoutMode layout_mode);
     void distribute_height_to_rows();
-    void position_row_boxes(CSSPixels&);
+    void position_row_boxes();
     void position_cell_boxes();
     void border_conflict_resolution();
     CSSPixels border_spacing_horizontal() const;


### PR DESCRIPTION
Track table grid height stretched to the specified height and use it to set the final box height in TFC.

Fixes #19563.