### PR TITLE
LibAudio: Optimize FlacLoader by avoiding allocations

### DIFF
--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -69,11 +69,11 @@ private:
     // Helper of next_frame that fetches a sub frame's header
     ErrorOr<FlacSubframeHeader, LoaderError> next_subframe_header(BigEndianInputBitStream& bit_input, u8 channel_index);
     // Helper of next_frame that decompresses a subframe
-    ErrorOr<Vector<i64>, LoaderError> parse_subframe(FlacSubframeHeader& subframe_header, BigEndianInputBitStream& bit_input);
+    ErrorOr<void, LoaderError> parse_subframe(Vector<i64>& samples, FlacSubframeHeader& subframe_header, BigEndianInputBitStream& bit_input);
     // Subframe-internal data decoders (heavy lifting)
     ErrorOr<Vector<i64>, LoaderError> decode_fixed_lpc(FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
     ErrorOr<Vector<i64>, LoaderError> decode_verbatim(FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
-    ErrorOr<Vector<i64>, LoaderError> decode_custom_lpc(FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
+    ErrorOr<void, LoaderError> decode_custom_lpc(Vector<i64>& decoded, FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
     MaybeLoaderError decode_residual(Vector<i64>& decoded, FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
     // decode a single rice partition that has its own rice parameter
     ALWAYS_INLINE ErrorOr<Vector<i64>, LoaderError> decode_rice_partition(u8 partition_type, u32 partitions, u32 partition_index, FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
@@ -110,6 +110,10 @@ private:
     Optional<FlacFrameHeader> m_current_frame;
     u64 m_current_sample_or_frame { 0 };
     SeekTable m_seektable;
+
+    // Keep around a few temporary buffers whose allocated space can be reused.
+    // This is an empirical optimization since allocations and deallocations take a lot of time in the decoder.
+    mutable Vector<Vector<i64>, 2> m_subframe_buffers;
 };
 
 }

--- a/Userland/Libraries/LibAudio/MultiChannel.h
+++ b/Userland/Libraries/LibAudio/MultiChannel.h
@@ -21,8 +21,9 @@ namespace Audio {
 // 6 channels = front left/right, center, LFE, back left/right
 // 7 channels = front left/right, center, LFE, back center, side left/right
 // 8 channels = front left/right, center, LFE, back left/right, side left/right
-template<ArrayLike<float> ChannelType, ArrayLike<ChannelType> InputType>
-ErrorOr<FixedArray<Sample>> downmix_surround_to_stereo(InputType input)
+// Additionally, performs sample rescaling to go from integer samples to floating-point samples.
+template<ArrayLike<i64> ChannelType, ArrayLike<ChannelType> InputType>
+ErrorOr<FixedArray<Sample>> downmix_surround_to_stereo(InputType const& input, float sample_scale_factor)
 {
     if (input.size() == 0)
         return Error::from_string_view("Cannot resample from 0 channels"sv);
@@ -38,43 +39,58 @@ ErrorOr<FixedArray<Sample>> downmix_surround_to_stereo(InputType input)
     switch (channel_count) {
     case 1:
         for (auto i = 0u; i < sample_count; ++i)
-            output[i] = Sample { input[0][i] };
+            output[i] = Sample { input[0][i] * sample_scale_factor };
         break;
     case 2:
         for (auto i = 0u; i < sample_count; ++i)
-            output[i] = Sample { input[0][i], input[1][i] };
+            output[i] = Sample {
+                input[0][i] * sample_scale_factor,
+                input[1][i] * sample_scale_factor
+            };
         break;
     case 3:
         for (auto i = 0u; i < sample_count; ++i)
-            output[i] = Sample { input[0][i] + input[2][i],
-                input[1][i] + input[2][i] };
+            output[i] = Sample {
+                input[0][i] * sample_scale_factor + input[2][i] * sample_scale_factor,
+                input[1][i] * sample_scale_factor + input[2][i] * sample_scale_factor
+            };
         break;
     case 4:
         for (auto i = 0u; i < sample_count; ++i)
-            output[i] = Sample { input[0][i] + input[2][i],
-                input[1][i] + input[3][i] };
+            output[i] = Sample {
+                input[0][i] * sample_scale_factor + input[2][i] * sample_scale_factor,
+                input[1][i] * sample_scale_factor + input[3][i] * sample_scale_factor
+            };
         break;
     case 5:
         for (auto i = 0u; i < sample_count; ++i)
-            output[i] = Sample { input[0][i] + input[3][i] + input[2][i],
-                input[1][i] + input[4][i] + input[2][i] };
+            output[i] = Sample {
+                input[0][i] * sample_scale_factor + input[3][i] * sample_scale_factor + input[2][i] * sample_scale_factor,
+                input[1][i] * sample_scale_factor + input[4][i] * sample_scale_factor + input[2][i] * sample_scale_factor
+            };
         break;
     case 6:
         for (auto i = 0u; i < sample_count; ++i) {
-            output[i] = Sample { input[0][i] + input[4][i] + input[2][i] + input[3][i],
-                input[1][i] + input[5][i] + input[2][i] + input[3][i] };
+            output[i] = Sample {
+                input[0][i] * sample_scale_factor + input[4][i] * sample_scale_factor + input[2][i] * sample_scale_factor + input[3][i] * sample_scale_factor,
+                input[1][i] * sample_scale_factor + input[5][i] * sample_scale_factor + input[2][i] * sample_scale_factor + input[3][i] * sample_scale_factor
+            };
         }
         break;
     case 7:
         for (auto i = 0u; i < sample_count; ++i) {
-            output[i] = Sample { input[0][i] + input[5][i] + input[2][i] + input[3][i] + input[4][i],
-                input[1][i] + input[6][i] + input[2][i] + input[3][i] + input[4][i] };
+            output[i] = Sample {
+                input[0][i] * sample_scale_factor + input[5][i] * sample_scale_factor + input[2][i] * sample_scale_factor + input[3][i] * sample_scale_factor + input[4][i] * sample_scale_factor,
+                input[1][i] * sample_scale_factor + input[6][i] * sample_scale_factor + input[2][i] * sample_scale_factor + input[3][i] * sample_scale_factor + input[4][i] * sample_scale_factor
+            };
         }
         break;
     case 8:
         for (auto i = 0u; i < sample_count; ++i) {
-            output[i] = Sample { input[0][i] + input[4][i] + input[6][i] + input[2][i] + input[3][i],
-                input[1][i] + input[5][i] + input[7][i] + input[2][i] + input[3][i] };
+            output[i] = Sample {
+                input[0][i] * sample_scale_factor + input[4][i] * sample_scale_factor + input[6][i] * sample_scale_factor + input[2][i] * sample_scale_factor + input[3][i] * sample_scale_factor,
+                input[1][i] * sample_scale_factor + input[5][i] * sample_scale_factor + input[7][i] * sample_scale_factor + input[2][i] * sample_scale_factor + input[3][i] * sample_scale_factor
+            };
         }
         break;
     default:


### PR DESCRIPTION
### Note: Untested after latest rebase, please review but do not merge.

- Pre-allocate and reuse sample decompression buffers. In many FLAC
  files, the amount of samples per frame is either constant or the
  largest frame will be hit within the first couple of frames. Also,
  during audio output, we need to move and combine the samples from the
  decompression buffers into the final output buffers anyways. Avoiding
  the reallocation of these large buffers provides an improvement from
  16x to 18x decode speed on strongly compressed but otherwise usual
  input.
- Leave a FIXME for a similar improvement that can be made in the
  residual decoder.
- Pre-allocate audio chunks if frame size is known.
- Use reasonable inline capacities in several places where we know the
  maximum or usual capacity needed.