### PR TITLE
LibJS/Bytecode: Improve export statement handling

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -2857,13 +2857,18 @@ Bytecode::CodeGenerationErrorOr<void> ExportStatement::generate_bytecode(Bytecod
     }
 
     if (is<ClassExpression>(*m_statement)) {
-        TODO();
+        TRY(m_statement->generate_bytecode(generator));
+
+        if (!static_cast<ClassExpression const&>(*m_statement).has_name())
+            generator.emit<Bytecode::Op::SetVariable>(generator.intern_identifier(ExportStatement::local_name_for_default), Bytecode::Op::SetVariable::InitializationMode::Initialize);
+
+        return {};
     }
 
     // ExportDeclaration : export default AssignmentExpression ;
     VERIFY(is<Expression>(*m_statement));
     TRY(generator.emit_named_evaluation_if_anonymous_function(static_cast<Expression const&>(*m_statement), DeprecatedFlyString("default"sv)));
-    generator.emit<Bytecode::Op::SetVariable>(generator.intern_identifier("default"sv));
+    generator.emit<Bytecode::Op::SetVariable>(generator.intern_identifier(ExportStatement::local_name_for_default), Bytecode::Op::SetVariable::InitializationMode::Initialize);
     return {};
 }
 


### PR DESCRIPTION
This adds support for exporting class expressions, which was previously TODO'd.

We now correctly set the binding name of exports to `"*default*"` if they are unnamed. I'm not sure what the difference between the `InitializationMode` kinds is, but using `Initialize` fixes a bunch of tests.
    
Note that some export tests (e.g. `eval-export-dflt-expr-cls-named.js`) still fail, as we don't set the "name" property of exported classes correctly.


176 new passes on test262

```
Summary:
    Diff Tests:
        +176 ✅    -152 ❌    -24 💥️   
```