### PR TITLE
LibWeb: Some layout & CSS parsing fixes for Mastodon

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-align-items.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-align-items.txt
@@ -1,0 +1,77 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x322 [BFC] children: not-inline
+    Box <body> at (10,10) content-size 780x304 flex-container(row) [FFC] children: not-inline
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+      Box <div.outer.normal> at (11,11) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (11,12) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 54.578125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [11,12 54.578125x17.46875]
+              "normal"
+          TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+      Box <div.outer.stretch> at (163,11) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (163,12) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 58.796875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 7, rect: [163,12 58.796875x17.46875]
+              "stretch"
+          TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+      Box <div.outer.start> at (315,11) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (315,12) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [315,12 41.234375x17.46875]
+              "start"
+          TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+      Box <div.outer.flex-start> at (467,11) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (467,12) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 10, rect: [467,12 76.8125x17.46875]
+              "flex-start"
+          TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+      Box <div.outer.end> at (619,11) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (619,110) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 3, rect: [619,110 26.1875x17.46875]
+              "end"
+          TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+      Box <div.outer.flex-end> at (11,163) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (11,262) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 8, rect: [11,262 61.765625x17.46875]
+              "flex-end"
+          TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+      Box <div.outer.center> at (163,163) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (163,213) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [163,213 51.625x17.46875]
+              "center"
+          TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+      Box <div.outer.self-start> at (315,163) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (315,164) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 76.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 10, rect: [315,164 76.453125x17.46875]
+              "self-start"
+          TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+      Box <div.outer.self-end> at (467,163) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (467,262) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 61.40625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 8, rect: [467,262 61.40625x17.46875]
+              "self-end"
+          TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-justify-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-justify-content.txt
@@ -1,0 +1,229 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x1754 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x1736 children: not-inline
+      BlockContainer <(anonymous)> at (10,10) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.outer.start> at (11,11) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (11,12) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [11,12 41.234375x17.46875]
+              "start"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,72) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.outer.flex-start> at (11,73) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (11,74) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 10, rect: [11,74 76.8125x17.46875]
+              "flex-start"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,134) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.outer.end> at (11,135) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (161,136) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 3, rect: [161,136 26.1875x17.46875]
+              "end"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,196) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.outer.flex-end> at (11,197) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (161,198) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 8, rect: [161,198 61.765625x17.46875]
+              "flex-end"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,258) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.outer.center> at (11,259) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (86,260) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [86,260 51.625x17.46875]
+              "center"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,320) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.outer.space-around> at (11,321) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (86,322) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [86,322 107.96875x17.46875]
+              "space-around"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,382) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.outer.space-between> at (11,383) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (11,384) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 13, rect: [11,384 115.515625x17.46875]
+              "space-between"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,444) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.reverse.outer.start> at (11,445) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (161,446) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [161,446 41.234375x17.46875]
+              "start"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,506) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.reverse.outer.flex-start> at (11,507) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (161,508) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 10, rect: [161,508 76.8125x17.46875]
+              "flex-start"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,568) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.reverse.outer.end> at (11,569) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (11,570) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 3, rect: [11,570 26.1875x17.46875]
+              "end"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,630) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.reverse.outer.flex-end> at (11,631) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (11,632) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 8, rect: [11,632 61.765625x17.46875]
+              "flex-end"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,692) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.reverse.outer.center> at (11,693) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (86,694) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [86,694 51.625x17.46875]
+              "center"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,754) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.reverse.outer.space-around> at (11,755) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (86,756) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [86,756 107.96875x17.46875]
+              "space-around"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,816) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.reverse.outer.space-between> at (11,817) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (11,818) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 13, rect: [11,818 115.515625x17.46875]
+              "space-between"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,878) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.outer.start> at (11,879) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,879) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [12,879 41.234375x17.46875]
+              "start"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,940) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.outer.flex-start> at (11,941) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,941) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 10, rect: [12,941 76.8125x17.46875]
+              "flex-start"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1002) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.outer.end> at (11,1003) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1013) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 3, rect: [12,1013 26.1875x17.46875]
+              "end"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1064) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.outer.flex-end> at (11,1065) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1075) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 8, rect: [12,1075 61.765625x17.46875]
+              "flex-end"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1126) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.outer.center> at (11,1127) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1132) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [12,1132 51.625x17.46875]
+              "center"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1188) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.outer.space-around> at (11,1189) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1194) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [12,1194 107.96875x17.46875]
+              "space-around"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1250) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.outer.space-between> at (11,1251) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1251) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 13, rect: [12,1251 115.515625x17.46875]
+              "space-between"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1312) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.start> at (11,1313) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,1323) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [12,1323 41.234375x17.46875]
+              "start"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1374) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.flex-start> at (11,1375) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,1385) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 10, rect: [12,1385 76.8125x17.46875]
+              "flex-start"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1436) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.end> at (11,1437) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,1437) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 3, rect: [12,1437 26.1875x17.46875]
+              "end"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1498) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.flex-end> at (11,1499) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,1499) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 8, rect: [12,1499 61.765625x17.46875]
+              "flex-end"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1560) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.center> at (11,1561) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,1566) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [12,1566 51.625x17.46875]
+              "center"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1622) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.space-around> at (11,1623) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,1628) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [12,1628 107.96875x17.46875]
+              "space-around"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1684) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.space-between> at (11,1685) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,1685) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 13, rect: [12,1685 115.515625x17.46875]
+              "space-between"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1746) content-size 780x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/font-with-many-normal-values.txt
+++ b/Tests/LibWeb/Layout/expected/font-with-many-normal-values.txt
@@ -1,0 +1,30 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x200 children: inline
+      line 0 width: 424, height: 200, bottom: 200, baseline: 159.960937
+        frag 0 from TextNode start: 0, length: 1, rect: [8,8 79.296875x200]
+          "1"
+        frag 1 from TextNode start: 0, length: 1, rect: [87,154 8x17.46875]
+          " "
+        frag 2 from TextNode start: 0, length: 1, rect: [95,8 110.15625x200]
+          "2"
+        frag 3 from TextNode start: 0, length: 1, rect: [205,154 8x17.46875]
+          " "
+        frag 4 from TextNode start: 0, length: 1, rect: [213,8 113.671875x200]
+          "3"
+        frag 5 from TextNode start: 0, length: 1, rect: [327,154 8x17.46875]
+          " "
+        frag 6 from TextNode start: 0, length: 1, rect: [335,8 96.875x200]
+          "4"
+      InlineNode <span.one>
+        TextNode <#text>
+      TextNode <#text>
+      InlineNode <span.two>
+        TextNode <#text>
+      TextNode <#text>
+      InlineNode <span.three>
+        TextNode <#text>
+      TextNode <#text>
+      InlineNode <span.four>
+        TextNode <#text>
+      TextNode <#text>

