### PR TITLE
LibGfx+LibGUI+ImageViewer: Support displaying vector graphics (at arbitrary scales) 

### DIFF
--- a/Userland/Applications/ImageViewer/ViewWidget.h
+++ b/Userland/Applications/ImageViewer/ViewWidget.h
@@ -5,6 +5,7 @@
  * Copyright (c) 2022, Mustafa Quraish <mustafa@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
  * Copyright (c) 2023, Caoimhe Byrne <caoimhebyrne06@gmail.com>
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,9 +15,79 @@
 #include <LibCore/Timer.h>
 #include <LibGUI/AbstractZoomPanWidget.h>
 #include <LibGUI/Painter.h>
-#include <LibImageDecoderClient/Client.h>
+#include <LibGfx/VectorGraphic.h>
 
 namespace ImageViewer {
+
+class Image : public RefCounted<Image> {
+public:
+    virtual Gfx::IntSize size() const = 0;
+    virtual Gfx::IntRect rect() const { return { {}, size() }; }
+
+    virtual void flip(Gfx::Orientation) = 0;
+    virtual void rotate(Gfx::RotationDirection) = 0;
+
+    virtual void draw_into(Gfx::Painter&, Gfx::IntRect const& dest, Gfx::Painter::ScalingMode) const = 0;
+
+    virtual ErrorOr<NonnullRefPtr<Gfx::Bitmap>> bitmap(Optional<Gfx::IntSize> ideal_size) const = 0;
+
+    virtual ~Image() = default;
+};
+
+class VectorImage final : public Image {
+public:
+    static NonnullRefPtr<VectorImage> create(Gfx::VectorGraphic& vector) { return adopt_ref(*new VectorImage(vector)); }
+
+    virtual Gfx::IntSize size() const override { return m_size; }
+
+    virtual void flip(Gfx::Orientation) override;
+    virtual void rotate(Gfx::RotationDirection) override;
+
+    virtual void draw_into(Gfx::Painter&, Gfx::IntRect const& dest, Gfx::Painter::ScalingMode) const override;
+
+    virtual ErrorOr<NonnullRefPtr<Gfx::Bitmap>> bitmap(Optional<Gfx::IntSize> ideal_size) const override;
+
+private:
+    VectorImage(Gfx::VectorGraphic& vector)
+        : m_vector(vector)
+        , m_size(vector.size())
+    {
+    }
+
+    void apply_transform(Gfx::AffineTransform transform)
+    {
+        m_transform = transform.multiply(m_transform);
+    }
+
+    NonnullRefPtr<Gfx::VectorGraphic> m_vector;
+    Gfx::IntSize m_size;
+    Gfx::AffineTransform m_transform;
+};
+
+class BitmapImage final : public Image {
+public:
+    static NonnullRefPtr<BitmapImage> create(Gfx::Bitmap& bitmap) { return adopt_ref(*new BitmapImage(bitmap)); }
+
+    virtual Gfx::IntSize size() const override { return m_bitmap->size(); }
+
+    virtual void flip(Gfx::Orientation) override;
+    virtual void rotate(Gfx::RotationDirection) override;
+
+    virtual void draw_into(Gfx::Painter&, Gfx::IntRect const& dest, Gfx::Painter::ScalingMode) const override;
+
+    virtual ErrorOr<NonnullRefPtr<Gfx::Bitmap>> bitmap(Optional<Gfx::IntSize>) const override
+    {
+        return m_bitmap;
+    }
+
+private:
+    BitmapImage(Gfx::Bitmap& bitmap)
+        : m_bitmap(bitmap)
+    {
+    }
+
+    NonnullRefPtr<Gfx::Bitmap> m_bitmap;
+};
 
 class ViewWidget final : public GUI::AbstractZoomPanWidget {
     C_OBJECT(ViewWidget)
@@ -30,7 +101,7 @@ public:
 
     virtual ~ViewWidget() override = default;
 
-    Gfx::Bitmap const* bitmap() const { return m_bitmap.ptr(); }
+    Image const* image() const { return m_image.ptr(); }
     String const& path() const { return m_path; }
     void set_toolbar_height(int height) { m_toolbar_height = height; }
     int toolbar_height() { return m_toolbar_height; }
@@ -52,7 +123,8 @@ public:
 
     Function<void()> on_doubleclick;
     Function<void(const GUI::DropEvent&)> on_drop;
-    Function<void(Gfx::Bitmap const*)> on_image_change;
+
+    Function<void(Image*)> on_image_change;
 
 private:
     ViewWidget();
@@ -64,14 +136,25 @@ private:
     virtual void drop_event(GUI::DropEvent&) override;
     virtual void resize_event(GUI::ResizeEvent&) override;
 
-    void set_bitmap(Gfx::Bitmap const* bitmap);
+    void set_image(Image const* image);
     void animate();
     Vector<DeprecatedString> load_files_from_directory(DeprecatedString const& path) const;
     ErrorOr<void> try_open_file(String const&, Core::File&);
 
     String m_path;
-    RefPtr<Gfx::Bitmap const> m_bitmap;
-    Optional<ImageDecoderClient::DecodedImage> m_decoded_image;
+    RefPtr<Image> m_image;
+
+    struct Animation {
+        struct Frame {
+            RefPtr<Image> image;
+            int duration { 0 };
+        };
+
+        size_t loop_count { 0 };
+        Vector<Frame> frames;
+    };
+
+    Optional<Animation> m_animation;
 
     size_t m_current_frame_index { 0 };
     size_t m_loops_completed { 0 };

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -663,10 +663,11 @@ static Threading::MutexProtected<ThumbnailCache> s_thumbnail_cache {};
 
 static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> render_thumbnail(StringView path)
 {
-    auto bitmap = TRY(Gfx::Bitmap::load_from_file(path));
-    auto thumbnail = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { 32, 32 }));
+    Gfx::IntSize thumbnail_size { 32, 32 };
+    auto bitmap = TRY(Gfx::Bitmap::load_from_file(path, 1, thumbnail_size));
+    auto thumbnail = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, thumbnail_size));
 
