### PR TITLE
LibWeb+LibXML: Make SVG file loaded directly

### DIFF
--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -22,6 +22,9 @@ ErrorOr<DeprecatedString> resolve_xml_resource(XML::SystemID const&, Optional<XM
         return Error::from_string_literal("Refusing to load disallowed external entity");
 
     auto public_literal = public_id->public_literal;
+    if (public_literal.is_one_of("-//W3C//DTD SVG 1.1//EN")) {
+        return "";
+    }
     if (!public_literal.is_one_of(
             "-//W3C//DTD XHTML 1.0 Transitional//EN",
             "-//W3C//DTD XHTML 1.1//EN",

--- a/Userland/Libraries/LibXML/Parser/Parser.cpp
+++ b/Userland/Libraries/LibXML/Parser/Parser.cpp
@@ -409,6 +409,7 @@ ErrorOr<void, ParseError> Parser::parse_standalone_document_decl()
     TRY(expect("standalone"sv));
     auto accept = accept_rule();
 
+    TRY(parse_eq());
     TRY(expect(is_any_of("'\""sv), "one of ' or \""sv));
     m_lexer.retreat();
 


### PR DESCRIPTION
The error happens when svg file starts with:
```
<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
```

The parser did not handle this properly before.

Before:
<img width="800" alt="Screenshot 2023-07-12 at 21 47 11" src="https://github.com/SerenityOS/serenity/assets/32867472/6cc04fed-46ed-4f90-af12-daec80f70678">

After:
<img width="799" alt="Screenshot 2023-07-12 at 21 40 27" src="https://github.com/SerenityOS/serenity/assets/32867472/cdeafb9e-f89c-4c02-8840-6482cd0f00ed">


