### PR TITLE
LibWeb: Make Web::Page GC-allocated

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <AK/URL.h>
+#include <LibJS/Heap/Handle.h>
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
 
@@ -43,7 +44,7 @@ public:
 private:
     ImageStyleValue(AK::URL const&);
 
-    RefPtr<HTML::SharedImageRequest> m_image_request;
+    JS::Handle<HTML::SharedImageRequest> m_image_request;
 
     void animate();
     Gfx::Bitmap const* bitmap(size_t frame_index, Gfx::IntSize = {}) const;

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -116,8 +116,7 @@ static JS::NonnullGCPtr<HTML::BrowsingContext> obtain_a_browsing_context_to_use_
     }
 
     // 3. Let newBrowsingContext be the result of creating a new top-level browsing context.
-    VERIFY(browsing_context.page());
-    auto new_browsing_context = HTML::BrowsingContext::create_a_new_top_level_browsing_context(*browsing_context.page());
+    auto new_browsing_context = HTML::BrowsingContext::create_a_new_top_level_browsing_context(browsing_context.page());
 
     // FIXME: 4. If navigationCOOP's value is "same-origin-plurs-COEP", then set newBrowsingContext's group's
     //           cross-origin isolation mode to either "logical" or "concrete". The choice of which is implementation-defined.
