### PR TITLE
LibJS/Bytecode: Support private class fields

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -382,6 +382,8 @@ Bytecode::CodeGenerationErrorOr<void> AssignmentExpression::generate_bytecode(By
                         // To be continued later with PutByValue.
                     } else if (expression.property().is_identifier()) {
                         // Do nothing, this will be handled by PutById later.
+                    } else if (expression.property().is_private_identifier()) {
+                        // Do nothing, this will be handled by PutPrivateById later.
                     } else {
                         return Bytecode::CodeGenerationError {
                             &expression,
@@ -415,6 +417,9 @@ Bytecode::CodeGenerationErrorOr<void> AssignmentExpression::generate_bytecode(By
                     } else if (expression.property().is_identifier()) {
                         auto identifier_table_ref = generator.intern_identifier(verify_cast<Identifier>(expression.property()).string());
                         generator.emit<Bytecode::Op::PutById>(*base_object_register, identifier_table_ref);
+                    } else if (expression.property().is_private_identifier()) {
+                        auto identifier_table_ref = generator.intern_identifier(verify_cast<PrivateIdentifier>(expression.property()).string());
+                        generator.emit<Bytecode::Op::PutPrivateById>(*base_object_register, identifier_table_ref);
                     } else {
                         return Bytecode::CodeGenerationError {
                             &expression,

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -198,6 +198,9 @@ CodeGenerationErrorOr<void> Generator::emit_load_from_reference(JS::ASTNode cons
             } else if (expression.property().is_identifier()) {
                 auto identifier_table_ref = intern_identifier(verify_cast<Identifier>(expression.property()).string());
                 emit<Bytecode::Op::GetById>(identifier_table_ref);
+            } else if (expression.property().is_private_identifier()) {
+                auto identifier_table_ref = intern_identifier(verify_cast<PrivateIdentifier>(expression.property()).string());
+                emit<Bytecode::Op::GetPrivateById>(identifier_table_ref);
             } else {
                 return CodeGenerationError {
                     &expression,
@@ -238,6 +241,10 @@ CodeGenerationErrorOr<void> Generator::emit_store_to_reference(JS::ASTNode const
             emit<Bytecode::Op::Load>(value_reg);
             auto identifier_table_ref = intern_identifier(verify_cast<Identifier>(expression.property()).string());
             emit<Bytecode::Op::PutById>(object_reg, identifier_table_ref);
+        } else if (expression.property().is_private_identifier()) {
+            emit<Bytecode::Op::Load>(value_reg);
+            auto identifier_table_ref = intern_identifier(verify_cast<PrivateIdentifier>(expression.property()).string());
+            emit<Bytecode::Op::PutPrivateById>(object_reg, identifier_table_ref);
         } else {
             return CodeGenerationError {
                 &expression,

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -38,6 +38,7 @@
     O(GetMethod)                     \
     O(GetNewTarget)                  \
     O(GetObjectPropertyIterator)     \
+    O(GetPrivateById)                \
     O(GetVariable)                   \
     O(GreaterThan)                   \
     O(GreaterThanEquals)             \
@@ -76,6 +77,7 @@
     O(PushDeclarativeEnvironment)    \
     O(PutById)                       \
     O(PutByValue)                    \
+    O(PutPrivateById)                \
     O(ResolveThisBinding)            \
     O(ResolveSuperBase)              \
     O(Return)                        \

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -517,6 +517,23 @@ private:
     IdentifierTableIndex m_property;
 };
 
+class GetPrivateById final : public Instruction {
+public:
+    explicit GetPrivateById(IdentifierTableIndex property)
+        : Instruction(Type::GetPrivateById)
+        , m_property(property)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
+
+private:
+    IdentifierTableIndex m_property;
+};
+
 enum class PropertyKind {
     Getter,
     Setter,
@@ -529,6 +546,31 @@ class PutById final : public Instruction {
 public:
     explicit PutById(Register base, IdentifierTableIndex property, PropertyKind kind = PropertyKind::KeyValue)
         : Instruction(Type::PutById)
+        , m_base(base)
+        , m_property(property)
+        , m_kind(kind)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register from, Register to)
+    {
+        if (m_base == from)
+            m_base = to;
+    }
+
+private:
+    Register m_base;
+    IdentifierTableIndex m_property;
+    PropertyKind m_kind;
+};
+
+class PutPrivateById final : public Instruction {
+public:
+    explicit PutPrivateById(Register base, IdentifierTableIndex property, PropertyKind kind = PropertyKind::KeyValue)
+        : Instruction(Type::PutPrivateById)
         , m_base(base)
         , m_property(property)
         , m_kind(kind)


### PR DESCRIPTION
This is accomplished with two new instructions:
- GetPrivateById
- PutPrivateById

test262 says:
        +1616 ✅   +160 ❌   +288 💥️    -2064 📝   
