### PR TITLE
LibGfx/WebP: Refactor the plugin interface

### DIFF
--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -29,7 +29,8 @@
     __ENUMERATE_IMAGE_FORMAT(dds, ".dds")   \
     __ENUMERATE_IMAGE_FORMAT(qoi, ".qoi")   \
     __ENUMERATE_IMAGE_FORMAT(tga, ".tga")   \
-    __ENUMERATE_IMAGE_FORMAT(tvg, ".tvg")
+    __ENUMERATE_IMAGE_FORMAT(tvg, ".tvg")   \
+    __ENUMERATE_IMAGE_FORMAT(tvg, ".webp")
 
 namespace Gfx {
 

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -772,7 +772,7 @@ ErrorOr<ImageFrameDescriptor> WebPImageDecoderPlugin::frame(size_t index, Option
     if (m_context->state == WebPLoadingContext::State::Error)
         return Error::from_string_literal("WebPImageDecoderPlugin: Decoding failed");
 
-    // In a a lambda so that only one check to set State::Error is needed, instead of one per TRY.
+    // In a lambda so that only one check to set State::Error is needed, instead of one per TRY.
     auto decode_frame = [this](size_t index) -> ErrorOr<ImageFrameDescriptor> {
         if (m_context->state < WebPLoadingContext::State::ChunksDecoded)
             TRY(decode_webp_chunks(*m_context));

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.h
@@ -21,7 +21,6 @@ public:
 
     virtual IntSize size() override;
 
-    virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override;
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;


### PR DESCRIPTION
**LibGfx/WebP: Decode the first chunk in `create()`**

And remove `initialize()`.

This is done as a part of #19893.

**LibGfx/WebP: Remove a typo**

:redthakis:

**LibGfx: Register WebP as a supported image format**

Basically, it means that we now render a thumbnail for WebP images.

---
cc @nico 