### PR TITLE
LibJS: Add optimized GetGlobal instruction to access global variables

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -2717,6 +2717,8 @@ void Identifier::dump(int indent) const
     print_indent(indent);
     if (is_local()) {
         outln("Identifier \"{}\" is_local=(true) index=({})", m_string, m_local_variable_index);
+    } else if (is_global()) {
+        outln("Identifier \"{}\" is_global=(true)", m_string);
     } else {
         outln("Identifier \"{}\"", m_string);
     }

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -684,6 +684,9 @@ public:
     }
     void set_local_variable_index(size_t index) { m_local_variable_index = index; }
 
+    bool is_global() const { return m_is_global; }
+    void set_is_global() { m_is_global = true; }
+
     virtual Completion execute(Interpreter&) const override;
     virtual void dump(int indent) const override;
     virtual ThrowCompletionOr<Reference> to_reference(Interpreter&) const override;
@@ -696,6 +699,7 @@ private:
     mutable EnvironmentCoordinate m_cached_environment_coordinate;
 
     Optional<size_t> m_local_variable_index;
+    bool m_is_global { false };
 };
 
 struct FunctionParameter {

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -295,7 +295,9 @@ Bytecode::CodeGenerationErrorOr<void> RegExpLiteral::generate_bytecode(Bytecode:
 
 Bytecode::CodeGenerationErrorOr<void> Identifier::generate_bytecode(Bytecode::Generator& generator) const
 {
-    if (is_local()) {
+    if (is_global()) {
+        generator.emit<Bytecode::Op::GetGlobal>(generator.intern_identifier(m_string), generator.next_global_variable_cache());
+    } else if (is_local()) {
         generator.emit<Bytecode::Op::GetLocal>(local_variable_index());
     } else {
         generator.emit<Bytecode::Op::GetVariable>(generator.intern_identifier(m_string));

--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -21,9 +21,14 @@ struct PropertyLookupCache {
     u64 unique_shape_serial_number { 0 };
 };
 
+struct GlobalVariableCache : public PropertyLookupCache {
+    u64 environment_serial_number { 0 };
+};
+
 struct Executable {
     DeprecatedFlyString name;
     Vector<PropertyLookupCache> property_lookup_caches;
+    Vector<GlobalVariableCache> global_variable_caches;
     Vector<NonnullOwnPtr<BasicBlock>> basic_blocks;
     NonnullOwnPtr<StringTable> string_table;
     NonnullOwnPtr<IdentifierTable> identifier_table;

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -57,9 +57,13 @@ CodeGenerationErrorOr<NonnullOwnPtr<Executable>> Generator::generate(ASTNode con
     Vector<PropertyLookupCache> property_lookup_caches;
     property_lookup_caches.resize(generator.m_next_property_lookup_cache);
 
+    Vector<GlobalVariableCache> global_variable_caches;
+    global_variable_caches.resize(generator.m_next_global_variable_cache);
+
     return adopt_own(*new Executable {
         .name = {},
         .property_lookup_caches = move(property_lookup_caches),
+        .global_variable_caches = move(global_variable_caches),
         .basic_blocks = move(generator.m_root_basic_blocks),
         .string_table = move(generator.m_string_table),
         .identifier_table = move(generator.m_identifier_table),

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -202,6 +202,8 @@ public:
     void emit_get_by_id(IdentifierTableIndex);
     void emit_get_by_id_with_this(IdentifierTableIndex, Register);
 
+    [[nodiscard]] size_t next_global_variable_cache() { return m_next_global_variable_cache++; }
+
 private:
     Generator();
     ~Generator() = default;
@@ -222,6 +224,7 @@ private:
     u32 m_next_register { 2 };
     u32 m_next_block { 1 };
     u32 m_next_property_lookup_cache { 0 };
+    u32 m_next_global_variable_cache { 0 };
     FunctionKind m_enclosing_function_kind { FunctionKind::Normal };
     Vector<LabelableScope> m_continuable_scopes;
     Vector<LabelableScope> m_breakable_scopes;

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -45,6 +45,7 @@
     O(GetObjectPropertyIterator)     \
     O(GetPrivateById)                \
     O(GetVariable)                   \
+    O(GetGlobal)                     \
     O(GetLocal)                      \
     O(GreaterThan)                   \
     O(GreaterThanEquals)             \

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -417,6 +417,61 @@ ThrowCompletionOr<void> GetVariable::execute_impl(Bytecode::Interpreter& interpr
     return {};
 }
 
+ThrowCompletionOr<void> GetGlobal::execute_impl(Bytecode::Interpreter& interpreter) const
+{
+    auto& vm = interpreter.vm();
+    auto& realm = *vm.current_realm();
+
+    auto const& name = interpreter.current_executable().get_identifier(m_identifier);
+
+    auto& cache = interpreter.current_executable().global_variable_caches[m_cache_index];
+    auto& binding_object = realm.global_environment().object_record().binding_object();
+    auto& declarative_record = realm.global_environment().declarative_record();
+
+    // OPTIMIZATION: If the shape of the object hasn't changed, we can use the cached property offset.
+    // NOTE: Unique shapes don't change identity, so we compare their serial numbers instead.
+    auto& shape = binding_object.shape();
+    if (cache.environment_serial_number == declarative_record.environment_serial_number()
+        && &shape == cache.shape
+        && (!shape.is_unique() || shape.unique_shape_serial_number() == cache.unique_shape_serial_number)) {
+        interpreter.accumulator() = binding_object.get_direct(cache.property_offset.value());
+        return {};
+    }
+
+    cache.environment_serial_number = declarative_record.environment_serial_number();
+
+    if (vm.running_execution_context().script_or_module.has<NonnullGCPtr<Module>>()) {
+        // NOTE: GetGlobal is used to access variables stored in the module environment and global environment.
+        //       The module environment is checked first since it precedes the global environment in the environment chain.
+        auto& module_environment = *vm.running_execution_context().script_or_module.get<NonnullGCPtr<Module>>()->environment();
+        if (TRY(module_environment.has_binding(name))) {
+            // TODO: Cache offset of binding value
+            interpreter.accumulator() = TRY(module_environment.get_binding_value(vm, name, vm.in_strict_mode()));
+            return {};
+        }
+    }
+
+    if (TRY(declarative_record.has_binding(name))) {
+        // TODO: Cache offset of binding value
+        interpreter.accumulator() = TRY(declarative_record.get_binding_value(vm, name, vm.in_strict_mode()));
+        return {};
+    }
+
+    if (TRY(binding_object.has_property(name))) {
+        CacheablePropertyMetadata cacheable_metadata;
+        interpreter.accumulator() = js_undefined();
+        interpreter.accumulator() = TRY(binding_object.internal_get(name, interpreter.accumulator(), &cacheable_metadata));
+        if (cacheable_metadata.type == CacheablePropertyMetadata::Type::OwnProperty) {
+            cache.shape = shape;
+            cache.property_offset = cacheable_metadata.property_offset.value();
+            cache.unique_shape_serial_number = shape.unique_shape_serial_number();
+        }
+        return {};
+    }
+
+    return vm.throw_completion<ReferenceError>(ErrorType::UnknownIdentifier, name);
+}
+
 ThrowCompletionOr<void> GetLocal::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
@@ -1461,6 +1516,11 @@ DeprecatedString ConcatString::to_deprecated_string_impl(Bytecode::Executable co
 DeprecatedString GetVariable::to_deprecated_string_impl(Bytecode::Executable const& executable) const
 {
     return DeprecatedString::formatted("GetVariable {} ({})", m_identifier, executable.identifier_table->get(m_identifier));
+}
+
+DeprecatedString GetGlobal::to_deprecated_string_impl(Bytecode::Executable const& executable) const
+{
+    return DeprecatedString::formatted("GetGlobal {} ({})", m_identifier, executable.identifier_table->get(m_identifier));
 }
 
 DeprecatedString GetLocal::to_deprecated_string_impl(Bytecode::Executable const&) const

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -524,6 +524,25 @@ private:
     Optional<EnvironmentCoordinate> mutable m_cached_environment_coordinate;
 };
 
+class GetGlobal final : public Instruction {
+public:
+    explicit GetGlobal(IdentifierTableIndex identifier, u32 cache_index)
+        : Instruction(Type::GetGlobal)
+        , m_identifier(identifier)
+        , m_cache_index(cache_index)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+    void replace_references_impl(Register, Register) { }
+
+private:
+    IdentifierTableIndex m_identifier;
+    u32 m_cache_index { 0 };
+};
+
 class GetLocal final : public Instruction {
 public:
     explicit GetLocal(size_t index)

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -316,8 +316,10 @@ private:
         bool allow_super_property_lookup { false };
         bool allow_super_constructor_call { false };
         bool in_function_context { false };
+        bool initiated_by_eval { false };
         bool in_eval_function_context { false }; // This controls if we allow new.target or not. Note that eval("return") is not allowed, so we have to have a separate state variable for eval.
         bool in_formal_parameter_context { false };
+        bool in_catch_parameter_context { false };
         bool in_generator_function_context { false };
         bool await_expression_is_valid { false };
         bool in_arrow_function_context { false };

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
@@ -77,6 +77,8 @@ ThrowCompletionOr<void> DeclarativeEnvironment::create_mutable_binding(VM&, Depr
         .initialized = false,
     });
 
+    ++m_environment_serial_number;
+
     // 3. Return unused.
     return {};
 }
@@ -96,6 +98,8 @@ ThrowCompletionOr<void> DeclarativeEnvironment::create_immutable_binding(VM&, De
         .can_be_deleted = false,
         .initialized = false,
     });
+
+    ++m_environment_serial_number;
 
     // 3. Return unused.
     return {};
@@ -216,6 +220,8 @@ ThrowCompletionOr<bool> DeclarativeEnvironment::delete_binding(VM&, DeprecatedFl
     // 3. Remove the binding for N from envRec.
     // NOTE: We keep the entries in m_bindings to avoid disturbing indices.
     binding_and_index->binding() = {};
+
+    ++m_environment_serial_number;
 
     // 4. Return true.
     return true;

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -60,6 +60,8 @@ public:
 
     void shrink_to_fit();
 
+    [[nodiscard]] u64 environment_serial_number() const { return m_environment_serial_number; }
+
 private:
     ThrowCompletionOr<Value> get_binding_value_direct(VM&, Binding&, bool strict);
     ThrowCompletionOr<void> set_mutable_binding_direct(VM&, Binding&, Value, bool strict);
@@ -121,6 +123,8 @@ private:
 
     Vector<Binding> m_bindings;
     Vector<DisposableResource> m_disposable_resource_stack;
+
+    u64 m_environment_serial_number { 0 };
 };
 
 template<>

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
@@ -103,7 +103,7 @@ ThrowCompletionOr<Value> perform_shadow_realm_eval(VM& vm, StringView source_tex
     // 2. Perform the following substeps in an implementation-defined order, possibly interleaving parsing and error detection:
 
     // a. Let script be ParseText(StringToCodePoints(sourceText), Script).
-    auto parser = Parser(Lexer(source_text));
+    auto parser = Parser(Lexer(source_text), Program::Type::Script, Parser::EvalInitialState {});
     auto program = parser.parse_program();
 
     // b. If script is a List of errors, throw a SyntaxError exception.


### PR DESCRIPTION
Using a special instruction to access global variables allows skipping the environment chain traversal for them and going directly to the module/global environment. Currently, this instruction only caches the offset for bindings that belong to the global object environment. However, there is also an opportunity to cache the offset in the global declarative record.

This change results in a 57% increase in speed for imaging-gaussian-blur.js in Kraken.
