### PR TITLE
LibPDF: Fix symbol for text_next_line_show_string_set_spacing operator

### DIFF
--- a/Userland/Libraries/LibPDF/Operator.h
+++ b/Userland/Libraries/LibPDF/Operator.h
@@ -106,7 +106,7 @@ public:
 
         if (symbol_string == "'")
             return OperatorType::TextNextLineShowString;
-        if (symbol_string == "''")
+        if (symbol_string == "\"")
             return OperatorType::TextNextLineShowStringSetSpacing;
 
         dbgln("unsupported graphics symbol {}", symbol_string);
@@ -140,7 +140,7 @@ public:
         if (operator_type == OperatorType::TextNextLineShowString)
             return "'";
         if (operator_type == OperatorType::TextNextLineShowStringSetSpacing)
-            return "''";
+            return "\"";
 
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -526,7 +526,7 @@ PDFErrorOr<Vector<Operator>> Parser::parse_operators()
     Vector<Value> operator_args;
 
     constexpr static auto is_operator_char = [](char ch) {
-        return isalpha(ch) || ch == '*' || ch == '\'';
+        return isalpha(ch) || ch == '*' || ch == '\'' || ch == '"';
     };
 
     m_reader.consume_whitespace();


### PR DESCRIPTION
It's `"`, not `''`.

Now the `text_next_line_show_string_set_spacing` gets called and logs a TODO at page render time if `"` is used in a PDF:

    warning: Rendering of feature not supported:
        draw operation: text_next_line_show_string_set_spacing

It caused a parse error (also at page render time) previously:

    [parse_value @ .../LibPDF/Parser.cpp:104]
        Parser error at offset 611: Unexpected char """