### PR TITLE
Ladybird+Meta: Minor build instruction modifications

### DIFF
--- a/.devcontainer/features/serenity/install.sh
+++ b/.devcontainer/features/serenity/install.sh
@@ -33,7 +33,7 @@ install_llvm_key() {
 apt update -y
 apt install -y build-essential cmake ninja-build ccache shellcheck
 if [ "${ENABLE_LADYBIRD}" = "true" ]; then
-    apt install -y libgl1-mesa-dev qt6-base-dev qt6-tools-dev-tools qt6-wayland
+    apt install -y libgl1-mesa-dev qt6-base-dev qt6-tools-dev-tools qt6-wayland qt6-multimedia-dev
 fi
 if [ "${ENABLE_SERENITY}" = "true" ]; then
     apt install -y curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs genext2fs qemu-system-gui qemu-system-x86 qemu-utils rsync unzip texinfo libssl-dev

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -7,7 +7,7 @@ Qt6 development packages and a C++20 capable compiler are required. g++-12 or cl
 On Debian/Ubuntu required packages include, but are not limited to:
 
 ```
-sudo apt install build-essential cmake libgl1-mesa-dev ninja-build qt6-base-dev qt6-tools-dev-tools qt6-multimedia-dev
+sudo apt install build-essential cmake libgl1-mesa-dev ninja-build qt6-base-dev qt6-tools-dev-tools qt6-multimedia-dev ccache
 ```
 
 For Ubuntu 20.04 and above, ensure that the Qt6 Wayland packages are available:
@@ -19,17 +19,17 @@ sudo apt install qt6-wayland
 On Arch Linux/Manjaro:
 
 ```
-sudo pacman -S --needed base-devel cmake libgl ninja qt6-base qt6-tools qt6-wayland qt6-multimedia
+sudo pacman -S --needed base-devel cmake libgl ninja qt6-base qt6-tools qt6-wayland qt6-multimedia ccache
 ```
 
 On Fedora or derivatives:
 ```
-sudo dnf install cmake libglvnd-devel ninja-build qt6-qtbase-devel qt6-qttools-devel qt6-qtwayland-devel qt6-qtmultimedia-devel
+sudo dnf install cmake libglvnd-devel ninja-build qt6-qtbase-devel qt6-qttools-devel qt6-qtwayland-devel qt6-qtmultimedia-devel ccache
 ```
 
 On openSUSE:
 ```
-sudo zypper install cmake libglvnd-devel ninja qt6-base-devel qt6-tools-devel qt6-wayland-devel
+sudo zypper install cmake libglvnd-devel ninja qt6-base-devel qt6-tools-devel qt6-wayland-devel ccache
 ```
 
 On Nix/NixOS:
@@ -43,7 +43,7 @@ Note that Xcode 13.x does not have sufficient C++20 support to build ladybird. X
 
 ```
 xcode-select --install
-brew install cmake qt ninja
+brew install cmake qt ninja ccache
 ```
 
 On OpenIndiana:

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -2,7 +2,7 @@
 
 ## Build Prerequisites
 
-Qt6 development packages and a C++20 capable compiler are required. gcc-12 or clang-15 are required at a minimum for c++20 support.
+Qt6 development packages and a C++20 capable compiler are required. g++-12 or clang-15 are required at a minimum for c++20 support.
 
 On Debian/Ubuntu required packages include, but are not limited to:
 


### PR DESCRIPTION
Replaced the `gcc-12` requirement with that of `g++-12` because without `g++-12`+ (or `clang-15`+), Ladybird doesn't build.

Added `ccache` as a build requirement for QOL.

Synced up the Devcontainer `install.sh` and the Ladybird build instructions by adding the missing `qt6-multimedia-dev`.

https://github.com/SerenityOS/serenity/issues/19706 