### PR TITLE
Kernel/Ext2: Write redundant superblocks and block group descriptor tables

### DIFF
--- a/AK/IntegralMath.h
+++ b/AK/IntegralMath.h
@@ -54,4 +54,18 @@ constexpr I pow(I base, I exponent)
     return res;
 }
 
+template<auto base, Unsigned U = decltype(base)>
+constexpr bool is_power_of(U x)
+{
+    if constexpr (base == 2)
+        return is_power_of_two(x);
+
+    // FIXME: I am naive! A log2-based approach (pow<U>(base, (log2(x) / log2(base))) == x) does not work due to rounding errors.
+    for (U exponent = 0; exponent <= log2(x) / log2(base) + 1; ++exponent) {
+        if (pow<U>(base, exponent) == x)
+            return true;
+    }
+    return false;
+}
+
 }

--- a/Kernel/FileSystem/BlockBasedFileSystem.h
+++ b/Kernel/FileSystem/BlockBasedFileSystem.h
@@ -17,7 +17,7 @@ public:
 
     virtual ~BlockBasedFileSystem() override;
 
-    u64 logical_block_size() const { return m_logical_block_size; }
+    u64 device_block_size() const { return m_device_block_size; }
 
     virtual void flush_writes() override;
     void flush_writes_impl();
@@ -39,7 +39,7 @@ protected:
     ErrorOr<void> write_block(BlockIndex, UserOrKernelBuffer const&, size_t count, u64 offset = 0, bool allow_cache = true);
     ErrorOr<void> write_blocks(BlockIndex, unsigned count, UserOrKernelBuffer const&, bool allow_cache = true);
 
-    u64 m_logical_block_size { 512 };
+    u64 m_device_block_size { 512 };
 
     void remove_disk_cache_before_last_unmount();
 

