### PR TITLE
LibWeb/LibGfx: Handle differences in overflow-x and overflow-y correctly

### DIFF
--- a/Tests/LibWeb/Layout/expected/overflow-x-hidden-clips-overflow.txt
+++ b/Tests/LibWeb/Layout/expected/overflow-x-hidden-clips-overflow.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x49.46875 children: not-inline
+      BlockContainer <div.x> at (8,8) content-size 0x49.46875 [BFC] children: not-inline
+        BlockContainer <p> at (8,24) content-size 0x17.46875 children: inline
+          line 0 width: 47.90625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [8,24 47.90625x17.46875]
+              "hidden"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,57.46875) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/overflow-y-hidden-clips-overflow.txt
+++ b/Tests/LibWeb/Layout/expected/overflow-y-hidden-clips-overflow.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <div.y> at (8,8) content-size 784x0 [BFC] children: not-inline
+        BlockContainer <p> at (8,24) content-size 784x17.46875 children: inline
+          line 0 width: 47.90625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [8,24 47.90625x17.46875]
+              "hidden"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/overflow-x-hidden-clips-overflow.html
+++ b/Tests/LibWeb/Layout/input/overflow-x-hidden-clips-overflow.html
@@ -1,0 +1,6 @@
+<style>
+.x {
+  width: 0;
+  overflow-x: hidden;
+}
+</style><div class="x"><p>hidden</p></div>

--- a/Tests/LibWeb/Layout/input/overflow-y-hidden-clips-overflow.html
+++ b/Tests/LibWeb/Layout/input/overflow-y-hidden-clips-overflow.html
@@ -1,0 +1,6 @@
+<style>
+.y {
+  height: 0;
+  overflow-y: hidden;
+}
+</style><div class="y"><p>hidden</p></div>

--- a/Userland/Libraries/LibGfx/Forward.h
+++ b/Userland/Libraries/LibGfx/Forward.h
@@ -43,6 +43,9 @@ template<typename T>
 class Size;
 
 template<typename T>
+class Range;
+
+template<typename T>
 class Rect;
 
 template<typename T>

--- a/Userland/Libraries/LibGfx/Range.h
+++ b/Userland/Libraries/LibGfx/Range.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023, Preston Taylor <PrestonLeeTaylor@proton.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Format.h>
+
+namespace Gfx {
+
+template<typename T>
+class Range {
+public:
+    constexpr Range() = default;
+
+    constexpr Range(T min, T max)
+        : m_min(min)
+        , m_max(max)
+    {
+    }
+
+    template<typename U>
+    constexpr Range(U min, U max)
+        : m_min(min)
+        , m_max(max)
+    {
+    }
+
+    template<typename U>
+    explicit constexpr Range(Range<U> const& other)
+        : m_min(other.min())
+        , m_max(other.max())
+    {
+    }
+
+    [[nodiscard]] ALWAYS_INLINE constexpr T min() const { return m_min; }
+    [[nodiscard]] ALWAYS_INLINE constexpr T max() const { return m_max; }
+
+    [[nodiscard]] ALWAYS_INLINE constexpr T dist() const { return m_max - m_min; }
+
+    ALWAYS_INLINE void set_min(T min) { m_min = min; }
+    ALWAYS_INLINE void set_max(T max) { m_max = max; }
+
+    ALWAYS_INLINE void translate_by(T const& delta)
+    {
+        m_min += delta;
+        m_max += delta;
+    }
+
+    void intersect(Range<T> const& other)
+    {
+        T intersected_min = AK::max(this->min(), other.min());
+        T intersected_max = AK::min(this->max(), other.max());
+
+        if (intersected_min > intersected_max) {
+            m_min = 0;
+            m_max = 0;
+            return;
+        }
+
+        set_min(intersected_min);
+        set_max(intersected_max);
+    }
+
+    [[nodiscard]] Range<T> translated(T const& delta) const
+    {
+        Range<T> range = *this;
+        range.translate_by(delta);
+        return range;
+    }
+
+    template<typename U>
+    requires(!IsSame<T, U>)
+    [[nodiscard]] ALWAYS_INLINE Range<U> to_type() const
+    {
+        return Range<U>(*this);
+    }
+
+private:
+    T m_min { 0 };
+    T m_max { 0 };
+};
+
+using IntRange = Range<int>;
+
+}
+
+namespace AK {
+
+template<typename T>
+struct Formatter<Gfx::Range<T>> : Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, Gfx::Range<T> const& value)
+    {
+        return Formatter<FormatString>::format(builder, "[{}-{}]"sv, value.min(), value.max());
+    }
+};
+
+}

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -14,6 +14,7 @@
 #include <LibGfx/Line.h>
 #include <LibGfx/Orientation.h>
 #include <LibGfx/Point.h>
