### PR TITLE
LibWeb: Do not crash if "fill: none" is specified for svg text

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
+++ b/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
@@ -1,0 +1,8 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x163 children: inline
+      line 0 width: 300, height: 163, bottom: 163, baseline: 13.53125
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,21 300x150]
+      SVGSVGBox <svg> at (8,21) content-size 300x150 [SVG] children: not-inline
+        SVGTextBox <text> at (8,21) content-size 0x0 children: not-inline
+      TextNode <#text>

--- a/Tests/LibWeb/Layout/input/svg/text-fill-none.html
+++ b/Tests/LibWeb/Layout/input/svg/text-fill-none.html
@@ -1,0 +1,1 @@
+<svg><text fill="none"></text></svg>

--- a/Userland/Libraries/LibWeb/Painting/SVGTextPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGTextPaintable.cpp
@@ -31,6 +31,9 @@ void SVGTextPaintable::paint(PaintContext& context, PaintPhase phase) const
     if (!is_visible())
         return;
 
+    if (!layout_node().computed_values().fill().has_value())
+        return;
+
     SVGGraphicsPaintable::paint(context, phase);
 
     if (phase != PaintPhase::Foreground)

--- a/Userland/Libraries/LibWeb/Painting/SVGTextPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGTextPaintable.cpp
@@ -34,6 +34,11 @@ void SVGTextPaintable::paint(PaintContext& context, PaintPhase phase) const
     if (!layout_node().computed_values().fill().has_value())
         return;
 
+    if (layout_node().computed_values().fill()->is_url()) {
+        dbgln("FIXME: Using url() as fill is not supported for svg text");
+        return;
+    }
+
     SVGGraphicsPaintable::paint(context, phase);
 
     if (phase != PaintPhase::Foreground)


### PR DESCRIPTION
Fix crashing on https://developer.mozilla.org/en-US/ and https://www.openstreetmap.org/