### PR TITLE
Meta/Fuzzers: Extract common audio fuzzing code

### DIFF
--- a/Meta/Lagom/Fuzzers/AudioFuzzerCommon.h
+++ b/Meta/Lagom/Fuzzers/AudioFuzzerCommon.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2021-2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Concepts.h>
+#include <AK/MemoryStream.h>
+#include <LibAudio/Loader.h>
+#include <stddef.h>
+#include <stdint.h>
+
+template<typename LoaderPluginType>
+requires(IsBaseOf<Audio::LoaderPlugin, LoaderPluginType>)
+int fuzz_audio_loader(uint8_t const* data, size_t size)
+{
+    auto const bytes = ReadonlyBytes { data, size };
+    auto stream = try_make<FixedMemoryStream>(bytes).release_value();
+    auto audio_or_error = LoaderPluginType::create(move(stream));
+
+    if (audio_or_error.is_error())
+        return 0;
+
+    auto audio = audio_or_error.release_value();
+
+    for (;;) {
+        auto samples = audio->load_chunks(4 * KiB);
+        if (samples.is_error())
+            return 0;
+        if (samples.value().size() == 0)
+            break;
+    }
+
+    return 0;
+}

--- a/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
@@ -1,32 +1,13 @@
 /*
- * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/MemoryStream.h>
+#include "AudioFuzzerCommon.h"
 #include <LibAudio/FlacLoader.h>
-#include <stddef.h>
-#include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto const flac_bytes = ByteBuffer::copy(data, size).release_value();
-    auto flac_data = try_make<FixedMemoryStream>(flac_bytes).release_value();
-    auto flac_or_error = Audio::FlacLoaderPlugin::create(move(flac_data));
-
-    if (flac_or_error.is_error())
-        return 0;
-
-    auto flac = flac_or_error.release_value();
-
-    for (;;) {
-        auto samples = flac->load_chunks(10 * KiB);
-        if (samples.is_error())
-            return 0;
-        if (samples.value().size() == 0)
-            break;
-    }
-
-    return 0;
+    return fuzz_audio_loader<Audio::FlacLoaderPlugin>(data, size);
 }

--- a/Meta/Lagom/Fuzzers/FuzzMP3Loader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMP3Loader.cpp
@@ -1,31 +1,13 @@
 /*
- * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "AudioFuzzerCommon.h"
 #include <LibAudio/MP3Loader.h>
-#include <stddef.h>
-#include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto const mp3_bytes = ByteBuffer::copy(data, size).release_value();
-    auto mp3_data = try_make<FixedMemoryStream>(mp3_bytes).release_value();
-    auto mp3_or_error = Audio::MP3LoaderPlugin::create(move(mp3_data));
-
-    if (mp3_or_error.is_error())
-        return 0;
-
-    auto mp3 = mp3_or_error.release_value();
-
-    for (;;) {
-        auto samples = mp3->load_chunks(1 * KiB);
-        if (samples.is_error())
-            return 0;
-        if (samples.value().size() == 0)
-            break;
-    }
-
-    return 0;
+    return fuzz_audio_loader<Audio::MP3LoaderPlugin>(data, size);
 }

--- a/Meta/Lagom/Fuzzers/FuzzQOALoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzQOALoader.cpp
@@ -4,29 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/MemoryStream.h>
+#include "AudioFuzzerCommon.h"
 #include <LibAudio/QOALoader.h>
-#include <stddef.h>
-#include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto const qoa_bytes = ByteBuffer::copy(data, size).release_value();
-    auto qoa_data = try_make<FixedMemoryStream>(qoa_bytes).release_value();
-    auto qoa_or_error = Audio::QOALoaderPlugin::create(move(qoa_data));
-
-    if (qoa_or_error.is_error())
-        return 0;
-
-    auto qoa = qoa_or_error.release_value();
-
-    for (;;) {
-        auto samples = qoa->load_chunks(5 * KiB);
-        if (samples.is_error())
-            return 0;
-        if (samples.value().size() == 0)
-            break;
-    }
-
-    return 0;
+    return fuzz_audio_loader<Audio::QOALoaderPlugin>(data, size);
 }

--- a/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
@@ -1,32 +1,13 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers.
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/MemoryStream.h>
+#include "AudioFuzzerCommon.h"
 #include <LibAudio/WavLoader.h>
-#include <stddef.h>
-#include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto const wav_bytes = ByteBuffer::copy(data, size).release_value();
-    auto wav_data = try_make<FixedMemoryStream>(wav_bytes).release_value();
-    auto wav_or_error = Audio::WavLoaderPlugin::create(move(wav_data));
-
-    if (wav_or_error.is_error())
-        return 0;
-
-    auto wav = wav_or_error.release_value();
-
-    for (;;) {
-        auto samples = wav->load_chunks(4 * KiB);
-        if (samples.is_error())
-            return 0;
-        if (samples.value().size() == 0)
-            break;
-    }
-
-    return 0;
+    return fuzz_audio_loader<Audio::WavLoaderPlugin>(data, size);
 }


### PR DESCRIPTION
Apart from the class used audio fuzzers have identical behavior: Create a memory stream from the fuzzer input and pass this to the loader, then try to load audio until an error occurs. Since the loader plugins need to have the same static create() function anyways for LibAudio itself, we can unify the fuzzer implementations and reduce code duplication.