### PR TITLE
Userland+LibGfx: Register the dds mime-type and give the DDS decoder a little refresh

### DIFF
--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -123,6 +123,7 @@ static Array const s_registered_mime_type = {
     MimeType { .name = "image/tiff"sv, .common_extensions = { ".tiff"sv }, .description = "TIFF image data"sv, .magic_bytes = Vector<u8> { 'I', 'I', '*', 0x00 } },
     MimeType { .name = "image/tiff"sv, .common_extensions = { ".tiff"sv }, .description = "TIFF image data"sv, .magic_bytes = Vector<u8> { 'M', 'M', 0x00, '*' } },
     MimeType { .name = "image/tinyvg"sv, .common_extensions = { ".tvg"sv }, .description = "TinyVG vector graphics"sv, .magic_bytes = Vector<u8> { 0x72, 0x56 } },
+    MimeType { .name = "image/vnd.ms-dds"sv, .common_extensions = { ".dds"sv }, .description = "DDS image data"sv, .magic_bytes = Vector<u8> { 'D', 'D', 'S', ' ' } },
     MimeType { .name = "image/webp"sv, .common_extensions = { ".webp"sv }, .description = "WebP image data"sv, .magic_bytes = Vector<u8> { 'W', 'E', 'B', 'P' }, .offset = 8 },
     MimeType { .name = "image/x-portable-bitmap"sv, .common_extensions = { ".pbm"sv }, .description = "PBM image data"sv, .magic_bytes = Vector<u8> { 0x50, 0x31, 0x0A } },
     MimeType { .name = "image/x-portable-graymap"sv, .common_extensions = { ".pgm"sv }, .description = "PGM image data"sv, .magic_bytes = Vector<u8> { 0x50, 0x32, 0x0A } },

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
@@ -410,7 +410,7 @@ static ErrorOr<void> decode_bitmap(Stream& stream, DDSLoadingContext& context, u
     return {};
 }
 
-static ErrorOr<void> decode_dds(DDSLoadingContext& context)
+static ErrorOr<void> decode_header(DDSLoadingContext& context)
 {
     // All valid DDS files are at least 128 bytes long.
     if (TRY(context.stream.size()) < 128) {
@@ -464,6 +464,13 @@ static ErrorOr<void> decode_dds(DDSLoadingContext& context)
         context.state = DDSLoadingContext::State::Error;
         return Error::from_string_literal("Format type is not supported at the moment");
     }
+
+    return {};
+}
+
+static ErrorOr<void> decode_dds(DDSLoadingContext& context)
+{
+    TRY(decode_header(context));
 
     // We support parsing mipmaps, but we only care about the largest one :^) (At least for now)
     if (size_t mipmap_level = 0; mipmap_level < max(context.header.mip_map_count, 1u)) {

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
@@ -634,15 +634,7 @@ IntSize DDSImageDecoderPlugin::size()
 
 ErrorOr<void> DDSImageDecoderPlugin::initialize()
 {
-    // The header is always at least 128 bytes, so if the file is smaller, it can't be a DDS.
-    if (m_context->data_size > 128
-        && m_context->data[0] == 0x44
-        && m_context->data[1] == 0x44
-        && m_context->data[2] == 0x53
-        && m_context->data[3] == 0x20)
-        return {};
-
-    return Error::from_string_literal("Bad image magic");
+    return {};
 }
 
 bool DDSImageDecoderPlugin::sniff(ReadonlyBytes data)

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
@@ -399,7 +399,7 @@ static ErrorOr<void> decode_dxt(Stream& stream, DDSLoadingContext& context, u64 
 }
 static ErrorOr<void> decode_bitmap(Stream& stream, DDSLoadingContext& context, u64 width, u64 height)
 {
-    Vector<u32> dxt_formats = { DXGI_FORMAT_BC1_UNORM, DXGI_FORMAT_BC2_UNORM, DXGI_FORMAT_BC3_UNORM };
+    static constexpr Array dxt_formats = { DXGI_FORMAT_BC1_UNORM, DXGI_FORMAT_BC2_UNORM, DXGI_FORMAT_BC3_UNORM };
     if (dxt_formats.contains_slow(context.format)) {
         for (u64 y = 0; y < height; y += 4) {
             TRY(decode_dxt(stream, context, width, y));
@@ -458,7 +458,7 @@ static ErrorOr<void> decode_header(DDSLoadingContext& context)
 
     context.format = get_format(context.header.pixel_format);
 
-    Vector<u32> supported_formats = { DXGI_FORMAT_BC1_UNORM, DXGI_FORMAT_BC2_UNORM, DXGI_FORMAT_BC3_UNORM };
+    static constexpr Array supported_formats = { DXGI_FORMAT_BC1_UNORM, DXGI_FORMAT_BC2_UNORM, DXGI_FORMAT_BC3_UNORM };
     if (!supported_formats.contains_slow(context.format)) {
         dbgln_if(DDS_DEBUG, "Format of type {} is not supported at the moment", to_underlying(context.format));
         context.state = DDSLoadingContext::State::Error;

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.h
@@ -243,7 +243,6 @@ public:
 
     virtual IntSize size() override;
 
-    virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override;
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/MemoryStream.h>
 #include <LibGfx/ImageFormats/ImageDecoder.h>
 
 namespace Gfx {
@@ -251,7 +252,7 @@ public:
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
-    DDSImageDecoderPlugin(u8 const*, size_t);
+    DDSImageDecoderPlugin(FixedMemoryStream);
 
     OwnPtr<DDSLoadingContext> m_context;
 };


### PR DESCRIPTION
**LibGfx/DDS: Don't double-check the magic number**

This is already done in `decode_dds()`.

**LibGfx/DDS: Only use a `FixedMemoryStream`**

This allows us to drop the data pointer in the `DDSLoadingContext`.

**LibGfx/DDS: Save the format in the context**

This allows us to simplify the signature of a few functions.

**LibGfx/DDS: Move the code to read the header in its own function**


**LibGfx/DDS: Prefer `static constexpr Array` over `Vector<u32>`**


**LibGfx/DDS: Read the header in `create()` and remove `initialize()`**

This is done as a part of #19893.

**LibCore: Register the image/vnd.ms-dds mime type**