### PR TITLE
LibJS/Bytecode: Two little optimizations for Kraken

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -19,7 +19,6 @@ struct UnwindInfo {
     BasicBlock const* finalizer;
 
     JS::GCPtr<Environment> lexical_environment;
-    JS::GCPtr<Environment> variable_environment;
 };
 
 class BasicBlock {

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -18,7 +18,7 @@
     O(BitwiseOr)                     \
     O(BitwiseXor)                    \
     O(BlockDeclarationInstantiation) \
-    O(Call)                          \
+    O(CallWithArgumentArray)         \
     O(ConcatString)                  \
     O(ContinuePendingUnwind)         \
     O(CopyObjectExcludingProperties) \
@@ -89,7 +89,7 @@
     O(StrictlyEquals)                \
     O(StrictlyInequals)              \
     O(Sub)                           \
-    O(SuperCall)                     \
+    O(SuperCallWithArgumentArray)    \
     O(Throw)                         \
     O(ThrowIfNotObject)              \
     O(ThrowIfNullish)                \

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -18,6 +18,7 @@
     O(BitwiseOr)                     \
     O(BitwiseXor)                    \
     O(BlockDeclarationInstantiation) \
+    O(Call)                          \
     O(CallWithArgumentArray)         \
     O(ConcatString)                  \
     O(ContinuePendingUnwind)         \

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -221,7 +221,7 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Realm& realm, Execu
     if (in_frame)
         push_register_window(in_frame, executable.number_of_registers);
     else
-        push_register_window(make<RegisterWindow>(MarkedVector<Value>(vm().heap()), MarkedVector<GCPtr<Environment>>(vm().heap()), MarkedVector<GCPtr<Environment>>(vm().heap()), Vector<UnwindInfo> {}), executable.number_of_registers);
+        push_register_window(make<RegisterWindow>(), executable.number_of_registers);
 
     for (;;) {
         Bytecode::InstructionStreamIterator pc(m_current_block->instruction_stream());
@@ -244,7 +244,6 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Realm& realm, Execu
                     break;
                 if (unwind_context.handler) {
                     vm().running_execution_context().lexical_environment = unwind_context.lexical_environment;
-                    vm().running_execution_context().variable_environment = unwind_context.variable_environment;
                     m_current_block = unwind_context.handler;
                     unwind_context.handler = nullptr;
 
@@ -361,8 +360,7 @@ void Interpreter::enter_unwind_context(Optional<Label> handler_target, Optional<
         m_current_executable,
         handler_target.has_value() ? &handler_target->block() : nullptr,
         finalizer_target.has_value() ? &finalizer_target->block() : nullptr,
-        vm().running_execution_context().lexical_environment,
-        vm().running_execution_context().variable_environment);
+        vm().running_execution_context().lexical_environment);
 }
 
 void Interpreter::leave_unwind_context()

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -26,16 +26,12 @@ struct RegisterWindow {
             visitor.visit(value);
         for (auto const& environment : saved_lexical_environments)
             visitor.visit(environment);
-        for (auto const& environment : saved_variable_environments)
-            visitor.visit(environment);
         for (auto& context : unwind_contexts) {
             visitor.visit(context.lexical_environment);
-            visitor.visit(context.variable_environment);
         }
     }
     Vector<Value> registers;
     Vector<GCPtr<Environment>> saved_lexical_environments;
-    Vector<GCPtr<Environment>> saved_variable_environments;
     Vector<UnwindInfo> unwind_contexts;
 };
 
@@ -70,7 +66,6 @@ public:
     Value& reg(Register const& r) { return registers()[r.index()]; }
 
     auto& saved_lexical_environment_stack() { return window().saved_lexical_environments; }
-    auto& saved_variable_environment_stack() { return window().saved_variable_environments; }
     auto& unwind_contexts() { return window().unwind_contexts; }
 
     void jump(Label const& label)

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -694,7 +694,7 @@ static MarkedVector<Value> argument_list_evaluation(Bytecode::Interpreter& inter
     return argument_values;
 }
 
