### PR TITLE
HackStudio: Fix code-folding bug, and remove some duplicate code

### DIFF
--- a/Userland/DevTools/HackStudio/CodeDocument.h
+++ b/Userland/DevTools/HackStudio/CodeDocument.h
@@ -29,8 +29,6 @@ public:
     DeprecatedString const& file_path() const { return m_file_path; }
     Optional<Syntax::Language> const& language() const { return m_language; }
 
-    virtual bool is_code_document() const override final { return true; }
-
     enum class DiffType {
         None,
         AddedLine,

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -146,18 +146,6 @@ EditorWrapper const& Editor::wrapper() const
     return static_cast<EditorWrapper const&>(*parent());
 }
 
-void Editor::focusin_event(GUI::FocusEvent& event)
-{
-    if (on_focus)
-        on_focus();
-    GUI::TextEditor::focusin_event(event);
-}
-
-void Editor::focusout_event(GUI::FocusEvent& event)
-{
-    GUI::TextEditor::focusout_event(event);
-}
-
 Gfx::IntRect Editor::gutter_icon_rect(size_t line_number) const
 {
     return gutter_content_rect(line_number).translated(frame_thickness(), 0);

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -146,11 +146,6 @@ EditorWrapper const& Editor::wrapper() const
     return static_cast<EditorWrapper const&>(*parent());
 }
 
-Gfx::IntRect Editor::gutter_icon_rect(size_t line_number) const
-{
-    return gutter_content_rect(line_number).translated(frame_thickness(), 0);
-}
-
 void Editor::paint_event(GUI::PaintEvent& event)
 {
     GUI::TextEditor::paint_event(event);
@@ -445,7 +440,6 @@ void Editor::clear_execution_position()
     size_t previous_position = execution_position().value();
     code_document().clear_execution_position();
     remove_gutter_indicator(m_execution_indicator_id, previous_position);
-    update(gutter_icon_rect(previous_position));
 }
 
 Gfx::Bitmap const& Editor::breakpoint_icon_bitmap()

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -456,9 +456,7 @@ Gfx::Bitmap const& Editor::current_position_icon_bitmap()
 
 CodeDocument const& Editor::code_document() const
 {
-    auto const& doc = document();
-    VERIFY(doc.is_code_document());
-    return static_cast<CodeDocument const&>(doc);
+    return verify_cast<CodeDocument const>(document());
 }
 
 CodeDocument& Editor::code_document()
@@ -471,7 +469,7 @@ void Editor::set_document(GUI::TextDocument& doc)
     if (has_document() && &document() == &doc)
         return;
 
-    VERIFY(doc.is_code_document());
+    VERIFY(is<CodeDocument>(doc));
     GUI::TextEditor::set_document(doc);
 
     set_override_cursor(Gfx::StandardCursor::IBeam);

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -77,7 +77,6 @@ private:
     void on_navigatable_link_click(const GUI::TextDocumentSpan&);
     void on_identifier_click(const GUI::TextDocumentSpan&);
 
-    Gfx::IntRect gutter_icon_rect(size_t line_number) const;
     static Gfx::Bitmap const& breakpoint_icon_bitmap();
     static Gfx::Bitmap const& current_position_icon_bitmap();
     static ErrorOr<void> initialize_tooltip_window();

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -116,7 +116,6 @@ private:
     GUI::TextPosition m_previous_text_position { 0, 0 };
     bool m_hovering_editor { false };
     bool m_hovering_clickable { false };
-    bool m_autocomplete_in_focus { false };
     RefPtr<GUI::Action> m_move_execution_to_line_action;
     RefPtr<Core::Timer> m_tokens_info_timer; // Used for querying language server for syntax highlighting info
     OwnPtr<LanguageClient> m_language_client;

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -28,7 +28,6 @@ public:
 
     virtual ~Editor() override = default;
 
-    Function<void()> on_focus;
     Function<void(DeprecatedString)> on_open;
 
     EditorWrapper& wrapper();
@@ -64,8 +63,6 @@ public:
     void set_semantic_syntax_highlighting(bool value);
 
 private:
-    virtual void focusin_event(GUI::FocusEvent&) override;
-    virtual void focusout_event(GUI::FocusEvent&) override;
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousemove_event(GUI::MouseEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;

--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -30,7 +30,7 @@ EditorWrapper::EditorWrapper()
     m_editor->set_ruler_visible(true);
     m_editor->set_automatic_indentation_enabled(true);
 
-    m_editor->on_focus = [this] {
+    m_editor->on_focusin = [this] {
         set_current_editor_wrapper(this);
     };
 

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -150,8 +150,6 @@ public:
     TextPosition insert_at(TextPosition const&, StringView, Client const* = nullptr);
     void remove(TextRange const&);
 
-    virtual bool is_code_document() const { return false; }
-
     bool is_empty() const;
     bool is_modified() const { return m_undo_stack.is_current_modified(); }
     void set_unmodified();

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -2167,10 +2167,8 @@ void TextEditor::recompute_visual_lines(size_t line_index, Vector<TextDocumentFo
         }
     }
 
-    if (is_wrapping_enabled())
-        visual_data->visual_rect = { m_horizontal_content_padding, 0, available_width, static_cast<int>(visual_data->visual_lines.size()) * line_height() };
-    else
-        visual_data->visual_rect = { m_horizontal_content_padding, 0, text_width_for_font(line.view(), font()), line_height() };
+    auto line_width = is_wrapping_enabled() ? available_width : text_width_for_font(line.view(), font());
+    visual_data->visual_rect = { m_horizontal_content_padding, 0, line_width, static_cast<int>(visual_data->visual_lines.size()) * line_height() };
 }
 
 template<typename Callback>


### PR DESCRIPTION
Before:
![image](https://github.com/SerenityOS/serenity/assets/222642/85a7242f-3bc7-4772-aa60-d39777c1e372)

After:
![image](https://github.com/SerenityOS/serenity/assets/222642/5cc3038b-631c-4968-a4ae-b4da0339391c)

While I was trying to search for the cause of this bug, I noticed a few places where the Editor and friends reimplement things that TextEditor already does, and removed them.