-    double scale = min(32 / (double)bitmap->width(), 32 / (double)bitmap->height());
+    double scale = min(thumbnail_size.width() / (double)bitmap->width(), thumbnail_size.height() / (double)bitmap->height());
     auto destination = Gfx::IntRect(0, 0, (int)(bitmap->width() * scale), (int)(bitmap->height() * scale)).centered_within(thumbnail->rect());
 
     Painter painter(thumbnail);

--- a/Userland/Libraries/LibGfx/AffineTransform.cpp
+++ b/Userland/Libraries/LibGfx/AffineTransform.cpp
@@ -134,18 +134,23 @@ AffineTransform& AffineTransform::rotate_radians(float radians)
     return *this;
 }
 
+float AffineTransform::determinant() const
+{
+    return a() * d() - b() * c();
+}
+
 Optional<AffineTransform> AffineTransform::inverse() const
 {
-    auto determinant = a() * d() - b() * c();
-    if (determinant == 0)
+    auto det = determinant();
+    if (det == 0)
         return {};
     return AffineTransform {
-        d() / determinant,
-        -b() / determinant,
-        -c() / determinant,
-        a() / determinant,
-        (c() * f() - d() * e()) / determinant,
-        (b() * e() - a() * f()) / determinant,
+        d() / det,
+        -b() / det,
+        -c() / det,
+        a() / det,
+        (c() * f() - d() * e()) / det,
+        (b() * e() - a() * f()) / det,
     };
 }
 

--- a/Userland/Libraries/LibGfx/AffineTransform.h
+++ b/Userland/Libraries/LibGfx/AffineTransform.h
@@ -68,6 +68,7 @@ public:
     AffineTransform& skew_radians(float x_radians, float y_radians);
     AffineTransform& multiply(AffineTransform const&);
 
+    float determinant() const;
     Optional<AffineTransform> inverse() const;
 
 private:

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -65,6 +65,7 @@ set(SOURCES
     TextDirection.cpp
     TextLayout.cpp
     Triangle.cpp
+    VectorGraphic.cpp
     WindowTheme.cpp
 )
 

--- a/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
@@ -12,6 +12,7 @@
 #include <AK/RefPtr.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Size.h>
