### PR TITLE
Userland: Convert config listener callbacks to use StringView

### DIFF
--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -155,17 +155,12 @@ void ClipboardHistoryModel::clear()
     invalidate_model_and_file(true).release_value_but_fixme_should_propagate_errors();
 }
 
-void ClipboardHistoryModel::config_string_did_change(StringView domain, StringView group, StringView key, StringView value_string)
+void ClipboardHistoryModel::config_i32_did_change(StringView domain, StringView group, StringView key, i32 value)
 {
     if (domain != "ClipboardHistory" || group != "ClipboardHistory")
         return;
 
-    // FIXME: Once we can get notified for `i32` changes, we can use that instead of this hack.
     if (key == "NumHistoryItems") {
-        auto value_or_error = value_string.to_int();
-        if (!value_or_error.has_value())
-            return;
-        auto value = value_or_error.value();
         if (value < (int)m_history_items.size()) {
             m_history_items.remove(value, m_history_items.size() - value);
             invalidate_model_and_file(false).release_value_but_fixme_should_propagate_errors();

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -155,7 +155,7 @@ void ClipboardHistoryModel::clear()
     invalidate_model_and_file(true).release_value_but_fixme_should_propagate_errors();
 }
 
-void ClipboardHistoryModel::config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value_string)
+void ClipboardHistoryModel::config_string_did_change(StringView domain, StringView group, StringView key, StringView value_string)
 {
     if (domain != "ClipboardHistory" || group != "ClipboardHistory")
         return;

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
@@ -53,7 +53,7 @@ public:
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
     // ^Config::Listener
-    virtual void config_string_did_change(StringView domain, StringView group, StringView key, StringView value) override;
+    virtual void config_i32_did_change(StringView domain, StringView group, StringView key, i32 value) override;
 
 private:
     ClipboardHistoryModel();

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
@@ -53,7 +53,7 @@ public:
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
     // ^Config::Listener
-    virtual void config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value) override;
+    virtual void config_string_did_change(StringView domain, StringView group, StringView key, StringView value) override;
 
 private:
     ClipboardHistoryModel();

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -681,7 +681,7 @@ void BrowserWindow::proxy_mappings_changed()
     });
 }
 
-void BrowserWindow::config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value)
+void BrowserWindow::config_string_did_change(StringView domain, StringView group, StringView key, StringView value)
 {
     if (domain != "Browser")
         return;
@@ -707,7 +707,7 @@ void BrowserWindow::config_string_did_change(DeprecatedString const& domain, Dep
     // TODO: ColorScheme
 }
 
-void BrowserWindow::config_bool_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, bool value)
+void BrowserWindow::config_bool_did_change(StringView domain, StringView group, StringView key, bool value)
 {
     dbgln("{} {} {} {}", domain, group, key, value);
     if (domain != "Browser" || group != "Preferences")

--- a/Userland/Applications/Browser/BrowserWindow.h
+++ b/Userland/Applications/Browser/BrowserWindow.h
@@ -56,8 +56,8 @@ private:
     ErrorOr<void> load_search_engines(GUI::Menu& settings_menu);
     void set_window_title_for_tab(Tab const&);
 
-    virtual void config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value) override;
-    virtual void config_bool_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, bool value) override;
+    virtual void config_string_did_change(StringView domain, StringView group, StringView key, StringView value) override;
+    virtual void config_bool_did_change(StringView domain, StringView group, StringView key, bool value) override;
 
     virtual void event(Core::Event&) override;
 

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -357,7 +357,7 @@ void DirectoryView::set_view_mode_from_string(DeprecatedString const& mode)
     }
 }
 
