### PR TITLE
LibWeb: Add a helper class to work around empty execution context stack

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -363,6 +363,7 @@ set(SOURCES
     HTML/Scripting/ModuleMap.cpp
     HTML/Scripting/ModuleScript.cpp
     HTML/Scripting/Script.cpp
+    HTML/Scripting/TemporaryExecutionContext.cpp
     HTML/Scripting/WindowEnvironmentSettingsObject.cpp
     HTML/SessionHistoryEntry.cpp
     HTML/SharedImageRequest.cpp

--- a/Userland/Libraries/LibWeb/Fetch/Body.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Body.cpp
@@ -16,6 +16,7 @@
 #include <LibWeb/Fetch/Body.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
 #include <LibWeb/FileAPI/Blob.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/Infra/JSON.h>
 #include <LibWeb/MimeSniff/MimeType.h>
 #include <LibWeb/Streams/ReadableStream.h>
@@ -165,15 +166,9 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> consume_body(JS::Realm& realm
     // 3. Let errorSteps given error be to reject promise with error.
     // NOTE: `promise` and `realm` is protected by JS::SafeFunction.
     auto error_steps = [promise, &realm](JS::GCPtr<WebIDL::DOMException> error) {
-        // NOTE: Not part of the spec, but we need to have an execution context on the stack to call native functions.
-        //       (In this case, Promise's reject function)
-        auto& environment_settings_object = Bindings::host_defined_environment_settings_object(realm);
-        environment_settings_object.prepare_to_run_script();
-
+        // AD-HOC: An execution context is required for Promise's reject function.
+        HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm) };
         WebIDL::reject_promise(realm, promise, error);
-
-        // See above NOTE.
-        environment_settings_object.clean_up_after_running_script();
     };
 
     // 4. Let successSteps given a byte sequence data be to resolve promise with the result of running convertBytesToJSValue
