### PR TITLE
Browser: Add option to disable switching to new tabs automatically

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -578,8 +578,8 @@ Tab& BrowserWindow::create_new_tab(URL url, Web::HTML::ActivateTab activate)
         m_tab_widget->set_tab_icon(new_tab, &bitmap);
     };
 
-    new_tab.on_tab_open_request = [this](auto& url) {
-        create_new_tab(url, Web::HTML::ActivateTab::Yes);
+    new_tab.on_tab_open_request = [this](auto& url, auto activate_tab) {
+        create_new_tab(url, activate_tab);
     };
 
     new_tab.on_activate_tab_request = [this](auto& tab) {

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -464,7 +464,7 @@ Tab::Tab(BrowserWindow& window, WebView::UseJavaScriptBytecode use_javascript_by
     };
 
     view().on_link_middle_click = [this](auto& url, auto&, auto modifiers) {
-        auto activate_tab = Browser::default_switch_to_new_tabs;
+        auto activate_tab = Config::read_bool("Browser"sv, "Preferences"sv, "SwitchToNewTabs"sv, Browser::default_switch_to_new_tabs);
         if (modifiers == Mod_Shift)
             activate_tab = !activate_tab;
         on_tab_open_request(url, activate_tab ? Web::HTML::ActivateTab::Yes : Web::HTML::ActivateTab::No);

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -15,6 +15,7 @@
 #include <LibGfx/ShareableBitmap.h>
 #include <LibHTTP/Job.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/ActivateTab.h>
 #include <LibWebView/ViewImplementation.h>
 
 namespace WebView {
@@ -63,7 +64,7 @@ public:
     void window_size_changed(Gfx::IntSize);
 
     Function<void(DeprecatedString const&)> on_title_change;
-    Function<void(const URL&)> on_tab_open_request;
+    Function<void(const URL&, Web::HTML::ActivateTab)> on_tab_open_request;
     Function<void(Tab&)> on_activate_tab_request;
     Function<void(Tab&)> on_tab_close_request;
     Function<void(Tab&)> on_tab_close_other_request;

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
@@ -120,6 +120,10 @@ ErrorOr<void> BrowserSettingsWidget::setup()
     m_auto_close_download_windows_checkbox->set_checked(Config::read_bool("Browser"sv, "Preferences"sv, "CloseDownloadWidgetOnFinish"sv, Browser::default_close_download_widget_on_finish), GUI::AllowCallback::No);
     m_auto_close_download_windows_checkbox->on_checked = [&](auto) { set_modified(true); };
 
+    m_switch_to_new_tabs_checkbox = find_descendant_of_type_named<GUI::CheckBox>("switch_to_new_tabs_checkbox");
+    m_switch_to_new_tabs_checkbox->set_checked(Config::read_bool("Browser"sv, "Preferences"sv, "SwitchToNewTabs"sv, Browser::default_switch_to_new_tabs), GUI::AllowCallback::No);
+    m_switch_to_new_tabs_checkbox->on_checked = [&](auto) { set_modified(true); };
+
     return {};
 }
 
@@ -208,6 +212,7 @@ void BrowserSettingsWidget::apply_settings()
     }
 
     Config::write_bool("Browser"sv, "Preferences"sv, "CloseDownloadWidgetOnFinish"sv, m_auto_close_download_windows_checkbox->is_checked());
+    Config::write_bool("Browser"sv, "Preferences"sv, "SwitchToNewTabs"sv, m_switch_to_new_tabs_checkbox->is_checked());
 }
 
 void BrowserSettingsWidget::reset_default_values()
@@ -217,5 +222,6 @@ void BrowserSettingsWidget::reset_default_values()
     m_show_bookmarks_bar_checkbox->set_checked(Browser::default_show_bookmarks_bar);
     set_color_scheme(Browser::default_color_scheme);
     m_auto_close_download_windows_checkbox->set_checked(Browser::default_close_download_widget_on_finish);
+    m_switch_to_new_tabs_checkbox->set_checked(Browser::default_switch_to_new_tabs);
     set_search_engine_url(Browser::default_search_engine);
 }

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.gml
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.gml
@@ -203,4 +203,30 @@
             }
         }
     }
+
+    @GUI::GroupBox {
+        title: "General"
+        fixed_height: 70
+        layout: @GUI::VerticalBoxLayout {
+            margins: [16, 8, 8]
+            spacing: 2
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 16
+            }
+
+            @GUI::ImageWidget {
+                fixed_width: 32
+                fixed_height: 32
+                bitmap: "/res/icons/32x32/app-settings.png"
+            }
+
+            @GUI::CheckBox {
+                name: "switch_to_new_tabs_checkbox"
+                text: "Automatically switch to new tabs"
+            }
+        }
+    }
 }

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.h
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.h
@@ -30,6 +30,7 @@ private:
     RefPtr<GUI::ComboBox> m_color_scheme_combobox;
     RefPtr<GUI::CheckBox> m_show_bookmarks_bar_checkbox;
     RefPtr<GUI::CheckBox> m_auto_close_download_windows_checkbox;
+    RefPtr<GUI::CheckBox> m_switch_to_new_tabs_checkbox;
 
     void set_search_engine_url(StringView);
     bool m_is_custom_search_engine { false };

--- a/Userland/Applications/BrowserSettings/Defaults.h
+++ b/Userland/Applications/BrowserSettings/Defaults.h
@@ -18,5 +18,6 @@ static constexpr bool default_enable_content_filters = true;
 static constexpr bool default_show_bookmarks_bar = true;
 static constexpr bool default_close_download_widget_on_finish = false;
 static constexpr bool default_allow_autoplay_on_all_websites = false;
+static constexpr bool default_switch_to_new_tabs = false;
 
 }

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -248,6 +248,8 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, unsigned button, unsig
                     run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::click, offset, client_offset, page_offset, button).release_value_but_fixme_should_propagate_errors());
                 else if (button == GUI::MouseButton::Secondary && !(modifiers & Mod_Shift)) // Allow the user to bypass custom context menus by holding shift, like Firefox.
                     run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::contextmenu, offset, client_offset, page_offset, button).release_value_but_fixme_should_propagate_errors());
+                else if (button == GUI::MouseButton::Middle)
+                    run_activation_behavior = true;
             }
 
             if (run_activation_behavior) {


### PR DESCRIPTION
When I middle-click a link I prefer to stay on the current tab and then, by myself, switch to that tab once I'm ready to look at it.

This PR adds an option to do that.