### PR TITLE
Ports/acpica-tools: Prevent dangling pointer compiler warning

### DIFF
--- a/Ports/acpica-tools/patches/0001-Stop-compiler-warnings-on-dangling-pointer.patch
+++ b/Ports/acpica-tools/patches/0001-Stop-compiler-warnings-on-dangling-pointer.patch
@@ -22,3 +22,12 @@ index f789e68..fd18f5c 100644
  
  
      AcpiGbl_EntryStackPointer = &CurrentSp;
+@@ -205,7 +205,7 @@ void
+ AcpiUtTrackStackPtr (
+     void)
+ {
+-    ACPI_SIZE               CurrentSp;
++    static ACPI_SIZE               CurrentSp;
+ 
+ 
+     if (&CurrentSp < AcpiGbl_LowestStackPointer)


### PR DESCRIPTION
Extended the existing patch to cover all occurences of assigning &CurrentSp to a non-local variable. Keeps the Port build from failing.

Contributing to issue #18238