### PR TITLE
LibJS: Re-implement the Array Grouping proposal as static methods

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
@@ -14,6 +14,7 @@
 #include <LibJS/Runtime/CanonicalIndex.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/IteratorOperations.h>
 #include <LibJS/Runtime/PrivateEnvironment.h>
 #include <LibJS/Runtime/Value.h>
 
@@ -178,6 +179,117 @@ Vector<T> merge_lists(Vector<T> const& a, Vector<T> const& b)
 
     // 4. Return merged.
     return merged;
+}
+
+// 4.2 AddValueToKeyedGroup ( groups, key, value ), https://tc39.es/proposal-array-grouping/#sec-add-value-to-keyed-group
+template<typename GroupsType, typename KeyType>
+void add_value_to_keyed_group(VM& vm, GroupsType& groups, KeyType key, Value value)
+{
+    // 1. For each Record { [[Key]], [[Elements]] } g of groups, do
+    //      a. If SameValue(g.[[Key]], key) is true, then
+    //      NOTE: This is performed in KeyedGroupTraits::equals for groupToMap and Traits<JS::PropertyKey>::equals for group.
+    auto existing_elements_iterator = groups.find(key);
+    if (existing_elements_iterator != groups.end()) {
+        // i. Assert: exactly one element of groups meets this criteria.
+        // NOTE: This is done on insertion into the hash map, as only `set` tells us if we overrode an entry.
+
+        // ii. Append value as the last element of g.[[Elements]].
+        existing_elements_iterator->value.append(value);
+
+        // iii. Return unused.
+        return;
+    }
+
+    // 2. Let group be the Record { [[Key]]: key, [[Elements]]: « value » }.
+    MarkedVector<Value> new_elements { vm.heap() };
+    new_elements.append(value);
+
+    // 3. Append group as the last element of groups.
+    auto result = groups.set(key, move(new_elements));
+    VERIFY(result == AK::HashSetResult::InsertedNewEntry);
+
+    // 4. Return unused.
+}
+
+// 4.1 GroupBy ( items, callbackfn, keyCoercion ), https://tc39.es/proposal-array-grouping/#sec-group-by
+template<typename GroupsType, typename KeyType>
+ThrowCompletionOr<GroupsType> group_by(VM& vm, Value items, Value callback_function)
+{
+    // 1. Perform ? RequireObjectCoercible(items).
+    TRY(require_object_coercible(vm, items));
+
+    // 2. If IsCallable(callbackfn) is false, throw a TypeError exception.
+    if (!callback_function.is_function())
+        return vm.throw_completion<TypeError>(ErrorType::NotAFunction, TRY_OR_THROW_OOM(vm, callback_function.to_string_without_side_effects()));
+
+    // 3. Let groups be a new empty List.
+    GroupsType groups;
+
+    // 4. Let iteratorRecord be ? GetIterator(items).
+    auto iterator_record = TRY(get_iterator(vm, items));
+
+    // 5. Let k be 0.
+    u64 k = 0;
+
+    // 6. Repeat,
+    while (true) {
+        // a. If k ≥ 2^53 - 1, then
+        if (k >= MAX_ARRAY_LIKE_INDEX) {
+            // i. Let error be ThrowCompletion(a newly created TypeError object).
+            auto error = vm.throw_completion<TypeError>(ErrorType::ArrayMaxSize);
+
+            // ii. Return ? IteratorClose(iteratorRecord, error).
+            return iterator_close(vm, iterator_record, move(error));
+        }
+
+        // b. Let next be ? IteratorStep(iteratorRecord).
+        auto next = TRY(iterator_step(vm, iterator_record));
+
+        // c. If next is false, then
+        if (!next) {
+            // i. Return groups.
+            return ThrowCompletionOr<GroupsType> { move(groups) };
+        }
+
+        // d. Let value be ? IteratorValue(next).
+        auto value = TRY(iterator_value(vm, *next));
+
+        // e. Let key be Completion(Call(callbackfn, undefined, « value, 𝔽(k) »)).
+        auto key = call(vm, callback_function, js_undefined(), value, Value(k));
+
+        // f. IfAbruptCloseIterator(key, iteratorRecord).
+        if (key.is_error())
+            return Completion { *TRY(iterator_close(vm, iterator_record, key.release_error())) };
+
+        // g. If keyCoercion is property, then
+        if constexpr (IsSame<KeyType, PropertyKey>) {
+            // i. Set key to Completion(ToPropertyKey(key)).
+            auto property_key = key.value().to_property_key(vm);
+
+            // ii. IfAbruptCloseIterator(key, iteratorRecord).
+            if (property_key.is_error())
+                return Completion { *TRY(iterator_close(vm, iterator_record, key.release_error())) };
+
+            add_value_to_keyed_group(vm, groups, property_key.release_value(), value);
+        }
+        // h. Else,
+        else {
+            // i. Assert: keyCoercion is zero.
+            static_assert(IsSame<KeyType, void>);
+
+            // ii. If key is -0𝔽, set key to +0𝔽.
+            if (key.value().is_negative_zero())
+                key = Value(0);
+
+            add_value_to_keyed_group(vm, groups, make_handle(key.release_value()), value);
+        }
+
+        // i. Perform AddValueToKeyedGroup(groups, key, value).
+        // NOTE: This is dependent on the `key_coercion` template parameter and thus done separately in the branches above.
+
+        // j. Set k to k + 1.
+        ++k;
+    }
 }
 
 // x modulo y, https://tc39.es/ecma262/#eqn-modulo

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -265,10 +265,10 @@ namespace JS {
     P(globalThis)                            \
     P(granularity)                           \
     P(group)                                 \
+    P(groupBy)                               \
     P(groupCollapsed)                        \
     P(groupEnd)                              \
     P(groups)                                \
-    P(groupToMap)                            \
     P(has)                                   \
     P(hasIndices)                            \
     P(hasOwn)                                \

--- a/Userland/Libraries/LibJS/Runtime/MapConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/MapConstructor.h
@@ -25,6 +25,8 @@ private:
 
     virtual bool has_constructor() const override { return true; }
 
+    JS_DECLARE_NATIVE_FUNCTION(group_by);
+
     JS_DECLARE_NATIVE_FUNCTION(symbol_species_getter);
 };
 

