### PR TITLE
LibWeb: Create EdgeStyleValue for BackgroundPositionXY with no offset

### DIFF
--- a/Base/res/html/misc/background-position-xy.html
+++ b/Base/res/html/misc/background-position-xy.html
@@ -15,6 +15,7 @@
 <div class="example" style="background-position-x: 25%"></div>
 <div class="example" style="background-position-x: 2rem"></div>
 <div class="example" style="background-position-x: right 32px"></div>
+<div class="example" style="background-position-x: right"></div>
 <br>
 <br>
 <b>background-position-y</b><br>
@@ -23,3 +24,4 @@
 <div class="example" style="background-position-y: 25%"></div>
 <div class="example" style="background-position-y: 2rem"></div>
 <div class="example" style="background-position-y: bottom 32px"></div>
+<div class="example" style="background-position-y: bottom"></div>

--- a/Tests/LibWeb/Text/expected/background-position-xy.txt
+++ b/Tests/LibWeb/Text/expected/background-position-xy.txt
@@ -1,0 +1,2 @@
+ right 0px
+bottom 0px

--- a/Tests/LibWeb/Text/input/background-position-xy.html
+++ b/Tests/LibWeb/Text/input/background-position-xy.html
@@ -1,0 +1,21 @@
+<script src="include.js"></script>
+<script>
+    test(() => {
+        var pos_x = document.getElementById("position-x")
+        var pos_y = document.getElementById("position-y")
+        println(getComputedStyle(pos_x).backgroundPositionX)
+        println(getComputedStyle(pos_y).backgroundPositionY)
+    });
+</script>
+<style>
+.example {
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  border: 1px solid black;
+  background-repeat: no-repeat;
+  background-size: 30px 30px;
+  background-image: linear-gradient(red, red);
+}
+</style>
+<div id="position-x" class="example" style="background-position-x: right"></div><div id="position-y" class="example" style="background-position-y: bottom"></div>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5552,7 +5552,9 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_single_background_position_x_or_y_valu
         return EdgeStyleValue::create(relative_edge, *offset);
     }
 
-    return nullptr;
+    // If no offset is provided create this element but with an offset of default value of zero
+    transaction.commit();
+    return EdgeStyleValue::create(relative_edge, Length::make_px(0));
 }
 
 ErrorOr<RefPtr<StyleValue>> Parser::parse_single_background_repeat_value(TokenStream<ComponentValue>& tokens)


### PR DESCRIPTION
When specifying `background-position-x: right` or `background-position-y: bottom` the case where no offset value was provided did not work.  This now creates the EdgeStyleValue setting the edge with an offset of 0 pixels.

Test added, but the output is identical with and without this fix as it does not include information about the background-position-xy offset.