### PR TITLE
AK: Automatically copy all warn/warnln logs to debug console

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -553,6 +553,9 @@ struct Formatter<nullptr_t> : Formatter<FlatPtr> {
 
 ErrorOr<void> vformat(StringBuilder&, StringView fmtstr, TypeErasedFormatParams&);
 
+void vdbg(StringView fmtstr, TypeErasedFormatParams&, bool newline = false);
+void dbgln();
+
 #ifndef KERNEL
 void vout(FILE*, StringView fmtstr, TypeErasedFormatParams&, bool newline = false);
 
@@ -589,13 +592,30 @@ inline void outln() { outln(stdout); }
 template<typename... Parameters>
 void warn(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
 {
+#    ifdef AK_OS_SERENITY
+    VariadicFormatParams<AllowDebugOnlyFormatters::Yes, Parameters...> variadic_format_params { parameters... };
+    vdbg(fmtstr.view(), variadic_format_params, false);
+#    endif
     out(stderr, move(fmtstr), parameters...);
 }
 
 template<typename... Parameters>
-void warnln(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters) { outln(stderr, move(fmtstr), parameters...); }
+void warnln(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
+{
+#    ifdef AK_OS_SERENITY
+    VariadicFormatParams<AllowDebugOnlyFormatters::Yes, Parameters...> variadic_format_params { parameters... };
+    vdbg(fmtstr.view(), variadic_format_params, true);
+#    endif
+    outln(stderr, move(fmtstr), parameters...);
+}
 
-inline void warnln() { outln(stderr); }
+inline void warnln()
+{
+#    ifdef AK_OS_SERENITY
+    dbgln();
+#    endif
+    outln(stderr);
+}
 
 #    define warnln_if(flag, fmt, ...)       \
         do {                                \
@@ -604,8 +624,6 @@ inline void warnln() { outln(stderr); }
         } while (0)
 
 #endif
-
-void vdbg(StringView fmtstr, TypeErasedFormatParams&, bool newline = false);
 
 template<typename... Parameters>
 void dbg(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -408,10 +408,8 @@ bool DirectoryView::open(DeprecatedString const& path)
         return false;
 
     auto real_path = error_or_real_path.release_value();
-    if (auto result = Core::System::chdir(real_path); result.is_error()) {
-        dbgln("Failed to open '{}': {}", real_path, result.error());
+    if (auto result = Core::System::chdir(real_path); result.is_error())
         warnln("Failed to open '{}': {}", real_path, result.error());
-    }
 
     if (model().root_path() == real_path.to_deprecated_string()) {
         refresh();

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -1009,7 +1009,6 @@ int snprintf(char* buffer, size_t size, char const* fmt, ...)
 void perror(char const* s)
 {
     int saved_errno = errno;
-    dbgln("perror(): {}: {}", s, strerror(saved_errno));
     warnln("{}: {}", s, strerror(saved_errno));
 }
 


### PR DESCRIPTION
As (briefly) discussed in #19607. For applications that we don't run inside Terminal, any logged warn()s and warnln()s are lost, which could be useful for debugging. People had to remember to add a duplicate `dbgln()` call any time they wanted to see the error in the console.

So, let's print all warnings to the debug console too!

Specifically, this makes `warn()` and `warnln()` send the same output to the debug console. I experimented with instead intercepting `stderr` output in `vout()`, which seems cleaner and more thorough, but it would panic the kernel every time I booted, so I gave up on that. :sweat_smile: 