### PR TITLE
LibGfx: Allow image decoder client to request what they want

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzBMPLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzBMPLoader.cpp
@@ -9,7 +9,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto decoder_or_error = Gfx::BMPImageDecoderPlugin::create({ data, size });
+    auto decoder_or_error = Gfx::BMPImageDecoderPlugin::create({ data, size }, Gfx::ImageDecoder::RequestType::Everything);
     if (decoder_or_error.is_error())
         return 0;
     auto decoder = decoder_or_error.release_value();

--- a/Meta/Lagom/Fuzzers/FuzzDDSLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzDDSLoader.cpp
@@ -8,7 +8,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto decoder_or_error = Gfx::DDSImageDecoderPlugin::create({ data, size });
+    auto decoder_or_error = Gfx::DDSImageDecoderPlugin::create({ data, size }, Gfx::ImageDecoderPlugin::RequestType::Everything);
     if (decoder_or_error.is_error())
         return 0;
     auto decoder = decoder_or_error.release_value();

--- a/Meta/Lagom/Fuzzers/FuzzGIFLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGIFLoader.cpp
@@ -12,7 +12,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto decoder_or_error = Gfx::GIFImageDecoderPlugin::create({ data, size });
+    auto decoder_or_error = Gfx::GIFImageDecoderPlugin::create({ data, size }, Gfx::ImageDecoder::RequestType::Everything);
     if (decoder_or_error.is_error())
         return 0;
     auto decoder = decoder_or_error.release_value();

--- a/Meta/Lagom/Fuzzers/FuzzICOLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzICOLoader.cpp
@@ -10,7 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto decoder_or_error = Gfx::ICOImageDecoderPlugin::create({ data, size });
+    auto decoder_or_error = Gfx::ICOImageDecoderPlugin::create({ data, size }, Gfx::ImageDecoder::RequestType::Everything);
     if (decoder_or_error.is_error())
         return 0;
     auto decoder = decoder_or_error.release_value();

--- a/Meta/Lagom/Fuzzers/FuzzJPEGLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzJPEGLoader.cpp
@@ -10,7 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto decoder_or_error = Gfx::JPEGImageDecoderPlugin::create({ data, size });
+    auto decoder_or_error = Gfx::JPEGImageDecoderPlugin::create({ data, size }, Gfx::ImageDecoder::RequestType::Everything);
     if (decoder_or_error.is_error())
         return 0;
     auto decoder = decoder_or_error.release_value();

--- a/Meta/Lagom/Fuzzers/FuzzPBMLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPBMLoader.cpp
@@ -10,7 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto decoder_or_error = Gfx::PBMImageDecoderPlugin::create({ data, size });
+    auto decoder_or_error = Gfx::PBMImageDecoderPlugin::create({ data, size }, Gfx::ImageDecoder::RequestType::Everything);
     if (decoder_or_error.is_error())
         return 0;
     auto decoder = decoder_or_error.release_value();

--- a/Meta/Lagom/Fuzzers/FuzzPGMLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPGMLoader.cpp
@@ -10,7 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto decoder_or_error = Gfx::PGMImageDecoderPlugin::create({ data, size });
+    auto decoder_or_error = Gfx::PGMImageDecoderPlugin::create({ data, size }, Gfx::ImageDecoder::RequestType::Everything);
     if (decoder_or_error.is_error())
         return 0;
     auto decoder = decoder_or_error.release_value();

--- a/Meta/Lagom/Fuzzers/FuzzPNGLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPNGLoader.cpp
@@ -10,7 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto decoder_or_error = Gfx::PNGImageDecoderPlugin::create({ data, size });
+    auto decoder_or_error = Gfx::PNGImageDecoderPlugin::create({ data, size }, Gfx::ImageDecoder::RequestType::Everything);
     if (decoder_or_error.is_error())
         return 0;
     auto decoder = decoder_or_error.release_value();

--- a/Meta/Lagom/Fuzzers/FuzzPPMLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPPMLoader.cpp
@@ -10,7 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto decoder_or_error = Gfx::PPMImageDecoderPlugin::create({ data, size });
+    auto decoder_or_error = Gfx::PPMImageDecoderPlugin::create({ data, size }, Gfx::ImageDecoder::RequestType::Everything);
     if (decoder_or_error.is_error())
         return 0;
     auto decoder = decoder_or_error.release_value();

--- a/Meta/Lagom/Fuzzers/FuzzQOILoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzQOILoader.cpp
@@ -10,7 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto decoder_or_error = Gfx::QOIImageDecoderPlugin::create({ data, size });
+    auto decoder_or_error = Gfx::QOIImageDecoderPlugin::create({ data, size }, Gfx::ImageDecoder::RequestType::Everything);
     if (decoder_or_error.is_error())
         return 0;
     auto decoder = decoder_or_error.release_value();

