### PR TITLE
Utilities/less: Add an option to show line numbers before printed lines

### DIFF
--- a/Base/usr/share/man/man1/less.md
+++ b/Base/usr/share/man/man1/less.md
@@ -21,6 +21,7 @@ but largely incompatible with
 
 * `-P`, `--prompt`: Set the prompt format string. See [Prompts](#prompts) for more details.
 * `-X`, `--no-init`: Don't switch to the xterm alternate buffer on startup.
+* `-N`, `--line-numbers`: Show line numbers before printed lines.
 * `-e`, `--quit-at-eof`: Immediately exit less when the last line of the document is reached.
 * `-m`, `--emulate-more`: Apply `-Xe`, set the prompt to `--More--`, and disable
   scrollback. This option is automatically applied when `less` is executed as `more`


### PR DESCRIPTION
This tries to mimick the GNU less utility behavior on that flag.