### PR TITLE
LibWeb: Two fixes for the twitter.com front page

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-justify-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-justify-content.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x1754 [BFC] children: not-inline
-    BlockContainer <body> at (10,10) content-size 780x1736 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x2002 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x1984 children: not-inline
       BlockContainer <(anonymous)> at (10,10) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.row.outer.start> at (11,11) content-size 300x60 flex-container(row) [FFC] children: not-inline
@@ -59,171 +59,203 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,444) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.row.reverse.outer.start> at (11,445) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (161,446) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [161,446 41.234375x17.46875]
-              "start"
+      Box <div.row.outer.space-evenly> at (11,445) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (86,446) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 98.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [86,446 98.859375x17.46875]
+              "space-evenly"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,506) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.row.reverse.outer.flex-start> at (11,507) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+      Box <div.row.reverse.outer.start> at (11,507) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (161,508) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [161,508 76.8125x17.46875]
-              "flex-start"
+          line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [161,508 41.234375x17.46875]
+              "start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,568) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.row.reverse.outer.end> at (11,569) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (11,570) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [11,570 26.1875x17.46875]
-              "end"
+      Box <div.row.reverse.outer.flex-start> at (11,569) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (161,570) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 10, rect: [161,570 76.8125x17.46875]
+              "flex-start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,630) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.row.reverse.outer.flex-end> at (11,631) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+      Box <div.row.reverse.outer.end> at (11,631) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (11,632) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [11,632 61.765625x17.46875]
-              "flex-end"
+          line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 3, rect: [11,632 26.1875x17.46875]
+              "end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,692) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.row.reverse.outer.center> at (11,693) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (86,694) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 6, rect: [86,694 51.625x17.46875]
-              "center"
+      Box <div.row.reverse.outer.flex-end> at (11,693) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (11,694) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 8, rect: [11,694 61.765625x17.46875]
+              "flex-end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,754) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.row.reverse.outer.space-around> at (11,755) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+      Box <div.row.reverse.outer.center> at (11,755) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <div> at (86,756) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 12, rect: [86,756 107.96875x17.46875]
-              "space-around"
+          line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [86,756 51.625x17.46875]
+              "center"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,816) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.row.reverse.outer.space-between> at (11,817) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (11,818) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 13, rect: [11,818 115.515625x17.46875]
-              "space-between"
+      Box <div.row.reverse.outer.space-around> at (11,817) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (86,818) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [86,818 107.96875x17.46875]
+              "space-around"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,878) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.column.outer.start> at (11,879) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (12,879) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [12,879 41.234375x17.46875]
-              "start"
+      Box <div.row.reverse.outer.space-between> at (11,879) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (11,880) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 13, rect: [11,880 115.515625x17.46875]
+              "space-between"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,940) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.column.outer.flex-start> at (11,941) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (12,941) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [12,941 76.8125x17.46875]
-              "flex-start"
+      Box <div.row.reverse.outer.space-evenly> at (11,941) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (86,942) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 98.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [86,942 98.859375x17.46875]
+              "space-evenly"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1002) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.column.outer.end> at (11,1003) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (12,1013) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [12,1013 26.1875x17.46875]
-              "end"
+      Box <div.column.outer.start> at (11,1003) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1003) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [12,1003 41.234375x17.46875]
+              "start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1064) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.column.outer.flex-end> at (11,1065) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (12,1075) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [12,1075 61.765625x17.46875]
-              "flex-end"
+      Box <div.column.outer.flex-start> at (11,1065) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1065) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 10, rect: [12,1065 76.8125x17.46875]
+              "flex-start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1126) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.column.outer.center> at (11,1127) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (12,1132) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 6, rect: [12,1132 51.625x17.46875]
-              "center"
+      Box <div.column.outer.end> at (11,1127) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1137) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 3, rect: [12,1137 26.1875x17.46875]
+              "end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1188) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.column.outer.space-around> at (11,1189) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (12,1194) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 12, rect: [12,1194 107.96875x17.46875]
-              "space-around"
+      Box <div.column.outer.flex-end> at (11,1189) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1199) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 8, rect: [12,1199 61.765625x17.46875]
+              "flex-end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1250) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.column.outer.space-between> at (11,1251) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (12,1251) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 13, rect: [12,1251 115.515625x17.46875]
-              "space-between"
+      Box <div.column.outer.center> at (11,1251) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1256) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [12,1256 51.625x17.46875]
+              "center"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1312) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.column.reverse.outer.start> at (11,1313) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (12,1323) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [12,1323 41.234375x17.46875]
-              "start"
+      Box <div.column.outer.space-around> at (11,1313) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1318) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [12,1318 107.96875x17.46875]
+              "space-around"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1374) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.column.reverse.outer.flex-start> at (11,1375) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (12,1385) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [12,1385 76.8125x17.46875]
-              "flex-start"
+      Box <div.column.outer.space-between> at (11,1375) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1375) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 13, rect: [12,1375 115.515625x17.46875]
+              "space-between"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1436) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.column.reverse.outer.end> at (11,1437) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (12,1437) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [12,1437 26.1875x17.46875]
-              "end"
+      Box <div.column.outer.space-evenly> at (11,1437) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1442) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 98.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [12,1442 98.859375x17.46875]
+              "space-evenly"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1498) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.column.reverse.outer.flex-end> at (11,1499) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (12,1499) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [12,1499 61.765625x17.46875]
-              "flex-end"
+      Box <div.column.reverse.outer.start> at (11,1499) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,1509) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [12,1509 41.234375x17.46875]
+              "start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1560) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.column.reverse.outer.center> at (11,1561) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (12,1566) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 6, rect: [12,1566 51.625x17.46875]
-              "center"
+      Box <div.column.reverse.outer.flex-start> at (11,1561) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,1571) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 10, rect: [12,1571 76.8125x17.46875]
+              "flex-start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1622) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.column.reverse.outer.space-around> at (11,1623) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (12,1628) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 12, rect: [12,1628 107.96875x17.46875]
-              "space-around"
+      Box <div.column.reverse.outer.end> at (11,1623) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,1623) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 3, rect: [12,1623 26.1875x17.46875]
+              "end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1684) content-size 780x0 children: inline
         TextNode <#text>
