### PR TITLE
LibPDF: Implement 7.6.4.3.4 Algorithm 2.B: Computing a hash

### DIFF
--- a/Userland/Libraries/LibCrypto/Cipher/Mode/Mode.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/Mode.h
@@ -24,7 +24,7 @@ public:
 
     T const& cipher() const { return m_cipher; }
 
-    ErrorOr<ByteBuffer> create_aligned_buffer(size_t input_size) const
+    static ErrorOr<ByteBuffer> create_aligned_buffer(size_t input_size)
     {
         size_t remainder = (input_size + T::block_size()) % T::block_size();
         if (remainder == 0)

--- a/Userland/Libraries/LibPDF/Encryption.h
+++ b/Userland/Libraries/LibPDF/Encryption.h
@@ -62,7 +62,12 @@ private:
 
     ByteBuffer compute_encryption_key_r2_to_r5(ByteBuffer password_string);
     ByteBuffer compute_encryption_key_r6_and_later(ByteBuffer password_string);
-    ByteBuffer computing_a_hash_r6_and_later(ByteBuffer password_string);
+
+    enum class HashKind {
+        Owner,
+        User,
+    };
+    ByteBuffer computing_a_hash_r6_and_later(ByteBuffer input, StringView input_password, HashKind);
 
     Document* m_document;
     size_t m_revision;


### PR DESCRIPTION
This is a step towards AESV3 support for PDF files.

The straight-forward way of writing this with our APIs is pretty
allocation-heavy, but this code won't run all that often for the
regular "open PDF, check password" flow. 