### PR TITLE
LibJS: Implement Array.fromAsync

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.h
@@ -26,6 +26,7 @@ private:
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(from);
+    JS_DECLARE_NATIVE_FUNCTION(from_async);
     JS_DECLARE_NATIVE_FUNCTION(is_array);
     JS_DECLARE_NATIVE_FUNCTION(of);
 

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -208,6 +208,7 @@ namespace JS {
     P(fractionalSecondDigits)                \
     P(freeze)                                \
     P(from)                                  \
+    P(fromAsync)                             \
     P(fromCharCode)                          \
     P(fromCodePoint)                         \
     P(fromEntries)                           \

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -754,10 +754,8 @@ void ECMAScriptFunctionObject::ordinary_call_bind_this(ExecutionContext& callee_
 }
 
 // 27.7.5.1 AsyncFunctionStart ( promiseCapability, asyncFunctionBody ), https://tc39.es/ecma262/#sec-async-functions-abstract-operations-async-function-start
-void ECMAScriptFunctionObject::async_function_start(PromiseCapability const& promise_capability)
+void async_function_start(VM& vm, PromiseCapability const& promise_capability, NonnullRefPtr<Statement const> const& async_function_body)
 {
-    auto& vm = this->vm();
-
     // 1. Let runningContext be the running execution context.
     auto& running_context = vm.running_execution_context();
 
@@ -767,7 +765,7 @@ void ECMAScriptFunctionObject::async_function_start(PromiseCapability const& pro
     // 3. NOTE: Copying the execution state is required for AsyncBlockStart to resume its execution. It is ill-defined to resume a currently executing context.
 
     // 4. Perform AsyncBlockStart(promiseCapability, asyncFunctionBody, asyncContext).
-    async_block_start(vm, m_ecmascript_code, promise_capability, async_context);
+    async_block_start(vm, async_function_body, promise_capability, async_context);
 
     // 5. Return unused.
 }
@@ -978,7 +976,7 @@ Completion ECMAScriptFunctionObject::ordinary_call_evaluate_body()
             // 4. Else,
             else {
                 // a. Perform AsyncFunctionStart(promiseCapability, FunctionBody).
-                async_function_start(promise_capability);
+                async_function_start(vm, promise_capability, m_ecmascript_code);
             }
 
             // 5. Return Completion Record { [[Type]]: return, [[Value]]: promiseCapability.[[Promise]], [[Target]]: empty }.

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -754,7 +754,8 @@ void ECMAScriptFunctionObject::ordinary_call_bind_this(ExecutionContext& callee_
 }
 
 // 27.7.5.1 AsyncFunctionStart ( promiseCapability, asyncFunctionBody ), https://tc39.es/ecma262/#sec-async-functions-abstract-operations-async-function-start
-void async_function_start(VM& vm, PromiseCapability const& promise_capability, NonnullRefPtr<Statement const> const& async_function_body)
+template<typename T>
+void async_function_start(VM& vm, PromiseCapability const& promise_capability, T const& async_function_body)
 {
     // 1. Let runningContext be the running execution context.
     auto& running_context = vm.running_execution_context();
@@ -771,7 +772,8 @@ void async_function_start(VM& vm, PromiseCapability const& promise_capability, N
 }
 
 // 27.7.5.2 AsyncBlockStart ( promiseCapability, asyncBody, asyncContext ), https://tc39.es/ecma262/#sec-asyncblockstart
-void async_block_start(VM& vm, NonnullRefPtr<Statement const> const& async_body, PromiseCapability const& promise_capability, ExecutionContext& async_context)
+template<typename T>
+void async_block_start(VM& vm, T const& async_body, PromiseCapability const& promise_capability, ExecutionContext& async_context)
 {
     auto& realm = *vm.current_realm();
 
@@ -846,6 +848,9 @@ void async_block_start(VM& vm, NonnullRefPtr<Statement const> const& async_body,
 
     // 8. Return unused.
 }
+
+template void async_block_start(VM&, NonnullGCPtr<Statement const> const& async_body, PromiseCapability const&, ExecutionContext&);
+template void async_function_start(VM&, PromiseCapability const&, NonnullGCPtr<Statement const> const& async_function_body);
 
 // 10.2.1.4 OrdinaryCallEvaluateBody ( F, argumentsList ), https://tc39.es/ecma262/#sec-ordinarycallevaluatebody
 // 15.8.4 Runtime Semantics: EvaluateAsyncFunctionBody, https://tc39.es/ecma262/#sec-runtime-semantics-evaluatefunctionbody

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -772,6 +772,7 @@ void async_function_start(VM& vm, PromiseCapability const& promise_capability, T
 }
 
 // 27.7.5.2 AsyncBlockStart ( promiseCapability, asyncBody, asyncContext ), https://tc39.es/ecma262/#sec-asyncblockstart
+// 12.7.1.1 AsyncBlockStart ( promiseCapability, asyncBody, asyncContext ), https://tc39.es/proposal-explicit-resource-management/#sec-asyncblockstart
 template<typename T>
 void async_block_start(VM& vm, T const& async_body, PromiseCapability const& promise_capability, ExecutionContext& async_context)
 {

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -15,8 +15,11 @@
 
 namespace JS {
 
-void async_block_start(VM&, NonnullRefPtr<Statement const> const& parse_node, PromiseCapability const&, ExecutionContext&);
-void async_function_start(VM&, PromiseCapability const&, NonnullRefPtr<Statement const> const& async_function_body);
+template<typename T>
+void async_block_start(VM&, T const& async_body, PromiseCapability const&, ExecutionContext&);
+
+template<typename T>
+void async_function_start(VM&, PromiseCapability const&, T const& async_function_body);
 
 // 10.2 ECMAScript Function Objects, https://tc39.es/ecma262/#sec-ecmascript-function-objects
 class ECMAScriptFunctionObject final : public FunctionObject {

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -16,6 +16,7 @@
 namespace JS {
 
 void async_block_start(VM&, NonnullRefPtr<Statement const> const& parse_node, PromiseCapability const&, ExecutionContext&);
+void async_function_start(VM&, PromiseCapability const&, NonnullRefPtr<Statement const> const& async_function_body);
 
 // 10.2 ECMAScript Function Objects, https://tc39.es/ecma262/#sec-ecmascript-function-objects
 class ECMAScriptFunctionObject final : public FunctionObject {
@@ -103,8 +104,6 @@ private:
 
     ThrowCompletionOr<void> prepare_for_ordinary_call(ExecutionContext& callee_context, Object* new_target);
     void ordinary_call_bind_this(ExecutionContext&, Value this_argument);
-
-    void async_function_start(PromiseCapability const&);
 
     ThrowCompletionOr<void> function_declaration_instantiation(Interpreter*);
 

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -737,7 +737,7 @@ ThrowCompletionOr<void> SourceTextModule::execute_module(VM& vm, GCPtr<PromiseCa
         VERIFY(capability != nullptr);
 
         // b. Perform AsyncBlockStart(capability, module.[[ECMAScriptCode]], moduleContext).
-        async_block_start(vm, m_ecmascript_code, *capability, module_context);
+        async_block_start<NonnullRefPtr<Statement const>>(vm, m_ecmascript_code, *capability, module_context);
     }
 
     // 11. Return unused.

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.fromAsync.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.fromAsync.js
@@ -1,0 +1,60 @@
+test("length is 1", () => {
+    expect(Array.fromAsync).toHaveLength(1);
+});
+
+describe("normal behavior", () => {
+    function checkResult(promise) {
+        expect(promise).toBeInstanceOf(Promise);
+        let error = null;
+        let passed = false;
+        promise
+            .then(value => {
+                expect(value instanceof Array).toBeTrue();
+                expect(value[0]).toBe(0);
+                expect(value[1]).toBe(2);
+                expect(value[2]).toBe(4);
+                passed = true;
+            })
+            .catch(value => {
+                error = value;
+            });
+        runQueuedPromiseJobs();
+        expect(error).toBeNull();
+        expect(passed).toBeTrue();
+    }
+
+    test("async from sync iterable no mapfn", () => {
+        const input = [0, Promise.resolve(2), Promise.resolve(4)].values();
+        const promise = Array.fromAsync(input);
+        checkResult(promise);
+    });
+
+    test("from object of promises no mapfn", () => {
+        let promise = Array.fromAsync({
+            length: 3,
+            0: Promise.resolve(0),
+            1: Promise.resolve(2),
+            2: Promise.resolve(4),
+        });
+        checkResult(promise);
+    });
+
+    test("async from sync iterable with mapfn", () => {
+        const input = [Promise.resolve(0), 1, Promise.resolve(2)].values();
+        const promise = Array.fromAsync(input, async element => element * 2);
+        checkResult(promise);
+    });
+
+    test("from object of promises with mapfn", () => {
+        let promise = Array.fromAsync(
+            {
+                length: 3,
+                0: Promise.resolve(0),
+                1: Promise.resolve(1),
+                2: Promise.resolve(2),
+            },
+            async element => element * 2
+        );
+        checkResult(promise);
+    });
+});


### PR DESCRIPTION
Diff Tests:
    +90 ✅    -90 ❌

There are four failing tests that are left failing in test262 that I have tried debugging. They are all likely for the same reason:

```
test262/test/built-ins/Array/fromAsync/asyncitems-array-add-to-singleton.js
test262/test/built-ins/Array/fromAsync/asyncitems-array-mutate.js
test262/test/built-ins/Array/fromAsync/asyncitems-array-remove.js
test262/test/built-ins/Array/fromAsync/asyncitems-array-add.js
```
The issue seems potentially related to the spec bug, as all of the tests that fail are going through that same code path as that spec issue. It could also be bytecode/ast related? Spent quite a while debugging that one, but don't have much of idea of what root cause would be as of yet.