### PR TITLE
patch: Add the beginnings of a patch utility

### DIFF
--- a/Userland/Libraries/LibDiff/Applier.cpp
+++ b/Userland/Libraries/LibDiff/Applier.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2023, Shannon Booth <shannon.ml.booth@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Stream.h>
+#include <LibDiff/Applier.h>
+#include <LibDiff/Hunks.h>
+
+namespace Diff {
+
+static size_t expected_line_number(HunkLocation const& location)
+{
+    auto line = location.old_range.start_line;
+
+    // NOTE: This is to handle the case we are adding a file, e.g for a range such as:
+    // '@@ -0,0 +1,3 @@'
+    if (location.old_range.start_line == 0)
+        ++line;
+
+    VERIFY(line != 0);
+
+    return line;
+}
+
+struct Location {
+    size_t line_number;
+    size_t fuzz { 0 };
+    ssize_t offset { 0 };
+};
+
+static Optional<Location> locate_hunk(Vector<StringView> const& content, Hunk const& hunk, ssize_t offset, size_t max_fuzz = 3)
+{
+    // Make a first best guess at where the from-file range is telling us where the hunk should be.
+    size_t offset_guess = expected_line_number(hunk.location) - 1 + offset;
+
+    // If there's no lines surrounding this hunk - it will always succeed, so there is no point in checking any further.
+    if (hunk.location.old_range.number_of_lines == 0)
+        return Location { offset_guess, 0, 0 };
+
+    size_t patch_prefix_context = 0;
+    for (auto const& line : hunk.lines) {
+        if (line.operation != Line::Operation::Context)
+            break;
+        ++patch_prefix_context;
+    }
+
+    size_t patch_suffix_context = 0;
+    for (auto const& line : hunk.lines.in_reverse()) {
+        if (line.operation != Line::Operation::Context)
+            break;
+        ++patch_suffix_context;
+    }
+
+    size_t context = max(patch_prefix_context, patch_suffix_context);
+
+    // Look through the file trying to match the hunk for it. If we can't find anything anywhere in the file, then try and
+    // match the hunk by ignoring an increasing amount of context lines. The number of context lines that are ignored is
+    // called the 'fuzz'.
+    for (size_t fuzz = 0; fuzz <= max_fuzz; ++fuzz) {
+
+        auto suffix_fuzz = max(fuzz + patch_suffix_context - context, 0);
+        auto prefix_fuzz = max(fuzz + patch_prefix_context - context, 0);
+
+        // If the fuzz is greater than the total number of lines for a hunk, then it may be possible for the hunk to match anything.
+        if (suffix_fuzz + prefix_fuzz >= hunk.lines.size())
+            return {};
+
+        auto hunk_matches_starting_from_line = [&](size_t line) {
+            line += prefix_fuzz;
+
+            // Ensure that all of the lines in the hunk match starting from 'line', ignoring the specified number of context lines.
+            return all_of(hunk.lines.begin() + prefix_fuzz, hunk.lines.end() - suffix_fuzz, [&](const Line& hunk_line) {
+                // Ignore additions in our increment of line and comparison as they are not part of the 'original file'
+                if (hunk_line.operation == Line::Operation::Addition)
+                    return true;
+
+                if (line >= content.size())
+                    return false;
+
+                if (content[line] != hunk_line.content)
+                    return false;
+
+                ++line;
+                return true;
+            });
+        };
+
+        for (size_t line = offset_guess; line < content.size(); ++line) {
+            if (hunk_matches_starting_from_line(line))
+                return Location { line, fuzz, static_cast<ssize_t>(line - offset_guess) };
+        }
+
+        for (size_t line = offset_guess; line != 0; --line) {
+            if (hunk_matches_starting_from_line(line - 1))
+                return Location { line - 1, fuzz, static_cast<ssize_t>(line - offset_guess) };
+        }
+    }
+
+    // No bueno.
+    return {};
+}
+
+static ErrorOr<size_t> write_hunk(Stream& out, Hunk const& hunk, Location const& location, Vector<StringView> const& lines)
+{
+    auto line_number = location.line_number;
+
+    for (auto const& patch_line : hunk.lines) {
+        if (patch_line.operation == Line::Operation::Context) {
+            TRY(out.write_formatted("{}\n", lines.at(line_number)));
+            ++line_number;
+        } else if (patch_line.operation == Line::Operation::Addition) {
+            TRY(out.write_formatted("{}\n", patch_line.content));
+        } else if (patch_line.operation == Line::Operation::Removal) {
+            ++line_number;
+        }
+    }
+
+    return line_number;
+}
+
+ErrorOr<void> apply_patch(Stream& out, Vector<StringView> const& lines, Patch const& patch)
+{
+    size_t line_number = 0; // NOTE: relative to 'old' file.
+    ssize_t offset_error = 0;
+
+    for (size_t hunk_num = 0; hunk_num < patch.hunks.size(); ++hunk_num) {
+        auto const& hunk = patch.hunks[hunk_num];
+
+        auto maybe_location = locate_hunk(lines, hunk, offset_error);
+        if (!maybe_location.has_value())
+            return Error::from_string_literal("Failed to locate where to apply patch");
+
+        auto location = *maybe_location;
+        offset_error += location.offset;
+
+        // Write up until where we have found this latest hunk from the old file.
+        for (; line_number < location.line_number; ++line_number)
+            TRY(out.write_formatted("{}\n", lines.at(line_number)));
+
+        // Then output the hunk to what we hope is the correct location in the file.
+        line_number = TRY(write_hunk(out, hunk, location, lines));
+    }
+
+    // We've finished applying all hunks, write out anything from the old file we haven't already.
+    for (; line_number < lines.size(); ++line_number)
+        TRY(out.write_formatted("{}\n", lines[line_number]));
+
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibDiff/Applier.h
+++ b/Userland/Libraries/LibDiff/Applier.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, Shannon Booth <shannon.ml.booth@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <LibDiff/Forward.h>
+
+namespace Diff {
+
+ErrorOr<void> apply_patch(Stream& out, Vector<StringView> const& lines, Patch const& patch);
+
+}

--- a/Userland/Libraries/LibDiff/CMakeLists.txt
+++ b/Userland/Libraries/LibDiff/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 set(SOURCES
+    Applier.cpp
     Format.cpp
     Generator.cpp
     Hunks.cpp

--- a/Userland/Libraries/LibDiff/Forward.h
+++ b/Userland/Libraries/LibDiff/Forward.h
@@ -8,6 +8,8 @@
 
 namespace Diff {
 
+class Parser;
+
 struct Hunk;
 struct HunkLocation;
 struct Line;

--- a/Userland/Libraries/LibDiff/Forward.h
+++ b/Userland/Libraries/LibDiff/Forward.h
@@ -8,8 +8,11 @@
 
 namespace Diff {
 
+enum class Format;
+
 class Parser;
 
+struct Header;
 struct Hunk;
 struct HunkLocation;
 struct Line;

--- a/Userland/Libraries/LibDiff/Forward.h
+++ b/Userland/Libraries/LibDiff/Forward.h
@@ -16,6 +16,7 @@ struct Header;
 struct Hunk;
 struct HunkLocation;
 struct Line;
+struct Patch;
 struct Range;
 
 }

--- a/Userland/Libraries/LibDiff/Hunks.cpp
+++ b/Userland/Libraries/LibDiff/Hunks.cpp
@@ -57,6 +57,33 @@ bool Parser::consume_line_number(size_t& number)
     return true;
 }
 
+ErrorOr<Header> Parser::parse_header()
+{
+    Header header;
+
+    while (!is_eof()) {
+
+        if (consume_specific("+++ ")) {
+            header.new_file_path = TRY(String::from_utf8(consume_line()));
+            continue;
+        }
+
+        if (consume_specific("--- ")) {
+            header.old_file_path = TRY(String::from_utf8(consume_line()));
+            continue;
+        }
+
+        if (next_is("@@ ")) {
+            header.format = Format::Unified;
+            return header;
+        }
+
+        consume_line();
+    }
+
+    return Error::from_string_literal("Unable to find any patch");
+}
+
 ErrorOr<Vector<Hunk>> Parser::parse_hunks()
 {
     Vector<Hunk> hunks;

--- a/Userland/Libraries/LibDiff/Hunks.cpp
+++ b/Userland/Libraries/LibDiff/Hunks.cpp
@@ -10,45 +10,100 @@
 
 namespace Diff {
 
-ErrorOr<Vector<Hunk>> parse_hunks(StringView diff)
+Optional<HunkLocation> Parser::consume_unified_location()
 {
-    Vector<StringView> diff_lines = diff.split_view('\n');
-    if (diff_lines.is_empty())
-        return Vector<Hunk> {};
+    auto consume_range = [this](Range& range) {
+        if (!consume_line_number(range.start_line))
+            return false;
 
+        if (consume_specific(',')) {
+            if (!consume_line_number(range.number_of_lines))
+                return false;
+        } else {
+            range.number_of_lines = 1;
+        }
+        return true;
+    };
+
+    if (!consume_specific("@@ -"))
+        return {};
+
+    HunkLocation location;
+
+    if (!consume_range(location.old_range))
+        return {};
+
+    if (!consume_specific(" +"))
+        return {};
+
+    if (!consume_range(location.new_range))
+        return {};
+
+    if (!consume_specific(" @@"))
+        return {};
+
+    return location;
+}
+
+bool Parser::consume_line_number(size_t& number)
+{
+    auto line = consume_while(is_ascii_digit);
+
+    auto maybe_number = line.to_uint<size_t>();
+    if (!maybe_number.has_value())
+        return false;
+
+    number = maybe_number.value();
+    return true;
+}
+
+ErrorOr<Vector<Hunk>> Parser::parse_hunks()
+{
     Vector<Hunk> hunks;
 
-    size_t line_index = 0;
-    HunkLocation current_location {};
+    while (!is_eof()) {
+        // Try an locate a hunk location in this hunk. It may be prefixed with information.
+        auto maybe_location = consume_unified_location();
+        consume_line();
 
-    // Skip to first hunk
-    while (diff_lines[line_index][0] != '@') {
-        ++line_index;
-    }
-
-    while (line_index < diff_lines.size()) {
-        if (diff_lines[line_index][0] == '@') {
-            current_location = parse_hunk_location(diff_lines[line_index]);
-            ++line_index;
+        if (!maybe_location.has_value())
             continue;
-        }
 
-        Hunk hunk {};
-        hunk.location = current_location;
+        Hunk hunk { *maybe_location, {} };
 
-        while (line_index < diff_lines.size()) {
-            auto const& line = diff_lines[line_index];
+        auto old_lines_expected = hunk.location.old_range.number_of_lines;
+        auto new_lines_expected = hunk.location.new_range.number_of_lines;
 
-            char const operation = line[0];
-            if (operation != ' ' && operation != '+' && operation != '-')
-                break;
+        // We've found a location. Now parse out all of the expected content lines.
+        while (old_lines_expected != 0 || new_lines_expected != 0) {
+            StringView line = consume_line();
+
+            if (line.is_empty())
+                return Error::from_string_literal("Malformed empty content line in patch");
+
+            if (line[0] != ' ' && line[0] != '+' && line[0] != '-')
+                return Error::from_string_literal("Invaid operation in patch");
+
+            auto const operation = Line::operation_from_symbol(line[0]);
+
+            if (operation != Line::Operation::Removal) {
+                if (new_lines_expected == 0)
+                    return Error::from_string_literal("Found more removal and context lines in patch than expected");
+
+                --new_lines_expected;
+            }
+
+            if (operation != Line::Operation::Addition) {
+                if (old_lines_expected == 0)
+                    return Error::from_string_literal("Found more addition and context lines in patch than expected");
+
+                --old_lines_expected;
+            }
 
             auto const content = line.substring_view(1, line.length() - 1);
-
-            TRY(hunk.lines.try_append(Line { Line::operation_from_symbol(operation), TRY(String::from_utf8(content)) }));
-
-            ++line_index;
+            TRY(hunk.lines.try_append(Line { operation, TRY(String::from_utf8(content)) }));
         }
+
         TRY(hunks.try_append(hunk));
     }
 
@@ -63,48 +118,9 @@ ErrorOr<Vector<Hunk>> parse_hunks(StringView diff)
     return hunks;
 }
 
-HunkLocation parse_hunk_location(StringView location_line)
+ErrorOr<Vector<Hunk>> parse_hunks(StringView diff)
 {
-    size_t char_index = 0;
-    auto parse_start_and_length_pair = [](StringView raw) {
-        auto maybe_index_of_separator = raw.find(',');
-
-        size_t start = 0;
-        size_t length = 0;
-        if (maybe_index_of_separator.has_value()) {
-            auto index_of_separator = maybe_index_of_separator.value();
-            start = raw.substring_view(0, index_of_separator).to_uint().value();
-            length = raw.substring_view(index_of_separator + 1, raw.length() - index_of_separator - 1).to_uint().value();
-        } else {
-            length = 1;
-            start = raw.to_uint().value();
-        }
-
-        return Range { start, length };
-    };
-    while (char_index < location_line.length() && location_line[char_index++] != '-') {
-    }
-    VERIFY(char_index < location_line.length());
-
-    size_t original_location_start_index = char_index;
-
-    while (char_index < location_line.length() && location_line[char_index++] != ' ') {
-    }
-    VERIFY(char_index < location_line.length() && location_line[char_index] == '+');
-    size_t original_location_end_index = char_index - 2;
-
-    size_t target_location_start_index = char_index + 1;
-
-    char_index += 1;
-    while (char_index < location_line.length() && location_line[char_index++] != ' ') {
-    }
-    VERIFY(char_index < location_line.length());
-
-    size_t target_location_end_index = char_index - 2;
-
-    auto old_range = parse_start_and_length_pair(location_line.substring_view(original_location_start_index, original_location_end_index - original_location_start_index + 1));
-    auto new_range = parse_start_and_length_pair(location_line.substring_view(target_location_start_index, target_location_end_index - target_location_start_index + 1));
-    return { old_range, new_range };
+    Parser lexer(diff);
+    return lexer.parse_hunks();
 }
-
-};
+}

--- a/Userland/Libraries/LibDiff/Hunks.h
+++ b/Userland/Libraries/LibDiff/Hunks.h
@@ -71,6 +71,11 @@ struct Header {
     String new_file_path;
 };
 
+struct Patch {
+    Header header;
+    Vector<Hunk> hunks;
+};
+
 class Parser : public GenericLexer {
 public:
     using GenericLexer::GenericLexer;

--- a/Userland/Libraries/LibDiff/Hunks.h
+++ b/Userland/Libraries/LibDiff/Hunks.h
@@ -59,11 +59,25 @@ struct Hunk {
     Vector<Line> lines;
 };
 
+enum class Format {
+    Unified,
+    Unknown,
+};
+
+struct Header {
+    Format format { Format::Unknown };
+
+    String old_file_path;
+    String new_file_path;
+};
+
 class Parser : public GenericLexer {
 public:
     using GenericLexer::GenericLexer;
 
     ErrorOr<Vector<Hunk>> parse_hunks();
+
+    ErrorOr<Header> parse_header();
 
 private:
     Optional<HunkLocation> consume_unified_location();

--- a/Userland/Libraries/LibDiff/Hunks.h
+++ b/Userland/Libraries/LibDiff/Hunks.h
@@ -9,6 +9,7 @@
 
 #include <AK/Assertions.h>
 #include <AK/Format.h>
+#include <AK/GenericLexer.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
@@ -58,9 +59,20 @@ struct Hunk {
     Vector<Line> lines;
 };
 
-ErrorOr<Vector<Hunk>> parse_hunks(StringView diff);
-HunkLocation parse_hunk_location(StringView location_line);
+class Parser : public GenericLexer {
+public:
+    using GenericLexer::GenericLexer;
+
+    ErrorOr<Vector<Hunk>> parse_hunks();
+
+private:
+    Optional<HunkLocation> consume_unified_location();
+    bool consume_line_number(size_t& number);
 };
+
+ErrorOr<Vector<Hunk>> parse_hunks(StringView diff);
+
+}
 
 template<>
 struct AK::Formatter<Diff::Line::Operation> : Formatter<FormatString> {

--- a/Userland/Libraries/LibFileSystem/FileSystem.cpp
+++ b/Userland/Libraries/LibFileSystem/FileSystem.cpp
@@ -121,6 +121,24 @@ bool is_char_device(int fd)
     return S_ISCHR(st.st_mode);
 }
 
+bool is_regular_file(StringView path)
+{
+    auto st_or_error = Core::System::stat(path);
+    if (st_or_error.is_error())
+        return false;
+    auto st = st_or_error.release_value();
+    return S_ISREG(st.st_mode);
+}
+
+bool is_regular_file(int fd)
+{
+    auto st_or_error = Core::System::fstat(fd);
+    if (st_or_error.is_error())
+        return false;
+    auto st = st_or_error.release_value();
+    return S_ISREG(st.st_mode);
+}
+
 bool is_directory(StringView path)
 {
     auto st_or_error = Core::System::stat(path);

--- a/Userland/Libraries/LibFileSystem/FileSystem.h
+++ b/Userland/Libraries/LibFileSystem/FileSystem.h
@@ -25,6 +25,9 @@ ErrorOr<String> real_path(StringView path);
 bool exists(StringView path);
 bool exists(int fd);
 
+bool is_regular_file(StringView path);
+bool is_regular_file(int fd);
+
 bool is_directory(StringView path);
 bool is_directory(int fd);
 

--- a/Userland/Libraries/LibFileSystem/FileSystem.h
+++ b/Userland/Libraries/LibFileSystem/FileSystem.h
@@ -66,6 +66,7 @@ AK_ENUM_BITWISE_OPERATORS(PreserveMode);
 ErrorOr<void> copy_file(StringView destination_path, StringView source_path, struct stat const& source_stat, Core::File& source, PreserveMode = PreserveMode::Nothing);
 ErrorOr<void> copy_directory(StringView destination_path, StringView source_path, struct stat const& source_stat, LinkMode = LinkMode::Disallowed, PreserveMode = PreserveMode::Nothing);
 ErrorOr<void> copy_file_or_directory(StringView destination_path, StringView source_path, RecursionMode = RecursionMode::Allowed, LinkMode = LinkMode::Disallowed, AddDuplicateFileMarker = AddDuplicateFileMarker::Yes, PreserveMode = PreserveMode::Nothing);
+ErrorOr<void> move_file(StringView destination_path, StringView source_path, PreserveMode = PreserveMode::Nothing);
 ErrorOr<void> remove(StringView path, RecursionMode);
 ErrorOr<size_t> size(StringView path);
 bool can_delete_or_move(StringView path);

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -3,7 +3,7 @@ list(APPEND SPECIAL_TARGETS test install)
 list(APPEND REQUIRED_TARGETS
     arp base64 basename cat chmod chown clear comm cp cut date dd df diff dirname dmesg du echo env expr false
     file find grep groups head host hostname id ifconfig kill killall ln logout ls mkdir mount mv network-settings nproc
-    pgrep pidof ping pkill pmap ps readlink realpath reboot rm rmdir sed route seq shutdown sleep sort stat stty su tail test
+    patch pgrep pidof ping pkill pmap ps readlink realpath reboot rm rmdir sed route seq shutdown sleep sort stat stty su tail test
     touch tr true umount uname uniq uptime w wc which whoami xargs yes
 )
 list(APPEND RECOMMENDED_TARGETS
@@ -123,6 +123,7 @@ target_link_libraries(notify PRIVATE LibGfx LibGUI)
 target_link_libraries(open PRIVATE LibDesktop LibFileSystem)
 target_link_libraries(passwd PRIVATE LibCrypt)
 target_link_libraries(paste PRIVATE LibGUI)
+target_link_libraries(patch PRIVATE LibDiff LibFileSystem)
 target_link_libraries(pdf PRIVATE LibGfx LibPDF)
 target_link_libraries(pgrep PRIVATE LibRegex)
 target_link_libraries(pixelflut PRIVATE LibImageDecoderClient LibIPC LibGfx)

--- a/Userland/Utilities/patch.cpp
+++ b/Userland/Utilities/patch.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023, Shannon Booth <shannon.ml.booth@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/ArgsParser.h>
+#include <LibCore/File.h>
+#include <LibCore/System.h>
+#include <LibDiff/Applier.h>
+#include <LibDiff/Hunks.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibMain/Main.h>
+
+static ErrorOr<void> do_patch(StringView path_of_file_to_patch, Diff::Patch const& patch)
+{
+    auto file_to_patch = TRY(Core::File::open(path_of_file_to_patch, Core::File::OpenMode::Read));
+    auto content = TRY(file_to_patch->read_until_eof());
+    auto lines = StringView(content).lines();
+
+    // Apply patch to a temporary file in case one or more of the hunks fails.
+    char tmp_output[] = "/tmp/patch.XXXXXX";
+    auto tmp_file = TRY(Core::File::adopt_fd(TRY(Core::System::mkstemp(tmp_output)), Core::File::OpenMode::ReadWrite));
+
+    TRY(Diff::apply_patch(*tmp_file, lines, patch));
+
+    return FileSystem::move_file(path_of_file_to_patch, StringView { tmp_output, sizeof(tmp_output) });
+}
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    Core::ArgsParser args_parser;
+    args_parser.parse(arguments);
+
+    auto input = TRY(Core::File::standard_input());
+
+    auto patch_content = TRY(input->read_until_eof());
+
+    // FIXME: Support multiple patches in the patch file.
+    Diff::Parser parser(patch_content);
+    Diff::Patch patch;
+    patch.header = TRY(parser.parse_header());
+    patch.hunks = TRY(parser.parse_hunks());
+
+    // FIXME: Support adding/removing a file, and asking for file to patch as fallback otherwise.
+    StringView to_patch;
+    if (FileSystem::is_regular_file(patch.header.old_file_path)) {
+        to_patch = patch.header.old_file_path;
+    } else if (FileSystem::is_regular_file(patch.header.new_file_path)) {
+        to_patch = patch.header.new_file_path;
+    } else {
+        warnln("Unable to determine file to patch");
+        return 1;
+    }
+
+    outln("patching file {}", to_patch);
+    TRY(do_patch(to_patch, patch));
+
+    return 0;
+}


### PR DESCRIPTION
This is still very bare bones, and there is _much_ more to still
handle. However, this implements enough functionality to parse a single
unified patch read from stdin, and apply it to a file.

![image](https://github.com/SerenityOS/serenity/assets/35911232/832f15ee-9137-462b-ac47-7ed39213bf40)

![image](https://github.com/SerenityOS/serenity/assets/35911232/ef22ec42-09a8-4161-a392-3dd6ad8817a1)

![image](https://github.com/SerenityOS/serenity/assets/35911232/82cd5e2e-844f-4880-a7b0-d336e8c40afd)