--- a/Meta/Lagom/Fuzzers/FuzzTGALoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTGALoader.cpp
@@ -10,7 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto decoder_or_error = Gfx::TGAImageDecoderPlugin::create({ data, size });
+    auto decoder_or_error = Gfx::TGAImageDecoderPlugin::create({ data, size }, Gfx::ImageDecoder::RequestType::Everything);
     if (decoder_or_error.is_error())
         return 0;
     auto decoder = decoder_or_error.release_value();

--- a/Meta/Lagom/Fuzzers/FuzzTinyVGLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTinyVGLoader.cpp
@@ -8,7 +8,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto decoder_or_error = Gfx::TinyVGImageDecoderPlugin::create({ data, size });
+    auto decoder_or_error = Gfx::TinyVGImageDecoderPlugin::create({ data, size }, Gfx::ImageDecoderPlugin::RequestType::Everything);
     if (decoder_or_error.is_error())
         return 0;
     auto decoder = decoder_or_error.release_value();

--- a/Meta/Lagom/Fuzzers/FuzzWebPLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWebPLoader.cpp
@@ -10,7 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
-    auto decoder_or_error = Gfx::WebPImageDecoderPlugin::create({ data, size });
+    auto decoder_or_error = Gfx::WebPImageDecoderPlugin::create({ data, size }, Gfx::ImageDecoder::RequestType::Everything);
     if (decoder_or_error.is_error())
         return 0;
     auto decoder = decoder_or_error.release_value();

--- a/Tests/LibGfx/BenchmarkJPEGLoader.cpp
+++ b/Tests/LibGfx/BenchmarkJPEGLoader.cpp
@@ -25,24 +25,24 @@ auto several_scans = Core::File::open(TEST_INPUT("jpg/several_scans.jpg"sv), Cor
 
 BENCHMARK_CASE(small_image)
 {
-    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(small_image));
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(small_image, Gfx::ImageDecoder::RequestType::Image));
     MUST(plugin_decoder->frame(0));
 }
 
 BENCHMARK_CASE(big_image)
 {
-    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(big_image));
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(big_image, Gfx::ImageDecoder::RequestType::Image));
     MUST(plugin_decoder->frame(0));
 }
 
 BENCHMARK_CASE(rgb_image)
 {
-    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(rgb_image));
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(rgb_image, Gfx::ImageDecoder::RequestType::Image));
     MUST(plugin_decoder->frame(0));
 }
 
 BENCHMARK_CASE(several_scans)
 {
-    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(several_scans));
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(several_scans, Gfx::ImageDecoder::RequestType::Image));
     MUST(plugin_decoder->frame(0));
 }

--- a/Tests/LibGfx/TestICCProfile.cpp
+++ b/Tests/LibGfx/TestICCProfile.cpp
@@ -24,7 +24,7 @@
 TEST_CASE(png)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("icc/icc-v2.png"sv)));
-    auto png = MUST(Gfx::PNGImageDecoderPlugin::create(file->bytes()));
+    auto png = MUST(Gfx::PNGImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
     auto icc_bytes = MUST(png->icc_data());
     EXPECT(icc_bytes.has_value());
 
@@ -35,7 +35,7 @@ TEST_CASE(png)
 TEST_CASE(jpg)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("icc/icc-v4.jpg"sv)));
-    auto jpg = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes()));
+    auto jpg = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
     auto icc_bytes = MUST(jpg->icc_data());
     EXPECT(icc_bytes.has_value());
 
@@ -57,7 +57,7 @@ TEST_CASE(jpg)
 TEST_CASE(webp_extended_lossless)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("icc/extended-lossless.webp"sv)));
-    auto webp = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto webp = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
     auto icc_bytes = MUST(webp->icc_data());
     EXPECT(icc_bytes.has_value());
 
@@ -68,7 +68,7 @@ TEST_CASE(webp_extended_lossless)
 TEST_CASE(webp_extended_lossy)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("icc/extended-lossy.webp"sv)));
-    auto webp = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto webp = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
     auto icc_bytes = MUST(webp->icc_data());
     EXPECT(icc_bytes.has_value());
 

--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -52,7 +52,7 @@ TEST_CASE(test_bmp)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("rgba32-1.bmp"sv)));
     EXPECT(Gfx::BMPImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::BMPImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::BMPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame(*plugin_decoder);
 }
@@ -61,7 +61,7 @@ TEST_CASE(test_gif)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("download-animation.gif"sv)));
     EXPECT(Gfx::GIFImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::GIFImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::GIFImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     EXPECT(plugin_decoder->frame_count());
     EXPECT(plugin_decoder->is_animated());
@@ -75,14 +75,14 @@ TEST_CASE(test_not_ico)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("buggie.png"sv)));
     EXPECT(!Gfx::ICOImageDecoderPlugin::sniff(file->bytes()));
-    EXPECT(Gfx::ICOImageDecoderPlugin::create(file->bytes()).is_error());
+    EXPECT(Gfx::ICOImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything).is_error());
 }
 
 TEST_CASE(test_bmp_embedded_in_ico)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("serenity.ico"sv)));
     EXPECT(Gfx::ICOImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::ICOImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::ICOImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame(*plugin_decoder);
 }
