### PR TITLE
AK: Never use assert() when targeting Windows platforms

### DIFF
--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -11,7 +11,7 @@
 #else
 #    include <assert.h>
 extern "C" __attribute__((noreturn)) void ak_verification_failed(char const*);
-#    ifndef NDEBUG
+#    if !defined(NDEBUG) && !defined(WIN32)
 #        define VERIFY assert
 #    else
 #        define __stringify_helper(x) #x


### PR DESCRIPTION
The Windows CRT definition of assert() is not noreturn, and causes compile errors when using it as the backing for VERIFY() in debug configurations of applications like the Jakt compiler.