### PR TITLE
LibWeb: Fully resolve max-width values on inline-block elements

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-max-width-fit-content.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-max-width-fit-content.txt
@@ -1,0 +1,10 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x35.46875 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x19.46875 children: inline
+      line 0 width: 102.203125, height: 19.46875, bottom: 19.46875, baseline: 14.53125
+        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 100.203125x17.46875]
+      BlockContainer <span> at (9,9) content-size 100.203125x17.46875 inline-block [BFC] children: inline
+        line 0 width: 100.203125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 13, rect: [9,9 100.203125x17.46875]
+            "hello friends"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/block-and-inline/inline-block-with-max-width-fit-content.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/inline-block-with-max-width-fit-content.html
@@ -1,0 +1,7 @@
+<!doctype html><style>
+    span {
+        border: 1px solid black;
+        display: inline-block;
+        max-width: fit-content;
+    }
+</style><span>hello friends

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -150,7 +150,7 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
 
     CSSPixels width = unconstrained_width;
     if (!should_treat_max_width_as_none(box, m_available_space->width)) {
-        auto max_width = box.computed_values().max_width().to_px(box, width_of_containing_block);
+        auto max_width = calculate_inner_width(box, m_available_space->width, box.computed_values().max_width()).to_px(box);
         width = min(width, max_width);
     }
 


### PR DESCRIPTION
This fixes an issue where `max-width: fit-content` (and other layout-dependent values) were treated as 0 on inline-blocks.

Visual progression on https://qt.io/

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/c260b962-f31e-48da-bdee-28a90074456d)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/40ed1e5e-62ca-473b-aa9c-8e6f1125121c)