@@ -91,7 +91,7 @@ TEST_CASE(test_jpeg_sof0_one_scan)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("jpg/rgb24.jpg"sv)));
     EXPECT(Gfx::JPEGImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame(*plugin_decoder);
 }
@@ -100,7 +100,7 @@ TEST_CASE(test_jpeg_sof0_several_scans)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("jpg/several_scans.jpg"sv)));
     EXPECT(Gfx::JPEGImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame_of_size(*plugin_decoder, { 592, 800 });
 }
@@ -109,7 +109,7 @@ TEST_CASE(test_jpeg_rgb_components)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("jpg/rgb_components.jpg"sv)));
     EXPECT(Gfx::JPEGImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame_of_size(*plugin_decoder, { 592, 800 });
 }
@@ -118,7 +118,7 @@ TEST_CASE(test_jpeg_sof2_spectral_selection)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("jpg/spectral_selection.jpg"sv)));
     EXPECT(Gfx::JPEGImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame_of_size(*plugin_decoder, { 592, 800 });
 }
@@ -127,7 +127,7 @@ TEST_CASE(test_jpeg_sof0_several_scans_odd_number_mcu)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("jpg/several_scans_odd_number_mcu.jpg"sv)));
     EXPECT(Gfx::JPEGImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame_of_size(*plugin_decoder, { 600, 600 });
 }
@@ -136,7 +136,7 @@ TEST_CASE(test_jpeg_sof2_successive_aproximation)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("jpg/successive_approximation.jpg"sv)));
     EXPECT(Gfx::JPEGImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame_of_size(*plugin_decoder, { 600, 800 });
 }
@@ -145,7 +145,7 @@ TEST_CASE(test_jpeg_sof1_12bits)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("jpg/12-bit.jpg"sv)));
     EXPECT(Gfx::JPEGImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame_of_size(*plugin_decoder, { 320, 240 });
 }
@@ -154,7 +154,7 @@ TEST_CASE(test_jpeg_sof2_12bits)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("jpg/12-bit-progressive.jpg"sv)));
     EXPECT(Gfx::JPEGImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame_of_size(*plugin_decoder, { 320, 240 });
 }
@@ -163,7 +163,7 @@ TEST_CASE(test_jpeg_empty_icc)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("jpg/gradient_empty_icc.jpg"sv)));
     EXPECT(Gfx::JPEGImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame_of_size(*plugin_decoder, { 80, 80 });
 }
@@ -172,7 +172,7 @@ TEST_CASE(test_jpeg_grayscale_with_app14)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("jpg/grayscale_app14.jpg"sv)));
     EXPECT(Gfx::JPEGImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::JPEGImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame_of_size(*plugin_decoder, { 80, 80 });
 }
@@ -181,7 +181,7 @@ TEST_CASE(test_pbm)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("pnm/buggie-raw.pbm"sv)));
     EXPECT(Gfx::PBMImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::PBMImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::PBMImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame(*plugin_decoder);
 }
@@ -190,7 +190,7 @@ TEST_CASE(test_pgm)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("pnm/buggie-raw.pgm"sv)));
     EXPECT(Gfx::PGMImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::PGMImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::PGMImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame(*plugin_decoder);
 }
@@ -199,7 +199,7 @@ TEST_CASE(test_png)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("buggie.png"sv)));
     EXPECT(Gfx::PNGImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::PNGImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::PNGImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame(*plugin_decoder);
 }
@@ -208,7 +208,7 @@ TEST_CASE(test_ppm)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("pnm/buggie-raw.ppm"sv)));
     EXPECT(Gfx::PPMImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::PPMImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::PPMImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame(*plugin_decoder);
 }
@@ -217,7 +217,7 @@ TEST_CASE(test_targa_bottom_left)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("tga/buggie-bottom-left-uncompressed.tga"sv)));
     EXPECT(MUST(Gfx::TGAImageDecoderPlugin::validate_before_create(file->bytes())));
-    auto plugin_decoder = MUST(Gfx::TGAImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::TGAImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame(*plugin_decoder);
 }
@@ -226,7 +226,7 @@ TEST_CASE(test_targa_top_left)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("tga/buggie-top-left-uncompressed.tga"sv)));
     EXPECT(MUST(Gfx::TGAImageDecoderPlugin::validate_before_create(file->bytes())));
-    auto plugin_decoder = MUST(Gfx::TGAImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::TGAImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame(*plugin_decoder);
 }
@@ -235,7 +235,7 @@ TEST_CASE(test_targa_bottom_left_compressed)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("tga/buggie-bottom-left-compressed.tga"sv)));
     EXPECT(MUST(Gfx::TGAImageDecoderPlugin::validate_before_create(file->bytes())));
