### PR TITLE
LibGfx/JPEGXL: Don't decode the header twice

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -1639,7 +1639,7 @@ public:
         auto result = [this]() -> ErrorOr<void> {
             // A.1 - Codestream structure
 
-            TRY(decode_image_header());
+            // The header is already decoded in JPEGXLImageDecoderPlugin::create()
 
             if (m_metadata.colour_encoding.want_icc)
                 TODO();


### PR DESCRIPTION
This is something I missed when I ported the JPEG XL decoder to the new plugin interface (decoding the header at creation). First sorry because that's entirely my fault, second sorry because a test should have caught that.