+#include <LibGfx/VectorGraphic.h>
 
 namespace Gfx {
 
@@ -25,6 +26,11 @@ struct ImageFrameDescriptor {
     int duration { 0 };
 };
 
+struct VectorImageFrameDescriptor {
+    RefPtr<VectorGraphic> image;
+    int duration { 0 };
+};
+
 class ImageDecoderPlugin {
 public:
     virtual ~ImageDecoderPlugin() = default;
@@ -34,11 +40,15 @@ public:
     virtual ErrorOr<void> initialize() = 0;
 
     virtual bool is_animated() = 0;
+
     virtual size_t loop_count() = 0;
     virtual size_t frame_count() = 0;
     virtual size_t first_animated_frame_index() = 0;
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) = 0;
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() = 0;
+
+    virtual bool is_vector() { return false; }
+    virtual ErrorOr<VectorImageFrameDescriptor> vector_frame(size_t) { VERIFY_NOT_REACHED(); }
 
 protected:
     ImageDecoderPlugin() = default;
@@ -58,6 +68,9 @@ public:
     size_t first_animated_frame_index() const { return m_plugin->first_animated_frame_index(); }
     ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) const { return m_plugin->frame(index, ideal_size); }
     ErrorOr<Optional<ReadonlyBytes>> icc_data() const { return m_plugin->icc_data(); }
+
+    bool is_vector() { return m_plugin->is_vector(); }
+    ErrorOr<VectorImageFrameDescriptor> vector_frame(size_t index) { return m_plugin->vector_frame(index); }
 
 private:
     explicit ImageDecoder(NonnullOwnPtr<ImageDecoderPlugin>);

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
@@ -14,6 +14,7 @@
 #include <LibGfx/ImageFormats/ImageDecoder.h>
 #include <LibGfx/PaintStyle.h>
 #include <LibGfx/Path.h>
+#include <LibGfx/VectorGraphic.h>
 
 namespace Gfx {
 
@@ -33,7 +34,7 @@ namespace Gfx {
 // Decoder from the "Tiny Vector Graphics" format (v1.0).
 // https://tinyvg.tech/download/specification.pdf
 
-class TinyVGDecodedImageData {
+class TinyVGDecodedImageData final : public VectorGraphic {
 public:
     using Style = Variant<Color, NonnullRefPtr<SVGGradientPaintStyle>>;
 
@@ -44,19 +45,19 @@ public:
         float stroke_width { 0.0f };
     };
 
-    ErrorOr<RefPtr<Gfx::Bitmap>> bitmap(IntSize size) const;
-
-    IntSize size() const
+    virtual IntSize intrinsic_size() const override
     {
         return m_size;
     }
+
+    virtual void draw_transformed(Painter&, AffineTransform) const override;
 
     ReadonlySpan<DrawCommand> draw_commands() const
     {
         return m_draw_commands;
     }
 
-    static ErrorOr<TinyVGDecodedImageData> decode(Stream& stream);
+    static ErrorOr<NonnullRefPtr<TinyVGDecodedImageData>> decode(Stream& stream);
 
 private:
     TinyVGDecodedImageData(IntSize size, Vector<DrawCommand> draw_commands)
@@ -71,7 +72,7 @@ private:
 
 struct TinyVGLoadingContext {
     ReadonlyBytes data;
-    OwnPtr<TinyVGDecodedImageData> decoded_image {};
+    RefPtr<TinyVGDecodedImageData> decoded_image {};
     RefPtr<Bitmap> bitmap {};
 };
 
@@ -88,6 +89,9 @@ public:
     virtual size_t first_animated_frame_index() override { return 0; }
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override { return OptionalNone {}; }
+
+    virtual bool is_vector() override { return true; }
+    virtual ErrorOr<VectorImageFrameDescriptor> vector_frame(size_t index) override;
 
     virtual ~TinyVGImageDecoderPlugin() override = default;
 

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
@@ -34,6 +34,8 @@ namespace Gfx {
 // Decoder from the "Tiny Vector Graphics" format (v1.0).
 // https://tinyvg.tech/download/specification.pdf
 
+struct TinyVGHeader;
+
 class TinyVGDecodedImageData final : public VectorGraphic {
 public:
     using Style = Variant<Color, NonnullRefPtr<SVGGradientPaintStyle>>;
@@ -58,6 +60,7 @@ public:
     }
 
     static ErrorOr<NonnullRefPtr<TinyVGDecodedImageData>> decode(Stream& stream);
+    static ErrorOr<NonnullRefPtr<TinyVGDecodedImageData>> decode(Stream& stream, TinyVGHeader const& header);
 
 private:
     TinyVGDecodedImageData(IntSize size, Vector<DrawCommand> draw_commands)
@@ -70,11 +73,7 @@ private:
     Vector<DrawCommand> m_draw_commands;
 };
 
-struct TinyVGLoadingContext {
-    ReadonlyBytes data;
-    RefPtr<TinyVGDecodedImageData> decoded_image {};
-    RefPtr<Bitmap> bitmap {};
-};
+struct TinyVGLoadingContext;
 
 class TinyVGImageDecoderPlugin final : public ImageDecoderPlugin {
 public:
@@ -98,7 +97,7 @@ public:
 private:
     TinyVGImageDecoderPlugin(ReadonlyBytes);
 
-    TinyVGLoadingContext m_context;
+    NonnullOwnPtr<TinyVGLoadingContext> m_context;
 };
 
 }

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -347,15 +347,16 @@ Path Path::copy_transformed(Gfx::AffineTransform const& transform) const
         }
         case Segment::Type::EllipticalArcTo: {
             auto const& arc_segment = static_cast<EllipticalArcSegment const&>(*segment);
+            auto det_negative = transform.determinant() < 0;
             result.elliptical_arc_to(
                 transform.map(segment->point()),
                 transform.map(arc_segment.center()),
                 transform.map(arc_segment.radii()),
                 arc_segment.x_axis_rotation() + transform.rotation(),
-                arc_segment.theta_1(),
-                arc_segment.theta_delta(),
+                det_negative ? AK::Pi<float> * 2 - arc_segment.theta_1() : arc_segment.theta_1(),
+                det_negative ? -arc_segment.theta_delta() : arc_segment.theta_delta(),
                 arc_segment.large_arc(),
-                arc_segment.sweep());
+                det_negative ? !arc_segment.sweep() : arc_segment.sweep());
             break;
         }
         case Segment::Type::Invalid:

