### PR TITLE
LibWeb: Fix min-content initialization for row measures

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
@@ -1,0 +1,34 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x21.46875 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 49.21875x21.46875 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 49.21875x21.46875 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (8,8) content-size 43.21875x15.46875 table-row-group children: not-inline
+            Box <tr> at (10,10) content-size 43.21875x7.734375 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,13.867187) content-size 0x0 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (16,10) content-size 37.21875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 37.21875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 4, rect: [16,10 37.21875x17.46875]
+                    "Test"
+                TextNode <#text>
+                InlineNode <a>
+                  TextNode <#text>
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (10,17.734375) content-size 43.21875x7.734375 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,23.601562) content-size 0x0 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>

--- a/Tests/LibWeb/Layout/input/table/row-outer-size-with-computed-size.html
+++ b/Tests/LibWeb/Layout/input/table/row-outer-size-with-computed-size.html
@@ -1,0 +1,11 @@
+<table style="border-collapse:separate;">
+    <tr>
+        <td style="height:6px"></td>
+        <td rowspan="2" style="border:1px solid black">
+            <a href="">Test</a>
+        </td>
+    </tr>
+    <tr>
+        <td style="height:6px"></td>
+    </tr>
+</table>

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -38,6 +38,8 @@ private:
     void calculate_row_column_grid(Box const&);
     void compute_cell_measures(AvailableSpace const& available_space);
     template<class RowOrColumn>
+    void initialize_table_measures();
+    template<class RowOrColumn>
     void compute_table_measures();
     void compute_table_width();
     void distribute_width_to_columns();


### PR DESCRIPTION
This ensures that min-content contributions from cells with no content are computed using their calculated values, which are never considered for min-content before then. The specification diverges from column measures algorithm, which doesn't use specified width of cells anywhere.