### PR TITLE
LibJS: Align NewPromiseCapability with spec changes

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/PromiseCapability.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseCapability.h
@@ -17,27 +17,24 @@ class PromiseCapability final : public Cell {
     JS_CELL(PromiseCapability, Cell);
 
 public:
-    static NonnullGCPtr<PromiseCapability> create(VM& vm, GCPtr<Object> promise, GCPtr<FunctionObject> resolve, GCPtr<FunctionObject> reject);
+    static NonnullGCPtr<PromiseCapability> create(VM& vm, NonnullGCPtr<Object> promise, NonnullGCPtr<FunctionObject> resolve, NonnullGCPtr<FunctionObject> reject);
 
     virtual ~PromiseCapability() = default;
 
-    [[nodiscard]] GCPtr<Object> promise() const { return m_promise; }
-    void set_promise(NonnullGCPtr<Object> promise) { m_promise = promise; }
+    [[nodiscard]] NonnullGCPtr<Object> promise() const { return m_promise; }
 
-    [[nodiscard]] GCPtr<FunctionObject> resolve() const { return m_resolve; }
-    void set_resolve(NonnullGCPtr<FunctionObject> resolve) { m_resolve = resolve; }
+    [[nodiscard]] NonnullGCPtr<FunctionObject> resolve() const { return m_resolve; }
 
-    [[nodiscard]] GCPtr<FunctionObject> reject() const { return m_reject; }
-    void set_reject(NonnullGCPtr<FunctionObject> reject) { m_reject = reject; }
+    [[nodiscard]] NonnullGCPtr<FunctionObject> reject() const { return m_reject; }
 
 private:
-    PromiseCapability(GCPtr<Object>, GCPtr<FunctionObject>, GCPtr<FunctionObject>);
+    PromiseCapability(NonnullGCPtr<Object>, NonnullGCPtr<FunctionObject>, NonnullGCPtr<FunctionObject>);
 
     virtual void visit_edges(Visitor&) override;
 
-    GCPtr<Object> m_promise;
-    GCPtr<FunctionObject> m_resolve;
-    GCPtr<FunctionObject> m_reject;
+    NonnullGCPtr<Object> m_promise;
+    NonnullGCPtr<FunctionObject> m_resolve;
+    NonnullGCPtr<FunctionObject> m_reject;
 };
 
 // 27.2.1.1.1 IfAbruptRejectPromise ( value, capability ), https://tc39.es/ecma262/#sec-ifabruptrejectpromise


### PR DESCRIPTION
See https://github.com/tc39/ecma262/commit/874ecf9

After this refactoring, we now correctly handle non-function / non-undefined objects being passed multiple times: instead of skipping assignment to promiseCapability altogether and failing with a NotAFunction error in the end; on the second time the executor closure is called, we return GetCapabilitiesExecutorCalledMultipleTimes.

This fixes the 7 `capability-executor-called-twice.js` test262 tests.

```
Summary:
    Diff Tests:
        +7 ✅    -7 ❌   

Diff Tests:
    test/built-ins/Promise/all/capability-executor-called-twice.js            ❌ -> ✅
    test/built-ins/Promise/allSettled/capability-executor-called-twice.js     ❌ -> ✅
    test/built-ins/Promise/any/capability-executor-called-twice.js            ❌ -> ✅
    test/built-ins/Promise/prototype/then/capability-executor-called-twice.js ❌ -> ✅
    test/built-ins/Promise/race/capability-executor-called-twice.js           ❌ -> ✅
    test/built-ins/Promise/reject/capability-executor-called-twice.js         ❌ -> ✅
    test/built-ins/Promise/resolve/capability-executor-called-twice.js        ❌ -> ✅
```