@@ -1705,12 +1704,12 @@ void Document::update_readiness(HTML::DocumentReadyState readiness_value)
 
 Page* Document::page()
 {
-    return m_browsing_context ? m_browsing_context->page() : nullptr;
+    return m_browsing_context ? &m_browsing_context->page() : nullptr;
 }
 
 Page const* Document::page() const
 {
-    return m_browsing_context ? m_browsing_context->page() : nullptr;
+    return m_browsing_context ? &m_browsing_context->page() : nullptr;
 }
 
 EventTarget* Document::get_parent(Event const& event)

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1371,9 +1371,7 @@ static ErrorOr<void> scroll_an_element_into_view(DOM::Element& element, Bindings
     if (!element.document().browsing_context())
         return Error::from_string_view("Element has no browsing context."sv);
 
-    auto* page = element.document().browsing_context()->page();
-    if (!page)
-        return Error::from_string_view("Element has no page."sv);
+    auto& page = element.document().browsing_context()->page();
 
     // If this element doesn't have a layout node, we can't scroll it into view.
     element.document().update_layout();
@@ -1388,8 +1386,8 @@ static ErrorOr<void> scroll_an_element_into_view(DOM::Element& element, Bindings
     if (!layout_node)
         return Error::from_string_view("Element has no parent layout node that is a box."sv);
 
-    if (element.document().browsing_context() == &page->top_level_browsing_context())
-        page->client().page_did_request_scroll_into_view(verify_cast<Layout::Box>(*layout_node).paintable_box()->absolute_padding_box_rect());
+    if (element.document().browsing_context() == &page.top_level_browsing_context())
+        page.client().page_did_request_scroll_into_view(verify_cast<Layout::Box>(*layout_node).paintable_box()->absolute_padding_box_rect());
 
     return {};
 }

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -1222,7 +1222,7 @@ WebIDL::ExceptionOr<void> BrowsingContext::navigate(
     (void)process_response_end_of_body;
 
     // AD-HOC:
-    auto request = LoadRequest::create_for_url_on_page(resource->url(), page());
+    auto request = LoadRequest::create_for_url_on_page(resource->url(), &page());
     request.set_method(DeprecatedString { resource->method() });
     for (auto& header : *resource->header_list()) {
         request.set_header(DeprecatedString { header.name.bytes() }, DeprecatedString { header.value.bytes() });

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -456,6 +456,7 @@ void BrowsingContext::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
 
+    visitor.visit(m_page);
     for (auto& entry : m_session_history)
         visitor.visit(entry);
     visitor.visit(m_container);

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -142,8 +142,8 @@ public:
     HTML::Window* active_window();
     HTML::Window const* active_window() const;
 
-    Page* page() { return m_page; }
-    Page const* page() const { return m_page; }
+    Page& page() { return m_page; }
+    Page const& page() const { return m_page; }
 
     CSSPixelSize size() const { return m_size; }
     void set_size(CSSPixelSize);

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -288,7 +288,7 @@ private:
 
     void scroll_offset_did_change();
 
-    WeakPtr<Page> m_page;
+    JS::NonnullGCPtr<Page> m_page;
 
     FrameLoader m_loader;
     Web::EventHandler m_event_handler;

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContextGroup.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContextGroup.cpp
@@ -31,6 +31,7 @@ BrowsingContextGroup::~BrowsingContextGroup()
 void BrowsingContextGroup::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
+    visitor.visit(m_page);
     for (auto& context : m_browsing_context_set)
         visitor.visit(context);
 }

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContextGroup.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContextGroup.h
@@ -44,7 +44,7 @@ private:
     // https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-group-set
     OrderedHashTable<JS::NonnullGCPtr<BrowsingContext>> m_browsing_context_set;
 
-    WeakPtr<Page> m_page;
+    JS::NonnullGCPtr<Page> m_page;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -42,6 +42,13 @@ HTMLImageElement::HTMLImageElement(DOM::Document& document, DOM::QualifiedName q
 
 HTMLImageElement::~HTMLImageElement() = default;
 
+void HTMLImageElement::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_current_request);
+    visitor.visit(m_pending_request);
+}
+
 JS::ThrowCompletionOr<void> HTMLImageElement::initialize(JS::Realm& realm)
 {
     MUST_OR_THROW_OOM(Base::initialize(realm));

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -87,6 +87,7 @@ public:
 private:
     HTMLImageElement(DOM::Document&, DOM::QualifiedName);
 
+    virtual void visit_edges(Visitor&) override;
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
@@ -111,10 +112,10 @@ private:
     Optional<String> m_last_selected_source;
 
     // https://html.spec.whatwg.org/multipage/images.html#current-request
-    RefPtr<ImageRequest> m_current_request;
+    JS::GCPtr<ImageRequest> m_current_request;
 
     // https://html.spec.whatwg.org/multipage/images.html#pending-request
-    RefPtr<ImageRequest> m_pending_request;
+    JS::GCPtr<ImageRequest> m_pending_request;
 
     SourceSet m_source_set;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -201,7 +201,7 @@ static void show_the_picker_if_applicable(HTMLInputElement& element)
 
         // FIXME: Pass along accept attribute information https://html.spec.whatwg.org/multipage/input.html#attr-input-accept
         //    The accept attribute may be specified to provide user agents with a hint of what file types will be accepted.
-        element.document().browsing_context()->top_level_browsing_context().page()->client().page_did_request_file_picker(weak_element, multiple);
+        element.document().browsing_context()->top_level_browsing_context().page().client().page_did_request_file_picker(weak_element, multiple);
         return;
     }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -33,6 +33,12 @@ HTMLObjectElement::HTMLObjectElement(DOM::Document& document, DOM::QualifiedName
 
 HTMLObjectElement::~HTMLObjectElement() = default;
 
+void HTMLObjectElement::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_image_request);
+}
+
 JS::ThrowCompletionOr<void> HTMLObjectElement::initialize(JS::Realm& realm)
 {
     MUST_OR_THROW_OOM(Base::initialize(realm));

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -48,6 +48,8 @@ public:
 private:
     HTMLObjectElement(DOM::Document&, DOM::QualifiedName);
 
+    virtual void visit_edges(Visitor&) override;
+
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
@@ -80,7 +82,7 @@ private:
 
     RefPtr<DecodedImageData const> image_data() const;
 
-    RefPtr<SharedImageRequest> m_image_request;
+    JS::GCPtr<SharedImageRequest> m_image_request;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/ImageRequest.h
+++ b/Userland/Libraries/LibWeb/HTML/ImageRequest.h
@@ -81,7 +81,7 @@ private:
     // which is either a struct consisting of a width and a height or is null. It must initially be null.
     Optional<Gfx::FloatSize> m_preferred_density_corrected_dimensions;
 
-    RefPtr<SharedImageRequest> m_shared_image_request;
+    JS::Handle<SharedImageRequest> m_shared_image_request;
 };
 
 // https://html.spec.whatwg.org/multipage/images.html#abort-the-image-request

