### PR TITLE
Tests/LibGfx: Call `ImageDecoder::size()` before `frame()`

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -42,8 +42,8 @@ static Gfx::ImageFrameDescriptor expect_single_frame(Gfx::ImageDecoderPlugin& pl
 
 static Gfx::ImageFrameDescriptor expect_single_frame_of_size(Gfx::ImageDecoderPlugin& plugin_decoder, Gfx::IntSize size)
 {
-    auto frame = expect_single_frame(plugin_decoder);
     EXPECT_EQ(plugin_decoder.size(), size);
+    auto frame = expect_single_frame(plugin_decoder);
     EXPECT_EQ(frame.image->size(), size);
     return frame;
 }


### PR DESCRIPTION
Reordering these calls allow us to ensure that all encoders are able to return the size of the image before they are requested to decode the whole bitmap.