### PR TITLE
LibWeb: support bgcolor attribute on tr elements

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.h
@@ -32,6 +32,7 @@ private:
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
     JS::GCPtr<DOM::HTMLCollection> mutable m_cells;
 };


### PR DESCRIPTION
Before:
![image](https://github.com/SerenityOS/serenity/assets/199648/b70ef917-4031-490e-a5dd-970b11bf751e)


After:
<img width="830" alt="Capture d’écran 2023-07-04 à 17 27 08" src="https://github.com/SerenityOS/serenity/assets/199648/71887a2d-dada-406b-b933-cc7cd51c1871">