### PR TITLE
AK: Re-enable consteval StringView literal workaround for oss-fuzz

### DIFF
--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -374,7 +374,9 @@ struct CaseInsensitiveASCIIStringViewTraits : public Traits<StringView> {
 // FIXME: Remove this when clang on BSD distributions fully support consteval (specifically in the context of default parameter initialization).
 //        Note that this is fixed in clang-15, but is not yet picked up by all downstream distributions.
 //        See: https://github.com/llvm/llvm-project/issues/48230
-#if defined(AK_OS_BSD_GENERIC)
+//        Additionally, oss-fuzz currently ships an llvm-project commit that is a pre-release of 15.0.0.
+//        See: https://github.com/google/oss-fuzz/issues/9989
+#if defined(AK_OS_BSD_GENERIC) or defined(OSS_FUZZ)
 #    define AK_STRING_VIEW_LITERAL_CONSTEVAL constexpr
 #else
 #    define AK_STRING_VIEW_LITERAL_CONSTEVAL consteval


### PR DESCRIPTION
oss-fuzz ships a pre-release commit of clang-15 for all of their build bots. Until they update to a release of clang-15 that includes the fix for this bug, or a later release, we need to keep the workaround in place.

#19482 introduced this bug by enabling consteval for clang on linux platforms. This is the second workaround we've had to add for oss-fuzz's bespoke clang-15 release, the first being #18708.