-Completion Call::throw_type_error_for_callee(Bytecode::Interpreter& interpreter, StringView callee_type) const
+Completion CallWithArgumentArray::throw_type_error_for_callee(Bytecode::Interpreter& interpreter, StringView callee_type) const
 {
     auto& vm = interpreter.vm();
     auto callee = interpreter.reg(m_callee);
@@ -705,7 +705,7 @@ Completion Call::throw_type_error_for_callee(Bytecode::Interpreter& interpreter,
     return vm.throw_completion<TypeError>(ErrorType::IsNotA, TRY_OR_THROW_OOM(vm, callee.to_string_without_side_effects()), callee_type);
 }
 
-ThrowCompletionOr<void> Call::execute_impl(Bytecode::Interpreter& interpreter) const
+ThrowCompletionOr<void> CallWithArgumentArray::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
 
@@ -738,7 +738,7 @@ ThrowCompletionOr<void> Call::execute_impl(Bytecode::Interpreter& interpreter) c
 }
 
 // 13.3.7.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-super-keyword-runtime-semantics-evaluation
-ThrowCompletionOr<void> SuperCall::execute_impl(Bytecode::Interpreter& interpreter) const
+ThrowCompletionOr<void> SuperCallWithArgumentArray::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
     // 1. Let newTarget be GetNewTarget().
@@ -896,7 +896,7 @@ void CopyObjectExcludingProperties::replace_references_impl(Register from, Regis
     }
 }
 
-void Call::replace_references_impl(Register from, Register to)
+void CallWithArgumentArray::replace_references_impl(Register from, Register to)
 {
     if (m_callee == from)
         m_callee = to;
@@ -1383,30 +1383,30 @@ DeprecatedString JumpUndefined::to_deprecated_string_impl(Bytecode::Executable c
     return DeprecatedString::formatted("JumpUndefined undefined:{} not undefined:{}", true_string, false_string);
 }
 
-DeprecatedString Call::to_deprecated_string_impl(Bytecode::Executable const& executable) const
+DeprecatedString CallWithArgumentArray::to_deprecated_string_impl(Bytecode::Executable const& executable) const
 {
     StringView type;
     switch (m_type) {
-    case Call::CallType::Call:
+    case CallType::Call:
         type = ""sv;
         break;
-    case Call::CallType::Construct:
+    case CallType::Construct:
         type = " (Construct)"sv;
         break;
-    case Call::CallType::DirectEval:
+    case CallType::DirectEval:
         type = " (DirectEval)"sv;
         break;
     }
 
     if (m_expression_string.has_value())
-        return DeprecatedString::formatted("Call{} callee:{}, this:{}, arguments:[...acc] ({})", type, m_callee, m_this_value, executable.get_string(m_expression_string.value()));
+        return DeprecatedString::formatted("CallWithArgumentArray{} callee:{}, this:{}, arguments:[...acc] ({})", type, m_callee, m_this_value, executable.get_string(m_expression_string.value()));
 
-    return DeprecatedString::formatted("Call{} callee:{}, this:{}, arguments:[...acc]", type, m_callee, m_this_value);
+    return DeprecatedString::formatted("CallWithArgumentArray{} callee:{}, this:{}, arguments:[...acc]", type, m_callee, m_this_value);
 }
 
-DeprecatedString SuperCall::to_deprecated_string_impl(Bytecode::Executable const&) const
+DeprecatedString SuperCallWithArgumentArray::to_deprecated_string_impl(Bytecode::Executable const&) const
 {
-    return "SuperCall arguments:[...acc]"sv;
+    return "SuperCallWithArgumentArray arguments:[...acc]"sv;
 }
 
 DeprecatedString NewFunction::to_deprecated_string_impl(Bytecode::Executable const&) const

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -770,17 +770,16 @@ public:
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
 };
 
