### PR TITLE
LibWeb: Resolve % top and bottom insets against containing block height

### DIFF
--- a/Tests/LibWeb/Layout/expected/abspos-with-percentage-insets.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-with-percentage-insets.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x0 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 500x400 positioned [BFC] children: inline
+      BlockContainer <div.one> at (311,211) content-size 28.6875x17.46875 positioned [BFC] children: inline
+        line 0 width: 28.6875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 3, rect: [311,211 28.6875x17.46875]
+            "one"
+        TextNode <#text>
+      BlockContainer <div.two> at (330.5625,351.53125) content-size 28.4375x17.46875 positioned [BFC] children: inline
+        line 0 width: 28.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 3, rect: [330.5625,351.53125 28.4375x17.46875]
+            "two"
+        TextNode <#text>
+      TextNode <#text>

--- a/Tests/LibWeb/Layout/input/abspos-with-percentage-insets.html
+++ b/Tests/LibWeb/Layout/input/abspos-with-percentage-insets.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html><style>
+    * {
+        border: 1px solid black;
+    }
+    body {
+        position: absolute;
+        width: 500px;
+        height: 400px;
+    }
+    .one {
+        position: absolute;
+        top: 50%;
+        left: 60%;
+    }
+    .two {
+        position: absolute;
+        bottom: 10%;
+        right: 30%;
+    }
+</style><body><div class=one>one</div><div class=two>two</div>

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1020,8 +1020,8 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     if (before_or_after_inside_layout == BeforeOrAfterInsideLayout::Before)
         return;
 
-    box_state.inset_top = top.to_px(box, width_of_containing_block);
-    box_state.inset_bottom = bottom.to_px(box, width_of_containing_block);
+    box_state.inset_top = top.to_px(box, height_of_containing_block);
+    box_state.inset_bottom = bottom.to_px(box, height_of_containing_block);
     box_state.margin_top = margin_top.to_px(box, width_of_containing_block);
     box_state.margin_bottom = margin_bottom.to_px(box, width_of_containing_block);
     box_state.padding_top = box.computed_values().padding().top().to_px(box, width_of_containing_block);


### PR DESCRIPTION
This makes cookie banner buttons show up on Linktree again. :^)

Regressed in fd37ad3a84e9330e89ce9aee22500e4c82144a8f