### PR TITLE
LibGfx/TinyVG: Refactor the plugin interface

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
@@ -489,13 +489,8 @@ struct TinyVGLoadingContext {
 static ErrorOr<void> decode_header_and_update_context(TinyVGLoadingContext& context)
 {
     VERIFY(context.state == TinyVGLoadingContext::State::NotDecoded);
-    auto header_or_error = decode_tinyvg_header(context.stream);
-    if (header_or_error.is_error()) {
-        context.state = TinyVGLoadingContext::State::Error;
-        return header_or_error.release_error();
-    }
+    context.header = TRY(decode_tinyvg_header(context.stream));
     context.state = TinyVGLoadingContext::State::HeaderDecoded;
-    context.header = header_or_error.release_value();
     return {};
 }
 
@@ -516,8 +511,6 @@ static ErrorOr<void> ensure_fully_decoded(TinyVGLoadingContext& context)
 {
     if (context.state == TinyVGLoadingContext::State::Error)
         return Error::from_string_literal("TinyVGImageDecoderPlugin: Decoding failed!");
-    if (context.state == TinyVGLoadingContext::State::NotDecoded)
-        TRY(decode_header_and_update_context(context));
     if (context.state == TinyVGLoadingContext::State::HeaderDecoded)
         TRY(decode_image_data_and_update_context(context));
     VERIFY(context.state == TinyVGLoadingContext::State::ImageDecoded);
@@ -531,7 +524,9 @@ TinyVGImageDecoderPlugin::TinyVGImageDecoderPlugin(ReadonlyBytes bytes)
 
 ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> TinyVGImageDecoderPlugin::create(ReadonlyBytes bytes)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) TinyVGImageDecoderPlugin(bytes));
+    auto plugin = TRY(adopt_nonnull_own_or_enomem(new (nothrow) TinyVGImageDecoderPlugin(bytes)));
+    TRY(decode_header_and_update_context(*plugin->m_context));
+    return plugin;
 }
 
 bool TinyVGImageDecoderPlugin::sniff(ReadonlyBytes bytes)
@@ -542,18 +537,7 @@ bool TinyVGImageDecoderPlugin::sniff(ReadonlyBytes bytes)
 
 IntSize TinyVGImageDecoderPlugin::size()
 {
-    if (m_context->state == TinyVGLoadingContext::State::NotDecoded)
-        (void)decode_header_and_update_context(*m_context);
-
-    if (m_context->state == TinyVGLoadingContext::State::Error)
-        return {};
-
     return { m_context->header.width, m_context->header.height };
-}
-
-ErrorOr<void> TinyVGImageDecoderPlugin::initialize()
-{
-    return decode_header_and_update_context(*m_context);
 }
 
 ErrorOr<ImageFrameDescriptor> TinyVGImageDecoderPlugin::frame(size_t, Optional<IntSize> ideal_size)

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
@@ -81,7 +81,6 @@ public:
     static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
 
     virtual IntSize size() override;
-    virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override { return false; }
     virtual size_t loop_count() override { return 0; }
     virtual size_t frame_count() override { return 1; }


### PR DESCRIPTION
**LibGfx/TinyVG: Decode the header in `create()` and remove `initialize()`**

This is done as a part of #19893.

---

cc @MacDue
~~This will unfortunately conflict with #19870, I tried to cherry-pick the commit: [LibGfx: Lazily load TinyVG image data](https://github.com/SerenityOS/serenity/pull/19870/commits/80d2aa4b4fa9e15d56c369758f9319441db6de97), but it depends on previous commit of the same PR.~~ Rebased!