### PR TITLE
LibJS/Bytecode: Do not rethrow caught exception from `finally`

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -19,6 +19,8 @@ struct UnwindInfo {
     BasicBlock const* finalizer;
 
     JS::GCPtr<Environment> lexical_environment;
+
+    bool handler_called { false };
 };
 
 class BasicBlock {


### PR DESCRIPTION
If the exception from the `try` block has already been caught by `catch`, we need to clear the saved exception before entering `finally` so that ContinuePendingUnwind will not re-throw it.

9 new passes on test262 :^)

```
Summary:
    Diff Tests:
        +9 ✅    -9 ❌   

Diff Tests:
    test/built-ins/Array/fromAsync/non-iterable-input-does-not-use-array-prototype.js ❌ -> ✅
    test/language/statements/try/S12.14_A10_T2.js                                     ❌ -> ✅
    test/language/statements/try/S12.14_A10_T3.js                                     ❌ -> ✅
    test/language/statements/try/S12.14_A11_T2.js                                     ❌ -> ✅
    test/language/statements/try/S12.14_A11_T3.js                                     ❌ -> ✅
    test/language/statements/try/S12.14_A12_T2.js                                     ❌ -> ✅
    test/language/statements/try/S12.14_A12_T3.js                                     ❌ -> ✅
    test/language/statements/try/S12.14_A9_T2.js                                      ❌ -> ✅
    test/language/statements/try/S12.14_A9_T3.js                                      ❌ -> ✅
```