### PR TITLE
LibWeb: Remove many redundant SVGUseElement clone calls

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1774,8 +1774,8 @@ void Document::completely_finish_loading()
 
     auto observers_to_notify = m_document_observers.values();
     for (auto& document_observer : observers_to_notify) {
-        if (document_observer->document_fully_loaded)
-            document_observer->document_fully_loaded();
+        if (document_observer->document_completely_loaded)
+            document_observer->document_completely_loaded();
     }
 }
 

--- a/Userland/Libraries/LibWeb/DOM/DocumentObserver.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentObserver.h
@@ -18,7 +18,7 @@ class DocumentObserver final : public Bindings::PlatformObject {
 
 public:
     JS::SafeFunction<void()> document_became_inactive;
-    JS::SafeFunction<void()> document_fully_loaded;
+    JS::SafeFunction<void()> document_completely_loaded;
 
 private:
     explicit DocumentObserver(JS::Realm&, DOM::Document&);

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -33,7 +33,7 @@ JS::ThrowCompletionOr<void> SVGUseElement::initialize(JS::Realm& realm)
     set_shadow_root(shadow_root);
 
     m_document_observer = TRY(realm.heap().allocate<DOM::DocumentObserver>(realm, realm, document()));
-    m_document_observer->document_fully_loaded = [this]() {
+    m_document_observer->document_completely_loaded = [this]() {
         clone_element_tree_as_our_shadow_tree(referenced_element());
     };
 


### PR DESCRIPTION
This prevents SVG elements referenced by "use" being repeatedly cloned in many redundant cases. 

This allows ladybird to load pages that use a large SVG "sprite" that then is referenced many times with "use" elements. (This would otherwise either load extremely slowly, or crash the page.)