### PR TITLE
LibJS/Bytecode: Do not clobber completion value with VariableDeclaration

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1353,6 +1353,11 @@ static Bytecode::CodeGenerationErrorOr<void> assign_accumulator_to_variable_decl
 
 Bytecode::CodeGenerationErrorOr<void> VariableDeclaration::generate_bytecode(Bytecode::Generator& generator) const
 {
+    // The completion value of a VariableDeclaration is empty, but there might already be a non-empty
+    // completion value in the accumulator. We need to save it and restore it after the declaration executed.
+    auto saved_accumulator = generator.allocate_register();
+    generator.emit<Bytecode::Op::Store>(saved_accumulator);
+
     for (auto& declarator : m_declarations) {
         if (declarator->init()) {
             if (auto const* lhs = declarator->target().get_pointer<NonnullRefPtr<Identifier const>>()) {
@@ -1367,6 +1372,7 @@ Bytecode::CodeGenerationErrorOr<void> VariableDeclaration::generate_bytecode(Byt
         }
     }
 
+    generator.emit<Bytecode::Op::Load>(saved_accumulator);
     return {};
 }
 


### PR DESCRIPTION
While the completion value of a variable declaration is specified to be empty, we might already have a completion value in the accumulator from a previous statement. Preserve it so as to avoid clobbering it.

This fixes 6 tests on test262.

```
Summary:
    Diff Tests:
        +6 ✅    -6 ❌   

Diff Tests:
    test/language/eval-code/direct/cptn-nrml-empty-var.js   ❌ -> ✅
    test/language/eval-code/indirect/cptn-nrml-empty-var.js ❌ -> ✅
    test/language/statements/const/cptn-value.js            ❌ -> ✅
    test/language/statements/for-of/scope-head-var-none.js  ❌ -> ✅
    test/language/statements/let/cptn-value.js              ❌ -> ✅
    test/language/statements/variable/cptn-value.js         ❌ -> ✅
```