### PR TITLE
LibWeb: Merge DOM::Element parse_attribute() and did_remove_attribute() into a single attribute_changed()

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -145,7 +145,7 @@ WebIDL::ExceptionOr<void> Element::set_attribute(DeprecatedFlyString const& name
         attribute->set_value(value);
     }
 
-    parse_attribute(attribute->local_name(), value);
+    attribute_changed(attribute->local_name(), value);
 
     if (value != old_value) {
         invalidate_style_after_attribute_change(name);
@@ -261,7 +261,7 @@ WebIDL::ExceptionOr<bool> Element::toggle_attribute(DeprecatedFlyString const& n
             auto new_attribute = TRY(Attr::create(document(), insert_as_lowercase ? name.to_lowercase() : name, ""));
             m_attributes->append_attribute(new_attribute);
 
-            parse_attribute(new_attribute->local_name(), "");
+            attribute_changed(new_attribute->local_name(), "");
 
             invalidate_style_after_attribute_change(name);
 
@@ -361,7 +361,7 @@ CSS::CSSStyleDeclaration const* Element::inline_style() const
     return m_inline_style.ptr();
 }
 
-void Element::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void Element::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
     if (name == HTML::AttributeNames::class_) {
         auto new_classes = value.split_view(Infra::is_ascii_whitespace);

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -122,7 +122,6 @@ public:
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const { }
     virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value);
-    virtual void did_remove_attribute(DeprecatedFlyString const&);
 
     struct [[nodiscard]] RequiredInvalidationAfterStyleChange {
         bool repaint { false };

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -121,7 +121,7 @@ public:
     Vector<FlyString> const& class_names() const { return m_classes; }
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const { }
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value);
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value);
     virtual void did_remove_attribute(DeprecatedFlyString const&);
 
     struct [[nodiscard]] RequiredInvalidationAfterStyleChange {

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -703,7 +703,7 @@ JS::ThrowCompletionOr<void> EventTarget::process_event_handler_for_event(FlyStri
 // https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-attributes:concept-element-attributes-change-ext
 void EventTarget::element_event_handler_attribute_changed(FlyString const& local_name, Optional<String> const& value)
 {
-    // NOTE: Step 1 of this algorithm was handled in HTMLElement::parse_attribute.
+    // NOTE: Step 1 of this algorithm was handled in HTMLElement::attribute_changed.
 
     // 2. Let eventTarget be the result of determining the target of an event handler given element and localName.
     // NOTE: element is `this`.

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -29,9 +29,9 @@ JS::ThrowCompletionOr<void> HTMLAnchorElement::initialize(JS::Realm& realm)
     return {};
 }
 
-void HTMLAnchorElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLAnchorElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    HTMLElement::parse_attribute(name, value);
+    HTMLElement::attribute_changed(name, value);
     if (name == HTML::AttributeNames::href) {
         set_the_url();
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -43,7 +43,7 @@ private:
     void run_activation_behavior(Web::DOM::Event const&);
 
     // ^DOM::Element
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
     virtual i32 default_tab_index_value() const override;
 
     // ^HTML::HTMLHyperlinkElementUtils

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -25,9 +25,9 @@ JS::ThrowCompletionOr<void> HTMLAreaElement::initialize(JS::Realm& realm)
     return {};
 }
 
-void HTMLAreaElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLAreaElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    HTMLElement::parse_attribute(name, value);
+    HTMLElement::attribute_changed(name, value);
     if (name == HTML::AttributeNames::href) {
         set_the_url();
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
@@ -26,7 +26,7 @@ private:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
     // ^DOM::Element
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
     virtual i32 default_tab_index_value() const override;
 
     // ^HTML::HTMLHyperlinkElementUtils

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -45,9 +45,9 @@ void HTMLBaseElement::removed_from(Node* parent)
     document().update_base_element({});
 }
 
-void HTMLBaseElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLBaseElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    HTMLElement::parse_attribute(name, value);
+    HTMLElement::attribute_changed(name, value);
 
     // The frozen base URL must be immediately set for an element whenever any of the following situations occur:
     // - The base element is the first base element in tree order with an href content attribute in its Document, and its href content attribute is changed.

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.h
@@ -23,7 +23,7 @@ public:
 
     virtual void inserted() override;
     virtual void removed_from(Node*) override;
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
 private:
     HTMLBaseElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -50,9 +50,9 @@ void HTMLBodyElement::apply_presentational_hints(CSS::StyleProperties& style) co
     });
 }
 
