### PR TITLE
LibJS: Make local variables faster by avoiding the environment when possible

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -314,7 +314,7 @@ Value FunctionExpression::instantiate_ordinary_function_expression(VM& vm, Depre
         given_name = "";
     auto has_own_name = !name().is_empty();
 
-    auto const& used_name = has_own_name ? name() : given_name;
+    auto const used_name = has_own_name ? name() : given_name.view();
     auto environment = NonnullGCPtr { *vm.running_execution_context().lexical_environment };
     if (has_own_name) {
         VERIFY(environment);
@@ -4805,7 +4805,7 @@ ThrowCompletionOr<void> Program::global_declaration_instantiation(VM& vm, Global
         // b. For each FunctionDeclaration f that is directly contained in the StatementList of a Block, CaseClause, or DefaultClause Contained within script, do
         TRY(for_each_function_hoistable_with_annexB_extension([&](FunctionDeclaration& function_declaration) -> ThrowCompletionOr<void> {
             // i. Let F be StringValue of the BindingIdentifier of f.
-            auto& function_name = function_declaration.name();
+            auto function_name = function_declaration.name();
 
             // ii. If replacing the FunctionDeclaration f with a VariableStatement that has F as a BindingIdentifier would not produce any Early Errors for script, then
             // Note: This step is already performed during parsing and for_each_function_hoistable_with_annexB_extension so this always passes here.

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -1852,7 +1852,7 @@ Completion ClassExpression::execute(Interpreter& interpreter) const
 
     // 1. Let className be StringValue of BindingIdentifier.
     // 2. Let value be ? ClassDefinitionEvaluation of ClassTail with arguments className and className.
-    auto* value = TRY(class_definition_evaluation(interpreter.vm(), m_name, m_name.is_null() ? "" : m_name));
+    auto* value = TRY(class_definition_evaluation(interpreter.vm(), name(), name()));
 
     // 3. Set value.[[SourceText]] to the source text matched by ClassExpression.
     value->set_source_text(m_source_text);
@@ -2311,7 +2311,7 @@ ThrowCompletionOr<void> ClassDeclaration::for_each_bound_name(ThrowCompletionOrV
 void ClassExpression::dump(int indent) const
 {
     print_indent(indent);
-    outln("ClassExpression: \"{}\"", m_name);
+    outln("ClassExpression: \"{}\"", name());
 
     print_indent(indent);
     outln("(Constructor)");

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -2679,7 +2679,11 @@ Completion Identifier::execute(Interpreter& interpreter) const
 void Identifier::dump(int indent) const
 {
     print_indent(indent);
-    outln("Identifier \"{}\"", m_string);
+    if (is_local()) {
+        outln("Identifier \"{}\" is_local=(true) index=({})", m_string, m_local_variable_index);
+    } else {
+        outln("Identifier \"{}\"", m_string);
+    }
 }
 
 Completion PrivateIdentifier::execute(Interpreter&) const
@@ -4429,6 +4433,16 @@ ThrowCompletionOr<void> ScopeNode::for_each_var_function_declaration_in_reverse_
 {
     for (ssize_t i = m_var_declarations.size() - 1; i >= 0; i--) {
         auto& declaration = m_var_declarations[i];
+        if (is<FunctionDeclaration>(declaration))
+            TRY(callback(static_cast<FunctionDeclaration const&>(*declaration)));
+    }
+    return {};
+}
+
+ThrowCompletionOr<void> ScopeNode::for_each_lexical_function_declaration_in_reverse_order(ThrowCompletionOrVoidCallback<FunctionDeclaration const&>&& callback) const
+{
+    for (ssize_t i = m_lexical_declarations.size() - 1; i >= 0; i--) {
+        auto& declaration = m_lexical_declarations[i];
         if (is<FunctionDeclaration>(declaration))
             TRY(callback(static_cast<FunctionDeclaration const&>(*declaration)));
     }

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -4488,6 +4488,16 @@ ThrowCompletionOr<void> ScopeNode::for_each_var_declared_name(ThrowCompletionOrV
     return {};
 }
 
+ThrowCompletionOr<void> ScopeNode::for_each_var_declared_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&& callback) const
+{
+    for (auto& declaration : m_var_declarations) {
+        TRY(declaration->for_each_bound_identifier([&](auto const& id) {
+            return callback(id);
+        }));
+    }
+    return {};
+}
+
 ThrowCompletionOr<void> ScopeNode::for_each_var_function_declaration_in_reverse_order(ThrowCompletionOrVoidCallback<FunctionDeclaration const&>&& callback) const
 {
     for (ssize_t i = m_var_declarations.size() - 1; i >= 0; i--) {

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1405,7 +1405,7 @@ public:
 
 class ClassExpression final : public Expression {
 public:
-    ClassExpression(SourceRange source_range, DeprecatedString name, DeprecatedString source_text, RefPtr<FunctionExpression const> constructor, RefPtr<Expression const> super_class, Vector<NonnullRefPtr<ClassElement const>> elements)
+    ClassExpression(SourceRange source_range, RefPtr<Identifier const> name, DeprecatedString source_text, RefPtr<FunctionExpression const> constructor, RefPtr<Expression const> super_class, Vector<NonnullRefPtr<ClassElement const>> elements)
         : Expression(source_range)
         , m_name(move(name))
         , m_source_text(move(source_text))
@@ -1415,7 +1415,8 @@ public:
     {
     }
 
-    StringView name() const { return m_name; }
+    StringView name() const { return m_name ? m_name->string().view() : ""sv; }
+
     DeprecatedString const& source_text() const { return m_source_text; }
     RefPtr<FunctionExpression const> constructor() const { return m_constructor; }
 
@@ -1424,7 +1425,7 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode_with_lhs_name(Bytecode::Generator&, Optional<Bytecode::IdentifierTableIndex> lhs_name) const;
 
-    bool has_name() const { return !m_name.is_empty(); }
+    bool has_name() const { return m_name; }
 
     ThrowCompletionOr<ECMAScriptFunctionObject*> class_definition_evaluation(VM&, DeprecatedFlyString const& binding_name = {}, DeprecatedFlyString const& class_name = {}) const;
     ThrowCompletionOr<ECMAScriptFunctionObject*> create_class_constructor(VM&, Environment* class_environment, Environment* environment, Value super_class, DeprecatedFlyString const& binding_name = {}, DeprecatedFlyString const& class_name = {}) const;
@@ -1432,7 +1433,7 @@ public:
 private:
     virtual bool is_class_expression() const override { return true; }
 
-    DeprecatedString m_name;
+    RefPtr<Identifier const> m_name;
     DeprecatedString m_source_text;
     RefPtr<FunctionExpression const> m_constructor;
     RefPtr<Expression const> m_super_class;

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -609,6 +609,7 @@ public:
     }
 
     virtual ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const = 0;
+    virtual ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&& callback) const = 0;
 
     // 8.1.3 Static Semantics: IsConstantDeclaration, https://tc39.es/ecma262/#sec-static-semantics-isconstantdeclaration
     virtual bool is_constant_declaration() const { return false; }
@@ -625,6 +626,11 @@ public:
     Completion execute(Interpreter&) const override { return {}; }
 
     ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&&) const override
+    {
+        VERIFY_NOT_REACHED();
+    }
+
+    ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&&) const override
     {
         VERIFY_NOT_REACHED();
     }
@@ -650,6 +656,7 @@ struct BindingPattern : RefCounted<BindingPattern> {
     void dump(int indent) const;
 
     ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const;
+    ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&& callback) const;
 
     bool contains_expression() const;
 
@@ -729,8 +736,9 @@ protected:
 
     void dump(int indent, DeprecatedString const& class_name) const;
 
-private:
     RefPtr<Identifier const> m_name { nullptr };
+
+private:
     DeprecatedString m_source_text;
     NonnullRefPtr<Statement const> m_body;
     Vector<FunctionParameter> const m_parameters;
@@ -761,6 +769,8 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     virtual ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const override;
+
+    ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&&) const override;
 
     virtual bool is_function_declaration() const override { return true; }
 
@@ -1458,6 +1468,8 @@ public:
 private:
     virtual bool is_class_expression() const override { return true; }
 
+    friend ClassDeclaration;
+
     RefPtr<Identifier const> m_name;
     DeprecatedString m_source_text;
     RefPtr<FunctionExpression const> m_constructor;
@@ -1478,6 +1490,8 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     virtual ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const override;
+
+    ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&&) const override;
 
     virtual bool is_lexical_declaration() const override { return true; }
 
@@ -1785,6 +1799,8 @@ public:
 
     virtual ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const override;
 
+    ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&&) const override;
+
     virtual bool is_constant_declaration() const override { return m_declaration_kind == DeclarationKind::Const; };
 
     virtual bool is_lexical_declaration() const override { return m_declaration_kind != DeclarationKind::Var; }
@@ -1808,6 +1824,8 @@ public:
     virtual void dump(int indent) const override;
 
     virtual ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const override;
+
+    ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&&) const override;
 
     virtual bool is_constant_declaration() const override { return true; };
 

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -310,6 +310,7 @@ public:
     ThrowCompletionOr<void> for_each_lexically_declared_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const;
 
     ThrowCompletionOr<void> for_each_var_declared_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const;
+    ThrowCompletionOr<void> for_each_var_declared_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&& callback) const;
 
     ThrowCompletionOr<void> for_each_var_function_declaration_in_reverse_order(ThrowCompletionOrVoidCallback<FunctionDeclaration const&>&& callback) const;
     ThrowCompletionOr<void> for_each_lexical_function_declaration_in_reverse_order(ThrowCompletionOrVoidCallback<FunctionDeclaration const&>&& callback) const;

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -2323,7 +2323,7 @@ Bytecode::CodeGenerationErrorOr<void> ClassExpression::generate_bytecode_with_lh
 
     if (has_name() || !lhs_name.has_value()) {
         // NOTE: Step 3.a is not a part of NewClass instruction because it is assumed to be done before super class expression evaluation
-        auto interned_index = generator.intern_identifier(m_name);
+        auto interned_index = generator.intern_identifier(name());
         generator.emit<Bytecode::Op::CreateVariable>(interned_index, Bytecode::Op::EnvironmentMode::Lexical, true);
     }
 

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -83,6 +83,8 @@ public:
     CodeGenerationErrorOr<void> emit_store_to_reference(JS::ASTNode const&);
     CodeGenerationErrorOr<void> emit_delete_reference(JS::ASTNode const&);
 
+    void emit_set_variable(JS::Identifier const& identifier, Bytecode::Op::SetVariable::InitializationMode initialization_mode = Bytecode::Op::SetVariable::InitializationMode::Set, Bytecode::Op::EnvironmentMode mode = Bytecode::Op::EnvironmentMode::Lexical);
+
     void push_home_object(Register);
     void pop_home_object();
     void emit_new_function(JS::FunctionExpression const&, Optional<IdentifierTableIndex> lhs_name);

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -41,6 +41,7 @@
     O(GetObjectPropertyIterator)     \
     O(GetPrivateById)                \
     O(GetVariable)                   \
+    O(GetLocal)                      \
     O(GreaterThan)                   \
     O(GreaterThanEquals)             \
     O(HasPrivateId)                  \
@@ -87,6 +88,7 @@
     O(RightShift)                    \
     O(ScheduleJump)                  \
     O(SetVariable)                   \
+    O(SetLocal)                      \
     O(Store)                         \
     O(StrictlyEquals)                \
     O(StrictlyInequals)              \
@@ -98,6 +100,7 @@
     O(ToNumeric)                     \
     O(Typeof)                        \
     O(TypeofVariable)                \
+    O(TypeofLocal)                   \
     O(UnaryMinus)                    \
     O(UnaryPlus)                     \
     O(UnsignedRightShift)            \

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -835,7 +835,7 @@ ThrowCompletionOr<void> NewFunction::execute_impl(Bytecode::Interpreter& interpr
             name = interpreter.current_executable().get_identifier(m_lhs_name.value());
         interpreter.accumulator() = m_function_node.instantiate_ordinary_function_expression(vm, name);
     } else {
-        interpreter.accumulator() = ECMAScriptFunctionObject::create(interpreter.realm(), m_function_node.name(), m_function_node.source_text(), m_function_node.body(), m_function_node.parameters(), m_function_node.function_length(), vm.lexical_environment(), vm.running_execution_context().private_environment, m_function_node.kind(), m_function_node.is_strict_mode(), m_function_node.might_need_arguments_object(), m_function_node.contains_direct_call_to_eval(), m_function_node.is_arrow_function());
+        interpreter.accumulator() = ECMAScriptFunctionObject::create(interpreter.realm(), m_function_node.name(), m_function_node.source_text(), m_function_node.body(), m_function_node.parameters(), m_function_node.function_length(), m_function_node.local_variables_names(), vm.lexical_environment(), vm.running_execution_context().private_environment, m_function_node.kind(), m_function_node.is_strict_mode(), m_function_node.might_need_arguments_object(), m_function_node.contains_direct_call_to_eval(), m_function_node.is_arrow_function());
     }
 
     if (m_home_object.has_value()) {

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -484,6 +484,25 @@ private:
     InitializationMode m_initialization_mode { InitializationMode::Set };
 };
 
+class SetLocal final : public Instruction {
+public:
+    explicit SetLocal(size_t index)
+        : Instruction(Type::SetLocal)
+        , m_index(index)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
+
+    size_t index() const { return m_index; }
+
+private:
+    size_t m_index;
+};
+
 class GetVariable final : public Instruction {
 public:
     explicit GetVariable(IdentifierTableIndex identifier)
@@ -503,6 +522,25 @@ private:
     IdentifierTableIndex m_identifier;
 
     Optional<EnvironmentCoordinate> mutable m_cached_environment_coordinate;
+};
+
+class GetLocal final : public Instruction {
+public:
+    explicit GetLocal(size_t index)
+        : Instruction(Type::GetLocal)
+        , m_index(index)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
+
+    size_t index() const { return m_index; }
+
+private:
+    size_t m_index;
 };
 
 class DeleteVariable final : public Instruction {
@@ -1336,6 +1374,23 @@ public:
 
 private:
     IdentifierTableIndex m_identifier;
+};
+
+class TypeofLocal final : public Instruction {
+public:
+    explicit TypeofLocal(size_t index)
+        : Instruction(Type::TypeofLocal)
+        , m_index(index)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
+
+private:
+    size_t m_index;
 };
 
 }

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -184,6 +184,7 @@ class HeapBlock;
 struct ImportEntry;
 class ImportStatement;
 class Interpreter;
+class Identifier;
 class Intrinsics;
 struct IteratorRecord;
 class MetaProperty;

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -35,10 +35,23 @@ class ScopePusher {
         StaticInitTopLevel
     };
 
+    enum class ScopeType {
+        Function,
+        Program,
+        Block,
+        ForLoop,
+        With,
+        Catch,
+        ClassStaticInit,
+        ClassField,
+        ClassDeclaration,
+    };
+
 private:
-    ScopePusher(Parser& parser, ScopeNode* node, ScopeLevel scope_level)
+    ScopePusher(Parser& parser, ScopeNode* node, ScopeLevel scope_level, ScopeType type)
         : m_parser(parser)
         , m_scope_level(scope_level)
+        , m_type(type)
     {
         m_parent_scope = exchange(m_parser.m_state.current_scope_pusher, this);
         VERIFY(node || (m_parent_scope && scope_level == ScopeLevel::NotTopLevel));
@@ -62,7 +75,7 @@ private:
 public:
     static ScopePusher function_scope(Parser& parser, FunctionBody& function_body, Vector<FunctionParameter> const& parameters)
     {
-        ScopePusher scope_pusher(parser, &function_body, ScopeLevel::FunctionTopLevel);
+        ScopePusher scope_pusher(parser, &function_body, ScopeLevel::FunctionTopLevel, ScopeType::Function);
         scope_pusher.m_function_parameters = parameters;
         for (auto& parameter : parameters) {
             parameter.binding.visit(
@@ -81,52 +94,61 @@ public:
 
     static ScopePusher program_scope(Parser& parser, Program& program)
     {
-        return ScopePusher(parser, &program, program.type() == Program::Type::Script ? ScopeLevel::ScriptTopLevel : ScopeLevel::ModuleTopLevel);
+        return ScopePusher(parser, &program, program.type() == Program::Type::Script ? ScopeLevel::ScriptTopLevel : ScopeLevel::ModuleTopLevel, ScopeType::Program);
     }
 
     static ScopePusher block_scope(Parser& parser, ScopeNode& node)
     {
-        return ScopePusher(parser, &node, ScopeLevel::NotTopLevel);
+        return ScopePusher(parser, &node, ScopeLevel::NotTopLevel, ScopeType::Block);
     }
 
-    static ScopePusher for_loop_scope(Parser& parser, RefPtr<ASTNode const> const& init)
+    static ScopePusher for_loop_scope(Parser& parser, ScopeNode& node)
     {
-        ScopePusher scope_pusher(parser, nullptr, ScopeLevel::NotTopLevel);
-        if (init && is<VariableDeclaration>(*init)) {
-            auto& variable_declaration = static_cast<VariableDeclaration const&>(*init);
-            if (variable_declaration.declaration_kind() != DeclarationKind::Var) {
-                // NOTE: Nothing in the callback throws an exception.
-                MUST(variable_declaration.for_each_bound_name([&](auto const& name) {
-                    scope_pusher.m_forbidden_var_names.set(name);
-                }));
-            }
-        }
+        return ScopePusher(parser, &node, ScopeLevel::NotTopLevel, ScopeType::ForLoop);
+    }
 
+    static ScopePusher with_scope(Parser& parser, ScopeNode& node)
+    {
+        ScopePusher scope_pusher(parser, &node, ScopeLevel::NotTopLevel, ScopeType::With);
         return scope_pusher;
     }
 
     static ScopePusher catch_scope(Parser& parser, RefPtr<BindingPattern const> const& pattern, DeprecatedFlyString const& parameter)
     {
-        ScopePusher scope_pusher(parser, nullptr, ScopeLevel::NotTopLevel);
+        ScopePusher scope_pusher(parser, nullptr, ScopeLevel::NotTopLevel, ScopeType::Catch);
         if (pattern) {
             // NOTE: Nothing in the callback throws an exception.
             MUST(pattern->for_each_bound_name([&](auto const& name) {
                 scope_pusher.m_forbidden_var_names.set(name);
+                scope_pusher.m_bound_names.set(name);
             }));
         } else if (!parameter.is_empty()) {
             scope_pusher.m_var_names.set(parameter);
+            scope_pusher.m_bound_names.set(parameter);
         }
+
         return scope_pusher;
     }
 
     static ScopePusher static_init_block_scope(Parser& parser, ScopeNode& node)
     {
-        return ScopePusher(parser, &node, ScopeLevel::StaticInitTopLevel);
+        ScopePusher scope_pusher(parser, &node, ScopeLevel::StaticInitTopLevel, ScopeType::ClassStaticInit);
+        return scope_pusher;
     }
 
-    static ScopePusher class_field_scope(Parser& parser)
+    static ScopePusher class_field_scope(Parser& parser, ScopeNode& node)
     {
-        return ScopePusher(parser, nullptr, ScopeLevel::NotTopLevel);
+        ScopePusher scope_pusher(parser, &node, ScopeLevel::NotTopLevel, ScopeType::ClassField);
+        return scope_pusher;
+    }
+
+    static ScopePusher class_declaration_scope(Parser& parser, RefPtr<Identifier const> class_name)
+    {
+        ScopePusher scope_pusher(parser, nullptr, ScopeLevel::NotTopLevel, ScopeType::ClassDeclaration);
+        if (class_name) {
+            scope_pusher.m_bound_names.set(class_name->string());
+        }
+        return scope_pusher;
     }
 
     void add_declaration(NonnullRefPtr<Declaration const> declaration)
@@ -176,7 +198,7 @@ public:
             } else {
                 VERIFY(is<FunctionDeclaration>(*declaration));
                 auto& function_declaration = static_cast<FunctionDeclaration const&>(*declaration);
-                auto& function_name = function_declaration.name();
+                auto function_name = function_declaration.name();
                 if (m_var_names.contains(function_name) || m_lexical_names.contains(function_name))
                     throw_identifier_declared(function_name, declaration);
 
@@ -222,7 +244,11 @@ public:
 
     bool contains_direct_call_to_eval() const { return m_contains_direct_call_to_eval; }
     bool contains_access_to_arguments_object() const { return m_contains_access_to_arguments_object; }
-    void set_contains_direct_call_to_eval() { m_contains_direct_call_to_eval = true; }
+    void set_contains_direct_call_to_eval()
+    {
+        m_contains_direct_call_to_eval = true;
+        m_can_use_local_variables = false;
+    }
     void set_contains_access_to_arguments_object() { m_contains_access_to_arguments_object = true; }
 
     ~ScopePusher()
@@ -241,10 +267,96 @@ public:
             }
         }
 
+        for (auto& it : m_identifier_groups) {
+            auto const& identifier_group_name = it.key;
+            auto& identifier_group = it.value;
+
+            if (identifier_group_name == "arguments"sv) {
+                // NOTE: arguments is a special variable that should not be treated as a candidate to become local
+                continue;
+            }
+
+            bool scope_has_declaration = false;
+            MUST(m_node->for_each_var_declared_name([&](auto const& name) {
+                if (m_function_parameters.has_value() && m_forbidden_lexical_names.contains(name))
+                    return;
+                if (name == identifier_group_name)
+                    scope_has_declaration = true;
+            }));
+            MUST(m_node->for_each_lexically_declared_name([&](auto const& name) {
+                if (name == identifier_group_name)
+                    scope_has_declaration = true;
+            }));
+
+            bool function_declaration = false;
+            MUST(m_node->for_each_var_function_declaration_in_reverse_order([&](auto const& declaration) {
+                if (declaration.name() == identifier_group_name)
+                    function_declaration = true;
+            }));
+            MUST(m_node->for_each_lexical_function_declaration_in_reverse_order([&](auto const& declaration) {
+                if (declaration.name() == identifier_group_name)
+                    function_declaration = true;
+            }));
+            MUST(m_node->for_each_function_hoistable_with_annexB_extension([&](auto const& declaration) {
+                if (declaration.name() == identifier_group_name)
+                    function_declaration = true;
+            }));
+
+            if ((m_type == ScopeType::ClassDeclaration || m_type == ScopeType::Catch) && m_bound_names.contains(identifier_group_name)) {
+                // NOTE: Currently class names and catch section parameters are not considered to become local variables
+                //       but this might be fixed in the future
+                continue;
+            }
+
+            if (m_type == ScopeType::ClassDeclaration || m_type == ScopeType::Catch) {
+                // NOTE: Class declaration and catch scopes do not have own ScopeNode hence can't contain declaration of any variable
+                scope_has_declaration = false;
+            }
+
+            if (scope_has_declaration) {
+                if (function_declaration)
+                    continue;
+
+                if (!identifier_group.captured_by_nested_function) {
+                    auto function_scope = last_function_scope();
+                    if (!function_scope || !m_can_use_local_variables) {
+                        continue;
+                    }
+
+                    auto local_variable_index = function_scope->m_node->add_local_variable(identifier_group_name);
+                    for (auto& identifier : identifier_group.identifiers)
+                        identifier->set_local_variable_index(local_variable_index);
+                }
+            } else {
+                if (m_function_parameters.has_value() || m_type == ScopeType::ClassField || m_type == ScopeType::ClassStaticInit || m_type == ScopeType::With) {
+                    // NOTE: Class fields and class static initialization sections implicitly create functions
+                    identifier_group.captured_by_nested_function = true;
+                }
+
+                if (m_parent_scope) {
+                    if (auto maybe_parent_scope_identifier_group = m_parent_scope->m_identifier_groups.get(identifier_group_name); maybe_parent_scope_identifier_group.has_value()) {
+                        maybe_parent_scope_identifier_group.value().identifiers.extend(identifier_group.identifiers);
+                        if (identifier_group.captured_by_nested_function)
+                            maybe_parent_scope_identifier_group.value().captured_by_nested_function = true;
+                    } else {
+                        m_parent_scope->m_identifier_groups.set(identifier_group_name, identifier_group);
+                    }
+                }
+            }
+        }
+
         if (m_parent_scope && !m_function_parameters.has_value()) {
             m_parent_scope->m_contains_access_to_arguments_object |= m_contains_access_to_arguments_object;
             m_parent_scope->m_contains_direct_call_to_eval |= m_contains_direct_call_to_eval;
             m_parent_scope->m_contains_await_expression |= m_contains_await_expression;
+        }
+
+        if (m_parent_scope) {
+            if (m_contains_direct_call_to_eval) {
+                m_parent_scope->m_can_use_local_variables = false;
+            } else {
+                m_can_use_local_variables = m_parent_scope->m_can_use_local_variables && m_can_use_local_variables;
+            }
         }
 
         VERIFY(m_parser.m_state.current_scope_pusher == this);
@@ -266,6 +378,18 @@ public:
         return m_scope_level != ScopeLevel::ScriptTopLevel;
     }
 
+    void register_identifier(NonnullRefPtr<Identifier> id)
+    {
+        if (auto maybe_identifier_group = m_identifier_groups.get(id->string()); maybe_identifier_group.has_value()) {
+            maybe_identifier_group.value().identifiers.append(id);
+        } else {
+            m_identifier_groups.set(id->string(), IdentifierGroup {
+                                                      .captured_by_nested_function = false,
+                                                      .identifiers = { id },
+                                                  });
+        }
+    }
+
 private:
     void throw_identifier_declared(DeprecatedFlyString const& name, NonnullRefPtr<Declaration const> const& declaration)
     {
@@ -275,6 +399,7 @@ private:
     Parser& m_parser;
     ScopeNode* m_node { nullptr };
     ScopeLevel m_scope_level { ScopeLevel::NotTopLevel };
+    ScopeType m_type;
 
     ScopePusher* m_parent_scope { nullptr };
     ScopePusher* m_top_level_scope { nullptr };
@@ -287,11 +412,20 @@ private:
     HashTable<DeprecatedFlyString> m_forbidden_var_names;
     Vector<NonnullRefPtr<FunctionDeclaration const>> m_functions_to_hoist;
 
+    HashTable<DeprecatedFlyString> m_bound_names;
+
+    struct IdentifierGroup {
+        bool captured_by_nested_function { false };
+        Vector<NonnullRefPtr<Identifier>> identifiers;
+    };
+    HashMap<DeprecatedFlyString, IdentifierGroup> m_identifier_groups;
+
     Optional<Vector<FunctionParameter>> m_function_parameters;
 
     bool m_contains_access_to_arguments_object { false };
     bool m_contains_direct_call_to_eval { false };
     bool m_contains_await_expression { false };
+    bool m_can_use_local_variables { true };
 };
 
 class OperatorPrecedenceTable {
@@ -860,6 +994,8 @@ RefPtr<FunctionExpression const> Parser::try_parse_arrow_function_expression(boo
     if (function_body_result.is_null())
         return nullptr;
 
+    auto local_variables_names = function_body_result->local_variables_names();
+
     state_rollback_guard.disarm();
     discard_saved_state();
     auto body = function_body_result.release_nonnull();
@@ -878,9 +1014,9 @@ RefPtr<FunctionExpression const> Parser::try_parse_arrow_function_expression(boo
     auto function_end_offset = position().offset - m_state.current_token.trivia().length();
     auto source_text = DeprecatedString { m_state.lexer.source().substring_view(function_start_offset, function_end_offset - function_start_offset) };
     return create_ast_node<FunctionExpression>(
-        { m_source_code, rule_start.position(), position() }, "", move(source_text),
+        { m_source_code, rule_start.position(), position() }, nullptr, move(source_text),
         move(body), move(parameters), function_length, function_kind, body->in_strict_mode(),
-        /* might_need_arguments_object */ false, contains_direct_call_to_eval, /* is_arrow_function */ true);
+        /* might_need_arguments_object */ false, contains_direct_call_to_eval, move(local_variables_names), /* is_arrow_function */ true);
 }
 
 RefPtr<LabelledStatement const> Parser::try_parse_labelled_statement(AllowLabelledFunction allow_function)
@@ -1071,13 +1207,12 @@ NonnullRefPtr<ClassExpression const> Parser::parse_class_expression(bool expect_
     RefPtr<FunctionExpression const> constructor;
     HashTable<DeprecatedFlyString> found_private_names;
 
-    RefPtr<Identifier const> class_name { nullptr };
+    RefPtr<Identifier const> class_name;
     if (expect_class_name || match_identifier() || match(TokenType::Yield) || match(TokenType::Await)) {
-        class_name = create_ast_node<Identifier const>(
-            { m_source_code, rule_start.position(), position() },
-            consume_identifier_reference().DeprecatedFlyString_value()
-        );
+        class_name = create_identifier_and_register_in_current_scope({ m_source_code, rule_start.position(), position() }, consume_identifier_reference().DeprecatedFlyString_value());
     }
+
+    ScopePusher class_declaration_scope = ScopePusher::class_declaration_scope(*this, class_name);
 
     if (class_name)
         check_identifier_name_for_assignment_validity(class_name->string(), true);
@@ -1337,7 +1472,8 @@ NonnullRefPtr<ClassExpression const> Parser::parse_class_expression(bool expect_
                 TemporaryChange super_property_access_rollback(m_state.allow_super_property_lookup, true);
                 TemporaryChange field_initializer_rollback(m_state.in_class_field_initializer, true);
 
-                auto class_field_scope = ScopePusher::class_field_scope(*this);
+                auto class_scope_node = create_ast_node<BlockStatement>({ m_source_code, rule_start.position(), position() });
+                auto class_field_scope = ScopePusher::class_field_scope(*this, *class_scope_node);
                 initializer = parse_expression(2);
                 contains_direct_call_to_eval = class_field_scope.contains_direct_call_to_eval();
             }
@@ -1370,14 +1506,14 @@ NonnullRefPtr<ClassExpression const> Parser::parse_class_expression(bool expect_
             constructor_body->append(create_ast_node<ReturnStatement>({ m_source_code, rule_start.position(), position() }, move(super_call)));
 
             constructor = create_ast_node<FunctionExpression>(
-                { m_source_code, rule_start.position(), position() }, class_name ? class_name->string() : "", "",
+                { m_source_code, rule_start.position(), position() }, class_name, "",
                 move(constructor_body), Vector { FunctionParameter { move(argument_name), nullptr, true } }, 0, FunctionKind::Normal,
-                /* is_strict_mode */ true, /* might_need_arguments_object */ false, /* contains_direct_call_to_eval */ false);
+                /* is_strict_mode */ true, /* might_need_arguments_object */ false, /* contains_direct_call_to_eval */ false, /* local_variables_names */ Vector<DeprecatedFlyString> {});
         } else {
             constructor = create_ast_node<FunctionExpression>(
-                { m_source_code, rule_start.position(), position() }, class_name ? class_name->string() : "", "",
+                { m_source_code, rule_start.position(), position() }, class_name, "",
                 move(constructor_body), Vector<FunctionParameter> {}, 0, FunctionKind::Normal,
-                /* is_strict_mode */ true, /* might_need_arguments_object */ false, /* contains_direct_call_to_eval */ false);
+                /* is_strict_mode */ true, /* might_need_arguments_object */ false, /* contains_direct_call_to_eval */ false, /* local_variables_names */ Vector<DeprecatedFlyString> {});
         }
     }
 
@@ -1759,7 +1895,7 @@ NonnullRefPtr<ObjectExpression const> Parser::parse_object_expression()
                 property_key = parse_property_key();
             } else {
                 property_key = create_ast_node<StringLiteral>({ m_source_code, rule_start.position(), position() }, identifier.value());
-                property_value = create_ast_node<Identifier>({ m_source_code, rule_start.position(), position() }, identifier.DeprecatedFlyString_value());
+                property_value = create_identifier_and_register_in_current_scope({ m_source_code, rule_start.position(), position() }, identifier.DeprecatedFlyString_value());
             }
         } else {
             property_key = parse_property_key();
@@ -2277,6 +2413,7 @@ RefPtr<BindingPattern const> Parser::synthesize_binding_pattern(Expression const
     Lexer lexer { source, m_state.lexer.filename(), expression.source_range().start.line, expression.source_range().start.column };
     Parser parser { lexer };
 
+    parser.m_state.current_scope_pusher = m_state.current_scope_pusher;
     parser.m_state.strict_mode = m_state.strict_mode;
     parser.m_state.allow_super_property_lookup = m_state.allow_super_property_lookup;
     parser.m_state.allow_super_constructor_call = m_state.allow_super_constructor_call;
@@ -2355,9 +2492,7 @@ NonnullRefPtr<Identifier const> Parser::parse_identifier()
     auto token = consume_identifier();
     if (m_state.in_class_field_initializer && token.value() == "arguments"sv)
         syntax_error("'arguments' is not allowed in class field initializer");
-    return create_ast_node<Identifier>(
-        { m_source_code, identifier_start, position() },
-        token.DeprecatedFlyString_value());
+    return create_identifier_and_register_in_current_scope({ m_source_code, identifier_start, position() }, token.DeprecatedFlyString_value());
 }
 
 Vector<CallExpression::Argument> Parser::parse_arguments()
@@ -2619,7 +2754,7 @@ NonnullRefPtr<FunctionNodeType> Parser::parse_function_node(u16 parse_options, O
         function_kind = FunctionKind::Async;
     else
         function_kind = FunctionKind::Normal;
-    DeprecatedFlyString name;
+    RefPtr<Identifier const> name;
     if (parse_options & FunctionNodeParseOptions::CheckForFunctionAndName) {
         if (function_kind == FunctionKind::Normal && match(TokenType::Async) && !next_token().trivia_contains_line_terminator()) {
             function_kind = FunctionKind::Async;
@@ -2633,20 +2768,29 @@ NonnullRefPtr<FunctionNodeType> Parser::parse_function_node(u16 parse_options, O
             parse_options |= FunctionNodeParseOptions::IsGeneratorFunction;
         }
 
-        if (parse_options & FunctionNodeParseOptions::HasDefaultExportName)
-            name = ExportStatement::local_name_for_default;
-        else if (FunctionNodeType::must_have_name() || match_identifier())
-            name = consume_identifier().DeprecatedFlyString_value();
-        else if (is_function_expression && (match(TokenType::Yield) || match(TokenType::Await)))
-            name = consume().DeprecatedFlyString_value();
+        if (parse_options & FunctionNodeParseOptions::HasDefaultExportName) {
+            name = create_ast_node<Identifier const>(
+                { m_source_code, rule_start.position(), position() },
+                ExportStatement::local_name_for_default);
+        } else if (FunctionNodeType::must_have_name() || match_identifier()) {
+            name = create_ast_node<Identifier const>(
+                { m_source_code, rule_start.position(), position() },
+                consume_identifier().DeprecatedFlyString_value());
+        } else if (is_function_expression && (match(TokenType::Yield) || match(TokenType::Await))) {
+            name = create_ast_node<Identifier const>(
+                { m_source_code, rule_start.position(), position() },
+                consume().DeprecatedFlyString_value());
+        }
 
-        check_identifier_name_for_assignment_validity(name);
+        if (name) {
+            check_identifier_name_for_assignment_validity(name->string());
 
-        if (function_kind == FunctionKind::AsyncGenerator && (name == "await"sv || name == "yield"sv))
-            syntax_error(DeprecatedString::formatted("async generator function is not allowed to be called '{}'", name));
+            if (function_kind == FunctionKind::AsyncGenerator && (name->string() == "await"sv || name->string() == "yield"sv))
+                syntax_error(DeprecatedString::formatted("async generator function is not allowed to be called '{}'", name->string()));
 
-        if (m_state.in_class_static_init_block && name == "await"sv)
-            syntax_error("'await' is a reserved word");
+            if (m_state.in_class_static_init_block && name->string() == "await"sv)
+                syntax_error("'await' is a reserved word");
+        }
     }
     TemporaryChange class_static_initializer_rollback(m_state.in_class_static_init_block, false);
     TemporaryChange generator_change(m_state.in_generator_function_context, function_kind == FunctionKind::Generator || function_kind == FunctionKind::AsyncGenerator);
@@ -2670,12 +2814,13 @@ NonnullRefPtr<FunctionNodeType> Parser::parse_function_node(u16 parse_options, O
     consume(TokenType::CurlyOpen);
     bool contains_direct_call_to_eval = false;
     auto body = parse_function_body(parameters, function_kind, contains_direct_call_to_eval);
+    auto local_variables_names = body->local_variables_names();
     consume(TokenType::CurlyClose);
 
     auto has_strict_directive = body->in_strict_mode();
 
-    if (has_strict_directive)
-        check_identifier_name_for_assignment_validity(name, true);
+    if (has_strict_directive && name)
+        check_identifier_name_for_assignment_validity(name->string(), true);
 
     auto function_start_offset = rule_start.position().offset;
     auto function_end_offset = position().offset - m_state.current_token.trivia().length();
@@ -2684,7 +2829,8 @@ NonnullRefPtr<FunctionNodeType> Parser::parse_function_node(u16 parse_options, O
         { m_source_code, rule_start.position(), position() },
         name, move(source_text), move(body), move(parameters), function_length,
         function_kind, has_strict_directive, m_state.function_might_need_arguments_object,
-        contains_direct_call_to_eval);
+        contains_direct_call_to_eval,
+        move(local_variables_names));
 }
 
 Vector<FunctionParameter> Parser::parse_formal_parameters(int& function_length, u16 parse_options)
@@ -2842,20 +2988,13 @@ RefPtr<BindingPattern const> Parser::parse_binding_pattern(Parser::AllowDuplicat
                 if (match(TokenType::StringLiteral)) {
                     auto token = consume(TokenType::StringLiteral);
                     auto string_literal = parse_string_literal(token);
-
-                    name = create_ast_node<Identifier const>(
-                        { m_source_code, rule_start.position(), position() },
-                        string_literal->value());
+                    name = create_identifier_and_register_in_current_scope({ m_source_code, rule_start.position(), position() }, string_literal->value());
                 } else if (match(TokenType::BigIntLiteral)) {
                     auto string_value = consume().DeprecatedFlyString_value();
                     VERIFY(string_value.ends_with("n"sv));
-                    name = create_ast_node<Identifier const>(
-                        { m_source_code, rule_start.position(), position() },
-                        DeprecatedFlyString(string_value.view().substring_view(0, string_value.length() - 1)));
+                    name = create_identifier_and_register_in_current_scope({ m_source_code, rule_start.position(), position() }, DeprecatedFlyString(string_value.view().substring_view(0, string_value.length() - 1)));
                 } else {
-                    name = create_ast_node<Identifier const>(
-                        { m_source_code, rule_start.position(), position() },
-                        consume().DeprecatedFlyString_value());
+                    name = create_identifier_and_register_in_current_scope({ m_source_code, rule_start.position(), position() }, consume().DeprecatedFlyString_value());
                 }
             } else if (match(TokenType::BracketOpen)) {
                 consume();
@@ -2891,10 +3030,7 @@ RefPtr<BindingPattern const> Parser::parse_binding_pattern(Parser::AllowDuplicat
                         return {};
                     alias = binding_pattern.release_nonnull();
                 } else if (match_identifier_name()) {
-                    alias = create_ast_node<Identifier const>(
-                        { m_source_code, rule_start.position(), position() },
-                        consume().DeprecatedFlyString_value());
-
+                    alias = create_identifier_and_register_in_current_scope({ m_source_code, rule_start.position(), position() }, consume().DeprecatedFlyString_value());
                 } else {
                     expected("identifier or binding pattern");
                     return {};
@@ -2930,9 +3066,7 @@ RefPtr<BindingPattern const> Parser::parse_binding_pattern(Parser::AllowDuplicat
             } else if (match_identifier_name()) {
                 // BindingElement must always have an Empty name field
                 auto identifier_name = consume_identifier().DeprecatedFlyString_value();
-                alias = create_ast_node<Identifier const>(
-                    { m_source_code, rule_start.position(), position() },
-                    identifier_name);
+                alias = create_identifier_and_register_in_current_scope({ m_source_code, rule_start.position(), position() }, identifier_name);
             } else {
                 expected("identifier or binding pattern");
                 return {};
@@ -2996,26 +3130,19 @@ RefPtr<Identifier const> Parser::parse_lexical_binding()
     auto binding_start = push_start();
 
     if (match_identifier()) {
-        auto name = consume_identifier().DeprecatedFlyString_value();
-        return create_ast_node<Identifier>(
-            { m_source_code, binding_start.position(), position() },
-            name);
+        return create_identifier_and_register_in_current_scope({ m_source_code, binding_start.position(), position() }, consume_identifier().DeprecatedFlyString_value());
     }
     if (!m_state.in_generator_function_context && match(TokenType::Yield)) {
         if (m_state.strict_mode)
             syntax_error("Identifier must not be a reserved word in strict mode ('yield')");
 
-        return create_ast_node<Identifier>(
-            { m_source_code, binding_start.position(), position() },
-            consume().DeprecatedFlyString_value());
+        return create_identifier_and_register_in_current_scope({ m_source_code, binding_start.position(), position() }, consume().DeprecatedFlyString_value());
     }
     if (!m_state.await_expression_is_valid && match(TokenType::Async)) {
         if (m_program_type == Program::Type::Module)
             syntax_error("Identifier must not be a reserved word in modules ('async')");
 
-        return create_ast_node<Identifier>(
-            { m_source_code, binding_start.position(), position() },
-            consume().DeprecatedFlyString_value());
+        return create_identifier_and_register_in_current_scope({ m_source_code, binding_start.position(), position() }, consume().DeprecatedFlyString_value());
     }
 
     return {};
@@ -3433,6 +3560,9 @@ NonnullRefPtr<WithStatement const> Parser::parse_with_statement()
 
     consume(TokenType::ParenClose);
 
+    auto with_scope_node = create_ast_node<BlockStatement>({ m_source_code, rule_start.position(), position() });
+    ScopePusher with_scope = ScopePusher::with_scope(*this, with_scope_node);
+
     auto body = parse_statement();
     return create_ast_node<WithStatement>({ m_source_code, rule_start.position(), position() }, move(object), move(body));
 }
@@ -3573,6 +3703,9 @@ NonnullRefPtr<Statement const> Parser::parse_for_statement()
     auto rule_start = push_start();
     auto is_await_loop = IsForAwaitLoop::No;
 
+    auto loop_scope_node = create_ast_node<BlockStatement>({ m_source_code, rule_start.position(), position() });
+    ScopePusher for_loop_scope = ScopePusher::for_loop_scope(*this, *loop_scope_node);
+
     auto match_of = [&](Token const& token) {
         return token.type() == TokenType::Identifier && token.original_value() == "of"sv;
     };
@@ -3638,18 +3771,7 @@ NonnullRefPtr<Statement const> Parser::parse_for_statement()
             init = move(declaration);
         } else if (match_variable_declaration()) {
             auto declaration = parse_variable_declaration(IsForLoopVariableDeclaration::Yes);
-            if (declaration->declaration_kind() == DeclarationKind::Var) {
-                m_state.current_scope_pusher->add_declaration(declaration);
-            } else {
-                // This does not follow the normal declaration structure so we need additional checks.
-                HashTable<DeprecatedFlyString> bound_names;
-                // NOTE: Nothing in the callback throws an exception.
-                MUST(declaration->for_each_bound_name([&](auto const& name) {
-                    if (bound_names.set(name) != AK::HashSetResult::InsertedNewEntry)
-                        syntax_error(DeprecatedString::formatted("Identifier '{}' already declared in for loop initializer", name), declaration->source_range().start);
-                }));
-            }
-
+            m_state.current_scope_pusher->add_declaration(declaration);
             if (match_for_in_of()) {
                 if (declaration->declarations().size() > 1)
                     syntax_error("Multiple declarations not allowed in for..in/of");
@@ -3697,7 +3819,7 @@ NonnullRefPtr<Statement const> Parser::parse_for_statement()
 
     TemporaryChange break_change(m_state.in_break_context, true);
     TemporaryChange continue_change(m_state.in_continue_context, true);
-    ScopePusher for_loop_scope = ScopePusher::for_loop_scope(*this, init);
+
     auto body = parse_statement();
 
     return create_ast_node<ForStatement>({ m_source_code, rule_start.position(), position() }, move(init), move(test), move(update), move(body));
@@ -3753,7 +3875,7 @@ NonnullRefPtr<Statement const> Parser::parse_for_in_of_statement(NonnullRefPtr<A
 
     TemporaryChange break_change(m_state.in_break_context, true);
     TemporaryChange continue_change(m_state.in_continue_context, true);
-    ScopePusher for_loop_scope = ScopePusher::for_loop_scope(*this, lhs);
+
     auto body = parse_statement();
     if (is_in)
         return create_ast_node<ForInStatement>({ m_source_code, rule_start.position(), position() }, move(for_declaration), move(rhs), move(body));
@@ -4862,4 +4984,12 @@ Parser::ForbiddenTokens Parser::ForbiddenTokens::forbid(std::initializer_list<To
 
 template NonnullRefPtr<FunctionExpression> Parser::parse_function_node(u16, Optional<Position> const&);
 template NonnullRefPtr<FunctionDeclaration> Parser::parse_function_node(u16, Optional<Position> const&);
+
+NonnullRefPtr<Identifier const> Parser::create_identifier_and_register_in_current_scope(SourceRange range, DeprecatedFlyString string)
+{
+    auto id = create_ast_node<Identifier const>(range, string);
+    m_state.current_scope_pusher->register_identifier(const_cast<Identifier&>(*id));
+    return id;
+}
+
 }

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -342,6 +342,8 @@ private:
         }
     };
 
+    NonnullRefPtr<Identifier const> create_identifier_and_register_in_current_scope(SourceRange range, DeprecatedFlyString string);
+
     NonnullRefPtr<SourceCode const> m_source_code;
     Vector<Position> m_rule_starts;
     ParserState m_state;

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -990,7 +990,7 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, Program const& pr
     for (auto& declaration : functions_to_initialize.in_reverse()) {
         // a. Let fn be the sole element of the BoundNames of f.
         // b. Let fo be InstantiateFunctionObject of f with arguments lexEnv and privateEnv.
-        auto function = ECMAScriptFunctionObject::create(realm, declaration.name(), declaration.source_text(), declaration.body(), declaration.parameters(), declaration.function_length(), lexical_environment, private_environment, declaration.kind(), declaration.is_strict_mode(), declaration.might_need_arguments_object());
+        auto function = ECMAScriptFunctionObject::create(realm, declaration.name(), declaration.source_text(), declaration.body(), declaration.parameters(), declaration.function_length(), declaration.local_variables_names(), lexical_environment, private_environment, declaration.kind(), declaration.is_strict_mode(), declaration.might_need_arguments_object());
 
         // c. If varEnv is a global Environment Record, then
         if (global_var_environment) {

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -845,7 +845,7 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, Program const& pr
         // b. For each FunctionDeclaration f that is directly contained in the StatementList of a Block, CaseClause, or DefaultClause Contained within body, do
         TRY(program.for_each_function_hoistable_with_annexB_extension([&](FunctionDeclaration& function_declaration) -> ThrowCompletionOr<void> {
             // i. Let F be StringValue of the BindingIdentifier of f.
-            auto& function_name = function_declaration.name();
+            auto function_name = function_declaration.name();
 
             // ii. If replacing the FunctionDeclaration f with a VariableStatement that has F as a BindingIdentifier would not produce any Early Errors for body, then
             // Note: This is checked during parsing and for_each_function_hoistable_with_annexB_extension so it always passes here.

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -149,6 +149,8 @@ ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(Value this_argu
 
     ExecutionContext callee_context(heap());
 
+    callee_context.local_variables.resize(m_local_variables_names.size());
+
     // Non-standard
     callee_context.arguments.extend(move(arguments_list));
     if (auto* interpreter = vm.interpreter_if_exists())
@@ -217,6 +219,8 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ECMAScriptFunctionObject::internal_const
     }
 
     ExecutionContext callee_context(heap());
+
+    callee_context.local_variables.resize(m_local_variables_names.size());
 
     // Non-standard
     callee_context.arguments.extend(move(arguments_list));

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -30,7 +30,7 @@
 
 namespace JS {
 
-NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::create(Realm& realm, DeprecatedFlyString name, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind kind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
+NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::create(Realm& realm, DeprecatedFlyString name, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind kind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
 {
     Object* prototype = nullptr;
     switch (kind) {
@@ -47,18 +47,19 @@ NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::create(Realm& r
         prototype = realm.intrinsics().async_generator_function_prototype();
         break;
     }
-    return realm.heap().allocate<ECMAScriptFunctionObject>(realm, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, parent_environment, private_environment, *prototype, kind, is_strict, might_need_arguments_object, contains_direct_call_to_eval, is_arrow_function, move(class_field_initializer_name)).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<ECMAScriptFunctionObject>(realm, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, move(local_variables_names), parent_environment, private_environment, *prototype, kind, is_strict, might_need_arguments_object, contains_direct_call_to_eval, is_arrow_function, move(class_field_initializer_name)).release_allocated_value_but_fixme_should_propagate_errors();
 }
 
-NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::create(Realm& realm, DeprecatedFlyString name, Object& prototype, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind kind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
+NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::create(Realm& realm, DeprecatedFlyString name, Object& prototype, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind kind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
 {
-    return realm.heap().allocate<ECMAScriptFunctionObject>(realm, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, parent_environment, private_environment, prototype, kind, is_strict, might_need_arguments_object, contains_direct_call_to_eval, is_arrow_function, move(class_field_initializer_name)).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<ECMAScriptFunctionObject>(realm, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, move(local_variables_names), parent_environment, private_environment, prototype, kind, is_strict, might_need_arguments_object, contains_direct_call_to_eval, is_arrow_function, move(class_field_initializer_name)).release_allocated_value_but_fixme_should_propagate_errors();
 }
 
-ECMAScriptFunctionObject::ECMAScriptFunctionObject(DeprecatedFlyString name, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> formal_parameters, i32 function_length, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind kind, bool strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
+ECMAScriptFunctionObject::ECMAScriptFunctionObject(DeprecatedFlyString name, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> formal_parameters, i32 function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind kind, bool strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
     : FunctionObject(prototype)
     , m_name(move(name))
     , m_function_length(function_length)
+    , m_local_variables_names(move(local_variables_names))
     , m_environment(parent_environment)
     , m_private_environment(private_environment)
     , m_formal_parameters(move(formal_parameters))
@@ -591,7 +592,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
 
     auto private_environment = callee_context.private_environment;
     for (auto& declaration : functions_to_initialize) {
-        auto function = ECMAScriptFunctionObject::create(realm, declaration.name(), declaration.source_text(), declaration.body(), declaration.parameters(), declaration.function_length(), lex_environment, private_environment, declaration.kind(), declaration.is_strict_mode(), declaration.might_need_arguments_object(), declaration.contains_direct_call_to_eval());
+        auto function = ECMAScriptFunctionObject::create(realm, declaration.name(), declaration.source_text(), declaration.body(), declaration.parameters(), declaration.function_length(), declaration.local_variables_names(), lex_environment, private_environment, declaration.kind(), declaration.is_strict_mode(), declaration.might_need_arguments_object(), declaration.contains_direct_call_to_eval());
         MUST(var_environment->set_mutable_binding(vm, declaration.name(), function, false));
     }
 

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -534,7 +534,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
         // NOTE: Due to the use of MUST with `create_mutable_binding` and `initialize_binding` below,
         //       an exception should not result from `for_each_function_hoistable_with_annexB_extension`.
         MUST(scope_body->for_each_function_hoistable_with_annexB_extension([&](FunctionDeclaration& function_declaration) {
-            auto& function_name = function_declaration.name();
+            auto function_name = function_declaration.name();
             if (parameter_names.contains(function_name))
                 return;
             // The spec says 'initializedBindings' here but that does not exist and it then adds it to 'instantiatedVarNames' so it probably means 'instantiatedVarNames'.

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -33,8 +33,8 @@ public:
         Global,
     };
 
-    static NonnullGCPtr<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, bool might_need_arguments_object = true, bool contains_direct_call_to_eval = true, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
-    static NonnullGCPtr<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, Object& prototype, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, bool might_need_arguments_object = true, bool contains_direct_call_to_eval = true, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
+    static NonnullGCPtr<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, bool might_need_arguments_object = true, bool contains_direct_call_to_eval = true, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
+    static NonnullGCPtr<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, Object& prototype, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, bool might_need_arguments_object = true, bool contains_direct_call_to_eval = true, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
 
     virtual ThrowCompletionOr<void> initialize(Realm&) override;
     virtual ~ECMAScriptFunctionObject() override = default;
@@ -80,6 +80,8 @@ public:
     // Equivalent to absence of [[Construct]]
     virtual bool has_constructor() const override { return m_kind == FunctionKind::Normal && !m_is_arrow_function; }
 
+    virtual Vector<DeprecatedFlyString> const& local_variables_names() const override { return m_local_variables_names; }
+
     FunctionKind kind() const { return m_kind; }
 
     // This is used by LibWeb to disassociate event handler attribute callback functions from the nearest script on the call stack.
@@ -94,7 +96,7 @@ protected:
     virtual Completion ordinary_call_evaluate_body();
 
 private:
-    ECMAScriptFunctionObject(DeprecatedFlyString name, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name);
+    ECMAScriptFunctionObject(DeprecatedFlyString name, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name);
 
     virtual bool is_ecmascript_function_object() const override { return true; }
     virtual void visit_edges(Visitor&) override;
@@ -110,6 +112,7 @@ private:
     OwnPtr<Bytecode::Executable> m_bytecode_executable;
     Vector<OwnPtr<Bytecode::Executable>> m_default_parameter_bytecode_executables;
     i32 m_function_length { 0 };
+    Vector<DeprecatedFlyString> m_local_variables_names;
 
     // Internal Slots of ECMAScript Function Objects, https://tc39.es/ecma262/#table-internal-slots-of-ecmascript-function-objects
     GCPtr<Environment> m_environment;                                        // [[Environment]]

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -13,17 +13,19 @@ namespace JS {
 
 ExecutionContext::ExecutionContext(Heap& heap)
     : arguments(heap)
+    , local_variables(heap)
 {
 }
 
-ExecutionContext::ExecutionContext(MarkedVector<Value> existing_arguments)
+ExecutionContext::ExecutionContext(MarkedVector<Value> existing_arguments, MarkedVector<Value> existing_local_variables)
     : arguments(move(existing_arguments))
+    , local_variables(move(existing_local_variables))
 {
 }
 
 ExecutionContext ExecutionContext::copy() const
 {
-    ExecutionContext copy { arguments };
+    ExecutionContext copy { arguments, local_variables };
 
     copy.function = function;
     copy.realm = realm;

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -29,7 +29,7 @@ struct ExecutionContext {
     void visit_edges(Cell::Visitor&);
 
 private:
-    explicit ExecutionContext(MarkedVector<Value> existing_arguments);
+    explicit ExecutionContext(MarkedVector<Value> existing_arguments, MarkedVector<Value> existing_local_variables);
 
 public:
     GCPtr<FunctionObject> function;                // [[Function]]
@@ -46,6 +46,7 @@ public:
     DeprecatedFlyString function_name;
     Value this_value;
     MarkedVector<Value> arguments;
+    MarkedVector<Value> local_variables;
     bool is_strict_mode { false };
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#skip-when-determining-incumbent-counter

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -225,7 +225,7 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> FunctionConstructor::create_dynamic
     PrivateEnvironment* private_environment = nullptr;
 
     // 28. Let F be OrdinaryFunctionCreate(proto, sourceText, parameters, body, non-lexical-this, env, privateEnv).
-    auto function = ECMAScriptFunctionObject::create(realm, "anonymous", *prototype, move(source_text), expr->body(), expr->parameters(), expr->function_length(), &environment, private_environment, expr->kind(), expr->is_strict_mode(), expr->might_need_arguments_object(), contains_direct_call_to_eval);
+    auto function = ECMAScriptFunctionObject::create(realm, "anonymous", *prototype, move(source_text), expr->body(), expr->parameters(), expr->function_length(), expr->local_variables_names(), &environment, private_environment, expr->kind(), expr->is_strict_mode(), expr->might_need_arguments_object(), contains_direct_call_to_eval);
 
     // FIXME: Remove the name argument from create() and do this instead.
     // 29. Perform SetFunctionName(F, "anonymous").

--- a/Userland/Libraries/LibJS/Runtime/FunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionObject.h
@@ -39,6 +39,8 @@ public:
     // [[Realm]]
     virtual Realm* realm() const { return nullptr; }
 
+    virtual Vector<DeprecatedFlyString> const& local_variables_names() const { VERIFY_NOT_REACHED(); };
+
 protected:
     explicit FunctionObject(Realm&, Object* prototype);
     explicit FunctionObject(Object& prototype);

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -488,7 +488,7 @@ ThrowCompletionOr<void> SourceTextModule::initialize_environment(VM& vm)
                 DeprecatedFlyString function_name = function_declaration.name();
                 if (function_name == ExportStatement::local_name_for_default)
                     function_name = "default"sv;
-                auto function = ECMAScriptFunctionObject::create(realm(), function_name, function_declaration.source_text(), function_declaration.body(), function_declaration.parameters(), function_declaration.function_length(), environment, private_environment, function_declaration.kind(), function_declaration.is_strict_mode(), function_declaration.might_need_arguments_object(), function_declaration.contains_direct_call_to_eval());
+                auto function = ECMAScriptFunctionObject::create(realm(), function_name, function_declaration.source_text(), function_declaration.body(), function_declaration.parameters(), function_declaration.function_length(), function_declaration.local_variables_names(), environment, private_environment, function_declaration.kind(), function_declaration.is_strict_mode(), function_declaration.might_need_arguments_object(), function_declaration.contains_direct_call_to_eval());
 
                 // 2. Perform ! env.InitializeBinding(dn, fo, normal).
                 MUST(environment->initialize_binding(vm, name, function, Environment::InitializeBindingHint::Normal));

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -476,7 +476,7 @@ WebIDL::CallbackType* EventTarget::get_current_value_of_event_handler(FlyString 
 
         //  6. Return scope. (NOTE: Not necessary)
 
-        auto function = JS::ECMAScriptFunctionObject::create(realm, name.to_deprecated_fly_string(), builder.to_deprecated_string(), program->body(), program->parameters(), program->function_length(), scope, nullptr, JS::FunctionKind::Normal, program->is_strict_mode(), program->might_need_arguments_object(), is_arrow_function);
+        auto function = JS::ECMAScriptFunctionObject::create(realm, name.to_deprecated_fly_string(), builder.to_deprecated_string(), program->body(), program->parameters(), program->function_length(), program->local_variables_names(), scope, nullptr, JS::FunctionKind::Normal, program->is_strict_mode(), program->might_need_arguments_object(), is_arrow_function);
 
         // 10. Remove settings object's realm execution context from the JavaScript execution context stack.
         VERIFY(vm.execution_context_stack().last() == &settings_object.realm_execution_context());

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -264,7 +264,7 @@ static JS::ThrowCompletionOr<JS::Value> execute_a_function_body(Web::Page& page,
     //    The result of parsing global scope above.
     // strict
     //    The result of parsing strict above.
-    auto function = JS::ECMAScriptFunctionObject::create(realm, "", move(source_text), function_expression->body(), function_expression->parameters(), function_expression->function_length(), &global_scope, nullptr, function_expression->kind(), function_expression->is_strict_mode(), function_expression->might_need_arguments_object(), contains_direct_call_to_eval);
+    auto function = JS::ECMAScriptFunctionObject::create(realm, "", move(source_text), function_expression->body(), function_expression->parameters(), function_expression->function_length(), function_expression->local_variables_names(), &global_scope, nullptr, function_expression->kind(), function_expression->is_strict_mode(), function_expression->might_need_arguments_object(), contains_direct_call_to_eval);
 
     // 9. Let completion be Function.[[Call]](window, parameters) with function as the this value.
     // NOTE: This is not entirely clear, but I don't think they mean actually passing `function` as


### PR DESCRIPTION
Implements https://github.com/SerenityOS/serenity/issues/17968

Kraken tests:

ai-astar.js
before: 16.64s after: 12.23s

stanford-crypto-aes.js
before: 3.81s, after: 2.93s

stanford-crypto-pbkdf2.js
before: 7.69s after: 5.48s
