### PR TITLE
LibWeb: Prevent max-with expanding the width

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-must-not-expand-element.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-must-not-expand-element.txt
@@ -1,0 +1,5 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x0 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 4x54 positioned [BFC] children: not-inline
+      BlockContainer <div.outer> at (11,11) content-size 2x52 children: not-inline
+        BlockContainer <div.inner> at (12,12) content-size 0x50 children: not-inline

--- a/Tests/LibWeb/Layout/input/block-and-inline/max-width-must-not-expand-element.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/max-width-must-not-expand-element.html
@@ -1,0 +1,8 @@
+<!doctype html><style>    
+    * { border: 1px solid black; }    
+    body { position: absolute; }
+    .inner {                       
+        max-width: 50px;            
+        height: 50px;       
+    }                       
+</style><body><div class="outer"><div class="inner">

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -255,7 +255,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
     if (!should_treat_max_width_as_none(box, available_space.width)) {
         auto max_width = calculate_inner_width(box, remaining_available_space.width, computed_values.max_width());
-        auto used_width_px = used_width.is_auto() ? remaining_available_space.width.to_px() : used_width.to_px(box);
+        auto used_width_px = used_width.is_auto() ? CSSPixels { 0 } : used_width.to_px(box);
         if (used_width_px > max_width.to_px(box)) {
             used_width = try_compute_width(max_width);
         }


### PR DESCRIPTION
This fixes #18778. Using the availlable space as the used with cased it to be infinite and makes no sense.