### PR TITLE
LibVideo/PlaybackManager: Don't crash when demuxer seek throws an error

### DIFF
--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -158,7 +158,7 @@ private:
 
     void timer_callback();
     // This must be called with m_demuxer_mutex locked!
-    Optional<Duration> seek_demuxer_to_most_recent_keyframe(Duration timestamp, Optional<Duration> earliest_available_sample = OptionalNone());
+    DecoderErrorOr<Optional<Duration>> seek_demuxer_to_most_recent_keyframe(Duration timestamp, Optional<Duration> earliest_available_sample = OptionalNone());
 
     Optional<FrameQueueItem> dequeue_one_frame();
     void set_state_update_timer(int delay_ms);


### PR DESCRIPTION
`seek_demuxer_to_most_recent_keyframe()` wasn't correctly returning in cases where an error was thrown by the demuxer. To avoid this, the function now returns the error, and the playback state handler must act on it instead, allowing it to exit the seeking state early.