### PR TITLE
LibWeb: Paint relatively positioned inline-level elements

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,6 +7,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/PaintableBox.h>
 
 namespace Web::Painting {
 
@@ -84,6 +85,13 @@ Paintable const* Paintable::previous_sibling() const
     for (; layout_node && !layout_node->paintable(); layout_node = layout_node->previous_sibling())
         ;
     return layout_node ? layout_node->paintable() : nullptr;
+}
+
+StackingContext const* Paintable::stacking_context_rooted_here() const
+{
+    if (!layout_node().is_box())
+        return nullptr;
+    return static_cast<PaintableBox const&>(*this).stacking_context();
 }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -83,6 +83,28 @@ public:
         return TraversalDecision::Continue;
     }
 
+    template<typename Callback>
+    TraversalDecision for_each_in_inclusive_subtree(Callback callback) const
+    {
+        if (auto decision = callback(*this); decision != TraversalDecision::Continue)
+            return decision;
+        for (auto* child = first_child(); child; child = child->next_sibling()) {
+            if (child->for_each_in_inclusive_subtree(callback) == TraversalDecision::Break)
+                return TraversalDecision::Break;
+        }
+        return TraversalDecision::Continue;
+    }
+
+    template<typename Callback>
+    TraversalDecision for_each_in_subtree(Callback callback) const
+    {
+        for (auto* child = first_child(); child; child = child->next_sibling()) {
+            if (child->for_each_in_inclusive_subtree(callback) == TraversalDecision::Break)
+                return TraversalDecision::Break;
+        }
+        return TraversalDecision::Continue;
+    }
+
     virtual void paint(PaintContext&, PaintPhase) const { }
 
     virtual void before_children_paint(PaintContext&, PaintPhase) const { }

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -134,6 +134,8 @@ public:
     template<typename T>
     bool fast_is() const = delete;
 
+    StackingContext const* stacking_context_rooted_here() const;
+
 protected:
     explicit Paintable(Layout::Node const& layout_node)
         : m_layout_node(layout_node)

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -444,7 +444,7 @@ Gfx::FloatPoint StackingContext::compute_transform_origin() const
 template<typename U, typename Callback>
 static TraversalDecision for_each_in_inclusive_subtree_of_type_within_same_stacking_context_in_reverse(Paintable const& paintable, Callback callback)
 {
-    if (is<PaintableBox>(paintable) && static_cast<PaintableBox const&>(paintable).stacking_context()) {
+    if (paintable.stacking_context_rooted_here()) {
         // Note: Include the stacking context (so we can hit test it), but don't recurse into it.
         if (auto decision = callback(static_cast<U const&>(paintable)); decision != TraversalDecision::Continue)
             return decision;


### PR DESCRIPTION
Since we deliberately skip positioned elements in `paint_descendants()`, we have to make sure we actually paint them in the subsequent `paint_internal()` pass.
    
Before this change, we were only painting positioned elements whose paintable was a `PaintableBox`, neglecting inline-level relpos elements.

Visual progression on https://thunderbird.net/

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/89516432-a527-461b-8e64-aa4d477248c2)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/3acc1d6a-3bc5-492a-a6ba-6c8943bc78e9)
