### PR TITLE
FileManager: Close the properties window on escape

### DIFF
--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -181,6 +181,11 @@ ErrorOr<void> PropertiesWindow::create_widgets(bool disable_rename)
         m_directory_statistics_calculator->start();
     }
 
+    m_on_escape = GUI::Action::create("Close properties", { Key_Escape }, [this](GUI::Action&) {
+        if (!m_apply_button->is_enabled())
+            close();
+    });
+
     update();
     return {};
 }

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -98,7 +98,7 @@ ErrorOr<void> PropertiesWindow::create_widgets(bool disable_rename)
     m_old_mode = st.st_mode;
 
     auto* type = general_tab->find_descendant_of_type_named<GUI::Label>("type");
-    type->set_text(TRY(String::from_deprecated_string(get_description(m_mode))));
+    type->set_text(TRY(String::from_utf8(get_description(m_mode))));
 
     if (S_ISLNK(m_mode)) {
         auto link_destination_or_error = FileSystem::read_link(m_path);

--- a/Userland/Applications/FileManager/PropertiesWindow.h
+++ b/Userland/Applications/FileManager/PropertiesWindow.h
@@ -90,6 +90,7 @@ private:
     RefPtr<GUI::ImageWidget> m_icon;
     RefPtr<GUI::Label> m_size_label;
     RefPtr<DirectoryStatisticsCalculator> m_directory_statistics_calculator;
+    RefPtr<GUI::Action> m_on_escape;
     DeprecatedString m_name;
     DeprecatedString m_parent_path;
     DeprecatedString m_path;

--- a/Userland/Applications/FileManager/PropertiesWindow.h
+++ b/Userland/Applications/FileManager/PropertiesWindow.h
@@ -56,26 +56,26 @@ private:
         Queue<DeprecatedString> m_work_queue;
     };
 
-    static DeprecatedString const get_description(mode_t const mode)
+    static StringView const get_description(mode_t const mode)
     {
         if (S_ISREG(mode))
-            return "File";
+            return "File"sv;
         if (S_ISDIR(mode))
-            return "Directory";
+            return "Directory"sv;
         if (S_ISLNK(mode))
-            return "Symbolic link";
+            return "Symbolic link"sv;
         if (S_ISCHR(mode))
-            return "Character device";
+            return "Character device"sv;
         if (S_ISBLK(mode))
-            return "Block device";
+            return "Block device"sv;
         if (S_ISFIFO(mode))
-            return "FIFO (named pipe)";
+            return "FIFO (named pipe)"sv;
         if (S_ISSOCK(mode))
-            return "Socket";
+            return "Socket"sv;
         if (mode & S_IXUSR)
-            return "Executable";
+            return "Executable"sv;
 
-        return "Unknown";
+        return "Unknown"sv;
     }
 
     static ErrorOr<NonnullRefPtr<GUI::Button>> make_button(String, GUI::Widget& parent);

--- a/Userland/Libraries/LibGUI/RegularEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/RegularEditingEngine.cpp
@@ -20,12 +20,6 @@ bool RegularEditingEngine::on_key(KeyEvent const& event)
     if (EditingEngine::on_key(event))
         return true;
 
-    if (event.key() == KeyCode::Key_Escape) {
-        if (m_editor->on_escape_pressed)
-            m_editor->on_escape_pressed();
-        return true;
-    }
-
     if (event.alt() && event.shift() && event.key() == KeyCode::Key_S) {
         sort_selected_lines();
         return true;

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1077,6 +1077,8 @@ void TextEditor::keydown_event(KeyEvent& event)
     if (event.key() == KeyCode::Key_Escape) {
         if (on_escape_pressed)
             on_escape_pressed();
+        else
+            event.ignore();
         return;
     }
 

--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -948,9 +948,7 @@ bool VimEditingEngine::on_key_in_normal_mode(KeyEvent const& event)
         // Handle first any key codes that are to be applied regardless of modifiers.
         switch (event.key()) {
         case (KeyCode::Key_Escape):
-            if (m_editor->on_escape_pressed)
-                m_editor->on_escape_pressed();
-            return true;
+            return false;
         default:
             break;
         }
@@ -1136,9 +1134,7 @@ bool VimEditingEngine::on_key_in_visual_mode(KeyEvent const& event)
     switch (event.key()) {
     case (KeyCode::Key_Escape):
         switch_to_normal_mode();
-        if (m_editor->on_escape_pressed)
-            m_editor->on_escape_pressed();
-        return true;
+        return false;
     default:
         break;
     }
@@ -1268,9 +1264,7 @@ bool VimEditingEngine::on_key_in_visual_line_mode(KeyEvent const& event)
     switch (event.key()) {
     case (KeyCode::Key_Escape):
         switch_to_normal_mode();
-        if (m_editor->on_escape_pressed)
-            m_editor->on_escape_pressed();
-        return true;
+        return false;
     default:
         break;
     }


### PR DESCRIPTION
**LibGUI: Don't call `on_escape_pressed` from EditingEngines**

The call will be handled in `TextEditor::keydown_event`, just after that
`EditingEngine::on_key()` is called.

**LibGUI: Bubble up Key_Escape if no hook is plugged in TextEditor**

The TextEditor widget was always accepting the Key_Escape event, even if
the `on_escape_pressed` was empty. In other words, it was discarding the
event.

This behavior prevented shortcuts to be activated at a higher level.

**FileManager: Return a StringView from PropertiesWindow::get_description**


**FileManager: Exit the properties window on escape**


