### PR TITLE
LibWeb: Make images load on the Twinings website :^)

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -234,9 +234,11 @@ bool HTMLImageElement::complete() const
         return true;
 
     // - The img element's current request's state is completely available and its pending request is null.
+    if (m_current_request->state() == ImageRequest::State::CompletelyAvailable && !m_pending_request)
+        return true;
+
     // - The img element's current request's state is broken and its pending request is null.
-    // FIXME: This is ad-hoc and should be updated once we are loading images via the Fetch mechanism.
-    if (auto bitmap = current_image_bitmap())
+    if (m_current_request->state() == ImageRequest::State::Broken && !m_pending_request)
         return true;
 
     return false;

--- a/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -175,7 +175,10 @@ CSSPixelRect IntersectionObserver::root_intersection_rectangle() const
 
         // Since the spec says that this is only reach if the document is fully active, that means it must have a browsing context.
         VERIFY(document->browsing_context());
-        rect = document->browsing_context()->viewport_rect();
+
+        // NOTE: This rect is the *size* of the viewport. The viewport *offset* is not relevant,
+        //       as intersections are computed using viewport-relative element rects.
+        rect = CSSPixelRect { CSSPixelPoint { 0, 0 }, document->browsing_context()->viewport_rect().size() };
     } else {
         VERIFY(intersection_root.has<JS::Handle<DOM::Element>>());
         auto element = intersection_root.get<JS::Handle<DOM::Element>>();


### PR DESCRIPTION
There were two issues here:
- Intersection observers were using an incorrectly offset viewport to check for intersections, causing them to fire at unexpected locations.
- `HTMLImageElement.complete` was not taking the state of the image requests into account.