### PR TITLE
LibWeb: Adjust specified table height

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
@@ -1,8 +1,8 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x122 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 24x122 [BFC] children: not-inline
-        Box <table> at (19,19) content-size 2x100 table-box [TFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 24x100 [BFC] children: not-inline
+        Box <table> at (19,19) content-size 2x78 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
           Box <tbody> at (19,19) content-size 0x0 table-row-group children: not-inline

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -590,9 +590,8 @@ void TableFormattingContext::compute_table_height(LayoutMode layout_mode)
         // ends up smaller than this number.
         CSSPixels height_of_table_containing_block = m_state.get(*table_wrapper().containing_block()).content_height();
         auto specified_table_height = table_box().computed_values().height().to_px(table_box(), height_of_table_containing_block);
-        if (m_table_height < specified_table_height) {
-            m_table_height = specified_table_height;
-        }
+        auto const& table_state = m_state.get(table_box());
+        m_table_height = max(m_table_height, specified_table_height - table_state.border_box_top() - table_state.border_box_bottom());
     }
 
     for (auto& row : m_rows) {


### PR DESCRIPTION
Subtract borders and padding from specified height before comparing to the used content height.