### PR TITLE
LibGUI: Do not start editing when escape key is pressed in TableView

### DIFF
--- a/Userland/Libraries/LibGUI/TableView.cpp
+++ b/Userland/Libraries/LibGUI/TableView.cpp
@@ -193,9 +193,10 @@ void TableView::keydown_event(KeyEvent& event)
 
     auto is_delete = event.key() == Key_Delete;
     auto is_backspace = event.key() == Key_Backspace;
+    auto is_escape = event.key() == Key_Escape;
     auto is_clear = is_delete || is_backspace;
     auto has_ctrl = event.modifiers() & KeyModifier::Mod_Ctrl;
-    if (is_editable() && edit_triggers() & EditTrigger::AnyKeyPressed && (event.code_point() != 0 || is_clear) && !has_ctrl) {
+    if (is_editable() && edit_triggers() & EditTrigger::AnyKeyPressed && (event.code_point() != 0 || is_clear) && !has_ctrl && !is_escape) {
         begin_editing(cursor_index());
         if (m_editing_delegate) {
             if (is_delete) {


### PR DESCRIPTION
When pressing escape inside an editable TableView, the escape character was passed to the editing delegate, causing an invalid character to be entered.

E.g. in Spreadsheet, when pressing escape, the application currently starts editing and inserts the escape character:

![](https://github.com/SerenityOS/serenity/assets/85876381/1ba8ccf3-5b05-4cec-aa1b-c8234403c5e9)
