### PR TITLE
AK: Prefer __builtin_{subc,addc} intrinsics to x86-specific ones  (and fix an Apple Clang miscompilation!)

### DIFF
--- a/AK/BigIntBase.h
+++ b/AK/BigIntBase.h
@@ -196,7 +196,7 @@ ALWAYS_INLINE constexpr NativeWord add_words(NativeWord word1, NativeWord word2,
 ALWAYS_INLINE constexpr NativeWord sub_words(NativeWord word1, NativeWord word2, bool& carry)
 {
     if (!is_constant_evaluated()) {
-#if __has_builtin(__builtin_subc)
+#if __has_builtin(__builtin_subc) && !defined(AK_BUILTIN_SUBC_BROKEN)
         NativeWord ncarry, output;
         if constexpr (SameAs<NativeWord, unsigned int>)
             output = __builtin_subc(word1, word2, carry, reinterpret_cast<unsigned int*>(&ncarry));

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -117,6 +117,13 @@
 #    define AK_HAS_CONDITIONALLY_TRIVIAL
 #endif
 
+// Apple Clang 14.0.3 (shipped in Xcode 14.3) has a bug that causes __builtin_subc{,l,ll}
+// to incorrectly return whether a borrow occurred on AArch64. See our writeup for the Qemu
+// issue also caused by it: https://gitlab.com/qemu-project/qemu/-/issues/1659#note_1408275831
+#if ARCH(AARCH64) && defined(__apple_build_version__) && __clang_major__ == 14
+#    define AK_BUILTIN_SUBC_BROKEN
+#endif
+
 #ifdef ALWAYS_INLINE
 #    undef ALWAYS_INLINE
 #endif


### PR DESCRIPTION
**AK: Prefer `__builtin_{subc,addc}` intrinsics to x86-specific ones**

GCC 14 (https://gcc.gnu.org/g:2b4e0415ad664cdb3ce87d1f7eee5ca26911a05b)
has added support for the previously Clang-specific add/subtract with
borrow builtins. Let's use `__has_builtin` to detect them instead of
assuming that only Clang has them. We should prefer these to the
x86-specific ones as architecture-independent middle-end optimizations
might deal with them better.

As an added bonus, this significantly improves codegen on AArch64
compared to the fallback implementation that uses
`__builtin_{add,sub}_overflow`.

For now, the code path with the x86-specific intrinsics stays so as to
avoid regressing the performance of builds with GCC 12 and 13.

A codegen comparison can be viewed here: https://godbolt.org/z/bax39qn7a

**AK: Work around Apple Clang `__builtin_subc` codegen issue**

Apple Clang 14.0.3 (Xcode 14.3) miscompiles this builtin on AArch64,
causing the borrow flag to be set incorrectly. I have added a detailed
writeup on Qemu's issue tracker, where the same issue led to a hang when
emulating x86:

https://gitlab.com/qemu-project/qemu/-/issues/1659#note_1408275831

I don't know of any specific issue caused by this on Lagom, but better
safe than sorry.