### PR TITLE
Ladybird/LibAudio: Use PulseAudio APIs directly for Lagom audio output

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -84,6 +84,7 @@ set(SOURCES
     BrowserWindow.cpp
     ConsoleWidget.cpp
     EventLoopImplementationQt.cpp
+    EventLoopImplementationQtEventTarget.cpp
     HelperProcess.cpp
     InspectorWidget.cpp
     LocationEdit.cpp

--- a/Ladybird/EventLoopImplementationQt.cpp
+++ b/Ladybird/EventLoopImplementationQt.cpp
@@ -49,13 +49,11 @@ int EventLoopImplementationQt::exec()
 size_t EventLoopImplementationQt::pump(PumpMode mode)
 {
     auto result = Core::ThreadEventQueue::current().process();
-    if (mode == PumpMode::WaitForEvents) {
-        if (is_main_loop())
-            QCoreApplication::processEvents(QEventLoop::WaitForMoreEvents);
-        else
-            m_event_loop.processEvents(QEventLoop::WaitForMoreEvents);
-    } else {
-    }
+    auto qt_mode = mode == PumpMode::WaitForEvents ? QEventLoop::WaitForMoreEvents : QEventLoop::AllEvents;
+    if (is_main_loop())
+        QCoreApplication::processEvents(qt_mode);
+    else
+        m_event_loop.processEvents(qt_mode);
     result += Core::ThreadEventQueue::current().process();
     return result;
 }

--- a/Ladybird/EventLoopImplementationQtEventTarget.cpp
+++ b/Ladybird/EventLoopImplementationQtEventTarget.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, Gregory Bertilson <zaggy1024@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "EventLoopImplementationQtEventTarget.h"
+
+namespace Ladybird {
+
+bool EventLoopImplementationQtEventTarget::event(QEvent* event)
+{
+    return EventLoopManagerQt::event_target_received_event({}, event);
+}
+
+}

--- a/Ladybird/EventLoopImplementationQtEventTarget.h
+++ b/Ladybird/EventLoopImplementationQtEventTarget.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023, Gregory Bertilson <zaggy1024@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <QEvent>
+
+#include "EventLoopImplementationQt.h"
+
+namespace Ladybird {
+
+class EventLoopImplementationQtEventTarget final : public QObject {
+    Q_OBJECT
+
+public:
+    virtual bool event(QEvent* event) override;
+};
+
+}

--- a/Ladybird/WebContent/CMakeLists.txt
+++ b/Ladybird/WebContent/CMakeLists.txt
@@ -29,3 +29,7 @@ target_link_libraries(WebContent PRIVATE Qt::Core Qt::Network Qt::Multimedia Lib
 if (ANDROID)
     link_android_libs(WebContent)
 endif()
+
+if (HAVE_PULSEAUDIO)
+    target_compile_definitions(WebContent PRIVATE HAVE_PULSEAUDIO=1)
+endif()

--- a/Ladybird/WebContent/CMakeLists.txt
+++ b/Ladybird/WebContent/CMakeLists.txt
@@ -9,6 +9,7 @@ set(WEBCONTENT_SOURCES
     ../AudioCodecPluginQt.cpp
     ../AudioThread.cpp
     ../EventLoopImplementationQt.cpp
+    ../EventLoopImplementationQtEventTarget.cpp
     ../FontPlugin.cpp
     ../HelperProcess.cpp
     ../ImageCodecPlugin.cpp

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -27,6 +27,7 @@
 #include <LibWeb/Loader/FrameLoader.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/PermissionsPolicy/AutoplayAllowlist.h>
+#include <LibWeb/Platform/AudioCodecPluginAgnostic.h>
 #include <LibWeb/Platform/EventLoopPluginSerenity.h>
 #include <LibWeb/WebSockets/WebSocket.h>
 #include <LibWebView/RequestServerAdapter.h>
@@ -54,7 +55,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Web::Platform::ImageCodecPlugin::install(*new Ladybird::ImageCodecPlugin);
 
     Web::Platform::AudioCodecPlugin::install_creation_hook([](auto loader) {
+#if defined(HAVE_PULSEAUDIO)
+        return Web::Platform::AudioCodecPluginAgnostic::create(move(loader));
+#else
         return Ladybird::AudioCodecPluginQt::create(move(loader));
+#endif
     });
 
     Web::FrameLoader::set_default_favicon_path(DeprecatedString::formatted("{}/res/icons/16x16/app-browser.png", s_serenity_resource_root));

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -662,6 +662,7 @@ if (BUILD_LAGOM)
         # LibCore
         if ((LINUX OR APPLE) AND NOT EMSCRIPTEN)
             lagom_test(../../Tests/LibCore/TestLibCoreFileWatcher.cpp)
+            lagom_test(../../Tests/LibCore/TestLibCorePromise.cpp LIBS LibThreading)
         endif()
 
         # RegexLibC test POSIX <regex.h> and contains many Serenity extensions

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -143,6 +143,8 @@ if (ENABLE_LAGOM_LADYBIRD AND (ENABLE_FUZZERS OR ENABLE_COMPILER_EXPLORER_BUILD)
     )
 endif()
 
+CHECK_INCLUDE_FILE(pulse/pulseaudio.h HAVE_PULSEAUDIO)
+
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     add_compile_options(-Wno-overloaded-virtual)
     # FIXME: Re-enable this check when the warning stops triggering, or document why we can't stop it from triggering.

--- a/Tests/LibCore/CMakeLists.txt
+++ b/Tests/LibCore/CMakeLists.txt
@@ -12,6 +12,7 @@ foreach(source IN LISTS TEST_SOURCES)
     serenity_test("${source}" LibCore)
 endforeach()
 
+target_link_libraries(TestLibCorePromise PRIVATE LibThreading)
 # NOTE: Required because of the LocalServer tests
 target_link_libraries(TestLibCoreStream PRIVATE LibThreading)
 target_link_libraries(TestLibCoreSharedSingleProducerCircularQueue PRIVATE LibThreading)

--- a/Tests/LibCore/TestLibCorePromise.cpp
+++ b/Tests/LibCore/TestLibCorePromise.cpp
@@ -6,7 +6,10 @@
 
 #include <LibCore/EventLoop.h>
 #include <LibCore/Promise.h>
+#include <LibCore/ThreadedPromise.h>
 #include <LibTest/TestSuite.h>
+#include <LibThreading/Thread.h>
+#include <unistd.h>
 
 TEST_CASE(promise_await_async_event)
 {
@@ -54,6 +57,111 @@ TEST_CASE(promise_chain_handlers)
     });
 
     (void)promise->await();
+    EXPECT(resolved);
+    EXPECT(!rejected);
+}
+
+TEST_CASE(threaded_promise_instantly_resolved)
+{
+    Core::EventLoop loop;
+
+    bool resolved = false;
+    bool rejected = true;
+    Optional<pthread_t> thread_id;
+
+    auto promise = Core::ThreadedPromise<int>::create();
+
+    auto thread = Threading::Thread::construct([&, promise] {
+        thread_id = pthread_self();
+        promise->resolve(42);
+        return 0;
+    });
+    thread->start();
+
+    promise
+        ->when_resolved([&](int result) {
+            EXPECT(thread_id.has_value());
+            EXPECT(pthread_equal(thread_id.value(), pthread_self()));
+            resolved = true;
+            rejected = false;
+            EXPECT_EQ(result, 42);
+        })
+        .when_rejected([](Error&&) {
+            VERIFY_NOT_REACHED();
+        });
+
+    promise->await();
+    EXPECT(promise->has_completed());
+    EXPECT(resolved);
+    EXPECT(!rejected);
+    MUST(thread->join());
+}
+
+TEST_CASE(threaded_promise_resolved_later)
+{
+    Core::EventLoop loop;
+
+    bool unblock_thread = false;
+    bool resolved = false;
+    bool rejected = true;
+    Optional<pthread_t> thread_id;
+
+    auto promise = Core::ThreadedPromise<int>::create();
+
+    auto thread = Threading::Thread::construct([&, promise] {
+        thread_id = pthread_self();
+        while (!unblock_thread)
+            usleep(500);
+        promise->resolve(42);
+        return 0;
+    });
+    thread->start();
+
+    promise
+        ->when_resolved([&]() {
+            EXPECT(thread_id.has_value());
+            EXPECT(pthread_equal(thread_id.value(), pthread_self()));
+            EXPECT(unblock_thread);
+            resolved = true;
+            rejected = false;
+        })
+        .when_rejected([](Error&&) {
+            VERIFY_NOT_REACHED();
+        });
+
+    Core::EventLoop::current().deferred_invoke([&]() { unblock_thread = true; });
+
+    promise->await();
+    EXPECT(promise->has_completed());
+    EXPECT(unblock_thread);
+    EXPECT(resolved);
+    EXPECT(!rejected);
+    MUST(thread->join());
+}
+
+TEST_CASE(threaded_promise_synchronously_resolved)
+{
+    Core::EventLoop loop;
+
+    bool resolved = false;
+    bool rejected = true;
+    auto thread_id = pthread_self();
+
+    auto promise = Core::ThreadedPromise<int>::create();
+    promise->resolve(1337);
+
+    promise
+        ->when_resolved([&]() {
+            EXPECT(pthread_equal(thread_id, pthread_self()));
+            resolved = true;
+            rejected = false;
+        })
+        .when_rejected([](Error&&) {
+            VERIFY_NOT_REACHED();
+        });
+
+    promise->await();
+    EXPECT(promise->has_completed());
     EXPECT(resolved);
     EXPECT(!rejected);
 }

--- a/Userland/Libraries/LibAudio/CMakeLists.txt
+++ b/Userland/Libraries/LibAudio/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES
     WavWriter.cpp
     Metadata.cpp
     MP3Loader.cpp
+    PlaybackStream.cpp
     QOALoader.cpp
     QOATypes.cpp
     UserSampleQueue.cpp
@@ -25,5 +26,17 @@ if (SERENITYOS)
     )
 endif()
 
