### PR TITLE
LibWeb: Fix alternating-sides float positioning

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-4.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-4.txt
@@ -1,0 +1,30 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x60 [BFC] children: not-inline
+    BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
+      TextNode <#text>
+    BlockContainer <body> at (8,8) content-size 780x0 children: inline
+      TextNode <#text>
+      BlockContainer <div.left> at (9,9) content-size 50x50 floating [BFC] children: inline
+        line 0 width: 39.21875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 5, rect: [14,9 39.21875x17.46875]
+            "Left1"
+        TextNode <#text>
+      TextNode <#text>
+      BlockContainer <div.right> at (737,9) content-size 50x50 floating [BFC] children: inline
+        line 0 width: 48.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 6, rect: [738,9 48.3125x17.46875]
+            "Right1"
+        TextNode <#text>
+      TextNode <#text>
+      BlockContainer <div.left> at (61,9) content-size 50x50 floating [BFC] children: inline
+        line 0 width: 41.6875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 5, rect: [65,9 41.6875x17.46875]
+            "Left2"
+        TextNode <#text>
+      TextNode <#text>
+      BlockContainer <div.right> at (685,9) content-size 50x50 floating [BFC] children: inline
+        line 0 width: 50.78125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 6, rect: [685,9 50.78125x17.46875]
+            "Right2"
+        TextNode <#text>
+      TextNode <#text>

--- a/Tests/LibWeb/Layout/input/block-and-inline/float-4.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/float-4.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    width: 780px;
+    text-align: center
+}
+ .right {
+    border: 1px solid red;
+    width: 50px;
+    height: 50px;
+    float: right;
+}
+.left {
+    border: 1px solid green;
+    width: 50px;
+    height: 50px;
+    float: left;
+}
+</style>
+</head>
+<body>
+    <div class="left" >Left1</div>
+    <div class="right">Right1</div>
+    <div class="left" >Left2</div>
+    <div class="right">Right2</div>
+</body>
+</html>

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -950,10 +950,11 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
         if (!line_builder)
             y += side_data.y_offset;
 
+        auto top_margin_edge = y - box_state.margin_box_top();
         side_data.all_boxes.append(adopt_own(*new FloatingBox {
             .box = box,
             .offset_from_edge = offset_from_edge,
-            .top_margin_edge = y - box_state.margin_box_top(),
+            .top_margin_edge = top_margin_edge,
             .bottom_margin_edge = y + box_state.content_height() + box_state.margin_box_bottom(),
         }));
         side_data.current_boxes.append(*side_data.all_boxes.last());
@@ -971,7 +972,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
 
         // If the new box was inserted below the bottom of the opposite side,
         // we reset the other side back to its edge.
-        if (y > other_side_data.y_offset)
+        if (top_margin_edge > other_side_data.y_offset)
             other_side_data.clear();
     };
 


### PR DESCRIPTION
The "y" check for when to reset float side positioning was comparing an offset that included the border, while the offset of the other side does not.