### PR TITLE
LibCore: Untriplicate the mime-type list

### DIFF
--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -166,6 +166,16 @@ Optional<StringView> guess_mime_type_based_on_sniffed_bytes(ReadonlyBytes bytes)
     return {};
 }
 
+Optional<StringView> get_description_from_mime_type(StringView mime_name)
+{
+    for (auto const& mime_type : s_registered_mime_type) {
+        if (mime_name == mime_type.name)
+            return mime_type.description;
+    }
+
+    return OptionalNone {};
+}
+
 Optional<StringView> guess_mime_type_based_on_sniffed_bytes(Core::File& file)
 {
     // Read accounts for longest possible offset + signature we currently match against (extra/iso-9660)

--- a/Userland/Libraries/LibCore/MimeData.h
+++ b/Userland/Libraries/LibCore/MimeData.h
@@ -53,4 +53,12 @@ StringView guess_mime_type_based_on_filename(StringView);
 Optional<StringView> guess_mime_type_based_on_sniffed_bytes(ReadonlyBytes);
 Optional<StringView> guess_mime_type_based_on_sniffed_bytes(Core::File&);
 
+struct MimeType {
+    StringView name {};
+    Vector<StringView> common_extensions {};
+    StringView description {};
+    Optional<Vector<u8>> magic_bytes {};
+    u64 offset { 0 };
+};
+
 }

--- a/Userland/Libraries/LibCore/MimeData.h
+++ b/Userland/Libraries/LibCore/MimeData.h
@@ -61,4 +61,6 @@ struct MimeType {
     u64 offset { 0 };
 };
 
+Optional<StringView> get_description_from_mime_type(StringView);
+
 }

--- a/Userland/Utilities/file.cpp
+++ b/Userland/Utilities/file.cpp
@@ -163,66 +163,32 @@ static ErrorOr<Optional<String>> elf_details(StringView description, StringView 
         is_dynamically_linked ? dynamic_section : String {}));
 }
 
-#define ENUMERATE_MIME_TYPE_DESCRIPTIONS                                                                                  \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/gzip"sv, "gzip compressed data"sv, gzip_details)                       \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/javascript"sv, "JavaScript source"sv, description_only)                \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/json"sv, "JSON data"sv, description_only)                              \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/pdf"sv, "PDF document"sv, description_only)                            \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/rtf"sv, "Rich text file"sv, description_only)                          \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/tar"sv, "tape archive"sv, description_only)                            \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/vnd.iccprofile"sv, "ICC color profile"sv, description_only)            \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/wasm"sv, "WebAssembly bytecode"sv, description_only)                   \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/x-7z-compressed"sv, "7-Zip archive"sv, description_only)               \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/x-bzip2"sv, "bzip2 compressed data"sv, description_only)               \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/x-sheets+json"sv, "Serenity Spreadsheet document"sv, description_only) \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/zip"sv, "ZIP archive"sv, zip_details)                                  \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("audio/flac"sv, "FLAC audio"sv, audio_details)                                      \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("audio/midi"sv, "MIDI notes"sv, audio_details)                                      \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("audio/mpeg"sv, "MP3 audio"sv, audio_details)                                       \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("audio/qoa"sv, "Quite OK Audio"sv, audio_details)                                   \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("audio/wav"sv, "WAVE audio"sv, audio_details)                                       \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/blender"sv, "Blender project file"sv, description_only)                      \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/elf"sv, "ELF"sv, elf_details)                                                \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/ext"sv, "ext filesystem"sv, description_only)                                \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/iso-9660"sv, "ISO 9660 CD/DVD image"sv, description_only)                    \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/isz"sv, "Compressed ISO image"sv, description_only)                          \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/lua-bytecode"sv, "Lua bytecode"sv, description_only)                         \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/matroska"sv, "Matroska container"sv, description_only)                       \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/nes-rom"sv, "Nintendo Entertainment System ROM"sv, description_only)         \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/qcow"sv, "qcow file"sv, description_only)                                    \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/raw-zlib"sv, "raw zlib stream"sv, description_only)                          \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/sqlite"sv, "sqlite database"sv, description_only)                            \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/win-31x-compressed"sv, "Windows 3.1X compressed file"sv, description_only)   \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/win-95-compressed"sv, "Windows 95 compressed file"sv, description_only)      \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/bmp"sv, "BMP image data"sv, image_details)                                   \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/gif"sv, "GIF image data"sv, image_details)                                   \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/jpeg"sv, "JPEG image data"sv, image_details)                                 \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/png"sv, "PNG image data"sv, image_details)                                   \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/svg+xml"sv, "Scalable Vector Graphics image"sv, description_only)            \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/tiff"sv, "TIFF image data"sv, image_details)                                 \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/tinyvg"sv, "TinyVG vector graphics"sv, image_details)                        \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/webp"sv, "WebP image data"sv, image_details)                                 \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/x-portable-bitmap"sv, "PBM image data"sv, image_details)                     \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/x-portable-graymap"sv, "PGM image data"sv, image_details)                    \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/x-portable-pixmap"sv, "PPM image data"sv, image_details)                     \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/x-qoi"sv, "QOI image data"sv, image_details)                                 \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/x-targa"sv, "Targa image data"sv, image_details)                             \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("text/css"sv, "Cascading Style Sheet"sv, description_only)                          \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("text/csv"sv, "CSV text"sv, description_only)                                       \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("text/html"sv, "HTML document"sv, description_only)                                 \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("text/markdown"sv, "Markdown document"sv, description_only)                         \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("text/plain"sv, "plain text"sv, description_only)                                   \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("text/x-shellscript"sv, "POSIX shell script text executable"sv, description_only)   \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("video/webm"sv, "WebM video"sv, description_only)
+struct PatternAndFunction {
+    StringView matching_pattern;
+    ErrorOr<Optional<String>> (*details)(StringView, StringView);
+};
+
+static constexpr Array s_pattern_with_specialized_functions {
+    PatternAndFunction { "application/gzip"sv, gzip_details },
+    PatternAndFunction { "application/zip"sv, zip_details },
+    PatternAndFunction { "extra/elf"sv, elf_details },
+    PatternAndFunction { "audio/*"sv, audio_details },
+    PatternAndFunction { "image/*"sv, image_details },
+};
 
 static ErrorOr<Optional<String>> get_description_from_mime_type(StringView mime, StringView path)
 {
-#define __ENUMERATE_MIME_TYPE_DESCRIPTION(mime_type, description, details) \
-    if (mime_type == mime)                                                 \
-        return details(description, path);
-    ENUMERATE_MIME_TYPE_DESCRIPTIONS;
-#undef __ENUMERATE_MIME_TYPE_DESCRIPTION
-    return OptionalNone {};
+    auto const description = Core::get_description_from_mime_type(mime);
+
+    if (!description.has_value())
+        return OptionalNone {};
+
+    for (auto const& pattern : s_pattern_with_specialized_functions) {
+        if (mime.matches(pattern.matching_pattern))
+            return pattern.details(*description, path);
+    }
+
+    return description_only(*description, path);
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)


### PR DESCRIPTION
Currently we have three lists, the first one associate mime-types to file extension, the second one to magic bytes and the last one to a small description.

This PR merge these three lists.

cc @AtkinsSJ, @vkoskiv 