### PR TITLE
LibJS: Replace for_each_bound_name with for_each_bound_identifier

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -4367,16 +4367,6 @@ ThrowCompletionOr<void> ScopeNode::for_each_lexically_scoped_declaration(ThrowCo
     return {};
 }
 
-ThrowCompletionOr<void> ScopeNode::for_each_lexically_declared_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const
-{
-    for (auto const& declaration : m_lexical_declarations) {
-        TRY(declaration->for_each_bound_identifier([&](auto const& identifier) {
-            return callback(identifier.string());
-        }));
-    }
-    return {};
-}
-
 ThrowCompletionOr<void> ScopeNode::for_each_lexically_declared_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&& callback) const
 {
     for (auto const& declaration : m_lexical_declarations) {

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -4377,16 +4377,6 @@ ThrowCompletionOr<void> ScopeNode::for_each_lexically_declared_identifier(ThrowC
     return {};
 }
 
-ThrowCompletionOr<void> ScopeNode::for_each_var_declared_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const
-{
-    for (auto& declaration : m_var_declarations) {
-        TRY(declaration->for_each_bound_identifier([&](auto const& identifier) {
-            return callback(identifier.string());
-        }));
-    }
-    return {};
-}
-
 ThrowCompletionOr<void> ScopeNode::for_each_var_declared_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&& callback) const
 {
     for (auto& declaration : m_var_declarations) {
@@ -4690,10 +4680,10 @@ ThrowCompletionOr<void> Program::global_declaration_instantiation(VM& vm, Global
     }));
 
     // 4. For each element name of varNames, do
-    TRY(for_each_var_declared_name([&](auto const& name) -> ThrowCompletionOr<void> {
+    TRY(for_each_var_declared_identifier([&](auto const& identifier) -> ThrowCompletionOr<void> {
         // a. If env.HasLexicalDeclaration(name) is true, throw a SyntaxError exception.
-        if (global_environment.has_lexical_declaration(name))
-            return vm.throw_completion<SyntaxError>(ErrorType::TopLevelVariableAlreadyDeclared, name);
+        if (global_environment.has_lexical_declaration(identifier.string()))
+            return vm.throw_completion<SyntaxError>(ErrorType::TopLevelVariableAlreadyDeclared, identifier.string());
 
         return {};
     }));

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -307,7 +307,6 @@ public:
     [[nodiscard]] size_t lexical_declaration_count() const { return m_lexical_declarations.size(); }
 
     ThrowCompletionOr<void> for_each_lexically_scoped_declaration(ThrowCompletionOrVoidCallback<Declaration const&>&& callback) const;
-    ThrowCompletionOr<void> for_each_lexically_declared_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const;
     ThrowCompletionOr<void> for_each_lexically_declared_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&& callback) const;
 
     ThrowCompletionOr<void> for_each_var_declared_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const;

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -309,7 +309,6 @@ public:
     ThrowCompletionOr<void> for_each_lexically_scoped_declaration(ThrowCompletionOrVoidCallback<Declaration const&>&& callback) const;
     ThrowCompletionOr<void> for_each_lexically_declared_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&& callback) const;
 
-    ThrowCompletionOr<void> for_each_var_declared_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const;
     ThrowCompletionOr<void> for_each_var_declared_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&& callback) const;
 
     ThrowCompletionOr<void> for_each_var_function_declaration_in_reverse_order(ThrowCompletionOrVoidCallback<FunctionDeclaration const&>&& callback) const;

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -609,7 +609,6 @@ public:
     {
     }
 
-    virtual ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const = 0;
     virtual ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&& callback) const = 0;
 
     // 8.1.3 Static Semantics: IsConstantDeclaration, https://tc39.es/ecma262/#sec-static-semantics-isconstantdeclaration
@@ -625,11 +624,6 @@ public:
     {
     }
     Completion execute(Interpreter&) const override { return {}; }
-
-    ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&&) const override
-    {
-        VERIFY_NOT_REACHED();
-    }
 
     ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&&) const override
     {
@@ -656,7 +650,6 @@ struct BindingPattern : RefCounted<BindingPattern> {
 
     void dump(int indent) const;
 
-    ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const;
     ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&& callback) const;
 
     bool contains_expression() const;
@@ -773,8 +766,6 @@ public:
     virtual Completion execute(Interpreter&) const override;
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
-
-    virtual ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const override;
 
     ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&&) const override;
 