@@ -183,15 +178,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> consume_body(JS::Realm& realm
     auto success_steps = [promise, &realm, &object, type](ByteBuffer const& data) {
         auto& vm = realm.vm();
 
-        // NOTE: Not part of the spec, but we need to have an execution context on the stack to call native functions.
-        //       (In this case, Promise's reject function and JSON.parse)
-        auto& environment_settings_object = Bindings::host_defined_environment_settings_object(realm);
-        environment_settings_object.prepare_to_run_script();
-
-        ScopeGuard guard = [&]() {
-            // See above NOTE.
-            environment_settings_object.clean_up_after_running_script();
-        };
+        // AD-HOC: An execution context is required for Promise's reject function and JSON.parse.
+        HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm) };
 
         auto value_or_error = Bindings::throw_dom_exception_if_needed(vm, [&]() -> WebIDL::ExceptionOr<JS::Value> {
             return package_data(realm, data, type, TRY_OR_THROW_OOM(vm, object.mime_type_impl()));

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -19,6 +19,7 @@
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Scripting/Fetching.h>
 #include <LibWeb/HTML/Scripting/ModuleScript.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Infra/Strings.h>
 #include <LibWeb/Loader/LoadRequest.h>
@@ -568,9 +569,7 @@ void fetch_descendants_of_and_link_a_module_script(JavaScriptModuleScript& modul
             return;
         }
 
-        // FIXME: This is an ad-hoc hack to make sure that there's an execution context on the VM stack in case linking throws an exception.
-        auto& vm = fetch_client_settings_object.vm();
-        vm.push_execution_context(fetch_client_settings_object.realm_execution_context());
+        TemporaryExecutionContext execution_context { fetch_client_settings_object };
 
         // FIXME: 2. Let parse error be the result of finding the first parse error given result.
 
@@ -590,9 +589,6 @@ void fetch_descendants_of_and_link_a_module_script(JavaScriptModuleScript& modul
             // FIXME: 4. Otherwise, set result's error to rethrow to parse error.
             TODO();
         }
-
-        // FIXME: This undoes the ad-hoc hack above.
-        vm.pop_execution_context();
 
         // 5. Run onComplete given result.
         on_complete(result);

--- a/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/HTML/Scripting/Environments.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
+
+namespace Web::HTML {
+
+TemporaryExecutionContext::TemporaryExecutionContext(EnvironmentSettingsObject& environment_settings)
+    : m_environment_settings(environment_settings)
+{
+    m_environment_settings.prepare_to_run_script();
+}
+
+TemporaryExecutionContext::~TemporaryExecutionContext()
+{
+    m_environment_settings.clean_up_after_running_script();
+}
+
+}

--- a/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Forward.h>
+
+namespace Web::HTML {
+
+// When JS is run from outside the context of any user script, we currently do not have a running execution context.
+// This results in a crash when we access VM::running_execution_context(). This is a spec issue. Until it is resolved,
+// this is a workaround to temporarily push an execution context.
+class TemporaryExecutionContext {
+public:
+    explicit TemporaryExecutionContext(EnvironmentSettingsObject&);
+    ~TemporaryExecutionContext();
+
+private:
+    EnvironmentSettingsObject& m_environment_settings;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 
@@ -300,12 +301,8 @@ WebIDL::ExceptionOr<void> Page::toggle_media_play_state()
     if (!media_element)
         return {};
 
-    // FIXME: This runs from outside the context of any user script, so we do not have a running execution
-    //        context. This pushes one to allow the promise creation hook to run.
-    auto& environment_settings = media_element->document().relevant_settings_object();
-    environment_settings.prepare_to_run_script();
-
-    ScopeGuard guard { [&] { environment_settings.clean_up_after_running_script(); } };
+    // AD-HOC: An execution context is required for Promise creation hooks.
+    HTML::TemporaryExecutionContext execution_context { media_element->document().relevant_settings_object() };
 
     if (media_element->potentially_playing())
         TRY(media_element->pause());
@@ -321,12 +318,9 @@ void Page::toggle_media_mute_state()
     if (!media_element)
         return;
 
-    // FIXME: This runs from outside the context of any user script, so we do not have a running execution
-    //        context. This pushes one to allow the promise creation hook to run.
-    auto& environment_settings = media_element->document().relevant_settings_object();
-    environment_settings.prepare_to_run_script();
+    // AD-HOC: An execution context is required for Promise creation hooks.
+    HTML::TemporaryExecutionContext execution_context { media_element->document().relevant_settings_object() };
 
-    ScopeGuard guard { [&] { environment_settings.clean_up_after_running_script(); } };
     media_element->set_muted(!media_element->muted());
 }
 
@@ -336,12 +330,8 @@ WebIDL::ExceptionOr<void> Page::toggle_media_loop_state()
     if (!media_element)
         return {};
 
-    // FIXME: This runs from outside the context of any user script, so we do not have a running execution
-    //        context. This pushes one to allow the promise creation hook to run.
-    auto& environment_settings = media_element->document().relevant_settings_object();
-    environment_settings.prepare_to_run_script();
-
-    ScopeGuard guard { [&] { environment_settings.clean_up_after_running_script(); } };
+    // AD-HOC: An execution context is required for Promise creation hooks.
+    HTML::TemporaryExecutionContext execution_context { media_element->document().relevant_settings_object() };
 
     if (media_element->has_attribute(HTML::AttributeNames::loop))
         media_element->remove_attribute(HTML::AttributeNames::loop);
@@ -357,12 +347,7 @@ WebIDL::ExceptionOr<void> Page::toggle_media_controls_state()
     if (!media_element)
         return {};
 
-    // FIXME: This runs from outside the context of any user script, so we do not have a running execution
-    //        context. This pushes one to allow the promise creation hook to run.
-    auto& environment_settings = media_element->document().relevant_settings_object();
-    environment_settings.prepare_to_run_script();
-
-    ScopeGuard guard { [&] { environment_settings.clean_up_after_running_script(); } };
+    HTML::TemporaryExecutionContext execution_context { media_element->document().relevant_settings_object() };
 
     if (media_element->has_attribute(HTML::AttributeNames::controls))
         media_element->remove_attribute(HTML::AttributeNames::controls);

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -25,6 +25,7 @@
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/HTMLOptionsCollection.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/WebDriver/Contexts.h>
@@ -325,18 +326,13 @@ ExecuteScriptResultSerialized execute_script(Web::Page& page, DeprecatedString c
 ExecuteScriptResultSerialized execute_async_script(Web::Page& page, DeprecatedString const& body, JS::MarkedVector<JS::Value> arguments, Optional<u64> const& timeout)
 {
     auto* document = page.top_level_browsing_context().active_document();
-    auto& settings_object = document->relevant_settings_object();
     auto* window = page.top_level_browsing_context().active_window();
     auto& realm = window->realm();
     auto& vm = window->vm();
     auto start = MonotonicTime::now();
 
-    // NOTE: We need to push an execution context in order to make create_resolving_functions() succeed.
-    vm.push_execution_context(settings_object.realm_execution_context());
-    ScopeGuard pop_guard = [&] {
-        VERIFY(&settings_object.realm_execution_context() == &vm.running_execution_context());
-        vm.pop_execution_context();
-    };
+    // AD-HOC: An execution context is required for Promise creation hooks.
+    HTML::TemporaryExecutionContext execution_context { document->relevant_settings_object() };
 
     // 4. Let promise be a new Promise.
     auto promise_capability = WebIDL::create_promise(realm);


### PR DESCRIPTION
We've peppered this workaround around the code base as needed in a few
different ways. This adds a helper class to perform this workaround in
order to simplify doing so, and ensure cleanup occurs in a RAII fashion.
This also makes it easier to grep for places where this workaround is
employed.