### PR TITLE
LibWeb: Adjust grid columns size to fit spanning items

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/item-span-exceeds-columns-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-span-exceeds-columns-size.txt
@@ -1,0 +1,5 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
+      Box <div.container> at (8,8) content-size 300x100 [GFC] children: not-inline
+        BlockContainer <div.item> at (8,8) content-size 300x100 [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/input/grid/item-span-exceeds-columns-size.html
+++ b/Tests/LibWeb/Layout/input/grid/item-span-exceeds-columns-size.html
@@ -1,0 +1,13 @@
+<style>
+    .container {
+        width: 300px;
+        display: grid;
+        grid-template-columns: 100px;
+        grid-template-rows: 100px;
+    }
+
+    .item {
+        background-color: purple;
+        grid-column: span 2;
+    }
+</style><div class="container"><div class="item"></div></div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -73,6 +73,8 @@ public:
         return abs(m_min_row_index) + m_max_row_index + 1;
     }
 
+    void set_max_column_index(size_t max_column_index) { m_max_column_index = max_column_index; }
+
     int min_column_index() const { return m_min_column_index; }
     int max_column_index() const { return m_max_column_index; }
     int min_row_index() const { return m_min_row_index; }


### PR DESCRIPTION
This change implements following paragraph from placement algorithm in the spec:
"If the largest column span among all the items without a definite column position is larger than the width of the implicit grid, add columns to the end of the implicit grid to accommodate that column span."

There were places in the grid implementation code with copies of this text, but those were completely unrelated to the code where they were being pasted so I removed them.

Fixes infinite spinning on https://www.thunderbird.net/en-GB/