### PR TITLE
LibDiff+HackStudio+diff: Remove use of DeprecatedString in LibDiff (and diff)

### DIFF
--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -88,7 +88,7 @@ void EditorWrapper::save()
 void EditorWrapper::update_diff()
 {
     if (m_git_repo) {
-        m_hunks = Diff::parse_hunks(m_git_repo->unstaged_diff(filename()).value());
+        m_hunks = Diff::parse_hunks(m_git_repo->unstaged_diff(filename()).value()).release_value_but_fixme_should_propagate_errors();
         editor().update_git_diff_indicators().release_value_but_fixme_should_propagate_errors();
     }
 }

--- a/Userland/DevTools/HackStudio/Git/DiffViewer.cpp
+++ b/Userland/DevTools/HackStudio/Git/DiffViewer.cpp
@@ -48,7 +48,7 @@ void DiffViewer::paint_event(GUI::PaintEvent& event)
             left_y_offset += line_height();
         }
         for (int i = 0; i < (int)hunk.added_lines.size() - (int)hunk.removed_lines.size(); ++i) {
-            draw_line(painter, "", left_y_offset, LinePosition::Left, LineType::Missing);
+            draw_line(painter, ""sv, left_y_offset, LinePosition::Left, LineType::Missing);
             left_y_offset += line_height();
         }
 
@@ -58,7 +58,7 @@ void DiffViewer::paint_event(GUI::PaintEvent& event)
             right_y_offset += line_height();
         }
         for (int i = 0; i < (int)hunk.removed_lines.size() - (int)hunk.added_lines.size(); ++i) {
-            draw_line(painter, "", right_y_offset, LinePosition::Right, LineType::Missing);
+            draw_line(painter, ""sv, right_y_offset, LinePosition::Right, LineType::Missing);
             right_y_offset += line_height();
         }
 
@@ -71,7 +71,7 @@ void DiffViewer::paint_event(GUI::PaintEvent& event)
     }
 }
 
