### PR TITLE
Kernel+AudioServer: Use interrupts for Intel HDA audio buffer completion

### DIFF
--- a/Kernel/Devices/Audio/Channel.h
+++ b/Kernel/Devices/Audio/Channel.h
@@ -7,10 +7,6 @@
 #pragma once
 
 #include <Kernel/Devices/CharacterDevice.h>
-#include <Kernel/Interrupts/IRQHandler.h>
-#include <Kernel/Memory/PhysicalAddress.h>
-#include <Kernel/Memory/PhysicalPage.h>
-#include <Kernel/Tasks/WaitQueue.h>
 
 namespace Kernel {
 

--- a/Kernel/Devices/Audio/Controller.h
+++ b/Kernel/Devices/Audio/Controller.h
@@ -6,18 +6,12 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/IntrusiveList.h>
-#include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
-#include <Kernel/Bus/PCI/Access.h>
-#include <Kernel/Bus/PCI/Device.h>
+#include <AK/Types.h>
 #include <Kernel/Devices/Audio/Channel.h>
-#include <Kernel/Devices/Device.h>
-#include <Kernel/Library/LockWeakable.h>
-#include <Kernel/Locking/Mutex.h>
-#include <Kernel/Memory/PhysicalAddress.h>
-#include <Kernel/Memory/PhysicalPage.h>
-#include <Kernel/Security/Random.h>
+#include <Kernel/Library/UserOrKernelBuffer.h>
 
 namespace Kernel {
 

--- a/Kernel/Devices/Audio/IntelHDA/Stream.h
+++ b/Kernel/Devices/Audio/IntelHDA/Stream.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Badge.h>
 #include <AK/Error.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/OwnPtr.h>
@@ -13,6 +14,7 @@
 #include <Kernel/Devices/Audio/IntelHDA/Format.h>
 #include <Kernel/Library/IOWindow.h>
 #include <Kernel/Locking/SpinlockProtected.h>
+#include <Kernel/Tasks/WaitQueue.h>
 
 namespace Kernel::Audio::IntelHDA {
 
@@ -20,12 +22,15 @@ class Stream {
 public:
     static constexpr u32 cyclic_buffer_size_in_ms = 40;
 
+    virtual ~Stream();
+
     u8 stream_number() const { return m_stream_number; }
     bool running() const { return m_running; }
     u32 sample_rate() const { return m_format_parameters.sample_rate; }
 
     void start();
     ErrorOr<void> stop();
+    virtual ErrorOr<void> handle_interrupt(Badge<Controller>) = 0;
 
     ErrorOr<void> set_format(FormatParameters);
 
@@ -49,6 +54,24 @@ protected:
     enum StreamControlFlag : u32 {
         StreamReset = 1u << 0,
         StreamRun = 1u << 1,
+        InterruptOnCompletionEnable = 1u << 2,
+    };
+
+    // 3.3.36 : Input/Output/Bidirectional Stream Descriptor Status
+    enum StreamStatusFlag : u8 {
+        BufferCompletionInterruptStatus = 1u << 2,
+    };
+
+    // 3.6.3: Buffer Descriptor List Entry
+    enum BufferDescriptorEntryFlag : u32 {
+        InterruptOnCompletion = 1u << 0,
+    };
+
+    // 3.6.3: Buffer Descriptor List Entry
+    struct BufferDescriptorEntry {
+        u64 address;
+        u32 size;
+        BufferDescriptorEntryFlag flags;
     };
 
     Stream(NonnullOwnPtr<IOWindow> stream_io_window, u8 stream_number)
@@ -56,8 +79,6 @@ protected:
         , m_stream_number(stream_number)
     {
     }
-
-    ~Stream();
 
     u32 read_control();
     void write_control(u32);
@@ -70,6 +91,7 @@ protected:
     OwnPtr<Memory::Region> m_buffer_descriptor_list;
     SpinlockProtected<OwnPtr<Memory::Region>, LockRank::None> m_buffers;
     size_t m_buffer_position { 0 };
+    WaitQueue m_irq_queue;
     bool m_running { false };
     FormatParameters m_format_parameters;
 };
@@ -82,6 +104,11 @@ public:
     {
         return adopt_nonnull_own_or_enomem(new (nothrow) OutputStream(move(stream_io_window), stream_number));
     }
+
+    ~OutputStream() = default;
+
+    // ^Stream
+    ErrorOr<void> handle_interrupt(Badge<Controller>) override;
 
     ErrorOr<size_t> write(UserOrKernelBuffer const&, size_t);
 
@@ -96,6 +123,8 @@ private:
         //          not intended for them."
         VERIFY(stream_number >= 1);
     }
+
+    u32 m_last_link_position { 0 };
 };
 
 // FIXME: implement InputStream and BidirectionalStream

--- a/Kernel/Devices/Audio/Management.cpp
+++ b/Kernel/Devices/Audio/Management.cpp
@@ -6,11 +6,10 @@
 
 #include <AK/Singleton.h>
 #include <Kernel/Bus/PCI/API.h>
-#include <Kernel/Bus/PCI/IDs.h>
+#include <Kernel/Bus/PCI/Access.h>
 #include <Kernel/Devices/Audio/AC97/AC97.h>
 #include <Kernel/Devices/Audio/IntelHDA/Controller.h>
 #include <Kernel/Devices/Audio/Management.h>
-#include <Kernel/Sections.h>
 
 namespace Kernel {
 

--- a/Kernel/Devices/Audio/Management.h
+++ b/Kernel/Devices/Audio/Management.h
@@ -6,12 +6,10 @@
 
 #pragma once
 
-#include <AK/Badge.h>
 #include <AK/Error.h>
 #include <AK/IntrusiveList.h>
 #include <AK/NonnullRefPtr.h>
-#include <AK/OwnPtr.h>
-#include <AK/Types.h>
+#include <Kernel/Bus/PCI/Definitions.h>
 #include <Kernel/Devices/Audio/Controller.h>
 
 namespace Kernel {

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -58,10 +58,7 @@ void Mixer::mix()
         {
             Threading::MutexLocker const locker(m_pending_mutex);
             // While we have nothing to mix, wait on the condition.
-            // HACK: HDA is currently broken when we don't constantly feed it a buffer stream.
-            //       Commenting out this line makes it "just work" for the time being. Please add this line back once the issue is fixed.
-            //       See:
-            // m_mixing_necessary.wait_while([this, &active_mix_queues]() { return m_pending_mixing.is_empty() && active_mix_queues.is_empty(); });
+            m_mixing_necessary.wait_while([this, &active_mix_queues]() { return m_pending_mixing.is_empty() && active_mix_queues.is_empty(); });
             if (!m_pending_mixing.is_empty()) {
                 active_mix_queues.extend(move(m_pending_mixing));
                 m_pending_mixing.clear();


### PR DESCRIPTION
We used to not care about stopping an audio output stream for Intel HDA since AudioServer would continuously send new buffers to play. Since 707f5ac150ef858760eb9faa52b9ba80c50c4262 however, that has changed.

Intel HDA now uses interrupts to detect when each buffer was completed by the device, and uses a simple heuristic to detect whether a buffer underrun has occurred so it can stop the output stream.

This was tested on Qemu's Intel HDA (Linux x86_64) and a bare metal MSI Starship/Matisse HD Audio Controller.

CC @kleinesfilmroellchen 