### PR TITLE
LibJS/Bytecode: Return the proper result for iteration statements + fix for catch blocks

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -2086,6 +2086,11 @@ Bytecode::CodeGenerationErrorOr<void> TryStatement::generate_bytecode(Bytecode::
                 return {};
             }));
 
+        // Set accumulator to undefined, otherwise we leak the error object through the accumulator.
+        // For example: `try { BigInt.call() } catch {}` would result in the error object. Note that
+        // the exception _is_ caught here, it just leaks the error object through to the result.
+        generator.emit<Bytecode::Op::LoadImmediate>(js_undefined());
+
         TRY(m_handler->body().generate_bytecode(generator));
         handler_target = Bytecode::Label { handler_block };
         generator.end_variable_scope();


### PR DESCRIPTION
```
Summary:
    Diff Tests:
        +16 ✅    -16 ❌   

Diff Tests:
    test/language/statements/do-while/S12.6.1_A3.js                    ❌ -> ✅
    test/language/statements/do-while/S12.6.1_A5.js                    ❌ -> ✅
    test/language/statements/do-while/S12.6.1_A7.js                    ❌ -> ✅
    test/language/statements/do-while/S12.6.1_A8.js                    ❌ -> ✅
    test/language/statements/do-while/cptn-abrupt-empty.js             ❌ -> ✅
    test/language/statements/do-while/cptn-normal.js                   ❌ -> ✅
    test/language/statements/if/cptn-no-else-true-abrupt-empty.js      ❌ -> ✅
    test/language/statements/switch/cptn-a-abrupt-empty.js             ❌ -> ✅
    test/language/statements/switch/cptn-b-abrupt-empty.js             ❌ -> ✅
    test/language/statements/switch/cptn-dflt-abrupt-empty.js          ❌ -> ✅
    test/language/statements/switch/cptn-dflt-b-abrupt-empty.js        ❌ -> ✅
    test/language/statements/switch/cptn-no-dflt-match-abrupt-empty.js ❌ -> ✅
    test/language/statements/try/cptn-catch.js                         ❌ -> ✅
    test/language/statements/while/S12.6.2_A5.js                       ❌ -> ✅
    test/language/statements/while/S12.6.2_A7.js                       ❌ -> ✅
    test/language/statements/while/S12.6.2_A8.js                       ❌ -> ✅
```