### PR TITLE
LibWeb: Fix js execution for js urls in anchor tags href

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -231,7 +231,8 @@ public:
 
     HTML::EnvironmentSettingsObject& relevant_settings_object();
 
-    JS::Value run_javascript(StringView source, StringView filename = "(unknown)"sv);
+    void navigate_to_javascript_url(StringView url);
+    void evaluate_javascript_url(StringView url);
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(DeprecatedString const& local_name, Variant<DeprecatedString, ElementCreationOptions> const& options);
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element_ns(DeprecatedString const& namespace_, DeprecatedString const& qualified_name, Variant<DeprecatedString, ElementCreationOptions> const& options);

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -55,6 +55,11 @@ void HTMLAnchorElement::run_activation_behavior(Web::DOM::Event const&)
     if (href().is_empty())
         return;
 
+    // AD-HOC: follow_the_hyperlink currently doesn't navigate properly with javascript urls
+    // EventHandler::handle_mouseup performs the navigation steps for javascript urls instead
+    if (href().starts_with("javascript:"sv))
+        return;
+
     // 2. Let hyperlinkSuffix be null.
     Optional<DeprecatedString> hyperlink_suffix {};
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -286,7 +286,7 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, unsigned button, unsig
                     dbgln("Web::EventHandler: Clicking on a link to {}", url);
                     if (button == GUI::MouseButton::Primary) {
                         if (href.starts_with("javascript:"sv)) {
-                            document->run_javascript(href.substring_view(11, href.length() - 11));
+                            document->navigate_to_javascript_url(href);
                         } else if (!url.fragment().is_null() && url.equals(document->url(), AK::URL::ExcludeFragment::Yes)) {
                             m_browsing_context->scroll_to_anchor(url.fragment());
                         } else {


### PR DESCRIPTION
This pr allows for javascript urls to be executed without crashing the browser! :^)

Example:
```html
<a href="javascript:alert(1)">javascript url</a>
```