### PR TITLE
LibJS/Bytecode: Use proper this for receiver in get/set for super expr and avoid RequireObjectCoercible when creating super references 

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -151,8 +151,9 @@ CodeGenerationErrorOr<void> Generator::emit_load_from_reference(JS::ASTNode cons
         if (is<SuperExpression>(expression.object())) {
             // 1. Let env be GetThisEnvironment().
             // 2. Let actualThis be ? env.GetThisBinding().
-            // NOTE: Whilst this isn't used, it's still observable (e.g. it throws if super() hasn't been called)
+            auto this_register = allocate_register();
             emit<Bytecode::Op::ResolveThisBinding>();
+            emit<Bytecode::Op::Store>(this_register);
 
             Optional<Bytecode::Register> computed_property_value_register;
 
@@ -180,11 +181,11 @@ CodeGenerationErrorOr<void> Generator::emit_load_from_reference(JS::ASTNode cons
                 auto super_base_register = allocate_register();
                 emit<Bytecode::Op::Store>(super_base_register);
                 emit<Bytecode::Op::Load>(*computed_property_value_register);
-                emit<Bytecode::Op::GetByValue>(super_base_register);
+                emit<Bytecode::Op::GetByValueWithThis>(super_base_register, this_register);
             } else {
                 // 3. Let propertyKey be StringValue of IdentifierName.
                 auto identifier_table_ref = intern_identifier(verify_cast<Identifier>(expression.property()).string());
-                emit<Bytecode::Op::GetById>(identifier_table_ref);
+                emit<Bytecode::Op::GetByIdWithThis>(identifier_table_ref, this_register);
             }
         } else {
             TRY(expression.object().generate_bytecode(*this));
@@ -226,31 +227,76 @@ CodeGenerationErrorOr<void> Generator::emit_store_to_reference(JS::ASTNode const
         emit<Bytecode::Op::Store>(value_reg);
 
         auto& expression = static_cast<MemberExpression const&>(node);
-        TRY(expression.object().generate_bytecode(*this));
 
-        auto object_reg = allocate_register();
-        emit<Bytecode::Op::Store>(object_reg);
+        // https://tc39.es/ecma262/#sec-super-keyword-runtime-semantics-evaluation
+        if (is<SuperExpression>(expression.object())) {
+            // 1. Let env be GetThisEnvironment().
+            // 2. Let actualThis be ? env.GetThisBinding().
+            auto this_register = allocate_register();
+            emit<Bytecode::Op::ResolveThisBinding>();
+            emit<Bytecode::Op::Store>(this_register);
 
-        if (expression.is_computed()) {
-            TRY(expression.property().generate_bytecode(*this));
-            auto property_reg = allocate_register();
-            emit<Bytecode::Op::Store>(property_reg);
+            Optional<Bytecode::Register> computed_property_value_register;
+
+            if (expression.is_computed()) {
+                // SuperProperty : super [ Expression ]
+                // 3. Let propertyNameReference be ? Evaluation of Expression.
+                // 4. Let propertyNameValue be ? GetValue(propertyNameReference).
+                TRY(expression.property().generate_bytecode(*this));
+                computed_property_value_register = allocate_register();
+                emit<Bytecode::Op::Store>(*computed_property_value_register);
+            }
+
+            // 5/7. Return ? MakeSuperPropertyReference(actualThis, propertyKey, strict).
+
+            // https://tc39.es/ecma262/#sec-makesuperpropertyreference
+            // 1. Let env be GetThisEnvironment().
+            // 2. Assert: env.HasSuperBinding() is true.
+            // 3. Let baseValue be ? env.GetSuperBase().
+            auto super_base_register = allocate_register();
+            emit<Bytecode::Op::ResolveSuperBase>();
+            emit<Bytecode::Op::Store>(super_base_register);
+
             emit<Bytecode::Op::Load>(value_reg);
-            emit<Bytecode::Op::PutByValue>(object_reg, property_reg);
-        } else if (expression.property().is_identifier()) {
-            emit<Bytecode::Op::Load>(value_reg);
-            auto identifier_table_ref = intern_identifier(verify_cast<Identifier>(expression.property()).string());
-            emit<Bytecode::Op::PutById>(object_reg, identifier_table_ref);
-        } else if (expression.property().is_private_identifier()) {
-            emit<Bytecode::Op::Load>(value_reg);
-            auto identifier_table_ref = intern_identifier(verify_cast<PrivateIdentifier>(expression.property()).string());
-            emit<Bytecode::Op::PutPrivateById>(object_reg, identifier_table_ref);
+
+            // 4. Return the Reference Record { [[Base]]: baseValue, [[ReferencedName]]: propertyKey, [[Strict]]: strict, [[ThisValue]]: actualThis }.
+            if (computed_property_value_register.has_value()) {
+                // 5. Let propertyKey be ? ToPropertyKey(propertyNameValue).
+                // FIXME: This does ToPropertyKey out of order, which is observable by Symbol.toPrimitive!
+                emit<Bytecode::Op::PutByValueWithThis>(super_base_register, *computed_property_value_register, this_register);
+            } else {
+                // 3. Let propertyKey be StringValue of IdentifierName.
+                auto identifier_table_ref = intern_identifier(verify_cast<Identifier>(expression.property()).string());
+                emit<Bytecode::Op::PutByIdWithThis>(super_base_register, this_register, identifier_table_ref);
+            }
         } else {
-            return CodeGenerationError {
-                &expression,
-                "Unimplemented non-computed member expression"sv
-            };
+            TRY(expression.object().generate_bytecode(*this));
+
+            auto object_reg = allocate_register();
+            emit<Bytecode::Op::Store>(object_reg);
+
+            if (expression.is_computed()) {
+                TRY(expression.property().generate_bytecode(*this));
+                auto property_reg = allocate_register();
+                emit<Bytecode::Op::Store>(property_reg);
+                emit<Bytecode::Op::Load>(value_reg);
+                emit<Bytecode::Op::PutByValue>(object_reg, property_reg);
+            } else if (expression.property().is_identifier()) {
+                emit<Bytecode::Op::Load>(value_reg);
+                auto identifier_table_ref = intern_identifier(verify_cast<Identifier>(expression.property()).string());
+                emit<Bytecode::Op::PutById>(object_reg, identifier_table_ref);
+            } else if (expression.property().is_private_identifier()) {
+                emit<Bytecode::Op::Load>(value_reg);
+                auto identifier_table_ref = intern_identifier(verify_cast<PrivateIdentifier>(expression.property()).string());
+                emit<Bytecode::Op::PutPrivateById>(object_reg, identifier_table_ref);
+            } else {
+                return CodeGenerationError {
+                    &expression,
+                    "Unimplemented non-computed member expression"sv
+                };
+            }
         }
+
         return {};
     }
 

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -34,7 +34,9 @@
     O(EnterObjectEnvironment)        \
     O(Exp)                           \
     O(GetById)                       \
+    O(GetByIdWithThis)               \
     O(GetByValue)                    \
+    O(GetByValueWithThis)            \
     O(GetIterator)                   \
     O(GetMethod)                     \
     O(GetNewTarget)                  \
@@ -80,7 +82,9 @@
     O(Not)                           \
     O(PushDeclarativeEnvironment)    \
     O(PutById)                       \
+    O(PutByIdWithThis)               \
     O(PutByValue)                    \
+    O(PutByValueWithThis)            \
     O(PutPrivateById)                \
     O(ResolveThisBinding)            \
     O(ResolveSuperBase)              \

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -660,10 +660,7 @@ ThrowCompletionOr<void> ResolveSuperBase::execute_impl(Bytecode::Interpreter& in
     VERIFY(env.has_super_binding());
 
     // 3. Let baseValue be ? env.GetSuperBase().
-    auto base_value = TRY(env.get_super_base());
-
-    // 4. Let bv be ? RequireObjectCoercible(baseValue).
-    interpreter.accumulator() = TRY(require_object_coercible(vm, base_value));
+    interpreter.accumulator() = TRY(env.get_super_base());
 
     return {};
 }

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -579,6 +579,29 @@ private:
     IdentifierTableIndex m_property;
 };
 
+class GetByIdWithThis final : public Instruction {
+public:
+    GetByIdWithThis(IdentifierTableIndex property, Register this_value)
+        : Instruction(Type::GetByIdWithThis)
+        , m_property(property)
+        , m_this_value(this_value)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register from, Register to)
+    {
+        if (m_this_value == from)
+            m_this_value = to;
+    }
+
+private:
+    IdentifierTableIndex m_property;
+    Register m_this_value;
+};
+
 class GetPrivateById final : public Instruction {
 public:
     explicit GetPrivateById(IdentifierTableIndex property)
@@ -646,6 +669,35 @@ private:
     PropertyKind m_kind;
 };
 
+class PutByIdWithThis final : public Instruction {
+public:
+    PutByIdWithThis(Register base, Register this_value, IdentifierTableIndex property, PropertyKind kind = PropertyKind::KeyValue)
+        : Instruction(Type::PutByIdWithThis)
+        , m_base(base)
+        , m_this_value(this_value)
+        , m_property(property)
+        , m_kind(kind)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register from, Register to)
+    {
+        if (m_base == from)
+            m_base = to;
+        if (m_this_value == from)
+            m_this_value = to;
+    }
+
+private:
+    Register m_base;
+    Register m_this_value;
+    IdentifierTableIndex m_property;
+    PropertyKind m_kind;
+};
+
 class PutPrivateById final : public Instruction {
 public:
     explicit PutPrivateById(Register base, IdentifierTableIndex property, PropertyKind kind = PropertyKind::KeyValue)
@@ -709,6 +761,31 @@ private:
     Register m_base;
 };
 
