### PR TITLE
Userland: Use AK::human_readable_digital_time() instead of custom code

### DIFF
--- a/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
+++ b/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
@@ -7,6 +7,7 @@
 #include "PlaylistWidget.h"
 #include "Player.h"
 #include <AK/LexicalPath.h>
+#include <AK/NumberFormat.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/HeaderView.h>
 #include <LibGUI/Model.h>
@@ -37,7 +38,7 @@ GUI::Variant PlaylistModel::data(const GUI::ModelIndex& index, GUI::ModelRole ro
         case 0:
             return m_playlist_items[index.row()].extended_info->track_display_title.value_or(LexicalPath::title(m_playlist_items[index.row()].path));
         case 1:
-            return format_duration(m_playlist_items[index.row()].extended_info->track_length_in_seconds.value_or(0));
+            return human_readable_digital_time(m_playlist_items[index.row()].extended_info->track_length_in_seconds.value_or(0));
         case 2:
             return m_playlist_items[index.row()].extended_info->group_name.value_or("");
         case 3:
@@ -66,11 +67,6 @@ DeprecatedString PlaylistModel::format_filesize(u64 size_in_bytes)
         return DeprecatedString::formatted("{:.2f} KiB", (double)size_in_bytes / KiB);
     else
         return DeprecatedString::formatted("{} B", size_in_bytes);
-}
-
-DeprecatedString PlaylistModel::format_duration(u32 duration_in_seconds)
-{
-    return DeprecatedString::formatted("{:02}:{:02}:{:02}", duration_in_seconds / 3600, (duration_in_seconds / 60) % 60, duration_in_seconds % 60);
 }
 
 ErrorOr<String> PlaylistModel::column_name(int column) const

--- a/Userland/Applications/SoundPlayer/PlaylistWidget.h
+++ b/Userland/Applications/SoundPlayer/PlaylistWidget.h
@@ -31,7 +31,6 @@ private:
     Vector<M3UEntry> m_playlist_items;
 
     static DeprecatedString format_filesize(u64 size_in_bytes);
-    static DeprecatedString format_duration(u32 duration_in_seconds);
 };
 
 class PlaylistTableView : public GUI::TableView {

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -13,6 +13,7 @@
 #include "SampleWidget.h"
 #include <AK/DeprecatedString.h>
 #include <AK/LexicalPath.h>
+#include <AK/NumberFormat.h>
 #include <AK/SIMD.h>
 #include <LibConfig/Client.h>
 #include <LibGUI/Action.h>
@@ -243,7 +244,7 @@ void SoundPlayerWidgetAdvancedView::shuffle_mode_changed(Player::ShuffleMode)
 
 void SoundPlayerWidgetAdvancedView::time_elapsed(int seconds)
 {
-    m_timestamp_label->set_text(String::formatted("Elapsed: {:02}:{:02}:{:02}", seconds / 3600, seconds / 60, seconds % 60).release_value_but_fixme_should_propagate_errors());
+    m_timestamp_label->set_text(String::formatted("Elapsed: {}", human_readable_digital_time(seconds)).release_value_but_fixme_should_propagate_errors());
 }
 
 void SoundPlayerWidgetAdvancedView::file_name_changed(StringView name)

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "Game.h"
+#include <AK/NumberFormat.h>
 #include <AK/URL.h>
 #include <Games/Solitaire/SolitaireGML.h>
 #include <LibConfig/Client.h>
@@ -92,7 +93,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& statusbar = *widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
     statusbar.set_text(0, TRY("Score: 0"_string));
     statusbar.set_text(1, TRY(String::formatted("High Score: {}", high_score())));
-    statusbar.set_text(2, TRY("Time: 00:00:00"_string));
+    statusbar.set_text(2, TRY("Time: 00:00"_string));
 
     app->on_action_enter = [&](GUI::Action& action) {
         statusbar.set_override_text(action.status_tip());
@@ -110,18 +111,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto timer = TRY(Core::Timer::create_repeating(1000, [&]() {
         ++seconds_elapsed;
-
-        uint64_t hours = seconds_elapsed / 3600;
-        uint64_t minutes = (seconds_elapsed / 60) % 60;
-        uint64_t seconds = seconds_elapsed % 60;
-
-        statusbar.set_text(2, String::formatted("Time: {:02}:{:02}:{:02}", hours, minutes, seconds).release_value_but_fixme_should_propagate_errors());
+        statusbar.set_text(2, String::formatted("Time: {}", human_readable_digital_time(seconds_elapsed)).release_value_but_fixme_should_propagate_errors());
     }));
 
     game.on_game_start = [&]() {
         seconds_elapsed = 0;
         timer->start();
-        statusbar.set_text(2, "Time: 00:00:00"_string.release_value_but_fixme_should_propagate_errors());
+        statusbar.set_text(2, "Time: 00:00"_string.release_value_but_fixme_should_propagate_errors());
     };
     game.on_game_end = [&](Solitaire::GameOverReason reason, uint32_t score) {
         if (timer->is_active())

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "Game.h"
+#include <AK/NumberFormat.h>
 #include <Games/Spider/SpiderGML.h>
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
@@ -28,15 +29,6 @@ enum class StatisticDisplay : u8 {
     BestTime,
     __Count
 };
-
-static DeprecatedString format_seconds(uint64_t seconds_elapsed)
-{
-    uint64_t hours = seconds_elapsed / 3600;
-    uint64_t minutes = (seconds_elapsed / 60) % 60;
-    uint64_t seconds = seconds_elapsed % 60;
-
-    return DeprecatedString::formatted("{:02}:{:02}:{:02}", hours, minutes, seconds);
-}
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -130,7 +122,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             statusbar.set_text(1, String::formatted("High Score: {}", high_score()).release_value_but_fixme_should_propagate_errors());
             break;
         case StatisticDisplay::BestTime:
-            statusbar.set_text(1, String::formatted("Best Time: {}", format_seconds(best_time())).release_value_but_fixme_should_propagate_errors());
+            statusbar.set_text(1, String::formatted("Best Time: {}", human_readable_digital_time(best_time())).release_value_but_fixme_should_propagate_errors());
             break;
         default:
             VERIFY_NOT_REACHED();
@@ -158,7 +150,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto timer = TRY(Core::Timer::create_repeating(1000, [&]() {
         ++seconds_elapsed;
 
-        statusbar.set_text(2, String::formatted("Time: {}", format_seconds(seconds_elapsed)).release_value_but_fixme_should_propagate_errors());
+        statusbar.set_text(2, String::formatted("Time: {}", human_readable_digital_time(seconds_elapsed)).release_value_but_fixme_should_propagate_errors());
     }));
 
     game.on_game_start = [&]() {


### PR DESCRIPTION
Use this handy AK function instead of reimplementing the formatting code several times. The one minor difference is that now, hours are only shown if the duration is at least an hour long, but that seems like an improvement to me. :^)