--- a/Userland/Libraries/LibWeb/HTML/ImageRequest.h
+++ b/Userland/Libraries/LibWeb/HTML/ImageRequest.h
@@ -17,9 +17,11 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/images.html#image-request
-class ImageRequest : public RefCounted<ImageRequest> {
+class ImageRequest final : public JS::Cell {
+    JS_CELL(ImageRequest, JS::Cell);
+
 public:
-    static ErrorOr<NonnullRefPtr<ImageRequest>> create(Page&);
+    static ErrorOr<JS::NonnullGCPtr<ImageRequest>> create(Page&);
     ~ImageRequest();
 
     // https://html.spec.whatwg.org/multipage/images.html#img-req-state
@@ -59,7 +61,9 @@ public:
 private:
     explicit ImageRequest(Page&);
 
-    Page& m_page;
+    virtual void visit_edges(Visitor&) override;
+
+    JS::NonnullGCPtr<Page> m_page;
 
     // https://html.spec.whatwg.org/multipage/images.html#img-req-state
     // An image request's state is initially unavailable.
@@ -81,7 +85,7 @@ private:
     // which is either a struct consisting of a width and a height or is null. It must initially be null.
     Optional<Gfx::FloatSize> m_preferred_density_corrected_dimensions;
 
-    JS::Handle<SharedImageRequest> m_shared_image_request;
+    JS::GCPtr<SharedImageRequest> m_shared_image_request;
 };
 
 // https://html.spec.whatwg.org/multipage/images.html#abort-the-image-request

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -137,9 +137,7 @@ void Navigable::activate_history_entry(JS::GCPtr<SessionHistoryEntry> entry)
 
     // Not in the spec:
     if (is<TraversableNavigable>(*this) && parent() == nullptr) {
-        if (auto* page = active_browsing_context()->page()) {
-            page->client().page_did_start_loading(entry->url, false);
-        }
+        active_browsing_context()->page().client().page_did_start_loading(entry->url, false);
     }
 }
 

--- a/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
@@ -24,11 +24,11 @@ static HashMap<AK::URL, SharedImageRequest*>& shared_image_requests()
     return requests;
 }
 
-ErrorOr<NonnullRefPtr<SharedImageRequest>> SharedImageRequest::get_or_create(Page& page, AK::URL const& url)
+ErrorOr<JS::NonnullGCPtr<SharedImageRequest>> SharedImageRequest::get_or_create(Page& page, AK::URL const& url)
 {
     if (auto it = shared_image_requests().find(url); it != shared_image_requests().end())
         return *it->value;
-    auto request = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) SharedImageRequest(page, url)));
+    auto request = page.heap().allocate_without_realm<SharedImageRequest>(page, url);
     shared_image_requests().set(url, request);
     return request;
 }
@@ -42,6 +42,13 @@ SharedImageRequest::SharedImageRequest(Page& page, AK::URL url)
 SharedImageRequest::~SharedImageRequest()
 {
     shared_image_requests().remove(m_url);
+}
+
+void SharedImageRequest::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_page);
+    visitor.visit(m_fetch_controller);
 }
 
 RefPtr<DecodedImageData const> SharedImageRequest::image_data() const

