### PR TITLE
LibJS/Bytecode: Mixed bag of bytecode codegen fixes

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -847,6 +847,7 @@ Bytecode::CodeGenerationErrorOr<void> ForStatement::generate_labelled_evaluation
     generator.switch_to_basic_block(*body_block_ptr);
     generator.begin_continuable_scope(Bytecode::Label { m_update ? *update_block_ptr : *test_block_ptr }, label_set);
     generator.begin_breakable_scope(Bytecode::Label { end_block }, label_set);
+    generator.emit<Bytecode::Op::LoadImmediate>(js_undefined());
     TRY(m_body->generate_bytecode(generator));
     generator.end_breakable_scope();
     generator.end_continuable_scope();

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -671,6 +671,7 @@ Bytecode::CodeGenerationErrorOr<void> WhileStatement::generate_labelled_evaluati
     generator.switch_to_basic_block(body_block);
     generator.begin_continuable_scope(Bytecode::Label { test_block }, label_set);
     generator.begin_breakable_scope(Bytecode::Label { end_block }, label_set);
+    generator.emit<Bytecode::Op::LoadImmediate>(js_undefined());
     TRY(m_body->generate_bytecode(generator));
     generator.end_breakable_scope();
     generator.end_continuable_scope();

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -2303,8 +2303,13 @@ Bytecode::CodeGenerationErrorOr<void> SwitchStatement::generate_labelled_evaluat
 
 Bytecode::CodeGenerationErrorOr<void> ClassDeclaration::generate_bytecode(Bytecode::Generator& generator) const
 {
+    auto accumulator_backup_reg = generator.allocate_register();
+    generator.emit<Bytecode::Op::Store>(accumulator_backup_reg);
+
     TRY(m_class_expression->generate_bytecode(generator));
     generator.emit<Bytecode::Op::SetVariable>(generator.intern_identifier(m_class_expression.ptr()->name()), Bytecode::Op::SetVariable::InitializationMode::Initialize);
+
+    generator.emit<Bytecode::Op::Load>(accumulator_backup_reg);
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -66,6 +66,13 @@ Bytecode::CodeGenerationErrorOr<void> ExpressionStatement::generate_bytecode(Byt
 
 Bytecode::CodeGenerationErrorOr<void> BinaryExpression::generate_bytecode(Bytecode::Generator& generator) const
 {
+    if (m_op == BinaryOp::In && is<PrivateIdentifier>(*m_lhs)) {
+        auto const& private_identifier = static_cast<PrivateIdentifier const&>(*m_lhs).string();
+        TRY(m_rhs->generate_bytecode(generator));
+        generator.emit<Bytecode::Op::HasPrivateId>(generator.intern_identifier(private_identifier));
+        return {};
+    }
+
     TRY(m_lhs->generate_bytecode(generator));
     auto lhs_reg = generator.allocate_register();
     generator.emit<Bytecode::Op::Store>(lhs_reg);

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -43,6 +43,7 @@
     O(GetVariable)                   \
     O(GreaterThan)                   \
     O(GreaterThanEquals)             \
+    O(HasPrivateId)                  \
     O(ImportCall)                    \
     O(In)                            \
     O(Increment)                     \

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -544,6 +544,20 @@ ThrowCompletionOr<void> GetPrivateById::execute_impl(Bytecode::Interpreter& inte
     return {};
 }
 
+ThrowCompletionOr<void> HasPrivateId::execute_impl(Bytecode::Interpreter& interpreter) const
+{
+    auto& vm = interpreter.vm();
+
+    if (!interpreter.accumulator().is_object())
+        return vm.throw_completion<TypeError>(ErrorType::InOperatorWithObject);
+
+    auto private_environment = vm.running_execution_context().private_environment;
+    VERIFY(private_environment);
+    auto private_name = private_environment->resolve_private_identifier(interpreter.current_executable().get_identifier(m_property));
+    interpreter.accumulator() = Value(interpreter.accumulator().as_object().private_element_find(private_name) != nullptr);
+    return {};
+}
+
 ThrowCompletionOr<void> PutById::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
@@ -1381,6 +1395,11 @@ DeprecatedString GetById::to_deprecated_string_impl(Bytecode::Executable const& 
 DeprecatedString GetPrivateById::to_deprecated_string_impl(Bytecode::Executable const& executable) const
 {
     return DeprecatedString::formatted("GetPrivateById {} ({})", m_property, executable.identifier_table->get(m_property));
+}
+
+DeprecatedString HasPrivateId::to_deprecated_string_impl(Bytecode::Executable const& executable) const
+{
+    return DeprecatedString::formatted("HasPrivateId {} ({})", m_property, executable.identifier_table->get(m_property));
 }
 
 DeprecatedString DeleteById::to_deprecated_string_impl(Bytecode::Executable const& executable) const

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -558,6 +558,23 @@ private:
     IdentifierTableIndex m_property;
 };
 
+class HasPrivateId final : public Instruction {
+public:
+    explicit HasPrivateId(IdentifierTableIndex property)
+        : Instruction(Type::HasPrivateId)
+        , m_property(property)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
+
+private:
+    IdentifierTableIndex m_property;
+};
+
 enum class PropertyKind {
     Getter,
     Setter,


### PR DESCRIPTION
See individual commits for details.

```
Summary:
    Diff Tests:
        +31 ✅    -20 ❌    -11 📝   

Diff Tests:
    test/language/expressions/in/private-field-presence-accessor-shadowed.js 📝 -> ✅
    test/language/expressions/in/private-field-presence-accessor.js          📝 -> ✅
    test/language/expressions/in/private-field-presence-field-shadowed.js    📝 -> ✅
    test/language/expressions/in/private-field-presence-field.js             📝 -> ✅
    test/language/expressions/in/private-field-presence-method-shadowed.js   📝 -> ✅
    test/language/expressions/in/private-field-presence-method.js            📝 -> ✅
    test/language/expressions/in/private-field-rhs-await-absent.js           📝 -> ✅
    test/language/expressions/in/private-field-rhs-await-present.js          📝 -> ✅
    test/language/expressions/in/private-field-rhs-non-object.js             📝 -> ✅
    test/language/expressions/in/private-field-rhs-unresolvable.js           📝 -> ✅
    test/language/expressions/in/private-field-rhs-yield-present.js          📝 -> ✅
    test/language/statementList/eval-class-block.js                          ❌ -> ✅
    test/language/statements/class/cptn-decl.js                              ❌ -> ✅
    test/language/statements/for-in/S12.6.4_A3.1.js                          ❌ -> ✅
    test/language/statements/for-in/S12.6.4_A3.js                            ❌ -> ✅
    test/language/statements/for-in/S12.6.4_A4.1.js                          ❌ -> ✅
    test/language/statements/for-in/S12.6.4_A4.js                            ❌ -> ✅
    test/language/statements/for-in/cptn-decl-itr.js                         ❌ -> ✅
    test/language/statements/for-in/cptn-decl-skip-itr.js                    ❌ -> ✅
    test/language/statements/for-in/cptn-decl-zero-itr.js                    ❌ -> ✅
    test/language/statements/for-in/cptn-expr-itr.js                         ❌ -> ✅
    test/language/statements/for-in/cptn-expr-skip-itr.js                    ❌ -> ✅
    test/language/statements/for-in/cptn-expr-zero-itr.js                    ❌ -> ✅
    test/language/statements/for-of/cptn-decl-itr.js                         ❌ -> ✅
    test/language/statements/for-of/cptn-decl-no-itr.js                      ❌ -> ✅
    test/language/statements/for-of/cptn-expr-itr.js                         ❌ -> ✅
    test/language/statements/for-of/cptn-expr-no-itr.js                      ❌ -> ✅
    test/language/statements/for/cptn-decl-expr-iter.js                      ❌ -> ✅
    test/language/statements/for/cptn-expr-expr-iter.js                      ❌ -> ✅
    test/language/statements/while/cptn-abrupt-empty.js                      ❌ -> ✅
    test/language/statements/while/cptn-iter.js                              ❌ -> ✅
```