### PR TITLE
LibWeb: Improve SVG `<text>` element support (font-size, scaling, and `text-anchor`)

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -83,6 +83,7 @@ public:
     static CSS::FillRule fill_rule() { return CSS::FillRule::Nonzero; }
     static float stroke_opacity() { return 1.0f; }
     static float stop_opacity() { return 1.0f; }
+    static CSS::TextAnchor text_anchor() { return CSS::TextAnchor::Start; }
     static CSS::Length border_radius() { return Length::make_px(0); }
     static Variant<CSS::VerticalAlign, CSS::LengthPercentage> vertical_align() { return CSS::VerticalAlign::Baseline; }
     static CSS::LengthBox inset() { return { CSS::Length::make_auto(), CSS::Length::make_auto(), CSS::Length::make_auto(), CSS::Length::make_auto() }; }
@@ -312,6 +313,7 @@ public:
     LengthPercentage const& stroke_width() const { return m_inherited.stroke_width; }
     Color stop_color() const { return m_noninherited.stop_color; }
     float stop_opacity() const { return m_noninherited.stop_opacity; }
+    CSS::TextAnchor text_anchor() const { return m_inherited.text_anchor; }
 
     Vector<CSS::Transformation> const& transformations() const { return m_noninherited.transformations; }
     CSS::TransformOrigin const& transform_origin() const { return m_noninherited.transform_origin; }
@@ -357,6 +359,7 @@ protected:
         float fill_opacity { InitialValues::fill_opacity() };
         float stroke_opacity { InitialValues::stroke_opacity() };
         LengthPercentage stroke_width { Length::make_px(1) };
+        CSS::TextAnchor text_anchor { InitialValues::text_anchor() };
 
         Vector<ShadowData> text_shadow;
     } m_inherited;
@@ -538,6 +541,7 @@ public:
     void set_stroke_width(LengthPercentage value) { m_inherited.stroke_width = value; }
     void set_stop_color(Color value) { m_noninherited.stop_color = value; }
     void set_stop_opacity(float value) { m_noninherited.stop_opacity = value; }
+    void set_text_anchor(CSS::TextAnchor value) { m_inherited.text_anchor = value; }
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Enums.json
+++ b/Userland/Libraries/LibWeb/CSS/Enums.json
@@ -275,6 +275,11 @@
         "to-zero",
         "up"
     ],
+    "text-anchor": [
+        "start",
+        "middle",
+        "end"
+    ],
     "text-align": [
         "center",
         "justify",

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1862,6 +1862,13 @@
     ],
     "percentages-resolve-to": "length"
   },
+  "text-anchor": {
+    "inherited": true,
+    "initial": "start",
+    "valid-types": [
+      "text-anchor"
+    ]
+  },
   "text-align": {
     "inherited": true,
     "initial": "left",

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -589,6 +589,12 @@ bool StyleProperties::operator==(StyleProperties const& other) const
     return true;
 }
 
