### PR TITLE
LibJS: Change error message for non-objects in GetIteratorFlattenable

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Iterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Iterator.cpp
@@ -46,7 +46,7 @@ ThrowCompletionOr<IteratorRecord> get_iterator_flattenable(VM& vm, Value object,
     if (!object.is_object()) {
         // a. If stringHandling is reject-strings or obj is not a String, throw a TypeError exception.
         if (string_handling == StringHandling::RejectStrings || !object.is_string())
-            return vm.throw_completion<TypeError>(ErrorType::NotAnObject, "obj"sv);
+            return vm.throw_completion<TypeError>(ErrorType::NotAnObject, TRY_OR_THROW_OOM(vm, object.to_string_without_side_effects()));
     }
 
     // 2. Let method be ? GetMethod(obj, @@iterator).
@@ -67,7 +67,7 @@ ThrowCompletionOr<IteratorRecord> get_iterator_flattenable(VM& vm, Value object,
 
     // 5. If iterator is not an Object, throw a TypeError exception.
     if (!iterator.is_object())
-        return vm.throw_completion<TypeError>(ErrorType::NotAnObject, "iterator"sv);
+        return vm.throw_completion<TypeError>(ErrorType::NotAnObject, TRY_OR_THROW_OOM(vm, iterator.to_string_without_side_effects()));
 
     // 6. Return ? GetIteratorDirect(iterator).
     return TRY(get_iterator_direct(vm, iterator.as_object()));

--- a/Userland/Libraries/LibJS/Tests/builtins/Iterator/Iterator.from.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Iterator/Iterator.from.js
@@ -2,7 +2,7 @@ describe("errors", () => {
     test("called with non-Object", () => {
         expect(() => {
             Iterator.from(Symbol.hasInstance);
-        }).toThrowWithMessage(TypeError, "obj is not an object");
+        }).toThrowWithMessage(TypeError, "Symbol(Symbol.hasInstance) is not an object");
     });
 
     test("@@iterator is not callable", () => {
@@ -35,7 +35,7 @@ describe("errors", () => {
 
         expect(() => {
             Iterator.from(iterable);
-        }).toThrowWithMessage(TypeError, "iterator is not an object");
+        }).toThrowWithMessage(TypeError, "Symbol(Symbol.hasInstance) is not an object");
     });
 });
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.flatMap.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.flatMap.js
@@ -69,7 +69,7 @@ describe("errors", () => {
         expect(() => {
             const iterator = generator().flatMap(() => Symbol.hasInstance);
             iterator.next();
-        }).toThrowWithMessage(TypeError, "obj is not an object");
+        }).toThrowWithMessage(TypeError, "Symbol(Symbol.hasInstance) is not an object");
     });
 });
 


### PR DESCRIPTION
Matches other usages in e.g. Temporal now.