-      Box <div.column.reverse.outer.space-between> at (11,1685) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+      Box <div.column.reverse.outer.flex-end> at (11,1685) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <div> at (12,1685) content-size 150x50 positioned [BFC] children: inline
-          line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 13, rect: [12,1685 115.515625x17.46875]
-              "space-between"
+          line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 8, rect: [12,1685 61.765625x17.46875]
+              "flex-end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,1746) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.center> at (11,1747) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,1752) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [12,1752 51.625x17.46875]
+              "center"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1808) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.space-around> at (11,1809) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,1814) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [12,1814 107.96875x17.46875]
+              "space-around"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1870) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.space-between> at (11,1871) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,1871) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 13, rect: [12,1871 115.515625x17.46875]
+              "space-between"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1932) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.space-evenly> at (11,1933) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,1938) content-size 150x50 positioned [BFC] children: inline
+          line 0 width: 98.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [12,1938 98.859375x17.46875]
+              "space-evenly"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1994) content-size 780x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-natural-aspect-ratio-and-automatic-cross-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-natural-aspect-ratio-and-automatic-cross-size.txt
@@ -1,0 +1,5 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x100 [BFC] children: not-inline
+    Box <body> at (0,0) content-size 800x100 flex-container(column) [FFC] children: not-inline
+      SVGSVGBox <svg> at (0,0) content-size 200x100 flex-item [SVG] children: not-inline
+        SVGGeometryBox <rect> at (0,0) content-size 200x100 children: not-inline

