### PR TITLE
LibJS/Bytecode: Always return false on attempt to delete local variable

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -707,6 +707,7 @@ struct FunctionParameter {
 class FunctionNode {
 public:
     StringView name() const { return m_name ? m_name->string().view() : ""sv; }
+    RefPtr<Identifier const> name_identifier() const { return m_name; }
     DeprecatedString const& source_text() const { return m_source_text; }
     Statement const& body() const { return *m_body; }
     Vector<FunctionParameter> const& parameters() const { return m_parameters; }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -298,7 +298,10 @@ CodeGenerationErrorOr<void> Generator::emit_delete_reference(JS::ASTNode const& 
 {
     if (is<Identifier>(node)) {
         auto& identifier = static_cast<Identifier const&>(node);
-        emit<Bytecode::Op::DeleteVariable>(intern_identifier(identifier.string()));
+        if (identifier.is_local())
+            emit<Bytecode::Op::LoadImmediate>(Value(false));
+        else
+            emit<Bytecode::Op::DeleteVariable>(intern_identifier(identifier.string()));
         return {};
     }
 


### PR DESCRIPTION
Since it is not possible for delete operator to return true when it is
applied to local variable, DeleteVariable can safely always return
false for locals.

This also fixes operators/delete-local-variable.js in test-js.