### PR TITLE
LibWeb: Fix whitespace getting trimmed incorrectly

### DIFF
--- a/Tests/LibWeb/Layout/expected/pre.txt
+++ b/Tests/LibWeb/Layout/expected/pre.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17.46875 children: inline
+      line 0 width: 21.875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+        frag 0 from TextNode start: 0, length: 3, rect: [9,8 19.875x17.46875]
+          " | "
+      InlineNode <pre>
+        TextNode <#text>
+      TextNode <#text>

--- a/Tests/LibWeb/Layout/input/pre.html
+++ b/Tests/LibWeb/Layout/input/pre.html
@@ -1,0 +1,7 @@
+<style>
+    pre {
+        display: inline;
+        border: 1px solid #000;
+    }
+</style>
+<pre> | </pre>

--- a/Userland/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBox.cpp
@@ -33,27 +33,39 @@ void LineBox::add_fragment(Node const& layout_node, int start, int length, CSSPi
 
 void LineBox::trim_trailing_whitespace()
 {
-    while (!m_fragments.is_empty() && m_fragments.last().is_justifiable_whitespace()) {
-        auto fragment = m_fragments.take_last();
-        m_width -= fragment.width();
+    auto should_trim = [](LineBoxFragment* fragment) {
+        auto ws = fragment->layout_node().computed_values().white_space();
+        return ws == CSS::WhiteSpace::Normal || ws == CSS::WhiteSpace::Nowrap || ws == CSS::WhiteSpace::PreLine;
+    };
+
+    LineBoxFragment* last_fragment = nullptr;
+    for (;;) {
+        if (m_fragments.is_empty())
+            return;
+        // last_fragment cannot be null from here on down, as m_fragments is not empty.
+        last_fragment = &m_fragments.last();
+        if (!should_trim(last_fragment))
+            return;
+        if (last_fragment->is_justifiable_whitespace()) {
+            m_width -= last_fragment->width();
+            m_fragments.remove(m_fragments.size() - 1);
+        } else {
+            break;
+        }
     }
 
-    if (m_fragments.is_empty())
-        return;
-
-    auto& last_fragment = m_fragments.last();
-    auto last_text = last_fragment.text();
+    auto last_text = last_fragment->text();
     if (last_text.is_null())
         return;
 
-    while (last_fragment.length()) {
-        auto last_character = last_text[last_fragment.length() - 1];
+    while (last_fragment->length()) {
+        auto last_character = last_text[last_fragment->length() - 1];
         if (!is_ascii_space(last_character))
             break;
 
-        int last_character_width = last_fragment.layout_node().font().glyph_width(last_character);
-        last_fragment.m_length -= 1;
-        last_fragment.set_width(last_fragment.width() - last_character_width);
+        int last_character_width = last_fragment->layout_node().font().glyph_width(last_character);
+        last_fragment->m_length -= 1;
+        last_fragment->set_width(last_fragment->width() - last_character_width);
         m_width -= last_character_width;
     }
 }


### PR DESCRIPTION
Whitespace at the end of line should only be trimmed when 'white-space' is set to 'normal', 'nowrap', or 'pre-line'.