-void HTMLBodyElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLBodyElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    HTMLElement::parse_attribute(name, value);
+    HTMLElement::attribute_changed(name, value);
     if (name.equals_ignoring_ascii_case("link"sv)) {
         // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-3
         auto color = parse_legacy_color_value(value);

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
@@ -20,7 +20,7 @@ class HTMLBodyElement final
 public:
     virtual ~HTMLBodyElement() override;
 
-    virtual void parse_attribute(DeprecatedFlyString const&, DeprecatedString const&) override;
+    virtual void attribute_changed(DeprecatedFlyString const&, DeprecatedString const&) override;
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
     // https://www.w3.org/TR/html-aria/#el-body

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -228,9 +228,9 @@ bool HTMLElement::cannot_navigate() const
     return !is<HTML::HTMLAnchorElement>(this) && !is_connected();
 }
 
-void HTMLElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    Element::parse_attribute(name, value);
+    Element::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::contenteditable) {
         if ((!value.is_null() && value.is_empty()) || value.equals_ignoring_ascii_case("true"sv)) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -233,15 +233,19 @@ void HTMLElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedS
     Element::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::contenteditable) {
-        if ((!value.is_null() && value.is_empty()) || value.equals_ignoring_ascii_case("true"sv)) {
-            // "true", an empty string or a missing value map to the "true" state.
-            m_content_editable_state = ContentEditableState::True;
-        } else if (value.equals_ignoring_ascii_case("false"sv)) {
-            // "false" maps to the "false" state.
-            m_content_editable_state = ContentEditableState::False;
-        } else {
-            // Having no such attribute or an invalid value maps to the "inherit" state.
+        if (value.is_null()) {
             m_content_editable_state = ContentEditableState::Inherit;
+        } else {
+            if (value.is_empty() || value.equals_ignoring_ascii_case("true"sv)) {
+                // "true", an empty string or a missing value map to the "true" state.
+                m_content_editable_state = ContentEditableState::True;
+            } else if (value.equals_ignoring_ascii_case("false"sv)) {
+                // "false" maps to the "false" state.
+                m_content_editable_state = ContentEditableState::False;
+            } else {
+                // Having no such attribute or an invalid value maps to the "inherit" state.
+                m_content_editable_state = ContentEditableState::Inherit;
+            }
         }
     }
 
@@ -254,14 +258,6 @@ void HTMLElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedS
     }
     ENUMERATE_GLOBAL_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE
-}
-
-void HTMLElement::did_remove_attribute(DeprecatedFlyString const& name)
-{
-    Base::did_remove_attribute(name);
-    if (name == HTML::AttributeNames::contenteditable) {
-        m_content_editable_state = ContentEditableState::Inherit;
-    }
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-focus

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -71,7 +71,6 @@ protected:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
     virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
-    virtual void did_remove_attribute(DeprecatedFlyString const& name) override;
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -70,7 +70,7 @@ protected:
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
     virtual void did_remove_attribute(DeprecatedFlyString const& name) override;
 
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
@@ -25,9 +25,9 @@ JS::ThrowCompletionOr<void> HTMLFrameSetElement::initialize(JS::Realm& realm)
     return {};
 }
 
-void HTMLFrameSetElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLFrameSetElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    HTMLElement::parse_attribute(name, value);
+    HTMLElement::attribute_changed(name, value);
 
 #undef __ENUMERATE
 #define __ENUMERATE(attribute_name, event_name)                                                                     \

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
@@ -24,7 +24,7 @@ private:
     HTMLFrameSetElement(DOM::Document&, DOM::QualifiedName);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
-    virtual void parse_attribute(DeprecatedFlyString const&, DeprecatedString const&) override;
+    virtual void attribute_changed(DeprecatedFlyString const&, DeprecatedString const&) override;
 
     // ^HTML::GlobalEventHandlers
     virtual EventTarget& global_event_handlers_to_event_target(FlyString const& event_name) override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -34,9 +34,9 @@ JS::GCPtr<Layout::Node> HTMLIFrameElement::create_layout_node(NonnullRefPtr<CSS:
     return heap().allocate_without_realm<Layout::FrameBox>(document(), *this, move(style));
 }
 
