### PR TITLE
LibJS/Tests: Add a test for an async function which returns a thenable

### DIFF
--- a/Userland/Libraries/LibJS/Tests/syntax/async-await.js
+++ b/Userland/Libraries/LibJS/Tests/syntax/async-await.js
@@ -200,3 +200,15 @@ describe("await cannot be used in class static init blocks", () => {
         expect("class A{ static { async function* await() {} } }").not.toEval();
     });
 });
+
+test("async returning a thenable", () => {
+    let isCalled = false;
+    const f = async () => ({
+        then() {
+            isCalled = true;
+        },
+    });
+    f();
+    runQueuedPromiseJobs();
+    expect(isCalled).toBe(true);
+});


### PR DESCRIPTION
This test passes when running in the AST interpreter, but fails when running for bytecode.