+Optional<CSS::TextAnchor> StyleProperties::text_anchor() const
+{
+    auto value = property(CSS::PropertyID::TextAnchor);
+    return value_id_to_text_anchor(value->to_identifier());
+}
+
 Optional<CSS::TextAlign> StyleProperties::text_align() const
 {
     auto value = property(CSS::PropertyID::TextAlign);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -48,6 +48,7 @@ public:
     Optional<LengthPercentage> length_percentage(CSS::PropertyID) const;
     LengthBox length_box(CSS::PropertyID left_id, CSS::PropertyID top_id, CSS::PropertyID right_id, CSS::PropertyID bottom_id, const CSS::Length& default_value) const;
     Color color_or_fallback(CSS::PropertyID, Layout::NodeWithStyle const&, Color fallback) const;
+    Optional<CSS::TextAnchor> text_anchor() const;
     Optional<CSS::TextAlign> text_align() const;
     Optional<CSS::TextJustify> text_justify() const;
     CSS::Length border_spacing_horizontal() const;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -724,6 +724,9 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     computed_values.set_stroke_opacity(computed_style.stroke_opacity());
     computed_values.set_stop_opacity(computed_style.stop_opacity());
 
+    if (auto text_anchor = computed_style.text_anchor(); text_anchor.has_value())
+        computed_values.set_text_anchor(*text_anchor);
+
     computed_values.set_column_gap(computed_style.size_value(CSS::PropertyID::ColumnGap));
     computed_values.set_row_gap(computed_style.size_value(CSS::PropertyID::RowGap));
 

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -123,6 +123,7 @@ public:
 
     Gfx::Font const& font() const;
     Gfx::Font const& scaled_font(PaintContext&) const;
+    Gfx::Font const& scaled_font(float scale_factor) const;
 
     CSS::ImmutableComputedValues const& computed_values() const;
     CSSPixels line_height() const;
@@ -253,7 +254,12 @@ inline Gfx::Font const& Node::font() const
 
 inline Gfx::Font const& Node::scaled_font(PaintContext& context) const
 {
-    return *FontCache::the().scaled_font(font(), context.device_pixels_per_css_pixel());
+    return scaled_font(context.device_pixels_per_css_pixel());
+}
+
+inline Gfx::Font const& Node::scaled_font(float scale_factor) const
+{
+    return *FontCache::the().scaled_font(font(), scale_factor);
 }
 
 inline const CSS::ImmutableComputedValues& Node::computed_values() const

--- a/Userland/Libraries/LibWeb/Layout/SVGTextBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGTextBox.cpp
@@ -25,6 +25,7 @@ CSSPixelPoint SVGTextBox::viewbox_origin() const
 
 Optional<Gfx::AffineTransform> SVGTextBox::layout_transform() const
 {
+    // FIXME: Since text layout boxes are currently 0x0 it is not possible handle viewBox scaling here.
     auto& geometry_element = dom_node();
     auto transform = geometry_element.get_transform();
     auto* svg_box = geometry_element.first_ancestor_of_type<SVG::SVGSVGElement>();

--- a/Userland/Libraries/LibWeb/Painting/SVGTextPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGTextPaintable.cpp
@@ -59,9 +59,16 @@ void SVGTextPaintable::paint(PaintContext& context, PaintPhase phase) const
     auto child_text_content = dom_node.child_text_content();
 
     auto transform = layout_box().layout_transform();
-    auto& scaled_font = layout_node().scaled_font(context);
+    if (!transform.has_value())
+        return;
+
+    // FIXME: Support arbitrary path transforms for fonts.
+    // FIMXE: This assumes transform->x_scale() == transform->y_scale().
+    auto& scaled_font = layout_node().scaled_font(static_cast<float>(context.device_pixels_per_css_pixel()) * transform->x_scale());
+
+    Utf8View text_content { child_text_content };
     auto text_offset = context.floored_device_point(dom_node.get_offset().transformed(*transform).to_type<CSSPixels>());
-    painter.draw_text_run(text_offset.to_type<int>(), Utf8View { child_text_content }, scaled_font, layout_node().computed_values().fill()->as_color());
+    painter.draw_text_run(text_offset.to_type<int>(), text_content, scaled_font, layout_node().computed_values().fill()->as_color());
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/AttributeParser.h
+++ b/Userland/Libraries/LibWeb/SVG/AttributeParser.h
@@ -125,6 +125,12 @@ enum class FillRule {
     Evenodd
 };
 
+enum class TextAnchor {
+    Start,
+    Middle,
+    End
+};
+
 class AttributeParser final {
 public:
     ~AttributeParser() = default;

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.h
@@ -6,9 +6,31 @@
 
 #pragma once
 
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 
 namespace Web::SVG {
+
+namespace FIXME {
+class TemporarilyEnableQuirksMode {
+public:
+    TemporarilyEnableQuirksMode(DOM::Document const& document)
+        : m_document(const_cast<DOM::Document&>(document))
+        , m_previous_quirks_mode(document.mode())
+    {
+        m_document.set_quirks_mode(DOM::QuirksMode::Yes);
+    }
+
+    ~TemporarilyEnableQuirksMode()
+    {
+        m_document.set_quirks_mode(m_previous_quirks_mode);
+    }
+
+private:
+    DOM::Document& m_document;
+    DOM::QuirksMode m_previous_quirks_mode {};
+};
+}
 
 class SVGElement : public DOM::Element {
     WEB_PLATFORM_OBJECT(SVGElement, DOM::Element);

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -142,6 +142,12 @@ void SVGGraphicsElement::apply_presentational_hints(CSS::StyleProperties& style)
         } else if (name.equals_ignoring_ascii_case(SVG::AttributeNames::opacity)) {
             if (auto stroke_opacity_value = parse_css_value(parsing_context, value, CSS::PropertyID::Opacity).release_value_but_fixme_should_propagate_errors())
                 style.set_property(CSS::PropertyID::Opacity, stroke_opacity_value.release_nonnull());
+        } else if (name.equals_ignoring_ascii_case("text-anchor"sv)) {
+            if (auto text_anchor_value = parse_css_value(parsing_context, value, CSS::PropertyID::TextAnchor).release_value_but_fixme_should_propagate_errors())
+                style.set_property(CSS::PropertyID::TextAnchor, text_anchor_value.release_nonnull());
+        } else if (name.equals_ignoring_ascii_case("font-size"sv)) {
+            if (auto font_size_value = parse_css_value(parsing_context, value, CSS::PropertyID::FontSize).release_value_but_fixme_should_propagate_errors())
+                style.set_property(CSS::PropertyID::FontSize, font_size_value.release_nonnull());
         }
     });
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -117,6 +117,9 @@ Gfx::AffineTransform SVGGraphicsElement::get_transform() const
 
 void SVGGraphicsElement::apply_presentational_hints(CSS::StyleProperties& style) const
 {
+    // FIXME: Hack to ensure unitless SVG properties (such as font-size) are parsed.
+    FIXME::TemporarilyEnableQuirksMode enable_quirks(document());
+
     CSS::Parser::ParsingContext parsing_context { document() };
     for_each_attribute([&](auto& name, auto& value) {
         if (name.equals_ignoring_ascii_case("fill"sv)) {

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -41,11 +41,7 @@ void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) cons
     Base::apply_presentational_hints(style);
 
     // NOTE: Hack to ensure SVG unitless widths/heights are parsed even with <!DOCTYPE html>
-    auto previous_quirks_mode = document().mode();
-    const_cast<DOM::Document&>(document()).set_quirks_mode(DOM::QuirksMode::Yes);
-    ScopeGuard reset_quirks_mode = [&] {
-        const_cast<DOM::Document&>(document()).set_quirks_mode(previous_quirks_mode);
-    };
+    FIXME::TemporarilyEnableQuirksMode enable_quirks(document());
 
     auto width_attribute = attribute(SVG::AttributeNames::width);
     auto parsing_context = CSS::Parser::ParsingContext { document() };

--- a/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.cpp
@@ -8,6 +8,7 @@
 #include <AK/Utf16View.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Utf16String.h>
+#include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/SVGTextBox.h>
 #include <LibWeb/SVG/AttributeNames.h>
@@ -28,6 +29,22 @@ JS::ThrowCompletionOr<void> SVGTextContentElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGTextContentElementPrototype>(realm, "SVGTextContentElement"));
 
     return {};
+}
+
+Optional<TextAnchor> SVGTextContentElement::text_anchor() const
+{
+    if (!layout_node())
+        return {};
+    switch (layout_node()->computed_values().text_anchor()) {
+    case CSS::TextAnchor::Start:
+        return TextAnchor::Start;
+    case CSS::TextAnchor::Middle:
+        return TextAnchor::Middle;
+    case CSS::TextAnchor::End:
+        return TextAnchor::End;
+    default:
+        VERIFY_NOT_REACHED();
+    }
 }
 
 void SVGTextContentElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)

--- a/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGGraphicsElement.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -23,6 +24,8 @@ public:
     WebIDL::ExceptionOr<int> get_number_of_chars() const;
 
     Gfx::FloatPoint get_offset() const;
+
+    Optional<TextAnchor> text_anchor() const;
 
 protected:
     SVGTextContentElement(DOM::Document&, DOM::QualifiedName);


### PR DESCRIPTION
See commits for details. This make the badges on Serenity's GitHub look a fair bit nicer :^) 

**Before:**
![Screenshot from 2023-07-20 21-06-13](https://github.com/SerenityOS/serenity/assets/11597044/277cf79f-6dff-47e8-a81f-5504db5d7691)
**After:**
![Screenshot from 2023-07-20 21-05-31](https://github.com/SerenityOS/serenity/assets/11597044/f9c5c3b2-60fc-4f84-9ccf-c2f4523e2d0c)
