### PR TITLE
LibJS/Bytecode: Transfer binding pattern aliases to function names

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1253,8 +1253,10 @@ static Bytecode::CodeGenerationErrorOr<void> generate_array_binding_pattern_byte
 
             generator.switch_to_basic_block(value_is_undefined_block);
 
-            if (auto const* lhs = name.get_pointer<NonnullRefPtr<Identifier const>>()) {
-                TRY(generator.emit_named_evaluation_if_anonymous_function(*initializer, (*lhs)->string()));
+            if (auto const* alias_identifier = alias.get_pointer<NonnullRefPtr<Identifier const>>()) {
+                TRY(generator.emit_named_evaluation_if_anonymous_function(*initializer, (*alias_identifier)->string()));
+            } else if (auto const* name_identifier = name.get_pointer<NonnullRefPtr<Identifier const>>()) {
+                TRY(generator.emit_named_evaluation_if_anonymous_function(*initializer, (*name_identifier)->string()));
             } else {
                 TRY(initializer->generate_bytecode(generator));
             }


### PR DESCRIPTION
60 new passes on test262. :^)