### PR TITLE
LibJS: Inline caching for same-shape property accesses

### DIFF
--- a/Userland/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Userland/Applications/Spreadsheet/JSIntegration.cpp
@@ -109,7 +109,7 @@ JS::ThrowCompletionOr<bool> SheetGlobalObject::internal_has_property(JS::Propert
     return Object::internal_has_property(name);
 }
 
-JS::ThrowCompletionOr<JS::Value> SheetGlobalObject::internal_get(const JS::PropertyKey& property_name, JS::Value receiver) const
+JS::ThrowCompletionOr<JS::Value> SheetGlobalObject::internal_get(const JS::PropertyKey& property_name, JS::Value receiver, JS::CacheablePropertyMetadata*) const
 {
     if (property_name.is_string()) {
         if (property_name.as_string() == "value") {

--- a/Userland/Applications/Spreadsheet/JSIntegration.h
+++ b/Userland/Applications/Spreadsheet/JSIntegration.h
@@ -28,7 +28,7 @@ public:
     virtual ~SheetGlobalObject() override = default;
 
     virtual JS::ThrowCompletionOr<bool> internal_has_property(JS::PropertyKey const& name) const override;
-    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver) const override;
+    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*) const override;
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver) override;
 
     JS_DECLARE_NATIVE_FUNCTION(get_real_cell_contents);

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1120,7 +1120,7 @@ static Bytecode::CodeGenerationErrorOr<void> generate_object_binding_pattern_byt
             }
 
             generator.emit<Bytecode::Op::Load>(value_reg);
-            generator.emit<Bytecode::Op::GetById>(generator.intern_identifier(identifier));
+            generator.emit_get_by_id(generator.intern_identifier(identifier));
         } else {
             auto expression = name.get<NonnullRefPtr<Expression const>>();
             TRY(expression->generate_bytecode(generator));
@@ -1474,7 +1474,7 @@ static Bytecode::CodeGenerationErrorOr<void> get_base_and_value_from_member_expr
         } else {
             // 3. Let propertyKey be StringValue of IdentifierName.
             auto identifier_table_ref = generator.intern_identifier(verify_cast<Identifier>(member_expression.property()).string());
-            generator.emit<Bytecode::Op::GetByIdWithThis>(identifier_table_ref, this_reg);
+            generator.emit_get_by_id_with_this(identifier_table_ref, this_reg);
         }
     } else {
         TRY(member_expression.object().generate_bytecode(generator));
@@ -1485,7 +1485,7 @@ static Bytecode::CodeGenerationErrorOr<void> get_base_and_value_from_member_expr
         } else if (is<PrivateIdentifier>(member_expression.property())) {
             generator.emit<Bytecode::Op::GetPrivateById>(generator.intern_identifier(verify_cast<PrivateIdentifier>(member_expression.property()).string()));
         } else {
-            generator.emit<Bytecode::Op::GetById>(generator.intern_identifier(verify_cast<Identifier>(member_expression.property()).string()));
+            generator.emit_get_by_id(generator.intern_identifier(verify_cast<Identifier>(member_expression.property()).string()));
         }
     }
 
@@ -1587,11 +1587,11 @@ Bytecode::CodeGenerationErrorOr<void> YieldExpression::generate_bytecode(Bytecod
         // The accumulator is set to an object, for example: { "type": 1 (normal), value: 1337 }
         generator.emit<Bytecode::Op::Store>(received_completion_register);
 
-        generator.emit<Bytecode::Op::GetById>(type_identifier);
+        generator.emit_get_by_id(type_identifier);
         generator.emit<Bytecode::Op::Store>(received_completion_type_register);
 
         generator.emit<Bytecode::Op::Load>(received_completion_register);
-        generator.emit<Bytecode::Op::GetById>(value_identifier);
+        generator.emit_get_by_id(value_identifier);
         generator.emit<Bytecode::Op::Store>(received_completion_value_register);
     };
 
