### PR TITLE
LibJS: Invalidate cached environment coordinate after delete in global

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -375,8 +375,10 @@ ThrowCompletionOr<void> GetVariable::execute_impl(Bytecode::Interpreter& interpr
         auto const& string = interpreter.current_executable().get_identifier(m_identifier);
         if (m_cached_environment_coordinate.has_value()) {
             Environment* environment = nullptr;
+            bool coordinate_screwed_by_delete_in_global_environment = false;
             if (m_cached_environment_coordinate->index == EnvironmentCoordinate::global_marker) {
                 environment = &interpreter.vm().current_realm()->global_environment();
+                coordinate_screwed_by_delete_in_global_environment = !TRY(environment->has_binding(string));
             } else {
                 environment = vm.running_execution_context().lexical_environment;
                 for (size_t i = 0; i < m_cached_environment_coordinate->hops; ++i)
@@ -384,7 +386,7 @@ ThrowCompletionOr<void> GetVariable::execute_impl(Bytecode::Interpreter& interpr
                 VERIFY(environment);
                 VERIFY(environment->is_declarative_environment());
             }
-            if (!environment->is_permanently_screwed_by_eval()) {
+            if (!coordinate_screwed_by_delete_in_global_environment && !environment->is_permanently_screwed_by_eval()) {
                 return Reference { *environment, string, vm.in_strict_mode(), m_cached_environment_coordinate };
             }
             m_cached_environment_coordinate = {};

--- a/Userland/Libraries/LibJS/Tests/operators/delete-global-variable.js
+++ b/Userland/Libraries/LibJS/Tests/operators/delete-global-variable.js
@@ -1,4 +1,5 @@
 a = 1;
+b = 42;
 
 test("basic functionality", () => {
     expect(delete a).toBeTrue();
@@ -6,4 +7,17 @@ test("basic functionality", () => {
     expect(() => {
         a;
     }).toThrowWithMessage(ReferenceError, "'a' is not defined");
+});
+
+test("delete global var after usage", () => {
+    let errors = 0;
+    for (let i = 0; i < 3; ++i) {
+        try {
+            b++;
+        } catch {
+            ++errors;
+        }
+        delete globalThis.b;
+    }
+    expect(errors).toBe(2);
 });


### PR DESCRIPTION
Fixes the bug in bytecode interpreter when cached environment coordinate is not invalidated after `delete` operator usage on global `this`.