### PR TITLE
PixelPaint: Fix BrushTool and EraseTool scaling issues and update cursors

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -11,6 +11,8 @@
 #include "ImageEditor.h"
 #include "Image.h"
 #include "Layer.h"
+#include "Tools/BrushTool.h"
+#include "Tools/EraseTool.h"
 #include "Tools/MoveTool.h"
 #include "Tools/Tool.h"
 #include <AK/IntegralMath.h>
@@ -430,6 +432,13 @@ void ImageEditor::mousemove_event(GUI::MouseEvent& event)
     auto image_event = event_with_pan_and_scale_applied(event);
     if (on_image_mouse_position_change) {
         on_image_mouse_position_change(image_event.position());
+
+        // Update the cursors when the mouse position is changed to allow the rectangles and ellipses to be clamped within
+        // the bounds of the ImageEditor and not draw ontop of the rest of the UI.
+        if (is<BrushTool>(*m_active_tool)) {
+            m_active_tool->set_current_position(m_mouse_position);
+            m_active_tool->refresh_editor_cursor();
+        }
     }
 
     auto layer_event = m_active_layer ? event_adjusted_for_layer(event, *m_active_layer) : event;

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
@@ -190,7 +190,6 @@ NonnullRefPtr<Gfx::Bitmap> BrushTool::build_cursor()
     auto new_scale = m_editor ? m_editor->scale() : 1;
     auto scaled_size = size() * new_scale;
     auto containing_box_size = 2 * scaled_size;
-    bool draw_ellipse = true;
 
     // If we have an ImageEditor scaled_size should not excede diagonal length of the ImageEditor
     if (m_editor) {
@@ -206,8 +205,6 @@ NonnullRefPtr<Gfx::Bitmap> BrushTool::build_cursor()
         if (scaled_size > max_scaled_size) {
             scaled_size = max_scaled_size;
             containing_box_size = scaled_size * 2;
-            // Due to performance issues when the cursor is too large we choose to draw it here.
-            draw_ellipse = false;
         }
     }
 
@@ -227,7 +224,7 @@ NonnullRefPtr<Gfx::Bitmap> BrushTool::build_cursor()
     // If no ImageEditor is present, we cannot bind the ellipse within the editor. Then we will just draw the ellipse.
     if (!m_editor) {
         aa_painter.draw_ellipse(Gfx::IntRect(0, 0, containing_box_size, containing_box_size), Color::LightGray, 1);
-    } else if (draw_ellipse) {
+    } else if (m_current_tool_position.x() + scaled_size <= m_editor->width() && m_current_tool_position.y() + scaled_size <= m_editor->height() && m_current_tool_position.x() - scaled_size > 0 && m_current_tool_position.y() - scaled_size > 0) {
         Color color = m_editor->color_for(GUI::MouseButton::Primary);
         aa_painter.fill_ellipse(Gfx::IntRect(0, 0, containing_box_size, containing_box_size), color.with_alpha(100));
     }

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.h
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.h
@@ -41,6 +41,8 @@ public:
         double multiplicand = hardness() == 100 ? 1.0 : 1.0 / (100 - hardness());
         return (1.0 - double { distance / size() }) * multiplicand;
     }
+    virtual void refresh_editor_cursor() override;
+    virtual void set_current_position(Gfx::IntPoint cursor_position) override;
 
 protected:
     virtual StringView tool_name() const override { return "Brush Tool"sv; }
@@ -49,7 +51,6 @@ protected:
     virtual void draw_point(Gfx::Bitmap& bitmap, Gfx::Color color, Gfx::IntPoint point);
     virtual void draw_line(Gfx::Bitmap& bitmap, Gfx::Color color, Gfx::IntPoint start, Gfx::IntPoint end);
     virtual NonnullRefPtr<Gfx::Bitmap> build_cursor();
-    void refresh_editor_cursor();
     float m_scale_last_created_cursor = 0;
 
 private:
@@ -60,6 +61,9 @@ private:
     bool m_has_clicked { false };
     Gfx::IntPoint m_last_position;
     NonnullRefPtr<Gfx::Bitmap const> m_cursor = build_cursor();
+    Gfx::IntSize m_editor_previous_size = Gfx::IntSize(0, 0);
+    int m_size_previous { 20 };
+    float max_scaled_size = 0;
 };
 
 }

