### PR TITLE
LibWeb: Min-width expands width of parent element

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/min-width-must-expand-parent-element.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/min-width-must-expand-parent-element.txt
@@ -1,0 +1,5 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x0 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 54x54 positioned [BFC] children: not-inline
+      BlockContainer <div.outer> at (11,11) content-size 52x52 children: not-inline
+        BlockContainer <div.inner> at (12,12) content-size 50x50 children: not-inline

--- a/Tests/LibWeb/Layout/input/block-and-inline/min-width-must-expand-parent-element.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/min-width-must-expand-parent-element.html
@@ -1,0 +1,9 @@
+<!doctype html><style>    
+    * { border: 1px solid black; }    
+    body { position: absolute; }
+    .inner {                       
+        min-width: 50px;            
+        height: 50px;    
+        background-color: red;   
+    }                       
+</style><body><div class="outer"><div class="inner">

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -265,7 +265,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto()) {
         auto min_width = calculate_inner_width(box, remaining_available_space.width, computed_values.min_width());
-        auto used_width_px = used_width.is_auto() ? remaining_available_space.width.to_px() : used_width.to_px(box);
+        auto used_width_px = used_width.is_auto() ? calculate_min_content_width(box) : used_width.to_px(box);
         if (used_width_px < min_width.to_px(box)) {
             used_width = try_compute_width(min_width);
         }


### PR DESCRIPTION
Follow up for #19946. This fixes a bug where the parent element is smaller than the child element if the width of the child element is defined by min-width.