### PR TITLE
LibWeb: Use max width from content for cells unless length is specified

### DIFF
--- a/Tests/LibWeb/Layout/expected/cell-auto-max-width-table-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/cell-auto-max-width-table-percentage-width.txt
@@ -1,0 +1,43 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x23.46875 children: not-inline
+      BlockContainer <div#container> at (8,8) content-size 80x23.46875 children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 80x0 children: inline
+          TextNode <#text>
+        TableWrapper <(anonymous)> at (8,8) content-size 80x23.46875 [BFC] children: not-inline
+          Box <table#table> at (8,8) content-size 80x23.46875 table-box [TFC] children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tbody> at (8,8) content-size 72x19.46875 table-row-group children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              Box <tr> at (10,10) content-size 72x19.46875 table-row children: not-inline
+                BlockContainer <(anonymous)> (not painted) children: inline
+                  TextNode <#text>
+                BlockContainer <td> at (11,11) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                  line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                    frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x17.46875]
+                      "A"
+                  TextNode <#text>
+                BlockContainer <(anonymous)> (not painted) children: inline
+                  TextNode <#text>
+                BlockContainer <td> at (29.265625,11) content-size 9.34375x17.46875 table-cell [BFC] children: inline
+                  line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                    frag 0 from TextNode start: 0, length: 1, rect: [29.265625,11 9.34375x17.46875]
+                      "B"
+                  TextNode <#text>
+                BlockContainer <(anonymous)> (not painted) children: inline
+                  TextNode <#text>
+                BlockContainer <td> at (42.609375,11) content-size 42.390625x17.46875 table-cell [BFC] children: inline
+                  line 0 width: 29.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                    frag 0 from TextNode start: 0, length: 3, rect: [42.609375,11 29.453125x17.46875]
+                      "C D"
+                  TextNode <#text>
+                BlockContainer <(anonymous)> (not painted) children: inline
+                  TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+        BlockContainer <(anonymous)> at (8,31.46875) content-size 80x0 children: inline
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/cell-auto-max-width-table-percentage-width.html
+++ b/Tests/LibWeb/Layout/input/cell-auto-max-width-table-percentage-width.html
@@ -1,0 +1,22 @@
+<style>
+    #container {
+        width: 5em;
+    }
+
+    #table {
+        width: 100%;
+    }
+</style>
+
+
+<div id="container">
+    <table id="table">
+        <tbody>
+            <tr>
+                <td>A</td>
+                <td>B</td>
+                <td>C D</td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -196,7 +196,7 @@ void TableFormattingContext::compute_cell_measures(AvailableSpace const& availab
             min_width = max(min_width, computed_values.min_width().to_px(cell.box, containing_block.content_width()));
 
         CSSPixels max_height = computed_values.height().is_auto() ? max_content_height : height;
-        CSSPixels max_width = (computed_values.width().is_length() || !table_width_is_auto) ? width : max_content_width;
+        CSSPixels max_width = computed_values.width().is_length() ? width : max_content_width;
         if (!should_treat_max_height_as_none(cell.box, available_space.height))
             max_height = min(max_height, computed_values.max_height().to_px(cell.box, containing_block.content_height()));
         if (!should_treat_max_width_as_none(cell.box, available_space.width))


### PR DESCRIPTION
Max width shouldn't be tied to min width, commit d33b99d went too far and made them the same when the table-root had a specified percentage width.

Fixes #19940.