### PR TITLE
AK+LibJS: ASAN fixes for detect_stack_use_after_return

### DIFF
--- a/AK/StackInfo.h
+++ b/AK/StackInfo.h
@@ -19,8 +19,8 @@ public:
     size_t size() const { return m_size; }
     size_t size_free() const
     {
-        FlatPtr dummy;
-        return reinterpret_cast<FlatPtr>(&dummy) - m_base;
+        auto p = reinterpret_cast<FlatPtr>(__builtin_frame_address(0));
+        return p - m_base;
     }
 
 private:

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -146,8 +146,7 @@ jobs:
         env:
           SERENITY_SOURCE_DIR: '$(Build.SourcesDirectory)'
           CTEST_OUTPUT_ON_FAILURE: 1
-          # FIXME: enable detect_stack_use_after_return=1 #7420
-          ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=0'
+          ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=1'
           UBSAN_OPTIONS: 'print_stacktrace=1:print_summary=1:halt_on_error=1'
 
     - ${{ if and(eq(parameters.fuzzer, 'NoFuzz'), eq(parameters.os, 'Linux') ) }}:

--- a/Userland/Libraries/LibJS/Heap/Heap.h
+++ b/Userland/Libraries/LibJS/Heap/Heap.h
@@ -85,6 +85,7 @@ private:
 
     void gather_roots(HashTable<Cell*>&);
     void gather_conservative_roots(HashTable<Cell*>&);
+    void gather_asan_fake_stack_roots(HashTable<FlatPtr>&, FlatPtr);
     void mark_live_cells(HashTable<Cell*> const& live_cells);
     void finalize_unmarked_cells();
     void sweep_dead_cells(bool print_report, Core::ElapsedTimer const&);


### PR DESCRIPTION
Fixes #17163

With clang 15.0.7, this provides the following diff-tests for libjs-test262 with ASAN and UBSAN on:
```
Duration:
     -23.55s

Summary:
    Diff Tests:
        +21 ✅   +33 ❌   +17 💀    -71 💥️  
 ```
 
 With the sanitizer settings
 ```
ASAN_OPTIONS=strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=1
UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1
```

And run with a 120s timeout:

```
python3 main.py --libjs-test262-runner ./Build/_deps/lagom-build/bin/test262-runner --test262-root ./test262/  --per-file asan-120s.json --memory-limit -1 --timeout 120
```

Note that the diff between this PR with ASAN and master without ASAN is like so:

```
Duration:
     +2456.43s

Summary:
    Diff Tests:
         -188 ✅    -48 ❌   +24 💀   +212 💥️   
 ```
 
 So still plenty of UB for folks to hunt :)
 
 Note x2: This also allows running `test-js -g` with ASAN enabled, but when I ran it on my Linux box with a 5950x, it took literally 8 hours to run :skull: 