### PR TITLE
LibPDF: Include `width` in Type1Font glyph cache key

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -79,7 +79,7 @@ void Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float w
     point = point.translated(translation);
 
     auto glyph_position = Gfx::GlyphRasterPosition::get_nearest_fit_for(point);
-    Gfx::GlyphIndexWithSubpixelOffset index { char_code, glyph_position.subpixel_offset };
+    Type1GlyphCacheKey index { char_code, glyph_position.subpixel_offset, width };
 
     RefPtr<Gfx::Bitmap> bitmap;
     auto maybe_bitmap = m_glyph_cache.get(index);

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -12,6 +12,14 @@
 
 namespace PDF {
 
+struct Type1GlyphCacheKey {
+    u32 glyph_id;
+    Gfx::GlyphSubpixelOffset subpixel_offset;
+    float width;
+
+    bool operator==(Type1GlyphCacheKey const&) const = default;
+};
+
 class Type1Font : public SimpleFont {
 public:
     float get_glyph_width(u8 char_code) const override;
@@ -25,7 +33,19 @@ protected:
 private:
     RefPtr<Type1FontProgram> m_font_program;
     RefPtr<Gfx::Font> m_font;
-    HashMap<Gfx::GlyphIndexWithSubpixelOffset, RefPtr<Gfx::Bitmap>> m_glyph_cache;
+    HashMap<Type1GlyphCacheKey, RefPtr<Gfx::Bitmap>> m_glyph_cache;
+};
+
+}
+
+namespace AK {
+
+template<>
+struct Traits<PDF::Type1GlyphCacheKey> : public GenericTraits<PDF::Type1GlyphCacheKey> {
+    static unsigned hash(PDF::Type1GlyphCacheKey const& index)
+    {
+        return pair_int_hash(pair_int_hash(index.glyph_id, (index.subpixel_offset.x << 8) | index.subpixel_offset.y), int_hash(bit_cast<u32>(index.width)));
+    }
 };
 
 }


### PR DESCRIPTION
LibGfx's ScaledFont doesn't do this, but in ScaledFont m_x_scale and m_y_scale are immutable once the class is created, so it can get away with not doing it.

In Type1Font, `width` changes in different calls to Type1Font::draw_glyph(), so we need to make it part of the cache key.

Fixes rendering of the word "Version" on the first page of pdf_reference_1-7.pdf.