--- a/Userland/Applications/PixelPaint/Tools/EraseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EraseTool.cpp
@@ -169,15 +169,23 @@ NonnullRefPtr<Gfx::Bitmap> EraseTool::build_cursor()
         if (m_current_tool_position.x() >= (half_scaled_size) && (m_current_tool_position.x() + half_scaled_size) <= m_editor->width() && m_current_tool_position.y() >= (half_scaled_size) && (m_current_tool_position.y() + half_scaled_size) <= m_editor->height()) {
             painter.draw_rect(rect, Color::LightGray);
         } else {
-            // FIXME: If you move the cursor rapidly the rectangle doesn't get updated properly and can shoot past the ImageEditor bounds
             int left_overlap = (m_current_tool_position.x() < (half_scaled_size)) ? ((half_scaled_size)-m_current_tool_position.x()) : 0;
             int right_overlap = ((m_current_tool_position.x() + half_scaled_size) > m_editor->width()) ? ((m_current_tool_position.x() + half_scaled_size) - m_editor->width()) : 0;
-
             int top_overlap = (m_current_tool_position.y() < (half_scaled_size)) ? ((half_scaled_size)-m_current_tool_position.y()) : 0;
             int bottom_overlap = ((m_current_tool_position.y() + half_scaled_size) > m_editor->height()) ? ((m_current_tool_position.y() + half_scaled_size) - m_editor->height()) : 0;
 
-            Gfx::IntRect new_rect { left_overlap, top_overlap, scaled_size - (left_overlap + right_overlap), scaled_size - (top_overlap + bottom_overlap) };
-            painter.draw_rect(new_rect, Color::LightGray);
+            if (left_overlap == 0) {
+                painter.draw_line(Gfx::IntPoint(0, top_overlap), Gfx::IntPoint(0, scaled_size - bottom_overlap), Color::LightGray);
+            }
+            if (right_overlap == 0) {
+                painter.draw_line(Gfx::IntPoint(scaled_size - 1, top_overlap), Gfx::IntPoint(scaled_size - 1, scaled_size - bottom_overlap), Color::LightGray);
+            }
+            if (top_overlap == 0) {
+                painter.draw_line(Gfx::IntPoint(left_overlap, 0), Gfx::IntPoint(scaled_size - right_overlap, 0), Color::LightGray);
+            }
+            if (bottom_overlap == 0) {
+                painter.draw_line(Gfx::IntPoint(left_overlap, scaled_size - 1), Gfx::IntPoint(scaled_size - right_overlap, scaled_size - 1), Color::LightGray);
+            }
         }
     }
     painter.draw_line({ half_scaled_size - 5, half_scaled_size }, { half_scaled_size + 5, half_scaled_size }, Color::LightGray, 3);

--- a/Userland/Applications/PixelPaint/Tools/Tool.h
+++ b/Userland/Applications/PixelPaint/Tools/Tool.h
@@ -85,6 +85,9 @@ public:
     // We only set the override_alt_key flag to true since the override is false by default. If false is desired do not call method.
     virtual bool is_overriding_alt() { return false; }
 
+    virtual void set_current_position(Gfx::IntPoint) { }
+    virtual void refresh_editor_cursor() { }
+
 protected:
     Tool() = default;
     WeakPtr<ImageEditor> m_editor;
@@ -105,6 +108,9 @@ protected:
     template<Gfx::StorageFormat>
     void set_pixel_with_possible_mask(int x, int y, Gfx::Color color, Gfx::Bitmap& bitmap);
     void set_pixel_with_possible_mask(int x, int y, Gfx::Color color, Gfx::Bitmap& bitmap);
+
+    // Current position of the tool within the widget
+    Gfx::IntPoint m_current_tool_position;
 };
 
 }


### PR DESCRIPTION
These commits fix issue PixelPaint: Brush tool crashes at both too high or too low zoom https://github.com/SerenityOS/serenity/issues/16232

Most of the changes are taken from this PR (https://github.com/SerenityOS/serenity/pull/16422) that was never merged

In addition I added:
* Disappear brush tool when edges escape ImageEditor window
* Modify eraser cursor to draw lines when edges escape ImageEditor window