-void HTMLIFrameElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLIFrameElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    HTMLElement::parse_attribute(name, value);
+    HTMLElement::attribute_changed(name, value);
     if (name == HTML::AttributeNames::src)
         load_src(value);
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -33,7 +33,7 @@ private:
     // ^DOM::Element
     virtual void inserted() override;
     virtual void removed_from(Node*) override;
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
     virtual i32 default_tab_index_value() const override;
 
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#process-the-iframe-attributes

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -80,7 +80,11 @@ void HTMLImageElement::attribute_changed(DeprecatedFlyString const& name, Deprec
     HTMLElement::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::crossorigin) {
-        m_cors_setting = cors_setting_attribute_from_keyword(String::from_deprecated_string(value).release_value_but_fixme_should_propagate_errors());
+        if (value.is_null()) {
+            m_cors_setting = CORSSettingAttribute::NoCORS;
+        } else {
+            m_cors_setting = cors_setting_attribute_from_keyword(String::from_deprecated_string(value).release_value_but_fixme_should_propagate_errors());
+        }
     }
 
     if (name.is_one_of(HTML::AttributeNames::src, HTML::AttributeNames::srcset)) {
@@ -90,15 +94,6 @@ void HTMLImageElement::attribute_changed(DeprecatedFlyString const& name, Deprec
     if (name == HTML::AttributeNames::alt) {
         if (layout_node())
             verify_cast<Layout::ImageBox>(*layout_node()).dom_node_did_update_alt_text({});
-    }
-}
-
-void HTMLImageElement::did_remove_attribute(DeprecatedFlyString const& name)
-{
-    Base::did_remove_attribute(name);
-
-    if (name == HTML::AttributeNames::crossorigin) {
-        m_cors_setting = CORSSettingAttribute::NoCORS;
     }
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -75,9 +75,9 @@ void HTMLImageElement::apply_presentational_hints(CSS::StyleProperties& style) c
     });
 }
 
-void HTMLImageElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLImageElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    HTMLElement::parse_attribute(name, value);
+    HTMLElement::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::crossorigin) {
         m_cors_setting = cors_setting_attribute_from_keyword(String::from_deprecated_string(value).release_value_but_fixme_should_propagate_errors());

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -29,7 +29,6 @@ public:
     virtual ~HTMLImageElement() override;
 
     virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
-    virtual void did_remove_attribute(DeprecatedFlyString const& name) override;
 
     DeprecatedString alt() const { return attribute(HTML::AttributeNames::alt); }
     DeprecatedString src() const { return attribute(HTML::AttributeNames::src); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -28,7 +28,7 @@ class HTMLImageElement final
 public:
     virtual ~HTMLImageElement() override;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
     virtual void did_remove_attribute(DeprecatedFlyString const& name) override;
 
     DeprecatedString alt() const { return attribute(HTML::AttributeNames::alt); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -493,9 +493,9 @@ void HTMLInputElement::did_lose_focus()
     });
 }
 
-void HTMLInputElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLInputElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    HTMLElement::parse_attribute(name, value);
+    HTMLElement::attribute_changed(name, value);
     if (name == HTML::AttributeNames::checked) {
         // When the checked content attribute is added, if the control does not have dirty checkedness,
         // the user agent must set the checkedness of the element to true

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -105,7 +105,6 @@ public:
 
     // ^HTMLElement
     virtual void attribute_changed(DeprecatedFlyString const&, DeprecatedString const&) override;
-    virtual void did_remove_attribute(DeprecatedFlyString const&) override;
 
     // ^FormAssociatedElement
     // https://html.spec.whatwg.org/multipage/forms.html#category-listed

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -104,7 +104,7 @@ public:
     virtual bool is_focusable() const override { return m_type != TypeAttributeState::Hidden; }
 
     // ^HTMLElement
-    virtual void parse_attribute(DeprecatedFlyString const&, DeprecatedString const&) override;
+    virtual void attribute_changed(DeprecatedFlyString const&, DeprecatedString const&) override;
     virtual void did_remove_attribute(DeprecatedFlyString const&) override;
 
     // ^FormAssociatedElement

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -77,9 +77,9 @@ bool HTMLLinkElement::has_loaded_icon() const
     return m_relationship & Relationship::Icon && resource() && resource()->is_loaded() && resource()->has_encoded_data();
 }
 
