### PR TITLE
LibWeb: Set up the Fetch response's body with the appropriate stream

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/BodyInit.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/BodyInit.cpp
@@ -8,7 +8,10 @@
 #include <LibJS/Runtime/Completion.h>
 #include <LibWeb/Fetch/BodyInit.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
+#include <LibWeb/FileAPI/Blob.h>
 #include <LibWeb/HTML/FormControlInfrastructure.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
+#include <LibWeb/Streams/AbstractOperations.h>
 #include <LibWeb/URL/URLSearchParams.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
@@ -32,6 +35,8 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> safely_extract_body(JS::Realm&
 // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
 WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm, BodyInitOrReadableBytes const& object, bool keepalive)
 {
+    HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm) };
+
     auto& vm = realm.vm();
 
     // 1. Let stream be null.
@@ -43,14 +48,12 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm,
     }
     // 3. Otherwise, if object is a Blob object, set stream to the result of running object’s get stream.
     else if (auto const* blob_handle = object.get_pointer<JS::Handle<FileAPI::Blob>>()) {
-        // FIXME: "set stream to the result of running object’s get stream"
-        (void)blob_handle;
-        stream = MUST_OR_THROW_OOM(realm.heap().allocate<Streams::ReadableStream>(realm, realm));
+        stream = TRY(blob_handle->cell()->get_stream());
     }
-    // 4. Otherwise, set stream to a new ReadableStream object, and set up stream.
+    // 4. Otherwise, set stream to a new ReadableStream object, and set up stream with byte reading support.
     else {
-        // FIXME: "set up stream"
         stream = MUST_OR_THROW_OOM(realm.heap().allocate<Streams::ReadableStream>(realm, realm));
+        TRY(Streams::set_up_readable_stream_controller_with_byte_reading_support(*stream));
     }
 
     // 5. Assert: stream is a ReadableStream object.

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -44,6 +44,7 @@ public:
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> slice(Optional<i64> start = {}, Optional<i64> end = {}, Optional<String> const& content_type = {});
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Streams::ReadableStream>> stream();
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<Streams::ReadableStream>> get_stream();
     WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> text();
     WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> array_buffer();
 
@@ -56,8 +57,6 @@ protected:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
 
 private:
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<Streams::ReadableStream>> get_stream();
-
     explicit Blob(JS::Realm&);
 
     ByteBuffer m_byte_buffer {};


### PR DESCRIPTION
Have been on-and-off looking into implementing the Bodies incremental read AO, the "set stream to a new ReadableStream object, and set up stream with byte reading support" branch in particular blocks it. Without this, we crash trying to reference a non-existing stream controller.