--- a/Userland/Libraries/LibGfx/VectorGraphic.cpp
+++ b/Userland/Libraries/LibGfx/VectorGraphic.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Painter.h>
+#include <LibGfx/VectorGraphic.h>
+
+namespace Gfx {
+
+void VectorGraphic::draw_into(Painter& painter, IntRect const& dest, AffineTransform transform) const
+{
+    // Apply the transform then center within destination rectangle (this ignores any translation from the transform):
+    // This allows you to easily rotate or flip the image before painting.
+    auto transformed_rect = transform.map(FloatRect { {}, size() });
+    auto scale = min(float(dest.width()) / transformed_rect.width(), float(dest.height()) / transformed_rect.height());
+    auto centered = FloatRect { {}, transformed_rect.size().scaled_by(scale) }.centered_within(dest.to_type<float>());
+    auto view_transform = AffineTransform {}
+                              .translate(centered.location())
+                              .multiply(AffineTransform {}.scale(scale, scale))
+                              .multiply(AffineTransform {}.translate(-transformed_rect.location()))
+                              .multiply(transform);
+    return draw_transformed(painter, view_transform);
+}
+
+ErrorOr<NonnullRefPtr<Gfx::Bitmap>> VectorGraphic::bitmap(IntSize size, AffineTransform transform) const
+{
+    auto bitmap = TRY(Bitmap::create(Gfx::BitmapFormat::BGRA8888, size));
+    Painter painter { *bitmap };
+    draw_into(painter, IntRect { {}, size }, transform);
+    return bitmap;
+}
+
+}

--- a/Userland/Libraries/LibGfx/VectorGraphic.h
+++ b/Userland/Libraries/LibGfx/VectorGraphic.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefCounted.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/Forward.h>
+#include <LibGfx/Size.h>
+
+namespace Gfx {
+
+class VectorGraphic : public RefCounted<VectorGraphic> {
+public:
+    virtual IntSize intrinsic_size() const = 0;
+    virtual void draw_transformed(Painter&, AffineTransform) const = 0;
+
+    IntSize size() const { return intrinsic_size(); }
+    IntRect rect() const { return { {}, size() }; }
+
+    ErrorOr<NonnullRefPtr<Gfx::Bitmap>> bitmap(IntSize size, AffineTransform = {}) const;
+    void draw_into(Painter&, IntRect const& dest, AffineTransform = {}) const;
+
+    virtual ~VectorGraphic() = default;
+};
+
+};


### PR DESCRIPTION

This PR updates `ImageViewer` to fully support vector graphics, and display them nicely at any size (while flipping or rotating them):

https://github.com/SerenityOS/serenity/assets/11597044/d3e28474-7817-4079-b1a5-69539e2461e7

It also improves thumbnails for vector graphics (by passing the ideal size while requesting the bitmap).
 
All (currently one format) vector graphics in LibGfx now implement `Gfx::VectorGraphic`, which allows generically handling them (similar to `Gfx::Bitmap`), though currently this class is ultra bare-bones.
 