### PR TITLE
 LibWeb: Implement Web::URL::url_encode closer to spec

### DIFF
--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -117,7 +117,7 @@ constexpr bool is_double_dot_path_segment(StringView input)
 }
 
 // https://url.spec.whatwg.org/#string-percent-encode-after-encoding
-static DeprecatedString percent_encode_after_encoding(StringView input, URL::PercentEncodeSet percent_encode_set, bool space_as_plus = false)
+DeprecatedString URLParser::percent_encode_after_encoding(StringView input, URL::PercentEncodeSet percent_encode_set, bool space_as_plus)
 {
     // NOTE: This is written somewhat ad-hoc since we don't yet implement the Encoding spec.
 

--- a/AK/URLParser.h
+++ b/AK/URLParser.h
@@ -57,6 +57,9 @@ public:
 
     static URL parse(StringView input, Optional<URL> const& base_url = {}, Optional<URL> url = {}, Optional<State> state_override = {});
 
+    // https://url.spec.whatwg.org/#string-percent-encode-after-encoding
+    static DeprecatedString percent_encode_after_encoding(StringView input, URL::PercentEncodeSet percent_encode_set, bool space_as_plus = false);
+
 private:
     static Optional<URL> parse_data_url(StringView raw_input);
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -96,7 +96,7 @@ private:
 
     ErrorOr<String> pick_an_encoding() const;
 
-    ErrorOr<void> mutate_action_url(AK::URL parsed_action, Vector<XHR::FormDataEntry> entry_list, JS::NonnullGCPtr<AbstractBrowsingContext> target_navigable, HistoryHandlingBehavior history_handling);
+    ErrorOr<void> mutate_action_url(AK::URL parsed_action, Vector<XHR::FormDataEntry> entry_list, String encoding, JS::NonnullGCPtr<AbstractBrowsingContext> target_navigable, HistoryHandlingBehavior history_handling);
     ErrorOr<void> submit_as_entity_body(AK::URL parsed_action, Vector<XHR::FormDataEntry> entry_list, EncodingTypeAttributeState encoding_type, String encoding, JS::NonnullGCPtr<AbstractBrowsingContext> target_navigable, HistoryHandlingBehavior history_handling);
     void get_action_url(AK::URL parsed_action, JS::NonnullGCPtr<AbstractBrowsingContext> target_navigable, HistoryHandlingBehavior history_handling);
     ErrorOr<void> mail_with_headers(AK::URL parsed_action, Vector<XHR::FormDataEntry> entry_list, String encoding, JS::NonnullGCPtr<AbstractBrowsingContext> target_navigable, HistoryHandlingBehavior history_handling);

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
@@ -276,11 +276,7 @@ WebIDL::ExceptionOr<void> URLSearchParams::sort()
              k != a_code_points.end() && l != b_code_points.end();
              ++k, ++l) {
             if (*k != *l) {
-                if (*k < *l) {
-                    return true;
-                } else {
-                    return false;
-                }
+                return *k < *l;
             }
         }
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
@@ -49,6 +49,8 @@ ErrorOr<String> url_encode(Vector<QueryParam> const& pairs, AK::URL::PercentEnco
     return builder.to_string();
 }
 
+// https://url.spec.whatwg.org/#concept-urlencoded-parser
+// The application/x-www-form-urlencoded parser takes a byte sequence input, and then runs these steps:
 ErrorOr<Vector<QueryParam>> url_decode(StringView input)
 {
     // 1. Let sequences be the result of splitting input on 0x26 (&).

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.h
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.h
@@ -16,7 +16,7 @@ struct QueryParam {
     String name;
     String value;
 };
-ErrorOr<String> url_encode(Vector<QueryParam> const&, AK::URL::PercentEncodeSet);
+ErrorOr<String> url_encode(Vector<QueryParam> const&, StringView encoding = "UTF-8"sv);
 ErrorOr<Vector<QueryParam>> url_decode(StringView);
 
 class URLSearchParams : public Bindings::PlatformObject {


### PR DESCRIPTION
Still left to be implemented are the encoding steps inside of percent_encode_after_encoding