### PR TITLE
Ladybird: Add initial support for Ctrl+Scroll to zoom in/out

### DIFF
--- a/Ladybird/BrowserWindow.cpp
+++ b/Ladybird/BrowserWindow.cpp
@@ -662,6 +662,16 @@ void BrowserWindow::moveEvent(QMoveEvent* event)
     }
 }
 
+void BrowserWindow::wheelEvent(QWheelEvent* event)
+{
+    if ((event->modifiers() & Qt::ControlModifier) != 0) {
+        if (event->angleDelta().y() > 0)
+            zoom_in();
+        else if (event->angleDelta().y() < 0)
+            zoom_out();
+    }
+}
+
 bool BrowserWindow::eventFilter(QObject* obj, QEvent* event)
 {
     if (event->type() == QEvent::MouseButtonRelease) {

--- a/Ladybird/BrowserWindow.h
+++ b/Ladybird/BrowserWindow.h
@@ -92,6 +92,7 @@ protected:
 private:
     virtual void resizeEvent(QResizeEvent*) override;
     virtual void moveEvent(QMoveEvent*) override;
+    virtual void wheelEvent(QWheelEvent*) override;
 
     void debug_request(DeprecatedString const& request, DeprecatedString const& argument = "");
 


### PR DESCRIPTION
This commit adds basic functionality to zoom in/out using the Ctrl+Scroll shortcut.