### PR TITLE
FileSystem/FATFS: Convert internal FAT inode attributes to dirent types

### DIFF
--- a/Kernel/FileSystem/FATFS/FileSystem.cpp
+++ b/Kernel/FileSystem/FATFS/FileSystem.cpp
@@ -91,4 +91,18 @@ BlockBasedFileSystem::BlockIndex FATFS::first_block_of_cluster(u32 cluster) cons
     return ((cluster - first_data_cluster) * boot_record()->sectors_per_cluster) + m_first_data_sector;
 }
 
+u8 FATFS::internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const
+{
+    FATAttributes attrib = static_cast<FATAttributes>(entry.file_type);
+    if (has_flag(attrib, FATAttributes::Directory)) {
+        return DT_DIR;
+    } else if (has_flag(attrib, FATAttributes::VolumeID)) {
+        return DT_UNKNOWN;
+    } else {
+        // ReadOnly, Hidden, System, Archive, LongFileName.
+        return DT_REG;
+    }
+    return DT_UNKNOWN;
+}
+
 }

--- a/Kernel/FileSystem/FATFS/FileSystem.h
+++ b/Kernel/FileSystem/FATFS/FileSystem.h
@@ -26,6 +26,7 @@ public:
     virtual ~FATFS() override = default;
     virtual StringView class_name() const override { return "FATFS"sv; }
     virtual Inode& root_inode() override;
+    virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const override;
 
 private:
     virtual ErrorOr<void> initialize_while_locked() override;


### PR DESCRIPTION
# FileSystem/FATFS: Convert internal FAT inode attributes to dirent types

Resolves an issue where file system access to FAT file systems would result in hitting a `VERIFY_NOT_REACHED()` in `directory_entry_type_from_posix()`:
https://github.com/SerenityOS/serenity/blob/d7644d1d864d51244e552889173d70bdd6d9180d/Userland/Libraries/LibCore/DirectoryEntry.cpp#L36

This was the result of `FATFS` not implementing `FileSystem::internal_file_type_to_directory_entry_type` to convert its internal file types ("attributes" in FAT parlance) into the standard `DT_` types.

## Verification
 1. Created a FAT file system image using a loopback device.
 2. Passed image to qemu by adding:
```
+SERENITY_BOOT_DRIVE="$SERENITY_BOOT_DRIVE -drive file=fat32.img,format=raw,index=2,media=disk"
```
 4. Mounted file system with:
```
su
mkdir /tmp/fat
mount -t /dev/hda /tmp/fat
```
 5. Verified that directory entries could be listed and files could be read:
![image](https://github.com/SerenityOS/serenity/assets/1073184/173b79bb-6e84-4334-ab83-ef626b790faf)

## Before
Behavior on master as of c4656a70c10d40f238c78d6af5e052a4bf38147d:
![image](https://github.com/SerenityOS/serenity/assets/1073184/16c9e800-988b-4535-a998-fac1ea90fff4)

```
13.497 [#0 mount(51:51)]: VirtualFileSystem: FileSystemID 7 (non file-backed), Mounting FATFS at inode 5:29 with flags 0
18.013 ls(52:52): ASSERTION FAILED: false
./Userland/Libraries/LibCore/DirectoryEntry.cpp:36
18.013 [#0 ls(52:52)]: Terminating ls(52) due to signal 6
18.013 [#0 Finalizer Task(5:5)]: Backtrace:
0x000000202e029953  Kernel::Processor::switch_context(Kernel::Thread*&, Kernel::Thread*&) + 0x3d3
0x000000202de8f9f2  Kernel::Scheduler::context_switch(Kernel::Thread*) [clone .localalias] + 0x1f2
0x000000202de94d28  Kernel::Scheduler::pick_next() [clone .localalias] + 0x178
0x000000202e0279c4  Kernel::Processor::clear_critical() + 0x114
0x000000202decd7c2  Kernel::Thread::die_if_needed() [clone .localalias] + 0x322
0x000000202dced108  syscall_handler + 0x1358
0x000000202e03ede1  syscall_entry + 0x51
0x000000094f39957e  /usr/lib/libc.so: .text + 0x257e
0x000000094f39fa86  /usr/lib/libc.so: .text + 0x8a86
0x000000198ed1cde6  /usr/lib/libcore.so.serenity: .text + 0x18de6
0x000000198ed1d060  /usr/lib/libcore.so.serenity: .text + 0x19060
0x0000000f206bb19b  /bin/ls: .text + 0x319b
0x0000000f206b865b  /bin/ls: .text + 0x65b
0x0000000f206b87f9  /bin/ls: .text + 0x7f9
18.031 [#0 Finalizer Task(5:5)]: Generating coredump for pid: 52
18.054 CrashDaemon(35:35): New coredump file: /tmp/coredump/ls_52_1688883205
```