### PR TITLE
pdf: Make --dump-contents print all objects referenced by a given page

### DIFF
--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -118,6 +118,7 @@ public:
 
     [[nodiscard]] u32 get_page_count() const;
 
+    PDFErrorOr<void> dump_page(u32 index);
     [[nodiscard]] PDFErrorOr<Page> get_page(u32 index);
 
     ALWAYS_INLINE Value get_value(u32 index) const

--- a/Userland/Utilities/pdf.cpp
+++ b/Userland/Utilities/pdf.cpp
@@ -120,15 +120,7 @@ static PDF::PDFErrorOr<int> pdf_main(Main::Arguments arguments)
     int page_index = page_number - 1;
 
     if (dump_contents) {
-        auto page = TRY(document->get_page(page_index));
-        auto contents = TRY(page.page_contents(*document));
-        for (u8 c : contents.bytes()) {
-            if (c < 128)
-                out("{:c}", c);
-            else
-                out("\\{:03o}", c);
-        }
-
+        TRY(document->dump_page(page_index));
         return 0;
     }
 


### PR DESCRIPTION
This now prints the page stream's dict in addition to the stream contents, and also all objects referenced from there.

Demo (note how it prints the font and procset referenced from the page object):

```
% time Build/lagom/bin/pdf --dump-contents ~/Downloads/sample.pdf
obj 4 0
<<
  /Contents 5 0 R
  /Type /Page
  /Resources   <<
    /Font     <<
      /F1 9 0 R
    >>
    /ProcSet 8 0 R
  >>
  /MediaBox [
    0
    0
    612
    792
  ]
  /Parent 3 0 R
>>
endobj
obj 5 0
<<
  /Length 1074
>>
stream
2 J
BT
0 0 0 rg
/F1 0027 Tf
57.3750 722.2800 Td
( A Simple PDF File ) Tj
...snip...
69.2500 557.1360 Td
( text. And more text. And more text. Even more. Continued on page 2 ...) Tj
ET
endstream
endobj
obj 9 0
<<
  /Type /Font
  /Encoding /WinAnsiEncoding
  /Subtype /Type1
  /BaseFont /Helvetica
  /Name /F1
>>
endobj
obj 8 0
[
  /PDF
  /Text
]
endobj
```