### PR TITLE
FileManager: Show information about image, audio, and font files in Properties window

### DIFF
--- a/Userland/Applications/FileManager/CMakeLists.txt
+++ b/Userland/Applications/FileManager/CMakeLists.txt
@@ -8,6 +8,7 @@ serenity_component(
 compile_gml(FileManagerWindow.gml FileManagerWindowGML.h file_manager_window_gml)
 compile_gml(FileOperationProgress.gml FileOperationProgressGML.h file_operation_progress_gml)
 compile_gml(PropertiesWindowAudioTab.gml PropertiesWindowAudioTabGML.h properties_window_audio_tab_gml)
+compile_gml(PropertiesWindowFontTab.gml PropertiesWindowFontTabGML.h properties_window_font_tab_gml)
 compile_gml(PropertiesWindowGeneralTab.gml PropertiesWindowGeneralTabGML.h properties_window_general_tab_gml)
 compile_gml(PropertiesWindowImageTab.gml PropertiesWindowImageTabGML.h properties_window_image_tab_gml)
 
@@ -24,6 +25,7 @@ set(GENERATED_SOURCES
     FileManagerWindowGML.h
     FileOperationProgressGML.h
     PropertiesWindowAudioTabGML.h
+    PropertiesWindowFontTabGML.h
     PropertiesWindowGeneralTabGML.h
     PropertiesWindowImageTabGML.h
 )

--- a/Userland/Applications/FileManager/CMakeLists.txt
+++ b/Userland/Applications/FileManager/CMakeLists.txt
@@ -9,6 +9,7 @@ compile_gml(FileManagerWindow.gml FileManagerWindowGML.h file_manager_window_gml
 compile_gml(FileOperationProgress.gml FileOperationProgressGML.h file_operation_progress_gml)
 compile_gml(PropertiesWindowAudioTab.gml PropertiesWindowAudioTabGML.h properties_window_audio_tab_gml)
 compile_gml(PropertiesWindowGeneralTab.gml PropertiesWindowGeneralTabGML.h properties_window_general_tab_gml)
+compile_gml(PropertiesWindowImageTab.gml PropertiesWindowImageTabGML.h properties_window_image_tab_gml)
 
 set(SOURCES
     DesktopWidget.cpp
@@ -24,6 +25,7 @@ set(GENERATED_SOURCES
     FileOperationProgressGML.h
     PropertiesWindowAudioTabGML.h
     PropertiesWindowGeneralTabGML.h
+    PropertiesWindowImageTabGML.h
 )
 
 serenity_app(FileManager ICON app-file-manager)

--- a/Userland/Applications/FileManager/CMakeLists.txt
+++ b/Userland/Applications/FileManager/CMakeLists.txt
@@ -7,6 +7,7 @@ serenity_component(
 
 compile_gml(FileManagerWindow.gml FileManagerWindowGML.h file_manager_window_gml)
 compile_gml(FileOperationProgress.gml FileOperationProgressGML.h file_operation_progress_gml)
+compile_gml(PropertiesWindowAudioTab.gml PropertiesWindowAudioTabGML.h properties_window_audio_tab_gml)
 compile_gml(PropertiesWindowGeneralTab.gml PropertiesWindowGeneralTabGML.h properties_window_general_tab_gml)
 
 set(SOURCES
@@ -21,8 +22,9 @@ set(SOURCES
 set(GENERATED_SOURCES
     FileManagerWindowGML.h
     FileOperationProgressGML.h
+    PropertiesWindowAudioTabGML.h
     PropertiesWindowGeneralTabGML.h
 )
 
 serenity_app(FileManager ICON app-file-manager)
-target_link_libraries(FileManager PRIVATE LibCore LibFileSystem LibGfx LibGUI LibDesktop LibConfig LibMain LibThreading)
+target_link_libraries(FileManager PRIVATE LibAudio LibCore LibFileSystem LibGfx LibGUI LibDesktop LibConfig LibMain LibThreading)

--- a/Userland/Applications/FileManager/PropertiesWindow.h
+++ b/Userland/Applications/FileManager/PropertiesWindow.h
@@ -31,6 +31,7 @@ private:
     ErrorOr<void> create_general_tab(GUI::TabWidget&, bool disable_rename);
     ErrorOr<void> create_file_type_specific_tabs(GUI::TabWidget&);
     ErrorOr<void> create_audio_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>);
+    ErrorOr<void> create_image_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>, StringView mime_type);
 
     struct PermissionMasks {
         mode_t read;

--- a/Userland/Applications/FileManager/PropertiesWindow.h
+++ b/Userland/Applications/FileManager/PropertiesWindow.h
@@ -31,6 +31,7 @@ private:
     ErrorOr<void> create_general_tab(GUI::TabWidget&, bool disable_rename);
     ErrorOr<void> create_file_type_specific_tabs(GUI::TabWidget&);
     ErrorOr<void> create_audio_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>);
+    ErrorOr<void> create_font_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>, StringView mime_type);
     ErrorOr<void> create_image_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>, StringView mime_type);
 
     struct PermissionMasks {

--- a/Userland/Applications/FileManager/PropertiesWindow.h
+++ b/Userland/Applications/FileManager/PropertiesWindow.h
@@ -28,6 +28,7 @@ public:
 private:
     PropertiesWindow(DeprecatedString const& path, Window* parent = nullptr);
     ErrorOr<void> create_widgets(bool disable_rename);
+    ErrorOr<void> create_general_tab(GUI::TabWidget&, bool disable_rename);
 
     struct PermissionMasks {
         mode_t read;

--- a/Userland/Applications/FileManager/PropertiesWindow.h
+++ b/Userland/Applications/FileManager/PropertiesWindow.h
@@ -29,6 +29,8 @@ private:
     PropertiesWindow(DeprecatedString const& path, Window* parent = nullptr);
     ErrorOr<void> create_widgets(bool disable_rename);
     ErrorOr<void> create_general_tab(GUI::TabWidget&, bool disable_rename);
+    ErrorOr<void> create_file_type_specific_tabs(GUI::TabWidget&);
+    ErrorOr<void> create_audio_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>);
 
     struct PermissionMasks {
         mode_t read;

--- a/Userland/Applications/FileManager/PropertiesWindow.h
+++ b/Userland/Applications/FileManager/PropertiesWindow.h
@@ -29,12 +29,6 @@ private:
     PropertiesWindow(DeprecatedString const& path, Window* parent = nullptr);
     ErrorOr<void> create_widgets(bool disable_rename);
 
-    struct PropertyValuePair {
-        DeprecatedString property;
-        DeprecatedString value;
-        Optional<URL> link = {};
-    };
-
     struct PermissionMasks {
         mode_t read;
         mode_t write;

--- a/Userland/Applications/FileManager/PropertiesWindowAudioTab.gml
+++ b/Userland/Applications/FileManager/PropertiesWindowAudioTab.gml
@@ -1,0 +1,228 @@
+@GUI::Widget {
+    layout: @GUI::VerticalBoxLayout {
+        margins: [8]
+        spacing: 12
+    }
+
+    @GUI::GroupBox {
+        title: "Audio"
+        preferred_height: "shrink"
+        layout: @GUI::VerticalBoxLayout {
+            margins: [12, 8, 0]
+            spacing: 2
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Type:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "audio_type"
+                text: "MP3"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Duration:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "audio_duration"
+                text: "3:21"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Sample rate:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "audio_sample_rate"
+                text: "44100 Hz"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Format:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "audio_format"
+                text: "16-bit"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Channels:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "audio_channels"
+                text: "2 (Stereo)"
+                text_alignment: "TopLeft"
+            }
+        }
+    }
+
+    @GUI::GroupBox {
+        title: "Track"
+        layout: @GUI::VerticalBoxLayout {
+            margins: [12, 8, 0]
+            spacing: 2
+        }
+
+        @GUI::Widget {
+            preferred_height: "shrink"
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Title:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "audio_title"
+                text: "Ana Ng"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            preferred_height: "shrink"
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Artist(s):"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "audio_artists"
+                text: "They Might Be Giants"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            preferred_height: "shrink"
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Album:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "audio_album"
+                text: "Lincoln"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            preferred_height: "shrink"
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Track number:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "audio_track_number"
+                text: "1"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            preferred_height: "shrink"
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Genre:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "audio_genre"
+                text: "Alternative"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            preferred_height: "grow"
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Comment:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                preferred_height: "grow"
+                name: "audio_comment"
+                text: "Ana Ng and I are getting old and we still haven't walked in the glow of each other's majestic presence."
+                text_alignment: "TopLeft"
+            }
+        }
+    }
+}

--- a/Userland/Applications/FileManager/PropertiesWindowFontTab.gml
+++ b/Userland/Applications/FileManager/PropertiesWindowFontTab.gml
@@ -1,0 +1,123 @@
+@GUI::Widget {
+    layout: @GUI::VerticalBoxLayout {
+        margins: [8]
+        spacing: 12
+    }
+
+    @GUI::GroupBox {
+        title: "Font"
+        preferred_height: "shrink"
+        layout: @GUI::VerticalBoxLayout {
+            margins: [12, 8, 0]
+            spacing: 2
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Format:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "font_format"
+                text: "TrueType"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Family:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "font_family"
+                text: "SerenitySans"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Fixed width:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "font_fixed_width"
+                text: "No"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Width:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "font_width"
+                text: "Normal"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Weight:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "font_weight"
+                text: "500 (Medium)"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Slope:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "font_slope"
+                text: "Regular"
+                text_alignment: "TopLeft"
+            }
+        }
+    }
+}

--- a/Userland/Applications/FileManager/PropertiesWindowGeneralTab.gml
+++ b/Userland/Applications/FileManager/PropertiesWindowGeneralTab.gml
@@ -59,6 +59,7 @@
             name: "location"
             text: "/home/anon/file"
             text_alignment: "CenterLeft"
+            text_wrapping: "DontWrap"
         }
     }
 
