### PR TITLE
LibJS: Fix integer overflow in Number::exponentiate

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -1936,7 +1936,7 @@ static Value exp_double(Value base, Value exponent)
 
     // 5. If base is -∞𝔽, then
     if (base.is_negative_infinity()) {
-        auto is_odd_integral_number = exponent.is_integral_number() && (static_cast<i32>(exponent.as_double()) % 2 != 0);
+        auto is_odd_integral_number = exponent.is_integral_number() && (fmod(exponent.as_double(), 2.0) != 0);
 
         // a. If exponent > +0𝔽, then
         if (exponent.as_double() > 0) {
@@ -1958,7 +1958,7 @@ static Value exp_double(Value base, Value exponent)
 
     // 7. If base is -0𝔽, then
     if (base.is_negative_zero()) {
-        auto is_odd_integral_number = exponent.is_integral_number() && (static_cast<i32>(exponent.as_double()) % 2 != 0);
+        auto is_odd_integral_number = exponent.is_integral_number() && (fmod(exponent.as_double(), 2.0) != 0);
 
         // a. If exponent > +0𝔽, then
         if (exponent.as_double() > 0) {


### PR DESCRIPTION
The exponent might be larger than the range of values representable by an i32, so we have to use the `fmod` function instead of the modulo operator.

This fixes 3 test262 tests on AArch64. No changes on x86-64.