### PR TITLE
LibWeb: Add vertical border heights to tr

### DIFF
--- a/Tests/LibWeb/Layout/expected/cell-relative-to-specified-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/cell-relative-to-specified-table-width.txt
@@ -34,7 +34,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,29.46875) content-size 776x19.46875 table-row children: not-inline
+            Box <tr> at (10,31.46875) content-size 776x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,32.46875) content-size 300.274545x17.46875 table-cell [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/table/basic.txt
+++ b/Tests/LibWeb/Layout/expected/table/basic.txt
@@ -37,7 +37,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tbody> at (8,29.46875) content-size 95.171875x19.46875 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,48.9375) content-size 95.171875x19.46875 table-row children: not-inline
+            Box <tr> at (10,50.9375) content-size 95.171875x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,51.9375) content-size 93.171875x17.46875 table-cell [BFC] children: inline
@@ -54,7 +54,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tfoot> at (8,48.9375) content-size 95.171875x19.46875 table-footer-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,68.40625) content-size 95.171875x19.46875 table-row children: not-inline
+            Box <tr> at (10,72.40625) content-size 95.171875x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,73.40625) content-size 93.171875x17.46875 table-cell [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
@@ -38,7 +38,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,58.46875) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,68.46875) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,79.46875) content-size 88.8125x17.46875 table-cell [BFC] children: inline
@@ -57,7 +57,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,97.9375) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,117.9375) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,128.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
@@ -83,7 +83,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,137.40625) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,167.40625) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,178.40625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
@@ -109,7 +109,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,176.875) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,216.875) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,227.875) content-size 14.265625x17.46875 table-cell [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
@@ -38,7 +38,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,58.46875) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,68.46875) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,79.46875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
@@ -57,7 +57,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,97.9375) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,117.9375) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,128.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
@@ -83,7 +83,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,137.40625) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,167.40625) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,178.40625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
@@ -109,7 +109,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,176.875) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,216.875) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,227.875) content-size 14.265625x17.46875 table-cell [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-spacing.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing.txt
@@ -38,7 +38,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,58.46875) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,68.46875) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,79.46875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
@@ -64,7 +64,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,97.9375) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,117.9375) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,128.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
@@ -90,7 +90,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,137.40625) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,167.40625) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,178.40625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
@@ -116,7 +116,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,176.875) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,216.875) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,227.875) content-size 14.265625x17.46875 table-cell [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/table/borders.txt
+++ b/Tests/LibWeb/Layout/expected/table/borders.txt
@@ -25,7 +25,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,32.46875) content-size 166.296875x21.46875 table-row children: not-inline
+            Box <tr> at (11,34.46875) content-size 166.296875x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,36.46875) content-size 82.015625x17.46875 table-cell [BFC] children: inline
@@ -44,7 +44,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,53.9375) content-size 166.296875x21.46875 table-row children: not-inline
+            Box <tr> at (11,57.9375) content-size 166.296875x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,59.9375) content-size 82.015625x17.46875 table-cell [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
+++ b/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
@@ -34,7 +34,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tbody> at (8,27.46875) content-size 95.171875x19.46875 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,29.46875) content-size 95.171875x19.46875 table-row children: not-inline
+            Box <tr> at (10,31.46875) content-size 95.171875x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,32.46875) content-size 93.171875x17.46875 table-cell [BFC] children: inline
@@ -51,7 +51,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tfoot> at (8,46.9375) content-size 95.171875x19.46875 table-footer-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,48.9375) content-size 95.171875x19.46875 table-row children: not-inline
+            Box <tr> at (10,52.9375) content-size 95.171875x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,53.9375) content-size 93.171875x17.46875 table-cell [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
@@ -18,7 +18,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                     frag 0 from TextNode start: 0, length: 4, rect: [103.90625,12 27.84375x17.46875]
                       "null"
                   TextNode <#text>
-              Box <tr> at (11,30.46875) content-size 129.984375x19.46875 table-row children: not-inline
+              Box <tr> at (11,32.46875) content-size 129.984375x19.46875 table-row children: not-inline
                 BlockContainer <td> at (12,33.46875) content-size 87.90625x17.46875 table-cell [BFC] children: inline
                   line 0 width: 87.90625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                     frag 0 from TextNode start: 0, length: 11, rect: [12,33.46875 87.90625x17.46875]

--- a/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
@@ -44,7 +44,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tbody> at (10,31.46875) content-size 53.046875x21.46875 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (12,66.875) content-size 53.046875x21.46875 table-row children: not-inline
+            Box <tr> at (12,68.875) content-size 53.046875x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (14,70.875) content-size 21.256598x17.46875 table-cell [BFC] children: inline
@@ -68,7 +68,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tfoot> at (10,52.9375) content-size 53.046875x21.46875 table-footer-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (12,88.34375) content-size 53.046875x21.46875 table-row children: not-inline
+            Box <tr> at (12,92.34375) content-size 53.046875x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (14,94.34375) content-size 21.256598x17.46875 table-cell [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
@@ -14,7 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,32.46875) content-size 75.4375x57.34375 table-row children: not-inline
+            Box <tr> at (11,34.46875) content-size 75.4375x57.34375 table-row children: not-inline
               BlockContainer <td> at (13,45.4375) content-size 71.4375x35.40625 table-cell [BFC] children: inline
                 line 0 width: 71.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 9, rect: [13,45.4375 71.4375x17.46875]

--- a/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
@@ -44,7 +44,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
                         TextNode <#text>
-                      Box <tr> at (65.5625,69.46875) content-size 34.265625x37.46875 table-row children: not-inline
+                      Box <tr> at (65.5625,71.46875) content-size 34.265625x37.46875 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                         BlockContainer <td> at (75.5625,81.46875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
@@ -64,7 +64,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (15,69.46875) content-size 99.828125x54.46875 table-row children: not-inline
+            Box <tr> at (15,71.46875) content-size 99.828125x54.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (25,89.96875) content-size 11.5625x17.46875 table-cell [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
@@ -24,7 +24,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,17.734375) content-size 43.21875x7.734375 table-row children: not-inline
+            Box <tr> at (10,19.734375) content-size 43.21875x7.734375 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,23.601562) content-size 0x0 table-cell [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
@@ -44,7 +44,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
                         TextNode <#text>
-                      Box <tr> at (45.5625,49.46875) content-size 26.265625x29.46875 table-row children: not-inline
+                      Box <tr> at (45.5625,51.46875) content-size 26.265625x29.46875 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                         BlockContainer <td> at (51.5625,57.46875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
@@ -56,7 +56,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
                         TextNode <#text>
-                      Box <tr> at (45.5625,78.9375) content-size 26.265625x29.46875 table-row children: not-inline
+                      Box <tr> at (45.5625,82.9375) content-size 26.265625x29.46875 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                         BlockContainer <td> at (51.5625,88.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
@@ -76,7 +76,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,65.203125) content-size 67.828125x54.203125 table-row children: not-inline
+            Box <tr> at (11,67.203125) content-size 67.828125x54.203125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (17,85.570312) content-size 11.5625x17.46875 table-cell [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/table/rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/rowspan.txt
@@ -36,7 +36,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,29.46875) content-size 221.359375x19.46875 table-row children: not-inline
+            Box <tr> at (10,31.46875) content-size 221.359375x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,43.203125) content-size 70.046875x17.46875 table-cell [BFC] children: inline
@@ -62,7 +62,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,48.9375) content-size 221.359375x19.46875 table-row children: not-inline
+            Box <tr> at (10,52.9375) content-size 221.359375x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (85.046875,53.9375) content-size 72.515625x17.46875 table-cell [BFC] children: inline
@@ -81,7 +81,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,68.40625) content-size 221.359375x19.46875 table-row children: not-inline
+            Box <tr> at (10,74.40625) content-size 221.359375x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,75.40625) content-size 70.046875x17.46875 table-cell [BFC] children: inline

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -775,7 +775,7 @@ void TableFormattingContext::position_row_boxes()
         row_state.set_content_width(row_width);
         row_state.set_content_x(row_left_offset);
         row_state.set_content_y(row_top_offset);