--- a/Kernel/FileSystem/Ext2FS/FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.cpp
@@ -30,12 +30,12 @@ ErrorOr<void> Ext2FS::flush_super_block()
 {
     MutexLocker locker(m_lock);
     auto super_block_buffer = UserOrKernelBuffer::for_kernel_buffer((u8*)&m_super_block);
-    auto const superblock_physical_block_count = (sizeof(ext2_super_block) / logical_block_size());
+    auto const superblock_physical_block_count = (sizeof(ext2_super_block) / device_block_size());
 
     // FIXME: We currently have no ability of writing within a device block, but the ability to do so would allow us to use device block sizes larger than 1024.
-    VERIFY((sizeof(ext2_super_block) % logical_block_size()) == 0);
+    VERIFY((sizeof(ext2_super_block) % device_block_size()) == 0);
     // First superblock is always at offset 1024 (physical block index 2).
-    TRY(raw_write_blocks(1024 / logical_block_size(), superblock_physical_block_count, super_block_buffer));
+    TRY(raw_write_blocks(1024 / device_block_size(), superblock_physical_block_count, super_block_buffer));
 
     auto is_sparse = has_flag(get_features_readonly(), FeaturesReadOnly::SparseSuperblock);
 
@@ -70,9 +70,9 @@ ErrorOr<void> Ext2FS::initialize_while_locked()
     VERIFY(m_lock.is_locked());
     VERIFY(!is_initialized_while_locked());
 
-    VERIFY((sizeof(ext2_super_block) % logical_block_size()) == 0);
+    VERIFY((sizeof(ext2_super_block) % device_block_size()) == 0);
     auto super_block_buffer = UserOrKernelBuffer::for_kernel_buffer((u8*)&m_super_block);
-    TRY(raw_read_blocks(1024 / logical_block_size(), (sizeof(ext2_super_block) / logical_block_size()), super_block_buffer));
+    TRY(raw_read_blocks(1024 / device_block_size(), (sizeof(ext2_super_block) / device_block_size()), super_block_buffer));
 
     auto const& super_block = this->super_block();
     if constexpr (EXT2_DEBUG) {

--- a/Kernel/FileSystem/Ext2FS/FileSystem.h
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.h
@@ -22,10 +22,13 @@ class Ext2FS final : public BlockBasedFileSystem {
     friend class Ext2FSInode;
 
 public:
+    // s_feature_ro_compat
     enum class FeaturesReadOnly : u32 {
         None = 0,
-        FileSize64bits = 1 << 1,
+        SparseSuperblock = EXT2_FEATURE_RO_COMPAT_SPARSE_SUPER,
+        FileSize64bits = EXT2_FEATURE_RO_COMPAT_LARGE_FILE,
     };
+    AK_ENUM_BITWISE_FRIEND_OPERATORS(FeaturesReadOnly);
 
     static ErrorOr<NonnullRefPtr<FileSystem>> try_create(OpenFileDescription&, ReadonlyBytes);
 

--- a/Kernel/FileSystem/Ext2FS/FileSystem.h
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.h
@@ -77,10 +77,12 @@ private:
     virtual void flush_writes() override;
 
     BlockIndex first_block_index() const;
+    BlockIndex first_block_of_block_group_descriptors() const;
     ErrorOr<InodeIndex> allocate_inode(GroupIndex preferred_group = 0);
     ErrorOr<Vector<BlockIndex>> allocate_blocks(GroupIndex preferred_group_index, size_t count);
     GroupIndex group_index_from_inode(InodeIndex) const;
     GroupIndex group_index_from_block_index(BlockIndex) const;
+    BlockIndex first_block_of_group(GroupIndex) const;
 
     ErrorOr<bool> get_inode_allocation_state(InodeIndex) const;
     ErrorOr<void> set_inode_allocation_state(InodeIndex, bool);

--- a/Kernel/FileSystem/FATFS/FileSystem.cpp
+++ b/Kernel/FileSystem/FATFS/FileSystem.cpp
@@ -31,7 +31,7 @@ ErrorOr<void> FATFS::initialize_while_locked()
     VERIFY(m_lock.is_locked());
     VERIFY(!is_initialized_while_locked());
 
-    m_boot_record = TRY(KBuffer::try_create_with_size("FATFS: Boot Record"sv, m_logical_block_size));
+    m_boot_record = TRY(KBuffer::try_create_with_size("FATFS: Boot Record"sv, m_device_block_size));
     auto boot_record_buffer = UserOrKernelBuffer::for_kernel_buffer(m_boot_record->data());
     TRY(raw_read(0, boot_record_buffer));
 
@@ -62,10 +62,10 @@ ErrorOr<void> FATFS::initialize_while_locked()
         return EINVAL;
     }
 
-    m_logical_block_size = boot_record()->bytes_per_sector;
-    set_block_size(m_logical_block_size);
+    m_device_block_size = boot_record()->bytes_per_sector;
+    set_block_size(m_device_block_size);
 
-    u32 root_directory_sectors = ((boot_record()->root_directory_entry_count * sizeof(FATEntry)) + (m_logical_block_size - 1)) / m_logical_block_size;
+    u32 root_directory_sectors = ((boot_record()->root_directory_entry_count * sizeof(FATEntry)) + (m_device_block_size - 1)) / m_device_block_size;
     m_first_data_sector = boot_record()->reserved_sector_count + (boot_record()->fat_count * boot_record()->sectors_per_fat) + root_directory_sectors;
 
     TRY(BlockBasedFileSystem::initialize_while_locked());

--- a/Kernel/FileSystem/FATFS/FileSystem.cpp
+++ b/Kernel/FileSystem/FATFS/FileSystem.cpp
@@ -63,7 +63,7 @@ ErrorOr<void> FATFS::initialize_while_locked()
     }
 
     m_device_block_size = boot_record()->bytes_per_sector;
-    set_block_size(m_device_block_size);
+    set_logical_block_size(m_device_block_size);
 
     u32 root_directory_sectors = ((boot_record()->root_directory_entry_count * sizeof(FATEntry)) + (m_device_block_size - 1)) / m_device_block_size;
     m_first_data_sector = boot_record()->reserved_sector_count + (boot_record()->fat_count * boot_record()->sectors_per_fat) + root_directory_sectors;

--- a/Kernel/FileSystem/FileSystem.h
+++ b/Kernel/FileSystem/FileSystem.h
@@ -53,7 +53,7 @@ public:
 
     virtual void flush_writes() { }
 
-    u64 block_size() const { return m_block_size; }
+    u64 logical_block_size() const { return m_logical_block_size; }
     size_t fragment_size() const { return m_fragment_size; }
 
     virtual bool is_file_backed() const { return false; }
@@ -66,7 +66,7 @@ public:
 protected:
     FileSystem();
 
-    void set_block_size(u64 size) { m_block_size = size; }
+    void set_logical_block_size(u64 size) { m_logical_block_size = size; }
     void set_fragment_size(size_t size) { m_fragment_size = size; }
 
     virtual ErrorOr<void> prepare_to_clear_last_mount([[maybe_unused]] Inode& mount_guest_inode) { return {}; }
@@ -75,7 +75,7 @@ protected:
 
 private:
     FileSystemID m_fsid;
-    u64 m_block_size { 0 };
+    u64 m_logical_block_size { 0 };
     size_t m_fragment_size { 0 };
     bool m_readonly { false };
 

--- a/Kernel/FileSystem/ISO9660FS/DirectoryIterator.cpp
+++ b/Kernel/FileSystem/ISO9660FS/DirectoryIterator.cpp
@@ -78,8 +78,8 @@ bool ISO9660DirectoryIterator::skip()
         // need to snap to the next logical block, because directory records
         // cannot span multiple logical blocks.
         u32 remaining_bytes = m_current_directory.entry->length - m_current_directory.offset;
-        if (remaining_bytes > m_fs.logical_block_size()) {
-            m_current_directory.offset += remaining_bytes % m_fs.logical_block_size();
+        if (remaining_bytes > m_fs.device_block_size()) {
+            m_current_directory.offset += remaining_bytes % m_fs.device_block_size();
             get_header();
 
             dbgln_if(ISO9660_VERY_DEBUG, "skip(): Snapped to next logical block (succeeded)");

--- a/Kernel/FileSystem/ISO9660FS/FileSystem.cpp
+++ b/Kernel/FileSystem/ISO9660FS/FileSystem.cpp
@@ -24,7 +24,7 @@ ErrorOr<NonnullRefPtr<FileSystem>> ISO9660FS::try_create(OpenFileDescription& de
 ISO9660FS::ISO9660FS(OpenFileDescription& description)
     : BlockBasedFileSystem(description)
 {
-    set_block_size(logical_sector_size);
+    set_logical_block_size(logical_sector_size);
     m_device_block_size = logical_sector_size;
 }
 

--- a/Kernel/FileSystem/ISO9660FS/Inode.cpp
+++ b/Kernel/FileSystem/ISO9660FS/Inode.cpp
@@ -20,17 +20,17 @@ ErrorOr<size_t> ISO9660Inode::read_bytes_locked(off_t offset, size_t size, UserO
     if (static_cast<u64>(offset) >= data_length)
         return 0;
 
-    auto block = TRY(KBuffer::try_create_with_size("ISO9660FS: Inode read buffer"sv, fs().m_logical_block_size));
+    auto block = TRY(KBuffer::try_create_with_size("ISO9660FS: Inode read buffer"sv, fs().device_block_size()));
     auto block_buffer = UserOrKernelBuffer::for_kernel_buffer(block->data());
 
     size_t total_bytes = min(size, data_length - offset);
     size_t nread = 0;
-    size_t blocks_already_read = offset / fs().m_logical_block_size;
-    size_t initial_offset = offset % fs().m_logical_block_size;
+    size_t blocks_already_read = offset / fs().device_block_size();
+    size_t initial_offset = offset % fs().device_block_size();
 
     auto current_block_index = BlockBasedFileSystem::BlockIndex { extent_location + blocks_already_read };
     while (nread != total_bytes) {
-        size_t bytes_to_read = min(total_bytes - nread, fs().logical_block_size() - initial_offset);
+        size_t bytes_to_read = min(total_bytes - nread, fs().device_block_size() - initial_offset);
         auto buffer_offset = buffer.offset(nread);
         dbgln_if(ISO9660_VERY_DEBUG, "ISO9660Inode::read_bytes: Reading {} bytes into buffer offset {}/{}, logical block index: {}", bytes_to_read, nread, total_bytes, current_block_index.value());
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/DiskUsage.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/DiskUsage.cpp
@@ -35,7 +35,7 @@ ErrorOr<void> SysFSDiskUsage::try_generate(KBufferBuilder& builder)
         TRY(fs_object.add("free_inode_count"sv, fs.free_inode_count()));
         auto mount_point = TRY(mount.absolute_path());
         TRY(fs_object.add("mount_point"sv, mount_point->view()));
-        TRY(fs_object.add("block_size"sv, static_cast<u64>(fs.block_size())));
+        TRY(fs_object.add("block_size"sv, static_cast<u64>(fs.logical_block_size())));
         TRY(fs_object.add("readonly"sv, fs.is_readonly()));
         TRY(fs_object.add("mount_flags"sv, mount.flags()));
 

--- a/Kernel/Syscalls/statvfs.cpp
+++ b/Kernel/Syscalls/statvfs.cpp
@@ -14,7 +14,7 @@ ErrorOr<FlatPtr> Process::do_statvfs(FileSystem const& fs, Custody const* custod
 {
     statvfs kernelbuf = {};
 
-    kernelbuf.f_bsize = static_cast<u64>(fs.block_size());
+    kernelbuf.f_bsize = static_cast<u64>(fs.logical_block_size());
     kernelbuf.f_frsize = fs.fragment_size();
     kernelbuf.f_blocks = fs.total_block_count();
     kernelbuf.f_bfree = fs.free_block_count();

--- a/Tests/AK/TestIntegerMath.cpp
+++ b/Tests/AK/TestIntegerMath.cpp
@@ -7,6 +7,7 @@
 #include <LibTest/TestCase.h>
 
 #include <AK/IntegralMath.h>
+#include <initializer_list>
 
 TEST_CASE(pow)
 {
@@ -17,4 +18,21 @@ TEST_CASE(pow)
     EXPECT_EQ(AK::pow<u64>(10, 4), 10'000ull);
     EXPECT_EQ(AK::pow<u64>(10, 5), 100'000ull);
     EXPECT_EQ(AK::pow<u64>(10, 6), 1'000'000ull);
+}
+
+TEST_CASE(is_power_of)
+{
+    constexpr auto check_prime = []<u64 prime>(u64 limit) {
+        for (u64 power = 0; power < limit; ++power)
+            EXPECT(AK::is_power_of<prime>(AK::pow(prime, power)));
+    };
+
+    // Limits calculated as floor( log_{prime}(2^64) ) to prevent overflows.
+    check_prime.operator()<2>(64);
+    check_prime.operator()<3>(40);
+    check_prime.operator()<5>(27);
+    check_prime.operator()<7>(20);
+    check_prime.operator()<11>(18);
+    check_prime.operator()<97>(9);
+    check_prime.operator()<257>(7);
 }


### PR DESCRIPTION
These superblocks and BGDTs are often referred to as "shadow" copies. They serve as backups in the case of corruption of the primary (or other) copies, since these datastructures are so essential. We were previously just ignoring them, so let's at least make sure they're consistent.

This should hopefully allow fsck (and other tooling) to more easily recover our file systems in case the driver does something stupid. For now, we don't actually consider the copies for recovering a broken file system, since we can't really do that anyways.

This change was heavily stress-tested with adding and removing plenty files, regular tests, whole-filesystem scans courtesy of SpaceAnalyzer, etc. No noticeable performance difference was observed.