### PR TITLE
Meta: Add a macOS bundle to gn build for ladybird 

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -59,7 +59,7 @@ jobs:
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main'
           sudo apt-get update
-          sudo apt-get install -y clang-format-16 ccache e2fsprogs gcc-12 g++-12 libstdc++-12-dev libmpfr-dev libmpc-dev ninja-build optipng qemu-utils qemu-system-i386 unzip
+          sudo apt-get install -y clang-format-16 ccache e2fsprogs gcc-12 g++-12 libstdc++-12-dev libmpfr-dev libmpc-dev ninja-build optipng qemu-utils qemu-system-i386 unzip generate-ninja
           if ${{ matrix.arch == 'aarch64' }}; then
             # FIXME: Remove this when we no longer build our own Qemu binary.
             sudo apt-get install libgtk-3-dev libpixman-1-dev libsdl2-dev libslirp-dev
@@ -72,7 +72,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 requests
       - name: Check versions
-        run: set +e; g++ --version; g++-12 --version; clang-format --version; clang-format-16 --version; prettier --version; python --version; python3 --version; ninja --version; flake8 --version; ccache --version; qemu-system-i386 --version
+        run: set +e; g++ --version; g++-12 --version; clang-format --version; clang-format-16 --version; prettier --version; python --version; python3 --version; ninja --version; flake8 --version; ccache --version; qemu-system-i386 --version; gn --version
 
       # === PREPARE FOR BUILDING ===
 

