### PR TITLE
LibGfx/BMP: Refactor the plugin interface

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.h
@@ -29,7 +29,6 @@ public:
 
     virtual IntSize size() override;
 
-    virtual ErrorOr<void> initialize() override;
     bool sniff_dib();
     virtual bool is_animated() override;
     virtual size_t loop_count() override;
@@ -40,6 +39,7 @@ public:
 
 private:
     BMPImageDecoderPlugin(u8 const*, size_t, IncludedInICO included_in_ico = IncludedInICO::No);
+    static ErrorOr<NonnullOwnPtr<BMPImageDecoderPlugin>> create_impl(ReadonlyBytes, IncludedInICO);
 
     OwnPtr<BMPLoadingContext> m_context;
 };

--- a/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.cpp
@@ -48,9 +48,11 @@ static OwnPtr<ImageDecoderPlugin> probe_and_sniff_for_appropriate_plugin(Readonl
         auto sniff_result = plugin.sniff(bytes);
         if (!sniff_result)
             continue;
-        auto plugin_decoder = plugin.create(bytes).release_value_but_fixme_should_propagate_errors();
-        if (!plugin_decoder->initialize().is_error())
-            return plugin_decoder;
+        auto plugin_decoder = plugin.create(bytes);
+        if (!plugin_decoder.is_error()) {
+            if (!plugin_decoder.value()->initialize().is_error())
+                return plugin_decoder.release_value();
+        }
     }
     return {};
 }


### PR DESCRIPTION
**LibGfx: Don't assume that image decoder plugin creation succeeds**

An image with an incorrect header should fail at this step, so we have
to handle that without crashing.

**LibGfx/BMP: Decode the header in `create()` and remove `initialize()`**

This is done as a part of #19893.