### PR TITLE
LibPDF: Fix quadratic runtime in stream dumping

### DIFF
--- a/Userland/Libraries/LibPDF/ObjectDerivatives.cpp
+++ b/Userland/Libraries/LibPDF/ObjectDerivatives.cpp
@@ -145,13 +145,14 @@ DeprecatedString StreamObject::to_deprecated_string(int indent) const
         }
     } else {
         auto string = encode_hex(bytes());
-        while (string.length() > 60) {
-            builder.appendff("{}\n", string.substring(0, 60));
+        StringView view { string };
+        while (view.length() > 60) {
+            builder.appendff("{}\n", view.substring_view(0, 60));
             append_indent(builder, indent);
-            string = string.substring(60);
+            view = view.substring_view(60);
         }
 
-        builder.appendff("{}\n", string);
+        builder.appendff("{}\n", view);
     }
 
     builder.append("endstream"sv);

--- a/Userland/Libraries/LibPDF/ObjectDerivatives.cpp
+++ b/Userland/Libraries/LibPDF/ObjectDerivatives.cpp
@@ -145,17 +145,13 @@ DeprecatedString StreamObject::to_deprecated_string(int indent) const
         }
     } else {
         auto string = encode_hex(bytes());
-        while (true) {
-            if (string.length() > 60) {
-                builder.appendff("{}\n", string.substring(0, 60));
-                append_indent(builder, indent);
-                string = string.substring(60);
-                continue;
-            }
-
-            builder.appendff("{}\n", string);
-            break;
+        while (string.length() > 60) {
+            builder.appendff("{}\n", string.substring(0, 60));
+            append_indent(builder, indent);
+            string = string.substring(60);
         }
+
+        builder.appendff("{}\n", string);
     }
 
     builder.append("endstream"sv);


### PR DESCRIPTION
DeprecatedString::substring() makes a copy of the substring.
Instead, use a StringView, which can make substring views in constant
time.

Reduces time for `pdf --dump-contents image-based-pdf-sample.pdf` to
2.2s (from not completing for 1+ minutes).

That file contains a 221 kB jpeg.

Find it on the internet here:
https://nlsblog.org/wp-content/uploads/2020/06/image-based-pdf-sample.pdf