@@ -1496,8 +1487,6 @@ public:
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
-    virtual ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const override;
-
     ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&&) const override;
 
     virtual bool is_lexical_declaration() const override { return true; }
@@ -1804,8 +1793,6 @@ public:
 
     Vector<NonnullRefPtr<VariableDeclarator const>> const& declarations() const { return m_declarations; }
 
-    virtual ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const override;
-
     ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&&) const override;
 
     virtual bool is_constant_declaration() const override { return m_declaration_kind == DeclarationKind::Const; }
@@ -1829,8 +1816,6 @@ public:
 
     virtual Completion execute(Interpreter&) const override;
     virtual void dump(int indent) const override;
-
-    virtual ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<DeprecatedFlyString const&>&& callback) const override;
 
     ThrowCompletionOr<void> for_each_bound_identifier(ThrowCompletionOrVoidCallback<Identifier const&>&&) const override;
 

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -769,8 +769,8 @@ void Parser::parse_module(Program& program)
             if (found)
                 continue;
             // NOTE: Nothing in the callback throws an exception.
-            MUST(program.for_each_var_declared_name([&](auto const& name) {
-                if (name == exported_name)
+            MUST(program.for_each_var_declared_identifier([&](auto const& identifier) {
+                if (identifier.string() == exported_name)
                     found = true;
             }));
             for (auto& import : program.imports()) {

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -762,8 +762,8 @@ void Parser::parse_module(Program& program)
             auto const& exported_name = entry.local_or_import_name;
             bool found = false;
             // NOTE: Nothing in the callback throws an exception.
-            MUST(program.for_each_lexically_declared_name([&](auto const& name) {
-                if (name == exported_name)
+            MUST(program.for_each_lexically_declared_identifier([&](auto const& identifier) {
+                if (identifier.string() == exported_name)
                     found = true;
             }));
             if (found)
@@ -3706,9 +3706,9 @@ NonnullRefPtr<CatchClause const> Parser::parse_catch_clause()
     auto body = parse_block_statement();
 
     // NOTE: Nothing in the callback throws an exception.
-    MUST(body->for_each_lexically_declared_name([&](auto const& name) {
-        if (bound_names.contains(name))
-            syntax_error(DeprecatedString::formatted("Identifier '{}' already declared as catch parameter", name));
+    MUST(body->for_each_lexically_declared_identifier([&](auto const& identifier) {
+        if (bound_names.contains(identifier.string()))
+            syntax_error(DeprecatedString::formatted("Identifier '{}' already declared as catch parameter", identifier.string()));
     }));
 
     if (pattern_parameter) {

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -743,10 +743,10 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, Program const& pr
         // a. If varEnv is a global Environment Record, then
         if (global_var_environment) {
             // i. For each element name of varNames, do
-            TRY(program.for_each_var_declared_name([&](auto const& name) -> ThrowCompletionOr<void> {
+            TRY(program.for_each_var_declared_identifier([&](auto const& identifier) -> ThrowCompletionOr<void> {
                 // 1. If varEnv.HasLexicalDeclaration(name) is true, throw a SyntaxError exception.
-                if (global_var_environment->has_lexical_declaration(name))
-                    return vm.throw_completion<SyntaxError>(ErrorType::TopLevelVariableAlreadyDeclared, name);
+                if (global_var_environment->has_lexical_declaration(identifier.string()))
+                    return vm.throw_completion<SyntaxError>(ErrorType::TopLevelVariableAlreadyDeclared, identifier.string());
 
                 // 2. NOTE: eval will not create a global var declaration that would be shadowed by a global lexical declaration.
                 return {};
@@ -763,7 +763,8 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, Program const& pr
             if (!is<ObjectEnvironment>(*this_environment)) {
                 // 1. NOTE: The environment of with statements cannot contain any lexical declaration so it doesn't need to be checked for var/let hoisting conflicts.
                 // 2. For each element name of varNames, do
-                TRY(program.for_each_var_declared_name([&](auto const& name) -> ThrowCompletionOr<void> {
+                TRY(program.for_each_var_declared_identifier([&](auto const& identifier) -> ThrowCompletionOr<void> {
+                    auto const& name = identifier.string();
                     // a. If ! thisEnv.HasBinding(name) is true, then
                     if (MUST(this_environment->has_binding(name))) {
                         // i. Throw a SyntaxError exception.

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -936,7 +936,9 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, Program const& pr
         // Note: This is handled by for_each_var_scoped_variable_declaration.
 
         // i. For each String vn of the BoundNames of d, do
-        return declaration.for_each_bound_name([&](auto const& name) -> ThrowCompletionOr<void> {
+        return declaration.for_each_bound_identifier([&](auto const& identifier) -> ThrowCompletionOr<void> {
+            auto const& name = identifier.string();
+
             // 1. If vn is not an element of declaredFunctionNames, then
             if (!declared_function_names.contains(name)) {
                 // a. If varEnv is a global Environment Record, then
@@ -965,7 +967,9 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, Program const& pr
         // a. NOTE: Lexically declared names are only instantiated here but not initialized.
 
         // b. For each element dn of the BoundNames of d, do
-        return declaration.for_each_bound_name([&](auto const& name) -> ThrowCompletionOr<void> {
+        return declaration.for_each_bound_identifier([&](auto const& identifier) -> ThrowCompletionOr<void> {
+            auto const& name = identifier.string();
+
             // i. If IsConstantDeclaration of d is true, then
             if (declaration.is_constant_declaration()) {
                 // 1. Perform ? lexEnv.CreateImmutableBinding(dn, true).

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -396,8 +396,8 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
 
         if (!has_parameter_expressions && arguments_object_needed) {
             // NOTE: Nothing in the callback throws an exception.
-            MUST(scope_body->for_each_lexically_declared_name([&](auto const& name) {
-                if (name == arguments_name)
+            MUST(scope_body->for_each_lexically_declared_identifier([&](auto const& identifier) {
+                if (identifier.string() == arguments_name)
                     arguments_object_needed = false;
             }));
         }

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -464,8 +464,9 @@ ThrowCompletionOr<void> SourceTextModule::initialize_environment(VM& vm)
     MUST(m_ecmascript_code->for_each_lexically_scoped_declaration([&](Declaration const& declaration) {
         // a. For each element dn of the BoundNames of d, do
         // NOTE: Due to the use of MUST with `create_immutable_binding`, `create_mutable_binding` and `initialize_binding` below,
-        //       an exception should not result from `for_each_bound_name`.
-        MUST(declaration.for_each_bound_name([&](DeprecatedFlyString const& name) {
+        //       an exception should not result from `for_each_bound_identifier`.
+        MUST(declaration.for_each_bound_identifier([&](auto const& identifier) {
+            auto const& name = identifier.string();
             // i. If IsConstantDeclaration of d is true, then
             if (declaration.is_constant_declaration()) {
                 // 1. Perform ! env.CreateImmutableBinding(dn, true).

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -438,8 +438,9 @@ ThrowCompletionOr<void> SourceTextModule::initialize_environment(VM& vm)
     // 21. For each element d of varDeclarations, do
     // a. For each element dn of the BoundNames of d, do
     // NOTE: Due to the use of MUST with `create_mutable_binding` and `initialize_binding` below,
-    //       an exception should not result from `for_each_var_declared_name`.
-    MUST(m_ecmascript_code->for_each_var_declared_name([&](auto const& name) {
+    //       an exception should not result from `for_each_var_declared_identifier`.
+    MUST(m_ecmascript_code->for_each_var_declared_identifier([&](auto const& identifier) {
+        auto const& name = identifier.string();
         // i. If dn is not an element of declaredVarNames, then
         if (!declared_var_names.contains_slow(name)) {
             // 1. Perform ! env.CreateMutableBinding(dn, false).


### PR DESCRIPTION
Deletes following functions in Declaration class because those mostly clone similar iteration functions but for identifiers.
- for_each_name
- for_each_lexically_declared_name
- for_each_var_declared_name