### PR TITLE
LibJS: Delete for_each_lexical_function_declaration_in_reverse_order()

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -4474,16 +4474,6 @@ ThrowCompletionOr<void> ScopeNode::for_each_var_function_declaration_in_reverse_
     return {};
 }
 
-ThrowCompletionOr<void> ScopeNode::for_each_lexical_function_declaration_in_reverse_order(ThrowCompletionOrVoidCallback<FunctionDeclaration const&>&& callback) const
-{
-    for (ssize_t i = m_lexical_declarations.size() - 1; i >= 0; i--) {
-        auto& declaration = m_lexical_declarations[i];
-        if (is<FunctionDeclaration>(declaration))
-            TRY(callback(static_cast<FunctionDeclaration const&>(*declaration)));
-    }
-    return {};
-}
-
 ThrowCompletionOr<void> ScopeNode::for_each_var_scoped_variable_declaration(ThrowCompletionOrVoidCallback<VariableDeclaration const&>&& callback) const
 {
     for (auto& declaration : m_var_declarations) {

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -314,7 +314,6 @@ public:
     ThrowCompletionOr<void> for_each_var_declared_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&& callback) const;
 
     ThrowCompletionOr<void> for_each_var_function_declaration_in_reverse_order(ThrowCompletionOrVoidCallback<FunctionDeclaration const&>&& callback) const;
-    ThrowCompletionOr<void> for_each_lexical_function_declaration_in_reverse_order(ThrowCompletionOrVoidCallback<FunctionDeclaration const&>&& callback) const;
     ThrowCompletionOr<void> for_each_var_scoped_variable_declaration(ThrowCompletionOrVoidCallback<VariableDeclaration const&>&& callback) const;
 
     void block_declaration_instantiation(VM&, Environment*) const;


### PR DESCRIPTION
This function became unused after the only place where it was used was refactored in  7af7e90e3f148954b77e07d05bf679fab9ab3bba