### PR TITLE
LibJS: Do not coerce nullish references to unresolvable references

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Reference.h
+++ b/Userland/Libraries/LibJS/Runtime/Reference.h
@@ -38,12 +38,6 @@ public:
         , m_this_value(this_value)
         , m_strict(strict)
     {
-        if (base.is_nullish()) {
-            m_base_type = BaseType::Unresolvable;
-            m_base_value = {};
-            m_this_value = {};
-            m_name = {};
-        }
     }
 
     Reference(Environment& base, DeprecatedFlyString referenced_name, bool strict = false, Optional<EnvironmentCoordinate> environment_coordinate = {})

--- a/Userland/Libraries/LibJS/Tests/operators/delete-basic.js
+++ b/Userland/Libraries/LibJS/Tests/operators/delete-basic.js
@@ -87,6 +87,12 @@ test("deleting super property", () => {
         }
     }
 
+    class C {
+        static foo() {
+            delete super.bar;
+        }
+    }
+
     const obj = new B();
     expect(() => {
         obj.bar();
@@ -94,6 +100,11 @@ test("deleting super property", () => {
 
     expect(() => {
         obj.baz();
+    }).toThrowWithMessage(ReferenceError, "Can't delete a property on 'super'");
+
+    Object.setPrototypeOf(C, null);
+    expect(() => {
+        C.foo();
     }).toThrowWithMessage(ReferenceError, "Can't delete a property on 'super'");
 });
 


### PR DESCRIPTION
These are not strictly unresolvable references. Treating them as such fails an assertion in the `delete UnaryExpression` semantic (which is Reference::delete_ in our implementation) - we enter the unresolvable, which then asserts that the [[Strict]] slot of the reference is false.

AST test262 diff:
```
Diff Tests: +7 ✅  -6 ❌  -1 💥

    test/language/expressions/assignment/target-super-computed-reference-null.js   ❌ -> ✅
    test/language/expressions/assignment/target-super-identifier-reference-null.js ❌ -> ✅
    test/language/expressions/delete/super-property-null-base.js                   💥 -> ✅
    test/language/expressions/super/prop-dot-cls-null-proto.js                     ❌ -> ✅
    test/language/expressions/super/prop-dot-obj-null-proto.js                     ❌ -> ✅
    test/language/expressions/super/prop-expr-cls-null-proto.js                    ❌ -> ✅
    test/language/expressions/super/prop-expr-obj-null-proto.js                    ❌ -> ✅

```

No change to bytecode test262.