### PR TITLE
LibJS/Bytecode: Correctly rethrow exception in `await` expression

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -278,7 +278,7 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Realm& realm, Execu
                 //       but we generate a Yield Operation in the case of returns in
                 //       generators as well, so we need to check if it will actually
                 //       continue or is a `return` in disguise
-                will_yield = instruction.type() == Instruction::Type::Yield && static_cast<Op::Yield const&>(instruction).continuation().has_value();
+                will_yield = (instruction.type() == Instruction::Type::Yield && static_cast<Op::Yield const&>(instruction).continuation().has_value()) || instruction.type() == Instruction::Type::Await;
                 break;
             }
             ++pc;

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
@@ -114,7 +114,7 @@ void AsyncFunctionDriverWrapper::continue_async_execution(VM& vm, Value value, b
                 continue;
             }
             if (m_current_promise->state() == Promise::State::Rejected) {
-                generator_result = m_generator_object->resume_abrupt(vm, m_current_promise->result(), {});
+                generator_result = m_generator_object->resume_abrupt(vm, throw_completion(m_current_promise->result()), {});
                 continue;
             }
             // Due to the nature of promise capabilities we might get called on either one path,


### PR DESCRIPTION
**LibJS/Bytecode: Do not unwind eagerly after throwing `Await`**

If an exception was thrown while evaluating the argument of an `await` expression, we should jump to the continuation block instead of eagerly rejecting the caller async function.

This restores the behavior prior to the addition of the separate `Await` instruction in d66eb4e3.

**LibJS/Bytecode: Correctly rethrow exception in `await` expression**

We were implicitly converting the throw completion's value into a normal completion in `AsyncFunctionDriverWrapper::continue_async_execution`, which meant the routine generated by `generate_await` didn't know that the value had to be thrown when execution resumed.

Without this change, we mistakenly pass 13 tests for `Array.fromAsync`, which we do not implement yet. But even with that "regression", we pass 17 more test262 tests in total.

```
    Diff Tests:
        +17 ✅    -17 ❌   
```

<details>
<summary>Full test diff</summary>
<pre>
Diff Tests:
    test/built-ins/Array/fromAsync/asyncitems-arraylike-length-accessor-throws.js                                                ✅ -> ❌
    test/built-ins/Array/fromAsync/asyncitems-arraylike-too-long.js                                                              ✅ -> ❌
    test/built-ins/Array/fromAsync/asyncitems-asynciterator-not-callable.js                                                      ✅ -> ❌
    test/built-ins/Array/fromAsync/asyncitems-asynciterator-throws.js                                                            ✅ -> ❌
    test/built-ins/Array/fromAsync/asyncitems-iterator-not-callable.js                                                           ✅ -> ❌
    test/built-ins/Array/fromAsync/asyncitems-iterator-throws.js                                                                 ✅ -> ❌
    test/built-ins/Array/fromAsync/asyncitems-null-undefined.js                                                                  ✅ -> ❌
    test/built-ins/Array/fromAsync/mapfn-async-throws.js                                                                         ✅ -> ❌
    test/built-ins/Array/fromAsync/mapfn-not-callable.js                                                                         ✅ -> ❌
    test/built-ins/Array/fromAsync/mapfn-sync-throws.js                                                                          ✅ -> ❌
    test/built-ins/Array/fromAsync/this-constructor-with-bad-length-setter.js                                                    ✅ -> ❌
    test/built-ins/Array/fromAsync/this-constructor-with-readonly-length.js                                                      ✅ -> ❌
    test/built-ins/Array/fromAsync/this-constructor-with-unsettable-element.js                                                   ✅ -> ❌
    test/built-ins/AsyncGeneratorPrototype/return/return-suspendedYield-try-finally-return.js                                    ❌ -> ✅
    test/built-ins/AsyncGeneratorPrototype/return/return-suspendedYield-try-finally-throw.js                                     ❌ -> ✅
    test/built-ins/AsyncGeneratorPrototype/return/return-suspendedYield-try-finally.js                                           ❌ -> ✅
    test/built-ins/AsyncGeneratorPrototype/throw/throw-suspendedYield-try-finally-return.js                                      ❌ -> ✅
    test/built-ins/AsyncGeneratorPrototype/throw/throw-suspendedYield-try-finally-throw.js                                       ❌ -> ✅
    test/harness/asyncHelpers-throwsAsync-custom-typeerror.js                                                                    ❌ -> ✅
    test/harness/asyncHelpers-throwsAsync-incorrect-ctor.js                                                                      ❌ -> ✅
    test/harness/asyncHelpers-throwsAsync-no-arg.js                                                                              ❌ -> ✅
    test/harness/asyncHelpers-throwsAsync-no-error.js                                                                            ❌ -> ✅
    test/harness/asyncHelpers-throwsAsync-null.js                                                                                ❌ -> ✅
    test/harness/asyncHelpers-throwsAsync-primitive.js                                                                           ❌ -> ✅
    test/harness/asyncHelpers-throwsAsync-resolved-error.js                                                                      ❌ -> ✅
    test/harness/asyncHelpers-throwsAsync-same-realm.js                                                                          ❌ -> ✅
    test/harness/asyncHelpers-throwsAsync-single-arg.js                                                                          ❌ -> ✅
    test/language/expressions/async-function/named-strict-error-reassign-fn-name-in-body-in-arrow.js                             ❌ -> ✅
    test/language/expressions/async-function/named-strict-error-reassign-fn-name-in-body-in-eval.js                              ❌ -> ✅
    test/language/expressions/async-function/named-strict-error-reassign-fn-name-in-body.js                                      ❌ -> ✅
    test/language/expressions/async-generator/named-strict-error-reassign-fn-name-in-body-in-arrow.js                            ❌ -> ✅
    test/language/expressions/async-generator/named-strict-error-reassign-fn-name-in-body-in-eval.js                             ❌ -> ✅
    test/language/expressions/async-generator/named-strict-error-reassign-fn-name-in-body.js                                     ❌ -> ✅
    test/language/expressions/await/await-throws-rejections.js                                                                   ❌ -> ✅
    test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-eval-rqstd-abrupt-typeerror.js       ❌ -> ✅
    test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-eval-rqstd-abrupt-urierror.js        ❌ -> ✅
    test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-eval-script-code-target.js           ❌ -> ✅
    test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-file-does-not-exist.js               ❌ -> ✅
    test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-instn-iee-err-ambiguous-import.js    ❌ -> ✅
    test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-instn-iee-err-circular.js            ❌ -> ✅
    test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-specifier-tostring-abrupt-rejects.js ❌ -> ✅
    test/language/expressions/dynamic-import/for-await-resolution-and-error-agen.js                                              ❌ -> ✅
    test/language/expressions/dynamic-import/for-await-resolution-and-error.js                                                   ❌ -> ✅
</pre>
</details>