### PR TITLE
LibWeb: Make two borders joints part painting work

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -149,8 +149,8 @@ void paint_border(PaintContext& context, BorderEdge edge, DevicePixelRect const&
 
     auto draw_border = [&](auto const& border, auto const& radius, auto const& opposite_border, auto const& opposite_radius, auto p1_step_translate, auto p2_step_translate) {
         auto [p1, p2] = points_for_edge(edge, rect);
-        auto p1_step = radius ? 0 : border.width / device_pixel_width.value();
-        auto p2_step = opposite_radius ? 0 : opposite_border.width / device_pixel_width.value();
+        auto p1_step = radius ? 0 : context.enclosing_device_pixels(border.width).value() / device_pixel_width.value();
+        auto p2_step = opposite_radius ? 0 : context.enclosing_device_pixels(opposite_border.width).value() / device_pixel_width.value();
         for (DevicePixels i = 0; i < device_pixel_width; ++i) {
             draw_horizontal_or_vertical_line(p1, p2);
             p1_step_translate(p1, p1_step);


### PR DESCRIPTION
Fix caret icon displaying in some situations

```
.triangle {
    width: 0;
    height: 0;
    border-top: 50px solid skyblue;
    border-right: 50px solid transparent;
    border-left: 50px solid transparent;
  }

<div class="triangle"></div>
```
Before
<img width="109" alt="Screenshot 2023-06-27 at 10 13 14" src="https://github.com/SerenityOS/serenity/assets/32867472/f806a2e8-a559-401b-829d-31015b27f700">

After
<img width="108" alt="Screenshot 2023-06-27 at 10 12 34" src="https://github.com/SerenityOS/serenity/assets/32867472/e84f9b00-953f-44de-8e7f-ec531beb898a">
