### PR TITLE
LibWeb: Treat non-finite containing block width as zero for percentages

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-width-with-max-content-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-width-with-max-content-containing-block-width.txt
@@ -1,0 +1,8 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 200x17.46875 children: not-inline
+      BlockContainer <div> at (8,8) content-size 200x17.46875 children: inline
+        line 0 width: 36.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17.46875]
+            "hello"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/block-and-inline/percentage-min-width-with-max-content-containing-block-width.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/percentage-min-width-with-max-content-containing-block-width.html
@@ -1,0 +1,9 @@
+<!doctype html><style>
+body {
+    width: max-content;
+}
+div {
+    width: 200px;
+    min-width: 100%;
+}
+</style><body><div>hello

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1372,7 +1372,7 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
 
 CSS::Length FormattingContext::calculate_inner_width(Layout::Box const& box, AvailableSize const& available_width, CSS::Size const& width) const
 {
-    auto width_of_containing_block = available_width.to_px();
+    auto width_of_containing_block = available_width.to_px_or_zero();
     auto width_of_containing_block_as_length_for_resolve = CSS::Length::make_px(width_of_containing_block);
     if (width.is_auto()) {
         return width.resolved(box, width_of_containing_block_as_length_for_resolve);


### PR DESCRIPTION
Fixes an assertion when loading https://bun.sh/