-void DiffViewer::draw_line(GUI::Painter& painter, DeprecatedString const& line, size_t y_offset, LinePosition line_position, LineType line_type)
+void DiffViewer::draw_line(GUI::Painter& painter, StringView line, size_t y_offset, LinePosition line_position, LineType line_type)
 {
     size_t line_width = font().width(line);
 

--- a/Userland/DevTools/HackStudio/Git/DiffViewer.cpp
+++ b/Userland/DevTools/HackStudio/Git/DiffViewer.cpp
@@ -134,7 +134,7 @@ Gfx::IntRect DiffViewer::separator_rect() const
 void DiffViewer::set_content(DeprecatedString const& original, DeprecatedString const& diff)
 {
     m_original_lines = split_to_lines(original);
-    m_hunks = Diff::parse_hunks(diff);
+    m_hunks = Diff::parse_hunks(diff).release_value_but_fixme_should_propagate_errors();
 
     if constexpr (DIFF_DEBUG) {
         for (size_t i = 0; i < m_original_lines.size(); ++i)
@@ -149,7 +149,7 @@ DiffViewer::DiffViewer()
 
 DiffViewer::DiffViewer(DeprecatedString const& original, DeprecatedString const& diff)
     : m_original_lines(split_to_lines(original))
-    , m_hunks(Diff::parse_hunks(diff))
+    , m_hunks(Diff::parse_hunks(diff).release_value_but_fixme_should_propagate_errors())
 {
     setup_properties();
 }

--- a/Userland/DevTools/HackStudio/Git/DiffViewer.h
+++ b/Userland/DevTools/HackStudio/Git/DiffViewer.h
@@ -43,7 +43,7 @@ private:
         Missing,
     };
 
-    void draw_line(GUI::Painter&, DeprecatedString const& line, size_t y_offset, LinePosition, LineType);
+    void draw_line(GUI::Painter&, StringView line, size_t y_offset, LinePosition, LineType);
 
     static Vector<DeprecatedString> split_to_lines(DeprecatedString const& text);
 

--- a/Userland/Libraries/LibCpp/SemanticSyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibCpp/SemanticSyntaxHighlighter.cpp
@@ -55,7 +55,7 @@ void SemanticSyntaxHighlighter::rehighlight(Palette const& palette)
 
         // FIXME: Computing the diff on the entire document's tokens is quite inefficient.
         //        An improvement over this could be only including the tokens that are in edited text ranges in the diff.
-        auto diff_hunks = Diff::from_text(previous.view(), current.view());
+        auto diff_hunks = Diff::from_text(previous.view(), current.view()).release_value_but_fixme_should_propagate_errors();
         for (auto& token : current_tokens) {
             new_tokens_info.append(CodeComprehension::TokenInfo { CodeComprehension::TokenInfo::SemanticType::Unknown,
                 token.start().line, token.start().column, token.end().line, token.end().column });

--- a/Userland/Libraries/LibDiff/Generator.cpp
+++ b/Userland/Libraries/LibDiff/Generator.cpp
@@ -72,9 +72,9 @@ ErrorOr<Vector<Hunk>> from_text(StringView old_text, StringView new_text)
             cur_hunk = { i, j, {}, {} };
         }
         if (direction == Direction::Down) {
-            TRY(cur_hunk.added_lines.try_append(new_lines[j]));
+            TRY(cur_hunk.added_lines.try_append(TRY(String::from_utf8(new_lines[j]))));
         } else if (direction == Direction::Right) {
-            TRY(cur_hunk.removed_lines.try_append(old_lines[i]));
+            TRY(cur_hunk.removed_lines.try_append(TRY(String::from_utf8(old_lines[i]))));
         }
 
         return {};

--- a/Userland/Libraries/LibDiff/Generator.h
+++ b/Userland/Libraries/LibDiff/Generator.h
@@ -7,9 +7,10 @@
 #pragma once
 
 #include "Hunks.h"
+#include <AK/Error.h>
 
 namespace Diff {
 
-Vector<Hunk> from_text(StringView old_text, StringView new_text);
+ErrorOr<Vector<Hunk>> from_text(StringView old_text, StringView new_text);
 
 }

--- a/Userland/Libraries/LibDiff/Hunks.cpp
+++ b/Userland/Libraries/LibDiff/Hunks.cpp
@@ -41,12 +41,12 @@ ErrorOr<Vector<Hunk>> parse_hunks(StringView diff)
         hunk.target_start_line = current_location.target_start_line;
 
         while (line_index < diff_lines.size() && diff_lines[line_index][0] == '-') {
-            TRY(hunk.removed_lines.try_append(diff_lines[line_index].substring_view(1, diff_lines[line_index].length() - 1)));
+            TRY(hunk.removed_lines.try_append(TRY(String::from_utf8(diff_lines[line_index].substring_view(1, diff_lines[line_index].length() - 1)))));
             current_location.apply_offset(1, HunkLocation::LocationType::Original);
             ++line_index;
         }
         while (line_index < diff_lines.size() && diff_lines[line_index][0] == '+') {
-            TRY(hunk.added_lines.try_append(diff_lines[line_index].substring_view(1, diff_lines[line_index].length() - 1)));
+            TRY(hunk.added_lines.try_append(TRY(String::from_utf8(diff_lines[line_index].substring_view(1, diff_lines[line_index].length() - 1)))));
             current_location.apply_offset(1, HunkLocation::LocationType::Target);
             ++line_index;
         }

--- a/Userland/Libraries/LibDiff/Hunks.cpp
+++ b/Userland/Libraries/LibDiff/Hunks.cpp
@@ -74,17 +74,17 @@ Vector<Hunk> parse_hunks(DeprecatedString const& diff)
     return hunks;
 }
 
-HunkLocation parse_hunk_location(DeprecatedString const& location_line)
+HunkLocation parse_hunk_location(StringView location_line)
 {
     size_t char_index = 0;
     struct StartAndLength {
         size_t start { 0 };
         size_t length { 0 };
     };
-    auto parse_start_and_length_pair = [](DeprecatedString const& raw) {
+    auto parse_start_and_length_pair = [](StringView raw) {
         auto index_of_separator = raw.find(',').value();
-        auto start = raw.substring(0, index_of_separator).to_uint().value();
-        auto length = raw.substring(index_of_separator + 1, raw.length() - index_of_separator - 1).to_uint().value();
+        auto start = raw.substring_view(0, index_of_separator).to_uint().value();
+        auto length = raw.substring_view(index_of_separator + 1, raw.length() - index_of_separator - 1).to_uint().value();
 
         if (start != 0)
             start--;
@@ -114,8 +114,8 @@ HunkLocation parse_hunk_location(DeprecatedString const& location_line)
 
     size_t target_location_end_index = char_index - 2;
 
-    auto original_pair = parse_start_and_length_pair(location_line.substring(original_location_start_index, original_location_end_index - original_location_start_index + 1));
-    auto target_pair = parse_start_and_length_pair(location_line.substring(target_location_start_index, target_location_end_index - target_location_start_index + 1));
+    auto original_pair = parse_start_and_length_pair(location_line.substring_view(original_location_start_index, original_location_end_index - original_location_start_index + 1));
+    auto target_pair = parse_start_and_length_pair(location_line.substring_view(target_location_start_index, target_location_end_index - target_location_start_index + 1));
     return { original_pair.start, original_pair.length, target_pair.start, target_pair.length };
 }
 

--- a/Userland/Libraries/LibDiff/Hunks.cpp
+++ b/Userland/Libraries/LibDiff/Hunks.cpp
@@ -9,9 +9,9 @@
 
 namespace Diff {
 
-ErrorOr<Vector<Hunk>> parse_hunks(DeprecatedString const& diff)
+ErrorOr<Vector<Hunk>> parse_hunks(StringView diff)
 {
-    Vector<DeprecatedString> diff_lines = diff.split('\n');
+    Vector<StringView> diff_lines = diff.split_view('\n');
     if (diff_lines.is_empty())
         return Vector<Hunk> {};
 
@@ -41,12 +41,12 @@ ErrorOr<Vector<Hunk>> parse_hunks(DeprecatedString const& diff)
         hunk.target_start_line = current_location.target_start_line;
 
         while (line_index < diff_lines.size() && diff_lines[line_index][0] == '-') {
-            TRY(hunk.removed_lines.try_append(diff_lines[line_index].substring(1, diff_lines[line_index].length() - 1)));
+            TRY(hunk.removed_lines.try_append(diff_lines[line_index].substring_view(1, diff_lines[line_index].length() - 1)));
             current_location.apply_offset(1, HunkLocation::LocationType::Original);
             ++line_index;
         }
         while (line_index < diff_lines.size() && diff_lines[line_index][0] == '+') {
-            TRY(hunk.added_lines.try_append(diff_lines[line_index].substring(1, diff_lines[line_index].length() - 1)));
+            TRY(hunk.added_lines.try_append(diff_lines[line_index].substring_view(1, diff_lines[line_index].length() - 1)));
             current_location.apply_offset(1, HunkLocation::LocationType::Target);
             ++line_index;
         }

--- a/Userland/Libraries/LibDiff/Hunks.h
+++ b/Userland/Libraries/LibDiff/Hunks.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
+#include <AK/StringView.h>
 #include <AK/Vector.h>
 
 namespace Diff {
@@ -32,6 +33,6 @@ struct Hunk {
     Vector<DeprecatedString> added_lines;
 };
 
-ErrorOr<Vector<Hunk>> parse_hunks(DeprecatedString const& diff);
+ErrorOr<Vector<Hunk>> parse_hunks(StringView diff);
 HunkLocation parse_hunk_location(StringView location_line);
 };

--- a/Userland/Libraries/LibDiff/Hunks.h
+++ b/Userland/Libraries/LibDiff/Hunks.h
@@ -33,5 +33,5 @@ struct Hunk {
 };
 
 Vector<Hunk> parse_hunks(DeprecatedString const& diff);
-HunkLocation parse_hunk_location(DeprecatedString const& location_line);
+HunkLocation parse_hunk_location(StringView location_line);
 };

--- a/Userland/Libraries/LibDiff/Hunks.h
+++ b/Userland/Libraries/LibDiff/Hunks.h
@@ -32,6 +32,6 @@ struct Hunk {
     Vector<DeprecatedString> added_lines;
 };
 
-Vector<Hunk> parse_hunks(DeprecatedString const& diff);
+ErrorOr<Vector<Hunk>> parse_hunks(DeprecatedString const& diff);
 HunkLocation parse_hunk_location(StringView location_line);
 };

--- a/Userland/Libraries/LibDiff/Hunks.h
+++ b/Userland/Libraries/LibDiff/Hunks.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 
@@ -29,8 +29,8 @@ struct HunkLocation {
 struct Hunk {
     size_t original_start_line { 0 };
     size_t target_start_line { 0 };
-    Vector<DeprecatedString> removed_lines;
-    Vector<DeprecatedString> added_lines;
+    Vector<String> removed_lines;
+    Vector<String> added_lines;
 };
 
 ErrorOr<Vector<Hunk>> parse_hunks(StringView diff);

--- a/Userland/Utilities/diff.cpp
+++ b/Userland/Utilities/diff.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto const color_output = TRY(Core::System::isatty(STDOUT_FILENO)) ? Diff::ColorOutput::Yes : Diff::ColorOutput::No;
 
-    auto hunks = Diff::from_text(TRY(file1->read_until_eof()), TRY(file2->read_until_eof()));
+    auto hunks = TRY(Diff::from_text(TRY(file1->read_until_eof()), TRY(file2->read_until_eof())));
     for (auto const& hunk : hunks)
         TRY(Diff::write_normal(hunk, *out, color_output));
 

--- a/Userland/Utilities/diff.cpp
+++ b/Userland/Utilities/diff.cpp
@@ -18,8 +18,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath"));
 
     Core::ArgsParser parser;
-    DeprecatedString filename1;
-    DeprecatedString filename2;
+    StringView filename1;
+    StringView filename2;
 
     parser.add_positional_argument(filename1, "First file to compare", "file1", Core::ArgsParser::Required::Yes);
     parser.add_positional_argument(filename2, "Second file to compare", "file2", Core::ArgsParser::Required::Yes);

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -254,7 +254,7 @@ static ErrorOr<TestResult> run_test(HeadlessWebContentView& view, StringView inp
     else
         outln("\nTest failed: {}", input_path);
 
-    auto hunks = Diff::from_text(expectation, actual);
+    auto hunks = TRY(Diff::from_text(expectation, actual));
     auto out = TRY(Core::File::standard_output());
     for (auto const& hunk : hunks) {
         TRY(out->write_formatted("Hunk: "));


### PR DESCRIPTION
Ready now that https://github.com/SerenityOS/serenity/pull/19530 is merged.