### PR TITLE
LibGfx/JPEGXL: Accept images with high bit depth

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -1081,11 +1081,16 @@ public:
         auto bitmap = TRY(Bitmap::create(BitmapFormat::BGRx8888, { width, height }));
 
         // FIXME: This assumes a raw image with RGB channels, other cases are possible
-        VERIFY(bits_per_sample == 8);
+        VERIFY(bits_per_sample >= 8);
         for (u32 y {}; y < height; ++y) {
             for (u32 x {}; x < width; ++x) {
                 auto const to_u8 = [&, bits_per_sample](i32 sample) -> u8 {
-                    return clamp(sample + .5, 0, (1 << bits_per_sample) - 1);
+                    // FIXME: Don't truncate the result to 8 bits
+                    static constexpr auto maximum_supported_bit_depth = 8;
+                    if (bits_per_sample > maximum_supported_bit_depth)
+                        sample >>= (bits_per_sample - maximum_supported_bit_depth);
+
+                    return clamp(sample + .5, 0, (1 << maximum_supported_bit_depth) - 1);
                 };
 
                 Color const color {


### PR DESCRIPTION
Instead of rejecting them, we truncate each value to 8 bits. This is
clearly a hack, but given the lack of support of variable bit-depth in
`Bitmap` this is the only sensible change.

This allows us to display "Iceberg" on https://jpegxl.info/art/.

---
I bet you can't see that in your daily browser:
![WHF](https://github.com/SerenityOS/serenity/assets/26030965/05c5dd9b-f178-4adc-9a5d-e0ba05b1df69)
