### PR TITLE
Ports/alpine: Force re-generation of all autotools files after patch

### DIFF
--- a/Ports/alpine/package.sh
+++ b/Ports/alpine/package.sh
@@ -21,18 +21,6 @@ launcher_command='/usr/local/bin/alpine'
 launcher_run_in_terminal='true'
 icon_file='web/cgi/favicon.ico'
 
-pre_configure() {
-    # Rebuild after patching configure.ac to support serenity host.
-
-    # `automake` may exit with a warning about how there is a mismatch
-    # between the versions of autoconf and automake that were previously
-    # used to generate aclocal and specifed in configure.ac.
-    # We just need `automake` to generate `./compile` (so that we can run
-    # autoreconf to regenerate everything).
-    run automake --add-missing || true
-    run autoreconf
-}
-
 configure() {
     run ./"$configscript" \
         "${configopts[@]}" \

--- a/Ports/alpine/patches/0001-Update-pith-Makefile.in-to-compile-helpers-for-build.patch
+++ b/Ports/alpine/patches/0001-Update-pith-Makefile.in-to-compile-helpers-for-build.patch
@@ -1,19 +1,20 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Taj Morton <tajmorton@gmail.com>
-Date: Sun, 27 Nov 2022 16:27:48 -0800
-Subject: [PATCH] Compiler helpers for build system, not host.
+Date: Sun, 9 Jul 2023 09:55:42 -0700
+Subject: [PATCH] Update pith/Makefile.in to compile helpers for build system,
+ not target
 
 ---
- pith/Makefile.am | 12 ++++++------
+ pith/Makefile.in | 12 ++++++------
  1 file changed, 6 insertions(+), 6 deletions(-)
 
-diff --git a/pith/Makefile.am b/pith/Makefile.am
-index 748b9ececd2b7e120a0bc25b1e949788bf55fc06..bfee7cce61e1a5b589aa153038064563d8f94220 100644
---- a/pith/Makefile.am
-+++ b/pith/Makefile.am
-@@ -30,12 +30,12 @@ libpith_a_SOURCES = ablookup.c abdlc.c addrbook.c addrstring.c adrbklib.c bldadd
- 	state.c status.c store.c stream.c string.c strlst.c takeaddr.c tempfile.c text.c \
- 	thread.c adjtime.c url.c util.c helptext.c smkeys.c smime.c
+diff --git a/pith/Makefile.in b/pith/Makefile.in
+index e97b5fa1077708ebea467f3de09b12f7a9494b6c..8bc867d528aca1ee485d30eadfb94e60884b7318 100644
+--- a/pith/Makefile.in
++++ b/pith/Makefile.in
+@@ -897,12 +897,12 @@ uninstall-am:
+ .PRECIOUS: Makefile
+ 
  
 -help_c_gen$(EXEEXT): $(help_c_gen_OBJECTS) $(help_c_gen_DEPENDENCIES)
 -	@rm -f help_c_gen$(EXEEXT)

--- a/Ports/alpine/patches/0002-Add-serenity-as-OS-type-in-Alpine.patch
+++ b/Ports/alpine/patches/0002-Add-serenity-as-OS-type-in-Alpine.patch
@@ -4,7 +4,7 @@ Date: Mon, 28 Nov 2022 19:55:04 -0800
 Subject: [PATCH] Add serenity as OS type in Alpine.
 
 ---
- configure.ac                      |  6 +++
+ configure                         |  6 +++
  imap/Makefile                     |  2 +-
  imap/src/osdep/unix/Makefile      |  9 +++++
  imap/src/osdep/unix/os_serenity.c | 59 +++++++++++++++++++++++++++++
@@ -13,11 +13,11 @@ Subject: [PATCH] Add serenity as OS type in Alpine.
  create mode 100644 imap/src/osdep/unix/os_serenity.c
  create mode 100644 imap/src/osdep/unix/os_serenity.h
 
-diff --git a/configure.ac b/configure.ac
-index 4fa94f16078daf6187131177b4153845fc0f2bce..1d899fa29ffb698a396a5756e707a51f20367679 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -1289,6 +1289,12 @@ case "$host" in
+diff --git a/configure b/configure
+index 2c417775d04165f3272767b3eb1025cbbe0a2fe3..5b9085b6e69d9faf838cbb9b7c54693f25d8bb9c 100755
+--- a/configure
++++ b/configure
+@@ -19007,6 +19007,12 @@ $as_echo "#define __EXTENSIONS__ 1" >>confdefs.h
      alpine_mode_readonly="(0600)"
      alpine_c_client_target="neb"
      ;;

--- a/Ports/alpine/patches/ReadMe.md
+++ b/Ports/alpine/patches/ReadMe.md
@@ -1,8 +1,8 @@
 # Patches for alpine on SerenityOS
 
-## `0001-Compiler-helpers-for-build-system-not-host.patch`
+## `0001-Update-pith-Makefile.in-to-compile-helpers-for-build.patch`
 
-Compiler helpers for build system, not host.
+Update pith/Makefile.in to compile helpers for build system, not target
 
 
 ## `0002-Add-serenity-as-OS-type-in-Alpine.patch`


### PR DESCRIPTION
## Ports/alpine: Force re-generation of all autotools files after patch

Required to ensure that all autogenerated files are compatible with the verions of autotools installed on the build system. Resolves SerenityOS/serenity#19891.

Verification:
 * Rebuild alpine package from scratch (`cd Ports/Alpine; ./package.sh`) and ensured Alpine launched successfully.
 * Equivalent patch tested by @BenWiederhake in #19891 on a system where the build previously failed (due to mismatch between libtool in the generated files and local build system).