### PR TITLE
LibWeb: Prevent crash when inspecting SVG documents

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1638,7 +1638,7 @@ void Node::build_accessibility_tree(AccessibilityTreeNode& parent)
     if (is_document()) {
         auto* document = static_cast<DOM::Document*>(this);
         auto* document_element = document->document_element();
-        if (document_element) {
+        if (document_element && document_element->include_in_accessibility_tree()) {
             parent.set_value(document_element);
             if (document_element->has_child_nodes())
                 document_element->for_each_child([&parent](DOM::Node& child) {

--- a/Userland/Libraries/LibWebView/AccessibilityTreeModel.cpp
+++ b/Userland/Libraries/LibWebView/AccessibilityTreeModel.cpp
@@ -93,8 +93,8 @@ GUI::Variant AccessibilityTreeModel::data(GUI::ModelIndex const& index, GUI::Mod
         if (type != "element")
             return node_role;
 
-        auto name = node.get_deprecated_string("name"sv).value();
-        auto description = node.get_deprecated_string("description"sv).value();
+        auto name = node.get_deprecated_string("name"sv).value_or("");
+        auto description = node.get_deprecated_string("description"sv).value_or("");
 
         StringBuilder builder;
         builder.append(node_role.to_lowercase());


### PR DESCRIPTION
(Or any document with aria-hidden=true on the root)