### PR TITLE
Ladybird: Add history view

### DIFF
--- a/Ladybird/BrowserWindow.cpp
+++ b/Ladybird/BrowserWindow.cpp
@@ -110,6 +110,11 @@ BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdrive
     view_menu->addAction(open_previous_tab_action);
     QObject::connect(open_previous_tab_action, &QAction::triggered, this, &BrowserWindow::open_previous_tab);
 
+    auto* open_history_window_action = new QAction("Open &History Window", this);
+    open_history_window_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_H));
+    view_menu->addAction(open_history_window_action);
+    QObject::connect(open_history_window_action, &QAction::triggered, this, &BrowserWindow::open_history_window);
+
     view_menu->addSeparator();
 
     m_zoom_menu = view_menu->addMenu("&Zoom");
@@ -564,6 +569,14 @@ void BrowserWindow::open_previous_tab()
     if (next_index < 0)
         next_index = m_tabs_container->count() - 1;
     m_tabs_container->setCurrentIndex(next_index);
+}
+
+void BrowserWindow::open_history_window()
+{
+    if (!m_current_tab)
+        return;
+
+    m_current_tab->show_history_window();
 }
 
 void BrowserWindow::enable_auto_color_scheme()

--- a/Ladybird/BrowserWindow.h
+++ b/Ladybird/BrowserWindow.h
@@ -76,6 +76,7 @@ public slots:
     void close_current_tab();
     void open_next_tab();
     void open_previous_tab();
+    void open_history_window();
     void open_file();
     void enable_auto_color_scheme();
     void enable_light_color_scheme();

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -81,10 +81,12 @@ set(SOURCES
     ${BROWSER_SOURCE_DIR}/CookieJar.cpp
     ${BROWSER_SOURCE_DIR}/Database.cpp
     ${BROWSER_SOURCE_DIR}/History.cpp
+    ${BROWSER_SOURCE_DIR}/History/HistoryModel.cpp
     BrowserWindow.cpp
     ConsoleWidget.cpp
     EventLoopImplementationQt.cpp
     HelperProcess.cpp
+    HistoryWidget.cpp
     InspectorWidget.cpp
     LocationEdit.cpp
     ModelTranslator.cpp

--- a/Ladybird/HistoryWidget.cpp
+++ b/Ladybird/HistoryWidget.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, Tobias Soppa <tobias@soppa.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "HistoryWidget.h"
+#include <Browser/History/HistoryModel.h>
+#include <QHeaderView>
+#include <QTableView>
+
+namespace Ladybird {
+
+HistoryWidget::HistoryWidget()
+{
+    auto* table_view = new QTableView;
+    table_view->setModel(&m_history_model);
+    table_view->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    table_view->verticalHeader()->setVisible(false);
+    table_view->horizontalHeader()->setVisible(false);
+    m_table_view = table_view;
+}
+
+void HistoryWidget::set_history_entries(Vector<Browser::History::URLTitlePair> entries)
+{
+    auto& browser_history_model = *new Browser::HistoryModel;
+    browser_history_model.set_items(entries);
+    m_history_model.set_underlying_model(browser_history_model);
+}
+
+void HistoryWidget::show()
+{
+    if (!m_table_view)
+        return;
+    m_table_view->show();
+}
+
+}

--- a/Ladybird/HistoryWidget.cpp
+++ b/Ladybird/HistoryWidget.cpp
@@ -17,7 +17,7 @@ HistoryWidget::HistoryWidget()
     table_view->setModel(&m_history_model);
     table_view->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
     table_view->verticalHeader()->setVisible(false);
-    table_view->horizontalHeader()->setVisible(false);
+    table_view->horizontalHeader()->setVisible(true);
     m_table_view = table_view;
 }
 

--- a/Ladybird/HistoryWidget.h
+++ b/Ladybird/HistoryWidget.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023, Tobias Soppa <tobias@soppa.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "ModelTranslator.h"
+#include <Browser/History.h>
+#include <QTableView>
+#include <QWidget>
+
+namespace Ladybird {
+
+class HistoryWidget final : public QWidget {
+    Q_OBJECT
+public:
+    HistoryWidget();
+    virtual ~HistoryWidget() override = default;
+
+    void set_history_entries(Vector<Browser::History::URLTitlePair> entries);
+    void show();
+
+private:
+    ModelTranslator m_history_model {};
+    QTableView* m_table_view { nullptr };
+};
+
+}

