### PR TITLE
AK: Rewrite `cleanup_unused_chunks` or how to optimize PNG decoding without touching LibGfx

### DIFF
--- a/AK/MemoryStream.cpp
+++ b/AK/MemoryStream.cpp
@@ -277,8 +277,6 @@ void AllocatingMemoryStream::cleanup_unused_chunks()
         auto buffer = m_chunks.take_first();
         m_read_offset -= CHUNK_SIZE;
         m_write_offset -= CHUNK_SIZE;
-
-        m_chunks.append(move(buffer));
     }
 }
 

--- a/AK/MemoryStream.cpp
+++ b/AK/MemoryStream.cpp
@@ -270,14 +270,14 @@ ErrorOr<Bytes> AllocatingMemoryStream::next_write_range()
 
 void AllocatingMemoryStream::cleanup_unused_chunks()
 {
-    // FIXME: Move these all at once.
-    while (m_read_offset >= CHUNK_SIZE) {
-        VERIFY(m_write_offset >= m_read_offset);
+    VERIFY(m_write_offset >= m_read_offset);
 
-        auto buffer = m_chunks.take_first();
-        m_read_offset -= CHUNK_SIZE;
-        m_write_offset -= CHUNK_SIZE;
-    }
+    auto const chunks_to_remove = m_read_offset / CHUNK_SIZE;
+
+    m_chunks.remove(0, chunks_to_remove);
+
+    m_read_offset -= CHUNK_SIZE * chunks_to_remove;
+    m_write_offset -= CHUNK_SIZE * chunks_to_remove;
 }
 
 }


### PR DESCRIPTION
**AK: Don't reuse chunks in `AllocatingMemoryStream`**

As confusing as it may sound, reusing them is terrible performance wise.
When profiling the PNG decoder, the result (which is dominated by the
Zlib decompression) shows that the `cleanup_unused_chunks()` function
represented 14.26% of the profile before this patch and only 7.7%
afterward.

On the same 6.5 Mo PNG image, it reduces the decompression time by more
than 5%.

**AK: Move chunks a single time in `cleanup_unused_chunks()`**

All elements of the vector were moved to the left, for each element to
remove. This patch make the function move each element exactly once.

On the same test case than the previous commit, it makes the function
disappear of the profile. These two commits combined reduce the
execution time by 12%.

---
cc @timschumi, I guess that it interests you, feel free to ignore