### PR TITLE
LibPDF: Fix enough issues that pdf_reference_1-7.pdf can be loaded by `pdf`

### DIFF
--- a/Userland/Libraries/LibPDF/Encryption.cpp
+++ b/Userland/Libraries/LibPDF/Encryption.cpp
@@ -323,8 +323,8 @@ void StandardSecurityHandler::encrypt(NonnullRefPtr<Object> object, Reference re
         auto stream = object->cast<StreamObject>();
         bytes = stream->bytes();
 
-        assign = [&stream](ByteBuffer const& buffer) {
-            stream->buffer() = buffer;
+        assign = [&object](ByteBuffer const& buffer) {
+            object->cast<StreamObject>()->buffer() = buffer;
         };
 
         if (stream->dict()->contains(CommonNames::Filter)) {
@@ -335,8 +335,8 @@ void StandardSecurityHandler::encrypt(NonnullRefPtr<Object> object, Reference re
     } else if (object->is<StringObject>()) {
         auto string = object->cast<StringObject>();
         bytes = string->string().bytes();
-        assign = [&string](ByteBuffer const& buffer) {
-            string->set_string(DeprecatedString(buffer.bytes()));
+        assign = [&object](ByteBuffer const& buffer) {
+            object->cast<StringObject>()->set_string(DeprecatedString(buffer.bytes()));
         };
     } else {
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibPDF/Reference.h
+++ b/Userland/Libraries/LibPDF/Reference.h
@@ -12,34 +12,26 @@
 namespace PDF {
 
 class Reference {
-    // We store refs as u32, with 18 bits for the index and 14 bits for the
-    // generation index. The generation index is stored in the higher bits.
-    // This may need to be rethought later, as the max generation index is
-    // 2^16 and the max for the object index is probably 2^32 (I don't know
-    // exactly)
-    static constexpr auto MAX_REF_INDEX = (1 << 19) - 1;            // 2 ^ 19 - 1
-    static constexpr auto MAX_REF_GENERATION_INDEX = (1 << 15) - 1; // 2 ^ 15 - 1
-
 public:
     Reference(u32 index, u32 generation_index)
+        : m_ref_index(index)
+        , m_generation_index(generation_index)
     {
-        VERIFY(index < MAX_REF_INDEX);
-        VERIFY(generation_index < MAX_REF_GENERATION_INDEX);
-        m_combined = (generation_index << 14) | index;
     }
 
     [[nodiscard]] ALWAYS_INLINE u32 as_ref_index() const
     {
-        return m_combined & 0x3ffff;
+        return m_ref_index;
     }
 
     [[nodiscard]] ALWAYS_INLINE u32 as_ref_generation_index() const
     {
-        return m_combined >> 18;
+        return m_generation_index;
     }
 
 private:
-    u32 m_combined;
+    u32 m_ref_index;
+    u32 m_generation_index;
 };
 
 }


### PR DESCRIPTION
It's just two bugs.

With this and #19923:

```
% Build/lagom/bin/pdf ~/Downloads/pdf_reference_1-7.pdf 
1310 pages
Title: PDF Reference, version 1.7
Author: Adobe Systems Incorporated
Subject: Adobe Portable Document Format (PDF)
Creator: FrameMaker 7.2
Producer: Acrobat Distiller 7.0.5 (Windows)
Creation date: D:20061017081020Z
Modification date: D:20061118211043-02'30'
```

@mattco98 