### PR TITLE
LibWeb: Support `valign` attribute on `td` elements

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/td-valign.txt
+++ b/Tests/LibWeb/Layout/expected/table/td-valign.txt
@@ -1,0 +1,24 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x220 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x204 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 144.1875x204 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 142.1875x202 table-box [TFC] children: not-inline
+          Box <tbody> at (9,9) content-size 134.1875x198 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 134.1875x198 table-row children: not-inline
+              BlockContainer <td> at (12,12) content-size 26.640625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 26.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 3, rect: [12,12 26.640625x17.46875]
+                    "top"
+                TextNode <#text>
+              BlockContainer <td> at (42.640625,101.265625) content-size 45.4375x17.46875 table-cell [BFC] children: inline
+                line 0 width: 45.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [42.640625,101.265625 45.4375x17.46875]
+                    "middle"
+                TextNode <#text>
+              BlockContainer <td> at (92.078125,190.53125) content-size 56.109375x17.46875 table-cell [BFC] children: inline
+                line 0 width: 56.109375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [92.078125,190.53125 56.109375x17.46875]
+                    "bottom"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>

--- a/Tests/LibWeb/Layout/input/table/td-valign.html
+++ b/Tests/LibWeb/Layout/input/table/td-valign.html
@@ -1,0 +1,6 @@
+<!doctype html><style>
+table {
+    height: 200px;
+    border: 1px solid black;
+}
+</style><table><td valign=top>top</td><td valign=middle>middle</td><td valign=bottom>bottom</td>

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -39,6 +39,11 @@ void HTMLTableCellElement::apply_presentational_hints(CSS::StyleProperties& styl
                 style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()).release_value_but_fixme_should_propagate_errors());
             return;
         }
+        if (name == HTML::AttributeNames::valign) {
+            if (auto parsed_value = parse_css_value(CSS::Parser::ParsingContext { document() }, value.view(), CSS::PropertyID::VerticalAlign).release_value_but_fixme_should_propagate_errors())
+                style.set_property(CSS::PropertyID::VerticalAlign, parsed_value.release_nonnull());
+            return;
+        }
         if (name == HTML::AttributeNames::align) {
             if (value.equals_ignoring_ascii_case("center"sv) || value.equals_ignoring_ascii_case("middle"sv)) {
                 style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::LibwebCenter).release_value_but_fixme_should_propagate_errors());


### PR DESCRIPTION
This presentational hint maps to the CSS `vertical-align` property.

Fixes #19786.