### PR TITLE
LibWeb: Add ::selection to pseudo elements

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -363,6 +363,8 @@ Optional<Selector::PseudoElement> pseudo_element_from_string(StringView name)
         return Selector::PseudoElement::ProgressValue;
     } else if (name.equals_ignoring_ascii_case("placeholder"sv)) {
         return Selector::PseudoElement::Placeholder;
+    } else if (name.equals_ignoring_ascii_case("selection"sv)) {
+        return Selector::PseudoElement::Selection;
     }
     return {};
 }

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -28,6 +28,7 @@ public:
         ProgressValue,
         ProgressBar,
         Placeholder,
+        Selection,
 
         // Keep this last.
         PseudoElementCount,
@@ -231,6 +232,8 @@ constexpr StringView pseudo_element_name(Selector::PseudoElement pseudo_element)
         return "-webkit-progress-value"sv;
     case Selector::PseudoElement::Placeholder:
         return "placeholder"sv;
+    case Selector::PseudoElement::Selection:
+        return "selection"sv;
     case Selector::PseudoElement::PseudoElementCount:
         break;
     }

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -595,6 +595,9 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 case CSS::Selector::PseudoElement::Placeholder:
                     pseudo_element_description = "placeholder";
                     break;
+                case CSS::Selector::PseudoElement::Selection:
+                    pseudo_element_description = "selection";
+                    break;
                 case CSS::Selector::PseudoElement::PseudoElementCount:
                     VERIFY_NOT_REACHED();
                     break;


### PR DESCRIPTION
fixes sites like github where they use a selector that includes they selection pseudo element