### PR TITLE
LibWeb: Seek media elements immediately while dragging the timeline

### DIFF
--- a/Ladybird/AudioCodecPluginLadybird.cpp
+++ b/Ladybird/AudioCodecPluginLadybird.cpp
@@ -68,6 +68,7 @@ public:
 
 Q_SIGNALS:
     void playback_position_updated(Duration);
+    void seek_completed();
 
 private:
     AudioThread(NonnullRefPtr<Audio::Loader> loader, AudioTaskQueue task_queue)
@@ -164,6 +165,7 @@ private:
                 case AudioTask::Type::Seek:
                     VERIFY(task.data.has_value());
                     m_position = Web::Platform::AudioCodecPlugin::set_loader_position(m_loader, *task.data, m_duration, audio_output->format().sampleRate());
+                    Q_EMIT seek_completed();
 
                     if (paused == Paused::Yes)
                         Q_EMIT playback_position_updated(m_position);
@@ -298,6 +300,10 @@ AudioCodecPluginLadybird::AudioCodecPluginLadybird(NonnullOwnPtr<AudioThread> au
     connect(m_audio_thread, &AudioThread::playback_position_updated, this, [this](auto position) {
         if (on_playback_position_updated)
             on_playback_position_updated(position);
+    });
+    connect(m_audio_thread, &AudioThread::seek_completed, this, [this]() {
+        if (on_seek_completed)
+            on_seek_completed();
     });
 }
 

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -149,7 +149,7 @@ void VideoPlayerWidget::open_file(FileSystemAccessClient::File file)
         set_current_timestamp(m_playback_manager->current_playback_time());
     };
 
-    m_playback_manager->on_playback_state_change = [this]() {
+    m_playback_manager->on_playback_state_change = [this](Video::PlaybackState) {
         update_play_pause_icon();
         // If we are seeking, do not set the timestamp, as that will override the seek position.
         if (!m_was_playing_before_seek && m_playback_manager->get_state() != Video::PlaybackState::Seeking) {

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -623,7 +623,8 @@ private:
             }
         }
 
-        return skip_samples_until_timestamp();
+        manager().set_state_update_timer(0);
+        return {};
     }
 
     ErrorOr<void> skip_samples_until_timestamp()

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -138,7 +138,7 @@ public:
     Duration duration();
 
     Function<void(RefPtr<Gfx::Bitmap>)> on_video_frame;
-    Function<void()> on_playback_state_change;
+    Function<void(PlaybackState)> on_playback_state_change;
     Function<void(DecoderError)> on_decoder_error;
     Function<void(Error)> on_fatal_playback_error;
 
@@ -169,7 +169,7 @@ private:
     void dispatch_new_frame(RefPtr<Gfx::Bitmap> frame);
     // Returns whether we changed playback states. If so, any PlaybackStateHandler processing must cease.
     [[nodiscard]] bool dispatch_frame_queue_item(FrameQueueItem&&);
-    void dispatch_state_change();
+    void dispatch_state_change(PlaybackState) const;
     void dispatch_fatal_error(Error);
 
     Duration m_last_present_in_media_time = Duration::zero();

--- a/Userland/Libraries/LibWeb/HTML/AudioTrack.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AudioTrack.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/HTML/AudioTrack.h>
 #include <LibWeb/HTML/AudioTrackList.h>
 #include <LibWeb/HTML/EventNames.h>
+#include <LibWeb/HTML/HTMLAudioElement.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Platform/AudioCodecPlugin.h>
@@ -33,6 +34,9 @@ AudioTrack::AudioTrack(JS::Realm& realm, JS::NonnullGCPtr<HTMLMediaElement> medi
 
         auto playback_position = static_cast<double>(position.to_milliseconds()) / 1000.0;
         m_media_element->set_current_playback_position(playback_position);
+    };
+    m_audio_plugin->on_seek_completed = [this]() {
+        verify_cast<HTMLAudioElement>(m_media_element.ptr())->on_seek_completed({});
     };
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
@@ -60,9 +60,14 @@ void HTMLAudioElement::on_seek(double position, MediaSeekMode seek_mode)
 {
     audio_tracks()->for_each_enabled_track([&](auto& audio_track) {
         audio_track.seek(position, seek_mode);
+        m_seeks_in_progress++;
     });
+}
 
-    finish_seek_element();
+void HTMLAudioElement::on_seek_completed(Badge<AudioTrack>)
+{
+    if (--m_seeks_in_progress == 0)
+        finish_seek_element();
 }
 
 void HTMLAudioElement::on_volume_change()