--- a/Tests/LibWeb/Layout/expected/flex/justify-content-1.txt
+++ b/Tests/LibWeb/Layout/expected/flex/justify-content-1.txt
@@ -1,0 +1,581 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x5842 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x5824 children: not-inline
+      BlockContainer <(anonymous)> at (10,10) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.outer.start> at (11,11) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (12,12) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [12,12 41.234375x17.46875]
+              "start"
+          TextNode <#text>
+        BlockContainer <div> at (64,12) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [64,12 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (116,12) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [116,12 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,72) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.outer.flex-start> at (11,73) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (12,74) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 10, rect: [12,74 76.8125x17.46875]
+              "flex-start"
+          TextNode <#text>
+        BlockContainer <div> at (64,74) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [64,74 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (116,74) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [116,74 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,134) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.outer.end> at (11,135) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (156,136) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 3, rect: [156,136 26.1875x17.46875]
+              "end"
+          TextNode <#text>
+        BlockContainer <div> at (208,136) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [208,136 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (260,136) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [260,136 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,196) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.outer.flex-end> at (11,197) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (156,198) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 8, rect: [156,198 61.765625x17.46875]
+              "flex-end"
+          TextNode <#text>
+        BlockContainer <div> at (208,198) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [208,198 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (260,198) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [260,198 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,258) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.outer.center> at (11,259) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (84,260) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [84,260 51.625x17.46875]
+              "center"
+          TextNode <#text>
+        BlockContainer <div> at (136,260) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [136,260 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (188,260) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [188,260 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,320) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.outer.space-around> at (11,321) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (36,322) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [36,322 107.96875x17.46875]
+              "space-around"
+          TextNode <#text>
+        BlockContainer <div> at (136,322) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [136,322 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (236,322) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [236,322 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,382) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.outer.space-between> at (11,383) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (12,384) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 13, rect: [12,384 115.515625x17.46875]
+              "space-between"
+          TextNode <#text>
+        BlockContainer <div> at (136,384) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [136,384 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (260,384) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [260,384 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,444) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.outer.space-evenly> at (11,445) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (48,446) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 98.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [48,446 98.859375x17.46875]
+              "space-evenly"
+          TextNode <#text>
+        BlockContainer <div> at (136,446) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [136,446 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (224,446) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [224,446 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,506) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.reverse.outer.start> at (11,507) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (260,508) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [260,508 41.234375x17.46875]
+              "start"
+          TextNode <#text>
+        BlockContainer <div> at (208,508) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [208,508 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (156,508) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [156,508 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,568) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.reverse.outer.flex-start> at (11,569) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (260,570) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 10, rect: [260,570 76.8125x17.46875]
+              "flex-start"
+          TextNode <#text>
+        BlockContainer <div> at (208,570) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [208,570 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (156,570) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [156,570 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,630) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.reverse.outer.end> at (11,631) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (-40,632) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 3, rect: [-40,632 26.1875x17.46875]
+              "end"
+          TextNode <#text>
+        BlockContainer <div> at (-92,632) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [-92,632 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (-144,632) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [-144,632 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,692) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.reverse.outer.flex-end> at (11,693) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (-40,694) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 8, rect: [-40,694 61.765625x17.46875]
+              "flex-end"
+          TextNode <#text>
+        BlockContainer <div> at (-92,694) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [-92,694 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (-144,694) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [-144,694 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,754) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.reverse.outer.center> at (11,755) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (188,756) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [188,756 51.625x17.46875]
+              "center"
+          TextNode <#text>
+        BlockContainer <div> at (136,756) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [136,756 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (84,756) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [84,756 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,816) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.reverse.outer.space-around> at (11,817) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (236,818) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [236,818 107.96875x17.46875]
+              "space-around"
+          TextNode <#text>
+        BlockContainer <div> at (136,818) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [136,818 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (36,818) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [36,818 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,878) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.reverse.outer.space-between> at (11,879) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (260,880) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 13, rect: [260,880 115.515625x17.46875]
+              "space-between"
+          TextNode <#text>
+        BlockContainer <div> at (136,880) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [136,880 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,880) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,880 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,940) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.row.reverse.outer.space-evenly> at (11,941) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (224,942) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 98.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [224,942 98.859375x17.46875]
+              "space-evenly"
+          TextNode <#text>
+        BlockContainer <div> at (136,942) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [136,942 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (48,942) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [48,942 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1002) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.outer.start> at (11,1003) content-size 60x300 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1004) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [12,1004 41.234375x17.46875]
+              "start"
+          TextNode <#text>
+        BlockContainer <div> at (12,1056) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,1056 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,1108) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,1108 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1304) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.outer.flex-start> at (11,1305) content-size 60x300 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1306) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 10, rect: [12,1306 76.8125x17.46875]
+              "flex-start"
+          TextNode <#text>
+        BlockContainer <div> at (12,1358) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,1358 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,1410) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,1410 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1606) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.outer.end> at (11,1607) content-size 60x300 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,1752) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 3, rect: [12,1752 26.1875x17.46875]
+              "end"
+          TextNode <#text>
+        BlockContainer <div> at (12,1804) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,1804 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,1856) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,1856 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,1908) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.outer.flex-end> at (11,1909) content-size 60x300 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,2054) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 8, rect: [12,2054 61.765625x17.46875]
+              "flex-end"
+          TextNode <#text>
+        BlockContainer <div> at (12,2106) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,2106 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,2158) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,2158 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,2210) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.outer.center> at (11,2211) content-size 60x300 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,2284) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [12,2284 51.625x17.46875]
+              "center"
+          TextNode <#text>
+        BlockContainer <div> at (12,2336) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,2336 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,2388) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,2388 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,2512) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.outer.space-around> at (11,2513) content-size 60x300 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,2538) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [12,2538 107.96875x17.46875]
+              "space-around"
+          TextNode <#text>
+        BlockContainer <div> at (12,2638) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,2638 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,2738) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,2738 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,2814) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.outer.space-between> at (11,2815) content-size 60x300 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,2816) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 13, rect: [12,2816 115.515625x17.46875]
+              "space-between"
+          TextNode <#text>
+        BlockContainer <div> at (12,2940) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,2940 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,3064) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,3064 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,3116) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.outer.space-evenly> at (11,3117) content-size 60x300 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (12,3154) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 98.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [12,3154 98.859375x17.46875]
+              "space-evenly"
+          TextNode <#text>
+        BlockContainer <div> at (12,3242) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,3242 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,3330) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,3330 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,3418) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.start> at (11,3419) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,3668) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [12,3668 41.234375x17.46875]
+              "start"
+          TextNode <#text>
+        BlockContainer <div> at (12,3616) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,3616 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,3564) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,3564 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,3720) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.flex-start> at (11,3721) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,3970) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 10, rect: [12,3970 76.8125x17.46875]
+              "flex-start"
+          TextNode <#text>
+        BlockContainer <div> at (12,3918) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,3918 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,3866) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,3866 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,4022) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.end> at (11,4023) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,3972) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 3, rect: [12,3972 26.1875x17.46875]
+              "end"
+          TextNode <#text>
+        BlockContainer <div> at (12,3920) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,3920 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,3868) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,3868 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,4324) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.flex-end> at (11,4325) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,4274) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 8, rect: [12,4274 61.765625x17.46875]
+              "flex-end"
+          TextNode <#text>
+        BlockContainer <div> at (12,4222) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,4222 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,4170) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,4170 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,4626) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.center> at (11,4627) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,4804) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [12,4804 51.625x17.46875]
+              "center"
+          TextNode <#text>
+        BlockContainer <div> at (12,4752) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,4752 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,4700) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,4700 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,4928) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.space-around> at (11,4929) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,5154) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [12,5154 107.96875x17.46875]
+              "space-around"
+          TextNode <#text>
+        BlockContainer <div> at (12,5054) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,5054 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,4954) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,4954 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,5230) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.space-between> at (11,5231) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,5480) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 13, rect: [12,5480 115.515625x17.46875]
+              "space-between"
+          TextNode <#text>
+        BlockContainer <div> at (12,5356) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,5356 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,5232) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,5232 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,5532) content-size 780x0 children: inline
+        TextNode <#text>
+      Box <div.column.reverse.outer.space-evenly> at (11,5533) content-size 60x300 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (12,5746) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 98.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 12, rect: [12,5746 98.859375x17.46875]
+              "space-evenly"
+          TextNode <#text>
+        BlockContainer <div> at (12,5658) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,5658 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (12,5570) content-size 50x50 flex-item [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [12,5570 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (10,5834) content-size 780x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/flex/abspos-flex-child-static-position-with-justify-content.html
+++ b/Tests/LibWeb/Layout/input/flex/abspos-flex-child-static-position-with-justify-content.html
@@ -21,6 +21,7 @@
       .center { justify-content: center; }
       .space-around { justify-content: space-around; }
       .space-between { justify-content: space-between; }
+      .space-evenly { justify-content: space-evenly; }
 
       .row { flex-direction: row; }
       .row.reverse { flex-direction: row-reverse; }
@@ -38,6 +39,7 @@
 <div class="row outer center"><div>center</div></div>
 <div class="row outer space-around"><div>space-around</div></div>
 <div class="row outer space-between"><div>space-between</div></div>
+<div class="row outer space-evenly"><div>space-evenly</div></div>
 <div class="row reverse outer start"><div>start</div></div>
 <div class="row reverse outer flex-start"><div>flex-start</div></div>
 <div class="row reverse outer end"><div>end</div></div>
@@ -45,6 +47,7 @@
 <div class="row reverse outer center"><div>center</div></div>
 <div class="row reverse outer space-around"><div>space-around</div></div>
 <div class="row reverse outer space-between"><div>space-between</div></div>
+<div class="row reverse outer space-evenly"><div>space-evenly</div></div>
 <div class="column outer start"><div>start</div></div>
 <div class="column outer flex-start"><div>flex-start</div></div>
 <div class="column outer end"><div>end</div></div>
@@ -52,6 +55,7 @@
 <div class="column outer center"><div>center</div></div>
 <div class="column outer space-around"><div>space-around</div></div>
 <div class="column outer space-between"><div>space-between</div></div>
+<div class="column outer space-evenly"><div>space-evenly</div></div>
 <div class="column reverse outer start"><div>start</div></div>
 <div class="column reverse outer flex-start"><div>flex-start</div></div>
 <div class="column reverse outer end"><div>end</div></div>
@@ -59,3 +63,4 @@
 <div class="column reverse outer center"><div>center</div></div>
 <div class="column reverse outer space-around"><div>space-around</div></div>
 <div class="column reverse outer space-between"><div>space-between</div></div>
+<div class="column reverse outer space-evenly"><div>space-evenly</div></div>

--- a/Tests/LibWeb/Layout/input/flex/flex-column-item-with-natural-aspect-ratio-and-automatic-cross-size.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-column-item-with-natural-aspect-ratio-and-automatic-cross-size.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html><style>
+    * {
+        margin: 0;
+        padding: 0;
+    }
+    body {
+        display: flex;
+        flex-direction: column
+    }
+    svg {
+        align-self: flex-start;
+        height: 100px;
+    }
+</style><svg viewBox="0 0 10 5"><rect fill="green" x="0" y="0" width="10" height="5"></svg>

--- a/Tests/LibWeb/Layout/input/flex/justify-content-1.html
+++ b/Tests/LibWeb/Layout/input/flex/justify-content-1.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html><style>
+* {
+    border: 1px solid black !important;
+}
+      .outer {
+        display: flex;
+        background: wheat;
+      }
+      .outer.row {
+        width: 300px;
+        height: 60px;
+      }
+      .outer.column {
+        width: 60px;
+        height: 300px;
+      }
+      .outer > div {
+        width: 50px;
+        height: 50px;
+        background: orange;
+      }
+      .flex-start { justify-content: flex-start; }
+      .flex-end { justify-content: flex-end; }
+      .start { justify-content: start; }
+      .end { justify-content: end; }
+      .center { justify-content: center; }
+      .space-around { justify-content: space-around; }
+      .space-between { justify-content: space-between; }
+      .space-evenly { justify-content: space-evenly; }
+
+      .row { flex-direction: row; }
+      .row.reverse { flex-direction: row-reverse; }
+      .column { flex-direction: column; }
+      .column.reverse { flex-direction: column-reverse; }
+      .reverse > div {
+          background: magenta;
+      }
+</style>
+<body>
+<div class="row outer start"><div>start</div><div>a</div><div>b</div></div>
+<div class="row outer flex-start"><div>flex-start</div><div>a</div><div>b</div></div>
+<div class="row outer end"><div>end</div><div>a</div><div>b</div></div>
+<div class="row outer flex-end"><div>flex-end</div><div>a</div><div>b</div></div>
+<div class="row outer center"><div>center</div><div>a</div><div>b</div></div>
+<div class="row outer space-around"><div>space-around</div><div>a</div><div>b</div></div>
+<div class="row outer space-between"><div>space-between</div><div>a</div><div>b</div></div>
+<div class="row outer space-evenly"><div>space-evenly</div><div>a</div><div>b</div></div>
+<div class="row reverse outer start"><div>start</div><div>a</div><div>b</div></div>
+<div class="row reverse outer flex-start"><div>flex-start</div><div>a</div><div>b</div></div>
+<div class="row reverse outer end"><div>end</div><div>a</div><div>b</div></div>
+<div class="row reverse outer flex-end"><div>flex-end</div><div>a</div><div>b</div></div>
+<div class="row reverse outer center"><div>center</div><div>a</div><div>b</div></div>
+<div class="row reverse outer space-around"><div>space-around</div><div>a</div><div>b</div></div>
+<div class="row reverse outer space-between"><div>space-between</div><div>a</div><div>b</div></div>
+<div class="row reverse outer space-evenly"><div>space-evenly</div><div>a</div><div>b</div></div>
+<div class="column outer start"><div>start</div><div>a</div><div>b</div></div>
+<div class="column outer flex-start"><div>flex-start</div><div>a</div><div>b</div></div>
+<div class="column outer end"><div>end</div><div>a</div><div>b</div></div>
+<div class="column outer flex-end"><div>flex-end</div><div>a</div><div>b</div></div>
+<div class="column outer center"><div>center</div><div>a</div><div>b</div></div>
+<div class="column outer space-around"><div>space-around</div><div>a</div><div>b</div></div>
+<div class="column outer space-between"><div>space-between</div><div>a</div><div>b</div></div>
+<div class="column outer space-evenly"><div>space-evenly</div><div>a</div><div>b</div></div>
+<div class="column reverse outer start"><div>start</div><div>a</div><div>b</div></div>
+<div class="column reverse outer flex-start"><div>flex-start</div><div>a</div><div>b</div></div>
+<div class="column reverse outer end"><div>end</div><div>a</div><div>b</div></div>
+<div class="column reverse outer flex-end"><div>flex-end</div><div>a</div><div>b</div></div>
+<div class="column reverse outer center"><div>center</div><div>a</div><div>b</div></div>
+<div class="column reverse outer space-around"><div>space-around</div><div>a</div><div>b</div></div>
+<div class="column reverse outer space-between"><div>space-between</div><div>a</div><div>b</div></div>
+<div class="column reverse outer space-evenly"><div>space-evenly</div><div>a</div><div>b</div></div>

--- a/Userland/Libraries/LibWeb/CSS/Enums.json
+++ b/Userland/Libraries/LibWeb/CSS/Enums.json
@@ -5,6 +5,7 @@
         "center",
         "space-between",
         "space-around",
+        "space-evenly",
         "stretch"
     ],
     "align-items": [
@@ -172,7 +173,8 @@
         "flex-end",
         "center",
         "space-between",
-        "space-around"
+        "space-around",
+        "space-evenly"
     ],
     "line-style": [
         "none",

--- a/Userland/Libraries/LibWeb/CSS/Identifiers.json
+++ b/Userland/Libraries/LibWeb/CSS/Identifiers.json
@@ -272,6 +272,7 @@
   "space",
   "space-around",
   "space-between",
+  "space-evenly",
   "square",
   "srgb",
   "standalone",

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -563,6 +563,13 @@ CSSPixels FlexFormattingContext::calculate_main_size_from_cross_size_and_aspect_
     return cross_size / aspect_ratio;
 }
 
+CSSPixels FlexFormattingContext::calculate_cross_size_from_main_size_and_aspect_ratio(CSSPixels main_size, double aspect_ratio) const
+{
+    if (is_row_layout())
+        return main_size / aspect_ratio;
+    return main_size * aspect_ratio;
+}
+
 // This function takes a size in the main axis and adjusts it according to the aspect ratio of the box
 // if the min/max constraints in the cross axis forces us to come up with a new main axis size.
 CSSPixels FlexFormattingContext::adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(Box const& box, CSSPixels main_size, CSS::Size const& min_cross_size, CSS::Size const& max_cross_size) const
@@ -1149,6 +1156,11 @@ void FlexFormattingContext::determine_hypothetical_cross_size_of_item(FlexItem& 
 
     if (should_treat_cross_size_as_auto(item.box)) {
         // Item has automatic cross size, layout with "fit-content"
+
+        if (item.box->has_preferred_aspect_ratio() && item.main_size.has_value()) {
+            item.hypothetical_cross_size = calculate_cross_size_from_main_size_and_aspect_ratio(item.main_size.value(), item.box->preferred_aspect_ratio().value());
+            return;
+        }
 
         CSSPixels fit_content_cross_size = 0;
         if (is_row_layout()) {

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1356,6 +1356,14 @@ void FlexFormattingContext::distribute_any_remaining_free_space()
                     initial_offset = space_between_items / 2.0;
                 }
                 break;
+            case CSS::JustifyContent::SpaceEvenly:
+                space_between_items = flex_line.remaining_free_space / (number_of_items + 1);
+                if (is_direction_reverse()) {
+                    initial_offset = inner_main_size(flex_container()) - space_between_items;
+                } else {
+                    initial_offset = space_between_items;
+                }
+                break;
             }
         }
 
@@ -1593,6 +1601,21 @@ void FlexFormattingContext::align_all_flex_lines()
             start_of_current_line = gap_size / 2;
             break;
         }
