### PR TITLE
cut: Bring closer to POSIX specification and add `-s` option

### DIFF
--- a/Base/usr/share/man/man1/cut.md
+++ b/Base/usr/share/man/man1/cut.md
@@ -23,6 +23,7 @@ With no FILE, or when FILE is -, read standard input.
 * `-b` `--bytes=list`: Select only these bytes
 * `-f` `--fields=list`: select only these fields; also print any line that contains no delimiter character
 * `-d` `--delimiter=delim`: use `delim` instead of `tab` for field delimiter
+* `-s`, `only-delimited`: suppress lines which don't contain any field delimiter characters
 
 ## Examples
 

--- a/Userland/Utilities/cut.cpp
+++ b/Userland/Utilities/cut.cpp
@@ -241,8 +241,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto file = TRY(Core::InputBufferedFile::create(maybe_file.release_value()));
 
         Array<u8, PAGE_SIZE> buffer;
-        while (!file->is_eof()) {
+        while (TRY(file->can_read_line())) {
             auto line = TRY(file->read_line(buffer));
+            if (line == "\n" && TRY(file->can_read_line()))
+                break;
 
             if (selected_bytes) {
                 process_line_bytes(line, disjoint_ranges);

--- a/Userland/Utilities/cut.cpp
+++ b/Userland/Utilities/cut.cpp
@@ -136,7 +136,7 @@ static void process_line_bytes(StringView line, Vector<Range> const& ranges)
 
 static void process_line_fields(StringView line, Vector<Range> const& ranges, char delimiter)
 {
-    auto string_split = DeprecatedString(line).split(delimiter);
+    auto string_split = DeprecatedString(line).split(delimiter, SplitBehavior::KeepEmpty);
     Vector<DeprecatedString> output_fields;
 
     for (auto& range : ranges) {

--- a/Userland/Utilities/cut.cpp
+++ b/Userland/Utilities/cut.cpp
@@ -137,8 +137,12 @@ static void process_line_bytes(StringView line, Vector<Range> const& ranges)
 static void process_line_fields(StringView line, Vector<Range> const& ranges, char delimiter)
 {
     auto string_split = DeprecatedString(line).split(delimiter, SplitBehavior::KeepEmpty);
-    Vector<DeprecatedString> output_fields;
+    if (string_split.size() == 1) {
+        outln("{}", line);
+        return;
+    }
 
+    Vector<DeprecatedString> output_fields;
     for (auto& range : ranges) {
         for (size_t i = range.m_from - 1; i < min(range.m_to, string_split.size()); i++) {
             output_fields.append(string_split[i]);

--- a/Userland/Utilities/cut.cpp
+++ b/Userland/Utilities/cut.cpp
@@ -134,11 +134,13 @@ static void process_line_bytes(StringView line, Vector<Range> const& ranges)
     outln();
 }
 
-static void process_line_fields(StringView line, Vector<Range> const& ranges, char delimiter)
+static void process_line_fields(StringView line, Vector<Range> const& ranges, char delimiter, bool only_print_delimited_lines)
 {
     auto string_split = DeprecatedString(line).split(delimiter, SplitBehavior::KeepEmpty);
     if (string_split.size() == 1) {
-        outln("{}", line);
+        if (!only_print_delimited_lines)
+            outln("{}", line);
+
         return;
     }
 
@@ -157,6 +159,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     DeprecatedString byte_list = "";
     DeprecatedString fields_list = "";
     DeprecatedString delimiter = "\t";
+    bool only_print_delimited_lines = false;
 
     Vector<StringView> files;
 
@@ -165,6 +168,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(byte_list, "select only these bytes", "bytes", 'b', "list");
     args_parser.add_option(fields_list, "select only these fields", "fields", 'f', "list");
     args_parser.add_option(delimiter, "set a custom delimiter", "delimiter", 'd', "delimiter");
+    args_parser.add_option(only_print_delimited_lines, "suppress lines which don't contain any field delimiter characters", "only-delimited", 's');
     args_parser.parse(arguments);
 
     bool selected_bytes = (byte_list != "");
@@ -249,7 +253,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (selected_bytes) {
                 process_line_bytes(line, disjoint_ranges);
             } else if (selected_fields) {
-                process_line_fields(line, disjoint_ranges, delimiter[0]);
+                process_line_fields(line, disjoint_ranges, delimiter[0], only_print_delimited_lines);
             } else {
                 VERIFY_NOT_REACHED();
             }

--- a/Userland/Utilities/cut.cpp
+++ b/Userland/Utilities/cut.cpp
@@ -35,7 +35,7 @@ struct Range {
 
 static bool expand_list(DeprecatedString& list, Vector<Range>& ranges)
 {
-    Vector<DeprecatedString> tokens = list.split(',');
+    Vector<DeprecatedString> tokens = list.split(',', SplitBehavior::KeepEmpty);
 
     for (auto& token : tokens) {
         if (token.length() == 0) {
@@ -75,7 +75,7 @@ static bool expand_list(DeprecatedString& list, Vector<Range>& ranges)
 
             ranges.append({ index.value(), SIZE_MAX });
         } else {
-            auto range = token.split('-');
+            auto range = token.split('-', SplitBehavior::KeepEmpty);
             if (range.size() == 2) {
                 auto index1 = range[0].to_uint();
                 if (!index1.has_value()) {


### PR DESCRIPTION
This PR brings `cut` closer to the POSIX specification by making the following changes:

* Lines containing no field delimiters are now passed through unmodified by default. Specifying the `-s` option causes these lines to be ignored.
* Field specifiers containing multiple consecutive commas or dashes (e.g: `-f1,,2`, `-f2--5`) are now treated as invalid.
* Empty fields on a line are no longer treated as though they aren't present. For example, a line such as `\t\tThis line has 3 fields`, previously had its first 2 empty fields ignored.
* A trailing newline before EOF is now ignored, rather than an empty line being printed.

Example usage:

![cut_tweaks](https://github.com/SerenityOS/serenity/assets/2817754/e65d60b2-c8db-4af9-9c3d-047b68ff7d38)
