### PR TITLE
LibGfx+LibWeb: Improve scrollable overflow measurement + fix old stacking context clipping bug

### DIFF
--- a/Tests/LibGfx/TestRect.cpp
+++ b/Tests/LibGfx/TestRect.cpp
@@ -56,3 +56,29 @@ TEST_CASE(rect_closest_to)
     closest = screen_rect.closest_to(p);
     EXPECT_EQ(screen_rect.side(closest), Gfx::IntRect::Side::Top);
 }
+
+TEST_CASE(rect_unite_horizontally)
+{
+    Gfx::IntRect rect { 10, 10, 100, 100 };
+    Gfx::IntRect huge_rect { 0, 0, 1000, 1000 };
+
+    rect.unite_horizontally(huge_rect);
+
+    EXPECT_EQ(rect.left(), 0);
+    EXPECT_EQ(rect.right(), 1000);
+    EXPECT_EQ(rect.top(), 10);
+    EXPECT_EQ(rect.bottom(), 110);
+}
+
+TEST_CASE(rect_unite_vertically)
+{
+    Gfx::IntRect rect { 10, 10, 100, 100 };
+    Gfx::IntRect huge_rect { 0, 0, 1000, 1000 };
+
+    rect.unite_vertically(huge_rect);
+
+    EXPECT_EQ(rect.top(), 0);
+    EXPECT_EQ(rect.bottom(), 1000);
+    EXPECT_EQ(rect.left(), 10);
+    EXPECT_EQ(rect.right(), 110);
+}

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -870,6 +870,22 @@ public:
         return { { point.x() - size.width() / 2, point.y() - size.height() / 2 }, size };
     }
 
+    void unite_horizontally(Rect<T> const& other)
+    {
+        auto new_left = min(left(), other.left());
+        auto new_right = max(right(), other.right());
+        set_left(new_left);
+        set_right(new_right);
+    }
+
+    void unite_vertically(Rect<T> const& other)
+    {
+        auto new_top = min(top(), other.top());
+        auto new_bottom = max(bottom(), other.bottom());
+        set_top(new_top);
+        set_bottom(new_bottom);
+    }
+
     [[nodiscard]] Rect<T> united(Rect<T> const& other) const
     {
         if (is_empty())

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -825,8 +825,8 @@ void dump_tree(StringBuilder& builder, Painting::Paintable const& paintable, boo
         auto const& paintable_box = static_cast<Painting::PaintableBox const&>(paintable);
         builder.appendff(" {}", paintable_box.absolute_border_box_rect());
 
-        if (paintable_box.has_overflow()) {
-            builder.appendff(" overflow: {}", paintable_box.scrollable_overflow_rect().value());
+        if (paintable_box.has_scrollable_overflow()) {
+            builder.appendff(" overflow: {}", paintable_box.scrollable_overflow_rect());
         }
     }
     builder.append("\n"sv);

--- a/Userland/Libraries/LibWeb/Layout/LineBox.h
+++ b/Userland/Libraries/LibWeb/Layout/LineBox.h
@@ -32,10 +32,15 @@ public:
 
     CSSPixels original_available_width() const { return m_original_available_width; }
 
+    CSSPixelRect const& absolute_rect() const { return m_absolute_rect; }
+    void set_absolute_rect(CSSPixelRect const& rect) { m_absolute_rect = rect; }
+
 private:
     friend class BlockContainer;
     friend class InlineFormattingContext;
     friend class LineBuilder;
+
+    CSSPixelRect m_absolute_rect;
 
     Vector<LineBoxFragment> m_fragments;
     CSSPixels m_width { 0 };

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -104,6 +104,13 @@ CSSPixelRect PaintableBox::compute_absolute_paint_rect() const
 {
     // FIXME: This likely incomplete:
     auto rect = absolute_border_box_rect();
+    if (has_scrollable_overflow()) {
+        auto scrollable_overflow_rect = this->scrollable_overflow_rect().value();
+        if (computed_values().overflow_x() == CSS::Overflow::Visible)
+            rect.unite_horizontally(scrollable_overflow_rect);
+        if (computed_values().overflow_y() == CSS::Overflow::Visible)
+            rect.unite_vertically(scrollable_overflow_rect);
+    }
     auto resolved_box_shadow_data = resolve_box_shadow_data();
     for (auto const& shadow : resolved_box_shadow_data) {
         if (shadow.placement == ShadowPlacement::Inner)

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -31,7 +31,8 @@ public:
 
     struct OverflowData {
         CSSPixelRect scrollable_overflow_rect;
-        CSSPixelPoint scroll_offset;
+        bool has_scrollable_overflow { false };
+        CSSPixelPoint scroll_offset {};
     };
 
     CSSPixelRect absolute_rect() const;
@@ -95,9 +96,9 @@ public:
     CSSPixels absolute_y() const { return absolute_rect().y(); }
     CSSPixelPoint absolute_position() const { return absolute_rect().location(); }
 
-    bool has_overflow() const { return m_overflow_data.has_value(); }
+    [[nodiscard]] bool has_scrollable_overflow() const { return m_overflow_data->has_scrollable_overflow; }
 
-    Optional<CSSPixelRect> scrollable_overflow_rect() const
+    [[nodiscard]] Optional<CSSPixelRect> scrollable_overflow_rect() const
     {
         if (!m_overflow_data.has_value())
             return {};
@@ -106,7 +107,7 @@ public:
 
     Optional<CSSPixelRect> calculate_overflow_clipped_rect() const;
 
-    void set_overflow_data(Optional<OverflowData> data) { m_overflow_data = move(data); }
+    void set_overflow_data(OverflowData data) { m_overflow_data = move(data); }
     void set_containing_line_box_fragment(Optional<Layout::LineBoxFragmentCoordinate>);
 
     StackingContext* stacking_context() { return m_stacking_context; }

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -168,7 +168,7 @@ void PageHost::page_did_layout()
 {
     auto* layout_root = this->layout_root();
     VERIFY(layout_root);
-    if (layout_root->paintable_box()->has_overflow())
+    if (layout_root->paintable_box()->has_scrollable_overflow())
         m_content_size = page().enclosing_device_rect(layout_root->paintable_box()->scrollable_overflow_rect().value()).size();
     else
         m_content_size = page().enclosing_device_rect(layout_root->paintable_box()->absolute_rect()).size();


### PR DESCRIPTION
Fixes the clipping of fundraising amounts on https://haiku-os.org/

(Yes, the text is still in the wrong place, but that's a separate issue :^)

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/6ad1069f-214e-4bb3-9de0-240be0f9dabe)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/be766228-1c69-4d60-b235-ce7eefef5e97)