-void HTMLLinkElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLLinkElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    HTMLElement::parse_attribute(name, value);
+    HTMLElement::attribute_changed(name, value);
 
     // 4.6.7 Link types - https://html.spec.whatwg.org/multipage/links.html#linkTypes
     if (name == HTML::AttributeNames::rel) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -149,25 +149,6 @@ void HTMLLinkElement::resource_did_load()
     }
 }
 
-void HTMLLinkElement::did_remove_attribute(DeprecatedFlyString const& attr)
-{
-    if (m_relationship & Relationship::Stylesheet) {
-        // https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet:fetch-and-process-the-linked-resource
-        // The appropriate times to fetch and process this type of link are:
-        if (
-            // - When the href attribute of the link element of an external resource link that is already browsing-context connected is changed.
-            attr == AttributeNames::href ||
-            // - When the disabled attribute of the link element of an external resource link that is already browsing-context connected is set, changed, or removed.
-            attr == AttributeNames::disabled ||
-            // - When the crossorigin attribute of the link element of an external resource link that is already browsing-context connected is set, changed, or removed.
-            attr == AttributeNames::crossorigin
-            // FIXME: - When the type attribute of the link element of an external resource link that is already browsing-context connected, but was previously not obtained due to the type attribute specifying an unsupported type, is removed or changed.
-        ) {
-            fetch_and_process_linked_resource();
-        }
-    }
-}
-
 // https://html.spec.whatwg.org/multipage/semantics.html#create-link-options-from-element
 HTMLLinkElement::LinkProcessingOptions HTMLLinkElement::create_link_options()
 {

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -39,7 +39,7 @@ private:
     HTMLLinkElement(DOM::Document&, DOM::QualifiedName);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
-    void parse_attribute(DeprecatedFlyString const&, DeprecatedString const&) override;
+    void attribute_changed(DeprecatedFlyString const&, DeprecatedString const&) override;
 
     // ^ResourceClient
     virtual void resource_did_fail() override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -46,7 +46,6 @@ private:
     virtual void resource_did_load() override;
 
     // ^ HTMLElement
-    virtual void did_remove_attribute(DeprecatedFlyString const&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
     struct LinkProcessingOptions {

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -88,20 +88,16 @@ void HTMLMediaElement::attribute_changed(DeprecatedFlyString const& name, Deprec
 {
     Base::attribute_changed(name, value);
 
-    if (name == HTML::AttributeNames::src)
+    if (name == HTML::AttributeNames::src) {
         load_element().release_value_but_fixme_should_propagate_errors();
-    else if (name == HTML::AttributeNames::crossorigin)
-        m_crossorigin = cors_setting_attribute_from_keyword(String::from_deprecated_string(value).release_value_but_fixme_should_propagate_errors());
-    else if (name == HTML::AttributeNames::muted)
+    } else if (name == HTML::AttributeNames::crossorigin) {
+        if (value.is_null())
+            m_crossorigin = cors_setting_attribute_from_keyword({});
+        else
+            m_crossorigin = cors_setting_attribute_from_keyword(String::from_deprecated_string(value).release_value_but_fixme_should_propagate_errors());
+    } else if (name == HTML::AttributeNames::muted) {
         set_muted(true);
-}
-
-void HTMLMediaElement::did_remove_attribute(DeprecatedFlyString const& name)
-{
-    Base::did_remove_attribute(name);
-
-    if (name == HTML::AttributeNames::crossorigin)
-        m_crossorigin = cors_setting_attribute_from_keyword({});
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#playing-the-media-resource:media-element-83

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -84,9 +84,9 @@ void HTMLMediaElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_fetch_controller);
 }
 
-void HTMLMediaElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLMediaElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    Base::parse_attribute(name, value);
+    Base::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::src)
         load_element().release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -124,7 +124,7 @@ protected:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
     virtual void did_remove_attribute(DeprecatedFlyString const&) override;
     virtual void removed_from(DOM::Node*) override;
     virtual void children_changed() override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -125,7 +125,6 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
-    virtual void did_remove_attribute(DeprecatedFlyString const&) override;
     virtual void removed_from(DOM::Node*) override;
     virtual void children_changed() override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -41,9 +41,9 @@ JS::ThrowCompletionOr<void> HTMLObjectElement::initialize(JS::Realm& realm)
     return {};
 }
 
-void HTMLObjectElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLObjectElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    NavigableContainer::parse_attribute(name, value);
+    NavigableContainer::attribute_changed(name, value);
 
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element
     // Whenever one of the following conditions occur:

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -34,7 +34,7 @@ class HTMLObjectElement final
 public:
     virtual ~HTMLObjectElement() override;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     DeprecatedString data() const;
     void set_data(DeprecatedString const& data) { MUST(set_attribute(HTML::AttributeNames::data, data)); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -33,9 +33,9 @@ JS::ThrowCompletionOr<void> HTMLOptionElement::initialize(JS::Realm& realm)
     return {};
 }
 
-void HTMLOptionElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLOptionElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    HTMLElement::parse_attribute(name, value);
+    HTMLElement::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::selected) {
         // Except where otherwise specified, when the element is created, its selectedness must be set to true

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -38,22 +38,17 @@ void HTMLOptionElement::attribute_changed(DeprecatedFlyString const& name, Depre
     HTMLElement::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::selected) {
-        // Except where otherwise specified, when the element is created, its selectedness must be set to true
-        // if the element has a selected attribute. Whenever an option element's selected attribute is added,
-        // if its dirtiness is false, its selectedness must be set to true.
-        if (!m_dirty)
-            m_selected = true;
-    }
-}
-
-void HTMLOptionElement::did_remove_attribute(DeprecatedFlyString const& name)
-{
-    HTMLElement::did_remove_attribute(name);
-
-    if (name == HTML::AttributeNames::selected) {
-        // Whenever an option element's selected attribute is removed, if its dirtiness is false, its selectedness must be set to false.
-        if (!m_dirty)
-            m_selected = false;
+        if (value.is_null()) {
+            // Whenever an option element's selected attribute is removed, if its dirtiness is false, its selectedness must be set to false.
+            if (!m_dirty)
+                m_selected = false;
+        } else {
+            // Except where otherwise specified, when the element is created, its selectedness must be set to true
+            // if the element has a selected attribute. Whenever an option element's selected attribute is added,
+            // if its dirtiness is false, its selectedness must be set to true.
+            if (!m_dirty)
+                m_selected = true;
+        }
     }
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -40,7 +40,7 @@ private:
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
-    void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
     void did_remove_attribute(DeprecatedFlyString const& name) override;
 
     void ask_for_a_reset();

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -41,7 +41,6 @@ private:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
     void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
-    void did_remove_attribute(DeprecatedFlyString const& name) override;
 
     void ask_for_a_reset();
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -51,20 +51,17 @@ void HTMLScriptElement::attribute_changed(DeprecatedFlyString const& name, Depre
 {
     Base::attribute_changed(name, value);
 
-    if (name == HTML::AttributeNames::crossorigin)
-        m_crossorigin = cors_setting_attribute_from_keyword(String::from_deprecated_string(value).release_value_but_fixme_should_propagate_errors());
-    else if (name == HTML::AttributeNames::referrerpolicy)
-        m_referrer_policy = ReferrerPolicy::from_string(value);
-}
-
-void HTMLScriptElement::did_remove_attribute(DeprecatedFlyString const& name)
-{
-    Base::did_remove_attribute(name);
-
-    if (name == HTML::AttributeNames::crossorigin)
-        m_crossorigin = cors_setting_attribute_from_keyword({});
-    else if (name == HTML::AttributeNames::referrerpolicy)
-        m_referrer_policy.clear();
+    if (name == HTML::AttributeNames::crossorigin) {
+        if (value.is_null())
+            m_crossorigin = cors_setting_attribute_from_keyword({});
+        else
+            m_crossorigin = cors_setting_attribute_from_keyword(String::from_deprecated_string(value).release_value_but_fixme_should_propagate_errors());
+    } else if (name == HTML::AttributeNames::referrerpolicy) {
+        if (value.is_null())
+            m_referrer_policy.clear();
+        else
+            m_referrer_policy = ReferrerPolicy::from_string(value);
+    }
 }
 
 void HTMLScriptElement::begin_delaying_document_load_event(DOM::Document& document)

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -47,9 +47,9 @@ void HTMLScriptElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_preparation_time_document.ptr());
 }
 
-void HTMLScriptElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLScriptElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    Base::parse_attribute(name, value);
+    Base::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::crossorigin)
         m_crossorigin = cors_setting_attribute_from_keyword(String::from_deprecated_string(value).release_value_but_fixme_should_propagate_errors());

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -63,7 +63,6 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
-    virtual void did_remove_attribute(DeprecatedFlyString const&) override;
 
     // https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element
     void prepare_script();

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -62,7 +62,7 @@ private:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
     virtual void did_remove_attribute(DeprecatedFlyString const&) override;
 
     // https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -46,16 +46,12 @@ void HTMLVideoElement::attribute_changed(DeprecatedFlyString const& name, Deprec
 {
     Base::attribute_changed(name, value);
 
-    if (name == HTML::AttributeNames::poster)
-        determine_element_poster_frame(value).release_value_but_fixme_should_propagate_errors();
-}
-
-void HTMLVideoElement::did_remove_attribute(DeprecatedFlyString const& name)
-{
-    Base::did_remove_attribute(name);
-
-    if (name == HTML::AttributeNames::poster)
-        determine_element_poster_frame({}).release_value_but_fixme_should_propagate_errors();
+    if (name == HTML::AttributeNames::poster) {
+        if (value.is_null())
+            determine_element_poster_frame({}).release_value_but_fixme_should_propagate_errors();
+        else
+            determine_element_poster_frame(value).release_value_but_fixme_should_propagate_errors();
+    }
 }
 
 JS::GCPtr<Layout::Node> HTMLVideoElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -42,9 +42,9 @@ void HTMLVideoElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_fetch_controller);
 }
 
