### PR TITLE
Ports/imagemagick: Added --with-sysroot

### DIFF
--- a/Ports/imagemagick/package.sh
+++ b/Ports/imagemagick/package.sh
@@ -5,5 +5,5 @@ workdir="ImageMagick-${version}"
 useconfigure="true"
 files="https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${version}.tar.gz ${port}-v${version}.tar.gz dd23689304b8cf41572c3af6b0ddccfe21c5b9d9abddaf978f314696408d0750"
 auth_type=sha256
-configopts=("--host=${SERENITY_ARCH}")
+configopts=("--with-sysroot=${SERENITY_INSTALL_ROOT}")
 depends=("libpng" "libtiff" "libjpeg")


### PR DESCRIPTION
... to prevent linking against libs from build host. I.e. if Ports/fontconfig is already installed imagemagick tries to link against it in /usr/local/lib and fails to build.
Also removed superfluous --host parameter since this will already be added by ../.port_include.sh

Contributing to #18238 