### PR TITLE
LibPDF: Correctly make text look justified on page 2 of the PDF 1.7 spec

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -27,7 +27,7 @@ public:
     virtual ~PDFFont() = default;
 
     virtual void set_font_size(float font_size) = 0;
-    virtual PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float font_size, float character_spacing, float horizontal_scaling) = 0;
+    virtual PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float font_size, float character_spacing, float word_spacing, float horizontal_scaling) = 0;
 
     virtual Type type() const = 0;
     DeprecatedFlyString base_font_name() const { return m_base_font_name; }

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
@@ -45,7 +45,7 @@ PDFErrorOr<void> SimpleFont::initialize(Document* document, NonnullRefPtr<DictOb
     return {};
 }
 
-PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_string(Gfx::Painter& painter, Gfx::FloatPoint glyph_position, DeprecatedString const& string, Color const& paint_color, float font_size, float character_spacing, float horizontal_scaling)
+PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_string(Gfx::Painter& painter, Gfx::FloatPoint glyph_position, DeprecatedString const& string, Color const& paint_color, float font_size, float character_spacing, float word_spacing, float horizontal_scaling)
 {
     for (auto char_code : string.bytes()) {
         // Use the width specified in the font's dictionary if available,
@@ -57,8 +57,17 @@ PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_string(Gfx::Painter& painter, Gfx::
             glyph_width = get_glyph_width(char_code);
 
         draw_glyph(painter, glyph_position, glyph_width, char_code, paint_color);
+
         auto tx = glyph_width;
         tx += character_spacing;
+
+        // ISO 32000 (PDF 2.0), 9.3.3 Wordspacing
+        // "Word spacing shall be applied to every occurrence of the single-byte character code 32
+        // in a string when using a simple font (including Type 3) or a composite font that defines
+        // code 32 as a single-byte code."
+        if (char_code == ' ')
+            tx += word_spacing;
+
         tx *= horizontal_scaling;
         glyph_position += { tx, 0.0f };
     }

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
@@ -13,7 +13,7 @@ namespace PDF {
 
 class SimpleFont : public PDFFont {
 public:
-    PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float font_size, float character_spacing, float horizontal_scaling) override;
+    PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float font_size, float character_spacing, float word_spacing, float horizontal_scaling) override;
 
 protected:
     PDFErrorOr<void> initialize(Document* document, NonnullRefPtr<DictObject> const& dict, float font_size) override;

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -91,7 +91,7 @@ void Type0Font::set_font_size(float)
 {
 }
 
-PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float, float, float)
+PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float, float, float, float)
 {
     return Error::rendering_unsupported_error("Type0 font not implemented yet");
 }

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -20,7 +20,7 @@ struct CIDSystemInfo {
 class Type0Font : public PDFFont {
 public:
     void set_font_size(float font_size) override;
-    PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint pos, DeprecatedString const&, Color const&, float, float, float) override;
+    PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint pos, DeprecatedString const&, Color const&, float, float, float, float) override;
     Type type() const override { return PDFFont::Type::Type0; }
 
 protected:

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -754,7 +754,7 @@ PDFErrorOr<void> Renderer::show_text(DeprecatedString const& string)
     auto font_size = text_rendering_matrix.x_scale() * text_state().font_size;
 
     auto start_position = text_rendering_matrix.map(Gfx::FloatPoint { 0.0f, 0.0f });
-    auto end_position = TRY(text_state().font->draw_string(m_painter, start_position, string, state().paint_color, font_size, text_state().character_spacing, text_state().word_spacing, text_state().horizontal_scaling));
+    auto end_position = TRY(text_state().font->draw_string(m_painter, start_position, string, state().paint_color, font_size, text_state().character_spacing * text_rendering_matrix.x_scale(), text_state().word_spacing * text_rendering_matrix.x_scale(), text_state().horizontal_scaling));
 
     // Update text matrix
     auto delta_x = end_position.x() - start_position.x();

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -754,7 +754,7 @@ PDFErrorOr<void> Renderer::show_text(DeprecatedString const& string)
     auto font_size = text_rendering_matrix.x_scale() * text_state().font_size;
 
     auto start_position = text_rendering_matrix.map(Gfx::FloatPoint { 0.0f, 0.0f });
-    auto end_position = TRY(text_state().font->draw_string(m_painter, start_position, string, state().paint_color, font_size, text_state().character_spacing, text_state().horizontal_scaling));
+    auto end_position = TRY(text_state().font->draw_string(m_painter, start_position, string, state().paint_color, font_size, text_state().character_spacing, text_state().word_spacing, text_state().horizontal_scaling));
 
     // Update text matrix
     auto delta_x = end_position.x() - start_position.x();


### PR DESCRIPTION
This helps a little bit with justifying the text on page 2 of pdf_reference_1-7.pdf, but doesn't fully fix it.