### PR TITLE
LibWeb: Resolve inline-block percentage padding against 0, not infinity

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-padding-on-inline-block-with-indefinite-containing-block-size.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-padding-on-inline-block-with-indefinite-containing-block-size.txt
@@ -1,0 +1,6 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 0x17.46875 children: inline
+      line 0 width: 0, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,21 0x0]
+      BlockContainer <div> at (8,21) content-size 0x0 inline-block [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/input/block-and-inline/percentage-padding-on-inline-block-with-indefinite-containing-block-size.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/percentage-padding-on-inline-block-with-indefinite-containing-block-size.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html><style>
+    body {
+        width: max-content;
+    }
+    div {
+        display: inline-block;
+        padding-left: 8%;
+    }
+</style><body><div>

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -89,7 +89,7 @@ void InlineFormattingContext::run(Box const&, LayoutMode layout_mode, AvailableS
 
 void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode layout_mode)
 {
-    auto width_of_containing_block = m_available_space->width.to_px();
+    auto width_of_containing_block = m_available_space->width.to_px_or_zero();
     auto& box_state = m_state.get_mutable(box);
     auto const& computed_values = box.computed_values();
 


### PR DESCRIPTION
When the containing block has an indefinite width, any descendants with a percentage size should resolve that against 0, not infinity.

Fixes an assertion failure when loading https://www.gnu.org/