### PR TITLE
ps: Add the `-o` option to specify a user-defined column format

### DIFF
--- a/Base/usr/share/man/man1/ps.md
+++ b/Base/usr/share/man/man1/ps.md
@@ -5,7 +5,7 @@ ps - list currently running processes
 ## Synopsis
 
 ```**sh
-$ ps [--version] [-a] [-A] [-e] [-f] [-p pid-list] [--ppid pid-list] [-q pid-list] [-t tty-list] [-u user-list]
+$ ps [--version] [-a] [-A] [-e] [-f] [-o column-format] [-p pid-list] [--ppid pid-list] [-q pid-list] [-t tty-list] [-u user-list]
 ```
 
 ## Description
@@ -18,6 +18,14 @@ For each process, print its PID (process ID), to which TTY it belongs, and invok
 * `-a`: Consider all processes that are associated with a TTY.
 * `-A` or `-e`: Consider all processes, not just those in the current TTY.
 * `-f`: Also print for each process: UID (as resolved username), PPID (parent PID), and STATE (Runnable, Sleeping, Selecting, Reading, etc.)
+* `-o column-format`:  Specify a user-defined format, as a list of column format specifiers separated by commas or spaces.
+
+    A column format specifier is of the form: `COLUMN_NAME[=COLUMN_TITLE]`.
+    Where `COLUMN_NAME` is any of the following: `uid`, `pid`, `ppid`, `pgid`, `sid`, `state`, `tty`, or `cmd`.
+
+    Specifying a `COLUMN_TITLE` will change the name shown in the column header. `COLUMN_TITLE` may be blank.
+    If all given column titles are blank, the column header is omitted.
+
 * `-p pid-list`: Select processes matching any of the given PIDs. `pid-list` is a list of PIDs, separated by commas or spaces.
 * `--ppid pid-list`: Select processes whose PPID matches any of the given PIDs. `pid-list` is a list of PIDs, separated by commas or spaces.
 * `-q pid-list`: Only consider the given PIDs, if they exist. Output the processes in the order provided by `pid-list`. `pid-list` is a list of PIDs, separated by commas or spaces.
@@ -26,8 +34,28 @@ For each process, print its PID (process ID), to which TTY it belongs, and invok
 
 ## Examples
 
+Show all processes (full format):
+
 ```sh
 $ ps -ef
+```
+
+Show the PID, state and name of all processes
+
+```sh
+$ ps -eo pid,state,cmd
+```
+
+Show the name and state of PID 42 and rename the first column from CMD to Command:
+
+```sh
+$ ps -q 42 -o cmd=Command,state
+```
+
+Show name of PID 42 and omit the header entirely
+
+```sh
+$ ps -q 42 -o cmd=
 ```
 
 ## See Also


### PR DESCRIPTION
This option allows the user to change which colums are displayed
by giving comma or space separated list of column format specifiers.

A column format specifier is of the form: `COLUMN_NAME[=COLUMN_TITLE]`.
Where `COLUMN_NAME` is any of: uid, pid, ppid, pgid, sid, state, tty,
or cmd. Specifying a `COLUMN_TITLE` will change the name shown in the
column header.

`COLUMN_TITLE` may be blank. If all given column titles
are blank, the header is omitted.

I'm also using this PR to sneak in a fix for a bug I introduced in aeb87d6e :see_no_evil:.
This caused the `-q` option to break, as the filtering logic allowed processes
to be selected that the user didn't specify.

Example usage:

![ps_custom_column_format](https://github.com/SerenityOS/serenity/assets/2817754/2d560e9d-f61c-4997-9ead-d643b4bc5987)