+class GetByValueWithThis final : public Instruction {
+public:
+    GetByValueWithThis(Register base, Register this_value)
+        : Instruction(Type::GetByValueWithThis)
+        , m_base(base)
+        , m_this_value(this_value)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register from, Register to)
+    {
+        if (m_base == from)
+            m_base = to;
+        if (m_this_value == from)
+            m_this_value = to;
+    }
+
+private:
+    Register m_base;
+    Register m_this_value;
+};
+
 class PutByValue final : public Instruction {
 public:
     PutByValue(Register base, Register property, PropertyKind kind = PropertyKind::KeyValue)
@@ -726,11 +803,44 @@ public:
     {
         if (m_base == from)
             m_base = to;
+        if (m_property == from)
+            m_property = to;
     }
 
 private:
     Register m_base;
     Register m_property;
+    PropertyKind m_kind;
+};
+
+class PutByValueWithThis final : public Instruction {
+public:
+    PutByValueWithThis(Register base, Register property, Register this_value, PropertyKind kind = PropertyKind::KeyValue)
+        : Instruction(Type::PutByValueWithThis)
+        , m_base(base)
+        , m_property(property)
+        , m_this_value(this_value)
+        , m_kind(kind)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register from, Register to)
+    {
+        if (m_base == from)
+            m_base = to;
+        if (m_property == from)
+            m_property = to;
+        if (m_this_value == from)
+            m_this_value = to;
+    }
+
+private:
+    Register m_base;
+    Register m_property;
+    Register m_this_value;
     PropertyKind m_kind;
 };
 

