### PR TITLE
SystemMonitor: Improve performance via reduced file I/O

### DIFF
--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -226,7 +226,7 @@ GUI::Variant ProcessModel::data(GUI::ModelIndex const& index, GUI::ModelRole rol
         case Column::Name:
             return thread.current_state.name;
         case Column::Command:
-            return thread.current_state.command;
+            return thread.current_state.command.visit([](String const& cmdline) { return cmdline; }, [](auto const&) { return ""_short_string; });
         case Column::Syscalls:
             return thread.current_state.syscall_count;
         case Column::InodeFaults:
@@ -296,7 +296,7 @@ GUI::Variant ProcessModel::data(GUI::ModelIndex const& index, GUI::ModelRole rol
                 return DeprecatedString::formatted("{} (*)", thread.current_state.name);
             return thread.current_state.name;
         case Column::Command:
-            return thread.current_state.command;
+            return thread.current_state.command.visit([](String const& cmdline) { return cmdline; }, [](auto const&) { return ""_short_string; });
         case Column::Syscalls:
             return thread.current_state.syscall_count;
         case Column::InodeFaults:
@@ -422,25 +422,16 @@ Vector<GUI::ModelIndex> ProcessModel::matches(StringView searching, unsigned fla
     return found_indices;
 }
 
-static ErrorOr<DeprecatedString> try_read_command_line(pid_t pid)
+ErrorOr<String> ProcessModel::read_command_line(pid_t pid)
 {
-    auto file = TRY(Core::File::open(DeprecatedString::formatted("/proc/{}/cmdline", pid), Core::File::OpenMode::Read));
+    auto file = TRY(Core::File::open(TRY(String::formatted("/proc/{}/cmdline", pid)), Core::File::OpenMode::Read));
     auto data = TRY(file->read_until_eof());
     auto json = TRY(JsonValue::from_string(StringView { data.bytes() }));
     auto array = json.as_array().values();
-    return DeprecatedString::join(" "sv, array);
+    return String::join(" "sv, array);
 }
 
-static DeprecatedString read_command_line(pid_t pid)
-{
-    auto string_or_error = try_read_command_line(pid);
-    if (string_or_error.is_error()) {
-        return "";
-    }
-    return string_or_error.release_value();
-}
-
-ErrorOr<void> ProcessModel::initialize_process_statistics_file()
+ErrorOr<void> ProcessModel::ensure_process_statistics_file()
 {
     if (!m_process_statistics_file || !m_process_statistics_file->is_open())
         m_process_statistics_file = TRY(Core::File::open("/sys/kernel/processes"sv, Core::File::OpenMode::Read));
@@ -450,7 +441,7 @@ ErrorOr<void> ProcessModel::initialize_process_statistics_file()
 
 void ProcessModel::update()
 {
-    auto result = initialize_process_statistics_file();
+    auto result = ensure_process_statistics_file();
     if (result.is_error()) {
         dbgln("Process model couldn't be updated: {}", result.release_error());
         return;
@@ -489,6 +480,8 @@ void ProcessModel::update()
                 auto thread_data = m_threads.ensure(tid, [&] { return make_ref_counted<Thread>(process_state); });
                 thread_data->previous_state = move(thread_data->current_state);
                 thread_data->current_state = move(state);
+                thread_data->read_command_line_if_necessary();
+
                 if (auto maybe_thread_index = process_state.threads.find_first_index(thread_data); maybe_thread_index.has_value()) {
                     process_state.threads[maybe_thread_index.value()] = thread_data;
                 } else {
@@ -511,7 +504,6 @@ void ProcessModel::update()
                     state.kernel = process.kernel;
                     state.executable = process.executable;
                     state.name = thread.name;
-                    state.command = read_command_line(process.pid);
                     state.uid = process.uid;
                     state.state = thread.state;
                     state.user = process.username;
@@ -554,7 +546,6 @@ void ProcessModel::update()
                 state.kernel = process.kernel;
                 state.executable = process.executable;
                 state.name = process.name;
-                state.command = read_command_line(process.pid);
                 state.uid = process.uid;
                 state.state = "Zombie";
                 state.user = process.username;

--- a/Userland/Applications/SystemMonitor/ProcessModel.h
+++ b/Userland/Applications/SystemMonitor/ProcessModel.h
@@ -240,6 +240,10 @@ private:
 
     int thread_model_row(Thread const& thread) const;
 
+    ErrorOr<void> initialize_process_statistics_file();
+
+    OwnPtr<Core::File> m_process_statistics_file;
+
     // The thread list contains the same threads as the Process structs.
     HashMap<int, NonnullRefPtr<Thread>> m_threads;
     Vector<NonnullOwnPtr<Process>> m_processes;


### PR DESCRIPTION
SystemMonitor was reading a lot of process statistics data from the sysfs and procfs, and much of it was done non-optimally. This PR improves that by reducing normal SystemMonitor load over 50%.

- Don't reopen the process list file every time it is read. Opening files is not exactly the cheapest operation.
- Don't read a process's command line every update, and don't read a command line which we know we're not allowed to access. This is the big one, previously it accounted for close to 50% of total SystemMonitor runtime.