+#include <LibGfx/Range.h>
 #include <LibGfx/Size.h>
 #include <LibGfx/TextAlignment.h>
 #include <math.h>
@@ -52,6 +53,13 @@ public:
     }
 
     template<typename U>
+    Rect(Range<U> const& horizontal, Range<U> const& vertical)
+        : m_location(horizontal.min(), vertical.min())
+        , m_size(horizontal.dist(), vertical.dist())
+    {
+    }
+
+    template<typename U>
     explicit Rect(Rect<U> const& other)
         : m_location(other.location())
         , m_size(other.size())
@@ -70,6 +78,9 @@ public:
 
     [[nodiscard]] ALWAYS_INLINE Point<T> const& location() const { return m_location; }
     [[nodiscard]] ALWAYS_INLINE Size<T> const& size() const { return m_size; }
+
+    [[nodiscard]] ALWAYS_INLINE Range<T> horizontal_range() const { return Range<T> { left(), right() }; }
+    [[nodiscard]] ALWAYS_INLINE Range<T> vertical_range() const { return Range<T> { top(), bottom() }; }
 
     [[nodiscard]] ALWAYS_INLINE bool is_empty() const { return width() <= 0 || height() <= 0; }
 
@@ -474,20 +485,47 @@ public:
 
     void intersect(Rect<T> const& other)
     {
+        intersect_horizontally(other);
+        intersect_vertically(other);
+    }
+
+    void intersect_horizontally(Range<T> const& range)
+    {
+        intersect_horizontally(Rect<T> { range, {} });
+    }
+
+    void intersect_horizontally(Rect<T> const& other)
+    {
         T l = max(left(), other.left());
         T r = min(right(), other.right());
-        T t = max(top(), other.top());
-        T b = min(bottom(), other.bottom());
 
-        if (l > r || t > b) {
+        if (l > r) {
             m_location = {};
             m_size = {};
             return;
         }
 
         set_x(l);
-        set_y(t);
         set_right(r);
+    }
+
+    void intersect_vertically(Range<T> const& range)
+    {
+        intersect_vertically(Rect<T> { {}, range });
+    }
+
+    void intersect_vertically(Rect<T> const& other)
+    {
+        T t = max(top(), other.top());
+        T b = min(bottom(), other.bottom());
+
+        if (t > b) {
+            m_location = {};
+            m_size = {};
+            return;
+        }
+
+        set_y(t);
         set_bottom(b);
     }
 

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -891,14 +891,25 @@ bool Element::is_potentially_scrollable() const
     VERIFY(parent());
 
     // - body has an associated box.
+    if (!layout_node())
+        return false;
+
     // - body’s parent element’s computed value of the overflow-x or overflow-y properties is neither visible nor clip.
+    if (!parent()->layout_node())
+        return false;
+
+    auto const& parent_computed_values = parent()->layout_node()->computed_values();
+    if ((parent_computed_values.overflow_x() == CSS::Overflow::Visible || parent_computed_values.overflow_x() == CSS::Overflow::Clip)
+        && (parent_computed_values.overflow_y() == CSS::Overflow::Visible || parent_computed_values.overflow_y() == CSS::Overflow::Clip))
+        return false;
+
     // - body’s computed value of the overflow-x or overflow-y properties is neither visible nor clip.
-    return layout_node()
-        && (parent()->layout_node()
-            && parent()->layout_node()->computed_values().overflow_x() != CSS::Overflow::Visible && parent()->layout_node()->computed_values().overflow_x() != CSS::Overflow::Clip
-            && parent()->layout_node()->computed_values().overflow_y() != CSS::Overflow::Visible && parent()->layout_node()->computed_values().overflow_y() != CSS::Overflow::Clip)
-        && (layout_node()->computed_values().overflow_x() != CSS::Overflow::Visible && layout_node()->computed_values().overflow_x() != CSS::Overflow::Clip
-            && layout_node()->computed_values().overflow_y() != CSS::Overflow::Visible && layout_node()->computed_values().overflow_y() != CSS::Overflow::Clip);
+    auto const& computed_values = layout_node()->computed_values();
+    if ((computed_values.overflow_x() == CSS::Overflow::Visible || computed_values.overflow_x() == CSS::Overflow::Clip)
+        && (computed_values.overflow_y() == CSS::Overflow::Visible || computed_values.overflow_y() == CSS::Overflow::Clip))
+        return false;
+
+    return true;
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scrolltop

--- a/Userland/Libraries/LibWeb/Painting/PaintContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintContext.cpp
@@ -58,6 +58,14 @@ DevicePixelPoint PaintContext::floored_device_point(CSSPixelPoint point) const
     };
 }
 