-        row_top_offset += row_state.content_height();
+        row_top_offset += row_state.content_height() + border_spacing_vertical();
     }
 
     CSSPixels row_group_top_offset = table_state.border_top + table_state.padding_top;
@@ -801,9 +801,6 @@ void TableFormattingContext::position_row_boxes()
     });
 
     auto total_content_height = max(row_top_offset, row_group_top_offset) - table_state.offset.y() - table_state.padding_top;
-    // The height of a table is the sum of the row heights plus any cell spacing or borders.
-    // Note that we've already added one vertical border-spacing to row_top_offset, so it's sufficient to multiply it by row count here.
-    total_content_height += m_rows.size() * border_spacing_vertical();
     m_table_height = max(total_content_height, m_table_height);
 }
 
@@ -856,7 +853,7 @@ void TableFormattingContext::position_cell_boxes()
         // FIXME: Account for visibility.
         cell_state.offset = row_state.offset.translated(
             cell_state.border_box_left() + m_columns[cell.column_index].left_offset + cell.column_index * border_spacing_horizontal(),
-            cell_state.border_box_top() + cell.row_index * border_spacing_vertical());
+            cell_state.border_box_top());
     }
 }
 


### PR DESCRIPTION
tr y offset is not being computed correctly, causing errors in hit testing