### PR TITLE
LibWeb: Set the definite width flag in set_max_content_width

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -401,7 +401,7 @@ void LayoutState::UsedValues::set_max_content_width()
 {
     width_constraint = SizeConstraint::MaxContent;
     m_content_width = INFINITY;
-    m_has_definite_height = false;
+    m_has_definite_width = false;
 }
 
 }


### PR DESCRIPTION
It was setting the definite flag for height.