### PR TITLE
LibJS/Bytecode: Support private identifiers in optional chaining

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -2698,11 +2698,11 @@ static Bytecode::CodeGenerationErrorOr<void> generate_optional_chain(Bytecode::G
                 generator.emit<Bytecode::Op::Store>(current_value_register);
                 return {};
             },
-            [&](OptionalChain::PrivateMemberReference const&) -> Bytecode::CodeGenerationErrorOr<void> {
-                return Bytecode::CodeGenerationError {
-                    &optional_chain,
-                    "Unimplemented reference: PrivateMemberReference"sv,
-                };
+            [&](OptionalChain::PrivateMemberReference const& ref) -> Bytecode::CodeGenerationErrorOr<void> {
+                generator.emit<Bytecode::Op::Store>(current_base_register);
+                generator.emit<Bytecode::Op::GetPrivateById>(generator.intern_identifier(ref.private_identifier->string()));
+                generator.emit<Bytecode::Op::Store>(current_value_register);
+                return {};
             }));
     }
 


### PR DESCRIPTION
Fixes 4 test262 tests :^)

```
Summary:
    Diff Tests:
        +4 ✅    -4 📝   

Diff Tests:
    test/language/expressions/class/elements/grammar-private-field-optional-chaining.js 📝 -> ✅
    test/language/expressions/class/elements/private-field-after-optional-chain.js      📝 -> ✅
    test/language/statements/class/elements/grammar-private-field-optional-chaining.js  📝 -> ✅
    test/language/statements/class/elements/private-field-after-optional-chain.js       📝 -> ✅
```