### PR TITLE
AK+Meta: Disable consteval completely when building for oss-fuzz

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -30,7 +30,8 @@ class StringData;
 }
 
 // FIXME: Remove this when OpenBSD Clang fully supports consteval.
-#if defined(AK_OS_OPENBSD)
+//        And once oss-fuzz updates to clang >15.
+#if defined(AK_OS_OPENBSD) || defined(OSS_FUZZ)
 #    define AK_SHORT_STRING_CONSTEVAL constexpr
 #else
 #    define AK_SHORT_STRING_CONSTEVAL consteval

--- a/Meta/Lagom/BuildFuzzers.sh
+++ b/Meta/Lagom/BuildFuzzers.sh
@@ -46,10 +46,15 @@ unset CFLAGS
 unset CXXFLAGS
 export AFL_NOOPT=1
 
+if [ "$#" -gt "0" ] && [ "--oss-fuzz" = "$1" ] ; then
+    CXXFLAGS="$CXXFLAGS -DOSS_FUZZ=ON"
+fi
+
 # FIXME: Replace these CMake invocations with a CMake superbuild?
 echo "Building Lagom Tools..."
 cmake -GNinja -B Build/tools \
     -DBUILD_LAGOM=OFF \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
     -DCMAKE_INSTALL_PREFIX=Build/tool-install \
     -Dpackage=LagomTools
 ninja -C Build/tools install


### PR DESCRIPTION
This was missed in 02b74e5a70e1eef2fe3123fe8aa157301424783a

We need to disable consteval in AK::String as well as AK::StringView, and we need to disable it when building both the tools build and the fuzzer build.

Verified by changing the Dockerfile in oss-fuzz/projects/serenity to point to my fork and this branch, and running

```
python3 infra/helper.py build_image serenity
python3 infra/helper.py build_fuzzers serenity
python3 infra/helper.py check_build serenity
```

After this, FuzzCSSParser and FuzzShell complain that they crash wayyy to early in the bad build checks.