### PR TITLE
LibWeb: Add interface for 'concept-url-parser'

### DIFF
--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -15,9 +15,9 @@
 
 namespace AK {
 
-// FIXME: It could make sense to force users of URL to use URLParser::parse() explicitly instead of using a constructor.
+// FIXME: It could make sense to force users of URL to use URLParser::basic_parse() explicitly instead of using a constructor.
 URL::URL(StringView string)
-    : URL(URLParser::parse(string))
+    : URL(URLParser::basic_parse(string))
 {
     if constexpr (URL_PARSER_DEBUG) {
         if (m_valid)
@@ -32,7 +32,7 @@ URL URL::complete_url(StringView relative_url) const
     if (!is_valid())
         return {};
 
-    return URLParser::parse(relative_url, *this);
+    return URLParser::basic_parse(relative_url, *this);
 }
 
 DeprecatedString URL::username(ApplyPercentDecoding apply_percent_decoding) const

--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -27,7 +27,7 @@ static bool is_url_code_point(u32 code_point)
 
 static void report_validation_error(SourceLocation const& location = SourceLocation::current())
 {
-    dbgln_if(URL_PARSER_DEBUG, "URLParser::parse: Validation error! {}", location);
+    dbgln_if(URL_PARSER_DEBUG, "URLParser::basic_parse: Validation error! {}", location);
 }
 
 static Optional<DeprecatedString> parse_opaque_host(StringView input)
@@ -194,7 +194,7 @@ Optional<URL> URLParser::parse_data_url(StringView raw_input)
 //       future for validation of URLs, which would then lead to infinite recursion.
 //       The same goes for base_url, because e.g. the port() getter does not always return m_port, and we are interested in the underlying member
 //       variables' values here, not what the URL class presents to its users.
-URL URLParser::parse(StringView raw_input, Optional<URL> const& base_url, Optional<URL> url, Optional<State> state_override)
+URL URLParser::basic_parse(StringView raw_input, Optional<URL> const& base_url, Optional<URL> url, Optional<State> state_override)
 {
     dbgln_if(URL_PARSER_DEBUG, "URLParser::parse: Parsing '{}'", raw_input);
     if (raw_input.is_empty())
@@ -287,11 +287,11 @@ URL URLParser::parse(StringView raw_input, Optional<URL> const& base_url, Option
 
         if constexpr (URL_PARSER_DEBUG) {
             if (code_point == end_of_file)
-                dbgln("URLParser::parse: {} state with EOF.", state_name(state));
+                dbgln("URLParser::basic_parse: {} state with EOF.", state_name(state));
             else if (is_ascii_printable(code_point))
-                dbgln("URLParser::parse: {} state with code point U+{:04X} ({:c}).", state_name(state), code_point, code_point);
+                dbgln("URLParser::basic_parse: {} state with code point U+{:04X} ({:c}).", state_name(state), code_point, code_point);
             else
-                dbgln("URLParser::parse: {} state with code point U+{:04X}.", state_name(state), code_point);
+                dbgln("URLParser::basic_parse: {} state with code point U+{:04X}.", state_name(state), code_point);
         }
 
         switch (state) {

--- a/AK/URLParser.h
+++ b/AK/URLParser.h
@@ -55,7 +55,8 @@ public:
         VERIFY_NOT_REACHED();
     }
 
-    static URL parse(StringView input, Optional<URL> const& base_url = {}, Optional<URL> url = {}, Optional<State> state_override = {});
+    // https://url.spec.whatwg.org/#concept-basic-url-parser
+    static URL basic_parse(StringView input, Optional<URL> const& base_url = {}, Optional<URL> url = {}, Optional<State> state_override = {});
 
     // https://url.spec.whatwg.org/#string-percent-encode-after-encoding
     static DeprecatedString percent_encode_after_encoding(StringView input, URL::PercentEncodeSet percent_encode_set, bool space_as_plus = false);

--- a/Tests/AK/TestURL.cpp
+++ b/Tests/AK/TestURL.cpp
@@ -417,7 +417,7 @@ TEST_CASE(complete_file_url_with_base)
 TEST_CASE(empty_url_with_base_url)
 {
     URL base_url { "https://foo.com/"sv };
-    URL parsed_url = URLParser::parse(""sv, base_url);
+    URL parsed_url = URLParser::basic_parse(""sv, base_url);
     EXPECT_EQ(parsed_url.is_valid(), true);
     EXPECT(base_url.equals(parsed_url));
 }

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/Debug.h>
 #include <AK/TypeCasts.h>
-#include <AK/URLParser.h>
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/VM.h>
@@ -14,6 +13,7 @@
 #include <LibWeb/Fetch/Infrastructure/FetchParams.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
+#include <LibWeb/URL/URL.h>
 
 namespace Web::Fetch::Infrastructure {
 
@@ -113,7 +113,7 @@ ErrorOr<Optional<AK::URL>> Response::location_url(Optional<String> const& reques
         return Optional<AK::URL> {};
 
     // 3. If location is a header value, then set location to the result of parsing location with response’s URL.
-    auto location = AK::URLParser::parse(location_values.first(), url());
+    auto location = URL::parse(location_values.first(), url());
     if (!location.is_valid())
         return Error::from_string_view("Invalid 'Location' header URL"sv);
 

--- a/Userland/Libraries/LibWeb/Fetch/Request.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Request.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/URLParser.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/RequestPrototype.h>
@@ -18,6 +17,7 @@
 #include <LibWeb/Fetch/Request.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
+#include <LibWeb/URL/URL.h>
 
 namespace Web::Fetch {
 
@@ -121,7 +121,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::construct_impl(JS::Realm
     // 5. If input is a string, then:
     if (input.has<String>()) {
         // 1. Let parsedURL be the result of parsing input with baseURL.
-        auto parsed_url = URLParser::parse(input.get<String>(), base_url);
+        auto parsed_url = URL::parse(input.get<String>(), base_url);
 
         // 2. If parsedURL is failure, then throw a TypeError.
         if (!parsed_url.is_valid())
@@ -299,7 +299,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::construct_impl(JS::Realm
         // 3. Otherwise:
         else {
             // 1. Let parsedReferrer be the result of parsing referrer with baseURL.
-            auto parsed_referrer = URLParser::parse(referrer, base_url);
+            auto parsed_referrer = URL::parse(referrer, base_url);
 
             // 2. If parsedReferrer is failure, then throw a TypeError.
             if (!parsed_referrer.is_valid())

--- a/Userland/Libraries/LibWeb/Fetch/Response.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Response.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/URLParser.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
@@ -15,6 +14,7 @@
 #include <LibWeb/Fetch/Response.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/Infra/JSON.h>
+#include <LibWeb/URL/URL.h>
 
 namespace Web::Fetch {
 
@@ -174,7 +174,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::redirect(JS::VM& vm, S
 
     // 1. Let parsedURL be the result of parsing url with current settings object’s API base URL.
     auto api_base_url = HTML::current_settings_object().api_base_url();
-    auto parsed_url = URLParser::parse(url, api_base_url);
+    auto parsed_url = URL::parse(url, api_base_url);
 
     // 2. If parsedURL is failure, then throw a TypeError.
     if (!parsed_url.is_valid())

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -78,7 +78,7 @@ void HTMLHyperlinkElementUtils::set_protocol(DeprecatedString protocol)
         return;
 
     // 3. Basic URL parse the given value, followed by ":", with this element's url as url and scheme start state as state override.
-    auto result_url = URLParser::parse(DeprecatedString::formatted("{}:", protocol), {}, m_url, URLParser::State::SchemeStart);
+    auto result_url = URLParser::basic_parse(DeprecatedString::formatted("{}:", protocol), {}, m_url, URLParser::State::SchemeStart);
     if (result_url.is_valid())
         m_url = move(result_url);
 
@@ -192,7 +192,7 @@ void HTMLHyperlinkElementUtils::set_host(DeprecatedString host)
         return;
 
     // 4. Basic URL parse the given value, with url as url and host state as state override.
-    auto result_url = URLParser::parse(host, {}, url, URLParser::State::Host);
+    auto result_url = URLParser::basic_parse(host, {}, url, URLParser::State::Host);
     if (result_url.is_valid())
         m_url = move(result_url);
 
@@ -225,7 +225,7 @@ void HTMLHyperlinkElementUtils::set_hostname(DeprecatedString hostname)
         return;
 
     // 4. Basic URL parse the given value, with url as url and hostname state as state override.
-    auto result_url = URLParser::parse(hostname, {}, m_url, URLParser::State::Hostname);
+    auto result_url = URLParser::basic_parse(hostname, {}, m_url, URLParser::State::Hostname);
     if (result_url.is_valid())
         m_url = move(result_url);
 
@@ -267,7 +267,7 @@ void HTMLHyperlinkElementUtils::set_port(DeprecatedString port)
         m_url->set_port({});
     } else {
         // 5. Otherwise, basic URL parse the given value, with url as url and port state as state override.
-        auto result_url = URLParser::parse(port, {}, m_url, URLParser::State::Port);
+        auto result_url = URLParser::basic_parse(port, {}, m_url, URLParser::State::Port);
         if (result_url.is_valid())
             m_url = move(result_url);
     }
@@ -311,7 +311,7 @@ void HTMLHyperlinkElementUtils::set_pathname(DeprecatedString pathname)
     url->set_paths({});
 
     // 5. Basic URL parse the given value, with url as url and path start state as state override.
-    auto result_url = URLParser::parse(pathname, {}, move(url), URLParser::State::PathStart);
+    auto result_url = URLParser::basic_parse(pathname, {}, move(url), URLParser::State::PathStart);
     if (result_url.is_valid())
         m_url = move(result_url);
 
@@ -358,7 +358,7 @@ void HTMLHyperlinkElementUtils::set_search(DeprecatedString search)
         url_copy->set_query(DeprecatedString::empty());
 
         //    3. Basic URL parse input, with null, this element's node document's document's character encoding, url as url, and query state as state override.
-        auto result_url = URLParser::parse(input, {}, move(url_copy), URLParser::State::Query);
+        auto result_url = URLParser::basic_parse(input, {}, move(url_copy), URLParser::State::Query);
         if (result_url.is_valid())
             m_url = move(result_url);
     }
@@ -406,7 +406,7 @@ void HTMLHyperlinkElementUtils::set_hash(DeprecatedString hash)
         url_copy->set_fragment(DeprecatedString::empty());
 
         //    3. Basic URL parse input, with url as url and fragment state as state override.
-        auto result_url = URLParser::parse(input, {}, move(url_copy), URLParser::State::Fragment);
+        auto result_url = URLParser::basic_parse(input, {}, move(url_copy), URLParser::State::Fragment);
         if (result_url.is_valid())
             m_url = move(result_url);
     }

--- a/Userland/Libraries/LibWeb/HTML/Location.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Location.cpp
@@ -312,7 +312,7 @@ WebIDL::ExceptionOr<void> Location::set_hash(String const& value)
     copy_url.set_fragment("");
 
     // 6. Basic URL parse input, with copyURL as url and fragment state as state override.
-    auto result_url = URLParser::parse(input, {}, copy_url, URLParser::State::Fragment);
+    auto result_url = URLParser::basic_parse(input, {}, copy_url, URLParser::State::Fragment);
 
     // 7. If copyURL's fragment is this's url's fragment, then return.
     if (copy_url.fragment() == this->url().fragment())

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/URLParser.h>
 #include <LibJS/Runtime/ModuleRequest.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibWeb/DOM/Document.h>
@@ -25,6 +24,7 @@
 #include <LibWeb/Loader/LoadRequest.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/MimeSniff/MimeType.h>
+#include <LibWeb/URL/URL.h>
 
 namespace Web::HTML {
 
@@ -170,7 +170,7 @@ WebIDL::ExceptionOr<Optional<AK::URL>> resolve_imports_match(DeprecatedString co
             VERIFY(resolution_result->serialize().ends_with("/"sv));
 
             // 5. Let url be the result of URL parsing afterPrefix with resolutionResult.
-            auto url = URLParser::parse(after_prefix, *resolution_result);
+            auto url = URL::parse(after_prefix, *resolution_result);
 
             // 6. If url is failure, then throw a TypeError indicating that resolution of normalizedSpecifier was blocked since the afterPrefix portion
             //    could not be URL-parsed relative to the resolutionResult mapped to by the specifierKey prefix.
@@ -200,7 +200,7 @@ Optional<AK::URL> resolve_url_like_module_specifier(DeprecatedString const& spec
     // 1. If specifier starts with "/", "./", or "../", then:
     if (specifier.starts_with("/"sv) || specifier.starts_with("./"sv) || specifier.starts_with("../"sv)) {
         // 1. Let url be the result of URL parsing specifier with baseURL.
-        auto url = URLParser::parse(specifier, base_url);
+        auto url = URL::parse(specifier, base_url);
 
         // 2. If url is failure, then return null.
         if (!url.is_valid())
@@ -211,7 +211,7 @@ Optional<AK::URL> resolve_url_like_module_specifier(DeprecatedString const& spec
     }
 
     // 2. Let url be the result of URL parsing specifier (with no base URL).
-    auto url = URLParser::parse(specifier);
+    auto url = URL::parse(specifier);
 
     // 3. If url is failure, then return null.
     if (!url.is_valid())

--- a/Userland/Libraries/LibWeb/URL/URL.cpp
+++ b/Userland/Libraries/LibWeb/URL/URL.cpp
@@ -31,7 +31,7 @@ static Optional<AK::URL> parse_api_url(String const& url, Optional<String> const
     // 2. If base is non-null:
     if (base.has_value()) {
         // 1. Set parsedBase to the result of running the basic URL parser on base.
-        auto parsed_base_url = URLParser::parse(*base);
+        auto parsed_base_url = URLParser::basic_parse(*base);
 
         // 2. If parsedBase is failure, then return failure.
         if (!parsed_base_url.is_valid())
@@ -41,7 +41,7 @@ static Optional<AK::URL> parse_api_url(String const& url, Optional<String> const
     }
 
     // 3. Return the result of running the basic URL parser on url with parsedBase.
-    auto parsed = URLParser::parse(url, parsed_base);
+    auto parsed = URLParser::basic_parse(url, parsed_base);
     return parsed.is_valid() ? parsed : Optional<AK::URL> {};
 }
 
@@ -180,7 +180,7 @@ WebIDL::ExceptionOr<void> URL::set_protocol(String const& protocol)
 
     // The protocol setter steps are to basic URL parse the given value, followed by U+003A (:), with this’s URL as
     // url and scheme start state as state override.
-    auto result_url = URLParser::parse(TRY_OR_THROW_OOM(vm, String::formatted("{}:", protocol)), {}, m_url, URLParser::State::SchemeStart);
+    auto result_url = URLParser::basic_parse(TRY_OR_THROW_OOM(vm, String::formatted("{}:", protocol)), {}, m_url, URLParser::State::SchemeStart);
     if (result_url.is_valid())
         m_url = move(result_url);
     return {};
@@ -254,7 +254,7 @@ void URL::set_host(String const& host)
         return;
 
     // 2. Basic URL parse the given value with this’s URL as url and host state as state override.
-    auto result_url = URLParser::parse(host, {}, m_url, URLParser::State::Host);
+    auto result_url = URLParser::basic_parse(host, {}, m_url, URLParser::State::Host);
     if (result_url.is_valid())
         m_url = move(result_url);
 }
@@ -280,7 +280,7 @@ void URL::set_hostname(String const& hostname)
         return;
 
     // 2. Basic URL parse the given value with this’s URL as url and hostname state as state override.
-    auto result_url = URLParser::parse(hostname, {}, m_url, URLParser::State::Hostname);
+    auto result_url = URLParser::basic_parse(hostname, {}, m_url, URLParser::State::Hostname);
     if (result_url.is_valid())
         m_url = move(result_url);
 }
@@ -311,7 +311,7 @@ void URL::set_port(String const& port)
     }
     // 3. Otherwise, basic URL parse the given value with this’s URL as url and port state as state override.
     else {
-        auto result_url = URLParser::parse(port, {}, m_url, URLParser::State::Port);
+        auto result_url = URLParser::basic_parse(port, {}, m_url, URLParser::State::Port);
         if (result_url.is_valid())
             m_url = move(result_url);
     }
@@ -339,7 +339,7 @@ void URL::set_pathname(String const& pathname)
     url.set_paths({});
 
     // 3. Basic URL parse the given value with this’s URL as url and path start state as state override.
-    auto result_url = URLParser::parse(pathname, {}, move(url), URLParser::State::PathStart);
+    auto result_url = URLParser::basic_parse(pathname, {}, move(url), URLParser::State::PathStart);
     if (result_url.is_valid())
         m_url = move(result_url);
 }
@@ -388,7 +388,7 @@ WebIDL::ExceptionOr<void> URL::set_search(String const& search)
     url_copy.set_query(DeprecatedString::empty());
 
     // 5. Basic URL parse input with url as url and query state as state override.
-    auto result_url = URLParser::parse(input, {}, move(url_copy), URLParser::State::Query);
+    auto result_url = URLParser::basic_parse(input, {}, move(url_copy), URLParser::State::Query);
     if (result_url.is_valid()) {
         m_url = move(result_url);
 
@@ -442,7 +442,7 @@ void URL::set_hash(String const& hash)
     url.set_fragment(DeprecatedString::empty());
 
     // 4. Basic URL parse input with this’s URL as url and fragment state as state override.
-    auto result_url = URLParser::parse(input, {}, move(url), URLParser::State::Fragment);
+    auto result_url = URLParser::basic_parse(input, {}, move(url), URLParser::State::Fragment);
     if (result_url.is_valid())
         m_url = move(result_url);
 }

--- a/Userland/Libraries/LibWeb/URL/URL.cpp
+++ b/Userland/Libraries/LibWeb/URL/URL.cpp
@@ -490,4 +490,27 @@ bool host_is_domain(StringView host)
         && !IPv6Address::from_string(host).has_value();
 }
 
+// https://url.spec.whatwg.org/#concept-url-parser
+AK::URL parse(StringView input, Optional<AK::URL> const& base_url)
+{
+    // FIXME: We should probably have an extended version of AK::URL for LibWeb instead of standalone functions like this.
+
+    // 1. Let url be the result of running the basic URL parser on input with base and encoding.
+    auto url = URLParser::basic_parse(input, base_url);
+
+    // 2. If url is failure, return failure.
+    if (url.is_valid())
+        return {};
+
+    // 3. If url’s scheme is not "blob",
+    if (url.scheme() != "blob")
+        return url;
+
+    // FIXME: 4. Set url’s blob URL entry to the result of resolving the blob URL url,
+    // FIXME: 5. if that did not return failure, and null otherwise.
+
+    // 6. Return url
+    return url;
+}
+
 }

--- a/Userland/Libraries/LibWeb/URL/URL.h
+++ b/Userland/Libraries/LibWeb/URL/URL.h
@@ -77,4 +77,7 @@ private:
 HTML::Origin url_origin(AK::URL const&);
 bool host_is_domain(StringView host);
 
+// https://url.spec.whatwg.org/#concept-url-parser
+AK::URL parse(StringView input, Optional<AK::URL> const& base_url = {});
+
 }

--- a/Userland/Utilities/xml.cpp
+++ b/Userland/Utilities/xml.cpp
@@ -364,7 +364,7 @@ static auto parse(StringView contents)
             .preserve_comments = true,
             .resolve_external_resource = [&](XML::SystemID const& system_id, Optional<XML::PublicID> const&) -> ErrorOr<DeprecatedString> {
                 auto base = URL::create_with_file_scheme(s_path.to_deprecated_string());
-                auto url = URLParser::parse(system_id.system_literal, base);
+                auto url = URLParser::basic_parse(system_id.system_literal, base);
                 if (!url.is_valid())
                     return Error::from_string_literal("Invalid URL");
 


### PR DESCRIPTION
Add an interface for `concept-url-parser` as a step towards implementing the File API spec "Blob URL store"

Also implement steps for state override in URL parser while we are at it .