### PR TITLE
LibAudio: Fix both fuzzer-found MP3 bugs

### DIFF
--- a/Userland/Libraries/LibAudio/MP3HuffmanTables.h
+++ b/Userland/Libraries/LibAudio/MP3HuffmanTables.h
@@ -112,9 +112,12 @@ HuffmanDecodeResult<T> huffman_decode(BigEndianInputBitStream& bitstream, Readon
     size_t bits_read = 0;
 
     while (!node->is_leaf() && max_bits_to_read-- > 0) {
-        bool const direction = bitstream.read_bit().release_value_but_fixme_should_propagate_errors();
+        auto const maybe_direction = bitstream.read_bit();
+        if (maybe_direction.is_error())
+            return { bits_read, {} };
+
         ++bits_read;
-        if (direction) {
+        if (maybe_direction.value()) {
             if (node->left == -1)
                 return {};
             node = &tree[node->left];


### PR DESCRIPTION
### LibAudio: Handle bitstream errors in MP3 Huffman decode


### LibAudio: Don't overread MP3 granule samples if big_values is too large

There are at most 576 granule samples/frequency lines, but the side data
can specify that the big_values granule type take up to 1024 samples.
The spec says in 2.4.3.4.6 that we should always stop reading Huffman
data once we have 576 samples, so that is what this change does. I also
add some useful spec comments while I'm here.