-void HTMLVideoElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLVideoElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    Base::parse_attribute(name, value);
+    Base::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::poster)
         determine_element_poster_frame(value).release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -47,7 +47,7 @@ private:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
     virtual void did_remove_attribute(DeprecatedFlyString const&) override;
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -48,7 +48,6 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
-    virtual void did_remove_attribute(DeprecatedFlyString const&) override;
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
@@ -24,9 +24,9 @@ JS::ThrowCompletionOr<void> SVGCircleElement::initialize(JS::Realm& realm)
     return {};
 }
 
-void SVGCircleElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGCircleElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    SVGGeometryElement::parse_attribute(name, value);
+    SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::cx) {
         m_center_x = AttributeParser::parse_coordinate(value);

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.h
@@ -17,7 +17,7 @@ class SVGCircleElement final : public SVGGeometryElement {
 public:
     virtual ~SVGCircleElement() override = default;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -37,9 +37,9 @@ void SVGElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_dataset);
 }
 
-void SVGElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    Base::parse_attribute(name, value);
+    Base::attribute_changed(name, value);
 
     update_use_elements_that_reference_this();
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.h
@@ -16,7 +16,7 @@ class SVGElement : public DOM::Element {
 public:
     virtual bool requires_svg_container() const override { return true; }
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     virtual void children_changed() override;
     virtual void inserted() override;

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
@@ -24,9 +24,9 @@ JS::ThrowCompletionOr<void> SVGEllipseElement::initialize(JS::Realm& realm)
     return {};
 }
 
