### PR TITLE
LibWeb+LibJS: Implement the HostGetImportMetaProperties hook

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -258,7 +258,7 @@ public:
     Function<ThrowCompletionOr<void>(ScriptOrModule, ModuleRequest, PromiseCapability const&)> host_import_module_dynamically;
     Function<void(ScriptOrModule, ModuleRequest const&, PromiseCapability const&, Promise*)> host_finish_dynamic_import;
 
-    Function<HashMap<PropertyKey, Value>(SourceTextModule const&)> host_get_import_meta_properties;
+    Function<HashMap<PropertyKey, Value>(SourceTextModule&)> host_get_import_meta_properties;
     Function<void(Object*, SourceTextModule const&)> host_finalize_import_meta;
 
     Function<Vector<DeprecatedString>()> host_get_supported_import_assertions;


### PR DESCRIPTION
Unfortunately this isn't testable from text tests, as [modules cannot be loaded from `file://` URLs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#other_differences_between_modules_and_standard_scripts):
> You need to pay attention to local testing — if you try to load the HTML file locally (i.e. with a file:// URL), you'll run into CORS errors due to JavaScript module security requirements. You need to do your testing through a server.

So we'll need to eventually come up with some way to run WebServer in CI and run tests that way for modules. But this is trivially manually testable:

index.html
```html
<script type="module" src="./index.js" crossorigin></script>
```

index.js:
```js
console.log(import.meta.url)
console.log(import.meta.resolve('./abc/def.js'))
```

Prints:
```
(js log) "http://0.0.0.0:8000/index.js"
(js log) "http://0.0.0.0:8000/abc/def.js"
```

Fixes #20052