-void DirectoryView::config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value)
+void DirectoryView::config_string_did_change(StringView domain, StringView group, StringView key, StringView value)
 {
     if (domain != "FileManager" || group != "DirectoryView")
         return;

--- a/Userland/Applications/FileManager/DirectoryView.h
+++ b/Userland/Applications/FileManager/DirectoryView.h
@@ -133,7 +133,7 @@ public:
     GUI::Action& view_as_columns_action() { return *m_view_as_columns_action; }
 
     // ^Config::Listener
-    virtual void config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value) override;
+    virtual void config_string_did_change(StringView domain, StringView group, StringView key, StringView value) override;
 
 private:
     explicit DirectoryView(Mode);

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -574,7 +574,7 @@ ErrorOr<int> run_in_desktop_mode()
     };
 
     struct BackgroundWallpaperListener : Config::Listener {
-        virtual void config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value) override
+        virtual void config_string_did_change(StringView domain, StringView group, StringView key, StringView value) override
         {
             if (domain == "WindowManager" && group == "Background" && key == "Wallpaper") {
                 if (value.is_empty()) {

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -54,7 +54,7 @@ public:
     {
     }
 
-    virtual void config_bool_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, bool value) override
+    virtual void config_bool_did_change(StringView domain, StringView group, StringView key, bool value) override
     {
         VERIFY(domain == "Terminal");
 
@@ -68,7 +68,7 @@ public:
         }
     }
 
-    virtual void config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value) override
+    virtual void config_string_did_change(StringView domain, StringView group, StringView key, StringView value) override
     {
         VERIFY(domain == "Terminal");
 
@@ -94,7 +94,7 @@ public:
         }
     }
 
-    virtual void config_i32_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, i32 value) override
+    virtual void config_i32_did_change(StringView domain, StringView group, StringView key, i32 value) override
     {
         VERIFY(domain == "Terminal");
 

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -744,7 +744,7 @@ bool ChessWidget::check_game_over(ClaimDrawBehavior claim_draw_behavior)
     return true;
 }
 
-void ChessWidget::config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value)
+void ChessWidget::config_string_did_change(StringView domain, StringView group, StringView key, StringView value)
 {
     if (domain != "Games"sv && group != "Chess"sv)
         return;
@@ -758,7 +758,7 @@ void ChessWidget::config_string_did_change(DeprecatedString const& domain, Depre
     }
 }
 
-void ChessWidget::config_bool_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, bool value)
+void ChessWidget::config_bool_did_change(StringView domain, StringView group, StringView key, bool value)
 {
     if (domain != "Games"sv && group != "Chess"sv)
         return;

--- a/Userland/Games/Chess/ChessWidget.h
+++ b/Userland/Games/Chess/ChessWidget.h
@@ -122,8 +122,8 @@ private:
 
     ChessWidget() = default;
 
-    virtual void config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value) override;
-    virtual void config_bool_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, bool value) override;
+    virtual void config_string_did_change(StringView domain, StringView group, StringView key, StringView value) override;
+    virtual void config_bool_did_change(StringView domain, StringView group, StringView key, bool value) override;
 
     bool check_game_over(ClaimDrawBehavior);
 

--- a/Userland/Games/Snake/Game.cpp
+++ b/Userland/Games/Snake/Game.cpp
@@ -325,7 +325,7 @@ Direction Game::direction_to_position(Snake::Coordinate const& from, Snake::Coor
     VERIFY_NOT_REACHED();
 }
 
-void Game::config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value)
+void Game::config_string_did_change(StringView domain, StringView group, StringView key, StringView value)
 {
     if (domain == "Snake"sv && group == "Snake"sv && key == "SnakeSkin"sv) {
         set_skin_name(value);
@@ -333,7 +333,7 @@ void Game::config_string_did_change(DeprecatedString const& domain, DeprecatedSt
     }
 }
 
-void Game::config_u32_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, u32 value)
+void Game::config_u32_did_change(StringView domain, StringView group, StringView key, u32 value)
 {
     if (domain == "Snake"sv && group == "Snake"sv && key == "BaseColor"sv) {
         set_skin_color(Color::from_argb(value));

--- a/Userland/Games/Snake/Game.h
+++ b/Userland/Games/Snake/Game.h
@@ -44,8 +44,8 @@ private:
     virtual void keydown_event(GUI::KeyEvent&) override;
     virtual void timer_event(Core::TimerEvent&) override;
 
-    virtual void config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value) override;
-    void config_u32_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, u32 value) override;
+    virtual void config_string_did_change(StringView domain, StringView group, StringView key, StringView value) override;
+    void config_u32_did_change(StringView domain, StringView group, StringView key, u32 value) override;
 
     void game_over();
     void spawn_fruit();

--- a/Userland/Libraries/LibCards/CardGame.cpp
+++ b/Userland/Libraries/LibCards/CardGame.cpp
@@ -112,7 +112,7 @@ void CardGame::dump_layout() const
         dbgln("{}", stack);
 }
 