@@ -79,6 +80,7 @@
             name: "link_location"
             text: "/home/anon/file"
             text_alignment: "CenterLeft"
+            text_wrapping: "DontWrap"
         }
     }
 

--- a/Userland/Applications/FileManager/PropertiesWindowImageTab.gml
+++ b/Userland/Applications/FileManager/PropertiesWindowImageTab.gml
@@ -1,0 +1,171 @@
+@GUI::Widget {
+    layout: @GUI::VerticalBoxLayout {
+        margins: [8]
+        spacing: 12
+    }
+
+    @GUI::GroupBox {
+        title: "Image"
+        preferred_height: "shrink"
+        layout: @GUI::VerticalBoxLayout {
+            margins: [12, 8, 0]
+            spacing: 2
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Type:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "image_type"
+                text: "JPEG"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Size:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "image_size"
+                text: "1920 x 1080"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Animation:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "image_animation"
+                text: "Loop indefinitely (12 frames)"
+                text_alignment: "TopLeft"
+                text_wrapping: "DontWrap"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "ICC profile:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "image_has_icc_profile"
+                text: "See below"
+                text_alignment: "TopLeft"
+            }
+        }
+    }
+
+    @GUI::GroupBox {
+        name: "image_icc_group"
+        title: "ICC Profile"
+        preferred_height: "shrink"
+        layout: @GUI::VerticalBoxLayout {
+            margins: [12, 8, 0]
+            spacing: 2
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Profile:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "image_icc_profile"
+                text: "e-sRGB"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Copyright:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "image_icc_copyright"
+                text: "(c) 1999 Adobe Systems Inc."
+                text_alignment: "TopLeft"
+                text_wrapping: "DontWrap"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Color space:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "image_icc_color_space"
+                text: "RGB"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Device class:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "image_icc_device_class"
+                text: "DisplayDevice"
+                text_alignment: "TopLeft"
+            }
+        }
+    }
+}