--- a/Tests/LibWeb/Layout/input/flex/abspos-flex-child-static-position-with-align-items.html
+++ b/Tests/LibWeb/Layout/input/flex/abspos-flex-child-static-position-with-align-items.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html><style>
+* {
+    border: 1px solid black !important;
+}
+      body {
+        display: flex;
+        flex-wrap: wrap;
+      }
+      .outer {
+        display: flex;
+        width: 150px;
+        height: 150px;
+        background: wheat;
+      }
+      .outer > div {
+        position: absolute;
+        width: 150px;
+        height: 50px;
+        background: orange;
+      }
+      .normal { align-items: normal; }
+      .stretch { align-items: stretch; }
+      .flex-start { align-items: flex-start; }
+      .flex-end { align-items: flex-end; }
+      .start { align-items: start; }
+      .end { align-items: end; }
+      .center { align-items: center; }
+      .self-start { align-items: self-start; }
+      .self-end { align-items: self-end; }
+</style>
+<body>
+<div class="outer normal"><div>normal</div></div>
+<div class="outer stretch"><div>stretch</div></div>
+<div class="outer start"><div>start</div></div>
+<div class="outer flex-start"><div>flex-start</div></div>
+<div class="outer end"><div>end</div></div>
+<div class="outer flex-end"><div>flex-end</div></div>
+<div class="outer center"><div>center</div></div>
+<div class="outer self-start"><div>self-start</div></div>
+<div class="outer self-end"><div>self-end</div></div>

