### PR TITLE
LibAudio: Three fixes for spec compliance

### DIFF
--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -22,6 +22,7 @@
 #include <LibAudio/FlacTypes.h>
 #include <LibAudio/GenericTypes.h>
 #include <LibAudio/LoaderError.h>
+#include <LibAudio/MultiChannel.h>
 #include <LibAudio/Resampler.h>
 #include <LibAudio/VorbisComment.h>
 #include <LibCore/File.h>
@@ -338,7 +339,7 @@ ErrorOr<Vector<FixedArray<Sample>>, LoaderError> FlacLoaderPlugin::load_chunks(s
 {
     ssize_t remaining_samples = static_cast<ssize_t>(m_total_samples - m_loaded_samples);
     // The first condition is relevant for unknown-size streams (total samples = 0 in the header)
-    if (m_stream->is_eof() || remaining_samples <= 0)
+    if (m_stream->is_eof() || (m_total_samples < NumericLimits<u64>::max() && remaining_samples <= 0))
         return Vector<FixedArray<Sample>> {};
 
     size_t samples_to_read = min(samples_to_read_from_input, remaining_samples);

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -923,7 +923,7 @@ ALWAYS_INLINE ErrorOr<Vector<i64>, LoaderError> FlacLoaderPlugin::decode_rice_pa
     if (k == (1 << partition_type) - 1) {
         u8 unencoded_bps = TRY(bit_input.read_bits<u8>(5));
         for (size_t r = 0; r < residual_sample_count; ++r) {
-            rice_partition[r] = TRY(bit_input.read_bits<u8>(unencoded_bps));
+            rice_partition[r] = sign_extend(TRY(bit_input.read_bits<u32>(unencoded_bps)), unencoded_bps);
         }
     } else {
         for (size_t r = 0; r < residual_sample_count; ++r) {

--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -91,10 +91,15 @@ public:
     // Will only read less samples if we're at the end of the stream.
     LoaderSamples get_more_samples(size_t samples_to_read_from_input = 128 * KiB);
 
-    MaybeLoaderError reset() const { return m_plugin->reset(); }
+    MaybeLoaderError reset() const
+    {
+        m_plugin_at_end_of_stream = false;
+        return m_plugin->reset();
+    }
     MaybeLoaderError seek(int const position) const
     {
         m_buffer.clear_with_capacity();
+        m_plugin_at_end_of_stream = false;
         return m_plugin->seek(position);
     }
 
@@ -114,6 +119,8 @@ private:
     explicit Loader(NonnullOwnPtr<LoaderPlugin>);
 
     mutable NonnullOwnPtr<LoaderPlugin> m_plugin;
+    // The plugin can signal an end of stream by returning no (or only empty) chunks.
+    mutable bool m_plugin_at_end_of_stream { false };
     mutable Vector<Sample, loader_buffer_size> m_buffer;
 };
 

--- a/Userland/Libraries/LibAudio/MultiChannel.h
+++ b/Userland/Libraries/LibAudio/MultiChannel.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Concepts.h>
+#include <AK/FixedArray.h>
+#include <LibAudio/Sample.h>
+
+namespace Audio {
+
+// Downmixes any number of channels to stereo, under the assumption that standard channel layout is followed:
+// 1 channel = mono
+// 2 channels = stereo (left, right)
+// 3 channels = left, right, center
+// 4 channels = front left/right, back left/right
+// 5 channels = front left/right, center, back left/right
+// 6 channels = front left/right, center, LFE, back left/right
+// 7 channels = front left/right, center, LFE, back center, side left/right
+// 8 channels = front left/right, center, LFE, back left/right, side left/right
+template<ArrayLike<float> ChannelType, ArrayLike<ChannelType> InputType>
+ErrorOr<FixedArray<Sample>> downmix_surround_to_stereo(InputType input)
+{
+    if (input.size() == 0)
+        return Error::from_string_view("Cannot resample from 0 channels"sv);
+
+    auto channel_count = input.size();
+    auto sample_count = input[0].size();
+
+    FixedArray<Sample> output = TRY(FixedArray<Sample>::create(sample_count));
+
+    // FIXME: We could figure out a better way to mix the channels, possibly spatially, but for now:
+    //        - Center and LFE channels are added to both left and right.
+    //        - All left channels are added together on the left, all right channels are added together on the right.
+    switch (channel_count) {
+    case 1:
+        for (auto i = 0u; i < sample_count; ++i)
+            output[i] = Sample { input[0][i] };
+        break;
+    case 2:
+        for (auto i = 0u; i < sample_count; ++i)
+            output[i] = Sample { input[0][i], input[1][i] };
+        break;
+    case 3:
+        for (auto i = 0u; i < sample_count; ++i)
+            output[i] = Sample { input[0][i] + input[2][i],
+                input[1][i] + input[2][i] };
+        break;
+    case 4:
+        for (auto i = 0u; i < sample_count; ++i)
+            output[i] = Sample { input[0][i] + input[2][i],
+                input[1][i] + input[3][i] };
+        break;
+    case 5:
+        for (auto i = 0u; i < sample_count; ++i)
+            output[i] = Sample { input[0][i] + input[3][i] + input[2][i],
+                input[1][i] + input[4][i] + input[2][i] };
+        break;
+    case 6:
+        for (auto i = 0u; i < sample_count; ++i) {
+            output[i] = Sample { input[0][i] + input[4][i] + input[2][i] + input[3][i],
+                input[1][i] + input[5][i] + input[2][i] + input[3][i] };
+        }
+        break;
+    case 7:
+        for (auto i = 0u; i < sample_count; ++i) {
+            output[i] = Sample { input[0][i] + input[5][i] + input[2][i] + input[3][i] + input[4][i],
+                input[1][i] + input[6][i] + input[2][i] + input[3][i] + input[4][i] };
+        }
+        break;
+    case 8:
+        for (auto i = 0u; i < sample_count; ++i) {
+            output[i] = Sample { input[0][i] + input[4][i] + input[6][i] + input[2][i] + input[3][i],
+                input[1][i] + input[5][i] + input[7][i] + input[2][i] + input[3][i] };
+        }
+        break;
+    default:
+        return Error::from_string_view("Invalid number of channels greater than 8"sv);
+    }
+
+    return output;
+}
+
+}


### PR DESCRIPTION
With this, we should be the most compliant decoder by numbers alone, with one mild crash and a few not-quite-right outputs, but no proper glitches or hard crashes.

### LibAudio: Fix escaped partitions

A missing sign extension and a wrong data type broke these before.

### LibAudio: Handle unknown-sized streams better

Especially FLAC had an issue here before, but the loader infrastructure
itself wouldn't handle end of stream properly if the "available samples"
information didn't match up.

### LibAudio: Mix multi-channel files more properly

We downsample multi-channel files into stereo for now, which at least
makes the other channels listenable. The new multi-channel downmix
helper is intended to be used for other formats with the same or similar
channel arrangement, such as QOA.

