### PR TITLE
LibJS: Stop using execute_ast_node in NewClass instruction

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1427,6 +1427,7 @@ public:
     bool has_name() const { return !m_name.is_empty(); }
 
     ThrowCompletionOr<ECMAScriptFunctionObject*> class_definition_evaluation(VM&, DeprecatedFlyString const& binding_name = {}, DeprecatedFlyString const& class_name = {}) const;
+    ThrowCompletionOr<ECMAScriptFunctionObject*> create_class_constructor(VM&, Environment* class_environment, Environment* environment, Value super_class, DeprecatedFlyString const& binding_name = {}, DeprecatedFlyString const& class_name = {}) const;
 
 private:
     virtual bool is_class_expression() const override { return true; }


### PR DESCRIPTION
This change replaces usage of `execute_ast_node` to evaluate super expression in NewClass by generating instructions instead.