### PR TITLE
LibCore: Exit EventLoop::spin_until() when exit requested

### DIFF
--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -78,7 +78,7 @@ int EventLoop::exec()
 void EventLoop::spin_until(Function<bool()> goal_condition)
 {
     EventLoopPusher pusher(*this);
-    while (!goal_condition())
+    while (!m_impl->was_exit_requested() && !goal_condition())
         pump();
 }
 


### PR DESCRIPTION
This keeps WebContent from staying open if it's spinning forever trying to load a page.

fixes #11854
