### PR TITLE
LibJS: Implement the resizable ArrayBuffer proposal

### DIFF
--- a/Userland/Libraries/LibJS/Print.cpp
+++ b/Userland/Libraries/LibJS/Print.cpp
@@ -501,7 +501,13 @@ ErrorOr<void> print_data_view(JS::PrintContext& print_context, JS::DataView cons
 {
     TRY(print_type(print_context, "DataView"sv));
     TRY(js_out(print_context, "\n  byteLength: "));
-    TRY(print_value(print_context, JS::Value(data_view.byte_length()), seen_objects));
+    auto get_buffer_byte_length = JS::make_idempotent_array_buffer_byte_length_getter(JS::ArrayBuffer::Order::Unordered);
+    auto byte_length = JS::get_view_byte_length(print_context.vm, data_view, get_buffer_byte_length);
+    if (!byte_length.has_value()) {
+        TRY(js_out(print_context, "(out of bounds)"));
+    } else {
+        TRY(print_value(print_context, JS::Value(byte_length.value()), seen_objects));
+    }
     TRY(js_out(print_context, "\n  byteOffset: "));
     TRY(print_value(print_context, JS::Value(data_view.byte_offset()), seen_objects));
     TRY(js_out(print_context, "\n  buffer: "));

--- a/Userland/Libraries/LibJS/Print.cpp
+++ b/Userland/Libraries/LibJS/Print.cpp
@@ -388,14 +388,20 @@ ErrorOr<void> print_array_buffer(JS::PrintContext& print_context, JS::ArrayBuffe
 
     auto byte_length = array_buffer.byte_length();
     TRY(js_out(print_context, "\n  byteLength: "));
-    TRY(print_value(print_context, JS::Value((double)byte_length), seen_objects));
+    TRY(print_value(print_context, JS::Value(byte_length), seen_objects));
     if (array_buffer.is_detached()) {
-        TRY(js_out(print_context, "\n  Detached"));
+        TRY(js_out(print_context, "\n  (detached)"));
         return {};
     }
 
     if (byte_length == 0)
         return {};
+
+    auto max_byte_length = array_buffer.max_byte_length();
+    if (max_byte_length.has_value()) {
+        TRY(js_out(print_context, "\n  maxByteLength: "));
+        TRY(print_value(print_context, JS::Value(max_byte_length.value()), seen_objects));
+    }
 
     auto& buffer = array_buffer.buffer();
     TRY(js_out(print_context, "\n"));

--- a/Userland/Libraries/LibJS/Print.cpp
+++ b/Userland/Libraries/LibJS/Print.cpp
@@ -445,18 +445,31 @@ ErrorOr<void> print_number(JS::PrintContext& print_context, T number)
 ErrorOr<void> print_typed_array(JS::PrintContext& print_context, JS::TypedArrayBase const& typed_array_base, HashTable<JS::Object*>& seen_objects)
 {
     auto& array_buffer = *typed_array_base.viewed_array_buffer();
-    auto length = typed_array_base.array_length();
+    auto get_buffer_byte_length = JS::make_idempotent_array_buffer_byte_length_getter(JS::ArrayBuffer::Order::SeqCst);
+    auto length = JS::integer_indexed_object_length(print_context.vm, typed_array_base, get_buffer_byte_length);
     TRY(print_type(print_context, typed_array_base.class_name()));
     TRY(js_out(print_context, "\n  length: "));
-    TRY(print_value(print_context, JS::Value(length), seen_objects));
+    if (!length.has_value()) {
+        TRY(js_out(print_context, "out of bounds"));
+        return {};
+    } else if (typed_array_base.is_array_length_auto()) {
+        TRY(js_out(print_context, "auto({})", length.value()));
+    } else {
+        TRY(print_value(print_context, JS::Value(length.value()), seen_objects));
+    }
     TRY(js_out(print_context, "\n  byteLength: "));
-    TRY(print_value(print_context, JS::Value(typed_array_base.byte_length()), seen_objects));
+    auto byte_length = JS::integer_indexed_object_byte_length(print_context.vm, typed_array_base, get_buffer_byte_length);
+    if (typed_array_base.is_byte_length_auto()) {
+        TRY(js_out(print_context, "auto({})", byte_length));
+    } else {
+        TRY(print_value(print_context, JS::Value(byte_length), seen_objects));
+    }
     TRY(js_out(print_context, "\n  buffer: "));
     TRY(print_type(print_context, "ArrayBuffer"sv));
     if (array_buffer.is_detached())
         TRY(js_out(print_context, " (detached)"));
     TRY(js_out(print_context, " @ {:p}", &array_buffer));
-    if (length == 0 || array_buffer.is_detached())
+    if (length.value() == 0 || array_buffer.is_detached())
         return {};
     TRY(js_out(print_context, "\n"));
     // FIXME: This kinda sucks.
@@ -465,7 +478,7 @@ ErrorOr<void> print_typed_array(JS::PrintContext& print_context, JS::TypedArrayB
         TRY(js_out(print_context, "[ "));                                                \
         auto& typed_array = static_cast<JS::ClassName const&>(typed_array_base);         \
         auto data = typed_array.data();                                                  \
-        for (size_t i = 0; i < length; ++i) {                                            \
+        for (size_t i = 0; i < length.value(); ++i) {                                    \
             if (i > 0)                                                                   \
                 TRY(js_out(print_context, ", "));                                        \
             TRY(print_number(print_context, data[i]));                                   \

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
@@ -21,11 +21,14 @@ public:
 private:
     explicit ArrayBufferPrototype(Realm&);
 
+    JS_DECLARE_NATIVE_FUNCTION(resize);
     JS_DECLARE_NATIVE_FUNCTION(slice);
     JS_DECLARE_NATIVE_FUNCTION(transfer);
     JS_DECLARE_NATIVE_FUNCTION(transfer_to_fixed_length);
     JS_DECLARE_NATIVE_FUNCTION(byte_length_getter);
     JS_DECLARE_NATIVE_FUNCTION(detached_getter);
+    JS_DECLARE_NATIVE_FUNCTION(resizable_getter);
+    JS_DECLARE_NATIVE_FUNCTION(max_byte_length_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
@@ -56,7 +56,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayIteratorPrototype::next)
         if (typed_array.viewed_array_buffer()->is_detached())
             return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
 
-        length = typed_array.array_length();
+        length = typed_array.idempotent_array_length();
     } else {
         length = TRY(length_of_array_like(vm, array));
     }

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -345,6 +345,7 @@ namespace JS {
     P(leftContext)                           \
     P(map)                                   \
     P(max)                                   \
+    P(maxByteLength)                         \
     P(maximize)                              \
     P(mergeFields)                           \
     P(message)                               \
@@ -419,6 +420,8 @@ namespace JS {
     P(reject)                                \
     P(relativeTo)                            \
     P(repeat)                                \
+    P(resize)                                \
+    P(resizable)                             \
     P(resolve)                               \
     P(resolvedOptions)                       \
     P(reverse)                               \

--- a/Userland/Libraries/LibJS/Runtime/DataView.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataView.cpp
@@ -8,15 +8,15 @@
 
 namespace JS {
 
-NonnullGCPtr<DataView> DataView::create(Realm& realm, ArrayBuffer* viewed_buffer, size_t byte_length, size_t byte_offset)
+NonnullGCPtr<DataView> DataView::create(Realm& realm, ArrayBuffer* viewed_buffer, Optional<size_t> byte_length, size_t byte_offset)
 {
     return realm.heap().allocate<DataView>(realm, viewed_buffer, byte_length, byte_offset, realm.intrinsics().data_view_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
 }
 
-DataView::DataView(ArrayBuffer* viewed_buffer, size_t byte_length, size_t byte_offset, Object& prototype)
+DataView::DataView(ArrayBuffer* viewed_buffer, Optional<size_t> byte_length, size_t byte_offset, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)
     , m_viewed_array_buffer(viewed_buffer)
-    , m_byte_length(byte_length)
+    , m_byte_length(move(byte_length))
     , m_byte_offset(byte_offset)
 {
 }

--- a/Userland/Libraries/LibJS/Runtime/DataView.h
+++ b/Userland/Libraries/LibJS/Runtime/DataView.h
@@ -12,25 +12,36 @@
 
 namespace JS {
 
+Optional<size_t> get_view_byte_length(VM& vm, DataView const& view, IdempotentArrayBufferByteLengthGetter& get_buffer_byte_length);
+
 class DataView : public Object {
     JS_OBJECT(DataView, Object);
 
 public:
-    static NonnullGCPtr<DataView> create(Realm&, ArrayBuffer*, size_t byte_length, size_t byte_offset);
+    static NonnullGCPtr<DataView> create(Realm&, ArrayBuffer*, Optional<size_t> byte_length, size_t byte_offset);
 
     virtual ~DataView() override = default;
 
     ArrayBuffer* viewed_array_buffer() const { return m_viewed_array_buffer; }
-    size_t byte_length() const { return m_byte_length; }
+    Optional<size_t> byte_length() const { return m_byte_length; }
+    bool is_byte_length_auto() const { return !m_byte_length.has_value(); }
     size_t byte_offset() const { return m_byte_offset; }
 
+    // FIXME: Some functions aren't aware of byte length being OOB in the resizable ArrayBuffers proposal
+    // These functions performs the steps to get the byte length that is used in other parts of the proposal
+    size_t idempotent_byte_length() const
+    {
+        auto get_buffer_byte_length = make_idempotent_array_buffer_byte_length_getter(ArrayBuffer::Order::Unordered);
+        return get_view_byte_length(vm(), *this, get_buffer_byte_length).value_or(0);
+    }
+
 private:
-    DataView(ArrayBuffer*, size_t byte_length, size_t byte_offset, Object& prototype);
+    DataView(ArrayBuffer*, Optional<size_t> byte_length, size_t byte_offset, Object& prototype);
 
     virtual void visit_edges(Visitor& visitor) override;
 
     GCPtr<ArrayBuffer> m_viewed_array_buffer;
-    size_t m_byte_length { 0 };
+    Optional<size_t> m_byte_length { 0 };
     size_t m_byte_offset { 0 };
 };
 

--- a/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
@@ -52,7 +52,10 @@ ThrowCompletionOr<void> DataViewPrototype::initialize(Realm& realm)
     return {};
 }
 
+bool is_view_out_of_bounds(VM& vm, DataView const& view, IdempotentArrayBufferByteLengthGetter& get_buffer_byte_length);
+
 // 25.3.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type ), https://tc39.es/ecma262/#sec-getviewvalue
+// 5.1.3 GetViewValue ( view, requestIndex, isLittleEndian, type ), https://tc39.es/proposal-resizablearraybuffer/#sec-getviewvalue
 template<typename T>
 static ThrowCompletionOr<Value> get_view_value(VM& vm, Value request_index, Value is_little_endian)
 {
@@ -69,31 +72,36 @@ static ThrowCompletionOr<Value> get_view_value(VM& vm, Value request_index, Valu
     // 5. Let buffer be view.[[ViewedArrayBuffer]].
     auto buffer = view->viewed_array_buffer();
 
-    // 6. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-    if (buffer->is_detached())
-        return vm.template throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+    // 6. Let getBufferByteLength be MakeIdempotentArrayBufferByteLengthGetter(Unordered).
+    auto get_buffer_byte_length = make_idempotent_array_buffer_byte_length_getter(ArrayBuffer::Order::Unordered);
 
-    // 7. Let viewOffset be view.[[ByteOffset]].
+    // FIXME: 7. NOTE: Bounds checking is not a synchronizing operation when view's backing buffer is a growable SharedArrayBuffer.
+
+    // 8. Let viewOffset be view.[[ByteOffset]].
     auto view_offset = view->byte_offset();
 
-    // 8. Let viewSize be view.[[ByteLength]].
-    auto view_size = view->byte_length();
+    // 9. Let viewSize be GetViewByteLength(view, getBufferByteLength).
+    auto view_size = get_view_byte_length(vm, *view, get_buffer_byte_length);
 
-    // 9. Let elementSize be the Element Size value specified in Table 68 for Element Type type.
+    // 10. If viewSize is out-of-bounds, throw a TypeError exception.
+    if (!view_size.has_value())
+        return vm.throw_completion<TypeError>(ErrorType::DataViewOverflowOrOutOfBounds, "view size");
+
+    // 11. Let elementSize be the Element Size value specified in Table 68 for Element Type type.
     auto element_size = sizeof(T);
 
-    // 11. Let bufferIndex be getIndex + viewOffset.
+    // 12. Let bufferIndex be getIndex + viewOffset.
     Checked<size_t> buffer_index = get_index;
     buffer_index += view_offset;
 
     Checked<size_t> end_index = get_index;
     end_index += element_size;
 
-    // 10. If getIndex + elementSize > viewSize, throw a RangeError exception.
-    if (buffer_index.has_overflow() || end_index.has_overflow() || end_index.value() > view_size)
-        return vm.throw_completion<RangeError>(ErrorType::DataViewOutOfRangeByteOffset, get_index, view_size);
+    // 13. If getIndex + elementSize > viewSize, throw a RangeError exception.
+    if (buffer_index.has_overflow() || end_index.has_overflow() || end_index.value() > view_size.value())
+        return vm.throw_completion<RangeError>(ErrorType::DataViewOutOfRangeByteOffset, get_index, view_size.value());
 
-    // 12. Return GetValueFromBuffer(buffer, bufferIndex, type, false, Unordered, isLittleEndian).
+    // 14. Return GetValueFromBuffer(buffer, bufferIndex, type, false, Unordered, isLittleEndian).
     return buffer->get_value<T>(buffer_index.value(), false, ArrayBuffer::Order::Unordered, little_endian);
 }
 
@@ -123,15 +131,20 @@ static ThrowCompletionOr<Value> set_view_value(VM& vm, Value request_index, Valu
     // 7. Let buffer be view.[[ViewedArrayBuffer]].
     auto buffer = view->viewed_array_buffer();
 
-    // 8. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-    if (buffer->is_detached())
-        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+    // 8. Let getBufferByteLength be MakeIdempotentArrayBufferByteLengthGetter(Unordered).
+    auto get_buffer_byte_length = make_idempotent_array_buffer_byte_length_getter(ArrayBuffer::Order::Unordered);
 
-    // 9. Let viewOffset be view.[[ByteOffset]].
+    // FIXME: 9. NOTE: Bounds checking is not a synchronizing operation when view's backing buffer is a growable SharedArrayBuffer.
+
+    // 10. Let viewOffset be view.[[ByteOffset]].
     auto view_offset = view->byte_offset();
 
-    // 10. Let viewSize be view.[[ByteLength]].
-    auto view_size = view->byte_length();
+    // 11. Let viewSize be GetViewByteLength(view, getBufferByteLength).
+    auto view_size = get_view_byte_length(vm, *view, get_buffer_byte_length);
+
+    // 12. If viewSize is out-of-bounds, throw a TypeError exception.
+    if (!view_size.has_value())
+        return vm.throw_completion<TypeError>(ErrorType::DataViewOverflowOrOutOfBounds, "view size");
 
     // 11. Let elementSize be the Element Size value specified in Table 68 for Element Type type.
     auto element_size = sizeof(T);
@@ -144,14 +157,73 @@ static ThrowCompletionOr<Value> set_view_value(VM& vm, Value request_index, Valu
     end_index += element_size;
 
     // 12. If getIndex + elementSize > viewSize, throw a RangeError exception.
-    if (buffer_index.has_overflow() || end_index.has_overflow() || end_index.value() > view_size)
-        return vm.throw_completion<RangeError>(ErrorType::DataViewOutOfRangeByteOffset, get_index, view_size);
+    if (buffer_index.has_overflow() || end_index.has_overflow() || end_index.value() > view_size.value())
+        return vm.throw_completion<RangeError>(ErrorType::DataViewOutOfRangeByteOffset, get_index, view_size.value());
 
     // 14. Perform SetValueInBuffer(buffer, bufferIndex, type, numberValue, false, Unordered, isLittleEndian).
     buffer->set_value<T>(buffer_index.value(), number_value, false, ArrayBuffer::Order::Unordered, little_endian);
 
     // 15. Return undefined.
     return js_undefined();
+}
+
+// 5.1.1 GetViewByteLength ( view, getBufferByteLength ), https://tc39.es/proposal-resizablearraybuffer/#sec-getviewbytelength
+Optional<size_t> get_view_byte_length(VM& vm, DataView const& view, IdempotentArrayBufferByteLengthGetter& get_buffer_byte_length)
+{
+    // 1. If IsViewOutOfBounds(view, getBufferByteLength) is true, return out-of-bounds.
+    if (is_view_out_of_bounds(vm, view, get_buffer_byte_length))
+        return {};
+
+    // 2. If view.[[ByteLength]] is not auto, return view.[[ByteLength]].
+    if (!view.is_byte_length_auto())
+        return view.byte_length().value();
+
+    // 3. Let buffer be view.[[ViewedArrayBuffer]].
+    auto buffer = view.viewed_array_buffer();
+
+    // 4. Let bufferByteLength be getBufferByteLength(buffer).
+    auto buffer_byte_length = get_buffer_byte_length(vm, *buffer);
+
+    // 5. Assert: IsResizableArrayBuffer(buffer) is true.
+    VERIFY(buffer->is_resizable());
+
+    // 6. Let byteOffset be view.[[ByteOffset]].
+    auto byte_offset = view.byte_offset();
+
+    // 7. Return bufferByteLength - byteOffset.
+    return buffer_byte_length - byte_offset;
+}
+
+// 5.1.2 IsViewOutOfBounds ( view, getBufferByteLength ), https://tc39.es/proposal-resizablearraybuffer/#sec-isviewoutofbounds
+bool is_view_out_of_bounds(VM& vm, DataView const& view, IdempotentArrayBufferByteLengthGetter& get_buffer_byte_length)
+{
+    // 1. Let buffer be view.[[ViewedArrayBuffer]].
+    auto buffer = view.viewed_array_buffer();
+
+    // 2. If IsDetachedBuffer(buffer) is true, return true.
+    if (buffer->is_detached())
+        return true;
+
+    // 3. Let bufferByteLength be getBufferByteLength(buffer).
+    auto buffer_byte_length = get_buffer_byte_length(vm, *buffer);
+
+    // 4. Let byteOffsetStart be view.[[ByteOffset]].
+    auto byte_offset_start = view.byte_offset();
+
+    // 5. If view.[[ByteLength]] is auto, then
+    // a. Let byteOffsetEnd be bufferByteLength.
+    // 6. Else,
+    // a. Let byteOffsetEnd be byteOffsetStart + view.[[ByteLength]].
+    auto byte_offset_end = view.is_byte_length_auto() ? buffer_byte_length : byte_offset_start + view.byte_length().value();
+
+    // 7. If byteOffsetStart > bufferByteLength or byteOffsetEnd > bufferByteLength, return true.
+    if (byte_offset_start > buffer_byte_length || byte_offset_end > buffer_byte_length)
+        return true;
+
+    // 8. NOTE: 0-length DataViews are not considered out-of-bounds.
+
+    // 9. Return false.
+    return false;
 }
 
 // 25.3.4.1 get DataView.prototype.buffer, https://tc39.es/ecma262/#sec-get-dataview.prototype.buffer
@@ -168,6 +240,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::buffer_getter)
 }
 
 // 25.3.4.2 get DataView.prototype.byteLength, https://tc39.es/ecma262/#sec-get-dataview.prototype.bytelength
+// 5.3.1 get DataView.prototype.byteLength, https://tc39.es/proposal-resizablearraybuffer/#sec-get-dataview.prototype.bytelength
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::byte_length_getter)
 {
     // 1. Let O be the this value.
@@ -176,13 +249,16 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::byte_length_getter)
     auto data_view = TRY(typed_this_value(vm));
 
     // 4. Let buffer be O.[[ViewedArrayBuffer]].
-    // 5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-    if (data_view->viewed_array_buffer()->is_detached())
-        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+    // 5. Let getBufferByteLength be MakeIdempotentArrayBufferByteLengthGetter(SeqCst).
+    auto get_buffer_byte_length = make_idempotent_array_buffer_byte_length_getter(ArrayBuffer::Order::SeqCst);
+
+    // 6. If IsViewOutOfBounds(O, getBufferByteLength) is true, throw a TypeError exception.
+    if (is_view_out_of_bounds(vm, *data_view, get_buffer_byte_length))
+        return vm.throw_completion<TypeError>(ErrorType::TypedArrayOverflowOrOutOfBounds, "byte length");
 
     // 6. Let size be O.[[ByteLength]].
     // 7. Return 𝔽(size).
-    return Value(data_view->byte_length());
+    return Value(get_view_byte_length(vm, *data_view, get_buffer_byte_length).value());
 }
 
 // 25.3.4.3 get DataView.prototype.byteOffset, https://tc39.es/ecma262/#sec-get-dataview.prototype.byteoffset
@@ -194,12 +270,15 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::byte_offset_getter)
     auto data_view = TRY(typed_this_value(vm));
 
     // 4. Let buffer be O.[[ViewedArrayBuffer]].
-    // 5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-    if (data_view->viewed_array_buffer()->is_detached())
-        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+    // 5. Let getBufferByteLength be MakeIdempotentArrayBufferByteLengthGetter(SeqCst).
+    auto get_buffer_byte_length = make_idempotent_array_buffer_byte_length_getter(ArrayBuffer::Order::SeqCst);
 
-    // 6. Let offset be O.[[ByteOffset]].
-    // 7. Return 𝔽(offset).
+    // 6. If IsViewOutOfBounds(O, getBufferByteLength) is true, throw a TypeError exception.
+    if (is_view_out_of_bounds(vm, *data_view, get_buffer_byte_length))
+        return vm.throw_completion<TypeError>(ErrorType::TypedArrayOverflowOrOutOfBounds, "byte offset");
+
+    // 7. Let offset be O.[[ByteOffset]].
+    // 8. Return 𝔽(offset).
     return Value(data_view->byte_offset());
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -58,6 +58,7 @@
     M(IntlNonNumericOr2DigitAfterNumericOr2Digit, "Styles other than 'numeric' and '2-digit' may not be used in smaller units after "   \
                                                   "being used in larger units")                                                         \
     M(InvalidAssignToConst, "Invalid assignment to const variable")                                                                     \
+    M(InvalidByteLengthForResizableArrayBuffer, "Invalid byte length for ArrayBuffer {} when the max byte length is {}")                \
     M(InvalidCodePoint, "Invalid code point {}, must be an integer no less than 0 and no greater than 0x10FFFF")                        \
     M(InvalidFormat, "Invalid {} format")                                                                                               \
     M(InvalidFractionDigits, "Fraction Digits must be an integer no less than 0, and no greater than 100")                              \
@@ -214,6 +215,7 @@
     M(RegExpObjectBadFlag, "Invalid RegExp flag '{}'")                                                                                  \
     M(RegExpObjectRepeatedFlag, "Repeated RegExp flag '{}'")                                                                            \
     M(RegExpObjectIncompatibleFlags, "RegExp flag '{}' is incompatible with flag '{}'")                                                 \
+    M(ResizingNonResizableArray, "Tried to resize an ArrayBuffer that is not resizable")                                                \
     M(RestrictedFunctionPropertiesAccess, "Restricted function properties like 'callee', 'caller' and 'arguments' may "                 \
                                           "not be accessed in strict mode")                                                             \
     M(RestrictedGlobalProperty, "Cannot declare global property '{}'")                                                                  \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -28,6 +28,7 @@
     M(ConstructorWithoutNew, "{} constructor must be called with 'new'")                                                                \
     M(Convert, "Cannot convert {} to {}")                                                                                               \
     M(DataViewOutOfRangeByteOffset, "Data view byte offset {} is out of range for buffer with length {}")                               \
+    M(DataViewOverflowOrOutOfBounds, "Overflow or out of bounds in {}")                                                                 \
     M(DerivedConstructorReturningInvalidValue, "Derived constructor return invalid value")                                              \
     M(DescWriteNonWritable, "Cannot write to non-writable property '{}'")                                                               \
     M(DetachedArrayBuffer, "ArrayBuffer is detached")                                                                                   \

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -18,6 +18,7 @@
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
+#include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/BoundFunction.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
@@ -167,6 +168,22 @@ VM::VM(OwnPtr<CustomData> custom_data, ErrorMessages error_messages)
         // This abstract operation is only invoked by ECMAScript hosts that are web browsers.
         // NOTE: Since LibJS has no way of knowing whether the current environment is a browser we always
         //       call HostEnsureCanAddPrivateElement when needed.
+    };
+
+    // 1.1.7 HostResizeArrayBuffer ( buffer, newByteLength ), https://tc39.es/proposal-resizablearraybuffer/#sec-hostresizearraybuffer
+    host_resize_array_buffer = [this](ArrayBuffer& buffer, size_t new_byte_length) -> ThrowCompletionOr<HostHandled> {
+        // The host-defined abstract operation HostResizeArrayBuffer takes arguments buffer (an ArrayBuffer)
+        // and newByteLength (a non-negative integer) and returns either a normal completion containing either handled or unhandled,
+        // or a throw completion. The host-defined abstract operation HostResizeArrayBuffer takes arguments buffer (an ArrayBuffer object)
+        // and newByteLength. It gives the host an opportunity to perform implementation-defined resizing of buffer.
+        // If the host chooses not to handle resizing of buffer, it may return unhandled for the default behaviour.
+        // The implementation of HostResizeArrayBuffer must conform to the following requirements:
+        // - The abstract operation must return either NormalCompletion(handled), NormalCompletion(unhandled), or an abrupt throw completion.
+        // - The abstract operation does not detach buffer.
+        // - If the abstract operation completes normally with handled, buffer.[[ArrayBufferByteLength]] is newByteLength.
+        // The default implementation of HostResizeArrayBuffer is to return unhandled.
+        TRY_OR_THROW_OOM(*this, buffer.buffer().try_resize(new_byte_length));
+        return HostHandled::Handled;
     };
 }
 

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -29,6 +29,11 @@ namespace JS {
 class Identifier;
 struct BindingPattern;
 
+enum class HostHandled {
+    Handled,
+    Unhandled
+};
+
 class VM : public RefCounted<VM> {
 public:
     struct CustomData {
@@ -270,6 +275,7 @@ public:
     Function<JobCallback(FunctionObject&)> host_make_job_callback;
     Function<ThrowCompletionOr<void>(Realm&)> host_ensure_can_compile_strings;
     Function<ThrowCompletionOr<void>(Object&)> host_ensure_can_add_private_element;
+    Function<ThrowCompletionOr<HostHandled>(ArrayBuffer&, size_t)> host_resize_array_buffer;
 
     // Execute a specific AST node either in AST or BC interpreter, depending on which one is enabled by default.
     // NOTE: This is meant as a temporary stopgap until everything is bytecode.

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.constructor.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.constructor.js
@@ -1,0 +1,12 @@
+test("invalid maxByteLength throws", () => {
+    expect(() => {
+        new ArrayBuffer(8, { maxByteLength: 4 });
+    }).toThrowWithMessage(
+        RangeError,
+        "Invalid byte length for ArrayBuffer 8 when the max byte length is 4"
+    );
+
+    expect(() => {
+        new ArrayBuffer(8, { maxByteLength: -1 });
+    }).toThrowWithMessage(RangeError, "Index must be a positive integer");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.maxByteLength.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.maxByteLength.js
@@ -1,0 +1,21 @@
+test("basic functionality", () => {
+    expect(new ArrayBuffer(0, { maxByteLength: 0 }).maxByteLength).toBe(0);
+    expect(new ArrayBuffer(0, { maxByteLength: 1 }).maxByteLength).toBe(1);
+    expect(new ArrayBuffer(0, { maxByteLength: 64 }).maxByteLength).toBe(64);
+    expect(new ArrayBuffer(0, { maxByteLength: 128 }).maxByteLength).toBe(128);
+});
+
+test("maxByteLength returning byteLength", () => {
+    expect(new ArrayBuffer(0).maxByteLength).toBe(0);
+    expect(new ArrayBuffer(1).maxByteLength).toBe(1);
+    expect(new ArrayBuffer(64).maxByteLength).toBe(64);
+    expect(new ArrayBuffer(128).maxByteLength).toBe(128);
+});
+
+test("detached returns 0", () => {
+    let source = new ArrayBuffer(8, { maxByteLength: 16 });
+    let dest = source.transfer();
+
+    expect(source.maxByteLength).toBe(0);
+    expect(dest.maxByteLength).toBe(16);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resizable.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resizable.js
@@ -1,0 +1,6 @@
+test("basic functionality", () => {
+    expect(new ArrayBuffer().resizable).toBeFalse();
+    expect(new ArrayBuffer(0, { byteLength: 16 }).resizable).toBeFalse();
+    expect(new ArrayBuffer(0, { maxByteLength: 0 }).resizable).toBeTrue();
+    expect(new ArrayBuffer(16, { maxByteLength: 16 }).resizable).toBeTrue();
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resize.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resize.js
@@ -1,0 +1,28 @@
+test("basic functionality", () => {
+    const resizableBuffer = new ArrayBuffer(8, { maxByteLength: 16 });
+
+    expect(resizableBuffer.resize(8)).toBeUndefined();
+    expect(resizableBuffer.resize(0)).toBeUndefined();
+    expect(resizableBuffer.resize(16)).toBeUndefined();
+
+    expect(() => {
+        resizableBuffer.resize(-1);
+    }).toThrowWithMessage(
+        RangeError,
+        "Invalid byte length for ArrayBuffer -1 when the max byte length is 16"
+    );
+    expect(() => {
+        resizableBuffer.resize(17);
+    }).toThrowWithMessage(
+        RangeError,
+        "Invalid byte length for ArrayBuffer 17 when the max byte length is 16"
+    );
+});
+
+test("un-resizable buffer should throw", () => {
+    const staticBuffer = new ArrayBuffer(8);
+
+    expect(() => {
+        staticBuffer.resize(0);
+    }).toThrowWithMessage(TypeError, "Tried to resize an ArrayBuffer that is not resizable");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.transfer.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.transfer.js
@@ -1,0 +1,25 @@
+test("basic functionality", () => {
+    const emptyArray = new ArrayBuffer(0);
+    const emptyDest = emptyArray.transfer();
+
+    expect(emptyArray.detached).toBe(true);
+    expect(emptyDest.detached).toBe(false);
+    expect(emptyDest.byteLength).toBe(0);
+    expect(emptyDest.maxByteLength).toBe(0);
+
+    const resizableArray = new ArrayBuffer(8, { maxByteLength: 16 });
+    const fullView = new Uint8Array(resizableArray);
+    fullView[0] = 1;
+
+    const resizableDest = resizableArray.transfer();
+    const fullDestView = new Uint8Array(resizableDest);
+
+    expect(resizableArray.detached).toBe(true);
+    expect(resizableDest.detached).toBe(false);
+    expect(resizableDest.resizable).toBe(true);
+    expect(fullView.byteLength).toBe(0);
+    expect(resizableDest.byteLength).toBe(8);
+    expect(resizableDest.maxByteLength).toBe(16);
+    expect(fullDestView.byteLength).toBe(8);
+    expect(fullDestView[0]).toBe(1);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.transferToFixedLength.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.transferToFixedLength.js
@@ -1,0 +1,33 @@
+test("basic functionality", () => {
+    const emptyArray = new ArrayBuffer(0);
+    const emptyDest = emptyArray.transferToFixedLength();
+
+    expect(emptyArray.detached).toBe(true);
+    expect(emptyDest.detached).toBe(false);
+    expect(emptyDest.byteLength).toBe(0);
+    expect(emptyDest.maxByteLength).toBe(0);
+
+    const resizableArray = new ArrayBuffer(8, { maxByteLength: 16 });
+    const resizableDest = resizableArray.transferToFixedLength();
+
+    expect(resizableArray.detached).toBe(true);
+    expect(resizableDest.detached).toBe(false);
+    expect(resizableDest.resizable).toBe(false);
+    expect(resizableDest.byteLength).toBe(8);
+    expect(resizableDest.maxByteLength).toBe(8);
+
+    const staticArray = new ArrayBuffer(8);
+    const fullView = new Uint8Array(staticArray);
+    fullView[0] = 1;
+
+    const staticDest = staticArray.transferToFixedLength();
+    const fullDestView = new Uint8Array(staticDest);
+
+    expect(staticArray.detached).toBe(true);
+    expect(fullView.byteLength).toBe(0);
+    expect(staticDest.detached).toBe(false);
+    expect(staticDest.byteLength).toBe(8);
+    expect(staticDest.maxByteLength).toBe(8);
+    expect(fullDestView.byteLength).toBe(8);
+    expect(fullDestView[0]).toBe(1);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.js
@@ -390,3 +390,19 @@ test("source is not the same value as the receiver, and the index is invalid", (
         expect(receiver[2]).toBeUndefined();
     });
 });
+
+test("resizing array buffer changes typed array length", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const resizable = new ArrayBuffer(4 * T.BYTES_PER_ELEMENT, {
+            maxByteLength: 8 * T.BYTES_PER_ELEMENT,
+        });
+        const array = new T(resizable);
+        expect(array.byteLength).toBe(4 * T.BYTES_PER_ELEMENT);
+
+        resizable.resize(8 * T.BYTES_PER_ELEMENT);
+        expect(array.byteLength).toBe(8 * T.BYTES_PER_ELEMENT);
+
+        resizable.resize(0);
+        expect(array.byteLength).toBe(0);
+    });
+});

--- a/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
@@ -52,7 +52,7 @@ WebIDL::ExceptionOr<JS::Value> Crypto::get_random_values(JS::Value array) const
     auto& typed_array = static_cast<JS::TypedArrayBase&>(array.as_object());
 
     // 2. If the byteLength of array is greater than 65536, throw a QuotaExceededError and terminate the algorithm.
-    if (typed_array.byte_length() > 65536)
+    if (typed_array.idempotent_byte_length() > 65536)
         return WebIDL::QuotaExceededError::create(realm(), "array's byteLength may not be greater than 65536");
 
     // IMPLEMENTATION DEFINED: If the viewed array buffer is detached, throw a InvalidStateError and terminate the algorithm.

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -1348,7 +1348,7 @@ WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue(ReadableByteSt
     auto byte_offset = typed_array->byte_offset();
 
     // 5. Let byteLength be chunk.[[ByteLength]].
-    auto byte_length = typed_array->byte_length();
+    auto byte_length = typed_array->idempotent_byte_length();
 
     // 6. If ! IsDetachedBuffer(buffer) is true, throw a TypeError exception.
     if (buffer->is_detached()) {

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -308,7 +308,7 @@ JS::ThrowCompletionOr<size_t> parse_module(JS::VM& vm, JS::Object* buffer_object
         data = buffer.buffer();
     } else if (is<JS::TypedArrayBase>(buffer_object)) {
         auto& buffer = static_cast<JS::TypedArrayBase&>(*buffer_object);
-        data = buffer.viewed_array_buffer()->buffer().span().slice(buffer.byte_offset(), buffer.byte_length());
+        data = buffer.viewed_array_buffer()->buffer().span().slice(buffer.byte_offset(), buffer.idempotent_byte_length());
     } else if (is<JS::DataView>(buffer_object)) {
         auto& buffer = static_cast<JS::DataView&>(*buffer_object);
         data = buffer.viewed_array_buffer()->buffer().span().slice(buffer.byte_offset(), buffer.byte_length());

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -311,7 +311,7 @@ JS::ThrowCompletionOr<size_t> parse_module(JS::VM& vm, JS::Object* buffer_object
         data = buffer.viewed_array_buffer()->buffer().span().slice(buffer.byte_offset(), buffer.idempotent_byte_length());
     } else if (is<JS::DataView>(buffer_object)) {
         auto& buffer = static_cast<JS::DataView&>(*buffer_object);
-        data = buffer.viewed_array_buffer()->buffer().span().slice(buffer.byte_offset(), buffer.byte_length());
+        data = buffer.viewed_array_buffer()->buffer().span().slice(buffer.byte_offset(), buffer.idempotent_byte_length());
     } else {
         return vm.throw_completion<JS::TypeError>("Not a BufferSource"sv);
     }

--- a/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -53,7 +53,7 @@ ErrorOr<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source)
         offset = es_buffer_source.byte_offset();
 
         // 3. Set length to esBufferSource.[[ByteLength]].
-        length = es_buffer_source.byte_length();
+        length = es_buffer_source.idempotent_byte_length();
     }
     // 6. Otherwise:
     else {

--- a/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -42,7 +42,7 @@ ErrorOr<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source)
         offset = es_buffer_source.byte_offset();
 
         // 3. Set length to esBufferSource.[[ByteLength]].
-        length = es_buffer_source.byte_length();
+        length = es_buffer_source.idempotent_byte_length();
     } else if (is<JS::DataView>(buffer_source)) {
         auto const& es_buffer_source = static_cast<JS::DataView const&>(buffer_source);
 


### PR DESCRIPTION
This pr fully supports resizable ArrayBuffers, as well as support for TypedArray/DataViews to have internal resizable ArrayBuffers.

[Link to proposal](https://tc39.es/proposal-resizablearraybuffer/)

Test262 Diff: ✅ +236 ❌ -236 :^)