### PR TITLE
file: Add `-b` option to omit file name from output

### DIFF
--- a/Base/usr/share/man/man1/file.md
+++ b/Base/usr/share/man/man1/file.md
@@ -17,6 +17,7 @@ First, an attempt is made to identify a given file based on predetermined binary
 ## Options
 
 * `--help`: Display this message
+* `-b`, `--brief`: Do not prepend file names to output lines
 * `-I`, `--mime-type`: Only show mime type.
 
 ## Arguments


### PR DESCRIPTION
Example usage: 

![file_brief_mode](https://github.com/SerenityOS/serenity/assets/2817754/2e457116-d2f6-4d1e-9f3c-fad8fff1c39f)
