### PR TITLE
LibIPC: Do not leak the Core::File fd by default

### DIFF
--- a/Userland/Libraries/LibIPC/File.h
+++ b/Userland/Libraries/LibIPC/File.h
@@ -40,9 +40,8 @@ public:
     {
     }
 
-    template<typename... Args>
-    File(Core::File& file, Args... args)
-        : File(file.leak_fd(Badge<File> {}), args...)
+    explicit File(Core::File& file)
+        : File(file.leak_fd(Badge<File> {}), CloseAfterSending)
     {
     }
 

--- a/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
+++ b/Userland/Services/FileSystemAccessServer/ConnectionFromClient.cpp
@@ -81,7 +81,7 @@ void ConnectionFromClient::request_file_handler(i32 request_id, i32 window_serve
             dbgln("FileSystemAccessServer: Couldn't open {}, error {}", path, file.error());
             async_handle_prompt_end(request_id, file.error().code(), Optional<IPC::File> {}, path);
         } else {
-            async_handle_prompt_end(request_id, 0, IPC::File(*file.release_value(), IPC::File::CloseAfterSending), path);
+            async_handle_prompt_end(request_id, 0, IPC::File(*file.release_value()), path);
         }
     } else {
         async_handle_prompt_end(request_id, EPERM, Optional<IPC::File> {}, path);
@@ -138,7 +138,7 @@ void ConnectionFromClient::prompt_helper(i32 request_id, Optional<DeprecatedStri
 
             m_approved_files.set(user_picked_file.value(), new_permissions);
 
-            async_handle_prompt_end(request_id, 0, IPC::File(*file.release_value(), IPC::File::CloseAfterSending), user_picked_file);
+            async_handle_prompt_end(request_id, 0, IPC::File(*file.release_value()), user_picked_file);
         }
     } else {
         async_handle_prompt_end(request_id, ECANCELED, Optional<IPC::File> {}, Optional<DeprecatedString> {});

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -120,7 +120,7 @@ private:
         if (file.is_error())
             client().async_handle_file_return(file.error().code(), {}, request_id);
         else
-            client().async_handle_file_return(0, IPC::File(*file.value(), IPC::File::CloseAfterSending), request_id);
+            client().async_handle_file_return(0, IPC::File(*file.value()), request_id);
     }
 
     void notify_server_did_finish_handling_input_event(bool) override { }


### PR DESCRIPTION
This prevents fd leaks when the user of the API forgets to pass CloseAfterSending to IPC::File. Since we are calling leak_fd in the constructor, we want it to also take care of closing.

Fixes at least 1 leak in `WebContentView::notify_server_did_request_file` that causes ladybird to silently crash / not load anymore after loading `ulimit -a` files from disk (256 or 2048 seem to be popular defaults).

This is a better fix related to the fd leak in headless-browser that was crashing the tests if the open file limit was 256, (PR #19853).