### PR TITLE
LibWeb: Do not fire click event if mouseup/down elements do not match

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -130,20 +130,6 @@ EventHandler::EventHandler(Badge<HTML::BrowsingContext>, HTML::BrowsingContext& 
 
 EventHandler::~EventHandler() = default;
 
-Layout::Viewport const* EventHandler::layout_root() const
-{
-    if (!m_browsing_context->active_document())
-        return nullptr;
-    return m_browsing_context->active_document()->layout_node();
-}
-
-Layout::Viewport* EventHandler::layout_root()
-{
-    if (!m_browsing_context->active_document())
-        return nullptr;
-    return m_browsing_context->active_document()->layout_node();
-}
-
 Painting::PaintableBox* EventHandler::paint_root()
 {
     if (!m_browsing_context->active_document())

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -242,7 +242,7 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, unsigned button, unsig
             node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mouseup, offset, client_offset, page_offset, buttons, button).release_value_but_fixme_should_propagate_errors());
             handled_event = true;
 
-            bool run_activation_behavior = true;
+            bool run_activation_behavior = false;
             if (node.ptr() == m_mousedown_target) {
                 if (button == GUI::MouseButton::Primary)
                     run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::click, offset, client_offset, page_offset, button).release_value_but_fixme_should_propagate_errors());

--- a/Userland/Libraries/LibWeb/Page/EventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.h
@@ -51,9 +51,6 @@ private:
     };
     Optional<Target> target_for_mouse_position(CSSPixelPoint position);
 
-    Layout::Viewport* layout_root();
-    Layout::Viewport const* layout_root() const;
-
     Painting::PaintableBox* paint_root();
     Painting::PaintableBox const* paint_root() const;
 


### PR DESCRIPTION
Click event logic should start as false, and after checking if the mousedown and subsequent mouseup have been on the same element, and if the node dispatches events it can become true.

This fixes the issue that clicking anywhere on the page, then dragging the mouse on top of a link or button, then releasing triggers the link. This is also happening when selecting text, if the selection stops over a link, the page navigates.

The first commit also removes 2 unused methods.