--- a/Tests/LibWeb/Layout/input/flex/abspos-flex-child-static-position-with-justify-content.html
+++ b/Tests/LibWeb/Layout/input/flex/abspos-flex-child-static-position-with-justify-content.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html><style>
+* {
+    border: 1px solid black !important;
+}
+      .outer {
+        display: flex;
+        width: 300px;
+        height: 60px;
+        background: wheat;
+      }
+      .outer > div {
+        position: absolute;
+        width: 150px;
+        height: 50px;
+        background: orange;
+      }
+      .flex-start { justify-content: flex-start; }
+      .flex-end { justify-content: flex-end; }
+      .start { justify-content: start; }
+      .end { justify-content: end; }
+      .center { justify-content: center; }
+      .space-around { justify-content: space-around; }
+      .space-between { justify-content: space-between; }
+
+      .row { flex-direction: row; }
+      .row.reverse { flex-direction: row-reverse; }
+      .column { flex-direction: column; }
+      .column.reverse { flex-direction: column-reverse; }
+      .reverse > div {
+          background: magenta;
+      }
+</style>
+<body>
+<div class="row outer start"><div>start</div></div>
+<div class="row outer flex-start"><div>flex-start</div></div>
+<div class="row outer end"><div>end</div></div>
+<div class="row outer flex-end"><div>flex-end</div></div>
+<div class="row outer center"><div>center</div></div>
+<div class="row outer space-around"><div>space-around</div></div>
+<div class="row outer space-between"><div>space-between</div></div>
+<div class="row reverse outer start"><div>start</div></div>
+<div class="row reverse outer flex-start"><div>flex-start</div></div>
+<div class="row reverse outer end"><div>end</div></div>
+<div class="row reverse outer flex-end"><div>flex-end</div></div>
+<div class="row reverse outer center"><div>center</div></div>
+<div class="row reverse outer space-around"><div>space-around</div></div>
+<div class="row reverse outer space-between"><div>space-between</div></div>
+<div class="column outer start"><div>start</div></div>
+<div class="column outer flex-start"><div>flex-start</div></div>
+<div class="column outer end"><div>end</div></div>
+<div class="column outer flex-end"><div>flex-end</div></div>
+<div class="column outer center"><div>center</div></div>
+<div class="column outer space-around"><div>space-around</div></div>
+<div class="column outer space-between"><div>space-between</div></div>
+<div class="column reverse outer start"><div>start</div></div>
+<div class="column reverse outer flex-start"><div>flex-start</div></div>
+<div class="column reverse outer end"><div>end</div></div>
+<div class="column reverse outer flex-end"><div>flex-end</div></div>
+<div class="column reverse outer center"><div>center</div></div>
+<div class="column reverse outer space-around"><div>space-around</div></div>
+<div class="column reverse outer space-between"><div>space-between</div></div>

