### PR TITLE
LibWeb+LibGfx: Close all subpaths before filling SVG paths

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
@@ -86,13 +86,13 @@ void SVGGeometryPaintable::paint(PaintContext& context, PaintPhase phase) const
     auto const& original_path = const_cast<SVG::SVGGeometryElement&>(geometry_element).get_path();
     Gfx::Path path = original_path.copy_transformed(paint_transform);
 
-    // Fills are computed as though all paths are closed (https://svgwg.org/svg2-draft/painting.html#FillProperties)
+    // Fills are computed as though all subpaths are closed (https://svgwg.org/svg2-draft/painting.html#FillProperties)
     auto closed_path = [&] {
         // We need to fill the path before applying the stroke, however the filled
         // path must be closed, whereas the stroke path may not necessary be closed.
         // Copy the path and close it for filling, but use the previous path for stroke
         auto copy = path;
-        copy.close();
+        copy.close_all_subpaths();
         return copy;
     };
 


### PR DESCRIPTION

| Before                                                                                                                              | After                                                                                                                               |
|-------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
| ![Screenshot from 2023-06-24 16-54-45](https://github.com/SerenityOS/serenity/assets/11597044/e17a5eb2-9392-4dd8-a87b-e2ea38dd7f9e) | ![Screenshot from 2023-06-24 16-54-10](https://github.com/SerenityOS/serenity/assets/11597044/135cc4e1-fdd2-4d8b-92f7-de220f303af4) |

This fixes some rasterization issues with the Deno logo, the remaining issues are due to lack of SVG mask support.  
