### PR TITLE
LibWeb: Resolve used insets for more than just abspos elements

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-block.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (2,2) content-size 796x62.9375 [BFC] children: not-inline
+    BlockContainer <body> at (12,12) content-size 600x42.9375 children: not-inline
+      BlockContainer <div.exekiller> at (14,14) content-size 200x17.46875 positioned children: inline
+        line 0 width: 65.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 9, rect: [14,14 65.4375x17.46875]
+            "exekiller"
+        TextNode <#text>
+      BlockContainer <div.athena> at (24,25.46875) content-size 200x17.46875 positioned children: inline
+        line 0 width: 53.171875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 6, rect: [24,25.46875 53.171875x17.46875]
+            "athena"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-float.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (2,2) content-size 796x31.46875 [BFC] children: not-inline
+    BlockContainer <body> at (12,12) content-size 600x0 children: not-inline
+      BlockContainer <div.exekiller> at (14,14) content-size 200x17.46875 positioned floating [BFC] children: inline
+        line 0 width: 65.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 9, rect: [14,14 65.4375x17.46875]
+            "exekiller"
+        TextNode <#text>
+      BlockContainer <div.athena> at (18,18) content-size 200x17.46875 positioned floating [BFC] children: inline
+        line 0 width: 53.171875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 6, rect: [18,18 53.171875x17.46875]
+            "athena"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex/relpos-flex-item.txt
+++ b/Tests/LibWeb/Layout/expected/flex/relpos-flex-item.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (2,2) content-size 796x41.46875 [BFC] children: not-inline
+    Box <body> at (12,12) content-size 600x21.46875 flex-container(row) [FFC] children: not-inline
+      BlockContainer <div.exekiller> at (14,14) content-size 200x17.46875 positioned flex-item [BFC] children: inline
+        line 0 width: 65.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 9, rect: [14,14 65.4375x17.46875]
+            "exekiller"
+        TextNode <#text>
+      BlockContainer <div.athena> at (18,18) content-size 200x17.46875 positioned flex-item [BFC] children: inline
+        line 0 width: 53.171875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 6, rect: [18,18 53.171875x17.46875]
+            "athena"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/relpos-grid-item.txt
+++ b/Tests/LibWeb/Layout/expected/grid/relpos-grid-item.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (2,2) content-size 796x62.9375 [BFC] children: not-inline
+    Box <body> at (12,12) content-size 600x42.9375 [GFC] children: not-inline
+      BlockContainer <div.exekiller> at (14,14) content-size 200x17.46875 positioned [BFC] children: inline
+        line 0 width: 65.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 9, rect: [14,14 65.4375x17.46875]
+            "exekiller"
+        TextNode <#text>
+      BlockContainer <div.athena> at (24,25.46875) content-size 200x17.46875 positioned [BFC] children: inline
+        line 0 width: 53.171875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 6, rect: [24,25.46875 53.171875x17.46875]
+            "athena"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/block-and-inline/relpos-block.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/relpos-block.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html><style>
+  * { border: 2px solid black; }
+  body { width: 600px; }
+  div {
+    width: 200px;
+    position: relative;
+  }
+  .athena {
+    background: green;
+    top: -10px;
+    left: 10px;
+  }
+  .exekiller {
+    background: red;
+  }
+</style><body><div class="exekiller">exekiller</div><div class="athena">athena</div></body>

--- a/Tests/LibWeb/Layout/input/block-and-inline/relpos-float.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/relpos-float.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html><style>
+  * { border: 2px solid black; }
+  body { width: 600px; }
+  div {
+    width: 200px;
+    position: relative;
+    float: left;
+  }
+  .athena {
+    background: green;
+    top: 4px;
+    left: -200px;
+  }
+  .exekiller {
+    background: red;
+  }
+</style><body><div class="exekiller">exekiller</div><div class="athena">athena</div></body>

--- a/Tests/LibWeb/Layout/input/flex/relpos-flex-item.html
+++ b/Tests/LibWeb/Layout/input/flex/relpos-flex-item.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html><style>
+  * { border: 2px solid black; }
+  body {
+    width: 600px;
+    display: flex;
+  }
+  div {
+    width: 200px;
+    position: relative;
+  }
+  .athena {
+    background: green;
+    top: 4px;
+    left: -200px;
+  }
+  .exekiller {
+    background: red;
+  }
+</style><body><div class="exekiller">exekiller</div><div class="athena">athena</div></body>

--- a/Tests/LibWeb/Layout/input/grid/relpos-grid-item.html
+++ b/Tests/LibWeb/Layout/input/grid/relpos-grid-item.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html><style>
+  * { border: 2px solid black; }
+  body {
+    width: 600px;
+    display: grid;
+  }
+  div {
+    width: 200px;
+    position: relative;
+  }
+  .athena {
+    background: green;
+    top: -10px;
+    left: 10px;
+  }
+  .exekiller {
+    background: red;
+  }
+</style><body><div class="exekiller">exekiller</div><div class="athena">athena</div></body>

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -988,6 +988,8 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     if (line_builder)
         line_builder->recalculate_available_space();
 
+    compute_inset(box);
+
     if (independent_formatting_context)
         independent_formatting_context->parent_context_did_dimension_child_root_box();
 }

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -216,6 +216,8 @@ void FlexFormattingContext::run(Box const& run_box, LayoutMode, AvailableSpace c
             auto& box_state = m_state.get(item.box);
             if (auto independent_formatting_context = layout_inside(item.box, LayoutMode::Normal, box_state.available_inner_space_or_constraints_from(m_available_space_for_flex_container->space)))
                 independent_formatting_context->parent_context_did_dimension_child_root_box();
+
+            compute_inset(item.box);
         }
     }
 }

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1609,6 +1609,8 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
             y_start + child_box_state.border_top + child_box_state.padding_top + child_box_state.margin_top
         };
 
+        compute_inset(child_box);
+
         auto available_space_for_children = AvailableSpace(AvailableSize::make_definite(child_box_state.content_width()), AvailableSize::make_definite(child_box_state.content_height()));
         if (auto independent_formatting_context = layout_inside(child_box, LayoutMode::Normal, available_space_for_children))
             independent_formatting_context->parent_context_did_dimension_child_root_box();


### PR DESCRIPTION
This makes the game carousel work on https://null.com/ :^)

Before:
![Screenshot at 2023-07-03 20-39-35](https://github.com/SerenityOS/serenity/assets/5954907/0432ff53-67f4-410d-bffe-9bc6970e4408)

After:
![Screenshot at 2023-07-03 20-39-10](https://github.com/SerenityOS/serenity/assets/5954907/059142a0-c6b3-4f32-857a-3da5e95e4445)

