### PR TITLE
LibWeb: Create Layout::Box for `display: inline-grid`

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/inline-grid-simple.txt
+++ b/Tests/LibWeb/Layout/expected/grid/inline-grid-simple.txt
@@ -1,0 +1,10 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: inline
+    line 0 width: 42.953125, height: 33.46875, bottom: 33.46875, baseline: 13.53125
+      frag 0 from Box start: 0, length: 0, rect: [8,8 26.953125x17.46875]
+    Box <body> at (8,8) content-size 26.953125x17.46875 [GFC] children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 26.953125x17.46875 [BFC] children: inline
+        line 0 width: 26.953125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 3, rect: [8,8 26.953125x17.46875]
+            "whf"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/grid/inline-grid-simple.html
+++ b/Tests/LibWeb/Layout/input/grid/inline-grid-simple.html
@@ -1,0 +1,5 @@
+<!doctype html><style>
+body {
+    display: inline-grid;
+}
+</style><body>whf

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -338,6 +338,8 @@ JS::GCPtr<Layout::Node> Element::create_layout_node_for_display_type(DOM::Docume
             return document.heap().allocate_without_realm<Layout::InlineNode>(document, element, move(style));
         if (display.is_flex_inside())
             return document.heap().allocate_without_realm<Layout::Box>(document, element, move(style));
+        if (display.is_grid_inside())
+            return document.heap().allocate_without_realm<Layout::Box>(document, element, move(style));
         dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Support display: {}", MUST(display.to_string()));
         return document.heap().allocate_without_realm<Layout::InlineNode>(document, element, move(style));
     }


### PR DESCRIPTION
This makes us actually run a GridFormattingContext instead of rendering inline-grid elements as nothing. :^)

Visual progression on https://haiku-os.org/

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/5a4a5571-1120-4c1a-88f8-707439505e35)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/aa04d314-fe1f-4ba5-ad11-3a56eea831cb)
