### PR TITLE
Toolchain: Replace `xlibsWrapper` dependency

### DIFF
--- a/Toolchain/serenity.nix
+++ b/Toolchain/serenity.nix
@@ -32,7 +32,17 @@ stdenv.mkDerivation {
     openssl
     parted
     qemu
-    xlibsWrapper
+
+    freetype
+    fontconfig
+    xorg.xorgproto
+    xorg.libX11
+    xorg.libXt
+    xorg.libXft
+    xorg.libXext
+    xorg.libSM
+    xorg.libICE
+
   ];
 
   hardeningDisable = [ "format" "fortify" ];


### PR DESCRIPTION
This commit replaces the `xlibWrapper` dependency found inside the nix-shell, as it has been removed within NixOS 23.05.

Fixes #19286