### PR TITLE
AK+LibC: Remove `AK/Atomic.h` includes from our `RefPtr`s

### DIFF
--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -9,7 +9,6 @@
 #define NONNULLREFPTR_SCRUB_BYTE 0xe1
 
 #include <AK/Assertions.h>
-#include <AK/Atomic.h>
 #include <AK/Format.h>
 #include <AK/Traits.h>
 #include <AK/Types.h>

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -9,7 +9,6 @@
 #define REFPTR_SCRUB_BYTE 0xe0
 
 #include <AK/Assertions.h>
-#include <AK/Atomic.h>
 #include <AK/Error.h>
 #include <AK/Format.h>
 #include <AK/Forward.h>

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Atomic.h>
 #include <AK/DateConstants.h>
 #include <AK/StringBuilder.h>
 #include <AK/Time.h>


### PR DESCRIPTION
We don't seem to be using it there.