### PR TITLE
LibManual: Error on section_number 0 instead of crashing

### DIFF
--- a/Userland/Libraries/LibManual/SectionNode.cpp
+++ b/Userland/Libraries/LibManual/SectionNode.cpp
@@ -22,8 +22,8 @@ ErrorOr<NonnullRefPtr<SectionNode>> SectionNode::try_create_from_number(StringVi
     if (!maybe_section_number.has_value())
         return Error::from_string_literal("Section is not a number");
     auto section_number = maybe_section_number.release_value();
-    if (section_number > number_of_sections)
-        return Error::from_string_literal("Section number too large");
+    if (section_number < 1 || section_number > number_of_sections)
+        return Error::from_string_literal("Section number is not valid");
     return sections[section_number - 1];
 }
 


### PR DESCRIPTION
Prior to this commit if you tried to access section 0 of the man page (`man 0 ls`) the application would just crash with an array out of bounds style error.

This commit just ensures that we return an explicit and helpful error message when you try to request the 0th section, instead of crashing.

| Before | After |
|--------|--------|
| ![image](https://github.com/SerenityOS/serenity/assets/3310215/3abb2470-e851-4ebd-bacd-dd8fad2834a1) | ![image](https://github.com/SerenityOS/serenity/assets/3310215/d6ce06ab-72f9-48f5-9d0e-ed3ef597b495) |


