### PR TITLE
LibGUI: Change cursor & selection behavior in single line TextEditor

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -142,9 +142,8 @@ void TextEditor::set_text(StringView text, AllowCallback allow_callback)
     update_content_size();
     recompute_all_visual_lines();
     if (is_single_line())
-        set_cursor(0, line(0).length());
-    else
-        set_cursor(0, 0);
+        m_selection = document().range_for_entire_line(0);
+    set_cursor(0, 0);
     did_update_selection();
     update();
 }


### PR DESCRIPTION
Now after assigning text to a single line TextEditor, whole line gets selected and cursor stays at the start of the line. This fixes ComboBox/TextBox/TextEditor widgets displaying end of the line when text is too long.

As a side effect, InputBox now also selects whole line as well, which is a good thing, you don't want to display just the end of the line if you want to input data.

|          | Before | After |
|----------|--------|-------|
| ComboBox | ![BeforeFix1](https://github.com/SerenityOS/serenity/assets/3995549/0ce6aa17-af79-43c6-91e1-1ad9866ea8c7) | ![Fix1](https://github.com/SerenityOS/serenity/assets/3995549/4cb8b6d5-c214-4b42-b81e-f473e1be433f) |
| ComboBox | ![BeforeFix2](https://github.com/SerenityOS/serenity/assets/3995549/906d83f2-e435-4615-a354-d7f0c57d0dd8) | ![Fix2](https://github.com/SerenityOS/serenity/assets/3995549/49fd35eb-4aff-402c-b3f2-859b802d1bfa) |
| InputBox | ![BeforeFix3](https://github.com/SerenityOS/serenity/assets/3995549/7fdbf26d-8de6-4c5d-974d-a18dfd792cac) | ![Fix3](https://github.com/SerenityOS/serenity/assets/3995549/bad1d061-a77a-414d-a2f5-2b6a71cd7585) |
| TextBox | ![BeforeFix4](https://github.com/SerenityOS/serenity/assets/3995549/cbe1cd69-450a-45b3-a026-576f1f34f6c3) | ![Fix4](https://github.com/SerenityOS/serenity/assets/3995549/ffb68841-b0a8-4fee-a207-a8a575a95a6e) | 







