### PR TITLE
LibWeb: Improve table colspan and rowspan spec alignment

### DIFF
--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_SOURCES
     TestCSSIDSpeed.cpp
     TestCSSPixels.cpp
     TestHTMLTokenizer.cpp
+    TestNumbers.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibWeb/Layout/expected/table/colspan-with-trailing-characters.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-with-trailing-characters.txt
@@ -1,0 +1,120 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x103.875 [BFC] children: not-inline
+    BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
+      TextNode <#text>
+    BlockContainer <body> at (8,8) content-size 784x87.875 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+        TextNode <#text>
+      TableWrapper <(anonymous)> at (8,8) content-size 229.359375x87.875 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 227.359375x85.875 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (9,9) content-size 227.359375x85.875 table-row-group children: not-inline
+            Box <tr> at (9,9) content-size 227.359375x21.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <th> at (11,11) content-size 70.046875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 70.046875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x17.46875]
+                    "Header 1"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <th> at (85.046875,11) content-size 72.515625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 72.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x17.46875]
+                    "Header 2"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <th> at (161.5625,11) content-size 72.796875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 72.796875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x17.46875]
+                    "Header 3"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (9,30.46875) content-size 227.359375x21.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,32.46875) content-size 223.359375x17.46875 table-cell [BFC] children: inline
+                line 0 width: 41.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [102,32.46875 41.84375x17.46875]
+                    "Cell 1"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (9,51.9375) content-size 227.359375x21.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,53.9375) content-size 223.359375x17.46875 table-cell [BFC] children: inline
+                line 0 width: 44.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [101,53.9375 44.3125x17.46875]
+                    "Cell 2"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (9,73.40625) content-size 227.359375x21.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,75.40625) content-size 70.046875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 44.59375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [24,75.40625 44.59375x17.46875]
+                    "Cell 3"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (85.046875,75.40625) content-size 72.515625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 43.25, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [100.046875,75.40625 43.25x17.46875]
+                    "Cell 4"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (161.5625,75.40625) content-size 72.796875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 43.953125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [175.5625,75.40625 43.953125x17.46875]
+                    "Cell 5"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+      BlockContainer <(anonymous)> at (8,95.875) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x103.875]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x87.875]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 229.359375x87.875]
+        PaintableBox (Box<TABLE>) [8,8 229.359375x87.875]
+          PaintableBox (Box<TBODY>) [9,9 227.359375x85.875]
+            PaintableBox (Box<TR>) [9,9 227.359375x21.46875]
+              PaintableWithLines (BlockContainer<TH>) [9,9 74.046875x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TH>) [83.046875,9 76.515625x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TH>) [159.5625,9 76.796875x21.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [9,30.46875 227.359375x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,30.46875 227.359375x21.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [9,51.9375 227.359375x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,51.9375 227.359375x21.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [9,73.40625 227.359375x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,73.40625 74.046875x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [83.046875,73.40625 76.515625x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [159.5625,73.40625 76.796875x21.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,95.875 784x0]

--- a/Tests/LibWeb/Layout/expected/table/rowspan-with-trailing-characters.txt
+++ b/Tests/LibWeb/Layout/expected/table/rowspan-with-trailing-characters.txt
@@ -1,0 +1,204 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x146.8125 [BFC] children: not-inline
+    BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
+      TextNode <#text>
+    BlockContainer <body> at (8,8) content-size 784x130.8125 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+        TextNode <#text>
+      TableWrapper <(anonymous)> at (8,8) content-size 229.359375x130.8125 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 227.359375x128.8125 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (9,9) content-size 227.359375x128.8125 table-row-group children: not-inline
+            Box <tr> at (9,9) content-size 227.359375x21.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <th> at (11,11) content-size 70.046875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 70.046875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x17.46875]
+                    "Header 1"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <th> at (85.046875,11) content-size 72.515625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 72.515625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x17.46875]
+                    "Header 2"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <th> at (161.5625,11) content-size 72.796875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 72.796875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x17.46875]
+                    "Header 3"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (9,30.46875) content-size 227.359375x21.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,32.46875) content-size 70.046875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 41.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [25,32.46875 41.84375x17.46875]
+                    "Cell 1"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (85.046875,32.46875) content-size 72.515625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 44.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [99.046875,32.46875 44.3125x17.46875]
+                    "Cell 2"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (161.5625,43.203125) content-size 72.796875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 44.59375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [175.5625,43.203125 44.59375x17.46875]
+                    "Cell 3"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (9,51.9375) content-size 227.359375x21.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,53.9375) content-size 70.046875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 43.25, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [24,53.9375 43.25x17.46875]
+                    "Cell 4"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (85.046875,53.9375) content-size 72.515625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 43.953125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [99.046875,53.9375 43.953125x17.46875]
+                    "Cell 5"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (9,73.40625) content-size 227.359375x21.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,75.40625) content-size 70.046875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 44.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [24,75.40625 44.234375x17.46875]
+                    "Cell 6"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (85.046875,75.40625) content-size 72.515625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 44.21875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [99.046875,75.40625 44.21875x17.46875]
+                    "Cell 7"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (161.5625,75.40625) content-size 72.796875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 44.984375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [175.5625,75.40625 44.984375x17.46875]
+                    "Cell 8"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (9,94.875) content-size 227.359375x21.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,96.875) content-size 70.046875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 44.328125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [24,96.875 44.328125x17.46875]
+                    "Cell 9"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (85.046875,96.875) content-size 72.515625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 51.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 7, rect: [96.046875,96.875 51.4375x17.46875]
+                    "Cell 10"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (161.5625,107.609375) content-size 72.796875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 48.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 7, rect: [173.5625,107.609375 48.1875x17.46875]
+                    "Cell 11"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (9,116.34375) content-size 227.359375x21.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,118.34375) content-size 70.046875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 50.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 7, rect: [21,118.34375 50.65625x17.46875]
+                    "Cell 12"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (85.046875,118.34375) content-size 72.515625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 50.9375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 7, rect: [96.046875,118.34375 50.9375x17.46875]
+                    "Cell 13"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+      BlockContainer <(anonymous)> at (8,138.8125) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x146.8125]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x130.8125]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 229.359375x130.8125]
+        PaintableBox (Box<TABLE>) [8,8 229.359375x130.8125]
+          PaintableBox (Box<TBODY>) [9,9 227.359375x128.8125]
+            PaintableBox (Box<TR>) [9,9 227.359375x21.46875]
+              PaintableWithLines (BlockContainer<TH>) [9,9 74.046875x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TH>) [83.046875,9 76.515625x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TH>) [159.5625,9 76.796875x21.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [9,30.46875 227.359375x21.46875] overflow: [9,30.46875 227.359375x42.9375]
+              PaintableWithLines (BlockContainer<TD>) [9,30.46875 74.046875x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [83.046875,30.46875 76.515625x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [159.5625,30.46875 76.796875x42.9375]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [9,51.9375 227.359375x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,51.9375 74.046875x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [83.046875,51.9375 76.515625x21.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [9,73.40625 227.359375x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,73.40625 74.046875x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [83.046875,73.40625 76.515625x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [159.5625,73.40625 76.796875x21.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [9,94.875 227.359375x21.46875] overflow: [9,94.875 227.359375x42.9375]
+              PaintableWithLines (BlockContainer<TD>) [9,94.875 74.046875x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [83.046875,94.875 76.515625x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [159.5625,94.875 76.796875x42.9375]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [9,116.34375 227.359375x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,116.34375 74.046875x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [83.046875,116.34375 76.515625x21.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,138.8125 784x0]

--- a/Tests/LibWeb/Layout/input/table/colspan-with-trailing-characters.html
+++ b/Tests/LibWeb/Layout/input/table/colspan-with-trailing-characters.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Colspan relaxed parsing</title>
+    <style>
+        table, td {
+            border: 1px solid black;
+            border-spacing: 0;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <table border="1">
+        <tr>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+        <tr>
+            <td colspan="3">Cell 1</td>
+        </tr>
+        <tr>
+            <td colspan="3foo">Cell 2</td>
+        </tr>
+        <tr>
+            <td>Cell 3</td>
+            <td>Cell 4</td>
+            <td>Cell 5</td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/Tests/LibWeb/Layout/input/table/rowspan-with-trailing-characters.html
+++ b/Tests/LibWeb/Layout/input/table/rowspan-with-trailing-characters.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Rowspan relaxed parsing</title>
+    <style>
+        table, td {
+            border: 1px solid black;
+            border-spacing: 0;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+<table border="1">
+    <tr>
+        <th>Header 1</th>
+        <th>Header 2</th>
+        <th>Header 3</th>
+    </tr>
+    <tr>
+        <td>Cell 1</td>
+        <td>Cell 2</td>
+        <td rowspan="2">Cell 3</td>
+    </tr>
+    <tr>
+        <td>Cell 4</td>
+        <td>Cell 5</td>
+    </tr>
+    <tr>
+        <td>Cell 6</td>
+        <td>Cell 7</td>
+        <td>Cell 8</td>
+    </tr>
+    <tr>
+        <td>Cell 9</td>
+        <td>Cell 10</td>
+        <td rowspan="2foo">Cell 11</td>
+    </tr>
+    <tr>
+        <td>Cell 12</td>
+        <td>Cell 13</td>
+    </tr>
+</table>
+</body>
+</html>

--- a/Tests/LibWeb/TestNumbers.cpp
+++ b/Tests/LibWeb/TestNumbers.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2023, Jonatan Klemets <jonatan.r.klemets@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <LibWeb/HTML/Numbers.h>
+
+TEST_CASE(parse_integer)
+{
+    auto optional_value = Web::HTML::parse_integer(""sv);
+    EXPECT(!optional_value.has_value());
+
+    optional_value = Web::HTML::parse_integer("123"sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 123);
+
+    optional_value = Web::HTML::parse_integer(" 456"sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 456);
+
+    optional_value = Web::HTML::parse_integer("789 "sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 789);
+
+    optional_value = Web::HTML::parse_integer("   22   "sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 22);
+
+    optional_value = Web::HTML::parse_integer(" \n\t31\t\t\n\n"sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 31);
+
+    optional_value = Web::HTML::parse_integer("765foo"sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 765);
+
+    optional_value = Web::HTML::parse_integer("3;"sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 3);
+
+    optional_value = Web::HTML::parse_integer("foo765"sv);
+    EXPECT(!optional_value.has_value());
+
+    optional_value = Web::HTML::parse_integer("1"sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 1);
+
+    optional_value = Web::HTML::parse_integer("+2"sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 2);
+
+    optional_value = Web::HTML::parse_integer("-3"sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), -3);
+}
+
+TEST_CASE(parse_non_negative_integer)
+{
+    auto optional_value = Web::HTML::parse_non_negative_integer(""sv);
+    EXPECT(!optional_value.has_value());
+
+    optional_value = Web::HTML::parse_non_negative_integer("123"sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 123u);
+
+    optional_value = Web::HTML::parse_non_negative_integer(" 456"sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 456u);
+
+    optional_value = Web::HTML::parse_non_negative_integer("789 "sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 789u);
+
+    optional_value = Web::HTML::parse_non_negative_integer("   22   "sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 22u);
+
+    optional_value = Web::HTML::parse_non_negative_integer(" \n\t31\t\t\n\n"sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 31u);
+
+    optional_value = Web::HTML::parse_non_negative_integer("765foo"sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 765u);
+
+    optional_value = Web::HTML::parse_non_negative_integer("3;"sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 3u);
+
+    optional_value = Web::HTML::parse_non_negative_integer("foo765"sv);
+    EXPECT(!optional_value.has_value());
+
+    optional_value = Web::HTML::parse_non_negative_integer("1"sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 1u);
+
+    optional_value = Web::HTML::parse_non_negative_integer("+2"sv);
+    EXPECT(optional_value.has_value());
+    EXPECT_EQ(optional_value.value(), 2u);
+
+    optional_value = Web::HTML::parse_non_negative_integer("-3"sv);
+    EXPECT(!optional_value.has_value());
+}

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -358,6 +358,7 @@ set(SOURCES
     HTML/NavigationTransition.cpp
     HTML/Navigator.cpp
     HTML/NavigatorID.cpp
+    HTML/Numbers.cpp
     HTML/PageTransitionEvent.cpp
     HTML/Parser/Entities.cpp
     HTML/Parser/HTMLEncodingDetection.cpp

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -95,9 +95,25 @@ void HTMLTableCellElement::apply_presentational_hints(CSS::StyleProperties& styl
     apply_border_style(CSS::PropertyID::BorderBottomStyle, CSS::PropertyID::BorderBottomWidth, CSS::PropertyID::BorderBottomColor);
 }
 
+// This implements step 8 in the spec here:
+// https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-processing-rows
 unsigned int HTMLTableCellElement::col_span() const
 {
-    return Web::HTML::parse_non_negative_integer(attribute(HTML::AttributeNames::colspan)).value_or(1);
+    auto optional_value = Web::HTML::parse_non_negative_integer(attribute(HTML::AttributeNames::colspan));
+
+    // If parsing that value failed, or returned zero, or if the attribute is absent, then let colspan be 1, instead.
+    if (!optional_value.has_value() || optional_value.value() == 0) {
+        return 1;
+    }
+
+    auto value = optional_value.value();
+
+    // If colspan is greater than 1000, let it be 1000 instead.
+    if (value > 1000) {
+        return 1000;
+    }
+
+    return value;
 }
 
 WebIDL::ExceptionOr<void> HTMLTableCellElement::set_col_span(unsigned int value)
@@ -105,9 +121,19 @@ WebIDL::ExceptionOr<void> HTMLTableCellElement::set_col_span(unsigned int value)
     return set_attribute(HTML::AttributeNames::colspan, DeprecatedString::number(value));
 }
 
+// This implements step 9 in the spec here:
+// https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-processing-rows
 unsigned int HTMLTableCellElement::row_span() const
 {
-    return Web::HTML::parse_non_negative_integer(attribute(HTML::AttributeNames::rowspan)).value_or(1);
+    // If parsing that value failed or if the attribute is absent, then let rowspan be 1, instead.
+    auto value = Web::HTML::parse_non_negative_integer(attribute(HTML::AttributeNames::rowspan)).value_or(1);
+
+    // If rowspan is greater than 65534, let it be 65534 instead.
+    if (value > 65534) {
+        return 65534;
+    }
+
+    return value;
 }
 
 WebIDL::ExceptionOr<void> HTMLTableCellElement::set_row_span(unsigned int value)

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLTableCellElement.h>
 #include <LibWeb/HTML/HTMLTableElement.h>
+#include <LibWeb/HTML/Numbers.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 
 namespace Web::HTML {
@@ -96,7 +97,7 @@ void HTMLTableCellElement::apply_presentational_hints(CSS::StyleProperties& styl
 
 unsigned int HTMLTableCellElement::col_span() const
 {
-    return attribute(HTML::AttributeNames::colspan).to_uint().value_or(1);
+    return Web::HTML::parse_non_negative_integer(attribute(HTML::AttributeNames::colspan)).value_or(1);
 }
 
 WebIDL::ExceptionOr<void> HTMLTableCellElement::set_col_span(unsigned int value)
@@ -106,7 +107,7 @@ WebIDL::ExceptionOr<void> HTMLTableCellElement::set_col_span(unsigned int value)
 
 unsigned int HTMLTableCellElement::row_span() const
 {
-    return attribute(HTML::AttributeNames::rowspan).to_uint().value_or(1);
+    return Web::HTML::parse_non_negative_integer(attribute(HTML::AttributeNames::rowspan)).value_or(1);
 }
 
 WebIDL::ExceptionOr<void> HTMLTableCellElement::set_row_span(unsigned int value)

--- a/Userland/Libraries/LibWeb/HTML/Numbers.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Numbers.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023, Jonatan Klemets <jonatan.r.klemets@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/GenericLexer.h>
+#include <LibWeb/HTML/Numbers.h>
+#include <LibWeb/Infra/CharacterTypes.h>
+
+namespace Web::HTML {
+
+// https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-integers
+Optional<i32> parse_integer(StringView string)
+{
+    // 1. Let input be the string being parsed.
+    // 2. Let position be a pointer into input, initially pointing at the start of the string.
+    GenericLexer lexer { string };
+
+    // 3. Let sign have the value "positive".
+    // NOTE: Skipped, see comment on step 6.
+
+    // 4. Skip ASCII whitespace within input given position.
+    lexer.ignore_while(Web::Infra::is_ascii_whitespace);
+
+    // 5. If position is past the end of input, return an error.
+    if (lexer.is_eof()) {
+        return {};
+    }
+
+    // 6. If the character indicated by position (the first character) is a U+002D HYPHEN-MINUS character (-):
+    //
+    // If we parse a signed integer, then we include the sign character (if present) in the collect step
+    // (step 8) and lean on `AK::StringUtils::convert_to_int` to handle it for us.
+    size_t start_index = lexer.tell();
+    if (lexer.peek() == '-' || lexer.peek() == '+') {
+        lexer.consume();
+    }
+
+    // 7. If the character indicated by position is not an ASCII digit, then return an error.
+    if (!lexer.next_is(is_ascii_digit)) {
+        return {};
+    }
+
+    // 8. Collect a sequence of code points that are ASCII digits from input given position, and interpret the resulting sequence as a base-ten integer. Let value be that integer.
+    lexer.consume_while(is_ascii_digit);
+    size_t end_index = lexer.tell();
+    auto digits = lexer.input().substring_view(start_index, end_index - start_index);
+    auto optional_value = AK::StringUtils::convert_to_int<i32>(digits);
+
+    // 9. If sign is "positive", return value, otherwise return the result of subtracting value from zero.
+    // NOTE: Skipped, see comment on step 6.
+
+    return optional_value;
+}
+
+// https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-non-negative-integers
+Optional<u32> parse_non_negative_integer(StringView string)
+{
+    // 1. Let input be the string being parsed.
+    // 2. Let value be the result of parsing input using the rules for parsing integers.
+    //
+    // NOTE: Because we call `parse_integer`, we parse all integers as signed. If we need the extra
+    //       size that an unsigned integer offers, then this would need to be improved. That said,
+    //       I don't think we need to support such large integers at the moment.
+    auto optional_value = parse_integer(string);
+
+    // 3. If value is an error, return an error.
+    if (!optional_value.has_value()) {
+        return {};
+    }
+
+    // 4. If value is less than zero, return an error.
+    if (optional_value.value() < 0) {
+        return {};
+    }
+
+    // 5. Return value.
+    return static_cast<u32>(optional_value.value());
+}
+
+}

--- a/Userland/Libraries/LibWeb/HTML/Numbers.h
+++ b/Userland/Libraries/LibWeb/HTML/Numbers.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023, Jonatan Klemets <jonatan.r.klemets@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <AK/String.h>
+
+namespace Web::HTML {
+
+Optional<i32> parse_integer(StringView string);
+
+Optional<u32> parse_non_negative_integer(StringView string);
+
+}


### PR DESCRIPTION
The spec [1] says the `colspan` and `rowspan` attributes should be valid
numbers. However, all major browsers ignore tailing non-numeric
characters and we should do the same.

This patch changes the `HTMLTableCellElement::col_span` and
`HTMLTableCellElement::row_span` methods to use a more relaxed number
parsing mode (`NumericParseMode::IgnoreTrailingCharacters`).

[1] https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-colspan

Fixes #19937
