### PR TITLE
truncate: Allow size suffixes to be used with the `-s` option

### DIFF
--- a/Userland/Utilities/truncate.cpp
+++ b/Userland/Utilities/truncate.cpp
@@ -46,20 +46,18 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     off_t size = 0;
 
     if (!resize.is_empty()) {
-        DeprecatedString str = resize;
-
-        switch (str[0]) {
+        switch (resize[0]) {
         case '+':
             op = OP_Grow;
-            str = str.substring(1, str.length() - 1);
+            resize = resize.substring_view(1);
             break;
         case '-':
             op = OP_Shrink;
-            str = str.substring(1, str.length() - 1);
+            resize = resize.substring_view(1);
             break;
         }
 
-        auto size_opt = str.to_int<off_t>();
+        auto size_opt = resize.to_int<off_t>();
         if (!size_opt.has_value()) {
             args_parser.print_usage(stderr, arguments.strings[0]);
             return 1;

--- a/Userland/Utilities/truncate.cpp
+++ b/Userland/Utilities/truncate.cpp
@@ -99,7 +99,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         size = stat.st_size + size;
         break;
     case OP_Shrink:
-        size = stat.st_size - size;
+        size = max(stat.st_size - size, 0);
         break;
     }
 

--- a/Userland/Utilities/truncate.cpp
+++ b/Userland/Utilities/truncate.cpp
@@ -7,10 +7,6 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
-#include <fcntl.h>
-#include <stdio.h>
-#include <sys/stat.h>
-#include <unistd.h>
 
 enum TruncateOperation {
     OP_Set,


### PR DESCRIPTION
The base 2 size suffixes: 'K', 'M' and 'G' may now be used when specifying a file size with the `-s` option.

I also made a small behavioral change where attempting to reduce a file to a size < 0 will now produce an empty file rather than an error. This matches the behavior of `truncate` on Linux and FreeBSD.

Example usage:

![truncate_size_suffixes](https://github.com/SerenityOS/serenity/assets/2817754/e3d28930-8cd3-446f-ad2a-6414a36369b0)
