### PR TITLE
LibJS: Do not fail a test if the flags list is empty

### DIFF
--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -349,11 +349,6 @@ static Result<TestMetadata, DeprecatedString> extract_metadata(StringView source
         if (line.starts_with("flags:"sv)) {
             auto flags = parse_list(line);
 
-            if (flags.is_empty()) {
-                failed_message = DeprecatedString::formatted("Failed to find flags in '{}'", line);
-                break;
-            }
-
             for (auto flag : flags) {
                 if (flag == "raw"sv) {
                     metadata.strict_mode = StrictMode::NoStrict;


### PR DESCRIPTION
There are hundreds of test262 tests with the following metadata line:

    flags: []

Other engine runners are apparently able to ignore those lines, so we should as well.

```
Diff Tests:
+9 ✅   +249 ❌    -258 📄
```