### PR TITLE
headless-browser: Ensure IPC::File is closed after sending

### DIFF
--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -120,7 +120,7 @@ private:
         if (file.is_error())
             client().async_handle_file_return(file.error().code(), {}, request_id);
         else
-            client().async_handle_file_return(0, IPC::File(*file.value()), request_id);
+            client().async_handle_file_return(0, IPC::File(*file.value(), IPC::File::CloseAfterSending), request_id);
     }
 
     void notify_server_did_finish_handling_input_event(bool) override { }


### PR DESCRIPTION
On systems with the default ulimit for open files <= 256 (default on some systems) the LibWeb tests were crashing because the input file handles are not closed in headless-browser.

Explicit closing might not be the right way to solve the issue, I was not sure how exactly to debug why these are not correctly destructed (cpp knowledge lacking). Am of course willing to change this to a proper fix if someone has a pointer to what could be happening.