### PR TITLE
LibPDF: Implement set_flatness_tolerance

### DIFF
--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -202,7 +202,12 @@ RENDERER_HANDLER(set_dash_pattern)
 }
 
 RENDERER_TODO(set_color_rendering_intent)
-RENDERER_TODO(set_flatness_tolerance)
+
+RENDERER_HANDLER(set_flatness_tolerance)
+{
+    state().flatness_tolerance = args[0].to_float();
+    return {};
+}
 
 RENDERER_HANDLER(set_graphics_state_from_dict)
 {

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -76,6 +76,7 @@ struct GraphicsState {
     RefPtr<ColorSpace> paint_color_space { DeviceGrayColorSpace::the() };
     Gfx::Color stroke_color { Gfx::Color::NamedColor::Black };
     Gfx::Color paint_color { Gfx::Color::NamedColor::Black };
+    float flatness_tolerance { 0.0f };
     float line_width { 1.0f };
     LineCapStyle line_cap_style { LineCapStyle::ButtCap };
     LineJoinStyle line_join_style { LineJoinStyle::Miter };
@@ -261,6 +262,7 @@ struct Formatter<PDF::GraphicsState> : Formatter<StringView> {
         builder.appendff("  ctm={}\n", state.ctm);
         builder.appendff("  stroke_color={}\n", state.stroke_color);
         builder.appendff("  paint_color={}\n", state.paint_color);
+        builder.appendff("  flatness_tolerance={}\n", state.flatness_tolerance);
         builder.appendff("  line_width={}\n", state.line_width);
         builder.appendff("  line_cap_style={}\n", state.line_cap_style);
         builder.appendff("  line_join_style={}\n", state.line_join_style);


### PR DESCRIPTION
We now track it in the graphics state. It isn't used for anything yet. Fixes the one thing that rendering the first 100 pages of pdf_reference_1-7.pdf complains about.