### PR TITLE
LibGfx: Remove `ImageDecoder::set_[non]volatile()`

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
@@ -1487,19 +1487,6 @@ IntSize BMPImageDecoderPlugin::size()
     return { m_context->dib.core.width, abs(m_context->dib.core.height) };
 }
 
-void BMPImageDecoderPlugin::set_volatile()
-{
-    if (m_context->bitmap)
-        m_context->bitmap->set_volatile();
-}
-
-bool BMPImageDecoderPlugin::set_nonvolatile(bool& was_purged)
-{
-    if (!m_context->bitmap)
-        return false;
-    return m_context->bitmap->set_nonvolatile(was_purged);
-}
-
 ErrorOr<void> BMPImageDecoderPlugin::initialize()
 {
     return decode_bmp_header(*m_context);

--- a/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.h
@@ -28,8 +28,7 @@ public:
     virtual ~BMPImageDecoderPlugin() override;
 
     virtual IntSize size() override;
-    virtual void set_volatile() override;
-    [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
+
     virtual ErrorOr<void> initialize() override;
     bool sniff_dib();
     virtual bool is_animated() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
@@ -632,19 +632,6 @@ IntSize DDSImageDecoderPlugin::size()
     return {};
 }
 
-void DDSImageDecoderPlugin::set_volatile()
-{
-    if (m_context->bitmap)
-        m_context->bitmap->set_volatile();
-}
-
-bool DDSImageDecoderPlugin::set_nonvolatile(bool& was_purged)
-{
-    if (!m_context->bitmap)
-        return false;
-    return m_context->bitmap->set_nonvolatile(was_purged);
-}
-
 ErrorOr<void> DDSImageDecoderPlugin::initialize()
 {
     // The header is always at least 128 bytes, so if the file is smaller, it can't be a DDS.

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.h
@@ -241,8 +241,7 @@ public:
     virtual ~DDSImageDecoderPlugin() override;
 
     virtual IntSize size() override;
-    virtual void set_volatile() override;
-    [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
+
     virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override;
     virtual size_t loop_count() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
@@ -548,20 +548,6 @@ IntSize GIFImageDecoderPlugin::size()
     return { m_context->logical_screen.width, m_context->logical_screen.height };
 }
 
-void GIFImageDecoderPlugin::set_volatile()
-{
-    if (m_context->frame_buffer) {
-        m_context->frame_buffer->set_volatile();
-    }
-}
-
-bool GIFImageDecoderPlugin::set_nonvolatile(bool& was_purged)
-{
-    if (!m_context->frame_buffer)
-        return false;
-    return m_context->frame_buffer->set_nonvolatile(was_purged);
-}
-
 ErrorOr<void> GIFImageDecoderPlugin::initialize()
 {
     FixedMemoryStream stream { { m_context->data, m_context->data_size } };

--- a/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.h
@@ -21,8 +21,7 @@ public:
     virtual ~GIFImageDecoderPlugin() override;
 
     virtual IntSize size() override;
-    virtual void set_volatile() override;
-    [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
+
     virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override;
     virtual size_t loop_count() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.cpp
@@ -215,19 +215,6 @@ IntSize ICOImageDecoderPlugin::size()
     return { m_context->images[m_context->largest_index].width, m_context->images[m_context->largest_index].height };
 }
 
-void ICOImageDecoderPlugin::set_volatile()
-{
-    if (m_context->images[0].bitmap)
-        m_context->images[0].bitmap->set_volatile();
-}
-
-bool ICOImageDecoderPlugin::set_nonvolatile(bool& was_purged)
-{
-    if (!m_context->images[0].bitmap)
-        return false;
-    return m_context->images[0].bitmap->set_nonvolatile(was_purged);
-}
-
 ErrorOr<void> ICOImageDecoderPlugin::initialize()
 {
     FixedMemoryStream stream { { m_context->data, m_context->data_size } };

--- a/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.h
@@ -20,8 +20,7 @@ public:
     virtual ~ICOImageDecoderPlugin() override;
 
     virtual IntSize size() override;
-    virtual void set_volatile() override;
-    [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
+
     virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override;
     virtual size_t loop_count() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
@@ -31,9 +31,6 @@ public:
 
     virtual IntSize size() = 0;
 
-    virtual void set_volatile() = 0;
-    [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) = 0;
-
     virtual ErrorOr<void> initialize() = 0;
 
     virtual bool is_animated() = 0;
@@ -55,8 +52,6 @@ public:
     IntSize size() const { return m_plugin->size(); }
     int width() const { return size().width(); }
     int height() const { return size().height(); }
-    void set_volatile() { m_plugin->set_volatile(); }
-    [[nodiscard]] bool set_nonvolatile(bool& was_purged) { return m_plugin->set_nonvolatile(was_purged); }
     bool is_animated() const { return m_plugin->is_animated(); }
     size_t loop_count() const { return m_plugin->loop_count(); }
     size_t frame_count() const { return m_plugin->frame_count(); }

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -1931,19 +1931,6 @@ IntSize JPEGImageDecoderPlugin::size()
     return {};
 }
 
-void JPEGImageDecoderPlugin::set_volatile()
-{
-    if (m_context->bitmap)
-        m_context->bitmap->set_volatile();
-}
-
-bool JPEGImageDecoderPlugin::set_nonvolatile(bool& was_purged)
-{
-    if (!m_context->bitmap)
-        return false;
-    return m_context->bitmap->set_nonvolatile(was_purged);
-}
-
 ErrorOr<void> JPEGImageDecoderPlugin::initialize()
 {
     return {};

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
@@ -23,8 +23,7 @@ public:
 
     virtual ~JPEGImageDecoderPlugin() override;
     virtual IntSize size() override;
-    virtual void set_volatile() override;
-    [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
+
     virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override;
     virtual size_t loop_count() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -1309,19 +1309,6 @@ IntSize PNGImageDecoderPlugin::size()
     return { m_context->width, m_context->height };
 }
 
-void PNGImageDecoderPlugin::set_volatile()
-{
-    if (m_context->bitmap)
-        m_context->bitmap->set_volatile();
-}
-
-bool PNGImageDecoderPlugin::set_nonvolatile(bool& was_purged)
-{
-    if (!m_context->bitmap)
-        return false;
-    return m_context->bitmap->set_nonvolatile(was_purged);
-}
-
 ErrorOr<void> PNGImageDecoderPlugin::initialize()
 {
     if (decode_png_header(*m_context))

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.h
@@ -20,8 +20,7 @@ public:
     virtual ~PNGImageDecoderPlugin() override;
 
     virtual IntSize size() override;
-    virtual void set_volatile() override;
-    [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
+
     virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override;
     virtual size_t loop_count() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/PortableImageMapLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PortableImageMapLoader.h
@@ -64,9 +64,6 @@ public:
 
     virtual IntSize size() override;
 
-    virtual void set_volatile() override;
-    [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
-
     virtual ErrorOr<void> initialize() override { return {}; }
     virtual bool is_animated() override;
     virtual size_t loop_count() override;
@@ -102,22 +99,6 @@ IntSize PortableImageDecoderPlugin<TContext>::size()
     }
 
     return { m_context->width, m_context->height };
-}
-
-template<typename TContext>
-void PortableImageDecoderPlugin<TContext>::set_volatile()
-{
-    if (m_context->bitmap)
-        m_context->bitmap->set_volatile();
-}
-
-template<typename TContext>
-bool PortableImageDecoderPlugin<TContext>::set_nonvolatile(bool& was_purged)
-{
-    if (!m_context->bitmap)
-        return false;
-
-    return m_context->bitmap->set_nonvolatile(was_purged);
 }
 
 template<typename TContext>

--- a/Userland/Libraries/LibGfx/ImageFormats/QOILoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/QOILoader.cpp
@@ -182,19 +182,6 @@ IntSize QOIImageDecoderPlugin::size()
     return { m_context->header.width, m_context->header.height };
 }
 
-void QOIImageDecoderPlugin::set_volatile()
-{
-    if (m_context->bitmap)
-        m_context->bitmap->set_volatile();
-}
-
-bool QOIImageDecoderPlugin::set_nonvolatile(bool& was_purged)
-{
-    if (!m_context->bitmap)
-        return false;
-    return m_context->bitmap->set_nonvolatile(was_purged);
-}
-
 ErrorOr<void> QOIImageDecoderPlugin::initialize()
 {
     return decode_header_and_update_context(*m_context->stream);

--- a/Userland/Libraries/LibGfx/ImageFormats/QOILoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/QOILoader.h
@@ -44,8 +44,7 @@ public:
     virtual ~QOIImageDecoderPlugin() override = default;
 
     virtual IntSize size() override;
-    virtual void set_volatile() override;
-    [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
+
     virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override { return false; }
     virtual size_t loop_count() override { return 0; }

--- a/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
@@ -174,19 +174,6 @@ IntSize TGAImageDecoderPlugin::size()
     return IntSize { m_context->header.width, m_context->header.height };
 }
 
-void TGAImageDecoderPlugin::set_volatile()
-{
-    if (m_context->bitmap)
-        m_context->bitmap->set_volatile();
-}
-
-bool TGAImageDecoderPlugin::set_nonvolatile(bool& was_purged)
-{
-    if (!m_context->bitmap)
-        return false;
-    return m_context->bitmap->set_nonvolatile(was_purged);
-}
-
 bool TGAImageDecoderPlugin::decode_tga_header()
 {
     auto& reader = m_context->reader;

--- a/Userland/Libraries/LibGfx/ImageFormats/TGALoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TGALoader.h
@@ -21,8 +21,7 @@ public:
     TGAImageDecoderPlugin(u8 const*, size_t);
 
     virtual IntSize size() override;
-    virtual void set_volatile() override;
-    [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
+
     virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override;
     virtual size_t loop_count() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
@@ -504,19 +504,6 @@ IntSize TinyVGImageDecoderPlugin::size()
     return {};
 }
 
-void TinyVGImageDecoderPlugin::set_volatile()
-{
-    if (m_context.bitmap)
-        m_context.bitmap->set_volatile();
-}
-
-bool TinyVGImageDecoderPlugin::set_nonvolatile(bool& was_purged)
-{
-    if (!m_context.bitmap)
-        return false;
-    return m_context.bitmap->set_nonvolatile(was_purged);
-}
-
 ErrorOr<void> TinyVGImageDecoderPlugin::initialize()
 {
     FixedMemoryStream stream { { m_context.data.data(), m_context.data.size() } };

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
@@ -81,8 +81,6 @@ public:
     static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
 
     virtual IntSize size() override;
-    virtual void set_volatile() override;
-    [[nodiscard]] virtual bool set_nonvolatile(bool&) override;
     virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override { return false; }
     virtual size_t loop_count() override { return 0; }

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -722,19 +722,6 @@ IntSize WebPImageDecoderPlugin::size()
     return m_context->size.value();
 }
 
-void WebPImageDecoderPlugin::set_volatile()
-{
-    if (m_context->bitmap)
-        m_context->bitmap->set_volatile();
-}
-
-bool WebPImageDecoderPlugin::set_nonvolatile(bool& was_purged)
-{
-    if (!m_context->bitmap)
-        return false;
-    return m_context->bitmap->set_nonvolatile(was_purged);
-}
-
 ErrorOr<void> WebPImageDecoderPlugin::initialize()
 {
     auto header_okay_or_error = decode_webp_header(*m_context);

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.h
@@ -20,8 +20,7 @@ public:
     virtual ~WebPImageDecoderPlugin() override;
 
     virtual IntSize size() override;
-    virtual void set_volatile() override;
-    [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
+
     virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override;
     virtual size_t loop_count() override;


### PR DESCRIPTION
These methods are unused so let's remove them.