### PR TITLE
LibWeb: Fully resolve min- and max-sizes for flex items

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/flex-item-min-width-fit-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-min-width-fit-content.txt
@@ -1,0 +1,22 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x70 [BFC] children: not-inline
+    Box <body> at (10,10) content-size 500x52 flex-container(row) [FFC] children: not-inline
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+      BlockContainer <div.big> at (11,11) content-size 381.625x50 flex-item [BFC] children: not-inline
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+      BlockContainer <div.buttons> at (394.625,11) content-size 114.375x50 flex-item [BFC] children: inline
+        line 0 width: 114.375, height: 19.46875, bottom: 19.46875, baseline: 14.53125
+          frag 0 from BlockContainer start: 0, length: 0, rect: [395.625,12 57.046875x17.46875]
+          frag 1 from BlockContainer start: 0, length: 0, rect: [454.625,12 53.328125x17.46875]
+        BlockContainer <div.button> at (395.625,12) content-size 57.046875x17.46875 inline-block [BFC] children: inline
+          line 0 width: 57.046875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [395.625,12 57.046875x17.46875]
+              "Accept"
+          TextNode <#text>
+        BlockContainer <div.button> at (454.625,12) content-size 53.328125x17.46875 inline-block [BFC] children: inline
+          line 0 width: 53.328125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [454.625,12 53.328125x17.46875]
+              "Reject"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/flex/flex-item-min-width-fit-content.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-item-min-width-fit-content.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html><style>
+    * {
+        border: 1px solid black;
+    }
+    body {
+        display: flex;
+        width: 500px;
+    }
+    .big {
+        width: 400px;
+        height: 50px;
+        background: pink;
+    }
+    .buttons {
+        min-width: fit-content;
+        background: orange;
+    }
+    .button {
+        display: inline-block;
+        border: 1px solid black;
+    }
+</style><body>
+<div class="big"></div>
+<div class="buttons"><div class="button">Accept</div><div class="button">Reject</div>

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -124,11 +124,11 @@ private:
     CSSPixels inner_cross_size(Box const&) const;
     bool has_main_min_size(Box const&) const;
     bool has_cross_min_size(Box const&) const;
-    CSSPixels specified_main_max_size(Box const&) const;
-    CSSPixels specified_cross_max_size(Box const&) const;
+    CSSPixels specified_main_max_size(Box const&, AvailableSpace const&) const;
+    CSSPixels specified_cross_max_size(Box const&, AvailableSpace const&) const;
     bool is_cross_auto(Box const&) const;
-    CSSPixels specified_main_min_size(Box const&) const;
-    CSSPixels specified_cross_min_size(Box const&) const;
+    CSSPixels specified_main_min_size(Box const&, AvailableSpace const&) const;
+    CSSPixels specified_cross_min_size(Box const&, AvailableSpace const&) const;
     bool has_main_max_size(Box const&) const;
     bool has_cross_max_size(Box const&) const;
     CSSPixels automatic_minimum_size(FlexItem const&) const;
@@ -143,8 +143,8 @@ private:
     CSS::Size const& computed_cross_min_size(Box const&) const;
     CSS::Size const& computed_cross_max_size(Box const&) const;
 
-    CSSPixels get_pixel_width(Box const&, CSS::Size const&) const;
-    CSSPixels get_pixel_height(Box const&, CSS::Size const&) const;
+    CSSPixels get_pixel_width(Box const&, AvailableSpace const&, CSS::Size const&) const;
+    CSSPixels get_pixel_height(Box const&, AvailableSpace const&, CSS::Size const&) const;
 
     bool flex_item_is_stretched(FlexItem const&) const;
 


### PR DESCRIPTION
We do this by piggybacking on `FormattingContext` helpers instead of reinventing the wheel in `FlexFormattingContext`.

This fixes an issue where `min-width: fit-content` (and other layout-dependent values) were treated as 0 on flex items.

This makes the cookie banners look okay on https://microsoft.com/ :^)

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/47485fb5-0256-411f-84fd-8fc1f0cafc1c)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/5f65a0d7-a1b7-4748-80e9-075d1824b662)
