### PR TITLE
LibGfx/TGA: Compute the number of pixels with a wider type

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
@@ -195,8 +195,7 @@ ErrorOr<void> TGAImageDecoderPlugin::decode_tga_header()
 
     auto bytes_remaining = reader->data().size() - reader->index();
 
-    // FIXME: Check for multiplication overflow!
-    if (m_context->header.data_type_code == TGADataType::UncompressedRGB && bytes_remaining < static_cast<size_t>(m_context->header.width * m_context->header.height * (m_context->header.bits_per_pixel / 8)))
+    if (m_context->header.data_type_code == TGADataType::UncompressedRGB && bytes_remaining < static_cast<u64>(m_context->header.width) * m_context->header.height * (m_context->header.bits_per_pixel / 8))
         return Error::from_string_literal("Not enough data to read an image with the expected size");
 
     if (m_context->header.bits_per_pixel < 8 || m_context->header.bits_per_pixel > 32)
@@ -210,8 +209,7 @@ ErrorOr<bool> TGAImageDecoderPlugin::validate_before_create(ReadonlyBytes data)
     if (data.size() < sizeof(TGAHeader))
         return false;
     TGAHeader const& header = *reinterpret_cast<TGAHeader const*>(data.data());
-    // FIXME: Check for multiplication overflow!
-    if (header.data_type_code == TGADataType::UncompressedRGB && data.size() < static_cast<size_t>(header.width * header.height * (header.bits_per_pixel / 8)))
+    if (header.data_type_code == TGADataType::UncompressedRGB && data.size() < static_cast<u64>(header.width) * header.height * (header.bits_per_pixel / 8))
         return false;
     if (header.bits_per_pixel < 8 || header.bits_per_pixel > 32)
         return false;


### PR DESCRIPTION
Both width and height are stored in an u16 inside the TGA header, computing the total number of pixel without using another type can easily lead to overflows.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=55309&q=serenity&can=2