### PR TITLE
IPC: Log errors on post_message

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -483,7 +483,7 @@ void do_message_for_proxy(SourceGenerator message_generator, Endpoint const& end
         } else {
             message_generator.append(R"~~~(
         // FIXME: Handle post_message failures.
-        (void) m_connection.post_message(Messages::@endpoint.name@::@message.pascal_name@ { )~~~");
+        if (auto result = m_connection.post_message(Messages::@endpoint.name@::@message.pascal_name@ { )~~~");
         }
 
         for (size_t i = 0; i < parameters.size(); ++i) {
@@ -523,7 +523,7 @@ void do_message_for_proxy(SourceGenerator message_generator, Endpoint const& end
         return { };)~~~");
             }
         } else {
-            message_generator.appendln(" });");
+            message_generator.appendln(" }); result.is_error()) { dbgln(\"post_message error: {}\", result.error()); }");
         }
 
         message_generator.appendln(R"~~~(


### PR DESCRIPTION
When post_message silently fails it produces difficult to debug errors as the message sender might timeout waiting for a response.

Running the LibWeb tests on OSX for example was hanging, it turned out that it was a "too many files open" error that was not logged or handled by post_message. Every test from the 256th onward then was timing out (15 seconds each).

I thought of trying to fix the "FIXME" and change the generated functions to return the error like the sync_ versions already do, but I don't sufficiently understand the IPC api and sync/async implications to be confident to try a fix.