### PR TITLE
LibGfx/PortableFormat: Refactor the plugin interface

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/PBMLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PBMLoader.cpp
@@ -49,7 +49,7 @@ ErrorOr<void> read_image_data(PBMLoadingContext& context)
         }
     }
 
-    context.state = PBMLoadingContext::State::Bitmap;
+    context.state = PBMLoadingContext::State::BitmapDecoded;
     return {};
 }
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/PGMLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PGMLoader.cpp
@@ -36,7 +36,7 @@ ErrorOr<void> read_image_data(PGMLoadingContext& context)
         }
     }
 
-    context.state = PGMLoadingContext::State::Bitmap;
+    context.state = PGMLoadingContext::State::BitmapDecoded;
     return {};
 }
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/PPMLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PPMLoader.cpp
@@ -45,7 +45,7 @@ ErrorOr<void> read_image_data(PPMLoadingContext& context)
         }
     }
 
-    context.state = PPMLoadingContext::State::Bitmap;
+    context.state = PPMLoadingContext::State::BitmapDecoded;
     return {};
 }
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
@@ -195,9 +195,8 @@ static ErrorOr<void> read_header(Context& context)
 template<typename TContext>
 static ErrorOr<void> decode(TContext& context)
 {
-    VERIFY(context.state == TContext::State::NotDecoded);
+    VERIFY(context.state == TContext::State::HeaderDecoded);
 
-    TRY(read_header(context));
     TRY(read_image_data(context));
 
     context.state = TContext::State::BitmapDecoded;

--- a/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
@@ -175,12 +175,9 @@ static ErrorOr<void> create_bitmap(TContext& context)
     return {};
 }
 
-template<typename TContext>
-static ErrorOr<void> decode(TContext& context)
+template<typename Context>
+static ErrorOr<void> read_header(Context& context)
 {
-    if (context.state >= TContext::State::Decoded)
-        return {};
-
     TRY(read_magic_number(context));
 
     TRY(read_whitespace(context));
@@ -201,6 +198,16 @@ static ErrorOr<void> decode(TContext& context)
         TRY(read_whitespace(context));
     }
 
+    return {};
+}
+
+template<typename TContext>
+static ErrorOr<void> decode(TContext& context)
+{
+    if (context.state >= TContext::State::Decoded)
+        return {};
+
+    TRY(read_header(context));
     TRY(read_image_data(context));
 
     context.state = TContext::State::Decoded;

--- a/Userland/Libraries/LibGfx/ImageFormats/PortableImageMapLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PortableImageMapLoader.h
@@ -64,7 +64,6 @@ public:
 
     virtual IntSize size() override;
 
-    virtual ErrorOr<void> initialize() override { return {}; }
     virtual bool is_animated() override;
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/PortableImageMapLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PortableImageMapLoader.h
@@ -30,12 +30,8 @@ struct PortableImageMapLoadingContext {
     enum class State {
         NotDecoded = 0,
         Error,
-        MagicNumber,
-        Width,
-        Height,
-        Maxval,
-        Bitmap,
-        Decoded
+        HeaderDecoded,
+        BitmapDecoded,
     };
 
     Type type { Type::Unknown };
@@ -89,7 +85,7 @@ IntSize PortableImageDecoderPlugin<TContext>::size()
     if (m_context->state == TContext::State::Error)
         return {};
 
-    if (m_context->state < TContext::State::Decoded) {
+    if (m_context->state < TContext::State::BitmapDecoded) {
         if (decode(*m_context).is_error()) {
             m_context->state = TContext::State::Error;
             // FIXME: We should propagate errors
@@ -156,7 +152,7 @@ ErrorOr<ImageFrameDescriptor> PortableImageDecoderPlugin<TContext>::frame(size_t
     if (m_context->state == TContext::State::Error)
         return Error::from_string_literal("PortableImageDecoderPlugin: Decoding failed");
 
-    if (m_context->state < TContext::State::Decoded) {
+    if (m_context->state < TContext::State::BitmapDecoded) {
         if (decode(*m_context).is_error()) {
             m_context->state = TContext::State::Error;
             return Error::from_string_literal("PortableImageDecoderPlugin: Decoding failed");


### PR DESCRIPTION
**LibGfx/PortableFormat: Remove `PortableImageDecoderPlugin::initialize()`**


**LibGfx/PortableFormat: Extract header reading in its own function**


**LibGfx/PortableFormat: Simplify the State enum**

This enum used to store very precise state about the decoding process,
let's simplify that by only including two steps: HeaderDecoder and
BitmapDecoded.

**LibGfx/PortableFormat: Read the header during initialization**

This is done as a part of #19893.