### PR TITLE
LibWeb: Check whether table box width is auto when resolving cell width

### DIFF
--- a/Tests/LibWeb/Layout/expected/cell-relative-to-specified-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/cell-relative-to-specified-table-width.txt
@@ -1,0 +1,64 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x44.9375 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 784x44.9375 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 784x44.9375 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (8,8) content-size 776x38.9375 table-row-group children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (10,10) content-size 776x19.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <th> at (11,11) content-size 300.274545x17.46875 table-cell [BFC] children: inline
+                line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [154,11 14.265625x17.46875]
+                    "A"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <th> at (315.274545,11) content-size 169.470316x17.46875 table-cell [BFC] children: inline
+                line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [395.274545,11 9.34375x17.46875]
+                    "B"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <th> at (488.744861,11) content-size 300.255138x17.46875 table-cell [BFC] children: inline
+                line 0 width: 29.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 3, rect: [623.744861,11 29.453125x17.46875]
+                    "C D"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (10,29.46875) content-size 776x19.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,32.46875) content-size 300.274545x17.46875 table-cell [BFC] children: inline
+                line 0 width: 11.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [155,32.46875 11.859375x17.46875]
+                    "E"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (315.274545,32.46875) content-size 169.470316x17.46875 table-cell [BFC] children: inline
+                line 0 width: 12.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [393.274545,32.46875 12.546875x17.46875]
+                    "F"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (488.744861,32.46875) content-size 300.255138x17.46875 table-cell [BFC] children: inline
+                line 0 width: 13.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [632.744861,32.46875 13.234375x17.46875]
+                    "G"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>

--- a/Tests/LibWeb/Layout/input/cell-relative-to-specified-table-width.html
+++ b/Tests/LibWeb/Layout/input/cell-relative-to-specified-table-width.html
@@ -1,0 +1,14 @@
+<table style="width: 100%;text-align: center">
+	<tbody>
+		<tr>
+			<th style="width: 39%">A</th>
+			<th style="width: 22%">B</th>
+			<th style="width: 39%">C D</th>
+		</tr>
+		<tr>
+			<td>E</td>
+			<td>F</td>
+			<td>G</td>
+		</tr>
+	</tbody>
+</table>

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -164,6 +164,7 @@ void TableFormattingContext::calculate_row_column_grid(Box const& box)
 void TableFormattingContext::compute_cell_measures(AvailableSpace const& available_space)
 {
     auto const& containing_block = m_state.get(*table_wrapper().containing_block());
+    auto table_width_is_auto = table_box().computed_values().width().is_auto();
 
     for (auto& cell : m_cells) {
         auto const& computed_values = cell.box->computed_values();
@@ -180,7 +181,7 @@ void TableFormattingContext::compute_cell_measures(AvailableSpace const& availab
         CSSPixels border_right = is_collapse ? cell_state.border_right : computed_values.border_right().width;
 
         auto height = computed_values.height().to_px(cell.box, containing_block.content_height());
-        auto width = computed_values.width().is_length() ? computed_values.width().to_px(cell.box, containing_block.content_width()) : 0;
+        auto width = (computed_values.width().is_length() || !table_width_is_auto) ? computed_values.width().to_px(cell.box, containing_block.content_width()) : 0;
         auto min_content_height = calculate_min_content_height(cell.box, available_space.width);
         auto max_content_height = calculate_max_content_height(cell.box, available_space.width);
         auto min_content_width = calculate_min_content_width(cell.box);
@@ -194,7 +195,7 @@ void TableFormattingContext::compute_cell_measures(AvailableSpace const& availab
             min_width = max(min_width, computed_values.min_width().to_px(cell.box, containing_block.content_width()));
 
         CSSPixels max_height = computed_values.height().is_auto() ? max_content_height : height;
-        CSSPixels max_width = computed_values.width().is_length() ? width : max_content_width;
+        CSSPixels max_width = (computed_values.width().is_length() || !table_width_is_auto) ? width : max_content_width;
         if (!should_treat_max_height_as_none(cell.box, available_space.height))
             max_height = min(max_height, computed_values.max_height().to_px(cell.box, containing_block.content_height()));
         if (!should_treat_max_width_as_none(cell.box, available_space.width))


### PR DESCRIPTION
Computing the table width algorithm bifurcates based on whether table-root width is auto. We only adjust the used table width based on cell percentage widths on the auto branch, thus the same check is needed when we initialize cell widths.