### PR TITLE
LibJS: Fix scope detection for ids in default function params

### DIFF
--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -211,6 +211,8 @@ public:
     // Needs to mess with m_state, and we're not going to expose a non-const getter for that :^)
     friend ThrowCompletionOr<ECMAScriptFunctionObject*> FunctionConstructor::create_dynamic_function(VM&, FunctionObject&, FunctionObject*, FunctionKind, MarkedVector<Value> const&);
 
+    static Parser parse_function_body_from_string(DeprecatedString const& body_string, u16 parse_options, Vector<FunctionParameter> const& parameters, FunctionKind kind, bool& contains_direct_call_to_eval);
+
 private:
     friend class ScopePusher;
 

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -183,14 +183,7 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> FunctionConstructor::create_dynamic
 
     // 18. Let body be ParseText(StringToCodePoints(bodyString), bodySym).
     bool contains_direct_call_to_eval = false;
-    auto body_parser = Parser { Lexer { body_string } };
-    // Set up some parser state to accept things like return await, and yield in the plain function body.
-    body_parser.m_state.in_function_context = true;
-    if ((parse_options & FunctionNodeParseOptions::IsAsyncFunction) != 0)
-        body_parser.m_state.await_expression_is_valid = true;
-    if ((parse_options & FunctionNodeParseOptions::IsGeneratorFunction) != 0)
-        body_parser.m_state.in_generator_function_context = true;
-    (void)body_parser.parse_function_body(parameters, kind, contains_direct_call_to_eval);
+    auto body_parser = Parser::parse_function_body_from_string(body_string, parse_options, parameters, kind, contains_direct_call_to_eval);
 
     // 19. If body is a List of errors, throw a SyntaxError exception.
     if (body_parser.has_errors()) {

--- a/Userland/Libraries/LibJS/Tests/functions/function-default-parameters.js
+++ b/Userland/Libraries/LibJS/Tests/functions/function-default-parameters.js
@@ -141,3 +141,13 @@ test("parameter with an object default value", () => {
     expect(arrowFunc()).toBe("bar");
     expect(arrowFunc({ foo: "baz" })).toBe("baz");
 });
+
+test("use variable as default function parameter", () => {
+    let a = 1;
+
+    function func(param = a) {
+        return param;
+    }
+
+    expect(func()).toBe(a);
+});


### PR DESCRIPTION
This change fixes an issue where identifiers used in default function parameters were being "registered" in the function's parent scope instead of its own scope. This bug resulted in incorrectly detected local variables. (Variables used in the default function parameter expression should be considered 'captured by nested function'.)

To resolve this issue, the function scope is now created before parsing function parameters. Since function parameters can no longer be passed in the constructor, a setter function has been introduced to set them later, when they are ready.

Fixes crash on https://www.apple.com/