### PR TITLE
LibXML: Parser handle standalone declaration

### DIFF
--- a/Userland/Libraries/LibXML/Parser/Parser.cpp
+++ b/Userland/Libraries/LibXML/Parser/Parser.cpp
@@ -409,6 +409,7 @@ ErrorOr<void, ParseError> Parser::parse_standalone_document_decl()
     TRY(expect("standalone"sv));
     auto accept = accept_rule();
 
+    TRY(parse_eq());
     TRY(expect(is_any_of("'\""sv), "one of ' or \""sv));
     m_lexer.retreat();
 


### PR DESCRIPTION
Previously here missed a equal sign parsing, which will break XML file parsing.