### PR TITLE
MailSettings: Make TLS option checked by default

### DIFF
--- a/Userland/Applications/MailSettings/MailSettingsWidget.cpp
+++ b/Userland/Applications/MailSettings/MailSettingsWidget.cpp
@@ -19,7 +19,7 @@ void MailSettingsWidget::reset_default_values()
 {
     m_server_inputbox->set_text(""sv);
     m_port_combobox->set_text("993"sv);
-    m_tls_checkbox->set_checked(false);
+    m_tls_checkbox->set_checked(true);
     m_email_inputbox->set_text(""sv);
 }
 
@@ -66,7 +66,7 @@ ErrorOr<void> MailSettingsWidget::setup()
     };
 
     m_tls_checkbox = *find_descendant_of_type_named<GUI::CheckBox>("tls_input");
-    m_tls_checkbox->set_checked(Config::read_bool("Mail"sv, "Connection"sv, "TLS"sv, false));
+    m_tls_checkbox->set_checked(Config::read_bool("Mail"sv, "Connection"sv, "TLS"sv, true));
     m_tls_checkbox->on_checked = [&](auto) {
         set_modified(true);
     };


### PR DESCRIPTION
The window by default showed port 993 with TLS unchecked, which was slightly misleading as port 993 uses implicit TLS connections and cleartext is on port 143.

This change also makes it consistent with the Mail app, as its fallback value is also set to true:

https://github.com/SerenityOS/serenity/blob/c006a1ef41b2d7b4920e6513671c3cb6d3b9b4e5/Userland/Applications/Mail/MailWidget.cpp#L110-L112