+if (HAVE_PULSEAUDIO)
+    list(APPEND SOURCES
+        PlaybackStreamPulseAudio.cpp
+        PulseAudioWrappers.cpp
+    )
+endif()
+
 serenity_lib(LibAudio audio)
 target_link_libraries(LibAudio PRIVATE LibCore LibIPC LibThreading LibUnicode LibCrypto)
+
+if (HAVE_PULSEAUDIO)
+    target_link_libraries(LibAudio PRIVATE pulse)
+    target_compile_definitions(LibAudio PRIVATE HAVE_PULSEAUDIO=1)
+endif()

--- a/Userland/Libraries/LibAudio/Forward.h
+++ b/Userland/Libraries/LibAudio/Forward.h
@@ -10,6 +10,7 @@ namespace Audio {
 
 class ConnectionToServer;
 class Loader;
+class PlaybackStream;
 struct Sample;
 
 template<typename SampleType>

--- a/Userland/Libraries/LibAudio/PlaybackStream.cpp
+++ b/Userland/Libraries/LibAudio/PlaybackStream.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, Gregory Bertilson <zaggy1024@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "PlaybackStream.h"
+
+#include <LibCore/ThreadedPromise.h>
+
+#if defined(HAVE_PULSEAUDIO)
+#    include <LibAudio/PlaybackStreamPulseAudio.h>
+#endif
+
+namespace Audio {
+
+#define TRY_OR_REJECT_AND_STOP(expression, promise)                \
+    ({                                                             \
+        auto&& __temporary_result = (expression);                  \
+        if (__temporary_result.is_error()) [[unlikely]] {          \
+            (promise)->reject(__temporary_result.release_error()); \
+            return 1;                                              \
+        }                                                          \
+        __temporary_result.release_value();                        \
+    })
+
+ErrorOr<NonnullRefPtr<PlaybackStream>> PlaybackStream::create(OutputState initial_output_state, u32 sample_rate, u8 channels, u32 target_latency_ms, AudioDataRequestCallback&& data_request_callback)
+{
+    VERIFY(data_request_callback);
+    // Create the platform-specific implementation for this stream.
+#if defined(HAVE_PULSEAUDIO)
+    return PlaybackStreamPulseAudio::create(initial_output_state, sample_rate, channels, target_latency_ms, move(data_request_callback));
+#else
+    (void)initial_output_state, (void)sample_rate, (void)channels, (void)target_latency_ms;
+    return Error::from_string_literal("Audio output is not available for this platform");
+#endif
+}
+
+}

--- a/Userland/Libraries/LibAudio/PlaybackStream.h
+++ b/Userland/Libraries/LibAudio/PlaybackStream.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023, Gregory Bertilson <zaggy1024@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/AtomicRefCounted.h>
+#include <AK/Function.h>
+#include <AK/Queue.h>
+#include <AK/Time.h>
+#include <LibAudio/SampleFormats.h>
+#include <LibCore/Forward.h>
+#include <LibThreading/ConditionVariable.h>
+#include <LibThreading/MutexProtected.h>
+#include <LibThreading/Thread.h>
+
+namespace Audio {
+
+enum class OutputState {
+    Playing,
+    Suspended,
+};
+
+// This class implements high-level audio playback behavior. It is primarily intended as an abstract cross-platform
+// interface to be used by Ladybird (and its dependent libraries) for playback.
+//
+// The interface is designed to be simple and robust. All control functions can be called safely from any thread.
+// Timing information provided by the class should allow audio timestamps to be tracked with the best accuracy possible.
+class PlaybackStream : public AtomicRefCounted<PlaybackStream> {
+public:
+    using AudioDataRequestCallback = Function<ReadonlyBytes(Bytes buffer, PcmSampleFormat format, size_t sample_count)>;
+
+    // Creates a new audio Output class.
+    //
+    // The initial_output_state parameter determines whether it will begin playback immediately.
+    //
+    // The AudioDataRequestCallback will be called when the Output needs more audio data to fill
+    // its buffers and continue playback.
+    static ErrorOr<NonnullRefPtr<PlaybackStream>> create(OutputState initial_output_state, u32 sample_rate, u8 channels, u32 target_latency_ms, AudioDataRequestCallback&&);
+
+    virtual ~PlaybackStream() = default;
+
+    // Sets the callback function that will be fired whenever the server consumes more data than is made available
+    // by the data request callback. It will fire when either the data request runs too long, or the data request
+    // returns no data. If all the input data has been exhausted and this event fires, that means that playback
+    // has ended.
+    virtual void set_underrun_callback(Function<void()>) = 0;
+
+    // Resume playback from the suspended state, requesting new data for audio buffers as soon as possible.
+    //
+    // The value provided to the promise resolution will match the `total_time_played()` at the exact moment that
+    // the stream was resumed.
+    virtual NonnullRefPtr<Core::ThreadedPromise<Duration>> resume() = 0;
+    // Completes playback of any buffered audio data and then suspends playback and buffering.
+    virtual NonnullRefPtr<Core::ThreadedPromise<void>> drain_buffer_and_suspend() = 0;
+    // Drops any buffered audio data and then suspends playback and buffering. This can used be to stop playback
+    // as soon as possible instead of waiting for remaining audio to play.
+    virtual NonnullRefPtr<Core::ThreadedPromise<void>> discard_buffer_and_suspend() = 0;
+
+    // Returns a accurate monotonically-increasing time duration that is based on the number of samples that have
+    // been played by the output device. The value is interpolated and takes into account latency to the speakers
+    // whenever possible.
+    //
+    // This function should be able to run from any thread safely.
+    virtual ErrorOr<Duration> total_time_played() = 0;
+
+    virtual NonnullRefPtr<Core::ThreadedPromise<void>> set_volume(double volume) = 0;
+};
+
+}

--- a/Userland/Libraries/LibAudio/PlaybackStreamPulseAudio.cpp
+++ b/Userland/Libraries/LibAudio/PlaybackStreamPulseAudio.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2023, Gregory Bertilson <zaggy1024@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "PlaybackStreamPulseAudio.h"
+
+#include <LibCore/ThreadedPromise.h>
+
+namespace Audio {
+
+#define TRY_OR_EXIT_THREAD(expression)                                                                       \
+    ({                                                                                                       \
+        auto&& __temporary_result = (expression);                                                            \
+        if (__temporary_result.is_error()) [[unlikely]] {                                                    \
+            warnln("Failure in PulseAudio control thread: {}", __temporary_result.error().string_literal()); \
+            internal_state->exit();                                                                          \
+            return 1;                                                                                        \
+        }                                                                                                    \
+        __temporary_result.release_value();                                                                  \
+    })
+
+ErrorOr<NonnullRefPtr<PlaybackStream>> PlaybackStreamPulseAudio::create(OutputState initial_state, u32 sample_rate, u8 channels, u32 target_latency_ms, AudioDataRequestCallback&& data_request_callback)
+{
+    VERIFY(data_request_callback);
+
+    // Create an internal state for the control thread to hold on to.
+    auto internal_state = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) InternalState()));
+    auto playback_stream = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) PlaybackStreamPulseAudio(internal_state)));
+
+    // Create the control thread and start it.
+    auto thread = TRY(Threading::Thread::try_create([=, data_request_callback = move(data_request_callback)]() mutable {
+        auto context = TRY_OR_EXIT_THREAD(PulseAudioContext::instance());
+        internal_state->set_stream(TRY_OR_EXIT_THREAD(context->create_stream(initial_state, sample_rate, channels, target_latency_ms, [data_request_callback = move(data_request_callback)](PulseAudioStream&, Bytes buffer, size_t sample_count) {
+            return data_request_callback(buffer, PcmSampleFormat::Float32, sample_count);
+        })));
+
+        // PulseAudio retains the last volume it sets for an application. We want to consistently
+        // start at 100% volume instead.
+        TRY_OR_EXIT_THREAD(internal_state->stream()->set_volume(1.0));
+
+        internal_state->thread_loop();
+        return 0;
+    },
+        "Audio::PlaybackStream"sv));
+
+    internal_state->set_thread(thread);
+    thread->start();
+    thread->detach();
+    return playback_stream;
+}
+
+PlaybackStreamPulseAudio::PlaybackStreamPulseAudio(NonnullRefPtr<InternalState> state)
+    : m_state(move(state))
+{
+}
+
+PlaybackStreamPulseAudio::~PlaybackStreamPulseAudio()
+{
+    m_state->exit();
+}
+
+#define TRY_OR_REJECT(expression, ...)                           \
+    ({                                                           \
+        auto&& __temporary_result = (expression);                \
+        if (__temporary_result.is_error()) [[unlikely]] {        \
+            promise->reject(__temporary_result.release_error()); \
+            return __VA_ARGS__;                                  \
+        }                                                        \
+        __temporary_result.release_value();                      \
+    })
+
+void PlaybackStreamPulseAudio::set_underrun_callback(Function<void()> callback)
+{
+    m_state->enqueue([this, callback = move(callback)]() mutable {
+        m_state->stream()->set_underrun_callback(move(callback));
+    });
+}
+
+NonnullRefPtr<Core::ThreadedPromise<Duration>> PlaybackStreamPulseAudio::resume()
+{
+    auto promise = Core::ThreadedPromise<Duration>::create();
+    TRY_OR_REJECT(m_state->check_is_running(), promise);
+    m_state->enqueue([this, promise]() {
+        TRY_OR_REJECT(m_state->stream()->resume());
+        promise->resolve(TRY_OR_REJECT(m_state->stream()->total_time_played()));
+    });
+    return promise;
+}
+
+NonnullRefPtr<Core::ThreadedPromise<void>> PlaybackStreamPulseAudio::drain_buffer_and_suspend()
+{
+    auto promise = Core::ThreadedPromise<void>::create();
+    TRY_OR_REJECT(m_state->check_is_running(), promise);
+    m_state->enqueue([this, promise]() {
+        TRY_OR_REJECT(m_state->stream()->drain_and_suspend());
+        promise->resolve();
+    });
+    return promise;
+}
+
+NonnullRefPtr<Core::ThreadedPromise<void>> PlaybackStreamPulseAudio::discard_buffer_and_suspend()
+{
+    auto promise = Core::ThreadedPromise<void>::create();
+    TRY_OR_REJECT(m_state->check_is_running(), promise);
+    m_state->enqueue([this, promise]() {
+        TRY_OR_REJECT(m_state->stream()->flush_and_suspend());
+        promise->resolve();
+    });
+    return promise;
+}
+
+ErrorOr<Duration> PlaybackStreamPulseAudio::total_time_played()
+{
+    if (m_state->stream() != nullptr)
+        return m_state->stream()->total_time_played();
+    return Duration::zero();
+}
+
+NonnullRefPtr<Core::ThreadedPromise<void>> PlaybackStreamPulseAudio::set_volume(double volume)
+{
+    auto promise = Core::ThreadedPromise<void>::create();
+    TRY_OR_REJECT(m_state->check_is_running(), promise);
+    m_state->enqueue([this, promise, volume]() {
+        TRY_OR_REJECT(m_state->stream()->set_volume(volume));
+        promise->resolve();
+    });
+    return promise;
+}
+
+ErrorOr<void> PlaybackStreamPulseAudio::InternalState::check_is_running()
+{
+    if (m_exit)
+        return Error::from_string_literal("PulseAudio control thread loop is not running");
+    return {};
+}
+
+void PlaybackStreamPulseAudio::InternalState::set_thread(NonnullRefPtr<Threading::Thread> const& thread)
+{
+    Threading::MutexLocker locker { m_mutex };
+    m_thread = thread;
+}
+
+void PlaybackStreamPulseAudio::InternalState::set_stream(NonnullRefPtr<PulseAudioStream> const& stream)
+{
+    m_stream = stream;
+}
+
+RefPtr<PulseAudioStream> PlaybackStreamPulseAudio::InternalState::stream()
+{
+    return m_stream;
+}
+
+void PlaybackStreamPulseAudio::InternalState::enqueue(Function<void()>&& task)
+{
+    Threading::MutexLocker locker { m_mutex };
+    m_tasks.enqueue(forward<Function<void()>>(task));
+    m_wake_condition.signal();
+}
+
+void PlaybackStreamPulseAudio::InternalState::thread_loop()
+{
+    while (true) {
+        auto task = [this]() -> Function<void()> {
+            Threading::MutexLocker locker { m_mutex };
+
+            while (m_tasks.is_empty() && !m_exit)
+                m_wake_condition.wait();
+            if (m_exit)
+                return nullptr;
+            return m_tasks.dequeue();
+        }();
+        if (!task) {
+            VERIFY(m_exit);
+            break;
+        }
+        task();
+    }
+
+    // Stop holding onto our thread so it can be deleted.
+    Threading::MutexLocker locker { m_mutex };
+    m_thread = nullptr;
+}
+
+void PlaybackStreamPulseAudio::InternalState::exit()
+{
+    m_exit = true;
+    m_wake_condition.signal();
+}
+
+}

