### PR TITLE
LibGfx/JPEG+image: Allow the user to choose JPEG's encoding quality

### DIFF
--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -470,14 +470,12 @@ void ArgsParser::add_option(I& value, char const* help_string, char const* long_
     add_option(move(option));
 }
 
-template void ArgsParser::add_option(int&, char const*, char const*, char, char const*, OptionHideMode);
-template void ArgsParser::add_option(long&, char const*, char const*, char, char const*, OptionHideMode);
-template void ArgsParser::add_option(long long&, char const*, char const*, char, char const*, OptionHideMode);
-template void ArgsParser::add_option(short&, char const*, char const*, char, char const*, OptionHideMode);
-template void ArgsParser::add_option(unsigned&, char const*, char const*, char, char const*, OptionHideMode);
-template void ArgsParser::add_option(unsigned long&, char const*, char const*, char, char const*, OptionHideMode);
-template void ArgsParser::add_option(unsigned long long&, char const*, char const*, char, char const*, OptionHideMode);
-template void ArgsParser::add_option(unsigned short&, char const*, char const*, char, char const*, OptionHideMode);
+template void ArgsParser::add_option(i16&, char const*, char const*, char, char const*, OptionHideMode);
+template void ArgsParser::add_option(i32&, char const*, char const*, char, char const*, OptionHideMode);
+template void ArgsParser::add_option(i64&, char const*, char const*, char, char const*, OptionHideMode);
+template void ArgsParser::add_option(u16&, char const*, char const*, char, char const*, OptionHideMode);
+template void ArgsParser::add_option(u32&, char const*, char const*, char, char const*, OptionHideMode);
+template void ArgsParser::add_option(u64&, char const*, char const*, char, char const*, OptionHideMode);
 
 void ArgsParser::add_option(double& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode)
 {

--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -473,6 +473,7 @@ void ArgsParser::add_option(I& value, char const* help_string, char const* long_
 template void ArgsParser::add_option(i16&, char const*, char const*, char, char const*, OptionHideMode);
 template void ArgsParser::add_option(i32&, char const*, char const*, char, char const*, OptionHideMode);
 template void ArgsParser::add_option(i64&, char const*, char const*, char, char const*, OptionHideMode);
+template void ArgsParser::add_option(u8&, char const*, char const*, char, char const*, OptionHideMode);
 template void ArgsParser::add_option(u16&, char const*, char const*, char, char const*, OptionHideMode);
 template void ArgsParser::add_option(u32&, char const*, char const*, char, char const*, OptionHideMode);
 template void ArgsParser::add_option(u64&, char const*, char const*, char, char const*, OptionHideMode);

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
@@ -475,14 +475,12 @@ ErrorOr<void> add_scan_header(Stream& stream)
 
 }
 
-ErrorOr<void> JPEGWriter::encode(Stream& stream, Bitmap const& bitmap)
+ErrorOr<void> JPEGWriter::encode(Stream& stream, Bitmap const& bitmap, Options const& options)
 {
     JPEGEncodingContext context { JPEGBigEndianOutputBitStream { stream } };
 
-    // FIXME: Let's take the quality as an option instead of hardcoding it
-    //        (there might also be a bug with quantization tables :^)).
-    context.set_luminance_quantization_table(s_default_luminance_quantization_table, 100);
-    context.set_chrominance_quantization_table(s_default_chrominance_quantization_table, 100);
+    context.set_luminance_quantization_table(s_default_luminance_quantization_table, options.quality);
+    context.set_chrominance_quantization_table(s_default_chrominance_quantization_table, options.quality);
 
     context.dc_luminance_huffman_table = s_default_dc_luminance_huffman_table;
     context.dc_chrominance_huffman_table = s_default_dc_chrominance_huffman_table;

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
@@ -398,8 +398,8 @@ ErrorOr<void> add_quantization_table(Stream& stream, QuantizationTable const& ta
     // Pq and Tq
     TRY(stream.write_value<u8>((0 << 4) | table.id));
 
-    for (auto coefficient : table.table)
-        TRY(stream.write_value<u8>(coefficient));
+    for (u8 i = 0; i < 64; ++i)
+        TRY(stream.write_value<u8>(table.table[zigzag_map[i]]));
 
     return {};
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.h
@@ -11,9 +11,15 @@
 
 namespace Gfx {
 
+struct JPEGEncoderOptions {
+    u8 quality { 75 };
+};
+
 class JPEGWriter {
 public:
-    static ErrorOr<void> encode(Stream&, Bitmap const&);
+    using Options = JPEGEncoderOptions;
+
+    static ErrorOr<void> encode(Stream&, Bitmap const&, Options const& = {});
 
 private:
     JPEGWriter() = delete;

--- a/Userland/Utilities/image.cpp
+++ b/Userland/Utilities/image.cpp
@@ -49,6 +49,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool strip_color_profile = false;
     args_parser.add_option(strip_color_profile, "Do not write color profile to output", "strip-color-profile", {});
 
+    u8 quality = 75;
+    args_parser.add_option(quality, "Quality used for the JPEG encoder, the default value is 75 on a scale from 0 to 100", "quality", {}, {});
+
     args_parser.parse(arguments);
 
     if (out_path.is_empty() ^ no_output) {
@@ -154,7 +157,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         TRY(Gfx::PortableFormatWriter::encode(*buffered_stream, *frame, { .format = format }));
         return 0;
     } else if (out_path.ends_with(".jpg"sv, CaseSensitivity::CaseInsensitive) || out_path.ends_with(".jpeg"sv, CaseSensitivity::CaseInsensitive)) {
-        TRY(Gfx::JPEGWriter::encode(*buffered_stream, *frame));
+        TRY(Gfx::JPEGWriter::encode(*buffered_stream, *frame, { .quality = quality }));
         return 0;
     } else if (out_path.ends_with(".qoi"sv, CaseSensitivity::CaseInsensitive)) {
         bytes = TRY(Gfx::QOIWriter::encode(*frame));


### PR DESCRIPTION
--quality 1:
![unicorn1](https://github.com/SerenityOS/serenity/assets/26030965/660fd1d9-9723-4e2d-baa2-ab9579c12a5b)

--quality 10:
![unicorn10](https://github.com/SerenityOS/serenity/assets/26030965/ba20a6f3-24ba-42e3-a207-f382175bcc19)

--quality 75 (default):
![unicorn75](https://github.com/SerenityOS/serenity/assets/26030965/c4d74392-4990-4d05-86f3-7ea6571a7bac)
