### PR TITLE
LibC: Relax `memmove()` to `memcpy()` in more cases

### DIFF
--- a/Userland/Libraries/LibC/string.cpp
+++ b/Userland/Libraries/LibC/string.cpp
@@ -167,6 +167,8 @@ void* memset(void* dest_ptr, int c, size_t n)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/memmove.html
 void* memmove(void* dest, void const* src, size_t n)
 {
+    if (dest < src)
+        return memcpy(dest, src, n);
     if (((FlatPtr)dest - (FlatPtr)src) >= n)
         return memcpy(dest, src, n);
 


### PR DESCRIPTION
`memcpy()` and `memmove()` are functionally equivalent if the source and destination memory regions do not overlap. If this is the case, we should prefer `memcpy()` as it's implemented in a simpler and faster way. As our `memcpy()` starts copying from the lowest address first, relaxing a `memmove()` call to `memcpy()` is safe if the destination
- starts at a lower address than the source
- starts at a higher address than the source's end