--- a/Userland/Libraries/LibAudio/PlaybackStreamPulseAudio.h
+++ b/Userland/Libraries/LibAudio/PlaybackStreamPulseAudio.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, Gregory Bertilson <zaggy1024@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibAudio/PlaybackStream.h>
+#include <LibAudio/PulseAudioWrappers.h>
+
+namespace Audio {
+
+class PlaybackStreamPulseAudio final
+    : public PlaybackStream {
+public:
+    static ErrorOr<NonnullRefPtr<PlaybackStream>> create(OutputState initial_state, u32 sample_rate, u8 channels, u32 target_latency_ms, AudioDataRequestCallback&& data_request_callback);
+
+    virtual void set_underrun_callback(Function<void()>) override;
+
+    virtual NonnullRefPtr<Core::ThreadedPromise<Duration>> resume() override;
+    virtual NonnullRefPtr<Core::ThreadedPromise<void>> drain_buffer_and_suspend() override;
+    virtual NonnullRefPtr<Core::ThreadedPromise<void>> discard_buffer_and_suspend() override;
+
+    virtual ErrorOr<Duration> total_time_played() override;
+
+    virtual NonnullRefPtr<Core::ThreadedPromise<void>> set_volume(double) override;
+
+private:
+    // This struct is kept alive until the control thread exits to prevent a use-after-free without blocking on
+    // the UI thread.
+    class InternalState : public AtomicRefCounted<InternalState> {
+    public:
+        void set_thread(NonnullRefPtr<Threading::Thread> const&);
+
+        void set_stream(NonnullRefPtr<PulseAudioStream> const&);
+        RefPtr<PulseAudioStream> stream();
+
+        void enqueue(Function<void()>&&);
+        void thread_loop();
+        ErrorOr<void> check_is_running();
+        void exit();
+
+    private:
+        RefPtr<PulseAudioStream> m_stream { nullptr };
+
+        Queue<Function<void()>> m_tasks;
+        Threading::Mutex m_mutex;
+        Threading::ConditionVariable m_wake_condition { m_mutex };
+
+        Atomic<bool> m_exit { false };
+
+        RefPtr<Threading::Thread> m_thread { nullptr };
+    };
+
+    PlaybackStreamPulseAudio(NonnullRefPtr<InternalState>);
+    ~PlaybackStreamPulseAudio();
+
+    RefPtr<InternalState> m_state;
+};
+
+}

