### PR TITLE
Ports: Generate OpenSSH host keys using a service

### DIFF
--- a/Ports/openssh/ReadMe.md
+++ b/Ports/openssh/ReadMe.md
@@ -16,7 +16,13 @@ cat <<EOF >> mnt/etc/SystemServer.ini
 [SSHServer]
 Executable=/usr/local/sbin/sshd
 Arguments=-D
-KeepAlive=1
+KeepAlive=true
+SystemModes=text,graphical
+
+[SSHServerGenKeys]
+Executable=/usr/local/bin/ssh-keygen
+Arguments=-A
+KeepAlive=false
 SystemModes=text,graphical
 EOF
 ```

--- a/Ports/openssh/package.sh
+++ b/Ports/openssh/package.sh
@@ -19,20 +19,4 @@ pre_configure() {
 install() {
     # Can't make keys outside of Serenity since ssh-keygen is built for Serenity.
     run make DESTDIR="${SERENITY_INSTALL_ROOT}" "${installopts[@]}" install-nokeys
-
-    if command -v ssh-keygen &>/dev/null; then
-        mkdir -p "${SERENITY_INSTALL_ROOT}/etc/ssh"
-        if [ ! -e "${SERENITY_INSTALL_ROOT}/etc/ssh/ssh_host_rsa_key" ]; then
-            ssh-keygen -f "${SERENITY_INSTALL_ROOT}/etc/ssh/ssh_host_rsa_key" -C serenity -N "" -t rsa
-        fi
-        if [ ! -e "${SERENITY_INSTALL_ROOT}/etc/ssh/ssh_host_dsa_key" ]; then
-            ssh-keygen -f "${SERENITY_INSTALL_ROOT}/etc/ssh/ssh_host_dsa_key" -C serenity -N "" -t dsa
-        fi
-        if [ ! -e "${SERENITY_INSTALL_ROOT}/etc/ssh/ssh_host_ecdsa_key" ]; then
-            ssh-keygen -f "${SERENITY_INSTALL_ROOT}/etc/ssh/ssh_host_ecdsa_key" -C serenity -N "" -t ecdsa -b 521
-        fi
-        if [ ! -e "${SERENITY_INSTALL_ROOT}/etc/ssh/ssh_host_ed25519_key" ]; then
-            ssh-keygen -f "${SERENITY_INSTALL_ROOT}/etc/ssh/ssh_host_ed25519_key" -C serenity -N "" -t ed25519
-        fi
-    fi
 }


### PR DESCRIPTION
In the current state, during OpenSSH installation, the host keys are generated and stored in the disk image.

Since storing fixed keys in the image is not a good security practice in case you need to distribute the image, I think it would be a better approach to generate the keys via a service.

This is what is done in Arch Linux [1], for example.

\[1\]: https://gitlab.archlinux.org/archlinux/packaging/packages/openssh/-/blob/9.3p1-2/sshdgenkeys.service