--- a/Ladybird/ModelTranslator.cpp
+++ b/Ladybird/ModelTranslator.cpp
@@ -55,6 +55,19 @@ QVariant ModelTranslator::data(QModelIndex const& index, int role) const
     }
 }
 
+QVariant ModelTranslator::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (orientation == Qt::Vertical)
+        return {};
+    VERIFY(m_model);
+    switch (role) {
+    case Qt::DisplayRole:
+        return convert_variant(m_model->column_name(section).release_value_but_fixme_should_propagate_errors());
+    default:
+        return {};
+    }
+}
+
 QModelIndex ModelTranslator::index(int row, int column, QModelIndex const& parent) const
 {
     VERIFY(m_model);

--- a/Ladybird/ModelTranslator.h
+++ b/Ladybird/ModelTranslator.h
@@ -31,6 +31,7 @@ public:
     virtual int columnCount(QModelIndex const& parent) const override;
     virtual int rowCount(QModelIndex const& parent) const override;
     virtual QVariant data(QModelIndex const&, int role) const override;
+    virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
     virtual QModelIndex index(int row, int column, QModelIndex const& parent) const override;
     virtual QModelIndex parent(QModelIndex const& index) const override;
 

--- a/Ladybird/Tab.cpp
+++ b/Ladybird/Tab.cpp
@@ -676,6 +676,14 @@ void Tab::show_console_window()
     m_console_widget->show();
 }
 
+void Tab::show_history_window()
+{
+    dbgln("FIXME: Create history window widget.");
+    for (auto& history_entry : m_history.get_all_history_entries()) {
+        dbgln("{} {}", history_entry.title, history_entry.url);
+    }
+}
+
 void Tab::close_sub_widgets()
 {
     auto close_widget_window = [](auto* widget) {

--- a/Ladybird/Tab.cpp
+++ b/Ladybird/Tab.cpp
@@ -8,6 +8,7 @@
 #include "Tab.h"
 #include "BrowserWindow.h"
 #include "ConsoleWidget.h"
+#include "HistoryWidget.h"
 #include "InspectorWidget.h"
 #include "Settings.h"
 #include "Utilities.h"
@@ -678,10 +679,14 @@ void Tab::show_console_window()
 
 void Tab::show_history_window()
 {
-    dbgln("FIXME: Create history window widget.");
-    for (auto& history_entry : m_history.get_all_history_entries()) {
-        dbgln("{} {}", history_entry.title, history_entry.url);
+    if (!m_history_widget) {
+        m_history_widget = new Ladybird::HistoryWidget;
+        m_history_widget->setWindowTitle("History");
+        m_history_widget->resize(640, 480);
     }
+
+    m_history_widget->set_history_entries(m_history.get_all_history_entries());
+    m_history_widget->show();
 }
 
 void Tab::close_sub_widgets()

--- a/Ladybird/Tab.h
+++ b/Ladybird/Tab.h
@@ -52,6 +52,7 @@ public:
     };
     void show_inspector_window(InspectorTarget = InspectorTarget::Document);
     void show_console_window();
+    void show_history_window();
 
     Ladybird::ConsoleWidget* console() { return m_console_widget; };
 

--- a/Ladybird/Tab.h
+++ b/Ladybird/Tab.h
@@ -22,6 +22,7 @@ class BrowserWindow;
 namespace Ladybird {
 class ConsoleWidget;
 class InspectorWidget;
+class HistoryWidget;
 }
 
 class Tab final : public QWidget {
@@ -115,4 +116,5 @@ private:
 
     Ladybird::ConsoleWidget* m_console_widget { nullptr };
     Ladybird::InspectorWidget* m_inspector_widget { nullptr };
+    Ladybird::HistoryWidget* m_history_widget { nullptr };
 };


### PR DESCRIPTION
Adds a view that allows to see historical navigations for a single tab.

This is my first PR to Serenity and I am currently getting myself familiar with the code base, code style and so on. So if this PR either lacks certain aspects, or if its not going into a desirable direction, please let me know.