### PR TITLE
LibGfx/PNG: Refactor the plugin interface

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -157,7 +157,7 @@ struct PNGLoadingContext {
         NotDecoded = 0,
         Error,
         HeaderDecoded,
-        SizeDecoded,
+        IHDRDecoded,
         ImageDataChunkDecoded,
         ChunksDecoded,
         BitmapDecoded,
@@ -609,9 +609,9 @@ static bool decode_png_header(PNGLoadingContext& context)
     return true;
 }
 
-static bool decode_png_size(PNGLoadingContext& context)
+static bool decode_png_ihdr(PNGLoadingContext& context)
 {
-    if (context.state >= PNGLoadingContext::SizeDecoded)
+    if (context.state >= PNGLoadingContext::IHDRDecoded)
         return true;
 
     if (context.state < PNGLoadingContext::HeaderDecoded) {
@@ -631,7 +631,7 @@ static bool decode_png_size(PNGLoadingContext& context)
         context.data_current_ptr = streamer.current_data_ptr();
 
         if (context.width && context.height) {
-            context.state = PNGLoadingContext::State::SizeDecoded;
+            context.state = PNGLoadingContext::State::IHDRDecoded;
             return true;
         }
     }
@@ -644,8 +644,8 @@ static bool decode_png_image_data_chunk(PNGLoadingContext& context)
     if (context.state >= PNGLoadingContext::ImageDataChunkDecoded)
         return true;
 
-    if (context.state < PNGLoadingContext::SizeDecoded) {
-        if (!decode_png_size(context))
+    if (context.state < PNGLoadingContext::IHDRDecoded) {
+        if (!decode_png_ihdr(context))
             return false;
     }
 
@@ -1303,8 +1303,8 @@ IntSize PNGImageDecoderPlugin::size()
     if (m_context->state == PNGLoadingContext::State::Error)
         return {};
 
-    if (m_context->state < PNGLoadingContext::State::SizeDecoded) {
-        bool success = decode_png_size(*m_context);
+    if (m_context->state < PNGLoadingContext::State::IHDRDecoded) {
+        bool success = decode_png_ihdr(*m_context);
         if (!success)
             return {};
     }

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -156,7 +156,6 @@ struct PNGLoadingContext {
     enum State {
         NotDecoded = 0,
         Error,
-        HeaderDecoded,
         IHDRDecoded,
         ImageDataChunkDecoded,
         ChunksDecoded,
@@ -589,9 +588,6 @@ NEVER_INLINE FLATTEN static ErrorOr<void> unfilter(PNGLoadingContext& context)
 
 static bool decode_png_header(PNGLoadingContext& context)
 {
-    if (context.state >= PNGLoadingContext::HeaderDecoded)
-        return true;
-
     if (!context.data || context.data_size < sizeof(PNG::header)) {
         dbgln_if(PNG_DEBUG, "Missing PNG header");
         context.state = PNGLoadingContext::State::Error;
@@ -605,7 +601,6 @@ static bool decode_png_header(PNGLoadingContext& context)
     }
 
     context.data_current_ptr = context.data + sizeof(PNG::header);
-    context.state = PNGLoadingContext::HeaderDecoded;
     return true;
 }
 

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -614,14 +614,15 @@ static ErrorOr<void> decode_png_ihdr(PNGLoadingContext& context)
     size_t data_remaining = context.data_size - (context.data_current_ptr - context.data);
 
     Streamer streamer(context.data_current_ptr, data_remaining);
-    while (!streamer.at_end() && !context.has_seen_iend) {
-        TRY(process_chunk(streamer, context));
 
-        context.data_current_ptr = streamer.current_data_ptr();
+    // https://www.w3.org/TR/png/#11IHDR
+    // The IHDR chunk shall be the first chunk in the PNG datastream.
+    TRY(process_chunk(streamer, context));
 
-        if (context.state == PNGLoadingContext::State::IHDRDecoded)
-            return {};
-    }
+    context.data_current_ptr = streamer.current_data_ptr();
+
+    VERIFY(context.state == PNGLoadingContext::State::IHDRDecoded);
+    return {};
 }
 
 static bool decode_png_image_data_chunk(PNGLoadingContext& context)

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -630,10 +630,8 @@ static bool decode_png_ihdr(PNGLoadingContext& context)
 
         context.data_current_ptr = streamer.current_data_ptr();
 
-        if (context.width && context.height) {
-            context.state = PNGLoadingContext::State::IHDRDecoded;
+        if (context.state == PNGLoadingContext::State::IHDRDecoded)
             return true;
-        }
     }
 
     return false;
@@ -1018,6 +1016,9 @@ static ErrorOr<void> process_IHDR(ReadonlyBytes data, PNGLoadingContext& context
     default:
         return Error::from_string_literal("Unsupported color type");
     }
+
+    context.state = PNGLoadingContext::IHDRDecoded;
+
     return {};
 }
 

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -1212,6 +1212,10 @@ static ErrorOr<void> process_chunk(Streamer& streamer, PNGLoadingContext& contex
 
     if (chunk_type == "IHDR"sv)
         return process_IHDR(chunk_data, context);
+
+    if (context.state < PNGLoadingContext::IHDRDecoded)
+        return Error::from_string_literal("IHDR is not the first chunk of the file");
+
     if (chunk_type == "IDAT"sv)
         return process_IDAT(chunk_data, context);
     if (chunk_type == "PLTE"sv)

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.h
@@ -21,7 +21,6 @@ public:
 
     virtual IntSize size() override;
 
-    virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override;
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;


### PR DESCRIPTION
**LibGfx/PNG: Use PNG specific vocabulary over a generic name**


**LibGfx/PNG: Don't try to guess if IHDR has been decoded**


**LibGfx/PNG: Decode the header in `create()` and remove `initialize()`**

This is done as a part of #19893. As `create()` is now the last user of
`decode_png_ihdr()`, we can easily make it return an `ErrorOr`.

**LibGfx/PNG: Don't use a loop to read chunks in `decode_png_ihdr()`**

This chunk is the first one, so we can remove that loop.

**LibGfx/PNG: Reject files that doesn't start with a IHDr chunk**


**LibGfx/PNG: Remove the useless `HeaderDecoded` state**