### PR TITLE
LibGfx/QOI: Refactor the plugin interface

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/QOILoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/QOILoader.h
@@ -45,7 +45,6 @@ public:
 
     virtual IntSize size() override;
 
-    virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override { return false; }
     virtual size_t loop_count() override { return 0; }
     virtual size_t frame_count() override { return 1; }

--- a/Userland/Libraries/LibGfx/ImageFormats/QOILoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/QOILoader.h
@@ -54,8 +54,8 @@ public:
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
-    ErrorOr<void> decode_header_and_update_context(Stream&);
-    ErrorOr<void> decode_image_and_update_context(Stream&);
+    ErrorOr<void> decode_header_and_update_context();
+    ErrorOr<void> decode_image_and_update_context();
 
     QOIImageDecoderPlugin(NonnullOwnPtr<Stream>);
 


### PR DESCRIPTION
Contributes to #19893 

---

**LibGfx/QOI: Remove useless parameters from member functions**

Both `decode_[header,image]_and_update_context()` used to take a
`Stream&` as parameter, but they are always called with the field
`m_context.stream` so no need to take it as a parameter.

**LibGfx/QOI: Decode the header in `create()` and remove `initialize()`**

This is done as a part of #19893.

