### PR TITLE
Kernel: Fix condition for write to succeed on pseudoterminal

### DIFF
--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -96,7 +96,7 @@ bool MasterPTY::can_write_from_slave() const
 {
     if (m_closed)
         return true;
-    return m_buffer->space_for_writing();
+    return m_buffer->space_for_writing() >= 2;
 }
 
 ErrorOr<void> MasterPTY::close()


### PR DESCRIPTION
As "\n" is translated to "\r\n" in TTYs, the condition for a write to succeed on a pseudoterminal should check if the underlying buffer has 2 bytes empty rather than 1.

Fixes SerenityOS#18888