@@ -1613,14 +1613,14 @@ Bytecode::CodeGenerationErrorOr<void> YieldExpression::generate_bytecode(Bytecod
         // 5. Let iterator be iteratorRecord.[[Iterator]].
         auto iterator_register = generator.allocate_register();
         auto iterator_identifier = generator.intern_identifier("iterator");
-        generator.emit<Bytecode::Op::GetById>(iterator_identifier);
+        generator.emit_get_by_id(iterator_identifier);
         generator.emit<Bytecode::Op::Store>(iterator_register);
 
         // Cache iteratorRecord.[[NextMethod]] for use in step 7.a.i.
         auto next_method_register = generator.allocate_register();
         auto next_method_identifier = generator.intern_identifier("next");
         generator.emit<Bytecode::Op::Load>(iterator_record_register);
-        generator.emit<Bytecode::Op::GetById>(next_method_identifier);
+        generator.emit_get_by_id(next_method_identifier);
         generator.emit<Bytecode::Op::Store>(next_method_register);
 
         // 6. Let received be NormalCompletion(undefined).
@@ -2424,11 +2424,11 @@ static void generate_await(Bytecode::Generator& generator)
     // The accumulator is set to an object, for example: { "type": 1 (normal), value: 1337 }
     generator.emit<Bytecode::Op::Store>(received_completion_register);
 
-    generator.emit<Bytecode::Op::GetById>(type_identifier);
+    generator.emit_get_by_id(type_identifier);
     generator.emit<Bytecode::Op::Store>(received_completion_type_register);
 
     generator.emit<Bytecode::Op::Load>(received_completion_register);
-    generator.emit<Bytecode::Op::GetById>(value_identifier);
+    generator.emit_get_by_id(value_identifier);
     generator.emit<Bytecode::Op::Store>(received_completion_value_register);
 
     auto& normal_completion_continuation_block = generator.make_block();
@@ -2923,7 +2923,7 @@ static Bytecode::CodeGenerationErrorOr<void> generate_optional_chain(Bytecode::G
             },
             [&](OptionalChain::MemberReference const& ref) -> Bytecode::CodeGenerationErrorOr<void> {
                 generator.emit<Bytecode::Op::Store>(current_base_register);
-                generator.emit<Bytecode::Op::GetById>(generator.intern_identifier(ref.identifier->string()));
+                generator.emit_get_by_id(generator.intern_identifier(ref.identifier->string()));
                 generator.emit<Bytecode::Op::Store>(current_value_register);
                 return {};
             },

--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,14 +8,21 @@
 
 #include <AK/DeprecatedFlyString.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/WeakPtr.h>
 #include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Bytecode/IdentifierTable.h>
 #include <LibJS/Bytecode/StringTable.h>
 
 namespace JS::Bytecode {
 
+struct PropertyLookupCache {
+    WeakPtr<Shape> shape;
+    Optional<u32> property_offset;
+};
+
 struct Executable {
     DeprecatedFlyString name;
+    Vector<PropertyLookupCache> property_lookup_caches;
     Vector<NonnullOwnPtr<BasicBlock>> basic_blocks;
     NonnullOwnPtr<StringTable> string_table;
     NonnullOwnPtr<IdentifierTable> identifier_table;

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -199,6 +199,9 @@ public:
         m_boundaries.take_last();
     }
 
+    void emit_get_by_id(IdentifierTableIndex);
+    void emit_get_by_id_with_this(IdentifierTableIndex, Register);
+
 private:
     Generator();
     ~Generator() = default;
@@ -218,6 +221,7 @@ private:
 
     u32 m_next_register { 2 };
     u32 m_next_block { 1 };
+    u32 m_next_property_lookup_cache { 0 };
     FunctionKind m_enclosing_function_kind { FunctionKind::Normal };
     Vector<LabelableScope> m_continuable_scopes;
     Vector<LabelableScope> m_breakable_scopes;

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -193,7 +193,7 @@ ThrowCompletionOr<Value> Interpreter::run(SourceTextModule& module)
     return js_undefined();
 }
 
-Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Realm& realm, Executable const& executable, BasicBlock const* entry_point, RegisterWindow* in_frame)
+Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Realm& realm, Executable& executable, BasicBlock const* entry_point, RegisterWindow* in_frame)
 {
     dbgln_if(JS_BYTECODE_DEBUG, "Bytecode::Interpreter will run unit {:p}", &executable);
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -50,7 +50,7 @@ public:
     ThrowCompletionOr<Value> run(Script&, JS::GCPtr<Environment> lexical_environment_override = nullptr);
     ThrowCompletionOr<Value> run(SourceTextModule&);
 
-    ThrowCompletionOr<Value> run(Realm& realm, Bytecode::Executable const& executable, Bytecode::BasicBlock const* entry_point = nullptr)
+    ThrowCompletionOr<Value> run(Realm& realm, Bytecode::Executable& executable, Bytecode::BasicBlock const* entry_point = nullptr)
     {
         auto value_and_frame = run_and_return_frame(realm, executable, entry_point);
         return move(value_and_frame.value);
@@ -60,7 +60,7 @@ public:
         ThrowCompletionOr<Value> value;
         OwnPtr<RegisterWindow> frame;
     };
-    ValueAndFrame run_and_return_frame(Realm&, Bytecode::Executable const&, Bytecode::BasicBlock const* entry_point, RegisterWindow* = nullptr);
+    ValueAndFrame run_and_return_frame(Realm&, Bytecode::Executable&, Bytecode::BasicBlock const* entry_point, RegisterWindow* = nullptr);
 
     ALWAYS_INLINE Value& accumulator() { return reg(Register::accumulator()); }
     Value& reg(Register const& r) { return registers()[r.index()]; }
@@ -88,7 +88,8 @@ public:
     void leave_unwind_context();
     ThrowCompletionOr<void> continue_pending_unwind(Label const& resume_label);
 
-    Executable const& current_executable() { return *m_current_executable; }
+    Executable& current_executable() { return *m_current_executable; }
+    Executable const& current_executable() const { return *m_current_executable; }
     BasicBlock const& current_block() const { return *m_current_block; }
     size_t pc() const;
     DeprecatedString debug_position() const;
@@ -124,7 +125,7 @@ private:
     Optional<Value> m_return_value;
     Optional<Value> m_saved_return_value;
     Optional<Value> m_saved_exception;
-    Executable const* m_current_executable { nullptr };
+    Executable* m_current_executable { nullptr };
     OwnPtr<JS::Interpreter> m_ast_interpreter;
     BasicBlock const* m_current_block { nullptr };
     InstructionStreamIterator* m_pc { nullptr };

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -564,9 +564,10 @@ private:
 
 class GetById final : public Instruction {
 public:
-    explicit GetById(IdentifierTableIndex property)
+    GetById(IdentifierTableIndex property, u32 cache_index)
         : Instruction(Type::GetById)
         , m_property(property)
+        , m_cache_index(cache_index)
     {
     }
 
@@ -577,14 +578,16 @@ public:
 
 private:
     IdentifierTableIndex m_property;
+    u32 m_cache_index { 0 };
 };
 
 class GetByIdWithThis final : public Instruction {
 public:
-    GetByIdWithThis(IdentifierTableIndex property, Register this_value)
+    GetByIdWithThis(IdentifierTableIndex property, Register this_value, u32 cache_index)
         : Instruction(Type::GetByIdWithThis)
         , m_property(property)
         , m_this_value(this_value)
+        , m_cache_index(cache_index)
     {
     }
 
@@ -600,6 +603,7 @@ public:
 private:
     IdentifierTableIndex m_property;
     Register m_this_value;
+    u32 m_cache_index { 0 };
 };
 
 class GetPrivateById final : public Instruction {

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
@@ -33,7 +33,7 @@ void ArgumentsObject::visit_edges(Cell::Visitor& visitor)
 }
 
 // 10.4.4.3 [[Get]] ( P, Receiver ), https://tc39.es/ecma262/#sec-arguments-exotic-objects-get-p-receiver
-ThrowCompletionOr<Value> ArgumentsObject::internal_get(PropertyKey const& property_key, Value receiver) const
+ThrowCompletionOr<Value> ArgumentsObject::internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata* cacheable_metadata) const
 {
     // 1. Let map be args.[[ParameterMap]].
     auto& map = *m_parameter_map;
@@ -44,7 +44,7 @@ ThrowCompletionOr<Value> ArgumentsObject::internal_get(PropertyKey const& proper
     // 3. If isMapped is false, then
     if (!is_mapped) {
         // a. Return ? OrdinaryGet(args, P, Receiver).
-        return Object::internal_get(property_key, receiver);
+        return Object::internal_get(property_key, receiver, cacheable_metadata);
     }
 
     // FIXME: a. Assert: map contains a formal parameter mapping for P.

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
@@ -23,7 +23,7 @@ public:
 
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&) override;
-    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver) const override;
+    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata*) const override;
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
 

