### PR TITLE
LibWeb: Don't crash with infinite heigh/width in table layout

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -682,7 +682,9 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         layout_list_item_marker(static_cast<ListItemBox const&>(box));
     }
 
-    bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, box_state.offset.y() + box_state.content_height() + box_state.margin_box_bottom());
+    auto calculated_bottom_of_lowest_margin_box = box_state.offset.y() + box_state.content_height() + box_state.margin_box_bottom();
+    if (isfinite(calculated_bottom_of_lowest_margin_box.to_double()))
+        bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, calculated_bottom_of_lowest_margin_box);
 
     if (independent_formatting_context)
         independent_formatting_context->parent_context_did_dimension_child_root_box();

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -420,6 +420,7 @@ CSSPixels BlockFormattingContext::compute_table_box_width_inside_table_wrapper(B
     else if (available_space.width.is_min_content())
         throwaway_state.get_mutable(box).set_min_content_width();
     else {
+        // ...here
         VERIFY(available_space.width.is_max_content());
         throwaway_state.get_mutable(box).set_max_content_width();
     }
@@ -1137,8 +1138,12 @@ CSSPixels BlockFormattingContext::greatest_child_width(Box const& box) const
         }
     } else {
         box.for_each_child_of_type<Box>([&](Box const& child) {
-            if (!child.is_absolutely_positioned())
-                max_width = max(max_width, m_state.get(child).margin_box_width());
+            if (!child.is_absolutely_positioned()) {
+                auto margin_box_width = m_state.get(child).margin_box_width();
+                // This crashes...
+                if (isfinite(margin_box_width.to_double()))
+                    max_width = max(max_width, margin_box_width);
+            }
         });
     }
     return max_width;


### PR DESCRIPTION
I'm pretty unsure about if this is the correct approach. While the first commit seems to work fine, the second one just crashes at another place.

Might fix #19521