--- a/Userland/Libraries/LibJS/Bytecode/Pass/LoadElimination.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/LoadElimination.cpp
@@ -122,9 +122,13 @@ static NonnullOwnPtr<BasicBlock> eliminate_loads(BasicBlock const& block, size_t
             // These can trigger proxies, which call into user code
             // So these are treated like calls
         case GetByValue:
+        case GetByValueWithThis:
         case GetById:
+        case GetByIdWithThis:
         case PutByValue:
+        case PutByValueWithThis:
         case PutById:
+        case PutByIdWithThis:
             // Attribute accesses (`a.o` or `a[o]`) may result in calls to getters or setters
             // or may trigger proxies
             // So these are treated like calls

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -513,11 +513,8 @@ ThrowCompletionOr<Reference> make_super_property_reference(VM& vm, Value actual_
     // 3. Let baseValue be ? env.GetSuperBase().
     auto base_value = TRY(env.get_super_base());
 
-    // 4. Let bv be ? RequireObjectCoercible(baseValue).
-    auto bv = TRY(require_object_coercible(vm, base_value));
-
-    // 5. Return the Reference Record { [[Base]]: bv, [[ReferencedName]]: propertyKey, [[Strict]]: strict, [[ThisValue]]: actualThis }.
-    return Reference { bv, property_key, actual_this, strict };
+    // 4. Return the Reference Record { [[Base]]: baseValue, [[ReferencedName]]: propertyKey, [[Strict]]: strict, [[ThisValue]]: actualThis }.
+    return Reference { base_value, property_key, actual_this, strict };
 }
 
 // 19.2.1.1 PerformEval ( x, strictCaller, direct ), https://tc39.es/ecma262/#sec-performeval


### PR DESCRIPTION
LibJS/Bytecode: Use proper this for receiver in get/set for super expr

```
Summary:
    Diff Tests:
        +14 ✅    -2 ❌    -12 📝
```
        
-----

LibJS: Avoid RequireObjectCoercible when creating super references

This is part of an old normative change that happened soon after
Andreas made `super` closer to spec in https://github.com/SerenityOS/serenity/commit/1270df257bd043e3b9970d47784bfaf77cc3edf1.
See https://github.com/tc39/ecma262/pull/2267

This was introduced into bytecode by virtue of copy and paste :^)

Bytecode results:
```
Summary:
    Diff Tests:
        +2 ✅    -2 ❌
```