### PR TITLE
LibC+Toolchain: Various header compliance fixes

### DIFF
--- a/Toolchain/BuildClang.sh
+++ b/Toolchain/BuildClang.sh
@@ -249,6 +249,7 @@ popd
 SRC_ROOT=$($REALPATH "$DIR"/..)
 FILES=$(find \
     "$SRC_ROOT"/Kernel/API \
+    "$SRC_ROOT"/Kernel/Arch \
     "$SRC_ROOT"/Userland/Libraries/LibC \
     "$SRC_ROOT"/Userland/Libraries/LibELF/ELFABI.h \
     "$SRC_ROOT"/Userland/Libraries/LibRegex/RegexDefs.h \
@@ -259,8 +260,8 @@ for arch in $ARCHS; do
         mkdir -p Root/usr/include/
         for header in $FILES; do
             target=$(echo "$header" | "$SED" \
-                -e "s|$SRC_ROOT/Userland/Libraries/LibC||" \
                 -e "s|$SRC_ROOT/Kernel/|Kernel/|" \
+                -e "s|$SRC_ROOT/Userland/Libraries/LibC||" \
                 -e "s|$SRC_ROOT/Userland/Libraries/LibELF/|LibELF/|" \
                 -e "s|$SRC_ROOT/Userland/Libraries/LibRegex/|LibRegex/|")
             buildstep "system_headers" "$INSTALL" -D "$header" "Root/usr/include/$target"

--- a/Toolchain/BuildGNU.sh
+++ b/Toolchain/BuildGNU.sh
@@ -266,7 +266,6 @@ pushd "$DIR/Build/$ARCH"
         mkdir -p Root/usr/include/
         SRC_ROOT=$($REALPATH "$DIR"/..)
         FILES=$(find \
-            "$SRC_ROOT"/AK \
             "$SRC_ROOT"/Kernel/API \
             "$SRC_ROOT"/Kernel/Arch \
             "$SRC_ROOT"/Userland/Libraries/LibC \
@@ -275,7 +274,6 @@ pushd "$DIR/Build/$ARCH"
             -name '*.h' -print)
         for header in $FILES; do
             target=$(echo "$header" | sed \
-                -e "s|$SRC_ROOT/AK/|AK/|" \
                 -e "s|$SRC_ROOT/Userland/Libraries/LibC||" \
                 -e "s|$SRC_ROOT/Kernel/|Kernel/|" \
                 -e "s|$SRC_ROOT/Userland/Libraries/LibELF/|LibELF/|" \

--- a/Userland/Libraries/LibC/arpa/inet.h
+++ b/Userland/Libraries/LibC/arpa/inet.h
@@ -6,8 +6,11 @@
 
 #pragma once
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/arpa_inet.h.html
 #include <inttypes.h>
 #include <netinet/in.h>
+
 #include <sys/cdefs.h>
 #include <sys/socket.h>
 

--- a/Userland/Libraries/LibC/bits/getopt.h
+++ b/Userland/Libraries/LibC/bits/getopt.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, the SerenityOS contributors.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS
+
+// If opterr is set (the default), print error messages to stderr.
+extern int opterr;
+// On errors, optopt is set to the erroneous *character*.
+extern int optopt;
+// Index of the next argument to process upon a getopt*() call.
+extern int optind;
+// If set, reset the internal state kept by getopt*(). You may also want to set
+// optind to 1 in that case.
+extern int optreset;
+// After parsing an option that accept an argument, set to point to the argument
+// value.
+extern char* optarg;
+
+int getopt(int argc, char* const* argv, char const* short_options);
+int getsubopt(char** optionp, char* const* tokens, char** valuep);
+
+__END_DECLS

--- a/Userland/Libraries/LibC/fcntl.h
+++ b/Userland/Libraries/LibC/fcntl.h
@@ -7,6 +7,11 @@
 
 #pragma once
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/fcntl.h.html
+#include <sys/stat.h>
+#include <unistd.h>
+
 #include <Kernel/API/POSIX/fcntl.h>
 #include <Kernel/API/POSIX/sys/stat.h>
 #include <sys/cdefs.h>

--- a/Userland/Libraries/LibC/getopt.h
+++ b/Userland/Libraries/LibC/getopt.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <bits/getopt.h>
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS
@@ -21,11 +22,6 @@ struct option {
     int val;
 };
 
-extern int opterr;
-extern int optopt;
-extern int optind;
-extern int optreset;
-extern char* optarg;
 int getopt_long(int argc, char* const* argv, char const* short_options, const struct option* long_options, int* out_long_option_index);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/langinfo.h
+++ b/Userland/Libraries/LibC/langinfo.h
@@ -6,7 +6,10 @@
 
 #pragma once
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/langinfo.h.html
 #include <nl_types.h>
+
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS

--- a/Userland/Libraries/LibC/netdb.h
+++ b/Userland/Libraries/LibC/netdb.h
@@ -6,6 +6,12 @@
 
 #pragma once
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netdb.h.html
+#include <inttypes.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
 #include <sys/cdefs.h>
 #include <sys/types.h>
 

--- a/Userland/Libraries/LibC/netinet/in.h
+++ b/Userland/Libraries/LibC/netinet/in.h
@@ -6,6 +6,11 @@
 
 #pragma once
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
+#include <inttypes.h>
+#include <sys/socket.h>
+
 #include <Kernel/API/POSIX/netinet/in.h>
 #include <endian.h>
 #include <sys/cdefs.h>

--- a/Userland/Libraries/LibC/pthread.h
+++ b/Userland/Libraries/LibC/pthread.h
@@ -6,12 +6,15 @@
 
 #pragma once
 
-#include <bits/pthread_integration.h>
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/pthread.h.html
 #include <sched.h>
+#include <time.h>
+
+#include <bits/pthread_integration.h>
 #include <stdint.h>
 #include <sys/cdefs.h>
 #include <sys/types.h>
-#include <time.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/sched.h
+++ b/Userland/Libraries/LibC/sched.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sched.h.html
+#include <time.h>
+
 #include <Kernel/API/POSIX/sched.h>
 #include <sys/cdefs.h>
 #include <sys/types.h>

--- a/Userland/Libraries/LibC/semaphore.h
+++ b/Userland/Libraries/LibC/semaphore.h
@@ -6,6 +6,11 @@
 
 #pragma once
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/semaphore.h.html
+#include <fcntl.h>
+#include <time.h>
+
 #include <limits.h>
 #include <pthread.h>
 #include <sys/cdefs.h>

--- a/Userland/Libraries/LibC/signal.h
+++ b/Userland/Libraries/LibC/signal.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/signal.h.html
+#include <time.h>
+
 #include <Kernel/API/POSIX/signal.h>
 #include <Kernel/API/POSIX/ucontext.h>
 #include <bits/sighow.h>

--- a/Userland/Libraries/LibC/spawn.h
+++ b/Userland/Libraries/LibC/spawn.h
@@ -13,8 +13,11 @@
 
 #pragma once
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/spawn.h.html
 #include <sched.h>
 #include <signal.h>
+
 #include <sys/cdefs.h>
 #include <sys/types.h>
 

--- a/Userland/Libraries/LibC/stdio.h
+++ b/Userland/Libraries/LibC/stdio.h
@@ -8,6 +8,10 @@
 
 #define _STDIO_H // Make GMP believe we exist.
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/stdio.h.html
+#include <stddef.h>
+
 #include <Kernel/API/POSIX/stdio.h>
 #include <bits/FILE.h>
 #include <limits.h>

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -6,8 +6,14 @@
 
 #pragma once
 
-#include <bits/wchar.h>
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/stdlib.h.html
+#include <limits.h>
+#include <math.h>
 #include <stddef.h>
+#include <sys/wait.h>
+
+#include <bits/wchar.h>
 #include <sys/cdefs.h>
 #include <sys/types.h>
 

--- a/Userland/Libraries/LibC/string.h
+++ b/Userland/Libraries/LibC/string.h
@@ -7,6 +7,10 @@
 
 #pragma once
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/string.h.html
+#include <stddef.h>
+
 #include <sys/cdefs.h>
 #include <sys/types.h>
 

--- a/Userland/Libraries/LibC/sys/resource.h
+++ b/Userland/Libraries/LibC/sys/resource.h
@@ -6,9 +6,12 @@
 
 #pragma once
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_resource.h.html
+#include <sys/time.h>
+
 #include <stdint.h>
 #include <sys/cdefs.h>
-#include <sys/time.h>
 
 __BEGIN_DECLS
 

--- a/Userland/Libraries/LibC/sys/select.h
+++ b/Userland/Libraries/LibC/sys/select.h
@@ -6,8 +6,12 @@
 
 #pragma once
 
-#include <fd_set.h>
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_select.h.html
 #include <signal.h>
+#include <time.h>
+
+#include <fd_set.h>
 #include <string.h>
 #include <sys/cdefs.h>
 #include <sys/time.h>

--- a/Userland/Libraries/LibC/sys/socket.h
+++ b/Userland/Libraries/LibC/sys/socket.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
+#include <sys/uio.h>
+
 #include <Kernel/API/POSIX/sys/socket.h>
 #include <sys/cdefs.h>
 #include <sys/un.h>

--- a/Userland/Libraries/LibC/sys/time.h
+++ b/Userland/Libraries/LibC/sys/time.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_time.h.html
+#include <sys/select.h>
+
 #include <Kernel/API/POSIX/sys/time.h>
 #include <sys/cdefs.h>
 #include <time.h>

--- a/Userland/Libraries/LibC/sys/wait.h
+++ b/Userland/Libraries/LibC/sys/wait.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_wait.h.html
+#include <signal.h>
+
 #include <Kernel/API/POSIX/signal.h>
 #include <Kernel/API/POSIX/sys/wait.h>
 #include <sys/cdefs.h>

--- a/Userland/Libraries/LibC/time.h
+++ b/Userland/Libraries/LibC/time.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/time.h.html
+#include <signal.h>
+
 #include <Kernel/API/POSIX/time.h>
 #include <sys/cdefs.h>
 

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/unistd.h>
+#include <bits/getopt.h>
 #include <fd_set.h>
 #include <limits.h>
 #include <sys/cdefs.h>
@@ -161,21 +162,5 @@ enum {
 #define _POSIX_VDISABLE '\0'
 
 long sysconf(int name);
-
-// If opterr is set (the default), print error messages to stderr.
-extern int opterr;
-// On errors, optopt is set to the erroneous *character*.
-extern int optopt;
-// Index of the next argument to process upon a getopt*() call.
-extern int optind;
-// If set, reset the internal state kept by getopt*(). You may also want to set
-// optind to 1 in that case.
-extern int optreset;
-// After parsing an option that accept an argument, set to point to the argument
-// value.
-extern char* optarg;
-
-int getopt(int argc, char* const* argv, char const* short_options);
-int getsubopt(char** optionp, char* const* tokens, char** valuep);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -6,10 +6,18 @@
 
 #pragma once
 
-#include <bits/FILE.h>
-#include <bits/wchar_size.h>
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/wchar.h.html
+#include <ctype.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <bits/FILE.h>
+#include <bits/wchar_size.h>
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS

--- a/Userland/Libraries/LibC/wctype.h
+++ b/Userland/Libraries/LibC/wctype.h
@@ -6,10 +6,19 @@
 
 #pragma once
 
-#include <assert.h>
+// Includes essentially mandated by POSIX:
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/wctype.h.html
 #include <ctype.h>
-#include <sys/cdefs.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 #include <wchar.h>
+
+#include <assert.h>
+#include <sys/cdefs.h>
 
 __BEGIN_DECLS
 


### PR DESCRIPTION
This fixes the `openssl` and `cmake` ports, and probably a few others as well.