### PR TITLE
LibJS/Bytecode: Handle shadowed non-enumerable properties in for-in loops

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -1189,7 +1189,7 @@ ThrowCompletionOr<void> GetObjectPropertyIterator::execute_impl(Bytecode::Interp
         .iterator = object,
         .next_method = NativeFunction::create(
             interpreter.realm(),
-            [seen_items = HashTable<PropertyKey>(), items = move(properties)](VM& vm) mutable -> ThrowCompletionOr<Value> {
+            [items = move(properties)](VM& vm) mutable -> ThrowCompletionOr<Value> {
                 auto& realm = *vm.current_realm();
                 auto iterated_object_value = vm.this_value();
                 if (!iterated_object_value.is_object())
@@ -1204,11 +1204,6 @@ ThrowCompletionOr<void> GetObjectPropertyIterator::execute_impl(Bytecode::Interp
                     }
 
                     auto key = items.take_first();
-
-                    // If the key was already seen, skip over it (invariant no. 4)
-                    auto result = seen_items.set(key);
-                    if (result != AK::HashSetResult::InsertedNewEntry)
-                        continue;
 
                     // If the property is deleted, don't include it (invariant no. 2)
                     if (!TRY(iterated_object.has_property(key)))


### PR DESCRIPTION
Invariants 5 and 6 of the `EnumerateObjectProperties` AO mean that we
must not include an enumerate property if there is a non-enumerable
property higher up the prototype chain with the same name. The previous
implementation did not adhere to this, as `EnumerableOwnPropertyNames`
does not carry information about present but non-enumerable properties.

```
Summary:
    Diff Tests:
        +2 ✅    -2 ❌   

Diff Tests:
    test/language/statements/for-in/12.6.4-2.js                  ❌ -> ✅
    test/language/statements/for-in/order-enumerable-shadowed.js ❌ -> ✅
```

---

This PR removes a pointless check about the uniqueness of property keys: this invariant is enforced by virtue of `items` being a HashTable.