--- a/Userland/Libraries/LibWeb/HTML/SharedImageRequest.h
+++ b/Userland/Libraries/LibWeb/HTML/SharedImageRequest.h
@@ -16,9 +16,11 @@
 
 namespace Web::HTML {
 
-class SharedImageRequest : public RefCounted<SharedImageRequest> {
+class SharedImageRequest : public JS::Cell {
+    JS_CELL(SharedImageRequest, JS::Cell);
+
 public:
-    static ErrorOr<NonnullRefPtr<SharedImageRequest>> get_or_create(Page&, AK::URL const&);
+    static ErrorOr<JS::NonnullGCPtr<SharedImageRequest>> get_or_create(Page&, AK::URL const&);
     ~SharedImageRequest();
 
     AK::URL const& url() const { return m_url; }
@@ -38,6 +40,8 @@ public:
 private:
     explicit SharedImageRequest(Page&, AK::URL);
 
+    virtual void visit_edges(Visitor&) override;
+
     void handle_successful_fetch(AK::URL const&, StringView mime_type, ByteBuffer data);
     void handle_failed_fetch();
 
@@ -50,7 +54,7 @@ private:
 
     State m_state { State::New };
 
-    Page& m_page;
+    JS::NonnullGCPtr<Page> m_page;
 
     struct Callbacks {
         JS::SafeFunction<void()> on_finish;
@@ -60,7 +64,7 @@ private:
 
     AK::URL m_url;
     RefPtr<DecodedImageData const> m_image_data;
-    JS::Handle<Fetch::Infrastructure::FetchController> m_fetch_controller;
+    JS::GCPtr<Fetch::Infrastructure::FetchController> m_fetch_controller;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -193,10 +193,9 @@ bool EventHandler::handle_mousewheel(CSSPixelPoint position, unsigned button, un
 
             auto offset = compute_mouse_event_offset(position, *layout_node);
             if (node->dispatch_event(UIEvents::WheelEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::wheel, offset.x(), offset.y(), position.x(), position.y(), wheel_delta_x, wheel_delta_y, buttons, button).release_value_but_fixme_should_propagate_errors())) {
-                if (auto* page = m_browsing_context->page()) {
-                    if (m_browsing_context == &page->top_level_browsing_context())
-                        page->client().page_did_request_scroll(wheel_delta_x * 20, wheel_delta_y * 20);
-                }
+                auto& page = m_browsing_context->page();
+                if (m_browsing_context == &page.top_level_browsing_context())
+                    page.client().page_did_request_scroll(wheel_delta_x * 20, wheel_delta_y * 20);
             }
 
             handled_event = true;
@@ -291,23 +290,19 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, unsigned button, unsig
                             m_browsing_context->scroll_to_anchor(url.fragment());
                         } else {
                             if (m_browsing_context->is_top_level()) {
-                                if (auto* page = m_browsing_context->page())
-                                    page->client().page_did_click_link(url, link->target(), modifiers);
+                                m_browsing_context->page().client().page_did_click_link(url, link->target(), modifiers);
                             }
                         }
                     } else if (button == GUI::MouseButton::Middle) {
-                        if (auto* page = m_browsing_context->page())
-                            page->client().page_did_middle_click_link(url, link->target(), modifiers);
+                        m_browsing_context->page().client().page_did_middle_click_link(url, link->target(), modifiers);
                     } else if (button == GUI::MouseButton::Secondary) {
-                        if (auto* page = m_browsing_context->page())
-                            page->client().page_did_request_link_context_menu(m_browsing_context->to_top_level_position(position), url, link->target(), modifiers);
+                        m_browsing_context->page().client().page_did_request_link_context_menu(m_browsing_context->to_top_level_position(position), url, link->target(), modifiers);
                     }
                 } else if (button == GUI::MouseButton::Secondary) {
                     if (is<HTML::HTMLImageElement>(*node)) {
                         auto& image_element = verify_cast<HTML::HTMLImageElement>(*node);
                         auto image_url = image_element.document().parse_url(image_element.src());
-                        if (auto* page = m_browsing_context->page())
-                            page->client().page_did_request_image_context_menu(m_browsing_context->to_top_level_position(position), image_url, "", modifiers, image_element.bitmap());
+                        m_browsing_context->page().client().page_did_request_image_context_menu(m_browsing_context->to_top_level_position(position), image_url, "", modifiers, image_element.bitmap());
                     } else if (is<HTML::HTMLMediaElement>(*node)) {
                         auto& media_element = verify_cast<HTML::HTMLMediaElement>(*node);
 
@@ -320,10 +315,9 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, unsigned button, unsig
                             .is_looping = media_element.has_attribute(HTML::AttributeNames::loop),
                         };
 
-                        if (auto* page = m_browsing_context->page())
-                            page->did_request_media_context_menu(media_element.id(), m_browsing_context->to_top_level_position(position), "", modifiers, move(menu));
-                    } else if (auto* page = m_browsing_context->page()) {
-                        page->client().page_did_request_context_menu(m_browsing_context->to_top_level_position(position));
+                        m_browsing_context->page().did_request_media_context_menu(media_element.id(), m_browsing_context->to_top_level_position(position), "", modifiers, move(menu));
+                    } else {
+                        m_browsing_context->page().client().page_did_request_context_menu(m_browsing_context->to_top_level_position(position));
                     }
                 }
             }