--- a/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -15,6 +15,8 @@ namespace JS {
 struct ValueAndAttributes {
     Value value;
     PropertyAttributes attributes { default_attributes };
+
+    Optional<u32> property_offset {};
 };
 
 class IndexedProperties;

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
@@ -137,14 +137,14 @@ ThrowCompletionOr<bool> ModuleNamespaceObject::internal_has_property(PropertyKey
 }
 
 // 10.4.6.8 [[Get]] ( P, Receiver ), https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-get-p-receiver
-ThrowCompletionOr<Value> ModuleNamespaceObject::internal_get(PropertyKey const& property_key, Value receiver) const
+ThrowCompletionOr<Value> ModuleNamespaceObject::internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata* cacheable_metadata) const
 {
     auto& vm = this->vm();
 
     // 1. If Type(P) is Symbol, then
     if (property_key.is_symbol()) {
         // a. Return ! OrdinaryGet(O, P, Receiver).
-        return MUST(Object::internal_get(property_key, receiver));
+        return MUST(Object::internal_get(property_key, receiver, cacheable_metadata));
     }
 
     // 2. Let exports be O.[[Exports]].

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
@@ -25,7 +25,7 @@ public:
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&) override;
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const override;
-    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver) const override;
+    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata* = nullptr) const override;
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
     virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const override;

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -39,6 +39,17 @@ struct PrivateElement {
     Handle<Value> value;
 };
 
