### PR TITLE
LibJS/Bytecode: Infer name of anonymous exported classes when possible

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -2899,7 +2899,7 @@ Bytecode::CodeGenerationErrorOr<void> ExportStatement::generate_bytecode(Bytecod
     }
 
     if (is<ClassExpression>(*m_statement)) {
-        TRY(m_statement->generate_bytecode(generator));
+        TRY(generator.emit_named_evaluation_if_anonymous_function(static_cast<ClassExpression const&>(*m_statement), generator.intern_identifier("default"sv)));
 
         if (!static_cast<ClassExpression const&>(*m_statement).has_name())
             generator.emit<Bytecode::Op::SetVariable>(generator.intern_identifier(ExportStatement::local_name_for_default), Bytecode::Op::SetVariable::InitializationMode::Initialize);


### PR DESCRIPTION
```
Summary:
    Diff Tests:
        +5 ✅    -5 ❌   

Diff Tests:
    test/language/expressions/class/elements/class-name-static-initializer-default-export.js ❌ -> ✅
    test/language/expressions/dynamic-import/eval-export-dflt-cls-anon.js                    ❌ -> ✅
    test/language/expressions/dynamic-import/eval-export-dflt-expr-cls-anon.js               ❌ -> ✅
    test/language/module-code/eval-export-dflt-cls-anon.js                                   ❌ -> ✅
    test/language/module-code/eval-export-dflt-expr-cls-anon.js                              ❌ -> ✅
```