### PR TITLE
diff: Allow configurable context for unified and context diffs

### DIFF
--- a/Base/usr/share/man/man1/diff.md
+++ b/Base/usr/share/man/man1/diff.md
@@ -5,7 +5,7 @@ diff - compare files line by line
 ## Synopsis
 
 ```**sh
-$ diff [files...]
+$ diff [options...] [files...]
 ```
 
 ## Description
@@ -16,16 +16,39 @@ Compare `files` line by line.
 
 * `files`: files to compare ex: `file1 file2`
 
+## Options
+
+* `-u`, `-U <context>`, `--unified <context>`: Write diff in unified format with `<unified>` number of surrounding context lines (default 3).
+* `-c`, `-C <context>`, `--context <context>`: Write diff in context format with `<context>` number of surrounding context lines (default 3).
+
 ## Examples
 
+First we create two files to compare:
+
 ```sh
-# View differences in two files
-$ echo 123 > file1
-$ echo 456 > file2
-$ diff file1 file2
-1c1
-< 123
----
-> 456
+$ printf '1\n2\n3\n' > file1
+$ printf '1\nb\n3\n' > file2
 ```
 
+Here's how to view differences between the two files in normal format:
+
+```sh
+$ diff file1 file2
+2c2
+< 2
+---
+> b
+```
+
+Here's how to view differences between the two files in unified format:
+
+```sh
+$ diff -u file1 file2
+--- file1
++++ file2
+@@ -1,3 +1,3 @@
+ 1
+-2
++b
+ 3
+```


### PR DESCRIPTION
Add the options '-C','--context' and '-U','--unified', which can be used
to ask diff to write a diff in that format with a given number of
context lines surrounding the diff.

Also update diff(1) to showcase the new unified and context options
which have been added to this utility.

![image](https://github.com/SerenityOS/serenity/assets/35911232/d363ecc3-b63b-46af-bffc-f583fc2846d9)

![image](https://github.com/SerenityOS/serenity/assets/35911232/0c9585a5-5247-4e83-af77-8c9b19e9bcf3)

