### PR TITLE
test262-runner+js: Respect the bytecode optimizations enabled flag

### DIFF
--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -32,7 +32,6 @@
 #endif
 
 static DeprecatedString s_current_test = "";
-static bool s_enable_bytecode_optimizations = false;
 static bool s_parse_only = false;
 static DeprecatedString s_harness_file_directory;
 static bool s_automatic_harness_detection_mode = false;
@@ -565,12 +564,13 @@ int main(int argc, char** argv)
     bool enable_debug_printing = false;
     bool disable_core_dumping = false;
     bool use_bytecode = false;
+    bool enable_bytecode_optimizations = false;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("LibJS test262 runner for streaming tests");
     args_parser.add_option(s_harness_file_directory, "Directory containing the harness files", "harness-location", 'l', "harness-files");
     args_parser.add_option(use_bytecode, "Use the bytecode interpreter", "use-bytecode", 'b');
-    args_parser.add_option(s_enable_bytecode_optimizations, "Enable the bytecode optimization passes", "enable-bytecode-optimizations", 'e');
+    args_parser.add_option(enable_bytecode_optimizations, "Enable the bytecode optimization passes", "enable-bytecode-optimizations", 'e');
     args_parser.add_option(s_parse_only, "Only parse the files", "parse-only", 'p');
     args_parser.add_option(timeout, "Seconds before test should timeout", "timeout", 't', "seconds");
     args_parser.add_option(enable_debug_printing, "Enable debug printing", "debug", 'd');
@@ -578,6 +578,7 @@ int main(int argc, char** argv)
     args_parser.parse(arguments);
 
     JS::Bytecode::Interpreter::set_enabled(use_bytecode);
+    JS::Bytecode::Interpreter::set_optimizations_enabled(enable_bytecode_optimizations);
 
 #if !defined(AK_OS_MACOS) && !defined(AK_OS_EMSCRIPTEN)
     if (disable_core_dumping && prctl(PR_SET_DUMPABLE, 0, 0) < 0) {

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -32,6 +32,13 @@ void Interpreter::set_enabled(bool enabled)
     s_bytecode_interpreter_enabled = enabled;
 }
 
+static bool s_optimizations_enabled = false;
+
+void Interpreter::set_optimizations_enabled(bool enabled)
+{
+    s_optimizations_enabled = enabled;
+}
+
 bool g_dump_bytecode = false;
 
 Interpreter::Interpreter(VM& vm)
@@ -104,7 +111,7 @@ ThrowCompletionOr<Value> Interpreter::run(Script& script_record, JS::GCPtr<Envir
         } else {
             auto executable = executable_result.release_value();
 
-            if (m_optimizations_enabled) {
+            if (s_optimizations_enabled) {
                 auto& passes = optimization_pipeline();
                 passes.perform(*executable);
             }
@@ -171,11 +178,6 @@ ThrowCompletionOr<Value> Interpreter::run(SourceTextModule& module)
     vm.run_queued_finalization_registry_cleanup_jobs();
 
     return js_undefined();
-}
-
-void Interpreter::set_optimizations_enabled(bool enabled)
-{
-    m_optimizations_enabled = enabled;
 }
 
 Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Realm& realm, Executable const& executable, BasicBlock const* entry_point, RegisterWindow* in_frame)

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -86,13 +86,7 @@ public:
     size_t pc() const;
     DeprecatedString debug_position() const;
 
-    enum class OptimizationLevel {
-        None,
-        Optimize,
-        __Count,
-        Default = None,
-    };
-    static Bytecode::PassManager& optimization_pipeline(OptimizationLevel = OptimizationLevel::Default);
+    static Bytecode::PassManager& optimization_pipeline();
 
     VM::InterpreterExecutionScope ast_interpreter_scope(Realm&);
 
@@ -108,8 +102,6 @@ private:
     }
 
     MarkedVector<Value>& registers() { return window().registers; }
-
-    static AK::Array<OwnPtr<PassManager>, static_cast<UnderlyingType<Interpreter::OptimizationLevel>>(Interpreter::OptimizationLevel::__Count)> s_optimization_pipelines;
 
     VM& m_vm;
     Vector<Variant<NonnullOwnPtr<RegisterWindow>, RegisterWindow*>> m_register_windows;

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -31,14 +31,13 @@ class Interpreter {
 public:
     [[nodiscard]] static bool enabled();
     static void set_enabled(bool);
+    static void set_optimizations_enabled(bool);
 
     explicit Interpreter(VM&);
     ~Interpreter();
 
     Realm& realm();
     VM& vm() { return m_vm; }
-
-    void set_optimizations_enabled(bool);
 
     ThrowCompletionOr<Value> run(Script&, JS::GCPtr<Environment> lexical_environment_override = nullptr);
     ThrowCompletionOr<Value> run(SourceTextModule&);
@@ -123,7 +122,6 @@ private:
     OwnPtr<JS::Interpreter> m_ast_interpreter;
     BasicBlock const* m_current_block { nullptr };
     InstructionStreamIterator* m_pc { nullptr };
-    bool m_optimizations_enabled { false };
 };
 
 extern bool g_dump_bytecode;

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -71,7 +71,6 @@ private:
 };
 
 static bool s_dump_ast = false;
-static bool s_opt_bytecode = false;
 static bool s_as_module = false;
 static bool s_print_last_result = false;
 static bool s_strip_ansi = false;
@@ -212,7 +211,6 @@ static ErrorOr<bool> parse_and_run(JS::Interpreter& interpreter, StringView sour
             script_or_module->parse_node().dump(0);
 
         if (auto* bytecode_interpreter = g_vm->bytecode_interpreter_if_exists()) {
-            bytecode_interpreter->set_optimizations_enabled(s_opt_bytecode);
             result = bytecode_interpreter->run(*script_or_module);
         } else {
             result = interpreter.run(*script_or_module);
@@ -578,13 +576,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView evaluate_script;
     Vector<StringView> script_paths;
     bool use_bytecode = false;
+    bool optimize_bytecode = false;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("This is a JavaScript interpreter.");
     args_parser.add_option(s_dump_ast, "Dump the AST", "dump-ast", 'A');
     args_parser.add_option(JS::Bytecode::g_dump_bytecode, "Dump the bytecode", "dump-bytecode", 'd');
     args_parser.add_option(use_bytecode, "Run the bytecode", "run-bytecode", 'b');
-    args_parser.add_option(s_opt_bytecode, "Optimize the bytecode", "optimize-bytecode", 'p');
+    args_parser.add_option(optimize_bytecode, "Optimize the bytecode", "optimize-bytecode", 'p');
     args_parser.add_option(s_as_module, "Treat as module", "as-module", 'm');
     args_parser.add_option(s_print_last_result, "Print last result", "print-last-result", 'l');
     args_parser.add_option(s_strip_ansi, "Disable ANSI colors", "disable-ansi-colors", 'i');
@@ -598,6 +597,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.parse(arguments);
 
     JS::Bytecode::Interpreter::set_enabled(use_bytecode);
+    JS::Bytecode::Interpreter::set_optimizations_enabled(optimize_bytecode);
 
     bool syntax_highlight = !disable_syntax_highlight;
 


### PR DESCRIPTION
This is going to look a bit silly on the libjs.dev graphs 😬 

```
Summary:
    Diff Tests:
         -11778 ✅   +945 ❌   +2864 ⚙️   +9299 💥️    -1330 📝   
```