-void SVGEllipseElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGEllipseElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    SVGGeometryElement::parse_attribute(name, value);
+    SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::cx) {
         m_center_x = AttributeParser::parse_coordinate(value);

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.h
@@ -17,7 +17,7 @@ class SVGEllipseElement final : public SVGGeometryElement {
 public:
     virtual ~SVGEllipseElement() override = default;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
@@ -17,9 +17,9 @@ SVGGradientElement::SVGGradientElement(DOM::Document& document, DOM::QualifiedNa
 {
 }
 
-void SVGGradientElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGGradientElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    SVGElement::parse_attribute(name, value);
+    SVGElement::attribute_changed(name, value);
     if (name == AttributeNames::gradientUnits) {
         m_gradient_units = AttributeParser::parse_gradient_units(value);
     } else if (name == AttributeNames::gradientTransform) {

--- a/Userland/Libraries/LibWeb/SVG/SVGGradientElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGradientElement.h
@@ -26,7 +26,7 @@ class SVGGradientElement : public SVGElement {
 public:
     virtual ~SVGGradientElement() override = default;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     virtual Optional<Gfx::PaintStyle const&> to_gfx_paint_style(SVGPaintContext const&) const = 0;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -32,9 +32,9 @@ JS::ThrowCompletionOr<void> SVGGraphicsElement::initialize(JS::Realm& realm)
     return {};
 }
 
-void SVGGraphicsElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGGraphicsElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    SVGElement::parse_attribute(name, value);
+    SVGElement::attribute_changed(name, value);
     if (name == "transform"sv) {
         auto transform_list = AttributeParser::parse_transform(value);
         if (transform_list.has_value())

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -24,7 +24,7 @@ class SVGGraphicsElement : public SVGElement {
 public:
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     Optional<Gfx::Color> fill_color() const;
     Optional<FillRule> fill_rule() const;

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
@@ -24,9 +24,9 @@ JS::ThrowCompletionOr<void> SVGLineElement::initialize(JS::Realm& realm)
     return {};
 }
 
-void SVGLineElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGLineElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    SVGGeometryElement::parse_attribute(name, value);
+    SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::x1) {
         m_x1 = AttributeParser::parse_coordinate(value);

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.h
@@ -17,7 +17,7 @@ class SVGLineElement final : public SVGGeometryElement {
 public:
     virtual ~SVGLineElement() override = default;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
@@ -26,9 +26,9 @@ JS::ThrowCompletionOr<void> SVGLinearGradientElement::initialize(JS::Realm& real
     return {};
 }
 
-void SVGLinearGradientElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGLinearGradientElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    SVGGradientElement::parse_attribute(name, value);
+    SVGGradientElement::attribute_changed(name, value);
 
     // FIXME: Should allow for `<number-percentage> | <length>` for x1, x2, y1, y2
     if (name == SVG::AttributeNames::x1) {

--- a/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
@@ -18,7 +18,7 @@ class SVGLinearGradientElement : public SVGGradientElement {
 public:
     virtual ~SVGLinearGradientElement() override = default;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     virtual Optional<Gfx::PaintStyle const&> to_gfx_paint_style(SVGPaintContext const&) const override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -97,9 +97,9 @@ JS::ThrowCompletionOr<void> SVGPathElement::initialize(JS::Realm& realm)
     return {};
 }
 
-void SVGPathElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGPathElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    SVGGeometryElement::parse_attribute(name, value);
+    SVGGeometryElement::attribute_changed(name, value);
 
     if (name == "d") {
         m_instructions = AttributeParser::parse_path_data(value);

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.h
@@ -19,7 +19,7 @@ class SVGPathElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPathElement() override = default;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
@@ -24,9 +24,9 @@ JS::ThrowCompletionOr<void> SVGPolygonElement::initialize(JS::Realm& realm)
     return {};
 }
 
-void SVGPolygonElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGPolygonElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    SVGGeometryElement::parse_attribute(name, value);
+    SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::points) {
         m_points = AttributeParser::parse_points(value);

--- a/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.h
@@ -16,7 +16,7 @@ class SVGPolygonElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPolygonElement() override = default;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
@@ -24,9 +24,9 @@ JS::ThrowCompletionOr<void> SVGPolylineElement::initialize(JS::Realm& realm)
     return {};
 }
 
-void SVGPolylineElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGPolylineElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    SVGGeometryElement::parse_attribute(name, value);
+    SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::points) {
         m_points = AttributeParser::parse_points(value);

--- a/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.h
@@ -16,7 +16,7 @@ class SVGPolylineElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPolylineElement() override = default;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
@@ -23,9 +23,9 @@ JS::ThrowCompletionOr<void> SVGRadialGradientElement::initialize(JS::Realm& real
     return {};
 }
 
-void SVGRadialGradientElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGRadialGradientElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    SVGGradientElement::parse_attribute(name, value);
+    SVGGradientElement::attribute_changed(name, value);
 
     // FIXME: These are <length> or <coordinate> in the spec, but all examples seem to allow percentages
     // and unitless values.

--- a/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
@@ -18,7 +18,7 @@ class SVGRadialGradientElement : public SVGGradientElement {
 public:
     virtual ~SVGRadialGradientElement() override = default;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     virtual Optional<Gfx::PaintStyle const&> to_gfx_paint_style(SVGPaintContext const&) const override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
@@ -26,9 +26,9 @@ JS::ThrowCompletionOr<void> SVGRectElement::initialize(JS::Realm& realm)
     return {};
 }
 
-void SVGRectElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGRectElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    SVGGeometryElement::parse_attribute(name, value);
+    SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::x) {
         m_x = AttributeParser::parse_coordinate(value);

--- a/Userland/Libraries/LibWeb/SVG/SVGRectElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGRectElement.h
@@ -17,7 +17,7 @@ class SVGRectElement final : public SVGGeometryElement {
 public:
     virtual ~SVGRectElement() override = default;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -70,9 +70,9 @@ void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) cons
     }
 }
 
-void SVGSVGElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGSVGElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    SVGGraphicsElement::parse_attribute(name, value);
+    SVGGraphicsElement::attribute_changed(name, value);
 
     if (name.equals_ignoring_ascii_case(SVG::AttributeNames::viewBox))
         m_view_box = try_parse_view_box(value);

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -36,7 +36,7 @@ private:
 
     virtual bool is_svg_svg_element() const override { return true; }
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     void update_fallback_view_box_for_svg_as_image();
 

--- a/Userland/Libraries/LibWeb/SVG/SVGStopElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGStopElement.cpp
@@ -19,9 +19,9 @@ SVGStopElement::SVGStopElement(DOM::Document& document, DOM::QualifiedName quali
 {
 }
 
-void SVGStopElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGStopElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    SVGElement::parse_attribute(name, value);
+    SVGElement::attribute_changed(name, value);
     if (name == SVG::AttributeNames::offset) {
         m_offset = AttributeParser::parse_number_percentage(value);
     }

--- a/Userland/Libraries/LibWeb/SVG/SVGStopElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGStopElement.h
@@ -19,7 +19,7 @@ class SVGStopElement final : public SVGElement {
 public:
     virtual ~SVGStopElement() override = default;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     JS::NonnullGCPtr<SVGAnimatedNumber> offset() const;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.cpp
@@ -30,9 +30,9 @@ JS::ThrowCompletionOr<void> SVGTextContentElement::initialize(JS::Realm& realm)
     return {};
 }
 
-void SVGTextContentElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGTextContentElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    SVGGraphicsElement::parse_attribute(name, value);
+    SVGGraphicsElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::x) {
         m_x = AttributeParser::parse_coordinate(value).value_or(m_x);

--- a/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.h
@@ -18,7 +18,7 @@ class SVGTextContentElement : public SVGGraphicsElement {
 public:
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     WebIDL::ExceptionOr<int> get_number_of_chars() const;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -46,9 +46,9 @@ void SVGUseElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_document_observer);
 }
 
-void SVGUseElement::parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGUseElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
-    Base::parse_attribute(name, value);
+    Base::attribute_changed(name, value);
 
     // https://svgwg.org/svg2-draft/struct.html#UseLayout
     if (name == SVG::AttributeNames::x) {
@@ -87,7 +87,7 @@ void SVGUseElement::svg_element_changed(SVGElement& svg_element)
         return;
     }
 
-    // NOTE: We need to check the ancestor because parse_attribute of a child doesn't call children_changed on the parent(s)
+    // NOTE: We need to check the ancestor because attribute_changed of a child doesn't call children_changed on the parent(s)
     if (to_clone == &svg_element || to_clone->is_ancestor_of(svg_element)) {
         clone_element_tree_as_our_shadow_tree(to_clone);
     }

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -19,7 +19,7 @@ class SVGUseElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGUseElement() override = default;
 
-    virtual void parse_attribute(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
     virtual void inserted() override;
 


### PR DESCRIPTION
The fact that attribute change notifications are spread across two virtuals has been annoying forever. :^)