### PR TITLE
LibWeb: Use Core::Timer for style and layout update timers in Document

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -11,6 +11,7 @@
 #include <AK/Debug.h>
 #include <AK/StringBuilder.h>
 #include <AK/Utf8View.h>
+#include <LibCore/Timer.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/FunctionObject.h>
@@ -84,7 +85,6 @@
 #include <LibWeb/Namespace.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/PermissionsPolicy/AutoplayAllowlist.h>
-#include <LibWeb/Platform/Timer.h>
 #include <LibWeb/SVG/SVGElement.h>
 #include <LibWeb/SVG/SVGTitleElement.h>
 #include <LibWeb/SVG/TagNames.h>
@@ -319,13 +319,13 @@ Document::Document(JS::Realm& realm, const AK::URL& url)
 {
     HTML::main_thread_event_loop().register_document({}, *this);
 
-    m_style_update_timer = Platform::Timer::create_single_shot(0, [this] {
+    m_style_update_timer = Core::Timer::create_single_shot(0, [this] {
         update_style();
-    });
+    }).release_value_but_fixme_should_propagate_errors();
 
-    m_layout_update_timer = Platform::Timer::create_single_shot(0, [this] {
+    m_layout_update_timer = Core::Timer::create_single_shot(0, [this] {
         update_layout();
-    });
+    }).release_value_but_fixme_should_propagate_errors();
 }
 
 Document::~Document()

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -531,8 +531,8 @@ private:
     Optional<Color> m_active_link_color;
     Optional<Color> m_visited_link_color;
 
-    RefPtr<Platform::Timer> m_style_update_timer;
-    RefPtr<Platform::Timer> m_layout_update_timer;
+    RefPtr<Core::Timer> m_style_update_timer;
+    RefPtr<Core::Timer> m_layout_update_timer;
 
     JS::GCPtr<HTML::HTMLParser> m_parser;
     bool m_active_parser_was_aborted { false };


### PR DESCRIPTION
Fixes leaking of DOM::Document by capturing it into JS::SafeFunction callback when using Platform::Timer for style and layout update timers.