### PR TITLE
LibWeb: Adopt shadow tree nodes in `parse_html_fragment`

### DIFF
--- a/Tests/LibWeb/Text/input/innerhtml-set-element-with-shadow-tree.html
+++ b/Tests/LibWeb/Text/input/innerhtml-set-element-with-shadow-tree.html
@@ -1,0 +1,8 @@
+<script src="include.js"></script>
+<script>
+    document.addEventListener("DOMContentLoaded", () => {
+        // This test ensures that the shadow tree (of <input />) can be garbage collected without crashing.
+        // The test is successful if it produces no output.
+        document.body.innerHTML = "<input />";
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -19,6 +19,7 @@
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/ProcessingInstruction.h>
+#include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/CustomElements/CustomElementDefinition.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
@@ -3746,6 +3747,11 @@ Vector<JS::Handle<DOM::Node>> HTMLParser::parse_html_fragment(DOM::Element& cont
     Vector<JS::Handle<DOM::Node>> children;
     while (JS::GCPtr<DOM::Node> child = root->first_child()) {
         MUST(root->remove_child(*child));
+        if (child->is_element()) {
+            auto* element = static_cast<DOM::Element*>(child.ptr());
+            if (element->is_shadow_host())
+                context_element.document().adopt_node(*element->shadow_root_internal());
+        }
         context_element.document().adopt_node(*child);
         children.append(JS::make_handle(*child));
     }

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -209,6 +209,7 @@ static ErrorOr<String> run_one_test(HeadlessWebContentView& view, StringView inp
     } else if (mode == TestMode::Text) {
         view.on_load_finish = [&](auto const&) {
             result = view.dump_text().release_value_but_fixme_should_propagate_errors();
+            view.debug_request("collect-garbage");
             loop.quit(0);
         };
     }


### PR DESCRIPTION
This change makes `parse_html_fragment` to adopt nodes from the shadow tree into the document of the parser's context element. This resolves the issue where non-adopted nodes in the tree, which pointed to the temporary parsing document, caused crash when attempting to access the non-existing browsing context of parsing temporary document.

Fixes crashing on https://gis.stackexchange.com/tags/postgis