### PR TITLE
LibWeb: Place the unique task source used by media elements last

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/EventLoop/Task.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/Task.h
@@ -32,15 +32,15 @@ public:
         TimerTask,
         JavaScriptEngine,
 
-        // Some elements, such as the HTMLMediaElement, must have a unique task source per instance.
-        // Keep this field last, to serve as the base value of all unique task sources.
-        UniqueTaskSourceStart,
-
         // https://html.spec.whatwg.org/multipage/webappapis.html#navigation-and-traversal-task-source
         NavigationAndTraversal,
 
         // https://w3c.github.io/FileAPI/#fileReadingTaskSource
         FileReading,
+
+        // Some elements, such as the HTMLMediaElement, must have a unique task source per instance.
+        // Keep this field last, to serve as the base value of all unique task sources.
+        UniqueTaskSourceStart,
     };
 
     static NonnullOwnPtr<Task> create(Source source, DOM::Document const* document, JS::SafeFunction<void()> steps)


### PR DESCRIPTION
In the merging of an extremely large navigables PR, a task queue source was added after the unique task source start value that was supposed to remain last in the enum.