+        case CSS::AlignContent::SpaceEvenly: {
+            auto leftover_free_space = cross_size_of_flex_container - sum_of_flex_line_cross_sizes;
+            if (leftover_free_space < 0) {
+                // If the leftover free-space is negative this value is identical to center.
+                start_of_current_line = (cross_size_of_flex_container / 2) - (sum_of_flex_line_cross_sizes / 2);
+                break;
+            }
+
+            gap_size = leftover_free_space / (m_flex_lines.size() + 1);
+
+            // The spacing between the first/last lines and the flex container edges is the size of the spacing between flex lines.
+            start_of_current_line = gap_size;
+            break;
+        }
+
         case CSS::AlignContent::Stretch:
             start_of_current_line = 0;
             break;
@@ -2180,6 +2203,7 @@ CSSPixelPoint FlexFormattingContext::calculate_static_position(Box const& box) c
         break;
     case CSS::JustifyContent::Center:
     case CSS::JustifyContent::SpaceAround:
+    case CSS::JustifyContent::SpaceEvenly:
         pack_from_end = false;
         main_offset = inner_main_size(flex_container()) / 2.0 - inner_main_size(box) / 2.0;
         break;

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -36,6 +36,7 @@ private:
 
     [[nodiscard]] CSSPixels adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(Box const&, CSSPixels main_size, CSS::Size const& min_cross_size, CSS::Size const& max_cross_size) const;
     [[nodiscard]] CSSPixels calculate_main_size_from_cross_size_and_aspect_ratio(CSSPixels cross_size, double aspect_ratio) const;
+    [[nodiscard]] CSSPixels calculate_cross_size_from_main_size_and_aspect_ratio(CSSPixels main_size, double aspect_ratio) const;
 
     void dump_items() const;
 


### PR DESCRIPTION
- Determine flex item automatic cross size from aspect ratio & main size when applicable.
- Add support for `justify-content: space-evenly` in flex layout.

Visual progression on https://twitter.com/ (note bird logo and alignment of cookie banner):

Before:
![Screenshot at 2023-07-05 17-51-49](https://github.com/SerenityOS/serenity/assets/5954907/bac1eec1-928c-4f9f-b076-c3ae734d150d)

After:
![Screenshot at 2023-07-05 17-50-49](https://github.com/SerenityOS/serenity/assets/5954907/eb6093ce-c402-4a5d-81d4-31cf0265ed2b)