--- a/Userland/Libraries/LibJS/Runtime/ObjectConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ObjectConstructor.h
@@ -34,6 +34,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(get_own_property_names);
     JS_DECLARE_NATIVE_FUNCTION(get_own_property_symbols);
     JS_DECLARE_NATIVE_FUNCTION(get_prototype_of);
+    JS_DECLARE_NATIVE_FUNCTION(group_by);
     JS_DECLARE_NATIVE_FUNCTION(set_prototype_of);
     JS_DECLARE_NATIVE_FUNCTION(is_extensible);
     JS_DECLARE_NATIVE_FUNCTION(is_frozen);

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype-generic-functions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype-generic-functions.js
@@ -306,43 +306,6 @@ describe("ability to work with generic non-array objects", () => {
         ]);
     });
 
-    test("group", () => {
-        const visited = [];
-        const o = { length: 5, 0: "foo", 1: "bar", 3: "baz" };
-        const result = Array.prototype.group.call(o, (value, _, object) => {
-            expect(object).toBe(o);
-            visited.push(value);
-            return value !== undefined ? value.startsWith("b") : false;
-        });
-        expect(visited).toEqual(["foo", "bar", undefined, "baz", undefined]);
-        expect(result.false).toEqual(["foo", undefined, undefined]);
-        expect(result.true).toEqual(["bar", "baz"]);
-    });
-
-    test("groupToMap", () => {
-        const visited = [];
-        const o = { length: 5, 0: "foo", 1: "bar", 3: "baz" };
-        const falseObject = { false: false };
-        const trueObject = { true: true };
-        const result = Array.prototype.groupToMap.call(o, (value, _, object) => {
-            expect(object).toBe(o);
-            visited.push(value);
-            return value !== undefined
-                ? value.startsWith("b")
-                    ? trueObject
-                    : falseObject
-                : falseObject;
-        });
-        expect(visited).toEqual(["foo", "bar", undefined, "baz", undefined]);
-        expect(result).toBeInstanceOf(Map);
-
-        const falseResult = result.get(falseObject);
-        expect(falseResult).toEqual(["foo", undefined, undefined]);
-
-        const trueResult = result.get(trueObject);
-        expect(trueResult).toEqual(["bar", "baz"]);
-    });
-
     test("toReversed", () => {
         const result = Array.prototype.toReversed.call(o);
         expect(result).toEqual([undefined, "baz", undefined, "bar", "foo"]);

--- a/Userland/Libraries/LibJS/Tests/builtins/Map/Map.groupBy.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Map/Map.groupBy.js
@@ -1,26 +1,26 @@
-test("length is 1", () => {
-    expect(Array.prototype.groupToMap).toHaveLength(1);
+test("length is 2", () => {
+    expect(Map.groupBy).toHaveLength(2);
 });
 
 describe("errors", () => {
     test("callback must be a function", () => {
         expect(() => {
-            [].groupToMap(undefined);
+            Map.groupBy([], undefined);
         }).toThrowWithMessage(TypeError, "undefined is not a function");
     });
 
-    test("null or undefined this value", () => {
+    test("null or undefined items value", () => {
         expect(() => {
-            Array.prototype.groupToMap.call();
-        }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
+            Map.groupBy();
+        }).toThrowWithMessage(TypeError, "undefined cannot be converted to an object");
 
         expect(() => {
-            Array.prototype.groupToMap.call(undefined);
-        }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
+            Map.groupBy(undefined);
+        }).toThrowWithMessage(TypeError, "undefined cannot be converted to an object");
 
         expect(() => {
-            Array.prototype.groupToMap.call(null);
-        }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
+            Map.groupBy(null);
+        }).toThrowWithMessage(TypeError, "null cannot be converted to an object");
     });
 });
 
@@ -31,7 +31,7 @@ describe("normal behavior", () => {
         const trueObject = { true: true };
         const falseObject = { false: false };
 
-        const firstResult = array.groupToMap(value => {
+        const firstResult = Map.groupBy(array, value => {
             visited.push(value);
             return value % 2 === 0 ? trueObject : falseObject;
         });
@@ -42,7 +42,7 @@ describe("normal behavior", () => {
         expect(firstResult.get(trueObject)).toEqual([2, 4, 6]);
         expect(firstResult.get(falseObject)).toEqual([1, 3, 5]);
 
-        const secondResult = array.groupToMap((_, index) => {
+        const secondResult = Map.groupBy(array, (_, index) => {
             return index < array.length / 2 ? trueObject : falseObject;
         });
 
@@ -50,33 +50,11 @@ describe("normal behavior", () => {
         expect(secondResult.size).toBe(2);
         expect(secondResult.get(trueObject)).toEqual([1, 2, 3]);
         expect(secondResult.get(falseObject)).toEqual([4, 5, 6]);
-
-        const thisArg = [7, 8, 9, 10, 11, 12];
-        const thirdResult = array.groupToMap(function (_, __, arrayVisited) {
-            expect(arrayVisited).toBe(array);
-            expect(this).toBe(thisArg);
-        }, thisArg);
-
-        expect(thirdResult).toBeInstanceOf(Map);
-        expect(thirdResult.size).toBe(1);
-        expect(thirdResult.get(undefined)).not.toBe(array);
-        expect(thirdResult.get(undefined)).not.toBe(thisArg);
-        expect(thirdResult.get(undefined)).toEqual(array);
-    });
-
-    test("is unscopable", () => {
-        expect(Array.prototype[Symbol.unscopables].groupToMap).toBeTrue();
-        const array = [];
-        with (array) {
-            expect(() => {
-                groupToMap;
-            }).toThrowWithMessage(ReferenceError, "'groupToMap' is not defined");
-        }
     });
 
     test("never calls callback with empty array", () => {
         var callbackCalled = 0;
-        const result = [].groupToMap(() => {
+        const result = Map.groupBy([], () => {
             callbackCalled++;
         });
         expect(result).toBeInstanceOf(Map);
@@ -86,7 +64,7 @@ describe("normal behavior", () => {
 
     test("calls callback once for every item", () => {
         var callbackCalled = 0;
-        const result = [1, 2, 3].groupToMap(() => {
+        const result = Map.groupBy([1, 2, 3], () => {
             callbackCalled++;
         });
         expect(result).toBeInstanceOf(Map);
@@ -96,8 +74,9 @@ describe("normal behavior", () => {
     });
 
     test("still returns a Map even if the global Map constructor was changed", () => {
+        const mapGroupBy = Map.groupBy;
         globalThis.Map = null;
-        const result = [1, 2].groupToMap(value => {
+        const result = mapGroupBy([1, 2], value => {
             return value % 2 === 0;
         });
         expect(result.size).toBe(2);

--- a/Userland/Libraries/LibJS/Tests/builtins/Object/Object.groupBy.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Object/Object.groupBy.js
@@ -1,26 +1,26 @@
-test("length is 1", () => {
-    expect(Array.prototype.group).toHaveLength(1);
+test("length is 2", () => {
+    expect(Object.groupBy).toHaveLength(2);
 });
 
 describe("errors", () => {
     test("callback must be a function", () => {
         expect(() => {
-            [].group(undefined);
+            Object.groupBy([], undefined);
         }).toThrowWithMessage(TypeError, "undefined is not a function");
     });
 
-    test("null or undefined this value", () => {
+    test("null or undefined items value", () => {
         expect(() => {
-            Array.prototype.group.call();
-        }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
+            Object.groupBy();
+        }).toThrowWithMessage(TypeError, "undefined cannot be converted to an object");
 
         expect(() => {
-            Array.prototype.group.call(undefined);
-        }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
+            Object.groupBy(undefined);
+        }).toThrowWithMessage(TypeError, "undefined cannot be converted to an object");
 
         expect(() => {
-            Array.prototype.group.call(null);
-        }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
+            Object.groupBy(null);
+        }).toThrowWithMessage(TypeError, "null cannot be converted to an object");
     });
 });
 
@@ -29,7 +29,7 @@ describe("normal behavior", () => {
         const array = [1, 2, 3, 4, 5, 6];
         const visited = [];
 
-        const firstResult = array.group(value => {
+        const firstResult = Object.groupBy(array, value => {
             visited.push(value);
             return value % 2 === 0;
         });
@@ -43,7 +43,7 @@ describe("normal behavior", () => {
         expect(firstKeys[0]).toBe("false");
         expect(firstKeys[1]).toBe("true");
 
-        const secondResult = array.group((_, index) => {
+        const secondResult = Object.groupBy(array, (_, index) => {
             return index < array.length / 2;
         });
 
@@ -54,36 +54,12 @@ describe("normal behavior", () => {
         expect(secondKeys).toHaveLength(2);
         expect(secondKeys[0]).toBe("true");
         expect(secondKeys[1]).toBe("false");
-
-        const thisArg = [7, 8, 9, 10, 11, 12];
-        const thirdResult = array.group(function (_, __, arrayVisited) {
-            expect(arrayVisited).toBe(array);
-            expect(this).toBe(thisArg);
-        }, thisArg);
-
-        expect(thirdResult.undefined).not.toBe(array);
-        expect(thirdResult.undefined).not.toBe(thisArg);
-        expect(thirdResult.undefined).toEqual(array);
-
-        const thirdKeys = Object.keys(thirdResult);
-        expect(thirdKeys).toHaveLength(1);
-        expect(thirdKeys[0]).toBe("undefined");
-    });
-
-    test("is unscopable", () => {
-        expect(Array.prototype[Symbol.unscopables].group).toBeTrue();
-        const array = [];
-        with (array) {
-            expect(() => {
-                group;
-            }).toThrowWithMessage(ReferenceError, "'group' is not defined");
-        }
     });
 
     test("never calls callback with empty array", () => {
         var callbackCalled = 0;
         expect(
-            [].group(() => {
+            Object.groupBy([], () => {
                 callbackCalled++;
             })
         ).toEqual({});
@@ -92,7 +68,7 @@ describe("normal behavior", () => {
 
     test("calls callback once for every item", () => {
         var callbackCalled = 0;
-        const result = [1, 2, 3].group(() => {
+        const result = Object.groupBy([1, 2, 3], () => {
             callbackCalled++;
         });
         expect(result.undefined).toEqual([1, 2, 3]);


### PR DESCRIPTION
This got conditional stage 3 approval in today's TC39 meeting, including confirmation of the `groupBy` name.