### PR TITLE
LibJS/Bytecode: Support destructuring function parameters

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -2489,11 +2489,11 @@ void FunctionNode::dump(int indent, DeprecatedString const& class_name) const
         outln("(Parameters)");
 
         for (auto& parameter : m_parameters) {
-            print_indent(indent + 2);
-            if (parameter.is_rest)
-                out("...");
             parameter.binding.visit(
                 [&](DeprecatedFlyString const& name) {
+                    print_indent(indent + 2);
+                    if (parameter.is_rest)
+                        out("...");
                     outln("{}", name);
                 },
                 [&](BindingPattern const& pattern) {

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -272,6 +272,10 @@ public:
     Function<ThrowCompletionOr<void>(Realm&)> host_ensure_can_compile_strings;
     Function<ThrowCompletionOr<void>(Object&)> host_ensure_can_add_private_element;
 
+    // Execute a specific AST node either in AST or BC interpreter, depending on which one is enabled by default.
+    // NOTE: This is meant as a temporary stopgap until everything is bytecode.
+    ThrowCompletionOr<Value> execute_ast_node(ASTNode const&);
+
 private:
     using ErrorMessages = AK::Array<String, to_underlying(ErrorMessage::__Count)>;
 


### PR DESCRIPTION
To reduce code duplication, I've added new `VM::execute_ast_node()` helper that handles bytecode compilation if needed.

918 new passes on test262. :^)
