### PR TITLE
LibGfx: Make ImageDecoder::size() fallible+Unify behavior among decoders+Various Improvements

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -42,8 +42,8 @@ static Gfx::ImageFrameDescriptor expect_single_frame(Gfx::ImageDecoderPlugin& pl
 
 static Gfx::ImageFrameDescriptor expect_single_frame_of_size(Gfx::ImageDecoderPlugin& plugin_decoder, Gfx::IntSize size)
 {
-    auto frame = expect_single_frame(plugin_decoder);
     EXPECT_EQ(MUST(plugin_decoder.size()), size);
+    auto frame = expect_single_frame(plugin_decoder);
     EXPECT_EQ(frame.image->size(), size);
     return frame;
 }

--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -43,7 +43,7 @@ static Gfx::ImageFrameDescriptor expect_single_frame(Gfx::ImageDecoderPlugin& pl
 static Gfx::ImageFrameDescriptor expect_single_frame_of_size(Gfx::ImageDecoderPlugin& plugin_decoder, Gfx::IntSize size)
 {
     auto frame = expect_single_frame(plugin_decoder);
-    EXPECT_EQ(plugin_decoder.size(), size);
+    EXPECT_EQ(MUST(plugin_decoder.size()), size);
     EXPECT_EQ(frame.image->size(), size);
     return frame;
 }
@@ -557,7 +557,7 @@ TEST_CASE(test_webp_extended_lossless_animated)
     EXPECT(plugin_decoder->is_animated());
     EXPECT_EQ(plugin_decoder->loop_count(), 42u);
 
-    EXPECT_EQ(plugin_decoder->size(), Gfx::IntSize(990, 1050));
+    EXPECT_EQ(MUST(plugin_decoder->size()), Gfx::IntSize(990, 1050));
 
     for (size_t frame_index = 0; frame_index < plugin_decoder->frame_count(); ++frame_index) {
         auto frame = MUST(plugin_decoder->frame(frame_index));

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -68,6 +68,8 @@ StringView guess_mime_type_based_on_filename(StringView path)
         return "image/gif"sv;
     if (path.ends_with(".bmp"sv, CaseSensitivity::CaseInsensitive))
         return "image/bmp"sv;
+    if (path.ends_with(".dds"sv, CaseSensitivity::CaseInsensitive))
+        return "image/vnd.ms-dds"sv;
     if (path.ends_with(".jpg"sv, CaseSensitivity::CaseInsensitive) || path.ends_with(".jpeg"sv, CaseSensitivity::CaseInsensitive))
         return "image/jpeg"sv;
     if (path.ends_with(".qoi"sv, CaseSensitivity::CaseInsensitive))
@@ -135,6 +137,7 @@ StringView guess_mime_type_based_on_filename(StringView path)
     __ENUMERATE_MIME_TYPE_HEADER(blend, "extra/blender"sv, 0, 7, 'B', 'L', 'E', 'N', 'D', 'E', 'R')                                                \
     __ENUMERATE_MIME_TYPE_HEADER(bmp, "image/bmp"sv, 0, 2, 'B', 'M')                                                                               \
     __ENUMERATE_MIME_TYPE_HEADER(bzip2, "application/x-bzip2"sv, 0, 3, 'B', 'Z', 'h')                                                              \
+    __ENUMERATE_MIME_TYPE_HEADER(dds, "image/vnd.ms-dds"sv, 0, 4, 'D', 'D', 'S', ' ')                                                              \
     __ENUMERATE_MIME_TYPE_HEADER(compressed_iso, "extra/isz"sv, 0, 4, 'I', 's', 'Z', '!')                                                          \
     __ENUMERATE_MIME_TYPE_HEADER(elf, "extra/elf"sv, 0, 4, 0x7F, 'E', 'L', 'F')                                                                    \
     __ENUMERATE_MIME_TYPE_HEADER(ext, "extra/ext"sv, 0x438, 2, 0x53, 0xEF)                                                                         \

--- a/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
@@ -16,8 +16,8 @@
 
 namespace Gfx {
 
-const u8 bmp_header_size = 14;
-const u32 color_palette_limit = 1024;
+u8 const bmp_header_size = 14;
+u32 const color_palette_limit = 1024;
 
 // Compression flags
 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wmf/4e588f70-bd92-4a6f-b77f-35d0feaf7a57
@@ -1229,7 +1229,7 @@ static ErrorOr<void> decode_bmp_pixel_data(BMPLoadingContext& context)
     if (context.state <= BMPLoadingContext::State::ColorTableDecoded)
         TRY(decode_bmp_color_table(context));
 
-    const u16 bits_per_pixel = context.dib.core.bpp;
+    u16 const bits_per_pixel = context.dib.core.bpp;
 
     BitmapFormat format = [&]() -> BitmapFormat {
         // NOTE: If this is an BMP included in an ICO, the bitmap format will be converted to BGRA8888.
@@ -1268,8 +1268,8 @@ static ErrorOr<void> decode_bmp_pixel_data(BMPLoadingContext& context)
         return Error::from_string_literal("BMP has invalid bpp");
     }
 
-    const u32 width = abs(context.dib.core.width);
-    const u32 height = !context.is_included_in_ico ? context.dib.core.height : (context.dib.core.height / 2);
+    u32 const width = abs(context.dib.core.width);
+    u32 const height = !context.is_included_in_ico ? context.dib.core.height : (context.dib.core.height / 2);
 
     context.bitmap = TRY(Bitmap::create(format, { static_cast<int>(width), static_cast<int>(height) }));
 
@@ -1284,7 +1284,7 @@ static ErrorOr<void> decode_bmp_pixel_data(BMPLoadingContext& context)
 
     InputStreamer streamer(bytes.data(), bytes.size());
 
-    auto process_row_padding = [&](const u8 consumed) -> ErrorOr<void> {
+    auto process_row_padding = [&](u8 const consumed) -> ErrorOr<void> {
         // Calculate padding
         u8 remaining = consumed % 4;
         u8 bytes_to_drop = remaining == 0 ? 0 : 4 - remaining;

--- a/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.h
@@ -27,7 +27,7 @@ public:
 
     virtual ~BMPImageDecoderPlugin() override;
 
-    virtual IntSize size() override;
+    virtual ErrorOr<IntSize> size() override;
     virtual void set_volatile() override;
     [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
     virtual ErrorOr<void> initialize() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
@@ -640,10 +640,10 @@ ErrorOr<IntSize> DDSImageDecoderPlugin::size()
     if (m_context->state == DDSLoadingContext::State::Error)
         return Error::from_string_literal("Decoder already had an error");
 
-    if (m_context->state == DDSLoadingContext::State::BitmapDecoded)
-        return IntSize { m_context->header.width, m_context->header.height };
+    if (m_context->state < DDSLoadingContext::State::HeaderDecoded)
+        TRY(decode_header(*m_context));
 
-    return Error::from_string_literal("Size not read yet");
+    return IntSize { get_width(m_context->header, 0), get_height(m_context->header, 0) };
 }
 
 void DDSImageDecoderPlugin::set_volatile()

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
@@ -621,15 +621,15 @@ DDSImageDecoderPlugin::DDSImageDecoderPlugin(u8 const* data, size_t size)
 
 DDSImageDecoderPlugin::~DDSImageDecoderPlugin() = default;
 
-IntSize DDSImageDecoderPlugin::size()
+ErrorOr<IntSize> DDSImageDecoderPlugin::size()
 {
     if (m_context->state == DDSLoadingContext::State::Error)
-        return {};
+        return Error::from_string_literal("Decoder already had an error");
 
     if (m_context->state == DDSLoadingContext::State::BitmapDecoded)
-        return { m_context->header.width, m_context->header.height };
+        return IntSize { m_context->header.width, m_context->header.height };
 
-    return {};
+    return Error::from_string_literal("Size not read yet");
 }
 
 void DDSImageDecoderPlugin::set_volatile()

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
@@ -647,15 +647,7 @@ bool DDSImageDecoderPlugin::set_nonvolatile(bool& was_purged)
 
 ErrorOr<void> DDSImageDecoderPlugin::initialize()
 {
-    // The header is always at least 128 bytes, so if the file is smaller, it can't be a DDS.
-    if (m_context->data_size > 128
-        && m_context->data[0] == 0x44
-        && m_context->data[1] == 0x44
-        && m_context->data[2] == 0x53
-        && m_context->data[3] == 0x20)
-        return {};
-
-    return Error::from_string_literal("Bad image magic");
+    return {};
 }
 
 bool DDSImageDecoderPlugin::sniff(ReadonlyBytes data)

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
@@ -23,6 +23,11 @@
 namespace Gfx {
 
 struct DDSLoadingContext {
+    DDSLoadingContext(FixedMemoryStream stream)
+        : stream(move(stream))
+    {
+    }
+
     enum State {
         NotDecoded = 0,
         Error,
@@ -31,8 +36,7 @@ struct DDSLoadingContext {
 
     State state { State::NotDecoded };
 
-    u8 const* data { nullptr };
-    size_t data_size { 0 };
+    FixedMemoryStream stream;
 
     DDSHeader header;
     DDSHeaderDXT10 header10;
@@ -408,15 +412,13 @@ static ErrorOr<void> decode_bitmap(Stream& stream, DDSLoadingContext& context, D
 static ErrorOr<void> decode_dds(DDSLoadingContext& context)
 {
     // All valid DDS files are at least 128 bytes long.
-    if (context.data_size < 128) {
+    if (TRY(context.stream.size()) < 128) {
         dbgln_if(DDS_DEBUG, "File is too short for DDS");
         context.state = DDSLoadingContext::State::Error;
         return Error::from_string_literal("File is too short for DDS");
     }
 
-    FixedMemoryStream stream { ReadonlyBytes { context.data, context.data_size } };
-
-    auto magic = TRY(stream.read_value<u32>());
+    auto magic = TRY(context.stream.read_value<u32>());
 
     if (magic != create_four_cc('D', 'D', 'S', ' ')) {
         dbgln_if(DDS_DEBUG, "Missing magic number");
@@ -424,7 +426,7 @@ static ErrorOr<void> decode_dds(DDSLoadingContext& context)
         return Error::from_string_literal("Missing magic number");
     }
 
-    context.header = TRY(stream.read_value<DDSHeader>());
+    context.header = TRY(context.stream.read_value<DDSHeader>());
 
     if (context.header.size != 124) {
         dbgln_if(DDS_DEBUG, "Header size is malformed");
@@ -439,13 +441,13 @@ static ErrorOr<void> decode_dds(DDSLoadingContext& context)
 
     if ((context.header.pixel_format.flags & PixelFormatFlags::DDPF_FOURCC) == PixelFormatFlags::DDPF_FOURCC) {
         if (context.header.pixel_format.four_cc == create_four_cc('D', 'X', '1', '0')) {
-            if (context.data_size < 148) {
+            if (TRY(context.stream.size()) < 148) {
                 dbgln_if(DDS_DEBUG, "DX10 header is too short");
                 context.state = DDSLoadingContext::State::Error;
                 return Error::from_string_literal("DX10 header is too short");
             }
 
-            context.header10 = TRY(stream.read_value<DDSHeaderDXT10>());
+            context.header10 = TRY(context.stream.read_value<DDSHeaderDXT10>());
         }
     }
 
@@ -469,7 +471,7 @@ static ErrorOr<void> decode_dds(DDSLoadingContext& context)
 
         context.bitmap = TRY(Bitmap::create(BitmapFormat::BGRA8888, { width, height }));
 
-        TRY(decode_bitmap(stream, context, format, width, height));
+        TRY(decode_bitmap(context.stream, context, format, width, height));
     }
 
     context.state = DDSLoadingContext::State::BitmapDecoded;
@@ -612,11 +614,9 @@ void DDSLoadingContext::dump_debug()
     dbgln("{}", builder.to_deprecated_string());
 }
 
-DDSImageDecoderPlugin::DDSImageDecoderPlugin(u8 const* data, size_t size)
+DDSImageDecoderPlugin::DDSImageDecoderPlugin(FixedMemoryStream stream)
 {
-    m_context = make<DDSLoadingContext>();
-    m_context->data = data;
-    m_context->data_size = size;
+    m_context = make<DDSLoadingContext>(move(stream));
 }
 
 DDSImageDecoderPlugin::~DDSImageDecoderPlugin() = default;
@@ -662,7 +662,8 @@ bool DDSImageDecoderPlugin::sniff(ReadonlyBytes data)
 
 ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> DDSImageDecoderPlugin::create(ReadonlyBytes data)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) DDSImageDecoderPlugin(data.data(), data.size()));
+    FixedMemoryStream stream { data };
+    return adopt_nonnull_own_or_enomem(new (nothrow) DDSImageDecoderPlugin(move(stream)));
 }
 
 bool DDSImageDecoderPlugin::is_animated()

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.h
@@ -240,7 +240,7 @@ public:
 
     virtual ~DDSImageDecoderPlugin() override;
 
-    virtual IntSize size() override;
+    virtual ErrorOr<IntSize> size() override;
     virtual void set_volatile() override;
     [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
     virtual ErrorOr<void> initialize() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/MemoryStream.h>
 #include <LibGfx/ImageFormats/ImageDecoder.h>
 
 namespace Gfx {
@@ -252,7 +253,7 @@ public:
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
-    DDSImageDecoderPlugin(u8 const*, size_t);
+    DDSImageDecoderPlugin(FixedMemoryStream);
 
     OwnPtr<DDSLoadingContext> m_context;
 };

--- a/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.h
@@ -20,7 +20,7 @@ public:
 
     virtual ~GIFImageDecoderPlugin() override;
 
-    virtual IntSize size() override;
+    virtual ErrorOr<IntSize> size() override;
     virtual void set_volatile() override;
     [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
     virtual ErrorOr<void> initialize() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.cpp
@@ -205,7 +205,7 @@ IntSize ICOImageDecoderPlugin::size()
     }
 
     if (m_context->state < ICOLoadingContext::State::DirectoryDecoded) {
-        if (!load_ico_directory(*m_context).is_error()) {
+        if (load_ico_directory(*m_context).is_error()) {
             m_context->state = ICOLoadingContext::State::Error;
             return {};
         }

--- a/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.cpp
@@ -198,21 +198,21 @@ ICOImageDecoderPlugin::ICOImageDecoderPlugin(u8 const* data, size_t size)
 
 ICOImageDecoderPlugin::~ICOImageDecoderPlugin() = default;
 
-IntSize ICOImageDecoderPlugin::size()
+ErrorOr<IntSize> ICOImageDecoderPlugin::size()
 {
     if (m_context->state == ICOLoadingContext::State::Error) {
-        return {};
+        return Error::from_string_literal("Decoder already had an error");
     }
 
     if (m_context->state < ICOLoadingContext::State::DirectoryDecoded) {
-        if (load_ico_directory(*m_context).is_error()) {
+        if (auto result = load_ico_directory(*m_context); result.is_error()) {
             m_context->state = ICOLoadingContext::State::Error;
-            return {};
+            return result.release_error();
         }
         m_context->state = ICOLoadingContext::State::DirectoryDecoded;
     }
 
-    return { m_context->images[m_context->largest_index].width, m_context->images[m_context->largest_index].height };
+    return IntSize { m_context->images[m_context->largest_index].width, m_context->images[m_context->largest_index].height };
 }
 
 void ICOImageDecoderPlugin::set_volatile()

--- a/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.h
@@ -19,7 +19,7 @@ public:
 
     virtual ~ICOImageDecoderPlugin() override;
 
-    virtual IntSize size() override;
+    virtual ErrorOr<IntSize> size() override;
     virtual void set_volatile() override;
     [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
     virtual ErrorOr<void> initialize() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
@@ -53,8 +53,6 @@ public:
     ~ImageDecoder() = default;
 
     IntSize size() const { return m_plugin->size(); }
-    int width() const { return size().width(); }
-    int height() const { return size().height(); }
     void set_volatile() { m_plugin->set_volatile(); }
     [[nodiscard]] bool set_nonvolatile(bool& was_purged) { return m_plugin->set_nonvolatile(was_purged); }
     bool is_animated() const { return m_plugin->is_animated(); }

--- a/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
@@ -52,7 +52,7 @@ public:
     static RefPtr<ImageDecoder> try_create_for_raw_bytes(ReadonlyBytes, Optional<DeprecatedString> mime_type = {});
     ~ImageDecoder() = default;
 
-    IntSize size() const { return m_plugin->size(); }
+    ErrorOr<IntSize> size() const { return m_plugin->size(); }
     void set_volatile() { m_plugin->set_volatile(); }
     [[nodiscard]] bool set_nonvolatile(bool& was_purged) { return m_plugin->set_nonvolatile(was_purged); }
     bool is_animated() const { return m_plugin->is_animated(); }

--- a/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
@@ -29,7 +29,7 @@ class ImageDecoderPlugin {
 public:
     virtual ~ImageDecoderPlugin() = default;
 
-    virtual IntSize size() = 0;
+    virtual ErrorOr<IntSize> size() = 0;
 
     virtual void set_volatile() = 0;
     [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) = 0;

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -1925,10 +1925,11 @@ ErrorOr<IntSize> JPEGImageDecoderPlugin::size()
 {
     if (m_context->state == JPEGLoadingContext::State::Error)
         return Error::from_string_literal("Decoder already had an error");
-    if (m_context->state >= JPEGLoadingContext::State::FrameDecoded)
-        return IntSize { m_context->frame.width, m_context->frame.height };
 
-    return Error::from_string_literal("Size not read yet");
+    if (m_context->state < JPEGLoadingContext::State::FrameDecoded)
+        TRY(decode_header(*m_context));
+
+    return IntSize { m_context->frame.width, m_context->frame.height };
 }
 
 void JPEGImageDecoderPlugin::set_volatile()

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -1921,14 +1921,14 @@ JPEGImageDecoderPlugin::JPEGImageDecoderPlugin(NonnullOwnPtr<FixedMemoryStream> 
 
 JPEGImageDecoderPlugin::~JPEGImageDecoderPlugin() = default;
 
-IntSize JPEGImageDecoderPlugin::size()
+ErrorOr<IntSize> JPEGImageDecoderPlugin::size()
 {
     if (m_context->state == JPEGLoadingContext::State::Error)
-        return {};
+        return Error::from_string_literal("Decoder already had an error");
     if (m_context->state >= JPEGLoadingContext::State::FrameDecoded)
-        return { m_context->frame.width, m_context->frame.height };
+        return IntSize { m_context->frame.width, m_context->frame.height };
 
-    return {};
+    return Error::from_string_literal("Size not read yet");
 }
 
 void JPEGImageDecoderPlugin::set_volatile()

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
@@ -22,7 +22,7 @@ public:
     static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
 
     virtual ~JPEGImageDecoderPlugin() override;
-    virtual IntSize size() override;
+    virtual ErrorOr<IntSize> size() override;
     virtual void set_volatile() override;
     [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
     virtual ErrorOr<void> initialize() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -1295,18 +1295,17 @@ bool PNGImageDecoderPlugin::ensure_animation_frame_was_decoded(u32 animation_fra
     return decode_png_animation_data_chunks(*m_context, animation_frame_index);
 }
 
-IntSize PNGImageDecoderPlugin::size()
+ErrorOr<IntSize> PNGImageDecoderPlugin::size()
 {
     if (m_context->state == PNGLoadingContext::State::Error)
-        return {};
+        return Error::from_string_literal("Decoder already had an error");
 
     if (m_context->state < PNGLoadingContext::State::SizeDecoded) {
-        bool success = decode_png_size(*m_context);
-        if (!success)
-            return {};
+        if (auto result = decode_png_size(*m_context); !result)
+            return Error::from_string_literal("Error in the PNG decoder");
     }
 
-    return { m_context->width, m_context->height };
+    return IntSize { m_context->width, m_context->height };
 }
 
 void PNGImageDecoderPlugin::set_volatile()

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.h
@@ -19,7 +19,7 @@ public:
 
     virtual ~PNGImageDecoderPlugin() override;
 
-    virtual IntSize size() override;
+    virtual ErrorOr<IntSize> size() override;
     virtual void set_volatile() override;
     [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
     virtual ErrorOr<void> initialize() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/QOILoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/QOILoader.cpp
@@ -168,18 +168,16 @@ QOIImageDecoderPlugin::QOIImageDecoderPlugin(NonnullOwnPtr<Stream> stream)
     m_context->stream = move(stream);
 }
 
-IntSize QOIImageDecoderPlugin::size()
+ErrorOr<IntSize> QOIImageDecoderPlugin::size()
 {
     if (m_context->state < QOILoadingContext::State::HeaderDecoded) {
-        // FIXME: This is a weird API (inherited from ImageDecoderPlugin), should probably propagate errors by returning ErrorOr<IntSize>.
-        //        For the time being, ignore the result and rely on the context's state.
-        (void)decode_header_and_update_context(*m_context->stream);
+        TRY(decode_header_and_update_context(*m_context->stream));
     }
 
     if (m_context->state == QOILoadingContext::State::Error)
-        return {};
+        return Error::from_string_literal("Decoder already had an error");
 
-    return { m_context->header.width, m_context->header.height };
+    return IntSize { m_context->header.width, m_context->header.height };
 }
 
 void QOIImageDecoderPlugin::set_volatile()

--- a/Userland/Libraries/LibGfx/ImageFormats/QOILoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/QOILoader.h
@@ -43,7 +43,7 @@ public:
 
     virtual ~QOIImageDecoderPlugin() override = default;
 
-    virtual IntSize size() override;
+    virtual ErrorOr<IntSize> size() override;
     virtual void set_volatile() override;
     [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
     virtual ErrorOr<void> initialize() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
@@ -169,7 +169,7 @@ TGAImageDecoderPlugin::TGAImageDecoderPlugin(u8 const* file_data, size_t file_si
 
 TGAImageDecoderPlugin::~TGAImageDecoderPlugin() = default;
 
-IntSize TGAImageDecoderPlugin::size()
+ErrorOr<IntSize> TGAImageDecoderPlugin::size()
 {
     return IntSize { m_context->header.width, m_context->header.height };
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/TGALoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TGALoader.h
@@ -20,7 +20,7 @@ public:
     virtual ~TGAImageDecoderPlugin() override;
     TGAImageDecoderPlugin(u8 const*, size_t);
 
-    virtual IntSize size() override;
+    virtual ErrorOr<IntSize> size() override;
     virtual void set_volatile() override;
     [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
     virtual ErrorOr<void> initialize() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
@@ -497,11 +497,11 @@ bool TinyVGImageDecoderPlugin::sniff(ReadonlyBytes bytes)
     return !decode_tinyvg_header(stream).is_error();
 }
 
-IntSize TinyVGImageDecoderPlugin::size()
+ErrorOr<IntSize> TinyVGImageDecoderPlugin::size()
 {
     if (m_context.decoded_image)
         return m_context.decoded_image->size();
-    return {};
+    return Error::from_string_literal("Size not known yet");
 }
 
 void TinyVGImageDecoderPlugin::set_volatile()

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
@@ -80,7 +80,7 @@ public:
     static bool sniff(ReadonlyBytes);
     static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
 
-    virtual IntSize size() override;
+    virtual ErrorOr<IntSize> size() override;
     virtual void set_volatile() override;
     [[nodiscard]] virtual bool set_nonvolatile(bool&) override;
     virtual ErrorOr<void> initialize() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.h
@@ -19,7 +19,7 @@ public:
 
     virtual ~WebPImageDecoderPlugin() override;
 
-    virtual IntSize size() override;
+    virtual ErrorOr<IntSize> size() override;
     virtual void set_volatile() override;
     [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
     virtual ErrorOr<void> initialize() override;

--- a/Userland/Utilities/file.cpp
+++ b/Userland/Utilities/file.cpp
@@ -36,7 +36,8 @@ static ErrorOr<Optional<String>> image_details(StringView description, StringVie
         return OptionalNone {};
 
     StringBuilder builder;
-    builder.appendff("{}, {} x {}", description, image_decoder->width(), image_decoder->height());
+    auto const image_size = image_decoder->size();
+    builder.appendff("{}, {} x {}", description, image_size.width(), image_size.height());
     if (image_decoder->is_animated()) {
         builder.appendff(", animated with {} frames that loop", image_decoder->frame_count());
         int loop_count = image_decoder->loop_count();

--- a/Userland/Utilities/file.cpp
+++ b/Userland/Utilities/file.cpp
@@ -170,6 +170,7 @@ static ErrorOr<Optional<String>> elf_details(StringView description, StringView 
     __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/win-31x-compressed"sv, "Windows 3.1X compressed file"sv, description_only) \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/win-95-compressed"sv, "Windows 95 compressed file"sv, description_only)    \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("image/bmp"sv, "BMP image data"sv, image_details)                                 \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/vnd.ms-dds"sv, "DDS image data"sv, image_details)                          \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("image/gif"sv, "GIF image data"sv, image_details)                                 \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("image/jpeg"sv, "JPEG image data"sv, image_details)                               \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("image/png"sv, "PNG image data"sv, image_details)                                 \

--- a/Userland/Utilities/file.cpp
+++ b/Userland/Utilities/file.cpp
@@ -36,8 +36,12 @@ static ErrorOr<Optional<String>> image_details(StringView description, StringVie
         return OptionalNone {};
 
     StringBuilder builder;
-    auto const image_size = image_decoder->size();
-    builder.appendff("{}, {} x {}", description, image_size.width(), image_size.height());
+    auto const maybe_image_size = image_decoder->size();
+    if (maybe_image_size.is_error())
+        builder.appendff("{}", description);
+    else
+        builder.appendff("{}, {} x {}", description, maybe_image_size.value().width(), maybe_image_size.value().height());
+
     if (image_decoder->is_animated()) {
         builder.appendff(", animated with {} frames that loop", image_decoder->frame_count());
         int loop_count = image_decoder->loop_count();


### PR DESCRIPTION
I initially created the branch to fix #19815, but I did a 100% completion run and there were a lot of side quests :yakkie:

Before:
![WHF](https://github.com/SerenityOS/serenity/assets/26030965/b02c8068-62cf-44f4-846e-7aefb4c473d4)


After:
![WHF](https://github.com/SerenityOS/serenity/assets/26030965/03bf2c45-2d5c-4976-95e9-c42e07010704)

In a nutshell, this PR is:
1. Make `ImageDecoder::size()` fallible in order to be able to decode header in the function
2. Fix the actual issue in the JPEG decoder
3. Prepare the DDS decoder to receive the same fix
4. Fix the issue in the DDS decoder