### PR TITLE
less: Restore original terminal state when SIGTERM is received

### DIFF
--- a/Userland/Utilities/less.cpp
+++ b/Userland/Utilities/less.cpp
@@ -554,6 +554,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     teardown_action.sa_handler = teardown_sigaction_handler;
     TRY(Core::System::sigaction(SIGTERM, &teardown_action, nullptr));
 
+    struct sigaction ignore_action;
+    ignore_action.sa_handler = { SIG_IGN };
+    TRY(Core::System::sigaction(SIGINT, &ignore_action, nullptr));
+
     Pager pager(filename, file, stdout, prompt);
     pager.init();
 


### PR DESCRIPTION
This PR makes 2 changes to less related to signal handling:

* The original terminal state is now restored when a `SIGTERM` is received, in the same way that it is when you exit the program normally.
* `SIGINT` is now ignored. This matches the behavior of `less` on Linux and FreeBSD.

Before:

https://github.com/SerenityOS/serenity/assets/2817754/0807e2f0-e21c-4974-8d76-6da7e80ab9c3

After:

https://github.com/SerenityOS/serenity/assets/2817754/fd66bf6b-3bf8-4f46-86bc-b29ee4c980f0
