### PR TITLE
Meta: Update path to ladybird in gdb invocation

### DIFF
--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -385,7 +385,6 @@ run_gdb() {
                 fi
                 LAGOM_EXECUTABLE="$arg"
                 if [ "$LAGOM_EXECUTABLE" = "ladybird" ]; then
-                    LAGOM_EXECUTABLE="Ladybird/ladybird"
                     # FIXME: Make ladybird less cwd-dependent while in the build directory
                     cd "$BUILD_DIR/Ladybird"
                 fi


### PR DESCRIPTION
It's possible that the entire "if" can be removed, I am not sure if the FIXME is still relevant. I tried running it without the "cd" and it seemed to work fine, but since I don't know what used to not work I did not remove it.