### PR TITLE
LibJS: Resolve rope strings directly to UTF-16 when preferable

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -59,7 +59,11 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    ThrowCompletionOr<void> resolve_rope_if_needed() const;
+    enum class EncodingPreference {
+        UTF8,
+        UTF16,
+    };
+    ThrowCompletionOr<void> resolve_rope_if_needed(EncodingPreference) const;
 
     mutable bool m_is_rope { false };
 


### PR DESCRIPTION
When someone calls PrimitiveString::utf16_string() on a rope string, we know for sure that the client wants a UTF-16 string and may not be interested in a UTF-8 version at all.

To avoid round-tripping through UTF-8 in this scenario, callers can now inform resolve_rope_if_needed() about their preferred encoding, should rope resolution take place. The UTF-16 case is actually a lot simpler than the UTF-8 case, since we can simply ask for UTF-16 data for each fiber of the rope, and then concatenate all the fibers.

Since LibJS always uses UTF-16 for regular expression matching, this avoids round-tripping through UTF-8 whenever the input to a regex test is already UTF-16. :^)