--- a/Userland/Libraries/LibAudio/PulseAudioWrappers.cpp
+++ b/Userland/Libraries/LibAudio/PulseAudioWrappers.cpp
@@ -1,0 +1,476 @@
+/*
+ * Copyright (c) 2023, Gregory Bertilson <zaggy1024@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "PulseAudioWrappers.h"
+
+#include <AK/WeakPtr.h>
+#include <LibThreading/Mutex.h>
+
+namespace Audio {
+
+ErrorOr<NonnullRefPtr<PulseAudioContext>> PulseAudioContext::instance()
+{
+    // Use a weak pointer to allow the context to be shut down if we stop outputting audio.
+    static WeakPtr<PulseAudioContext> the_instance;
+    static Threading::Mutex instantiation_mutex;
+    auto instantiation_locker = Threading::MutexLocker(instantiation_mutex);
+
+    RefPtr<PulseAudioContext> strong_instance_pointer = the_instance.strong_ref();
+
+    if (strong_instance_pointer == nullptr) {
+        auto* main_loop = pa_threaded_mainloop_new();
+        if (main_loop == nullptr)
+            return Error::from_string_literal("Failed to create PulseAudio main loop");
+
+        auto* api = pa_threaded_mainloop_get_api(main_loop);
+        if (api == nullptr)
+            return Error::from_string_literal("Failed to get PulseAudio API");
+
+        auto* context = pa_context_new(api, "Ladybird");
+        if (context == nullptr)
+            return Error::from_string_literal("Failed to get PulseAudio connection context");
+
+        strong_instance_pointer = make_ref_counted<PulseAudioContext>(main_loop, api, context);
+
+        // Set a callback to signal ourselves to wake when the state changes, so that we can
+        // synchronously wait for the connection.
+        pa_context_set_state_callback(
+            context, [](pa_context*, void* user_data) {
+                static_cast<PulseAudioContext*>(user_data)->signal_to_wake();
+            },
+            strong_instance_pointer.ptr());
+
+        if (auto error = pa_context_connect(context, nullptr, PA_CONTEXT_NOFLAGS, nullptr); error < 0) {
+            warnln("Starting PulseAudio context connection failed with error: {}", pulse_audio_error_to_string(static_cast<PulseAudioErrorCode>(-error)));
+            return Error::from_string_literal("Error while starting PulseAudio daemon connection");
+        }
+
+        if (auto error = pa_threaded_mainloop_start(main_loop); error < 0) {
+            warnln("Starting PulseAudio main loop failed with error: {}", pulse_audio_error_to_string(static_cast<PulseAudioErrorCode>(-error)));
+            return Error::from_string_literal("Failed to start PulseAudio main loop");
+        }
+
+        {
+            auto locker = strong_instance_pointer->main_loop_locker();
+            while (true) {
+                bool is_ready = false;
+                switch (strong_instance_pointer->get_connection_state()) {
+                case PulseAudioContextState::Connecting:
+                case PulseAudioContextState::Authorizing:
+                case PulseAudioContextState::SettingName:
+                    break;
+                case PulseAudioContextState::Ready:
+                    is_ready = true;
+                    break;
+                case PulseAudioContextState::Failed:
+                    warnln("PulseAudio server connection failed with error: {}", pulse_audio_error_to_string(strong_instance_pointer->get_last_error()));
+                    return Error::from_string_literal("Failed to connect to PulseAudio server");
+                case PulseAudioContextState::Unconnected:
+                case PulseAudioContextState::Terminated:
+                    VERIFY_NOT_REACHED();
+                    break;
+                }
+
+                if (is_ready)
+                    break;
+
+                strong_instance_pointer->wait_for_signal();
+            }
+
+            pa_context_set_state_callback(context, nullptr, nullptr);
+        }
+
+        the_instance = strong_instance_pointer;
+    }
+
+    return strong_instance_pointer.release_nonnull();
+}
+
+PulseAudioContext::PulseAudioContext(pa_threaded_mainloop* main_loop, pa_mainloop_api* api, pa_context* context)
+    : m_main_loop(main_loop)
+    , m_api(api)
+    , m_context(context)
+{
+}
+
+PulseAudioContext::~PulseAudioContext()
+{
+    pa_context_disconnect(m_context);
+    pa_context_unref(m_context);
+    pa_threaded_mainloop_stop(m_main_loop);
+    pa_threaded_mainloop_free(m_main_loop);
+}
+
+bool PulseAudioContext::current_thread_is_main_loop_thread()
+{
+    return static_cast<bool>(pa_threaded_mainloop_in_thread(m_main_loop));
+}
+
+void PulseAudioContext::lock_main_loop()
+{
+    if (!current_thread_is_main_loop_thread())
+        pa_threaded_mainloop_lock(m_main_loop);
+}
+
+void PulseAudioContext::unlock_main_loop()
+{
+    if (!current_thread_is_main_loop_thread())
+        pa_threaded_mainloop_unlock(m_main_loop);
+}
+
+void PulseAudioContext::wait_for_signal()
+{
+    pa_threaded_mainloop_wait(m_main_loop);
+}
+
+void PulseAudioContext::signal_to_wake()
+{
+    pa_threaded_mainloop_signal(m_main_loop, 0);
+}
+
+PulseAudioContextState PulseAudioContext::get_connection_state()
+{
+    return static_cast<PulseAudioContextState>(pa_context_get_state(m_context));
+}
+
+bool PulseAudioContext::connection_is_good()
+{
+    return PA_CONTEXT_IS_GOOD(pa_context_get_state(m_context));
+}
+
+PulseAudioErrorCode PulseAudioContext::get_last_error()
+{
+    return static_cast<PulseAudioErrorCode>(pa_context_errno(m_context));
+}
+
+#define STREAM_SIGNAL_CALLBACK(stream)                                          \
+    [](auto*, int, void* user_data) {                                           \
+        static_cast<PulseAudioStream*>(user_data)->m_context->signal_to_wake(); \
+    },                                                                          \
+        (stream)
+
+ErrorOr<NonnullRefPtr<PulseAudioStream>> PulseAudioContext::create_stream(OutputState initial_state, u32 sample_rate, u8 channels, u32 target_latency_ms, PulseAudioDataRequestCallback write_callback)
+{
+    auto locker = main_loop_locker();
+
+    VERIFY(get_connection_state() == PulseAudioContextState::Ready);
+    pa_sample_spec sample_specification {
+        // FIXME: Support more audio sample types.
+        __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ ? PA_SAMPLE_FLOAT32LE : PA_SAMPLE_FLOAT32BE,
+        sample_rate,
+        channels,
+    };
+
+    // Check the sample specification and channel map here. These are also checked by stream_new(),
+    // but we can return a more accurate error if we check beforehand.
+    if (pa_sample_spec_valid(&sample_specification) == 0)
+        return Error::from_string_literal("PulseAudio sample specification is invalid");
+    pa_channel_map channel_map;
+    if (pa_channel_map_init_auto(&channel_map, sample_specification.channels, PA_CHANNEL_MAP_DEFAULT) == 0) {
+        warnln("Getting default PulseAudio channel map failed with error: {}", pulse_audio_error_to_string(get_last_error()));
+        return Error::from_string_literal("Failed to get default PulseAudio channel map");
+    }
+
+    // Create the stream object and set a callback to signal ourselves to wake when the stream changes states,
+    // allowing us to wait synchronously for it to become Ready or Failed.
+    auto* stream = pa_stream_new_with_proplist(m_context, "Audio Stream", &sample_specification, &channel_map, nullptr);
+    if (stream == nullptr) {
+        warnln("Instantiating PulseAudio stream failed with error: {}", pulse_audio_error_to_string(get_last_error()));
+        return Error::from_string_literal("Failed to create PulseAudio stream");
+    }
+    pa_stream_set_state_callback(
+        stream, [](pa_stream*, void* user_data) {
+            static_cast<PulseAudioContext*>(user_data)->signal_to_wake();
+        },
+        this);
+
+    auto stream_wrapper = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) PulseAudioStream(NonnullRefPtr(*this), stream)));
+
+    stream_wrapper->m_write_callback = move(write_callback);
+    pa_stream_set_write_callback(
+        stream, [](pa_stream* stream, size_t bytes_to_write, void* user_data) {
+            auto& stream_wrapper = *static_cast<PulseAudioStream*>(user_data);
+            VERIFY(stream_wrapper.m_stream == stream);
+            stream_wrapper.on_write_requested(bytes_to_write);
+        },
+        stream_wrapper.ptr());
+
+    // Borrowing logic from cubeb to set reasonable buffer sizes for a target latency:
+    // https://searchfox.org/mozilla-central/rev/3b707c8fd7e978eebf24279ee51ccf07895cfbcb/third_party/rust/cubeb-sys/libcubeb/src/cubeb_pulse.c#910-927
+    pa_buffer_attr buffer_attributes;
+    buffer_attributes.maxlength = -1;
+    buffer_attributes.prebuf = -1;
+    buffer_attributes.tlength = target_latency_ms * sample_rate / 1000;
+    buffer_attributes.minreq = buffer_attributes.tlength / 4;
+    buffer_attributes.fragsize = buffer_attributes.minreq;
+    auto flags = static_cast<pa_stream_flags>(PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_ADJUST_LATENCY | PA_STREAM_RELATIVE_VOLUME);
+
+    if (initial_state == OutputState::Suspended) {
+        stream_wrapper->m_suspended = true;
+        flags = static_cast<pa_stream_flags>(static_cast<u32>(flags) | PA_STREAM_START_CORKED);
+    }
+
+    // This is a workaround for an issue with starting the stream corked, see PulseAudioPlaybackStream::total_time_played().
+    pa_stream_set_started_callback(
+        stream, [](pa_stream* stream, void* user_data) {
+            static_cast<PulseAudioStream*>(user_data)->m_started_playback = true;
+            pa_stream_set_started_callback(stream, nullptr, nullptr);
+        },
+        stream_wrapper.ptr());
+
+    pa_stream_set_underflow_callback(
+        stream, [](pa_stream*, void* user_data) {
+            auto& stream = *static_cast<PulseAudioStream*>(user_data);
+            if (stream.m_underrun_callback)
+                stream.m_underrun_callback();
+        },
+        stream_wrapper.ptr());
+
+    if (auto error = pa_stream_connect_playback(stream, nullptr, &buffer_attributes, flags, nullptr, nullptr); error != 0) {
+        warnln("PulseAudio stream connection failed with error: {}", pulse_audio_error_to_string(static_cast<PulseAudioErrorCode>(error)));
+        return Error::from_string_literal("Error while connecting the PulseAudio stream");
+    }
+
+    // FIXME: This should be asynchronous if connection can take longer than a fraction of a second.
+    while (true) {
+        bool is_ready = false;
+        switch (stream_wrapper->get_connection_state()) {
+        case PulseAudioStreamState::Creating:
+            break;
+        case PulseAudioStreamState::Ready:
+            is_ready = true;
+            break;
+        case PulseAudioStreamState::Failed:
+            return Error::from_string_literal("Failed to connect to PulseAudio daemon");
+        case PulseAudioStreamState::Unconnected:
+        case PulseAudioStreamState::Terminated:
+            VERIFY_NOT_REACHED();
+            break;
+        }
+        if (is_ready)
+            break;
+
+        wait_for_signal();
+    }
+
+    return stream_wrapper;
+}
+
+PulseAudioStream::~PulseAudioStream()
+{
+    pa_stream_unref(m_stream);
+}
+
+PulseAudioStreamState PulseAudioStream::get_connection_state()
+{
+    return static_cast<PulseAudioStreamState>(pa_stream_get_state(m_stream));
+}
+
+bool PulseAudioStream::connection_is_good()
+{
+    return PA_STREAM_IS_GOOD(pa_stream_get_state(m_stream));
+}
+
+void PulseAudioStream::set_underrun_callback(Function<void()> callback)
+{
+    auto locker = m_context->main_loop_locker();
+    m_underrun_callback = move(callback);
+}
+
+u32 PulseAudioStream::sample_rate()
+{
+    return pa_stream_get_sample_spec(m_stream)->rate;
+}
+
+size_t PulseAudioStream::sample_size()
+{
+    return pa_sample_size(pa_stream_get_sample_spec(m_stream));
+}
+
+size_t PulseAudioStream::frame_size()
+{
+    return pa_frame_size(pa_stream_get_sample_spec(m_stream));
+}
+
+u8 PulseAudioStream::channel_count()
+{
+    return pa_stream_get_sample_spec(m_stream)->channels;
+}
+
+void PulseAudioStream::on_write_requested(size_t bytes_to_write)
+{
+    VERIFY(m_write_callback);
+    if (m_suspended)
+        return;
+    while (bytes_to_write > 0) {
+        auto buffer = begin_write(bytes_to_write).release_value_but_fixme_should_propagate_errors();
+        auto frame_size = this->frame_size();
+        VERIFY(buffer.size() % frame_size == 0);
+        auto written_buffer = m_write_callback(*this, buffer, buffer.size() / frame_size);
+        if (written_buffer.size() == 0) {
+            cancel_write().release_value_but_fixme_should_propagate_errors();
+            break;
+        }
+        bytes_to_write -= written_buffer.size();
+        write(written_buffer).release_value_but_fixme_should_propagate_errors();
+    }
+}
+
+ErrorOr<Bytes> PulseAudioStream::begin_write(size_t bytes_to_write)
+{
+    void* data_pointer;
+    size_t data_size = bytes_to_write;
+    if (pa_stream_begin_write(m_stream, &data_pointer, &data_size) != 0 || data_pointer == nullptr)
+        return Error::from_string_literal("Failed to get the playback stream's write buffer from PulseAudio");
+    return Bytes { data_pointer, data_size };
+}
+
+ErrorOr<void> PulseAudioStream::write(ReadonlyBytes data)
+{
+    if (pa_stream_write(m_stream, data.data(), data.size(), nullptr, 0, PA_SEEK_RELATIVE) != 0)
+        return Error::from_string_literal("Failed to write data to PulseAudio playback stream");
+    return {};
+}
+
+ErrorOr<void> PulseAudioStream::cancel_write()
+{
+    if (pa_stream_cancel_write(m_stream) != 0)
+        return Error::from_string_literal("Failed to get the playback stream's write buffer from PulseAudio");
+    return {};
+}
+
+bool PulseAudioStream::is_suspended() const
+{
+    return m_suspended;
+}
+
+StringView pulse_audio_error_to_string(PulseAudioErrorCode code)
+{
+    if (code < PulseAudioErrorCode::OK || code >= PulseAudioErrorCode::Sentinel)
+        return "Unknown error code"sv;
+
+    char const* string = pa_strerror(static_cast<int>(code));
+    return StringView { string, strlen(string) };
+}
+
+ErrorOr<void> PulseAudioStream::wait_for_operation(pa_operation* operation, StringView error_message)
+{
+    while (pa_operation_get_state(operation) == PA_OPERATION_RUNNING)
+        m_context->wait_for_signal();
+    if (!m_context->connection_is_good() || !this->connection_is_good()) {
+        auto pulse_audio_error_name = pulse_audio_error_to_string(m_context->get_last_error());
+        warnln("Encountered stream error: {}", pulse_audio_error_name);
+        return Error::from_string_view(error_message);
+    }
+    pa_operation_unref(operation);
+    return {};
+}
+
+ErrorOr<void> PulseAudioStream::drain_and_suspend()
+{
+    auto locker = m_context->main_loop_locker();
+
+    if (m_suspended)
+        return {};
+    m_suspended = true;
+
+    if (pa_stream_is_corked(m_stream) > 0)
+        return {};
+
+    TRY(wait_for_operation(pa_stream_drain(m_stream, STREAM_SIGNAL_CALLBACK(this)), "Draining PulseAudio stream failed"sv));
+    TRY(wait_for_operation(pa_stream_cork(m_stream, 1, STREAM_SIGNAL_CALLBACK(this)), "Corking PulseAudio stream after drain failed"sv));
+    return {};
+}
+
+ErrorOr<void> PulseAudioStream::flush_and_suspend()
+{
+    auto locker = m_context->main_loop_locker();
+
+    if (m_suspended)
+        return {};
+    m_suspended = true;
+
+    if (pa_stream_is_corked(m_stream) > 0)
+        return {};
+
+    TRY(wait_for_operation(pa_stream_flush(m_stream, STREAM_SIGNAL_CALLBACK(this)), "Flushing PulseAudio stream failed"sv));
+    TRY(wait_for_operation(pa_stream_cork(m_stream, 1, STREAM_SIGNAL_CALLBACK(this)), "Corking PulseAudio stream after flush failed"sv));
+    return {};
+}
+
+ErrorOr<void> PulseAudioStream::resume()
+{
+    auto locker = m_context->main_loop_locker();
+
+    if (!m_suspended)
+        return {};
+    m_suspended = false;
+
+    TRY(wait_for_operation(pa_stream_cork(m_stream, 0, STREAM_SIGNAL_CALLBACK(this)), "Uncorking PulseAudio stream failed"sv));
+
+    // Defer a write to the playback buffer on the PulseAudio main loop. Otherwise, playback will not
+    // begin again, despite the fact that we uncorked.
+    // NOTE: We ref here and then unref in the callback so that this stream will not be deleted until
+    //       it finishes.
+    ref();
+    pa_mainloop_api_once(
+        m_context->m_api, [](pa_mainloop_api*, void* user_data) {
+            auto& stream = *static_cast<PulseAudioStream*>(user_data);
+            // NOTE: writable_size() returns -1 in case of an error. However, the value is still safe
+            //       since begin_write() will interpret -1 as a default parameter and choose a good size.
+            auto bytes_to_write = pa_stream_writable_size(stream.m_stream);
+            stream.on_write_requested(bytes_to_write);
+            stream.unref();
+        },
+        this);
+    return {};
+}
+
+ErrorOr<Duration> PulseAudioStream::total_time_played()
+{
+    auto locker = m_context->main_loop_locker();
+
+    // NOTE: This is a workaround for a PulseAudio issue. When a stream is started corked,
+    //       the time smoother doesn't seem to be aware of it, so it will return the time
+    //       since the stream was connected. Once the playback actually starts, the time
+    //       resets back to zero. However, since we request monotonically-increasing time,
+    //       this means that the smoother will register that it had a larger time before,
+    //       and return that time instead, until we reach a timestamp greater than the
+    //       last-returned time. If we never call pa_stream_get_time() until after giving
+    //       the stream its first samples, the issue never occurs.
+    if (!m_started_playback)
+        return Duration::zero();
+
+    pa_usec_t time = 0;
+    auto error = pa_stream_get_time(m_stream, &time);
+    if (error == -PA_ERR_NODATA)
+        return Duration::zero();
+    if (error != 0)
+        return Error::from_string_literal("Failed to get time from PulseAudio stream");
+    if (time > NumericLimits<i64>::max()) {
+        warnln("WARNING: Audio time is too large!");
+        time -= NumericLimits<i64>::max();
+    }
+    return Duration::from_microseconds(static_cast<i64>(time));
+}
+
+ErrorOr<void> PulseAudioStream::set_volume(double volume)
+{
+    auto locker = m_context->main_loop_locker();
+
+    auto index = pa_stream_get_index(m_stream);
+    if (index == PA_INVALID_INDEX)
+        return Error::from_string_literal("Failed to get PulseAudio stream index while setting volume");
+
+    auto pulse_volume = pa_sw_volume_from_linear(volume);
+    pa_cvolume per_channel_volumes;
+    pa_cvolume_set(&per_channel_volumes, channel_count(), pulse_volume);
+
+    auto* operation = pa_context_set_sink_input_volume(m_context->m_context, index, &per_channel_volumes, STREAM_SIGNAL_CALLBACK(this));
+    return wait_for_operation(operation, "Failed to set PulseAudio stream volume"sv);
+}
+
+}

--- a/Userland/Libraries/LibAudio/PulseAudioWrappers.h
+++ b/Userland/Libraries/LibAudio/PulseAudioWrappers.h
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2023, Gregory Bertilson <zaggy1024@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/AtomicRefCounted.h>
+#include <AK/Error.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/Time.h>
+#include <LibAudio/Forward.h>
+#include <LibAudio/PlaybackStream.h>
+#include <LibAudio/SampleFormats.h>
+#include <LibThreading/Thread.h>
+#include <pulse/pulseaudio.h>
+
+namespace Audio {
+
+class PulseAudioStream;
+
+enum class PulseAudioContextState {
+    Unconnected = PA_CONTEXT_UNCONNECTED,
+    Connecting = PA_CONTEXT_CONNECTING,
+    Authorizing = PA_CONTEXT_AUTHORIZING,
+    SettingName = PA_CONTEXT_SETTING_NAME,
+    Ready = PA_CONTEXT_READY,
+    Failed = PA_CONTEXT_FAILED,
+    Terminated = PA_CONTEXT_TERMINATED,
+};
+
+enum class PulseAudioErrorCode;
+
+using PulseAudioDataRequestCallback = Function<ReadonlyBytes(PulseAudioStream&, Bytes buffer, size_t sample_count)>;
+
+// A wrapper around the PulseAudio main loop and context structs.
+// Generally, only one instance of this should be needed for a single process.
+class PulseAudioContext
+    : public AtomicRefCounted<PulseAudioContext>
+    , public Weakable<PulseAudioContext> {
+public:
+    static ErrorOr<NonnullRefPtr<PulseAudioContext>> instance();
+
+    explicit PulseAudioContext(pa_threaded_mainloop*, pa_mainloop_api*, pa_context*);
+    PulseAudioContext(PulseAudioContext const& other) = delete;
+    ~PulseAudioContext();
+
+    bool current_thread_is_main_loop_thread();
+    void lock_main_loop();
+    void unlock_main_loop();
+    [[nodiscard]] auto main_loop_locker()
+    {
+        lock_main_loop();
+        return ScopeGuard([this]() { unlock_main_loop(); });
+    }
+    // Waits for signal_to_wake() to be called.
+    // This must be called with the main loop locked.
+    void wait_for_signal();
+    // Signals to wake all threads from calls to signal_to_wake()
+    void signal_to_wake();
+
+    PulseAudioContextState get_connection_state();
+    bool connection_is_good();
+    PulseAudioErrorCode get_last_error();
+
+    ErrorOr<NonnullRefPtr<PulseAudioStream>> create_stream(OutputState initial_state, u32 sample_rate, u8 channels, u32 target_latency_ms, PulseAudioDataRequestCallback write_callback);
+
+private:
+    friend class PulseAudioStream;
+
+    pa_threaded_mainloop* m_main_loop { nullptr };
+    pa_mainloop_api* m_api { nullptr };
+    pa_context* m_context;
+};
+
+enum class PulseAudioStreamState {
+    Unconnected = PA_STREAM_UNCONNECTED,
+    Creating = PA_STREAM_CREATING,
+    Ready = PA_STREAM_READY,
+    Failed = PA_STREAM_FAILED,
+    Terminated = PA_STREAM_TERMINATED,
+};
+
+class PulseAudioStream : public AtomicRefCounted<PulseAudioStream> {
+public:
+    static constexpr bool start_corked = true;
+
+    ~PulseAudioStream();
+
+    PulseAudioStreamState get_connection_state();
+    bool connection_is_good();
+
+    // Sets the callback to be run when the server consumes more of the buffer than
+    // has been written yet.
+    void set_underrun_callback(Function<void()>);
+
+    u32 sample_rate();
+    size_t sample_size();
+    size_t frame_size();
+    u8 channel_count();
+    // Gets a data buffer that can be written to and then passed back to PulseAudio through
+    // the write() function. This avoids a copy vs directly calling write().
+    ErrorOr<Bytes> begin_write(size_t bytes_to_write = NumericLimits<size_t>::max());
+    // Writes a data buffer to the playback stream.
+    ErrorOr<void> write(ReadonlyBytes data);
+    // Cancels the previous begin_write() call.
+    ErrorOr<void> cancel_write();
+
+    bool is_suspended() const;
+    // Plays back all buffered data and corks the stream. Until resume() is called, no data
+    // will be written to the stream.
+    ErrorOr<void> drain_and_suspend();
+    // Drops all buffered data and corks the stream. Until resume() is called, no data will
+    // be written to the stream.
+    ErrorOr<void> flush_and_suspend();
+    // Uncorks the stream and forces data to be written to the buffers to force playback to
+    // resume as soon as possible.
+    ErrorOr<void> resume();
+    ErrorOr<Duration> total_time_played();
+
+    ErrorOr<void> set_volume(double volume);
+
+    PulseAudioContext& context() { return *m_context; }
+
+private:
+    friend class PulseAudioContext;
+
+    explicit PulseAudioStream(NonnullRefPtr<PulseAudioContext>&& context, pa_stream* stream)
+        : m_context(context)
+        , m_stream(stream)
+    {
+    }
+    PulseAudioStream(PulseAudioStream const& other) = delete;
+
+    ErrorOr<void> wait_for_operation(pa_operation*, StringView error_message);
+
+    void on_write_requested(size_t bytes_to_write);
+
+    NonnullRefPtr<PulseAudioContext> m_context;
+    pa_stream* m_stream { nullptr };
+    bool m_started_playback { false };
+    PulseAudioDataRequestCallback m_write_callback { nullptr };
+    // Determines whether we will allow the write callback to run. This should only be true
+    // if the stream is becoming or is already corked.
+    bool m_suspended { false };
+
+    Function<void()> m_underrun_callback;
+};
+
+enum class PulseAudioErrorCode {
+    OK = 0,
+    AccessFailure,
+    UnknownCommand,
+    InvalidArgument,
+    EntityExists,
+    NoSuchEntity,
+    ConnectionRefused,
+    ProtocolError,
+    Timeout,
+    NoAuthenticationKey,
+    InternalError,
+    ConnectionTerminated,
+    EntityKilled,
+    InvalidServer,
+    NoduleInitFailed,
+    BadState,
+    NoData,
+    IncompatibleProtocolVersion,
+    DataTooLarge,
+    NotSupported,
+    Unknown,
+    NoExtension,
+    Obsolete,
+    NotImplemented,
+    CalledFromFork,
+    IOError,
+    Busy,
+    Sentinel
+};
+
+StringView pulse_audio_error_to_string(PulseAudioErrorCode code);
+
+}

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -17,11 +17,11 @@
 namespace Core {
 
 namespace {
-thread_local Vector<EventLoop&>* s_event_loop_stack;
 Vector<EventLoop&>& event_loop_stack()
 {
-    if (!s_event_loop_stack)
-        s_event_loop_stack = new Vector<EventLoop&>;
+    thread_local OwnPtr<Vector<EventLoop&>> s_event_loop_stack = nullptr;
+    if (s_event_loop_stack == nullptr)
+        s_event_loop_stack = make<Vector<EventLoop&>>();
     return *s_event_loop_stack;
 }
 }

--- a/Userland/Libraries/LibCore/EventLoop.h
+++ b/Userland/Libraries/LibCore/EventLoop.h
@@ -92,6 +92,7 @@ public:
     };
     static void notify_forked(ForkEvent);
 
+    static bool is_running();
     static EventLoop& current();
 
     EventLoopImplementation& impl() { return *m_impl; }

--- a/Userland/Libraries/LibCore/Forward.h
+++ b/Userland/Libraries/LibCore/Forward.h
@@ -36,6 +36,8 @@ class ProcessStatisticsReader;
 class Socket;
 template<typename Result, typename TError = AK::Error>
 class Promise;
+template<typename Result, typename TError = AK::Error>
+class ThreadedPromise;
 class SocketAddress;
 class TCPServer;
 class TCPSocket;

--- a/Userland/Libraries/LibCore/ThreadedPromise.h
+++ b/Userland/Libraries/LibCore/ThreadedPromise.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2021, Kyle Pereira <hey@xylepereira.me>
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2021-2023, Ali Mohammad Pur <mpfard@serenityos.org>
+ * Copyright (c) 2023, Gregory Bertilson <zaggy1024@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/AtomicRefCounted.h>
+#include <AK/Concepts.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/Object.h>
+#include <LibThreading/Mutex.h>
+
+namespace Core {
+
+template<typename TResult, typename TError>
+class ThreadedPromise
+    : public AtomicRefCounted<ThreadedPromise<TResult, TError>> {
+public:
+    static NonnullRefPtr<ThreadedPromise<TResult, TError>> create()
+    {
+        return adopt_ref(*new ThreadedPromise<TResult, TError>());
+    }
+
+    using ResultType = Conditional<IsSame<TResult, void>, Empty, TResult>;
+    using ErrorType = TError;
+
+    void resolve(ResultType&& result)
+    {
+        when_error_handler_is_ready([self = NonnullRefPtr(*this), result = move(result)]() mutable {
+            if (self->m_resolution_handler) {
+                auto handler_result = self->m_resolution_handler(forward<ResultType>(result));
+                if (handler_result.is_error())
+                    self->m_rejection_handler(handler_result.release_error());
+                self->m_has_completed = true;
+            }
+        });
+    }
+    void resolve()
+    requires IsSame<ResultType, Empty>
+    {
+        resolve(Empty());
+    }
+
+    void reject(ErrorType&& error)
+    {
+        when_error_handler_is_ready([this, error = move(error)]() mutable {
+            m_rejection_handler(forward<ErrorType>(error));
+            m_has_completed = true;
+        });
+    }
+    void reject(ErrorType const& error)
+    requires IsTriviallyCopyable<ErrorType>
+    {
+        reject(ErrorType(error));
+    }
+
+    bool has_completed()
+    {
+        Threading::MutexLocker locker { m_mutex };
+        return m_has_completed;
+    }
+
+    void await()
+    {
+        while (!has_completed())
+            Core::EventLoop::current().pump(EventLoop::WaitMode::PollForEvents);
+    }
+
+    // Set the callback to be called when the promise is resolved. A rejection callback
+    // must also be provided before any callback will be called.
+    template<CallableAs<ErrorOr<void>, ResultType&&> ResolvedHandler>
+    ThreadedPromise& when_resolved(ResolvedHandler handler)
+    {
+        Threading::MutexLocker locker { m_mutex };
+        VERIFY(!m_resolution_handler);
+        m_resolution_handler = move(handler);
+        return *this;
+    }
+
+    template<CallableAs<void, ResultType&&> ResolvedHandler>
+    ThreadedPromise& when_resolved(ResolvedHandler handler)
+    {
+        return when_resolved([handler = move(handler)](ResultType&& result) -> ErrorOr<void> {
+            handler(forward<ResultType>(result));
+            return {};
+        });
+    }
+
+    template<CallableAs<ErrorOr<void>> ResolvedHandler>
+    ThreadedPromise& when_resolved(ResolvedHandler handler)
+    {
+        return when_resolved([handler = move(handler)](ResultType&&) -> ErrorOr<void> {
+            return handler();
+        });
+    }
+
+    template<CallableAs<void> ResolvedHandler>
+    ThreadedPromise& when_resolved(ResolvedHandler handler)
+    {
+        return when_resolved([handler = move(handler)](ResultType&&) -> ErrorOr<void> {
+            handler();
+            return {};
+        });
+    }
+
+    // Set the callback to be called when the promise is rejected. Setting this callback
+    // will cause the promise fulfillment to be ready to be handled.
+    template<CallableAs<void, ErrorType&&> RejectedHandler>
+    ThreadedPromise& when_rejected(RejectedHandler when_rejected = [](ErrorType&) {})
+    {
+        Threading::MutexLocker locker { m_mutex };
+        VERIFY(!m_rejection_handler);
+        m_rejection_handler = move(when_rejected);
+        return *this;
+    }
+
+    template<typename T, CallableAs<NonnullRefPtr<ThreadedPromise<T, ErrorType>>, ResultType&&> ChainedResolution>
+    NonnullRefPtr<ThreadedPromise<T, ErrorType>> chain_promise(ChainedResolution chained_resolution)
+    {
+        auto new_promise = ThreadedPromise<T, ErrorType>::create();
+        when_resolved([=, chained_resolution = move(chained_resolution)](ResultType&& result) mutable -> ErrorOr<void> {
+            chained_resolution(forward<ResultType>(result))
+                ->when_resolved([=](auto&& new_result) { new_promise->resolve(move(new_result)); })
+                .when_rejected([=](ErrorType&& error) { new_promise->reject(move(error)); });
+            return {};
+        });
+        when_rejected([=](ErrorType&& error) { new_promise->reject(move(error)); });
+        return new_promise;
+    }
+
+    template<typename T, CallableAs<ErrorOr<T, ErrorType>, ResultType&&> MappingFunction>
+    NonnullRefPtr<ThreadedPromise<T, ErrorType>> map(MappingFunction mapping_function)
+    {
+        auto new_promise = ThreadedPromise<T, ErrorType>::create();
+        when_resolved([=, mapping_function = move(mapping_function)](ResultType&& result) -> ErrorOr<void> {
+            new_promise->resolve(TRY(mapping_function(forward<ResultType>(result))));
+            return {};
+        });
+        when_rejected([=](ErrorType&& error) { new_promise->reject(move(error)); });
+        return new_promise;
+    }
+
+private:
+    template<typename F>
+    static void deferred_handler_check(NonnullRefPtr<ThreadedPromise> self, F&& function)
+    {
+        Threading::MutexLocker locker { self->m_mutex };
+        if (self->m_rejection_handler) {
+            function();
+            return;
+        }
+        EventLoop::current().deferred_invoke([self, function = forward<F>(function)]() mutable {
+            deferred_handler_check(self, move(function));
+        });
+    }
+
+    template<typename F>
+    void when_error_handler_is_ready(F function)
+    {
+        if (EventLoop::is_running()) {
+            deferred_handler_check(NonnullRefPtr(*this), move(function));
+        } else {
+            // NOTE: Handlers should always be set almost immediately, so we can expect this
+            //       to spin extremely briefly. Therefore, sleeping the thread should not be
+            //       necessary.
+            while (true) {
+                Threading::MutexLocker locker { m_mutex };
+                if (m_rejection_handler)
+                    break;
+            }
+            VERIFY(m_rejection_handler);
+            function();
+        }
+    }
+
+    ThreadedPromise() = default;
+    ThreadedPromise(Object* parent)
+        : Object(parent)
+    {
+    }
+
+    Function<ErrorOr<void>(ResultType&&)> m_resolution_handler;
+    Function<void(ErrorType&&)> m_rejection_handler;
+    Threading::Mutex m_mutex;
+    bool m_has_completed;
+};
+
+}

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -489,6 +489,7 @@ set(SOURCES
     PermissionsPolicy/AutoplayAllowlist.cpp
     PixelUnits.cpp
     Platform/AudioCodecPlugin.cpp
+    Platform/AudioCodecPluginAgnostic.cpp
     Platform/EventLoopPlugin.cpp
     Platform/EventLoopPluginSerenity.cpp
     Platform/FontPlugin.cpp

--- a/Userland/Libraries/LibWeb/Platform/AudioCodecPluginAgnostic.cpp
+++ b/Userland/Libraries/LibWeb/Platform/AudioCodecPluginAgnostic.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2023, Gregory Bertilson <zaggy1024@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/MemoryStream.h>
+#include <AK/WeakPtr.h>
+#include <LibAudio/Loader.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/ThreadedPromise.h>
+#include <LibCore/Timer.h>
+
+#include "AudioCodecPluginAgnostic.h"
+
+namespace Web::Platform {
+
+constexpr int update_interval = 10;
+
+static Duration timestamp_from_samples(i64 samples, u32 sample_rate)
+{
+    return Duration::from_milliseconds(samples * 1000 / sample_rate);
+}
+
+static Duration get_loader_timestamp(NonnullRefPtr<Audio::Loader> const& loader)
+{
+    return timestamp_from_samples(loader->loaded_samples(), loader->sample_rate());
+}
+
+ErrorOr<NonnullOwnPtr<AudioCodecPluginAgnostic>> AudioCodecPluginAgnostic::create(NonnullRefPtr<Audio::Loader> const& loader)
+{
+    auto duration = timestamp_from_samples(loader->total_samples(), loader->sample_rate());
+
+    auto update_timer = TRY(Core::Timer::try_create());
+    update_timer->set_interval(update_interval);
+
+    auto plugin = TRY(adopt_nonnull_own_or_enomem(new (nothrow) AudioCodecPluginAgnostic(loader, duration, move(update_timer))));
+
+    constexpr u32 latency_ms = 100;
+    RefPtr<Audio::PlaybackStream> output = TRY(Audio::PlaybackStream::create(
+        Audio::OutputState::Suspended, loader->sample_rate(), loader->num_channels(), latency_ms,
+        [&plugin = *plugin, loader](Bytes buffer, Audio::PcmSampleFormat format, size_t sample_count) -> ReadonlyBytes {
+            VERIFY(format == Audio::PcmSampleFormat::Float32);
+            auto samples = loader->get_more_samples(sample_count).release_value_but_fixme_should_propagate_errors();
+            VERIFY(samples.size() <= sample_count);
+            FixedMemoryStream writing_stream { buffer };
+
+            for (auto& sample : samples) {
+                MUST(writing_stream.write_value(sample.left));
+                MUST(writing_stream.write_value(sample.right));
+            }
+
+            // FIXME: Check if we have loaded samples past the current known duration, and if so, update it
+            //        and notify the media element.
+            return buffer.trim(writing_stream.offset());
+        }));
+
+    output->set_underrun_callback([&plugin = *plugin, loader, output]() {
+        auto new_device_time = output->total_time_played().release_value_but_fixme_should_propagate_errors();
+        auto new_media_time = timestamp_from_samples(loader->loaded_samples(), loader->sample_rate());
+        plugin.m_main_thread_event_loop.deferred_invoke([&plugin, new_device_time, new_media_time]() {
+            plugin.m_last_resume_in_device_time = new_device_time;
+            plugin.m_last_resume_in_media_time = new_media_time;
+        });
+    });
+
+    plugin->m_output = move(output);
+
+    return plugin;
+}
+
+AudioCodecPluginAgnostic::AudioCodecPluginAgnostic(NonnullRefPtr<Audio::Loader> loader, Duration duration, NonnullRefPtr<Core::Timer> update_timer)
+    : m_loader(move(loader))
+    , m_duration(duration)
+    , m_main_thread_event_loop(Core::EventLoop::current())
+    , m_update_timer(move(update_timer))
+{
+    m_update_timer->on_timeout = [this]() {
+        update_timestamp();
+    };
+    m_update_timer->start();
+}
+
+void AudioCodecPluginAgnostic::resume_playback()
+{
+    m_paused = false;
+    m_output->resume()
+        ->when_resolved([this](Duration new_device_time) {
+            m_main_thread_event_loop.deferred_invoke([this, new_device_time]() {
+                m_last_resume_in_device_time = new_device_time;
+                m_update_timer->start();
+            });
+        })
+        .when_rejected([](Error&&) {
+            // FIXME: Propagate errors.
+        });
+}
+
+void AudioCodecPluginAgnostic::pause_playback()
+{
+    m_paused = true;
+    m_output->drain_buffer_and_suspend()
+        ->when_resolved([this]() -> ErrorOr<void> {
+            auto new_media_time = timestamp_from_samples(m_loader->loaded_samples(), m_loader->sample_rate());
+            auto new_device_time = TRY(m_output->total_time_played());
+            m_main_thread_event_loop.deferred_invoke([this, new_media_time, new_device_time]() {
+                m_last_resume_in_media_time = new_media_time;
+                m_last_resume_in_device_time = new_device_time;
+                m_update_timer->stop();
+                update_timestamp();
+            });
+            return {};
+        })
+        .when_rejected([](Error&&) {
+            // FIXME: Propagate errors.
+        });
+}
+
+void AudioCodecPluginAgnostic::set_volume(double volume)
+{
+    m_output->set_volume(volume)->when_rejected([](Error&&) {
+        // FIXME: Propagate errors.
+    });
+}
+
+void AudioCodecPluginAgnostic::seek(double position)
+{
+    m_output->discard_buffer_and_suspend()
+        ->when_resolved([this, position, was_paused = m_paused]() -> ErrorOr<void> {
+            auto sample_position = static_cast<i32>(position * m_loader->sample_rate());
+            auto seek_result = m_loader->seek(sample_position);
+            if (seek_result.is_error())
+                return Error::from_string_literal("Seeking in audio loader failed");
+
+            auto new_media_time = get_loader_timestamp(m_loader);
+            auto new_device_time = m_output->total_time_played().release_value_but_fixme_should_propagate_errors();
+
+            m_main_thread_event_loop.deferred_invoke([this, was_paused, new_device_time, new_media_time]() {
+                m_last_resume_in_device_time = new_device_time;
+                m_last_resume_in_media_time = new_media_time;
+                if (was_paused) {
+                    update_timestamp();
+                } else {
+                    m_output->resume()->when_rejected([](Error&&) {
+                        // FIXME: Propagate errors.
+                    });
+                }
+            });
+
+            return {};
+        })
+        .when_rejected([](Error&&) {
+            // FIXME: Propagate errors.
+        });
+}
+
+Duration AudioCodecPluginAgnostic::duration()
+{
+    return m_duration;
+}
+
+void AudioCodecPluginAgnostic::update_timestamp()
+{
+    auto current_device_time_result = m_output->total_time_played();
+    if (!current_device_time_result.is_error())
+        m_last_good_device_time = current_device_time_result.release_value();
+    auto current_device_time_delta = m_last_good_device_time - m_last_resume_in_device_time;
+
+    auto current_media_time = m_last_resume_in_media_time + current_device_time_delta;
+    current_media_time = min(current_media_time, m_duration);
+    on_playback_position_updated(current_media_time);
+}
+
+}

--- a/Userland/Libraries/LibWeb/Platform/AudioCodecPluginAgnostic.h
+++ b/Userland/Libraries/LibWeb/Platform/AudioCodecPluginAgnostic.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023, Gregory Bertilson <zaggy1024@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibAudio/PlaybackStream.h>
+#include <LibWeb/Platform/AudioCodecPlugin.h>
+
+namespace Web::Platform {
+
+class AudioCodecPluginAgnostic final : public AudioCodecPlugin {
+public:
+    static ErrorOr<NonnullOwnPtr<AudioCodecPluginAgnostic>> create(NonnullRefPtr<Audio::Loader> const&);
+
+    virtual void resume_playback() override;
+    virtual void pause_playback() override;
+    virtual void set_volume(double) override;
+    virtual void seek(double) override;
+
+    virtual Duration duration() override;
+
+private:
+    explicit AudioCodecPluginAgnostic(NonnullRefPtr<Audio::Loader> loader, Duration, NonnullRefPtr<Core::Timer> update_timer);
+
+    void update_timestamp();
+
+    NonnullRefPtr<Audio::Loader> m_loader;
+    RefPtr<Audio::PlaybackStream> m_output { nullptr };
+    Duration m_duration { Duration::zero() };
+    Duration m_last_resume_in_media_time { Duration::zero() };
+    Duration m_last_resume_in_device_time { Duration::zero() };
+    Duration m_last_good_device_time { Duration::zero() };
+    Core::EventLoop& m_main_thread_event_loop;
+    NonnullRefPtr<Core::Timer> m_update_timer;
+    bool m_paused { true };
+};
+
+}


### PR DESCRIPTION
This adds an abstract audio output interface to LibAudio that allows applications to play back audio without needing to be aware of the platform on which they are running. The only implementation currently is for PulseAudio, but an implementation for Serenity should not be difficult to add.

The interface is used by a new Ladybird audio output plugin which will eventually replace the existing plugins, once platform support is good enough.

The benefits over the current Qt-based audio playback plugin in Ladybird are:

- Low latency: With direct access to PulseAudio, we can ask for a small 100ms latency to output to allow minimal delay when pausing or seeking a stream.
- Accurate timestamps: The Qt audio playback API does not expose audio time properly. When we have access directly to PulseAudio APIs, we can enable their interpolation to get an accurate monotonically-increasing timestamp.
- Resiliency: With more control over how the underlying audio API is called, we have the power to fix most bugs we might encounter. The PulseAudio wrappers already avoid some bugs that occur with QAudioSink when running through WSLg.