+// Non-standard: This is information optionally returned by object property access functions.
+//               It can be used to implement inline caches for property lookup.
+struct CacheablePropertyMetadata {
+    enum class Type {
+        NotCacheable,
+        OwnProperty,
+    };
+    Type type { Type::NotCacheable };
+    Optional<u32> property_offset;
+};
+
 class Object : public Cell {
     JS_CELL(Object, Cell);
 
@@ -118,7 +129,7 @@ public:
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&);
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const;
-    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver) const;
+    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata* = nullptr) const;
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver);
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&);
     virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const;

--- a/Userland/Libraries/LibJS/Runtime/PropertyDescriptor.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyDescriptor.h
@@ -40,6 +40,8 @@ public:
     Optional<bool> writable {};
     Optional<bool> enumerable {};
     Optional<bool> configurable {};
+
+    Optional<u32> property_offset {};
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -452,8 +452,10 @@ ThrowCompletionOr<bool> ProxyObject::internal_has_property(PropertyKey const& pr
 }
 
 // 10.5.8 [[Get]] ( P, Receiver ), https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver
-ThrowCompletionOr<Value> ProxyObject::internal_get(PropertyKey const& property_key, Value receiver) const
+ThrowCompletionOr<Value> ProxyObject::internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata*) const
 {
+    // NOTE: We don't return any cacheable metadata for proxy lookups.
+
     VERIFY(!receiver.is_empty());
 
     auto& vm = this->vm();

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.h
@@ -38,7 +38,7 @@ public:
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&) override;
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const override;
-    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver) const override;
+    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata*) const override;
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
     virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const override;

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -288,7 +288,7 @@ public:
     }
 
     // 10.4.5.4 [[Get]] ( P, Receiver ), 10.4.5.4 [[Get]] ( P, Receiver )
-    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const& property_key, Value receiver) const override
+    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata* cacheable_metadata) const override
     {
         VERIFY(!receiver.is_empty());
 
@@ -310,7 +310,7 @@ public:
         }
 
         // 2. Return ? OrdinaryGet(O, P, Receiver).
-        return Object::internal_get(property_key, receiver);
+        return Object::internal_get(property_key, receiver, cacheable_metadata);
     }
 
     // 10.4.5.5 [[Set]] ( P, V, Receiver ), https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-set-p-v-receiver

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -396,13 +396,13 @@ JS::ThrowCompletionOr<bool> CSSStyleDeclaration::internal_has_property(JS::Prope
     return property_id_from_name(name.to_string()) != CSS::PropertyID::Invalid;
 }
 
-JS::ThrowCompletionOr<JS::Value> CSSStyleDeclaration::internal_get(JS::PropertyKey const& name, JS::Value receiver) const
+JS::ThrowCompletionOr<JS::Value> CSSStyleDeclaration::internal_get(JS::PropertyKey const& name, JS::Value receiver, JS::CacheablePropertyMetadata* cacheable_metadata) const
 {
     if (!name.is_string())
-        return Base::internal_get(name, receiver);
+        return Base::internal_get(name, receiver, cacheable_metadata);
     auto property_id = property_id_from_name(name.to_string());
     if (property_id == CSS::PropertyID::Invalid)
-        return Base::internal_get(name, receiver);
+        return Base::internal_get(name, receiver, cacheable_metadata);
     if (auto maybe_property = property(property_id); maybe_property.has_value())
         return { JS::PrimitiveString::create(vm(), maybe_property->value->to_string().release_value_but_fixme_should_propagate_errors().to_deprecated_string()) };
     return { JS::PrimitiveString::create(vm(), String {}) };

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -41,7 +41,7 @@ public:
     virtual DeprecatedString serialized() const = 0;
 
     virtual JS::ThrowCompletionOr<bool> internal_has_property(JS::PropertyKey const& name) const override;
-    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver) const override;
+    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*) const override;
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver) override;
 
 protected:

