### PR TITLE
LibPDF+pdf: Print PDF metadata

### DIFF
--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -13,6 +13,7 @@
     A(Alternate)                  \
     A(ASCII85Decode)              \
     A(ASCIIHexDecode)             \
+    A(Author)                     \
     A(BG)                         \
     A(BG2)                        \
     A(BM)                         \
@@ -31,6 +32,8 @@
     A(Columns)                    \
     A(Contents)                   \
     A(Count)                      \
+    A(CreationDate)               \
+    A(Creator)                    \
     A(CropBox)                    \
     A(Crypt)                      \
     A(D)                          \
@@ -79,8 +82,10 @@
     A(Image)                      \
     A(ImageMask)                  \
     A(Index)                      \
+    A(Info)                       \
     A(JBIG2Decode)                \
     A(JPXDecode)                  \
+    A(Keywords)                   \
     A(Kids)                       \
     A(L)                          \
     A(LC)                         \
@@ -99,6 +104,7 @@
     A(Matrix)                     \
     A(MediaBox)                   \
     A(MissingWidth)               \
+    A(ModDate)                    \
     A(N)                          \
     A(Names)                      \
     A(Next)                       \
@@ -113,6 +119,7 @@
     A(Pattern)                    \
     A(Predictor)                  \
     A(Prev)                       \
+    A(Producer)                   \
     A(R)                          \
     A(RI)                         \
     A(Registry)                   \
@@ -123,6 +130,7 @@
     A(SA)                         \
     A(SM)                         \
     A(SMask)                      \
+    A(Subject)                    \
     A(Subtype)                    \
     A(Supplement)                 \
     A(T)                          \

--- a/Userland/Libraries/LibPDF/Document.cpp
+++ b/Userland/Libraries/LibPDF/Document.cpp
@@ -34,6 +34,46 @@ DeprecatedString OutlineItem::to_deprecated_string(int indent) const
     return builder.to_deprecated_string();
 }
 
+PDFErrorOr<Optional<DeprecatedString>> InfoDict::title() const
+{
+    return get(CommonNames::Title);
+}
+
+PDFErrorOr<Optional<DeprecatedString>> InfoDict::author() const
+{
+    return get(CommonNames::Author);
+}
+
+PDFErrorOr<Optional<DeprecatedString>> InfoDict::subject() const
+{
+    return get(CommonNames::Subject);
+}
+
+PDFErrorOr<Optional<DeprecatedString>> InfoDict::keywords() const
+{
+    return get(CommonNames::Keywords);
+}
+
+PDFErrorOr<Optional<DeprecatedString>> InfoDict::creator() const
+{
+    return get(CommonNames::Creator);
+}
+
+PDFErrorOr<Optional<DeprecatedString>> InfoDict::producer() const
+{
+    return get(CommonNames::Producer);
+}
+
+PDFErrorOr<Optional<DeprecatedString>> InfoDict::creation_date() const
+{
+    return get(CommonNames::CreationDate);
+}
+
+PDFErrorOr<Optional<DeprecatedString>> InfoDict::modification_date() const
+{
+    return get(CommonNames::ModDate);
+}
+
 PDFErrorOr<NonnullRefPtr<Document>> Document::create(ReadonlyBytes bytes)
 {
     auto parser = adopt_ref(*new DocumentParser({}, bytes));
@@ -187,6 +227,14 @@ PDFErrorOr<Value> Document::resolve(Value const& value)
         return static_ptr_cast<IndirectValue>(obj)->value();
 
     return value;
+}
+
+PDFErrorOr<Optional<InfoDict>> Document::info_dict()
+{
+    if (!trailer()->contains(CommonNames::Info))
+        return OptionalNone {};
+
+    return InfoDict(this, TRY(trailer()->get_dict(this, CommonNames::Info)));
 }
 
 PDFErrorOr<void> Document::build_page_tree()

--- a/Userland/Utilities/pdf.cpp
+++ b/Userland/Utilities/pdf.cpp
@@ -7,7 +7,31 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <LibCore/MappedFile.h>
+#include <LibPDF/CommonNames.h>
 #include <LibPDF/Document.h>
+
+static PDF::PDFErrorOr<void> print_document_info_dict(PDF::Document& document)
+{
+    if (auto info_dict = TRY(document.info_dict()); info_dict.has_value()) {
+        if (auto title = TRY(info_dict->title()); title.has_value())
+            outln("Title: {}", title);
+        if (auto author = TRY(info_dict->author()); author.has_value())
+            outln("Author: {}", author);
+        if (auto subject = TRY(info_dict->subject()); subject.has_value())
+            outln("Subject: {}", subject);
+        if (auto keywords = TRY(info_dict->keywords()); keywords.has_value())
+            outln("Keywords: {}", keywords);
+        if (auto creator = TRY(info_dict->creator()); creator.has_value())
+            outln("Creator: {}", creator);
+        if (auto producer = TRY(info_dict->producer()); producer.has_value())
+            outln("Producer: {}", producer);
+        if (auto creation_date = TRY(info_dict->creation_date()); creation_date.has_value())
+            outln("Creation date: {}", creation_date);
+        if (auto modification_date = TRY(info_dict->modification_date()); modification_date.has_value())
+            outln("Modification date: {}", modification_date);
+    }
+    return {};
+}
 
 static PDF::PDFErrorOr<int> pdf_main(Main::Arguments arguments)
 {
@@ -31,6 +55,7 @@ static PDF::PDFErrorOr<int> pdf_main(Main::Arguments arguments)
     TRY(document->initialize());
 
     outln("{} pages", document->get_page_count());
+    TRY(print_document_info_dict(*document));
 
     return 0;
 }


### PR DESCRIPTION
It'd be nicer to show this metadata in the GUI too at some point, probably behind an "I" info toolbar button in the PDF viewer, and maybe in a tab in the file viewer properties window.

@mattco98 for LibPDF.

@AtkinsSJ who might be interested in doing the GUI integration once this is in :)