-    auto plugin_decoder = MUST(Gfx::TGAImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::TGAImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame(*plugin_decoder);
 }
@@ -244,7 +244,7 @@ TEST_CASE(test_targa_top_left_compressed)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("tga/buggie-top-left-compressed.tga"sv)));
     EXPECT(MUST(Gfx::TGAImageDecoderPlugin::validate_before_create(file->bytes())));
-    auto plugin_decoder = MUST(Gfx::TGAImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::TGAImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame(*plugin_decoder);
 }
@@ -253,7 +253,7 @@ TEST_CASE(test_webp_simple_lossy)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("webp/simple-vp8.webp"sv)));
     EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     auto frame = expect_single_frame_of_size(*plugin_decoder, { 240, 240 });
 
@@ -267,7 +267,7 @@ TEST_CASE(test_webp_simple_lossless)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("webp/simple-vp8l.webp"sv)));
     EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     // Ironically, simple-vp8l.webp is a much more complex file than extended-lossless.webp tested below.
     // extended-lossless.webp tests the decoding basics.
@@ -288,7 +288,7 @@ TEST_CASE(test_webp_simple_lossless_alpha_used_false)
     // The file still contains alpha data. This tests that the decoder replaces the stored alpha data with 0xff if `is_alpha_used` is false.
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("webp/simple-vp8l-alpha-used-false.webp"sv)));
     EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     auto frame = expect_single_frame_of_size(*plugin_decoder, { 386, 395 });
     EXPECT_EQ(frame.image->get_pixel(0, 0), Gfx::Color(0, 0, 0, 0xff));
@@ -299,7 +299,7 @@ TEST_CASE(test_webp_extended_lossy)
     // This extended lossy image has an ALPH chunk for (losslessly compressed) alpha data.
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("webp/extended-lossy.webp"sv)));
     EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     auto frame = expect_single_frame_of_size(*plugin_decoder, { 417, 223 });
 
@@ -326,7 +326,7 @@ TEST_CASE(test_webp_extended_lossy_alpha_horizontal_filter)
     // The image should look like smolkling.webp, but with a horizontal alpha gradient.
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("webp/smolkling-horizontal-alpha.webp"sv)));
     EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     auto frame = expect_single_frame_of_size(*plugin_decoder, { 264, 264 });
 
@@ -342,7 +342,7 @@ TEST_CASE(test_webp_extended_lossy_alpha_vertical_filter)
     // The image should look like smolkling.webp, but with a vertical alpha gradient, and with a fully transparent first column.
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("webp/smolkling-vertical-alpha.webp"sv)));
     EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     auto frame = expect_single_frame_of_size(*plugin_decoder, { 264, 264 });
 
@@ -358,7 +358,7 @@ TEST_CASE(test_webp_extended_lossy_alpha_gradient_filter)
     // The image should look like smolkling.webp, but with a few transparent pixels in the shape of a C on it. Most of the image should not be transparent.
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("webp/smolkling-gradient-alpha.webp"sv)));
     EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     auto frame = expect_single_frame_of_size(*plugin_decoder, { 264, 264 });
 
@@ -373,7 +373,7 @@ TEST_CASE(test_webp_extended_lossy_uncompressed_alpha)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("webp/extended-lossy-uncompressed-alpha.webp"sv)));
     EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     auto frame = expect_single_frame_of_size(*plugin_decoder, { 417, 223 });
 
@@ -390,7 +390,7 @@ TEST_CASE(test_webp_extended_lossy_negative_quantization_offset)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("webp/smolkling.webp"sv)));
     EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     auto frame = expect_single_frame_of_size(*plugin_decoder, { 264, 264 });
 
@@ -407,7 +407,7 @@ TEST_CASE(test_webp_lossy_4)
     // No other changes have been made.
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("webp/4.webp"sv)));
     EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     auto frame = expect_single_frame_of_size(*plugin_decoder, { 1024, 772 });
 
@@ -420,7 +420,7 @@ TEST_CASE(test_webp_lossy_4_with_partitions)
     // Same input file as in the previous test, but re-encoded to use 8 secondary partitions.
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("webp/4-with-8-partitions.webp"sv)));
     EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     auto frame = expect_single_frame_of_size(*plugin_decoder, { 1024, 772 });
     EXPECT_EQ(frame.image->get_pixel(780, 570), Gfx::Color(0x73, 0xc9, 0xf9, 255));
@@ -430,7 +430,7 @@ TEST_CASE(test_webp_extended_lossless)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("webp/extended-lossless.webp"sv)));
     EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     auto frame = expect_single_frame_of_size(*plugin_decoder, { 417, 223 });
 
@@ -453,7 +453,7 @@ TEST_CASE(test_webp_simple_lossless_color_index_transform)
     // In addition to testing the index transform, this file also tests handling of explicity setting max_symbol.
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("webp/Qpalette.webp"sv)));
     EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     auto frame = expect_single_frame_of_size(*plugin_decoder, { 256, 256 });
 