@@ -375,8 +369,7 @@ bool EventHandler::handle_mousedown(CSSPixelPoint position, unsigned button, uns
             return false;
         }
 
-        if (auto* page = m_browsing_context->page())
-            page->set_focused_browsing_context({}, m_browsing_context);
+        m_browsing_context->page().set_focused_browsing_context({}, m_browsing_context);
 
         // Search for the first parent of the hit target that's an element.
         // "The click event type MUST be dispatched on the topmost event target indicated by the pointer." (https://www.w3.org/TR/uievents/#event-type-click)
@@ -457,8 +450,7 @@ bool EventHandler::handle_mousemove(CSSPixelPoint position, unsigned buttons, un
                 return false;
 
             // FIXME: It feels a bit aggressive to always update the cursor like this.
-            if (auto* page = m_browsing_context->page())
-                page->client().page_did_request_cursor_change(Gfx::StandardCursor::None);
+            m_browsing_context->page().client().page_did_request_cursor_change(Gfx::StandardCursor::None);
         }
 
         auto node = dom_node_for_event_dispatch(*paintable);
@@ -520,27 +512,26 @@ bool EventHandler::handle_mousemove(CSSPixelPoint position, unsigned buttons, un
                 }
                 m_browsing_context->set_needs_display();
             }
-            if (auto* page = m_browsing_context->page())
-                page->client().page_did_change_selection();
+            m_browsing_context->page().client().page_did_change_selection();
         }
     }
 
