### PR TITLE
LibPDF: Fix incorrectly parsing xref stream subsections

### DIFF
--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -387,6 +387,8 @@ PDFErrorOr<NonnullRefPtr<XRefTable>> DocumentParser::parse_xref_stream()
     auto field_sizes = TRY(dict->get_array(m_document, "W"));
     if (field_sizes->size() != 3)
         return error("Malformed xref dictionary");
+    if (field_sizes->at(1).get_u32() == 0)
+        return error("Malformed xref dictionary");
 
     auto highest_object_number = dict->get_value("Size").get<int>() - 1;
 

--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -43,16 +43,10 @@ PDFErrorOr<Version> DocumentParser::initialize()
 
     bool is_linearized = m_linearization_dictionary.has_value();
     if (is_linearized) {
-        // The file may have been linearized at one point, but could have been updated afterwards,
-        // which means it is no longer a linearized PDF file.
+        // If the length given in the linearization dictionary is not equal to the length
+        // of the document, then this file has most likely been incrementally updated, and
+        // should no longer be treated as linearized.
         is_linearized = m_linearization_dictionary.value().length_of_file == m_reader.bytes().size();
-
-        if (!is_linearized) {
-            // FIXME: The file shouldn't be treated as linearized, yet the xref tables are still
-            // split. This might take some tweaking to ensure correct behavior, which can be
-            // implemented later.
-            TODO();
-        }
     }
 
     if (is_linearized)


### PR DESCRIPTION
This allows us to open the now-publicly-available PDF 2.0 spec!