--- a/Userland/Libraries/LibAudio/Loader.cpp
+++ b/Userland/Libraries/LibAudio/Loader.cpp
@@ -47,7 +47,8 @@ ErrorOr<NonnullRefPtr<Loader>, LoaderError> Loader::create(StringView path)
     auto stream = TRY(Core::InputBufferedFile::create(TRY(Core::File::open(path, Core::File::OpenMode::Read))));
     return adopt_ref(*new (nothrow) Loader(TRY(Loader::create_plugin(move(stream)))));
 }
-ErrorOr<NonnullRefPtr<Loader>, LoaderError> Loader::create(Bytes buffer)
+
+ErrorOr<NonnullRefPtr<Loader>, LoaderError> Loader::create(ReadonlyBytes buffer)
 {
     auto stream = TRY(try_make<FixedMemoryStream>(buffer));
     return adopt_ref(*new (nothrow) Loader(TRY(Loader::create_plugin(move(stream)))));

--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -86,7 +86,7 @@ protected:
 class Loader : public RefCounted<Loader> {
 public:
     static ErrorOr<NonnullRefPtr<Loader>, LoaderError> create(StringView path);
-    static ErrorOr<NonnullRefPtr<Loader>, LoaderError> create(Bytes buffer);
+    static ErrorOr<NonnullRefPtr<Loader>, LoaderError> create(ReadonlyBytes buffer);
 
     // Will only read less samples if we're at the end of the stream.
     LoaderSamples get_more_samples(size_t samples_to_read_from_input = 128 * KiB);

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -104,7 +104,7 @@ static ErrorOr<double> read_sample(Stream& stream)
     }
 }
 
