### PR TITLE
Ports/libgd: Added --without-x to prevent linking against /usr/lib

### DIFF
--- a/Ports/libgd/package.sh
+++ b/Ports/libgd/package.sh
@@ -3,6 +3,7 @@ port=libgd
 version=2.3.3
 useconfigure=true
 use_fresh_config_sub=true
+configopts=("--without-x")
 config_sub_paths=("config/config.sub")
 files="https://github.com/libgd/libgd/releases/download/gd-${version}/libgd-${version}.tar.gz libgd-${version}.tar.gz dd3f1f0bb016edcc0b2d082e8229c822ad1d02223511997c80461481759b1ed2"
 auth_type=sha256


### PR DESCRIPTION
Making port libgd (and also npiet) build again

Contributing to #18238 