-void CardGame::config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value)
+void CardGame::config_string_did_change(StringView domain, StringView group, StringView key, StringView value)
 {
     if (domain == "Games" && group == "Cards") {
         if (key == "BackgroundColor") {

--- a/Userland/Libraries/LibCards/CardGame.h
+++ b/Userland/Libraries/LibCards/CardGame.h
@@ -57,7 +57,7 @@ protected:
     CardGame();
 
 private:
-    virtual void config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value) override;
+    virtual void config_string_did_change(StringView domain, StringView group, StringView key, StringView value) override;
 
     Vector<NonnullRefPtr<CardStack>> m_stacks;
 

--- a/Userland/Libraries/LibConfig/Listener.cpp
+++ b/Userland/Libraries/LibConfig/Listener.cpp
@@ -29,31 +29,31 @@ void Listener::for_each(Function<void(Listener&)> callback)
         callback(*listener);
 }
 
-void Listener::config_string_did_change(DeprecatedString const&, DeprecatedString const&, DeprecatedString const&, DeprecatedString const&)
+void Listener::config_string_did_change(StringView, StringView, StringView, StringView)
 {
 }
 
-void Listener::config_i32_did_change(DeprecatedString const&, DeprecatedString const&, DeprecatedString const&, i32)
+void Listener::config_i32_did_change(StringView, StringView, StringView, i32)
 {
 }
 
-void Listener::config_u32_did_change(DeprecatedString const&, DeprecatedString const&, DeprecatedString const&, u32)
+void Listener::config_u32_did_change(StringView, StringView, StringView, u32)
 {
 }
 
-void Listener::config_bool_did_change(DeprecatedString const&, DeprecatedString const&, DeprecatedString const&, bool)
+void Listener::config_bool_did_change(StringView, StringView, StringView, bool)
 {
 }
 
-void Listener::config_key_was_removed(DeprecatedString const&, DeprecatedString const&, DeprecatedString const&)
+void Listener::config_key_was_removed(StringView, StringView, StringView)
 {
 }
 
-void Listener::config_group_was_removed(DeprecatedString const&, DeprecatedString const&)
+void Listener::config_group_was_removed(StringView, StringView)
 {
 }
 
-void Listener::config_group_was_added(DeprecatedString const&, DeprecatedString const&)
+void Listener::config_group_was_added(StringView, StringView)
 {
 }
 

--- a/Userland/Libraries/LibConfig/Listener.h
+++ b/Userland/Libraries/LibConfig/Listener.h
@@ -16,13 +16,13 @@ public:
 
     static void for_each(Function<void(Listener&)>);
 
-    virtual void config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value);
-    virtual void config_i32_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, i32 value);
-    virtual void config_u32_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, u32 value);
-    virtual void config_bool_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, bool value);
-    virtual void config_key_was_removed(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key);
-    virtual void config_group_was_removed(DeprecatedString const& domain, DeprecatedString const& group);
-    virtual void config_group_was_added(DeprecatedString const& domain, DeprecatedString const& group);
+    virtual void config_string_did_change(StringView domain, StringView group, StringView key, StringView value);
+    virtual void config_i32_did_change(StringView domain, StringView group, StringView key, i32 value);
+    virtual void config_u32_did_change(StringView domain, StringView group, StringView key, u32 value);
+    virtual void config_bool_did_change(StringView domain, StringView group, StringView key, bool value);
+    virtual void config_key_was_removed(StringView domain, StringView group, StringView key);
+    virtual void config_group_was_removed(StringView domain, StringView group);
+    virtual void config_group_was_added(StringView domain, StringView group);
 
 protected:
     Listener();

--- a/Userland/Libraries/LibGUI/Calendar.cpp
+++ b/Userland/Libraries/LibGUI/Calendar.cpp
@@ -769,7 +769,7 @@ size_t Calendar::day_of_week_index(DeprecatedString const& day_name)
     return AK::find_index(day_names.begin(), day_names.end(), day_name);
 }
 
