### PR TITLE
LibGUI+Userland: Make `GUI::ColorPicker` interactive

### DIFF
--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -123,10 +123,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto choose_grid_color_action = GUI::Action::create(
         "Choose Grid &Color", [&](auto& action [[maybe_unused]]) {
             auto dialog = GUI::ColorPicker::construct(magnifier->grid_color(), window, "Magnifier: choose grid color");
+            dialog->on_color_changed = [&magnifier](Gfx::Color color) {
+                magnifier->set_grid_color(color);
+            };
             dialog->set_color_has_alpha_channel(true);
             if (dialog->exec() == GUI::Dialog::ExecResult::OK) {
                 Config::write_string("Magnifier"sv, "Grid"sv, "Color"sv, dialog->color().to_deprecated_string());
-                magnifier->set_grid_color(dialog->color());
             }
         });
     {

--- a/Userland/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Userland/Applications/PixelPaint/PaletteWidget.cpp
@@ -33,13 +33,14 @@ public:
     {
         if (event.modifiers() & KeyModifier::Mod_Ctrl) {
             auto dialog = GUI::ColorPicker::construct(m_color, window());
-            if (dialog->exec() == GUI::Dialog::ExecResult::OK) {
-                m_color = dialog->color();
+            dialog->on_color_changed = [this](Gfx::Color color) {
+                m_color = color;
                 auto pal = palette();
                 pal.set_color(ColorRole::Background, m_color);
                 set_palette(pal);
                 update();
-            }
+            };
+            dialog->exec();
         }
 
         if (event.button() == GUI::MouseButton::Primary)
@@ -72,8 +73,10 @@ public:
             return;
 
         auto dialog = GUI::ColorPicker::construct(m_color, window());
-        if (dialog->exec() == GUI::Dialog::ExecResult::OK)
-            on_color_change(dialog->color());
+        dialog->on_color_changed = [this](Gfx::Color color) {
+            on_color_change(color);
+        };
+        dialog->exec();
     }
 
     void set_background_color(Color color)

--- a/Userland/Games/Snake/Game.h
+++ b/Userland/Games/Snake/Game.h
@@ -34,6 +34,7 @@ public:
     Function<bool(u32)> on_score_update;
 
     void set_skin_color(Color);
+    Gfx::Color get_skin_color() const { return m_snake_color; }
     void set_skin_name(DeprecatedString);
     void set_skin(NonnullOwnPtr<SnakeSkin> skin);
 

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -108,11 +108,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto was_paused = game.is_paused();
         if (!was_paused)
             game.pause();
-        auto dialog = GUI::ColorPicker::construct(Gfx::Color::White, window);
-        if (dialog->exec() == GUI::Dialog::ExecResult::OK) {
+        auto dialog = GUI::ColorPicker::construct(game.get_skin_color(), window);
+        dialog->on_color_changed = [&game](Gfx::Color color) {
+            game.set_skin_color(color);
+        };
+        if (dialog->exec() == GUI::Dialog::ExecResult::OK)
             Config::write_u32("Snake"sv, "Snake"sv, "BaseColor"sv, dialog->color().value());
-            game.set_skin_color(dialog->color());
-        }
         if (!was_paused)
             game.start();
     });

--- a/Userland/Libraries/LibGUI/ColorInput.cpp
+++ b/Userland/Libraries/LibGUI/ColorInput.cpp
@@ -71,9 +71,11 @@ void ColorInput::mouseup_event(MouseEvent& event)
         m_may_be_color_rect_click = false;
         if (is_color_rect_click) {
             auto dialog = GUI::ColorPicker::construct(m_color, window(), m_color_picker_title);
+            dialog->on_color_changed = [this](Gfx::Color color) {
+                set_color(color);
+            };
             dialog->set_color_has_alpha_channel(m_color_has_alpha_channel);
-            if (dialog->exec() == GUI::Dialog::ExecResult::OK)
-                set_color(dialog->color());
+            dialog->exec();
             event.accept();
             return;
         }

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -185,6 +185,7 @@ private:
 
 ColorPicker::ColorPicker(Color color, Window* parent_window, DeprecatedString title)
     : Dialog(parent_window)
+    , m_original_color(color)
     , m_color(color)
 {
     set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/color-chooser.png"sv).release_value_but_fixme_should_propagate_errors());
@@ -230,6 +231,8 @@ void ColorPicker::build_ui()
     auto& ok_button = button_container.add<DialogButton>();
     ok_button.set_text("OK"_short_string);
     ok_button.on_click = [this](auto) {
+        if (on_color_changed)
+            on_color_changed(m_color);
         done(ExecResult::OK);
     };
     ok_button.set_default(true);
@@ -237,6 +240,8 @@ void ColorPicker::build_ui()
     auto& cancel_button = button_container.add<DialogButton>();
     cancel_button.set_text("Cancel"_short_string);
     cancel_button.on_click = [this](auto) {
+        if (on_color_changed)
+            on_color_changed(m_original_color);
         done(ExecResult::Cancel);
     };
 }
@@ -439,6 +444,8 @@ void ColorPicker::update_color_widgets()
     m_alpha_spinbox->set_enabled(m_color_has_alpha_channel);
     m_alpha->set_value(m_color.alpha());
     m_alpha->set_visible(m_color_has_alpha_channel);
+    if (on_color_changed)
+        on_color_changed(m_color);
 }
 
 void ColorPicker::create_color_button(Widget& container, unsigned rgb)

--- a/Userland/Libraries/LibGUI/ColorPicker.h
+++ b/Userland/Libraries/LibGUI/ColorPicker.h
@@ -26,6 +26,7 @@ public:
     bool color_has_alpha_channel() const { return m_color_has_alpha_channel; }
     void set_color_has_alpha_channel(bool);
     Color color() const { return m_color; }
+    Function<void(Color)> on_color_changed;
 
 private:
     explicit ColorPicker(Color, Window* parent_window = nullptr, DeprecatedString title = "Color Picker");
@@ -36,6 +37,7 @@ private:
     void update_color_widgets();
     void create_color_button(Widget& container, unsigned rgb);
 
+    Color m_original_color;
     Color m_color;
     bool m_color_has_alpha_channel { true };
 


### PR DESCRIPTION
I added a callback to `GUI::ColorPicker` that clients can optionally use to receive real-time color updates, and applied this new feature to every location in the system that uses it, namely:
* Spreadsheet
* PixelPaint
* Magnifier
* Snake
* `LibGUI` itself, in `GUI::ColorInput`, which is used in many more places.

Quick demo:

https://github.com/SerenityOS/serenity/assets/20117975/b65fe275-59e7-4d8c-a609-4bb63172ebc9

