### PR TITLE
LibGfx/TGA: Refactor the plugin interface

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
@@ -156,7 +156,7 @@ private:
 };
 
 struct TGALoadingContext {
-    TGAHeader header;
+    TGAHeader header {};
     OwnPtr<TGAReader> reader = { nullptr };
     RefPtr<Gfx::Bitmap> bitmap;
 };
@@ -180,7 +180,6 @@ bool TGAImageDecoderPlugin::decode_tga_header()
     if (reader->data().size() < sizeof(TGAHeader))
         return false;
 
-    m_context->header = TGAHeader();
     m_context->header.id_length = reader->read_u8();
     m_context->header.color_map_type = reader->read_u8();
     m_context->header.data_type_code = static_cast<TGADataType>(reader->read_u8());

--- a/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
@@ -205,11 +205,6 @@ ErrorOr<void> TGAImageDecoderPlugin::decode_tga_header()
     return {};
 }
 
-ErrorOr<void> TGAImageDecoderPlugin::initialize()
-{
-    return decode_tga_header();
-}
-
 ErrorOr<bool> TGAImageDecoderPlugin::validate_before_create(ReadonlyBytes data)
 {
     if (data.size() < sizeof(TGAHeader))
@@ -225,7 +220,9 @@ ErrorOr<bool> TGAImageDecoderPlugin::validate_before_create(ReadonlyBytes data)
 
 ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> TGAImageDecoderPlugin::create(ReadonlyBytes data)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) TGAImageDecoderPlugin(data.data(), data.size()));
+    auto plugin = TRY(adopt_nonnull_own_or_enomem(new (nothrow) TGAImageDecoderPlugin(data.data(), data.size())));
+    TRY(plugin->decode_tga_header());
+    return plugin;
 }
 
 bool TGAImageDecoderPlugin::is_animated()

--- a/Userland/Libraries/LibGfx/ImageFormats/TGALoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TGALoader.h
@@ -31,7 +31,7 @@ public:
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
-    bool decode_tga_header();
+    ErrorOr<void> decode_tga_header();
     OwnPtr<TGALoadingContext> m_context;
 };
 

--- a/Userland/Libraries/LibGfx/ImageFormats/TGALoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TGALoader.h
@@ -22,7 +22,6 @@ public:
 
     virtual IntSize size() override;
 
-    virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override;
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;


### PR DESCRIPTION
~~Depends on #19894.~~ Merged!
Contributes to #19893

---

**LibGfx/TGA: Default initialize the `TGAHeader` in the context**


**LibGfx/TGA: Make `TGAImageDecoderPlugin::decode_tga_header()` fallible**


**LibGfx/TGA: Decode the header in `create()` and remove `initialize()`**

This is done as a part of #19893.

**file: Register the "image/x-targa" mime-type**


