### PR TITLE
env: Add `-u` option to unset environment variables

### DIFF
--- a/Base/usr/share/man/man1/env.md
+++ b/Base/usr/share/man/man1/env.md
@@ -1,0 +1,19 @@
+## Name
+
+env - Execute a command with a modified environment
+
+## Synopsis
+
+```sh
+$ env [--ignore-environment] [--split-string S] [--unset name] [env/command...]
+```
+
+## Options
+
+* `-i`, `--ignore-environment`: Start with an empty environment
+* `-S S`, `--split-string S`: Process and split S into separate arguments; used to pass multiple arguments on shebang lines
+* `-u name`, `--unset name`: Remove variable from the environment
+
+## Arguments
+
+* `env/command`: Environment and commands

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -431,6 +431,11 @@ char* secure_getenv(char const* name)
 int unsetenv(char const* name)
 {
     auto new_var_len = strlen(name);
+    if (new_var_len == 0 || strchr(name, '=')) {
+        errno = EINVAL;
+        return -1;
+    }
+
     size_t environ_size = 0;
     int skip = -1;
 

--- a/Userland/Utilities/env.cpp
+++ b/Userland/Utilities/env.cpp
@@ -17,24 +17,44 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     bool ignore_env = false;
     StringView split_string {};
-    Vector<DeprecatedString> values;
+    Vector<DeprecatedString> values_to_set;
+    Vector<DeprecatedString> values_to_unset;
 
     Core::ArgsParser args_parser;
     args_parser.set_stop_on_first_non_option(true);
 
     args_parser.add_option(ignore_env, "Start with an empty environment", "ignore-environment", 'i');
     args_parser.add_option(split_string, "Process and split S into separate arguments; used to pass multiple arguments on shebang lines", "split-string", 'S', "S");
+    args_parser.add_option(Core::ArgsParser::Option {
+        .argument_mode = Core::ArgsParser::OptionArgumentMode::Required,
+        .help_string = "Remove variable from the environment",
+        .long_name = "unset",
+        .short_name = 'u',
+        .value_name = "name",
+        .accept_value = [&values_to_unset](StringView value) {
+            values_to_unset.append(value);
+            return true;
+        },
+    });
 
-    args_parser.add_positional_argument(values, "Environment and commands", "env/command", Core::ArgsParser::Required::No);
+    args_parser.add_positional_argument(values_to_set, "Environment and commands", "env/command", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    if (ignore_env)
+    if (ignore_env) {
         clearenv();
+    } else {
+        for (auto const& value : values_to_unset) {
+            if (unsetenv(value.characters()) < 0) {
+                warnln("env: cannot unset '{}': {}", value, strerror(errno));
+                return 1;
+            }
+        }
+    }
 
     size_t argv_start;
-    for (argv_start = 0; argv_start < values.size(); ++argv_start) {
-        if (values[argv_start].contains('=')) {
-            putenv(const_cast<char*>(values[argv_start].characters()));
+    for (argv_start = 0; argv_start < values_to_set.size(); ++argv_start) {
+        if (values_to_set[argv_start].contains('=')) {
+            putenv(const_cast<char*>(values_to_set[argv_start].characters()));
         } else {
             break;
         }
@@ -47,8 +67,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     }
 
-    for (size_t i = argv_start; i < values.size(); ++i) {
-        new_argv.append(values[i]);
+    for (size_t i = argv_start; i < values_to_set.size(); ++i) {
+        new_argv.append(values_to_set[i]);
     }
 
     if (new_argv.size() == 0) {


### PR DESCRIPTION
This PR adds the `-u` option to `env`.  This removes the given variable from the environment if it is present; the option may be specified more than once.

I also made a small change to the `unsetenv()` function in LibC. `EINVAL` is now returned if it is given an empty string or a string containing an "=" character. This brings it in line with the POSIX specification.

Example usage:

![env_unset](https://github.com/SerenityOS/serenity/assets/2817754/0bf56134-a1c0-40dc-80cb-f9a7f9429967)