+DevicePixelRange PaintContext::enclosing_device_range(CSSPixelRange range) const
+{
+    return {
+        floorf(range.min().to_double() * m_device_pixels_per_css_pixel),
+        ceilf(range.max().to_double() * m_device_pixels_per_css_pixel)
+    };
+}
+
 DevicePixelRect PaintContext::enclosing_device_rect(CSSPixelRect rect) const
 {
     return {

--- a/Userland/Libraries/LibWeb/Painting/PaintContext.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintContext.h
@@ -39,6 +39,7 @@ public:
     DevicePixels rounded_device_pixels(CSSPixels css_pixels) const;
     DevicePixelPoint rounded_device_point(CSSPixelPoint) const;
     DevicePixelPoint floored_device_point(CSSPixelPoint) const;
+    DevicePixelRange enclosing_device_range(CSSPixelRange range) const;
     DevicePixelRect enclosing_device_rect(CSSPixelRect) const;
     DevicePixelRect rounded_device_rect(CSSPixelRect) const;
     DevicePixelSize enclosing_device_size(CSSPixelSize) const;

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -85,6 +85,22 @@ CSSPixelPoint PaintableBox::effective_offset() const
     return offset;
 }
 
+// FIXME: Support overflow values of clip/scroll/auto
+bool PaintableBox::can_potentially_hit(CSSPixelPoint position) const
+{
+    if (computed_values().overflow_x() == CSS::Overflow::Hidden) {
+        if (!absolute_border_box_rect().contains_horizontally(position.x()))
+            return false;
+    }
+
+    if (computed_values().overflow_y() == CSS::Overflow::Hidden) {
+        if (!absolute_border_box_rect().contains_vertically(position.y()))
+            return false;
+    }
+
+    return true;
+}
+
 CSSPixelRect PaintableBox::compute_absolute_rect() const
 {
     CSSPixelRect rect { effective_offset(), content_size() };

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -37,6 +37,8 @@ public:
     CSSPixelRect absolute_rect() const;
     CSSPixelPoint effective_offset() const;
 
+    bool can_potentially_hit(CSSPixelPoint) const;
+
     void set_offset(CSSPixelPoint);
     void set_offset(float x, float y) { set_offset({ x, y }); }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/Range.h>
 #include <LibWeb/Painting/BorderPainting.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/Paintable.h>
@@ -100,7 +101,8 @@ public:
         return m_overflow_data->scrollable_overflow_rect;
     }
 
-    Optional<CSSPixelRect> calculate_overflow_clipped_rect() const;
+    Optional<CSSPixelRange> calculate_horizontal_clip_range() const;
+    Optional<CSSPixelRange> calculate_vertical_clip_range() const;
 
     void set_overflow_data(Optional<OverflowData> data) { m_overflow_data = move(data); }
     void set_containing_line_box_fragment(Optional<Layout::LineBoxFragmentCoordinate>);
@@ -160,6 +162,9 @@ private:
 
     Optional<CSSPixelRect> mutable m_absolute_rect;
     Optional<CSSPixelRect> mutable m_absolute_paint_rect;
+
+    Optional<CSSPixelRange> mutable m_horizontal_clip;
+    Optional<CSSPixelRange> mutable m_vertical_clip;
 
     Optional<CSSPixelRect> mutable m_clip_rect;
 

--- a/Userland/Libraries/LibWeb/PixelUnits.h
+++ b/Userland/Libraries/LibWeb/PixelUnits.h
@@ -201,11 +201,13 @@ constexpr CSSPixels operator%(CSSPixels left, T right) { return left.to_double()
 
 using CSSPixelLine = Gfx::Line<CSSPixels>;
 using CSSPixelPoint = Gfx::Point<CSSPixels>;
+using CSSPixelRange = Gfx::Range<CSSPixels>;
 using CSSPixelRect = Gfx::Rect<CSSPixels>;
 using CSSPixelSize = Gfx::Size<CSSPixels>;
 
 using DevicePixelLine = Gfx::Line<DevicePixels>;
 using DevicePixelPoint = Gfx::Point<DevicePixels>;
+using DevicePixelRange = Gfx::Range<DevicePixels>;
 using DevicePixelRect = Gfx::Rect<DevicePixels>;
 using DevicePixelSize = Gfx::Size<DevicePixels>;
 


### PR DESCRIPTION
This pr allows for handling of overflow-x and overflow-y being different correctly.

This would cause issues if only one dimension of overflow was hidden and could cause content to be rendered when it should be hidden.

Example code:
```html
<style>
  .x {
    width: 0rem;
    overflow-x: hidden;
  }

  .y {
    height: 0rem;
    overflow-y: hidden;
  }
</style>
<div class="x">
  <p>Should be hidden!</p>
</div>
<div class="y">
  <p>Should be hidden!</p>
</div>
```

Before:
![Screenshot of ladybird before PR](https://i.imgur.com/oe1RLMc.png)

After:
![Screenshot of ladybird after PR](https://i.imgur.com/4Mqrxfc.png)