### PR TITLE
LibPDF: Fix text/line matrices not being retroactively applied to font size + using LibGfx::ICC

### DIFF
--- a/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.cpp
@@ -22,7 +22,7 @@ ScaledFont::ScaledFont(NonnullRefPtr<VectorFont> font, float point_width, float 
 
     auto metrics = m_font->metrics(m_x_scale, m_y_scale);
 
-    m_pixel_size = m_point_height * 1.33333333f;
+    m_pixel_size = m_point_height * (DEFAULT_DPI / POINTS_PER_INCH);
     m_pixel_size_rounded_up = static_cast<int>(ceilf(m_pixel_size));
 
     m_pixel_metrics = Gfx::FontPixelMetrics {

--- a/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.h
+++ b/Userland/Libraries/LibGfx/ICC/WellKnownProfiles.h
@@ -12,6 +12,7 @@
 namespace Gfx::ICC {
 
 class Profile;
+class TagData;
 
 ErrorOr<NonnullRefPtr<Profile>> sRGB();
 

--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -4,12 +4,15 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGfx/ICC/WellKnownProfiles.h>
 #include <LibPDF/ColorSpace.h>
 #include <LibPDF/CommonNames.h>
 #include <LibPDF/Document.h>
 #include <LibPDF/ObjectDerivatives.h>
 
 namespace PDF {
+
+RefPtr<Gfx::ICC::Profile> ICCBasedColorSpace::s_srgb_profile;
 
 #define ENUMERATE(name, ever_needs_parameters) \
     ColorSpaceFamily ColorSpaceFamily::name { #name, ever_needs_parameters };
@@ -303,39 +306,66 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> ICCBasedColorSpace::create(Document* docum
     if (!param.has<NonnullRefPtr<Object>>() || !param.get<NonnullRefPtr<Object>>()->is<StreamObject>())
         return Error { Error::Type::MalformedPDF, "ICCBased color space expects a stream parameter" };
 
-    auto dict = param.get<NonnullRefPtr<Object>>()->cast<StreamObject>()->dict();
+    auto stream = param.get<NonnullRefPtr<Object>>()->cast<StreamObject>();
+    auto dict = stream->dict();
 
-    DeprecatedFlyString name;
-    if (!dict->contains(CommonNames::Alternate)) {
-        auto number_of_components = dict->get_value(CommonNames::N).to_int();
-        if (number_of_components == 1)
-            name = CommonNames::DeviceGray;
-        else if (number_of_components == 3)
-            name = CommonNames::DeviceRGB;
-        else if (number_of_components == 4)
-            name = CommonNames::DeviceCMYK;
-        else
-            VERIFY_NOT_REACHED();
-        return ColorSpace::create(name);
+    auto maybe_profile = Gfx::ICC::Profile::try_load_from_externally_owned_memory(stream->bytes());
+    if (!maybe_profile.is_error())
+        return adopt_ref(*new ICCBasedColorSpace(maybe_profile.release_value()));
+
+    if (dict->contains(CommonNames::Alternate)) {
+        auto alternate_color_space_object = MUST(dict->get_object(document, CommonNames::Alternate));
+        if (alternate_color_space_object->is<NameObject>())
+            return ColorSpace::create(alternate_color_space_object->cast<NameObject>()->name());
+
+        return Error { Error::Type::Internal, "Alternate color spaces in array format are not supported" };
     }
 
-    auto alternate_color_space_object = MUST(dict->get_object(document, CommonNames::Alternate));
-    if (alternate_color_space_object->is<NameObject>()) {
-        return ColorSpace::create(alternate_color_space_object->cast<NameObject>()->name());
-    }
-
-    dbgln("Alternate color spaces in array format not supported yet ");
-    TODO();
+    return Error { Error::Type::MalformedPDF, "Failed to load ICC color space with malformed profile and no alternate" };
 }
 
-Color ICCBasedColorSpace::color(Vector<Value> const&) const
+ICCBasedColorSpace::ICCBasedColorSpace(NonnullRefPtr<Gfx::ICC::Profile> profile)
+    : m_profile(profile)
 {
-    VERIFY_NOT_REACHED();
+}
+
+Color ICCBasedColorSpace::color(Vector<Value> const& arguments) const
+{
+    if (!s_srgb_profile)
+        s_srgb_profile = MUST(Gfx::ICC::sRGB());
+
+    Vector<u8> bytes;
+    for (auto const& arg : arguments) {
+        VERIFY(arg.has_number());
+        bytes.append(static_cast<u8>(arg.to_float() * 255.0f));
+    }
+
+    auto pcs = MUST(m_profile->to_pcs(bytes));
+    Array<u8, 3> output;
+    MUST(s_srgb_profile->from_pcs(pcs, output.span()));
+
+    return Color(output[0], output[1], output[2]);
 }
 
 Vector<float> ICCBasedColorSpace::default_decode() const
 {
-    VERIFY_NOT_REACHED();
+    auto color_space = m_profile->data_color_space();
+    switch (color_space) {
+    case Gfx::ICC::ColorSpace::Gray:
+        return { 0.0, 1.0 };
+    case Gfx::ICC::ColorSpace::RGB:
+        return { 0.0, 1.0, 0.0, 1.0, 0.0, 1.0 };
+    case Gfx::ICC::ColorSpace::CMYK:
+        return { 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0 };
+    default:
+        warnln("PDF: Unknown default_decode params for color space {}", Gfx::ICC::data_color_space_name(color_space));
+        Vector<float> decoding_ranges;
+        for (u8 i = 0; i < Gfx::ICC::number_of_components_in_color_space(color_space); i++) {
+            decoding_ranges.append(0.0);
+            decoding_ranges.append(1.0);
+        }
+        return decoding_ranges;
+    }
 }
 
 }

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -9,6 +9,7 @@
 #include <AK/DeprecatedFlyString.h>
 #include <AK/Forward.h>
 #include <LibGfx/Color.h>
+#include <LibGfx/ICC/Profile.h>
 #include <LibPDF/Value.h>
 
 #define ENUMERATE_COLOR_SPACE_FAMILIES(V) \
@@ -137,7 +138,10 @@ public:
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::ICCBased; }
 
 private:
-    ICCBasedColorSpace() = delete;
+    ICCBasedColorSpace(NonnullRefPtr<Gfx::ICC::Profile>);
+
+    static RefPtr<Gfx::ICC::Profile> s_srgb_profile;
+    NonnullRefPtr<Gfx::ICC::Profile> m_profile;
 };
 
 }

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -55,7 +55,7 @@ public:
 
     virtual ~ColorSpace() = default;
 
-    virtual Color color(Vector<Value> const& arguments) const = 0;
+    virtual PDFErrorOr<Color> color(Vector<Value> const& arguments) const = 0;
     virtual int number_of_components() const = 0;
     virtual Vector<float> default_decode() const = 0;
     virtual ColorSpaceFamily const& family() const = 0;
@@ -67,7 +67,7 @@ public:
 
     ~DeviceGrayColorSpace() override = default;
 
-    Color color(Vector<Value> const& arguments) const override;
+    PDFErrorOr<Color> color(Vector<Value> const& arguments) const override;
     int number_of_components() const override { return 1; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceGray; }
@@ -82,7 +82,7 @@ public:
 
     ~DeviceRGBColorSpace() override = default;
 
-    Color color(Vector<Value> const& arguments) const override;
+    PDFErrorOr<Color> color(Vector<Value> const& arguments) const override;
     int number_of_components() const override { return 3; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceRGB; }
@@ -97,7 +97,7 @@ public:
 
     ~DeviceCMYKColorSpace() override = default;
 
-    Color color(Vector<Value> const& arguments) const override;
+    PDFErrorOr<Color> color(Vector<Value> const& arguments) const override;
     int number_of_components() const override { return 4; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceCMYK; }
@@ -112,7 +112,7 @@ public:
 
     ~CalRGBColorSpace() override = default;
 
-    Color color(Vector<Value> const& arguments) const override;
+    PDFErrorOr<Color> color(Vector<Value> const& arguments) const override;
     int number_of_components() const override { return 3; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::CalRGB; }
@@ -132,7 +132,7 @@ public:
 
     ~ICCBasedColorSpace() override = default;
 
-    Color color(Vector<Value> const& arguments) const override;
+    PDFErrorOr<Color> color(Vector<Value> const& arguments) const override;
     int number_of_components() const override { VERIFY_NOT_REACHED(); }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::ICCBased; }

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -26,6 +26,7 @@ public:
 
     virtual ~PDFFont() = default;
 
+    virtual void set_font_size(float font_size) = 0;
     virtual PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float font_size, float character_spacing, float horizontal_scaling) = 0;
 
     virtual Type type() const = 0;

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -40,6 +40,11 @@ float TrueTypeFont::get_glyph_width(u8 char_code) const
     return m_font->glyph_width(char_code);
 }
 
