### PR TITLE
LibWeb: Prioritize video duration when loading video element media

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1141,12 +1141,12 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::process_media_data(Function<void(Str
         // 4. Update the duration attribute with the time of the last frame of the resource, if known, on the media timeline established above. If it is
         //    not known (e.g. a stream that is in principle infinite), update the duration attribute to the value positive Infinity.
         // FIXME: Handle unbounded media resources.
-        auto duration = audio_track ? audio_track->duration() : video_track->duration();
-        set_duration(static_cast<double>(duration.to_milliseconds()) / 1000.0);
-
         // 5. For video elements, set the videoWidth and videoHeight attributes, and queue a media element task given the media element to fire an event
         //    named resize at the media element.
         if (video_track && is<HTMLVideoElement>(*this)) {
+            auto duration = video_track ? video_track->duration() : audio_track->duration();
+            set_duration(static_cast<double>(duration.to_milliseconds()) / 1000.0);
+
             auto& video_element = verify_cast<HTMLVideoElement>(*this);
             video_element.set_video_width(video_track->pixel_width());
             video_element.set_video_height(video_track->pixel_height());
@@ -1154,6 +1154,9 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::process_media_data(Function<void(Str
             queue_a_media_element_task([this] {
                 dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::resize).release_value_but_fixme_should_propagate_errors());
             });
+        } else {
+            auto duration = audio_track ? audio_track->duration() : video_track->duration();
+            set_duration(static_cast<double>(duration.to_milliseconds()) / 1000.0);
         }
 
         // 6. Set the readyState attribute to HAVE_METADATA.


### PR DESCRIPTION
Previously, an audio loader could succeed for an HTMLVideoElement that contains a video file, which caused the duration to be set to the bogus duration of the audio loader instead of the correct duration from the video container. Instead of setting the duration based on audio always, set it to the video duration if we are creating a video element.

Before:
![image](https://github.com/SerenityOS/serenity/assets/3149592/a54cba2b-2e9e-430a-ad56-4e6b8d5d42fc)

After:
![image](https://github.com/SerenityOS/serenity/assets/3149592/04dd2917-1a69-4912-9eb7-61bd1015e739)
