### PR TITLE
Services+Userland: Add a sweet blur effect to Terminal :^)

### DIFF
--- a/Base/home/anon/.config/Terminal.ini
+++ b/Base/home/anon/.config/Terminal.ini
@@ -5,6 +5,7 @@ ShowScrollBar=true
 MaxHistorySize=1024
 [Window]
 Opacity=255
+AlphaBlurRadius=0
 Bell=Visible
 ColorScheme=Default
 [Cursor]

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -94,6 +94,8 @@ public:
             m_parent_terminal.set_max_history_size(value);
         } else if (group == "Window" && key == "Opacity") {
             m_parent_terminal.set_opacity(value);
+        } else if (group == "Window" && key == "AlphaBlurRadius") {
+            m_parent_terminal.set_alpha_blur_radius(value);
         }
     }
 
@@ -320,6 +322,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto new_opacity = Config::read_i32("Terminal"sv, "Window"sv, "Opacity"sv, 255);
     terminal->set_opacity(new_opacity);
     window->set_has_alpha_channel(new_opacity < 255);
+
+    auto new_alpha_blur_opacity = Config::read_i32("Terminal"sv, "Window"sv, "AlphaBlurRadius"sv, 0);
+    window->set_alpha_blur_radius(new_alpha_blur_opacity);
 
     auto new_scrollback_size = Config::read_i32("Terminal"sv, "Terminal"sv, "MaxHistorySize"sv, terminal->max_history_size());
     terminal->set_max_history_size(new_scrollback_size);

