### PR TITLE
LibWeb: Don't ignore pseudo-elements when computing BFC height

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-inline-style.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-inline-style.txt
@@ -3,9 +3,6 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x102 children: not-inline
       BlockContainer <div.outer> at (11,11) content-size 100x100 children: not-inline
         BlockContainer <(anonymous)> at (12,12) content-size 50x50 children: inline
-          line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
-            frag 0 from TextNode start: 0, length: 0, rect: [12,12 0x21.828125]
-              ""
           TextNode <#text>
         BlockContainer <div.inner> at (12,64) content-size 98x0 children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
@@ -5,9 +5,6 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (11,11) content-size 108x104 table-box [TFC] children: not-inline
           Box <tbody> at (11,11) content-size 104x100 table-row-group children: not-inline
             Box <tr> at (13,13) content-size 104x100 table-row children: not-inline
-              BlockContainer <td> at (15,51.078125) content-size 100x23.828125 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (16,52.078125) content-size 98x21.828125 children: inline
-                  line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
-                    frag 0 from TextNode start: 0, length: 0, rect: [16,52.078125 0x21.828125]
-                      ""
+              BlockContainer <td> at (15,62) content-size 100x2 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (16,63) content-size 98x0 children: inline
                   TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/position-empty-pseudo-elements.txt
+++ b/Tests/LibWeb/Layout/expected/position-empty-pseudo-elements.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x158 [BFC] children: not-inline
+    BlockContainer <body> at (8,25) content-size 784x125 children: not-inline
+      BlockContainer <div.empty_content> at (33,25) content-size 50x50 children: not-inline
+        BlockContainer <(anonymous)> at (33,75) content-size 50x0 children: inline
+          TextNode <#text>
+      BlockContainer <div.content_with_space> at (33,100) content-size 50x50 children: not-inline
+        BlockContainer <(anonymous)> at (33,150) content-size 50x0 children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,175) content-size 784x0 children: inline
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties-2.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties-2.txt
@@ -9,12 +9,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BreakNode <br>
         TextNode <#text>
       BlockContainer <div.a> at (8,29.828125) content-size 784x100 children: inline
-        line 0 width: 200, height: 100, bottom: 100, baseline: 16.890625
+        line 0 width: 200, height: 100, bottom: 100, baseline: 100
           frag 0 from BlockContainer start: 0, length: 0, rect: [8,29.828125 200x100]
         BlockContainer <(anonymous)> at (8,29.828125) content-size 200x100 inline-block [BFC] children: inline
-          line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
-            frag 0 from TextNode start: 0, length: 0, rect: [8,29.828125 0x21.828125]
-              ""
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,129.828125) content-size 784x65.484375 children: inline
         line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
@@ -29,12 +26,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BreakNode <br>
         TextNode <#text>
       BlockContainer <div.b> at (8,195.3125) content-size 784x100 children: inline
-        line 0 width: 200, height: 100, bottom: 100, baseline: 16.890625
+        line 0 width: 200, height: 100, bottom: 100, baseline: 100
           frag 0 from BlockContainer start: 0, length: 0, rect: [8,195.3125 200x100]
         BlockContainer <(anonymous)> at (8,195.3125) content-size 200x100 inline-block [BFC] children: inline
-          line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
-            frag 0 from TextNode start: 0, length: 0, rect: [8,195.3125 0x21.828125]
-              ""
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,295.3125) content-size 784x65.484375 children: inline
         line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
@@ -49,12 +43,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BreakNode <br>
         TextNode <#text>
       BlockContainer <div.c> at (8,360.796875) content-size 784x100 children: inline
-        line 0 width: 200, height: 100, bottom: 100, baseline: 16.890625
+        line 0 width: 200, height: 100, bottom: 100, baseline: 100
           frag 0 from BlockContainer start: 0, length: 0, rect: [8,360.796875 200x100]
         BlockContainer <(anonymous)> at (8,360.796875) content-size 200x100 inline-block [BFC] children: inline
-          line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
-            frag 0 from TextNode start: 0, length: 0, rect: [8,360.796875 0x21.828125]
-              ""
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,460.796875) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties.txt
@@ -3,7 +3,4 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <div.hello> at (8,8) content-size 784x0 children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 500x100 positioned [BFC] children: inline
-          line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
-            frag 0 from TextNode start: 0, length: 0, rect: [8,8 0x21.828125]
-              ""
           TextNode <#text>

--- a/Tests/LibWeb/Layout/input/position-empty-pseudo-elements.html
+++ b/Tests/LibWeb/Layout/input/position-empty-pseudo-elements.html
@@ -1,0 +1,20 @@
+<!doctype html><style>
+div {
+    background: green;
+    display: block;
+    width: 50px;
+    margin: 25px;
+}
+
+div.empty_content::after {
+    content: "";
+    display: block;
+    padding-top: 100%;
+}
+
+div.content_with_space::after {
+    content: " ";
+    display: block;
+    padding-top: 100%;
+}
+</style><div class=empty_content></div><div class=content_with_space></div></div>

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -568,8 +568,7 @@ CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Bo
 
             auto const& child_box_state = m_state.get(*child_box);
 
-            // Ignore anonymous block containers with no lines. These don't count as in-flow block boxes.
-            if (!child_box->is_table_wrapper() && child_box->is_anonymous() && child_box->is_block_container() && child_box_state.line_boxes.is_empty())
+            if (margins_collapse_through(*child_box, m_state))
                 continue;
 
             auto margin_bottom = m_margin_state.current_collapsed_margin();

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -57,6 +57,10 @@ static bool margins_collapse_through(Box const& box, LayoutState& state)
     // FIXME: For the purpose of margin collapsing (CSS 2 §8.3.1 Collapsing margins), if the block axis is the
     //        ratio-dependent axis, it is not considered to have a computed block-size of auto.
     //        https://www.w3.org/TR/css-sizing-4/#aspect-ratio-margin-collapse
