### PR TITLE
AK: Revert "AK: Automatically copy all warn/warnln logs to debug console"

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -557,9 +557,6 @@ struct Formatter<nullptr_t> : Formatter<FlatPtr> {
 
 ErrorOr<void> vformat(StringBuilder&, StringView fmtstr, TypeErasedFormatParams&);
 
-void vdbg(StringView fmtstr, TypeErasedFormatParams&, bool newline = false);
-void dbgln();
-
 #ifndef KERNEL
 void vout(FILE*, StringView fmtstr, TypeErasedFormatParams&, bool newline = false);
 
@@ -596,30 +593,13 @@ inline void outln() { outln(stdout); }
 template<typename... Parameters>
 void warn(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
 {
-#    ifdef AK_OS_SERENITY
-    VariadicFormatParams<AllowDebugOnlyFormatters::Yes, Parameters...> variadic_format_params { parameters... };
-    vdbg(fmtstr.view(), variadic_format_params, false);
-#    endif
     out(stderr, move(fmtstr), parameters...);
 }
 
 template<typename... Parameters>
-void warnln(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
-{
-#    ifdef AK_OS_SERENITY
-    VariadicFormatParams<AllowDebugOnlyFormatters::Yes, Parameters...> variadic_format_params { parameters... };
-    vdbg(fmtstr.view(), variadic_format_params, true);
-#    endif
-    outln(stderr, move(fmtstr), parameters...);
-}
+void warnln(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters) { outln(stderr, move(fmtstr), parameters...); }
 
-inline void warnln()
-{
-#    ifdef AK_OS_SERENITY
-    dbgln();
-#    endif
-    outln(stderr);
-}
+inline void warnln() { outln(stderr); }
 
 #    define warnln_if(flag, fmt, ...)       \
         do {                                \
@@ -628,6 +608,8 @@ inline void warnln()
         } while (0)
 
 #endif
+
+void vdbg(StringView fmtstr, TypeErasedFormatParams&, bool newline = false);
 
 template<typename... Parameters>
 void dbg(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -408,8 +408,10 @@ bool DirectoryView::open(DeprecatedString const& path)
         return false;
 
     auto real_path = error_or_real_path.release_value();
-    if (auto result = Core::System::chdir(real_path); result.is_error())
+    if (auto result = Core::System::chdir(real_path); result.is_error()) {
+        dbgln("Failed to open '{}': {}", real_path, result.error());
         warnln("Failed to open '{}': {}", real_path, result.error());
+    }
 
     if (model().root_path() == real_path.to_deprecated_string()) {
         refresh();

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -1009,6 +1009,7 @@ int snprintf(char* buffer, size_t size, char const* fmt, ...)
 void perror(char const* s)
 {
     int saved_errno = errno;
+    dbgln("perror(): {}: {}", s, strerror(saved_errno));
     warnln("{}: {}", s, strerror(saved_errno));
 }
 


### PR DESCRIPTION
Reverting until we come up with a better way of detecting what exactly should be copied, to prevent stuff like this:

![Screenshot_2023-07-21_at_3 03 14_PM](https://github.com/SerenityOS/serenity/assets/5600524/352cf017-31c3-46a4-a54c-48d45164d63f)