-LoaderSamples WavLoaderPlugin::samples_from_pcm_data(Bytes const& data, size_t samples_to_read) const
+LoaderSamples WavLoaderPlugin::samples_from_pcm_data(ReadonlyBytes data, size_t samples_to_read) const
 {
     FixedArray<Sample> samples = TRY(FixedArray<Sample>::create(samples_to_read));
     FixedMemoryStream stream { data };

--- a/Userland/Libraries/LibAudio/WavLoader.h
+++ b/Userland/Libraries/LibAudio/WavLoader.h
@@ -48,7 +48,7 @@ private:
     MaybeLoaderError parse_header();
     MaybeLoaderError load_wav_info_block(Vector<RIFF::Chunk> info_chunks);
 
-    LoaderSamples samples_from_pcm_data(Bytes const& data, size_t samples_to_read) const;
+    LoaderSamples samples_from_pcm_data(ReadonlyBytes data, size_t samples_to_read) const;
     template<typename SampleReader>
     MaybeLoaderError read_samples_from_stream(Stream& stream, SampleReader read_sample, FixedArray<Sample>& samples) const;
 

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -114,6 +114,11 @@ static Array const s_registered_mime_type = {
     MimeType { .name = "extra/win-31x-compressed"sv, .description = "Windows 3.1X compressed file"sv, .magic_bytes = Vector<u8> { 'K', 'W', 'A', 'J' } },
     MimeType { .name = "extra/win-95-compressed"sv, .description = "Windows 95 compressed file"sv, .magic_bytes = Vector<u8> { 'S', 'Z', 'D', 'D' } },
 
+    MimeType { .name = "font/otf"sv, .common_extensions = { "otf"sv }, .description = "OpenType font"sv, .magic_bytes = Vector<u8> { 'O', 'T', 'T', 'F' } },
+    MimeType { .name = "font/ttf"sv, .common_extensions = { "ttf"sv }, .description = "TrueType font"sv, .magic_bytes = Vector<u8> { 0x00, 0x01, 0x00, 0x00, 0x00 } },
+    MimeType { .name = "font/woff"sv, .common_extensions = { "woff"sv }, .description = "WOFF font"sv, .magic_bytes = Vector<u8> { 'W', 'O', 'F', 'F' } },
+    MimeType { .name = "font/woff2"sv, .common_extensions = { "woff2"sv }, .description = "WOFF2 font"sv, .magic_bytes = Vector<u8> { 'W', 'O', 'F', '2' } },
+
     MimeType { .name = "image/bmp"sv, .common_extensions = { ".bmp"sv }, .description = "BMP image data"sv, .magic_bytes = Vector<u8> { 'B', 'M' } },
     MimeType { .name = "image/gif"sv, .common_extensions = { ".gif"sv }, .description = "GIF image data"sv, .magic_bytes = Vector<u8> { 'G', 'I', 'F', '8', '7', 'a' } },
     MimeType { .name = "image/gif"sv, .common_extensions = { ".gif"sv }, .description = "GIF image data"sv, .magic_bytes = Vector<u8> { 'G', 'I', 'F', '8', '9', 'a' } },

--- a/Userland/Libraries/LibGfx/Font/FontStyleMapping.h
+++ b/Userland/Libraries/LibGfx/Font/FontStyleMapping.h
@@ -36,6 +36,18 @@ static constexpr Array<FontStyleMapping, 4> font_slope_names = { {
     { 3, "Reclined"sv },
 } };
 
+static constexpr Array<FontStyleMapping, 9> font_width_names = { {
+    { 1, "Ultra Condensed"sv },
+    { 2, "Extra Condensed"sv },
+    { 3, "Condensed"sv },
+    { 4, "Semi Condensed"sv },
+    { 5, "Normal"sv },
+    { 6, "Semi Expanded"sv },
+    { 7, "Expanded"sv },
+    { 8, "Extra Expanded"sv },
+    { 9, "Ultra Expanded"sv },
+} };
+
 static constexpr StringView weight_to_name(int weight)
 {
     for (auto& it : font_weight_names) {
@@ -66,6 +78,24 @@ static constexpr StringView slope_to_name(int slope)
 static constexpr int name_to_slope(StringView name)
 {
     for (auto& it : font_slope_names) {
+        if (it.name == name)
+            return it.style;
+    }
+    return {};
+}
+
+static constexpr StringView width_to_name(int width)
+{
+    for (auto& it : font_width_names) {
+        if (it.style == width)
+            return it.name;
+    }
+    return {};
+}
+
+static constexpr int name_to_width(StringView name)
+{
+    for (auto& it : font_width_names) {
         if (it.name == name)
             return it.style;
     }

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -254,6 +254,11 @@ public:
         return {};
     }
 
+    Optional<TagData const&> tag_data(TagSignature signature) const
+    {
+        return m_tag_table.get(signature).map([](auto it) -> TagData const& { return *it; });
+    }
+
     size_t tag_count() const { return m_tag_table.size(); }
 
     // Only versions 2 and 4 are in use.

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -259,6 +259,8 @@ public:
         return m_tag_table.get(signature).map([](auto it) -> TagData const& { return *it; });
     }
 
+    Optional<String> tag_string_data(TagSignature signature) const;
+
     size_t tag_count() const { return m_tag_table.size(); }
 
     // Only versions 2 and 4 are in use.


### PR DESCRIPTION
The "General" tab on this window felt lonely, and it's nice to be able to view some basic information about a file, beyond its size, modification date, and that it is a file. So, this PR adds some tabs for Image, Audio, and Font files to give more information.

There are a few random other changes in related libraries too.

![image](https://github.com/SerenityOS/serenity/assets/222642/537cd7e7-5681-4313-8b94-8a07a6ab14a3)

![image](https://github.com/SerenityOS/serenity/assets/222642/15329fe9-1728-48cb-b742-d11a0b4f6a27)

## NOTE: The font preview shown has since been removed, so ignore that part. :^)

![image](https://github.com/SerenityOS/serenity/assets/222642/3c346605-3e2b-4a29-b2b9-660292a691eb)

My concern with this is, it means decoding these files inside FileManager, which is one of the more dangerous applications to become compromised since it can see the whole filesystem that the user can. Also it does slow down opening the properties window a bit. Maybe in future it could lazy-load the files when you open the file-type-specific tab.