### PR TITLE
Ports: Remove support for `auth_type`s other than sha256

### DIFF
--- a/Meta/lint-ports.py
+++ b/Meta/lint-ports.py
@@ -90,7 +90,7 @@ def read_port_dirs():
     return ports, all_good
 
 
-PORT_PROPERTIES = ('port', 'version', 'files', 'auth_type')
+PORT_PROPERTIES = ('port', 'version', 'files')
 
 
 def resolve_script_values(value: str, props: dict) -> str:
@@ -193,13 +193,7 @@ def check_package_files(ports):
             print(f"Ports/{port} should use '{port}' for 'port' but is using '{props['port']}' instead")
             all_good = False
 
-        if not props['auth_type'] in ('sha256', 'sig', ''):
-            print(f"Ports/{port} uses invalid signature algorithm '{props['auth_type']}' for 'auth_type'")
-            all_good = False
-
         for prop in PORT_PROPERTIES:
-            if prop == 'auth_type' and re.match('^https://github.com/SerenityPorts/', props["files"]):
-                continue
             if props[prop] == '':
                 print(f"Ports/{port} is missing required property '{prop}'")
                 all_good = False

--- a/Ports/Another-World/package.sh
+++ b/Ports/Another-World/package.sh
@@ -6,7 +6,6 @@ depends=("SDL2" "zlib")
 workdir=Another-World-Bytecode-Interpreter-master
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt" "-DSDL2_INCLUDE_DIR=${SERENITY_INSTALL_ROOT}/usr/local/include/SDL2")
 files="https://github.com/fabiensanglard/Another-World-Bytecode-Interpreter/archive/refs/heads/master.zip master.zip 326de7622e5f83a83fce76e6032240157a9dde83c0d65319095c7e0b312af317"
-auth_type=sha256
 launcher_name="Another World"
 launcher_category=Games
 launcher_command="/opt/Another-World/raw --datapath=/opt/Another-World"

--- a/Ports/ClassiCube/package.sh
+++ b/Ports/ClassiCube/package.sh
@@ -3,7 +3,6 @@
 port='ClassiCube'
 version='1.3.3'
 files="https://github.com/UnknownShadow200/ClassiCube/archive/refs/tags/${version}.tar.gz ClassiCube-${version}.tar.gz f90acfeb82fd440ead6e086694d99bd1583b0174da1801687c4c3d0fcb21d83d"
