### PR TITLE
AK: Use compiler builtins for `MakeIntegerSequence`/`TypeListElement`

### DIFF
--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -454,6 +454,13 @@ struct IntegerSequence {
 template<unsigned... Indices>
 using IndexSequence = IntegerSequence<unsigned, Indices...>;
 
+#if __has_builtin(__make_integer_seq)
+template<typename T, T N>
+using MakeIntegerSequence = __make_integer_seq<IntegerSequence, T, N>;
+#elif __has_builtin(__integer_pack)
+template<typename T, T N>
+using MakeIntegerSequence = IntegerSequence<T, __integer_pack(N)...>;
+#else
 template<typename T, T N, T... Ts>
 auto make_integer_sequence_impl()
 {
@@ -465,6 +472,7 @@ auto make_integer_sequence_impl()
 
 template<typename T, T N>
 using MakeIntegerSequence = decltype(make_integer_sequence_impl<T, N>());
+#endif
 
 template<unsigned N>
 using MakeIndexSequence = MakeIntegerSequence<unsigned, N>;

--- a/AK/TypeList.h
+++ b/AK/TypeList.h
@@ -16,6 +16,12 @@ struct TypeList;
 template<unsigned Index, typename List>
 struct TypeListElement;
 
+#if __has_builtin(__type_pack_element)
+template<unsigned Index, typename... Types>
+struct TypeListElement<Index, TypeList<Types...>> {
+    using Type = __type_pack_element<Index, Types...>;
+};
+#else
 template<unsigned Index, typename Head, typename... Tail>
 struct TypeListElement<Index, TypeList<Head, Tail...>>
     : TypeListElement<Index - 1, TypeList<Tail...>> {
@@ -25,6 +31,7 @@ template<typename Head, typename... Tail>
 struct TypeListElement<0, TypeList<Head, Tail...>> {
     using Type = Head;
 };
+#endif
 
 template<typename... Types>
 struct TypeList {


### PR DESCRIPTION
These recursive templates have a measurable impact on the compile speed of Variant-heavy code like LibWeb. Using these builtins leads to a 2.5% speedup for the measured compilation units.