### PR TITLE
LibJS/Bytecode: Generate bytecode for deleting super properties

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1435,6 +1435,7 @@ public:
 
     virtual Completion execute(Interpreter&) const override;
     virtual void dump(int indent) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     virtual bool is_super_expression() const override { return true; }
 };

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -2348,6 +2348,12 @@ Bytecode::CodeGenerationErrorOr<void> SwitchStatement::generate_labelled_evaluat
     return {};
 }
 
+Bytecode::CodeGenerationErrorOr<void> SuperExpression::generate_bytecode(Bytecode::Generator&) const
+{
+    // The semantics for SuperExpression are handled in CallExpression and SuperCall.
+    VERIFY_NOT_REACHED();
+}
+
 Bytecode::CodeGenerationErrorOr<void> ClassDeclaration::generate_bytecode(Bytecode::Generator& generator) const
 {
     auto accumulator_backup_reg = generator.allocate_register();

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -83,6 +83,13 @@ public:
     CodeGenerationErrorOr<void> emit_store_to_reference(JS::ASTNode const&);
     CodeGenerationErrorOr<void> emit_delete_reference(JS::ASTNode const&);
 
+    struct ReferenceRegisters {
+        Register base;                                // [[Base]]
+        Optional<Bytecode::Register> referenced_name; // [[ReferencedName]]
+        Register this_value;                          // [[ThisValue]]
+    };
+    CodeGenerationErrorOr<ReferenceRegisters> emit_super_reference(MemberExpression const&);
+
     void emit_set_variable(JS::Identifier const& identifier, Bytecode::Op::SetVariable::InitializationMode initialization_mode = Bytecode::Op::SetVariable::InitializationMode::Set, Bytecode::Op::EnvironmentMode mode = Bytecode::Op::EnvironmentMode::Lexical);
 
     void push_home_object(Register);

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -27,7 +27,9 @@
     O(CreateVariable)                \
     O(Decrement)                     \
     O(DeleteById)                    \
+    O(DeleteByIdWithThis)            \
     O(DeleteByValue)                 \
+    O(DeleteByValueWithThis)         \
     O(DeleteVariable)                \
     O(Div)                           \
     O(EnterUnwindContext)            \

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -619,10 +619,10 @@ ThrowCompletionOr<void> PutPrivateById::execute_impl(Bytecode::Interpreter& inte
 ThrowCompletionOr<void> DeleteById::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
-    auto object = TRY(interpreter.accumulator().to_object(vm));
+    auto base_value = interpreter.accumulator();
     auto const& identifier = interpreter.current_executable().get_identifier(m_property);
     bool strict = vm.in_strict_mode();
-    auto reference = Reference { object, identifier, {}, strict };
+    auto reference = Reference { base_value, identifier, {}, strict };
     interpreter.accumulator() = Value(TRY(reference.delete_(vm)));
     return {};
 };
@@ -1107,10 +1107,10 @@ ThrowCompletionOr<void> DeleteByValue::execute_impl(Bytecode::Interpreter& inter
     // NOTE: Get the property key from the accumulator before side effects have a chance to overwrite it.
     auto property_key_value = interpreter.accumulator();
 
-    auto object = TRY(interpreter.reg(m_base).to_object(vm));
+    auto base_value = interpreter.reg(m_base);
     auto property_key = TRY(property_key_value.to_property_key(vm));
     bool strict = vm.in_strict_mode();
-    auto reference = Reference { object, property_key, {}, strict };
+    auto reference = Reference { base_value, property_key, {}, strict };
     interpreter.accumulator() = Value(TRY(reference.delete_(vm)));
     return {};
 }

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -740,6 +740,25 @@ private:
     IdentifierTableIndex m_property;
 };
 
+class DeleteByIdWithThis final : public Instruction {
+public:
+    DeleteByIdWithThis(Register this_value, IdentifierTableIndex property)
+        : Instruction(Type::DeleteByIdWithThis)
+        , m_this_value(this_value)
+        , m_property(property)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
+
+private:
+    Register m_this_value;
+    IdentifierTableIndex m_property;
+};
+
 class GetByValue final : public Instruction {
 public:
     explicit GetByValue(Register base)
@@ -863,6 +882,29 @@ public:
 
 private:
     Register m_base;
+};
+
+class DeleteByValueWithThis final : public Instruction {
+public:
+    DeleteByValueWithThis(Register base, Register this_value)
+        : Instruction(Type::DeleteByValueWithThis)
+        , m_base(base)
+        , m_this_value(this_value)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register from, Register to)
+    {
+        if (m_base == from)
+            m_base = to;
+    }
+
+private:
+    Register m_base;
+    Register m_this_value;
 };
 
 class Jump : public Instruction {

--- a/Userland/Libraries/LibJS/Bytecode/Pass/LoadElimination.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/LoadElimination.cpp
@@ -118,7 +118,9 @@ static NonnullOwnPtr<BasicBlock> eliminate_loads(BasicBlock const& block, size_t
             break;
         }
         case DeleteById:
+        case DeleteByIdWithThis:
         case DeleteByValue:
+        case DeleteByValueWithThis:
             // These can trigger proxies, which call into user code
             // So these are treated like calls
         case GetByValue:

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -187,6 +187,7 @@ class Interpreter;
 class Identifier;
 class Intrinsics;
 struct IteratorRecord;
+class MemberExpression;
 class MetaProperty;
 class Module;
 struct ModuleRequest;

--- a/Userland/Libraries/LibJS/Runtime/Reference.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Reference.cpp
@@ -170,8 +170,8 @@ ThrowCompletionOr<bool> Reference::delete_(VM& vm)
         if (is_super_reference())
             return vm.throw_completion<ReferenceError>(ErrorType::UnsupportedDeleteSuperProperty);
 
-        // c. Let baseObj be ! ToObject(ref.[[Base]]).
-        auto base_obj = MUST(m_base_value.to_object(vm));
+        // c. Let baseObj be ? ToObject(ref.[[Base]]).
+        auto base_obj = TRY(m_base_value.to_object(vm));
 
         // d. Let deleteStatus be ? baseObj.[[Delete]](ref.[[ReferencedName]]).
         bool delete_status = TRY(base_obj->internal_delete(m_name));


### PR DESCRIPTION
Bytecode test262 diff:
```
Diff Tests:
    test/language/expressions/delete/super-property-method.js    📝 -> ✅
    test/language/expressions/delete/super-property-null-base.js 📝 -> ✅
    test/language/expressions/delete/super-property.js           📝 -> ✅
```

We now pass all tests in `test/language/expressions/delete` in bytecode mode :)