### PR TITLE
Base: Render checksum man page synopsis using a multi-line code block

### DIFF
--- a/Base/usr/share/man/man1/checksum.md
+++ b/Base/usr/share/man/man1/checksum.md
@@ -4,10 +4,12 @@ checksum - helper program for calculating checksums
 
 ## Synopsis
 
-`$ md5sum [options...] <file...>`  
-`$ sha1sum [options...] <file...>`  
-`$ sha256sum [options...] <file...>`  
-`$ sha512sum [options...] <file...>`  
+```**sh
+$ md5sum [options...] <file...>
+$ sha1sum [options...] <file...>  
+$ sha256sum [options...] <file...>  
+$ sha512sum [options...] <file...>
+```  
 
 ## Description
 


### PR DESCRIPTION
EDIT 2: I've reverted the PR back to its original form. More work is needed to render styled markdown correctly.

~~EDIT: I have updated this PR to include fixes that ensure multi-line code blocks with a style are rendered correctly, see below for more info~~

This PR updates the `checksum(1)` man page to use multi-line code blocks, this is consistent with other man pages and makes the synopsis render correctly in the terminal.

This doesn't fix the underlying rendering issue detailed in #19534. I've included an explanation of what I believe the underlying problem to be on that issue.

Before:
![checksum_rendering_before](https://github.com/SerenityOS/serenity/assets/2817754/5bba2bfb-434d-4dd7-8e61-d856c488fe70)

After:
![checksum_rendering_after](https://github.com/SerenityOS/serenity/assets/2817754/5aca1d78-8076-411d-9c5f-3da8b612aac8)


