### PR TITLE
LibJS: Two little optimizations for Kraken

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -101,10 +101,15 @@ private:
         return const_cast<Interpreter*>(this)->window();
     }
 
-    MarkedVector<Value>& registers() { return window().registers; }
+    Span<Value> registers() { return m_current_register_window; }
+    ReadonlySpan<Value> registers() const { return m_current_register_window; }
+
+    void push_register_window(Variant<NonnullOwnPtr<RegisterWindow>, RegisterWindow*>, size_t register_count);
+    [[nodiscard]] Variant<NonnullOwnPtr<RegisterWindow>, RegisterWindow*> pop_register_window();
 
     VM& m_vm;
     Vector<Variant<NonnullOwnPtr<RegisterWindow>, RegisterWindow*>> m_register_windows;
+    Span<Value> m_current_register_window;
     Optional<BasicBlock const*> m_pending_jump;
     BasicBlock const* m_scheduled_jump { nullptr };
     Value m_return_value;

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -1344,6 +1344,10 @@ ThrowCompletionOr<Value> less_than_equals(VM& vm, Value lhs, Value rhs)
 // BitwiseANDExpression : BitwiseANDExpression & EqualityExpression
 ThrowCompletionOr<Value> bitwise_and(VM& vm, Value lhs, Value rhs)
 {
+    // OPTIMIZATION: Fast path when both values are Int32.
+    if (lhs.is_int32() && rhs.is_int32())
+        return Value(lhs.as_i32() & rhs.as_i32());
+
     // 13.15.3 ApplyStringOrNumericBinaryOperator ( lval, opText, rval ), https://tc39.es/ecma262/#sec-applystringornumericbinaryoperator
     // 1-2, 6. N/A.
 
@@ -1377,6 +1381,10 @@ ThrowCompletionOr<Value> bitwise_and(VM& vm, Value lhs, Value rhs)
 // BitwiseORExpression : BitwiseORExpression | BitwiseXORExpression
 ThrowCompletionOr<Value> bitwise_or(VM& vm, Value lhs, Value rhs)
 {
+    // OPTIMIZATION: Fast path when both values are Int32.
+    if (lhs.is_int32() && rhs.is_int32())
+        return Value(lhs.as_i32() | rhs.as_i32());
+
     // 13.15.3 ApplyStringOrNumericBinaryOperator ( lval, opText, rval ), https://tc39.es/ecma262/#sec-applystringornumericbinaryoperator
     // 1-2, 6. N/A.
 
@@ -1414,6 +1422,10 @@ ThrowCompletionOr<Value> bitwise_or(VM& vm, Value lhs, Value rhs)
 // BitwiseXORExpression : BitwiseXORExpression ^ BitwiseANDExpression
 ThrowCompletionOr<Value> bitwise_xor(VM& vm, Value lhs, Value rhs)
 {
+    // OPTIMIZATION: Fast path when both values are Int32.
+    if (lhs.is_int32() && rhs.is_int32())
+        return Value(lhs.as_i32() ^ rhs.as_i32());
+
     // 13.15.3 ApplyStringOrNumericBinaryOperator ( lval, opText, rval ), https://tc39.es/ecma262/#sec-applystringornumericbinaryoperator
     // 1-2, 6. N/A.
 
@@ -1598,6 +1610,12 @@ ThrowCompletionOr<Value> left_shift(VM& vm, Value lhs, Value rhs)
 // ShiftExpression : ShiftExpression >> AdditiveExpression
 ThrowCompletionOr<Value> right_shift(VM& vm, Value lhs, Value rhs)
 {
+    // OPTIMIZATION: Fast path when both values are suitable Int32 values.
+    if (lhs.is_int32() && rhs.is_int32() && rhs.as_i32() >= 0) {
+        auto shift_count = static_cast<u32>(rhs.as_i32()) % 32;
+        return Value(lhs.as_i32() >> shift_count);
+    }
+
     // 13.15.3 ApplyStringOrNumericBinaryOperator ( lval, opText, rval ), https://tc39.es/ecma262/#sec-applystringornumericbinaryoperator
     // 1-2, 6. N/A.
 
@@ -1649,6 +1667,12 @@ ThrowCompletionOr<Value> right_shift(VM& vm, Value lhs, Value rhs)
 // ShiftExpression : ShiftExpression >>> AdditiveExpression
 ThrowCompletionOr<Value> unsigned_right_shift(VM& vm, Value lhs, Value rhs)
 {
+    // OPTIMIZATION: Fast path when both values are suitable Int32 values.
+    if (lhs.is_int32() && rhs.is_int32() && lhs.as_i32() >= 0 && rhs.as_i32() >= 0) {
+        auto shift_count = static_cast<u32>(rhs.as_i32()) % 32;
+        return Value(static_cast<u32>(lhs.as_i32()) >> shift_count);
+    }
+
     // 13.15.3 ApplyStringOrNumericBinaryOperator ( lval, opText, rval ), https://tc39.es/ecma262/#sec-applystringornumericbinaryoperator
     // 1-2, 5-6. N/A.
 

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -428,6 +428,17 @@ public:
 #endif
     }
 
+    // A double is any Value which does not have the full exponent and top mantissa bit set or has
+    // exactly only those bits set.
+    bool is_double() const { return (m_value.encoded & CANON_NAN_BITS) != CANON_NAN_BITS || (m_value.encoded == CANON_NAN_BITS); }
+    bool is_int32() const { return m_value.tag == INT32_TAG; }
+
+    i32 as_i32() const
+    {
+        VERIFY(is_int32());
+        return static_cast<i32>(m_value.encoded & 0xFFFFFFFF);
+    }
+
 private:
     Value(u64 tag, u64 val)
     {
@@ -457,17 +468,6 @@ private:
             //       See also: Value::extract_pointer.
             m_value.encoded = tag | (reinterpret_cast<u64>(ptr) & 0x0000ffffffffffffULL);
         }
-    }
-
-    // A double is any Value which does not have the full exponent and top mantissa bit set or has
-    // exactly only those bits set.
-    bool is_double() const { return (m_value.encoded & CANON_NAN_BITS) != CANON_NAN_BITS || (m_value.encoded == CANON_NAN_BITS); }
-    bool is_int32() const { return m_value.tag == INT32_TAG; }
-
-    i32 as_i32() const
-    {
-        VERIFY(is_int32());
-        return static_cast<i32>(m_value.encoded & 0xFFFFFFFF);
     }
 
     template<typename PointerType>


### PR DESCRIPTION
- One ~17% speed-up for the bytecode VM. This one benefits basically all workloads.
- One ~9% speed-up for all VMs. (Fast path for bitwise ops on two Int32 values)