### PR TITLE
Kernet/Net: Close a TCP connection using FIN|ACK instead of just FIN.

### DIFF
--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -534,7 +534,7 @@ void TCPSocket::shut_down_for_writing()
 {
     if (state() == State::Established) {
         dbgln_if(TCP_SOCKET_DEBUG, " Sending FIN from Established and moving into FinWait1");
-        (void)send_tcp_packet(TCPFlags::FIN);
+        (void)send_tcp_packet(TCPFlags::FIN | TCPFlags::ACK);
         set_state(State::FinWait1);
     } else {
         dbgln(" Shutting down TCPSocket for writing but not moving to FinWait1 since state is {}", to_string(state()));


### PR DESCRIPTION
When initiating a connection termination, the FIN should be sent with a ACK from the last received segment even if that ACK already been sent.

This is fixing a problem where a connected remote host wouldn't receive the FIN packet from the SerenityOS host initiating the disconnection. QEMU's hostfwd feature uses libslirp which won't forward a segment when initiating a close if it only has the FIN flag set. (https://gitlab.freedesktop.org/slirp/libslirp/-/blob/master/src/tcp_input.c#L1347).

While at this point I can't find a specific location and explanation in an RFC/spec that says we should do so, most RFCs and documentation show diagrams where the first FIN is sent with an ACK (even if a previous packet with the same ACK has already been sent):
* https://www.rfc-editor.org/rfc/rfc793#page-38
* TCP/IP Illustrated Volume 1 (Stevens) : page 232
* https://madpackets.com/2018/04/17/tcp-connection-close-what-does-it-look-like-in-wireshark/

Linux also behave that way.

