### PR TITLE
LibCompress/Brotli: Remove `CanonicalCode::clear()`

### DIFF
--- a/Userland/Libraries/LibCompress/Brotli.cpp
+++ b/Userland/Libraries/LibCompress/Brotli.cpp
@@ -446,11 +446,10 @@ ErrorOr<void> BrotliDecompressionStream::read_block_configuration(Block& block)
     block.type_previous = 1;
     block.number_of_types = blocks_of_type;
 
-    block.type_code.clear();
-    block.length_code.clear();
-
     if (blocks_of_type == 1) {
         block.length = 16 * MiB;
+        block.type_code = {};
+        block.length_code = {};
     } else {
         block.type_code = TRY(CanonicalCode::read_prefix_code(m_input_stream, 2 + blocks_of_type));
         block.length_code = TRY(CanonicalCode::read_prefix_code(m_input_stream, 26));

--- a/Userland/Libraries/LibCompress/Brotli.h
+++ b/Userland/Libraries/LibCompress/Brotli.h
@@ -27,11 +27,6 @@ public:
     static ErrorOr<CanonicalCode> read_complex_prefix_code(LittleEndianInputBitStream&, size_t alphabet_size, size_t hskip);
 
     ErrorOr<size_t> read_symbol(LittleEndianInputBitStream&) const;
-    void clear()
-    {
-        m_symbol_codes.clear();
-        m_symbol_values.clear();
-    }
 
 private:
     static ErrorOr<size_t> read_complex_prefix_code_length(LittleEndianInputBitStream&);


### PR DESCRIPTION
This function was used in a single place and don't provide a huge benefit over simply recreating the object.