### PR TITLE
LibJS: Make class definition evaluation work in bytecode mode

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1301,7 +1301,7 @@ public:
 
     // We use the Completion also as a ClassStaticBlockDefinition Record.
     using ClassValue = Variant<ClassFieldDefinition, Completion, PrivateElement>;
-    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(Interpreter&, Object& home_object) const = 0;
+    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(VM&, Object& home_object) const = 0;
 
     virtual Optional<DeprecatedFlyString> private_bound_identifier() const { return {}; };
 
@@ -1330,7 +1330,7 @@ public:
     virtual ElementKind class_element_kind() const override { return ElementKind::Method; }
 
     virtual void dump(int indent) const override;
-    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(Interpreter&, Object& home_object) const override;
+    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(VM&, Object& home_object) const override;
     virtual Optional<DeprecatedFlyString> private_bound_identifier() const override;
 
 private:
@@ -1357,7 +1357,7 @@ public:
     virtual ElementKind class_element_kind() const override { return ElementKind::Field; }
 
     virtual void dump(int indent) const override;
-    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(Interpreter&, Object& home_object) const override;
+    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(VM&, Object& home_object) const override;
     virtual Optional<DeprecatedFlyString> private_bound_identifier() const override;
 
 private:
@@ -1376,7 +1376,7 @@ public:
     }
 
     virtual ElementKind class_element_kind() const override { return ElementKind::StaticInitializer; }
-    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(Interpreter&, Object& home_object) const override;
+    virtual ThrowCompletionOr<ClassValue> class_element_evaluation(VM&, Object& home_object) const override;
 
     virtual void dump(int indent) const override;
 
@@ -1421,7 +1421,7 @@ public:
 
     bool has_name() const { return !m_name.is_empty(); }
 
-    ThrowCompletionOr<ECMAScriptFunctionObject*> class_definition_evaluation(Interpreter&, DeprecatedFlyString const& binding_name = {}, DeprecatedFlyString const& class_name = {}) const;
+    ThrowCompletionOr<ECMAScriptFunctionObject*> class_definition_evaluation(VM&, DeprecatedFlyString const& binding_name = {}, DeprecatedFlyString const& class_name = {}) const;
 
 private:
     virtual bool is_class_expression() const override { return true; }

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -1137,16 +1137,15 @@ ThrowCompletionOr<void> IteratorResultValue::execute_impl(Bytecode::Interpreter&
 
 ThrowCompletionOr<void> NewClass::execute_impl(Bytecode::Interpreter& interpreter) const
 {
+    auto& vm = interpreter.vm();
     auto name = m_class_expression.name();
-    auto scope = interpreter.ast_interpreter_scope(interpreter.realm());
-    auto& ast_interpreter = scope.interpreter();
 
     ECMAScriptFunctionObject* class_object = nullptr;
 
     if (!m_class_expression.has_name() && m_lhs_name.has_value())
-        class_object = TRY(m_class_expression.class_definition_evaluation(ast_interpreter, {}, m_lhs_name.value()));
+        class_object = TRY(m_class_expression.class_definition_evaluation(vm, {}, m_lhs_name.value()));
     else
-        class_object = TRY(m_class_expression.class_definition_evaluation(ast_interpreter, name, name.is_null() ? ""sv : name));
+        class_object = TRY(m_class_expression.class_definition_evaluation(vm, name, name.is_null() ? ""sv : name));
 
     class_object->set_source_text(m_class_expression.source_text());
 

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -291,7 +291,7 @@ ThrowCompletionOr<Value> VM::named_evaluation_if_anonymous_function(ASTNode cons
     } else if (is<ClassExpression>(expression)) {
         auto& class_expression = static_cast<ClassExpression const&>(expression);
         if (!class_expression.has_name()) {
-            return TRY(class_expression.class_definition_evaluation(interpreter(), {}, name));
+            return TRY(class_expression.class_definition_evaluation(*this, {}, name));
         }
     }
 


### PR DESCRIPTION
Instead of assuming that there's an active AST interpreter, this code now takes VM& everywhere and invokes the appropriate interpreter.

92 new passes on test262. :^)