### PR TITLE
Mail: Fix crash caused by migration from NonnullRefPtrVector

### DIFF
--- a/Userland/Applications/Mail/MailboxTreeModel.cpp
+++ b/Userland/Applications/Mail/MailboxTreeModel.cpp
@@ -21,17 +21,17 @@ GUI::ModelIndex MailboxTreeModel::index(int row, int column, GUI::ModelIndex con
     if (!parent.is_valid()) {
         if (m_account_holder.accounts().is_empty())
             return {};
-        return create_index(row, column, &m_account_holder.accounts().at(row));
+        return create_index(row, column, m_account_holder.accounts().at(row));
     }
     auto& base_node = *static_cast<BaseNode*>(parent.internal_data());
 
     if (is<MailboxNode>(base_node)) {
         auto& remote_mailbox = verify_cast<MailboxNode>(base_node);
-        return create_index(row, column, &remote_mailbox.children().at(row));
+        return create_index(row, column, remote_mailbox.children().at(row));
     }
 
     auto& remote_parent = verify_cast<AccountNode>(base_node);
-    return create_index(row, column, &remote_parent.mailboxes().at(row));
+    return create_index(row, column, remote_parent.mailboxes().at(row));
 }
 
 GUI::ModelIndex MailboxTreeModel::parent_index(GUI::ModelIndex const& index) const


### PR DESCRIPTION
When we moved from NonnullRefPtrVector<T> to Vector<NonnullRefPtr<T>> in commit 8a48246ed1a93983668a25f5b9b0af0e745e3f04, the `at()` function started returning a NonnullRefPtr<T>& instead of T&.

The code calling create_index() was not then updated and ended up taking a pointer to a temporary NonnullRefPtr<>, instead of an actual object, leading to a crash after logging in.