--- a/Userland/Applications/TerminalSettings/TerminalSettingsView.gml
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsView.gml
@@ -41,18 +41,43 @@
     }
 
     @GUI::GroupBox {
-        title: "Background opacity"
+        title: "Background properties"
         preferred_height: "fit"
         layout: @GUI::VerticalBoxLayout {
             margins: [8]
             spacing: 8
         }
 
-        @GUI::HorizontalOpacitySlider {
-            name: "background_opacity_slider"
-            min: 0
-            max: 255
-            orientation: "Horizontal"
+        @GUI::GroupBox {
+            title: "Opacity"
+            preferred_height: "fit"
+            layout: @GUI::VerticalBoxLayout {
+                margins: [8]
+                spacing: 8
+            }
+
+            @GUI::HorizontalOpacitySlider {
+                name: "background_opacity_slider"
+                min: 0
+                max: 255
+                orientation: "Horizontal"
+            }
+        }
+
+        @GUI::GroupBox {
+            title: "Blur"
+            preferred_height: "fit"
+            layout: @GUI::VerticalBoxLayout {
+                margins: [8]
+                spacing: 8
+            }
+
+            @GUI::HorizontalOpacitySlider {
+                name: "background_blur_slider"
+                min: 0
+                max: 8
+                orientation: "Horizontal"
+            }
         }
     }
 

--- a/Userland/Applications/TerminalSettings/TerminalSettingsWidget.cpp
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsWidget.cpp
@@ -22,6 +22,7 @@
 #include <LibGUI/OpacitySlider.h>
 #include <LibGUI/RadioButton.h>
 #include <LibGUI/SpinBox.h>
+#include <LibGUI/ValueSlider.h>
 #include <LibGUI/Widget.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
@@ -105,6 +106,16 @@ ErrorOr<void> TerminalSettingsViewWidget::setup()
     slider.on_change = [this](int value) {
         m_opacity = value;
         Config::write_i32("Terminal"sv, "Window"sv, "Opacity"sv, static_cast<i32>(m_opacity));
+        set_modified(true);
+    };
+
+    auto& blur_slider = *find_descendant_of_type_named<GUI::HorizontalOpacitySlider>("background_blur_slider");
+    m_blur_radius = Config::read_i32("Terminal"sv, "Window"sv, "AlphaBlurRadius"sv);
+    m_original_blur_radius = m_blur_radius;
+    blur_slider.set_value(m_blur_radius);
+    blur_slider.on_change = [this](int value) {
+        m_blur_radius = value;
+        Config::write_i32("Terminal"sv, "Window"sv, "AlphaBlurRadius"sv, static_cast<i32>(m_blur_radius));
         set_modified(true);
     };
 
@@ -267,6 +278,7 @@ void TerminalSettingsMainWidget::cancel_settings()
 void TerminalSettingsViewWidget::apply_settings()
 {
     m_original_opacity = m_opacity;
+    m_original_blur_radius = m_blur_radius;
     m_original_font = m_font;
     m_original_cursor_shape = m_cursor_shape;
     m_original_cursor_is_blinking_set = m_cursor_is_blinking_set;
@@ -278,6 +290,7 @@ void TerminalSettingsViewWidget::apply_settings()
 void TerminalSettingsViewWidget::write_back_settings() const
 {
     Config::write_i32("Terminal"sv, "Window"sv, "Opacity"sv, static_cast<i32>(m_original_opacity));
+    Config::write_i32("Terminal"sv, "Window"sv, "AlphaBlurRadius"sv, static_cast<i32>(m_original_blur_radius));
     Config::write_string("Terminal"sv, "Text"sv, "Font"sv, m_original_font->qualified_name());
     Config::write_string("Terminal"sv, "Cursor"sv, "Shape"sv, VT::TerminalWidget::stringify_cursor_shape(m_original_cursor_shape));
     Config::write_bool("Terminal"sv, "Cursor"sv, "Blinking"sv, m_original_cursor_is_blinking_set);

--- a/Userland/Applications/TerminalSettings/TerminalSettingsWidget.h
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsWidget.h
@@ -51,6 +51,7 @@ private:
 
     RefPtr<Gfx::Font const> m_font;
     float m_opacity;
+    u8 m_blur_radius;
     DeprecatedString m_color_scheme;
     VT::CursorShape m_cursor_shape { VT::CursorShape::Block };
     bool m_cursor_is_blinking_set { true };
@@ -59,6 +60,7 @@ private:
 
     RefPtr<Gfx::Font const> m_original_font;
     float m_original_opacity;
+    u8 m_original_blur_radius;
     DeprecatedString m_original_color_scheme;
     VT::CursorShape m_original_cursor_shape;
     bool m_original_cursor_is_blinking_set;

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -160,6 +160,7 @@ void Window::show()
         m_frameless,
         m_forced_shadow,
         m_alpha_hit_threshold,
+        m_alpha_blur_radius,
         m_base_size,
         m_size_increment,
         m_minimum_size_when_windowless,
@@ -870,6 +871,18 @@ void Window::set_automatic_cursor_tracking_widget(Widget* widget)
     if (widget == m_automatic_cursor_tracking_widget)
         return;
     m_automatic_cursor_tracking_widget = widget;
+}
+
+void Window::set_alpha_blur_radius(u8 value)
+{
+    if (m_alpha_blur_radius == value)
+        return;
+    m_alpha_blur_radius = value;
+    if (!is_visible())
+        return;
+
+    ConnectionToWindowServer::the().async_set_window_alpha_blur_radius(m_window_id, value);
+    update();
 }
 
 void Window::set_has_alpha_channel(bool value)

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -73,8 +73,12 @@ public:
     void set_closeable(bool closeable) { m_closeable = closeable; }
 
     void set_double_buffering_enabled(bool);
+
     void set_has_alpha_channel(bool);
     bool has_alpha_channel() const { return m_has_alpha_channel; }
+
+    void set_alpha_blur_radius(u8); // A radius of 0 disables blur compositing entirely.
+    u8 alpha_blur_radius() const { return m_alpha_blur_radius; }
 
     void set_alpha_hit_threshold(float);
     float alpha_hit_threshold() const { return m_alpha_hit_threshold; }
@@ -289,6 +293,7 @@ private:
 
     RefPtr<Gfx::Bitmap const> m_icon;
     int m_window_id { 0 };
+    u8 m_alpha_blur_radius { 0 };
     float m_alpha_hit_threshold { 0.0f };
     RefPtr<Widget> m_main_widget;
     WeakPtr<Widget> m_default_return_key_widget;

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -555,6 +555,16 @@ void TerminalWidget::set_opacity(u8 new_opacity)
     update();
 }
 
+void TerminalWidget::set_alpha_blur_radius(u8 new_alpha_blur_radius)
+{
+    if (m_alpha_blur_radius == new_alpha_blur_radius)
+        return;
+
+    window()->set_alpha_blur_radius(new_alpha_blur_radius);
+    m_alpha_blur_radius = new_alpha_blur_radius;
+    update();
+}
+
 void TerminalWidget::set_show_scrollbar(bool show_scrollbar)
 {
     m_scrollbar->set_visible(show_scrollbar);

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -44,6 +44,9 @@ public:
     void set_opacity(u8);
     float opacity() { return m_opacity; }
 
+    void set_alpha_blur_radius(u8);
+    u8 alpha_blur_radius() const { return m_alpha_blur_radius; }
+
     void set_show_scrollbar(bool);
 
     enum class BellMode {
@@ -204,6 +207,7 @@ private:
     RefPtr<Core::Notifier> m_notifier;
 
     u8 m_opacity { 255 };
+    u8 m_alpha_blur_radius { 0 };
     bool m_cursor_blink_state { true };
     bool m_automatic_size_policy { false };
 

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -604,7 +604,7 @@ Window* ConnectionFromClient::window_from_id(i32 window_id)
 void ConnectionFromClient::create_window(i32 window_id, Gfx::IntRect const& rect,
     bool auto_position, bool has_alpha_channel, bool minimizable, bool closeable, bool resizable,
     bool fullscreen, bool frameless, bool forced_shadow,
-    float alpha_hit_threshold, Gfx::IntSize base_size, Gfx::IntSize size_increment,
+    float alpha_hit_threshold, u8 alpha_blur_radius, Gfx::IntSize base_size, Gfx::IntSize size_increment,
     Gfx::IntSize minimum_size, Optional<Gfx::IntSize> const& resize_aspect_ratio, i32 type, i32 mode,
     DeprecatedString const& title, i32 parent_window_id, Gfx::IntRect const& launch_origin_rect)
 {
@@ -666,6 +666,7 @@ void ConnectionFromClient::create_window(i32 window_id, Gfx::IntRect const& rect
         window->recalculate_rect();
     }
     window->set_alpha_hit_threshold(alpha_hit_threshold);
+    window->set_alpha_blur_radius(alpha_blur_radius);
     window->set_size_increment(size_increment);
     window->set_base_size(base_size);
     if (resize_aspect_ratio.has_value() && !resize_aspect_ratio.value().is_empty())
@@ -829,6 +830,16 @@ void ConnectionFromClient::set_window_has_alpha_channel(i32 window_id, bool has_
         return;
     }
     it->value->set_has_alpha_channel(has_alpha_channel);
+}
+
+void ConnectionFromClient::set_window_alpha_blur_radius(i32 window_id, u8 radius)
+{
+    auto it = m_windows.find(window_id);
+    if (it == m_windows.end()) {
+        did_misbehave("SetWindowAlphaBlurRadius: Bad window ID");
+        return;
+    }
+    it->value->set_alpha_blur_radius(radius);
 }
 
 void ConnectionFromClient::set_window_alpha_hit_threshold(i32 window_id, float threshold)

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -103,7 +103,7 @@ private:
     virtual void remove_menu_item(i32 menu_id, i32 identifier) override;
     virtual void flash_menubar_menu(i32, i32) override;
     virtual void create_window(i32, Gfx::IntRect const&, bool, bool, bool,
-        bool, bool, bool, bool, bool, float, Gfx::IntSize, Gfx::IntSize, Gfx::IntSize,
+        bool, bool, bool, bool, bool, float, u8, Gfx::IntSize, Gfx::IntSize, Gfx::IntSize,
         Optional<Gfx::IntSize> const&, i32, i32, DeprecatedString const&, i32, Gfx::IntRect const&) override;
     virtual Messages::WindowServer::DestroyWindowResponse destroy_window(i32) override;
     virtual void set_window_title(i32, DeprecatedString const&) override;
@@ -123,6 +123,7 @@ private:
     virtual void set_global_mouse_tracking(bool) override;
     virtual void set_window_backing_store(i32, i32, i32, IPC::File const&, i32, bool, Gfx::IntSize, Gfx::IntSize, bool) override;
     virtual void set_window_has_alpha_channel(i32, bool) override;
+    virtual void set_window_alpha_blur_radius(i32, u8) override;
     virtual void set_window_alpha_hit_threshold(i32, float) override;
     virtual void move_window_to_front(i32) override;
     virtual void set_fullscreen(i32, bool) override;

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -1079,6 +1079,15 @@ void Window::set_modified(bool modified)
     frame().invalidate_titlebar();
 }
 
+void Window::set_alpha_blur_radius(u8 value)
+{
+    if (m_alpha_blur_radius == value)
+        return;
+    m_alpha_blur_radius = value;
+    Compositor::the().invalidate_occlusions();
+    invalidate(false);
+}
+
 DeprecatedString Window::computed_title() const
 {
     DeprecatedString title = m_title.replace("[*]"sv, is_modified() ? " (*)"sv : ""sv, ReplaceMode::FirstOnly);

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -234,6 +234,12 @@ public:
     Gfx::Bitmap const* backing_store() const { return m_backing_store.ptr(); }
     Gfx::Bitmap* backing_store() { return m_backing_store.ptr(); }
 
+    // FIXME: This probably needs double buffering too
+    void update_blur_background_cache(RefPtr<Gfx::Bitmap> background_bitmap)
+    {
+        m_blur_background_cache = move(background_bitmap);
+    }
+
     void set_backing_store(RefPtr<Gfx::Bitmap> backing_store, i32 serial)
     {
         m_last_backing_store = move(m_backing_store);
@@ -436,6 +442,7 @@ private:
     bool m_occluded { false };
     RefPtr<Gfx::Bitmap> m_backing_store;
     RefPtr<Gfx::Bitmap> m_last_backing_store;
+    RefPtr<Gfx::Bitmap> m_blur_background_cache;
     Gfx::IntSize m_backing_store_visible_size {};
     i32 m_backing_store_serial { -1 };
     i32 m_last_backing_store_serial { -1 };

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -157,6 +157,10 @@ public:
     {
         m_hit_testing_enabled = value;
     }
+
+    u8 alpha_blur_radius() const { return m_alpha_blur_radius; }
+    void set_alpha_blur_radius(u8);
+
     float alpha_hit_threshold() const { return m_alpha_hit_threshold; }
     void set_alpha_hit_threshold(float threshold)
     {
@@ -437,6 +441,7 @@ private:
     i32 m_last_backing_store_serial { -1 };
     int m_window_id { -1 };
     i32 m_client_id { -1 };
+    u8 m_alpha_blur_radius { 0 };
     float m_alpha_hit_threshold { 0.0f };
     Gfx::IntSize m_size_increment;
     Gfx::IntSize m_base_size;

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -54,6 +54,7 @@ endpoint WindowServer
         bool frameless,
         bool forced_shadow,
         float alpha_hit_threshold,
+        u8 alpha_blur_radius,
         Gfx::IntSize base_size,
         Gfx::IntSize size_increment,
         Gfx::IntSize minimum_size,
@@ -96,6 +97,7 @@ endpoint WindowServer
     set_global_mouse_tracking(bool enabled) =|
 
     set_window_alpha_hit_threshold(i32 window_id, float threshold) =|
+    set_window_alpha_blur_radius(i32 window_id, u8 radius) =|
 
     set_window_backing_store(i32 window_id, i32 bpp, i32 pitch, IPC::File anon_file, i32 serial, bool has_alpha_channel, Gfx::IntSize size, Gfx::IntSize visible_size, bool flush_immediately) => ()
 


### PR DESCRIPTION
Demo:

https://github.com/SerenityOS/serenity/assets/20117975/a9597623-3856-4a02-9241-a8cba21b4a7b

`WindowServer` now exposes `set_window_alpha_blur_radius(i32, u8)`, which `LibGUI` uses to enable programs to specify a desired window-global blur setting for any transparent regions.
More granular control of this compositing effect could be investigated, but I felt that was outside the scope of this PR.

There are some caveats to consider before merging these changes:

- The performance penalty of using `Gfx::StackBlur` directly in the compositor without any GPU acceleration is significant. It's less noticeable with SMP and multiple CPUs, but I think for the time being, this should be off by default, as sad as that is.
- There is some artifacting remaining. I suspect `Gfx::StackBlur` isn't intended for use-cases where we do partial updates, like we're doing here in `WindowServer::Compositor`. I currently have no working solution to resolve this.