### PR TITLE
LibWeb: Support cellspacing attribute on table elements

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -61,6 +61,11 @@ void HTMLTableElement::apply_presentational_hints(CSS::StyleProperties& style) c
                 style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()).release_value_but_fixme_should_propagate_errors());
             return;
         }
+        if (name == HTML::AttributeNames::cellspacing) {
+            if (auto parsed_value = parse_dimension_value(value))
+                style.set_property(CSS::PropertyID::BorderSpacing, parsed_value.release_nonnull());
+            return;
+        }
     });
 }
 


### PR DESCRIPTION
Before:
![Capture d’écran 2023-07-05 à 12 20 08](https://github.com/SerenityOS/serenity/assets/199648/21af3582-752b-4eb9-8a1b-3df518d3a7e3)

After:
![Capture d’écran 2023-07-05 à 12 20 53](https://github.com/SerenityOS/serenity/assets/199648/7f6858cc-2a74-4144-b041-0d9fe6c91853)

Fixes #19807 