### PR TITLE
LibGfx: Provide a default implementation for `ImageDecoder::initialize`

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
@@ -31,7 +31,7 @@ public:
 
     virtual IntSize size() = 0;
 
-    virtual ErrorOr<void> initialize() = 0;
+    virtual ErrorOr<void> initialize() { return {}; }
 
     virtual bool is_animated() = 0;
     virtual size_t loop_count() = 0;


### PR DESCRIPTION
In order to ease the removal of this function, let's provide a no-op default implementation so decoders can stop implementing it one by one.

First step of #19893