### PR TITLE
Meta: Improve portability with compat for non-GNU, non-sudo systems

### DIFF
--- a/Meta/build-image-extlinux.sh
+++ b/Meta/build-image-extlinux.sh
@@ -35,14 +35,6 @@ if [ -z $syslinux_dir ]; then
     exit 1
 fi
 
-disk_usage() {
-if [ "$(uname -s)" = "Darwin" ]; then
-    du -sm "$1" | cut -f1
-else
-    du -sm --apparent-size "$1" | cut -f1
-fi
-}
-
 DISK_SIZE=$(($(disk_usage "$SERENITY_SOURCE_DIR/Base") + $(disk_usage Root) + 300))
 
 echo "setting up disk image..."

--- a/Meta/build-image-extlinux.sh
+++ b/Meta/build-image-extlinux.sh
@@ -8,7 +8,7 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
 if [ "$(id -u)" != 0 ]; then
     set +e
-    ${SUDO} -- sh -c "\"$0\" $* || exit 42"
+    ${SUDO} "${SHELL}" -c -- "\"$0\" $* || exit 42"
     case $? in
         1)
             die "this script needs to run as root"

--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -8,7 +8,7 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
 if [ "$(id -u)" != 0 ]; then
     set +e
-    ${SUDO} -- sh -c "\"$0\" $* || exit 42"
+    ${SUDO} "${SHELL}" -c -- "\"$0\" $* || exit 42"
     case $? in
         1)
             die "this script needs to run as root"

--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -34,14 +34,6 @@ if [ -z "$grub" ]; then
 fi
 echo "using grub-install at ${grub}"
 
-disk_usage() {
-if [ "$(uname -s)" = "Darwin" ]; then
-    du -sm "$1" | cut -f1
-else
-    du -sm --apparent-size "$1" | cut -f1
-fi
-}
-
 DISK_SIZE=$(($(disk_usage "$SERENITY_SOURCE_DIR/Base") + $(disk_usage Root) + 300))
 
 echo "setting up disk image..."

--- a/Meta/build-image-limine.sh
+++ b/Meta/build-image-limine.sh
@@ -33,14 +33,6 @@ else
     : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
 fi
 
-disk_usage() {
-    if [ "$(uname -s)" = "Darwin" ]; then
-        du -sm "$1" | cut -f1
-    else
-        du -sm --apparent-size "$1" | cut -f1
-    fi
-}
-
 DISK_SIZE=$(($(disk_usage "$SERENITY_SOURCE_DIR/Base") + $(disk_usage Root) + 300))
 
 echo "setting up disk image..."

--- a/Meta/build-image-limine.sh
+++ b/Meta/build-image-limine.sh
@@ -17,7 +17,7 @@ fi
 
 if [ "$(id -u)" != 0 ]; then
     set +e
-    ${SUDO} -- sh -c "\"$0\" $* || exit 42"
+    ${SUDO} "${SHELL}" -c -- "\"$0\" $* || exit 42"
     case $? in
         1)
             die "this script needs to run as root"

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -32,27 +32,10 @@ fi
 # Prepend the toolchain qemu directory so we pick up QEMU from there
 PATH="$SCRIPT_DIR/../Toolchain/Local/qemu/bin:$PATH"
 
-# We depend on GNU coreutils du for the --apparent-size extension.
-# GNU coreutils is a build dependency.
-if command -v gdu > /dev/null 2>&1 && gdu --version | grep -q "GNU coreutils"; then
-    GNUDU="gdu"
-else
-    GNUDU="du"
-fi
-
-disk_usage() {
-    # shellcheck disable=SC2003,SC2307
-    expr "$(${GNUDU} -sk --apparent-size "$1" | cut -f1)"
-}
-
-inode_usage() {
-    find "$1" | wc -l
-}
-
 INODE_SIZE=128
 INODE_COUNT=$(($(inode_usage "$SERENITY_SOURCE_DIR/Base") + $(inode_usage Root)))
 INODE_COUNT=$((INODE_COUNT + 2000))  # Some additional inodes for toolchain files, could probably also be calculated
-DISK_SIZE_BYTES=$((($(disk_usage "$SERENITY_SOURCE_DIR/Base") + $(disk_usage Root)) * 1024))
+DISK_SIZE_BYTES=$((($(disk_usage "$SERENITY_SOURCE_DIR/Base") + $(disk_usage Root) ) * 1024 * 1024))
 DISK_SIZE_BYTES=$((DISK_SIZE_BYTES + (INODE_COUNT * INODE_SIZE)))
 
 if [ -z "$SERENITY_DISK_SIZE_BYTES" ]; then

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -12,7 +12,7 @@ if [ "$(id -u)" != 0 ]; then
         USE_FUSE2FS=1
     else
         set +e