--- a/Userland/Libraries/LibWeb/HTML/Location.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Location.cpp
@@ -442,13 +442,13 @@ JS::ThrowCompletionOr<bool> Location::internal_define_own_property(JS::PropertyK
 }
 
 // 7.10.5.7 [[Get]] ( P, Receiver ), https://html.spec.whatwg.org/multipage/history.html#location-get
-JS::ThrowCompletionOr<JS::Value> Location::internal_get(JS::PropertyKey const& property_key, JS::Value receiver) const
+JS::ThrowCompletionOr<JS::Value> Location::internal_get(JS::PropertyKey const& property_key, JS::Value receiver, JS::CacheablePropertyMetadata* cacheable_metadata) const
 {
     auto& vm = this->vm();
 
     // 1. If IsPlatformObjectSameOrigin(this) is true, then return ? OrdinaryGet(this, P, Receiver).
     if (HTML::is_platform_object_same_origin(*this))
-        return JS::Object::internal_get(property_key, receiver);
+        return JS::Object::internal_get(property_key, receiver, cacheable_metadata);
 
     // 2. Return ? CrossOriginGet(this, P, Receiver).
     return HTML::cross_origin_get(vm, static_cast<JS::Object const&>(*this), property_key, receiver);

--- a/Userland/Libraries/LibWeb/HTML/Location.h
+++ b/Userland/Libraries/LibWeb/HTML/Location.h
@@ -58,7 +58,7 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
     virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor const&) override;
-    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver) const override;
+    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*) const override;
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
@@ -144,7 +144,7 @@ JS::ThrowCompletionOr<bool> WindowProxy::internal_define_own_property(JS::Proper
 }
 
 // 7.4.7 [[Get]] ( P, Receiver ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-get
-JS::ThrowCompletionOr<JS::Value> WindowProxy::internal_get(JS::PropertyKey const& property_key, JS::Value receiver) const
+JS::ThrowCompletionOr<JS::Value> WindowProxy::internal_get(JS::PropertyKey const& property_key, JS::Value receiver, JS::CacheablePropertyMetadata* cacheable_metadata) const
 {
     auto& vm = this->vm();
 
@@ -156,7 +156,7 @@ JS::ThrowCompletionOr<JS::Value> WindowProxy::internal_get(JS::PropertyKey const
     // 3. If IsPlatformObjectSameOrigin(W) is true, then return ? OrdinaryGet(this, P, Receiver).
     // NOTE: this is passed rather than W as OrdinaryGet and CrossOriginGet will invoke the [[GetOwnProperty]] internal method.
     if (is_platform_object_same_origin(*m_window))
-        return JS::Object::internal_get(property_key, receiver);
+        return JS::Object::internal_get(property_key, receiver, cacheable_metadata);
 
     // 4. Return ? CrossOriginGet(this, P, Receiver).
     // NOTE: this is passed rather than W as OrdinaryGet and CrossOriginGet will invoke the [[GetOwnProperty]] internal method.

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.h
@@ -26,7 +26,7 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
     virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor const&) override;
-    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver) const override;
+    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*) const override;
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;


### PR DESCRIPTION
This has two steps:

1. We teach `Object::internal_get()` to inform callers about *where* the property was found. In this first version, we only reveal the property offset for own properties. Properties found in the prototype chain are ignored for now.

2. We give each `GetById` and `GetByIdWithThis` instruction a corresponding inline cache (stored in `Bytecode::Executable` so the instruction itself just has an index into a vector of caches). The cache remembers the last seen `JS::Shape` and property offset. When executed and the base object has the same shape as before, we reuse the property offset and call `Object::get_direct()`, bypassing the lookup machinery.

~23% speedup on Kraken/ai-astar.js (and many other tests) :^)

This is work towards #17984