### PR TITLE
LibPDF: Mark PDF::Error nodiscard

### DIFF
--- a/Userland/Libraries/LibPDF/Error.h
+++ b/Userland/Libraries/LibPDF/Error.h
@@ -12,7 +12,7 @@
 
 namespace PDF {
 
-class Error {
+class [[nodiscard]] Error {
 public:
     enum class Type {
         Parse,


### PR DESCRIPTION
No behavior change. Prevents mistakes like the one fixed in 26de2fd0b2.