### PR TITLE
LibGfx/JPEG: Refactor the plugin interface

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -1931,11 +1931,6 @@ IntSize JPEGImageDecoderPlugin::size()
     return {};
 }
 
-ErrorOr<void> JPEGImageDecoderPlugin::initialize()
-{
-    return {};
-}
-
 bool JPEGImageDecoderPlugin::sniff(ReadonlyBytes data)
 {
     return data.size() > 3

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
@@ -24,7 +24,6 @@ public:
     virtual ~JPEGImageDecoderPlugin() override;
     virtual IntSize size() override;
 
-    virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override;
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;


### PR DESCRIPTION
Contributes to #19893 and fixes #19815

---
**LibGfx/JPEG: Remove the unused method `initialize()`**

**LibGfx/JPEG: Decode the header in `create()`**

This is done as a part of #19893.

