### PR TITLE
Ladybird: add initial page to history

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -495,8 +495,7 @@ Tab& BrowserWindow::new_tab(QString const& url, Web::HTML::ActivateTab activate_
 
     tab_ptr->focus_location_editor();
 
-    // We make it HistoryNavigation so that the initial page doesn't get added to the history.
-    tab_ptr->navigate(url, Tab::LoadType::HistoryNavigation);
+    tab_ptr->navigate(url);
 
     return *tab_ptr;
 }


### PR DESCRIPTION
This fixes a bug where the reload button does not work on the page that was initially loaded