### PR TITLE
LibGfx: Fix error & crash in Rect::closest_to

### DIFF
--- a/Tests/LibGfx/TestRect.cpp
+++ b/Tests/LibGfx/TestRect.cpp
@@ -45,3 +45,14 @@ TEST_CASE(rect_shatter)
 
     EXPECT_EQ(glass_plate.size().area() - hammer.size().area(), total_shard_area);
 }
+
+TEST_CASE(rect_closest_to)
+{
+    Gfx::IntRect const screen_rect = { 0, 0, 960, 540 };
+    Gfx::Point<int> p = { 460, 592 }; // point is below the rect
+    Gfx::Point<int> closest = screen_rect.closest_to(p);
+    EXPECT_EQ(screen_rect.side(closest), Gfx::IntRect::Side::Bottom);
+    p = { 960, 0 }; // point exactly on top right corner
+    closest = screen_rect.closest_to(p);
+    EXPECT_EQ(screen_rect.side(closest), Gfx::IntRect::Side::Top);
+}

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -656,8 +656,8 @@ public:
             }
         };
 
-        check_distance({ top_left(), top_right() });
-        check_distance({ bottom_left(), bottom_right() });
+        check_distance({ top_left(), top_right().moved_left(1) });
+        check_distance({ bottom_left().moved_up(1), bottom_right().translated(-1) });
         if (height() > 2) {
             check_distance({ { x(), y() + 1 }, { x(), bottom() - 2 } });
             check_distance({ { right() - 1, y() + 1 }, { right() - 1, bottom() - 2 } });


### PR DESCRIPTION
Assertion fails if the point is outside of the rect. This was introduced in introduced in #18970 and causes serenity to crash when changing to 2x resolution for a monitor, if the cursor after resizing is outside of the new screen.

Added test to reproduce.