### PR TITLE
LibJS: Handle `Call`s argument range during `EliminateLoads` pass

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -794,6 +794,9 @@ public:
     Register this_value() const { return m_this_value; }
     Optional<StringTableIndex> const& expression_string() const { return m_expression_string; }
 
+    Register first_argument() const { return m_first_argument; }
+    u32 argument_count() const { return m_argument_count; }
+
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
     void replace_references_impl(BasicBlock const&, BasicBlock const&) { }

--- a/Userland/Libraries/LibJS/Bytecode/Pass/LoadElimination.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/LoadElimination.cpp
@@ -20,6 +20,10 @@ static NonnullOwnPtr<BasicBlock> eliminate_loads(BasicBlock const& block, size_t
             Op::NewArray const& array_instruction = static_cast<Op::NewArray const&>(*it);
             if (size_t element_count = array_instruction.element_count())
                 array_ranges.set_range<true, false>(array_instruction.start().index(), element_count);
+        } else if ((*it).type() == Instruction::Type::Call) {
+            auto const& call_instruction = static_cast<Op::Call const&>(*it);
+            if (size_t element_count = call_instruction.argument_count())
+                array_ranges.set_range<true, false>(call_instruction.first_argument().index(), element_count);
         }
     }
 


### PR DESCRIPTION
Otherwise we could forget to emit stores those registers, thinking that they are only directly accessed.

----

Fixes all optimized bytecode regressions caused by c37b204