### PR TITLE
LibAudio: Fix all current fuzzer-found FLAC issues

### DIFF
--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -768,7 +768,7 @@ ErrorOr<Vector<i64>, LoaderError> FlacLoaderPlugin::decode_custom_lpc(FlacSubfra
     // read coefficients
     for (auto i = 0; i < subframe.order; ++i) {
         u64 raw_coefficient = LOADER_TRY(bit_input.read_bits<u64>(lpc_precision));
-        i64 coefficient = static_cast<i64>(sign_extend(raw_coefficient, lpc_precision));
+        i64 coefficient = sign_extend(raw_coefficient, lpc_precision);
         coefficients.unchecked_append(coefficient);
     }
 
@@ -970,7 +970,7 @@ i64 sign_extend(u32 n, u8 size)
 {
     // negative
     if ((n & (1 << (size - 1))) > 0) {
-        return static_cast<i64>(n | (0xffffffff << size));
+        return static_cast<i64>(n | (0xffffffffffffffffLL << size));
     }
     // positive
     return n;

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -156,20 +156,28 @@ MaybeLoaderError FlacLoaderPlugin::load_picture(FlacRawMetadataBlock& block)
     FixedMemoryStream memory_stream { block.data.bytes() };
     BigEndianInputBitStream picture_block_bytes { MaybeOwned<Stream>(memory_stream) };
 
-    PictureData picture {};
+    PictureData picture;
 
     picture.type = static_cast<ID3PictureType>(LOADER_TRY(picture_block_bytes.read_bits(32)));
 
     auto const mime_string_length = LOADER_TRY(picture_block_bytes.read_bits(32));
-    // Note: We are seeking before reading the value to ensure that we stayed inside buffer's size.
     auto offset_before_seeking = memory_stream.offset();
-    LOADER_TRY(memory_stream.seek(mime_string_length, SeekMode::FromCurrentPosition));
-    picture.mime_string = { block.data.bytes().data() + offset_before_seeking, (size_t)mime_string_length };
+    if (offset_before_seeking + mime_string_length >= block.data.size())
+        return LoaderError { LoaderError::Category::Format, LOADER_TRY(m_stream->tell()), "Picture MIME type exceeds available data" };
+
+    // "The MIME type string, in printable ASCII characters 0x20-0x7E."
+    picture.mime_string = LOADER_TRY(String::from_stream(memory_stream, mime_string_length));
+    for (auto code_point : picture.mime_string.code_points()) {
+        if (code_point < 0x20 || code_point > 0x7E)
+            return LoaderError { LoaderError::Category::Format, LOADER_TRY(m_stream->tell()), "Picture MIME type is not ASCII in range 0x20 - 0x7E" };
+    }
 
     auto const description_string_length = LOADER_TRY(picture_block_bytes.read_bits(32));
     offset_before_seeking = memory_stream.offset();
-    LOADER_TRY(memory_stream.seek(description_string_length, SeekMode::FromCurrentPosition));
-    picture.description_string = Vector<u32> { Span<u32> { reinterpret_cast<u32*>(block.data.bytes().data() + offset_before_seeking), (size_t)description_string_length } };
+    if (offset_before_seeking + description_string_length >= block.data.size())
+        return LoaderError { LoaderError::Category::Format, LOADER_TRY(m_stream->tell()), "Picture description exceeds available data" };
+
+    picture.description_string = LOADER_TRY(String::from_stream(memory_stream, description_string_length));
 
     picture.width = LOADER_TRY(picture_block_bytes.read_bits(32));
     picture.height = LOADER_TRY(picture_block_bytes.read_bits(32));
@@ -179,8 +187,11 @@ MaybeLoaderError FlacLoaderPlugin::load_picture(FlacRawMetadataBlock& block)
 
     auto const picture_size = LOADER_TRY(picture_block_bytes.read_bits(32));
     offset_before_seeking = memory_stream.offset();
+    if (offset_before_seeking + picture_size > block.data.size())
+        return LoaderError { LoaderError::Category::Format, static_cast<size_t>(TRY(m_stream->tell())), "Picture size exceeds available data" };
+
     LOADER_TRY(memory_stream.seek(picture_size, SeekMode::FromCurrentPosition));
-    picture.data = Vector<u8> { Span<u8> { block.data.bytes().data() + offset_before_seeking, (size_t)picture_size } };
+    picture.data = Vector<u8> { block.data.bytes().slice(offset_before_seeking, picture_size) };
 
     m_pictures.append(move(picture));
 

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -699,6 +699,10 @@ ErrorOr<Vector<i32>, LoaderError> FlacLoaderPlugin::parse_subframe(FlacSubframeH
         samples[i] <<= subframe_header.wasted_bits_per_sample;
     }
 
+    // Resamplers VERIFY that the sample rate is non-zero.
+    if (m_current_frame->sample_rate == 0 || m_sample_rate == 0)
+        return samples;
+
     ResampleHelper<i32> resampler(m_current_frame->sample_rate, m_sample_rate);
     return resampler.resample(samples);
 }

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -724,6 +724,10 @@ ErrorOr<Vector<i32>, LoaderError> FlacLoaderPlugin::decode_verbatim(FlacSubframe
 // Decode a subframe encoded with a custom linear predictor coding, i.e. the subframe provides the polynomial order and coefficients
 ErrorOr<Vector<i32>, LoaderError> FlacLoaderPlugin::decode_custom_lpc(FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input)
 {
+    // LPC must provide at least as many samples as its order.
+    if (subframe.order > m_current_frame->sample_count)
+        return LoaderError { LoaderError::Category::Format, static_cast<size_t>(m_current_sample_or_frame), "Too small frame for LPC order" };
+
     Vector<i32> decoded;
     decoded.ensure_capacity(m_current_frame->sample_count);
 
@@ -779,6 +783,10 @@ ErrorOr<Vector<i32>, LoaderError> FlacLoaderPlugin::decode_custom_lpc(FlacSubfra
 // Decode a subframe encoded with one of the fixed linear predictor codings
 ErrorOr<Vector<i32>, LoaderError> FlacLoaderPlugin::decode_fixed_lpc(FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input)
 {
+    // LPC must provide at least as many samples as its order.
+    if (subframe.order > m_current_frame->sample_count)
+        return LoaderError { LoaderError::Category::Format, static_cast<size_t>(m_current_sample_or_frame), "Too small frame for LPC order" };
+
     Vector<i32> decoded;
     decoded.ensure_capacity(m_current_frame->sample_count);
 

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -69,14 +69,14 @@ private:
     // Helper of next_frame that fetches a sub frame's header
     ErrorOr<FlacSubframeHeader, LoaderError> next_subframe_header(BigEndianInputBitStream& bit_input, u8 channel_index);
     // Helper of next_frame that decompresses a subframe
-    ErrorOr<Vector<i32>, LoaderError> parse_subframe(FlacSubframeHeader& subframe_header, BigEndianInputBitStream& bit_input);
+    ErrorOr<Vector<i64>, LoaderError> parse_subframe(FlacSubframeHeader& subframe_header, BigEndianInputBitStream& bit_input);
     // Subframe-internal data decoders (heavy lifting)
-    ErrorOr<Vector<i32>, LoaderError> decode_fixed_lpc(FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
-    ErrorOr<Vector<i32>, LoaderError> decode_verbatim(FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
-    ErrorOr<Vector<i32>, LoaderError> decode_custom_lpc(FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
-    MaybeLoaderError decode_residual(Vector<i32>& decoded, FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
+    ErrorOr<Vector<i64>, LoaderError> decode_fixed_lpc(FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
+    ErrorOr<Vector<i64>, LoaderError> decode_verbatim(FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
+    ErrorOr<Vector<i64>, LoaderError> decode_custom_lpc(FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
+    MaybeLoaderError decode_residual(Vector<i64>& decoded, FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
     // decode a single rice partition that has its own rice parameter
-    ALWAYS_INLINE ErrorOr<Vector<i32>, LoaderError> decode_rice_partition(u8 partition_type, u32 partitions, u32 partition_index, FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
+    ALWAYS_INLINE ErrorOr<Vector<i64>, LoaderError> decode_rice_partition(u8 partition_type, u32 partitions, u32 partition_index, FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
     MaybeLoaderError load_seektable(FlacRawMetadataBlock&);
     // Note that failing to read a Vorbis comment block is not treated as an error of the FLAC loader, since metadata is optional.
     void load_vorbis_comment(FlacRawMetadataBlock&);

--- a/Userland/Libraries/LibAudio/GenericTypes.cpp
+++ b/Userland/Libraries/LibAudio/GenericTypes.cpp
@@ -27,7 +27,12 @@ Optional<SeekPoint const&> SeekTable::seek_point_before(u64 sample_index) const
         return {};
     size_t nearby_seek_point_index = 0;
     AK::binary_search(m_seek_points, sample_index, &nearby_seek_point_index, [](auto const& sample_index, auto const& seekpoint_candidate) {
-        return static_cast<i64>(sample_index) - static_cast<i64>(seekpoint_candidate.sample_index);
+        // Subtraction with i64 cast may cause overflow.
+        if (sample_index > seekpoint_candidate.sample_index)
+            return 1;
+        if (sample_index == seekpoint_candidate.sample_index)
+            return 0;
+        return -1;
     });
     // Binary search will always give us a close index, but it may be too large or too small.
     // By doing the index adjustment in this order, we will always find a seek point before the given sample.

--- a/Userland/Libraries/LibAudio/GenericTypes.h
+++ b/Userland/Libraries/LibAudio/GenericTypes.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 
 namespace Audio {
@@ -40,8 +40,8 @@ enum class ID3PictureType : u32 {
 // Note: This was first implemented for Flac but is compatible with ID3v2
 struct PictureData {
     ID3PictureType type {};
-    DeprecatedString mime_string {};
-    Vector<u32> description_string {};
+    String mime_string {};
+    String description_string {};
 
     u32 width {};
     u32 height {};


### PR DESCRIPTION
Most of them are non-critical overflow bugs that can only happen on invalid inputs anyways. However, there's one heap buffer overflow that could be exploitable together with a bug in an image decoder, as it allowed the image decoder to read 4 x (description length) past the end of the picture data.

### LibAudio: Check that LPC order is smaller than subframe sample count

An LPC predictor (fixed or not) contains as many warm-up samples as its
order. Therefore, the corresponding subframe must have at least this
many samples.

This turns this fuzzer-found crash into a handleable format error.

### LibAudio: Don't try to resample FLAC frames with sample rate 0

Although this sample rate is more or less bogus, we might as well not
crash.

### LibAudio: Prevent multiple kinds of buffer overruns in FLAC picture load

The fuzzer found one heap buffer overflow here due to confusion between
u32* and u8* (the given size is for bytes, but we used it for 32-bit
elements, quadrupling it), and it looks like there's an opportunity for
several more. This commit modernizes the picture loader by using
String's built-in stream loader, and also adds several spec-compliance
checks: The MIME type must be ASCII in a specific range, and the picture
description must be UTF-8.

### LibAudio: Prevent integer overflows in intermediate FLAC calculations

Since we can have up to 32 bits of input data, multiplications may need
up to 63 bits. This was accounted for in some places, but by far not in
all, and oss-fuzz found multiple integer overflows. We now use i64 in
all of the decoding, since we need to rescale samples to float later on
anyways. If a final sample value ends up out of range (and the range can
be a maximum of 32 bits), we may get samples past 1, but that then is a
non-compliant input file, and using over-range samples (and most likely
clipping audio) is considerably less weird than overflowing and
glitching audio.

### LibAudio: Fix 32-bit/64-bit mixup in FLAC sign extend

The bit magic for two's complement sign extension was only sign
extending to 32-bit signed. This issue was exposed by the last commit,
where now we actually use the 64-bit return value.

### LibAudio: Prevent FLAC Rice partitions getting smaller than 1 sample

This would cause an integer underflow leading to us trying to allocate
over 4GB for residual samples.

### LibAudio: Account for 0xFF start byte in FLAC UTF-8 decoder

This specialized UTF-8 decoder is more powerful than a normal UTF-8
decoder anyways, but it couldn't account for the never spec-compliant
0xff start byte. This commit makes that byte behave as expected if
taking UTF-8 to its extreme, even if it is a little silly and likely not
relevant for real applications.

### LibAudio: Perform seekpoint comparison without subtraction

For very large seekpoint indices, the casts necessary for the "simple"
subtraction comparison will yield wrong and overflowing results.
Therefore, we perform the seekpoint comparison manually instead.