@@ -485,7 +485,7 @@ TEST_CASE(test_webp_simple_lossless_color_index_transform_pixel_bundling)
     for (auto test_case : test_cases) {
         auto file = MUST(Core::MappedFile::map(MUST(String::formatted("{}{}", TEST_INPUT(""), test_case.file_name))));
         EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
-        auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+        auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
         auto frame = expect_single_frame_of_size(*plugin_decoder, { 32, 32 });
 
@@ -508,7 +508,7 @@ TEST_CASE(test_webp_simple_lossless_color_index_transform_pixel_bundling_odd_wid
 
     for (auto file_name : file_names) {
         auto file = MUST(Core::MappedFile::map(MUST(String::formatted("{}{}", TEST_INPUT(""), file_name))));
-        auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+        auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
         expect_single_frame_of_size(*plugin_decoder, { 11, 11 });
     }
 }
@@ -517,7 +517,7 @@ TEST_CASE(test_webp_extended_lossless_animated)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("webp/extended-lossless-animated.webp"sv)));
     EXPECT(Gfx::WebPImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::WebPImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     EXPECT_EQ(plugin_decoder->frame_count(), 8u);
     EXPECT(plugin_decoder->is_animated());
@@ -541,7 +541,7 @@ TEST_CASE(test_tvg)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("tvg/yak.tvg"sv)));
     EXPECT(Gfx::TinyVGImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = MUST(Gfx::TinyVGImageDecoderPlugin::create(file->bytes()));
+    auto plugin_decoder = MUST(Gfx::TinyVGImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
     expect_single_frame_of_size(*plugin_decoder, { 1024, 1024 });
 }
@@ -556,7 +556,7 @@ TEST_CASE(test_everything_tvg)
     for (auto file_name : file_names) {
         auto file = MUST(Core::MappedFile::map(file_name));
         EXPECT(Gfx::TinyVGImageDecoderPlugin::sniff(file->bytes()));
-        auto plugin_decoder = MUST(Gfx::TinyVGImageDecoderPlugin::create(file->bytes()));
+        auto plugin_decoder = MUST(Gfx::TinyVGImageDecoderPlugin::create(file->bytes(), Gfx::ImageDecoder::RequestType::Everything));
 
         expect_single_frame_of_size(*plugin_decoder, { 400, 768 });
     }

--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -212,7 +212,7 @@ Icon FileIconProvider::icon_for_executable(DeprecatedString const& path)
         } else {
             // FIXME: Use the ImageDecoder service.
             if (Gfx::PNGImageDecoderPlugin::sniff({ section->raw_data(), section->size() })) {
-                auto png_decoder = Gfx::PNGImageDecoderPlugin::create({ section->raw_data(), section->size() });
+                auto png_decoder = Gfx::PNGImageDecoderPlugin::create({ section->raw_data(), section->size() }, Gfx::ImageDecoder::RequestType::Image);
                 if (!png_decoder.is_error()) {
                     auto frame_or_error = png_decoder.value()->frame(0);
                     if (!frame_or_error.is_error()) {

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -1015,7 +1015,7 @@ RefPtr<Gfx::Bitmap> Font::color_bitmap(u32 glyph_id) const
     return embedded_bitmap_data_for_glyph(glyph_id).visit(
         [&](EmbeddedBitmapWithFormat17 const& data) -> RefPtr<Gfx::Bitmap> {
             auto data_slice = ReadonlyBytes { data.format17.data, static_cast<u32>(data.format17.data_len) };
-            auto decoder = Gfx::PNGImageDecoderPlugin::create(data_slice).release_value_but_fixme_should_propagate_errors();
+            auto decoder = Gfx::PNGImageDecoderPlugin::create(data_slice, Gfx::ImageDecoder::RequestType::Image).release_value_but_fixme_should_propagate_errors();
             auto frame = decoder->frame(0);
             if (frame.is_error()) {
                 dbgln("PNG decode failed");

--- a/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.h
@@ -17,7 +17,7 @@ class ICOImageDecoderPlugin;
 class BMPImageDecoderPlugin final : public ImageDecoderPlugin {
 public:
     static bool sniff(ReadonlyBytes);
-    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
+    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes, RequestType);
     static ErrorOr<NonnullOwnPtr<BMPImageDecoderPlugin>> create_as_included_in_ico(Badge<ICOImageDecoderPlugin>, ReadonlyBytes);
 
     enum class IncludedInICO {
@@ -34,8 +34,8 @@ public:
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
-    BMPImageDecoderPlugin(u8 const*, size_t, IncludedInICO included_in_ico = IncludedInICO::No);
-    static ErrorOr<NonnullOwnPtr<BMPImageDecoderPlugin>> create_impl(ReadonlyBytes, IncludedInICO);
+    BMPImageDecoderPlugin(u8 const*, size_t, RequestType, IncludedInICO included_in_ico = IncludedInICO::No);
+    static ErrorOr<NonnullOwnPtr<BMPImageDecoderPlugin>> create_impl(ReadonlyBytes, RequestType, IncludedInICO);
 
     OwnPtr<BMPLoadingContext> m_context;
 };

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.cpp
@@ -671,9 +671,4 @@ ErrorOr<ImageFrameDescriptor> DDSImageDecoderPlugin::frame(size_t index, Optiona
     return ImageFrameDescriptor { m_context->bitmap, 0 };
 }
 
-ErrorOr<Optional<ReadonlyBytes>> DDSImageDecoderPlugin::icc_data()
-{
-    return OptionalNone {};
-}
-
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.h
@@ -244,7 +244,6 @@ public:
     virtual IntSize size() override;
 
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
-    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
     DDSImageDecoderPlugin(FixedMemoryStream);

--- a/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/DDSLoader.h
@@ -237,7 +237,7 @@ struct DDSLoadingContext;
 class DDSImageDecoderPlugin final : public ImageDecoderPlugin {
 public:
     static bool sniff(ReadonlyBytes);
-    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
+    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes, RequestType);
 
     virtual ~DDSImageDecoderPlugin() override;
 
@@ -246,7 +246,7 @@ public:
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
 
 private:
-    DDSImageDecoderPlugin(FixedMemoryStream);
+    DDSImageDecoderPlugin(FixedMemoryStream, RequestType);
 
     OwnPtr<DDSLoadingContext> m_context;
 };

--- a/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
@@ -649,9 +649,4 @@ ErrorOr<ImageFrameDescriptor> GIFImageDecoderPlugin::frame(size_t index, Optiona
     return frame;
 }
 
-ErrorOr<Optional<ReadonlyBytes>> GIFImageDecoderPlugin::icc_data()
-{
-    return OptionalNone {};
-}
-
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.h
@@ -28,7 +28,6 @@ public:
     virtual size_t frame_count() override;
     virtual size_t first_animated_frame_index() override;
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
-    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
     GIFImageDecoderPlugin(FixedMemoryStream);

--- a/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.h
@@ -17,7 +17,7 @@ struct GIFLoadingContext;
 class GIFImageDecoderPlugin final : public ImageDecoderPlugin {
 public:
     static bool sniff(ReadonlyBytes);
-    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
+    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes, RequestType);
 
     virtual ~GIFImageDecoderPlugin() override;
 
@@ -30,7 +30,7 @@ public:
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
 
 private:
-    GIFImageDecoderPlugin(FixedMemoryStream);
+    GIFImageDecoderPlugin(FixedMemoryStream, RequestType);
 
     OwnPtr<GIFLoadingContext> m_context;
 };

--- a/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.cpp
@@ -225,9 +225,4 @@ ErrorOr<ImageFrameDescriptor> ICOImageDecoderPlugin::frame(size_t index, Optiona
     return ImageFrameDescriptor { m_context->images[m_context->largest_index].bitmap, 0 };
 }
 
-ErrorOr<Optional<ReadonlyBytes>> ICOImageDecoderPlugin::icc_data()
-{
-    return OptionalNone {};
-}
-
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.cpp
@@ -136,13 +136,11 @@ static ErrorOr<void> load_ico_directory(ICOLoadingContext& context)
     return {};
 }
 
-ErrorOr<void> ICOImageDecoderPlugin::load_ico_bitmap(ICOLoadingContext& context, Optional<size_t> index)
+ErrorOr<void> ICOImageDecoderPlugin::load_ico_bitmap(ICOLoadingContext& context)
 {
     VERIFY(context.state >= ICOLoadingContext::State::DirectoryDecoded);
 
     size_t real_index = context.largest_index;
-    if (index.has_value())
-        real_index = index.value();
     if (real_index >= context.images.size())
         return Error::from_string_literal("Index out of bounds");
 
@@ -213,7 +211,7 @@ ErrorOr<ImageFrameDescriptor> ICOImageDecoderPlugin::frame(size_t index, Optiona
 
     if (m_context->state < ICOLoadingContext::State::BitmapDecoded) {
         // NOTE: This forces the chunk decoding to happen.
-        auto maybe_error = load_ico_bitmap(*m_context, {});
+        auto maybe_error = load_ico_bitmap(*m_context);
         if (maybe_error.is_error()) {
             m_context->state = ICOLoadingContext::State::Error;
             return Error::from_string_literal("ICOImageDecoderPlugin: Decoding failed");

--- a/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.h
@@ -25,7 +25,7 @@ public:
 
 private:
     ICOImageDecoderPlugin(u8 const*, size_t);
-    static ErrorOr<void> load_ico_bitmap(ICOLoadingContext& context, Optional<size_t> index);
+    static ErrorOr<void> load_ico_bitmap(ICOLoadingContext& context);
 
     OwnPtr<ICOLoadingContext> m_context;
 };

--- a/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.h
@@ -22,7 +22,6 @@ public:
     virtual IntSize size() override;
 
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
-    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
     ICOImageDecoderPlugin(u8 const*, size_t);

--- a/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ICOLoader.h
@@ -15,7 +15,7 @@ struct ICOLoadingContext;
 class ICOImageDecoderPlugin final : public ImageDecoderPlugin {
 public:
     static bool sniff(ReadonlyBytes);
-    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
+    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes, RequestType);
 
     virtual ~ICOImageDecoderPlugin() override;
 
@@ -24,7 +24,7 @@ public:
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
 
 private:
-    ICOImageDecoderPlugin(u8 const*, size_t);
+    ICOImageDecoderPlugin(u8 const*, size_t, RequestType);
     static ErrorOr<void> load_ico_bitmap(ICOLoadingContext& context);
 
     OwnPtr<ICOLoadingContext> m_context;

--- a/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
@@ -53,8 +53,12 @@ public:
     virtual size_t frame_count() { return 1; }
     virtual size_t first_animated_frame_index() { return 0; }
 
+    // Override this function if the format can embed an ICC profile.
+    // As some formats store the profile at the end of the file, it can't
+    // be read during `create`, hence being fallible.
+    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() { return OptionalNone {}; }
+
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) = 0;
-    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() = 0;
 
     virtual bool is_vector() { return false; }
     virtual ErrorOr<VectorImageFrameDescriptor> vector_frame(size_t) { VERIFY_NOT_REACHED(); }

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
@@ -19,7 +19,7 @@ struct JPEGLoadingContext;
 class JPEGImageDecoderPlugin : public ImageDecoderPlugin {
 public:
     static bool sniff(ReadonlyBytes);
-    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
+    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes, RequestType);
 
     virtual ~JPEGImageDecoderPlugin() override;
     virtual IntSize size() override;
@@ -28,7 +28,7 @@ public:
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
-    JPEGImageDecoderPlugin(NonnullOwnPtr<FixedMemoryStream>);
+    JPEGImageDecoderPlugin(NonnullOwnPtr<FixedMemoryStream>, RequestType);
 
     OwnPtr<JPEGLoadingContext> m_context;
 };

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.h
@@ -15,7 +15,7 @@ struct PNGLoadingContext;
 class PNGImageDecoderPlugin final : public ImageDecoderPlugin {
 public:
     static bool sniff(ReadonlyBytes);
-    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
+    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes, RequestType);
 
     virtual ~PNGImageDecoderPlugin() override;
 
@@ -29,7 +29,7 @@ public:
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
-    PNGImageDecoderPlugin(u8 const*, size_t);
+    PNGImageDecoderPlugin(u8 const*, size_t, RequestType);
     bool ensure_image_data_chunk_was_decoded();
     bool ensure_animation_frame_was_decoded(u32);
 

--- a/Userland/Libraries/LibGfx/ImageFormats/PortableImageMapLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PortableImageMapLoader.h
@@ -61,7 +61,6 @@ public:
     virtual IntSize size() override;
 
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
-    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
     PortableImageDecoderPlugin(NonnullOwnPtr<SeekableStream> stream);
@@ -124,12 +123,6 @@ ErrorOr<ImageFrameDescriptor> PortableImageDecoderPlugin<TContext>::frame(size_t
 
     VERIFY(m_context->bitmap);
     return ImageFrameDescriptor { m_context->bitmap, 0 };
-}
-
-template<typename TContext>
-ErrorOr<Optional<ReadonlyBytes>> PortableImageDecoderPlugin<TContext>::icc_data()
-{
-    return OptionalNone {};
 }
 
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/QOILoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/QOILoader.cpp
@@ -224,9 +224,4 @@ ErrorOr<void> QOIImageDecoderPlugin::decode_image_and_update_context()
     return {};
 }
 
-ErrorOr<Optional<ReadonlyBytes>> QOIImageDecoderPlugin::icc_data()
-{
-    return OptionalNone {};
-}
-
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/QOILoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/QOILoader.h
@@ -46,7 +46,6 @@ public:
     virtual IntSize size() override;
 
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
-    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
     ErrorOr<void> decode_header_and_update_context();

--- a/Userland/Libraries/LibGfx/ImageFormats/QOILoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/QOILoader.h
@@ -39,7 +39,7 @@ struct QOILoadingContext {
 class QOIImageDecoderPlugin final : public ImageDecoderPlugin {
 public:
     static bool sniff(ReadonlyBytes);
-    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
+    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes, RequestType);
 
     virtual ~QOIImageDecoderPlugin() override = default;
 
@@ -51,7 +51,7 @@ private:
     ErrorOr<void> decode_header_and_update_context();
     ErrorOr<void> decode_image_and_update_context();
 
-    QOIImageDecoderPlugin(NonnullOwnPtr<Stream>);
+    QOIImageDecoderPlugin(NonnullOwnPtr<Stream>, RequestType);
 
     OwnPtr<QOILoadingContext> m_context;
 };

--- a/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TGALoader.cpp
@@ -328,9 +328,4 @@ ErrorOr<ImageFrameDescriptor> TGAImageDecoderPlugin::frame(size_t index, Optiona
     return ImageFrameDescriptor { m_context->bitmap, 0 };
 }
 
-ErrorOr<Optional<ReadonlyBytes>> TGAImageDecoderPlugin::icc_data()
-{
-    return OptionalNone {};
-}
-
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/TGALoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TGALoader.h
@@ -23,7 +23,6 @@ public:
     virtual IntSize size() override;
 
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
-    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
 private:
     ErrorOr<void> decode_tga_header();

--- a/Userland/Libraries/LibGfx/ImageFormats/TGALoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TGALoader.h
@@ -15,10 +15,10 @@ struct TGALoadingContext;
 class TGAImageDecoderPlugin final : public ImageDecoderPlugin {
 public:
     static ErrorOr<bool> validate_before_create(ReadonlyBytes);
-    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
+    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes, RequestType);
 
     virtual ~TGAImageDecoderPlugin() override;
-    TGAImageDecoderPlugin(u8 const*, size_t);
+    TGAImageDecoderPlugin(u8 const*, size_t, RequestType);
 
     virtual IntSize size() override;
 

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
@@ -82,7 +82,6 @@ public:
 
     virtual IntSize size() override;
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
-    virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override { return OptionalNone {}; }
 
     virtual bool is_vector() override { return true; }
     virtual ErrorOr<VectorImageFrameDescriptor> vector_frame(size_t index) override;

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
@@ -78,7 +78,7 @@ struct TinyVGLoadingContext;
 class TinyVGImageDecoderPlugin final : public ImageDecoderPlugin {
 public:
     static bool sniff(ReadonlyBytes);
-    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
+    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes, RequestType);
 
     virtual IntSize size() override;
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
@@ -89,7 +89,7 @@ public:
     virtual ~TinyVGImageDecoderPlugin() override = default;
 
 private:
-    TinyVGImageDecoderPlugin(ReadonlyBytes);
+    TinyVGImageDecoderPlugin(ReadonlyBytes, RequestType);
 
     NonnullOwnPtr<TinyVGLoadingContext> m_context;
 };

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.h
@@ -15,7 +15,7 @@ struct WebPLoadingContext;
 class WebPImageDecoderPlugin final : public ImageDecoderPlugin {
 public:
     static bool sniff(ReadonlyBytes);
-    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
+    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes, RequestType);
 
     virtual ~WebPImageDecoderPlugin() override;
 

--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -271,7 +271,7 @@ PDFErrorOr<ByteBuffer> Filter::decode_jbig2(ReadonlyBytes)
 PDFErrorOr<ByteBuffer> Filter::decode_dct(ReadonlyBytes bytes)
 {
     if (Gfx::JPEGImageDecoderPlugin::sniff({ bytes.data(), bytes.size() })) {
-        auto decoder = Gfx::JPEGImageDecoderPlugin::create({ bytes.data(), bytes.size() }).release_value_but_fixme_should_propagate_errors();
+        auto decoder = Gfx::JPEGImageDecoderPlugin::create({ bytes.data(), bytes.size() }, Gfx::ImageDecoder::RequestType::Image).release_value_but_fixme_should_propagate_errors();
         auto frame = TRY(decoder->frame(0));
         return TRY(frame.image->serialize_to_byte_buffer());
     }

--- a/Userland/Utilities/icc.cpp
+++ b/Userland/Utilities/icc.cpp
@@ -247,7 +247,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
         auto file = TRY(Core::MappedFile::map(path));
 
-        auto decoder = Gfx::ImageDecoder::try_create_for_raw_bytes(file->bytes());
+        auto decoder = Gfx::ImageDecoder::try_create_for_raw_bytes(file->bytes(), {}, Gfx::ImageDecoder::RequestType::ICCProfile);
         if (decoder) {
             if (auto embedded_icc_bytes = TRY(decoder->icc_data()); embedded_icc_bytes.has_value()) {
                 icc_bytes = *embedded_icc_bytes;

--- a/Userland/Utilities/image.cpp
+++ b/Userland/Utilities/image.cpp
@@ -60,7 +60,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     auto file = TRY(Core::MappedFile::map(in_path));
-    auto decoder = Gfx::ImageDecoder::try_create_for_raw_bytes(file->bytes());
+    auto decoder = Gfx::ImageDecoder::try_create_for_raw_bytes(file->bytes(), {}, Gfx::ImageDecoder::RequestType::Everything);
     if (!decoder) {
         warnln("Failed to decode input file '{}'", in_path);
         return 1;


### PR DESCRIPTION
The idea is to allow the decoder to skip parts (as metadata, the ICC profile or the bitmap) if the client doesn't need them. 

cc @nico 

Note for reviewers:

- There are a lot of +1/-1 due to the change of the signature of ImageDecoder::create(), but the only places where it matters are where we are doing something with ICC profiles.
- In `icc.cpp`, and `image.cpp` the two places in userland where we are reading a profile from an image
- WebP, PNG, BMP and JPEG loaders, our decoders that are able to handle ICC profiles.