### PR TITLE
LibJS/Bytecode: ElimiateLoads lost knowledge via ternaries

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/PassManager.h
+++ b/Userland/Libraries/LibJS/Bytecode/PassManager.h
@@ -129,6 +129,12 @@ public:
 
 private:
     virtual void perform(PassPipelineExecutable&) override;
+    virtual void generate_cfg(PassPipelineExecutable& executable)
+    {
+        PassManager pass_manager;
+        pass_manager.add<GenerateCFG>();
+        pass_manager.perform(executable);
+    }
 };
 
 }


### PR DESCRIPTION
When certain ternary statements are passed a block barrier can be created resulting in knowledge being lost between blocks. Further, this causes access to a not initialized register. This is fixed by changing `preform()` to walk the blocks in CFG order and replace their entries with new blocks after `eliminate_loads()` is preformed. Additionally, the register rerouting table must be made static in order for its order to be preserved between function calls.