--- a/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
@@ -61,6 +61,8 @@ void HTMLAudioElement::on_seek(double position, MediaSeekMode seek_mode)
     audio_tracks()->for_each_enabled_track([&](auto& audio_track) {
         audio_track.seek(position, seek_mode);
     });
+
+    finish_seek_element();
 }
 
 void HTMLAudioElement::on_volume_change()

--- a/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.h
@@ -19,6 +19,8 @@ public:
     Layout::AudioBox* layout_node();
     Layout::AudioBox const* layout_node() const;
 
+    void on_seek_completed(Badge<AudioTrack>);
+
 private:
     HTMLAudioElement(DOM::Document&, DOM::QualifiedName);
 
@@ -30,6 +32,8 @@ private:
     virtual void on_paused() override;
     virtual void on_seek(double, MediaSeekMode) override;
     virtual void on_volume_change() override;
+
+    size_t m_seeks_in_progress { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1841,26 +1841,18 @@ void HTMLMediaElement::reject_pending_play_promises(ReadonlySpan<JS::NonnullGCPt
     environment_settings.clean_up_after_running_script();
 }
 
-void HTMLMediaElement::set_layout_display_time(Badge<Painting::MediaPaintable>, Optional<double> display_time)
+void HTMLMediaElement::pause_temporarily(Badge<Painting::MediaPaintable>)
 {
-    if (display_time.has_value() && !m_display_time.has_value()) {
-        if (potentially_playing()) {
-            m_tracking_mouse_position_while_playing = true;
-            on_paused();
-        }
-    } else if (!display_time.has_value() && m_display_time.has_value()) {
-        if (m_tracking_mouse_position_while_playing) {
-            m_tracking_mouse_position_while_playing = false;
-            on_playing();
-        }
-    }
-
-    m_display_time = move(display_time);
+    if (potentially_playing())
+        m_was_playing_before_temporary_pause = true;
+    on_paused();
 }
 
-double HTMLMediaElement::layout_display_time(Badge<Painting::MediaPaintable>) const
+void HTMLMediaElement::resume_from_temporary_pause(Badge<Painting::MediaPaintable>)
 {
-    return m_display_time.value_or(current_time());
+    if (m_was_playing_before_temporary_pause)
+        on_playing();
+    m_was_playing_before_temporary_pause = false;
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -96,6 +96,8 @@ public:
     JS::NonnullGCPtr<AudioTrackList> audio_tracks() const { return *m_audio_tracks; }
     JS::NonnullGCPtr<VideoTrackList> video_tracks() const { return *m_video_tracks; }
 
+    void finish_seek_element();
+
     enum class MouseTrackingComponent {
         Timeline,
         Volume,
@@ -135,8 +137,8 @@ protected:
     virtual void on_paused() { }
 
     // Override in subclasses to handle implementation-specific seeking behavior. When seeking is complete,
-    // subclasses must invoke set_current_playback_position() to unblock the user agent.
-    virtual void on_seek(double, MediaSeekMode) { m_seek_in_progress = false; }
+    // subclasses must call finish_seek_element() to complete the seeking steps required by the spec.
+    virtual void on_seek(double, MediaSeekMode) { }
 
     virtual void on_volume_change() { }
 
@@ -265,8 +267,6 @@ private:
     JS::GCPtr<SourceElementSelector> m_source_element_selector;
 
     JS::GCPtr<Fetch::Infrastructure::FetchController> m_fetch_controller;
-
-    bool m_seek_in_progress = false;
 
     // Cached state for layout.
     Optional<MouseTrackingComponent> m_mouse_tracking_component;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -108,8 +108,8 @@ public:
     void set_layout_mouse_position(Badge<Painting::MediaPaintable>, Optional<CSSPixelPoint> mouse_position) { m_mouse_position = move(mouse_position); }
     Optional<CSSPixelPoint> const& layout_mouse_position(Badge<Painting::MediaPaintable>) const { return m_mouse_position; }
 
-    void set_layout_display_time(Badge<Painting::MediaPaintable>, Optional<double> display_time);
-    double layout_display_time(Badge<Painting::MediaPaintable>) const;
+    void pause_temporarily(Badge<Painting::MediaPaintable>);
+    void resume_from_temporary_pause(Badge<Painting::MediaPaintable>);
 
     struct CachedLayoutBoxes {
         Optional<CSSPixelRect> control_box_rect;
@@ -270,9 +270,8 @@ private:
 
     // Cached state for layout.
     Optional<MouseTrackingComponent> m_mouse_tracking_component;
-    bool m_tracking_mouse_position_while_playing { false };
+    bool m_was_playing_before_temporary_pause { false };
     Optional<CSSPixelPoint> m_mouse_position;
-    Optional<double> m_display_time;
     mutable CachedLayoutBoxes m_layout_boxes;
 };
 

--- a/Userland/Libraries/LibWeb/HTML/VideoTrack.cpp
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrack.cpp
@@ -38,7 +38,7 @@ VideoTrack::VideoTrack(JS::Realm& realm, JS::NonnullGCPtr<HTMLMediaElement> medi
         m_media_element->set_current_playback_position(playback_position);
     };
 
-    m_playback_manager->on_playback_state_change = [this]() {
+    m_playback_manager->on_playback_state_change = [this](Video::PlaybackState) {
         switch (m_playback_manager->get_state()) {
         case Video::PlaybackState::Stopped: {
             auto playback_position_ms = static_cast<double>(duration().to_milliseconds());

--- a/Userland/Libraries/LibWeb/HTML/VideoTrack.cpp
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrack.cpp
@@ -38,7 +38,11 @@ VideoTrack::VideoTrack(JS::Realm& realm, JS::NonnullGCPtr<HTMLMediaElement> medi
         m_media_element->set_current_playback_position(playback_position);
     };
 
-    m_playback_manager->on_playback_state_change = [this](Video::PlaybackState) {
+    m_playback_manager->on_playback_state_change = [this](Video::PlaybackState old_state) {
+        if (old_state == Video::PlaybackState::Seeking && m_playback_manager->get_state() != Video::PlaybackState::Seeking) {
+            m_media_element->finish_seek_element();
+        }
+
         switch (m_playback_manager->get_state()) {
         case Video::PlaybackState::Stopped: {
             auto playback_position_ms = static_cast<double>(duration().to_milliseconds());

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.h
@@ -53,11 +53,7 @@ private:
     static void paint_control_bar_speaker(PaintContext&, HTML::HTMLMediaElement const&, Components const& components, Optional<DevicePixelPoint> const& mouse_position);
     static void paint_control_bar_volume(PaintContext&, HTML::HTMLMediaElement const&, Components const&, Optional<DevicePixelPoint> const& mouse_position);
 
-    enum class Temporary {
-        Yes,
-        No,
-    };
-    static void set_current_time(HTML::HTMLMediaElement& media_element, CSSPixelRect timeline_rect, CSSPixelPoint mouse_position, Temporary);
+    static void set_current_time(HTML::HTMLMediaElement& media_element, CSSPixelRect timeline_rect, CSSPixelPoint mouse_position);
     static void set_volume(HTML::HTMLMediaElement& media_element, CSSPixelRect volume_rect, CSSPixelPoint mouse_position);
 
     static bool rect_is_hovered(HTML::HTMLMediaElement const& media_element, Optional<DevicePixelRect> const& rect, Optional<DevicePixelPoint> const& mouse_position, Optional<HTML::HTMLMediaElement::MouseTrackingComponent> const& allowed_mouse_tracking_component = {});

--- a/Userland/Libraries/LibWeb/Platform/AudioCodecPlugin.h
+++ b/Userland/Libraries/LibWeb/Platform/AudioCodecPlugin.h
@@ -35,6 +35,7 @@ public:
     virtual Duration duration() = 0;
 
     Function<void(Duration)> on_playback_position_updated;
+    Function<void()> on_seek_completed;
 
 protected:
     AudioCodecPlugin();

--- a/Userland/Services/WebContent/AudioCodecPluginSerenity.cpp
+++ b/Userland/Services/WebContent/AudioCodecPluginSerenity.cpp
@@ -91,6 +91,8 @@ void AudioCodecPluginSerenity::set_volume(double volume)
 void AudioCodecPluginSerenity::seek(double position)
 {
     m_position = set_loader_position(m_loader, position, m_duration, m_device_sample_rate);
+    if (on_seek_completed)
+        on_seek_completed();
 
     if (on_playback_position_updated)
         on_playback_position_updated(m_position);


### PR DESCRIPTION
Seeking will now be done asynchronously, completing the `seek_element()` steps after the implementation of the element (HTMLAudioElement or PlaybackManager for video) signals that the seeking has been completed.

@trflynn89 currently I just made the HTMLAudioElement immediately call `finish_seek_element()`, which I believe is the same behavior as previously, but I'm not entirely sure. Please correct me if I need to change something there.

With the seeking done entirely asynchronously, we can now seek immediately for each mousemove, allowing us to preview a video frame as soon as possible while scrubbing. The display time field in HTMLMediaElement could be deleted thanks to this change, since we don't have to fake the timeline. We only have to track whether the element was playing before the drag begun, so that we can resume after the mouse button is released.

https://github.com/SerenityOS/serenity/assets/3149592/4f91c409-06e5-478b-854a-90f79f36c2ba