### PR TITLE
AK: Enable consteval workaround for Android NDK

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -31,7 +31,8 @@ class StringData;
 
 // FIXME: Remove this when OpenBSD Clang fully supports consteval.
 //        And once oss-fuzz updates to clang >15.
-#if defined(AK_OS_OPENBSD) || defined(OSS_FUZZ)
+//        And once Android ships an NDK with clang >14
+#if defined(AK_OS_OPENBSD) || defined(OSS_FUZZ) || defined(AK_OS_ANDROID)
 #    define AK_SHORT_STRING_CONSTEVAL constexpr
 #else
 #    define AK_SHORT_STRING_CONSTEVAL consteval

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -376,7 +376,8 @@ struct CaseInsensitiveASCIIStringViewTraits : public Traits<StringView> {
 //        See: https://github.com/llvm/llvm-project/issues/48230
 //        Additionally, oss-fuzz currently ships an llvm-project commit that is a pre-release of 15.0.0.
 //        See: https://github.com/google/oss-fuzz/issues/9989
-#if defined(AK_OS_BSD_GENERIC) or defined(OSS_FUZZ)
+//        Android currently doesn't ship clang-15 in any NDK
+#if defined(AK_OS_BSD_GENERIC) || defined(OSS_FUZZ) || defined(AK_OS_ANDROID)
 #    define AK_STRING_VIEW_LITERAL_CONSTEVAL constexpr
 #else
 #    define AK_STRING_VIEW_LITERAL_CONSTEVAL consteval


### PR DESCRIPTION
Android isn't shipping clang-15 yet in any NDK, so use the existing workaround on that platform.