### PR TITLE
LibGfx: Approximate elliptical arcs with cubic beziers (and fix transforming arcs)

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
+++ b/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
@@ -23,12 +23,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         SVGGraphicsBox <g> at (50,150) content-size 0x0 children: inline
           TextNode <#text>
-          SVGGeometryBox <path> at (45.693222,199.830932) content-size 118.782173x47.453796 children: not-inline
+          SVGGeometryBox <path> at (45.690780,199.828884) content-size 118.784614x47.455844 children: not-inline
           TextNode <#text>
         TextNode <#text>
         SVGGraphicsBox <g> at (50,150) content-size 0x0 children: inline
           TextNode <#text>
-          SVGGeometryBox <path> at (84.5,159.504878) content-size 81x80.995117 children: not-inline
+          SVGGeometryBox <path> at (84.5,159.499996) content-size 81x81 children: not-inline
           TextNode <#text>
         TextNode <#text>
       TextNode <#text>

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2451,11 +2451,6 @@ void Painter::stroke_path(Path const& path, Color color, int thickness)
             cursor = segment->point();
             break;
         }
-        case Segment::Type::EllipticalArcTo:
-            auto& arc = static_cast<EllipticalArcSegment const&>(*segment);
-            draw_elliptical_arc(cursor.to_type<int>(), segment->point().to_type<int>(), arc.center().to_type<int>(), arc.radii(), arc.x_axis_rotation(), arc.theta_1(), arc.theta_delta(), color, thickness);
-            cursor = segment->point();
-            break;
         }
     }
 }

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -21,8 +21,9 @@ void Path::elliptical_arc_to(FloatPoint point, FloatSize radii, float x_axis_rot
     double rx = radii.width();
     double ry = radii.height();
 
-    double x_axis_rotation_c = AK::cos(static_cast<double>(x_axis_rotation));
-    double x_axis_rotation_s = AK::sin(static_cast<double>(x_axis_rotation));
+    double x_axis_rotation_s;
+    double x_axis_rotation_c;
+    AK::sincos(static_cast<double>(x_axis_rotation), x_axis_rotation_s, x_axis_rotation_c);
 
     // Find the last point
     FloatPoint last_point { 0, 0 };
@@ -99,9 +100,9 @@ void Path::elliptical_arc_to(FloatPoint point, FloatSize radii, float x_axis_rot
     auto theta_delta = theta_2 - theta_1;
 
     if (!sweep && theta_delta > 0.0) {
-        theta_delta -= 2 * M_PI;
+        theta_delta -= 2 * AK::Pi<double>;
     } else if (sweep && theta_delta < 0) {
-        theta_delta += 2 * M_PI;
+        theta_delta += 2 * AK::Pi<double>;
     }
 
     elliptical_arc_to(

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -14,15 +14,15 @@
 
 namespace Gfx {
 
-void Path::elliptical_arc_to(FloatPoint point, FloatSize radii, double x_axis_rotation, bool large_arc, bool sweep)
+void Path::elliptical_arc_to(FloatPoint point, FloatSize radii, float x_axis_rotation, bool large_arc, bool sweep)
 {
     auto next_point = point;
 
     double rx = radii.width();
     double ry = radii.height();
 
-    double x_axis_rotation_c = AK::cos(x_axis_rotation);
-    double x_axis_rotation_s = AK::sin(x_axis_rotation);
+    double x_axis_rotation_c = AK::cos(static_cast<double>(x_axis_rotation));
+    double x_axis_rotation_s = AK::sin(static_cast<double>(x_axis_rotation));
 
     // Find the last point
     FloatPoint last_point { 0, 0 };

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -184,14 +184,14 @@ public:
         invalidate_split_lines();
     }
 
-    void elliptical_arc_to(FloatPoint point, FloatSize radii, double x_axis_rotation, bool large_arc, bool sweep);
+    void elliptical_arc_to(FloatPoint point, FloatSize radii, float x_axis_rotation, bool large_arc, bool sweep);
     void arc_to(FloatPoint point, float radius, bool large_arc, bool sweep)
     {
         elliptical_arc_to(point, { radius, radius }, 0, large_arc, sweep);
     }
 
     // Note: This does not do any sanity checks!
-    void elliptical_arc_to(FloatPoint endpoint, FloatPoint center, FloatSize radii, double x_axis_rotation, double theta, double theta_delta, bool large_arc, bool sweep)
+    void elliptical_arc_to(FloatPoint endpoint, FloatPoint center, FloatSize radii, float x_axis_rotation, float theta, float theta_delta, bool large_arc, bool sweep)
     {
         append_segment<EllipticalArcSegment>(
             endpoint,


### PR DESCRIPTION
See commits for details. Using beziers for arcs greatly simplifies transforming paths. 
This fixes a few cases that have bugged me for a while (and probably more I've not spotted):

|                                      | Before                                                                                                                              | After                                                                                                                               |
|--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
| SVG heart  (`svg-transforms.html`)                         | ![Screenshot from 2023-07-15 16-20-06](https://github.com/SerenityOS/serenity/assets/11597044/db8c3061-40c9-4383-a878-0e5e3d6e8e93) | ![Screenshot from 2023-07-15 16-18-26](https://github.com/SerenityOS/serenity/assets/11597044/19e4569c-2303-4a3f-ad69-e09b4940832f) |
| everything.tvg (flipped vertically)  | ![Screenshot from 2023-07-15 16-25-01](https://github.com/SerenityOS/serenity/assets/11597044/3e8b0ba5-71d4-405f-bebb-3855ed0b0dfe) | ![Screenshot from 2023-07-15 16-27-27](https://github.com/SerenityOS/serenity/assets/11597044/17aade88-9ec6-4c8f-8fb7-db10367a1735) |

(everything.tvg requires fixes from #20027)
