### PR TITLE
LibJS: Propagate "contains await" flag to parent scope in ScopePusher

### DIFF
--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -244,6 +244,7 @@ public:
         if (m_parent_scope && !m_function_parameters.has_value()) {
             m_parent_scope->m_contains_access_to_arguments_object |= m_contains_access_to_arguments_object;
             m_parent_scope->m_contains_direct_call_to_eval |= m_contains_direct_call_to_eval;
+            m_parent_scope->m_contains_await_expression |= m_contains_await_expression;
         }
 
         VERIFY(m_parser.m_state.current_scope_pusher == this);


### PR DESCRIPTION
The flag indicating the presence of an await expression should be passed up to the parent scope until the nearest function scope is reached. This resolves several problems related to identifying top-level awaits, which are currently not recognized correctly when used within a nested scope.

+37 ✅   +12 ❌  -49 💥️