### PR TITLE
Kernel: Fixes for bare metal SD Card I/O

### DIFF
--- a/Kernel/Devices/Storage/SD/Registers.h
+++ b/Kernel/Devices/Storage/SD/Registers.h
@@ -42,7 +42,34 @@ struct HostControlRegisterMap {
     u32 response_2;
     u32 response_3;
     u32 buffer_data_port;
-    u32 present_state;
+    union PresentState {
+        struct { // SDHC 2.2.9 Present State Register (Cat.C Offset 024h)
+            u32 command_inhibit_cmd : 1;
+            u32 command_inhibit_dat : 1;
+            u32 dat_line_active : 1;
+            u32 re_tuning_request : 1;
+            u32 dat_7_4_line_signal_level : 4;
+            u32 write_transfer_active : 1;
+            u32 read_transfer_active : 1;
+            u32 buffer_write_enable : 1;
+            u32 buffer_read_enable : 1;
+            u32 : 4;
+            u32 card_inserted : 1;
+            u32 card_state_stable : 1;
+            u32 card_detect_pin_level : 1;
+            u32 write_protect_switch_pin_level : 1;
+            u32 dat_3_0_line_signal_level : 4;
+            u32 cmd_line_signal_level : 1;
+            u32 host_regulator_voltage_stable : 1;
+            u32 : 1;
+            u32 command_not_issued_by_error : 1;
+            u32 sub_command_status : 1;
+            u32 in_dormant_state : 1;
+            u32 lane_synchronization : 1;
+            u32 uhs_2_if_detection : 1;
+        };
+        u32 raw;
+    } present_state;
     u32 host_configuration_0;
     u32 host_configuration_1;
     union InterruptStatus {

--- a/Kernel/Devices/Storage/SD/SDHostController.cpp
+++ b/Kernel/Devices/Storage/SD/SDHostController.cpp
@@ -44,6 +44,7 @@ constexpr u32 dma_select_adma2_64 = 0b11 << 3;
 constexpr u32 internal_clock_enable = 1 << 0;
 constexpr u32 internal_clock_stable = 1 << 1;
 constexpr u32 sd_clock_enable = 1 << 2;
+constexpr u32 sd_clock_divisor_mask = 0x0000ffc0;
 
 // In sub-register "Software Reset"
 constexpr u32 software_reset_for_all = 0x01000000;
@@ -446,7 +447,7 @@ ErrorOr<void> SDHostController::sd_clock_supply(u32 frequency)
         const u32 two_upper_bits_of_sdclk_frequency_select = (divisor >> 8 & 0x3) << 6;
         sdclk_frequency_select |= two_upper_bits_of_sdclk_frequency_select;
     }
-    m_registers->host_configuration_1 = m_registers->host_configuration_1 | internal_clock_enable | sdclk_frequency_select;
+    m_registers->host_configuration_1 = (m_registers->host_configuration_1 & ~sd_clock_divisor_mask) | internal_clock_enable | sdclk_frequency_select;
 
     // 3. Check Internal Clock Stable in the Clock Control register until it is 1
     if (!retry_with_timeout([&] { return m_registers->host_configuration_1 & internal_clock_stable; })) {

--- a/Kernel/Devices/Storage/SD/SDHostController.h
+++ b/Kernel/Devices/Storage/SD/SDHostController.h
@@ -43,8 +43,7 @@ private:
 
     bool is_card_inserted() const
     {
-        constexpr u32 card_inserted = 1 << 16;
-        return m_registers->present_state & card_inserted;
+        return m_registers->present_state.card_inserted;
     }
 
     SD::HostVersion host_version() { return m_registers->slot_interrupt_status_and_version.specification_version_number; }

--- a/Kernel/Devices/Storage/SD/SDHostController.h
+++ b/Kernel/Devices/Storage/SD/SDHostController.h
@@ -61,7 +61,7 @@ private:
     ErrorOr<u32> calculate_sd_clock_divisor(u32 sd_clock_frequency, u32 frequency);
     bool is_sd_clock_enabled();
     ErrorOr<void> sd_clock_supply(u32 frequency);
-    void sd_clock_stop();
+    ErrorOr<void> sd_clock_stop();
     ErrorOr<void> sd_clock_frequency_change(u32 frequency);
     ErrorOr<u32> retrieve_sd_clock_frequency();
 


### PR DESCRIPTION
This PR fixes a few logic bugs that didn't manifest when running under Qemu, only when trying to boot on the Raspberry Pi from the SD card.

@mrkct 