### PR TITLE
LibJS: Use the IdentifierTable for NewFunction and NewClass lhs names

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -16,6 +16,7 @@
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibJS/Bytecode/CodeGenerationError.h>
+#include <LibJS/Bytecode/IdentifierTable.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Handle.h>
 #include <LibJS/Runtime/ClassFieldDefinition.h>
@@ -738,7 +739,7 @@ public:
     virtual void dump(int indent) const override;
 
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
-    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode_with_lhs_name(Bytecode::Generator&, Optional<DeprecatedFlyString const&> lhs_name) const;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode_with_lhs_name(Bytecode::Generator&, Optional<Bytecode::IdentifierTableIndex> lhs_name) const;
 
     bool has_name() const { return !name().is_empty(); }
 
@@ -1421,7 +1422,7 @@ public:
     virtual Completion execute(Interpreter&) const override;
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
-    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode_with_lhs_name(Bytecode::Generator&, Optional<DeprecatedFlyString const&> lhs_name) const;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode_with_lhs_name(Bytecode::Generator&, Optional<Bytecode::IdentifierTableIndex> lhs_name) const;
 
     bool has_name() const { return !m_name.is_empty(); }
 

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -452,7 +452,7 @@ void Generator::pop_home_object()
     m_home_objects.take_last();
 }
 
-void Generator::emit_new_function(FunctionExpression const& function_node, Optional<DeprecatedFlyString const&> lhs_name)
+void Generator::emit_new_function(FunctionExpression const& function_node, Optional<IdentifierTableIndex> lhs_name)
 {
     if (m_home_objects.is_empty())
         emit<Op::NewFunction>(function_node, lhs_name);
@@ -460,7 +460,7 @@ void Generator::emit_new_function(FunctionExpression const& function_node, Optio
         emit<Op::NewFunction>(function_node, lhs_name, m_home_objects.last());
 }
 
-CodeGenerationErrorOr<void> Generator::emit_named_evaluation_if_anonymous_function(Expression const& expression, Optional<DeprecatedFlyString const&> lhs_name)
+CodeGenerationErrorOr<void> Generator::emit_named_evaluation_if_anonymous_function(Expression const& expression, Optional<IdentifierTableIndex> lhs_name)
 {
     if (is<FunctionExpression>(expression)) {
         auto const& function_expression = static_cast<FunctionExpression const&>(expression);

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -85,9 +85,9 @@ public:
 
     void push_home_object(Register);
     void pop_home_object();
-    void emit_new_function(JS::FunctionExpression const&, Optional<DeprecatedFlyString const&> lhs_name);
+    void emit_new_function(JS::FunctionExpression const&, Optional<IdentifierTableIndex> lhs_name);
 
-    CodeGenerationErrorOr<void> emit_named_evaluation_if_anonymous_function(Expression const&, Optional<DeprecatedFlyString const&> lhs_name);
+    CodeGenerationErrorOr<void> emit_named_evaluation_if_anonymous_function(Expression const&, Optional<IdentifierTableIndex> lhs_name);
 
     void begin_continuable_scope(Label continue_target, Vector<DeprecatedFlyString> const& language_label_set);
     void end_continuable_scope();

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -795,7 +795,10 @@ ThrowCompletionOr<void> NewFunction::execute_impl(Bytecode::Interpreter& interpr
     auto& vm = interpreter.vm();
 
     if (!m_function_node.has_name()) {
-        interpreter.accumulator() = m_function_node.instantiate_ordinary_function_expression(vm, m_lhs_name.value_or({}));
+        DeprecatedFlyString name = {};
+        if (m_lhs_name.has_value())
+            name = interpreter.current_executable().get_identifier(m_lhs_name.value());
+        interpreter.accumulator() = m_function_node.instantiate_ordinary_function_expression(vm, name);
     } else {
         interpreter.accumulator() = ECMAScriptFunctionObject::create(interpreter.realm(), m_function_node.name(), m_function_node.source_text(), m_function_node.body(), m_function_node.parameters(), m_function_node.function_length(), vm.lexical_environment(), vm.running_execution_context().private_environment, m_function_node.kind(), m_function_node.is_strict_mode(), m_function_node.might_need_arguments_object(), m_function_node.contains_direct_call_to_eval(), m_function_node.is_arrow_function());
     }
@@ -1149,7 +1152,7 @@ ThrowCompletionOr<void> NewClass::execute_impl(Bytecode::Interpreter& interprete
     ECMAScriptFunctionObject* class_object = nullptr;
 
     if (!m_class_expression.has_name() && m_lhs_name.has_value())
-        class_object = TRY(m_class_expression.class_definition_evaluation(vm, {}, m_lhs_name.value()));
+        class_object = TRY(m_class_expression.class_definition_evaluation(vm, {}, interpreter.current_executable().get_identifier(m_lhs_name.value())));
     else
         class_object = TRY(m_class_expression.class_definition_evaluation(vm, name, name.is_null() ? ""sv : name));
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -822,10 +822,10 @@ private:
 
 class NewClass final : public Instruction {
 public:
-    explicit NewClass(ClassExpression const& class_expression, Optional<DeprecatedFlyString const&> lhs_name)
+    explicit NewClass(ClassExpression const& class_expression, Optional<IdentifierTableIndex> lhs_name)
         : Instruction(Type::NewClass)
         , m_class_expression(class_expression)
-        , m_lhs_name(lhs_name.has_value() ? *lhs_name : Optional<DeprecatedFlyString> {})
+        , m_lhs_name(lhs_name)
     {
     }
 
@@ -836,15 +836,15 @@ public:
 
 private:
     ClassExpression const& m_class_expression;
-    Optional<DeprecatedFlyString> m_lhs_name;
+    Optional<IdentifierTableIndex> m_lhs_name;
 };
 
 class NewFunction final : public Instruction {
 public:
-    explicit NewFunction(FunctionExpression const& function_node, Optional<DeprecatedFlyString const&> lhs_name, Optional<Register> home_object = {})
+    explicit NewFunction(FunctionExpression const& function_node, Optional<IdentifierTableIndex> lhs_name, Optional<Register> home_object = {})
         : Instruction(Type::NewFunction)
         , m_function_node(function_node)
-        , m_lhs_name(lhs_name.has_value() ? *lhs_name : Optional<DeprecatedFlyString> {})
+        , m_lhs_name(lhs_name)
         , m_home_object(move(home_object))
     {
     }
@@ -856,7 +856,7 @@ public:
 
 private:
     FunctionExpression const& m_function_node;
-    Optional<DeprecatedFlyString> m_lhs_name;
+    Optional<IdentifierTableIndex> m_lhs_name;
     Optional<Register> m_home_object;
 };
 


### PR DESCRIPTION
This makes them trivially copyable, which is an assumption multiple optimizations use when rebuilding the instruction stream.

This fixes most optimized crashes in the test262 suite.

----

Fixes #19690

----

This puts the interning quite early if it is deemed to be better, I can move it into the the `emit_named_evaluation_if_anonymous_function` function and Co, which would most likely decrease the lines changed as well