### PR TITLE
LibJS: Actually generate the bytecode CFG

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Pass/GenerateCFG.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/GenerateCFG.cpp
@@ -23,7 +23,7 @@ static BasicBlock const* next_handler_or_finalizer()
     return unwind_frames.last()->handler ?: unwind_frames.last()->finalizer;
 }
 
-static void generate_cfg_for_block(BasicBlock const& current_block, PassPipelineExecutable executable)
+static void generate_cfg_for_block(BasicBlock const& current_block, PassPipelineExecutable& executable)
 {
     seen_blocks.set(&current_block);
 


### PR DESCRIPTION
This is just something I spotted looking around the code, previously the PassPipelineExecutable was passed by value to
generate_cfg_for_block, which generated the CFG then just dropped it on the floor. Making this a reference results in the CFG actually getting generated.