### PR TITLE
LibCore: Add fd() and address() accessors to Core::TCPSocket

### DIFF
--- a/Userland/Libraries/LibCore/Socket.h
+++ b/Userland/Libraries/LibCore/Socket.h
@@ -193,9 +193,13 @@ public:
 
     virtual ~TCPSocket() override { close(); }
 
+    int fd() const { return m_helper.fd(); }
+    SocketAddress address() const { return m_address; }
+
 private:
-    TCPSocket(PreventSIGPIPE prevent_sigpipe = PreventSIGPIPE::No)
+    TCPSocket(SocketAddress address, PreventSIGPIPE prevent_sigpipe = PreventSIGPIPE::No)
         : Socket(prevent_sigpipe)
+        , m_address(move(address))
     {
     }
 
@@ -211,6 +215,7 @@ private:
     }
 
     PosixSocketHelper m_helper { Badge<TCPSocket> {} };
+    SocketAddress m_address;
 };
 
 class UDPSocket final : public Socket {


### PR DESCRIPTION
It wasn't possible to obtain the SocketAddress or fd used by a TCPSocket. Accessing these values makes it possible to use non-blocking sockets with the class. Non-blocking use cases at the moment require direct usage of syscalls and knowledge of the fd. Mixing this with a TCPSocket is only convenient if we have TCPSocket::fd().

TCPSocket::adopt_fd() allowed the class to be instantiated with a non-connected fd; this was inconsistent because the class offers no way to initiate a connection once instantiated.

A TCPSocket without a SocketAddress wouldn't make sense, so it's safe and very convenient to have it as a member and make it accessible.


The need for these changes was brought forward by an upcoming SerenityOS BitTorrent client implementation PR making heavy use of non-blocking TCPSocket.