### PR TITLE
LibJS: Refactor GetIterator, and replace Set's GetKeysIterator AO with GetIteratorFromMethod

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1533,8 +1533,9 @@ void IDL::ParameterizedType::generate_sequence_from_iterable(SourceGenerator& ge
     //      4. Initialize Si to the result of converting nextItem to an IDL value of type T.
     //      5. Set i to i + 1.
 
+    // FIXME: The WebIDL spec is out of date - it should be using GetIteratorFromMethod.
     sequence_generator.append(R"~~~(
-    auto iterator@recursion_depth@ = TRY(JS::get_iterator(vm, @iterable_cpp_name@, JS::IteratorHint::Sync, @iterator_method_cpp_name@));
+    auto iterator@recursion_depth@ = TRY(JS::get_iterator_from_method(vm, @iterable_cpp_name@, *@iterator_method_cpp_name@));
 )~~~");
 
     if (sequence_cpp_type.sequence_storage_type == SequenceStorageType::Vector) {

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -1295,7 +1295,7 @@ Completion ForAwaitOfStatement::loop_evaluation(Interpreter& interpreter, Vector
     auto rhs_result = for_of_head_state.rhs_value;
 
     // NOTE: Perform step 7 from ForIn/OfHeadEvaluation. And since this is always async we only have to do step 7.d.
-    // d. Return ? GetIterator(exprValue, iteratorHint).
+    // d. Return ? GetIterator(exprValue, iteratorKind).
     auto iterator = TRY(get_iterator(vm, rhs_result, IteratorHint::Async));
 
     // 14.7.5.7 ForIn/OfBodyEvaluation ( lhs, stmt, iteratorRecord, iterationKind, lhsKind, labelSet [ , iteratorKind ] ), https://tc39.es/ecma262/#sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -2669,12 +2669,12 @@ static Bytecode::CodeGenerationErrorOr<ForInOfHeadEvaluationResult> for_in_of_he
     // 7. Else,
     else {
         // a. Assert: iterationKind is iterate or async-iterate.
-        // b. If iterationKind is async-iterate, let iteratorHint be async.
-        // c. Else, let iteratorHint be sync.
-        auto iterator_hint = iteration_kind == IterationKind::AsyncIterate ? IteratorHint::Async : IteratorHint::Sync;
+        // b. If iterationKind is async-iterate, let iteratorKind be async.
+        // c. Else, let iteratorKind be sync.
+        auto iterator_kind = iteration_kind == IterationKind::AsyncIterate ? IteratorHint::Async : IteratorHint::Sync;
 
-        // d. Return ? GetIterator(exprValue, iteratorHint).
-        generator.emit<Bytecode::Op::GetIterator>(iterator_hint);
+        // d. Return ? GetIterator(exprValue, iteratorKind).
+        generator.emit<Bytecode::Op::GetIterator>(iterator_kind);
     }
 
     return result;

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
@@ -226,7 +226,8 @@ ThrowCompletionOr<GroupsType> group_by(VM& vm, Value items, Value callback_funct
     GroupsType groups;
 
     // 4. Let iteratorRecord be ? GetIterator(items).
-    auto iterator_record = TRY(get_iterator(vm, items));
+    // FIXME: The Array Grouping proposal is out of date - the `kind` parameter is now required.
+    auto iterator_record = TRY(get_iterator(vm, items, IteratorHint::Sync));
 
     // 5. Let k be 0.
     u64 k = 0;

--- a/Userland/Libraries/LibJS/Runtime/AggregateErrorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AggregateErrorConstructor.cpp
@@ -64,8 +64,8 @@ ThrowCompletionOr<NonnullGCPtr<Object>> AggregateErrorConstructor::construct(Fun
     // 4. Perform ? InstallErrorCause(O, options).
     TRY(aggregate_error->install_error_cause(options));
 
-    // 5. Let errorsList be ? IterableToList(errors).
-    auto errors_list = TRY(iterable_to_list(vm, errors));
+    // 5. Let errorsList be ? IteratorToList(? GetIterator(errors, sync)).
+    auto errors_list = TRY(iterator_to_list(vm, TRY(get_iterator(vm, errors, IteratorHint::Sync))));
 
     // 6. Perform ! DefinePropertyOrThrow(O, "errors", PropertyDescriptor { [[Configurable]]: true, [[Enumerable]]: false, [[Writable]]: true, [[Value]]: CreateArrayFromList(errorsList) }).
     MUST(aggregate_error->define_property_or_throw(vm.names.errors, { .value = Array::create_from(realm, errors_list), .writable = true, .enumerable = false, .configurable = true }));

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -179,8 +179,8 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from)
             array = MUST(Array::create(realm, 0));
         }
 
-        // c. Let iteratorRecord be ? GetIterator(items, sync, usingIterator).
-        auto iterator = TRY(get_iterator(vm, items, IteratorHint::Sync, using_iterator));
+        // c. Let iteratorRecord be ? GetIteratorFromMethod(items, usingIterator).
+        auto iterator = TRY(get_iterator_from_method(vm, items, *using_iterator));
 
         // d. Let k be 0.
         // e. Repeat,
@@ -356,12 +356,14 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from_async)
         // h. If usingAsyncIterator is not undefined, then
         if (using_async_iterator) {
             // i. Set iteratorRecord to ? GetIterator(asyncItems, async, usingAsyncIterator).
-            iterator_record = TRY(get_iterator(vm, async_items, IteratorHint::Async, using_async_iterator));
+            // FIXME: The Array.from proposal is out of date - it should be using GetIteratorFromMethod.
+            iterator_record = TRY(get_iterator_from_method(vm, async_items, *using_async_iterator));
         }
         // i. Else if usingSyncIterator is not undefined, then
         else if (using_sync_iterator) {
             // i. Set iteratorRecord to ? CreateAsyncFromSyncIterator(GetIterator(asyncItems, sync, usingSyncIterator)).
-            iterator_record = create_async_from_sync_iterator(vm, TRY(get_iterator(vm, async_items, IteratorHint::Sync, using_sync_iterator)));
+            // FIXME: The Array.from proposal is out of date - it should be using GetIteratorFromMethod.
+            iterator_record = create_async_from_sync_iterator(vm, TRY(get_iterator_from_method(vm, async_items, *using_sync_iterator)));
         }
 
         // j. If iteratorRecord is not undefined, then

--- a/Userland/Libraries/LibJS/Runtime/IteratorOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorOperations.cpp
@@ -34,15 +34,13 @@ ThrowCompletionOr<IteratorRecord> get_iterator_from_method(VM& vm, Value object,
     return iterator_record;
 }
 
-// 7.4.3 GetIterator ( obj [ , hint ] ), https://tc39.es/ecma262/#sec-getiterator
-ThrowCompletionOr<IteratorRecord> get_iterator(VM& vm, Value object, IteratorHint hint)
+// 7.4.3 GetIterator ( obj, kind ), https://tc39.es/ecma262/#sec-getiterator
+ThrowCompletionOr<IteratorRecord> get_iterator(VM& vm, Value object, IteratorHint kind)
 {
     JS::GCPtr<FunctionObject> method;
 
-    // 1. If hint is not present, set hint to sync.
-
-    // 2. If hint is async, then
-    if (hint == IteratorHint::Async) {
+    // 1. If kind is async, then
+    if (kind == IteratorHint::Async) {
         // a. Let method be ? GetMethod(obj, @@asyncIterator).
         method = TRY(object.get_method(vm, vm.well_known_symbol_async_iterator()));
 
@@ -62,7 +60,7 @@ ThrowCompletionOr<IteratorRecord> get_iterator(VM& vm, Value object, IteratorHin
             return create_async_from_sync_iterator(vm, sync_iterator_record);
         }
     }
-    // 3. Else,
+    // 2. Else,
     else {
         // a. Let method be ? GetMethod(obj, @@iterator).
         method = TRY(object.get_method(vm, vm.well_known_symbol_iterator()));
@@ -72,7 +70,7 @@ ThrowCompletionOr<IteratorRecord> get_iterator(VM& vm, Value object, IteratorHin
     if (!method)
         return vm.throw_completion<TypeError>(ErrorType::NotIterable, TRY_OR_THROW_OOM(vm, object.to_string_without_side_effects()));
 
-    // 4. Return ? GetIteratorFromMethod(obj, method).
+    // 3. Return ? GetIteratorFromMethod(obj, method).
     return TRY(get_iterator_from_method(vm, object, *method));
 }
 

--- a/Userland/Libraries/LibJS/Runtime/IteratorOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorOperations.cpp
@@ -49,14 +49,14 @@ ThrowCompletionOr<IteratorRecord> get_iterator(VM& vm, Value object, IteratorHin
             // i. Let syncMethod be ? GetMethod(obj, @@iterator).
             auto sync_method = TRY(object.get_method(vm, vm.well_known_symbol_iterator()));
 
-            // NOTE: Additional type check to produce a better error message than Call().
+            // ii. If syncMethod is undefined, throw a TypeError exception.
             if (!sync_method)
                 return vm.throw_completion<TypeError>(ErrorType::NotIterable, TRY_OR_THROW_OOM(vm, object.to_string_without_side_effects()));
 
-            // ii. Let syncIteratorRecord be ? GetIteratorFromMethod(obj, syncMethod).
+            // iii. Let syncIteratorRecord be ? GetIteratorFromMethod(obj, syncMethod).
             auto sync_iterator_record = TRY(get_iterator_from_method(vm, object, *sync_method));
 
-            // iii. Return CreateAsyncFromSyncIterator(syncIteratorRecord).
+            // iv. Return CreateAsyncFromSyncIterator(syncIteratorRecord).
             return create_async_from_sync_iterator(vm, sync_iterator_record);
         }
     }
@@ -66,11 +66,11 @@ ThrowCompletionOr<IteratorRecord> get_iterator(VM& vm, Value object, IteratorHin
         method = TRY(object.get_method(vm, vm.well_known_symbol_iterator()));
     }
 
-    // NOTE: Additional type check to produce a better error message than Call().
+    // 3. If method is undefined, throw a TypeError exception.
     if (!method)
         return vm.throw_completion<TypeError>(ErrorType::NotIterable, TRY_OR_THROW_OOM(vm, object.to_string_without_side_effects()));
 
-    // 3. Return ? GetIteratorFromMethod(obj, method).
+    // 4. Return ? GetIteratorFromMethod(obj, method).
     return TRY(get_iterator_from_method(vm, object, *method));
 }
 

--- a/Userland/Libraries/LibJS/Runtime/IteratorOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorOperations.cpp
@@ -208,29 +208,16 @@ NonnullGCPtr<Object> create_iterator_result_object(VM& vm, Value value, bool don
     return object;
 }
 
-// 7.4.13 IterableToList ( items [ , method ] ), https://tc39.es/ecma262/#sec-iterabletolist
-ThrowCompletionOr<MarkedVector<Value>> iterable_to_list(VM& vm, Value items, GCPtr<FunctionObject> method)
+// 7.4.13 IteratorToList ( iteratorRecord ), https://tc39.es/ecma262/#sec-iteratortolist
+ThrowCompletionOr<MarkedVector<Value>> iterator_to_list(VM& vm, IteratorRecord const& iterator_record)
 {
-    IteratorRecord iterator_record;
-
-    // 1. If method is present, then
-    if (method) {
-        // a. Let iteratorRecord be ? GetIteratorFromMethod(items, method).
-        iterator_record = TRY(get_iterator_from_method(vm, items, *method));
-    }
-    // 2. Else,
-    else {
-        // b. Let iteratorRecord be ? GetIterator(items, sync).
-        iterator_record = TRY(get_iterator(vm, items, IteratorHint::Sync));
-    }
-
-    // 3. Let values be a new empty List.
+    // 1. Let values be a new empty List.
     MarkedVector<Value> values(vm.heap());
 
-    // 4. Let next be true.
+    // 2. Let next be true.
     GCPtr<Object> next;
 
-    // 5. Repeat, while next is not false,
+    // 3. Repeat, while next is not false,
     do {
         // a. Set next to ? IteratorStep(iteratorRecord).
         next = TRY(iterator_step(vm, iterator_record));
@@ -245,7 +232,7 @@ ThrowCompletionOr<MarkedVector<Value>> iterable_to_list(VM& vm, Value items, GCP
         }
     } while (next);
 
-    // 6. Return values.
+    // 4. Return values.
     return values;
 }
 

--- a/Userland/Libraries/LibJS/Runtime/IteratorOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/IteratorOperations.h
@@ -31,7 +31,7 @@ ThrowCompletionOr<Value> iterator_value(VM&, Object& iterator_result);
 Completion iterator_close(VM&, IteratorRecord const&, Completion);
 Completion async_iterator_close(VM&, IteratorRecord const&, Completion);
 NonnullGCPtr<Object> create_iterator_result_object(VM&, Value, bool done);
-ThrowCompletionOr<MarkedVector<Value>> iterable_to_list(VM&, Value iterable, GCPtr<FunctionObject> method = {});
+ThrowCompletionOr<MarkedVector<Value>> iterator_to_list(VM&, IteratorRecord const&);
 
 using IteratorValueCallback = Function<Optional<Completion>(Value)>;
 Completion get_iterator_values(VM&, Value iterable, IteratorValueCallback callback);

--- a/Userland/Libraries/LibJS/Runtime/IteratorOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/IteratorOperations.h
@@ -23,7 +23,7 @@ enum class IteratorHint {
 };
 
 ThrowCompletionOr<IteratorRecord> get_iterator_from_method(VM&, Value, NonnullGCPtr<FunctionObject>);
-ThrowCompletionOr<IteratorRecord> get_iterator(VM&, Value, IteratorHint = IteratorHint::Sync);
+ThrowCompletionOr<IteratorRecord> get_iterator(VM&, Value, IteratorHint);
 ThrowCompletionOr<NonnullGCPtr<Object>> iterator_next(VM&, IteratorRecord const&, Optional<Value> = {});
 ThrowCompletionOr<GCPtr<Object>> iterator_step(VM&, IteratorRecord const&);
 ThrowCompletionOr<bool> iterator_complete(VM&, Object& iterator_result);

--- a/Userland/Libraries/LibJS/Runtime/IteratorOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/IteratorOperations.h
@@ -22,7 +22,8 @@ enum class IteratorHint {
     Async,
 };
 
-ThrowCompletionOr<IteratorRecord> get_iterator(VM&, Value, IteratorHint = IteratorHint::Sync, Optional<Value> method = {});
+ThrowCompletionOr<IteratorRecord> get_iterator_from_method(VM&, Value, NonnullGCPtr<FunctionObject>);
+ThrowCompletionOr<IteratorRecord> get_iterator(VM&, Value, IteratorHint = IteratorHint::Sync);
 ThrowCompletionOr<NonnullGCPtr<Object>> iterator_next(VM&, IteratorRecord const&, Optional<Value> = {});
 ThrowCompletionOr<GCPtr<Object>> iterator_step(VM&, IteratorRecord const&);
 ThrowCompletionOr<bool> iterator_complete(VM&, Object& iterator_result);
@@ -30,9 +31,9 @@ ThrowCompletionOr<Value> iterator_value(VM&, Object& iterator_result);
 Completion iterator_close(VM&, IteratorRecord const&, Completion);
 Completion async_iterator_close(VM&, IteratorRecord const&, Completion);
 NonnullGCPtr<Object> create_iterator_result_object(VM&, Value, bool done);
-ThrowCompletionOr<MarkedVector<Value>> iterable_to_list(VM&, Value iterable, Optional<Value> method = {});
+ThrowCompletionOr<MarkedVector<Value>> iterable_to_list(VM&, Value iterable, GCPtr<FunctionObject> method = {});
 
 using IteratorValueCallback = Function<Optional<Completion>(Value)>;
-Completion get_iterator_values(VM&, Value iterable, IteratorValueCallback callback, Optional<Value> method = {});
+Completion get_iterator_values(VM&, Value iterable, IteratorValueCallback callback);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -324,9 +324,9 @@ JS_DEFINE_NATIVE_FUNCTION(PromiseConstructor::all)
     // 4. IfAbruptRejectPromise(promiseResolve, promiseCapability).
     auto promise_resolve = TRY_OR_REJECT(vm, promise_capability, get_promise_resolve(vm, constructor));
 
-    // 5. Let iteratorRecord be Completion(GetIterator(iterable)).
+    // 5. Let iteratorRecord be Completion(GetIterator(iterable, sync)).
     // 6. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
-    auto iterator_record = TRY_OR_REJECT(vm, promise_capability, get_iterator(vm, vm.argument(0)));
+    auto iterator_record = TRY_OR_REJECT(vm, promise_capability, get_iterator(vm, vm.argument(0), IteratorHint::Sync));
 
     // 7. Let result be Completion(PerformPromiseAll(iteratorRecord, C, promiseCapability, promiseResolve)).
     auto result = perform_promise_all(vm, iterator_record, constructor, promise_capability, promise_resolve);
@@ -358,9 +358,9 @@ JS_DEFINE_NATIVE_FUNCTION(PromiseConstructor::all_settled)
     // 4. IfAbruptRejectPromise(promiseResolve, promiseCapability).
     auto promise_resolve = TRY_OR_REJECT(vm, promise_capability, get_promise_resolve(vm, constructor));
 
-    // 5. Let iteratorRecord be Completion(GetIterator(iterable)).
+    // 5. Let iteratorRecord be Completion(GetIterator(iterable, sync)).
     // 6. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
-    auto iterator_record = TRY_OR_REJECT(vm, promise_capability, get_iterator(vm, vm.argument(0)));
+    auto iterator_record = TRY_OR_REJECT(vm, promise_capability, get_iterator(vm, vm.argument(0), IteratorHint::Sync));
 
     // 7. Let result be Completion(PerformPromiseAllSettled(iteratorRecord, C, promiseCapability, promiseResolve)).
     auto result = perform_promise_all_settled(vm, iterator_record, constructor, promise_capability, promise_resolve);
@@ -392,9 +392,9 @@ JS_DEFINE_NATIVE_FUNCTION(PromiseConstructor::any)
     // 4. IfAbruptRejectPromise(promiseResolve, promiseCapability).
     auto promise_resolve = TRY_OR_REJECT(vm, promise_capability, get_promise_resolve(vm, constructor));
 
-    // 5. Let iteratorRecord be Completion(GetIterator(iterable)).
+    // 5. Let iteratorRecord be Completion(GetIterator(iterable, sync)).
     // 6. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
-    auto iterator_record = TRY_OR_REJECT(vm, promise_capability, get_iterator(vm, vm.argument(0)));
+    auto iterator_record = TRY_OR_REJECT(vm, promise_capability, get_iterator(vm, vm.argument(0), IteratorHint::Sync));
 
     // 7. Let result be Completion(PerformPromiseAny(iteratorRecord, C, promiseCapability, promiseResolve)).
     auto result = perform_promise_any(vm, iterator_record, constructor, promise_capability, promise_resolve);
@@ -426,9 +426,9 @@ JS_DEFINE_NATIVE_FUNCTION(PromiseConstructor::race)
     // 4. IfAbruptRejectPromise(promiseResolve, promiseCapability).
     auto promise_resolve = TRY_OR_REJECT(vm, promise_capability, get_promise_resolve(vm, constructor));
 
-    // 5. Let iteratorRecord be Completion(GetIterator(iterable)).
+    // 5. Let iteratorRecord be Completion(GetIterator(iterable, sync)).
     // 6. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
-    auto iterator_record = TRY_OR_REJECT(vm, promise_capability, get_iterator(vm, vm.argument(0)));
+    auto iterator_record = TRY_OR_REJECT(vm, promise_capability, get_iterator(vm, vm.argument(0), IteratorHint::Sync));
 
     // 7. Let result be Completion(PerformPromiseRace(iteratorRecord, C, promiseCapability, promiseResolve)).
     auto result = perform_promise_race(vm, iterator_record, constructor, promise_capability, promise_resolve);

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -529,7 +529,7 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
             } else {                                                                                                                                                                   \
                 auto iterator = TRY(first_argument.get_method(vm, vm.well_known_symbol_iterator()));                                                                                   \
                 if (iterator) {                                                                                                                                                        \
-                    auto values = TRY(iterable_to_list(vm, first_argument, iterator));                                                                                                 \
+                    auto values = TRY(iterator_to_list(vm, TRY(get_iterator_from_method(vm, first_argument, *iterator))));                                                             \
                     TRY(initialize_typed_array_from_list(vm, *typed_array, values));                                                                                                   \
                 } else {                                                                                                                                                               \
                     TRY(initialize_typed_array_from_array_like(vm, *typed_array, first_argument.as_object()));                                                                         \

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
@@ -86,7 +86,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayConstructor::from)
     // 6. If usingIterator is not undefined, then
     if (using_iterator) {
         // a. Let values be ? IteratorToList(? GetIteratorFromMethod(source, usingIterator)).
-        auto values = TRY(iterable_to_list(vm, source, using_iterator));
+        auto values = TRY(iterator_to_list(vm, TRY(get_iterator_from_method(vm, source, *using_iterator))));
 
         // b. Let len be the number of elements in values.
         auto length = values.size();

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -337,8 +337,8 @@ ThrowCompletionOr<void> VM::binding_initialization(NonnullRefPtr<BindingPattern 
     }
     // BindingPattern : ArrayBindingPattern
     else {
-        // 1. Let iteratorRecord be ? GetIterator(value).
-        auto iterator_record = TRY(get_iterator(vm, value));
+        // 1. Let iteratorRecord be ? GetIterator(value, sync).
+        auto iterator_record = TRY(get_iterator(vm, value, IteratorHint::Sync));
 
         // 2. Let result be Completion(IteratorBindingInitialization of ArrayBindingPattern with arguments iteratorRecord and environment).
         auto result = iterator_binding_initialization(*target, iterator_record, environment);

--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
@@ -67,7 +67,8 @@ static JS::ThrowCompletionOr<Vector<String>> convert_value_to_sequence_of_string
     // https://webidl.spec.whatwg.org/#create-sequence-from-iterable
     // To create an IDL value of type sequence<T> given an iterable iterable and an iterator getter method, perform the following steps:
     // 1. Let iter be ? GetIterator(iterable, sync, method).
-    auto iterator = TRY(JS::get_iterator(vm, value, JS::IteratorHint::Sync, method));
+    // FIXME: The WebIDL spec is out of date - it should be using GetIteratorFromMethod.
+    auto iterator = TRY(JS::get_iterator_from_method(vm, value, *method));
 
     // 2. Initialize i to be 0.
     Vector<String> sequence_of_strings;

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -203,7 +203,7 @@ JS::ThrowCompletionOr<size_t> instantiate_module(JS::VM& vm, Wasm::Module const&
                             if (method == JS::js_undefined())
                                 return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotIterable, TRY_OR_THROW_OOM(vm, result.to_string_without_side_effects()));
 
-                            auto values = TRY(JS::iterable_to_list(vm, result, method));
+                            auto values = TRY(JS::iterator_to_list(vm, TRY(JS::get_iterator_from_method(vm, result, *method))));
 
                             if (values.size() != type.results().size())
                                 return vm.throw_completion<JS::TypeError>(DeprecatedString::formatted("Invalid number of return values for multi-value wasm return of {} objects", type.results().size()));


### PR DESCRIPTION
This is a set of editorial changes to split `GetIterator` into 2 AOs, followed by a normative change in the Set Methods proposal to make use of one of the new AOs.

There's a few downstream consumers of these AOs that have not been updated. I'll be making spec issues / just fixing them when I get a chance later.