### PR TITLE
LibJS/Bytecode: Always make own properties in object expressions

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -936,7 +936,7 @@ Bytecode::CodeGenerationErrorOr<void> ObjectExpression::generate_bytecode(Byteco
         Bytecode::Op::PropertyKind property_kind;
         switch (property->type()) {
         case ObjectProperty::Type::KeyValue:
-            property_kind = Bytecode::Op::PropertyKind::KeyValue;
+            property_kind = Bytecode::Op::PropertyKind::DirectKeyValue;
             break;
         case ObjectProperty::Type::Getter:
             property_kind = Bytecode::Op::PropertyKind::Getter;

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -76,6 +76,9 @@ static ThrowCompletionOr<void> put_by_property_key(VM& vm, Value base, Value thi
             return vm.throw_completion<TypeError>(ErrorType::ReferenceNullishSetProperty, name, TRY_OR_THROW_OOM(vm, base.to_string_without_side_effects()));
         break;
     }
+    case PropertyKind::DirectKeyValue:
+        object->define_direct_property(name, value, Attribute::Enumerable | Attribute::Writable | Attribute::Configurable);
+        break;
     case PropertyKind::Spread:
         TRY(object->copy_data_properties(vm, value, {}));
         break;

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -644,6 +644,7 @@ enum class PropertyKind {
     Getter,
     Setter,
     KeyValue,
+    DirectKeyValue, // Used for Object expressions. Always sets an own property, never calls a setter.
     Spread,
     ProtoSetter,
 };


### PR DESCRIPTION
When building an object from an object expression, we don't want to go through the full property setting machinery. This patch adds a new `PropertyKind::DirectKeyValue` for `PutById` which guarantees that the property becomes an own property.

This fixes an issue where setting the `__proto__` property in object expressions wasn't working right.

12 new passes on test262. :^)

```
Summary:
    Diff Tests:
        +12 ✅    -12 ❌   

Diff Tests:
    test/built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-6.js           ❌ -> ✅
    test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-6.js       ❌ -> ✅
    test/intl402/Collator/taint-Object-prototype.js                       ❌ -> ✅
    test/intl402/DateTimeFormat/taint-Object-prototype.js                 ❌ -> ✅
    test/intl402/NumberFormat/taint-Object-prototype.js                   ❌ -> ✅
    test/intl402/constructors-taint-Object-prototype-2.js                 ❌ -> ✅
    test/language/expressions/object/11.1.5_3-3-1.js                      ❌ -> ✅
    test/language/expressions/object/11.1.5_4-5-1.js                      ❌ -> ✅
    test/language/expressions/object/__proto__-duplicate-computed.js      ❌ -> ✅
    test/language/expressions/object/__proto__-permitted-dup-shorthand.js ❌ -> ✅
    test/language/expressions/object/computed-__proto__.js                ❌ -> ✅
    test/language/expressions/object/prop-dup-get-data.js                 ❌ -> ✅
```