### PR TITLE
LibAudio: Fixes for seeking in a FLAC file with no seek table

### DIFF
--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -284,7 +284,6 @@ MaybeLoaderError FlacLoaderPlugin::seek(int int_sample_index)
         return {};
 
     auto maybe_target_seekpoint = m_seektable.seek_point_before(sample_index);
-    auto const seek_tolerance = (seek_tolerance_ms * m_sample_rate) / 1000;
     // No seektable or no fitting entry: Perform normal forward read
     if (!maybe_target_seekpoint.has_value()) {
         if (sample_index < m_loaded_samples) {
@@ -309,11 +308,15 @@ MaybeLoaderError FlacLoaderPlugin::seek(int int_sample_index)
         }
     }
 
-    // Skip frames until we're within the seek tolerance.
-    while (sample_index - m_loaded_samples > seek_tolerance) {
+    // Skip frames until we're just before the target sample.
+    VERIFY(m_loaded_samples <= sample_index);
+    size_t frame_start_location;
+    while (m_loaded_samples <= sample_index) {
+        frame_start_location = TRY(m_stream->tell());
         (void)TRY(next_frame());
         m_loaded_samples += m_current_frame->sample_count;
     }
+    TRY(m_stream->seek(frame_start_location, SeekMode::SetPosition));
 
     return {};
 }

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -146,6 +146,7 @@ MaybeLoaderError FlacLoaderPlugin::parse_header()
     }
 
     dbgln_if(AFLACLOADER_DEBUG, "Parsed FLAC header: blocksize {}-{}{}, framesize {}-{}, {}Hz, {}bit, {} channels, {} samples total ({:.2f}s), MD5 {}, data start at {:x} bytes, {} headers total (skipped {})", m_min_block_size, m_max_block_size, is_fixed_blocksize_stream() ? " (constant)" : "", m_min_frame_size, m_max_frame_size, m_sample_rate, pcm_bits_per_sample(m_sample_format), m_num_channels, m_total_samples, static_cast<float>(m_total_samples) / static_cast<float>(m_sample_rate), m_md5_checksum, m_data_start_location, total_meta_blocks, total_meta_blocks - meta_blocks_parsed);
+    TRY(m_seektable.insert_seek_point({ 0, 0 }));
 
     return {};
 }

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -324,7 +324,8 @@ bool FlacLoaderPlugin::should_insert_seekpoint_at(u64 sample_index) const
     auto const max_seekpoint_distance = (maximum_seekpoint_distance_ms * m_sample_rate) / 1000;
     auto const seek_tolerance = (seek_tolerance_ms * m_sample_rate) / 1000;
     auto const current_seekpoint_distance = m_seektable.seek_point_sample_distance_around(sample_index).value_or(NumericLimits<u64>::max());
-    auto const distance_to_previous_seekpoint = sample_index - m_seektable.seek_point_before(sample_index).value_or({ 0, 0 }).sample_index;
+    auto const previous_seekpoint = m_seektable.seek_point_before(sample_index);
+    auto const distance_to_previous_seekpoint = previous_seekpoint.has_value() ? sample_index - previous_seekpoint->sample_index : NumericLimits<u64>::max();
 
     // We insert a seekpoint only under two conditions:
     // - The seek points around us are spaced too far for what the loader recommends.

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -299,15 +299,14 @@ MaybeLoaderError FlacLoaderPlugin::seek(int int_sample_index)
 
         // When a small seek happens, we may already be closer to the target than the seekpoint.
         if (sample_index - target_seekpoint.sample_index > sample_index - m_loaded_samples) {
-            dbgln_if(AFLACLOADER_DEBUG, "Close enough to target ({} samples): not seeking", sample_index - m_loaded_samples);
-            return {};
+            dbgln_if(AFLACLOADER_DEBUG, "Close enough to target ({} samples): ignoring seek point", sample_index - m_loaded_samples);
+        } else {
+            dbgln_if(AFLACLOADER_DEBUG, "Seeking to seektable: sample index {}, byte offset {}", target_seekpoint.sample_index, target_seekpoint.byte_offset);
+            auto position = target_seekpoint.byte_offset + m_data_start_location;
+            if (m_stream->seek(static_cast<i64>(position), SeekMode::SetPosition).is_error())
+                return LoaderError { LoaderError::Category::IO, m_loaded_samples, DeprecatedString::formatted("Invalid seek position {}", position) };
+            m_loaded_samples = target_seekpoint.sample_index;
         }
-
-        dbgln_if(AFLACLOADER_DEBUG, "Seeking to seektable: sample index {}, byte offset {}", target_seekpoint.sample_index, target_seekpoint.byte_offset);
-        auto position = target_seekpoint.byte_offset + m_data_start_location;
-        if (m_stream->seek(static_cast<i64>(position), SeekMode::SetPosition).is_error())
-            return LoaderError { LoaderError::Category::IO, m_loaded_samples, DeprecatedString::formatted("Invalid seek position {}", position) };
-        m_loaded_samples = target_seekpoint.sample_index;
     }
 
     // Skip frames until we're within the seek tolerance.

--- a/Userland/Libraries/LibAudio/GenericTypes.cpp
+++ b/Userland/Libraries/LibAudio/GenericTypes.cpp
@@ -40,6 +40,8 @@ Optional<SeekPoint const&> SeekTable::seek_point_before(u64 sample_index) const
         ++nearby_seek_point_index;
     while (nearby_seek_point_index > 0 && m_seek_points[nearby_seek_point_index].sample_index > sample_index)
         --nearby_seek_point_index;
+    if (m_seek_points[nearby_seek_point_index].sample_index > sample_index)
+        return {};
     return m_seek_points[nearby_seek_point_index];
 }
 


### PR DESCRIPTION
The FLAC loader did not properly handle files in which there was no seek table. This PR fixes the following:
- Seek table would return a sample after the target seek point if there exists no seek point before the target.
- The FLAC loader would not skip samples forward to the target seek point if it determined that the loader's current position is closer to the target than the found seek point.
- The seek point distance calculation treated a missing previous seek point as a seek point at sample 0, meaning that it would never insert a seek point at 0.
- Seeking used a "tolerance" value to get close enough to the target sample, but we can just seek accurately to the frame containing the target sample instead.

**Old summary:**
> The FLAC loader would often fail to seek back to the start of the file, so to prevent that, we can add a fast path for seeking to zero, since we know we don't need to skip forward from the data start position and can just return immediately.
>
> Seeking to zero is used by HTMLMediaElement to implement looping.
>
> @kleinesfilmroellchen Not sure if this papers over an issue with the seek table, but having a fast path here seems beneficial anyway. I'll be having a look at the seeking system when I work on chunked audio decoding, though, so I'll probably end up fixing any issues I find then.