### PR TITLE
LibWeb: Make cell percentage widths relative to table

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
@@ -1,0 +1,38 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x23.46875 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 93.328125x23.46875 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 91.328125x21.46875 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (9,9) content-size 91.328125x21.46875 table-row-group children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (9,9) content-size 91.328125x21.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x17.46875]
+                    "A"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (29.265625,11) content-size 50.796875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [50.265625,11 9.34375x17.46875]
+                    "B"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (84.0625,11) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [86.0625,11 10.3125x17.46875]
+                    "C"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>

--- a/Tests/LibWeb/Layout/input/table/percentage-width-columns.html
+++ b/Tests/LibWeb/Layout/input/table/percentage-width-columns.html
@@ -1,0 +1,21 @@
+<style>
+    table {
+        border: 1px solid;
+        border-collapse: collapse;
+        text-align: center;
+    }
+
+    td {
+        border: 1px solid;
+    }
+</style>
+
+<table>
+    <tbody>
+        <tr>
+            <td style="width: 20%;">A</td>
+            <td style="width: 60%;">B</td>
+            <td style="width: 20%;">C</td>
+        </tr>
+    </tbody>
+</table>


### PR DESCRIPTION
Cell percentage widths are relative to table width, not containing block width. If the table width is auto, there isn't a normative specification, only a brief mention that the user agent should try to meet it.

As a starting point, we increase the width of the table such that it's sufficient to cover min-width of cells with a percentage width. This matches the behavior of other browsers, at least for simple cases.