### PR TITLE
LibJS/Bytecode: Handle ImportStatement in codegen

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -373,6 +373,8 @@ public:
 
     virtual void dump(int indent) const override;
 
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
+
     bool has_bound_name(DeprecatedFlyString const& name) const;
     Vector<ImportEntry> const& entries() const { return m_entries; }
     ModuleRequest const& module_request() const { return m_module_request; }

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -2851,4 +2851,9 @@ Bytecode::CodeGenerationErrorOr<void> ExportStatement::generate_bytecode(Bytecod
     return {};
 }
 
+Bytecode::CodeGenerationErrorOr<void> ImportStatement::generate_bytecode(Bytecode::Generator&) const
+{
+    return {};
+}
+
 }


### PR DESCRIPTION
There is nothing to do here at runtime as imports are handled in `Interpreter::run`.

```
Summary:
    Diff Tests:
        +79 ✅   +33 ❌   +1 💥️    -113 📝   
```