### PR TITLE
LibJS: Always init arguments stored in locals for generator functions

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -479,7 +479,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
                 Environment* used_environment = has_duplicates ? nullptr : environment;
 
                 if constexpr (IsSame<NonnullRefPtr<Identifier const> const&, decltype(param)>) {
-                    if (vm.bytecode_interpreter_if_exists() && param->is_local()) {
+                    if ((vm.bytecode_interpreter_if_exists() || kind() == FunctionKind::Generator) && param->is_local()) {
                         // NOTE: Local variables are supported only in bytecode interpreter
                         callee_context.local_variables[param->local_variable_index()] = argument_value;
                         return {};


### PR DESCRIPTION
Since AST interpreter switches to bytecode to execute generator functions, arguments stored in local variables always need to be initialized for such functions.