### PR TITLE
Ladybird+LibWebView: Respawn with same JS interpreter after crash

### DIFF
--- a/Ladybird/WebContentView.cpp
+++ b/Ladybird/WebContentView.cpp
@@ -52,7 +52,8 @@
 bool is_using_dark_system_theme(QWidget&);
 
 WebContentView::WebContentView(StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling, WebView::UseJavaScriptBytecode use_javascript_bytecode)
-    : m_webdriver_content_ipc_path(webdriver_content_ipc_path)
+    : WebView::ViewImplementation(use_javascript_bytecode)
+    , m_webdriver_content_ipc_path(webdriver_content_ipc_path)
 {
     setMouseTracking(true);
     setAcceptDrops(true);
@@ -72,7 +73,7 @@ WebContentView::WebContentView(StringView webdriver_content_ipc_path, WebView::E
         update_viewport_rect();
     });
 
-    create_client(enable_callgrind_profiling, use_javascript_bytecode);
+    create_client(enable_callgrind_profiling);
 }
 
 WebContentView::~WebContentView() = default;
@@ -525,12 +526,12 @@ void WebContentView::update_palette(PaletteMode mode)
     client().async_update_system_theme(make_system_theme_from_qt_palette(*this, mode));
 }
 
-void WebContentView::create_client(WebView::EnableCallgrindProfiling enable_callgrind_profiling, WebView::UseJavaScriptBytecode use_javascript_bytecode)
+void WebContentView::create_client(WebView::EnableCallgrindProfiling enable_callgrind_profiling)
 {
     m_client_state = {};
 
     auto candidate_web_content_paths = get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
-    auto new_client = launch_web_content_process(candidate_web_content_paths, enable_callgrind_profiling, WebView::IsLayoutTestMode::No, use_javascript_bytecode).release_value_but_fixme_should_propagate_errors();
+    auto new_client = launch_web_content_process(candidate_web_content_paths, enable_callgrind_profiling, WebView::IsLayoutTestMode::No, use_javascript_bytecode()).release_value_but_fixme_should_propagate_errors();
 
     m_client_state.client = new_client;
     m_client_state.client->on_web_content_process_crash = [this] {

--- a/Ladybird/WebContentView.h
+++ b/Ladybird/WebContentView.h
@@ -98,7 +98,7 @@ signals:
 
 private:
     // ^WebView::ViewImplementation
-    virtual void create_client(WebView::EnableCallgrindProfiling = WebView::EnableCallgrindProfiling::No, WebView::UseJavaScriptBytecode = WebView::UseJavaScriptBytecode::No) override;
+    virtual void create_client(WebView::EnableCallgrindProfiling = WebView::EnableCallgrindProfiling::No) override;
     virtual void update_zoom() override;
     virtual Gfx::IntRect viewport_rect() const override;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const override;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -25,7 +25,8 @@ REGISTER_WIDGET(WebView, OutOfProcessWebView)
 
 namespace WebView {
 
-OutOfProcessWebView::OutOfProcessWebView()
+OutOfProcessWebView::OutOfProcessWebView(UseJavaScriptBytecode use_javascript_bytecode)
+    : ViewImplementation(use_javascript_bytecode)
 {
     set_should_hide_unnecessary_scrollbars(true);
     set_focus_policy(GUI::FocusPolicy::StrongFocus);
@@ -35,7 +36,7 @@ OutOfProcessWebView::OutOfProcessWebView()
 
 OutOfProcessWebView::~OutOfProcessWebView() = default;
 
-void OutOfProcessWebView::create_client(EnableCallgrindProfiling, UseJavaScriptBytecode)
+void OutOfProcessWebView::create_client(EnableCallgrindProfiling)
 {
     m_client_state = {};
 

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -55,7 +55,7 @@ public:
     void set_content_scales_to_viewport(bool);
 
 private:
-    OutOfProcessWebView();
+    explicit OutOfProcessWebView(UseJavaScriptBytecode = UseJavaScriptBytecode::No);
 
     // ^Widget
     virtual void paint_event(GUI::PaintEvent&) override;
@@ -78,7 +78,7 @@ private:
     virtual void did_scroll() override;
 
     // ^WebView::ViewImplementation
-    virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No, UseJavaScriptBytecode = UseJavaScriptBytecode::No) override;
+    virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No) override;
     virtual void update_zoom() override;
     virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) override;
     virtual void notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize) override;

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -14,7 +14,8 @@
 
 namespace WebView {
 
-ViewImplementation::ViewImplementation()
+ViewImplementation::ViewImplementation(UseJavaScriptBytecode use_javascript_bytecode)
+    : m_use_javascript_bytecode(use_javascript_bytecode)
 {
     m_backing_store_shrink_timer = Core::Timer::create_single_shot(3000, [this] {
         resize_backing_stores_if_needed(WindowResizeInProgress::No);

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -74,6 +74,8 @@ public:
     void clear_inspected_dom_node();
     i32 get_hovered_node_id();
 
+    UseJavaScriptBytecode use_javascript_bytecode() const { return m_use_javascript_bytecode; }
+
     void debug_request(DeprecatedString const& request, DeprecatedString const& argument = {});
 
     void run_javascript(StringView);
@@ -158,7 +160,7 @@ protected:
     static constexpr auto ZOOM_MAX_LEVEL = 5.0f;
     static constexpr auto ZOOM_STEP = 0.1f;
 
-    ViewImplementation();
+    explicit ViewImplementation(UseJavaScriptBytecode);
 
     WebContentClient& client();
     WebContentClient const& client() const;
@@ -173,7 +175,7 @@ protected:
     void request_repaint();
     void handle_resize();
 
-    virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No, UseJavaScriptBytecode = UseJavaScriptBytecode::No) { }
+    virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No) { }
 
 #if !defined(AK_OS_SERENITY)
     ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(ReadonlySpan<String> candidate_web_content_paths, EnableCallgrindProfiling = EnableCallgrindProfiling::No, IsLayoutTestMode = IsLayoutTestMode::No, UseJavaScriptBytecode = UseJavaScriptBytecode::No);
@@ -210,6 +212,8 @@ protected:
 
     size_t m_crash_count = 0;
     RefPtr<Core::Timer> m_repeated_crash_timer;
+
+    UseJavaScriptBytecode m_use_javascript_bytecode {};
 };
 
 }

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -49,7 +49,7 @@ class HeadlessWebContentView final : public WebView::ViewImplementation {
 public:
     static ErrorOr<NonnullOwnPtr<HeadlessWebContentView>> create(Core::AnonymousBuffer theme, Gfx::IntSize const& window_size, StringView web_driver_ipc_path, WebView::IsLayoutTestMode is_layout_test_mode = WebView::IsLayoutTestMode::No, WebView::UseJavaScriptBytecode use_javascript_bytecode = WebView::UseJavaScriptBytecode::No)
     {
-        auto view = TRY(adopt_nonnull_own_or_enomem(new (nothrow) HeadlessWebContentView()));
+        auto view = TRY(adopt_nonnull_own_or_enomem(new (nothrow) HeadlessWebContentView(use_javascript_bytecode)));
 
 #if defined(AK_OS_SERENITY)
         view->m_client_state.client = TRY(WebView::WebContentClient::try_create(*view));
@@ -94,7 +94,10 @@ public:
     }
 
 private:
-    HeadlessWebContentView() = default;
+    HeadlessWebContentView(WebView::UseJavaScriptBytecode use_javascript_bytecode)
+        : WebView::ViewImplementation(use_javascript_bytecode)
+    {
+    }
 
     void notify_server_did_layout(Badge<WebView::WebContentClient>, Gfx::IntSize) override { }
     void notify_server_did_paint(Badge<WebView::WebContentClient>, i32, Gfx::IntSize) override { }
@@ -125,7 +128,7 @@ private:
 
     void notify_server_did_finish_handling_input_event(bool) override { }
     void update_zoom() override { }
-    void create_client(WebView::EnableCallgrindProfiling, WebView::UseJavaScriptBytecode) override { }
+    void create_client(WebView::EnableCallgrindProfiling) override { }
 
     virtual Gfx::IntRect viewport_rect() const override { return m_viewport_rect; }
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const override { return widget_position; }


### PR DESCRIPTION
WebView::ViewImplementation now remembers which JS interpreter it started with, and uses the same setting if the WebContent process crashes and we have to spawn a new one.