-    if (auto* page = m_browsing_context->page()) {
-        page->client().page_did_request_cursor_change(hovered_node_cursor);
+    auto& page = m_browsing_context->page();
+    page.client().page_did_request_cursor_change(hovered_node_cursor);
 
-        if (hovered_node_changed) {
-            JS::GCPtr<HTML::HTMLElement const> hovered_html_element = document.hovered_node() ? document.hovered_node()->enclosing_html_element_with_attribute(HTML::AttributeNames::title) : nullptr;
-            if (hovered_html_element && !hovered_html_element->title().is_null()) {
-                page->client().page_did_enter_tooltip_area(m_browsing_context->to_top_level_position(position), hovered_html_element->title());
-            } else {
-                page->client().page_did_leave_tooltip_area();
-            }
-            if (is_hovering_link)
-                page->client().page_did_hover_link(document.parse_url(hovered_link_element->href()));
-            else
-                page->client().page_did_unhover_link();
+    if (hovered_node_changed) {
+        JS::GCPtr<HTML::HTMLElement const> hovered_html_element = document.hovered_node() ? document.hovered_node()->enclosing_html_element_with_attribute(HTML::AttributeNames::title) : nullptr;
+        if (hovered_html_element && !hovered_html_element->title().is_null()) {
+            page.client().page_did_enter_tooltip_area(m_browsing_context->to_top_level_position(position), hovered_html_element->title());
+        } else {
+            page.client().page_did_leave_tooltip_area();
         }
+        if (is_hovering_link)
+            page.client().page_did_hover_link(document.parse_url(hovered_link_element->href()));
+        else
+            page.client().page_did_unhover_link();
     }
+
     return true;
 }
 

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -19,6 +19,11 @@
 
 namespace Web {
 
+JS::NonnullGCPtr<Page> Page::create(JS::VM& vm, PageClient& page_client)
+{
+    return vm.heap().allocate_without_realm<Page>(page_client);
+}
+
 Page::Page(PageClient& client)
     : m_client(client)
 {
@@ -26,6 +31,12 @@ Page::Page(PageClient& client)
 }
 
 Page::~Page() = default;
+
+void Page::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_top_level_browsing_context);
+}
 
 HTML::BrowsingContext& Page::focused_context()
 {

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021-2022, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
  *
@@ -22,7 +22,7 @@
 #include <LibGfx/Size.h>
 #include <LibGfx/StandardCursor.h>
 #include <LibIPC/Forward.h>
-#include <LibJS/Heap/Handle.h>
+#include <LibJS/Heap/Cell.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Forward.h>
@@ -34,12 +34,13 @@ namespace Web {
 
 class PageClient;
 
-class Page : public Weakable<Page> {
-    AK_MAKE_NONCOPYABLE(Page);
-    AK_MAKE_NONMOVABLE(Page);
+class Page final
+    : public JS::Cell
+    , public Weakable<Page> {
+    JS_CELL(Page, JS::Cell);
 
 public:
-    explicit Page(PageClient&);
+    static JS::NonnullGCPtr<Page> create(JS::VM&, PageClient&);
     ~Page();
 
     PageClient& client() { return m_client; }
@@ -138,11 +139,14 @@ public:
     bool pdf_viewer_supported() const { return m_pdf_viewer_supported; }
 
 private:
+    explicit Page(PageClient&);
+    virtual void visit_edges(Visitor&) override;
+
     JS::GCPtr<HTML::HTMLMediaElement> media_context_menu_element();
 
     PageClient& m_client;
 
-    JS::Handle<HTML::BrowsingContext> m_top_level_browsing_context;
+    JS::GCPtr<HTML::BrowsingContext> m_top_level_browsing_context;
     WeakPtr<HTML::BrowsingContext> m_focused_context;
 
     // FIXME: Enable this by default once CORS preflight checks are supported.

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -13,7 +13,7 @@ namespace Web::SVG {
 
 class SVGDecodedImageData final : public HTML::DecodedImageData {
 public:
-    static ErrorOr<NonnullRefPtr<SVGDecodedImageData>> create(Page&, AK::URL const&, ByteBuffer encoded_svg);
+    static ErrorOr<NonnullRefPtr<SVGDecodedImageData>> create(JS::NonnullGCPtr<Page>, AK::URL const&, ByteBuffer encoded_svg);
     virtual ~SVGDecodedImageData() override;
 
     virtual RefPtr<Gfx::Bitmap const> bitmap(size_t frame_index, Gfx::IntSize) const override;
@@ -32,12 +32,12 @@ public:
 
 private:
     class SVGPageClient;
-    SVGDecodedImageData(NonnullOwnPtr<Page>, NonnullOwnPtr<SVGPageClient>, JS::Handle<DOM::Document>, JS::Handle<SVG::SVGSVGElement>);
+    SVGDecodedImageData(JS::NonnullGCPtr<Page>, NonnullOwnPtr<SVGPageClient>, JS::Handle<DOM::Document>, JS::Handle<SVG::SVGSVGElement>);
 
     void render(Gfx::IntSize) const;
     mutable RefPtr<Gfx::Bitmap> m_bitmap;
 
-    NonnullOwnPtr<Page> m_page;
+    JS::Handle<Page> m_page;
     NonnullOwnPtr<SVGPageClient> m_page_client;
 
     JS::Handle<DOM::Document> m_document;

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -10,6 +10,7 @@
 #include <LibGfx/Painter.h>
 #include <LibGfx/ShareableBitmap.h>
 #include <LibGfx/SystemTheme.h>
+#include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/Layout/Viewport.h>
@@ -22,7 +23,7 @@ namespace WebContent {
 
 PageHost::PageHost(ConnectionFromClient& client)
     : m_client(client)
-    , m_page(make<Web::Page>(*this))
+    , m_page(Web::Page::create(Web::Bindings::main_thread_vm(), *this))
 {
     setup_palette();
     m_invalidation_coalescing_timer = Web::Platform::Timer::create_single_shot(0, [this] {

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibGfx/Rect.h>
+#include <LibJS/Heap/Handle.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
 #include <WebContent/Forward.h>
@@ -117,7 +118,7 @@ private:
     void setup_palette();
 
     ConnectionFromClient& m_client;
-    NonnullOwnPtr<Web::Page> m_page;
+    JS::Handle<Web::Page> m_page;
     RefPtr<Gfx::PaletteImpl> m_palette_impl;
     Web::DevicePixelRect m_screen_rect;
     Web::DevicePixelSize m_content_size;


### PR DESCRIPTION
...and take advantage of it in various places.

This trivializes lifetime management for `Web::Page` which was previously incomprehensible.