--- a/Tests/LibWeb/Layout/input/font-with-many-normal-values.html
+++ b/Tests/LibWeb/Layout/input/font-with-many-normal-values.html
@@ -1,0 +1,10 @@
+<!doctype html><style>
+.one { font: normal 200px/1 SerenitySans; }
+.two { font: normal normal 200px/1 SerenitySans; }
+.three { font: normal normal normal 200px/1 SerenitySans; }
+.four { font: normal normal normal normal 200px/1 SerenitySans; }
+</style>
+<span class=one>1</span>
+<span class=two>2</span>
+<span class=three>3</span>
+<span class=four>4</span>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -6587,7 +6587,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_font_value(Vector<ComponentValue> cons
     // Since normal is the default value for all the properties that can have it, we don't have to actually
     // set anything to normal here. It'll be set when we create the FontStyleValue below.
     // We just need to make sure we were not given more normals than will fit.
-    int unset_value_count = (font_style ? 0 : 1) + (font_weight ? 0 : 1);
+    int unset_value_count = (font_style ? 0 : 1) + (font_weight ? 0 : 1) + (font_variant ? 0 : 1) + (font_stretch ? 0 : 1);
     if (unset_value_count < normal_count)
         return nullptr;
 

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -2125,10 +2125,13 @@ CSSPixelPoint FlexFormattingContext::calculate_static_position(Box const& box) c
         //  Fallthrough
     case CSS::AlignItems::Start:
     case CSS::AlignItems::FlexStart:
+    case CSS::AlignItems::SelfStart:
     case CSS::AlignItems::Stretch:
+    case CSS::AlignItems::Normal:
         cross_offset = -half_line_size + cross_margin_before + cross_border_before + cross_padding_before;
         break;
     case CSS::AlignItems::End:
+    case CSS::AlignItems::SelfEnd:
     case CSS::AlignItems::FlexEnd:
         cross_offset = half_line_size - inner_cross_size(box) - cross_margin_after - cross_border_after - cross_padding_after;
         break;

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -2150,40 +2150,22 @@ CSSPixelPoint FlexFormattingContext::calculate_static_position(Box const& box) c
     CSSPixels main_offset = 0;
     switch (flex_container().computed_values().justify_content()) {
     case CSS::JustifyContent::Start:
-        if (is_direction_reverse()) {
-            main_offset = inner_main_size(flex_container());
-        } else {
-            main_offset = 0;
-        }
+    case CSS::JustifyContent::FlexStart:
+        main_offset = 0;
+        pack_from_end = is_direction_reverse();
         break;
     case CSS::JustifyContent::End:
-        if (is_direction_reverse()) {
-            main_offset = 0;
-        } else {
-            main_offset = inner_main_size(flex_container());
-        }
-        break;
-    case CSS::JustifyContent::FlexStart:
-        if (is_direction_reverse()) {
-            pack_from_end = false;
-            main_offset = inner_main_size(flex_container());
-        } else {
-            main_offset = 0;
-        }
-        break;
     case CSS::JustifyContent::FlexEnd:
-        if (is_direction_reverse()) {
-            main_offset = 0;
-        } else {
-            pack_from_end = false;
-            main_offset = inner_main_size(flex_container());
-        }
+        main_offset = 0;
+        pack_from_end = !is_direction_reverse();
         break;
     case CSS::JustifyContent::SpaceBetween:
+        pack_from_end = false;
         main_offset = 0;
         break;
     case CSS::JustifyContent::Center:
     case CSS::JustifyContent::SpaceAround:
+        pack_from_end = false;
         main_offset = inner_main_size(flex_container()) / 2.0 - inner_main_size(box) / 2.0;
         break;
     }
@@ -2191,12 +2173,12 @@ CSSPixelPoint FlexFormattingContext::calculate_static_position(Box const& box) c
     // NOTE: Next, we add the flex container's padding since abspos boxes are placed relative to the padding edge
     //       of their abspos containing block.
     if (pack_from_end) {
-        main_offset += is_row_layout() ? m_flex_container_state.padding_left : m_flex_container_state.padding_top;
-    } else {
         main_offset += is_row_layout() ? m_flex_container_state.padding_right : m_flex_container_state.padding_bottom;
+    } else {
+        main_offset += is_row_layout() ? m_flex_container_state.padding_left : m_flex_container_state.padding_top;
     }
 
-    if (!pack_from_end)
+    if (pack_from_end)
         main_offset += inner_main_size(flex_container()) - inner_main_size(box);
 
     auto static_position_offset = is_row_layout() ? CSSPixelPoint { main_offset, cross_offset } : CSSPixelPoint { cross_offset, main_offset };


### PR DESCRIPTION
Improvements to `align-items` and `justify-content` for absolutely positioned children of a flex container, and a `font` parsing fix.

Sam before:
![Screenshot at 2023-07-04 15-36-59](https://github.com/SerenityOS/serenity/assets/5954907/7ccc8299-084e-4f09-8bca-48fbe246e18f)

Sam after:
![Screenshot at 2023-07-04 15-37-56](https://github.com/SerenityOS/serenity/assets/5954907/96051b8c-8127-462d-9afc-d22b750d9778)