### PR TITLE
Note that Ladybird build requires qt6-multimedia-devel on openSUSE

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -29,7 +29,7 @@ sudo dnf install cmake libglvnd-devel ninja-build qt6-qtbase-devel qt6-qttools-d
 
 On openSUSE:
 ```
-sudo zypper install cmake libglvnd-devel ninja qt6-base-devel qt6-tools-devel qt6-wayland-devel ccache
+sudo zypper install cmake libglvnd-devel ninja qt6-base-devel qt6-multimedia-devel qt6-tools-devel qt6-wayland-devel ccache
 ```
 
 On Nix/NixOS:


### PR DESCRIPTION
The documentation for building Ladybird gives a list of packages to install under openSUSE, but is missing the Qt6 Multimedia development package, ``qt6-multimedia-devel``.

Include it.