### PR TITLE
LibJS/Tests: Enable running bytecode tests in CI

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -665,6 +665,12 @@ if (BUILD_LAGOM)
         )
         set_tests_properties(JS PROPERTIES ENVIRONMENT SERENITY_SOURCE_DIR=${SERENITY_PROJECT_ROOT})
 
+        add_test(
+            NAME JS-Bytecode
+            COMMAND test-js -b --show-progress=false
+        )
+        set_tests_properties(JS-Bytecode PROPERTIES ENVIRONMENT SERENITY_SOURCE_DIR=${SERENITY_PROJECT_ROOT})
+
         # Extra tests from Tests/LibJS
         lagom_test(../../Tests/LibJS/test-invalid-unicode-js.cpp LIBS LibJS)
         lagom_test(../../Tests/LibJS/test-value-js.cpp LIBS LibJS)

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -12,6 +12,11 @@ TEST_ROOT("Userland/Libraries/LibJS/Tests");
 
 TESTJS_PROGRAM_FLAG(test262_parser_tests, "Run test262 parser tests", "test262-parser-tests", 0);
 
+TESTJS_GLOBAL_FUNCTION(is_bytecode_interpreter_enabled, isBytecodeInterpreterEnabled, 0)
+{
+    return JS::Value(JS::Bytecode::Interpreter::enabled());
+}
+
 TESTJS_GLOBAL_FUNCTION(is_strict_mode, isStrictMode, 0)
 {
     return JS::Value(vm.in_strict_mode());

--- a/Userland/Libraries/LibJS/Tests/builtins/DisposableStack/DisposableStack.prototype.@@dispose.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/DisposableStack/DisposableStack.prototype.@@dispose.js
@@ -7,7 +7,7 @@ test("is the same as dispose", () => {
 });
 
 describe("used in using functionality", () => {
-    test("make the stack marked as disposed", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "make the stack marked as disposed", () => {
         let innerStack;
         {
             using stack = new DisposableStack();

--- a/Userland/Libraries/LibJS/Tests/builtins/Error/Error.prototype.stack.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Error/Error.prototype.stack.js
@@ -3,12 +3,13 @@ const stackGetter = stackDescriptor.get;
 const stackSetter = stackDescriptor.set;
 
 describe("getter - normal behavior", () => {
-    test("basic functionality", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "basic functionality", () => {
         const stackFrames = [
             /^    at .*Error \(.*\/Error\.prototype\.stack\.js:\d+:\d+\)$/,
             /^    at .+\/Error\/Error\.prototype\.stack\.js:\d+:\d+$/,
             /^    at test \(.+\/test-common.js:\d+:\d+\)$/,
-            /^    at .+\/Error\/Error\.prototype\.stack\.js:6:33$/,
+            /^    at (.+\/test-common.js:\d+:\d+)/,
+            /^    at .+\/Error\/Error\.prototype\.stack\.js:6:73$/,
             /^    at describe \(.+\/test-common\.js:\d+:\d+\)$/,
             /^    at .+\/Error\/Error\.prototype\.stack\.js:5:38$/,
         ];

--- a/Userland/Libraries/LibJS/Tests/builtins/FinalizationRegistry/FinalizationRegistry.prototype.cleanupSome.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/FinalizationRegistry/FinalizationRegistry.prototype.cleanupSome.js
@@ -8,7 +8,7 @@ function registerInDifferentScope(registry) {
     return target;
 }
 
-test("basic functionality", () => {
+test.xfailIf(isBytecodeInterpreterEnabled(), "basic functionality", () => {
     var registry = new FinalizationRegistry(() => {});
 
     var count = 0;

--- a/Userland/Libraries/LibJS/Tests/builtins/ShadowRealm/ShadowRealm.prototype.importValue.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ShadowRealm/ShadowRealm.prototype.importValue.js
@@ -40,7 +40,7 @@ describe("normal behavior", () => {
         expect(passed).toBeTrue();
     });
 
-    test("value from async module", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "value from async module", () => {
         const shadowRealm = new ShadowRealm();
         const promise = shadowRealm.importValue("./async-module.mjs", "foo");
         expect(promise).toBeInstanceOf(Promise);

--- a/Userland/Libraries/LibJS/Tests/builtins/WeakMap/WeakMap.prototype.set.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/WeakMap/WeakMap.prototype.set.js
@@ -21,25 +21,29 @@ test("invalid values", () => {
     });
 });
 
-test("automatic removal of garbage-collected values", () => {
-    const weakMap = new WeakMap();
-    const objectKey = { e: 3 };
+test.xfailIf(
+    isBytecodeInterpreterEnabled(),
+    "automatic removal of garbage-collected values",
+    () => {
+        const weakMap = new WeakMap();
+        const objectKey = { e: 3 };
 
-    expect(weakMap.set(objectKey, 1)).toBe(weakMap);
-    expect(getWeakMapSize(weakMap)).toBe(1);
+        expect(weakMap.set(objectKey, 1)).toBe(weakMap);
+        expect(getWeakMapSize(weakMap)).toBe(1);
 
-    markAsGarbage("objectKey");
-    gc();
+        markAsGarbage("objectKey");
+        gc();
 
-    expect(getWeakMapSize(weakMap)).toBe(0);
+        expect(getWeakMapSize(weakMap)).toBe(0);
 
-    const symbolKey = Symbol("foo");
+        const symbolKey = Symbol("foo");
 
-    expect(weakMap.set(symbolKey, "bar")).toBe(weakMap);
-    expect(getWeakMapSize(weakMap)).toBe(1);
+        expect(weakMap.set(symbolKey, "bar")).toBe(weakMap);
+        expect(getWeakMapSize(weakMap)).toBe(1);
 
-    markAsGarbage("symbolKey");
-    gc();
+        markAsGarbage("symbolKey");
+        gc();
 
-    expect(getWeakMapSize(weakMap)).toBe(0);
-});
+        expect(getWeakMapSize(weakMap)).toBe(0);
+    }
+);

--- a/Userland/Libraries/LibJS/Tests/builtins/WeakSet/WeakSet.prototype.add.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/WeakSet/WeakSet.prototype.add.js
@@ -16,25 +16,29 @@ test("invalid values", () => {
     });
 });
 
-test("automatic removal of garbage-collected values", () => {
-    const weakSet = new WeakSet();
-    const objectItem = { a: 1 };
+test.xfailIf(
+    isBytecodeInterpreterEnabled(),
+    "automatic removal of garbage-collected values",
+    () => {
+        const weakSet = new WeakSet();
+        const objectItem = { a: 1 };
 
-    expect(weakSet.add(objectItem)).toBe(weakSet);
-    expect(getWeakSetSize(weakSet)).toBe(1);
+        expect(weakSet.add(objectItem)).toBe(weakSet);
+        expect(getWeakSetSize(weakSet)).toBe(1);
 
-    markAsGarbage("objectItem");
-    gc();
+        markAsGarbage("objectItem");
+        gc();
 
-    expect(getWeakSetSize(weakSet)).toBe(0);
+        expect(getWeakSetSize(weakSet)).toBe(0);
 
-    const symbolItem = Symbol("foo");
+        const symbolItem = Symbol("foo");
 
-    expect(weakSet.add(symbolItem)).toBe(weakSet);
-    expect(getWeakSetSize(weakSet)).toBe(1);
+        expect(weakSet.add(symbolItem)).toBe(weakSet);
+        expect(getWeakSetSize(weakSet)).toBe(1);
 
-    markAsGarbage("symbolItem");
-    gc();
+        markAsGarbage("symbolItem");
+        gc();
 
-    expect(getWeakSetSize(weakSet)).toBe(0);
-});
+        expect(getWeakSetSize(weakSet)).toBe(0);
+    }
+);

--- a/Userland/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
+++ b/Userland/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
@@ -1,4 +1,4 @@
-test("assignment to function call", () => {
+test.xfailIf(isBytecodeInterpreterEnabled(), "assignment to function call", () => {
     expect(() => {
         function foo() {}
         foo() = "foo";
@@ -9,7 +9,7 @@ test("assignment to function call in strict mode", () => {
     expect("'use strict'; foo() = 'foo'").toEval();
 });
 
-test("assignment to inline function call", () => {
+test.xfailIf(isBytecodeInterpreterEnabled(), "assignment to inline function call", () => {
     expect(() => {
         (function () {})() = "foo";
     }).toThrowWithMessage(ReferenceError, "Invalid left-hand side in assignment");

--- a/Userland/Libraries/LibJS/Tests/loops/for-of-basic.js
+++ b/Userland/Libraries/LibJS/Tests/loops/for-of-basic.js
@@ -130,26 +130,37 @@ describe("special left hand sides", () => {
         expect(f().a).toBe("c");
     });
 
-    test("call function is allowed in parsing but fails in runtime", () => {
-        function f() {
-            expect().fail();
+    test.xfailIf(
+        isBytecodeInterpreterEnabled(),
+        "call function is allowed in parsing but fails in runtime",
+        () => {
+            function f() {
+                expect().fail();
+            }
+
+            // Does not fail since it does not iterate but prettier does not like it so we use eval.
+            expect("for (f() of []);").toEvalTo(undefined);
+
+            expect(() => {
+                eval("for (f() of [0]) { expect().fail() }");
+            }).toThrowWithMessage(ReferenceError, "Invalid left-hand side in assignment");
         }
+    );
 
-        // Does not fail since it does not iterate but prettier does not like it so we use eval.
-        expect("for (f() of []);").toEvalTo(undefined);
+    test.xfailIf(
+        isBytecodeInterpreterEnabled(),
+        "Cannot change constant declaration in body",
+        () => {
+            const vals = [];
+            for (const v of [1, 2]) {
+                expect(() => v++).toThrowWithMessage(
+                    TypeError,
+                    "Invalid assignment to const variable"
+                );
+                vals.push(v);
+            }
 
-        expect(() => {
-            eval("for (f() of [0]) { expect().fail() }");
-        }).toThrowWithMessage(ReferenceError, "Invalid left-hand side in assignment");
-    });
-
-    test("Cannot change constant declaration in body", () => {
-        const vals = [];
-        for (const v of [1, 2]) {
-            expect(() => v++).toThrowWithMessage(TypeError, "Invalid assignment to const variable");
-            vals.push(v);
+            expect(vals).toEqual([1, 2]);
         }
-
-        expect(vals).toEqual([1, 2]);
-    });
+    );
 });

--- a/Userland/Libraries/LibJS/Tests/modules/basic-modules.js
+++ b/Userland/Libraries/LibJS/Tests/modules/basic-modules.js
@@ -207,9 +207,13 @@ describe("in- and exports", () => {
         expectModulePassed("./anon-func-decl-default-export.mjs");
     });
 
-    test("can have top level using declarations which trigger at the end of running a module", () => {
-        expectModulePassed("./top-level-dispose.mjs");
-    });
+    test.xfailIf(
+        isBytecodeInterpreterEnabled(),
+        "can have top level using declarations which trigger at the end of running a module",
+        () => {
+            expectModulePassed("./top-level-dispose.mjs");
+        }
+    );
 
     test("can export default a RegExp", () => {
         const result = expectModulePassed("./default-regexp-export.mjs");

--- a/Userland/Libraries/LibJS/Tests/object-basic.js
+++ b/Userland/Libraries/LibJS/Tests/object-basic.js
@@ -221,13 +221,13 @@ describe("naming of anon functions", () => {
         expect({ func() {} }.func.name).toBe("func");
     });
 
-    test("getter has name", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "getter has name", () => {
         expect(Object.getOwnPropertyDescriptor({ get func() {} }, "func").get.name).toBe(
             "get func"
         );
     });
 
-    test("setter has name", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "setter has name", () => {
         expect(Object.getOwnPropertyDescriptor({ set func(v) {} }, "func").set.name).toBe(
             "set func"
         );

--- a/Userland/Libraries/LibJS/Tests/object-spread.js
+++ b/Userland/Libraries/LibJS/Tests/object-spread.js
@@ -144,7 +144,7 @@ describe("modification of spreadable objects during spread", () => {
         expect(Object.getOwnPropertyNames(result)).toContain("bar");
     });
 
-    test("spreading array", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "spreading array", () => {
         const array = [0];
         array[2] = 2;
         array[999] = 999;

--- a/Userland/Libraries/LibJS/Tests/operators/delete-basic.js
+++ b/Userland/Libraries/LibJS/Tests/operators/delete-basic.js
@@ -198,7 +198,7 @@ test("deleting a symbol returned by @@toPrimitive", () => {
 });
 
 // FIXME: This currently does not work with the AST interpreter, but works with Bytecode.
-test.skip("delete always evaluates the lhs", () => {
+test.xfailIf(!isBytecodeInterpreterEnabled(), "delete always evaluates the lhs", () => {
     const obj = { prop: 1 };
     let called = false;
     function a() {

--- a/Userland/Libraries/LibJS/Tests/strict-mode-errors.js
+++ b/Userland/Libraries/LibJS/Tests/strict-mode-errors.js
@@ -1,6 +1,6 @@
 "use strict";
 
-test("basic functionality", () => {
+test.xfailIf(isBytecodeInterpreterEnabled(), "basic functionality", () => {
     [true, false, "foo", 123].forEach(primitive => {
         expect(() => {
             primitive.foo = "bar";

--- a/Userland/Libraries/LibJS/Tests/syntax/async-await.js
+++ b/Userland/Libraries/LibJS/Tests/syntax/async-await.js
@@ -201,7 +201,7 @@ describe("await cannot be used in class static init blocks", () => {
     });
 });
 
-test("async returning a thenable", () => {
+test.xfailIf(isBytecodeInterpreterEnabled(), "async returning a thenable", () => {
     let isCalled = false;
     const f = async () => ({
         then() {

--- a/Userland/Libraries/LibJS/Tests/tagged-template-literals.js
+++ b/Userland/Libraries/LibJS/Tests/tagged-template-literals.js
@@ -154,7 +154,7 @@ describe("tagged template literal functionality", () => {
         expect(stringsValue.raw[1]).toBe("invalid\\u");
     });
 
-    test("string value gets cached per AST node", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "string value gets cached per AST node", () => {
         function call(func, val) {
             return func`template${val}second`;
         }
@@ -164,7 +164,7 @@ describe("tagged template literal functionality", () => {
         expect(firstResult).toBe(secondResult);
     });
 
-    test("this value of call comes from reference", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "this value of call comes from reference", () => {
         let thisValue = null;
         const obj = {
             func() {

--- a/Userland/Libraries/LibJS/Tests/using-declaration.js
+++ b/Userland/Libraries/LibJS/Tests/using-declaration.js
@@ -1,5 +1,5 @@
 describe("basic usage", () => {
-    test("disposes after block exit", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "disposes after block exit", () => {
         let disposed = false;
         let inBlock = false;
         {
@@ -13,7 +13,7 @@ describe("basic usage", () => {
         expect(disposed).toBeTrue();
     });
 
-    test("disposes in reverse order after block exit", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "disposes in reverse order after block exit", () => {
         const disposed = [];
         {
             expect(disposed).toHaveLength(0);
@@ -25,7 +25,7 @@ describe("basic usage", () => {
         expect(disposed).toEqual(['b', 'a']);
     });
 
-    test("disposes in reverse order after block exit even in same declaration", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "disposes in reverse order after block exit even in same declaration", () => {
         const disposed = [];
         {
             expect(disposed).toHaveLength(0);
@@ -41,7 +41,7 @@ describe("basic usage", () => {
 describe("behavior with exceptions", () => {
     function ExpectedError(name) { this.name = name; }
 
-    test("is run even after throw", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "is run even after throw", () => {
         let disposed = false;
         let inBlock = false;
         let inCatch = false;
@@ -62,7 +62,7 @@ describe("behavior with exceptions", () => {
         expect(inCatch).toBeTrue();
     });
 
-    test("throws error if dispose method does", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "throws error if dispose method does", () => {
         let disposed = false;
         let endOfTry = false;
         let inCatch = false;
@@ -84,7 +84,7 @@ describe("behavior with exceptions", () => {
         expect(inCatch).toBeTrue();
     });
 
-    test("if block and using throw get suppressed error", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "if block and using throw get suppressed error", () => {
         let disposed = false;
         let inCatch = false;
         try {
@@ -108,7 +108,7 @@ describe("behavior with exceptions", () => {
         expect(inCatch).toBeTrue();
     });
 
-    test("multiple throwing disposes give suppressed error", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "multiple throwing disposes give suppressed error", () => {
         let inCatch = false;
         try {
             {
@@ -133,7 +133,7 @@ describe("behavior with exceptions", () => {
         expect(inCatch).toBeTrue();
     });
 
-    test("3 throwing disposes give chaining suppressed error", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "3 throwing disposes give chaining suppressed error", () => {
         let inCatch = false;
         try {
             {
@@ -168,7 +168,7 @@ describe("behavior with exceptions", () => {
         expect(inCatch).toBeTrue();
     });
 
-    test("normal error and multiple disposing erorrs give chaining suppressed errors", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "normal error and multiple disposing erorrs give chaining suppressed errors", () => {
         let inCatch = false;
         try {
             using a = { [Symbol.dispose]() {
@@ -199,7 +199,7 @@ describe("behavior with exceptions", () => {
 });
 
 describe("works in a bunch of scopes", () => {
-    test("works in block", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "works in block", () => {
         let dispose = false;
         expect(dispose).toBeFalse();
         {
@@ -210,7 +210,7 @@ describe("works in a bunch of scopes", () => {
         expect(dispose).toBeTrue();
     });
 
-    test("works in static class block", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "works in static class block", () => {
         let dispose = false;
         expect(dispose).toBeFalse();
         class A {
@@ -223,7 +223,7 @@ describe("works in a bunch of scopes", () => {
         expect(dispose).toBeTrue();
     });
 
-    test("works in function", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "works in function", () => {
         let dispose = [];
         function f(val) {
             const disposeLength = dispose.length;
@@ -237,7 +237,7 @@ describe("works in a bunch of scopes", () => {
         expect(dispose).toEqual([0, 1]);
     });
 
-    test("switch block is treated as full block in function", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "switch block is treated as full block in function", () => {
         let disposeFull = [];
         let disposeInner = false;
 
@@ -284,13 +284,13 @@ describe("works in a bunch of scopes", () => {
 });
 
 describe("invalid using bindings", () => {
-    test("nullish values do not throw", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "nullish values do not throw", () => {
         using a = null, b = undefined;
         expect(a).toBeNull();
         expect(b).toBeUndefined();
     });
 
-    test("non-object throws", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "non-object throws", () => {
         [0, "a", true, NaN, 4n, Symbol.dispose].forEach(value => {
             expect(() => {
                 using v = value;
@@ -298,13 +298,13 @@ describe("invalid using bindings", () => {
         });
     });
 
-    test("object without dispose throws", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "object without dispose throws", () => {
         expect(() => {
             using a = {};
         }).toThrowWithMessage(TypeError, "does not have dispose method");
     });
 
-    test("object with non callable dispose throws", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "object with non callable dispose throws", () => {
         [0, "a", true, NaN, 4n, Symbol.dispose, [], {}].forEach(value => {
             expect(() => {
                 using a = { [Symbol.dispose]: value };
@@ -332,7 +332,7 @@ describe("using is still a valid variable name", () => {
         expect(using).toBe(1);
     });
 
-    test("using", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "using", () => {
         "use strict";
         using using = null;
         expect(using).toBeNull();

--- a/Userland/Libraries/LibJS/Tests/using-for-loops.js
+++ b/Userland/Libraries/LibJS/Tests/using-for-loops.js
@@ -1,5 +1,5 @@
 describe("basic usage", () => {
-    test("using in normal for loop", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "using in normal for loop", () => {
         let isDisposed = false;
         let lastI = -1;
         for (
@@ -27,7 +27,7 @@ describe("basic usage", () => {
         expect(lastI).toBe(2);
     });
 
-    test("using in normal for loop with expression body", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "using in normal for loop with expression body", () => {
         let isDisposed = false;
         let outerI = 0;
         for (
@@ -53,7 +53,7 @@ describe("basic usage", () => {
         expect(outerI).toBe(3);
     });
 
-    test("using in for of loop", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "using in for of loop", () => {
         const disposable = [];
         const values = [];
 
@@ -75,7 +75,7 @@ describe("basic usage", () => {
         expect(disposable).toEqual(['a', 'b', 'c']);
     });
 
-    test("using in for of loop with expression body", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "using in for of loop with expression body", () => {
         let disposableCalls = 0;
         let i = 0;
 
@@ -91,7 +91,7 @@ describe("basic usage", () => {
         expect(disposableCalls).toBe(3);
     });
 
-    test("can have multiple declaration in normal for loop", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "can have multiple declaration in normal for loop", () => {
         let disposed = 0;
         const a = {
             [Symbol.dispose]() {
@@ -106,7 +106,7 @@ describe("basic usage", () => {
         expect(disposed).toBe(2);
     });
 
-    test("can have using in block in for loop", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "can have using in block in for loop", () => {
         const disposed = [];
         const values = [];
         for (let i = 0; i < 3; i++) {
@@ -123,7 +123,7 @@ describe("basic usage", () => {
         expect(disposed).toEqual([0, 1, 2]);
     });
 
-    test("can have using in block in for-in loop", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "can have using in block in for-in loop", () => {
         const disposed = [];
         const values = [];
         for (const i in ['a', 'b', 'c']) {
@@ -140,7 +140,7 @@ describe("basic usage", () => {
         expect(disposed).toEqual(["0", "1", "2"]);
     });
 
-    test("dispose is called even if throw in for of loop", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "dispose is called even if throw in for of loop", () => {
         let disposableCalls = 0;
 
         const obj = {
@@ -209,7 +209,7 @@ describe("using is still a valid variable in loops", () => {
         expect(enteredLoop).toBeTrue();
     });
 
-    test("using using of", () => {
+    test.xfailIf(isBytecodeInterpreterEnabled(), "using using of", () => {
         let enteredLoop = false;
         for (using using of [null]) {
             enteredLoop = true;

--- a/Userland/Libraries/LibTest/Results.h
+++ b/Userland/Libraries/LibTest/Results.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2020, Matthew Olsson <mattco@serenityos.org>
  * Copyright (c) 2020-2021, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021, Brian Gianforcaro <bgianf@serenityos.org>
+ * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -17,6 +18,7 @@ enum class Result {
     Pass,
     Fail,
     Skip,
+    ExpectedFail,
     Crashed,
 };
 
@@ -42,6 +44,7 @@ struct Counts {
     unsigned tests_failed { 0 };
     unsigned tests_passed { 0 };
     unsigned tests_skipped { 0 };
+    unsigned tests_expected_failed { 0 };
     unsigned suites_failed { 0 };
     unsigned suites_passed { 0 };
     unsigned files_total { 0 };

--- a/Userland/Libraries/LibTest/TestRunner.h
+++ b/Userland/Libraries/LibTest/TestRunner.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2020-2021, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -184,12 +185,17 @@ inline void TestRunner::print_test_results() const
         out("{} skipped, ", m_counts.tests_skipped);
         print_modifiers({ CLEAR });
     }
+    if (m_counts.tests_expected_failed) {
+        print_modifiers({ FG_ORANGE });
+        out("{} expected failed, ", m_counts.tests_expected_failed);
+        print_modifiers({ CLEAR });
+    }
     if (m_counts.tests_passed) {
         print_modifiers({ FG_GREEN });
         out("{} passed, ", m_counts.tests_passed);
         print_modifiers({ CLEAR });
     }
-    outln("{} total", m_counts.tests_failed + m_counts.tests_skipped + m_counts.tests_passed);
+    outln("{} total", m_counts.tests_failed + m_counts.tests_skipped + m_counts.tests_passed + m_counts.tests_expected_failed);
 
     outln("Files:       {} total", m_counts.files_total);
 
@@ -227,6 +233,9 @@ inline void TestRunner::print_test_results_as_json() const
                 case Result::Skip:
                     result_name = "SKIPPED"sv;
                     break;
+                case Result::ExpectedFail:
+                    result_name = "XFAIL"sv;
+                    break;
                 case Result::Crashed:
                     result_name = "PROCESS_ERROR"sv;
                     break;
@@ -254,7 +263,8 @@ inline void TestRunner::print_test_results_as_json() const
         tests.set("failed", m_counts.tests_failed);
         tests.set("passed", m_counts.tests_passed);
         tests.set("skipped", m_counts.tests_skipped);
-        tests.set("total", m_counts.tests_failed + m_counts.tests_passed + m_counts.tests_skipped);
+        tests.set("xfail", m_counts.tests_expected_failed);
+        tests.set("total", m_counts.tests_failed + m_counts.tests_passed + m_counts.tests_skipped + m_counts.tests_expected_failed);
 
         JsonObject results;
         results.set("suites", suites);

--- a/Userland/Utilities/run-tests.cpp
+++ b/Userland/Utilities/run-tests.cpp
@@ -120,8 +120,11 @@ void TestRunner::do_run_single_test(DeprecatedString const& test_path, size_t cu
     case Test::Result::Pass:
         ++m_counts.tests_passed;
         break;
+    case Test::Result::ExpectedFail:
+        ++m_counts.tests_passed;
+        break;
     case Test::Result::Skip:
-        ++m_counts.tests_skipped;
+        ++m_counts.tests_expected_failed;
         break;
     case Test::Result::Fail:
         ++m_counts.tests_failed;
@@ -196,7 +199,8 @@ void TestRunner::do_run_single_test(DeprecatedString const& test_path, size_t cu
             outln("{} ({})", test_result.file_path.basename(), test_result.result == Test::Result::Fail ? "failed" : "crashed");
         } else {
             print_modifiers({ Test::CLEAR, Test::FG_ORANGE });
-            outln("{} (skipped)", test_result.file_path.basename());
+            auto const status = test_result.result == Test::Result::Skip ? "skipped"sv : "expected fail"sv;
+            outln("{} ({})", test_result.file_path.basename(), status);
         }
         print_modifiers({ Test::CLEAR });
     }


### PR DESCRIPTION
The motivation for this change is the fourth commit in particular, where the test does not work in AST mode, but does for bytecode mode. I then figured that using this functionality, this should also allow us to run test-js in bytecode mode in CI.

![image](https://github.com/SerenityOS/serenity/assets/35911232/844d39c0-10ef-48e1-9483-b3ba101d5f52)

![image](https://github.com/SerenityOS/serenity/assets/35911232/1eb676bb-21e3-4e4b-a4dd-fcfd411b4df2)

![image](https://github.com/SerenityOS/serenity/assets/35911232/cec73e1e-7eda-4a95-b8d1-582db6e7aaef)
