### PR TITLE
nohup: Don't leak fd used to open nohup.out

### DIFF
--- a/Userland/Utilities/nohup.cpp
+++ b/Userland/Utilities/nohup.cpp
@@ -44,6 +44,8 @@ void dup_out_file(int fd_to_redirect)
         exit(127);
     }
 
+    MUST(Core::System::close(fd));
+
     if (fd_to_redirect != STDERR_FILENO)
         outln(stderr, "appending output to {}", path);
 }


### PR DESCRIPTION
A little oopsie that I forgot to account for in #19743.

Since we may redirect stdout, stderr, or both to the file description referring to the nohup.out file, there is no need to keep the fd that created that file description around.