+
+    if (box.computed_values().clear() != CSS::Clear::None)
+        return false;
+
     return state.get(box).border_box_height() == 0;
 }
 

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -266,7 +266,7 @@ void InlineLevelIterator::enter_text_node(Layout::TextNode const& text_node)
         .do_respect_linebreaks = do_respect_linebreaks,
         .is_first_chunk = true,
         .is_last_chunk = false,
-        .chunk_iterator = TextNode::ChunkIterator { text_node.text_for_rendering(), do_wrap_lines, do_respect_linebreaks, text_node.is_generated() && text_node.text_for_rendering().is_empty() },
+        .chunk_iterator = TextNode::ChunkIterator { text_node.text_for_rendering(), do_wrap_lines, do_respect_linebreaks },
     };
     m_text_node_context->next_chunk = m_text_node_context->chunk_iterator.next();
 }

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -124,10 +124,9 @@ void TextNode::compute_text_for_rendering()
     m_text_for_rendering = builder.to_deprecated_string();
 }
 
-TextNode::ChunkIterator::ChunkIterator(StringView text, bool wrap_lines, bool respect_linebreaks, bool is_generated_empty_string)
+TextNode::ChunkIterator::ChunkIterator(StringView text, bool wrap_lines, bool respect_linebreaks)
     : m_wrap_lines(wrap_lines)
     , m_respect_linebreaks(respect_linebreaks)
-    , m_should_emit_one_empty_chunk(is_generated_empty_string)
     , m_utf8_view(text)
     , m_iterator(m_utf8_view.begin())
 {
@@ -135,17 +134,6 @@ TextNode::ChunkIterator::ChunkIterator(StringView text, bool wrap_lines, bool re
 
 Optional<TextNode::Chunk> TextNode::ChunkIterator::next()
 {
-    if (m_should_emit_one_empty_chunk) {
-        m_should_emit_one_empty_chunk = false;
-        return Chunk {
-            .view = {},
-            .start = 0,
-            .length = 0,
-            .has_breaking_newline = false,
-            .is_all_whitespace = false,
-        };
-    }
-
     if (m_iterator == m_utf8_view.end())
         return {};
 

--- a/Userland/Libraries/LibWeb/Layout/TextNode.h
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.h
@@ -35,7 +35,7 @@ public:
 
     class ChunkIterator {
     public:
-        ChunkIterator(StringView text, bool wrap_lines, bool respect_linebreaks, bool is_generated_empty_string);
+        ChunkIterator(StringView text, bool wrap_lines, bool respect_linebreaks);
         Optional<Chunk> next();
 
     private:
@@ -43,7 +43,6 @@ public:
 
         bool const m_wrap_lines;
         bool const m_respect_linebreaks;
-        bool m_should_emit_one_empty_chunk { false };
         Utf8View m_utf8_view;
         Utf8View::Iterator m_iterator;
     };


### PR DESCRIPTION
- **Revert "LibWeb: Make TextNode::ChunkIterator emit an empty chunk for content:"""**

  This reverts commit b062a0fb7cb44036d16a36269164c537b137c3a4.

  This made a calculation of pseudo-elements' height incorrect when they had `height` set to `auto` and used other techniques (like setting `padding-top`) to set height, as it was now also adding an empty line.

  Additionally, the case didn't work for content containing whitespace characters, so a pseudo-element with `content: " "` didn't have *this* particular problem.

- **LibWeb: Include anonymous boxes with no lines into computing BFC height**

  Pseudo-elements like `::before` and `::after` were discarded when their content property was an empty string (ignoring whitespace), because they are anonymous containers, with no lines.

  Our previous way around it was to add an empty line box (see b062a0fb7c) however it didn't actually work for cases 
 described in the previous commit.

  This makes avatars and cover arts square on last.fm and "fixes" the test [css-pseudo-element-should-not-be-affected-by-presentational-hints.html](/SerenityOS/serenity/blob/master/Tests/LibWeb/Layout/input/css-pseudo-element-should-not-be-affected-by-presentational-hints.html). Unfortunately, this also regresses on [block-and-inline/clearfix.html](/SerenityOS/serenity/blob/master/Tests/LibWeb/Layout/input/block-and-inline/clearfix.html), but that hopefully will be handled in subsequent commit.

- **LibWeb: Don't collapse boxes with CSS clear property set**

  I'm not sure if this is exactly correct, the link to CSS2 spec above says something that clearance cannot separate boxes, but I'm not sure if I understood it correctly or if I've done it in the right place.

  However, this change fixes our  [block-and-inline/clearfix.html](/SerenityOS/serenity/blob/master/Tests/LibWeb/Layout/input/block-and-inline/clearfix.html) test again (was regressed in previous commit).

screenshots:

<table><tr><th align=center>before<th align=center>after
<tr><td align=center><img src=https://github.com/SerenityOS/serenity/assets/16520278/4e9e94d5-2825-4019-afcc-10d382040db0>a box has an empty line<td align=center><img src=https://github.com/SerenityOS/serenity/assets/16520278/da936863-c39d-4d5c-80b0-0e80e66937c7>a test appears as in other browsers, making it instantly correct✓✓✓
<tr><td align=center><img src=https://github.com/SerenityOS/serenity/assets/16520278/e18f03a7-75b6-4716-b147-ee335f6e4747>cover arts and avatars are stretched<td><img src=https://github.com/SerenityOS/serenity/assets/16520278/c9869363-f184-4bf0-a2ad-3d1817e54a94>
</table>

---

pinging @kalenikaliaksandr because he was recently touching this code and think he might more know more than i do