### PR TITLE
LibGfx/PNG: Make invalid sRGB chunk size non-fatal

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -1104,8 +1104,11 @@ static ErrorOr<void> process_gAMA(ReadonlyBytes data, PNGLoadingContext& context
 static ErrorOr<void> process_sRGB(ReadonlyBytes data, PNGLoadingContext& context)
 {
     // https://www.w3.org/TR/png/#srgb-standard-colour-space
-    if (data.size() != 1)
-        return Error::from_string_literal("sRGB chunk has an abnormal size");
+    if (data.size() != 1) {
+        // Invalid per spec, but (rarely) happens in the wild. Log and ignore.
+        warnln("warning: PNG sRGB chunk has an abnormal size; ignoring");
+        return {};
+    }
 
     u8 rendering_intent = data[0];
     if (rendering_intent > 3)


### PR DESCRIPTION
https://www.haiku-os.org/images/bg-page.png has a size of 0 for example.

Just ignoring the chunk instead of assuming that the image is sRGB and has Perceptual rendering intent matches what libpng does (cf `png_handle_sRGB()`), so let's do that too.

(All other chunk handlers are still strict about size.)