### PR TITLE
LibJS+LibWeb: Add fast_is<DOM::Node> for JS::Object

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -169,6 +169,7 @@ public:
     void define_native_function(Realm&, PropertyKey const&, SafeFunction<ThrowCompletionOr<Value>(VM&)>, i32 length, PropertyAttributes attributes);
     void define_native_accessor(Realm&, PropertyKey const&, SafeFunction<ThrowCompletionOr<Value>(VM&)> getter, SafeFunction<ThrowCompletionOr<Value>(VM&)> setter, PropertyAttributes attributes);
 
+    virtual bool is_dom_node() const { return false; }
     virtual bool is_function() const { return false; }
     virtual bool is_typed_array() const { return false; }
     virtual bool is_string_object() const { return false; }

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -84,6 +84,7 @@ public:
 
     virtual bool is_editable() const;
 
+    virtual bool is_dom_node() const final { return true; }
     virtual bool is_html_element() const { return false; }
     virtual bool is_html_html_element() const { return false; }
     virtual bool is_html_anchor_element() const { return false; }
@@ -704,3 +705,6 @@ private:
 };
 
 }
+
+template<>
+inline bool JS::Object::fast_is<Web::DOM::Node>() const { return is_dom_node(); }


### PR DESCRIPTION
Solves problem that is<DOM::Node, JS::Object>() is quite hot in profiles while loading https://www.postgresql.org/about/featurematrix/.