### PR TITLE
Kernel: Mark sys$poll as not needing the big lock

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -139,7 +139,7 @@ enum class NeedsBigProcessLock {
     S(perf_register_string, NeedsBigProcessLock::Yes)      \
     S(pipe, NeedsBigProcessLock::No)                       \
     S(pledge, NeedsBigProcessLock::No)                     \
-    S(poll, NeedsBigProcessLock::Yes)                      \
+    S(poll, NeedsBigProcessLock::No)                       \
     S(posix_fallocate, NeedsBigProcessLock::No)            \
     S(prctl, NeedsBigProcessLock::No)                      \
     S(profiling_disable, NeedsBigProcessLock::Yes)         \

--- a/Kernel/Syscalls/poll.cpp
+++ b/Kernel/Syscalls/poll.cpp
@@ -17,7 +17,7 @@ using BlockFlags = Thread::FileBlocker::BlockFlags;
 
 ErrorOr<FlatPtr> Process::sys$poll(Userspace<Syscall::SC_poll_params const*> user_params)
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
     TRY(require_promise(Pledge::stdio));
 
     auto params = TRY(copy_typed_from_user(user_params));


### PR DESCRIPTION
I verified that everything that looks sensible was accessed through a mutex or a spinlock, so I guess that's okay, but I'm pretty sure someone with more kernel experience wants to give it a close look.