-auth_type='sha256'
 workdir="${port}-${version}/src/"
 depends=(
     'SDL2'

--- a/Ports/OpenJDK/package.sh
+++ b/Ports/OpenJDK/package.sh
@@ -8,7 +8,6 @@ use_fresh_config_guess='true'
 config_guess_paths=("make/autoconf/build-aux/autoconf-config.guess")
 use_fresh_config_sub='true'
 config_sub_paths=("make/autoconf/build-aux/autoconf-config.sub")
-auth_type='sha256'
 files="https://github.com/openjdk/jdk17u-dev/archive/refs/tags/jdk-${version}-ga.tar.gz jdk-${version}-ga.tar.gz 4bd3d2534d7b584c01711e64b9e5b7e79052a1759d3fded8d64107ebc9d37dc2"
 depends=("fontconfig" "libffi")
 

--- a/Ports/README.md
+++ b/Ports/README.md
@@ -145,36 +145,6 @@ all the magic happens.
 
 The following variables have special functionality:
 
-#### `auth_import_key`
-
-PGP key to import (from `keyserver.ubuntu.com`) when [`auth_type`](#auth_type)
-is `sig`.
-
-#### `auth_opts`
-
-Options passed to `gpg --verify` when [`auth_type`](#auth_type) is `sig`.
-
-Usually used like this:
-
-```bash
-auth_opts="foo-${version}.tar.xz.asc foo-${version}.tar.xz"
-```
-
-#### `auth_type`
-
-The type of file validation to use, can be one of:
-
-- `sha256`: Use SHA256 hashes defined in [`files`](#files)
-- `sig`: Use PGP signatures (see [`auth_opts`](#auth_opts))
-
-Most ports use `sig` as `.asc` files are widely available.
-
-This _has_ to be specified in order for `lint-ports` to pass.
-
-If no signature or hash is provided by the author of the files, just create the
-hash yourself by calling `sha256sum` on the downloaded file and specifying the
-hash along with the [`files`](#files).
-
 #### `configopts`
 
 Options passed to the port's [`configscript`](#configscript) in the default
@@ -221,27 +191,17 @@ URL NAME HASH
 ```
 
 Where `URL` is the URL from where the file will be downloaded (using `curl`),
-`NAME` is the output name of the downloaded file, and `HASH` is an optional
-MD5, SHA1, or SHA256 hash that will be used for verification when
-[`auth_type`](#auth_type) is set to either of those hash functions.
+`NAME` is the output name of the downloaded file, and `HASH` is an SHA256 hash
+that will be used for verification.
 
 For example:
 
-_With PGP signatures_
-```bash
-files="https://example.com/foo-${version}.tar.xz foo-${version}.tar.xz
-https://example.com/foo-${version}.tar.xz.asc foo-${version}.tar.xz.asc"
-```
-_With a SHA256 hash_
 ```bash
 files="https://example.com/foo-${version}.tar.xz foo-${version}.tar.xz 9acd50f9a2af37e471f761c3fe7b8dea5617e51dac802fe6c177b74abf0abb5a"
 ```
 
 If a file is a compressed tar archive, a gzip compressed file or a zip
 compressed file, it will be extracted.
-
-If a file is an `.asc` file (PGP signature) it will be imported into `gpg`'s
-keyring and can later be used for verification using [`auth_opts`](#auth_opts).
 
 #### `icon_file`
 

--- a/Ports/RISCVEmu/package.sh
+++ b/Ports/RISCVEmu/package.sh
@@ -2,7 +2,6 @@
 port=RISCVEmu
 version=ad8ad6a0eb8591385318b2ec1cffde6078ff0185
 files="https://github.com/IdanHo/RISCVEmu/archive/${version}.tar.gz RISCVEmu-${version}.tar.gz b4636284dd407e490ba6dd783b65caf8c019785285d6a86aece3860465276b33"
-auth_type="sha256"
 
 build() {
     run "${CXX}" -o RISCVEmu RISCVEmu.cpp RISCV.cpp

--- a/Ports/RetroArch/package.sh
+++ b/Ports/RetroArch/package.sh
@@ -4,7 +4,6 @@ useconfigure="true"
 version="1.12.0"
 archive_hash="c912e32a0300f16ade827d48a4a948d5dab40b764cd1169f61108c6f5803649a"
 files="https://github.com/libretro/${port}/archive/refs/tags/v${version}.tar.gz ${port}-${version}.tar.gz $archive_hash"
-auth_type=sha256
 depends=("freetype" "SDL2" "zlib")
 
 configopts=(

--- a/Ports/SDL2-GNUBoy/package.sh
+++ b/Ports/SDL2-GNUBoy/package.sh
@@ -4,5 +4,4 @@ port=SDL2-GNUBoy
 version=1.2.1
 useconfigure=false
 files="https://github.com/AlexOberhofer/SDL2-GNUBoy/archive/refs/tags/v${version}.tar.gz SDL2-GNUBoy-${version}.tar.gz d8b729aa88747301ed39514ad9dc857b842332ac87242993881e15125af1be20"
-auth_type=sha256
 depends=("SDL2")

--- a/Ports/SDL2/package.sh
+++ b/Ports/SDL2/package.sh
@@ -2,7 +2,6 @@
 port='SDL2'
 version='2.24.0'
 useconfigure='true'
-auth_type='sha256'
 files="https://github.com/libsdl-org/SDL/releases/download/release-${version}/SDL2-${version}.tar.gz SDL2-${version}.tar.gz 91e4c34b1768f92d399b078e171448c6af18cafda743987ed2064a28954d6d97"
 configopts=(
     "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"

--- a/Ports/SDL2_gfx/package.sh
+++ b/Ports/SDL2_gfx/package.sh
@@ -3,7 +3,6 @@
 port=SDL2_gfx
 version=1.0.4
 files="https://downloads.sourceforge.net/project/sdl2gfx/SDL2_gfx-${version}.tar.gz SDL2_gfx-${version}.tar.gz 63e0e01addedc9df2f85b93a248f06e8a04affa014a835c2ea34bfe34e576262"
-auth_type=sha256
 depends=("SDL2")
 useconfigure=true
 use_fresh_config_sub=true

--- a/Ports/SDL2_image/package.sh
+++ b/Ports/SDL2_image/package.sh
@@ -4,7 +4,6 @@ useconfigure='true'
 version='2.6.2'
 depends=("SDL2" "libpng" "libjpeg" "libtiff")
 files="https://github.com/libsdl-org/SDL_image/releases/download/release-${version}/SDL2_image-${version}.tar.gz SDL2_image-${version}.tar.gz 48355fb4d8d00bac639cd1c4f4a7661c4afef2c212af60b340e06b7059814777"
-auth_type='sha256'
 
 configure() {
     run ./configure \

--- a/Ports/SDL2_mixer/package.sh
+++ b/Ports/SDL2_mixer/package.sh
@@ -3,7 +3,6 @@ port='SDL2_mixer'
 version='2.6.2'
 useconfigure='true'
 files="https://github.com/libsdl-org/SDL_mixer/releases/download/release-${version}/SDL2_mixer-${version}.tar.gz SDL2_mixer-${version}.tar.gz 8cdea810366decba3c33d32b8071bccd1c309b2499a54946d92b48e6922aa371"
-auth_type='sha256'
 depends=("libmodplug" "libmpg123" "libvorbis" "SDL2" "timidity")
 
 configure() {

--- a/Ports/SDL2_net/package.sh
+++ b/Ports/SDL2_net/package.sh
@@ -8,5 +8,4 @@ configopts=(
     "--enable-shared"
 )
 files="https://github.com/libsdl-org/SDL_net/releases/download/release-${version}/SDL2_net-${version}.tar.gz SDL2_net-${version}.tar.gz 4e4a891988316271974ff4e9585ed1ef729a123d22c08bd473129179dc857feb"
-auth_type='sha256'
 depends=("SDL2")

--- a/Ports/SDL2_sound/package.sh
+++ b/Ports/SDL2_sound/package.sh
@@ -6,7 +6,6 @@ workdir="SDL_sound-${_commit}"
 useconfigure='true'
 depends=('SDL2')
 files="https://github.com/icculus/SDL_sound/archive/${_commit}.zip ${_commit}.zip d29f90dd5abacf9f818f0b1567fab6b3dc6292d0a942e8e8d1e8f84130eea7a1"
-auth_type='sha256'
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 
 configure() {

--- a/Ports/SDL2_ttf/package.sh
+++ b/Ports/SDL2_ttf/package.sh
@@ -3,7 +3,6 @@ port='SDL2_ttf'
 version='2.20.1'
 useconfigure='true'
 files="https://github.com/libsdl-org/SDL_ttf/releases/download/release-${version}/SDL2_ttf-${version}.tar.gz SDL2_ttf-${version}.tar.gz 78cdad51f3cc3ada6932b1bb6e914b33798ab970a1e817763f22ddbfd97d0c57"
-auth_type='sha256'
 depends=("SDL2" "freetype")
 
 configure() {

--- a/Ports/SDLPoP/package.sh
+++ b/Ports/SDLPoP/package.sh
@@ -7,7 +7,6 @@ commitid="86988c668eeaa10f218e1d4938fc5b4e42314d68"
 workdir="${port}-${commitid}"
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 files="https://github.com/NagyD/SDLPoP/archive/${commitid}.zip PoP.zip d18cae8541fb8cbcc374fd998316993d561429a83f92061bc0754337ada774c5"
-auth_type=sha256
 launcher_name="Prince of Persia"
 launcher_category=Games
 launcher_command=/opt/PrinceOfPersia/prince

--- a/Ports/SDL_mixer/package.sh
+++ b/Ports/SDL_mixer/package.sh
@@ -6,7 +6,6 @@ configopts=("--disable-static")
 use_fresh_config_sub=true
 config_sub_paths=("build-scripts/config.sub")
 files="https://www.libsdl.org/projects/SDL_mixer/release/SDL_mixer-${version}.tar.gz SDL_mixer-${version}.tar.gz 1644308279a975799049e4826af2cfc787cad2abb11aa14562e402521f86992a"
-auth_type=sha256
 depends=("libmikmod" "libvorbis" "sdl12-compat" "timidity")
 
 # Explicitly point to the config binaries installed by our ports. Otherwise, it will

--- a/Ports/SDL_sound/package.sh
+++ b/Ports/SDL_sound/package.sh
@@ -5,7 +5,6 @@ useconfigure='true'
 use_fresh_config_sub='true'
 depends=("sdl12-compat" "libmikmod")
 files="https://www.icculus.org/SDL_sound/downloads/${port}-${version}.tar.gz ${port}-${version}.tar.gz 3999fd0bbb485289a52be14b2f68b571cb84e380cc43387eadf778f64c79e6df" 
-auth_type='sha256'
 configopts=(
     "--with-sdl-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
     "--enable-ogg=no"

--- a/Ports/Super-Mario/package.sh
+++ b/Ports/Super-Mario/package.sh
@@ -6,7 +6,6 @@ depends=("SDL2" "SDL2_mixer" "SDL2_image")
 workdir=Super-Mario-Clone-Cpp-master
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 files="https://github.com/Bennyhwanggggg/Super-Mario-Clone-Cpp/archive/refs/heads/master.zip master.zip fcacc15d3b5afccb3227f982d3e05f2cfeb198f0fffd008fdcda005cb7f87f91"
-auth_type=sha256
 launcher_name="Super Mario"
 launcher_category=Games
 launcher_command=/opt/Super_Mario/uMario

--- a/Ports/SuperTuxKart/package.sh
+++ b/Ports/SuperTuxKart/package.sh
@@ -4,7 +4,6 @@ useconfigure='true'
 version='1.4'
 archive_hash='9890392419baf4715313f14d5ad60746f276eed36eb580636caf44e2532c0f03'
 files="https://github.com/supertuxkart/stk-code/releases/download/${version}/supertuxkart-${version}-src.tar.xz ${port}-${version}-src.tar.xz $archive_hash"
-auth_type='sha256'
 workdir="${port}-${version}-src"
 launcher_name='SuperTuxKart'
 launcher_category='Games'

--- a/Ports/VVVVVV/package.sh
+++ b/Ports/VVVVVV/package.sh
@@ -2,7 +2,6 @@
 port='VVVVVV'
 version='2.3.6'
 useconfigure='true'
-auth_type='sha256'
 files="https://github.com/TerryCavanagh/VVVVVV/archive/refs/tags/${version}.tar.gz VVVVVV-${version}.tar.gz a3366aab9e8462d330044ab1ec63927e9f5c3801c0ed96b24f08c553dcb911e9"
 configopts=(
     "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"

--- a/Ports/aclock/package.sh
+++ b/Ports/aclock/package.sh
@@ -2,7 +2,6 @@
 port='aclock'
 version='2.3'
 files="https://github.com/tenox7/aclock/raw/f9668617eac365fe8b5416cfbd801b727d8a3746/sources/aclock-unix-curses.c aclock-${version}.c 2b098996409c4740f492fb8fd5a63cb5e3e15283c2f7e3f06c75d6a9ad916669"
-auth_type='sha256'
 depends=("ncurses")
 
 build() {

--- a/Ports/acpica-tools/package.sh
+++ b/Ports/acpica-tools/package.sh
@@ -2,7 +2,6 @@
 port=acpica-tools
 version=20220331
 workdir="acpica-unix-${version}"
-auth_type=sha256
 files="https://acpica.org/sites/acpica/files/acpica-unix-${version}.tar.gz acpica-unix-${version}.tar.gz acaff68b14f1e0804ebbfc4b97268a4ccbefcfa053b02ed9924f2b14d8a98e21"
 
 

--- a/Ports/alpine/package.sh
+++ b/Ports/alpine/package.sh
@@ -9,7 +9,6 @@ configopts=(
 use_fresh_config_sub='true'
 use_fresh_config_guess='true'
 files="https://alpineapp.email/alpine/release/src/alpine-2.26.tar.xz alpine-${version}.tar.xz c0779c2be6c47d30554854a3e14ef5e36539502b331068851329275898a9baba"
-auth_type='sha256'
 depends=(
     'openssl'
     'ncurses'

--- a/Ports/angband/package.sh
+++ b/Ports/angband/package.sh
@@ -5,7 +5,6 @@ workdir="Angband-${version}"
 useconfigure=true
 use_fresh_config_sub=true
 files="https://github.com/angband/angband/releases/download/${version}/Angband-${version}.tar.gz Angband-${version}.tar.gz a07c78c1dd05e48ddbe4d8ef5d1880fcdeab55fd05f1336d9cba5dd110b15ff3"
-auth_type=sha256
 depends=("ncurses" "SDL2" "SDL2_image" "SDL2_ttf" "SDL2_mixer")
 configopts=(
     "--prefix=/usr/local"

--- a/Ports/aria2/package.sh
+++ b/Ports/aria2/package.sh
@@ -2,7 +2,6 @@
 port='aria2'
 version='1.36.0'
 files="https://github.com/aria2/aria2/releases/download/release-${version}/aria2-${version}.tar.xz ${port}-${version}.tar.xz 58d1e7608c12404f0229a3d9a4953d0d00c18040504498b483305bcb3de907a5"
-auth_type='sha256'
 depends=(
     "libssh2"
     "libxml2"

--- a/Ports/awk/package.sh
+++ b/Ports/awk/package.sh
@@ -3,7 +3,6 @@ port=awk
 version=20220122
 useconfigure="false"
 files="https://github.com/onetrueawk/awk/archive/refs/tags/${version}.tar.gz awk-${version}.tar.gz 720a06ff8dcc12686a5176e8a4c74b1295753df816e38468a6cf077562d54042"
-auth_type=sha256
 patchlevel=1
 
 build() {

--- a/Ports/backward-cpp/package.sh
+++ b/Ports/backward-cpp/package.sh
@@ -3,7 +3,6 @@ port='backward-cpp'
 version='65a769f'
 files="https://github.com/bombela/backward-cpp/tarball/65a769ffe77cf9d759d801bc792ac56af8e911a3 backward-cpp-${version}.tar.gz 233271162bf09ce7c41026416e5d6f59a66f42f83c3ea370f110980ac219144a"
 workdir="bombela-backward-cpp-${version}"
-auth_type='sha256'
 useconfigure='true'
 configopts=(
     "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"

--- a/Ports/bash/package.sh
+++ b/Ports/bash/package.sh
@@ -8,7 +8,6 @@ config_sub_paths=("support/config.sub")
 config_guess_paths=("support/config.guess")
 configopts=("--disable-nls" "--without-bash-malloc")
 files="https://ftpmirror.gnu.org/gnu/bash/bash-${version}.tar.gz bash-${version}.tar.gz 13720965b5f4fc3a0d4b61dd37e7565c741da9a5be24edc2ae00182fc1b3588c"
-auth_type='sha256'
 
 build() {
     run_replace_in_file "s/define GETCWD_BROKEN 1/undef GETCWD_BROKEN/" config.h

--- a/Ports/bass/package.sh
+++ b/Ports/bass/package.sh
@@ -2,7 +2,6 @@
 port=bass
 version="cd-1.2"
 files="https://downloads.scummvm.org/frs/extras/Beneath%20a%20Steel%20Sky/bass-${version}.zip bass-${version}.zip 53209b9400eab6fd7fa71518b2f357c8de75cfeaa5ba57024575ab79cc974593"
-auth_type=sha256
 depends=("scummvm")
 
 bass_resource_path="/usr/local/share/games/${port}-${version}"

--- a/Ports/bc/package.sh
+++ b/Ports/bc/package.sh
@@ -2,7 +2,6 @@
 port='bc'
 version='6.5.0'
 files="https://github.com/gavinhoward/bc/releases/download/${version}/bc-${version}.tar.xz bc-${version}.tar.xz b1afb1f50c0bce6119c98590bcc8afc22f520bc85c2b512c83938dbb8321cc30"
-auth_type='sha256'
 useconfigure='true'
 configscript='configure.sh'
 configopts=("--prefix=/usr/local" "--disable-nls")

--- a/Ports/bdwgc/package.sh
+++ b/Ports/bdwgc/package.sh
@@ -6,7 +6,6 @@ use_fresh_config_sub='true'
 files="https://github.com/ivmai/bdwgc/releases/download/v$version/gc-$version.tar.gz bdwgc.tar.gz f30107bcb062e0920a790ffffa56d9512348546859364c23a14be264b38836a0"
 depends=("libatomic_ops")
 workdir="gc-$version"
-auth_type='sha256'
 
 useconfigure='true'
 configopts=("--enable-threads=posix")

--- a/Ports/binutils/package.sh
+++ b/Ports/binutils/package.sh
@@ -13,8 +13,6 @@ configopts=(
     "--enable-libiberty"
 )
 files="https://ftpmirror.gnu.org/gnu/binutils/binutils-${version}.tar.xz binutils-${version}.tar.xz 0f8a4c272d7f17f369ded10a4aca28b8e304828e95526da482b0ccc4dfc9d8e1"
-auth_type='sha256'
-auth_opts=("--keyring" "./gnu-keyring.gpg" "binutils-${version}.tar.xz.sig")
 depends=("zlib")
 
 export ac_cv_func_getrusage=no

--- a/Ports/bison/package.sh
+++ b/Ports/bison/package.sh
@@ -4,4 +4,3 @@ version='3.8'
 useconfigure='true'
 configopts=("--prefix=${SERENITY_INSTALL_ROOT}/usr/local")
 files="https://ftpmirror.gnu.org/gnu/bison/bison-${version}.tar.gz bison-${version}.tar.gz d5d184d421aee15603939973a6b0f372f908edfb24c5bc740697497021ad9458"
-auth_type='sha256'

--- a/Ports/bochs/package.sh
+++ b/Ports/bochs/package.sh
@@ -3,7 +3,6 @@ port=bochs
 version=2.7
 depends=("SDL2")
 files="https://download.sourceforge.net/project/bochs/bochs/$version/bochs-$version.tar.gz bochs-${version}.tar.gz a010ab1bfdc72ac5a08d2e2412cd471c0febd66af1d9349bc0d796879de5b17a"
-auth_type=sha256
 useconfigure=true
 use_fresh_config_sub=true
 configopts=("--with-sdl2")

--- a/Ports/boost/package.sh
+++ b/Ports/boost/package.sh
@@ -11,7 +11,6 @@ depends=(
     'libicu'
 )
 files="https://boostorg.jfrog.io/artifactory/main/release/${version}/source/boost_${version//./_}.tar.bz2 boost_${version//./_}.tar.bz2 1e19565d82e43bc59209a168f5ac899d3ba471d55c7610c677d4ccf2c9c500c0"
-auth_type='sha256'
 bjamopts=(
     '--user-config=user-config.jam'
     'toolset=gcc'

--- a/Ports/brogue/package.sh
+++ b/Ports/brogue/package.sh
@@ -4,7 +4,6 @@ depends=("SDL2" "SDL2_image")
 version='1.11.1'
 workdir="BrogueCE-${version}"
 files="https://github.com/tmewett/BrogueCE/archive/refs/tags/v${version}.tar.gz brogue-${version}.tar.gz dc562cf774f88b12b6aeebdac5a00e62e8598b3f84da2130a54a67a60c5debf2"
-auth_type='sha256'
 makeopts+=("bin/brogue")
 
 install() {

--- a/Ports/brotli/package.sh
+++ b/Ports/brotli/package.sh
@@ -4,7 +4,6 @@ port='brotli'
 version='1.0.9'
 files="https://github.com/google/brotli/archive/refs/tags/v${version}.tar.gz brotli-v${version}.tar.gz f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46"
 useconfigure='true'
-auth_type='sha256'
 
 configure() {
     run ./configure-cmake

--- a/Ports/byacc/package.sh
+++ b/Ports/byacc/package.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=byacc
 version=20220128
-files="https://invisible-mirror.net/archives/byacc/byacc-${version}.tgz byacc-${version}.tgz
-https://invisible-mirror.net/archives/byacc/byacc-${version}.tgz.asc byacc-${version}.tgz.asc"
+files="https://invisible-mirror.net/archives/byacc/byacc-${version}.tgz byacc-${version}.tgz 42c1805cc529314e6a76326fe1b33e80c70862a44b01474da362e2f7db2d749c"
 useconfigure=true
-auth_type="sig"
-auth_import_key="19882D92DDA4C400C22C0D56CC2AF4472167BE03"
-auth_opts=("byacc-${version}.tgz.asc" "byacc-${version}.tgz")
+auth_type='sha256'

--- a/Ports/byacc/package.sh
+++ b/Ports/byacc/package.sh
@@ -3,4 +3,3 @@ port=byacc
 version=20220128
 files="https://invisible-mirror.net/archives/byacc/byacc-${version}.tgz byacc-${version}.tgz 42c1805cc529314e6a76326fe1b33e80c70862a44b01474da362e2f7db2d749c"
 useconfigure=true
-auth_type='sha256'

--- a/Ports/bzip2/package.sh
+++ b/Ports/bzip2/package.sh
@@ -2,7 +2,6 @@
 port=bzip2
 version=1.0.8
 files="https://sourceware.org/pub/bzip2/bzip2-${version}.tar.gz bzip2-${version}.tar.gz ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269"
-auth_type=sha256
 makeopts=("bzip2")
 installopts=("PREFIX=${SERENITY_INSTALL_ROOT}/usr/local")
 

--- a/Ports/bzip3/package.sh
+++ b/Ports/bzip3/package.sh
@@ -2,7 +2,6 @@
 port='bzip3'
 version='1.2.2'
 files="https://github.com/kspalaiologos/bzip3/releases/download/${version}/bzip3-${version}.tar.gz bzip3-${version}.tar.gz 19e8d379f48610f945a04a988fd0c330ff6613b3df96405d56bed35a7d216dee"
-auth_type='sha256'
 useconfigure='true'
 installopts=("PREFIX=${SERENITY_INSTALL_ROOT}/usr/local")
 configopts=(

--- a/Ports/c-ares/package.sh
+++ b/Ports/c-ares/package.sh
@@ -2,7 +2,6 @@
 port='c-ares'
 version='1.19.0'
 files="https://c-ares.org/download/c-ares-${version}.tar.gz c-ares-${version}.tar.gz bfceba37e23fd531293829002cac0401ef49a6dc55923f7f92236585b7ad1dd3"
-auth_type='sha256'
 useconfigure=true
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 

--- a/Ports/c-ray/package.sh
+++ b/Ports/c-ray/package.sh
@@ -3,7 +3,6 @@ port=c-ray
 version=8f30eb9904a4d20a78e9387d79dc049c5ed69b0c
 useconfigure=true
 files="https://github.com/vkoskiv/c-ray/archive/${version}.tar.gz ${version}.tar.gz 27fa6496721faf69f18dc0946f0747b64f3ced748440a8f906f51fcb7e5cb008"
-auth_type=sha256
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 depends=("SDL2")
 workdir="${port}-${version}"

--- a/Ports/ca-certificates/package.sh
+++ b/Ports/ca-certificates/package.sh
@@ -2,7 +2,6 @@
 port=ca-certificates
 version=2022-04-26
 files="https://curl.se/ca/cacert-${version}.pem cacert-${version}.pem 08df40e8f528ed283b0e480ba4bcdbfdd2fdcf695a7ada1668243072d80f8b6f"
-auth_type=sha256
 workdir="."
 
 configure() {

--- a/Ports/carl/package.sh
+++ b/Ports/carl/package.sh
@@ -3,7 +3,6 @@ port=carl
 version=1.5
 workdir=cryanc-"${version}"
 files="https://github.com/classilla/cryanc/archive/refs/tags/${version}.tar.gz cryanc-${version}.tar.gz 019c2a4df4ce5a332fc29b7903244d6a76bb0bd8bb3e406326b6239416a5b0f6"
-auth_type=sha256
 
 build() {
     run $CC -O3 carl.c -o carl

--- a/Ports/cavestory/package.sh
+++ b/Ports/cavestory/package.sh
@@ -2,7 +2,6 @@
 port='cavestory'
 version='2.6.5-1'
 files=('https://github.com/gloof11/nxengine-evo/archive/0f45555c64bae21116bac30cd46002e70b1b6495.zip nxengine-evo-0f45555c64bae21116bac30cd46002e70b1b6495.zip c93cb2c1e16f49cd87bcc886cf6adf289355fabe7b5a30d506ec066cc1d86d1d')
-auth_type='sha256'
 depends=(
     'libjpeg'
     'libpng'

--- a/Ports/cbonsai/package.sh
+++ b/Ports/cbonsai/package.sh
@@ -2,7 +2,6 @@
 port='cbonsai'
 version='1.3.1'
 files="https://gitlab.com/jallbrit/cbonsai/-/archive/v${version}/cbonsai-v${version}.tar cbonsai-v${version}.tar.bz2 686e4af58f8e44e09b689da6e9a98a404fc0a779da7c7da1a5403283e0e471d8"
-auth_type='sha256'
 workdir="cbonsai-v${version}"
 makeopts+=(CC="${CC}")
 depends=("ncurses")

--- a/Ports/ccache/package.sh
+++ b/Ports/ccache/package.sh
@@ -3,7 +3,6 @@ port='ccache'
 version='4.6.3'
 useconfigure='true'
 files="https://github.com/ccache/ccache/releases/download/v${version}/ccache-${version}.tar.gz ccache-$version.tar.gz f46ba3706ad80c30d4d5874dee2bf9227a7fcd0ccaac31b51919a3053d84bd05"
-auth_type='sha256'
 depends=('zstd')
 configopts=(
     "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"

--- a/Ports/cfunge/package.sh
+++ b/Ports/cfunge/package.sh
@@ -4,7 +4,6 @@ port='cfunge'
 version='2bc4fb27ade2a816ca9a90a6d9f6958111123fa9'
 useconfigure='true'
 files="https://codeload.github.com/VorpalBlade/cfunge/zip/${version} cfunge.zip 364994a890ed1083684956db576a2a5cfb94b3117bae868910d6a75111033f55"
-auth_type='sha256'
 
 configure() {
     run cmake -B build "${configopts[@]}"

--- a/Ports/chester/package.sh
+++ b/Ports/chester/package.sh
@@ -6,7 +6,6 @@ depends=("SDL2")
 workdir=chester-public
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 files="https://github.com/veikkos/chester/archive/public.tar.gz chester.tar.gz b3ea7ad40608e1050fa434258f5c69b93e7bad10523c4c4a86fe08d1442a907b"
-auth_type=sha256
 
 configure() {
     run cmake "${configopts[@]}"

--- a/Ports/chocolate-doom/package.sh
+++ b/Ports/chocolate-doom/package.sh
@@ -5,7 +5,6 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('autotools/config.sub')
 files="https://www.chocolate-doom.org/downloads/${version}/chocolate-doom-${version}.tar.gz chocolate-doom-${version}.tar.gz d435d6177423491d60be706da9f07d3ab4fabf3e077ec2a3fc216e394fcfc8c7"
-auth_type='sha256'
 depends=(
     'libpng'
     'libsamplerate'

--- a/Ports/citron/package.sh
+++ b/Ports/citron/package.sh
@@ -6,7 +6,6 @@ depends=(sparsehash libffi pcre)
 commit_hash=d28b7d62bd61397e46152aa6e4ee59b115c0e2d7
 archive_hash=0e31ab638c4fd1438f68fdf069336e2541eb4cfc5db2f55888f6175e0171a2ef
 files="https://github.com/alimpfard/citron/archive/$commit_hash.tar.gz citron.tar.gz $archive_hash"
-auth_type=sha256
 workdir="citron-$commit_hash"
 
 pre_install() {

--- a/Ports/cmake/package.sh
+++ b/Ports/cmake/package.sh
@@ -3,7 +3,6 @@ port='cmake'
 version='3.26.1'
 useconfigure='true'
 files="https://github.com/Kitware/CMake/releases/download/v${version}/cmake-${version}.tar.gz cmake-${version}.tar.gz f29964290ad3ced782a1e58ca9fda394a82406a647e24d6afd4e6c32e42c412f"
-auth_type='sha256'
 depends=(
     'bash'
     'make'

--- a/Ports/cmatrix/package.sh
+++ b/Ports/cmatrix/package.sh
@@ -5,7 +5,6 @@ version=3112b127babe72d2222059edd2d7eb7fb8bddfb1
 depends=("ncurses")
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 files="https://github.com/abishekvashok/cmatrix/archive/${version}.tar.gz ${port}-${version}.tar.gz a1d313d49a39cb5ae3a1c675872712f9f871114a161c38cbe94ce78967825f87"
-auth_type=sha256
 launcher_name=cmatrix
 launcher_category=Games
 launcher_command=cmatrix

--- a/Ports/composer/package.sh
+++ b/Ports/composer/package.sh
@@ -2,7 +2,6 @@
 port='composer'
 version='2.4.3'
 files="https://getcomposer.org/download/${version}/composer.phar composer.phar 26d72f2790502bc9b22209e1cec1e0e43d33b368606ad227d327cccb388b609a"
-auth_type='sha256'
 depends=('php')
 
 build() {

--- a/Ports/coreutils/package.sh
+++ b/Ports/coreutils/package.sh
@@ -5,7 +5,6 @@ useconfigure="true"
 use_fresh_config_sub="true"
 config_sub_paths=("build-aux/config.sub")
 files="https://ftpmirror.gnu.org/gnu/coreutils/coreutils-${version}.tar.gz coreutils-${version}.tar.gz 6055df9268603e8239a5c9c1d64cb25b9a992530df66e33b8d78a660edb37b35"
-auth_type='sha256'
 
 # Exclude some non-working utilities:
 #  - arch, coreutils, and hostname are already excluded in the default configuration

--- a/Ports/coreutils/package.sh
+++ b/Ports/coreutils/package.sh
@@ -4,11 +4,8 @@ version=9.1
 useconfigure="true"
 use_fresh_config_sub="true"
 config_sub_paths=("build-aux/config.sub")
-files="https://ftpmirror.gnu.org/gnu/coreutils/coreutils-${version}.tar.gz coreutils-${version}.tar.gz
-https://ftpmirror.gnu.org/gnu/coreutils/coreutils-${version}.tar.gz.sig coreutils-${version}.tar.gz.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg" "coreutils-${version}.tar.gz.sig")
+files="https://ftpmirror.gnu.org/gnu/coreutils/coreutils-${version}.tar.gz coreutils-${version}.tar.gz 6055df9268603e8239a5c9c1d64cb25b9a992530df66e33b8d78a660edb37b35"
+auth_type='sha256'
 
 # Exclude some non-working utilities:
 #  - arch, coreutils, and hostname are already excluded in the default configuration

--- a/Ports/cpio/package.sh
+++ b/Ports/cpio/package.sh
@@ -5,4 +5,3 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('build-aux/config.sub')
 files="https://ftpmirror.gnu.org/gnu/cpio/cpio-${version}.tar.gz cpio-${version}.tar.gz e87470d9c984317f658567c03bfefb6b0c829ff17dbf6b0de48d71a4c8f3db88"
-auth_type='sha256'

--- a/Ports/curl/package.sh
+++ b/Ports/curl/package.sh
@@ -3,7 +3,6 @@ port='curl'
 version='8.0.1'
 useconfigure='true'
 files="https://curl.se/download/curl-${version}.tar.bz2 curl-${version}.tar.bz2 9b6b1e96b748d04b968786b6bdf407aa5c75ab53a3d37c1c8c81cdb736555ccf"
-auth_type='sha256'
 depends=(
   'ca-certificates'
   'openssl'

--- a/Ports/dash/package.sh
+++ b/Ports/dash/package.sh
@@ -3,7 +3,6 @@ port=dash
 version=0.5.10.2
 useconfigure=true
 files="http://gondor.apana.org.au/~herbert/dash/files/dash-${version}.tar.gz dash-${version}.tar.gz 3c663919dc5c66ec991da14c7cf7e0be8ad00f3db73986a987c118862b5f6071"
-auth_type="sha256"
 
 configure() {
     host_env

--- a/Ports/deutex/package.sh
+++ b/Ports/deutex/package.sh
@@ -3,7 +3,6 @@ port='deutex'
 version='5.2.2'
 useconfigure='true'
 files="https://github.com/Doom-Utils/deutex/releases/download/v${version}/deutex-${version}.tar.zst deutex-${version}.tar.zst 10ed0e7a533ec97cb6d03548d4258fbec88852a45b5ea4cf5434376ad4174b5f"
-auth_type='sha256'
 depends=(
     'libpng'
 )

--- a/Ports/dialog/package.sh
+++ b/Ports/dialog/package.sh
@@ -2,7 +2,6 @@
 port='dialog'
 version='1.3-20220526'
 files="https://invisible-mirror.net/archives/dialog/dialog-${version}.tgz dialog-${version}.tgz 858c9a625b20fde19fb7b19949ee9e9efcade23c56d917b1adb30e98ff6d6b33"
-auth_type='sha256'
 useconfigure='true'
 use_fresh_config_sub='true'
 configopts=("--prefix=/usr/local" "--with-ncurses" "--with-curses-dir=${SERENITY_INSTALL_ROOT}/usr/local/include/ncurses")

--- a/Ports/diffutils/package.sh
+++ b/Ports/diffutils/package.sh
@@ -2,7 +2,6 @@
 port=diffutils
 version=3.8
 files="https://ftpmirror.gnu.org/gnu/diffutils/diffutils-${version}.tar.xz diffutils-${version}.tar.xz a6bdd7d1b31266d11c4f4de6c1b748d4607ab0231af5188fc2533d0ae2438fec"
-auth_type=sha256
 useconfigure=true
 use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")

--- a/Ports/dmidecode/package.sh
+++ b/Ports/dmidecode/package.sh
@@ -2,4 +2,3 @@
 port='dmidecode'
 version='3.5'
 files="https://download-mirror.savannah.gnu.org/releases/dmidecode/dmidecode-${version}.tar.xz dmidecode-${version}.tar.xz 79d76735ee8e25196e2a722964cf9683f5a09581503537884b256b01389cc073"
-auth_type='sha256'

--- a/Ports/dos2unix/package.sh
+++ b/Ports/dos2unix/package.sh
@@ -4,4 +4,3 @@ version=7.5.0
 workdir="${port}-${version}"
 files="https://waterlan.home.xs4all.nl/dos2unix/dos2unix-${version}.tar.gz ${port}-${version}.tar.gz 7a3b01d01e214d62c2b3e04c3a92e0ddc728a385566e4c0356efa66fd6eb95af"
 depends=("gettext")
-auth_type='sha256'

--- a/Ports/dos2unix/package.sh
+++ b/Ports/dos2unix/package.sh
@@ -2,9 +2,6 @@
 port=dos2unix
 version=7.5.0
 workdir="${port}-${version}"
-files="https://waterlan.home.xs4all.nl/dos2unix/dos2unix-${version}.tar.gz ${port}-${version}.tar.gz
-https://waterlan.home.xs4all.nl/dos2unix/dos2unix-${version}.tar.gz.asc ${port}-${version}.tar.gz.asc"
+files="https://waterlan.home.xs4all.nl/dos2unix/dos2unix-${version}.tar.gz ${port}-${version}.tar.gz 7a3b01d01e214d62c2b3e04c3a92e0ddc728a385566e4c0356efa66fd6eb95af"
 depends=("gettext")
-auth_type=sig
-auth_import_key="f8f1bea490496a09cca328cc38c1f572b12725be"
-auth_opts=("${port}-${version}.tar.gz.asc" "${port}-${version}.tar.gz")
+auth_type='sha256'

--- a/Ports/dosbox-staging/package.sh
+++ b/Ports/dosbox-staging/package.sh
@@ -13,7 +13,6 @@ configopts=(
     '-Duse_png=false'
 )
 files="https://github.com/dosbox-staging/dosbox-staging/archive/refs/tags/v${version}.tar.gz v${version}.tar.gz 85359efb7cd5c5c0336d88bdf023b7b462a8233490e00274fef0b85cca2f5f3c"
-auth_type='sha256'
 depends=(
     'libslirp'
     'libpng'

--- a/Ports/dosfstools/package.sh
+++ b/Ports/dosfstools/package.sh
@@ -5,7 +5,6 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('config.sub')
 files="https://github.com/dosfstools/dosfstools/releases/download/v${version}/dosfstools-${version}.tar.gz dosfstools-${version}.tar.gz 64926eebf90092dca21b14259a5301b7b98e7b1943e8a201c7d726084809b527"
-auth_type='sha256'
 configopts=(
     "--enable-compat-symlinks"
 )

--- a/Ports/double-conversion/package.sh
+++ b/Ports/double-conversion/package.sh
@@ -2,7 +2,6 @@
 port='double-conversion'
 version='3.2.1'
 files="https://github.com/google/double-conversion/archive/refs/tags/v${version}.tar.gz ${port}-${version}.tar.gz e40d236343cad807e83d192265f139481c51fc83a1c49e406ac6ce0a0ba7cd35"
-auth_type='sha256'
 useconfigure='true'
 configopts=(
     "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"

--- a/Ports/drascula/package.sh
+++ b/Ports/drascula/package.sh
@@ -2,7 +2,6 @@
 port=drascula
 version="1.0"
 files="https://downloads.scummvm.org/frs/extras/Drascula_%20The%20Vampire%20Strikes%20Back/drascula-1.0.zip ${port}-${version}.zip b731f6cb5a22ba8b4c3b3362f570b9a10a67b6cb0b395394b19a94b36e4e42de"
-auth_type=sha256
 depends=("scummvm")
 
 resource_path="/usr/local/share/games/${port}-${version}"

--- a/Ports/dreamweb/package.sh
+++ b/Ports/dreamweb/package.sh
@@ -2,7 +2,6 @@
 port=dreamweb
 version="1.1"
 files="https://downloads.scummvm.org/frs/extras/Dreamweb/dreamweb-cd-uk-1.1.zip ${port}-${version}.zip 4a6f13911ce67d62c526e41048ec067b279f1b378c9210f39e0ce8d3f2b80142"
-auth_type=sha256
 depends=("scummvm")
 
 resource_path="/usr/local/share/games/${port}-${version}"

--- a/Ports/dropbear/package.sh
+++ b/Ports/dropbear/package.sh
@@ -2,7 +2,6 @@
 port=dropbear
 version=2022.82
 files="https://mirror.dropbear.nl/mirror/releases/dropbear-${version}.tar.bz2 dropbear-${version}.tar.bz2 3a038d2bbc02bf28bbdd20c012091f741a3ec5cbe460691811d714876aad75d1"
-auth_type="sha256"
 useconfigure=true
 use_fresh_config_sub=true
 # don't care about zlib, less deps is better

--- a/Ports/dtc/package.sh
+++ b/Ports/dtc/package.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port='dtc'
 version='1.7.0'
-auth_type='sha256'
 files="https://github.com/dgibson/dtc/archive/refs/tags/v${version}.tar.gz dtc-${version}.tar.gz 70d9c156ec86d63de0f7bdae50540ffa492b25ec1d69491c7520845c860b9a62"
 depends=('bash')
 

--- a/Ports/dungeonrush/package.sh
+++ b/Ports/dungeonrush/package.sh
@@ -4,7 +4,6 @@ version=1.1-beta
 useconfigure=true
 workdir="DungeonRush-${version}"
 files="https://github.com/Rapiz1/DungeonRush/archive/refs/tags/v${version}.tar.gz v${version}.tar.gz 295b83cb023bf5d21318992daee125399892bdf16a87c835dfc90b841c929eda"
-auth_type=sha256
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 depends=("SDL2" "SDL2_image" "SDL2_mixer" "SDL2_ttf" "SDL2_net")
 launcher_name="DungeonRush"

--- a/Ports/e2fsprogs/package.sh
+++ b/Ports/e2fsprogs/package.sh
@@ -2,5 +2,4 @@
 port='e2fsprogs'
 version='1.46.5'
 files="https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v${version}/e2fsprogs-${version}.tar.xz e2fsprogs-${version}.tar.xz 2f16c9176704cf645dc69d5b15ff704ae722d665df38b2ed3cfc249757d8d81e"
-auth_type='sha256'
 useconfigure='true'

--- a/Ports/ed/package.sh
+++ b/Ports/ed/package.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=ed
 version=1.18
-files="https://ftpmirror.gnu.org/gnu/ed/ed-${version}.tar.lz ed-${version}.tar.lz
-https://ftpmirror.gnu.org/gnu/ed/ed-${version}.tar.lz.sig ed-${version}.tar.lz.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg" "ed-${version}.tar.lz.sig")
+files="https://ftpmirror.gnu.org/gnu/ed/ed-${version}.tar.lz ed-${version}.tar.lz aca8efad9800c587724a20b97aa8fc47e6b5a47df81606feaba831b074462b4f"
+auth_type='sha256'
 useconfigure=true
 depends=("pcre2")
 

--- a/Ports/ed/package.sh
+++ b/Ports/ed/package.sh
@@ -2,7 +2,6 @@
 port=ed
 version=1.18
 files="https://ftpmirror.gnu.org/gnu/ed/ed-${version}.tar.lz ed-${version}.tar.lz aca8efad9800c587724a20b97aa8fc47e6b5a47df81606feaba831b074462b4f"
-auth_type='sha256'
 useconfigure=true
 depends=("pcre2")
 

--- a/Ports/edid-decode/package.sh
+++ b/Ports/edid-decode/package.sh
@@ -3,4 +3,3 @@ port='edid-decode'
 version='20220315.cb74358c2896'
 workdir="${port}-0.1~git${version}"
 files="https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/edid-decode/0.1~git${version}-1/edid-decode_0.1~git${version}.orig.tar.xz edid-decode_0.1~git${version}.orig.tar.xz 3cb9903663d71b571480ec5cfd88c4c8dd3e77d352b3e2533c3426d61ae296b2"
-auth_type='sha256'

--- a/Ports/editline/package.sh
+++ b/Ports/editline/package.sh
@@ -6,4 +6,3 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('aux/config.sub')
 files="https://github.com/troglobit/editline/releases/download/${version}/editline-${version}.tar.gz editline-${version}.tar.gz 781e03b6a935df75d99fb963551e2e9f09a714a8c49fc53280c716c90bf44d26"
-auth_type='sha256'

--- a/Ports/emu2/package.sh
+++ b/Ports/emu2/package.sh
@@ -2,7 +2,6 @@
 port=emu2
 version="2021.01"
 files="https://github.com/dmsc/emu2/archive/refs/tags/v${version}.tar.gz emu2-${version}.tar.gz 32ea656ad9b034d2c91a20f1a9ac1779cb6905a019c5bdeda9338cfd673bbd72"
-auth_type=sha256
 
 build() {
     export CC="${SERENITY_SOURCE_DIR}/Toolchain/Local/${SERENITY_ARCH}/bin/${SERENITY_ARCH}-pc-serenity-gcc"

--- a/Ports/epsilon/package.sh
+++ b/Ports/epsilon/package.sh
@@ -2,7 +2,6 @@
 port=epsilon
 version=15.5.0
 files="https://github.com/numworks/epsilon/archive/refs/tags/${version}.tar.gz ${port}-${version}.tar.gz 38c3b6baaf00863bbd179bce5e9cc42bbdbd0cd485b5bf3bbf4473383591bf83"
-auth_type=sha256
 makeopts=("PLATFORM=simulator" "TARGET=serenity" "SERENITY_INSTALL_ROOT=${SERENITY_INSTALL_ROOT}")
 depends=("SDL2" "libpng" "libjpeg" "freetype")
 launcher_name=Epsilon

--- a/Ports/expat/package.sh
+++ b/Ports/expat/package.sh
@@ -4,4 +4,3 @@ version='2.5.0'
 versionpath='2_5_0'
 useconfigure='true'
 files="https://github.com/libexpat/libexpat/releases/download/R_${versionpath}/expat-${version}.tar.xz expat-${version}.tar.xz ef2420f0232c087801abf705e89ae65f6257df6b7931d37846a193ef2e8cdcbe"
-auth_type='sha256'

--- a/Ports/ffmpeg/package.sh
+++ b/Ports/ffmpeg/package.sh
@@ -4,7 +4,6 @@ version=5.0
 useconfigure=true
 depends=("libiconv" "libtiff" "xz" "bzip2" "SDL2" "x264" "x265")
 files="https://ffmpeg.org/releases/ffmpeg-${version}.tar.gz ffmpeg-${version}.tar.gz 7bf52bc242b5db8df67c62cb826df134d917dedcf6abf1289e15e4057bcc1750"
-auth_type="sha256"
 installopts=("INSTALL_TOP=${SERENITY_INSTALL_ROOT}/usr/local")
 configopts=("SRC_PATH=.")
 

--- a/Ports/figlet/package.sh
+++ b/Ports/figlet/package.sh
@@ -2,7 +2,6 @@
 port=figlet
 version=2.2.5
 files="http://ftp.figlet.org/pub/figlet/program/unix/figlet-${version}.tar.gz figlet-${version}.tar.gz bf88c40fd0f077dab2712f54f8d39ac952e4e9f2e1882f1195be9e5e4257417d"
-auth_type=sha256
 
 build() {
     run make CC="${CC}" LD="${CC}" "${makeopts[@]}"

--- a/Ports/file/package.sh
+++ b/Ports/file/package.sh
@@ -5,4 +5,3 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('config.sub')
 files="http://ftp.astron.com/pub/file/file-${version}.tar.gz file-${version}.tar.gz 3751c7fba8dbc831cb8d7cc8aff21035459b8ce5155ef8b0880a27d028475f3b"
-auth_type='sha256'

--- a/Ports/findutils/package.sh
+++ b/Ports/findutils/package.sh
@@ -5,4 +5,3 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('build-aux/config.sub')
 files="https://ftpmirror.gnu.org/gnu/findutils/findutils-${version}.tar.xz findutils-${version}.tar.xz a2bfb8c09d436770edc59f50fa483e785b161a3b7b9d547573cb08065fd462fe"
-auth_type='sha256'

--- a/Ports/fio/package.sh
+++ b/Ports/fio/package.sh
@@ -2,7 +2,6 @@
 port='fio'
 version='3.33'
 files="https://brick.kernel.dk/snaps/${port}-${version}.tar.gz ${port}-${version}.tar.gz d2410e13e0f379d061d077cc5ae325835bb7c6186aa7bafc1df954cbc9b014fc"
-auth_type='sha256'
 depends=("zlib")
 
 export LDFLAGS='-ldl'

--- a/Ports/flac/package.sh
+++ b/Ports/flac/package.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port='flac'
 version='1.4.2'
-auth_type='sha256'
 useconfigure='true'
 depends=('libogg')
 files="https://downloads.xiph.org/releases/flac/flac-${version}.tar.xz flac-${version}.tar.xz e322d58a1f48d23d9dd38f432672865f6f79e73a6f9cc5a5f57fcaa83eb5a8e4"

--- a/Ports/flatbuffers/package.sh
+++ b/Ports/flatbuffers/package.sh
@@ -2,7 +2,6 @@
 
 port=flatbuffers
 version=2.0.0
-auth_type=sha256
 files="https://github.com/google/flatbuffers/archive/refs/tags/v${version}.tar.gz v${version}.tar.gz 9ddb9031798f4f8754d00fca2f1a68ecf9d0f83dfac7239af1311e4fd9a565c4"
 useconfigure=true
 # Since we are cross-compiling, we cannot build the tests, because we need

--- a/Ports/flex/package.sh
+++ b/Ports/flex/package.sh
@@ -7,4 +7,3 @@ use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 configopts=("--disable-bootstrap")
 depends=("m4" "pcre2")
-auth_type='sha256'

--- a/Ports/flex/package.sh
+++ b/Ports/flex/package.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=flex
 version=2.6.4
-files="https://github.com/westes/flex/releases/download/v${version}/flex-${version}.tar.gz flex-${version}.tar.gz
-https://github.com/westes/flex/releases/download/v${version}/flex-${version}.tar.gz.sig flex-${version}.tar.gz.sig"
+files="https://github.com/westes/flex/releases/download/v${version}/flex-${version}.tar.gz flex-${version}.tar.gz e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995"
 useconfigure=true
 use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 configopts=("--disable-bootstrap")
 depends=("m4" "pcre2")
-auth_type="sig"
-auth_import_key="E4B29C8D64885307"
-auth_opts=("flex-${version}.tar.gz.sig")
+auth_type='sha256'

--- a/Ports/fontconfig/package.sh
+++ b/Ports/fontconfig/package.sh
@@ -5,7 +5,6 @@ useconfigure="true"
 use_fresh_config_sub="true"
 depends=("libxml2" "freetype")
 files="https://www.freedesktop.org/software/fontconfig/release/fontconfig-${version}.tar.xz fontconfig-${version}.tar.xz dcbeb84c9c74bbfdb133d535fe1c7bedc9f2221a8daf3914b984c44c520e9bac"
-auth_type="sha256"
 configopts=(
     "--with-sysroot=${SERENITY_INSTALL_ROOT}"
     "--prefix=/usr/local"

--- a/Ports/fotaq/package.sh
+++ b/Ports/fotaq/package.sh
@@ -2,7 +2,6 @@
 port=fotaq
 version="1.0"
 files="https://downloads.scummvm.org/frs/extras/Flight%20of%20the%20Amazon%20Queen/FOTAQ_Talkie-original.zip ${port}-${version}.zip a298e68243f18a741d4816ef636a5a77a1593816fb2c9e23a09124c35a95dfec"
-auth_type=sha256
 depends=("scummvm")
 
 resource_path="/usr/local/share/games/${port}-${version}"

--- a/Ports/freeciv/package.sh
+++ b/Ports/freeciv/package.sh
@@ -6,7 +6,6 @@ use_fresh_config_sub=true
 config_sub_paths=("bootstrap/config.sub")
 configopts=("--enable-client=sdl2" "--enable-fcmp=no")
 files="http://files.freeciv.org/beta/freeciv-${version}.tar.xz freeciv-${version}.tar.xz 9f44dc28068b239c18bda68192ddb27622030880f8ab9c17f777eac28391269e"
-auth_type=sha256
 depends=("SDL2" "SDL2_image" "SDL2_mixer" "SDL2_ttf" "SDL2_gfx" "zstd" "libicu" "xz" "gettext" "curl")
 launcher_name=Freeciv
 launcher_category=Games

--- a/Ports/freedink/package.sh
+++ b/Ports/freedink/package.sh
@@ -8,7 +8,6 @@ depends=("SDL2" "SDL2_image" "SDL2_mixer" "SDL2_ttf" "SDL2_gfx" "gettext" "fontc
 freedink_data="freedink-data-1.08.20190120"
 files="https://ftpmirror.gnu.org/gnu/freedink/freedink-${version}.tar.gz freedink-${version}.tar.gz 5e0b35ac8f46d7bb87e656efd5f9c7c2ac1a6c519a908fc5b581e52657981002
 https://ftpmirror.gnu.org/gnu/freedink/${freedink_data}.tar.gz ${freedink_data}.tar.gz 715f44773b05b73a9ec9b62b0e152f3f281be1a1512fbaaa386176da94cffb9d"
-auth_type='sha256'
 configopts=("--prefix=/usr/local" "--disable-rpath" "--disable-tests" "LDFLAGS=-ldl -lfontconfig -lxml2")
 
 resource_path="/usr/local/share/games/dink"

--- a/Ports/freedink/package.sh
+++ b/Ports/freedink/package.sh
@@ -6,12 +6,9 @@ use_fresh_config_sub="true"
 config_sub_paths=("autotools/config.sub")
 depends=("SDL2" "SDL2_image" "SDL2_mixer" "SDL2_ttf" "SDL2_gfx" "gettext" "fontconfig" "glm")
 freedink_data="freedink-data-1.08.20190120"
-files="https://ftpmirror.gnu.org/gnu/freedink/freedink-${version}.tar.gz freedink-${version}.tar.gz
-https://ftpmirror.gnu.org/gnu/freedink/freedink-${version}.tar.gz.sig freedink-${version}.tar.gz.sig
-https://ftpmirror.gnu.org/gnu/freedink/${freedink_data}.tar.gz ${freedink_data}.tar.gz 715f44773b05b73a9ec9b62b0e152f3f281be1a1512fbaaa386176da94cffb9d
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg" "freedink-${version}.tar.gz.sig")
+files="https://ftpmirror.gnu.org/gnu/freedink/freedink-${version}.tar.gz freedink-${version}.tar.gz 5e0b35ac8f46d7bb87e656efd5f9c7c2ac1a6c519a908fc5b581e52657981002
+https://ftpmirror.gnu.org/gnu/freedink/${freedink_data}.tar.gz ${freedink_data}.tar.gz 715f44773b05b73a9ec9b62b0e152f3f281be1a1512fbaaa386176da94cffb9d"
+auth_type='sha256'
 configopts=("--prefix=/usr/local" "--disable-rpath" "--disable-tests" "LDFLAGS=-ldl -lfontconfig -lxml2")
 
 resource_path="/usr/local/share/games/dink"

--- a/Ports/freetype/package.sh
+++ b/Ports/freetype/package.sh
@@ -2,7 +2,6 @@
 port='freetype'
 version='2.13.0'
 files="https://download.savannah.gnu.org/releases/freetype/freetype-${version}.tar.gz freetype-${version}.tar.gz a7aca0e532a276ea8d85bd31149f0a74c33d19c8d287116ef8f5f8357b4f1f80"
-auth_type='sha256'
 useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=("builds/unix/config.sub")

--- a/Ports/frotz/package.sh
+++ b/Ports/frotz/package.sh
@@ -2,7 +2,6 @@
 port='frotz'
 version='2.54'
 files="https://gitlab.com/DavidGriffith/frotz/-/archive/${version}/frotz-${version}.tar.bz2 frotz-${version}.tar.bz2 bdf9131e6de49108c9f032200cea3cb4011e5ca0c9fbdbf5b0c05f7c56c81395"
-auth_type='sha256'
 depends=("ncurses")
 
 build() {

--- a/Ports/gawk/package.sh
+++ b/Ports/gawk/package.sh
@@ -3,4 +3,3 @@ port=gawk
 version=5.2.1
 useconfigure="true"
 files="https://ftpmirror.gnu.org/gnu/gawk/gawk-${version}.tar.gz gawk-${version}.tar.gz 529e7c8c6acf21ff3a6183f4d763c632810908989c24675c77995d51ac37b79c"
-auth_type='sha256'

--- a/Ports/gawk/package.sh
+++ b/Ports/gawk/package.sh
@@ -2,8 +2,5 @@
 port=gawk
 version=5.2.1
 useconfigure="true"
-files="https://ftpmirror.gnu.org/gnu/gawk/gawk-${version}.tar.gz gawk-${version}.tar.gz
-https://ftpmirror.gnu.org/gnu/gawk/gawk-${version}.tar.gz.sig gawk-${version}.tar.gz.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg" "gawk-${version}.tar.gz.sig")
+files="https://ftpmirror.gnu.org/gnu/gawk/gawk-${version}.tar.gz gawk-${version}.tar.gz 529e7c8c6acf21ff3a6183f4d763c632810908989c24675c77995d51ac37b79c"
+auth_type='sha256'

--- a/Ports/gcc/package.sh
+++ b/Ports/gcc/package.sh
@@ -7,7 +7,6 @@ files="https://ftpmirror.gnu.org/gnu/gcc/gcc-${version}/gcc-${version}.tar.xz gc
 makeopts=("all-gcc" "all-target-libgcc" "all-target-libstdc++-v3" "-j$(nproc)")
 installopts=("DESTDIR=${SERENITY_INSTALL_ROOT}" "install-gcc" "install-target-libgcc" "install-target-libstdc++-v3")
 depends=("binutils" "gmp" "mpfr" "mpc" "isl")
-auth_type="sha256"
 
 
 build() {

--- a/Ports/gdb/package.sh
+++ b/Ports/gdb/package.sh
@@ -7,7 +7,6 @@ files="https://ftpmirror.gnu.org/gnu/gdb/gdb-${version}.tar.xz gdb-${version}.ta
 makeopts+=("all")
 installopts=("DESTDIR=${SERENITY_INSTALL_ROOT}")
 depends=("gmp" "binutils")
-auth_type="sha256"
 
 # We only have a stub of getrusage(..)
 export ac_cv_func_getrusage=no

--- a/Ports/gemrb/package.sh
+++ b/Ports/gemrb/package.sh
@@ -3,7 +3,6 @@ port='gemrb'
 version='0.9.1'
 useconfigure='true'
 files="https://github.com/gemrb/gemrb/archive/refs/tags/v${version}.tar.gz gemrb-${version}.tar.gz 6e5dbcf7398d5566751f434b0d4647196bfbe9a813e3b65ad6a4ee2f1bbfb9ba"
-auth_type='sha256'
 depends=(
 	'freetype'
 	'libiconv'

--- a/Ports/genemu/package.sh
+++ b/Ports/genemu/package.sh
@@ -3,7 +3,6 @@ port=genemu
 version=e39f690157d8f969adfbaba30a4e639d20b34768
 useconfigure=true
 files="https://github.com/rasky/genemu/archive/${version}.tar.gz genemu-${version}.tar.gz 9b9616f6237e621a169422058caeccb2d0f4399374dc38f34837980154c89497"
-auth_type=sha256
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 depends=("SDL2")
 

--- a/Ports/genext2fs/package.sh
+++ b/Ports/genext2fs/package.sh
@@ -2,7 +2,6 @@
 port='genext2fs'
 version='1.5.0'
 files="https://github.com/bestouff/genext2fs/archive/v${version}.tar.gz genext2fs-${version}.tar.xz d3861e4fe89131bd21fbd25cf0b683b727b5c030c4c336fadcd738ada830aab0"
-auth_type='sha256'
 useconfigure='true'
 
 pre_patch() {

--- a/Ports/gettext/package.sh
+++ b/Ports/gettext/package.sh
@@ -3,7 +3,6 @@ port='gettext'
 version='0.21.1'
 useconfigure='true'
 files="https://ftpmirror.gnu.org/gettext/gettext-${version}.tar.gz gettext-${version}.tar.gz e8c3650e1d8cee875c4f355642382c1df83058bd5a11ee8555c0cf276d646d45"
-auth_type='sha256'
 depends=("libiconv")
 use_fresh_config_sub='true'
 config_sub_paths=("build-aux/config.sub" "libtextstyle/build-aux/config.sub")

--- a/Ports/git/package.sh
+++ b/Ports/git/package.sh
@@ -2,7 +2,6 @@
 port='git'
 version='2.40.0'
 files="https://mirrors.edge.kernel.org/pub/software/scm/git/git-${version}.tar.xz git-${version}.tar.xz b17a598fbf58729ef13b577465eb93b2d484df1201518b708b5044ff623bf46d"
-auth_type='sha256'
 useconfigure='true'
 configopts=("--target=${SERENITY_ARCH}-pc-serenity" "--with-lib=${SERENITY_INSTALL_ROOT}/usr/local" "CFLAGS=-DNO_IPV6" "LDFLAGS=-L${SERENITY_INSTALL_ROOT}/usr/local/lib")
 depends=("zlib" "curl")

--- a/Ports/glib/package.sh
+++ b/Ports/glib/package.sh
@@ -2,7 +2,6 @@
 port='glib'
 version='2.76.1'
 files="https://download.gnome.org/sources/glib/2.76/glib-${version}.tar.xz glib-${version}.tar.xz 43dc0f6a126958f5b454136c4398eab420249c16171a769784486e25f2fda19f"
-auth_type='sha256'
 useconfigure='true'
 configopts=("--cross-file" "${SERENITY_BUILD_DIR}/meson-cross-file.txt")
 depends=("libiconv" "libffi" "zlib" "gettext" "pcre")

--- a/Ports/glm/package.sh
+++ b/Ports/glm/package.sh
@@ -2,7 +2,6 @@
 port=glm
 version=0.9.9.8
 files="https://github.com/g-truc/glm/releases/download/${version}/glm-${version}.zip glm-${version}.zip 37e2a3d62ea3322e43593c34bae29f57e3e251ea89f4067506c94043769ade4c"
-auth_type=sha256
 depends=()
 workdir=glm
 useconfigure=true

--- a/Ports/gltron/package.sh
+++ b/Ports/gltron/package.sh
@@ -4,7 +4,6 @@ useconfigure='true'
 use_fresh_config_sub='true'
 version='0.70'
 files="http://mirror.sobukus.de/files/grimoire/games-arcade-2d/gltron-${version}-source.tar.gz gltron-${version}.tar.gz e0c8ebb41a18a1f8d7302a9c2cb466f5b1dd63e9a9966c769075e6b6bdad8bb0"
-auth_type='sha256'
 depends=("libpng" "glu" "SDL_sound" "sdl12-compat" "zlib")
 configopts=(
     "--disable-warn"

--- a/Ports/glu/package.sh
+++ b/Ports/glu/package.sh
@@ -3,7 +3,6 @@ port=glu
 useconfigure="true"
 version="9.0.2"
 files="https://archive.mesa3d.org/glu/glu-${version}.tar.gz glu-${version}.tar.gz 24effdfb952453cc00e275e1c82ca9787506aba0282145fff054498e60e19a65"
-auth_type=sha256
 depends=("pkgconf")
 use_fresh_config_sub=true
 

--- a/Ports/gmp/package.sh
+++ b/Ports/gmp/package.sh
@@ -2,8 +2,4 @@
 port=gmp
 version=6.2.1
 useconfigure="true"
-files="https://ftpmirror.gnu.org/gnu/gmp/gmp-${version}.tar.bz2 gmp-${version}.tar.bz2
-https://ftpmirror.gnu.org/gnu/gmp/gmp-${version}.tar.bz2.sig gmp-${version}.tar.bz2.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg" "gmp-${version}.tar.bz2.sig")
+files="https://ftpmirror.gnu.org/gnu/gmp/gmp-${version}.tar.bz2 gmp-${version}.tar.bz2 eae9326beb4158c386e39a356818031bd28f3124cf915f8c5b1dc4c7a36b4d7c"

--- a/Ports/gnuapl/package.sh
+++ b/Ports/gnuapl/package.sh
@@ -6,5 +6,4 @@ useconfigure="true"
 workdir="apl-${version}"
 configopts=("CXX_WERROR=no")
 files="https://ftpmirror.gnu.org/gnu/apl/apl-${version}.tar.gz apl-${version}.tar.gz 144f4c858a0d430ce8f28be90a35920dd8e0951e56976cb80b55053fa0d8bbcb"
-auth_type=sha256
 use_fresh_config_sub=true

--- a/Ports/gnucobol/package.sh
+++ b/Ports/gnucobol/package.sh
@@ -6,7 +6,6 @@ use_fresh_config_sub="true"
 config_sub_paths=("build_aux/config.sub")
 depends=("gmp" "gcc" "bash" "ncurses")
 files="https://ftpmirror.gnu.org/gnu/gnucobol/gnucobol-${version}.tar.bz2 gnucobol-${version}.tar.bz2 11181da708dbe65c7d047baadafb4bd49d5cde9b603bec0c842576a84e293fd5"
-auth_type='sha256'
 configopts=(
     "--with-sysroot=${SERENITY_INSTALL_ROOT}"
     "--prefix=/usr/local"

--- a/Ports/gnucobol/package.sh
+++ b/Ports/gnucobol/package.sh
@@ -5,11 +5,8 @@ useconfigure="true"
 use_fresh_config_sub="true"
 config_sub_paths=("build_aux/config.sub")
 depends=("gmp" "gcc" "bash" "ncurses")
-files="https://ftpmirror.gnu.org/gnu/gnucobol/gnucobol-${version}.tar.bz2 gnucobol-${version}.tar.bz2
-https://ftpmirror.gnu.org/gnu/gnucobol/gnucobol-${version}.tar.bz2.sig gnucobol-${version}.tar.bz2.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg" "gnucobol-${version}.tar.bz2.sig")
+files="https://ftpmirror.gnu.org/gnu/gnucobol/gnucobol-${version}.tar.bz2 gnucobol-${version}.tar.bz2 11181da708dbe65c7d047baadafb4bd49d5cde9b603bec0c842576a84e293fd5"
+auth_type='sha256'
 configopts=(
     "--with-sysroot=${SERENITY_INSTALL_ROOT}"
     "--prefix=/usr/local"

--- a/Ports/gnupg/package.sh
+++ b/Ports/gnupg/package.sh
@@ -11,7 +11,6 @@ configopts=("--with-libgpg-error-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
   "--with-npth-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
   "--disable-dirmngr")
 files="https://gnupg.org/ftp/gcrypt/gnupg/gnupg-${version}.tar.bz2 gnupg-${version}.tar.bz2 84c1ef39e8621cfb70f31463a5d1d8edeab44332bc1e0e1af9b78b6f9ed05bb4"
-auth_type=sha256
 depends=("libiconv" "libgpg-error" "libgcrypt" "libksba" "libassuan" "npth" "ntbtls")
 
 pre_configure() {

--- a/Ports/gnuplot/package.sh
+++ b/Ports/gnuplot/package.sh
@@ -4,7 +4,6 @@ version=5.2.8
 useconfigure=true
 # Note: gnuplot's source code is hosted on SourceForge, but using the GitHub mirror makes downloading a versioned .tar.gz easier.
 files="https://github.com/gnuplot/gnuplot/archive/${version}.tar.gz gnuplot-${version}.tar.gz b55f591e2ad9d01ffca821f2f91ce781b481bb5dd602ce5188bfad3140f44ac0"
-auth_type=sha256
 configopts=("--prefix=${SERENITY_INSTALL_ROOT}/usr/local" "--with-readline=builtin" "--without-latex")
 
 pre_configure() {

--- a/Ports/gperf/package.sh
+++ b/Ports/gperf/package.sh
@@ -4,5 +4,4 @@ version=3.1
 useconfigure="true"
 depends=()
 files="https://ftpmirror.gnu.org/gnu/gperf/gperf-${version}.tar.gz gperf-${version}.tar.gz 588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2"
-auth_type='sha256'
 configopts=("--prefix=/usr/local")

--- a/Ports/gperf/package.sh
+++ b/Ports/gperf/package.sh
@@ -3,9 +3,6 @@ port=gperf
 version=3.1
 useconfigure="true"
 depends=()
-files="https://ftpmirror.gnu.org/gnu/gperf/gperf-${version}.tar.gz gperf-${version}.tar.gz
-https://ftpmirror.gnu.org/gnu/gperf/gperf-${version}.tar.gz.sig gperf-${version}.tar.gz.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg" "gperf-${version}.tar.gz.sig")
+files="https://ftpmirror.gnu.org/gnu/gperf/gperf-${version}.tar.gz gperf-${version}.tar.gz 588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2"
+auth_type='sha256'
 configopts=("--prefix=/usr/local")

--- a/Ports/grep/package.sh
+++ b/Ports/grep/package.sh
@@ -4,4 +4,3 @@ version='3.10'
 files="https://ftpmirror.gnu.org/gnu/grep/grep-${version}.tar.gz grep-${version}.tar.gz de7b21d8e3348ea6569c6fd5734e90a31169ef62429ea3dce48a6fc1dd85d260"
 useconfigure='true'
 configopts=("--disable-perl-regexp")
-auth_type='sha256'

--- a/Ports/grep/package.sh
+++ b/Ports/grep/package.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port='grep'
 version='3.10'
-files="https://ftpmirror.gnu.org/gnu/grep/grep-${version}.tar.gz grep-${version}.tar.gz
-https://ftpmirror.gnu.org/gnu/grep/grep-${version}.tar.gz.sig grep-${version}.tar.gz.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-
+files="https://ftpmirror.gnu.org/gnu/grep/grep-${version}.tar.gz grep-${version}.tar.gz de7b21d8e3348ea6569c6fd5734e90a31169ef62429ea3dce48a6fc1dd85d260"
 useconfigure='true'
 configopts=("--disable-perl-regexp")
-auth_type='sig'
-auth_opts=("--keyring" "./gnu-keyring.gpg" "grep-${version}.tar.gz.sig")
+auth_type='sha256'

--- a/Ports/grepcidr/package.sh
+++ b/Ports/grepcidr/package.sh
@@ -2,4 +2,3 @@
 port='grepcidr'
 version='2.0'
 files="http://www.pc-tools.net/files/unix/grepcidr-${version}.tar.gz grepcidr-${version}.tar.gz 61886a377dabf98797145c31f6ba95e6837b6786e70c932324b7d6176d50f7fb"
-auth_type='sha256'

--- a/Ports/griffon/package.sh
+++ b/Ports/griffon/package.sh
@@ -2,7 +2,6 @@
 port=griffon
 version="1.0"
 files="https://downloads.scummvm.org/frs/extras/Griffon%20Legend/${port}-${version}.zip ${port}-${version}.zip 0aad5fb10f51afb5c121cf04cc86539a6f0d89db85809f9e1767dfdc8d3191a4"
-auth_type=sha256
 depends=("scummvm")
 
 resource_path="/usr/local/share/games/${port}-${version}"

--- a/Ports/gsl/package.sh
+++ b/Ports/gsl/package.sh
@@ -4,5 +4,4 @@ port=gsl
 version=2.7.1
 useconfigure=true
 files="https://ftpmirror.gnu.org/gnu/gsl/gsl-${version}.tar.gz gsl-${version}.tar.gz dcb0fbd43048832b757ff9942691a8dd70026d5da0ff85601e52687f6deeb34b"
-auth_type='sha256'
 use_fresh_config_sub=true

--- a/Ports/gsl/package.sh
+++ b/Ports/gsl/package.sh
@@ -3,9 +3,6 @@
 port=gsl
 version=2.7.1
 useconfigure=true
-files="https://ftpmirror.gnu.org/gnu/gsl/gsl-${version}.tar.gz gsl-${version}.tar.gz
-https://ftpmirror.gnu.org/gnu/gsl/gsl-${version}.tar.gz.sig gsl-${version}.tar.gz.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-auth_type=sig
-auth_opts=("--keyring" "./gnu-keyring.gpg" "gsl-${version}.tar.gz.sig")
+files="https://ftpmirror.gnu.org/gnu/gsl/gsl-${version}.tar.gz gsl-${version}.tar.gz dcb0fbd43048832b757ff9942691a8dd70026d5da0ff85601e52687f6deeb34b"
+auth_type='sha256'
 use_fresh_config_sub=true

--- a/Ports/guile/package.sh
+++ b/Ports/guile/package.sh
@@ -3,7 +3,6 @@ port=guile
 version=3.0.8
 files="https://ftpmirror.gnu.org/gnu/guile/guile-${version}.tar.gz guile-${version}.tar.gz f25ae0c26e911af1b5005292d4f56621879f74d6958b30741cf67d8b6feb2016"
 depends=("gmp" "libunistring" "libffi" "bdwgc" "libiconv")
-auth_type=sha256
 
 useconfigure=true
 use_fresh_config_sub=true

--- a/Ports/gzip/package.sh
+++ b/Ports/gzip/package.sh
@@ -5,4 +5,3 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('build-aux/config.sub')
 files="https://ftpmirror.gnu.org/gnu/gzip/gzip-${version}.tar.gz gzip-${version}.tar.gz 5b4fb14d38314e09f2fc8a1c510e7cd540a3ea0e3eb9b0420046b82c3bf41085"
-auth_type='sha256'

--- a/Ports/halflife/package.sh
+++ b/Ports/halflife/package.sh
@@ -6,7 +6,6 @@ useconfigure='true'
 depends=("xash3d-fwgs")
 workdir="hlsdk-portable-${_hlsdk_commit}"
 files="https://github.com/FWGS/hlsdk-portable/archive/${_hlsdk_commit}.tar.gz hlsdk-portable-${_hlsdk_commit}.tar.gz b010c94ed400e44508f43706aeea68b82615c6ad22d2b1b892e8d6201d97503d"
-auth_type='sha256'
 launcher_name='Half-Life'
 launcher_category='Games'
 launcher_command='sh /home/anon/Games/halflife/hl.sh'

--- a/Ports/harfbuzz/package.sh
+++ b/Ports/harfbuzz/package.sh
@@ -3,7 +3,6 @@ port='harfbuzz'
 version='4.3.0'
 files="https://github.com/harfbuzz/harfbuzz/releases/download/${version}/harfbuzz-${version}.tar.xz harfbuzz-${version}.tar.xz a49628f4c4c8e6d8df95ef44935a93446cf2e46366915b0e3ca30df21fffb530"
 useconfigure='true'
-auth_type='sha256'
 depends=("freetype" "libicu")
 configopts=(
     "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"

--- a/Ports/hatari/package.sh
+++ b/Ports/hatari/package.sh
@@ -7,7 +7,6 @@ commit=6a86f054cc560a858bbe60c7529dafe2cf6ec604
 workdir="${port}-${commit}"
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 files="https://github.com/hatari/hatari/archive/${commit}.tar.gz ${commit}.tar.gz bcb5d2e3bf3a3f8b34d21565354aa8eb085e3d92eb466c5d28e42e2022e7da3d"
-auth_type=sha256
 launcher_name=Hatari
 launcher_category=Games
 launcher_command=hatari

--- a/Ports/hexedit/package.sh
+++ b/Ports/hexedit/package.sh
@@ -2,7 +2,6 @@
 port='hexedit'
 version='1.6'
 files="https://github.com/pixel/hexedit/archive/refs/tags/${version}.tar.gz hexedit-${version}.tar.gz 598906131934f88003a6a937fab10542686ce5f661134bc336053e978c4baae3"
-auth_type='sha256'
 depends=("ncurses")
 useconfigure='true'
 

--- a/Ports/imagemagick/package.sh
+++ b/Ports/imagemagick/package.sh
@@ -4,6 +4,5 @@ version='7.1.1-5'
 workdir="ImageMagick-${version}"
 useconfigure="true"
 files="https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${version}.tar.gz ${port}-v${version}.tar.gz dd23689304b8cf41572c3af6b0ddccfe21c5b9d9abddaf978f314696408d0750"
-auth_type=sha256
 configopts=("--with-sysroot=${SERENITY_INSTALL_ROOT}")
 depends=("libpng" "libtiff" "libjpeg")

--- a/Ports/imgcat/package.sh
+++ b/Ports/imgcat/package.sh
@@ -5,4 +5,3 @@ useconfigure=true
 installopts=("PREFIX=${SERENITY_INSTALL_ROOT}/usr/local")
 depends=("ncurses" "libpng" "libjpeg" "termcap")
 files="https://github.com/eddieantonio/imgcat/releases/download/v${version}/imgcat-${version}.tar.gz imgcat-v${version}.tar.gz 8faaac392df315b4973bb6927c0eec659e879df6c15ad6f8461073e05b70c537"
-auth_type=sha256

--- a/Ports/indent/package.sh
+++ b/Ports/indent/package.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=indent
 version=2.2.11
-files="https://ftpmirror.gnu.org/gnu/indent/indent-${version}.tar.gz indent-${version}.tar.gz
-https://ftpmirror.gnu.org/gnu/indent/indent-${version}.tar.gz.sig indent-${version}.tar.gz.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="https://ftpmirror.gnu.org/gnu/indent/indent-${version}.tar.gz indent-${version}.tar.gz aaff60ce4d255efb985f0eb78cca4d1ad766c6e051666073050656b6753a0893"
+auth_type='sha256'
 useconfigure=true
 use_fresh_config_sub=true
 config_sub_paths=("config/config.sub")
-auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg" "indent-${version}.tar.gz.sig")
 
 post_install() {
     man_dir="${SERENITY_INSTALL_ROOT}/usr/local/share/man/man1/"

--- a/Ports/indent/package.sh
+++ b/Ports/indent/package.sh
@@ -2,7 +2,6 @@
 port=indent
 version=2.2.11
 files="https://ftpmirror.gnu.org/gnu/indent/indent-${version}.tar.gz indent-${version}.tar.gz aaff60ce4d255efb985f0eb78cca4d1ad766c6e051666073050656b6753a0893"
-auth_type='sha256'
 useconfigure=true
 use_fresh_config_sub=true
 config_sub_paths=("config/config.sub")

--- a/Ports/isl/package.sh
+++ b/Ports/isl/package.sh
@@ -4,7 +4,6 @@ version=0.24
 useconfigure=true
 use_fresh_config_sub=true
 files="https://libisl.sourceforge.io/isl-${version}.tar.xz isl-${version}.tar.xz 043105cc544f416b48736fff8caf077fb0663a717d06b1113f16e391ac99ebad"
-auth_type=sha256
 depends=("gmp")
 
 if [ "$SERENITY_TOOLCHAIN" = "Clang" ]; then

--- a/Ports/ja2/package.sh
+++ b/Ports/ja2/package.sh
@@ -4,7 +4,6 @@ version=0.15.x
 depends=("SDL2")
 workdir="ja2-stracciatella-${version}"
 files="https://github.com/ja2-stracciatella/ja2-stracciatella/archive/refs/heads/${version}.zip ja2-stracciatella-${version}.zip 178375de4859d16a76276c781455bf48d3fa862841387c8aa6cfa4162f4f0ca4"
-auth_type=sha256
 makeopts="SERENITY=1"
 launcher_name="Jagged Alliance 2"
 launcher_category=Games

--- a/Ports/jakt/package.sh
+++ b/Ports/jakt/package.sh
@@ -8,7 +8,6 @@ depends=(
 commit_hash='063e9767ff80db1a1cfe1a805cc8b7e2e577d9f3'
 archive_hash='0cb858291d0426e80c8378d7d5876a2a8de747467a289bb691782316c79a2f59'
 files="https://github.com/SerenityOS/jakt/archive/${commit_hash}.tar.gz jakt.tar.gz ${archive_hash}"
-auth_type='sha256'
 workdir="jakt-${commit_hash}"
 
 configure() {

--- a/Ports/jfduke3d/package.sh
+++ b/Ports/jfduke3d/package.sh
@@ -5,7 +5,6 @@ workdir="jfduke3d-${version}"
 launcher_name='Duke Nukem 3D'
 launcher_category='Games'
 launcher_command='duke3d'
-auth_type='sha256'
 depends=(
     'SDL2'
 )

--- a/Ports/joe/package.sh
+++ b/Ports/joe/package.sh
@@ -3,7 +3,6 @@ port=joe
 version=4.6
 files="https://sourceforge.net/projects/joe-editor/files/JOE%20sources/joe-${version}/joe-${version}.tar.gz/download joe-${version}.tar.gz 495a0a61f26404070fe8a719d80406dc7f337623788e445b92a9f6de512ab9de"
 useconfigure="true"
-auth_type=sha256
 configopts=(
     "--disable-curses"
     "--disable-termcap"

--- a/Ports/jot/package.sh
+++ b/Ports/jot/package.sh
@@ -2,5 +2,4 @@
 port=jot
 version=6.6
 files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/jot-${version}.tar.gz jot-${version}.tar.gz ad7d955e6a22b5c71d32479703cdac6f2c009765e7bf1bb860775f05b1e1d303"
-auth_type=sha256
 depends=("libpuffy")

--- a/Ports/jq/package.sh
+++ b/Ports/jq/package.sh
@@ -4,7 +4,6 @@ version=1.6
 useconfigure=true
 configopts=("--with-oniguruma=builtin" "--disable-maintainer-mode")
 files="https://github.com/stedolan/jq/releases/download/jq-${version}/jq-${version}.tar.gz jq-${version}.tar.gz 5de8c8e29aaa3fb9cc6b47bb27299f271354ebb72514e3accadc7d38b5bbaa72"
-auth_type=sha256
 makeopts=("LDFLAGS=-all-static")
 use_fresh_config_sub=true
 config_sub_paths=("config/config.sub" "modules/oniguruma/config.sub")

--- a/Ports/kakoune/package.sh
+++ b/Ports/kakoune/package.sh
@@ -2,7 +2,6 @@
 port='kakoune'
 version='24d6072353f7c7e7cac84b4eb085036a8c852f96'
 files="https://github.com/mawww/kakoune/archive/${version}.tar.gz ${version}.tar.gz 16440b204770972f318e24e4e178ada474b7cfeb029cefa69e9ff035700a129e"
-auth_type='sha256'
 depends=("bash" "sed")
 makeopts+=(
     "LDFLAGS=-L${DESTDIR}/usr/local/lib"

--- a/Ports/klong/package.sh
+++ b/Ports/klong/package.sh
@@ -2,6 +2,5 @@
 port=klong
 version=20220315
 files="http://t3x.org/klong/klong${version}.tgz klong${version}.tgz 018b75ca2b2ee86eabc9ac3b6c14b0a2aa9200998d4d860e04432fdc80285191"
-auth_type=sha256
 useconfigure=false
 workdir=klong

--- a/Ports/less/package.sh
+++ b/Ports/less/package.sh
@@ -4,7 +4,6 @@ version=590
 useconfigure="true"
 files="https://ftpmirror.gnu.org/gnu/less/less-${version}.tar.gz less-${version}.tar.gz 6aadf54be8bf57d0e2999a3c5d67b1de63808bb90deb8f77b028eafae3a08e10"
 depends=("ncurses")
-auth_type='sha256'
 
 post_configure() {
     run_replace_in_file "s/#define HAVE_WCTYPE 1/\/* #undef HAVE_WCTYPE *\//" defines.h

--- a/Ports/less/package.sh
+++ b/Ports/less/package.sh
@@ -2,13 +2,9 @@
 port=less
 version=590
 useconfigure="true"
-files="https://ftpmirror.gnu.org/gnu/less/less-${version}.tar.gz less-${version}.tar.gz
-https://ftpmirror.gnu.org/gnu/less/less-${version}.tar.gz.sig less-${version}.tar.gz.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-
+files="https://ftpmirror.gnu.org/gnu/less/less-${version}.tar.gz less-${version}.tar.gz 6aadf54be8bf57d0e2999a3c5d67b1de63808bb90deb8f77b028eafae3a08e10"
 depends=("ncurses")
-auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg" "less-${version}.tar.gz.sig")
+auth_type='sha256'
 
 post_configure() {
     run_replace_in_file "s/#define HAVE_WCTYPE 1/\/* #undef HAVE_WCTYPE *\//" defines.h

--- a/Ports/libarchive/package.sh
+++ b/Ports/libarchive/package.sh
@@ -7,6 +7,5 @@ config_sub_paths=("build/autoconf/config.sub")
 configopts=("--without-xml2")
 files="https://libarchive.org/downloads/libarchive-${version}.tar.gz libarchive-${version}.tar.gz c676146577d989189940f1959d9e3980d28513d74eedfbc6b7f15ea45fe54ee2"
 depends=("zlib" "pcre")
-auth_type='sha256'
 
 export ac_cv_header_regex_h=no

--- a/Ports/libarchive/package.sh
+++ b/Ports/libarchive/package.sh
@@ -5,11 +5,8 @@ useconfigure=true
 use_fresh_config_sub=true
 config_sub_paths=("build/autoconf/config.sub")
 configopts=("--without-xml2")
-files="https://libarchive.org/downloads/libarchive-${version}.tar.gz libarchive-${version}.tar.gz
-https://libarchive.org/downloads/libarchive-${version}.tar.gz.asc libarchive-${version}.tar.gz.asc"
+files="https://libarchive.org/downloads/libarchive-${version}.tar.gz libarchive-${version}.tar.gz c676146577d989189940f1959d9e3980d28513d74eedfbc6b7f15ea45fe54ee2"
 depends=("zlib" "pcre")
-auth_type="sig"
-auth_import_key="A5A45B12AD92D964B89EEE2DEC560C81CEC2276E"
-auth_opts=("libarchive-${version}.tar.gz.asc" "libarchive-${version}.tar.gz")
+auth_type='sha256'
 
 export ac_cv_header_regex_h=no

--- a/Ports/libassuan/package.sh
+++ b/Ports/libassuan/package.sh
@@ -6,7 +6,6 @@ use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 depends=("libgpg-error")
 files="https://gnupg.org/ftp/gcrypt/libassuan/libassuan-${version}.tar.bz2 libassuan-${version}.tar.bz2 8e8c2fcc982f9ca67dcbb1d95e2dc746b1739a4668bc20b3a3c5be632edb34e4"
-auth_type=sha256
 configopts=(
     "--with-libgpg-error-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
 )

--- a/Ports/libatomic_ops/package.sh
+++ b/Ports/libatomic_ops/package.sh
@@ -5,4 +5,3 @@ version=7.6.12
 useconfigure=true
 use_fresh_config_sub=true
 files="https://www.hboehm.info/gc/gc_source/libatomic_ops-${version}.tar.gz libatomic_ops-${version}.tar.gz f0ab566e25fce08b560e1feab6a3db01db4a38e5bc687804334ef3920c549f3e"
-auth_type=sha256

--- a/Ports/libexpat/package.sh
+++ b/Ports/libexpat/package.sh
@@ -6,4 +6,3 @@ use_fresh_config_sub=true
 config_sub_paths=("conftools/config.sub")
 files="https://github.com/libexpat/libexpat/releases/download/R_${version//./_}/expat-${version}.tar.xz expat-${version}.tar.xz f79b8f904b749e3e0d20afeadecf8249c55b2e32d4ebb089ae378df479dcaf25"
 workdir=expat-${version}
-auth_type='sha256'

--- a/Ports/libexpat/package.sh
+++ b/Ports/libexpat/package.sh
@@ -4,9 +4,6 @@ version=2.4.8
 useconfigure=true
 use_fresh_config_sub=true
 config_sub_paths=("conftools/config.sub")
-files="https://github.com/libexpat/libexpat/releases/download/R_${version//./_}/expat-${version}.tar.xz expat-${version}.tar.xz
-https://github.com/libexpat/libexpat/releases/download/R_${version//./_}/expat-${version}.tar.xz.asc expat-${version}.tar.xz.asc"
+files="https://github.com/libexpat/libexpat/releases/download/R_${version//./_}/expat-${version}.tar.xz expat-${version}.tar.xz f79b8f904b749e3e0d20afeadecf8249c55b2e32d4ebb089ae378df479dcaf25"
 workdir=expat-${version}
-auth_type="sig"
-auth_import_key="CB8DE70A90CFBF6C3BF5CC5696262ACFFBD3AEC6"
-auth_opts=("expat-${version}.tar.xz.asc" "expat-${version}.tar.xz")
+auth_type='sha256'

--- a/Ports/libffi/package.sh
+++ b/Ports/libffi/package.sh
@@ -4,4 +4,3 @@ version=3.4.2
 useconfigure=true
 use_fresh_config_sub=true
 files="https://github.com/libffi/libffi/releases/download/v${version}/libffi-${version}.tar.gz libffi-${version}.tar.gz 540fb721619a6aba3bdeef7d940d8e9e0e6d2c193595bc243241b77ff9e93620"
-auth_type=sha256

--- a/Ports/libfftw3f/package.sh
+++ b/Ports/libfftw3f/package.sh
@@ -5,5 +5,4 @@ useconfigure=true
 configopts=("--enable-float")
 use_fresh_config_sub=true
 files="http://fftw.org/fftw-${version}.tar.gz fftw-${version}.tar.gz 56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467"
-auth_type=sha256
 workdir="fftw-${version}"

--- a/Ports/libgcrypt/package.sh
+++ b/Ports/libgcrypt/package.sh
@@ -7,7 +7,6 @@ config_sub_paths=("build-aux/config.sub")
 configopts=("--with-libgpg-error-prefix=${SERENITY_INSTALL_ROOT}/usr/local")
 depends=("libgpg-error")
 files="https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${version}.tar.bz2 libgcrypt-${version}.tar.bz2 ef14ae546b0084cd84259f61a55e07a38c3b53afc0f546bffcef2f01baffe9de"
-auth_type=sha256
 
 pre_configure() {
     export ac_cv_lib_pthread_pthread_create=no

--- a/Ports/libgd/package.sh
+++ b/Ports/libgd/package.sh
@@ -6,5 +6,4 @@ use_fresh_config_sub=true
 configopts=("--without-x")
 config_sub_paths=("config/config.sub")
 files="https://github.com/libgd/libgd/releases/download/gd-${version}/libgd-${version}.tar.gz libgd-${version}.tar.gz dd3f1f0bb016edcc0b2d082e8229c822ad1d02223511997c80461481759b1ed2"
-auth_type=sha256
 depends=("libpng")

--- a/Ports/libgpg-error/package.sh
+++ b/Ports/libgpg-error/package.sh
@@ -2,7 +2,6 @@
 port='libgpg-error'
 version='1.45'
 files="https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-${version}.tar.bz2 libgpg-error-${version}.tar.bz2 570f8ee4fb4bff7b7495cff920c275002aea2147e9a1d220c068213267f80a26"
-auth_type='sha256'
 useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=("build-aux/config.sub")

--- a/Ports/libiconv/package.sh
+++ b/Ports/libiconv/package.sh
@@ -2,7 +2,6 @@
 port='libiconv'
 version='1.17'
 files="https://ftpmirror.gnu.org/gnu/libiconv/libiconv-${version}.tar.gz libiconv-${version}.tar.gz 8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313"
-auth_type='sha256'
 useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=("build-aux/config.sub" "libcharset/build-aux/config.sub")

--- a/Ports/libicu/package.sh
+++ b/Ports/libicu/package.sh
@@ -5,7 +5,6 @@ useconfigure=true
 use_fresh_config_sub=true
 workdir=icu/source
 files="https://github.com/unicode-org/icu/releases/download/release-${version//./-}/icu4c-${version//./_}-src.tgz icu4c-${version//./_}-src.tgz 4cba7b7acd1d3c42c44bb0c14be6637098c7faf2b330ce876bc5f3b915d09745"
-auth_type=sha256
 
 configure() {
     host_env

--- a/Ports/libjpeg/package.sh
+++ b/Ports/libjpeg/package.sh
@@ -4,5 +4,4 @@ version=9e
 useconfigure=true
 configopts=("--disable-static" "--enable-shared")
 files="https://ijg.org/files/jpegsrc.v${version}.tar.gz jpeg-${version}.tar.gz 4077d6a6a75aeb01884f708919d25934c93305e49f7e3f36db9129320e6f4f3d"
-auth_type=sha256
 workdir="jpeg-$version"

--- a/Ports/libksba/package.sh
+++ b/Ports/libksba/package.sh
@@ -6,7 +6,6 @@ use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 depends=("libgpg-error")
 files="https://gnupg.org/ftp/gcrypt/libksba/libksba-${version}.tar.bz2 libksba-${version}.tar.bz2 b0f4c65e4e447d9a2349f6b8c0e77a28be9531e4548ba02c545d1f46dc7bf921"
-auth_type=sha256
 configopts=(
     "--with-libgpg-error-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
 )

--- a/Ports/libmad/package.sh
+++ b/Ports/libmad/package.sh
@@ -6,4 +6,3 @@ use_fresh_config_sub=true
 use_fresh_config_guess=true
 configopts=("--disable-static")
 files="https://downloads.sourceforge.net/mad/libmad-${version}.tar.gz libmad-${version}.tar.gz bbfac3ed6bfbc2823d3775ebb931087371e142bb0e9bb1bee51a76a6e0078690"
-auth_type=sha256

--- a/Ports/libmikmod/package.sh
+++ b/Ports/libmikmod/package.sh
@@ -6,7 +6,6 @@ configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 use_fresh_config_sub=true
 config_sub_paths=("autotools/config.sub")
 files="https://downloads.sourceforge.net/project/mikmod/libmikmod/${version}/libmikmod-${version}.tar.gz libmikmod-${version}.tar.gz ad9d64dfc8f83684876419ea7cd4ff4a41d8bcd8c23ef37ecb3a200a16b46d19"
-auth_type=sha256
 
 configure() {
     run cmake "${configopts[@]}" .

--- a/Ports/libmodplug/package.sh
+++ b/Ports/libmodplug/package.sh
@@ -5,5 +5,4 @@ useconfigure=true
 use_fresh_config_sub=true
 configopts=("ac_cv_c_bigendian=no")
 files="https://download.sourceforge.net/modplug-xmms/libmodplug-${version}.tar.gz libmodplug-${version}.tar.gz 457ca5a6c179656d66c01505c0d95fafaead4329b9dbaa0f997d00a3508ad9de"
-auth_type=sha256
 workdir="libmodplug-$version"

--- a/Ports/libmpeg2/package.sh
+++ b/Ports/libmpeg2/package.sh
@@ -6,4 +6,3 @@ use_fresh_config_sub=true
 config_sub_paths=(".auto/config.sub")
 configopts=("--disable-sdl")
 files="https://libmpeg2.sourceforge.io/files/libmpeg2-${version}.tar.gz libmpeg2-${version}.tar.gz dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4"
-auth_type=sha256

--- a/Ports/libmpg123/package.sh
+++ b/Ports/libmpg123/package.sh
@@ -6,4 +6,3 @@ workdir=mpg123-${version}
 use_fresh_config_sub=true
 config_sub_paths=("build/config.sub")
 files="https://download.sourceforge.net/project/mpg123/mpg123/${version}/mpg123-${version}.tar.bz2 mpg123-${version}.tar.bz2 963885d8cc77262f28b77187c7d189e32195e64244de2530b798ddf32183e847"
-auth_type='sha256'

--- a/Ports/libogg/package.sh
+++ b/Ports/libogg/package.sh
@@ -5,4 +5,3 @@ useconfigure=true
 configopts=("--disable-static" "--enable-shared")
 use_fresh_config_sub=true
 files="https://github.com/xiph/ogg/releases/download/v${version}/libogg-${version}.tar.gz libogg-${version}.tar.gz 0eb4b4b9420a0f51db142ba3f9c64b333f826532dc0f48c6410ae51f4799b664"
-auth_type=sha256

--- a/Ports/liboggz/package.sh
+++ b/Ports/liboggz/package.sh
@@ -4,5 +4,4 @@ version=1.1.1
 useconfigure=true
 use_fresh_config_sub=true
 files="https://downloads.xiph.org/releases/liboggz/liboggz-${version}.tar.gz liboggz-${version}.tar.gz 6bafadb1e0a9ae4ac83304f38621a5621b8e8e32927889e65a98706d213d415a"
-auth_type=sha256
 depends=("libogg")

--- a/Ports/libopenal/package.sh
+++ b/Ports/libopenal/package.sh
@@ -12,7 +12,6 @@ configopts=(
     '-DALSOFT_BACKEND_SDL2=ON'
 )
 files="https://openal-soft.org/openal-releases/openal-soft-${version}.tar.bz2 openal-soft-${version}.tar.bz2 c8ad767e9a3230df66756a21cc8ebf218a9d47288f2514014832204e666af5d8"
-auth_type=sha256
 
 configure() {
     run cmake "${configopts[@]}"

--- a/Ports/libopus/package.sh
+++ b/Ports/libopus/package.sh
@@ -5,4 +5,3 @@ workdir='opus-1.3.1'
 useconfigure='true'
 use_fresh_config_sub='true'
 files="https://archive.mozilla.org/pub/opus/opus-${version}.tar.gz opus-${version}.tar.gz 65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d"
-auth_type='sha256'

--- a/Ports/libphysfs/package.sh
+++ b/Ports/libphysfs/package.sh
@@ -5,7 +5,6 @@ version=3.0.2
 workdir="physfs-${version}"
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 files="https://icculus.org/physfs/downloads/physfs-${version}.tar.bz2 physfs-${version}.tar.bz2 304df76206d633df5360e738b138c94e82ccf086e50ba84f456d3f8432f9f863"
-auth_type=sha256
 
 configure() {
     run cmake "${configopts[@]}"

--- a/Ports/libpng/package.sh
+++ b/Ports/libpng/package.sh
@@ -5,5 +5,4 @@ useconfigure='true'
 configopts=("--disable-static" "--enable-shared")
 use_fresh_config_sub='true'
 files="https://download.sourceforge.net/libpng/libpng-${version}.tar.gz libpng-${version}.tar.gz af4fb7f260f839919e5958e5ab01a275d4fe436d45442a36ee62f73e5beb75ba"
-auth_type='sha256'
 depends=("zlib")

--- a/Ports/libpuffy/package.sh
+++ b/Ports/libpuffy/package.sh
@@ -2,4 +2,3 @@
 port=libpuffy
 version=1.0
 files="https://github.com/ibara/libpuffy/releases/download/libpuffy-${version}/libpuffy-${version}.tar.gz libpuffy-${version}.tar.gz 919bb025fed88227fe464116194c978513a864a223542f50c59a7c17b0dd9caa"
-auth_type=sha256

--- a/Ports/libsamplerate/package.sh
+++ b/Ports/libsamplerate/package.sh
@@ -9,4 +9,3 @@ configopts=(
     '--enable-shared'
 )
 files="https://github.com/libsndfile/libsamplerate/releases/download/${version}/libsamplerate-${version}.tar.xz libsamplerate-${version}.tar.xz 3258da280511d24b49d6b08615bbe824d0cacc9842b0e4caf11c52cf2b043893"
-auth_type='sha256'

--- a/Ports/libsixel/package.sh
+++ b/Ports/libsixel/package.sh
@@ -4,7 +4,6 @@ version=1.8.6
 files="https://github.com/saitoha/libsixel/archive/refs/tags/v${version}.tar.gz ${port}-${version}.tar.gz 37611d60c7dbcee701346967336dbf135fdd5041024d5f650d52fae14c731ab9"
 useconfigure=true
 use_fresh_config_sub=true
-auth_type=sha256
 configopts=("--prefix=${SERENITY_INSTALL_ROOT}/usr/local")
 
 install() {

--- a/Ports/libslirp/package.sh
+++ b/Ports/libslirp/package.sh
@@ -3,7 +3,6 @@ port='libslirp'
 version='4.7.0'
 workdir="libslirp-v${version}"
 files="https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v${version}/libslirp-v${version}.tar.gz libslirp-v${version}.tar.xz 9398f0ec5a581d4e1cd6856b88ae83927e458d643788c3391a39e61b75db3d3b"
-auth_type='sha256'
 useconfigure='true'
 configopts=("--cross-file=${SERENITY_BUILD_DIR}/meson-cross-file.txt")
 depends=('glib')

--- a/Ports/libsodium/package.sh
+++ b/Ports/libsodium/package.sh
@@ -7,4 +7,3 @@ use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 workdir=libsodium-${version}
 files="https://download.libsodium.org/libsodium/releases/libsodium-${version}.tar.gz libsodium-${version}.tar.gz 6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1"
-auth_type=sha256

--- a/Ports/libssh2/package.sh
+++ b/Ports/libssh2/package.sh
@@ -2,12 +2,9 @@
 port=libssh2
 version=1.10.0
 useconfigure=true
-files="https://www.libssh2.org/download/libssh2-${version}.tar.gz libssh2-${version}.tar.gz
-https://www.libssh2.org/download/libssh2-${version}.tar.gz.asc libssh2-${version}.tar.gz.asc"
+files="https://www.libssh2.org/download/libssh2-${version}.tar.gz libssh2-${version}.tar.gz 2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51"
 depends=("libgcrypt")
-auth_type="sig"
-auth_import_key="27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2"
-auth_opts=("libssh2-${version}.tar.gz.asc" "libssh2-${version}.tar.gz")
+auth_type='sha256'
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt" "-GNinja")
 
 configure() {

--- a/Ports/libssh2/package.sh
+++ b/Ports/libssh2/package.sh
@@ -4,7 +4,6 @@ version=1.10.0
 useconfigure=true
 files="https://www.libssh2.org/download/libssh2-${version}.tar.gz libssh2-${version}.tar.gz 2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51"
 depends=("libgcrypt")
-auth_type='sha256'
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt" "-GNinja")
 
 configure() {

--- a/Ports/libtheora/package.sh
+++ b/Ports/libtheora/package.sh
@@ -5,6 +5,5 @@ useconfigure=true
 configopts=()
 use_fresh_config_sub=true
 files="https://ftp.osuosl.org/pub/xiph/releases/theora/libtheora-${version}.tar.bz2 libtheora-${version}.tar.bz2 b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc"
-auth_type="sha256"
 depends=("libvorbis")
 configopts=("--disable-examples" "--disable-static" "--enable-shared")

--- a/Ports/libtiff/package.sh
+++ b/Ports/libtiff/package.sh
@@ -2,7 +2,6 @@
 port='libtiff'
 version='4.5.0'
 files="http://download.osgeo.org/libtiff/tiff-${version}.tar.xz tiff-${version}.tar.xz dafac979c5e7b6c650025569c5a4e720995ba5f17bc17e6276d1f12427be267c"
-auth_type='sha256'
 useconfigure='true'
 configopts=(
     "--with-sysroot=${SERENITY_INSTALL_ROOT}"

--- a/Ports/libtool/package.sh
+++ b/Ports/libtool/package.sh
@@ -6,7 +6,6 @@ use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 depends=("bash" "sed")
 files="https://ftpmirror.gnu.org/gnu/libtool/libtool-${version}.tar.xz libtool-${version}.tar.xz 4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d"
-auth_type='sha256'
 configopts=("--prefix=/usr/local")
 
 post_install() {

--- a/Ports/libtool/package.sh
+++ b/Ports/libtool/package.sh
@@ -5,11 +5,8 @@ useconfigure=true
 use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 depends=("bash" "sed")
-files="https://ftpmirror.gnu.org/gnu/libtool/libtool-${version}.tar.xz libtool-${version}.tar.xz
-https://ftpmirror.gnu.org/gnu/libtool/libtool-${version}.tar.xz.sig libtool-${version}.tar.xz.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-auth_type=sig
-auth_opts=("--keyring" "./gnu-keyring.gpg" "libtool-${version}.tar.xz.sig")
+files="https://ftpmirror.gnu.org/gnu/libtool/libtool-${version}.tar.xz libtool-${version}.tar.xz 4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d"
+auth_type='sha256'
 configopts=("--prefix=/usr/local")
 
 post_install() {

--- a/Ports/libunistring/package.sh
+++ b/Ports/libunistring/package.sh
@@ -2,6 +2,5 @@
 port=libunistring
 version=1.0
 files="https://ftpmirror.gnu.org/gnu/libunistring/libunistring-${version}.tar.gz libunistring-${version}.tar.gz 3c0184c0e492d7c208ce31d25dd1d2c58f0c3ed6cbbe032c5b248cddad318544"
-auth_type=sha256
 
 useconfigure=true

--- a/Ports/libuuid/package.sh
+++ b/Ports/libuuid/package.sh
@@ -8,4 +8,3 @@ configopts=("--prefix=/usr/local" "--disable-all-programs" "--enable-libuuid")
 files="https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v${version}/util-linux-${version}.tar.gz util-linux-${version}.tar.gz c31d4e54f30b56b0f7ec8b342658c07de81378f2c067941c2b886da356f8ad42"
 use_fresh_config_sub=true
 config_sub_paths=("config/config.sub")
-auth_type=sha256

--- a/Ports/libuv/package.sh
+++ b/Ports/libuv/package.sh
@@ -3,7 +3,6 @@ port=libuv
 version=1.44.1
 useconfigure=true
 files="https://github.com/libuv/libuv/archive/refs/tags/v$version.tar.gz $port-$version.tar.gz e91614e6dc2dd0bfdd140ceace49438882206b7a6fb00b8750914e67a9ed6d6b"
-auth_type=sha256
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt" "-GNinja" "-DCMAKE_BUILD_WITH_INSTALL_RPATH=true")
 
 configure() {

--- a/Ports/libvorbis/package.sh
+++ b/Ports/libvorbis/package.sh
@@ -5,7 +5,6 @@ useconfigure=true
 configopts=("--disable-static" "--enable-shared")
 use_fresh_config_sub=true
 files="https://github.com/xiph/vorbis/releases/download/v${version}/libvorbis-${version}.tar.gz libvorbis-${version}.tar.gz 0e982409a9c3fc82ee06e08205b1355e5c6aa4c36bca58146ef399621b0ce5ab"
-auth_type=sha256
 depends=("libogg")
 
 post_install() {

--- a/Ports/libxml2/package.sh
+++ b/Ports/libxml2/package.sh
@@ -2,7 +2,6 @@
 port='libxml2'
 version='2.9.14'
 files="https://download.gnome.org/sources/libxml2/2.9/libxml2-${version}.tar.xz libxml2-${version}.tar.xz 60d74a257d1ccec0475e749cba2f21559e48139efba6ff28224357c7c798dfee"
-auth_type='sha256'
 useconfigure='true'
 use_fresh_config_sub='true'
 configopts=("--with-sysroot=${SERENITY_INSTALL_ROOT}" "--prefix=/usr/local" "--without-python" "--disable-static" "--enable-shared")

--- a/Ports/libyaml/package.sh
+++ b/Ports/libyaml/package.sh
@@ -2,7 +2,6 @@
 port='libyaml'
 version='0.2.5'
 files="https://github.com/yaml/libyaml/releases/download/${version}/yaml-${version}.tar.gz yaml-${version}.tar.gz c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4"
-auth_type='sha256'
 useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=("config/config.sub")

--- a/Ports/libzip/package.sh
+++ b/Ports/libzip/package.sh
@@ -2,7 +2,6 @@
 port='libzip'
 version='1.8.0'
 files="https://libzip.org/download/libzip-${version}.tar.gz libzip-${version}.tar.gz 30ee55868c0a698d3c600492f2bea4eb62c53849bcf696d21af5eb65f3f3839e"
-auth_type='sha256'
 useconfigure='true'
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 depends=("zlib")

--- a/Ports/links/package.sh
+++ b/Ports/links/package.sh
@@ -3,4 +3,3 @@ port='links'
 version='2.26'
 useconfigure='true'
 files="http://links.twibright.com/download/links-${version}.tar.bz2 links-${version}.tar.bz2 f05b3577f25dbe63e491c424f0ecb31f7bfadce9b2bc2f111dfed049c004c9cb"
-auth_type='sha256'

--- a/Ports/lite-xl/package.sh
+++ b/Ports/lite-xl/package.sh
@@ -15,7 +15,6 @@ depends=(
 )
 files="https://github.com/lite-xl/lite-xl/archive/${commit_hash}.tar.gz lite-xl-97ba91af8.tar.gz 25a0dd0a6ef856fd312eecd54983d401224eb8d7a5d5aa4a37c9131ac77bd9ca"
 workdir="lite-xl-${commit_hash}"
-auth_type='sha256'
 launcher_name='Lite-XL'
 icon_file='resources/icons/icon.ico'
 launcher_category='Development'

--- a/Ports/llvm/package.sh
+++ b/Ports/llvm/package.sh
@@ -7,7 +7,6 @@ configopts=(
     "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"
 )
 files="https://github.com/llvm/llvm-project/releases/download/llvmorg-${version}/llvm-project-${version}.src.tar.xz llvm-project-${version}.src.tar.xz ce5e71081d17ce9e86d7cbcfa28c4b04b9300f8fb7e78422b1feb6bc52c3028e"
-auth_type='sha256'
 depends=(
     "ncurses"
     "zlib"

--- a/Ports/lowdown/package.sh
+++ b/Ports/lowdown/package.sh
@@ -5,7 +5,6 @@ version='1.0.2'
 workdir="lowdown-VERSION_${version//./_}"
 files="https://github.com/kristapsdz/lowdown/archive/refs/tags/VERSION_${version//./_}.tar.gz lowdown-${version}.tar.gz 049b7883874f8a8e528dc7c4ed7b27cf7ceeb9ecf8fe71c3a8d51d574fddf84b"
 useconfigure='true'
-auth_type='sha256'
 
 configure() {
     run ./configure

--- a/Ports/lrzip/package.sh
+++ b/Ports/lrzip/package.sh
@@ -4,7 +4,6 @@ version='0.651'
 useconfigure='true'
 use_fresh_config_sub='true'
 files="http://ck.kolivas.org/apps/lrzip/lrzip-${version}.tar.xz lrzip-${version}.tar.xz 48bd8decb097c1596c9b3777959cd3e332819434ed77a2823e65aa436f1602f9"
-auth_type='sha256'
 depends=(
   'bzip2'
   'lz4'

--- a/Ports/lua/package.sh
+++ b/Ports/lua/package.sh
@@ -3,7 +3,6 @@ port='lua'
 version='5.4.4'
 files="http://www.lua.org/ftp/lua-${version}.tar.gz lua-${version}.tar.gz 164c7849653b80ae67bec4b7473b884bf5cc8d2dca05653475ec2ed27b9ebf61"
 depends=("readline")
-auth_type='sha256'
 makeopts=(
     "-Csrc/"
     "-j$(nproc)"

--- a/Ports/luajit/package.sh
+++ b/Ports/luajit/package.sh
@@ -3,7 +3,6 @@ port=luajit
 version=2.1.0-beta3
 useconfigure=true
 files="https://luajit.org/download/LuaJIT-${version}.tar.gz LuaJIT-${version}.tar.gz 1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
-auth_type=sha256
 workdir="LuaJIT-${version}"
 
 if [ ${SERENITY_ARCH} = "x86_64" ]; then

--- a/Ports/luarocks/package.sh
+++ b/Ports/luarocks/package.sh
@@ -4,7 +4,6 @@ version=3.8.0
 useconfigure=true
 depends=("lua" "git" "readline")
 files="https://luarocks.org/releases/luarocks-${version}.tar.gz luarocks-${version}.tar.gz 56ab9b90f5acbc42eb7a94cf482e6c058a63e8a1effdf572b8b2a6323a06d923"
-auth_type=sha256
 
 configure() {
     run ./configure --with-lua-include=${SERENITY_INSTALL_ROOT}/usr/local/include --prefix=/usr/local --with-lua-interpreter=lua

--- a/Ports/lure/package.sh
+++ b/Ports/lure/package.sh
@@ -2,7 +2,6 @@
 port=lure
 version="1.1"
 files="https://downloads.scummvm.org/frs/extras/Lure%20of%20the%20Temptress/lure-1.1.zip ${port}-${version}.zip f3178245a1483da1168c3a11e70b65d33c389f1f5df63d4f3a356886c1890108"
-auth_type=sha256
 depends=("scummvm")
 workdir="lure"
 

--- a/Ports/lynx/package.sh
+++ b/Ports/lynx/package.sh
@@ -3,7 +3,6 @@ port='lynx'
 version='2.8.9rel.1'
 files="https://invisible-island.net/archives/lynx/tarballs/lynx${version}.tar.bz2 lynx${version}.tar.bz2 387f193d7792f9cfada14c60b0e5c0bff18f227d9257a39483e14fa1aaf79595"
 workdir="lynx${version}"
-auth_type='sha256'
 depends=('ncurses' 'openssl' 'zlib')
 useconfigure='true'
 use_fresh_config_sub='true'

--- a/Ports/lz4/package.sh
+++ b/Ports/lz4/package.sh
@@ -2,4 +2,3 @@
 port='lz4'
 version='1.9.4'
 files="https://github.com/lz4/lz4/archive/refs/tags/v${version}.tar.gz lz4-${version}.tar.gz 0b0e3aa07c8c063ddf40b082bdf7e37a1562bda40a0ff5272957f3e987e0e54b"
-auth_type='sha256'

--- a/Ports/lzo/package.sh
+++ b/Ports/lzo/package.sh
@@ -5,4 +5,3 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('autoconf/config.sub')
 files="https://www.oberhumer.com/opensource/lzo/download/lzo-${version}.tar.gz lzo-${version}.tar.gz c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072"
-auth_type='sha256'

--- a/Ports/lzop/package.sh
+++ b/Ports/lzop/package.sh
@@ -5,5 +5,4 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('autoconf/config.sub')
 files="https://www.lzop.org/download/lzop-${version}.tar.gz lzop-${version}.tar.gz 7e72b62a8a60aff5200a047eea0773a8fb205caf7acbe1774d95147f305a2f41"
-auth_type='sha256'
 depends=("lzo")

--- a/Ports/m4/package.sh
+++ b/Ports/m4/package.sh
@@ -2,7 +2,6 @@
 port='m4'
 version='1.4.19'
 files="https://ftpmirror.gnu.org/gnu/m4/m4-${version}.tar.gz m4-${version}.tar.gz 3be4a26d825ffdfda52a56fc43246456989a3630093cced3fbddf4771ee58a70"
-auth_type='sha256'
 useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=("build-aux/config.sub")

--- a/Ports/make/package.sh
+++ b/Ports/make/package.sh
@@ -4,9 +4,5 @@ version='4.4.1'
 useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=("build-aux/config.sub")
-files="https://ftpmirror.gnu.org/gnu/make/make-${version}.tar.gz make-${version}.tar.gz
-https://ftpmirror.gnu.org/gnu/make/make-${version}.tar.gz.sig make-${version}.tar.gz.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg" "make-${version}.tar.gz.sig")
+files="https://ftpmirror.gnu.org/gnu/make/make-${version}.tar.gz make-${version}.tar.gz dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3"
 configopts=("--target=${SERENITY_ARCH}-pc-serenity" "--with-sysroot=/" "--without-guile")

--- a/Ports/mandoc/package.sh
+++ b/Ports/mandoc/package.sh
@@ -4,4 +4,3 @@ version=1.14.5
 useconfigure=true
 files="https://mandoc.bsd.lv/snapshots/mandoc-${version}.tar.gz mandoc-${version}.tar.gz 8219b42cb56fc07b2aa660574e6211ac38eefdbf21f41b698d3348793ba5d8f7"
 depends=("less" "pcre2" "zlib")
-auth_type="sha256"

--- a/Ports/mawk/package.sh
+++ b/Ports/mawk/package.sh
@@ -4,7 +4,6 @@ version=1.3.4-20200120
 files="https://invisible-mirror.net/archives/mawk/mawk-${version}.tgz mawk-${version}.tgz 7fd4cd1e1fae9290fe089171181bbc6291dfd9bca939ca804f0ddb851c8b8237"
 useconfigure=true
 use_fresh_config_sub=true
-auth_type='sha256'
 
 post_install() {
     ln -sf mawk "${SERENITY_INSTALL_ROOT}/usr/local/bin/awk"

--- a/Ports/mawk/package.sh
+++ b/Ports/mawk/package.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=mawk
 version=1.3.4-20200120
-files="https://invisible-mirror.net/archives/mawk/mawk-${version}.tgz mawk-${version}.tgz
-https://invisible-mirror.net/archives/mawk/mawk-${version}.tgz.asc mawk-${version}.tgz.asc"
+files="https://invisible-mirror.net/archives/mawk/mawk-${version}.tgz mawk-${version}.tgz 7fd4cd1e1fae9290fe089171181bbc6291dfd9bca939ca804f0ddb851c8b8237"
 useconfigure=true
 use_fresh_config_sub=true
-auth_type="sig"
-auth_import_key="C52048C0C0748FEE227D47A2702353E0F7E48EDB"
-auth_opts=("mawk-${version}.tgz.asc" "mawk-${version}.tgz")
+auth_type='sha256'
 
 post_install() {
     ln -sf mawk "${SERENITY_INSTALL_ROOT}/usr/local/bin/awk"

--- a/Ports/mbedtls/package.sh
+++ b/Ports/mbedtls/package.sh
@@ -5,7 +5,6 @@ files="https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v${version}.tar.gz 
 makeopts=(
     "SHARED=1"
 )
-auth_type='sha256'
 
 install() {
     run make DESTDIR="${SERENITY_INSTALL_ROOT}/usr/local" "${installopts[@]}" install

--- a/Ports/mc/package.sh
+++ b/Ports/mc/package.sh
@@ -3,7 +3,6 @@ port=mc
 version=4.8.29
 useconfigure=true
 files="http://ftp.midnight-commander.org/mc-${version}.tar.xz ${port}-${version}.tar.xz 01d8a3b94f58180cca5bf17257b5078d1fd6fd27a9b5c0e970ec767549540ad4"
-auth_type=sha256
 depends=("gettext" "glib" "libtool" "ncurses" "vim")
 configopts=(
     "--disable-largefile"

--- a/Ports/md4c/package.sh
+++ b/Ports/md4c/package.sh
@@ -3,7 +3,6 @@ port='md4c'
 version='0.4.8'
 workdir="md4c-release-${version}"
 files="https://github.com/mity/md4c/archive/release-${version}.tar.gz md4c-${version}.tar.gz 4a457df853425b6bb6e3457aa1d1a13bccec587a04c38c622b1013a0da41439f"
-auth_type='sha256'
 useconfigure='true'
 
 configure() {

--- a/Ports/mednafen/package.sh
+++ b/Ports/mednafen/package.sh
@@ -2,7 +2,6 @@
 port='mednafen'
 version='1.31.0-UNSTABLE'
 files="https://mednafen.github.io/releases/files/mednafen-${version}.tar.xz mednafen-${version}.tar.xz bfcff72e370e09e12ba3791600782187fbf5e2cc9d6b5fe4f9f3471642046367"
-auth_type='sha256'
 workdir="mednafen"
 useconfigure='true'
 use_fresh_config_sub='true'

--- a/Ports/mgba/package.sh
+++ b/Ports/mgba/package.sh
@@ -2,7 +2,6 @@
 port=mgba
 version=0.9.3
 files="https://github.com/mgba-emu/mgba/archive/refs/tags/${version}.tar.gz mgba-${version}.tar.gz 692ff0ac50e18380df0ff3ee83071f9926715200d0dceedd9d16a028a59537a0"
-auth_type=sha256
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 useconfigure=true
 depends=("SDL2" "zlib" "sqlite" "libpng" "libzip")

--- a/Ports/milkytracker/package.sh
+++ b/Ports/milkytracker/package.sh
@@ -4,7 +4,6 @@ version=1.03.00
 workdir=MilkyTracker-$version
 useconfigure=true
 files="https://github.com/milkytracker/MilkyTracker/archive/v$version.tar.gz MilkyTracker-$version.tar.gz 72d5357e303380b52383b66b51f944a77cd77e2b3bfeb227d87cc0e72ab292f7"
-auth_type=sha256
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 depends=("SDL2" "zlib")
 launcher_name="MilkyTracker"

--- a/Ports/mold/package.sh
+++ b/Ports/mold/package.sh
@@ -2,7 +2,6 @@
 port=mold
 version=1.5.1
 files="https://github.com/rui314/mold/archive/refs/tags/v${version}.tar.gz mold-${version}.tgz ec94aa74758f1bc199a732af95c6304ec98292b87f2f4548ce8436a7c5b054a1"
-auth_type=sha256
 depends=("zlib" "openssl" "zstd")
 useconfigure='true'
 configopts=(

--- a/Ports/mpc/package.sh
+++ b/Ports/mpc/package.sh
@@ -5,9 +5,6 @@ useconfigure=true
 use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 configopts=("--target=${SERENITY_ARCH}-pc-serenity" "--with-sysroot=${SERENITY_INSTALL_ROOT}")
-files="https://ftpmirror.gnu.org/gnu/mpc/mpc-${version}.tar.gz mpc-${version}.tar.gz
-https://ftpmirror.gnu.org/gnu/mpc/mpc-${version}.tar.gz.sig mpc-${version}.tar.gz.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg" "mpc-${version}.tar.gz.sig")
+files="https://ftpmirror.gnu.org/gnu/mpc/mpc-${version}.tar.gz mpc-${version}.tar.gz 17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459"
+auth_type='sha256'
 depends=("gmp" "mpfr")

--- a/Ports/mpc/package.sh
+++ b/Ports/mpc/package.sh
@@ -6,5 +6,4 @@ use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 configopts=("--target=${SERENITY_ARCH}-pc-serenity" "--with-sysroot=${SERENITY_INSTALL_ROOT}")
 files="https://ftpmirror.gnu.org/gnu/mpc/mpc-${version}.tar.gz mpc-${version}.tar.gz 17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459"
-auth_type='sha256'
 depends=("gmp" "mpfr")

--- a/Ports/mpfr/package.sh
+++ b/Ports/mpfr/package.sh
@@ -4,9 +4,6 @@ version=4.1.0
 useconfigure=true
 use_fresh_config_sub=true
 configopts=("--target=${SERENITY_ARCH}-pc-serenity" "--with-sysroot=/")
-files="https://ftpmirror.gnu.org/gnu/mpfr/mpfr-${version}.tar.xz mpfr-${version}.tar.xz
-https://ftpmirror.gnu.org/gnu/mpfr/mpfr-${version}.tar.xz.sig mpfr-${version}.tar.xz.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg" "mpfr-${version}.tar.xz.sig")
+files="https://ftpmirror.gnu.org/gnu/mpfr/mpfr-${version}.tar.xz mpfr-${version}.tar.xz 0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f"
+auth_type='sha256'
 depends=("gmp")

--- a/Ports/mpfr/package.sh
+++ b/Ports/mpfr/package.sh
@@ -5,5 +5,4 @@ useconfigure=true
 use_fresh_config_sub=true
 configopts=("--target=${SERENITY_ARCH}-pc-serenity" "--with-sysroot=/")
 files="https://ftpmirror.gnu.org/gnu/mpfr/mpfr-${version}.tar.xz mpfr-${version}.tar.xz 0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f"
-auth_type='sha256'
 depends=("gmp")

--- a/Ports/mrsh/package.sh
+++ b/Ports/mrsh/package.sh
@@ -2,7 +2,6 @@
 port=mrsh
 version=cd3c3a48055ab4085d83f149ff4b4feba40b40cb
 files="https://github.com/emersion/mrsh/archive/${version}.tar.gz ${port}-${version}.tar.gz d26e3fdee71ef168cf3f8ad2912c148b20aab524048e4ea899d6b83fb299ceab"
-auth_type=sha256
 useconfigure=true
 configopts=(
     "--without-readline"

--- a/Ports/mruby/package.sh
+++ b/Ports/mruby/package.sh
@@ -2,7 +2,6 @@
 port=mruby
 version=3.0.0
 files="https://github.com/mruby/mruby/archive/refs/tags/${version}.tar.gz mruby-${version}.tar.gz 95b798cdd931ef29d388e2b0b267cba4dc469e8722c37d4ef8ee5248bc9075b0"
-auth_type="sha256"
 
 build_config="serenity"
 build_dir="build/${build_config}"

--- a/Ports/mysthous/package.sh
+++ b/Ports/mysthous/package.sh
@@ -2,7 +2,6 @@
 port=mysthous
 version="1.0"
 files="https://downloads.scummvm.org/frs/extras/Mystery%20House/MYSTHOUS.zip ${port}-${version}.zip ada412228a149394489b28c6c7f9ebab0722b52e04732fd0aa22949673cfa3a0"
-auth_type=sha256
 depends=("scummvm")
 
 resource_path="/usr/local/share/games/${port}-${version}"

--- a/Ports/nano/package.sh
+++ b/Ports/nano/package.sh
@@ -2,7 +2,6 @@
 port='nano'
 version='7.2'
 files="https://www.nano-editor.org/dist/v7/nano-${version}.tar.xz nano-${version}.tar.xz 86f3442768bd2873cec693f83cdf80b4b444ad3cc14760b74361474fc87a4526"
-auth_type='sha256'
 useconfigure='true'
 use_fresh_config_sub='true'
 configopts=("--target=${SERENITY_ARCH}-pc-serenity" "--disable-browser" "--disable-utf8")

--- a/Ports/nasm/package.sh
+++ b/Ports/nasm/package.sh
@@ -2,7 +2,6 @@
 port=nasm
 version=2.16.01
 files="https://www.nasm.us/pub/nasm/releasebuilds/${version}/nasm-${version}.tar.gz nasm-${version}.tar.gz d833bf0f5716e89dbcd345b7f545f25fe348c6e2ef16dbc293e1027bcd22d881"
-auth_type=sha256
 useconfigure=true
 use_fresh_config_sub=true
 config_sub_paths=("autoconf/helpers/config.sub")

--- a/Ports/ncdu/package.sh
+++ b/Ports/ncdu/package.sh
@@ -2,6 +2,5 @@
 port='ncdu'
 version='1.18.1'
 files="https://dev.yorhel.nl/download/ncdu-${version}.tar.gz ncdu-${version}.tar.gz 7c0fa1eb29d85aaed4ba174164bdbb8f011b5c390d017c57d668fc7231332405"
-auth_type='sha256'
 useconfigure='true'
 depends=("ncurses")

--- a/Ports/ncurses/package.sh
+++ b/Ports/ncurses/package.sh
@@ -13,7 +13,6 @@ configopts=(
     "--enable-widec"
 )
 files="https://invisible-mirror.net/archives/ncurses/ncurses-${version}.tar.gz ncurses-${version}.tar.gz 97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059"
-auth_type="sha256"
 
 check_tic_version() {
     local tic_path="$1"

--- a/Ports/neofetch/package.sh
+++ b/Ports/neofetch/package.sh
@@ -5,7 +5,6 @@ version=7.1.0
 useconfigure=false
 depends=("bash" "jq")
 files="https://github.com/dylanaraps/neofetch/archive/${version}.tar.gz neofetch-${version}.tar.gz 58a95e6b714e41efc804eca389a223309169b2def35e57fa934482a6b47c27e7"
-auth_type=sha256
 
 install() {
     run make DESTDIR=${SERENITY_INSTALL_ROOT} PREFIX=/usr/local "${installopts[@]}" install

--- a/Ports/nesalizer/package.sh
+++ b/Ports/nesalizer/package.sh
@@ -2,7 +2,6 @@
 port=nesalizer
 version=5bb045845a5cc829a78b7384f848fdd886cd98c8
 files="https://github.com/ulfalizer/nesalizer/archive/${version}.tar.gz ${port}-${version}.tar.gz 4282cb0e4af0585af4a594dfa30b2e350dd0efc39e5bc2d8312f637f50397107"
-auth_type=sha256
 depends=("SDL2")
 makeopts+=("CONF=release")
 

--- a/Ports/nethack/package.sh
+++ b/Ports/nethack/package.sh
@@ -3,7 +3,6 @@ port='nethack'
 version='3.6.7'
 workdir="NetHack-${version}"
 files="https://www.nethack.org/download/${version}/nethack-${version//.}-src.tgz nethack-${version//.}-src.tgz 98cf67df6debf9668a61745aa84c09bcab362e5d33f5b944ec5155d44d2aacb2"
-auth_type='sha256'
 depends=(
     'ncurses'
     'bash'

--- a/Ports/ninja/package.sh
+++ b/Ports/ninja/package.sh
@@ -2,7 +2,6 @@
 port='ninja'
 version='1.11.0'
 files="https://github.com/ninja-build/ninja/archive/v${version}.tar.gz ninja-v${version}.tar.gz 3c6ba2e66400fe3f1ae83deb4b235faf3137ec20bd5b08c29bfc368db143e4c6"
-auth_type='sha256'
 
 build() {
     CXXFLAGS="--sysroot=${SERENITY_INSTALL_ROOT}" \

--- a/Ports/nippon/package.sh
+++ b/Ports/nippon/package.sh
@@ -2,7 +2,6 @@
 port=nippon
 version="1.0"
 files="https://downloads.scummvm.org/frs/extras/Nippon%20Safes/nippon-1.0.zip ${port}-${version}.zip  53e7e2c60065e4aed193169bbcdcfd1113fa68d3efe1c8240ba073c0e20d613f"
-auth_type=sha256
 depends=("scummvm")
 
 resource_path="/usr/local/share/games/${port}-${version}"

--- a/Ports/nlohmann-json/package.sh
+++ b/Ports/nlohmann-json/package.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port='nlohmann-json'
 version='3.11.2'
-auth_type='sha256'
 workdir="json-${version}"
 files="https://github.com/nlohmann/json/archive/refs/tags/v${version}.tar.gz json-${version}.tar.gz d69f9deb6a75e2580465c6c4c5111b89c4dc2fa94e3a85fcd2ffcd9a143d9273"
 useconfigure='true'

--- a/Ports/npiet/package.sh
+++ b/Ports/npiet/package.sh
@@ -5,4 +5,3 @@ version=1.3f
 depends=("libgd" "libpng")
 configopts=()
 files="https://www.bertnase.de/npiet/npiet-${version}.tar.gz npiet-${version}.tar.gz 2ded856062abd73599e85e1e768ce6bc60ba2db22dc7d6a9b62763dca04b855a"
-auth_type=sha256

--- a/Ports/npth/package.sh
+++ b/Ports/npth/package.sh
@@ -5,7 +5,6 @@ useconfigure=true
 use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 files="https://gnupg.org/ftp/gcrypt/npth/npth-${version}.tar.bz2 npth-${version}.tar.bz2 1393abd9adcf0762d34798dc34fdcf4d0d22a8410721e76f1e3afcd1daa4e2d1"
-auth_type=sha256
 
 configure() {
     run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" "${configopts[@]}"

--- a/Ports/ntbtls/package.sh
+++ b/Ports/ntbtls/package.sh
@@ -6,7 +6,6 @@ use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 depends=("libgpg-error" "libksba" "libgcrypt" "zlib")
 files="https://gnupg.org/ftp/gcrypt/ntbtls/ntbtls-${version}.tar.bz2 ntbtls-${version}.tar.bz2 649fe74a311d13e43b16b26ebaa91665ddb632925b73902592eac3ed30519e17"
-auth_type=sha256
 configopts=(
     "--with-libgcrypt-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
     "--with-libgpg-error-prefix=${SERENITY_INSTALL_ROOT}/usr/local"

--- a/Ports/nyancat/package.sh
+++ b/Ports/nyancat/package.sh
@@ -3,7 +3,6 @@ port=nyancat
 version=git
 workdir=nyancat-master
 files="https://github.com/klange/nyancat/archive/master.tar.gz nyancat-git.tar.gz cfd6c817f25adcecc9490321991ecb571bfdfe0d8c249663843d3df4194f935d"
-auth_type=sha256
 launcher_name=Nyancat
 launcher_category=Games
 launcher_command=nyancat

--- a/Ports/oksh/package.sh
+++ b/Ports/oksh/package.sh
@@ -2,7 +2,6 @@
 port='oksh'
 version='7.1'
 files="https://github.com/ibara/oksh/releases/download/oksh-${version}/oksh-${version}.tar.gz oksh-${version}.tar.gz 9dc0b0578d9d64d10c834f9757ca11f526b562bc5454da64b2cb270122f52064"
-auth_type='sha256'
 useconfigure='true'
 depends=("ncurses")
 

--- a/Ports/openrct2/package.sh
+++ b/Ports/openrct2/package.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port='openrct2'
 version='0.4.4'
-auth_type='sha256'
 depends=(
     'curl'
     'flac'

--- a/Ports/openssh/package.sh
+++ b/Ports/openssh/package.sh
@@ -3,7 +3,6 @@ port=openssh
 workdir=openssh-portable-94eb6858efecc1b4f02d8a6bd35e149f55c814c8
 version=9.0-94eb685
 files="https://github.com/openssh/openssh-portable/archive/94eb6858efecc1b4f02d8a6bd35e149f55c814c8.tar.gz openssh-9.0-94eb685.tar.gz 8a6bfb4c21d32f4e82d6d7734cd68585337cdd57428a2799295e1b1e72c332b5"
-auth_type=sha256
 depends=("zlib" "openssl")
 useconfigure=true
 use_fresh_config_sub=true

--- a/Ports/openssl/package.sh
+++ b/Ports/openssl/package.sh
@@ -5,7 +5,6 @@ version="${branch}s"
 useconfigure=true
 configscript=Configure
 files="https://www.openssl.org/source/openssl-${version}.tar.gz openssl-${version}.tar.gz c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa"
-auth_type=sha256
 
 depends=("zlib")
 configopts=("--prefix=/usr/local" "-DOPENSSL_SYS_SERENITY=1" "-DOPENSSL_USE_IPV6=0" "zlib" "threads" "no-tests" "no-asm" "serenity-generic")

--- a/Ports/openttd-opengfx/package.sh
+++ b/Ports/openttd-opengfx/package.sh
@@ -3,7 +3,6 @@ port=openttd-opengfx
 version=7.1
 workdir=.
 files="https://cdn.openttd.org/opengfx-releases/${version}/opengfx-${version}-all.zip opengfx-${version}-all.zip 928fcf34efd0719a3560cbab6821d71ce686b6315e8825360fba87a7a94d7846"
-auth_type=sha256
 
 build() {
     # The ZIP file we downloaded contains a tarball.

--- a/Ports/openttd-opensfx/package.sh
+++ b/Ports/openttd-opensfx/package.sh
@@ -3,7 +3,6 @@ port=openttd-opensfx
 version=1.0.3
 workdir=.
 files="https://cdn.openttd.org/opensfx-releases/${version}/opensfx-${version}-all.zip opensfx-${version}-all.zip e0a218b7dd9438e701503b0f84c25a97c1c11b7c2f025323fb19d6db16ef3759"
-auth_type=sha256
 
 build() {
     # The ZIP file we downloaded contains a tarball.

--- a/Ports/openttd/package.sh
+++ b/Ports/openttd/package.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=openttd
 version=12.2
-auth_type=sha256
 depends=("freetype" "SDL2" "libicu" "libpng" "zlib" "xz" "openttd-opengfx" "openttd-opensfx")
 files="https://cdn.openttd.org/openttd-releases/${version}/openttd-${version}-source.tar.xz openttd-${version}.tar.xz 81508f0de93a0c264b216ef56a05f8381fff7bffa6d010121a21490b4dace95c"
 useconfigure=true

--- a/Ports/opentyrian-data/package.sh
+++ b/Ports/opentyrian-data/package.sh
@@ -3,7 +3,6 @@ port=opentyrian-data
 version=1.0.0
 workdir=.
 files="http://camanis.net/tyrian/tyrian21.zip tyrian21.zip 7790d09a2a3addcd33c66ef063d5900eb81cc9c342f4807eb8356364dd1d9277"
-auth_type=sha256
 
 build() {
     run_nocd rm -v tyrian21/*.exe

--- a/Ports/opentyrian/package.sh
+++ b/Ports/opentyrian/package.sh
@@ -3,7 +3,6 @@ port=opentyrian
 version=84b820f852f3f6b812b4d00d6b3906adbbf3bbdb
 useconfigure=true
 files="https://github.com/opentyrian/opentyrian/archive/${version}.tar.gz ${version}.tar.gz 7429cc8e3468e3462b886cb99fe6cc0f5d232c193b68a94dc427493107c30dec"
-auth_type=sha256
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 depends=("SDL2" "opentyrian-data")
 

--- a/Ports/opfor/package.sh
+++ b/Ports/opfor/package.sh
@@ -6,7 +6,6 @@ useconfigure='true'
 depends=("xash3d-fwgs")
 workdir="hlsdk-portable-${_hlsdk_commit}"
 files="https://github.com/FWGS/hlsdk-portable/archive/${_hlsdk_commit}.tar.gz hlsdk-portable-${_hlsdk_commit}.tar.gz 0cf2cb120c3e350d05233cc718126436e68f4f2f1289c1f31623a4c8aef419eb"
-auth_type='sha256'
 launcher_name='Half-Life: Opposing Force'
 launcher_category='Games'
 launcher_command='sh /home/anon/Games/halflife/opfor.sh'

--- a/Ports/optipng/package.sh
+++ b/Ports/optipng/package.sh
@@ -3,7 +3,6 @@
 port='optipng'
 version='0.7.7'
 files="http://downloads.sourceforge.net/optipng/optipng-${version}.tar.gz optipng-${version}.tar.gz 4f32f233cef870b3f95d3ad6428bfe4224ef34908f1b42b0badf858216654452"
-auth_type='sha256'
 useconfigure='true'
 
 configure() {

--- a/Ports/opusfile/package.sh
+++ b/Ports/opusfile/package.sh
@@ -4,7 +4,6 @@ version='0.12'
 useconfigure='true'
 use_fresh_config_sub='true'
 files="https://downloads.xiph.org/releases/opus/opusfile-${version}.tar.gz opusfile-${version}.tar.gz 118d8601c12dd6a44f52423e68ca9083cc9f2bfe72da7a8c1acb22a80ae3550b"
-auth_type='sha256'
 depends=(
     'libogg'
     'libopus'

--- a/Ports/p7zip/package.sh
+++ b/Ports/p7zip/package.sh
@@ -3,7 +3,6 @@
 port="p7zip"
 version="17.04"
 useconfigure=true
-auth_type=sha256
 files="https://github.com/jinfeihan57/p7zip/archive/refs/tags/v${version}.tar.gz p7zip-${version}.tar.gz ea029a2e21d2d6ad0a156f6679bd66836204aa78148a4c5e498fe682e77127ef"
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 workdir=$port-$version/CPP

--- a/Ports/pacman/package.sh
+++ b/Ports/pacman/package.sh
@@ -2,7 +2,6 @@
 port='pacman'
 version='b6241a373cc09f021c2ab29714eca5f9e33463f8'
 files="https://codeload.github.com/ebuc99/pacman/zip/${version} pacman.zip d688f75d33c7bf4f217bfcaf0d5ee507fd73bb233d77303927d15b54988f0231"
-auth_type='sha256'
 useconfigure='true'
 depends=(
     'SDL2'

--- a/Ports/patch/package.sh
+++ b/Ports/patch/package.sh
@@ -5,4 +5,3 @@ useconfigure=true
 use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 files="https://ftpmirror.gnu.org/gnu/patch/patch-${version}.tar.gz patch-${version}.tar.gz 8cf86e00ad3aaa6d26aca30640e86b0e3e1f395ed99f189b06d4c9f74bc58a4e"
-auth_type=sha256

--- a/Ports/pcre/package.sh
+++ b/Ports/pcre/package.sh
@@ -3,9 +3,5 @@ port=pcre
 version=8.45
 useconfigure=true
 use_fresh_config_sub=true
-files="https://downloads.sourceforge.net/project/pcre/pcre/${version}/pcre-${version}.tar.gz pcre-${version}.tar.gz
-https://downloads.sourceforge.net/project/pcre/pcre/${version}/pcre-${version}.tar.gz.sig pcre-${version}.tar.gz.sig"
-
-auth_type="sig"
-auth_import_key="45F68D54BBE23FB3039B46E59766E084FB0F43D8"
-auth_opts=("pcre-${version}.tar.gz.sig")
+files="https://downloads.sourceforge.net/project/pcre/pcre/${version}/pcre-${version}.tar.gz pcre-${version}.tar.gz 4e6ce03e0336e8b4a3d6c2b70b1c5e18590a5673a98186da90d4f33c23defc09"
+auth_type='sha256'

--- a/Ports/pcre/package.sh
+++ b/Ports/pcre/package.sh
@@ -4,4 +4,3 @@ version=8.45
 useconfigure=true
 use_fresh_config_sub=true
 files="https://downloads.sourceforge.net/project/pcre/pcre/${version}/pcre-${version}.tar.gz pcre-${version}.tar.gz 4e6ce03e0336e8b4a3d6c2b70b1c5e18590a5673a98186da90d4f33c23defc09"
-auth_type='sha256'

--- a/Ports/pcre2/package.sh
+++ b/Ports/pcre2/package.sh
@@ -2,5 +2,4 @@
 port='pcre2'
 version='10.40'
 files="https://github.com/PhilipHazel/pcre2/releases/download/pcre2-${version}/pcre2-${version}.tar.gz pcre2-${version}.tar.gz ded42661cab30ada2e72ebff9e725e745b4b16ce831993635136f2ef86177724"
-auth_type='sha256'
 useconfigure='true'

--- a/Ports/pfetch/package.sh
+++ b/Ports/pfetch/package.sh
@@ -3,4 +3,3 @@ port=pfetch
 version=a906ff89680c78cec9785f3ff49ca8b272a0f96b
 depends=("bash")
 files="https://github.com/dylanaraps/pfetch/archive/${version}.zip pfetch.zip 33ed7a0cf1826ded7cf8368972274cd261d236bfa1ad9fb378d3cb0a45376f4a"
-auth_type=sha256

--- a/Ports/php/package.sh
+++ b/Ports/php/package.sh
@@ -3,7 +3,6 @@ port='php'
 useconfigure='true'
 version='8.1.12'
 files="https://www.php.net/distributions/php-${version}.tar.xz php-${version}.tar.xz 08243359e2204d842082269eedc15f08d2eca726d0e65b93fb11f4bfc51bbbab"
-auth_type='sha256'
 depends=(
     'libiconv'
     'libxml2'

--- a/Ports/pixman/package.sh
+++ b/Ports/pixman/package.sh
@@ -3,5 +3,4 @@ port='pixman'
 version='0.40.0'
 useconfigure='true'
 files="https://www.cairographics.org/releases/pixman-${version}.tar.gz pixman-${version}.tar.gz 6d200dec3740d9ec4ec8d1180e25779c00bc749f94278c8b9021f5534db223fc"
-auth_type='sha256'
 use_fresh_config_sub='true'

--- a/Ports/pkgconf/package.sh
+++ b/Ports/pkgconf/package.sh
@@ -2,7 +2,6 @@
 port=pkgconf
 version=1.8.0
 files="https://distfiles.ariadne.space/pkgconf/pkgconf-${version}.tar.xz pkgconf-${version}.tar.xz ef9c7e61822b7cb8356e6e9e1dca58d9556f3200d78acab35e4347e9d4c2bbaf"
-auth_type=sha256
 useconfigure=true
 use_fresh_config_sub=true
 # FIXME: This looks suspiciously host-y...

--- a/Ports/poppler/package.sh
+++ b/Ports/poppler/package.sh
@@ -4,7 +4,6 @@ version='23.07.0'
 version_data='0.4.12'
 files="https://poppler.freedesktop.org/poppler-${version}.tar.xz poppler-${version}.tar.xz f29b4b4bf47572611176454c8f21506d71d27eca5011a39aa44038b30b957db0
 https://poppler.freedesktop.org/poppler-data-${version_data}.tar.gz poppler-data-${version_data}.tar.gz c835b640a40ce357e1b83666aabd95edffa24ddddd49b8daff63adb851cdab74"
-auth_type='sha256'
 depends=(
     'fontconfig'
     'freetype'

--- a/Ports/potrace/package.sh
+++ b/Ports/potrace/package.sh
@@ -5,7 +5,6 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('config.sub')
 files="https://potrace.sourceforge.net/download/${version}/potrace-${version}.tar.gz potrace-${version}.tar.gz be8248a17dedd6ccbaab2fcc45835bb0502d062e40fbded3bc56028ce5eb7acc"
-auth_type='sha256'
 configopts=(
     "--with-libpotrace"
 )

--- a/Ports/powdertoy/package.sh
+++ b/Ports/powdertoy/package.sh
@@ -5,7 +5,6 @@ useconfigure=true
 configopts=("-Dbuildtype=release" "build-release" "--cross-file" "${SERENITY_BUILD_DIR}/meson-cross-file.txt")
 depends=("luajit" "curl" "libfftw3f" "zlib" "SDL2")
 files="https://github.com/The-Powder-Toy/The-Powder-Toy/archive/refs/tags/v${version}.tar.gz The-Powder-Toy-${version}.tar.gz d95cbadee22632687661e8fc488bd64405d81c0dca737e16420f26e93ea5bf58"
-auth_type=sha256
 workdir="The-Powder-Toy-${version}"
 launcher_name="The Powder Toy"
 icon_file="resources/icon.ico"

--- a/Ports/prboom-plus/package.sh
+++ b/Ports/prboom-plus/package.sh
@@ -5,7 +5,6 @@ useconfigure='true'
 squashed_version=$(echo "${version}" | tr -d '.')
 files="https://github.com/coelckers/prboom-plus/archive/refs/tags/v${version}.tar.gz prboom-plus-v4${version}.tar.gz 5cfeec96fbfe4fc3bd5dbc2b8d581ff5f6617dd74b2799680ba5b1e2e38c4aff
 https://github.com/coelckers/prboom-plus/releases/download/v${version}/prboom-plus-${squashed_version}-w32.zip prboom-plus-w32.zip 20313e00d8841a618e23e7c671d65870194bee634468fecd2f3697ac05f21476"
-auth_type='sha256'
 workdir="prboom-plus-${version}/prboom2"
 depends=("glu" "libmad" "libvorbis" "SDL2" "SDL2_image" "SDL2_mixer" "SDL2_net")
 configopts=(

--- a/Ports/printf/package.sh
+++ b/Ports/printf/package.sh
@@ -2,5 +2,4 @@
 port=printf
 version=6.6
 files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/printf-${version}.tar.gz printf-${version}.tar.gz 44b68af9795a3cde7dfc73a588fd2b12054dd84d1ab520106713d49935d791a8"
-auth_type=sha256
 depends=("libpuffy")

--- a/Ports/pt2-clone/package.sh
+++ b/Ports/pt2-clone/package.sh
@@ -2,7 +2,6 @@
 port='pt2-clone'
 version='1.49'
 files="https://github.com/8bitbubsy/pt2-clone/archive/v${version}.tar.gz v${version}.tar.gz c2e796b25aba625551c50b2c0743ccc83b007d2eeac2f5eaad870b60f5a1554b"
-auth_type='sha256'
 useconfigure='true'
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 depends=("SDL2")

--- a/Ports/pv/package.sh
+++ b/Ports/pv/package.sh
@@ -4,7 +4,6 @@ version=1.6.20
 useconfigure=true
 configopts=("--disable-nls")
 files="http://www.ivarch.com/programs/sources/pv-${version}.tar.bz2 pv-${version}.tar.bz2 e831951eff0718fba9b1ef286128773b9d0e723e1fbfae88d5a3188814fdc603"
-auth_type=sha256
 
 export CFLAGS=-Wno-deprecated-declarations
 

--- a/Ports/python3/package.sh
+++ b/Ports/python3/package.sh
@@ -11,7 +11,6 @@ useconfigure='true'
 use_fresh_config_sub='true'
 files="${PYTHON_ARCHIVE_URL} ${PYTHON_ARCHIVE} ${PYTHON_ARCHIVE_SHA256SUM}
 https://raw.githubusercontent.com/python/cpython/942dd9f3f77eef08fabddbd9fb883a866ad6d4cb/PC/pycon.ico launcher.ico 55c1e1fcabc2f254a6d02242912359d29f141d11c4892c20375d58b6dcd89ac0"
-auth_type='sha256'
 launcher_name='Python'
 launcher_category='Development'
 launcher_command='/usr/local/bin/python3'

--- a/Ports/qemu/package.sh
+++ b/Ports/qemu/package.sh
@@ -23,7 +23,6 @@ depends=(
   'pixman'
   'SDL2'
 )
-auth_type='sha256'
 files="${QEMU_ARCHIVE_URL} ${QEMU_ARCHIVE} ${QEMU_ARCHIVE_SHA256SUM}"
 
 pre_patch() {

--- a/Ports/qoi/package.sh
+++ b/Ports/qoi/package.sh
@@ -2,7 +2,6 @@
 port='qoi'
 version='edb8d7b1140be3168cc99ed87edc605c7c1cf31f'
 files="https://github.com/phoboslab/qoi/archive/${version}.zip qoi-${version}.zip 3d3df95fb0b59aca2113ce45396f887eaba1be914cd54b56804efc241f93f203"
-auth_type='sha256'
 depends=('libpng' 'stb')
 
 install() {

--- a/Ports/qt6-qt5compat/package.sh
+++ b/Ports/qt6-qt5compat/package.sh
@@ -4,7 +4,6 @@ version='6.4.0'
 workdir="qt5compat-everywhere-src-${version}"
 useconfigure='true'
 files="https://download.qt.io/official_releases/qt/$(cut -d. -f1,2 <<< ${version})/${version}/submodules/qt5compat-everywhere-src-${version}.tar.xz qt6-qt5compat-${version}.tar.xz 73475d0837f78246d509199f211a35c71fc36cccf64b3de258ebc6387194a4c0"
-auth_type='sha256'
 depends=(
     'qt6-qtbase'
     'libiconv'

--- a/Ports/qt6-qtbase/package.sh
+++ b/Ports/qt6-qtbase/package.sh
@@ -4,7 +4,6 @@ version='6.4.0'
 workdir="qtbase-everywhere-src-${version}"
 useconfigure='true'
 files="https://download.qt.io/official_releases/qt/$(cut -d. -f1,2 <<< ${version})/${version}/submodules/qtbase-everywhere-src-${version}.tar.xz qt6-qtbase-${version}.tar.xz cb6475a0bd8567c49f7ffbb072a05516ee6671171bed55db75b22b94ead9b37d"
-auth_type='sha256'
 configopts=(
     '-GNinja'
     "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"

--- a/Ports/quake2/package.sh
+++ b/Ports/quake2/package.sh
@@ -5,7 +5,6 @@ useconfigure='true'
 commit_hash='d26d00845e95dc7d781459d0c1a7fd48ea4b6be3'
 archive_hash='f940d71e0a4e15c040776979c6c99cb3520208744b3c22921f484d70ba82d675'
 files="https://github.com/shamazmazum/quake2sdl/archive/${commit_hash}.tar.gz quake2.tar.gz ${archive_hash}"
-auth_type='sha256'
 workdir="quake2sdl-${commit_hash}"
 makeopts=()
 configopts=(

--- a/Ports/quake3/package.sh
+++ b/Ports/quake3/package.sh
@@ -4,7 +4,6 @@ version=1.34
 commit_hash=6d74896557d8c193a9f19bc6845a47e9d0f77db2
 archive_hash=1db91cfd05170ed5b37c1ab56cdf7bbe6b3c86fc6baee8b68e8e539fddfd88c1
 files="https://github.com/ioquake/ioq3/archive/$commit_hash.tar.gz ioq3.tar.gz $archive_hash"
-auth_type=sha256
 workdir="ioq3-${commit_hash}"
 depends=("SDL2")
 launcher_name="Quake III Arena"

--- a/Ports/r0/package.sh
+++ b/Ports/r0/package.sh
@@ -4,5 +4,4 @@ version=0.8
 useconfigure=false
 workdir=$port-$version
 files="https://codeload.github.com/radareorg/r0/tar.gz/refs/tags/$version r0-$version.tar.gz a31722838a21cd3391c41bbb2e63f60552544244362b21f6d9a30d6c24c43bbe"
-auth_type=sha256
 depends=()

--- a/Ports/radare2/package.sh
+++ b/Ports/radare2/package.sh
@@ -2,7 +2,6 @@
 port='radare2'
 version='5.7.6'
 files="https://github.com/radareorg/radare2/archive/refs/tags/${version}.tar.gz radare2-${version}.tar.gz 1e798504a978929803ac7d6e42530b06c44be7e1abb5842877a88d7a34d9fd8f"
-auth_type='sha256'
 useconfigure='true'
 configopts=("--disable-debugger" "--disable-threads" "--with-ostype=serenityos" "--host=${SERENITY_ARCH}-serenityos")
 

--- a/Ports/readline/package.sh
+++ b/Ports/readline/package.sh
@@ -6,7 +6,6 @@ useconfigure=true
 config_sub_paths=("support/config.sub")
 use_fresh_config_sub=true
 files="https://ftpmirror.gnu.org/gnu/readline/readline-${version}.tar.gz readline-${version}.tar.gz 7589a2381a8419e68654a47623ce7dfcb756815c8fee726b98f90bf668af7bc6"
-auth_type=sha256
 configopts=(
     "--disable-static"
     "--enable-shared"

--- a/Ports/rsync/package.sh
+++ b/Ports/rsync/package.sh
@@ -4,5 +4,4 @@ version=3.1.3
 useconfigure="true"
 use_fresh_config_sub="true"
 files="https://download.samba.org/pub/rsync/src/rsync-${version}.tar.gz rsync-${version}.tar.gz 55cc554efec5fdaad70de921cd5a5eeb6c29a95524c715f3bbf849235b0800c0"
-auth_type=sha256
 configopts=("--target=${SERENITY_ARCH}-pc-serenity")

--- a/Ports/ruby/package.sh
+++ b/Ports/ruby/package.sh
@@ -11,7 +11,6 @@ use_fresh_config_sub=true
 config_sub_paths=("tool/config.sub")
 files="${RUBY_ARCHIVE_URL} ${RUBY_ARCHIVE} ${RUBY_ARCHIVE_SHA256SUM}
 https://cache.ruby-lang.org/pub/misc/logo/ruby-logo-kit.zip ruby-logo-kit.zip 7f0a980e09874d35d80b958949dc2460e683957de3d2494a1499aea9d9989055"
-auth_type="sha256"
 launcher_name="Ruby IRB"
 launcher_category="Development"
 launcher_command="/usr/local/bin/ruby /usr/local/bin/irb --legacy"

--- a/Ports/rvvm/package.sh
+++ b/Ports/rvvm/package.sh
@@ -3,7 +3,6 @@ port='rvvm'
 version='0.5'
 archive_hash='3a1dbb91ad04f068078bc6c6c27cc5792eebc111907cb5a14bde158fe6e757c9'
 files="https://github.com/LekKit/RVVM/archive/v${version}.tar.gz rvvm.tar.gz ${archive_hash}"
-auth_type='sha256'
 workdir="RVVM-${version}"
 depends=('sdl12-compat')
 

--- a/Ports/sam/package.sh
+++ b/Ports/sam/package.sh
@@ -3,7 +3,6 @@ port=sam
 version=c86ea395743b8ea4ad071c2167fd1f7f96648f7b
 workdir="SAM-${version}"
 files="https://github.com/vidarh/SAM/archive/${version}.tar.gz ${version}.tar.gz 1f534245e2c7a096de5f886fd96ea1ad966c4e674c1ed91e0c6a59662e8d6c11"
-auth_type=sha256
 depends=("SDL2")
 
 build() {

--- a/Ports/scummvm/package.sh
+++ b/Ports/scummvm/package.sh
@@ -3,7 +3,6 @@ port=scummvm
 useconfigure="true"
 version="2.7.0"
 files="https://downloads.scummvm.org/frs/scummvm/${version}/scummvm-${version}.tar.xz scummvm-${version}.tar.xz 444b1ffd61774fe867824e57bb3033c9998ffa8a4ed3a13246b01611d5cf9993"
-auth_type=sha256
 depends=("freetype" "libiconv" "libjpeg" "libmad" "libmpeg2" "libpng" "libtheora" "SDL2")
 configopts=(
     "--enable-engine=monkey4"

--- a/Ports/sdl12-compat/package.sh
+++ b/Ports/sdl12-compat/package.sh
@@ -4,7 +4,6 @@ version='1.2.56'
 workdir=sdl12-compat-release-${version}
 useconfigure='true'
 files="https://github.com/libsdl-org/sdl12-compat/archive/refs/tags/release-${version}.tar.gz ${port}-${version}.tar.gz f62f3e15f95aade366ee6c03f291e8825c4689390a6be681535259a877259c58"
-auth_type='sha256'
 configopts=(
     "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"
     "-DCMAKE_BUILD_TYPE=Release"

--- a/Ports/sed/package.sh
+++ b/Ports/sed/package.sh
@@ -4,8 +4,5 @@ version=4.9
 useconfigure="true"
 use_fresh_config_sub="true"
 config_sub_paths=("build-aux/config.sub")
-files="https://ftpmirror.gnu.org/gnu/sed/sed-${version}.tar.gz sed-${version}.tar.gz
-https://ftpmirror.gnu.org/gnu/sed/sed-${version}.tar.gz.sig sed-${version}.tar.gz.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg" "sed-${version}.tar.gz.sig")
+files="https://ftpmirror.gnu.org/gnu/sed/sed-${version}.tar.gz sed-${version}.tar.gz d1478a18f033a73ac16822901f6533d30b6be561bcbce46ffd7abce93602282e"
+auth_type='sha256'

--- a/Ports/sed/package.sh
+++ b/Ports/sed/package.sh
@@ -5,4 +5,3 @@ useconfigure="true"
 use_fresh_config_sub="true"
 config_sub_paths=("build-aux/config.sub")
 files="https://ftpmirror.gnu.org/gnu/sed/sed-${version}.tar.gz sed-${version}.tar.gz d1478a18f033a73ac16822901f6533d30b6be561bcbce46ffd7abce93602282e"
-auth_type='sha256'

--- a/Ports/serenity-theming/package.sh
+++ b/Ports/serenity-theming/package.sh
@@ -3,7 +3,6 @@ port=serenity-theming
 version=103b0add39f9e167e8f6c6d4715d9ffbf87d6d07
 workdir="theming-${version}"
 files="https://github.com/SerenityOS/theming/archive/${version}.zip serenity-theming-${version}.zip 1c3a99d961b1013dbc8b499daa3ee872c5cba29f0efb7f6f885f7f292b3dbeda"
-auth_type="sha256"
 
 build() {
     :

--- a/Ports/serious-sam-classic/package.sh
+++ b/Ports/serious-sam-classic/package.sh
@@ -3,7 +3,6 @@ port='serious-sam-classic'
 useconfigure='false'
 version='1.10.4'
 files="https://github.com/tx00100xt/SeriousSamClassic/archive/refs/tags/v${version}.tar.gz ${port}.tar.gz c42e1434e03f713ffc60aa627f0a24c64287598bc5ee7cdbd2cbe91aa363ef51"
-auth_type='sha256'
 depends=(
     'libvorbis'
     'SDL2'

--- a/Ports/sfinx/package.sh
+++ b/Ports/sfinx/package.sh
@@ -2,7 +2,6 @@
 port=sfinx
 version="1.1"
 files="https://downloads.scummvm.org/frs/extras/Sfinx/sfinx-en-v1.1.zip ${port}-en-v${version}.zip f516b30a046526f78cbc923d8f907d267ab964ccd9b770afc72350e8d467ec4d"
-auth_type=sha256
 depends=("scummvm")
 workdir="${port}-en-v${version}"
 

--- a/Ports/sl/package.sh
+++ b/Ports/sl/package.sh
@@ -3,7 +3,6 @@ port=sl
 version=git
 workdir=sl-master
 files="https://github.com/mtoyoda/sl/archive/master.tar.gz sl-git.tar.gz 3270434e28c4f4e15b8e98de60ea98508a7486485f52356a61f36ac5430fbc80"
-auth_type=sha256
 depends=("ncurses")
 
 build() {

--- a/Ports/soltys/package.sh
+++ b/Ports/soltys/package.sh
@@ -2,7 +2,6 @@
 port=soltys
 version="1.0"
 files="https://downloads.scummvm.org/frs/extras/Soltys/soltys-en-v1.0.zip ${port}-en-v${version}.zip 87b89e654b8a5b8ebe342cb4c5c6049ab9a43a5efb474d9c49bafb77dcce48f6"
-auth_type=sha256
 depends=("scummvm")
 
 resource_path="/usr/local/share/games/${port}-${version}"

--- a/Ports/sparsehash/package.sh
+++ b/Ports/sparsehash/package.sh
@@ -3,5 +3,4 @@ port=sparsehash
 version=2.0.4
 useconfigure=true
 files="https://github.com/sparsehash/sparsehash/archive/refs/tags/$port-$version.tar.gz $port-$version.tar.gz 8cd1a95827dfd8270927894eb77f62b4087735cbede953884647f16c521c7e58"
-auth_type=sha256
 workdir=$port-$port-$version

--- a/Ports/speexdsp/package.sh
+++ b/Ports/speexdsp/package.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port='speexdsp'
 version='1.2.1'
-auth_type='sha256'
 useconfigure='true'
 files="https://downloads.xiph.org/releases/speex/speexdsp-${version}.tar.gz speexdsp-${version}.tar.gz 8c777343e4a6399569c72abc38a95b24db56882c83dbdb6c6424a5f4aeb54d3d"

--- a/Ports/sqlite/package.sh
+++ b/Ports/sqlite/package.sh
@@ -2,7 +2,6 @@
 port='sqlite'
 version='3410200'
 files="https://www.sqlite.org/2023/sqlite-autoconf-${version}.tar.gz sqlite-autoconf-${version}.tar.gz e98c100dd1da4e30fa460761dab7c0b91a50b785e167f8c57acc46514fae9499"
-auth_type='sha256'
 useconfigure='true'
 use_fresh_config_sub='true'
 workdir="sqlite-autoconf-${version}"

--- a/Ports/ssmtp/package.sh
+++ b/Ports/ssmtp/package.sh
@@ -2,7 +2,6 @@
 port='ssmtp'
 version='2.64-11'
 files="https://salsa.debian.org/debian/ssmtp/-/archive/debian/${version}/ssmtp-debian-${version}.tar.gz ssmtp-debian-${version}.tar.gz 82abe0fb54e2ee209e9f8745498ce5f4e35f2f2b1bf95bd5e6dfbcfc61a8ebe2"
-auth_type='sha256'
 useconfigure='true'
 workdir="ssmtp-debian-${version}"
 configopts=(

--- a/Ports/stb/package.sh
+++ b/Ports/stb/package.sh
@@ -2,7 +2,6 @@
 port='stb'
 version='af1a5bc352164740c1cc1354942b1c6b72eacb8a'
 files="https://github.com/nothings/stb/archive/${version}.zip stb-${version}.zip e3d0edbecd356506d3d69b87419de2f9d180a98099134c6343177885f6c2cbef"
-auth_type='sha256'
 
 build() {
     :

--- a/Ports/stockfish/package.sh
+++ b/Ports/stockfish/package.sh
@@ -3,7 +3,6 @@ port='stockfish'
 version='16'
 useconfigure='false'
 files="https://github.com/official-stockfish/Stockfish/archive/refs/tags/sf_${version}.tar.gz sf_${version}.tar.gz a1600ebdaf4e324ba3e10cec2e0c9a810dc64c6f0db5cc955b2fd5e1eefa1cc6"
-auth_type='sha256'
 workdir="Stockfish-sf_${version}/src/"
 makeopts+=(ARCH="${SERENITY_ARCH}" SUPPORTED_ARCH=true COMPCXX="${CXX}")
 

--- a/Ports/stress-ng/package.sh
+++ b/Ports/stress-ng/package.sh
@@ -2,7 +2,6 @@
 port=stress-ng
 version=0.14.03
 files="https://github.com/ColinIanKing/stress-ng/archive/V${version}.tar.gz stress-ng-${version}.tar.gz 95012c62883ab5826e6157557a075df98cce3cbce2a48bb40851bcc968a8441a"
-auth_type=sha256
 depends=("zlib")
 
 pre_configure() {

--- a/Ports/tar/package.sh
+++ b/Ports/tar/package.sh
@@ -5,7 +5,6 @@ useconfigure='true'
 use_fresh_config_sub='true'
 config_sub_paths=('build-aux/config.sub')
 files="https://ftpmirror.gnu.org/gnu/tar/tar-${version}.tar.gz tar-${version}.tar.gz 03d908cf5768cfe6b7ad588c921c6ed21acabfb2b79b788d1330453507647aed"
-auth_type='sha256'
 configopts=(
     "--without-selinux"
     "--without-posix-acls"

--- a/Ports/taskwarrior/package.sh
+++ b/Ports/taskwarrior/package.sh
@@ -3,7 +3,6 @@ port='taskwarrior'
 version='2.6.2'
 useconfigure='true'
 files="https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v${version}/task-${version}.tar.gz taskwarrior-${version}.tar.gz b1d3a7f000cd0fd60640670064e0e001613c9e1cb2242b9b3a9066c78862cfec"
-auth_type='sha256'
 workdir="task-${version}"
 configopts=("-DCMAKE_BUILD_TYPE=release" "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt" "-DENABLE_SYNC=OFF" "-DTASK_DOCDIR=share/doc/taskwarrior-2.6.2" "-DTASK_RCDIR=share/taskwarrior/rc")
 depends=("libuuid")

--- a/Ports/tcl/package.sh
+++ b/Ports/tcl/package.sh
@@ -4,4 +4,3 @@ version=8.6.12
 workdir=tcl${version}/unix
 useconfigure=true
 files="https://prdownloads.sourceforge.net/tcl/tcl${version}-src.tar.gz tcl${version}.tar.gz 26c995dd0f167e48b11961d891ee555f680c175f7173ff8cb829f4ebcde4c1a6"
-auth_type=sha256

--- a/Ports/termcap/package.sh
+++ b/Ports/termcap/package.sh
@@ -4,4 +4,3 @@ version=1.3.1
 useconfigure=true
 configopts=("--prefix=${SERENITY_INSTALL_ROOT}/usr/local")
 files="https://ftpmirror.gnu.org/gnu/termcap/termcap-${version}.tar.gz termcap-${version}.tar.gz 91a0e22e5387ca4467b5bcb18edf1c51b930262fd466d5fda396dd9d26719100"
-auth_type=sha256

--- a/Ports/thesilversearcher/package.sh
+++ b/Ports/thesilversearcher/package.sh
@@ -6,7 +6,6 @@ files="https://geoff.greer.fm/ag/releases/the_silver_searcher-${version}.tar.gz 
 workdir="the_silver_searcher-${version}"
 configopts=("--target=${SERENITY_ARCH}-pc-serenity" "--disable-utf8")
 depends=("pcre" "xz")
-auth_type="sha256"
 use_fresh_config_sub=true
 
 export CFLAGS="-fcommon -D_GNU_SOURCE -lpthread"

--- a/Ports/tig/package.sh
+++ b/Ports/tig/package.sh
@@ -3,5 +3,4 @@ port=tig
 version=2.5.5
 useconfigure="true"
 files="https://github.com/jonas/tig/releases/download/tig-${version}/tig-${version}.tar.gz tig-${version}.tar.gz 24ba2c8beae889e6002ea7ced0e29851dee57c27fde8480fb9c64d5eb8765313"
-auth_type=sha256
 depends=("ncurses" "pcre" "readline" "libiconv")

--- a/Ports/timidity/package.sh
+++ b/Ports/timidity/package.sh
@@ -4,7 +4,6 @@ useconfigure='true'
 version='2.15.0'
 files="https://netcologne.dl.sourceforge.net/project/timidity/TiMidity%2B%2B/TiMidity%2B%2B-${version}/TiMidity%2B%2B-${version}.tar.xz timidity-${version}.tar.xz 9eaf4fadb0e19eb8e35cd4ac16142d604c589e43d0e8798237333697e6381d39
 https://www.quaddicted.com/files/idgames/sounds/eawpats.zip eawpats.zip.no_extract 19087fa4a40e25ec39a09cffcc9f775fc22d88bc971a7a9831e075cdae2ee1e3"
-auth_type='sha256'
 workdir="TiMidity++-${version}"
 use_fresh_config_sub='true'
 use_fresh_config_guess='true'

--- a/Ports/tinycc/package.sh
+++ b/Ports/tinycc/package.sh
@@ -2,7 +2,6 @@
 port=tinycc
 version=dev
 files="https://github.com/TinyCC/tinycc/archive/dev.tar.gz tinycc-dev.tar.gz 1e16fd9926e8e2662a35c790b7c56e8e7e8769c6a8a86a59a534c26046d0d83e"
-auth_type=sha256
 useconfigure=true
 makeopts=("tcc")
 

--- a/Ports/tinyscheme/package.sh
+++ b/Ports/tinyscheme/package.sh
@@ -2,7 +2,6 @@
 port=tinyscheme
 version=1.42
 files="https://downloads.sourceforge.net/project/tinyscheme/tinyscheme/tinyscheme-${version}/tinyscheme-${version}.tar.gz tinyscheme-${version}.tar.gz 17b0b1bffd22f3d49d5833e22a120b339039d2cfda0b46d6fc51dd2f01b407ad"
-auth_type=sha256
 useconfigure=false
 
 build() {

--- a/Ports/tr/package.sh
+++ b/Ports/tr/package.sh
@@ -2,5 +2,4 @@
 port=tr
 version=6.7
 files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/tr-${version}.tar.gz tr-${version}.tar.gz 6390b9f90baf097c7ee660e3d1f107161dd422e3048ce7b7bea65043b916d416"
-auth_type=sha256
 depends=("libpuffy")

--- a/Ports/tree/package.sh
+++ b/Ports/tree/package.sh
@@ -2,7 +2,6 @@
 port='tree'
 version='2.0.4'
 files="https://github.com/Old-Man-Programmer/tree/archive/refs/tags/${version}.tar.gz tree-${version}.tar.gz 3ebeaf77a3b3829bcf665329e9d0f3624079c2c4cb4ef14cf6d7129a1a208b59"
-auth_type='sha256'
 
 build() {
     run make CC="${CC}" all

--- a/Ports/tuxracer/package.sh
+++ b/Ports/tuxracer/package.sh
@@ -4,7 +4,6 @@ useconfigure="true"
 version="0.61"
 files="http://ftp.e.kth.se/pub/mpkg/distfiles/tuxracer/${version}/tuxracer-${version}.tar.gz tuxracer-${version}.tar.gz a311d09080598fe556134d4b9faed7dc0c2ed956ebb10d062e5d4df022f91eff
 http://ftp.e.kth.se/pub/mpkg/distfiles/tuxracer/${version}/tuxracer-data-${version}.tar.gz tuxracer-data-${version}.tar.gz 3783d204b7bb1ed16aa5e5a1d5944de10fbee05bc7cebb8f616fce84301f3651"
-auth_type=sha256
 depends=("glu" "SDL_mixer" "sdl12-compat" "tcl")
 configopts=(
     "--with-gl-inc=${SERENITY_INSTALL_ROOT}/usr/include/LibGL"

--- a/Ports/vim/package.sh
+++ b/Ports/vim/package.sh
@@ -4,7 +4,6 @@ version=8.2.4554
 workdir="${port}-${version}"
 useconfigure="true"
 files="https://github.com/vim/vim/archive/refs/tags/v${version}.tar.gz vim-v${version}.tar.gz 206c8fc2535df33b9ea62fa1c9acae66c981a3e3aa4de0f652ef3a25e2b92571"
-auth_type=sha256
 configopts=("--with-tlib=tinfo" "--with-features=normal")
 depends=("ncurses" "gettext")
 

--- a/Ports/vitetris/package.sh
+++ b/Ports/vitetris/package.sh
@@ -4,7 +4,6 @@ useconfigure="true"
 version="0.59.1"
 files="https://github.com/vicgeralds/vitetris/archive/refs/tags/v${version}.tar.gz vitetris.tar.gz 699443df03c8d4bf2051838c1015da72039bbbdd0ab0eede891c59c840bdf58d"
 configopts=("--without-xlib" "--without-joystick" "--without-network")
-auth_type=sha256
 launcher_name=vitetris
 launcher_category=Games
 launcher_command=tetris

--- a/Ports/vlang/package.sh
+++ b/Ports/vlang/package.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=vlang
-auth_type=sha256
 version=weekly.2021.31
 workdir="v-${version}"
 files="https://codeload.github.com/vlang/v/tar.gz/refs/tags/${version} v-${version}.tar.gz b0daf0a2e2cb6d463710952f4d2e8705c17d02a9270355b20861ff3fd5f72563"

--- a/Ports/vttest/package.sh
+++ b/Ports/vttest/package.sh
@@ -3,4 +3,3 @@ port=vttest
 version=20220215
 useconfigure=true
 files="https://invisible-mirror.net/archives/vttest/vttest-$version.tgz vttest-$version.tar.gz 4a65998c5e12cf08ced2cfce119adb44fa842ac1495d0f150f21c8a6785915a1"
-auth_type=sha256

--- a/Ports/wayland/package.sh
+++ b/Ports/wayland/package.sh
@@ -15,7 +15,6 @@ depends=(
     'libxml2'
 )
 files="https://gitlab.freedesktop.org/wayland/wayland/-/releases/${version}/downloads/wayland-${version}.tar.xz wayland-${version}.tar.xz 6dc64d7fc16837a693a51cfdb2e568db538bfdc9f457d4656285bb9594ef11ac"
-auth_type='sha256'
 
 configure() {
     # TODO: Figure out why GCC doesn't autodetect that libgcc_s is needed.

--- a/Ports/wget/package.sh
+++ b/Ports/wget/package.sh
@@ -6,7 +6,6 @@ use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 depends=("openssl")
 files="https://ftpmirror.gnu.org/gnu/wget/wget-${version}.tar.gz wget-${version}.tar.gz 5726bb8bc5ca0f6dc7110f6416e4bb7019e2d2ff5bf93d1ca2ffcc6656f220e5"
-auth_type='sha256'
 configopts=("--with-ssl=openssl" "--disable-ipv6")
 
 export OPENSSL_LIBS="-lssl -lcrypto -ldl"

--- a/Ports/wget/package.sh
+++ b/Ports/wget/package.sh
@@ -5,11 +5,8 @@ useconfigure="true"
 use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 depends=("openssl")
-files="https://ftpmirror.gnu.org/gnu/wget/wget-${version}.tar.gz wget-${version}.tar.gz
-https://ftpmirror.gnu.org/gnu/wget/wget-${version}.tar.gz.sig wget-${version}.tar.gz.sig
-https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
-auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg" "wget-${version}.tar.gz.sig")
+files="https://ftpmirror.gnu.org/gnu/wget/wget-${version}.tar.gz wget-${version}.tar.gz 5726bb8bc5ca0f6dc7110f6416e4bb7019e2d2ff5bf93d1ca2ffcc6656f220e5"
+auth_type='sha256'
 configopts=("--with-ssl=openssl" "--disable-ipv6")
 
 export OPENSSL_LIBS="-lssl -lcrypto -ldl"

--- a/Ports/which/package.sh
+++ b/Ports/which/package.sh
@@ -3,4 +3,3 @@ port='which'
 version='2.21'
 useconfigure='true'
 files="https://ftpmirror.gnu.org/gnu/which/which-${version}.tar.gz which-${version}.tar.gz f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad"
-auth_type='sha256'

--- a/Ports/wireguard-tools/package.sh
+++ b/Ports/wireguard-tools/package.sh
@@ -2,7 +2,6 @@
 port=wireguard-tools
 version=1.0.20210914
 files="https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-${version}.tar.xz wireguard-tools-${version}.tar.xz 97ff31489217bb265b7ae850d3d0f335ab07d2652ba1feec88b734bc96bd05ac"
-auth_type=sha256
 makeopts=("--directory=src")
 # NOTE: PREFIX extends DESTDIR and therefore must not include $SERENITY_INSTALL_ROOT!
 installopts=("--directory=src" "PREFIX=/usr/local")

--- a/Ports/x264/package.sh
+++ b/Ports/x264/package.sh
@@ -3,7 +3,6 @@
 port='x264'
 version='baee400fa9ced6f5481a728138fed6e867b0ff7f'
 files="https://code.videolan.org/videolan/x264/-/archive/${version}/x264-master.tar.gz libx264-${version}.tar.gz 436a2be54d8bc0cb05dd33ecbbcb7df9c3b57362714fcdaa3a5991189a33319b"
-auth_type='sha256'
 useconfigure='true'
 use_fresh_config_sub='true'
 configopts=("--enable-shared")

--- a/Ports/x265/package.sh
+++ b/Ports/x265/package.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=x265
 version=3.5
-auth_type=sha256
 workdir="${port}_${version}"
 files=("https://bitbucket.org/multicoreware/x265_git/downloads/x265_${version}.tar.gz x265_${version}.tar.gz e70a3335cacacbba0b3a20ec6fecd6783932288ebc8163ad74bcc9606477cae8")
 useconfigure=true

--- a/Ports/xash3d-fwgs/package.sh
+++ b/Ports/xash3d-fwgs/package.sh
@@ -18,7 +18,6 @@ https://github.com/FWGS/mainui_cpp/archive/${_mainui_commit}.tar.gz mainui_cpp-$
 https://github.com/FWGS/MiniUTL/archive/${_miniutl_commit}.tar.gz MiniUTL-${_miniutl_commit}.tar.gz 7b7b26377854b3fc741c8d652d8b3c9c540512644943ca6efb63df941b2861e3
 https://github.com/xiph/opus/archive/${_opus_commit}.tar.gz opus-${_opus_commit}.tar.gz 56156f1f7a19fcd356041604ce9fdd7d70a67a0e91153f25970dcc8710ea057e
 https://github.com/FWGS/xash-extras/archive/${_extras_commit}.tar.gz xash-extras-${_extras_commit}.tar.gz 020b4c35f97fabbd70a7444a98451f0f5be4dcbf149e42e5e49598a5651805ab"
-auth_type='sha256'
 
 export PKG_CONFIG_PATH="${SERENITY_INSTALL_ROOT}/usr/local/lib/pkgconfig"
 

--- a/Ports/xz/package.sh
+++ b/Ports/xz/package.sh
@@ -6,5 +6,4 @@ configopts=("--disable-static" "--enable-shared")
 use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 files="https://tukaani.org/xz/xz-${version}.tar.gz xz-${version}.tar.gz f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10"
-auth_type=sha256
 depends=("zlib" "libiconv")

--- a/Ports/yasm/package.sh
+++ b/Ports/yasm/package.sh
@@ -2,7 +2,6 @@
 port=yasm
 version=1.3.0
 files="https://www.tortall.net/projects/yasm/releases/yasm-${version}.tar.gz yasm-${version}.tar.gz 3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f"
-auth_type="sha256"
 useconfigure=true
 use_fresh_config_sub=true
 config_sub_paths=("config/config.sub")

--- a/Ports/zig/package.sh
+++ b/Ports/zig/package.sh
@@ -3,7 +3,6 @@
 port='zig'
 version='0.11.0-dev.670+f7fea080b'
 files='https://github.com/ziglang/zig-bootstrap/archive/b9a466fd23d7777e1b3b87d49074ce66370fb7b3.tar.gz zig-bootstrap-b9a466f.tar.gz 84cf91d727c53ef49220ea6b2864dae3bd48e5e5a73be95bf3672c38a72b0946'
-auth_type='sha256'
 workdir='zig-bootstrap-b9a466fd23d7777e1b3b87d49074ce66370fb7b3'
 
 post_fetch() {

--- a/Ports/zlib/package.sh
+++ b/Ports/zlib/package.sh
@@ -3,7 +3,6 @@ port=zlib
 version=1.2.13
 useconfigure=true
 files="https://www.zlib.net/zlib-${version}.tar.gz zlib-${version}.tar.gz b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
-auth_type="sha256"
 
 configure() {
     # Set uname to linux to prevent it finding the host's `libtool` on e.g. Darwin

--- a/Ports/zsh/package.sh
+++ b/Ports/zsh/package.sh
@@ -2,7 +2,6 @@
 port=zsh
 version=5.9
 files="https://sourceforge.net/projects/zsh/files/zsh/${version}/zsh-${version}.tar.xz zsh-${version}.tar.xz 9b8d1ecedd5b5e81fbf1918e876752a7dd948e05c1a0dba10ab863842d45acd5"
-auth_type="sha256"
 useconfigure=true
 use_fresh_config_sub=true
 

--- a/Ports/zstd/package.sh
+++ b/Ports/zstd/package.sh
@@ -2,7 +2,6 @@
 port=zstd
 version=1.5.2
 files="https://github.com/facebook/zstd/releases/download/v${version}/zstd-${version}.tar.gz zstd-${version}.tar.gz 7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0"
-auth_type=sha256
 useconfigure='true'
 configopts=(
     "-Sbuild/cmake"


### PR DESCRIPTION
We decided some time ago that we ultimately want to phase out signature-based checking, and `sha256` was the only other type that was ever supported (even if the README file claims otherwise).

While a lot of the signature-based checks were removed over time through package updates, the remaining ones seem to have held on until now. Since we want to look into modernizing the `files` array a bit, remove the remaining non-sha256 ones to make the 'array' more uniform.