### PR TITLE
LibWeb: Paint border to handle more cases

### DIFF
--- a/Base/res/html/misc/border-radius.html
+++ b/Base/res/html/misc/border-radius.html
@@ -57,6 +57,19 @@
             border-radius: 10px;
         }
 
+        .box-1-11 {
+            border-top: 20px solid black;
+            border-radius: 10px;
+        }
+
+        .box-1-12 {
+            border-radius: 20px;
+            border-top: 5px solid red;
+            border-right: 10px solid yellow;
+            border-bottom: 15px solid lime;
+            border-left: 20px solid blue;
+        }
+
         .box-3 {
             border: 1px solid black;
             border-top-right-radius: 10px;
@@ -398,6 +411,12 @@
     <br>
     <em>All round 10px 20px thick outset</em>
     <div class="box box-1-10"></div>
+    <br>
+    <em>Single border with minor radius</em>
+    <div class="box box-1-11"></div>
+    <br>
+    <em>Four border with different colors</em>
+    <div class="box box-1-12"></div>
     <br>
     <em>top-left 10px</em>
     <div class="box box-2"></div>

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.h
@@ -74,7 +74,9 @@ struct BordersData {
 
 RefPtr<Gfx::Bitmap> get_cached_corner_bitmap(DevicePixelSize corners_size);
 
-void paint_border(PaintContext& context, BorderEdge edge, DevicePixelRect const& rect, BorderRadiiData const& border_radii_data, BordersData const& borders_data);
+void paint_border(PaintContext& context, BorderEdge edge, DevicePixelRect const& rect, Gfx::AntiAliasingPainter::CornerRadius const& radius, Gfx::AntiAliasingPainter::CornerRadius const& opposite_radius, BordersData const& borders_data, Gfx::Path& path, bool last);
 void paint_all_borders(PaintContext& context, CSSPixelRect const& bordered_rect, BorderRadiiData const& border_radii_data, BordersData const&);
+
+Gfx::Color border_color(BorderEdge edge, BordersData const& borders_data);
 
 }


### PR DESCRIPTION
The refactor of the border painting mainly to handle:
1. single border with minor border radius
2. different border widths and border colors joined way
This refactor only apply to solid border

Before:
![Screenshot 2023-07-10 at 16 47 42](https://github.com/SerenityOS/serenity/assets/32867472/b0f46751-95c7-4e85-9d21-56b4f102e7a7)

After:
<img width="414" alt="Screenshot 2023-07-10 at 16 50 01" src="https://github.com/SerenityOS/serenity/assets/32867472/9cf23986-da68-4d01-8fc9-a8660fcf1475">