### PR TITLE
System Monitor: Fix calculation of CPU percentage

### DIFF
--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -574,6 +574,9 @@ void ProcessModel::update()
             tids_to_remove.append(it.key);
             continue;
         }
+        if (it.value->current_state.state == "Zombie") {
+            continue;
+        }
         auto& thread = *it.value;
         u64 time_scheduled_diff = (thread.current_state.time_user + thread.current_state.time_kernel)
             - (thread.previous_state.time_user + thread.previous_state.time_kernel);


### PR DESCRIPTION
This commit addresses an issue when 'Zombie' threads are included in CPU % calculation. This caused negative time_scheduled_diff, resulting in a data type overflow.

Fixes https://github.com/SerenityOS/serenity/issues/19842