### PR TITLE
FileManager: Restore inline message behavior for inaccessible dirs

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -408,9 +408,9 @@ bool DirectoryView::open(DeprecatedString const& path)
         return false;
 
     auto real_path = error_or_real_path.release_value();
-    if (Core::System::chdir(real_path).is_error()) {
-        perror("chdir");
-        return false;
+    if (auto result = Core::System::chdir(real_path); result.is_error()) {
+        dbgln("Failed to open '{}': {}", real_path, result.error());
+        warnln("Failed to open '{}': {}", real_path, result.error());
     }
 
     if (model().root_path() == real_path.to_deprecated_string()) {


### PR DESCRIPTION
Print the correct error from Core::System::chdir() instead of errno, and display the error in the DirectoryView instead of continuing to show the previous location's contents.

This regressed in 1dc3ba6ed5bfbb0055d9335a32f580a73f3ab254.

(Side note: Having to warnln() and dbgln() feels a bit silly, but that's what perror() does. Should we automatically output warnln() to the debug console as well?)