-        ${SUDO} -- sh -c "\"$0\" $* || exit 42"
+        ${SUDO} "${SHELL}" -c -- "\"$0\" $* || exit 42"
         case $? in
             1)
                 die "this script needs to run as root"

--- a/Meta/build-native-partition.sh
+++ b/Meta/build-native-partition.sh
@@ -16,7 +16,7 @@ cleanup() {
 
 if [ "$(id -u)" != 0 ]; then
     set +e
-    ${SUDO} -- sh -c "\"$0\" $* || exit 42"
+    ${SUDO} "${SHELL}" -c -- "\"$0\" $* || exit 42"
     case $? in
         1)
             die "this script needs to run as root"

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -8,15 +8,6 @@ utmp_gid=5
 window_uid=13
 window_gid=13
 
-CP="cp"
-
-# cp on macOS and BSD systems do not support the --preserve= option.
-# gcp comes with coreutils, which is already a dependency.
-OS="$(uname -s)"
-if [ "$OS" = "Darwin" ] || echo "$OS" | grep -qe 'BSD$'; then
-	CP="gcp"
-fi
-
 die() {
     echo "die: $*"
     exit 1
@@ -45,13 +36,13 @@ SERENITY_ARCH="${SERENITY_ARCH:-x86_64}"
 
 if [ "$SERENITY_TOOLCHAIN" = "Clang" ]; then
     TOOLCHAIN_DIR="$SERENITY_SOURCE_DIR"/Toolchain/Local/clang/
-    $CP --preserve=timestamps "$TOOLCHAIN_DIR"/lib/"$SERENITY_ARCH"-pc-serenity/* mnt/usr/lib
+    rsync -aH --update -t "$TOOLCHAIN_DIR"/lib/"$SERENITY_ARCH"-pc-serenity/* mnt/usr/lib
     mkdir -p mnt/usr/include/"$SERENITY_ARCH"-pc-serenity
-    $CP --preserve=timestamps -r "$TOOLCHAIN_DIR"/include/c++ mnt/usr/include
-    $CP --preserve=timestamps -r "$TOOLCHAIN_DIR"/include/"$SERENITY_ARCH"-pc-serenity/c++ mnt/usr/include/"$SERENITY_ARCH"-pc-serenity
+    rsync -aH --update -t -r "$TOOLCHAIN_DIR"/include/c++ mnt/usr/include
+    rsync -aH --update -t -r "$TOOLCHAIN_DIR"/include/"$SERENITY_ARCH"-pc-serenity/c++ mnt/usr/include/"$SERENITY_ARCH"-pc-serenity
 else
-    $CP --preserve=timestamps -r "$SERENITY_SOURCE_DIR"/Toolchain/Local/"$SERENITY_ARCH"/"$SERENITY_ARCH"-pc-serenity/lib/* mnt/usr/lib
-    $CP --preserve=timestamps -r "$SERENITY_SOURCE_DIR"/Toolchain/Local/"$SERENITY_ARCH"/"$SERENITY_ARCH"-pc-serenity/include/c++ mnt/usr/include
+    rsync -aH --update -t -r "$SERENITY_SOURCE_DIR"/Toolchain/Local/"$SERENITY_ARCH"/"$SERENITY_ARCH"-pc-serenity/lib/* mnt/usr/lib
+    rsync -aH --update -t -r "$SERENITY_SOURCE_DIR"/Toolchain/Local/"$SERENITY_ARCH"/"$SERENITY_ARCH"-pc-serenity/include/c++ mnt/usr/include
 fi
 
 # If umask was 027 or similar when the repo was cloned,

--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -82,3 +82,20 @@ get_number_of_processing_units() {
 
   ($number_of_processing_units)
 }
+
+# We depend on GNU coreutils du for the --apparent-size extension.
+# GNU coreutils is a build dependency.
+if command -v gdu > /dev/null 2>&1 && gdu --version | grep -q "GNU coreutils"; then
+    GNUDU="gdu"
+else
+    GNUDU="du"
+fi
+
+disk_usage() {
+    # shellcheck disable=SC2003,SC2307
+    expr "$(${GNUDU} -sbm "$1" | cut -f1)"
+}
+
+inode_usage() {
+    find "$1" | wc -l
+}


### PR DESCRIPTION
This MR fixes the build scripts on Alpine w/o coreutils (and other distros without GNU and sudo :p)

Firstly, we depend on GNU-specific du switch `--apparent-size`. Busybox has
this implemented, but as `-b` instead.

Secondly, there's now logic to detect if your system has doas instead of sudo.
If the user has neither, we bail out quickly instead.

