### PR TITLE
LibWeb: First steps towards proper calc() typing

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES
     CSS/CSSKeyframesRule.cpp
     CSS/CSSFontFaceRule.cpp
     CSS/CSSMediaRule.cpp
+    CSS/CSSNumericType.cpp
     CSS/CSSRule.cpp
     CSS/CSSRuleList.cpp
     CSS/CSSStyleDeclaration.cpp

--- a/Userland/Libraries/LibWeb/CSS/CSSNumericType.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSNumericType.cpp
@@ -1,0 +1,432 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "CSSNumericType.h"
+#include <AK/HashMap.h>
+#include <LibWeb/CSS/Angle.h>
+#include <LibWeb/CSS/Frequency.h>
+#include <LibWeb/CSS/Length.h>
+#include <LibWeb/CSS/Percentage.h>
+#include <LibWeb/CSS/Resolution.h>
+#include <LibWeb/CSS/Time.h>
+
+namespace Web::CSS {
+
+Optional<CSSNumericType::BaseType> CSSNumericType::base_type_from_value_type(ValueType value_type)
+{
+    switch (value_type) {
+    case ValueType::Angle:
+        return BaseType::Angle;
+    case ValueType::Frequency:
+        return BaseType::Frequency;
+    case ValueType::Length:
+        return BaseType::Length;
+    case ValueType::Percentage:
+        return BaseType::Percent;
+    case ValueType::Resolution:
+        return BaseType::Resolution;
+    case ValueType::Time:
+        return BaseType::Time;
+
+    case ValueType::Color:
+    case ValueType::CustomIdent:
+    case ValueType::FilterValueList:
+    case ValueType::Image:
+    case ValueType::Integer:
+    case ValueType::Paint:
+    case ValueType::Number:
+    case ValueType::Position:
+    case ValueType::Ratio:
+    case ValueType::Rect:
+    case ValueType::String:
+    case ValueType::Url:
+        return {};
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-create-a-type
+Optional<CSSNumericType> CSSNumericType::create_from_unit(StringView unit)
+{
+    // To create a type from a string unit, follow the appropriate branch of the following:
+
+    // unit is "number"
+    if (unit == "number"sv) {
+        // Return «[ ]» (empty map)
+        return CSSNumericType {};
+    }
+
+    // unit is "percent"
+    if (unit == "percent"sv) {
+        // Return «[ "percent" → 1 ]»
+        return CSSNumericType { BaseType::Percent, 1 };
+    }
+
+    // unit is a <length> unit
+    if (Length::unit_from_name(unit).has_value()) {
+        // Return «[ "length" → 1 ]»
+        return CSSNumericType { BaseType::Length, 1 };
+    }
+
+    // unit is an <angle> unit
+    if (Angle::unit_from_name(unit).has_value()) {
+        //    Return «[ "angle" → 1 ]»
+        return CSSNumericType { BaseType::Angle, 1 };
+    }
+
+    // unit is a <time> unit
+    if (Time::unit_from_name(unit).has_value()) {
+        //    Return «[ "time" → 1 ]»
+        return CSSNumericType { BaseType::Time, 1 };
+    }
+
+    // unit is a <frequency> unit
+    if (Frequency::unit_from_name(unit).has_value()) {
+        //    Return «[ "frequency" → 1 ]»
+        return CSSNumericType { BaseType::Frequency, 1 };
+    }
+
+    // unit is a <resolution> unit
+    if (Resolution::unit_from_name(unit).has_value()) {
+        //    Return «[ "resolution" → 1 ]»
+        return CSSNumericType { BaseType::Resolution, 1 };
+    }
+
+    // unit is a <flex> unit
+    // FIXME: We don't have <flex> as a type yet.
+    //    Return «[ "flex" → 1 ]»
+
+    // anything else
+    //    Return failure.
+    return {};
+
+    // In all cases, the associated percent hint is null.
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-add-two-types
+Optional<CSSNumericType> CSSNumericType::added_to(CSSNumericType const& other) const
+{
+    // To add two types type1 and type2, perform the following steps:
+
+    // 1. Replace type1 with a fresh copy of type1, and type2 with a fresh copy of type2.
+    //    Let finalType be a new type with an initially empty ordered map and an initially null percent hint.
+    CSSNumericType type1 = *this;
+    CSSNumericType type2 = other;
+    CSSNumericType final_type {};
+
+    // 2. If both type1 and type2 have non-null percent hints with different values
+    if (type1.percent_hint().has_value() && type2.percent_hint().has_value() && type1.percent_hint() != type2.percent_hint()) {
+        // The types can’t be added. Return failure.
+        return {};
+    }
+    //    If type1 has a non-null percent hint hint and type2 doesn’t
+    else if (type1.percent_hint().has_value() && !type2.percent_hint().has_value()) {
+        // Apply the percent hint hint to type2.
+        type2.apply_percent_hint(type1.percent_hint().value());
+    }
+    //    Vice versa if type2 has a non-null percent hint and type1 doesn’t.
+    else if (type2.percent_hint().has_value() && !type1.percent_hint().has_value()) {
+        type1.apply_percent_hint(type2.percent_hint().value());
+    }
+    // Otherwise
+    //     Continue to the next step.
+
+    // 3. If all the entries of type1 with non-zero values are contained in type2 with the same value, and vice-versa
+    if (type2.contains_all_the_non_zero_entries_of_other_with_the_same_value(type1)
+        && type1.contains_all_the_non_zero_entries_of_other_with_the_same_value(type2)) {
+        // Copy all of type1’s entries to finalType, and then copy all of type2’s entries to finalType that
+        // finalType doesn’t already contain. Set finalType’s percent hint to type1’s percent hint. Return finalType.
+        final_type.copy_all_entries_from(type1, SkipIfAlreadyPresent::No);
+        final_type.copy_all_entries_from(type2, SkipIfAlreadyPresent::Yes);
+        final_type.set_percent_hint(type1.percent_hint());
+        return final_type;
+    }
+    //    If type1 and/or type2 contain "percent" with a non-zero value,
+    //    and type1 and/or type2 contain a key other than "percent" with a non-zero value
+    else if ((type1.exponent(BaseType::Percent) != 0 || type2.exponent(BaseType::Percent) != 0)
+        && (type1.contains_a_key_other_than_percent_with_a_non_zero_value() || type2.contains_a_key_other_than_percent_with_a_non_zero_value())) {
+        // For each base type other than "percent" hint:
+        for (auto hint_int = 0; hint_int < to_underlying(BaseType::__Count); ++hint_int) {
+            auto hint = static_cast<BaseType>(hint_int);
+            if (hint == BaseType::Percent)
+                continue;
+
+            // 1. Provisionally apply the percent hint hint to both type1 and type2.
+            auto provisional_type1 = type1;
+            provisional_type1.apply_percent_hint(hint);
+            auto provisional_type2 = type2;
+            provisional_type2.apply_percent_hint(hint);
+
+            // 2. If, afterwards, all the entries of type1 with non-zero values are contained in type2
+            //    with the same value, and vice versa, then copy all of type1’s entries to finalType,
+            //    and then copy all of type2’s entries to finalType that finalType doesn’t already contain.
+            //    Set finalType’s percent hint to hint. Return finalType.
+            if (provisional_type2.contains_all_the_non_zero_entries_of_other_with_the_same_value(provisional_type1)
+                && provisional_type1.contains_all_the_non_zero_entries_of_other_with_the_same_value(provisional_type2)) {
+
+                final_type.copy_all_entries_from(provisional_type1, SkipIfAlreadyPresent::No);
+                final_type.copy_all_entries_from(provisional_type2, SkipIfAlreadyPresent::Yes);
+                final_type.set_percent_hint(hint);
+                return final_type;
+            }
+
+            // 3. Otherwise, revert type1 and type2 to their state at the start of this loop.
+            // NOTE: We did the modifications to provisional_type1/2 so this is a no-op.
+        }
+
+        // If the loop finishes without returning finalType, then the types can’t be added. Return failure.
+        return {};
+    }
+    // Otherwise
+    //     The types can’t be added. Return failure.
+    return {};
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-multiply-two-types
+Optional<CSSNumericType> CSSNumericType::multiplied_by(CSSNumericType const& other) const
+{
+    // To multiply two types type1 and type2, perform the following steps:
+
+    // 1. Replace type1 with a fresh copy of type1, and type2 with a fresh copy of type2.
+    //    Let finalType be a new type with an initially empty ordered map and an initially null percent hint.
+    CSSNumericType type1 = *this;
+    CSSNumericType type2 = other;
+    CSSNumericType final_type {};
+
+    // 2. If both type1 and type2 have non-null percent hints with different values,
+    //    the types can’t be multiplied. Return failure.
+    if (type1.percent_hint().has_value() && type2.percent_hint().has_value() && type1.percent_hint() != type2.percent_hint())
+        return {};
+
+    // 3. If type1 has a non-null percent hint hint and type2 doesn’t, apply the percent hint hint to type2.
+    if (type1.percent_hint().has_value() && !type2.percent_hint().has_value()) {
+        type2.apply_percent_hint(type1.percent_hint().value());
+    }
+    //    Vice versa if type2 has a non-null percent hint and type1 doesn’t.
+    else if (type2.percent_hint().has_value() && !type1.percent_hint().has_value()) {
+        type1.apply_percent_hint(type2.percent_hint().value());
+    }
+
+    // 4. Copy all of type1’s entries to finalType, then for each baseType → power of type2:
+    final_type.copy_all_entries_from(type1, SkipIfAlreadyPresent::No);
+    for (auto i = 0; i < to_underlying(BaseType::__Count); ++i) {
+        auto base_type = static_cast<BaseType>(i);
+        if (!type2.exponent(base_type).has_value())
+            continue;
+        auto power = type2.exponent(base_type).value();
+
+        // 1. If finalType[baseType] exists, increment its value by power.
+        if (auto exponent = final_type.exponent(base_type); exponent.has_value()) {
+            final_type.set_exponent(base_type, exponent.value() + power);
+        }
+        // 2. Otherwise, set finalType[baseType] to power.
+        else {
+            final_type.set_exponent(base_type, power);
+        }
+    }
+    //    Set finalType’s percent hint to type1’s percent hint.
+    final_type.set_percent_hint(type1.percent_hint());
+
+    // 5. Return finalType.
+    return final_type;
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-invert-a-type
+CSSNumericType CSSNumericType::inverted() const
+{
+    // To invert a type type, perform the following steps:
+
+    // 1. Let result be a new type with an initially empty ordered map and an initially null percent hint
+    CSSNumericType result;
+
+    // 2. For each unit → exponent of type, set result[unit] to (-1 * exponent).
+    for (auto i = 0; i < to_underlying(BaseType::__Count); ++i) {
+        auto base_type = static_cast<BaseType>(i);
+        if (!exponent(base_type).has_value())
+            continue;
+        auto power = exponent(base_type).value();
+        result.set_exponent(base_type, -1 * power);
+    }
+
+    // 3. Return result.
+    return result;
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#apply-the-percent-hint
+void CSSNumericType::apply_percent_hint(BaseType hint)
+{
+    // To apply the percent hint hint to a type, perform the following steps:
+
+    // 1. If type doesn’t contain hint, set type[hint] to 0.
+    if (!exponent(hint).has_value())
+        set_exponent(hint, 0);
+
+    // 2. If type contains "percent", add type["percent"] to type[hint], then set type["percent"] to 0.
+    if (exponent(BaseType::Percent).has_value()) {
+        set_exponent(hint, exponent(BaseType::Percent).value() + exponent(hint).value());
+        set_exponent(BaseType::Percent, 0);
+    }
+
+    // 3. Set type’s percent hint to hint.
+    set_percent_hint(hint);
+}
+
+bool CSSNumericType::contains_all_the_non_zero_entries_of_other_with_the_same_value(CSSNumericType const& other) const
+{
+    for (auto i = 0; i < to_underlying(BaseType::__Count); ++i) {
+        auto other_exponent = other.exponent(static_cast<BaseType>(i));
+        if (other_exponent.has_value() && other_exponent != 0
+            && this->exponent(static_cast<BaseType>(i)) != other_exponent) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool CSSNumericType::contains_a_key_other_than_percent_with_a_non_zero_value() const
+{
+    for (auto i = 0; i < to_underlying(BaseType::__Count); ++i) {
+        if (i == to_underlying(BaseType::Percent))
+            continue;
+        if (m_type_exponents[i].has_value() && m_type_exponents[i] != 0)
+            return true;
+    }
+    return false;
+}
+
+void CSSNumericType::copy_all_entries_from(CSSNumericType const& other, SkipIfAlreadyPresent ignore_existing_values)
+{
+    for (auto i = 0; i < to_underlying(BaseType::__Count); ++i) {
+        auto base_type = static_cast<BaseType>(i);
+        auto exponent = other.exponent(base_type);
+        if (!exponent.has_value())
+            continue;
+        if (ignore_existing_values == SkipIfAlreadyPresent::Yes && this->exponent(base_type).has_value())
+            continue;
+        set_exponent(base_type, *exponent);
+    }
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-match
+bool CSSNumericType::matches_dimension(BaseType type) const
+{
+    // A type matches <length> if its only non-zero entry is «[ "length" → 1 ]» and its percent hint is null.
+    // Similarly for <angle>, <time>, <frequency>, <resolution>, and <flex>.
+
+    if (percent_hint().has_value())
+        return false;
+
+    for (auto i = 0; i < to_underlying(BaseType::__Count); ++i) {
+        auto base_type = static_cast<BaseType>(i);
+        auto type_exponent = exponent(base_type);
+        if (base_type == type) {
+            if (type_exponent != 1)
+                return false;
+        } else {
+            if (type_exponent.has_value() && type_exponent != 0)
+                return false;
+        }
+    }
+
+    return true;
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-match
+bool CSSNumericType::matches_percentage() const
+{
+    // A type matches <percentage> if its only non-zero entry is «[ "percent" → 1 ]».
+    for (auto i = 0; i < to_underlying(BaseType::__Count); ++i) {
+        auto base_type = static_cast<BaseType>(i);
+        auto type_exponent = exponent(base_type);
+        if (base_type == BaseType::Percent) {
+            if (!type_exponent.has_value() || type_exponent == 0)
+                return false;
+        } else {
+            if (type_exponent.has_value() && type_exponent != 0)
+                return false;
+        }
+    }
+    return true;
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-match
+bool CSSNumericType::matches_dimension_percentage(BaseType type) const
+{
+    // A type matches <length-percentage> if its only non-zero entry is either «[ "length" → 1 ]»
+    // or «[ "percent" → 1 ]» Same for <angle-percentage>, <time-percentage>, etc.
+
+    // Check for percent -> 1 or type -> 1, but not both
+    if ((exponent(type) == 1) == (exponent(BaseType::Percent) == 1))
+        return false;
+
+    // Ensure all other types are absent or 0
+    for (auto i = 0; i < to_underlying(BaseType::__Count); ++i) {
+        auto base_type = static_cast<BaseType>(i);
+        auto type_exponent = exponent(base_type);
+        if (base_type == type || base_type == BaseType::Percent)
+            continue;
+
+        if (type_exponent.has_value() && type_exponent != 0)
+            return false;
+    }
+
+    return true;
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-match
+bool CSSNumericType::matches_number() const
+{
+    // A type matches <number> if it has no non-zero entries and its percent hint is null.
+    if (percent_hint().has_value())
+        return false;
+
+    for (auto i = 0; i < to_underlying(BaseType::__Count); ++i) {
+        auto base_type = static_cast<BaseType>(i);
+        auto type_exponent = exponent(base_type);
+        if (type_exponent.has_value() && type_exponent != 0)
+            return false;
+    }
+
+    return true;
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-match
+bool CSSNumericType::matches_number_percentage() const
+{
+    // A type matches <number-percentage> if it has no non-zero entries, or its only non-zero entry is «[ "percent" → 1 ]».
+    for (auto i = 0; i < to_underlying(BaseType::__Count); ++i) {
+        auto base_type = static_cast<BaseType>(i);
+        auto type_exponent = exponent(base_type);
+
+        if (base_type == BaseType::Percent && type_exponent.has_value() && type_exponent != 0 && type_exponent != 1) {
+            return false;
+        } else if (type_exponent.has_value() && type_exponent != 0) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+ErrorOr<String> CSSNumericType::dump() const
+{
+    StringBuilder builder;
+    TRY(builder.try_appendff("{{ hint: {}", m_percent_hint.map([](auto base_type) { return base_type_name(base_type); })));
+
+    for (auto i = 0; i < to_underlying(BaseType::__Count); ++i) {
+        auto base_type = static_cast<BaseType>(i);
+        auto type_exponent = exponent(base_type);
+
+        if (type_exponent.has_value())
+            TRY(builder.try_appendff(", \"{}\" → {}", base_type_name(base_type), type_exponent.value()));
+    }
+
+    TRY(builder.try_append(" }"sv));
+    return builder.to_string();
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/CSSNumericType.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSNumericType.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Array.h>
+#include <AK/Optional.h>
+#include <LibWeb/CSS/PropertyID.h>
+
+namespace Web::CSS {
+
+// https://drafts.css-houdini.org/css-typed-om-1/#numeric-typing
+// FIXME: Add IDL for this.
+class CSSNumericType {
+public:
+    // https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-base-type
+    enum class BaseType {
+        Length,
+        Angle,
+        Time,
+        Frequency,
+        Resolution,
+        Flex,
+        Percent,
+        __Count,
+    };
+
+    static Optional<BaseType> base_type_from_value_type(ValueType);
+    static constexpr StringView base_type_name(BaseType base_type)
+    {
+        switch (base_type) {
+        case BaseType::Length:
+            return "length"sv;
+        case BaseType::Angle:
+            return "angle"sv;
+        case BaseType::Time:
+            return "time"sv;
+        case BaseType::Frequency:
+            return "frequency"sv;
+        case BaseType::Resolution:
+            return "resolution"sv;
+        case BaseType::Flex:
+            return "flex"sv;
+        case BaseType::Percent:
+            return "percent"sv;
+        case BaseType::__Count:
+            break;
+        }
+        VERIFY_NOT_REACHED();
+    }
+
+    static Optional<CSSNumericType> create_from_unit(StringView unit);
+    CSSNumericType() = default;
+    CSSNumericType(BaseType type, i32 power)
+    {
+        set_exponent(type, power);
+    }
+
+    Optional<CSSNumericType> added_to(CSSNumericType const& other) const;
+    Optional<CSSNumericType> multiplied_by(CSSNumericType const& other) const;
+    CSSNumericType inverted() const;
+
+    bool matches_angle() const { return matches_dimension(BaseType::Angle); }
+    bool matches_angle_percentage() const { return matches_dimension_percentage(BaseType::Angle); }
+    bool matches_flex() const { return matches_dimension(BaseType::Flex); }
+    bool matches_flex_percentage() const { return matches_dimension_percentage(BaseType::Flex); }
+    bool matches_frequency() const { return matches_dimension(BaseType::Frequency); }
+    bool matches_frequency_percentage() const { return matches_dimension_percentage(BaseType::Frequency); }
+    bool matches_length() const { return matches_dimension(BaseType::Length); }
+    bool matches_length_percentage() const { return matches_dimension_percentage(BaseType::Length); }
+    bool matches_number() const;
+    bool matches_number_percentage() const;
+    bool matches_percentage() const;
+    bool matches_resolution() const { return matches_dimension(BaseType::Resolution); }
+    bool matches_resolution_percentage() const { return matches_dimension_percentage(BaseType::Resolution); }
+    bool matches_time() const { return matches_dimension(BaseType::Time); }
+    bool matches_time_percentage() const { return matches_dimension_percentage(BaseType::Time); }
+
+    Optional<i32> const& exponent(BaseType type) const { return m_type_exponents[to_underlying(type)]; }
+    void set_exponent(BaseType type, i32 exponent) { m_type_exponents[to_underlying(type)] = exponent; }
+
+    Optional<BaseType> const& percent_hint() const { return m_percent_hint; }
+    void set_percent_hint(Optional<BaseType> hint) { m_percent_hint = hint; }
+    void apply_percent_hint(BaseType hint);
+
+    bool operator==(CSSNumericType const& other) const = default;
+
+    ErrorOr<String> dump() const;
+
+private:
+    bool contains_all_the_non_zero_entries_of_other_with_the_same_value(CSSNumericType const& other) const;
+    bool contains_a_key_other_than_percent_with_a_non_zero_value() const;
+    enum class SkipIfAlreadyPresent {
+        No,
+        Yes,
+    };
+    void copy_all_entries_from(CSSNumericType const& other, SkipIfAlreadyPresent);
+
+    bool matches_dimension(BaseType) const;
+    bool matches_dimension_percentage(BaseType) const;
+
+    Array<Optional<i32>, to_underlying(BaseType::__Count)> m_type_exponents;
+    Optional<BaseType> m_percent_hint;
+};
+
+}

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -8770,6 +8770,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override { VERIFY_NOT_REACHED(); }
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override { VERIFY_NOT_REACHED(); }
+    virtual Optional<CSSNumericType> determine_type(Web::CSS::PropertyID) const override { VERIFY_NOT_REACHED(); }
     virtual bool contains_percentage() const override { VERIFY_NOT_REACHED(); }
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override { VERIFY_NOT_REACHED(); }
 

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -236,6 +236,7 @@
       "right",
       "top"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ],
@@ -256,7 +257,8 @@
       "center",
       "left",
       "right"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "background-position-y": {
     "inherited": false,
@@ -270,7 +272,8 @@
       "center",
       "bottom",
       "top"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "background-repeat": {
     "affects-layout": false,
@@ -298,7 +301,8 @@
       "auto",
       "cover",
       "contain"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "border": {
     "inherited": false,
@@ -364,7 +368,8 @@
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "border-bottom-right-radius": {
     "affects-layout": false,
@@ -374,7 +379,8 @@
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "border-bottom-style": {
     "initial": "none",
@@ -542,7 +548,8 @@
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "border-top-right-radius": {
     "affects-layout": false,
@@ -552,7 +559,8 @@
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "border-top-style": {
     "initial": "none",
@@ -607,6 +615,7 @@
     "valid-identifiers": [
       "auto"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -673,7 +682,8 @@
     ],
     "valid-identifiers": [
       "auto"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "content": {
     "inherited": false,
@@ -749,7 +759,8 @@
     "valid-types": [
       "number [-∞,∞]",
       "percentage [-∞,∞]"
-    ]
+    ],
+    "percentages-resolve-to": "number"
   },
   "fill-rule": {
     "affects-layout": false,
@@ -782,7 +793,8 @@
     "valid-identifiers": [
       "auto",
       "content"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "flex-direction": {
     "inherited": false,
@@ -860,6 +872,7 @@
       "xx-small",
       "xxx-large"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -922,6 +935,7 @@
     "valid-identifiers": [
       "auto"
     ],
+    "percentages-resolve-to": "length",
     "longhands": [
       "row-gap",
       "column-gap"
@@ -976,7 +990,8 @@
     ],
     "valid-identifiers": [
       "auto"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "grid-column-start": {
     "inherited": false,
@@ -999,6 +1014,7 @@
     "valid-identifiers": [
       "auto"
     ],
+    "percentages-resolve-to": "length",
     "longhands": [
       "grid-row-gap",
       "grid-column-gap"
@@ -1037,7 +1053,8 @@
     ],
     "valid-identifiers": [
       "auto"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "grid-row-start": {
     "inherited": false,
@@ -1060,6 +1077,7 @@
       "percentage",
       "string"
     ],
+    "percentages-resolve-to": "length",
     "longhands": [
       "grid-template"
     ]
@@ -1075,6 +1093,7 @@
       "percentage",
       "string"
     ],
+    "percentages-resolve-to": "length",
     "longhands": [
       "grid-template-areas",
       "grid-template-rows",
@@ -1101,7 +1120,8 @@
       "length",
       "percentage",
       "string"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "grid-auto-rows": {
     "inherited": false,
@@ -1113,7 +1133,8 @@
       "length",
       "percentage",
       "string"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "grid-template-columns": {
     "inherited": false,
@@ -1126,7 +1147,8 @@
       "length",
       "percentage",
       "string"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "grid-template-rows": {
     "inherited": false,
@@ -1139,7 +1161,8 @@
       "length",
       "percentage",
       "string"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "height": {
     "inherited": false,
@@ -1151,6 +1174,7 @@
     "valid-identifiers": [
       "auto"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1179,7 +1203,8 @@
     ],
     "valid-identifiers": [
       "auto"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "justify-content": {
     "inherited": false,
@@ -1198,6 +1223,7 @@
     "valid-identifiers": [
       "auto"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1209,6 +1235,7 @@
       "length [-∞,∞]",
       "percentage [-∞,∞]"
     ],
+    "percentages-resolve-to": "length",
     "valid-identifiers": [
       "normal"
     ],
@@ -1226,7 +1253,8 @@
     ],
     "valid-identifiers": [
       "normal"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "list-style": {
     "inherited": true,
@@ -1279,6 +1307,7 @@
     "valid-identifiers": [
       "auto"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1315,6 +1344,7 @@
     "valid-identifiers": [
       "auto"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1351,6 +1381,7 @@
     "valid-identifiers": [
       "auto"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1365,6 +1396,7 @@
     "valid-identifiers": [
       "auto"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1379,6 +1411,7 @@
     "valid-identifiers": [
       "auto"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1393,6 +1426,7 @@
     "valid-identifiers": [
       "none"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1417,6 +1451,7 @@
       "min-content",
       "none"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1432,6 +1467,7 @@
       "auto",
       "none"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1457,6 +1493,7 @@
       "min-content",
       "none"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1469,7 +1506,8 @@
     "valid-types": [
       "number [-∞,∞]",
       "percentage [-∞,∞]"
-    ]
+    ],
+    "percentages-resolve-to": "number"
   },
   "order": {
     "inherited": false,
@@ -1561,6 +1599,7 @@
       "length [0,∞]",
       "percentage [0,∞]"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1594,6 +1633,7 @@
       "length [0,∞]",
       "percentage [0,∞]"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1627,6 +1667,7 @@
       "length [0,∞]",
       "percentage [0,∞]"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1638,6 +1679,7 @@
       "length [0,∞]",
       "percentage [0,∞]"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1649,6 +1691,7 @@
       "length [0,∞]",
       "percentage [0,∞]"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1686,6 +1729,7 @@
     "valid-identifiers": [
       "auto"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1699,7 +1743,8 @@
     ],
     "valid-identifiers": [
       "auto"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "stroke": {
     "affects-layout": false,
@@ -1716,7 +1761,8 @@
     "valid-types": [
       "number [-∞,∞]",
       "percentage [-∞,∞]"
-    ]
+    ],
+    "percentages-resolve-to": "number"
   },
   "stop-color": {
     "affects-layout": false,
@@ -1733,7 +1779,8 @@
     "valid-types": [
       "number [-∞,∞]",
       "percentage [-∞,∞]"
-    ]
+    ],
+    "percentages-resolve-to": "number"
   },
   "stroke-width": {
     "affects-layout": false,
@@ -1743,7 +1790,8 @@
       "length [0,∞]",
       "number [0,∞]",
       "percentage [0,∞]"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "text-align": {
     "inherited": true,
@@ -1799,7 +1847,8 @@
     "valid-identifiers": [
       "auto",
       "from-font"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "text-indent": {
     "inherited": true,
@@ -1808,6 +1857,7 @@
       "length [-∞,∞]",
       "percentage [-∞,∞]"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1844,6 +1894,7 @@
     "valid-identifiers": [
       "auto"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1868,7 +1919,8 @@
       "left",
       "right",
       "top"
-    ]
+    ],
+    "percentages-resolve-to": "length"
   },
   "transition-delay": {
     "inherited": false,
@@ -1897,6 +1949,7 @@
       "percentage [-∞,∞]",
       "vertical-align"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1921,6 +1974,7 @@
       "max-content",
       "min-content"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]
@@ -1942,6 +1996,7 @@
     "valid-identifiers": [
       "normal"
     ],
+    "percentages-resolve-to": "length",
     "quirks": [
       "unitless-length"
     ]

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -265,13 +265,13 @@ static float resolve_opacity_value(CSS::StyleValue const& value)
         unclamped_opacity = value.as_number().number();
     } else if (value.is_calculated()) {
         auto& calculated = value.as_calculated();
-        if (calculated.resolved_type() == CalculatedStyleValue::ResolvedType::Percentage) {
+        if (calculated.resolves_to_percentage()) {
             auto maybe_percentage = value.as_calculated().resolve_percentage();
             if (maybe_percentage.has_value())
                 unclamped_opacity = maybe_percentage->as_fraction();
             else
                 dbgln("Unable to resolve calc() as opacity (percentage): {}", value.to_string());
-        } else {
+        } else if (calculated.resolves_to_number()) {
             auto maybe_number = const_cast<CalculatedStyleValue&>(value.as_calculated()).resolve_number();
             if (maybe_number.has_value())
                 unclamped_opacity = maybe_number.value();

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -193,12 +193,43 @@ public:
 
     Type type() const { return m_type; }
 
+    // https://www.w3.org/TR/css-values-4/#calculation-tree-operator-nodes
     bool is_operator_node() const
     {
-        // FIXME: Check for operator node types once they exist
-        return is_calc_operator_node();
+        return is_calc_operator_node() || is_math_function_node();
     }
 
+    bool is_math_function_node() const
+    {
+        switch (m_type) {
+        case Type::Min:
+        case Type::Max:
+        case Type::Clamp:
+        case Type::Abs:
+        case Type::Sign:
+        case Type::Sin:
+        case Type::Cos:
+        case Type::Tan:
+        case Type::Asin:
+        case Type::Acos:
+        case Type::Atan:
+        case Type::Atan2:
+        case Type::Pow:
+        case Type::Sqrt:
+        case Type::Hypot:
+        case Type::Log:
+        case Type::Exp:
+        case Type::Round:
+        case Type::Mod:
+        case Type::Rem:
+            return true;
+
+        default:
+            return false;
+        }
+    }
+
+    // https://www.w3.org/TR/css-values-4/#calculation-tree-calc-operator-nodes
     bool is_calc_operator_node() const
     {
         return first_is_one_of(m_type, Type::Sum, Type::Product, Type::Negate, Type::Invert);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -65,51 +65,54 @@ public:
         Value m_value;
     };
 
-    static ErrorOr<ValueComparingNonnullRefPtr<CalculatedStyleValue>> create(NonnullOwnPtr<CalculationNode> calculation, ResolvedType resolved_type)
+    static ErrorOr<ValueComparingNonnullRefPtr<CalculatedStyleValue>> create(NonnullOwnPtr<CalculationNode> calculation, CSSNumericType resolved_type)
     {
         return adopt_nonnull_ref_or_enomem(new (nothrow) CalculatedStyleValue(move(calculation), resolved_type));
     }
 
     ErrorOr<String> to_string() const override;
     virtual bool equals(StyleValue const& other) const override;
-    ResolvedType resolved_type() const { return m_resolved_type; }
 
-    bool resolves_to_angle() const { return m_resolved_type == ResolvedType::Angle; }
+    bool resolves_to_angle() const { return m_resolved_type.matches_angle(); }
+    bool resolves_to_angle_percentage() const { return m_resolved_type.matches_angle_percentage(); }
     Optional<Angle> resolve_angle() const;
     Optional<Angle> resolve_angle_percentage(Angle const& percentage_basis) const;
 
-    bool resolves_to_frequency() const { return m_resolved_type == ResolvedType::Frequency; }
+    bool resolves_to_frequency() const { return m_resolved_type.matches_frequency(); }
+    bool resolves_to_frequency_percentage() const { return m_resolved_type.matches_frequency_percentage(); }
     Optional<Frequency> resolve_frequency() const;
     Optional<Frequency> resolve_frequency_percentage(Frequency const& percentage_basis) const;
 
-    bool resolves_to_length() const { return m_resolved_type == ResolvedType::Length; }
+    bool resolves_to_length() const { return m_resolved_type.matches_length(); }
+    bool resolves_to_length_percentage() const { return m_resolved_type.matches_length_percentage(); }
     [[nodiscard]] Optional<Length> resolve_length(Length::ResolutionContext const&) const;
     Optional<Length> resolve_length(Layout::Node const& layout_node) const;
     Optional<Length> resolve_length_percentage(Layout::Node const&, Length const& percentage_basis) const;
 
-    bool resolves_to_percentage() const { return m_resolved_type == ResolvedType::Percentage; }
+    bool resolves_to_percentage() const { return m_resolved_type.matches_percentage(); }
     Optional<Percentage> resolve_percentage() const;
 
-    bool resolves_to_time() const { return m_resolved_type == ResolvedType::Time; }
+    bool resolves_to_time() const { return m_resolved_type.matches_time(); }
+    bool resolves_to_time_percentage() const { return m_resolved_type.matches_time_percentage(); }
     Optional<Time> resolve_time() const;
     Optional<Time> resolve_time_percentage(Time const& percentage_basis) const;
 
-    bool resolves_to_integer() const { return m_resolved_type == ResolvedType::Integer; }
-    bool resolves_to_number() const { return resolves_to_integer() || m_resolved_type == ResolvedType::Number; }
+    bool resolves_to_number() const { return m_resolved_type.matches_number(); }
+    bool resolves_to_number_percentage() const { return m_resolved_type.matches_number_percentage(); }
     Optional<double> resolve_number() const;
     Optional<i64> resolve_integer();
 
     bool contains_percentage() const;
 
 private:
-    explicit CalculatedStyleValue(NonnullOwnPtr<CalculationNode> calculation, ResolvedType resolved_type)
+    explicit CalculatedStyleValue(NonnullOwnPtr<CalculationNode> calculation, CSSNumericType resolved_type)
         : StyleValue(Type::Calculated)
         , m_resolved_type(resolved_type)
         , m_calculation(move(calculation))
     {
     }
 
-    ResolvedType m_resolved_type;
+    CSSNumericType m_resolved_type;
     NonnullOwnPtr<CalculationNode> m_calculation;
 };
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <LibWeb/CSS/Angle.h>
+#include <LibWeb/CSS/CSSNumericType.h>
 #include <LibWeb/CSS/Frequency.h>
 #include <LibWeb/CSS/Length.h>
 #include <LibWeb/CSS/Percentage.h>
@@ -237,6 +238,7 @@ public:
 
     virtual ErrorOr<String> to_string() const = 0;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const = 0;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const = 0;
     virtual bool contains_percentage() const = 0;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const = 0;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) { return {}; }
@@ -257,6 +259,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
 
@@ -274,6 +277,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -292,6 +296,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -310,6 +315,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -328,6 +334,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -346,6 +353,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -364,6 +372,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -382,6 +391,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -402,6 +412,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -420,6 +431,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -438,6 +450,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override { return false; };
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&> context, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -456,6 +469,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -474,6 +488,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -492,6 +507,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -510,6 +526,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -528,6 +545,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -546,6 +564,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -564,6 +583,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -583,6 +603,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override { return false; };
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -602,6 +623,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override { return false; };
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -620,6 +642,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -638,6 +661,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override { return false; };
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -657,6 +681,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override { return false; };
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -675,6 +700,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -695,6 +721,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
@@ -714,6 +741,7 @@ public:
 
     virtual ErrorOr<String> to_string() const override;
     virtual Optional<CalculatedStyleValue::ResolvedType> resolved_type() const override;
+    virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
     virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;


### PR DESCRIPTION
This is not the end result, and we still have the `ResolvedType` enum around which should disappear eventually. However, after a lot of trial and error (and confusion) I've decided the best way to continue is to implement simplification, and then remove all this not-to-spec value-resolving stuff. That's going to be quite a big change, and this is already over 1000 lines, so let's break here. :^)