### PR TITLE
LibAudio: Use channel coupling for FLAC encoding

### DIFF
--- a/AK/Statistics.h
+++ b/AK/Statistics.h
@@ -17,11 +17,18 @@ namespace AK {
 static constexpr int ODD_NAIVE_MEDIAN_CUTOFF = 200;
 static constexpr int EVEN_NAIVE_MEDIAN_CUTOFF = 350;
 
-template<Arithmetic T = float>
+template<Arithmetic T = float, typename ContainerType = Vector<T>>
 class Statistics {
 public:
     Statistics() = default;
     ~Statistics() = default;
+
+    explicit Statistics(ContainerType&& existing_container)
+        : m_values(forward<ContainerType>(existing_container))
+    {
+        for (auto const& value : m_values)
+            m_sum += value;
+    }
 
     void add(T const& value)
     {
@@ -107,11 +114,11 @@ public:
         return summation;
     }
 
-    Vector<T> const& values() const { return m_values; }
+    ContainerType const& values() const { return m_values; }
     size_t size() const { return m_values.size(); }
 
 private:
-    Vector<T> m_values;
+    ContainerType m_values;
     T m_sum {};
 };
 

--- a/Userland/Libraries/LibAudio/FlacWriter.cpp
+++ b/Userland/Libraries/LibAudio/FlacWriter.cpp
@@ -40,10 +40,11 @@ ErrorOr<void> FlacWriter::finalize()
     if (m_state == WriteState::FullyFinalized)
         return Error::from_string_view("File is already finalized"sv);
 
-    // TODO: Write missing sample data instead of discarding it.
-
     if (m_state == WriteState::HeaderUnwritten)
         TRY(finalize_header_format());
+
+    if (!m_sample_buffer.is_empty())
+        TRY(write_frame());
 
     {
         // 1 byte metadata block header + 3 bytes size + 2*2 bytes min/max block size

--- a/Userland/Libraries/LibAudio/FlacWriter.h
+++ b/Userland/Libraries/LibAudio/FlacWriter.h
@@ -87,15 +87,16 @@ private:
     ErrorOr<void> write_header();
 
     ErrorOr<void> write_frame();
-    ErrorOr<void> write_subframe(ReadonlySpan<i64> subframe, BigEndianOutputBitStream& bit_stream);
-    ErrorOr<void> write_lpc_subframe(FlacLPCEncodedSubframe lpc_subframe, BigEndianOutputBitStream& bit_stream);
-    ErrorOr<void> write_verbatim_subframe(ReadonlySpan<i64> subframe, BigEndianOutputBitStream& bit_stream);
+    ErrorOr<void> write_frame_for(ReadonlySpan<Vector<i64, block_size>> subblock, FlacFrameChannelType channel_type);
+    ErrorOr<void> write_subframe(ReadonlySpan<i64> subframe, BigEndianOutputBitStream& bit_stream, u8 bits_per_sample);
+    ErrorOr<void> write_lpc_subframe(FlacLPCEncodedSubframe lpc_subframe, BigEndianOutputBitStream& bit_stream, u8 bits_per_sample);
+    ErrorOr<void> write_verbatim_subframe(ReadonlySpan<i64> subframe, BigEndianOutputBitStream& bit_stream, u8 bits_per_sample);
     // Assumes 4-bit k for now.
     ErrorOr<void> write_rice_partition(u8 k, ReadonlySpan<i64> residuals, BigEndianOutputBitStream& bit_stream);
 
     // Aborts encoding once the costs exceed the previous minimum, thereby speeding up the encoder's parameter search.
     // In this case, an empty Optional is returned.
-    ErrorOr<Optional<FlacLPCEncodedSubframe>> encode_fixed_lpc(FlacFixedLPC order, ReadonlySpan<i64> subframe, size_t current_min_cost);
+    ErrorOr<Optional<FlacLPCEncodedSubframe>> encode_fixed_lpc(FlacFixedLPC order, ReadonlySpan<i64> subframe, size_t current_min_cost, u8 bits_per_sample);
 
     NonnullOwnPtr<SeekableStream> m_stream;
     WriteState m_state { WriteState::HeaderUnwritten };


### PR DESCRIPTION
The estimation for this is fast but not very accurate, meaning we save around 5-10% storage space. (We also don’t try other channel coupling methods, but I am sceptical of how much benefit that actually provides.)