### PR TITLE
LibJS/Tests: Enable some now passing Array length tests

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.slice.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.slice.js
@@ -38,10 +38,7 @@ test("basic functionality", () => {
     expect(slice).toEqual(["hello", "friends", "serenity", 1]);
 });
 
-// FIXME: These tests are currently skipped because an invalid array length in this case is 2**32 or above.
-//        The codebase currently uses size_t for lengths, which is currently the same as u32 when building for Serenity.
-//        This means these lengths wrap around to 0, making the test not work correctly.
-test.skip("Invalid lengths", () => {
+test("Invalid lengths", () => {
     var length = Math.pow(2, 32);
 
     var obj = {

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.splice.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.splice.js
@@ -48,10 +48,7 @@ test("basic functionality", () => {
     expect(removed).toEqual(["foo", "bar", "baz"]);
 });
 
-// FIXME: These tests are currently skipped because an invalid array length in this case is 2**32 or above.
-//        The codebase currently uses size_t for lengths, which is currently the same as u32 when building for Serenity.
-//        This means these lengths wrap around to 0, making the test not work correctly.
-test.skip("Invalid lengths", () => {
+test("Invalid lengths", () => {
     var length = Math.pow(2, 32);
 
     var obj = {

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.toSpliced.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.toSpliced.js
@@ -91,7 +91,7 @@ describe("errors", () => {
         }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
     });
 
-    test.skip("maximum array size exceeded", () => {
+    test("maximum array size exceeded", () => {
         const a = { length: 2 ** 53 - 1 };
         expect(() => {
             Array.prototype.toSpliced.call(a, 0, 0, "foo");


### PR DESCRIPTION
Now that serenity is 64 bit only these tests no longer need to be skipped :^)