### PR TITLE
LibJS/Bytecode: Make Bytecode::Interpreter participate in GC marking

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -18,8 +18,8 @@ struct UnwindInfo {
     BasicBlock const* handler;
     BasicBlock const* finalizer;
 
-    Handle<Environment> lexical_environment;
-    Handle<Environment> variable_environment;
+    JS::GCPtr<Environment> lexical_environment;
+    JS::GCPtr<Environment> variable_environment;
 };
 
 class BasicBlock {

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -10,6 +10,7 @@
 #include <AK/StackInfo.h>
 #include <AK/TemporaryChange.h>
 #include <LibCore/ElapsedTimer.h>
+#include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Heap/CellAllocator.h>
 #include <LibJS/Heap/Handle.h>
 #include <LibJS/Heap/Heap.h>
@@ -270,6 +271,10 @@ void Heap::mark_live_cells(HashTable<Cell*> const& roots)
     dbgln_if(HEAP_DEBUG, "mark_live_cells:");
 
     MarkingVisitor visitor(roots);
+
+    if (auto* bytecode_interpreter = vm().bytecode_interpreter_if_exists())
+        bytecode_interpreter->visit_edges(visitor);
+
     visitor.mark_all_live_cells();
 
     for (auto& inverse_root : m_uprooted_cells)

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
@@ -52,6 +52,8 @@ void GeneratorObject::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_generating_function);
     visitor.visit(m_previous_value);
     m_execution_context.visit_edges(visitor);
+    if (m_frame.has_value())
+        m_frame->visit_edges(visitor);
 }
 
 // 27.5.3.2 GeneratorValidate ( generator, generatorBrand ), https://tc39.es/ecma262/#sec-generatorvalidate


### PR DESCRIPTION
Since the relationship between `VM` and `Bytecode::Interpreter` is now clear, we can have `VM` ask the `Interpreter` for roots in the GC marking pass. This avoids having to register and unregister `Handle`s and `MarkedVectors` over and over.

Since `GeneratorObject` can also own a `RegisterWindow`, we share the code in a `RegisterWindow::visit_edges()` helper.

~4% speed-up on Kraken/stanford-crypto-ccm.js :^)