--- a/Meta/gn/build/toolchain/BUILD.gn
+++ b/Meta/gn/build/toolchain/BUILD.gn
@@ -68,7 +68,7 @@ template("unix_toolchain") {
     tool("solink") {
       outfile = "{{output_dir}}/{{target_output_name}}{{output_extension}}"
       if (current_os == "ios" || current_os == "mac") {
-        command = "$ld -shared {{ldflags}} -o $outfile {{inputs}} {{libs}} {{frameworks}}"
+        command = "$ld -shared {{ldflags}} -o $outfile {{inputs}} {{libs}} {{frameworks}} -Wl,-install_name,@rpath/{{target_output_name}}{{output_extension}}"
         default_output_extension = ".dylib"
       } else {
         command = "$ld -shared {{ldflags}} -Wl,-soname,{{target_output_name}}{{output_extension}} -Wl,-rpath,\\\$ORIGIN -o $outfile {{inputs}} {{libs}}"
@@ -86,7 +86,7 @@ template("unix_toolchain") {
     tool("solink_module") {
       outfile = "{{output_dir}}/{{target_output_name}}{{output_extension}}"
       if (current_os == "ios" || current_os == "mac") {
-        command = "$ld -shared {{ldflags}} -Wl,-flat_namespace -Wl,-undefined,suppress -o $outfile {{inputs}} {{libs}} {{frameworks}}"
+        command = "$ld -shared {{ldflags}} -Wl,-flat_namespace -Wl,-undefined,suppress -o $outfile {{inputs}} {{libs}} {{frameworks}} -Wl,-install_name,@rpath/{{target_output_name}}{{output_extension}}"
         default_output_extension = ".dylib"
       } else {
         command = "$ld -shared {{ldflags}} -Wl,-soname,{{target_output_name}}{{output_extension}} -Wl,-rpath,\\\$ORIGIN -o $outfile {{inputs}} {{libs}}"
@@ -103,8 +103,7 @@ template("unix_toolchain") {
     tool("link") {
       outfile = "{{output_dir}}/{{target_output_name}}{{output_extension}}"
       if (current_os == "ios" || current_os == "mac") {
-        command =
-            "$ld {{ldflags}} -o $outfile {{inputs}} {{libs}} {{frameworks}}"
+        command = "$ld {{ldflags}} -o $outfile {{inputs}} {{libs}} {{frameworks}} -Wl,-rpath,@executable_path/../lib"
       } else {
         command = "$ld {{ldflags}} -o $outfile -Wl,--start-group {{inputs}} -Wl,--end-group -Wl,-rpath,\\\$ORIGIN/../lib {{libs}}"
       }

--- a/Meta/gn/secondary/Ladybird/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/BUILD.gn
@@ -2,6 +2,14 @@ import("//Ladybird/compile_qt_resource_file.gni")
 import("//Ladybird/link_qt.gni")
 import("//Ladybird/moc_qt_objects.gni")
 
+group("ladybird") {
+  if (current_os == "mac") {
+    deps = [ ":ladybird.app" ]
+  } else {
+    deps = [ ":ladybird_executable" ]
+  }
+}
+
 moc_qt_objects("generate_moc") {
   sources = [
     "BrowserWindow.h",
@@ -37,7 +45,7 @@ config("ladybird_config") {
   defines = [ "AK_DONT_REPLACE_STD" ]
 }
 
-executable("ladybird") {
+executable("ladybird_executable") {
   configs += [
     ":ladybird_config",
     ":ladybird_qt_components",
@@ -86,6 +94,7 @@ executable("ladybird") {
   if (current_os == "android") {
     sources += [ "AndroidPlatform.cpp" ]
   }
+  output_name = "ladybird"
 }
 
 link_qt("headless_browser_qt") {
@@ -120,4 +129,136 @@ executable("headless-browser") {
     "HelperProcess.cpp",
     "Utilities.cpp",
   ]
+}
+
+if (current_os == "mac") {
+  bundle_data("ladybird_bundle_info_plist") {
+    sources = [ "Info.plist" ]
+    outputs = [ "{{bundle_contents_dir}}/Info.plist" ]
+  }
+
+  bundle_data("ladybird_bundle_executables") {
+    public_deps = [
+      ":headless-browser",
+      ":ladybird_executable",
+      "SQLServer",
+      "WebContent",
+      "WebDriver",
+    ]
+    sources = [
+      "$root_out_dir/bin/SQLServer",
+      "$root_out_dir/bin/WebContent",
+      "$root_out_dir/bin/WebDriver",
+      "$root_out_dir/bin/headless-browser",
+      "$root_out_dir/bin/ladybird",
+    ]
+    outputs = [ "{{bundle_executable_dir}}/{{source_file_part}}" ]
+  }
+
+  bundle_data("ladybird_bundle_libs") {
+    public_deps = [
+      "//Userland/Libraries/LibAudio",
+      "//Userland/Libraries/LibCompress",
+      "//Userland/Libraries/LibCore",
+      "//Userland/Libraries/LibCrypto",
+      "//Userland/Libraries/LibDiff",
+      "//Userland/Libraries/LibFileSystem",
+      "//Userland/Libraries/LibGL",
+      "//Userland/Libraries/LibGLSL",
+      "//Userland/Libraries/LibGPU",
+      "//Userland/Libraries/LibGUI",
+      "//Userland/Libraries/LibGemini",
+      "//Userland/Libraries/LibGfx",
+      "//Userland/Libraries/LibHTTP",
+      "//Userland/Libraries/LibIDL",
+      "//Userland/Libraries/LibIPC",
+      "//Userland/Libraries/LibJS",
+      "//Userland/Libraries/LibLine",
+      "//Userland/Libraries/LibMarkdown",
+      "//Userland/Libraries/LibRegex",
+      "//Userland/Libraries/LibSQL",
+      "//Userland/Libraries/LibSoftGPU",
+      "//Userland/Libraries/LibSyntax",
+      "//Userland/Libraries/LibTLS",
+      "//Userland/Libraries/LibTextCodec",
+      "//Userland/Libraries/LibThreading",
+      "//Userland/Libraries/LibVideo",
+      "//Userland/Libraries/LibWasm",
+      "//Userland/Libraries/LibWeb",
+      "//Userland/Libraries/LibWebSocket",
+      "//Userland/Libraries/LibWebView",
+      "//Userland/Libraries/LibXML",
+    ]
+    sources = [
+      "$root_out_dir/lib/liblagom-audio.dylib",
+      "$root_out_dir/lib/liblagom-compress.dylib",
+      "$root_out_dir/lib/liblagom-core.dylib",
+      "$root_out_dir/lib/liblagom-crypto.dylib",
+      "$root_out_dir/lib/liblagom-diff.dylib",
+      "$root_out_dir/lib/liblagom-filesystem.dylib",
+      "$root_out_dir/lib/liblagom-gemini.dylib",
+      "$root_out_dir/lib/liblagom-gfx.dylib",
+      "$root_out_dir/lib/liblagom-gl.dylib",
+      "$root_out_dir/lib/liblagom-glsl.dylib",
+      "$root_out_dir/lib/liblagom-gpu.dylib",
+      "$root_out_dir/lib/liblagom-gui.dylib",
+      "$root_out_dir/lib/liblagom-http.dylib",
+      "$root_out_dir/lib/liblagom-idl.dylib",
+      "$root_out_dir/lib/liblagom-ipc.dylib",
+      "$root_out_dir/lib/liblagom-js.dylib",
+      "$root_out_dir/lib/liblagom-line.dylib",
+      "$root_out_dir/lib/liblagom-markdown.dylib",
+      "$root_out_dir/lib/liblagom-regex.dylib",
+      "$root_out_dir/lib/liblagom-softgpu.dylib",
+      "$root_out_dir/lib/liblagom-sql.dylib",
+      "$root_out_dir/lib/liblagom-syntax.dylib",
+      "$root_out_dir/lib/liblagom-textcodec.dylib",
+      "$root_out_dir/lib/liblagom-threading.dylib",
+      "$root_out_dir/lib/liblagom-tls.dylib",
+      "$root_out_dir/lib/liblagom-video.dylib",
+      "$root_out_dir/lib/liblagom-wasm.dylib",
+      "$root_out_dir/lib/liblagom-web.dylib",
+      "$root_out_dir/lib/liblagom-websocket.dylib",
+      "$root_out_dir/lib/liblagom-webview.dylib",
+      "$root_out_dir/lib/liblagom-xml.dylib",
+    ]
+    outputs = [ "{{bundle_contents_dir}}/lib/{{source_file_part}}" ]
+  }
+
+  bundle_data("ladybird_resources") {
+    sources = [
+      "//Base/res/color-palettes",
+      "//Base/res/cursor-themes",
+      "//Base/res/fonts",
+      "//Base/res/html",
+      "//Base/res/icons",
+      "//Base/res/themes",
+    ]
+    outputs = [ "{{bundle_resources_dir}}/res/" + "{{source_file_part}}" ]
+  }
+
+  bundle_data("ladybird_config_resources") {
+    sources = [
+      "//Base/home/anon/.config/BrowserAutoplayAllowlist.txt",
+      "//Base/home/anon/.config/BrowserContentFilters.txt",
+    ]
+    outputs = [ "{{bundle_resources_dir}}/res/ladybird/{{source_file_part}}" ]
+  }
+
+  create_bundle("ladybird.app") {
+    product_type = "com.apple.product-type.application"
+
+    bundle_root_dir = "$root_build_dir/$target_name"
+    bundle_contents_dir = "$bundle_root_dir/Contents"
+    bundle_resources_dir = "$bundle_contents_dir/Resources"
+    bundle_executable_dir = "$bundle_contents_dir/MacOS"
+
+    deps = [
+      ":ladybird_bundle_executables",
+      ":ladybird_bundle_info_plist",
+      ":ladybird_bundle_libs",
+      ":ladybird_config_resources",
+      ":ladybird_resources",
+    ]
+  }
 }

--- a/Meta/gn/secondary/Meta/Lagom/Tools/CodeGenerators/LibWeb/BUILD.gn
+++ b/Meta/gn/secondary/Meta/Lagom/Tools/CodeGenerators/LibWeb/BUILD.gn
@@ -12,6 +12,14 @@ lagom_tool("GenerateAriaRoles") {
   ]
 }
 
+lagom_tool("GenerateCSSEasingFunctions") {
+  sources = [ "GenerateCSSEasingFunctions.cpp" ]
+  deps = [
+    ":headers",
+    "//Userland/Libraries/LibMain",
+  ]
+}
+
 lagom_tool("GenerateCSSEnums") {
   sources = [ "GenerateCSSEnums.cpp" ]
   deps = [

--- a/Meta/gn/secondary/Userland/Libraries/LibIPC/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibIPC/BUILD.gn
@@ -9,7 +9,6 @@ shared_library("LibIPC") {
     "ConnectionToServer.h",
     "Decoder.cpp",
     "Decoder.h",
-    "Dictionary.h",
     "Encoder.cpp",
     "Encoder.h",
     "File.h",

--- a/Meta/gn/secondary/Userland/Libraries/LibJS/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibJS/BUILD.gn
@@ -33,6 +33,7 @@ shared_library("LibJS") {
     "Bytecode/Pass/MergeBlocks.cpp",
     "Bytecode/Pass/PlaceBlocks.cpp",
     "Bytecode/Pass/UnifySameBlocks.cpp",
+    "Bytecode/RegexTable.cpp",
     "Bytecode/StringTable.cpp",
     "Console.cpp",
     "Contrib/Test262/AgentObject.cpp",

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/ARIA/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/ARIA/BUILD.gn
@@ -2,10 +2,10 @@ source_set("ARIA") {
   configs += [ "//Userland/Libraries/LibWeb:configs" ]
   deps = [ "//Userland/Libraries/LibWeb:all_generated" ]
   sources = [
-    "AriaData.cpp",
-    "AriaData.h",
     "ARIAMixin.cpp",
     "ARIAMixin.h",
+    "AriaData.cpp",
+    "AriaData.h",
     "RoleType.cpp",
     "RoleType.h",
     "Roles.cpp",

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/BUILD.gn
@@ -67,7 +67,7 @@ compiled_action("generate_aria_roles") {
   inputs = [ "ARIA/AriaRoles.json" ]
   outputs = [
     "$target_gen_dir/ARIA/AriaRoles.h",
-    "$target_gen_dir/ARIA/AriaRoles.cpp"
+    "$target_gen_dir/ARIA/AriaRoles.cpp",
   ]
   args = [
     "-h",
@@ -75,7 +75,7 @@ compiled_action("generate_aria_roles") {
     "-c",
     rebase_path(outputs[1], root_build_dir),
     "-j",
-    rebase_path(inputs[0], root_build_dir)
+    rebase_path(inputs[0], root_build_dir),
   ]
 }
 

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/BUILD.gn
@@ -79,6 +79,23 @@ compiled_action("generate_aria_roles") {
   ]
 }
 
+compiled_action("generate_css_easing_functions") {
+  tool = "//Meta/Lagom/Tools/CodeGenerators/LibWeb:GenerateCSSEasingFunctions"
+  inputs = [ "CSS/EasingFunctions.json" ]
+  outputs = [
+    "$target_gen_dir/CSS/EasingFunctions.h",
+    "$target_gen_dir/CSS/EasingFunctions.cpp",
+  ]
+  args = [
+    "-h",
+    rebase_path(outputs[0], root_build_dir),
+    "-c",
+    rebase_path(outputs[1], root_build_dir),
+    "-j",
+    rebase_path(inputs[0], root_build_dir),
+  ]
+}
+
 compiled_action("generate_css_enums") {
   tool = "//Meta/Lagom/Tools/CodeGenerators/LibWeb:GenerateCSSEnums"
   inputs = [ "CSS/Enums.json" ]
@@ -182,6 +199,7 @@ embed_as_string_view("generate_quirks_mode_stylesheet_source") {
 source_set("all_generated") {
   generated_deps = [
     ":generate_aria_roles",
+    ":generate_css_easing_functions",
     ":generate_css_enums",
     ":generate_css_media_feature_id",
     ":generate_css_property_id",

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/CSS/StyleValues/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/CSS/StyleValues/BUILD.gn
@@ -15,6 +15,7 @@ source_set("StyleValues") {
     "ConicGradientStyleValue.cpp",
     "ContentStyleValue.cpp",
     "DisplayStyleValue.cpp",
+    "EasingStyleValue.cpp",
     "EdgeStyleValue.cpp",
     "FilterValueListStyleValue.cpp",
     "FlexFlowStyleValue.cpp",

--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -29,6 +29,7 @@ for cmd in \
         Meta/check-style.py \
         Meta/lint-executable-resources.sh \
         Meta/lint-gml-format.sh \
+        Meta/lint-gn.sh \
         Meta/lint-keymaps.py \
         Meta/lint-prettier.sh \
         Meta/lint-python.sh \

--- a/Meta/lint-gn.sh
+++ b/Meta/lint-gn.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+cd "${script_path}/.." || exit 1
+
+if [ "$#" -eq "0" ]; then
+    mapfile -t files < <(
+        git ls-files '*.gn' '*.gni'
+    )
+else
+    files=()
+    for file in "$@"; do
+        if [[ "${file}" == *".gn" ]] || [[ "${file}" == *".gni" ]]; then
+            files+=("${file}")
+        fi
+    done
+fi
+
+if (( ${#files[@]} )); then
+    if ! command -v gn >/dev/null 2>&1 ; then
+        echo "gn is not available, but gn files need linting! Either skip this script, or install gn."
+        exit 1
+    fi
+    gn format "${files[@]}"
+else
+    echo "No .gn or .gni files to check."
+fi


### PR DESCRIPTION
This adds an app bundle to the gn build for ladybird.  It includes all the libraries, dependent apps and resource files. 

One can now open the ladybird.app app bundle on macOS, use Xcode tools like Instruments on the applications in the app bundle, and even install the app bundle into /Applications :^)

As I asked on the gn mailing list, there's no real "nice" way to currently bundle all the dependent libraries without listing them twice. Perhaps @nico will have a simpler solution :^)

https://groups.google.com/a/chromium.org/g/gn-dev/c/qU5xchay4OE