### PR TITLE
LibGfx/JPEG: Teach JPEGLoader how to be patient with non-compliant images [3/N]

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -1649,7 +1649,9 @@ static void ycck_to_rgb(JPEGLoadingContext const& context, Vector<Macroblock>& m
 
 static ErrorOr<void> handle_color_transform(JPEGLoadingContext const& context, Vector<Macroblock>& macroblocks)
 {
-    if (context.color_transform.has_value()) {
+    // Note: This is non-standard but some encoder still add the App14 segment for grayscale images.
+    //       So let's ignore the color transform value if we only have one component.
+    if (context.color_transform.has_value() && context.components.size() != 1) {
         // https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-T.872-201206-I!!PDF-E&type=items
         // 6.5.3 - APP14 marker segment for colour encoding
 

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -1524,7 +1524,7 @@ static void ycbcr_to_rgb(JPEGLoadingContext const& context, Vector<Macroblock>& 
     // 7 - Conversion to and from RGB
     for (u32 vcursor = 0; vcursor < context.mblock_meta.vcount; vcursor += context.vsample_factor) {
         for (u32 hcursor = 0; hcursor < context.mblock_meta.hcount; hcursor += context.hsample_factor) {
-            const u32 chroma_block_index = vcursor * context.mblock_meta.hpadded_count + hcursor;
+            u32 const chroma_block_index = vcursor * context.mblock_meta.hpadded_count + hcursor;
             Macroblock const& chroma = macroblocks[chroma_block_index];
             // Overflows are intentional.
             for (u8 vfactor_i = context.vsample_factor - 1; vfactor_i < context.vsample_factor; --vfactor_i) {
@@ -1535,10 +1535,10 @@ static void ycbcr_to_rgb(JPEGLoadingContext const& context, Vector<Macroblock>& 
                     auto* cr = macroblocks[macroblock_index].cr;
                     for (u8 i = 7; i < 8; --i) {
                         for (u8 j = 7; j < 8; --j) {
-                            const u8 pixel = i * 8 + j;
-                            const u32 chroma_pxrow = (i / context.vsample_factor) + 4 * vfactor_i;
-                            const u32 chroma_pxcol = (j / context.hsample_factor) + 4 * hfactor_i;
-                            const u32 chroma_pixel = chroma_pxrow * 8 + chroma_pxcol;
+                            u8 const pixel = i * 8 + j;
+                            u32 const chroma_pxrow = (i / context.vsample_factor) + 4 * vfactor_i;
+                            u32 const chroma_pxcol = (j / context.hsample_factor) + 4 * hfactor_i;
+                            u32 const chroma_pixel = chroma_pxrow * 8 + chroma_pxcol;
                             int r = y[pixel] + 1.402f * (chroma.cr[chroma_pixel] - 128);
                             int g = y[pixel] - 0.3441f * (chroma.cb[chroma_pixel] - 128) - 0.7141f * (chroma.cr[chroma_pixel] - 128);
                             int b = y[pixel] + 1.772f * (chroma.cb[chroma_pixel] - 128);
@@ -1700,14 +1700,14 @@ static ErrorOr<void> compose_bitmap(JPEGLoadingContext& context, Vector<Macroblo
     context.bitmap = TRY(Bitmap::create(BitmapFormat::BGRx8888, { context.frame.width, context.frame.height }));
 
     for (u32 y = context.frame.height - 1; y < context.frame.height; y--) {
-        const u32 block_row = y / 8;
-        const u32 pixel_row = y % 8;
+        u32 const block_row = y / 8;
+        u32 const pixel_row = y % 8;
         for (u32 x = 0; x < context.frame.width; x++) {
-            const u32 block_column = x / 8;
+            u32 const block_column = x / 8;
             auto& block = macroblocks[block_row * context.mblock_meta.hpadded_count + block_column];
-            const u32 pixel_column = x % 8;
-            const u32 pixel_index = pixel_row * 8 + pixel_column;
-            const Color color { (u8)block.y[pixel_index], (u8)block.cb[pixel_index], (u8)block.cr[pixel_index] };
+            u32 const pixel_column = x % 8;
+            u32 const pixel_index = pixel_row * 8 + pixel_column;
+            Color const color { (u8)block.y[pixel_index], (u8)block.cb[pixel_index], (u8)block.cr[pixel_index] };
             context.bitmap->set_pixel(x, y, color);
         }
     }


### PR DESCRIPTION
Fix this image:
![gray-sample](https://github.com/SerenityOS/serenity/assets/26030965/42a350f9-f887-4d4c-bbf6-72dd8862c14d)


I have modified this file for a few months now, but `clang-format` decided to come out of hibernation today and moved some `const` to the east. Hence, the second commit :tada: