### PR TITLE
LibWeb: Absolute positioning fixes

### DIFF
--- a/Tests/LibWeb/Layout/expected/abspos-not-replaced-multiple-auto-variants.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-not-replaced-multiple-auto-variants.txt
@@ -1,0 +1,10 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x0 children: inline
+      TextNode <#text>
+      BlockContainer <div.only-t-l> at (6,6) content-size 10x10 positioned [BFC] children: not-inline
+      TextNode <#text>
+      BlockContainer <div.only-mt-ml> at (16,16) content-size 10x10 positioned [BFC] children: not-inline
+      TextNode <#text>
+      BlockContainer <div.both> at (11,11) content-size 10x10 positioned [BFC] children: not-inline
+      TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-abspos-item-with-preceding-whitespace.txt
+++ b/Tests/LibWeb/Layout/expected/flex-abspos-item-with-preceding-whitespace.txt
@@ -1,7 +1,8 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x20 [BFC] children: not-inline
-    BlockContainer <body> at (10,10) content-size 780x2 children: not-inline
-      Box <div.pink> at (11,11) content-size 778x0 flex-container(row) [FFC] children: not-inline
+  BlockContainer <html> at (10,10) content-size 780x56 [BFC] children: not-inline
+    BlockContainer <body> at (28,28) content-size 744x20 children: not-inline
+      Box <div.pink> at (38,38) content-size 724x0 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.orange> at (11,-39) content-size 100x100 positioned [BFC] children: not-inline
+        BlockContainer <div.orange> at (38,-12) content-size 100x100 positioned [BFC] children: inline
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-abspos-item-with-preceding-whitespace.txt
+++ b/Tests/LibWeb/Layout/expected/flex-abspos-item-with-preceding-whitespace.txt
@@ -4,5 +4,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.pink> at (38,38) content-size 724x0 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.orange> at (38,-12) content-size 100x100 positioned [BFC] children: inline
+        BlockContainer <div.orange> at (48,-12) content-size 100x100 positioned [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-align-items.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-align-items.txt
@@ -4,73 +4,73 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.normal> at (38,38) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (38,48) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (48,48) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 54.578125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 6, rect: [38,48 54.578125x17.46875]
+            frag 0 from TextNode start: 0, length: 6, rect: [48,48 54.578125x17.46875]
               "normal"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.stretch> at (208,38) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (208,48) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (218,48) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 58.796875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 7, rect: [208,48 58.796875x17.46875]
+            frag 0 from TextNode start: 0, length: 7, rect: [218,48 58.796875x17.46875]
               "stretch"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.start> at (378,38) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (378,48) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (388,48) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [378,48 41.234375x17.46875]
+            frag 0 from TextNode start: 0, length: 5, rect: [388,48 41.234375x17.46875]
               "start"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.flex-start> at (548,38) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (548,48) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (558,48) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [548,48 76.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 10, rect: [558,48 76.8125x17.46875]
               "flex-start"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.end> at (38,208) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (38,298) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (48,308) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [38,298 26.1875x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [48,308 26.1875x17.46875]
               "end"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.flex-end> at (208,208) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (208,298) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (218,308) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [208,298 61.765625x17.46875]
+            frag 0 from TextNode start: 0, length: 8, rect: [218,308 61.765625x17.46875]
               "flex-end"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.center> at (378,208) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (378,258) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (388,258) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 6, rect: [378,258 51.625x17.46875]
+            frag 0 from TextNode start: 0, length: 6, rect: [388,258 51.625x17.46875]
               "center"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.self-start> at (548,208) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (548,218) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (558,218) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 76.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [548,218 76.453125x17.46875]
+            frag 0 from TextNode start: 0, length: 10, rect: [558,218 76.453125x17.46875]
               "self-start"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
       Box <div.outer.self-end> at (38,378) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (38,468) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (48,478) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 61.40625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [38,468 61.40625x17.46875]
+            frag 0 from TextNode start: 0, length: 8, rect: [48,478 61.40625x17.46875]
               "self-end"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-align-items.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-align-items.txt
@@ -1,76 +1,76 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x322 [BFC] children: not-inline
-    Box <body> at (10,10) content-size 780x304 flex-container(row) [FFC] children: not-inline
+  BlockContainer <html> at (10,10) content-size 780x546 [BFC] children: not-inline
+    Box <body> at (28,28) content-size 744x510 flex-container(row) [FFC] children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
-      Box <div.outer.normal> at (11,11) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (11,12) content-size 150x50 positioned [BFC] children: inline
+      Box <div.outer.normal> at (38,38) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (38,48) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 54.578125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 6, rect: [11,12 54.578125x17.46875]
+            frag 0 from TextNode start: 0, length: 6, rect: [38,48 54.578125x17.46875]
               "normal"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
-      Box <div.outer.stretch> at (163,11) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (163,12) content-size 150x50 positioned [BFC] children: inline
+      Box <div.outer.stretch> at (208,38) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (208,48) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 58.796875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 7, rect: [163,12 58.796875x17.46875]
+            frag 0 from TextNode start: 0, length: 7, rect: [208,48 58.796875x17.46875]
               "stretch"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
-      Box <div.outer.start> at (315,11) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (315,12) content-size 150x50 positioned [BFC] children: inline
+      Box <div.outer.start> at (378,38) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (378,48) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [315,12 41.234375x17.46875]
+            frag 0 from TextNode start: 0, length: 5, rect: [378,48 41.234375x17.46875]
               "start"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
-      Box <div.outer.flex-start> at (467,11) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (467,12) content-size 150x50 positioned [BFC] children: inline
+      Box <div.outer.flex-start> at (548,38) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (548,48) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [467,12 76.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 10, rect: [548,48 76.8125x17.46875]
               "flex-start"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
-      Box <div.outer.end> at (619,11) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (619,110) content-size 150x50 positioned [BFC] children: inline
+      Box <div.outer.end> at (38,208) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (38,298) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [619,110 26.1875x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [38,298 26.1875x17.46875]
               "end"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
-      Box <div.outer.flex-end> at (11,163) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (11,262) content-size 150x50 positioned [BFC] children: inline
+      Box <div.outer.flex-end> at (208,208) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (208,298) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [11,262 61.765625x17.46875]
+            frag 0 from TextNode start: 0, length: 8, rect: [208,298 61.765625x17.46875]
               "flex-end"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
-      Box <div.outer.center> at (163,163) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (163,213) content-size 150x50 positioned [BFC] children: inline
+      Box <div.outer.center> at (378,208) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (378,258) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 6, rect: [163,213 51.625x17.46875]
+            frag 0 from TextNode start: 0, length: 6, rect: [378,258 51.625x17.46875]
               "center"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
-      Box <div.outer.self-start> at (315,163) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (315,164) content-size 150x50 positioned [BFC] children: inline
+      Box <div.outer.self-start> at (548,208) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (548,218) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 76.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [315,164 76.453125x17.46875]
+            frag 0 from TextNode start: 0, length: 10, rect: [548,218 76.453125x17.46875]
               "self-start"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
-      Box <div.outer.self-end> at (467,163) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div> at (467,262) content-size 150x50 positioned [BFC] children: inline
+      Box <div.outer.self-end> at (38,378) content-size 150x150 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div> at (38,468) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 61.40625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [467,262 61.40625x17.46875]
+            frag 0 from TextNode start: 0, length: 8, rect: [38,468 61.40625x17.46875]
               "self-end"
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-justify-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-justify-content.txt
@@ -1,261 +1,261 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x2002 [BFC] children: not-inline
-    BlockContainer <body> at (10,10) content-size 780x1984 children: not-inline
-      BlockContainer <(anonymous)> at (10,10) content-size 780x0 children: inline
+  BlockContainer <html> at (15,15) content-size 770x2926 [BFC] children: not-inline
+    BlockContainer <body> at (38,38) content-size 724x2880 children: not-inline
+      BlockContainer <(anonymous)> at (38,38) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.outer.start> at (11,11) content-size 300x60 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div> at (11,12) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.outer.start> at (53,53) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (53,68) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [11,12 41.234375x17.46875]
+            frag 0 from TextNode start: 0, length: 5, rect: [53,68 41.234375x17.46875]
               "start"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,72) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,128) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.outer.flex-start> at (11,73) content-size 300x60 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div> at (11,74) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.outer.flex-start> at (53,143) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (53,158) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [11,74 76.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 10, rect: [53,158 76.8125x17.46875]
               "flex-start"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,134) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,218) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.outer.end> at (11,135) content-size 300x60 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div> at (161,136) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.outer.end> at (53,233) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (203,248) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [161,136 26.1875x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [203,248 26.1875x17.46875]
               "end"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,196) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,308) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.outer.flex-end> at (11,197) content-size 300x60 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div> at (161,198) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.outer.flex-end> at (53,323) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (203,338) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [161,198 61.765625x17.46875]
+            frag 0 from TextNode start: 0, length: 8, rect: [203,338 61.765625x17.46875]
               "flex-end"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,258) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,398) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.outer.center> at (11,259) content-size 300x60 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div> at (86,260) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.outer.center> at (53,413) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (128,428) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 6, rect: [86,260 51.625x17.46875]
+            frag 0 from TextNode start: 0, length: 6, rect: [128,428 51.625x17.46875]
               "center"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,320) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,488) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.outer.space-around> at (11,321) content-size 300x60 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div> at (86,322) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.outer.space-around> at (53,503) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (128,518) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 12, rect: [86,322 107.96875x17.46875]
+            frag 0 from TextNode start: 0, length: 12, rect: [128,518 107.96875x17.46875]
               "space-around"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,382) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,578) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.outer.space-between> at (11,383) content-size 300x60 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div> at (11,384) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.outer.space-between> at (53,593) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (53,608) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 13, rect: [11,384 115.515625x17.46875]
+            frag 0 from TextNode start: 0, length: 13, rect: [53,608 115.515625x17.46875]
               "space-between"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,444) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,668) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.outer.space-evenly> at (11,445) content-size 300x60 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div> at (86,446) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.outer.space-evenly> at (53,683) content-size 300x60 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (128,698) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 98.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 12, rect: [86,446 98.859375x17.46875]
+            frag 0 from TextNode start: 0, length: 12, rect: [128,698 98.859375x17.46875]
               "space-evenly"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,506) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,758) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.reverse.outer.start> at (11,507) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (161,508) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.reverse.outer.start> at (53,773) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (203,788) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [161,508 41.234375x17.46875]
+            frag 0 from TextNode start: 0, length: 5, rect: [203,788 41.234375x17.46875]
               "start"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,568) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,848) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.reverse.outer.flex-start> at (11,569) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (161,570) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.reverse.outer.flex-start> at (53,863) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (203,878) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [161,570 76.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 10, rect: [203,878 76.8125x17.46875]
               "flex-start"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,630) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,938) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.reverse.outer.end> at (11,631) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (11,632) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.reverse.outer.end> at (53,953) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (53,968) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [11,632 26.1875x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [53,968 26.1875x17.46875]
               "end"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,692) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,1028) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.reverse.outer.flex-end> at (11,693) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (11,694) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.reverse.outer.flex-end> at (53,1043) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (53,1058) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [11,694 61.765625x17.46875]
+            frag 0 from TextNode start: 0, length: 8, rect: [53,1058 61.765625x17.46875]
               "flex-end"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,754) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,1118) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.reverse.outer.center> at (11,755) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (86,756) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.reverse.outer.center> at (53,1133) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (128,1148) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 6, rect: [86,756 51.625x17.46875]
+            frag 0 from TextNode start: 0, length: 6, rect: [128,1148 51.625x17.46875]
               "center"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,816) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,1208) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.reverse.outer.space-around> at (11,817) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (86,818) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.reverse.outer.space-around> at (53,1223) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (128,1238) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 12, rect: [86,818 107.96875x17.46875]
+            frag 0 from TextNode start: 0, length: 12, rect: [128,1238 107.96875x17.46875]
               "space-around"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,878) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,1298) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.reverse.outer.space-between> at (11,879) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (11,880) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.reverse.outer.space-between> at (53,1313) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (53,1328) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 13, rect: [11,880 115.515625x17.46875]
+            frag 0 from TextNode start: 0, length: 13, rect: [53,1328 115.515625x17.46875]
               "space-between"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,940) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,1388) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.row.reverse.outer.space-evenly> at (11,941) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (86,942) content-size 150x50 positioned [BFC] children: inline
+      Box <div.row.reverse.outer.space-evenly> at (53,1403) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (128,1418) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 98.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 12, rect: [86,942 98.859375x17.46875]
+            frag 0 from TextNode start: 0, length: 12, rect: [128,1418 98.859375x17.46875]
               "space-evenly"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1002) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,1478) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.outer.start> at (11,1003) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (12,1003) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.outer.start> at (53,1493) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (68,1493) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [12,1003 41.234375x17.46875]
+            frag 0 from TextNode start: 0, length: 5, rect: [68,1493 41.234375x17.46875]
               "start"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1064) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,1568) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.outer.flex-start> at (11,1065) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (12,1065) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.outer.flex-start> at (53,1583) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (68,1583) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [12,1065 76.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 10, rect: [68,1583 76.8125x17.46875]
               "flex-start"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1126) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,1658) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.outer.end> at (11,1127) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (12,1137) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.outer.end> at (53,1673) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (68,1683) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [12,1137 26.1875x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [68,1683 26.1875x17.46875]
               "end"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1188) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,1748) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.outer.flex-end> at (11,1189) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (12,1199) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.outer.flex-end> at (53,1763) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (68,1773) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [12,1199 61.765625x17.46875]
+            frag 0 from TextNode start: 0, length: 8, rect: [68,1773 61.765625x17.46875]
               "flex-end"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1250) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,1838) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.outer.center> at (11,1251) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (12,1256) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.outer.center> at (53,1853) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (68,1858) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 6, rect: [12,1256 51.625x17.46875]
+            frag 0 from TextNode start: 0, length: 6, rect: [68,1858 51.625x17.46875]
               "center"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1312) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,1928) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.outer.space-around> at (11,1313) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (12,1318) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.outer.space-around> at (53,1943) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (68,1948) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 12, rect: [12,1318 107.96875x17.46875]
+            frag 0 from TextNode start: 0, length: 12, rect: [68,1948 107.96875x17.46875]
               "space-around"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1374) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,2018) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.outer.space-between> at (11,1375) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (12,1375) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.outer.space-between> at (53,2033) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (68,2033) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 13, rect: [12,1375 115.515625x17.46875]
+            frag 0 from TextNode start: 0, length: 13, rect: [68,2033 115.515625x17.46875]
               "space-between"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1436) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,2108) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.outer.space-evenly> at (11,1437) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (12,1442) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.outer.space-evenly> at (53,2123) content-size 300x60 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div> at (68,2128) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 98.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 12, rect: [12,1442 98.859375x17.46875]
+            frag 0 from TextNode start: 0, length: 12, rect: [68,2128 98.859375x17.46875]
               "space-evenly"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1498) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,2198) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.reverse.outer.start> at (11,1499) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (12,1509) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.reverse.outer.start> at (53,2213) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (68,2223) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [12,1509 41.234375x17.46875]
+            frag 0 from TextNode start: 0, length: 5, rect: [68,2223 41.234375x17.46875]
               "start"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1560) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,2288) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.reverse.outer.flex-start> at (11,1561) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (12,1571) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.reverse.outer.flex-start> at (53,2303) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (68,2313) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [12,1571 76.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 10, rect: [68,2313 76.8125x17.46875]
               "flex-start"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1622) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,2378) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.reverse.outer.end> at (11,1623) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (12,1623) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.reverse.outer.end> at (53,2393) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (68,2393) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [12,1623 26.1875x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [68,2393 26.1875x17.46875]
               "end"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1684) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,2468) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.reverse.outer.flex-end> at (11,1685) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (12,1685) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.reverse.outer.flex-end> at (53,2483) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (68,2483) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [12,1685 61.765625x17.46875]
+            frag 0 from TextNode start: 0, length: 8, rect: [68,2483 61.765625x17.46875]
               "flex-end"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1746) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,2558) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.reverse.outer.center> at (11,1747) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (12,1752) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.reverse.outer.center> at (53,2573) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (68,2578) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 6, rect: [12,1752 51.625x17.46875]
+            frag 0 from TextNode start: 0, length: 6, rect: [68,2578 51.625x17.46875]
               "center"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1808) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,2648) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.reverse.outer.space-around> at (11,1809) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (12,1814) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.reverse.outer.space-around> at (53,2663) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (68,2668) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 107.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 12, rect: [12,1814 107.96875x17.46875]
+            frag 0 from TextNode start: 0, length: 12, rect: [68,2668 107.96875x17.46875]
               "space-around"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1870) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,2738) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.reverse.outer.space-between> at (11,1871) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (12,1871) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.reverse.outer.space-between> at (53,2753) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (68,2753) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 13, rect: [12,1871 115.515625x17.46875]
+            frag 0 from TextNode start: 0, length: 13, rect: [68,2753 115.515625x17.46875]
               "space-between"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1932) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,2828) content-size 724x0 children: inline
         TextNode <#text>
-      Box <div.column.reverse.outer.space-evenly> at (11,1933) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (12,1938) content-size 150x50 positioned [BFC] children: inline
+      Box <div.column.reverse.outer.space-evenly> at (53,2843) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (68,2848) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 98.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 12, rect: [12,1938 98.859375x17.46875]
+            frag 0 from TextNode start: 0, length: 12, rect: [68,2848 98.859375x17.46875]
               "space-evenly"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,1994) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (38,2918) content-size 724x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-justify-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-justify-content.txt
@@ -4,33 +4,33 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (38,38) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.outer.start> at (53,53) content-size 300x60 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div> at (53,68) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (68,68) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [53,68 41.234375x17.46875]
+            frag 0 from TextNode start: 0, length: 5, rect: [68,68 41.234375x17.46875]
               "start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,128) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.outer.flex-start> at (53,143) content-size 300x60 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div> at (53,158) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (68,158) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [53,158 76.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 10, rect: [68,158 76.8125x17.46875]
               "flex-start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,218) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.outer.end> at (53,233) content-size 300x60 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div> at (203,248) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (188,248) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [203,248 26.1875x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [188,248 26.1875x17.46875]
               "end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,308) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.outer.flex-end> at (53,323) content-size 300x60 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div> at (203,338) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (188,338) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [203,338 61.765625x17.46875]
+            frag 0 from TextNode start: 0, length: 8, rect: [188,338 61.765625x17.46875]
               "flex-end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,398) content-size 724x0 children: inline
@@ -52,9 +52,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (38,578) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.outer.space-between> at (53,593) content-size 300x60 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div> at (53,608) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (68,608) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 13, rect: [53,608 115.515625x17.46875]
+            frag 0 from TextNode start: 0, length: 13, rect: [68,608 115.515625x17.46875]
               "space-between"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,668) content-size 724x0 children: inline
@@ -68,33 +68,33 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (38,758) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.start> at (53,773) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (203,788) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (218,788) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [203,788 41.234375x17.46875]
+            frag 0 from TextNode start: 0, length: 5, rect: [218,788 41.234375x17.46875]
               "start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,848) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.flex-start> at (53,863) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (203,878) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (218,878) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [203,878 76.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 10, rect: [218,878 76.8125x17.46875]
               "flex-start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,938) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.end> at (53,953) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (53,968) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (38,968) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [53,968 26.1875x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [38,968 26.1875x17.46875]
               "end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1028) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.flex-end> at (53,1043) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (53,1058) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (38,1058) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [53,1058 61.765625x17.46875]
+            frag 0 from TextNode start: 0, length: 8, rect: [38,1058 61.765625x17.46875]
               "flex-end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1118) content-size 724x0 children: inline
@@ -116,9 +116,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (38,1298) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.row.reverse.outer.space-between> at (53,1313) content-size 300x60 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (53,1328) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (68,1328) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 13, rect: [53,1328 115.515625x17.46875]
+            frag 0 from TextNode start: 0, length: 13, rect: [68,1328 115.515625x17.46875]
               "space-between"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1388) content-size 724x0 children: inline
@@ -132,33 +132,33 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (38,1478) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.outer.start> at (53,1493) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (68,1493) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (68,1508) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [68,1493 41.234375x17.46875]
+            frag 0 from TextNode start: 0, length: 5, rect: [68,1508 41.234375x17.46875]
               "start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1568) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.outer.flex-start> at (53,1583) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (68,1583) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (68,1598) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [68,1583 76.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 10, rect: [68,1598 76.8125x17.46875]
               "flex-start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1658) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.outer.end> at (53,1673) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (68,1683) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (68,1668) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [68,1683 26.1875x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [68,1668 26.1875x17.46875]
               "end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1748) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.outer.flex-end> at (53,1763) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (68,1773) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (68,1758) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [68,1773 61.765625x17.46875]
+            frag 0 from TextNode start: 0, length: 8, rect: [68,1758 61.765625x17.46875]
               "flex-end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,1838) content-size 724x0 children: inline
@@ -180,9 +180,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (38,2018) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.outer.space-between> at (53,2033) content-size 300x60 flex-container(column) [FFC] children: not-inline
-        BlockContainer <div> at (68,2033) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (68,2048) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 13, rect: [68,2033 115.515625x17.46875]
+            frag 0 from TextNode start: 0, length: 13, rect: [68,2048 115.515625x17.46875]
               "space-between"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2108) content-size 724x0 children: inline
@@ -196,33 +196,33 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (38,2198) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.start> at (53,2213) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (68,2223) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (68,2238) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 41.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [68,2223 41.234375x17.46875]
+            frag 0 from TextNode start: 0, length: 5, rect: [68,2238 41.234375x17.46875]
               "start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2288) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.flex-start> at (53,2303) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (68,2313) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (68,2328) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 76.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [68,2313 76.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 10, rect: [68,2328 76.8125x17.46875]
               "flex-start"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2378) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.end> at (53,2393) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (68,2393) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (68,2378) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 26.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [68,2393 26.1875x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [68,2378 26.1875x17.46875]
               "end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2468) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.flex-end> at (53,2483) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (68,2483) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (68,2468) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 61.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [68,2483 61.765625x17.46875]
+            frag 0 from TextNode start: 0, length: 8, rect: [68,2468 61.765625x17.46875]
               "flex-end"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2558) content-size 724x0 children: inline
@@ -244,9 +244,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (38,2738) content-size 724x0 children: inline
         TextNode <#text>
       Box <div.column.reverse.outer.space-between> at (53,2753) content-size 300x60 flex-container(column-reverse) [FFC] children: not-inline
-        BlockContainer <div> at (68,2753) content-size 150x50 positioned [BFC] children: inline
+        BlockContainer <div> at (68,2768) content-size 150x50 positioned [BFC] children: inline
           line 0 width: 115.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 13, rect: [68,2753 115.515625x17.46875]
+            frag 0 from TextNode start: 0, length: 13, rect: [68,2768 115.515625x17.46875]
               "space-between"
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2828) content-size 724x0 children: inline

--- a/Tests/LibWeb/Layout/expected/position-absolute-from-edges.txt
+++ b/Tests/LibWeb/Layout/expected/position-absolute-from-edges.txt
@@ -1,14 +1,14 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: inline
-      BlockContainer <div#container> at (8,8) content-size 500x400 positioned [BFC] children: inline
+      BlockContainer <div#container> at (28,28) content-size 500x400 positioned [BFC] children: inline
         TextNode <#text>
-        BlockContainer <div#red> at (38,38) content-size 100x100 positioned [BFC] children: not-inline
+        BlockContainer <div#red> at (58,58) content-size 100x100 positioned [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div#green> at (338,78) content-size 100x100 positioned [BFC] children: not-inline
+        BlockContainer <div#green> at (358,98) content-size 100x100 positioned [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div#blue> at (28,288) content-size 100x100 positioned [BFC] children: not-inline
+        BlockContainer <div#blue> at (48,308) content-size 100x100 positioned [BFC] children: not-inline
         TextNode <#text>
-        BlockContainer <div#yellow> at (388,288) content-size 100x100 positioned [BFC] children: not-inline
+        BlockContainer <div#yellow> at (408,308) content-size 100x100 positioned [BFC] children: not-inline
         TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/input/abspos-not-replaced-multiple-auto-variants.html
+++ b/Tests/LibWeb/Layout/input/abspos-not-replaced-multiple-auto-variants.html
@@ -1,0 +1,27 @@
+<style>
+*  { border: 1px solid black; }
+div {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+}
+.only-t-l {
+    top: 5px;
+    left: 5px;
+    background-color: red;
+}
+.only-mt-ml {
+    margin: 5px;
+    background-color: orange;
+}
+.both {
+    top: 5px;
+    left: 5px;
+    margin: 5px;
+    background-color: green;
+}
+</style>
+<body>
+    <div class="only-t-l"></div>
+    <div class="only-mt-ml"></div>
+    <div class="both"></div>

--- a/Tests/LibWeb/Layout/input/flex-abspos-item-with-preceding-whitespace.html
+++ b/Tests/LibWeb/Layout/input/flex-abspos-item-with-preceding-whitespace.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html><head><style>
       * {
-        border: 1px solid black !important;
+        border: 10px solid black !important;
       }
       .pink {
         background: pink;

--- a/Tests/LibWeb/Layout/input/flex/abspos-flex-child-static-position-with-align-items.html
+++ b/Tests/LibWeb/Layout/input/flex/abspos-flex-child-static-position-with-align-items.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><style>
 * {
-    border: 1px solid black !important;
+    border: 10px solid black !important;
 }
       body {
         display: flex;

--- a/Tests/LibWeb/Layout/input/flex/abspos-flex-child-static-position-with-justify-content.html
+++ b/Tests/LibWeb/Layout/input/flex/abspos-flex-child-static-position-with-justify-content.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><style>
 * {
-    border: 1px solid black !important;
+    border: 15px solid black;
 }
       .outer {
         display: flex;
@@ -23,7 +23,7 @@
       .space-between { justify-content: space-between; }
       .space-evenly { justify-content: space-evenly; }
 
-      .row { flex-direction: row; }
+      .row { flex-direction: row; border-color: red; }
       .row.reverse { flex-direction: row-reverse; }
       .column { flex-direction: column; }
       .column.reverse { flex-direction: column-reverse; }

--- a/Tests/LibWeb/Layout/input/position-absolute-from-edges.html
+++ b/Tests/LibWeb/Layout/input/position-absolute-from-edges.html
@@ -3,7 +3,7 @@
     position: absolute;
     width: 500px;
     height: 400px;
-    border: 1px solid black;
+    border: 20px solid black;
 }
 #red {
     position: absolute;

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -2155,8 +2155,9 @@ CSSPixelPoint FlexFormattingContext::calculate_static_position(Box const& box) c
     CSSPixels cross_margin_after = is_row_layout() ? box_state.margin_bottom : box_state.margin_right;
     CSSPixels cross_border_before = is_row_layout() ? box_state.border_top : box_state.border_left;
     CSSPixels cross_border_after = is_row_layout() ? box_state.border_bottom : box_state.border_right;
-    CSSPixels cross_padding_before = is_row_layout() ? box_state.padding_top : box_state.padding_left;
     CSSPixels cross_padding_after = is_row_layout() ? box_state.padding_bottom : box_state.padding_right;
+    CSSPixels main_border_before = is_row_layout() ? box_state.border_left : box_state.border_top;
+    CSSPixels main_border_after = is_row_layout() ? box_state.border_right : box_state.border_bottom;
 
     switch (alignment_for_item(box)) {
     case CSS::AlignItems::Baseline:
@@ -2167,7 +2168,7 @@ CSSPixelPoint FlexFormattingContext::calculate_static_position(Box const& box) c
     case CSS::AlignItems::SelfStart:
     case CSS::AlignItems::Stretch:
     case CSS::AlignItems::Normal:
-        cross_offset = -half_line_size + cross_margin_before + cross_border_before + cross_padding_before;
+        cross_offset = -half_line_size + cross_margin_before;
         break;
     case CSS::AlignItems::End:
     case CSS::AlignItems::SelfEnd:
@@ -2175,7 +2176,7 @@ CSSPixelPoint FlexFormattingContext::calculate_static_position(Box const& box) c
         cross_offset = half_line_size - inner_cross_size(box) - cross_margin_after - cross_border_after - cross_padding_after;
         break;
     case CSS::AlignItems::Center:
-        cross_offset = -(inner_cross_size(box) / 2.0);
+        cross_offset = -((inner_cross_size(box) + cross_border_before + cross_border_after) / 2.0);
         break;
     default:
         break;
@@ -2198,7 +2199,7 @@ CSSPixelPoint FlexFormattingContext::calculate_static_position(Box const& box) c
         break;
     case CSS::JustifyContent::End:
     case CSS::JustifyContent::FlexEnd:
-        main_offset = 0;
+        main_offset = -main_border_before - main_border_after;
         pack_from_end = !is_direction_reverse();
         break;
     case CSS::JustifyContent::SpaceBetween:
@@ -2209,7 +2210,7 @@ CSSPixelPoint FlexFormattingContext::calculate_static_position(Box const& box) c
     case CSS::JustifyContent::SpaceAround:
     case CSS::JustifyContent::SpaceEvenly:
         pack_from_end = false;
-        main_offset = inner_main_size(flex_container()) / 2.0 - inner_main_size(box) / 2.0;
+        main_offset = (inner_main_size(flex_container()) - inner_main_size(box) - main_border_before - main_border_after) / 2.0;
         break;
     }
 

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -734,12 +734,84 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
 void FormattingContext::compute_width_for_absolutely_positioned_replaced_element(Box const& box, AvailableSpace const& available_space)
 {
     // 10.3.8 Absolutely positioned, replaced elements
-    // The used value of 'width' is determined as for inline replaced elements.
+    // In this case, section 10.3.7 applies up through and including the constraint equation,
+    // but the rest of section 10.3.7 is replaced by the following rules:
+
+    // 1. The used value of 'width' is determined as for inline replaced elements.
     if (is<ReplacedBox>(box)) {
         // FIXME: This const_cast is gross.
         static_cast<ReplacedBox&>(const_cast<Box&>(box)).prepare_for_replaced_layout();
     }
-    m_state.get_mutable(box).set_content_width(compute_width_for_replaced_element(box, available_space));
+
+    auto width = compute_width_for_replaced_element(box, available_space);
+    auto width_of_containing_block = available_space.width.to_px();
+    auto available = width_of_containing_block - width;
+    auto const& computed_values = box.computed_values();
+    auto left = computed_values.inset().left();
+    auto margin_left = computed_values.margin().left();
+    auto right = computed_values.inset().right();
+    auto margin_right = computed_values.margin().right();
+    auto static_position = calculate_static_position(box);
+
+    auto to_px = [&](const CSS::LengthPercentage& l) {
+        return l.to_px(box, width_of_containing_block);
+    };
+
+    // If 'margin-left' or 'margin-right' is specified as 'auto' its used value is determined by the rules below.
+    // 2. If both 'left' and 'right' have the value 'auto', then if the 'direction' property of the
+    // element establishing the static-position containing block is 'ltr', set 'left' to the static
+    // position; else if 'direction' is 'rtl', set 'right' to the static position.
+    if (left.is_auto() && right.is_auto()) {
+        left = CSS::Length::make_px(static_position.x());
+    }
+
+    // 3. If 'left' or 'right' are 'auto', replace any 'auto' on 'margin-left' or 'margin-right' with '0'.
+    if (left.is_auto() || right.is_auto()) {
+        if (margin_left.is_auto())
+            margin_left = CSS::Length::make_px(0);
+        if (margin_right.is_auto())
+            margin_right = CSS::Length::make_px(0);
+    }
+
+    // 4. If at this point both 'margin-left' and 'margin-right' are still 'auto', solve the equation
+    // under the extra constraint that the two margins must get equal values, unless this would make
+    // them negative, in which case when the direction of the containing block is 'ltr' ('rtl'),
+    // set 'margin-left' ('margin-right') to zero and solve for 'margin-right' ('margin-left').
+    if (margin_left.is_auto() && margin_right.is_auto()) {
+        auto remainder = available - to_px(left) - to_px(right);
+        if (remainder < 0) {
+            margin_left = CSS::Length::make_px(0);
+            margin_right = CSS::Length::make_px(0);
+        } else {
+            margin_left = CSS::Length::make_px(remainder / 2);
+            margin_right = CSS::Length::make_px(remainder / 2);
+        }
+    }
+
+    // 5. If at this point there is an 'auto' left, solve the equation for that value.
+    if (left.is_auto()) {
+        left = CSS::Length::make_px(available - to_px(right) - to_px(margin_left) - to_px(margin_right));
+    } else if (right.is_auto()) {
+        right = CSS::Length::make_px(available - to_px(left) - to_px(margin_left) - to_px(margin_right));
+    } else if (margin_left.is_auto()) {
+        margin_left = CSS::Length::make_px(available - to_px(left) - to_px(right) - to_px(margin_right));
+    } else if (margin_right.is_auto()) {
+        margin_right = CSS::Length::make_px(available - to_px(left) - to_px(margin_left) - to_px(right));
+    }
+
+    // 6. If at this point the values are over-constrained, ignore the value for either 'left'
+    // (in case the 'direction' property of the containing block is 'rtl') or 'right'
+    // (in case 'direction' is 'ltr') and solve for that value.
+    if (0 != available - to_px(left) - to_px(right) - to_px(margin_left) - to_px(margin_right)) {
+        right = CSS::Length::make_px(available - to_px(left) - to_px(margin_left) - to_px(margin_right));
+    }
+
+    auto& box_state = m_state.get_mutable(box);
+    box_state.inset_left = to_px(left);
+    box_state.inset_right = to_px(right);
+    box_state.margin_left = to_px(margin_left);
+    box_state.margin_right = to_px(margin_right);
+    box_state.set_content_width(width);
 }
 
 // https://drafts.csswg.org/css-position-3/#abs-non-replaced-height
@@ -1093,11 +1165,75 @@ void FormattingContext::layout_absolutely_positioned_element(Box const& box, Ava
         independent_formatting_context->parent_context_did_dimension_child_root_box();
 }
 
-void FormattingContext::compute_height_for_absolutely_positioned_replaced_element(Box const& box, AvailableSpace const& available_space, BeforeOrAfterInsideLayout)
+void FormattingContext::compute_height_for_absolutely_positioned_replaced_element(Box const& box, AvailableSpace const& available_space, BeforeOrAfterInsideLayout before_or_after_inside_layout)
 {
     // 10.6.5 Absolutely positioned, replaced elements
+    // This situation is similar to 10.6.4, except that the element has an intrinsic height.
+
     // The used value of 'height' is determined as for inline replaced elements.
-    m_state.get_mutable(box).set_content_height(compute_height_for_replaced_element(box, available_space));
+    auto height = compute_height_for_replaced_element(box, available_space);
+
+    auto height_of_containing_block = available_space.height.to_px();
+    auto available = height_of_containing_block - height;
+    auto const& computed_values = box.computed_values();
+    auto top = computed_values.inset().top();
+    auto margin_top = computed_values.margin().top();
+    auto bottom = computed_values.inset().bottom();
+    auto margin_bottom = computed_values.margin().bottom();
+    auto static_position = calculate_static_position(box);
+
+    auto to_px = [&](const CSS::LengthPercentage& l) {
+        return l.to_px(box, height_of_containing_block);
+    };
+
+    // If 'margin-top' or 'margin-bottom' is specified as 'auto' its used value is determined by the rules below.
+    // 2. If both 'top' and 'bottom' have the value 'auto', replace 'top' with the element's static position.
+    if (top.is_auto() && bottom.is_auto()) {
+        top = CSS::Length::make_px(static_position.x());
+    }
+
+    // 3. If 'bottom' is 'auto', replace any 'auto' on 'margin-top' or 'margin-bottom' with '0'.
+    if (bottom.is_auto()) {
+        if (margin_top.is_auto())
+            margin_top = CSS::Length::make_px(0);
+        if (margin_bottom.is_auto())
+            margin_bottom = CSS::Length::make_px(0);
+    }
+
+    // 4. If at this point both 'margin-top' and 'margin-bottom' are still 'auto',
+    // solve the equation under the extra constraint that the two margins must get equal values.
+    if (margin_top.is_auto() && margin_bottom.is_auto()) {
+        auto remainder = available - to_px(top) - to_px(bottom);
+        margin_top = CSS::Length::make_px(remainder / 2);
+        margin_bottom = CSS::Length::make_px(remainder / 2);
+    }
+
+    // 5. If at this point there is an 'auto' left, solve the equation for that value.
+    if (top.is_auto()) {
+        top = CSS::Length::make_px(available - to_px(bottom) - to_px(margin_top) - to_px(margin_bottom));
+    } else if (bottom.is_auto()) {
+        bottom = CSS::Length::make_px(available - to_px(top) - to_px(margin_top) - to_px(margin_bottom));
+    } else if (margin_top.is_auto()) {
+        margin_top = CSS::Length::make_px(available - to_px(top) - to_px(bottom) - to_px(margin_bottom));
+    } else if (margin_bottom.is_auto()) {
+        margin_bottom = CSS::Length::make_px(available - to_px(top) - to_px(margin_top) - to_px(bottom));
+    }
+
+    // 6. If at this point the values are over-constrained, ignore the value for 'bottom' and solve for that value.
+    if (0 != available - to_px(top) - to_px(bottom) - to_px(margin_top) - to_px(margin_bottom)) {
+        bottom = CSS::Length::make_px(available - to_px(top) - to_px(margin_top) - to_px(margin_bottom));
+    }
+
+    auto& box_state = m_state.get_mutable(box);
+    box_state.set_content_height(height);
+
+    // do not set calculated insets or margins on the first pass, there will be a second pass
+    if (before_or_after_inside_layout == BeforeOrAfterInsideLayout::Before)
+        return;
+    box_state.inset_top = to_px(top);
+    box_state.inset_bottom = to_px(bottom);
+    box_state.margin_top = to_px(margin_top);
+    box_state.margin_bottom = to_px(margin_bottom);
 }
 
 // https://www.w3.org/TR/css-position-3/#relpos-insets


### PR DESCRIPTION
The first commit in this PR changes slightly a few of the absolute positioning tests to highlight current bugs in the layouting. Many subtle errors were hidden by the 1px wide border and become more visible with thicker borders.

The screenshots at the bottom show the current behavior of those tests.

The subsequent commits implement the missing specification chapters that deal with replaced absolute elements, and attempt to fix some of the existing issues. 

The calculated insets and margins from the `compute_height_for_absolutely_positioned_replaced_element` & co were being ignored by the final method deciding the layout, `layout_absolutely_positioned_element`. This contained ad-hoc code that re-attempted to assign margins and insets. I have attempted to clean up the spec methods and simplify the layout method to apply the calculated values, to the best of my understanding.

I have also adjusted several calculations in static_position that appeared to be wrong.

The existing layout tests do not really test padding usage so I assume there are bugs hiding there as well, but that is for a future PR. 

<img width="1014" alt="Screenshot 2023-07-07 at 16 24 04" src="https://github.com/SerenityOS/serenity/assets/74406/f7759833-d987-445c-9397-3dd6f50e9f2c">
<img width="420" alt="Screenshot 2023-07-07 at 15 33 30" src="https://github.com/SerenityOS/serenity/assets/74406/8841bf85-e5d4-4d61-8667-569d7c8ac740">
<img width="1160" alt="Screenshot 2023-07-07 at 15 30 41" src="https://github.com/SerenityOS/serenity/assets/74406/5c6b13fa-4785-49fc-8c2e-c83f3b74b8c0">
