### PR TITLE
LibJS/Bytecode: Throw on destructuring object assignment to nullish LHS

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -989,6 +989,8 @@ Bytecode::CodeGenerationErrorOr<void> FunctionExpression::generate_bytecode(Byte
 
 static Bytecode::CodeGenerationErrorOr<void> generate_object_binding_pattern_bytecode(Bytecode::Generator& generator, BindingPattern const& pattern, Bytecode::Op::SetVariable::InitializationMode initialization_mode, Bytecode::Register const& value_reg, bool create_variables)
 {
+    generator.emit<Bytecode::Op::ThrowIfNullish>();
+
     Vector<Bytecode::Register> excluded_property_names;
     auto has_rest = false;
     if (pattern.entries.size() > 0)

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -92,6 +92,7 @@
     O(SuperCall)                     \
     O(Throw)                         \
     O(ThrowIfNotObject)              \
+    O(ThrowIfNullish)                \
     O(ToNumeric)                     \
     O(Typeof)                        \
     O(TypeofVariable)                \

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -844,6 +844,15 @@ ThrowCompletionOr<void> ThrowIfNotObject::execute_impl(Bytecode::Interpreter& in
     return {};
 }
 
+ThrowCompletionOr<void> ThrowIfNullish::execute_impl(Bytecode::Interpreter& interpreter) const
+{
+    auto& vm = interpreter.vm();
+    auto value = interpreter.accumulator();
+    if (value.is_nullish())
+        return vm.throw_completion<TypeError>(ErrorType::NotObjectCoercible, TRY_OR_THROW_OOM(vm, value.to_string_without_side_effects()));
+    return {};
+}
+
 ThrowCompletionOr<void> EnterUnwindContext::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     interpreter.enter_unwind_context(m_handler_target, m_finalizer_target);
@@ -1430,6 +1439,11 @@ DeprecatedString Throw::to_deprecated_string_impl(Bytecode::Executable const&) c
 DeprecatedString ThrowIfNotObject::to_deprecated_string_impl(Bytecode::Executable const&) const
 {
     return "ThrowIfNotObject";
+}
+
+DeprecatedString ThrowIfNullish::to_deprecated_string_impl(Bytecode::Executable const&) const
+{
+    return "ThrowIfNullish";
 }
 
 DeprecatedString EnterUnwindContext::to_deprecated_string_impl(Bytecode::Executable const&) const

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -958,6 +958,19 @@ public:
     void replace_references_impl(Register, Register) { }
 };
 
+class ThrowIfNullish final : public Instruction {
+public:
+    ThrowIfNullish()
+        : Instruction(Type::ThrowIfNullish)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
+};
+
 class EnterUnwindContext final : public Instruction {
 public:
     constexpr static bool IsTerminator = true;


### PR DESCRIPTION
24 new passes on test262. :^)