### PR TITLE
LibJS: Null check current scope pusher before register_identifier call

### DIFF
--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -4988,7 +4988,8 @@ template NonnullRefPtr<FunctionDeclaration> Parser::parse_function_node(u16, Opt
 NonnullRefPtr<Identifier const> Parser::create_identifier_and_register_in_current_scope(SourceRange range, DeprecatedFlyString string)
 {
     auto id = create_ast_node<Identifier const>(range, string);
-    m_state.current_scope_pusher->register_identifier(const_cast<Identifier&>(*id));
+    if (m_state.current_scope_pusher)
+        m_state.current_scope_pusher->register_identifier(const_cast<Identifier&>(*id));
     return id;
 }
 


### PR DESCRIPTION
This fixes crashing when current scope pusher is null during identifier parsing.