### PR TITLE
LibJS: Deduplicate continue & break bytecode generation

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -217,6 +217,7 @@ private:
         Break,
     };
     void generate_scoped_jump(JumpType);
+    void generate_labelled_jump(JumpType, DeprecatedFlyString const& label);
 
     Generator();
     ~Generator() = default;

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -212,6 +212,12 @@ public:
     [[nodiscard]] size_t next_global_variable_cache() { return m_next_global_variable_cache++; }
 
 private:
+    enum class JumpType {
+        Continue,
+        Break,
+    };
+    void generate_scoped_jump(JumpType);
+
     Generator();
     ~Generator() = default;
 


### PR DESCRIPTION
No behavioral changes intended

(no change in bytecode test262)
⚙️=112, ✅=47247, ❌=2010, 💀=2, 💥️=14, 📝
