### PR TITLE
Help: Fix images locations in Documentation

### DIFF
--- a/Base/usr/share/man/man1/Applications/3DFileViewer.md
+++ b/Base/usr/share/man/man1/Applications/3DFileViewer.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-3d-file-viewer.png) 3D File Viewer
+![Icon](file:///res/icons/16x16/app-3d-file-viewer.png) 3D File Viewer
 
 [Open](file:///bin/3DFileViewer)
 

--- a/Base/usr/share/man/man1/Applications/About.md
+++ b/Base/usr/share/man/man1/Applications/About.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/ladyball.png) About - About SerenityOS
+![Icon](file:///res/icons/16x16/ladyball.png) About - About SerenityOS
 
 [Open](file:///bin/About)
 

--- a/Base/usr/share/man/man1/Applications/AnalogClock.md
+++ b/Base/usr/share/man/man1/Applications/AnalogClock.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-analog-clock.png) Analog Clock - Serenity analog clock
+![Icon](file:///res/icons/16x16/app-analog-clock.png) Analog Clock - Serenity analog clock
 
 [Open](file:///bin/AnalogClock)
 

--- a/Base/usr/share/man/man1/Applications/Assistant.md
+++ b/Base/usr/share/man/man1/Applications/Assistant.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-assistant.png) Assistant - Serenity Assistant
+![Icon](file:///res/icons/16x16/app-assistant.png) Assistant - Serenity Assistant
 
 [Open](file:///bin/Assistant)
 

--- a/Base/usr/share/man/man1/Applications/Browser.md
+++ b/Base/usr/share/man/man1/Applications/Browser.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-browser.png) Browser - Serenity WWW Browser
+![Icon](file:///res/icons/16x16/app-browser.png) Browser - Serenity WWW Browser
 
 [Open](file:///bin/Browser)
 

--- a/Base/usr/share/man/man1/Applications/Calculator.md
+++ b/Base/usr/share/man/man1/Applications/Calculator.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-calculator.png) Calculator - Serenity calculator
+![Icon](file:///res/icons/16x16/app-calculator.png) Calculator - Serenity calculator
 
 [Open](file:///bin/Calculator)
 

--- a/Base/usr/share/man/man1/Applications/Calendar.md
+++ b/Base/usr/share/man/man1/Applications/Calendar.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-calendar.png) Calendar - Serenity calendar
+![Icon](file:///res/icons/16x16/app-calendar.png) Calendar - Serenity calendar
 
 [Open](file:///bin/Calendar)
 

--- a/Base/usr/share/man/man1/Applications/CatDog.md
+++ b/Base/usr/share/man/man1/Applications/CatDog.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-catdog.png) CatDog - A helpful companion
+![Icon](file:///res/icons/16x16/app-catdog.png) CatDog - A helpful companion
 
 [Open](file:///bin/CatDog)
 

--- a/Base/usr/share/man/man1/Applications/CertificateSettings.md
+++ b/Base/usr/share/man/man1/Applications/CertificateSettings.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/certificate.png) Certificate Settings
+![Icon](file:///res/icons/16x16/certificate.png) Certificate Settings
 
 [Open](file:///bin/CertificateSettings)
 

--- a/Base/usr/share/man/man1/Applications/CharacterMap.md
+++ b/Base/usr/share/man/man1/Applications/CharacterMap.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-character-map.png) Character Map - Unicode character viewer
+![Icon](file:///res/icons/16x16/app-character-map.png) Character Map - Unicode character viewer
 
 [Open](file:///bin/CharacterMap)
 

--- a/Base/usr/share/man/man1/Applications/Eyes.md
+++ b/Base/usr/share/man/man1/Applications/Eyes.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-eyes.png) Eyes - follow the mouse LibGUI demo
+![Icon](file:///res/icons/16x16/app-eyes.png) Eyes - follow the mouse LibGUI demo
 
 [Open](file:///bin/Eyes)
 

--- a/Base/usr/share/man/man1/Applications/FontEditor.md
+++ b/Base/usr/share/man/man1/Applications/FontEditor.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-font-editor.png) FontEditor - Serenity font editor
+![Icon](file:///res/icons/16x16/app-font-editor.png) FontEditor - Serenity font editor
 
 [Open](file:///bin/FontEditor)
 

--- a/Base/usr/share/man/man1/Applications/GMLPlayground.md
+++ b/Base/usr/share/man/man1/Applications/GMLPlayground.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-gml-playground.png) GML Playground - GUI Markup Language (GML) editor
+![Icon](file:///res/icons/16x16/app-gml-playground.png) GML Playground - GUI Markup Language (GML) editor
 
 [Open](file:///bin/GMLPlayground)
 

--- a/Base/usr/share/man/man1/Applications/Help.md
+++ b/Base/usr/share/man/man1/Applications/Help.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-help.png) Help - digital manual
+![Icon](file:///res/icons/16x16/app-help.png) Help - digital manual
 
 [Open](file:///bin/Help)
 

--- a/Base/usr/share/man/man1/Applications/HexEditor.md
+++ b/Base/usr/share/man/man1/Applications/HexEditor.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/hex.png) Hex Editor - Binary file editor
+![Icon](file:///res/icons/16x16/hex.png) Hex Editor - Binary file editor
 
 [Open](file:///bin/HexEditor)
 

--- a/Base/usr/share/man/man1/Applications/ImageViewer.md
+++ b/Base/usr/share/man/man1/Applications/ImageViewer.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/filetype-image.png) Image Viewer - SerenityOS image viewer
+![Icon](file:///res/icons/16x16/filetype-image.png) Image Viewer - SerenityOS image viewer
 
 [Open](file:///bin/ImageViewer)
 

--- a/Base/usr/share/man/man1/Applications/Magnifier.md
+++ b/Base/usr/share/man/man1/Applications/Magnifier.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-magnifier.png) Magnifier - Magnifier application
+![Icon](file:///res/icons/16x16/app-magnifier.png) Magnifier - Magnifier application
 
 [Open](file:///bin/Magnifier)
 

--- a/Base/usr/share/man/man1/Applications/Mail.md
+++ b/Base/usr/share/man/man1/Applications/Mail.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-mail.png)  Mail - Serenity e-mail client
+![Icon](file:///res/icons/16x16/app-mail.png)  Mail - Serenity e-mail client
 
 [Open](file:///bin/Mail)
 

--- a/Base/usr/share/man/man1/Applications/MouseSettings.md
+++ b/Base/usr/share/man/man1/Applications/MouseSettings.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-mouse.png) Mouse Settings - Mouse settings application
+![Icon](file:///res/icons/16x16/app-mouse.png) Mouse Settings - Mouse settings application
 
 [Open](file:///bin/MouseSettings)
 

--- a/Base/usr/share/man/man1/Applications/Presenter.md
+++ b/Base/usr/share/man/man1/Applications/Presenter.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-presenter.png) Presenter - Present slides to an audience
+![Icon](file:///res/icons/16x16/app-presenter.png) Presenter - Present slides to an audience
 
 [Open](file:///bin/Presenter)
 

--- a/Base/usr/share/man/man1/Applications/Profiler.md
+++ b/Base/usr/share/man/man1/Applications/Profiler.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-profiler.png) Profiler - Serenity process profiler
+![Icon](file:///res/icons/16x16/app-profiler.png) Profiler - Serenity process profiler
 
 [Open](file:///bin/Profiler)
 

--- a/Base/usr/share/man/man1/Applications/SQLStudio.md
+++ b/Base/usr/share/man/man1/Applications/SQLStudio.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-sql-studio.png) SQL Studio - SerenityOS SQL Manager
+![Icon](file:///res/icons/16x16/app-sql-studio.png) SQL Studio - SerenityOS SQL Manager
 
 [Open](file:///bin/SQLStudio)
 

--- a/Base/usr/share/man/man1/Applications/Terminal.md
+++ b/Base/usr/share/man/man1/Applications/Terminal.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-terminal.png) Terminal - Serenity terminal emulator
+![Icon](file:///res/icons/16x16/app-terminal.png) Terminal - Serenity terminal emulator
 
 [Open](file:///bin/Terminal)
 

--- a/Base/usr/share/man/man1/Applications/TextEditor.md
+++ b/Base/usr/share/man/man1/Applications/TextEditor.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-text-editor.png) TextEditor - SerenityOS text editor
+![Icon](file:///res/icons/16x16/app-text-editor.png) TextEditor - SerenityOS text editor
 
 [Open](file:///bin/TextEditor)
 

--- a/Base/usr/share/man/man6/2048.md
+++ b/Base/usr/share/man/man6/2048.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-2048.png) 2048
+![Icon](file:///res/icons/16x16/app-2048.png) 2048
 
 [Open](file:///bin/2048)
 

--- a/Base/usr/share/man/man6/BrickGame.md
+++ b/Base/usr/share/man/man6/BrickGame.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-brickgame.png) BrickGame
+![Icon](file:///res/icons/16x16/app-brickgame.png) BrickGame
 
 [Open](file:///bin/BrickGame)
 

--- a/Base/usr/share/man/man6/Chess.md
+++ b/Base/usr/share/man/man6/Chess.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-chess.png) Chess
+![Icon](file:///res/icons/16x16/app-chess.png) Chess
 
 [Open](file:///bin/Chess)
 

--- a/Base/usr/share/man/man6/ColorLines.md
+++ b/Base/usr/share/man/man6/ColorLines.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-colorlines.png) Color Lines
+![Icon](file:///res/icons/16x16/app-colorlines.png) Color Lines
 
 [Open](file:///bin/ColorLines)
 

--- a/Base/usr/share/man/man6/FlappyBug.md
+++ b/Base/usr/share/man/man6/FlappyBug.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-flappybug.png) Flappy Bug
+![Icon](file:///res/icons/16x16/app-flappybug.png) Flappy Bug
 
 [Open](file:///bin/FlappyBug)
 

--- a/Base/usr/share/man/man6/Flood.md
+++ b/Base/usr/share/man/man6/Flood.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-flood.png) Flood
+![Icon](file:///res/icons/16x16/app-flood.png) Flood
 
 [Open](file:///bin/Flood)
 

--- a/Base/usr/share/man/man6/GameOfLife.md
+++ b/Base/usr/share/man/man6/GameOfLife.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-gameoflife.png) GameOfLife
+![Icon](file:///res/icons/16x16/app-gameoflife.png) GameOfLife
 
 [Open](file:///bin/GameOfLife)
 

--- a/Base/usr/share/man/man6/Hearts.md
+++ b/Base/usr/share/man/man6/Hearts.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-hearts.png) Hearts - The Hearts card game
+![Icon](file:///res/icons/16x16/app-hearts.png) Hearts - The Hearts card game
 
 [Open](file:///bin/Hearts)
 

--- a/Base/usr/share/man/man6/MasterWord.md
+++ b/Base/usr/share/man/man6/MasterWord.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-masterword.png) MasterWord
+![Icon](file:///res/icons/16x16/app-masterword.png) MasterWord
 
 [Open](file:///bin/MasterWord)
 

--- a/Base/usr/share/man/man6/Minesweeper.md
+++ b/Base/usr/share/man/man6/Minesweeper.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-minesweeper.png) Minesweeper
+![Icon](file:///res/icons/16x16/app-minesweeper.png) Minesweeper
 
 [Open](file:///bin/Minesweeper)
 

--- a/Base/usr/share/man/man6/Snake.md
+++ b/Base/usr/share/man/man6/Snake.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-snake.png) Snake
+![Icon](file:///res/icons/16x16/app-snake.png) Snake
 
 [Open](file:///bin/Snake)
 

--- a/Base/usr/share/man/man6/Solitaire.md
+++ b/Base/usr/share/man/man6/Solitaire.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-solitaire.png) Solitaire - The Solitaire card game
+![Icon](file:///res/icons/16x16/app-solitaire.png) Solitaire - The Solitaire card game
 
 [Open](file:///bin/Solitaire)
 

--- a/Base/usr/share/man/man6/Spider.md
+++ b/Base/usr/share/man/man6/Spider.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-spider.png) Spider - The Spider card game
+![Icon](file:///res/icons/16x16/app-spider.png) Spider - The Spider card game
 
 [Open](file:///bin/Spider)
 

--- a/Base/usr/share/man/man7/Help-index.md
+++ b/Base/usr/share/man/man7/Help-index.md
@@ -1,4 +1,4 @@
-![Help Icon](/res/icons/32x32/app-help.png)
+![Help Icon](file:///res/icons/32x32/app-help.png)
 
 ## Welcome to the SerenityOS on-line help system!
 

--- a/Base/usr/share/man/man7/KeyboardShortcuts.md
+++ b/Base/usr/share/man/man7/KeyboardShortcuts.md
@@ -1,4 +1,4 @@
-![Keyboard Icon](/res/icons/32x32/app-keyboard-settings.png)
+![Keyboard Icon](file:///res/icons/32x32/app-keyboard-settings.png)
 
 ## Name
 Keyboard Shortcuts

--- a/Base/usr/share/man/man7/Tips-and-Tricks.md
+++ b/Base/usr/share/man/man7/Tips-and-Tricks.md
@@ -1,4 +1,4 @@
-![Welcome Icon](/res/icons/32x32/app-welcome.png)
+![Welcome Icon](file:///res/icons/32x32/app-welcome.png)
 
 ## Name
 Tips and Tricks


### PR DESCRIPTION
**Help** Utility fails to find the location of the images in man pages, this happens because `/res/icons/16x16/` actually points to `/usr/share/man/manx/res/icons/16x16/`.