### PR TITLE
LibCore: Remove some dead code in wait_for_events

### DIFF
--- a/Userland/Libraries/LibCore/EventLoopImplementationUnix.cpp
+++ b/Userland/Libraries/LibCore/EventLoopImplementationUnix.cpp
@@ -153,10 +153,8 @@ retry:
             max_fd = fd;
     };
 
-    int max_fd_added = -1;
     // The wake pipe informs us of POSIX signals as well as manual calls to wake()
     add_fd_to_set(thread_data.wake_pipe_fds[0], read_fds);
-    max_fd = max(max_fd, max_fd_added);
 
     for (auto& notifier : thread_data.notifiers) {
         if (notifier->type() == Notifier::Type::Read)


### PR DESCRIPTION
Since `max_fd_added` and `max_fd` are initialized to -1 and 0 respectively the former could never be greater than the latter.