-// NOTE: This instruction is variable-width depending on the number of arguments!
-class Call final : public Instruction {
-public:
-    enum class CallType {
-        Call,
-        Construct,
-        DirectEval,
-    };
+enum class CallType {
+    Call,
+    Construct,
+    DirectEval,
+};
 
-    Call(CallType type, Register callee, Register this_value, Optional<StringTableIndex> expression_string = {})
-        : Instruction(Type::Call)
+class CallWithArgumentArray final : public Instruction {
+public:
+    CallWithArgumentArray(CallType type, Register callee, Register this_value, Optional<StringTableIndex> expression_string = {})
+        : Instruction(Type::CallWithArgumentArray)
         , m_callee(callee)
         , m_this_value(this_value)
         , m_type(type)
@@ -802,11 +801,10 @@ private:
     Optional<StringTableIndex> m_expression_string;
 };
 
-// NOTE: This instruction is variable-width depending on the number of arguments!
-class SuperCall : public Instruction {
+class SuperCallWithArgumentArray : public Instruction {
 public:
-    explicit SuperCall(bool is_synthetic)
-        : Instruction(Type::SuperCall)
+    explicit SuperCallWithArgumentArray(bool is_synthetic)
+        : Instruction(Type::SuperCallWithArgumentArray)
         , m_is_synthetic(is_synthetic)
     {
     }

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -776,6 +776,38 @@ enum class CallType {
     DirectEval,
 };
 
+class Call final : public Instruction {
+public:
+    Call(CallType type, Register callee, Register this_value, Register first_argument, u32 argument_count, Optional<StringTableIndex> expression_string = {})
+        : Instruction(Type::Call)
+        , m_callee(callee)
+        , m_this_value(this_value)
+        , m_first_argument(first_argument)
+        , m_argument_count(argument_count)
+        , m_type(type)
+        , m_expression_string(expression_string)
+    {
+    }
+
+    CallType call_type() const { return m_type; }
+    Register callee() const { return m_callee; }
+    Register this_value() const { return m_this_value; }
+    Optional<StringTableIndex> const& expression_string() const { return m_expression_string; }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register);
+
+private:
+    Register m_callee;
+    Register m_this_value;
+    Register m_first_argument;
+    u32 m_argument_count { 0 };
+    CallType m_type;
+    Optional<StringTableIndex> m_expression_string;
+};
+
 class CallWithArgumentArray final : public Instruction {
 public:
     CallWithArgumentArray(CallType type, Register callee, Register this_value, Optional<StringTableIndex> expression_string = {})
@@ -787,12 +819,15 @@ public:
     {
     }
 
+    CallType call_type() const { return m_type; }
+    Register callee() const { return m_callee; }
+    Register this_value() const { return m_this_value; }
+    Optional<StringTableIndex> const& expression_string() const { return m_expression_string; }
+
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
     void replace_references_impl(Register, Register);
-
-    Completion throw_type_error_for_callee(Bytecode::Interpreter&, StringView callee_type) const;
 
 private:
     Register m_callee;

--- a/Userland/Libraries/LibJS/Bytecode/Pass/LoadElimination.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/LoadElimination.cpp
@@ -124,7 +124,7 @@ static NonnullOwnPtr<BasicBlock> eliminate_loads(BasicBlock const& block, size_t
             // Attribute accesses (`a.o` or `a[o]`) may result in calls to getters or setters
             // or may trigger proxies
             // So these are treated like calls
-        case Call:
+        case CallWithArgumentArray:
             // Calls, especially to local functions and eval, may poison visible and
             // cached variables, hence we need to clear the lookup cache after emitting them
             // FIXME: In strict mode and with better identifier metrics, we might be able

--- a/Userland/Libraries/LibJS/Bytecode/Pass/LoadElimination.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/LoadElimination.cpp
@@ -124,6 +124,7 @@ static NonnullOwnPtr<BasicBlock> eliminate_loads(BasicBlock const& block, size_t
             // Attribute accesses (`a.o` or `a[o]`) may result in calls to getters or setters
             // or may trigger proxies
             // So these are treated like calls
+        case Call:
         case CallWithArgumentArray:
             // Calls, especially to local functions and eval, may poison visible and
             // cached variables, hence we need to clear the lookup cache after emitting them


### PR DESCRIPTION
- Remove unnecessary fidgeting with the var environment in `Bytecode::Interpreter`
- Don't make a new `Array` for every function call (unless the call has spread arguments)