-void Calendar::config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value)
+void Calendar::config_string_did_change(StringView domain, StringView group, StringView key, StringView value)
 {
     if (domain == "Calendar" && group == "View" && key == "FirstDayOfWeek") {
         m_first_day_of_week = static_cast<DayOfWeek>(day_of_week_index(value));
@@ -780,7 +780,7 @@ void Calendar::config_string_did_change(DeprecatedString const& domain, Deprecat
     }
 }
 
-void Calendar::config_i32_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, i32 value)
+void Calendar::config_i32_did_change(StringView domain, StringView group, StringView key, i32 value)
 {
     if (domain == "Calendar" && group == "View" && key == "WeekendLength") {
         m_weekend_length = value;

--- a/Userland/Libraries/LibGUI/Calendar.h
+++ b/Userland/Libraries/LibGUI/Calendar.h
@@ -71,8 +71,8 @@ public:
         m_unadjusted_tile_size.set_height(height);
     }
 
-    virtual void config_string_did_change(DeprecatedString const&, DeprecatedString const&, DeprecatedString const&, DeprecatedString const&) override;
-    virtual void config_i32_did_change(DeprecatedString const&, DeprecatedString const&, DeprecatedString const&, i32 value) override;
+    virtual void config_string_did_change(StringView, StringView, StringView, StringView) override;
+    virtual void config_i32_did_change(StringView, StringView, StringView, i32 value) override;
 
     Function<void()> on_tile_click;
     Function<void()> on_tile_doubleclick;

--- a/Userland/Services/Taskbar/QuickLaunchWidget.cpp
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.cpp
@@ -208,7 +208,7 @@ ErrorOr<void> QuickLaunchWidget::add_or_adjust_button(DeprecatedString const& bu
     return {};
 }
 
-void QuickLaunchWidget::config_key_was_removed(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key)
+void QuickLaunchWidget::config_key_was_removed(StringView domain, StringView group, StringView key)
 {
     if (domain == "Taskbar" && group == quick_launch) {
         auto button = find_child_of_type_named<GUI::Button>(key);
@@ -217,7 +217,7 @@ void QuickLaunchWidget::config_key_was_removed(DeprecatedString const& domain, D
     }
 }
 
-void QuickLaunchWidget::config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value)
+void QuickLaunchWidget::config_string_did_change(StringView domain, StringView group, StringView key, StringView value)
 {
     if (domain == "Taskbar" && group == quick_launch) {
         auto entry = QuickLaunchEntry::create_from_config_value(value);

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -83,8 +83,8 @@ public:
     static ErrorOr<NonnullRefPtr<QuickLaunchWidget>> create();
     virtual ~QuickLaunchWidget() override = default;
 
-    virtual void config_key_was_removed(DeprecatedString const&, DeprecatedString const&, DeprecatedString const&) override;
-    virtual void config_string_did_change(DeprecatedString const&, DeprecatedString const&, DeprecatedString const&, DeprecatedString const&) override;
+    virtual void config_key_was_removed(StringView, StringView, StringView) override;
+    virtual void config_string_did_change(StringView, StringView, StringView, StringView) override;
 
     virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -121,7 +121,7 @@ void TaskbarWindow::add_system_menu(NonnullRefPtr<GUI::Menu> system_menu)
     main->insert_child_before(*m_start_button, *m_quick_launch);
 }
 
-void TaskbarWindow::config_string_did_change(DeprecatedString const& domain, DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value)
+void TaskbarWindow::config_string_did_change(StringView domain, StringView group, StringView key, StringView value)
 {
     if (domain == "Taskbar" && group == "Clock" && key == "TimeFormat") {
         m_clock_widget->update_format(value);

--- a/Userland/Services/Taskbar/TaskbarWindow.h
+++ b/Userland/Services/Taskbar/TaskbarWindow.h
@@ -28,7 +28,7 @@ public:
     static int taskbar_height() { return 27; }
     static int taskbar_icon_size() { return 16; }
 
-    virtual void config_string_did_change(DeprecatedString const&, DeprecatedString const&, DeprecatedString const&, DeprecatedString const&) override;
+    virtual void config_string_did_change(StringView, StringView, StringView, StringView) override;
     virtual void add_system_menu(NonnullRefPtr<GUI::Menu> system_menu);
 
 private:


### PR DESCRIPTION
The immutability of the string is not relevant here, since the string we're given was allocated in the IPC serialization layer and will be destroyed shortly afterwards. Additionally, noone relies on DeprecatedString-specific functionality. This will make it easier to convert the IPC layer itself to String later on.

The second commit is a trivial FIXME resolution I stumbled over.
