### PR TITLE
Meta: Pass -- to sudo instead of '$SHELL -c' in build scripts

### DIFF
--- a/Meta/build-image-extlinux.sh
+++ b/Meta/build-image-extlinux.sh
@@ -8,7 +8,7 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
 if [ "$(id -u)" != 0 ]; then
     set +e
-    ${SUDO} "${SHELL}" -c -- "\"$0\" $* || exit 42"
+    ${SUDO} -- "${SHELL}" -c "\"$0\" $* || exit 42"
     case $? in
         1)
             die "this script needs to run as root"

--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -8,7 +8,7 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
 if [ "$(id -u)" != 0 ]; then
     set +e
-    ${SUDO} "${SHELL}" -c -- "\"$0\" $* || exit 42"
+    ${SUDO} -- "${SHELL}" -c "\"$0\" $* || exit 42"
     case $? in
         1)
             die "this script needs to run as root"

--- a/Meta/build-image-limine.sh
+++ b/Meta/build-image-limine.sh
@@ -17,7 +17,7 @@ fi
 
 if [ "$(id -u)" != 0 ]; then
     set +e
-    ${SUDO} "${SHELL}" -c -- "\"$0\" $* || exit 42"
+    ${SUDO} -- "${SHELL}" -c "\"$0\" $* || exit 42"
     case $? in
         1)
             die "this script needs to run as root"

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -12,7 +12,7 @@ if [ "$(id -u)" != 0 ]; then
         USE_FUSE2FS=1
     else
         set +e
-        ${SUDO} "${SHELL}" -c -- "\"$0\" $* || exit 42"
+        ${SUDO} -- "${SHELL}" -c "\"$0\" $* || exit 42"
         case $? in
             1)
                 die "this script needs to run as root"
@@ -70,7 +70,7 @@ nearest_power_of_2() {
     echo $p
 }
 if [ "$SERENITY_ARCH" = "aarch64" ] || { [ -n "$SERENITY_USE_SDCARD" ] && [ "$SERENITY_USE_SDCARD" -eq 1 ]; }; then
-    # SD cards must have a size that is a power of 2. The Aarch64 port loads from an SD card. 
+    # SD cards must have a size that is a power of 2. The Aarch64 port loads from an SD card.
     DISK_SIZE_BYTES=$(nearest_power_of_2 "$DISK_SIZE_BYTES")
 fi
 

--- a/Meta/build-native-partition.sh
+++ b/Meta/build-native-partition.sh
@@ -16,7 +16,7 @@ cleanup() {
 
 if [ "$(id -u)" != 0 ]; then
     set +e
-    ${SUDO} "${SHELL}" -c -- "\"$0\" $* || exit 42"
+    ${SUDO} -- "${SHELL}" -c "\"$0\" $* || exit 42"
     case $? in
         1)
             die "this script needs to run as root"


### PR DESCRIPTION
fddbd11baa97295d903834bacf7280857256b1ba made it so the command executed read `sh -c -- '"script" args*'`, the -- in this command is redundant as the script name never starts with a dash and can never be interpreted as an option or a flag.
The actually meaningful placement for -- here is after `$SUDO`, to make sure `$SUDO` does not incorrectly treat `-c` as an option to itself, and `$SHELL` cannot be interpreted as an option/flag in the extremely unlikely event that it starts with a dash.