### PR TITLE
AK: Let `Array::from_span` take a readonly Span

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -29,7 +29,7 @@ struct Array {
     using ValueType = T;
 
     // This is a static function because constructors mess up Array's POD-ness.
-    static Array from_span(Span<T> span)
+    static Array from_span(ReadonlySpan<T> span)
     {
         Array array;
         VERIFY(span.size() == Size);


### PR DESCRIPTION
We are copying here, so there is no need to require a non-const Span.