### PR TITLE
LibGfx/GIF: Refactor the plugin interface

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
@@ -548,13 +548,6 @@ IntSize GIFImageDecoderPlugin::size()
     return { m_context->logical_screen.width, m_context->logical_screen.height };
 }
 
-ErrorOr<void> GIFImageDecoderPlugin::initialize()
-{
-    FixedMemoryStream stream { { m_context->data, m_context->data_size } };
-    TRY(decode_gif_header(stream));
-    return {};
-}
-
 bool GIFImageDecoderPlugin::sniff(ReadonlyBytes data)
 {
     FixedMemoryStream stream { data };

--- a/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
@@ -381,7 +381,7 @@ static ErrorOr<void> decode_frame(GIFLoadingContext& context, size_t frame_index
     return {};
 }
 
-static ErrorOr<void> load_gif_frame_descriptors(GIFLoadingContext& context)
+static ErrorOr<void> load_header_and_logical_screen(GIFLoadingContext& context)
 {
     if (TRY(context.stream.size()) < 32)
         return Error::from_string_literal("Size too short for GIF frame descriptors");
@@ -411,6 +411,13 @@ static ErrorOr<void> load_gif_frame_descriptors(GIFLoadingContext& context)
         u8 b = TRY(context.stream.read_value<u8>());
         context.logical_screen.color_map[i] = { r, g, b };
     }
+
+    return {};
+}
+
+static ErrorOr<void> load_gif_frame_descriptors(GIFLoadingContext& context)
+{
+    TRY(load_header_and_logical_screen(context));
 
     NonnullOwnPtr<GIFImageDescriptor> current_image = make<GIFImageDescriptor>();
     for (;;) {

--- a/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.h
@@ -22,7 +22,6 @@ public:
 
     virtual IntSize size() override;
 
-    virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override;
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;

--- a/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/MemoryStream.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageFormats/ImageDecoder.h>
 
@@ -30,7 +31,7 @@ public:
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
-    GIFImageDecoderPlugin(u8 const*, size_t);
+    GIFImageDecoderPlugin(FixedMemoryStream);
 
     OwnPtr<GIFLoadingContext> m_context;
 };


### PR DESCRIPTION
**LibGfx/GIF: Don't read the header twice**

This is already done in `load_gif_frame_descriptors()`. As the method
`initialize()` is now empty, we can delete it.

**LibGfx/GIF: Only use a `FixedMemoryStream`**

This allows us to drop the data pointer in the `GIFLoadingContext`.

**LibGfx/GIF: Move the code to read the header to its own function**

By header, I include the logical screen descriptor here, so all the
information that is not specific to each frame.

**LibGfx/GIF: Decode the header in `create()`**

Again, header includes the logical screen descriptor here. This is done
as a part of #19893.