### PR TITLE
LibJS: Allow usage of locals if function parameters have default values

### DIFF
--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -244,12 +244,9 @@ public:
     void set_function_parameters(Vector<FunctionParameter> const& parameters)
     {
         m_function_parameters = parameters;
-        auto has_parameters_with_default_values = false;
         for (auto& parameter : parameters) {
             parameter.binding.visit(
                 [&](Identifier const& identifier) {
-                    if (parameter.default_value)
-                        has_parameters_with_default_values = true;
                     register_identifier(identifier);
                     m_function_parameters_candidates_for_local_variables.set(identifier.string());
                     m_forbidden_lexical_names.set(identifier.string());
@@ -260,10 +257,6 @@ public:
                         m_forbidden_lexical_names.set(name);
                     }));
                 });
-        }
-
-        if (has_parameters_with_default_values) {
-            m_function_parameters_candidates_for_local_variables.clear();
         }
     }
 


### PR DESCRIPTION
Initially, the usage of local variables for parameters had to be disabled when default values were used because there was a bug that didn't allow to correctly find the scope to which identifiers used within the default parameter expression belonged, and hence correctly identify if a variable can be local. However, this bug was fixed in 2f85faef0ff1cc823d4021dd3f3af589d6fc850f, so now this restriction is no longer needed.