### PR TITLE
LibPDF: Implement rest of AESV3 support :^)

### DIFF
--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -111,6 +111,7 @@
     A(Names)                      \
     A(Next)                       \
     A(O)                          \
+    A(OE)                         \
     A(OP)                         \
     A(OPM)                        \
     A(Ordering)                   \
@@ -119,6 +120,7 @@
     A(Pages)                      \
     A(Parent)                     \
     A(Pattern)                    \
+    A(Perms)                      \
     A(Predictor)                  \
     A(Prev)                       \
     A(Producer)                   \
@@ -146,6 +148,7 @@
     A(Type)                       \
     A(Type1C)                     \
     A(U)                          \
+    A(UE)                         \
     A(UCR)                        \
     A(UseBlackPTComp)             \
     A(UserUnit)                   \

--- a/Userland/Libraries/LibPDF/Encryption.cpp
+++ b/Userland/Libraries/LibPDF/Encryption.cpp
@@ -276,7 +276,7 @@ bool StandardSecurityHandler::authenticate_user_password_r2_to_r5(StringView pas
     return u_bytes == password_buffer.bytes();
 }
 
-bool StandardSecurityHandler::authenticate_user_password_r6_and_later(StringView)
+bool StandardSecurityHandler::authenticate_user_password_r6_and_later(StringView password)
 {
     // ISO 32000 (PDF 2.0), 7.6.4.4.10 Algorithm 11: Authenticating the user password (Security handlers of
     // revision 6)
@@ -286,7 +286,12 @@ bool StandardSecurityHandler::authenticate_user_password_r6_and_later(StringView
     //    concatenated with the 8 bytes of User Validation Salt (see 7.6.4.4.7, "Algorithm 8: Computing the
     //    encryption dictionary's U (user password) and UE (user encryption) values (Security handlers of
     //    revision 6)"). If the 32- byte result matches the first 32 bytes of the U string, this is the user password.
-    TODO();
+    ByteBuffer input;
+    input.append(password.bytes());
+    input.append(m_u_entry.bytes().slice(32, 8)); // See comment in compute_encryption_key_r6_and_later() re "Validation Salt".
+    auto hash = computing_a_hash_r6_and_later(input, password, HashKind::User);
+
+    return hash == m_u_entry.bytes().trim(32);
 }
 
 bool StandardSecurityHandler::try_provide_user_password(StringView password_string)

--- a/Userland/Libraries/LibPDF/Encryption.cpp
+++ b/Userland/Libraries/LibPDF/Encryption.cpp
@@ -342,10 +342,13 @@ bool StandardSecurityHandler::authenticate_owner_password_r6_and_later(StringVie
 bool StandardSecurityHandler::try_provide_user_password(StringView password_string)
 {
     bool has_user_password;
-    if (m_revision >= 6)
-        has_user_password = authenticate_user_password_r6_and_later(password_string);
-    else
+    if (m_revision >= 6) {
+        // This checks both owner and user password.
+        auto password = ByteBuffer::copy(password_string.bytes()).release_value_but_fixme_should_propagate_errors();
+        has_user_password = compute_encryption_key_r6_and_later(move(password));
+    } else {
         has_user_password = authenticate_user_password_r2_to_r5(password_string);
+    }
 
     if (!has_user_password)
         m_encryption_key = {};

--- a/Userland/Libraries/LibPDF/Encryption.cpp
+++ b/Userland/Libraries/LibPDF/Encryption.cpp
@@ -675,22 +675,6 @@ void StandardSecurityHandler::crypt(NonnullRefPtr<Object> object, Reference refe
         TODO();
     }
 
-    // 7.6.2 General Encryption Algorithm
-    // Algorithm 1: Encryption of data using the RC3 or AES algorithms
-
-    // a) Obtain the object number and generation number from the object identifier of
-    //    the string or stream to be encrypted. If the string is a direct object, use
-    //    the identifier of the indirect object containing it.
-    //
-    // Note: This is always passed in at parse time because objects don't know their own
-    //       object number.
-
-    // b) For all strings and streams with crypt filter specifier; treating the object
-    //    number as binary integers, extend the original n-byte encryption key to n + 5
-    //    bytes by appending the low-order 3 bytes of the object number and the low-order
-    //    2 bytes of the generation number in that order, low-order byte first. ...
-
-    auto encryption_key = m_encryption_key.value();
     ReadonlyBytes bytes;
     Function<void(ByteBuffer)> assign;
 
@@ -717,6 +701,22 @@ void StandardSecurityHandler::crypt(NonnullRefPtr<Object> object, Reference refe
         VERIFY_NOT_REACHED();
     }
 
+    // 7.6.2 General Encryption Algorithm
+    // Algorithm 1: Encryption of data using the RC3 or AES algorithms
+
+    // a) Obtain the object number and generation number from the object identifier of
+    //    the string or stream to be encrypted. If the string is a direct object, use
+    //    the identifier of the indirect object containing it.
+    //
+    // Note: This is always passed in at parse time because objects don't know their own
+    //       object number.
+
+    // b) For all strings and streams with crypt filter specifier; treating the object
+    //    number as binary integers, extend the original n-byte encryption key to n + 5
+    //    bytes by appending the low-order 3 bytes of the object number and the low-order
+    //    2 bytes of the generation number in that order, low-order byte first. ...
+
+    auto encryption_key = m_encryption_key.value();
     auto index = reference.as_ref_index();
     auto generation = reference.as_ref_generation_index();
 

--- a/Userland/Libraries/LibPDF/Encryption.cpp
+++ b/Userland/Libraries/LibPDF/Encryption.cpp
@@ -567,7 +567,7 @@ ByteBuffer StandardSecurityHandler::computing_a_hash_r6_and_later(ByteBuffer ori
         ReadonlyBytes key = K.bytes().trim(16);
         ReadonlyBytes initialization_vector = K.bytes().slice(16);
 
-        // (PaddingMode doesn't matter here since input is block-aligned.)
+        // [Implementor's note: PaddingMode doesn't matter here since input is block-aligned.]
         auto cipher = Crypto::Cipher::AESCipher::CBCMode(key, 128, Crypto::Cipher::Intent::Encryption, Crypto::Cipher::PaddingMode::Null);
         auto E = cipher.create_aligned_buffer(K1.size()).release_value_but_fixme_should_propagate_errors();
         Bytes E_span = E.bytes();
@@ -603,7 +603,8 @@ ByteBuffer StandardSecurityHandler::computing_a_hash_r6_and_later(ByteBuffer ori
         // Repeat the process (a-d) with this new value of K. Following 64 rounds (round number 0 to round
         // number 63), do the following, starting with round number 64:
 
-        if (round_number < 64)
+        // [Implementor's note: Conceptually, steps e)-f) are at the top of the loop for rounds >= 64, so this has to continue for < 63, not for < 64.]
+        if (round_number < 63)
             continue;
 
         // NOTE 2 The reason for multiple rounds is to defeat the possibility of running all paths in parallel. With 64

--- a/Userland/Libraries/LibPDF/Encryption.cpp
+++ b/Userland/Libraries/LibPDF/Encryption.cpp
@@ -663,18 +663,6 @@ void StandardSecurityHandler::crypt(NonnullRefPtr<Object> object, Reference refe
         }
     };
 
-    if (m_method == CryptFilterMethod::AESV3) {
-        // ISO 32000 (PDF 2.0), 7.6.3.3 Algorithm 1.A: Encryption of data using the AES algorithms
-
-        // a) Use the 32-byte file encryption key for the AES-256 symmetric key algorithm, along with the string or
-        //    stream data to be encrypted.
-        //
-        //    Use the AES algorithm in Cipher Block Chaining (CBC) mode, which requires an initialization
-        //    vector. The block size parameter is set to 16 bytes, and the initialization vector is a 16-byte random
-        //    number that is stored as the first 16 bytes of the encrypted stream or string.
-        TODO();
-    }
-
     ReadonlyBytes bytes;
     Function<void(ByteBuffer)> assign;
 
@@ -699,6 +687,19 @@ void StandardSecurityHandler::crypt(NonnullRefPtr<Object> object, Reference refe
         };
     } else {
         VERIFY_NOT_REACHED();
+    }
+
+    if (m_method == CryptFilterMethod::AESV3) {
+        // ISO 32000 (PDF 2.0), 7.6.3.3 Algorithm 1.A: Encryption of data using the AES algorithms
+
+        // a) Use the 32-byte file encryption key for the AES-256 symmetric key algorithm, along with the string or
+        //    stream data to be encrypted.
+        //
+        //    Use the AES algorithm in Cipher Block Chaining (CBC) mode, which requires an initialization
+        //    vector. The block size parameter is set to 16 bytes, and the initialization vector is a 16-byte random
+        //    number that is stored as the first 16 bytes of the encrypted stream or string.
+        assign(aes(bytes, m_encryption_key.value()));
+        return;
     }
 
     // 7.6.2 General Encryption Algorithm

--- a/Userland/Libraries/LibPDF/Encryption.h
+++ b/Userland/Libraries/LibPDF/Encryption.h
@@ -59,6 +59,7 @@ private:
 
     bool authenticate_user_password_r2_to_r5(StringView password_string);
     bool authenticate_user_password_r6_and_later(StringView password_string);
+    bool authenticate_owner_password_r6_and_later(StringView password_string);
 
     ByteBuffer compute_encryption_key_r2_to_r5(ByteBuffer password_string);
     ByteBuffer compute_encryption_key_r6_and_later(ByteBuffer password_string);

--- a/Userland/Libraries/LibPDF/Encryption.h
+++ b/Userland/Libraries/LibPDF/Encryption.h
@@ -62,7 +62,7 @@ private:
     bool authenticate_owner_password_r6_and_later(StringView password_string);
 
     ByteBuffer compute_encryption_key_r2_to_r5(ByteBuffer password_string);
-    ByteBuffer compute_encryption_key_r6_and_later(ByteBuffer password_string);
+    bool compute_encryption_key_r6_and_later(ByteBuffer password_string);
 
     enum class HashKind {
         Owner,

--- a/Userland/Libraries/LibPDF/Encryption.h
+++ b/Userland/Libraries/LibPDF/Encryption.h
@@ -39,7 +39,7 @@ class StandardSecurityHandler : public SecurityHandler {
 public:
     static PDFErrorOr<NonnullRefPtr<StandardSecurityHandler>> create(Document*, NonnullRefPtr<DictObject> encryption_dict);
 
-    StandardSecurityHandler(Document*, size_t revision, DeprecatedString const& o_entry, DeprecatedString const& u_entry, u32 flags, bool encrypt_metadata, size_t length, CryptFilterMethod method);
+    StandardSecurityHandler(Document*, size_t revision, DeprecatedString const& o_entry, DeprecatedString const& oe_entry, DeprecatedString const& u_entry, DeprecatedString const& ue_entry, DeprecatedString const& perms, u32 flags, bool encrypt_metadata, size_t length, CryptFilterMethod method);
 
     ~StandardSecurityHandler() override = default;
 
@@ -74,7 +74,10 @@ private:
     size_t m_revision;
     Optional<ByteBuffer> m_encryption_key;
     DeprecatedString m_o_entry;
+    DeprecatedString m_oe_entry;
     DeprecatedString m_u_entry;
+    DeprecatedString m_ue_entry;
+    DeprecatedString m_perms_entry;
     u32 m_flags;
     bool m_encrypt_metadata;
     size_t m_length;


### PR DESCRIPTION
Demo:

```sh
% Build/lagom/bin/pdf /Users/thakis/Downloads/CIPA_DC-007-2021_E.pdf
PDF Version: 1.7
Number of pages: 63
Title: CIPA DC-007-Translation-2021 Multi-Picture Format.
Author: CIPA
Subject: 
Keywords: 
Creator: Word 用 Acrobat PDFMaker 17
Producer: Adobe PDF Library 17.11.238
Creation date: D:20211224140020+09'00'
Modification date: D:20211224140459+09'00'
```

"LibPDF: Implement 7.6.4.3.3 Algorithm 2.A: Retrieve file encryption key" is the most interesting commit. The commit message is fairly detailed. The rest is fairly straightforward. (That commit is also fairly straightforward, but a bit longer.)