+void TrueTypeFont::set_font_size(float font_size)
+{
+    m_font = m_font->with_size((font_size * POINTS_PER_INCH) / DEFAULT_DPI);
+}
+
 void TrueTypeFont::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float, u8 char_code, Color color)
 {
     // Account for the reversed font baseline

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -15,6 +15,7 @@ namespace PDF {
 class TrueTypeFont : public SimpleFont {
 public:
     float get_glyph_width(u8 char_code) const override;
+    void set_font_size(float font_size) override;
     void draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8, Color) override;
     Type type() const override { return PDFFont::Type::TrueType; }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -87,6 +87,10 @@ float Type0Font::get_char_width(u16 char_code) const
     return static_cast<float>(width) / 1000.0f;
 }
 
+void Type0Font::set_font_size(float)
+{
+}
+
 PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float, float, float)
 {
     return Error::rendering_unsupported_error("Type0 font not implemented yet");

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -19,6 +19,7 @@ struct CIDSystemInfo {
 
 class Type0Font : public PDFFont {
 public:
+    void set_font_size(float font_size) override;
     PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint pos, DeprecatedString const&, Color const&, float, float, float) override;
     Type type() const override { return PDFFont::Type::Type0; }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -54,6 +54,12 @@ float Type1Font::get_glyph_width(u8 char_code) const
     return m_font->glyph_width(char_code);
 }
 
+void Type1Font::set_font_size(float font_size)
+{
+    if (m_font)
+        m_font = m_font->with_size((font_size * POINTS_PER_INCH) / DEFAULT_DPI);
+}
+
 void Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color)
 {
     if (!m_font_program) {

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -15,6 +15,7 @@ namespace PDF {
 class Type1Font : public SimpleFont {
 public:
     float get_glyph_width(u8 char_code) const override;
+    void set_font_size(float font_size) override;
     void draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color) override;
     Type type() const override { return PDFFont::Type::Type1; }
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -458,6 +458,13 @@ RENDERER_HANDLER(text_set_matrix_and_line_matrix)
     m_text_line_matrix = new_transform;
     m_text_matrix = new_transform;
     m_text_rendering_matrix_is_dirty = true;
+
+    // Settings the text/line matrix retroactively affects fonts
+    if (text_state().font) {
+        auto new_text_rendering_matrix = calculate_text_rendering_matrix();
+        text_state().font->set_font_size(text_state().font_size * new_text_rendering_matrix.x_scale());
+    }
+
     return {};
 }
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -523,7 +523,7 @@ RENDERER_HANDLER(set_painting_space)
 
 RENDERER_HANDLER(set_stroking_color)
 {
-    state().stroke_color = state().stroke_color_space->color(args);
+    state().stroke_color = TRY(state().stroke_color_space->color(args));
     return {};
 }
 
@@ -534,13 +534,13 @@ RENDERER_HANDLER(set_stroking_color_extended)
     if (last_arg.has<NonnullRefPtr<Object>>() && last_arg.get<NonnullRefPtr<Object>>()->is<NameObject>())
         TODO();
 
-    state().stroke_color = state().stroke_color_space->color(args);
+    state().stroke_color = TRY(state().stroke_color_space->color(args));
     return {};
 }
 
 RENDERER_HANDLER(set_painting_color)
 {
-    state().paint_color = state().paint_color_space->color(args);
+    state().paint_color = TRY(state().paint_color_space->color(args));
     return {};
 }
 
@@ -551,49 +551,49 @@ RENDERER_HANDLER(set_painting_color_extended)
     if (last_arg.has<NonnullRefPtr<Object>>() && last_arg.get<NonnullRefPtr<Object>>()->is<NameObject>())
         TODO();
 
-    state().paint_color = state().paint_color_space->color(args);
+    state().paint_color = TRY(state().paint_color_space->color(args));
     return {};
 }
 
 RENDERER_HANDLER(set_stroking_color_and_space_to_gray)
 {
     state().stroke_color_space = DeviceGrayColorSpace::the();
-    state().stroke_color = state().stroke_color_space->color(args);
+    state().stroke_color = TRY(state().stroke_color_space->color(args));
     return {};
 }
 
 RENDERER_HANDLER(set_painting_color_and_space_to_gray)
 {
     state().paint_color_space = DeviceGrayColorSpace::the();
-    state().paint_color = state().paint_color_space->color(args);
+    state().paint_color = TRY(state().paint_color_space->color(args));
     return {};
 }
 
 RENDERER_HANDLER(set_stroking_color_and_space_to_rgb)
 {
     state().stroke_color_space = DeviceRGBColorSpace::the();
-    state().stroke_color = state().stroke_color_space->color(args);
+    state().stroke_color = TRY(state().stroke_color_space->color(args));
     return {};
 }
 
 RENDERER_HANDLER(set_painting_color_and_space_to_rgb)
 {
     state().paint_color_space = DeviceRGBColorSpace::the();
-    state().paint_color = state().paint_color_space->color(args);
+    state().paint_color = TRY(state().paint_color_space->color(args));
     return {};
 }
 
 RENDERER_HANDLER(set_stroking_color_and_space_to_cmyk)
 {
     state().stroke_color_space = DeviceCMYKColorSpace::the();
-    state().stroke_color = state().stroke_color_space->color(args);
+    state().stroke_color = TRY(state().stroke_color_space->color(args));
     return {};
 }
 
 RENDERER_HANDLER(set_painting_color_and_space_to_cmyk)
 {
     state().paint_color_space = DeviceCMYKColorSpace::the();
-    state().paint_color = state().paint_color_space->color(args);
+    state().paint_color = TRY(state().paint_color_space->color(args));
     return {};
 }
 
@@ -795,7 +795,7 @@ PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> Renderer::load_image(NonnullRefPtr<Stream
             sample = sample.slice(bytes_per_component);
             component_values[i] = Value { component_value_decoders[i].interpolate(component[0]) };
         }
-        auto color = color_space->color(component_values);
+        auto color = TRY(color_space->color(component_values));
         bitmap->set_pixel(x, y, color);
         ++x;
         if (x == width) {


### PR DESCRIPTION
Page 1 of the PDF 2.0 spec:

<details><summary>Before</summary>
<img height="700px" src="https://i.imgur.com/ltyId9C.png" />
</details> 

<details><summary>After</summary>
<img height="700px" src="https://i.imgur.com/T6rIwRO.png" />
</details> 

cc @nico for the ICC stuff. Turns out the ICC changes don't actually do anything to contribute to the images above. I thought it did, and then implemented it all only to find out I misinterpreted the color information I was seeing from the PDF. But if it looks ok, might as well merge it. 