### PR TITLE
LibGfx/ICO: Refactor the plugin interface

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -77,14 +77,7 @@ TEST_CASE(test_not_ico)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("buggie.png"sv)));
     EXPECT(!Gfx::ICOImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::ICOImageDecoderPlugin::create(file->bytes()));
-    EXPECT(plugin_decoder->initialize().is_error());
-
-    EXPECT(plugin_decoder->frame_count());
-    EXPECT(!plugin_decoder->is_animated());
-    EXPECT(!plugin_decoder->loop_count());
-
-    EXPECT(plugin_decoder->frame(0).is_error());
+    EXPECT(Gfx::ICOImageDecoderPlugin::create(file->bytes()).is_error());
 }
 
 TEST_CASE(test_bmp_embedded_in_ico)

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -125,6 +125,7 @@ static Array const s_registered_mime_type = {
     MimeType { .name = "image/tinyvg"sv, .common_extensions = { ".tvg"sv }, .description = "TinyVG vector graphics"sv, .magic_bytes = Vector<u8> { 0x72, 0x56 } },
     MimeType { .name = "image/vnd.ms-dds"sv, .common_extensions = { ".dds"sv }, .description = "DDS image data"sv, .magic_bytes = Vector<u8> { 'D', 'D', 'S', ' ' } },
     MimeType { .name = "image/webp"sv, .common_extensions = { ".webp"sv }, .description = "WebP image data"sv, .magic_bytes = Vector<u8> { 'W', 'E', 'B', 'P' }, .offset = 8 },
+    MimeType { .name = "image/x-icon"sv, .common_extensions = { ".ico"sv }, .description = "ICO image data"sv },
     MimeType { .name = "image/x-portable-bitmap"sv, .common_extensions = { ".pbm"sv }, .description = "PBM image data"sv, .magic_bytes = Vector<u8> { 0x50, 0x31, 0x0A } },
     MimeType { .name = "image/x-portable-graymap"sv, .common_extensions = { ".pgm"sv }, .description = "PGM image data"sv, .magic_bytes = Vector<u8> { 0x50, 0x32, 0x0A } },
     MimeType { .name = "image/x-portable-pixmap"sv, .common_extensions = { ".ppm"sv }, .description = "PPM image data"sv, .magic_bytes = Vector<u8> { 0x50, 0x33, 0x0A } },

--- a/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.h
@@ -21,7 +21,6 @@ public:
 
     virtual IntSize size() override;
 
-    virtual ErrorOr<void> initialize() override;
     virtual bool is_animated() override;
     virtual size_t loop_count() override;
     virtual size_t frame_count() override;


### PR DESCRIPTION
**LibGfx/ICO: Decode the header in `create()` and remove `initialize()`**

This is done as a part of #19893.

**LibGfx: Register the mime type image/x-icon**