### PR TITLE
LibWeb: Use fixed-point arithmetics for CSSPixels

### DIFF
--- a/AK/Math.h
+++ b/AK/Math.h
@@ -906,6 +906,17 @@ constexpr T round(T x)
     return ceil(x - .5);
 }
 
+template<typename T>
+constexpr int clamp_to_int(T value)
+{
+    if (value >= NumericLimits<int>::max()) {
+        return NumericLimits<int>::max();
+    } else if (value <= NumericLimits<int>::min()) {
+        return NumericLimits<int>::min();
+    }
+    return value;
+}
+
 #undef CONSTEXPR_STATE
 #undef AARCH64_INSTRUCTION
 }

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     TestCSSIDSpeed.cpp
+    TestCSSPixels.cpp
     TestHTMLTokenizer.cpp
 )
 

--- a/Tests/LibWeb/Layout/expected/abspos-box-with-replaced-element.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-box-with-replaced-element.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x0 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 500x100 positioned [BFC] children: not-inline
-      BlockContainer <div.image-container> at (261,11) content-size 248x28.4836 positioned [BFC] children: inline
-        line 0 width: 250, height: 28.4836, bottom: 28.4836, baseline: 28.4836
-          frag 0 from ImageBox start: 0, length: 0, rect: [262,12 248x26.4836]
-        ImageBox <img> at (262,12) content-size 248x26.4836 children: not-inline
+      BlockContainer <div.image-container> at (261,11) content-size 248x25.25 positioned [BFC] children: inline
+        line 0 width: 250, height: 25.25, bottom: 25.25, baseline: 25.25
+          frag 0 from ImageBox start: 0, length: 0, rect: [262,12 248x23.25]
+        ImageBox <img> at (262,12) content-size 248x23.25 children: not-inline

--- a/Tests/LibWeb/Layout/expected/acid1.txt
+++ b/Tests/LibWeb/Layout/expected/acid1.txt
@@ -1,15 +1,15 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x419.999999 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x419.921875 [BFC] children: not-inline
     BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
       TextNode <#text>
-    BlockContainer <body> at (20,20) content-size 480x379.999999 children: not-inline
+    BlockContainer <body> at (20,20) content-size 480x379.921875 children: not-inline
       BlockContainer <(anonymous)> at (20,20) content-size 480x0 children: inline
         TextNode <#text>
       BlockContainer <dl> at (25,25) content-size 470x0 children: inline
         TextNode <#text>
-        BlockContainer <dt> at (40,40) content-size 49.999x280 floating [BFC] children: inline
-          line 0 width: 28.310546, height: 10, bottom: 10, baseline: 7.998046
-            frag 0 from TextNode start: 0, length: 6, rect: [40,40 28.310546x10]
+        BlockContainer <dt> at (40,40) content-size 49.984375x280 floating [BFC] children: inline
+          line 0 width: 28.296875, height: 10, bottom: 10, baseline: 7.984375
+            frag 0 from TextNode start: 0, length: 6, rect: [40,40 28.296875x10]
               "toggle"
           TextNode <#text>
         TextNode <#text>
@@ -19,56 +19,56 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <ul> at (135,45) content-size 340x0 children: inline
             TextNode <#text>
             BlockContainer <li> at (150,60) content-size 50x90 floating [BFC] children: inline
-              line 0 width: 37.880859, height: 10, bottom: 10, baseline: 7.998046
-                frag 0 from TextNode start: 0, length: 7, rect: [150,60 37.880859x10]
+              line 0 width: 37.875, height: 10, bottom: 10, baseline: 7.984375
+                frag 0 from TextNode start: 0, length: 7, rect: [150,60 37.875x10]
                   "the way"
               TextNode <#text>
             TextNode <#text>
-            BlockContainer <li#bar> at (235,55) content-size 139.978x90 floating [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (235,55) content-size 139.978x0 children: inline
+            BlockContainer <li#bar> at (235,55) content-size 139.96875x90 floating [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (235,55) content-size 139.96875x0 children: inline
                 TextNode <#text>
-              BlockContainer <p> at (235,55) content-size 139.978x10 children: inline
-                line 0 width: 74.316406, height: 10, bottom: 10, baseline: 7.998046
-                  frag 0 from TextNode start: 0, length: 14, rect: [235,55 74.316406x10]
+              BlockContainer <p> at (235,55) content-size 139.96875x10 children: inline
+                line 0 width: 74.3125, height: 10, bottom: 10, baseline: 7.984375
+                  frag 0 from TextNode start: 0, length: 14, rect: [235,55 74.3125x10]
                     "the world ends"
                 TextNode <#text>
-              BlockContainer <(anonymous)> at (235,65) content-size 139.978x0 children: inline
+              BlockContainer <(anonymous)> at (235,65) content-size 139.96875x0 children: inline
                 TextNode <#text>
                 InlineNode <form>
                   TextNode <#text>
                   TextNode <#text>
                   TextNode <#text>
-              BlockContainer <p> at (235,65) content-size 139.978x18.999999 children: inline
-                line 0 width: 39.490234, height: 18.999999, bottom: 18.999999, baseline: 12.498046
-                  frag 0 from TextNode start: 1, length: 5, rect: [235,65 27.490234x18.999999]
+              BlockContainer <p> at (235,65) content-size 139.96875x18.984375 children: inline
+                line 0 width: 39.484375, height: 18.984375, bottom: 18.984375, baseline: 12.46875
+                  frag 0 from TextNode start: 1, length: 5, rect: [235,65 27.484375x18.984375]
                     "bang "
-                  frag 1 from RadioButton start: 0, length: 0, rect: [262,65 12x12]
+                  frag 1 from RadioButton start: 0, length: 0, rect: [262.484375,65.46875 12x12]
                 TextNode <#text>
-                RadioButton <input> at (262,65) content-size 12x12 inline-block children: not-inline
+                RadioButton <input> at (262.484375,65.46875) content-size 12x12 inline-block children: not-inline
                 TextNode <#text>
-              BlockContainer <p> at (235,83.999999) content-size 139.978x18.999999 children: inline
-                line 0 width: 57.15625, height: 18.999999, bottom: 18.999999, baseline: 12.498046
-                  frag 0 from TextNode start: 1, length: 8, rect: [235,83.999999 45.15625x18.999999]
+              BlockContainer <p> at (235,83.984375) content-size 139.96875x18.984375 children: inline
+                line 0 width: 57.15625, height: 18.984375, bottom: 18.984375, baseline: 12.46875
+                  frag 0 from TextNode start: 1, length: 8, rect: [235,83.984375 45.15625x18.984375]
                     "whimper "
-                  frag 1 from RadioButton start: 0, length: 0, rect: [280,83.999999 12x12]
+                  frag 1 from RadioButton start: 0, length: 0, rect: [280.15625,84.453125 12x12]
                 TextNode <#text>
-                RadioButton <input> at (280,83.999999) content-size 12x12 inline-block children: not-inline
+                RadioButton <input> at (280.15625,84.453125) content-size 12x12 inline-block children: not-inline
                 TextNode <#text>
-              BlockContainer <(anonymous)> at (235,102.999999) content-size 139.978x0 children: inline
+              BlockContainer <(anonymous)> at (235,102.96875) content-size 139.96875x0 children: inline
                 TextNode <#text>
             TextNode <#text>
-            BlockContainer <li> at (409.978,60) content-size 50x90 floating [BFC] children: inline
-              line 0 width: 31.582031, height: 10, bottom: 10, baseline: 7.998046
-                frag 0 from TextNode start: 0, length: 6, rect: [409.978,60 31.582031x10]
+            BlockContainer <li> at (409.96875,60) content-size 50x90 floating [BFC] children: inline
+              line 0 width: 31.5625, height: 10, bottom: 10, baseline: 7.984375
+                frag 0 from TextNode start: 0, length: 6, rect: [409.96875,60 31.5625x10]
                   "i grow"
-              line 1 width: 14.033203, height: 10, bottom: 20, baseline: 7.998046
-                frag 0 from TextNode start: 7, length: 3, rect: [409.978,70 14.033203x10]
+              line 1 width: 14.03125, height: 10, bottom: 20, baseline: 7.984375
+                frag 0 from TextNode start: 7, length: 3, rect: [409.96875,70 14.03125x10]
                   "old"
               TextNode <#text>
             TextNode <#text>
             BlockContainer <li#baz> at (145,185) content-size 100x100 floating [BFC] children: inline
-              line 0 width: 29.423828, height: 10, bottom: 10, baseline: 7.998046
-                frag 0 from TextNode start: 0, length: 6, rect: [145,185 29.423828x10]
+              line 0 width: 29.421875, height: 10, bottom: 10, baseline: 7.984375
+                frag 0 from TextNode start: 0, length: 6, rect: [145,185 29.421875x10]
                   "pluot?"
               TextNode <#text>
             TextNode <#text>
@@ -78,51 +78,51 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> at (280,195) content-size 50x0 children: inline
                 TextNode <#text>
               BlockContainer <address> at (280,195) content-size 50x20 children: inline
-                line 0 width: 17.275390, height: 10, bottom: 10, baseline: 7.998046
-                  frag 0 from TextNode start: 0, length: 3, rect: [280,195 17.275390x10]
+                line 0 width: 17.265625, height: 10, bottom: 10, baseline: 7.984375
+                  frag 0 from TextNode start: 0, length: 3, rect: [280,195 17.265625x10]
                     "bar"
-                line 1 width: 30.224609, height: 10, bottom: 20, baseline: 7.998046
-                  frag 0 from TextNode start: 4, length: 6, rect: [280,205 30.224609x10]
+                line 1 width: 30.21875, height: 10, bottom: 20, baseline: 7.984375
+                  frag 0 from TextNode start: 4, length: 6, rect: [280,205 30.21875x10]
                     "maids,"
                 TextNode <#text>
               BlockContainer <(anonymous)> at (280,215) content-size 50x0 children: inline
                 TextNode <#text>
             TextNode <#text>
             BlockContainer <h1> at (365,185) content-size 100x100 floating [BFC] children: inline
-              line 0 width: 56.416015, height: 10, bottom: 10, baseline: 7.998046
-                frag 0 from TextNode start: 0, length: 11, rect: [365,185 56.416015x10]
+              line 0 width: 56.390625, height: 10, bottom: 10, baseline: 7.984375
+                frag 0 from TextNode start: 0, length: 11, rect: [365,185 56.390625x10]
                   "sing to me,"
-              line 1 width: 65.449218, height: 10, bottom: 20, baseline: 7.998046
-                frag 0 from TextNode start: 12, length: 12, rect: [365,195 65.449218x10]
+              line 1 width: 65.4375, height: 10, bottom: 20, baseline: 7.984375
+                frag 0 from TextNode start: 12, length: 12, rect: [365,195 65.4375x10]
                   "erbarme dich"
               TextNode <#text>
             TextNode <#text>
         TextNode <#text>
       BlockContainer <(anonymous)> at (20,30) content-size 480x0 children: inline
         TextNode <#text>
-      BlockContainer <p> at (20,335) content-size 480x64.999999 children: inline
-        line 0 width: 473.642578, height: 12.999999, bottom: 12.999999, baseline: 9.498046
-          frag 0 from TextNode start: 1, length: 90, rect: [20,335 473.642578x12.999999]
+      BlockContainer <p> at (20,335) content-size 480x64.921875 children: inline
+        line 0 width: 473.5625, height: 12.984375, bottom: 12.984375, baseline: 9.46875
+          frag 0 from TextNode start: 1, length: 90, rect: [20,335 473.5625x12.984375]
             "This is a nonsensical document, but syntactically valid HTML 4.0. All 100%-conformant CSS1"
-        line 1 width: 396.953125, height: 13, bottom: 25.999999, baseline: 9.498046
-          frag 0 from TextNode start: 92, length: 74, rect: [20,348 396.953125x12.999999]
+        line 1 width: 396.859375, height: 12.984375, bottom: 25.96875, baseline: 9.46875
+          frag 0 from TextNode start: 92, length: 74, rect: [20,347.984375 396.859375x12.984375]
             "agents should be able to render the document elements above this paragraph"
-        line 2 width: 470.585937, height: 13, bottom: 38.999999, baseline: 9.498046
-          frag 0 from TextNode start: 167, length: 43, rect: [20,361 207.900390x12.999999]
+        line 2 width: 470.5, height: 12.984375, bottom: 38.953125, baseline: 9.46875
+          frag 0 from TextNode start: 167, length: 43, rect: [20,360.96875 207.875x12.984375]
             "indistinguishably (to the pixel) from this "
-          frag 1 from TextNode start: 0, length: 20, rect: [228,361 103.007812x12.999999]
+          frag 1 from TextNode start: 0, length: 20, rect: [227.875,360.96875 102.984375x12.984375]
             "reference rendering,"
-          frag 2 from TextNode start: 0, length: 31, rect: [331,361 159.677734x12.999999]
+          frag 2 from TextNode start: 0, length: 31, rect: [330.859375,360.96875 159.640625x12.984375]
             " (except font rasterization and"
-        line 3 width: 465.019531, height: 13.000000, bottom: 51.999999, baseline: 9.498046
-          frag 0 from TextNode start: 32, length: 89, rect: [20,374 465.019531x12.999999]
+        line 3 width: 464.9375, height: 12.984375, bottom: 51.9375, baseline: 9.46875
+          frag 0 from TextNode start: 32, length: 89, rect: [20,373.953125 464.9375x12.984375]
             "form widgets). All discrepancies should be traceable to CSS1 implementation shortcomings."
-        line 4 width: 408.164062, height: 13.000001, bottom: 64.999999, baseline: 9.498046
-          frag 0 from TextNode start: 122, length: 67, rect: [20,387 345.556640x12.999999]
+        line 4 width: 408.046875, height: 12.984375, bottom: 64.921875, baseline: 9.46875
+          frag 0 from TextNode start: 122, length: 67, rect: [20,386.9375 345.46875x12.984375]
             "Once you have finished evaluating this test, you can return to the "
-          frag 1 from TextNode start: 0, length: 11, rect: [366,387 59.892578x12.999999]
+          frag 1 from TextNode start: 0, length: 11, rect: [365.46875,386.9375 59.875x12.984375]
             "parent page"
-          frag 2 from TextNode start: 0, length: 1, rect: [425,387 2.714843x12.999999]
+          frag 2 from TextNode start: 0, length: 1, rect: [425.34375,386.9375 2.703125x12.984375]
             "."
         TextNode <#text>
         InlineNode <a>
@@ -131,5 +131,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         InlineNode <a>
           TextNode <#text>
         TextNode <#text>
-      BlockContainer <(anonymous)> at (20,399.999999) content-size 480x0 children: inline
+      BlockContainer <(anonymous)> at (20,399.921875) content-size 480x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/anonymous-wrappers-continue-to-inherit-style-after-change.txt
+++ b/Tests/LibWeb/Layout/expected/anonymous-wrappers-continue-to-inherit-style-after-change.txt
@@ -1,13 +1,13 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x89.846250 [BFC] children: not-inline
-    BlockContainer <body> at (8,21.440000) content-size 784x73.846250 children: not-inline
-      BlockContainer <h1> at (8,21.440000) content-size 784x34.9375 children: inline
+  BlockContainer <html> at (0,0) content-size 800x89.84375 [BFC] children: not-inline
+    BlockContainer <body> at (8,21.4375) content-size 784x73.84375 children: not-inline
+      BlockContainer <h1> at (8,21.4375) content-size 784x34.9375 children: inline
         line 0 width: 105.53125, height: 34.9375, bottom: 34.9375, baseline: 27.0625
-          frag 0 from TextNode start: 0, length: 6, rect: [8,21.440000 105.53125x34.9375]
+          frag 0 from TextNode start: 0, length: 6, rect: [8,21.4375 105.53125x34.9375]
             "header"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,77.817501) content-size 784x17.46875 children: inline
+      BlockContainer <(anonymous)> at (8,77.8125) content-size 784x17.46875 children: inline
         line 0 width: 212.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 24, rect: [8,77.817501 212.125x17.46875]
+          frag 0 from TextNode start: 0, length: 24, rect: [8,77.8125 212.125x17.46875]
             "anonymously wrapped text"
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-percentage-vertical-align.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-percentage-vertical-align.txt
@@ -1,9 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x62.50625 [BFC] children: not-inline
-    BlockContainer <body> at (2,2) content-size 796x60.50625 children: inline
-      line 0 width: 34, height: 28.50625, bottom: 28.50625, baseline: 28.50625
+  BlockContainer <html> at (1,1) content-size 798x62.515625 [BFC] children: not-inline
+    BlockContainer <body> at (2,2) content-size 796x60.515625 children: inline
+      line 0 width: 34, height: 28.515625, bottom: 28.515625, baseline: 28.515625
         frag 0 from BlockContainer start: 0, length: 0, rect: [4,3 30x30]
-      line 1 width: 32, height: 28.50625, bottom: 60.50625, baseline: 28.50625
+      line 1 width: 32, height: 28.515625, bottom: 60.515625, baseline: 28.515625
         frag 0 from BlockContainer start: 0, length: 0, rect: [3,35 30x30]
       BlockContainer <div.clump> at (4,3) content-size 30x30 inline-block [BFC] children: not-inline
       BreakNode <br>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/bfc-consider-all-currently-stacked-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/bfc-consider-all-currently-stacked-floats.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x34.9375 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x17.46875 children: inline
         line 0 width: 27.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 1, length: 3, rect: [137,8 27.640625x17.46875]
+          frag 0 from TextNode start: 1, length: 3, rect: [137.109375,8 27.640625x17.46875]
             "bar"
         BlockContainer <div.big-float> at (8,8) content-size 100x100 floating [BFC] children: not-inline
         TextNode <#text>
@@ -17,7 +17,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <div> at (8,25.46875) content-size 784x17.46875 children: inline
         line 0 width: 27.203125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 1, length: 3, rect: [130,25.46875 27.203125x17.46875]
+          frag 0 from TextNode start: 1, length: 3, rect: [129.515625,25.46875 27.203125x17.46875]
             "baz"
         TextNode <#text>
         BlockContainer <div.yyy> at (108,25.46875) content-size 21.515625x17.46875 floating [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-min-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-min-content-width.txt
@@ -1,33 +1,33 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x130.21875 [BFC] children: not-inline
-    BlockContainer <body> at (10,10) content-size 780x112.21875 children: not-inline
-      BlockContainer <div.foo> at (11,11) content-size 93.765625x35.40625 children: inline
+  BlockContainer <html> at (1,1) content-size 798x128.8125 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x110.8125 children: not-inline
+      BlockContainer <div.foo> at (11,11) content-size 93.765625x34.9375 children: inline
         line 0 width: 43.578125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
           frag 0 from TextNode start: 0, length: 6, rect: [11,11 43.578125x17.46875]
             "width:"
-        line 1 width: 93.765625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-          frag 0 from TextNode start: 7, length: 11, rect: [11,28 93.765625x17.46875]
+        line 1 width: 93.765625, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+          frag 0 from TextNode start: 7, length: 11, rect: [11,28.46875 93.765625x17.46875]
             "min-content"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (10,47.40625) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (10,46.9375) content-size 780x0 children: inline
         TextNode <#text>
-      BlockContainer <div.bar> at (11,48.40625) content-size 93.765625x35.40625 children: inline
+      BlockContainer <div.bar> at (11,47.9375) content-size 93.765625x34.9375 children: inline
         line 0 width: 81.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 10, rect: [11,48.40625 81.3125x17.46875]
+          frag 0 from TextNode start: 0, length: 10, rect: [11,47.9375 81.3125x17.46875]
             "max-width:"
-        line 1 width: 93.765625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+        line 1 width: 93.765625, height: 17.46875, bottom: 34.9375, baseline: 13.53125
           frag 0 from TextNode start: 11, length: 11, rect: [11,65.40625 93.765625x17.46875]
             "min-content"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (10,84.8125) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (10,83.875) content-size 780x0 children: inline
         TextNode <#text>
-      BlockContainer <div.baz> at (11,85.8125) content-size 93.765625x35.40625 children: inline
+      BlockContainer <div.baz> at (11,84.875) content-size 93.765625x34.9375 children: inline
         line 0 width: 76.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 10, rect: [11,85.8125 76.4375x17.46875]
+          frag 0 from TextNode start: 0, length: 10, rect: [11,84.875 76.4375x17.46875]
             "min-width:"
-        line 1 width: 93.765625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-          frag 0 from TextNode start: 11, length: 11, rect: [11,102.8125 93.765625x17.46875]
+        line 1 width: 93.765625, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+          frag 0 from TextNode start: 11, length: 11, rect: [11,102.34375 93.765625x17.46875]
             "min-content"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (10,122.21875) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (10,120.8125) content-size 780x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-negative-margin-and-no-intruding-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-negative-margin-and-no-intruding-floats.txt
@@ -1,11 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x55.40625 [BFC] children: not-inline
-    BlockContainer <body> at (110,10) content-size 300x37.40625 positioned children: not-inline
-      BlockContainer <div> at (61,11) content-size 200x35.40625 children: inline
+  BlockContainer <html> at (1,1) content-size 798x54.9375 [BFC] children: not-inline
+    BlockContainer <body> at (110,10) content-size 300x36.9375 positioned children: not-inline
+      BlockContainer <div> at (61,11) content-size 200x34.9375 children: inline
         line 0 width: 159.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
           frag 0 from TextNode start: 0, length: 19, rect: [61,11 159.859375x17.46875]
             "there are no floats"
-        line 1 width: 163.875, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-          frag 0 from TextNode start: 20, length: 21, rect: [61,28 163.875x17.46875]
+        line 1 width: 163.875, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+          frag 0 from TextNode start: 20, length: 21, rect: [61,28.46875 163.875x17.46875]
             "intruding on this div"
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-1.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x332.34375 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x331.90625 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (8,8) content-size 784x0 children: inline
@@ -51,64 +51,64 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
-      BlockContainer <div> at (8,8) content-size 784x332.34375 children: inline
+      BlockContainer <div> at (8,8) content-size 784x331.90625 children: inline
         line 0 width: 414.5625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
           frag 0 from TextNode start: 1, length: 47, rect: [228,8 414.5625x17.46875]
             "lorem ipsum lorem ipsum lorem ipsum lorem ipsum"
-        line 1 width: 414.5625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-          frag 0 from TextNode start: 49, length: 47, rect: [228,25 414.5625x17.46875]
+        line 1 width: 414.5625, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+          frag 0 from TextNode start: 49, length: 47, rect: [228,25.46875 414.5625x17.46875]
             "lorem ipsum lorem ipsum lorem ipsum lorem ipsum"
-        line 2 width: 466.90625, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-          frag 0 from TextNode start: 97, length: 53, rect: [228,42 466.90625x17.46875]
+        line 2 width: 466.90625, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+          frag 0 from TextNode start: 97, length: 53, rect: [228,42.9375 466.90625x17.46875]
             "lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 3 width: 573.5, height: 17.875, bottom: 70.28125, baseline: 13.53125
-          frag 0 from TextNode start: 151, length: 65, rect: [188,60 573.5x17.46875]
+        line 3 width: 573.5, height: 17.46875, bottom: 69.875, baseline: 13.53125
+          frag 0 from TextNode start: 151, length: 65, rect: [188,60.40625 573.5x17.46875]
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum"
-        line 4 width: 572.546875, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-          frag 0 from TextNode start: 217, length: 65, rect: [188,77 572.546875x17.46875]
+        line 4 width: 572.546875, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+          frag 0 from TextNode start: 217, length: 65, rect: [188,77.875 572.546875x17.46875]
             "lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 5 width: 679.140625, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-          frag 0 from TextNode start: 283, length: 77, rect: [108,95 679.140625x17.46875]
+        line 5 width: 679.140625, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+          frag 0 from TextNode start: 283, length: 77, rect: [108,95.34375 679.140625x17.46875]
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum"
-        line 6 width: 783.828125, height: 18.28125, bottom: 123.09375, baseline: 13.53125
-          frag 0 from TextNode start: 361, length: 89, rect: [8,112 783.828125x17.46875]
+        line 6 width: 783.828125, height: 17.46875, bottom: 122.28125, baseline: 13.53125
+          frag 0 from TextNode start: 361, length: 89, rect: [8,112.8125 783.828125x17.46875]
             "lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 7 width: 731.484375, height: 17.75, bottom: 140.03125, baseline: 13.53125
-          frag 0 from TextNode start: 451, length: 83, rect: [8,130 731.484375x17.46875]
+        line 7 width: 731.484375, height: 17.46875, bottom: 139.75, baseline: 13.53125
+          frag 0 from TextNode start: 451, length: 83, rect: [8,130.28125 731.484375x17.46875]
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 8 width: 731.484375, height: 18.21875, bottom: 157.96875, baseline: 13.53125
-          frag 0 from TextNode start: 535, length: 83, rect: [8,147 731.484375x17.46875]
+        line 8 width: 731.484375, height: 17.46875, bottom: 157.21875, baseline: 13.53125
+          frag 0 from TextNode start: 535, length: 83, rect: [8,147.75 731.484375x17.46875]
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 9 width: 731.484375, height: 17.6875, bottom: 174.90625, baseline: 13.53125
-          frag 0 from TextNode start: 619, length: 83, rect: [8,165 731.484375x17.46875]
+        line 9 width: 731.484375, height: 17.46875, bottom: 174.6875, baseline: 13.53125
+          frag 0 from TextNode start: 619, length: 83, rect: [8,165.21875 731.484375x17.46875]
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 10 width: 731.484375, height: 18.15625, bottom: 192.84375, baseline: 13.53125
-          frag 0 from TextNode start: 703, length: 83, rect: [8,182 731.484375x17.46875]
+        line 10 width: 731.484375, height: 17.46875, bottom: 192.15625, baseline: 13.53125
+          frag 0 from TextNode start: 703, length: 83, rect: [8,182.6875 731.484375x17.46875]
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 11 width: 731.484375, height: 17.625, bottom: 209.78125, baseline: 13.53125
-          frag 0 from TextNode start: 787, length: 83, rect: [8,200 731.484375x17.46875]
+        line 11 width: 731.484375, height: 17.46875, bottom: 209.625, baseline: 13.53125
+          frag 0 from TextNode start: 787, length: 83, rect: [8,200.15625 731.484375x17.46875]
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 12 width: 731.484375, height: 18.09375, bottom: 227.71875, baseline: 13.53125
-          frag 0 from TextNode start: 871, length: 83, rect: [8,217 731.484375x17.46875]
+        line 12 width: 731.484375, height: 17.46875, bottom: 227.09375, baseline: 13.53125
+          frag 0 from TextNode start: 871, length: 83, rect: [8,217.625 731.484375x17.46875]
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 13 width: 731.484375, height: 17.5625, bottom: 244.65625, baseline: 13.53125
-          frag 0 from TextNode start: 955, length: 83, rect: [8,235 731.484375x17.46875]
+        line 13 width: 731.484375, height: 17.46875, bottom: 244.5625, baseline: 13.53125
+          frag 0 from TextNode start: 955, length: 83, rect: [8,235.09375 731.484375x17.46875]
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 14 width: 731.484375, height: 18.03125, bottom: 262.59375, baseline: 13.53125
-          frag 0 from TextNode start: 1039, length: 83, rect: [8,252 731.484375x17.46875]
+        line 14 width: 731.484375, height: 17.46875, bottom: 262.03125, baseline: 13.53125
+          frag 0 from TextNode start: 1039, length: 83, rect: [8,252.5625 731.484375x17.46875]
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 15 width: 731.484375, height: 17.5, bottom: 279.53125, baseline: 13.53125
-          frag 0 from TextNode start: 1123, length: 83, rect: [8,270 731.484375x17.46875]
+        line 15 width: 731.484375, height: 17.46875, bottom: 279.5, baseline: 13.53125
+          frag 0 from TextNode start: 1123, length: 83, rect: [8,270.03125 731.484375x17.46875]
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 16 width: 731.484375, height: 17.96875, bottom: 297.46875, baseline: 13.53125
-          frag 0 from TextNode start: 1207, length: 83, rect: [8,287 731.484375x17.46875]
+        line 16 width: 731.484375, height: 17.46875, bottom: 296.96875, baseline: 13.53125
+          frag 0 from TextNode start: 1207, length: 83, rect: [8,287.5 731.484375x17.46875]
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 17 width: 731.484375, height: 18.4375, bottom: 315.40625, baseline: 13.53125
-          frag 0 from TextNode start: 1291, length: 83, rect: [8,304 731.484375x17.46875]
+        line 17 width: 731.484375, height: 17.46875, bottom: 314.4375, baseline: 13.53125
+          frag 0 from TextNode start: 1291, length: 83, rect: [8,304.96875 731.484375x17.46875]
             "ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem"
-        line 18 width: 45.296875, height: 17.90625, bottom: 332.34375, baseline: 13.53125
-          frag 0 from TextNode start: 1375, length: 5, rect: [8,322 45.296875x17.46875]
+        line 18 width: 45.296875, height: 17.46875, bottom: 331.90625, baseline: 13.53125
+          frag 0 from TextNode start: 1375, length: 5, rect: [8,322.4375 45.296875x17.46875]
             "ipsum"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,340.34375) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,339.90625) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-3.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-3.txt
@@ -17,7 +17,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <div#text> at (9,109) content-size 778x17.46875 children: inline
           line 0 width: 54.796875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 6, rect: [371,109 54.796875x17.46875]
+            frag 0 from TextNode start: 0, length: 6, rect: [370.59375,109 54.796875x17.46875]
               "foobar"
           TextNode <#text>
         BlockContainer <(anonymous)> at (9,126.46875) content-size 778x0 children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-4.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-4.txt
@@ -6,19 +6,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
       BlockContainer <div.left> at (9,9) content-size 50x50 floating [BFC] children: inline
         line 0 width: 39.21875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 5, rect: [14,9 39.21875x17.46875]
+          frag 0 from TextNode start: 0, length: 5, rect: [14.390625,9 39.21875x17.46875]
             "Left1"
         TextNode <#text>
       TextNode <#text>
       BlockContainer <div.right> at (737,9) content-size 50x50 floating [BFC] children: inline
         line 0 width: 48.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 6, rect: [738,9 48.3125x17.46875]
+          frag 0 from TextNode start: 0, length: 6, rect: [737.84375,9 48.3125x17.46875]
             "Right1"
         TextNode <#text>
       TextNode <#text>
       BlockContainer <div.left> at (61,9) content-size 50x50 floating [BFC] children: inline
         line 0 width: 41.6875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 5, rect: [65,9 41.6875x17.46875]
+          frag 0 from TextNode start: 0, length: 5, rect: [65.15625,9 41.6875x17.46875]
             "Left2"
         TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-justified-text-in-between.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-justified-text-in-between.txt
@@ -1,200 +1,200 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
-    BlockContainer <body> at (252,10) content-size 538x399.257812 children: inline
-      line 0 width: 228.339843, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-        frag 0 from TextNode start: 1, length: 5, rect: [554,10 63.710937x21.835937]
+    BlockContainer <body> at (252,10) content-size 538x398.90625 children: inline
+      line 0 width: 228.3125, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+        frag 0 from TextNode start: 1, length: 5, rect: [554,10 63.703125x21.828125]
           "Lorem"
-        frag 1 from TextNode start: 6, length: 1, rect: [618,10 12.553385x21.835937]
+        frag 1 from TextNode start: 6, length: 1, rect: [617.703125,10 12.5625x21.828125]
           " "
-        frag 2 from TextNode start: 7, length: 5, rect: [630.553385,10 56.621093x21.835937]
+        frag 2 from TextNode start: 7, length: 5, rect: [630.265625,10 56.609375x21.828125]
           "ipsum"
-        frag 3 from TextNode start: 12, length: 1, rect: [686.553385,10 12.553385x21.835937]
+        frag 3 from TextNode start: 12, length: 1, rect: [686.875,10 12.5625x21.828125]
           " "
-        frag 4 from TextNode start: 13, length: 5, rect: [699.106770,10 52.050781x21.835937]
+        frag 4 from TextNode start: 13, length: 5, rect: [699.4375,10 52.046875x21.828125]
           "dolor"
-        frag 5 from TextNode start: 18, length: 1, rect: [751.106770,10 12.553385x21.835937]
+        frag 5 from TextNode start: 18, length: 1, rect: [751.484375,10 12.5625x21.828125]
           " "
-        frag 6 from TextNode start: 19, length: 3, rect: [763.660156,10 25.957031x21.835937]
+        frag 6 from TextNode start: 19, length: 3, rect: [764.046875,10 25.953125x21.828125]
           "sit"
-      line 1 width: 183.769531, height: 22.671875, bottom: 44.507812, baseline: 16.914062
-        frag 0 from TextNode start: 23, length: 5, rect: [554,31 52.714843x21.835937]
+      line 1 width: 183.75, height: 21.828125, bottom: 43.65625, baseline: 16.890625
+        frag 0 from TextNode start: 23, length: 5, rect: [554,31.828125 52.703125x21.828125]
           "amet,"
-        frag 1 from TextNode start: 28, length: 1, rect: [607,31 62.230468x21.835937]
+        frag 1 from TextNode start: 28, length: 1, rect: [606.703125,31.828125 62.25x21.828125]
           " "
-        frag 2 from TextNode start: 29, length: 11, rect: [669.230468,31 121.054687x21.835937]
+        frag 2 from TextNode start: 29, length: 11, rect: [668.953125,31.828125 121.046875x21.828125]
           "consectetur"
-      line 2 width: 140.546875, height: 22.507812, bottom: 66.179687, baseline: 16.914062
-        frag 0 from TextNode start: 41, length: 10, rect: [554,53 94.648437x21.835937]
+      line 2 width: 140.53125, height: 21.828125, bottom: 65.484375, baseline: 16.890625
+        frag 0 from TextNode start: 41, length: 10, rect: [554,53.65625 94.640625x21.828125]
           "adipiscing"
-        frag 1 from TextNode start: 51, length: 1, rect: [649,53 105.453125x21.835937]
+        frag 1 from TextNode start: 51, length: 1, rect: [648.640625,53.65625 105.46875x21.828125]
           " "
-        frag 2 from TextNode start: 52, length: 5, rect: [754.453125,53 35.898437x21.835937]
+        frag 2 from TextNode start: 52, length: 5, rect: [754.109375,53.65625 35.890625x21.828125]
           "elit."
-      line 3 width: 145, height: 22.34375, bottom: 87.851562, baseline: 16.914062
-        frag 0 from TextNode start: 58, length: 11, rect: [554,75 123.320312x21.835937]
+      line 3 width: 144.984375, height: 21.828125, bottom: 87.3125, baseline: 16.890625
+        frag 0 from TextNode start: 58, length: 11, rect: [554,75.484375 123.3125x21.828125]
           "Suspendisse"
-        frag 1 from TextNode start: 69, length: 1, rect: [677,75 101x21.835937]
+        frag 1 from TextNode start: 69, length: 1, rect: [677.3125,75.484375 101.015625x21.828125]
           " "
-        frag 2 from TextNode start: 70, length: 1, rect: [778,75 11.679687x21.835937]
+        frag 2 from TextNode start: 70, length: 1, rect: [778.328125,75.484375 11.671875x21.828125]
           "a"
-      line 4 width: 196.699218, height: 22.179687, bottom: 109.523437, baseline: 16.914062
-        frag 0 from TextNode start: 72, length: 8, rect: [554,97 82.050781x21.835937]
+      line 4 width: 196.6875, height: 21.828125, bottom: 109.140625, baseline: 16.890625
+        frag 0 from TextNode start: 72, length: 8, rect: [554,97.3125 82.046875x21.828125]
           "placerat"
-        frag 1 from TextNode start: 80, length: 1, rect: [636,97 29.650390x21.835937]
+        frag 1 from TextNode start: 80, length: 1, rect: [636.046875,97.3125 29.65625x21.828125]
           " "
-        frag 2 from TextNode start: 81, length: 7, rect: [665.650390,97 73.867187x21.835937]
+        frag 2 from TextNode start: 81, length: 7, rect: [665.703125,97.3125 73.859375x21.828125]
           "mauris,"
-        frag 3 from TextNode start: 88, length: 1, rect: [739.650390,97 29.650390x21.835937]
+        frag 3 from TextNode start: 88, length: 1, rect: [739.5625,97.3125 29.65625x21.828125]
           " "
-        frag 4 from TextNode start: 89, length: 2, rect: [769.300781,97 20.78125x21.835937]
+        frag 4 from TextNode start: 89, length: 2, rect: [769.21875,97.3125 20.78125x21.828125]
           "ut"
-      line 5 width: 234.6875, height: 22.015625, bottom: 131.195312, baseline: 16.914062
-        frag 0 from TextNode start: 92, length: 9, rect: [554,119 101.289062x21.835937]
+      line 5 width: 234.65625, height: 21.828125, bottom: 130.96875, baseline: 16.890625
+        frag 0 from TextNode start: 92, length: 9, rect: [554,119.140625 101.28125x21.828125]
           "elementum"
-        frag 1 from TextNode start: 101, length: 1, rect: [655,119 10.4375x21.835937]
+        frag 1 from TextNode start: 101, length: 1, rect: [655.28125,119.140625 10.4375x21.828125]
           " "
-        frag 2 from TextNode start: 102, length: 3, rect: [665.4375,119 26.386718x21.835937]
+        frag 2 from TextNode start: 102, length: 3, rect: [665.71875,119.140625 26.375x21.828125]
           "mi."
-        frag 3 from TextNode start: 105, length: 1, rect: [692.4375,119 10.4375x21.835937]
+        frag 3 from TextNode start: 105, length: 1, rect: [692.09375,119.140625 10.4375x21.828125]
           " "
-        frag 4 from TextNode start: 106, length: 5, rect: [702.875,119 56.230468x21.835937]
+        frag 4 from TextNode start: 106, length: 5, rect: [702.53125,119.140625 56.21875x21.828125]
           "Morbi"
-        frag 5 from TextNode start: 111, length: 1, rect: [758.875,119 10.4375x21.835937]
+        frag 5 from TextNode start: 111, length: 1, rect: [758.75,119.140625 10.4375x21.828125]
           " "
-        frag 6 from TextNode start: 112, length: 2, rect: [769.3125,119 20.78125x21.835937]
+        frag 6 from TextNode start: 112, length: 2, rect: [769.1875,119.140625 20.78125x21.828125]
           "ut"
-      line 6 width: 201.523437, height: 21.851562, bottom: 152.867187, baseline: 16.914062
-        frag 0 from TextNode start: 115, length: 8, rect: [554,141 78.769531x21.835937]
+      line 6 width: 201.5, height: 21.828125, bottom: 152.796875, baseline: 16.890625
+        frag 0 from TextNode start: 115, length: 8, rect: [554,140.96875 78.765625x21.828125]
           "vehicula"
-        frag 1 from TextNode start: 123, length: 1, rect: [633,141 27.238281x21.835937]
+        frag 1 from TextNode start: 123, length: 1, rect: [632.765625,140.96875 27.25x21.828125]
           " "
-        frag 2 from TextNode start: 124, length: 6, rect: [660.238281,141 62.929687x21.835937]
+        frag 2 from TextNode start: 124, length: 6, rect: [660.015625,140.96875 62.921875x21.828125]
           "ipsum,"
-        frag 3 from TextNode start: 130, length: 1, rect: [723.238281,141 27.238281x21.835937]
+        frag 3 from TextNode start: 130, length: 1, rect: [722.9375,140.96875 27.25x21.828125]
           " "
-        frag 4 from TextNode start: 131, length: 4, rect: [750.476562,141 39.824218x21.835937]
+        frag 4 from TextNode start: 131, length: 4, rect: [750.1875,140.96875 39.8125x21.828125]
           "eget"
-      line 7 width: 232.539062, height: 22.6875, bottom: 175.539062, baseline: 16.914062
-        frag 0 from TextNode start: 136, length: 8, rect: [554,162 82.050781x21.835937]
+      line 7 width: 232.53125, height: 21.828125, bottom: 174.625, baseline: 16.890625
+        frag 0 from TextNode start: 136, length: 8, rect: [554,162.796875 82.046875x21.828125]
           "placerat"
-        frag 1 from TextNode start: 144, length: 1, rect: [636,162 11.730468x21.835937]
+        frag 1 from TextNode start: 144, length: 1, rect: [636.046875,162.796875 11.734375x21.828125]
           " "
-        frag 2 from TextNode start: 145, length: 6, rect: [647.730468,162 61.875x21.835937]
+        frag 2 from TextNode start: 145, length: 6, rect: [647.78125,162.796875 61.875x21.828125]
           "augue."
-        frag 3 from TextNode start: 151, length: 1, rect: [709.730468,162 11.730468x21.835937]
+        frag 3 from TextNode start: 151, length: 1, rect: [709.65625,162.796875 11.734375x21.828125]
           " "
-        frag 4 from TextNode start: 152, length: 7, rect: [721.460937,162 68.613281x21.835937]
+        frag 4 from TextNode start: 152, length: 7, rect: [721.390625,162.796875 68.609375x21.828125]
           "Integer"
-      line 8 width: 202.96875, height: 22.523437, bottom: 197.210937, baseline: 16.914062
-        frag 0 from TextNode start: 160, length: 6, rect: [554,184 70.3125x21.835937]
+      line 8 width: 202.953125, height: 21.828125, bottom: 196.453125, baseline: 16.890625
+        frag 0 from TextNode start: 160, length: 6, rect: [554,184.625 70.3125x21.828125]
           "rutrum"
-        frag 1 from TextNode start: 166, length: 1, rect: [624,184 21.010416x21.835937]
+        frag 1 from TextNode start: 166, length: 1, rect: [624.3125,184.625 21.015625x21.828125]
           " "
-        frag 2 from TextNode start: 167, length: 4, rect: [645.010416,184 35.097656x21.835937]
+        frag 2 from TextNode start: 167, length: 4, rect: [645.328125,184.625 35.09375x21.828125]
           "nisi"
-        frag 3 from TextNode start: 171, length: 1, rect: [680.010416,184 21.010416x21.835937]
+        frag 3 from TextNode start: 171, length: 1, rect: [680.421875,184.625 21.015625x21.828125]
           " "
-        frag 4 from TextNode start: 172, length: 4, rect: [701.020833,184 39.824218x21.835937]
+        frag 4 from TextNode start: 172, length: 4, rect: [701.4375,184.625 39.8125x21.828125]
           "eget"
-        frag 5 from TextNode start: 176, length: 1, rect: [741.020833,184 21.010416x21.835937]
+        frag 5 from TextNode start: 176, length: 1, rect: [741.25,184.625 21.015625x21.828125]
           " "
-        frag 6 from TextNode start: 177, length: 3, rect: [762.03125,184 27.734375x21.835937]
+        frag 6 from TextNode start: 177, length: 3, rect: [762.265625,184.625 27.734375x21.828125]
           "dui"
       line 9 width: 0, height: 0, bottom: 0, baseline: 0
-      line 10 width: 208.828125, height: 22.359375, bottom: 224.882812, baseline: 16.914062
-        frag 0 from TextNode start: 181, length: 7, rect: [252,212 68.984375x21.835937]
+      line 10 width: 208.8125, height: 21.828125, bottom: 224.28125, baseline: 16.890625
+        frag 0 from TextNode start: 181, length: 7, rect: [252,212.453125 68.984375x21.828125]
           "dictum,"
-        frag 1 from TextNode start: 188, length: 1, rect: [321,212 23.585937x21.835937]
+        frag 1 from TextNode start: 188, length: 1, rect: [320.984375,212.453125 23.59375x21.828125]
           " "
-        frag 2 from TextNode start: 189, length: 2, rect: [344.585937,212 23.105468x21.835937]
+        frag 2 from TextNode start: 189, length: 2, rect: [344.578125,212.453125 23.09375x21.828125]
           "eu"
-        frag 3 from TextNode start: 191, length: 1, rect: [367.585937,212 23.585937x21.835937]
+        frag 3 from TextNode start: 191, length: 1, rect: [367.671875,212.453125 23.59375x21.828125]
           " "
-        frag 4 from TextNode start: 192, length: 8, rect: [391.171875,212 96.738281x21.835937]
+        frag 4 from TextNode start: 192, length: 8, rect: [391.265625,212.453125 96.734375x21.828125]
           "accumsan"
-      line 11 width: 180.195312, height: 22.195312, bottom: 246.554687, baseline: 16.914062
-        frag 0 from TextNode start: 201, length: 4, rect: [252,234 43.867187x21.835937]
+      line 11 width: 180.171875, height: 21.828125, bottom: 246.109375, baseline: 16.890625
+        frag 0 from TextNode start: 201, length: 4, rect: [252,234.28125 43.859375x21.828125]
           "enim"
-        frag 1 from TextNode start: 205, length: 1, rect: [296,234 37.902343x21.835937]
+        frag 1 from TextNode start: 205, length: 1, rect: [295.859375,234.28125 37.90625x21.828125]
           " "
-        frag 2 from TextNode start: 206, length: 10, rect: [333.902343,234 93.632812x21.835937]
+        frag 2 from TextNode start: 206, length: 10, rect: [333.765625,234.28125 93.625x21.828125]
           "tristique."
-        frag 3 from TextNode start: 216, length: 1, rect: [427.902343,234 37.902343x21.835937]
+        frag 3 from TextNode start: 216, length: 1, rect: [427.390625,234.28125 37.90625x21.828125]
           " "
-        frag 4 from TextNode start: 217, length: 2, rect: [465.804687,234 22.695312x21.835937]
+        frag 4 from TextNode start: 217, length: 2, rect: [465.296875,234.28125 22.6875x21.828125]
           "Ut"
-      line 12 width: 195.273437, height: 22.03125, bottom: 268.226562, baseline: 16.914062
-        frag 0 from TextNode start: 220, length: 8, rect: [252,256 80.019531x21.835937]
+      line 12 width: 195.25, height: 21.828125, bottom: 267.9375, baseline: 16.890625
+        frag 0 from TextNode start: 220, length: 8, rect: [252,256.109375 80.015625x21.828125]
           "lobortis"
-        frag 1 from TextNode start: 228, length: 1, rect: [332,256 30.363281x21.835937]
+        frag 1 from TextNode start: 228, length: 1, rect: [332.015625,256.109375 30.375x21.828125]
           " "
-        frag 2 from TextNode start: 229, length: 5, rect: [362.363281,256 55.429687x21.835937]
+        frag 2 from TextNode start: 229, length: 5, rect: [362.390625,256.109375 55.421875x21.828125]
           "lorem"
-        frag 3 from TextNode start: 234, length: 1, rect: [417.363281,256 30.363281x21.835937]
+        frag 3 from TextNode start: 234, length: 1, rect: [417.8125,256.109375 30.375x21.828125]
           " "
-        frag 4 from TextNode start: 235, length: 4, rect: [447.726562,256 39.824218x21.835937]
+        frag 4 from TextNode start: 235, length: 4, rect: [448.1875,256.109375 39.8125x21.828125]
           "eget"
-      line 13 width: 222.910156, height: 21.867187, bottom: 289.898437, baseline: 16.914062
-        frag 0 from TextNode start: 240, length: 3, rect: [252,278 31.152343x21.835937]
+      line 13 width: 222.875, height: 21.828125, bottom: 289.765625, baseline: 16.890625
+        frag 0 from TextNode start: 240, length: 3, rect: [252,277.9375 31.140625x21.828125]
           "est"
-        frag 1 from TextNode start: 243, length: 1, rect: [283,278 16.544921x21.835937]
+        frag 1 from TextNode start: 243, length: 1, rect: [283.140625,277.9375 16.5625x21.828125]
           " "
-        frag 2 from TextNode start: 244, length: 9, rect: [299.544921,278 91.464843x21.835937]
+        frag 2 from TextNode start: 244, length: 9, rect: [299.703125,277.9375 91.453125x21.828125]
           "vulputate"
-        frag 3 from TextNode start: 253, length: 1, rect: [391.544921,278 16.544921x21.835937]
+        frag 3 from TextNode start: 253, length: 1, rect: [391.15625,277.9375 16.5625x21.828125]
           " "
-        frag 4 from TextNode start: 254, length: 8, rect: [408.089843,278 80.292968x21.835937]
+        frag 4 from TextNode start: 254, length: 8, rect: [407.71875,277.9375 80.28125x21.828125]
           "egestas."
-      line 14 width: 223.125, height: 22.703125, bottom: 312.570312, baseline: 16.914062
-        frag 0 from TextNode start: 263, length: 7, rect: [252,299 68.613281x21.835937]
+      line 14 width: 223.109375, height: 21.828125, bottom: 311.59375, baseline: 16.890625
+        frag 0 from TextNode start: 263, length: 7, rect: [252,299.765625 68.609375x21.828125]
           "Integer"
-        frag 1 from TextNode start: 270, length: 1, rect: [321,299 16.4375x21.835937]
+        frag 1 from TextNode start: 270, length: 1, rect: [320.609375,299.765625 16.4375x21.828125]
           " "
-        frag 2 from TextNode start: 271, length: 7, rect: [337.4375,299 71.328125x21.835937]
+        frag 2 from TextNode start: 271, length: 7, rect: [337.046875,299.765625 71.328125x21.828125]
           "laoreet"
-        frag 3 from TextNode start: 278, length: 1, rect: [408.4375,299 16.4375x21.835937]
+        frag 3 from TextNode start: 278, length: 1, rect: [408.375,299.765625 16.4375x21.828125]
           " "
-        frag 4 from TextNode start: 279, length: 7, rect: [424.875,299 63.183593x21.835937]
+        frag 4 from TextNode start: 279, length: 7, rect: [424.8125,299.765625 63.171875x21.828125]
           "lacinia"
-      line 15 width: 222.617187, height: 22.539062, bottom: 334.242187, baseline: 16.914062
-        frag 0 from TextNode start: 287, length: 4, rect: [252,321 43.164062x21.835937]
+      line 15 width: 222.59375, height: 21.828125, bottom: 333.421875, baseline: 16.890625
+        frag 0 from TextNode start: 287, length: 4, rect: [252,321.59375 43.15625x21.828125]
           "ante"
-        frag 1 from TextNode start: 291, length: 1, rect: [295,321 16.691406x21.835937]
+        frag 1 from TextNode start: 291, length: 1, rect: [295.15625,321.59375 16.703125x21.828125]
           " "
-        frag 2 from TextNode start: 292, length: 7, rect: [311.691406,321 74.003906x21.835937]
+        frag 2 from TextNode start: 292, length: 7, rect: [311.859375,321.59375 74x21.828125]
           "sodales"
-        frag 3 from TextNode start: 299, length: 1, rect: [385.691406,321 16.691406x21.835937]
+        frag 3 from TextNode start: 299, length: 1, rect: [385.859375,321.59375 16.703125x21.828125]
           " "
-        frag 4 from TextNode start: 300, length: 9, rect: [402.382812,321 85.449218x21.835937]
+        frag 4 from TextNode start: 300, length: 9, rect: [402.5625,321.59375 85.4375x21.828125]
           "lobortis."
-      line 16 width: 178.300781, height: 22.375, bottom: 355.914062, baseline: 16.914062
-        frag 0 from TextNode start: 310, length: 5, rect: [252,343 60.898437x21.835937]
+      line 16 width: 178.28125, height: 21.828125, bottom: 355.25, baseline: 16.890625
+        frag 0 from TextNode start: 310, length: 5, rect: [252,343.421875 60.890625x21.828125]
           "Donec"
-        frag 1 from TextNode start: 315, length: 1, rect: [313,343 38.849609x21.835937]
+        frag 1 from TextNode start: 315, length: 1, rect: [312.890625,343.421875 38.859375x21.828125]
           " "
-        frag 2 from TextNode start: 316, length: 1, rect: [351.849609,343 11.679687x21.835937]
+        frag 2 from TextNode start: 316, length: 1, rect: [351.75,343.421875 11.671875x21.828125]
           "a"
-        frag 3 from TextNode start: 317, length: 1, rect: [363.849609,343 38.849609x21.835937]
+        frag 3 from TextNode start: 317, length: 1, rect: [363.421875,343.421875 38.859375x21.828125]
           " "
-        frag 4 from TextNode start: 318, length: 9, rect: [402.699218,343 85.722656x21.835937]
+        frag 4 from TextNode start: 318, length: 9, rect: [402.28125,343.421875 85.71875x21.828125]
           "tincidunt"
-      line 17 width: 231.074218, height: 22.210937, bottom: 377.585937, baseline: 16.914062
-        frag 0 from TextNode start: 328, length: 5, rect: [252,365 48.59375x21.835937]
+      line 17 width: 231.0625, height: 21.828125, bottom: 377.078125, baseline: 16.890625
+        frag 0 from TextNode start: 328, length: 5, rect: [252,365.25 48.59375x21.828125]
           "ante."
-        frag 1 from TextNode start: 333, length: 1, rect: [301,365 11.641927x21.835937]
+        frag 1 from TextNode start: 333, length: 1, rect: [300.59375,365.25 11.640625x21.828125]
           " "
-        frag 2 from TextNode start: 334, length: 9, rect: [312.641927,365 94.765625x21.835937]
+        frag 2 from TextNode start: 334, length: 9, rect: [312.234375,365.25 94.765625x21.828125]
           "Phasellus"
-        frag 3 from TextNode start: 343, length: 1, rect: [406.641927,365 11.641927x21.835937]
+        frag 3 from TextNode start: 343, length: 1, rect: [407,365.25 11.640625x21.828125]
           " "
-        frag 4 from TextNode start: 344, length: 1, rect: [418.283854,365 11.679687x21.835937]
+        frag 4 from TextNode start: 344, length: 1, rect: [418.640625,365.25 11.671875x21.828125]
           "a"
-        frag 5 from TextNode start: 345, length: 1, rect: [430.283854,365 11.641927x21.835937]
+        frag 5 from TextNode start: 345, length: 1, rect: [430.3125,365.25 11.640625x21.828125]
           " "
-        frag 6 from TextNode start: 346, length: 4, rect: [441.925781,365 46.035156x21.835937]
+        frag 6 from TextNode start: 346, length: 4, rect: [441.953125,365.25 46.03125x21.828125]
           "arcu"
-      line 18 width: 70.546875, height: 22.046875, bottom: 399.257812, baseline: 16.914062
-        frag 0 from TextNode start: 351, length: 7, rect: [252,387 70.546875x21.835937]
+      line 18 width: 70.546875, height: 21.828125, bottom: 398.90625, baseline: 16.890625
+        frag 0 from TextNode start: 351, length: 7, rect: [252,387.078125 70.546875x21.828125]
           "tortor."
       BlockContainer <div.left> at (253,11) content-size 300x200 floating [BFC] children: not-inline
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-text-in-between.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-text-in-between.txt
@@ -1,60 +1,60 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
-    BlockContainer <body> at (252,10) content-size 538x399.257812 children: inline
-      line 0 width: 228.339843, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-        frag 0 from TextNode start: 1, length: 21, rect: [554,10 228.339843x21.835937]
+    BlockContainer <body> at (252,10) content-size 538x398.90625 children: inline
+      line 0 width: 228.3125, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+        frag 0 from TextNode start: 1, length: 21, rect: [554,10 228.3125x21.828125]
           "Lorem ipsum dolor sit"
-      line 1 width: 183.769531, height: 22.671875, bottom: 44.507812, baseline: 16.914062
-        frag 0 from TextNode start: 23, length: 17, rect: [554,31 183.769531x21.835937]
+      line 1 width: 183.75, height: 21.828125, bottom: 43.65625, baseline: 16.890625
+        frag 0 from TextNode start: 23, length: 17, rect: [554,31.828125 183.75x21.828125]
           "amet, consectetur"
-      line 2 width: 140.546875, height: 22.507812, bottom: 66.179687, baseline: 16.914062
-        frag 0 from TextNode start: 41, length: 16, rect: [554,53 140.546875x21.835937]
+      line 2 width: 140.53125, height: 21.828125, bottom: 65.484375, baseline: 16.890625
+        frag 0 from TextNode start: 41, length: 16, rect: [554,53.65625 140.53125x21.828125]
           "adipiscing elit."
-      line 3 width: 145, height: 22.34375, bottom: 87.851562, baseline: 16.914062
-        frag 0 from TextNode start: 58, length: 13, rect: [554,75 145x21.835937]
+      line 3 width: 144.984375, height: 21.828125, bottom: 87.3125, baseline: 16.890625
+        frag 0 from TextNode start: 58, length: 13, rect: [554,75.484375 144.984375x21.828125]
           "Suspendisse a"
-      line 4 width: 196.699218, height: 22.179687, bottom: 109.523437, baseline: 16.914062
-        frag 0 from TextNode start: 72, length: 19, rect: [554,97 196.699218x21.835937]
+      line 4 width: 196.6875, height: 21.828125, bottom: 109.140625, baseline: 16.890625
+        frag 0 from TextNode start: 72, length: 19, rect: [554,97.3125 196.6875x21.828125]
           "placerat mauris, ut"
-      line 5 width: 234.6875, height: 22.015625, bottom: 131.195312, baseline: 16.914062
-        frag 0 from TextNode start: 92, length: 22, rect: [554,119 234.6875x21.835937]
+      line 5 width: 234.65625, height: 21.828125, bottom: 130.96875, baseline: 16.890625
+        frag 0 from TextNode start: 92, length: 22, rect: [554,119.140625 234.65625x21.828125]
           "elementum mi. Morbi ut"
-      line 6 width: 201.523437, height: 21.851562, bottom: 152.867187, baseline: 16.914062
-        frag 0 from TextNode start: 115, length: 20, rect: [554,141 201.523437x21.835937]
+      line 6 width: 201.5, height: 21.828125, bottom: 152.796875, baseline: 16.890625
+        frag 0 from TextNode start: 115, length: 20, rect: [554,140.96875 201.5x21.828125]
           "vehicula ipsum, eget"
-      line 7 width: 232.539062, height: 22.6875, bottom: 175.539062, baseline: 16.914062
-        frag 0 from TextNode start: 136, length: 23, rect: [554,162 232.539062x21.835937]
+      line 7 width: 232.53125, height: 21.828125, bottom: 174.625, baseline: 16.890625
+        frag 0 from TextNode start: 136, length: 23, rect: [554,162.796875 232.53125x21.828125]
           "placerat augue. Integer"
-      line 8 width: 202.96875, height: 22.523437, bottom: 197.210937, baseline: 16.914062
-        frag 0 from TextNode start: 160, length: 20, rect: [554,184 202.96875x21.835937]
+      line 8 width: 202.953125, height: 21.828125, bottom: 196.453125, baseline: 16.890625
+        frag 0 from TextNode start: 160, length: 20, rect: [554,184.625 202.953125x21.828125]
           "rutrum nisi eget dui"
       line 9 width: 0, height: 0, bottom: 0, baseline: 0
-      line 10 width: 208.828125, height: 22.359375, bottom: 224.882812, baseline: 16.914062
-        frag 0 from TextNode start: 181, length: 19, rect: [252,212 208.828125x21.835937]
+      line 10 width: 208.8125, height: 21.828125, bottom: 224.28125, baseline: 16.890625
+        frag 0 from TextNode start: 181, length: 19, rect: [252,212.453125 208.8125x21.828125]
           "dictum, eu accumsan"
-      line 11 width: 180.195312, height: 22.195312, bottom: 246.554687, baseline: 16.914062
-        frag 0 from TextNode start: 201, length: 18, rect: [252,234 180.195312x21.835937]
+      line 11 width: 180.171875, height: 21.828125, bottom: 246.109375, baseline: 16.890625
+        frag 0 from TextNode start: 201, length: 18, rect: [252,234.28125 180.171875x21.828125]
           "enim tristique. Ut"
-      line 12 width: 195.273437, height: 22.03125, bottom: 268.226562, baseline: 16.914062
-        frag 0 from TextNode start: 220, length: 19, rect: [252,256 195.273437x21.835937]
+      line 12 width: 195.25, height: 21.828125, bottom: 267.9375, baseline: 16.890625
+        frag 0 from TextNode start: 220, length: 19, rect: [252,256.109375 195.25x21.828125]
           "lobortis lorem eget"
-      line 13 width: 222.910156, height: 21.867187, bottom: 289.898437, baseline: 16.914062
-        frag 0 from TextNode start: 240, length: 22, rect: [252,278 222.910156x21.835937]
+      line 13 width: 222.875, height: 21.828125, bottom: 289.765625, baseline: 16.890625
+        frag 0 from TextNode start: 240, length: 22, rect: [252,277.9375 222.875x21.828125]
           "est vulputate egestas."
-      line 14 width: 223.125, height: 22.703125, bottom: 312.570312, baseline: 16.914062
-        frag 0 from TextNode start: 263, length: 23, rect: [252,299 223.125x21.835937]
+      line 14 width: 223.109375, height: 21.828125, bottom: 311.59375, baseline: 16.890625
+        frag 0 from TextNode start: 263, length: 23, rect: [252,299.765625 223.109375x21.828125]
           "Integer laoreet lacinia"
-      line 15 width: 222.617187, height: 22.539062, bottom: 334.242187, baseline: 16.914062
-        frag 0 from TextNode start: 287, length: 22, rect: [252,321 222.617187x21.835937]
+      line 15 width: 222.59375, height: 21.828125, bottom: 333.421875, baseline: 16.890625
+        frag 0 from TextNode start: 287, length: 22, rect: [252,321.59375 222.59375x21.828125]
           "ante sodales lobortis."
-      line 16 width: 178.300781, height: 22.375, bottom: 355.914062, baseline: 16.914062
-        frag 0 from TextNode start: 310, length: 17, rect: [252,343 178.300781x21.835937]
+      line 16 width: 178.28125, height: 21.828125, bottom: 355.25, baseline: 16.890625
+        frag 0 from TextNode start: 310, length: 17, rect: [252,343.421875 178.28125x21.828125]
           "Donec a tincidunt"
-      line 17 width: 231.074218, height: 22.210937, bottom: 377.585937, baseline: 16.914062
-        frag 0 from TextNode start: 328, length: 22, rect: [252,365 231.074218x21.835937]
+      line 17 width: 231.0625, height: 21.828125, bottom: 377.078125, baseline: 16.890625
+        frag 0 from TextNode start: 328, length: 22, rect: [252,365.25 231.0625x21.828125]
           "ante. Phasellus a arcu"
-      line 18 width: 70.546875, height: 22.046875, bottom: 399.257812, baseline: 16.914062
-        frag 0 from TextNode start: 351, length: 7, rect: [252,387 70.546875x21.835937]
+      line 18 width: 70.546875, height: 21.828125, bottom: 398.90625, baseline: 16.890625
+        frag 0 from TextNode start: 351, length: 7, rect: [252,387.078125 70.546875x21.828125]
           "tortor."
       BlockContainer <div.left> at (253,11) content-size 300x200 floating [BFC] children: not-inline
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-1.txt
@@ -40,7 +40,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         line 11 width: 239.203125, height: 16, bottom: 180, baseline: 12.796875
           frag 0 from TextNode start: 57, length: 16, rect: [61,173 141.203125x16]
             "baz foo bar baz "
-          frag 1 from TextNode start: 1, length: 11, rect: [202,173 98x16]
+          frag 1 from TextNode start: 1, length: 11, rect: [202.203125,173 98x16]
             "foo bar baz"
         line 12 width: 204, height: 16, bottom: 196, baseline: 12.796875
           frag 0 from TextNode start: 13, length: 12, rect: [61,189 106x16]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-positioned-with-top-left.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-positioned-with-top-left.txt
@@ -4,13 +4,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       line 0 width: 352.34375, height: 20, bottom: 20, baseline: 13.53125
         frag 0 from TextNode start: 0, length: 14, rect: [8,8 112.421875x17.46875]
           "text text text"
-        frag 1 from BlockContainer start: 0, length: 0, rect: [120,8 110.375x20]
-        frag 2 from TextNode start: 0, length: 16, rect: [231,8 129.546875x17.46875]
+        frag 1 from BlockContainer start: 0, length: 0, rect: [120.421875,8 110.375x20]
+        frag 2 from TextNode start: 0, length: 16, rect: [230.796875,8 129.546875x17.46875]
           "more inline text"
       TextNode <#text>
-      BlockContainer <span.displaced_text> at (150,48) content-size 110.375x20 positioned inline-block [BFC] children: inline
+      BlockContainer <span.displaced_text> at (150.421875,48) content-size 110.375x20 positioned inline-block [BFC] children: inline
         line 0 width: 110.375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 14, rect: [150,48 110.375x17.46875]
+          frag 0 from TextNode start: 0, length: 14, rect: [150.421875,48 110.375x17.46875]
             "displaced text"
         TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins-vertical-align-top.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins-vertical-align-top.txt
@@ -4,9 +4,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       line 0 width: 210.828125, height: 175, bottom: 175, baseline: 13.53125
         frag 0 from TextNode start: 0, length: 6, rect: [8,8 43.125x17.46875]
           "Well, "
-        frag 1 from BlockContainer start: 0, length: 0, rect: [51,58 100x100]
-        frag 2 from TextNode start: 0, length: 9, rect: [151,8 67.703125x17.46875]
+        frag 1 from BlockContainer start: 0, length: 0, rect: [51.125,58 100x100]
+        frag 2 from TextNode start: 0, length: 9, rect: [151.125,8 67.703125x17.46875]
           " friends."
       TextNode <#text>
-      BlockContainer <div#inline-box> at (51,58) content-size 100x100 inline-block [BFC] children: not-inline
+      BlockContainer <div#inline-box> at (51.125,58) content-size 100x100 inline-block [BFC] children: not-inline
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x178.46875 children: inline
-      line 0 width: 210.828125, height: 178.46875, bottom: 178.46875, baseline: 175
-        frag 0 from TextNode start: 0, length: 6, rect: [8,169 43.125x17.46875]
+    BlockContainer <body> at (8,8) content-size 784x178.9375 children: inline
+      line 0 width: 210.828125, height: 178.9375, bottom: 178.9375, baseline: 175
+        frag 0 from TextNode start: 0, length: 6, rect: [8,169.46875 43.125x17.46875]
           "Well, "
-        frag 1 from BlockContainer start: 0, length: 0, rect: [51,58 100x100]
-        frag 2 from TextNode start: 0, length: 9, rect: [151,169 67.703125x17.46875]
+        frag 1 from BlockContainer start: 0, length: 0, rect: [51.125,58 100x100]
+        frag 2 from TextNode start: 0, length: 9, rect: [151.125,169.46875 67.703125x17.46875]
           " friends."
       TextNode <#text>
-      BlockContainer <div#inline-box> at (51,58) content-size 100x100 inline-block [BFC] children: not-inline
+      BlockContainer <div#inline-box> at (51.125,58) content-size 100x100 inline-block [BFC] children: not-inline
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-5.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-5.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x134.46875 [BFC] children: inline
-    line 0 width: 170.96875, height: 134.46875, bottom: 134.46875, baseline: 13.53125
-      frag 0 from BlockContainer start: 0, length: 0, rect: [2,15 168.96875x119.46875]
-    BlockContainer <body> at (2,15) content-size 168.96875x119.46875 inline-block [BFC] children: not-inline
-      BlockContainer <div.hmm> at (3,16) content-size 166.96875x17.46875 children: inline
+  BlockContainer <html> at (1,1) content-size 798x135 [BFC] children: inline
+    line 0 width: 170.96875, height: 135, bottom: 135, baseline: 13.53125
+      frag 0 from BlockContainer start: 0, length: 0, rect: [2,15.53125 168.96875x119.46875]
+    BlockContainer <body> at (2,15.53125) content-size 168.96875x119.46875 inline-block [BFC] children: not-inline
+      BlockContainer <div.hmm> at (3,16.53125) content-size 166.96875x17.46875 children: inline
         line 0 width: 166.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 21, rect: [3,16 166.96875x17.46875]
+          frag 0 from TextNode start: 0, length: 21, rect: [3,16.53125 166.96875x17.46875]
             "suspiciously tall box"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (2,134.46875) content-size 168.96875x0 children: inline
+      BlockContainer <(anonymous)> at (2,135) content-size 168.96875x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/narrow-bfc-width-to-avoid-overlap-with-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/narrow-bfc-width-to-avoid-overlap-with-floats.txt
@@ -1,22 +1,22 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x1008 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x108.21875 children: not-inline
-      BlockContainer <div.wrapper> at (8,8) content-size 784x108.21875 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x107.34375 children: not-inline
+      BlockContainer <div.wrapper> at (8,8) content-size 784x107.34375 children: not-inline
         BlockContainer <div.float> at (592,8) content-size 200x1000 floating [BFC] children: not-inline
-        BlockContainer <div.bfc> at (18,18) content-size 564x88.21875 [BFC] children: inline
+        BlockContainer <div.bfc> at (18,18) content-size 564x87.34375 [BFC] children: inline
           line 0 width: 458.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 56, rect: [18,18 458.125x17.46875]
               "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-          line 1 width: 511.796875, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 57, length: 60, rect: [18,35 511.796875x17.46875]
+          line 1 width: 511.796875, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 57, length: 60, rect: [18,35.46875 511.796875x17.46875]
               "Pellentesque vitae neque nunc. Nam fermentum libero a lectus"
-          line 2 width: 537.078125, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 118, length: 67, rect: [18,52 537.078125x17.46875]
+          line 2 width: 537.078125, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 118, length: 67, rect: [18,52.9375 537.078125x17.46875]
               "vulputate eleifend. Nam sagittis tristique augue, id sodales mauris"
-          line 3 width: 537.34375, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 186, length: 65, rect: [18,70 537.34375x17.46875]
+          line 3 width: 537.34375, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 186, length: 65, rect: [18,70.40625 537.34375x17.46875]
               "suscipit at. Vivamus eget placerat ex. Suspendisse potenti. Morbi"
-          line 4 width: 455.375, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 252, length: 57, rect: [18,87 455.375x17.46875]
+          line 4 width: 455.375, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+            frag 0 from TextNode start: 252, length: 57, rect: [18,87.875 455.375x17.46875]
               "pulvinar ipsum eget nulla dapibus, ac varius mi eleifend."
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-padding-on-inline-block-with-indefinite-containing-block-size.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-padding-on-inline-block-with-indefinite-containing-block-size.txt
@@ -2,5 +2,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 0x17.46875 children: inline
       line 0 width: 0, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,21 0x0]
-      BlockContainer <div> at (8,21) content-size 0x0 inline-block [BFC] children: not-inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,21.53125 0x0]
+      BlockContainer <div> at (8,21.53125) content-size 0x0 inline-block [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/width-auto-margins-set-zero-if-containing-size-smaller.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/width-auto-margins-set-zero-if-containing-size-smaller.txt
@@ -1,15 +1,15 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x0 [BFC] children: not-inline
-    BlockContainer <body> at (10,10) content-size 102x57.34375 positioned [BFC] children: not-inline
-      BlockContainer <div#container> at (11,11) content-size 100x55.34375 children: not-inline
-        BlockContainer <div#child> at (72,12) content-size 50x53.34375 children: inline
+    BlockContainer <body> at (10,10) content-size 102x56.40625 positioned [BFC] children: not-inline
+      BlockContainer <div#container> at (11,11) content-size 100x54.40625 children: not-inline
+        BlockContainer <div#child> at (72,12) content-size 50x52.40625 children: inline
           line 0 width: 28.40625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 4, rect: [72,12 28.40625x17.46875]
               "well"
-          line 1 width: 36.84375, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 5, length: 5, rect: [72,29 36.84375x17.46875]
+          line 1 width: 36.84375, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 5, length: 5, rect: [72,29.46875 36.84375x17.46875]
               "hello"
-          line 2 width: 55.359375, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 11, length: 7, rect: [72,46 55.359375x17.46875]
+          line 2 width: 55.359375, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 11, length: 7, rect: [72,46.9375 55.359375x17.46875]
               "friends"
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/box-sizing-border-box-for-definite-sizes-without-layout.txt
+++ b/Tests/LibWeb/Layout/expected/box-sizing-border-box-for-definite-sizes-without-layout.txt
@@ -1,11 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x66 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x50 children: inline
-      line 0 width: 89.726562, height: 50, bottom: 50, baseline: 16.914062
-        frag 0 from Box start: 0, length: 0, rect: [28,38 49.726562x0]
-      Box <div.button> at (28,38) content-size 49.726562x0 flex-container(row) [FFC] children: not-inline
-        BlockContainer <(anonymous)> at (28,27.082031) content-size 49.726562x21.835937 flex-item [BFC] children: inline
-          line 0 width: 49.726562, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-            frag 0 from TextNode start: 0, length: 5, rect: [28,27.082031 49.726562x21.835937]
+  BlockContainer <html> at (0,0) content-size 800x66.90625 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x50.90625 children: inline
+      line 0 width: 89.71875, height: 50.90625, bottom: 50.90625, baseline: 16.890625
+        frag 0 from Box start: 0, length: 0, rect: [28,38.90625 49.71875x0]
+      Box <div.button> at (28,38.90625) content-size 49.71875x0 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (28,28) content-size 49.71875x21.828125 flex-item [BFC] children: inline
+          line 0 width: 49.71875, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+            frag 0 from TextNode start: 0, length: 5, rect: [28,28 49.71875x21.828125]
               "Hello"
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/css-ex-unit.txt
+++ b/Tests/LibWeb/Layout/expected/css-ex-unit.txt
@@ -1,4 +1,4 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x177.132812 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x161.132812 children: not-inline
-      BlockContainer <div> at (8,8) content-size 107.421875x161.132812 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x177.015625 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x161.015625 children: not-inline
+      BlockContainer <div> at (8,8) content-size 107.34375x161.015625 children: not-inline

--- a/Tests/LibWeb/Layout/expected/css-font-size-calc.txt
+++ b/Tests/LibWeb/Layout/expected/css-font-size-calc.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x125.179687 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x109.179687 children: inline
-      line 0 width: 644.628906, height: 109.179687, bottom: 109.179687, baseline: 84.570312
-        frag 0 from TextNode start: 0, length: 13, rect: [8,8 644.628906x109.179687]
+  BlockContainer <html> at (0,0) content-size 800x125.171875 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x109.171875 children: inline
+      line 0 width: 644.609375, height: 109.171875, bottom: 109.171875, baseline: 84.546875
+        frag 0 from TextNode start: 0, length: 13, rect: [8,8 644.609375x109.171875]
           "Hello friends"
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/css-import-rule.txt
+++ b/Tests/LibWeb/Layout/expected/css-import-rule.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x54.589843 children: inline
-      line 0 width: 137.646484, height: 54.589843, bottom: 54.589843, baseline: 42.285156
-        frag 0 from TextNode start: 0, length: 5, rect: [8,8 137.646484x54.589843]
+    BlockContainer <body> at (8,8) content-size 784x54.578125 children: inline
+      line 0 width: 137.640625, height: 54.578125, bottom: 54.578125, baseline: 42.265625
+        frag 0 from TextNode start: 0, length: 5, rect: [8,8 137.640625x54.578125]
           "Crazy"
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/css-imported-sheet-with-media-rule.txt
+++ b/Tests/LibWeb/Layout/expected/css-imported-sheet-with-media-rule.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x109.179687 children: inline
-      line 0 width: 275.292968, height: 109.179687, bottom: 109.179687, baseline: 84.570312
-        frag 0 from TextNode start: 0, length: 5, rect: [8,8 275.292968x109.179687]
+    BlockContainer <body> at (8,8) content-size 784x109.171875 children: inline
+      line 0 width: 275.28125, height: 109.171875, bottom: 109.171875, baseline: 84.546875
+        frag 0 from TextNode start: 0, length: 5, rect: [8,8 275.28125x109.171875]
           "Crazy"
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/css-line-height-percentage-inheritance.txt
+++ b/Tests/LibWeb/Layout/expected/css-line-height-percentage-inheritance.txt
@@ -2,7 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x52 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x34 children: not-inline
       BlockContainer <div> at (11,11) content-size 778x32 children: inline
-        line 0 width: 552.109375, height: 32, bottom: 32, baseline: 27.992187
-          frag 0 from TextNode start: 0, length: 25, rect: [11,11 552.109375x32]
+        line 0 width: 552.09375, height: 32, bottom: 32, baseline: 27.984375
+          frag 0 from TextNode start: 0, length: 25, rect: [11,11 552.09375x32]
             "The Linux Kernel Archives"
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-inline-style.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-inline-style.txt
@@ -3,8 +3,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x102 children: not-inline
       BlockContainer <div.outer> at (11,11) content-size 100x100 children: not-inline
         BlockContainer <(anonymous)> at (12,12) content-size 50x50 children: inline
-          line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-            frag 0 from TextNode start: 0, length: 0, rect: [12,12 0x21.835937]
+          line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+            frag 0 from TextNode start: 0, length: 0, rect: [12,12 0x21.828125]
               ""
           TextNode <#text>
         BlockContainer <div.inner> at (12,64) content-size 98x0 children: inline

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
@@ -5,9 +5,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (11,11) content-size 108x104 table-box [TFC] children: not-inline
           Box <tbody> at (11,11) content-size 104x100 table-row-group children: not-inline
             Box <tr> at (13,13) content-size 104x100 table-row children: not-inline
-              BlockContainer <td> at (15,51.082031) content-size 100x23.835937 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (16,52.082031) content-size 98x21.835937 children: inline
-                  line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-                    frag 0 from TextNode start: 0, length: 0, rect: [16,52.082031 0x21.835937]
+              BlockContainer <td> at (15,51.078125) content-size 100x23.828125 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (16,52.078125) content-size 98x21.828125 children: inline
+                  line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+                    frag 0 from TextNode start: 0, length: 0, rect: [16,52.078125 0x21.828125]
                       ""
                   TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/div_align.txt
+++ b/Tests/LibWeb/Layout/expected/div_align.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div> at (8,165.46875) content-size 784x137.46875 children: not-inline
         BlockContainer <(anonymous)> at (8,165.46875) content-size 784x17.46875 children: inline
           line 0 width: 418.6875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 49, rect: [191,165.46875 418.6875x17.46875]
+            frag 0 from TextNode start: 0, length: 49, rect: [190.65625,165.46875 418.6875x17.46875]
               "This text and the green square are both centered:"
           TextNode <#text>
         BlockContainer <div.square> at (350,202.9375) content-size 100x100 children: not-inline
@@ -22,7 +22,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div> at (8,322.9375) content-size 784x137.46875 children: not-inline
         BlockContainer <(anonymous)> at (8,322.9375) content-size 784x17.46875 children: inline
           line 0 width: 447.484375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 54, rect: [345,322.9375 447.484375x17.46875]
+            frag 0 from TextNode start: 0, length: 54, rect: [344.515625,322.9375 447.484375x17.46875]
               "This text and the green square are both right aligned:"
           TextNode <#text>
         BlockContainer <div.square> at (672,360.40625) content-size 100x100 children: not-inline
@@ -33,45 +33,45 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           line 0 width: 512.53125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 4, rect: [8,480.40625 35.5x17.46875]
               "This"
-            frag 1 from TextNode start: 4, length: 1, rect: [44,480.40625 8x17.46875]
+            frag 1 from TextNode start: 4, length: 1, rect: [43.5,480.40625 8x17.46875]
               " "
-            frag 2 from TextNode start: 5, length: 4, rect: [52,480.40625 32.140625x17.46875]
+            frag 2 from TextNode start: 5, length: 4, rect: [51.5,480.40625 32.140625x17.46875]
               "text"
-            frag 3 from TextNode start: 9, length: 1, rect: [84,480.40625 8x17.46875]
+            frag 3 from TextNode start: 9, length: 1, rect: [83.640625,480.40625 8x17.46875]
               " "
-            frag 4 from TextNode start: 10, length: 2, rect: [92,480.40625 13.90625x17.46875]
+            frag 4 from TextNode start: 10, length: 2, rect: [91.640625,480.40625 13.90625x17.46875]
               "is"
-            frag 5 from TextNode start: 12, length: 1, rect: [106,480.40625 8x17.46875]
+            frag 5 from TextNode start: 12, length: 1, rect: [105.546875,480.40625 8x17.46875]
               " "
-            frag 6 from TextNode start: 13, length: 16, rect: [114,480.40625 102.96875x17.46875]
+            frag 6 from TextNode start: 13, length: 16, rect: [113.546875,480.40625 102.96875x17.46875]
               "'full-justified'"
-            frag 7 from TextNode start: 29, length: 1, rect: [217,480.40625 8x17.46875]
+            frag 7 from TextNode start: 29, length: 1, rect: [216.515625,480.40625 8x17.46875]
               " "
-            frag 8 from TextNode start: 30, length: 3, rect: [225,480.40625 26.8125x17.46875]
+            frag 8 from TextNode start: 30, length: 3, rect: [224.515625,480.40625 26.8125x17.46875]
               "and"
-            frag 9 from TextNode start: 33, length: 1, rect: [251,480.40625 8x17.46875]
+            frag 9 from TextNode start: 33, length: 1, rect: [251.328125,480.40625 8x17.46875]
               " "
-            frag 10 from TextNode start: 34, length: 3, rect: [259,480.40625 24.875x17.46875]
+            frag 10 from TextNode start: 34, length: 3, rect: [259.328125,480.40625 24.875x17.46875]
               "the"
-            frag 11 from TextNode start: 37, length: 1, rect: [284,480.40625 8x17.46875]
+            frag 11 from TextNode start: 37, length: 1, rect: [284.203125,480.40625 8x17.46875]
               " "
-            frag 12 from TextNode start: 38, length: 5, rect: [292,480.40625 43.4375x17.46875]
+            frag 12 from TextNode start: 38, length: 5, rect: [292.203125,480.40625 43.4375x17.46875]
               "green"
-            frag 13 from TextNode start: 43, length: 1, rect: [336,480.40625 8x17.46875]
+            frag 13 from TextNode start: 43, length: 1, rect: [335.640625,480.40625 8x17.46875]
               " "
-            frag 14 from TextNode start: 44, length: 6, rect: [344,480.40625 57.0625x17.46875]
+            frag 14 from TextNode start: 44, length: 6, rect: [343.640625,480.40625 57.0625x17.46875]
               "square"
-            frag 15 from TextNode start: 50, length: 1, rect: [401,480.40625 8x17.46875]
+            frag 15 from TextNode start: 50, length: 1, rect: [400.703125,480.40625 8x17.46875]
               " "
-            frag 16 from TextNode start: 51, length: 2, rect: [409,480.40625 13.90625x17.46875]
+            frag 16 from TextNode start: 51, length: 2, rect: [408.703125,480.40625 13.90625x17.46875]
               "is"
-            frag 17 from TextNode start: 53, length: 1, rect: [423,480.40625 8x17.46875]
+            frag 17 from TextNode start: 53, length: 1, rect: [422.609375,480.40625 8x17.46875]
               " "
-            frag 18 from TextNode start: 54, length: 4, rect: [431,480.40625 26.25x17.46875]
+            frag 18 from TextNode start: 54, length: 4, rect: [430.609375,480.40625 26.25x17.46875]
               "left"
-            frag 19 from TextNode start: 58, length: 1, rect: [457,480.40625 8x17.46875]
+            frag 19 from TextNode start: 58, length: 1, rect: [456.859375,480.40625 8x17.46875]
               " "
-            frag 20 from TextNode start: 59, length: 8, rect: [465,480.40625 55.671875x17.46875]
+            frag 20 from TextNode start: 59, length: 8, rect: [464.859375,480.40625 55.671875x17.46875]
               "aligned:"
           TextNode <#text>
         BlockContainer <div.square> at (28,517.875) content-size 100x100 children: not-inline

--- a/Tests/LibWeb/Layout/expected/div_align_nested.txt
+++ b/Tests/LibWeb/Layout/expected/div_align_nested.txt
@@ -1,27 +1,27 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x252.875 children: not-inline
-      BlockContainer <div> at (8,8) content-size 784x252.875 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x252.40625 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x252.40625 children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 784x17.46875 children: inline
           line 0 width: 447.484375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 54, rect: [345,8 447.484375x17.46875]
+            frag 0 from TextNode start: 0, length: 54, rect: [344.515625,8 447.484375x17.46875]
               "This text and the green square are both right aligned:"
           TextNode <#text>
         BlockContainer <div.square> at (692,25.46875) content-size 100x100 children: not-inline
         BlockContainer <(anonymous)> at (8,125.46875) content-size 784x0 children: inline
           TextNode <#text>
-        BlockContainer <div> at (8,125.46875) content-size 784x135.40625 children: not-inline
-          BlockContainer <(anonymous)> at (8,125.46875) content-size 784x35.40625 children: inline
+        BlockContainer <div> at (8,125.46875) content-size 784x134.9375 children: not-inline
+          BlockContainer <(anonymous)> at (8,125.46875) content-size 784x34.9375 children: inline
             line 0 width: 711.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
               frag 0 from TextNode start: 1, length: 87, rect: [8,125.46875 711.4375x17.46875]
                 "This text and the green square are both left aligned despite being nested in a div with"
-            line 1 width: 94.296875, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-              frag 0 from TextNode start: 89, length: 14, rect: [8,142.46875 94.296875x17.46875]
+            line 1 width: 94.296875, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+              frag 0 from TextNode start: 89, length: 14, rect: [8,142.9375 94.296875x17.46875]
                 "align="right":"
             TextNode <#text>
-          BlockContainer <div.square> at (8,160.875) content-size 100x100 children: inline
+          BlockContainer <div.square> at (8,160.40625) content-size 100x100 children: inline
             TextNode <#text>
-          BlockContainer <(anonymous)> at (8,260.875) content-size 784x0 children: inline
+          BlockContainer <(anonymous)> at (8,260.40625) content-size 784x0 children: inline
             TextNode <#text>
-        BlockContainer <(anonymous)> at (8,260.875) content-size 784x0 children: inline
+        BlockContainer <(anonymous)> at (8,260.40625) content-size 784x0 children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-auto.txt
+++ b/Tests/LibWeb/Layout/expected/flex-auto.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.container> at (9,9) content-size 500x102 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 164.666666x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,10) content-size 164.65625x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (176.666666,10) content-size 164.666666x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (176.65625,10) content-size 164.65625x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [176.666666,10 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [176.65625,10 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (343.333333,10) content-size 164.666666x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (343.3125,10) content-size 164.65625x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [343.333333,10 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [343.3125,10 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-column-constrained-nowrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-constrained-nowrap.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.container.column> at (9,9) content-size 782x250 flex-container(column) [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 100x81.333333 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,10) content-size 100x81.34375 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,93.333333) content-size 100x81.333333 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,93.34375) content-size 100x81.34375 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [10,93.333333 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [10,93.34375 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,176.666666) content-size 100x81.333333 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,176.6875) content-size 100x81.34375 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [10,176.666666 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [10,176.6875 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-column-height-constrained-width-constrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-height-constrained-width-constrained.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.container.column> at (9,9) content-size 250x250 flex-container(column) [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 100x81.333333 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,10) content-size 100x81.34375 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,93.333333) content-size 100x81.333333 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,93.34375) content-size 100x81.34375 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [10,93.333333 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [10,93.34375 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,176.666666) content-size 100x81.333333 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,176.6875) content-size 100x81.34375 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [10,176.666666 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [10,176.6875 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-column-height-constrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-height-constrained.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.container> at (9,9) content-size 782x250 flex-container(column) [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 100x81.333333 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,10) content-size 100x81.34375 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,93.333333) content-size 100x81.333333 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,93.34375) content-size 100x81.34375 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [10,93.333333 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [10,93.34375 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,176.666666) content-size 100x81.333333 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,176.6875) content-size 100x81.34375 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [10,176.666666 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [10,176.6875 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-and-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-and-max-width.txt
@@ -1,20 +1,20 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x92.21875 [BFC] children: not-inline
-    Box <body> at (2,2) content-size 796x90.21875 flex-container(column) [FFC] children: not-inline
-      BlockContainer <main> at (3,3) content-size 400x88.21875 flex-item [BFC] children: inline
+  BlockContainer <html> at (1,1) content-size 798x91.34375 [BFC] children: not-inline
+    Box <body> at (2,2) content-size 796x89.34375 flex-container(column) [FFC] children: not-inline
+      BlockContainer <main> at (3,3) content-size 400x87.34375 flex-item [BFC] children: inline
         line 0 width: 346.984375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
           frag 0 from TextNode start: 0, length: 41, rect: [3,3 346.984375x17.46875]
             "For my day job I'm currently working as a"
-        line 1 width: 337.59375, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-          frag 0 from TextNode start: 42, length: 39, rect: [3,20 337.59375x17.46875]
+        line 1 width: 337.59375, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+          frag 0 from TextNode start: 42, length: 39, rect: [3,20.46875 337.59375x17.46875]
             "Software Engineer at For my day job I'm"
-        line 2 width: 368.203125, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-          frag 0 from TextNode start: 82, length: 43, rect: [3,37 368.203125x17.46875]
+        line 2 width: 368.203125, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+          frag 0 from TextNode start: 82, length: 43, rect: [3,37.9375 368.203125x17.46875]
             "currently working as a Software Engineer at"
-        line 3 width: 346.984375, height: 17.875, bottom: 70.28125, baseline: 13.53125
-          frag 0 from TextNode start: 126, length: 41, rect: [3,55 346.984375x17.46875]
+        line 3 width: 346.984375, height: 17.46875, bottom: 69.875, baseline: 13.53125
+          frag 0 from TextNode start: 126, length: 41, rect: [3,55.40625 346.984375x17.46875]
             "For my day job I'm currently working as a"
-        line 4 width: 175.40625, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-          frag 0 from TextNode start: 168, length: 20, rect: [3,72 175.40625x17.46875]
+        line 4 width: 175.40625, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+          frag 0 from TextNode start: 168, length: 20, rect: [3,72.875 175.40625x17.46875]
             "Software Engineer at"
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-auto-width-with-max-width-constraint.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-auto-width-with-max-width-constraint.txt
@@ -1,20 +1,20 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x331.570312 [BFC] children: not-inline
-    Box <body.hero> at (2,2) content-size 600x329.570312 flex-container(column) [FFC] children: not-inline
-      BlockContainer <div.header> at (102,3) content-size 400x327.570312 flex-item [BFC] children: inline
-        line 0 width: 340.488281, height: 65.507812, bottom: 65.507812, baseline: 50.742187
-          frag 0 from TextNode start: 0, length: 11, rect: [102,3 340.488281x65.507812]
+  BlockContainer <html> at (1,1) content-size 798x331.5 [BFC] children: not-inline
+    Box <body.hero> at (2,2) content-size 600x329.5 flex-container(column) [FFC] children: not-inline
+      BlockContainer <div.header> at (102,3) content-size 400x327.5 flex-item [BFC] children: inline
+        line 0 width: 340.484375, height: 65.5, bottom: 65.5, baseline: 50.734375
+          frag 0 from TextNode start: 0, length: 11, rect: [102,3 340.484375x65.5]
             "This entire"
-        line 1 width: 341.25, height: 66.015625, bottom: 131.523437, baseline: 50.742187
-          frag 0 from TextNode start: 12, length: 11, rect: [102,68 341.25x65.507812]
+        line 1 width: 341.234375, height: 65.5, bottom: 131, baseline: 50.734375
+          frag 0 from TextNode start: 12, length: 11, rect: [102,68.5 341.234375x65.5]
             "text should"
-        line 2 width: 274.160156, height: 65.523437, bottom: 196.539062, baseline: 50.742187
-          frag 0 from TextNode start: 24, length: 8, rect: [102,134 274.160156x65.507812]
+        line 2 width: 274.140625, height: 65.5, bottom: 196.5, baseline: 50.734375
+          frag 0 from TextNode start: 24, length: 8, rect: [102,134 274.140625x65.5]
             "be on an"
-        line 3 width: 204.082031, height: 66.03125, bottom: 262.554687, baseline: 50.742187
-          frag 0 from TextNode start: 33, length: 6, rect: [102,199 204.082031x65.507812]
+        line 3 width: 204.078125, height: 65.5, bottom: 262, baseline: 50.734375
+          frag 0 from TextNode start: 33, length: 6, rect: [102,199.5 204.078125x65.5]
             "orange"
-        line 4 width: 351.5625, height: 65.539062, bottom: 327.570312, baseline: 50.742187
-          frag 0 from TextNode start: 40, length: 11, rect: [102,265 351.5625x65.507812]
+        line 4 width: 351.5625, height: 65.5, bottom: 327.5, baseline: 50.734375
+          frag 0 from TextNode start: 40, length: 11, rect: [102,265 351.5625x65.5]
             "background."
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-on-auto-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-on-auto-width.txt
@@ -1,21 +1,21 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x457.09375 [BFC] children: not-inline
-    Box <body.hero> at (10,10) content-size 500x439.09375 flex-container(column) [FFC] children: not-inline
-      BlockContainer <div.upper> at (10,11) content-size 500x437.09375 flex-item [BFC] children: inline
+  BlockContainer <html> at (1,1) content-size 798x456.71875 [BFC] children: not-inline
+    Box <body.hero> at (10,10) content-size 500x438.71875 flex-container(column) [FFC] children: not-inline
+      BlockContainer <div.upper> at (10,11) content-size 500x436.71875 flex-item [BFC] children: inline
         line 0 width: 453.984375, height: 87.34375, bottom: 87.34375, baseline: 67.65625
           frag 0 from TextNode start: 0, length: 11, rect: [10,11 453.984375x87.34375]
             "This entire"
-        line 1 width: 455, height: 87.6875, bottom: 175.03125, baseline: 67.65625
-          frag 0 from TextNode start: 12, length: 11, rect: [10,98 455x87.34375]
+        line 1 width: 455, height: 87.34375, bottom: 174.6875, baseline: 67.65625
+          frag 0 from TextNode start: 12, length: 11, rect: [10,98.34375 455x87.34375]
             "text should"
-        line 2 width: 230.78125, height: 88.03125, bottom: 262.71875, baseline: 67.65625
-          frag 0 from TextNode start: 24, length: 5, rect: [10,185 230.78125x87.34375]
+        line 2 width: 230.78125, height: 87.34375, bottom: 262.03125, baseline: 67.65625
+          frag 0 from TextNode start: 24, length: 5, rect: [10,185.6875 230.78125x87.34375]
             "be on"
-        line 3 width: 272.109375, height: 87.375, bottom: 349.40625, baseline: 67.65625
-          frag 0 from TextNode start: 30, length: 6, rect: [10,273 272.109375x87.34375]
+        line 3 width: 272.109375, height: 87.34375, bottom: 349.375, baseline: 67.65625
+          frag 0 from TextNode start: 30, length: 6, rect: [10,273.03125 272.109375x87.34375]
             "orange"
-        line 4 width: 468.75, height: 87.71875, bottom: 437.09375, baseline: 67.65625
-          frag 0 from TextNode start: 37, length: 11, rect: [10,360 468.75x87.34375]
+        line 4 width: 468.75, height: 87.34375, bottom: 436.71875, baseline: 67.65625
+          frag 0 from TextNode start: 37, length: 11, rect: [10,360.375 468.75x87.34375]
             "background."
         TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-container-constrained-nowrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-constrained-nowrap.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.container> at (9,9) content-size 250x102 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 81.333333x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,10) content-size 81.34375x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (93.333333,10) content-size 81.333333x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (93.34375,10) content-size 81.34375x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [93.333333,10 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [93.34375,10 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (176.666666,10) content-size 81.333333x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (176.6875,10) content-size 81.34375x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [176.666666,10 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [176.6875,10 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-container-width-constrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-width-constrained.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.container.width-constrained> at (9,9) content-size 250x102 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 81.333333x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,10) content-size 81.34375x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (93.333333,10) content-size 81.333333x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (93.34375,10) content-size 81.34375x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [93.333333,10 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [93.34375,10 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (176.666666,10) content-size 81.333333x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (176.6875,10) content-size 81.34375x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [176.666666,10 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [176.6875,10 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-grow-1.txt
+++ b/Tests/LibWeb/Layout/expected/flex-grow-1.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.container> at (9,9) content-size 500x102 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 229.333333x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,10) content-size 229.328125x100 flex-item [BFC] children: inline
           line 0 width: 144.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 17, rect: [10,10 144.546875x17.46875]
               "1 I grow the most"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (241.333333,10) content-size 164.666666x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (241.328125,10) content-size 164.65625x100 flex-item [BFC] children: inline
           line 0 width: 67.375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 8, rect: [241.333333,10 67.375x17.46875]
+            frag 0 from TextNode start: 0, length: 8, rect: [241.328125,10 67.375x17.46875]
               "2 I grow"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (408,10) content-size 100x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (407.984375,10) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 68, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 9, rect: [408,10 68x17.46875]
+            frag 0 from TextNode start: 0, length: 9, rect: [407.984375,10 68x17.46875]
               "3 I don't"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-grow-2.txt
+++ b/Tests/LibWeb/Layout/expected/flex-grow-2.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.container> at (9,9) content-size 500x102 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 82.333333x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,10) content-size 82.328125x100 flex-item [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [10,10 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (94.333333,10) content-size 164.666666x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (94.328125,10) content-size 164.65625x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [94.333333,10 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [94.328125,10 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (261,10) content-size 247x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (260.984375,10) content-size 247x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [261,10 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [260.984375,10 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-shrink-1.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-1.txt
@@ -4,32 +4,32 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.container> at (9,9) content-size 250x102 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (10,10) content-size 62.666666x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (10,10) content-size 62.671875x100 flex-item [BFC] children: inline
           line 0 width: 18.9375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 3, rect: [10,10 18.9375x17.46875]
               "1 I"
-          line 1 width: 49.359375, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 4, length: 6, rect: [10,27 49.359375x17.46875]
+          line 1 width: 49.359375, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 4, length: 6, rect: [10,27.46875 49.359375x17.46875]
               "shrink"
-          line 2 width: 24.875, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 11, length: 3, rect: [10,44 24.875x17.46875]
+          line 2 width: 24.875, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 11, length: 3, rect: [10,44.9375 24.875x17.46875]
               "the"
-          line 3 width: 38.765625, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 15, length: 4, rect: [10,62 38.765625x17.46875]
+          line 3 width: 38.765625, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 15, length: 4, rect: [10,62.40625 38.765625x17.46875]
               "most"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (74.666666,10) content-size 81.333333x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (74.671875,10) content-size 81.34375x100 flex-item [BFC] children: inline
           line 0 width: 78.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 10, rect: [74.666666,10 78.765625x17.46875]
+            frag 0 from TextNode start: 0, length: 10, rect: [74.671875,10 78.765625x17.46875]
               "2 I shrink"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (158,10) content-size 100x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (158.015625,10) content-size 100x100 flex-item [BFC] children: inline
           line 0 width: 68, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 9, rect: [158,10 68x17.46875]
+            frag 0 from TextNode start: 0, length: 9, rect: [158.015625,10 68x17.46875]
               "3 I don't"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex-shrink-2.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-2.txt
@@ -11,16 +11,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (59,10) content-size 164.666666x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (59,10) content-size 164.671875x100 flex-item [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [59,10 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.box> at (225.666666,10) content-size 282.333333x100 flex-item [BFC] children: inline
+        BlockContainer <div.box> at (225.671875,10) content-size 282.34375x100 flex-item [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [225.666666,10 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [225.671875,10 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/flex/calc-flex-basis.txt
+++ b/Tests/LibWeb/Layout/expected/flex/calc-flex-basis.txt
@@ -3,22 +3,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x62 children: not-inline
       Box <div.flex-container> at (11,11) content-size 778x60 flex-container(row) [FFC] children: not-inline
         BlockContainer <div.flex-item> at (12,12) content-size 386x28 flex-item [BFC] children: inline
-          line 0 width: 58.398437, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-            frag 0 from TextNode start: 0, length: 6, rect: [12,12 58.398437x21.835937]
+          line 0 width: 58.390625, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+            frag 0 from TextNode start: 0, length: 6, rect: [12,12 58.390625x21.828125]
               "Item 1"
           TextNode <#text>
         BlockContainer <div.flex-item> at (401,12) content-size 386x28 flex-item [BFC] children: inline
-          line 0 width: 61.484375, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-            frag 0 from TextNode start: 0, length: 6, rect: [401,12 61.484375x21.835937]
+          line 0 width: 61.484375, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+            frag 0 from TextNode start: 0, length: 6, rect: [401,12 61.484375x21.828125]
               "Item 2"
           TextNode <#text>
         BlockContainer <div.flex-item> at (12,42) content-size 386x28 flex-item [BFC] children: inline
-          line 0 width: 61.835937, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-            frag 0 from TextNode start: 0, length: 6, rect: [12,42 61.835937x21.835937]
+          line 0 width: 61.828125, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+            frag 0 from TextNode start: 0, length: 6, rect: [12,42 61.828125x21.828125]
               "Item 3"
           TextNode <#text>
         BlockContainer <div.flex-item> at (401,42) content-size 386x28 flex-item [BFC] children: inline
-          line 0 width: 60.15625, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-            frag 0 from TextNode start: 0, length: 6, rect: [401,42 60.15625x21.835937]
+          line 0 width: 60.15625, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+            frag 0 from TextNode start: 0, length: 6, rect: [401,42 60.15625x21.828125]
               "Item 4"
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex/cross-size-of-item-with-box-sizing-border-box-and-nonzero-padding.txt
+++ b/Tests/LibWeb/Layout/expected/flex/cross-size-of-item-with-box-sizing-border-box-and-nonzero-padding.txt
@@ -1,27 +1,27 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x245.09375 [BFC] children: not-inline
-    BlockContainer <body> at (10,10) content-size 780x227.09375 children: not-inline
-      Box <div.outer.flex.flex-wrap> at (11,11) content-size 778x225.09375 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div.inner> at (12,62) content-size 776x123.09375 flex-item [BFC] children: inline
+  BlockContainer <html> at (1,1) content-size 798x244.28125 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x226.28125 children: not-inline
+      Box <div.outer.flex.flex-wrap> at (11,11) content-size 778x224.28125 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div.inner> at (12,62) content-size 776x122.28125 flex-item [BFC] children: inline
           line 0 width: 741.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 90, rect: [12,62 741.640625x17.46875]
               "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus interdum libero et urna"
-          line 1 width: 765.03125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 91, length: 95, rect: [12,79 765.03125x17.46875]
+          line 1 width: 765.03125, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 91, length: 95, rect: [12,79.46875 765.03125x17.46875]
               "sodales auctor. Nullam sodales bibendum turpis quis blandit. Ut fringilla erat et erat laoreet,"
-          line 2 width: 747.5625, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 187, length: 90, rect: [12,96 747.5625x17.46875]
+          line 2 width: 747.5625, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 187, length: 90, rect: [12,96.9375 747.5625x17.46875]
               "faucibus rhoncus orci hendrerit. Etiam at sagittis diam. Etiam nec neque non dolor iaculis"
-          line 3 width: 732.109375, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 278, length: 90, rect: [12,114 732.109375x17.46875]
+          line 3 width: 732.109375, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 278, length: 90, rect: [12,114.40625 732.109375x17.46875]
               "finibus euismod eget erat. Pellentesque vitae purus vitae nisi vehicula vestibulum quis ut"
-          line 4 width: 759.453125, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 369, length: 95, rect: [12,131 759.453125x17.46875]
+          line 4 width: 759.453125, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+            frag 0 from TextNode start: 369, length: 95, rect: [12,131.875 759.453125x17.46875]
               "diam. Integer convallis, justo ullamcorper sollicitudin varius, enim enim pellentesque erat, eu"
-          line 5 width: 767.1875, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-            frag 0 from TextNode start: 465, length: 94, rect: [12,149 767.1875x17.46875]
+          line 5 width: 767.1875, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+            frag 0 from TextNode start: 465, length: 94, rect: [12,149.34375 767.1875x17.46875]
               "pellentesque sem arcu eu purus. Phasellus id erat sed felis luctus mollis eget sit amet dolor."
-          line 6 width: 765.578125, height: 18.28125, bottom: 123.09375, baseline: 13.53125
-            frag 0 from TextNode start: 560, length: 95, rect: [12,166 765.578125x17.46875]
+          line 6 width: 765.578125, height: 17.46875, bottom: 122.28125, baseline: 13.53125
+            frag 0 from TextNode start: 560, length: 95, rect: [12,166.8125 765.578125x17.46875]
               "Pellentesque eget justo nulla. Duis consectetur imperdiet nisi, ac tincidunt urna blandit quis."
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-min-width-fit-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-min-width-fit-content.txt
@@ -9,14 +9,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.buttons> at (394.625,11) content-size 114.375x50 flex-item [BFC] children: inline
         line 0 width: 114.375, height: 19.46875, bottom: 19.46875, baseline: 14.53125
           frag 0 from BlockContainer start: 0, length: 0, rect: [395.625,12 57.046875x17.46875]
-          frag 1 from BlockContainer start: 0, length: 0, rect: [454.625,12 53.328125x17.46875]
+          frag 1 from BlockContainer start: 0, length: 0, rect: [454.671875,12 53.328125x17.46875]
         BlockContainer <div.button> at (395.625,12) content-size 57.046875x17.46875 inline-block [BFC] children: inline
           line 0 width: 57.046875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 6, rect: [395.625,12 57.046875x17.46875]
               "Accept"
           TextNode <#text>
-        BlockContainer <div.button> at (454.625,12) content-size 53.328125x17.46875 inline-block [BFC] children: inline
+        BlockContainer <div.button> at (454.671875,12) content-size 53.328125x17.46875 inline-block [BFC] children: inline
           line 0 width: 53.328125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 6, rect: [454.625,12 53.328125x17.46875]
+            frag 0 from TextNode start: 0, length: 6, rect: [454.671875,12 53.328125x17.46875]
               "Reject"
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-with-calc-main-size-and-layout-dependent-containing-block-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-with-calc-main-size-and-layout-dependent-containing-block-size.txt
@@ -1,15 +1,15 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x69.34375 [BFC] children: not-inline
-    Box <body.pink> at (8,8) content-size 784x53.34375 flex-container(row) [FFC] children: not-inline
-      Box <div.orange> at (8,8) content-size 194.71875x53.34375 flex-container(row) flex-item [FFC] children: not-inline
-        BlockContainer <div.lime> at (8,8) content-size 87.358999x53.34375 flex-item [BFC] children: inline
+  BlockContainer <html> at (0,0) content-size 800x68.40625 [BFC] children: not-inline
+    Box <body.pink> at (8,8) content-size 784x52.40625 flex-container(row) [FFC] children: not-inline
+      Box <div.orange> at (8,8) content-size 194.71875x52.40625 flex-container(row) flex-item [FFC] children: not-inline
+        BlockContainer <div.lime> at (8,8) content-size 87.34375x52.40625 flex-item [BFC] children: inline
           line 0 width: 74.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 9, rect: [8,8 74.75x17.46875]
               "This is a"
-          line 1 width: 71.828125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 10, length: 8, rect: [8,25 71.828125x17.46875]
+          line 1 width: 71.828125, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 10, length: 8, rect: [8,25.46875 71.828125x17.46875]
               "bunch of"
-          line 2 width: 32.140625, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 19, length: 4, rect: [8,42 32.140625x17.46875]
+          line 2 width: 32.140625, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 19, length: 4, rect: [8,42.9375 32.140625x17.46875]
               "text"
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x70 [BFC] children: not-inline
-    Box <body> at (10,10) content-size 780x52 flex-container(row) [FFC] children: not-inline
-      ImageBox <img> at (11,11) content-size 66.666668x50 flex-item children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x69.96875 [BFC] children: not-inline
+    Box <body> at (10,10) content-size 780x51.96875 flex-container(row) [FFC] children: not-inline
+      ImageBox <img> at (11,11) content-size 66.65625x49.984375 flex-item children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex/reverse-flex-layout-with-space-between-and-space-around.txt
+++ b/Tests/LibWeb/Layout/expected/flex/reverse-flex-layout-with-space-between-and-space-around.txt
@@ -2,37 +2,37 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x616 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x600 children: not-inline
       Box <div.outer.row> at (8,8) content-size 150x150 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div.inner> at (12.619791,8) content-size 30.078125x150 flex-item [BFC] children: inline
+        BlockContainer <div.inner> at (12.609375,8) content-size 30.078125x150 flex-item [BFC] children: inline
           line 0 width: 30.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 4, rect: [12.619791,8 30.078125x17.46875]
+            frag 0 from TextNode start: 0, length: 4, rect: [12.609375,8 30.078125x17.46875]
               "Well"
           TextNode <#text>
-        BlockContainer <div.inner> at (51.9375,8) content-size 36.84375x150 flex-item [BFC] children: inline
+        BlockContainer <div.inner> at (51.921875,8) content-size 36.84375x150 flex-item [BFC] children: inline
           line 0 width: 36.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [51.9375,8 36.84375x17.46875]
+            frag 0 from TextNode start: 0, length: 5, rect: [51.921875,8 36.84375x17.46875]
               "hello"
           TextNode <#text>
-        BlockContainer <div.inner> at (98.020833,8) content-size 55.359375x150 flex-item [BFC] children: inline
+        BlockContainer <div.inner> at (98,8) content-size 55.359375x150 flex-item [BFC] children: inline
           line 0 width: 55.359375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 7, rect: [98.020833,8 55.359375x17.46875]
+            frag 0 from TextNode start: 0, length: 7, rect: [98,8 55.359375x17.46875]
               "friends"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,158) content-size 784x0 children: inline
         TextNode <#text>
       Box <div.outer.row-reverse> at (8,158) content-size 150x150 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div.inner> at (123.302083,158) content-size 30.078125x150 flex-item [BFC] children: inline
+        BlockContainer <div.inner> at (123.3125,158) content-size 30.078125x150 flex-item [BFC] children: inline
           line 0 width: 30.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 4, rect: [123.302083,158 30.078125x17.46875]
+            frag 0 from TextNode start: 0, length: 4, rect: [123.3125,158 30.078125x17.46875]
               "Well"
           TextNode <#text>
-        BlockContainer <div.inner> at (77.21875,158) content-size 36.84375x150 flex-item [BFC] children: inline
+        BlockContainer <div.inner> at (77.234375,158) content-size 36.84375x150 flex-item [BFC] children: inline
           line 0 width: 36.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [77.21875,158 36.84375x17.46875]
+            frag 0 from TextNode start: 0, length: 5, rect: [77.234375,158 36.84375x17.46875]
               "hello"
           TextNode <#text>
-        BlockContainer <div.inner> at (12.619791,158) content-size 55.359375x150 flex-item [BFC] children: inline
+        BlockContainer <div.inner> at (12.640625,158) content-size 55.359375x150 flex-item [BFC] children: inline
           line 0 width: 55.359375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 7, rect: [12.619791,158 55.359375x17.46875]
+            frag 0 from TextNode start: 0, length: 7, rect: [12.640625,158 55.359375x17.46875]
               "friends"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,308) content-size 784x0 children: inline

--- a/Tests/LibWeb/Layout/expected/flex/stretch-alignment-with-cross-gap.txt
+++ b/Tests/LibWeb/Layout/expected/flex/stretch-alignment-with-cross-gap.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.flex> at (11,11) content-size 300x200 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (12,12) content-size 100x20 flex-item [BFC] children: not-inline
         BlockContainer <div> at (114,12) content-size 100x20 flex-item [BFC] children: not-inline
-        BlockContainer <div> at (12,95.333333) content-size 100x20 flex-item [BFC] children: not-inline
-        BlockContainer <div> at (114,95.333333) content-size 100x20 flex-item [BFC] children: not-inline
-        BlockContainer <div> at (12,178.666666) content-size 100x20 flex-item [BFC] children: not-inline
-        BlockContainer <div> at (114,178.666666) content-size 100x20 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (12,95.328125) content-size 100x20 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (114,95.328125) content-size 100x20 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (12,178.65625) content-size 100x20 flex-item [BFC] children: not-inline
+        BlockContainer <div> at (114,178.65625) content-size 100x20 flex-item [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/font-with-many-normal-values.txt
+++ b/Tests/LibWeb/Layout/expected/font-with-many-normal-values.txt
@@ -1,20 +1,20 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x200 children: inline
-      line 0 width: 424, height: 200, bottom: 200, baseline: 159.960937
+  BlockContainer <html> at (0,0) content-size 800x215.984375 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x199.984375 children: inline
+      line 0 width: 424, height: 199.984375, bottom: 199.984375, baseline: 159.953125
         frag 0 from TextNode start: 0, length: 1, rect: [8,8 79.296875x200]
           "1"
-        frag 1 from TextNode start: 0, length: 1, rect: [87,154 8x17.46875]
+        frag 1 from TextNode start: 0, length: 1, rect: [87.296875,154.421875 8x17.46875]
           " "
-        frag 2 from TextNode start: 0, length: 1, rect: [95,8 110.15625x200]
+        frag 2 from TextNode start: 0, length: 1, rect: [95.296875,8 110.15625x200]
           "2"
-        frag 3 from TextNode start: 0, length: 1, rect: [205,154 8x17.46875]
+        frag 3 from TextNode start: 0, length: 1, rect: [205.453125,154.421875 8x17.46875]
           " "
-        frag 4 from TextNode start: 0, length: 1, rect: [213,8 113.671875x200]
+        frag 4 from TextNode start: 0, length: 1, rect: [213.453125,8 113.671875x200]
           "3"
-        frag 5 from TextNode start: 0, length: 1, rect: [327,154 8x17.46875]
+        frag 5 from TextNode start: 0, length: 1, rect: [327.125,154.421875 8x17.46875]
           " "
-        frag 6 from TextNode start: 0, length: 1, rect: [335,8 96.875x200]
+        frag 6 from TextNode start: 0, length: 1, rect: [335.125,8 96.875x200]
           "4"
       InlineNode <span.one>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/getComputedStyle-on-unconnected-element.txt
+++ b/Tests/LibWeb/Layout/expected/getComputedStyle-on-unconnected-element.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x37.835937 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x21.835937 children: inline
-      line 0 width: 362.617187, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-        frag 0 from TextNode start: 0, length: 35, rect: [8,8 362.617187x21.835937]
+  BlockContainer <html> at (0,0) content-size 800x37.828125 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x21.828125 children: inline
+      line 0 width: 362.59375, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+        frag 0 from TextNode start: 0, length: 35, rect: [8,8 362.59375x21.828125]
           "This test passes if we don't crash."
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/auto-fill.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fill.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 261.333333x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 261.328125x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (269.333333,8) content-size 261.333333x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (269.328125,8) content-size 261.328125x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [269.333333,8 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [269.328125,8 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (530.666666,8) content-size 261.333333x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (530.65625,8) content-size 261.328125x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [530.666666,8 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [530.65625,8 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/auto-fit.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fit.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 261.333333x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 261.328125x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (269.333333,8) content-size 261.333333x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (269.328125,8) content-size 261.328125x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [269.333333,8 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [269.328125,8 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (530.666666,8) content-size 261.333333x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (530.65625,8) content-size 261.328125x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [530.666666,8 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [530.65625,8 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/borders.txt
+++ b/Tests/LibWeb/Layout/expected/grid/borders.txt
@@ -103,14 +103,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,275.34375) content-size 784x90.9375 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (444.2,285.34375) content-size 337.8x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (444.1875,285.34375) content-size 337.796875x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [444.2,285.34375 6.34375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [444.1875,285.34375 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (18,338.8125) content-size 337.8x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (18,338.8125) content-size 337.796875x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [18,338.8125 8.8125x17.46875]
               "2"

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
@@ -2,12 +2,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x50.9375 children: not-inline
       Box <div.container> at (8,8) content-size 784x50.9375 [GFC] children: not-inline
-        BlockContainer <div.item> at (434.2,8) content-size 357.8x17.46875 [BFC] children: inline
+        BlockContainer <div.item> at (434.1875,8) content-size 357.796875x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [434.2,8 6.34375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [434.1875,8 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <div.item> at (8,41.46875) content-size 357.8x17.46875 [BFC] children: inline
+        BlockContainer <div.item> at (8,41.46875) content-size 357.796875x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,41.46875 8.8125x17.46875]
               "2"

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-paddings.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-paddings.txt
@@ -1,36 +1,36 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x355.507812 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x355.507812 [GFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x355.5 children: not-inline
+      Box <div.grid-container> at (8,8) content-size 784x355.5 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (68,68) content-size 17.050781x32.753906 [BFC] children: inline
-          line 0 width: 11.894531, height: 32.753906, bottom: 32.753906, baseline: 25.371093
-            frag 0 from TextNode start: 0, length: 1, rect: [71,68 11.894531x32.753906]
+        BlockContainer <div.grid-item> at (68,68) content-size 17.046875x32.75 [BFC] children: inline
+          line 0 width: 11.890625, height: 32.75, bottom: 32.75, baseline: 25.359375
+            frag 0 from TextNode start: 0, length: 1, rect: [70.578125,68 11.890625x32.75]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (255.050781,68) content-size 16.523437x32.753906 [BFC] children: inline
-          line 0 width: 16.523437, height: 32.753906, bottom: 32.753906, baseline: 25.371093
-            frag 0 from TextNode start: 0, length: 1, rect: [255.050781,68 16.523437x32.753906]
+        BlockContainer <div.grid-item> at (255.046875,68) content-size 16.515625x32.75 [BFC] children: inline
+          line 0 width: 16.515625, height: 32.75, bottom: 32.75, baseline: 25.359375
+            frag 0 from TextNode start: 0, length: 1, rect: [255.046875,68 16.515625x32.75]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (68,270.753906) content-size 17.050781x32.753906 [BFC] children: inline
-          line 0 width: 17.050781, height: 32.753906, bottom: 32.753906, baseline: 25.371093
-            frag 0 from TextNode start: 0, length: 1, rect: [68,270.753906 17.050781x32.753906]
+        BlockContainer <div.grid-item> at (68,270.75) content-size 17.046875x32.75 [BFC] children: inline
+          line 0 width: 17.046875, height: 32.75, bottom: 32.75, baseline: 25.359375
+            frag 0 from TextNode start: 0, length: 1, rect: [68,270.75 17.046875x32.75]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (255.050781,270.753906) content-size 16.523437x32.753906 [BFC] children: inline
-          line 0 width: 14.53125, height: 32.753906, bottom: 32.753906, baseline: 25.371093
-            frag 0 from TextNode start: 0, length: 1, rect: [256.050781,270.753906 14.53125x32.753906]
+        BlockContainer <div.grid-item> at (255.046875,270.75) content-size 16.515625x32.75 [BFC] children: inline
+          line 0 width: 14.53125, height: 32.75, bottom: 32.75, baseline: 25.359375
+            frag 0 from TextNode start: 0, length: 1, rect: [256.03125,270.75 14.53125x32.75]
               "4"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-      BlockContainer <(anonymous)> at (8,363.507812) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,363.5) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-horizontal-margins-auto.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-horizontal-margins-auto.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x458.28125 [BFC] children: not-inline
-    BlockContainer <body> at (10,10) content-size 780x440.28125 children: not-inline
-      Box <div.grid> at (11,11) content-size 500x438.28125 [GFC] children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x457.25 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x439.25 children: not-inline
+      Box <div.grid> at (11,11) content-size 500x437.25 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.left-margin-auto.right-margin-auto> at (99.71875,12) content-size 322.5625x17.46875 [BFC] children: inline
@@ -25,9 +25,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.left-margin-auto.right-margin-auto.fit-content-width> at (75.257812,70.40625) content-size 371.484375x17.46875 [BFC] children: inline
+        BlockContainer <div.left-margin-auto.right-margin-auto.fit-content-width> at (75.25,70.40625) content-size 371.484375x17.46875 [BFC] children: inline
           line 0 width: 371.484375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 45, rect: [75.257812,70.40625 371.484375x17.46875]
+            frag 0 from TextNode start: 0, length: 45, rect: [75.25,70.40625 371.484375x17.46875]
               "auto horizontal margins and fit-content width"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -46,71 +46,71 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.left-margin-auto.right-margin-auto.fixed-width> at (236,128.8125) content-size 50x105.15625 [BFC] children: inline
+        BlockContainer <div.left-margin-auto.right-margin-auto.fixed-width> at (236,128.8125) content-size 50x104.8125 [BFC] children: inline
           line 0 width: 36.328125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 4, rect: [236,128.8125 36.328125x17.46875]
               "auto"
-          line 1 width: 81.84375, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 5, length: 10, rect: [236,145.8125 81.84375x17.46875]
+          line 1 width: 81.84375, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 5, length: 10, rect: [236,146.28125 81.84375x17.46875]
               "horizontal"
-          line 2 width: 61.453125, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 16, length: 7, rect: [236,162.8125 61.453125x17.46875]
+          line 2 width: 61.453125, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 16, length: 7, rect: [236,163.75 61.453125x17.46875]
               "margins"
-          line 3 width: 26.8125, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 24, length: 3, rect: [236,180.8125 26.8125x17.46875]
+          line 3 width: 26.8125, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 24, length: 3, rect: [236,181.21875 26.8125x17.46875]
               "and"
-          line 4 width: 37.28125, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 28, length: 5, rect: [236,197.8125 37.28125x17.46875]
+          line 4 width: 37.28125, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+            frag 0 from TextNode start: 28, length: 5, rect: [236,198.6875 37.28125x17.46875]
               "fixed"
-          line 5 width: 39.796875, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-            frag 0 from TextNode start: 34, length: 5, rect: [236,215.8125 39.796875x17.46875]
+          line 5 width: 39.796875, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+            frag 0 from TextNode start: 34, length: 5, rect: [236,216.15625 39.796875x17.46875]
               "width"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.left-margin-auto.fixed-width> at (460,235.96875) content-size 50x105.15625 [BFC] children: inline
+        BlockContainer <div.left-margin-auto.fixed-width> at (460,235.625) content-size 50x104.8125 [BFC] children: inline
           line 0 width: 36.328125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 4, rect: [460,235.96875 36.328125x17.46875]
+            frag 0 from TextNode start: 0, length: 4, rect: [460,235.625 36.328125x17.46875]
               "auto"
-          line 1 width: 26.25, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 5, length: 4, rect: [460,252.96875 26.25x17.46875]
+          line 1 width: 26.25, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 5, length: 4, rect: [460,253.09375 26.25x17.46875]
               "left"
-          line 2 width: 52.109375, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 10, length: 6, rect: [460,269.96875 52.109375x17.46875]
+          line 2 width: 52.109375, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 10, length: 6, rect: [460,270.5625 52.109375x17.46875]
               "margin"
-          line 3 width: 26.8125, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 17, length: 3, rect: [460,287.96875 26.8125x17.46875]
+          line 3 width: 26.8125, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 17, length: 3, rect: [460,288.03125 26.8125x17.46875]
               "and"
-          line 4 width: 37.28125, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 21, length: 5, rect: [460,304.96875 37.28125x17.46875]
+          line 4 width: 37.28125, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+            frag 0 from TextNode start: 21, length: 5, rect: [460,305.5 37.28125x17.46875]
               "fixed"
-          line 5 width: 39.796875, height: 17.8125, bottom: 105.15625, baseline: 13.53125
+          line 5 width: 39.796875, height: 17.46875, bottom: 104.8125, baseline: 13.53125
             frag 0 from TextNode start: 27, length: 5, rect: [460,322.96875 39.796875x17.46875]
               "width"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.right-margin-auto.fixed-width> at (12,343.125) content-size 50x105.15625 [BFC] children: inline
+        BlockContainer <div.right-margin-auto.fixed-width> at (12,342.4375) content-size 50x104.8125 [BFC] children: inline
           line 0 width: 36.328125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 4, rect: [12,343.125 36.328125x17.46875]
+            frag 0 from TextNode start: 0, length: 4, rect: [12,342.4375 36.328125x17.46875]
               "auto"
-          line 1 width: 37.109375, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 5, length: 5, rect: [12,360.125 37.109375x17.46875]
+          line 1 width: 37.109375, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 5, length: 5, rect: [12,359.90625 37.109375x17.46875]
               "right"
-          line 2 width: 52.109375, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 11, length: 6, rect: [12,377.125 52.109375x17.46875]
+          line 2 width: 52.109375, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 11, length: 6, rect: [12,377.375 52.109375x17.46875]
               "margin"
-          line 3 width: 26.8125, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 18, length: 3, rect: [12,395.125 26.8125x17.46875]
+          line 3 width: 26.8125, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 18, length: 3, rect: [12,394.84375 26.8125x17.46875]
               "and"
-          line 4 width: 37.28125, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 22, length: 5, rect: [12,412.125 37.28125x17.46875]
+          line 4 width: 37.28125, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+            frag 0 from TextNode start: 22, length: 5, rect: [12,412.3125 37.28125x17.46875]
               "fixed"
-          line 5 width: 39.796875, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-            frag 0 from TextNode start: 28, length: 5, rect: [12,430.125 39.796875x17.46875]
+          line 5 width: 39.796875, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+            frag 0 from TextNode start: 28, length: 5, rect: [12,429.78125 39.796875x17.46875]
               "width"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-      BlockContainer <(anonymous)> at (10,450.28125) content-size 780x0 children: inline
+      BlockContainer <(anonymous)> at (10,449.25) content-size 780x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-margins.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-margins.txt
@@ -3,8 +3,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x17.46875 children: not-inline
         Box <div.grid> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
-          BlockContainer <div.item> at (243.2,8) content-size 313.6x17.46875 [BFC] children: inline
+          BlockContainer <div.item> at (243.1875,8) content-size 313.625x17.46875 [BFC] children: inline
             line 0 width: 121.0625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-              frag 0 from TextNode start: 0, length: 16, rect: [243.2,8 121.0625x17.46875]
+              frag 0 from TextNode start: 0, length: 16, rect: [243.1875,8 121.0625x17.46875]
                 "A filthy t-shirt"
             TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width-2.txt
@@ -1,60 +1,60 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
-      Box <div.container> at (8,8) content-size 200x315.40625 floating [GFC] children: not-inline
-        BlockContainer <div.item> at (8,8) content-size 100x315.40625 [BFC] children: inline
+      Box <div.container> at (8,8) content-size 200x314.4375 floating [GFC] children: not-inline
+        BlockContainer <div.item> at (8,8) content-size 100x314.4375 [BFC] children: inline
           line 0 width: 50.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 1, length: 5, rect: [8,8 50.96875x17.46875]
               "Lorem"
-          line 1 width: 94.9375, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 7, length: 11, rect: [8,25 94.9375x17.46875]
+          line 1 width: 94.9375, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 7, length: 11, rect: [8,25.46875 94.9375x17.46875]
               "ipsum dolor"
-          line 2 width: 70.9375, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 19, length: 9, rect: [8,42 70.9375x17.46875]
+          line 2 width: 70.9375, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 19, length: 9, rect: [8,42.9375 70.9375x17.46875]
               "sit amet,"
-          line 3 width: 96.84375, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 29, length: 11, rect: [8,60 96.84375x17.46875]
+          line 3 width: 96.84375, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 29, length: 11, rect: [8,60.40625 96.84375x17.46875]
               "consectetur"
-          line 4 width: 75.71875, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 41, length: 10, rect: [8,77 75.71875x17.46875]
+          line 4 width: 75.71875, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+            frag 0 from TextNode start: 41, length: 10, rect: [8,77.875 75.71875x17.46875]
               "adipiscing"
-          line 5 width: 28.71875, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-            frag 0 from TextNode start: 52, length: 5, rect: [8,95 28.71875x17.46875]
+          line 5 width: 28.71875, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+            frag 0 from TextNode start: 52, length: 5, rect: [8,95.34375 28.71875x17.46875]
               "elit."
-          line 6 width: 65.40625, height: 18.28125, bottom: 123.09375, baseline: 13.53125
-            frag 0 from TextNode start: 58, length: 7, rect: [8,112 65.40625x17.46875]
+          line 6 width: 65.40625, height: 17.46875, bottom: 122.28125, baseline: 13.53125
+            frag 0 from TextNode start: 58, length: 7, rect: [8,112.8125 65.40625x17.46875]
               "Vivamus"
-          line 7 width: 88.640625, height: 17.75, bottom: 140.03125, baseline: 13.53125
-            frag 0 from TextNode start: 66, length: 11, rect: [8,130 88.640625x17.46875]
+          line 7 width: 88.640625, height: 17.46875, bottom: 139.75, baseline: 13.53125
+            frag 0 from TextNode start: 66, length: 11, rect: [8,130.28125 88.640625x17.46875]
               "eget turpis"
-          line 8 width: 77.40625, height: 18.21875, bottom: 157.96875, baseline: 13.53125
-            frag 0 from TextNode start: 78, length: 9, rect: [8,147 77.40625x17.46875]
+          line 8 width: 77.40625, height: 17.46875, bottom: 157.21875, baseline: 13.53125
+            frag 0 from TextNode start: 78, length: 9, rect: [8,147.75 77.40625x17.46875]
               "eget urna"
-          line 9 width: 53.25, height: 17.6875, bottom: 174.90625, baseline: 13.53125
-            frag 0 from TextNode start: 88, length: 7, rect: [8,165 53.25x17.46875]
+          line 9 width: 53.25, height: 17.46875, bottom: 174.6875, baseline: 13.53125
+            frag 0 from TextNode start: 88, length: 7, rect: [8,165.21875 53.25x17.46875]
               "feugiat"
-          line 10 width: 84.984375, height: 18.15625, bottom: 192.84375, baseline: 13.53125
-            frag 0 from TextNode start: 96, length: 10, rect: [8,182 84.984375x17.46875]
+          line 10 width: 84.984375, height: 17.46875, bottom: 192.15625, baseline: 13.53125
+            frag 0 from TextNode start: 96, length: 10, rect: [8,182.6875 84.984375x17.46875]
               "pretium ut"
-          line 11 width: 65.359375, height: 17.625, bottom: 209.78125, baseline: 13.53125
-            frag 0 from TextNode start: 107, length: 8, rect: [8,200 65.359375x17.46875]
+          line 11 width: 65.359375, height: 17.46875, bottom: 209.625, baseline: 13.53125
+            frag 0 from TextNode start: 107, length: 8, rect: [8,200.15625 65.359375x17.46875]
               "eu ante."
-          line 12 width: 72.46875, height: 18.09375, bottom: 227.71875, baseline: 13.53125
-            frag 0 from TextNode start: 116, length: 8, rect: [8,217 72.46875x17.46875]
+          line 12 width: 72.46875, height: 17.46875, bottom: 227.09375, baseline: 13.53125
+            frag 0 from TextNode start: 116, length: 8, rect: [8,217.625 72.46875x17.46875]
               "Nunc sed"
-          line 13 width: 70.640625, height: 17.5625, bottom: 244.65625, baseline: 13.53125
-            frag 0 from TextNode start: 125, length: 8, rect: [8,235 70.640625x17.46875]
+          line 13 width: 70.640625, height: 17.46875, bottom: 244.5625, baseline: 13.53125
+            frag 0 from TextNode start: 125, length: 8, rect: [8,235.09375 70.640625x17.46875]
               "pharetra"
-          line 14 width: 39.015625, height: 18.03125, bottom: 262.59375, baseline: 13.53125
-            frag 0 from TextNode start: 134, length: 5, rect: [8,252 39.015625x17.46875]
+          line 14 width: 39.015625, height: 17.46875, bottom: 262.03125, baseline: 13.53125
+            frag 0 from TextNode start: 134, length: 5, rect: [8,252.5625 39.015625x17.46875]
               "diam,"
-          line 15 width: 56.25, height: 17.5, bottom: 279.53125, baseline: 13.53125
-            frag 0 from TextNode start: 140, length: 6, rect: [8,270 56.25x17.46875]
+          line 15 width: 56.25, height: 17.46875, bottom: 279.5, baseline: 13.53125
+            frag 0 from TextNode start: 140, length: 6, rect: [8,270.03125 56.25x17.46875]
               "rutrum"
-          line 16 width: 50.546875, height: 17.96875, bottom: 297.46875, baseline: 13.53125
-            frag 0 from TextNode start: 147, length: 7, rect: [8,287 50.546875x17.46875]
+          line 16 width: 50.546875, height: 17.46875, bottom: 296.96875, baseline: 13.53125
+            frag 0 from TextNode start: 147, length: 7, rect: [8,287.5 50.546875x17.46875]
               "lacinia"
-          line 17 width: 47.5, height: 18.4375, bottom: 315.40625, baseline: 13.53125
-            frag 0 from TextNode start: 155, length: 7, rect: [8,304 47.5x17.46875]
+          line 17 width: 47.5, height: 17.46875, bottom: 314.4375, baseline: 13.53125
+            frag 0 from TextNode start: 155, length: 7, rect: [8,304.96875 47.5x17.46875]
               "tellus."
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width.txt
@@ -2,12 +2,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
-        BlockContainer <div.first> at (8,8) content-size 313.6x17.46875 [BFC] children: inline
+        BlockContainer <div.first> at (8,8) content-size 313.59375x17.46875 [BFC] children: inline
           line 0 width: 42.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 5, rect: [8,8 42.140625x17.46875]
               "First"
           TextNode <#text>
-        BlockContainer <div.second> at (400,8) content-size 78.4x17.46875 [BFC] children: inline
+        BlockContainer <div.second> at (400,8) content-size 78.390625x17.46875 [BFC] children: inline
           line 0 width: 57.40625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 6, rect: [400,8 57.40625x17.46875]
               "Second"

--- a/Tests/LibWeb/Layout/expected/grid/grid-row-height-affected-by-item-margins.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-row-height-affected-by-item-margins.txt
@@ -1,8 +1,8 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x97.817501 [BFC] children: not-inline
-    Box <body> at (10,10) content-size 780x79.817501 [GFC] children: not-inline
-      BlockContainer <h1> at (55.5,32.440000) content-size 689x34.9375 [BFC] children: inline
+  BlockContainer <html> at (1,1) content-size 798x97.8125 [BFC] children: not-inline
+    Box <body> at (10,10) content-size 780x79.8125 [GFC] children: not-inline
+      BlockContainer <h1> at (55.5,32.4375) content-size 689x34.9375 [BFC] children: inline
         line 0 width: 492.96875, height: 34.9375, bottom: 34.9375, baseline: 27.0625
-          frag 0 from TextNode start: 0, length: 31, rect: [55.5,32.440000 492.96875x34.9375]
+          frag 0 from TextNode start: 0, length: 31, rect: [55.5,32.4375 492.96875x34.9375]
             "Null publishes fine indie games"
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
+++ b/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
@@ -1,14 +1,14 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x23.999999 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x23.999999 [GFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x24 children: not-inline
+      Box <div.grid-container> at (8,8) content-size 784x24 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.wrapper> at (8,8) content-size 64x23.999999 [BFC] children: inline
-          line 0 width: 64, height: 23.999999, bottom: 23.999999, baseline: 23.999999
-            frag 0 from ImageBox start: 0, length: 0, rect: [8,8 64x23.999999]
+        BlockContainer <div.wrapper> at (8,8) content-size 64.015625x24 [BFC] children: inline
+          line 0 width: 64.015625, height: 24, bottom: 24, baseline: 24
+            frag 0 from ImageBox start: 0, length: 0, rect: [8,8 64.015625x24]
           TextNode <#text>
-          ImageBox <img> at (8,8) content-size 64x23.999999 children: not-inline
+          ImageBox <img> at (8,8) content-size 64.015625x24 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/item-column-span-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-column-span-2.txt
@@ -1,21 +1,21 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x35.40625 children: not-inline
-      Box <div.container> at (8,8) content-size 784x35.40625 [GFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x34.9375 children: not-inline
+      Box <div.container> at (8,8) content-size 784x34.9375 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.item-left> at (8,8) content-size 100x35.40625 [BFC] children: not-inline
+        BlockContainer <div.item-left> at (8,8) content-size 100x34.9375 [BFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.item-right> at (108,8) content-size 683.999999x35.40625 [BFC] children: inline
+        BlockContainer <div.item-right> at (108.03125,8) content-size 683.96875x34.9375 [BFC] children: inline
           line 0 width: 625.953125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 77, rect: [108,8 625.953125x17.46875]
+            frag 0 from TextNode start: 0, length: 77, rect: [108.03125,8 625.953125x17.46875]
               "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut iaculis venenatis"
-          line 1 width: 304.0625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 78, length: 39, rect: [108,25 304.0625x17.46875]
+          line 1 width: 304.0625, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 78, length: 39, rect: [108.03125,25.46875 304.0625x17.46875]
               "purus, eget blandit velit venenatis at."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-      BlockContainer <(anonymous)> at (8,43.40625) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,42.9375) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/justify-items.txt
+++ b/Tests/LibWeb/Layout/expected/grid/justify-items.txt
@@ -12,9 +12,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,31.46875) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.grid.center> at (11,32.46875) content-size 778x19.46875 [GFC] children: not-inline
-        BlockContainer <div> at (373.476562,33.46875) content-size 53.046875x17.46875 [BFC] children: inline
+        BlockContainer <div> at (373.46875,33.46875) content-size 53.046875x17.46875 [BFC] children: inline
           line 0 width: 53.046875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 6, rect: [373.476562,33.46875 53.046875x17.46875]
+            frag 0 from TextNode start: 0, length: 6, rect: [373.46875,33.46875 53.046875x17.46875]
               "Center"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,52.9375) content-size 780x0 children: inline

--- a/Tests/LibWeb/Layout/expected/grid/justify-self.txt
+++ b/Tests/LibWeb/Layout/expected/grid/justify-self.txt
@@ -10,9 +10,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
-      BlockContainer <div> at (373.476562,30.46875) content-size 53.046875x17.46875 [BFC] children: inline
+      BlockContainer <div> at (373.46875,30.46875) content-size 53.046875x17.46875 [BFC] children: inline
         line 0 width: 53.046875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 6, rect: [373.476562,30.46875 53.046875x17.46875]
+          frag 0 from TextNode start: 0, length: 6, rect: [373.46875,30.46875 53.046875x17.46875]
             "Center"
         TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/minmax-with-max-function-inside.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-with-max-function-inside.txt
@@ -2,22 +2,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x34.9375 children: not-inline
       Box <div.grid> at (8,8) content-size 784x34.9375 [GFC] children: not-inline
-        BlockContainer <div> at (8,8) content-size 261.333333x17.46875 [BFC] children: inline
+        BlockContainer <div> at (8,8) content-size 261.328125x17.46875 [BFC] children: inline
           line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17.46875]
               "a"
           TextNode <#text>
-        BlockContainer <div> at (269.333333,8) content-size 261.333333x17.46875 [BFC] children: inline
+        BlockContainer <div> at (269.328125,8) content-size 261.328125x17.46875 [BFC] children: inline
           line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [269.333333,8 9.46875x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [269.328125,8 9.46875x17.46875]
               "b"
           TextNode <#text>
-        BlockContainer <div> at (530.666666,8) content-size 261.333333x17.46875 [BFC] children: inline
+        BlockContainer <div> at (530.65625,8) content-size 261.328125x17.46875 [BFC] children: inline
           line 0 width: 8.890625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [530.666666,8 8.890625x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [530.65625,8 8.890625x17.46875]
               "c"
           TextNode <#text>
-        BlockContainer <div> at (8,25.46875) content-size 261.333333x17.46875 [BFC] children: inline
+        BlockContainer <div> at (8,25.46875) content-size 261.328125x17.46875 [BFC] children: inline
           line 0 width: 7.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,25.46875 7.859375x17.46875]
               "d"

--- a/Tests/LibWeb/Layout/expected/grid/named-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/named-tracks.txt
@@ -25,30 +25,30 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,25.46875) content-size 784x75 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,25.46875) content-size 261.333333x75 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,25.46875) content-size 261.328125x75 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,25.46875 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (530.666666,25.46875) content-size 261.333333x50 [BFC] children: inline
+        BlockContainer <div.grid-item> at (530.65625,25.46875) content-size 261.328125x50 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [530.666666,25.46875 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [530.65625,25.46875 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (269.333333,25.46875) content-size 261.333333x25 [BFC] children: inline
+        BlockContainer <div.grid-item> at (269.328125,25.46875) content-size 261.328125x25 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [269.333333,25.46875 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [269.328125,25.46875 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (269.333333,75.46875) content-size 522.666666x25 [BFC] children: inline
+        BlockContainer <div.grid-item> at (269.328125,75.46875) content-size 522.65625x25 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [269.333333,75.46875 7.75x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [269.328125,75.46875 7.75x17.46875]
               "4"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/positions-and-spans.txt
+++ b/Tests/LibWeb/Layout/expected/grid/positions-and-spans.txt
@@ -4,16 +4,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 522.666666x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 522.5x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (530.666666,8) content-size 261.333333x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (530.5,8) content-size 261.25x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [530.666666,8 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [530.5,8 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -25,16 +25,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,25.46875) content-size 784x17.46875 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,25.46875) content-size 261.333333x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,25.46875) content-size 261.25x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [8,25.46875 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (269.333333,25.46875) content-size 522.666666x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (269.25,25.46875) content-size 522.5x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [269.333333,25.46875 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [269.25,25.46875 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-maxcontent.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-maxcontent.txt
@@ -1,104 +1,104 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x315.40625 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x315.40625 [GFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x314.4375 children: not-inline
+      Box <div.grid-container> at (8,8) content-size 784x314.4375 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.item-span-one-one> at (401.46875,8) content-size 392x131.296875 [BFC] children: inline
+        BlockContainer <div.grid-item.item-span-one-one> at (401.46875,8) content-size 392x131.015625 [BFC] children: inline
           line 0 width: 319.171875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 1, length: 40, rect: [401.46875,8 319.171875x17.46875]
               "In a sollicitudin augue. Sed ante augue,"
-          line 1 width: 335.125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 42, length: 42, rect: [401.46875,25 335.125x17.46875]
+          line 1 width: 335.125, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 42, length: 42, rect: [401.46875,25.46875 335.125x17.46875]
               "rhoncus nec porttitor id, lacinia et nibh."
-          line 2 width: 378.625, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 85, length: 48, rect: [401.46875,42 378.625x17.46875]
+          line 2 width: 378.625, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 85, length: 48, rect: [401.46875,42.9375 378.625x17.46875]
               "Pellentesque diam libero, ultrices eget eleifend"
-          line 3 width: 182.8125, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 134, length: 22, rect: [401.46875,60 182.8125x17.46875]
+          line 3 width: 182.8125, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 134, length: 22, rect: [401.46875,60.40625 182.8125x17.46875]
               "at, consequat ut orci."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.item-span-one-two> at (401.46875,139.296875) content-size 392x184.109375 [BFC] children: inline
+        BlockContainer <div.grid-item.item-span-one-two> at (401.46875,139.015625) content-size 392x183.421875 [BFC] children: inline
           line 0 width: 359.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 1, length: 43, rect: [401.46875,139.296875 359.15625x17.46875]
+            frag 0 from TextNode start: 1, length: 43, rect: [401.46875,139.015625 359.15625x17.46875]
               "Suspendisse potenti. Pellentesque at varius"
-          line 1 width: 318.5625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 45, length: 41, rect: [401.46875,156.296875 318.5625x17.46875]
+          line 1 width: 318.5625, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 45, length: 41, rect: [401.46875,156.484375 318.5625x17.46875]
               "lacus, sed sollicitudin leo. Pellentesque"
-          line 2 width: 377.640625, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 87, length: 44, rect: [401.46875,173.296875 377.640625x17.46875]
+          line 2 width: 377.640625, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 87, length: 44, rect: [401.46875,173.953125 377.640625x17.46875]
               "malesuada mi eget pellentesque tempor. Donec"
-          line 3 width: 378.03125, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 132, length: 47, rect: [401.46875,191.296875 378.03125x17.46875]
+          line 3 width: 378.03125, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 132, length: 47, rect: [401.46875,191.421875 378.03125x17.46875]
               "egestas mauris est, ut lobortis nisi luctus at."
-          line 4 width: 345.953125, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 180, length: 41, rect: [401.46875,208.296875 345.953125x17.46875]
+          line 4 width: 345.953125, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+            frag 0 from TextNode start: 180, length: 41, rect: [401.46875,208.890625 345.953125x17.46875]
               "Vivamus eleifend, lorem vulputate maximus"
-          line 5 width: 312.765625, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-            frag 0 from TextNode start: 222, length: 37, rect: [401.46875,226.296875 312.765625x17.46875]
+          line 5 width: 312.765625, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+            frag 0 from TextNode start: 222, length: 37, rect: [401.46875,226.359375 312.765625x17.46875]
               "porta, nunc metus porttitor nibh, nec"
-          line 6 width: 242.921875, height: 18.28125, bottom: 123.09375, baseline: 13.53125
-            frag 0 from TextNode start: 260, length: 31, rect: [401.46875,243.296875 242.921875x17.46875]
+          line 6 width: 242.921875, height: 17.46875, bottom: 122.28125, baseline: 13.53125
+            frag 0 from TextNode start: 260, length: 31, rect: [401.46875,243.828125 242.921875x17.46875]
               "bibendum nulla lectus ut felis."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.item-span-two> at (8,8) content-size 393.46875x315.40625 [BFC] children: inline
+        BlockContainer <div.grid-item.item-span-two> at (8,8) content-size 393.46875x314.4375 [BFC] children: inline
           line 0 width: 337.6875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 1, length: 39, rect: [8,8 337.6875x17.46875]
               "Lorem ipsum dolor sit amet, consectetur"
-          line 1 width: 376.34375, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 41, length: 47, rect: [8,25 376.34375x17.46875]
+          line 1 width: 376.34375, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 41, length: 47, rect: [8,25.46875 376.34375x17.46875]
               "adipiscing elit. Sed vitae condimentum erat, ac"
-          line 2 width: 365.84375, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 89, length: 45, rect: [8,42 365.84375x17.46875]
+          line 2 width: 365.84375, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 89, length: 45, rect: [8,42.9375 365.84375x17.46875]
               "posuere arcu. Aenean tincidunt mi ligula, vel"
-          line 3 width: 381.96875, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 135, length: 46, rect: [8,60 381.96875x17.46875]
+          line 3 width: 381.96875, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 135, length: 46, rect: [8,60.40625 381.96875x17.46875]
               "semper dolor aliquet at. Phasellus scelerisque"
-          line 4 width: 377.203125, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 182, length: 45, rect: [8,77 377.203125x17.46875]
+          line 4 width: 377.203125, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+            frag 0 from TextNode start: 182, length: 45, rect: [8,77.875 377.203125x17.46875]
               "dapibus diam sed rhoncus. Proin sed orci leo."
-          line 5 width: 375.390625, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-            frag 0 from TextNode start: 228, length: 45, rect: [8,95 375.390625x17.46875]
+          line 5 width: 375.390625, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+            frag 0 from TextNode start: 228, length: 45, rect: [8,95.34375 375.390625x17.46875]
               "Praesent pellentesque mi eu nunc gravida, vel"
-          line 6 width: 383.53125, height: 18.28125, bottom: 123.09375, baseline: 13.53125
-            frag 0 from TextNode start: 274, length: 46, rect: [8,112 383.53125x17.46875]
+          line 6 width: 383.53125, height: 17.46875, bottom: 122.28125, baseline: 13.53125
+            frag 0 from TextNode start: 274, length: 46, rect: [8,112.8125 383.53125x17.46875]
               "consectetur nulla malesuada. Sed pellentesque,"
-          line 7 width: 344.8125, height: 17.75, bottom: 140.03125, baseline: 13.53125
-            frag 0 from TextNode start: 321, length: 47, rect: [8,130 344.8125x17.46875]
+          line 7 width: 344.8125, height: 17.46875, bottom: 139.75, baseline: 13.53125
+            frag 0 from TextNode start: 321, length: 47, rect: [8,130.28125 344.8125x17.46875]
               "elit sit amet sollicitudin sollicitudin, lectus"
-          line 8 width: 374.703125, height: 18.21875, bottom: 157.96875, baseline: 13.53125
-            frag 0 from TextNode start: 369, length: 46, rect: [8,147 374.703125x17.46875]
+          line 8 width: 374.703125, height: 17.46875, bottom: 157.21875, baseline: 13.53125
+            frag 0 from TextNode start: 369, length: 46, rect: [8,147.75 374.703125x17.46875]
               "justo facilisis lacus, ac vehicula metus neque"
-          line 9 width: 384.125, height: 17.6875, bottom: 174.90625, baseline: 13.53125
-            frag 0 from TextNode start: 416, length: 45, rect: [8,165 384.125x17.46875]
+          line 9 width: 384.125, height: 17.46875, bottom: 174.6875, baseline: 13.53125
+            frag 0 from TextNode start: 416, length: 45, rect: [8,165.21875 384.125x17.46875]
               "ac mi. In in augue et massa maximus venenatis"
-          line 10 width: 373.25, height: 18.15625, bottom: 192.84375, baseline: 13.53125
-            frag 0 from TextNode start: 462, length: 44, rect: [8,182 373.25x17.46875]
+          line 10 width: 373.25, height: 17.46875, bottom: 192.15625, baseline: 13.53125
+            frag 0 from TextNode start: 462, length: 44, rect: [8,182.6875 373.25x17.46875]
               "auctor fermentum dui. Aliquam dictum finibus"
-          line 11 width: 288.203125, height: 17.625, bottom: 209.78125, baseline: 13.53125
-            frag 0 from TextNode start: 507, length: 35, rect: [8,200 288.203125x17.46875]
+          line 11 width: 288.203125, height: 17.46875, bottom: 209.625, baseline: 13.53125
+            frag 0 from TextNode start: 507, length: 35, rect: [8,200.15625 288.203125x17.46875]
               "urna, quis lacinia massa laoreet a."
-          line 12 width: 316.296875, height: 18.09375, bottom: 227.71875, baseline: 13.53125
-            frag 0 from TextNode start: 543, length: 36, rect: [8,217 316.296875x17.46875]
+          line 12 width: 316.296875, height: 17.46875, bottom: 227.09375, baseline: 13.53125
+            frag 0 from TextNode start: 543, length: 36, rect: [8,217.625 316.296875x17.46875]
               "Suspendisse elementum non lectus nec"
-          line 13 width: 388.78125, height: 17.5625, bottom: 244.65625, baseline: 13.53125
-            frag 0 from TextNode start: 580, length: 48, rect: [8,235 388.78125x17.46875]
+          line 13 width: 388.78125, height: 17.46875, bottom: 244.5625, baseline: 13.53125
+            frag 0 from TextNode start: 580, length: 48, rect: [8,235.09375 388.78125x17.46875]
               "elementum. Quisque ultricies suscipit porttitor."
-          line 14 width: 373.828125, height: 18.03125, bottom: 262.59375, baseline: 13.53125
-            frag 0 from TextNode start: 629, length: 45, rect: [8,252 373.828125x17.46875]
+          line 14 width: 373.828125, height: 17.46875, bottom: 262.03125, baseline: 13.53125
+            frag 0 from TextNode start: 629, length: 45, rect: [8,252.5625 373.828125x17.46875]
               "Sed non urna rutrum, mattis nulla at, feugiat"
-          line 15 width: 368.75, height: 17.5, bottom: 279.53125, baseline: 13.53125
-            frag 0 from TextNode start: 675, length: 48, rect: [8,270 368.75x17.46875]
+          line 15 width: 368.75, height: 17.46875, bottom: 279.5, baseline: 13.53125
+            frag 0 from TextNode start: 675, length: 48, rect: [8,270.03125 368.75x17.46875]
               "erat. Duis orci elit, vehicula sed blandit eget,"
-          line 16 width: 390.625, height: 17.96875, bottom: 297.46875, baseline: 13.53125
-            frag 0 from TextNode start: 724, length: 46, rect: [8,287 390.625x17.46875]
+          line 16 width: 390.625, height: 17.46875, bottom: 296.96875, baseline: 13.53125
+            frag 0 from TextNode start: 724, length: 46, rect: [8,287.5 390.625x17.46875]
               "auctor in arcu. Ut cursus magna sit amet nulla"
-          line 17 width: 294.90625, height: 18.4375, bottom: 315.40625, baseline: 13.53125
-            frag 0 from TextNode start: 771, length: 36, rect: [8,304 294.90625x17.46875]
+          line 17 width: 294.90625, height: 17.46875, bottom: 314.4375, baseline: 13.53125
+            frag 0 from TextNode start: 771, length: 36, rect: [8,304.96875 294.90625x17.46875]
               "cursus, vitae gravida mauris dictum."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-mincontent.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-mincontent.txt
@@ -1,185 +1,185 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x560.0625 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x560.0625 [GFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x559 children: not-inline
+      Box <div.grid-container> at (8,8) content-size 784x559 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.item-span-one-one> at (108.640625,8) content-size 101.515625x244.65625 [BFC] children: inline
+        BlockContainer <div.grid-item.item-span-one-one> at (108.640625,8) content-size 101.515625x244.5625 [BFC] children: inline
           line 0 width: 31.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 1, length: 4, rect: [108.640625,8 31.546875x17.46875]
               "In a"
-          line 1 width: 84.84375, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 6, length: 12, rect: [108.640625,25 84.84375x17.46875]
+          line 1 width: 84.84375, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 6, length: 12, rect: [108.640625,25.46875 84.84375x17.46875]
               "sollicitudin"
-          line 2 width: 86.046875, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 19, length: 10, rect: [108.640625,42 86.046875x17.46875]
+          line 2 width: 86.046875, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 19, length: 10, rect: [108.640625,42.9375 86.046875x17.46875]
               "augue. Sed"
-          line 3 width: 92.734375, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 30, length: 11, rect: [108.640625,60 92.734375x17.46875]
+          line 3 width: 92.734375, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 30, length: 11, rect: [108.640625,60.40625 92.734375x17.46875]
               "ante augue,"
-          line 4 width: 101.3125, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 42, length: 11, rect: [108.640625,77 101.3125x17.46875]
+          line 4 width: 101.3125, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+            frag 0 from TextNode start: 42, length: 11, rect: [108.640625,77.875 101.3125x17.46875]
               "rhoncus nec"
-          line 5 width: 98.40625, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-            frag 0 from TextNode start: 54, length: 13, rect: [108.640625,95 98.40625x17.46875]
+          line 5 width: 98.40625, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+            frag 0 from TextNode start: 54, length: 13, rect: [108.640625,95.34375 98.40625x17.46875]
               "porttitor id,"
-          line 6 width: 74.125, height: 18.28125, bottom: 123.09375, baseline: 13.53125
-            frag 0 from TextNode start: 68, length: 10, rect: [108.640625,112 74.125x17.46875]
+          line 6 width: 74.125, height: 17.46875, bottom: 122.28125, baseline: 13.53125
+            frag 0 from TextNode start: 68, length: 10, rect: [108.640625,112.8125 74.125x17.46875]
               "lacinia et"
-          line 7 width: 37.28125, height: 17.75, bottom: 140.03125, baseline: 13.53125
-            frag 0 from TextNode start: 79, length: 5, rect: [108.640625,130 37.28125x17.46875]
+          line 7 width: 37.28125, height: 17.46875, bottom: 139.75, baseline: 13.53125
+            frag 0 from TextNode start: 79, length: 5, rect: [108.640625,130.28125 37.28125x17.46875]
               "nibh."
-          line 8 width: 101.515625, height: 18.21875, bottom: 157.96875, baseline: 13.53125
-            frag 0 from TextNode start: 85, length: 12, rect: [108.640625,147 101.515625x17.46875]
+          line 8 width: 101.515625, height: 17.46875, bottom: 157.21875, baseline: 13.53125
+            frag 0 from TextNode start: 85, length: 12, rect: [108.640625,147.75 101.515625x17.46875]
               "Pellentesque"
-          line 9 width: 93.1875, height: 17.6875, bottom: 174.90625, baseline: 13.53125
-            frag 0 from TextNode start: 98, length: 12, rect: [108.640625,165 93.1875x17.46875]
+          line 9 width: 93.1875, height: 17.46875, bottom: 174.6875, baseline: 13.53125
+            frag 0 from TextNode start: 98, length: 12, rect: [108.640625,165.21875 93.1875x17.46875]
               "diam libero,"
-          line 10 width: 101.0625, height: 18.15625, bottom: 192.84375, baseline: 13.53125
-            frag 0 from TextNode start: 111, length: 13, rect: [108.640625,182 101.0625x17.46875]
+          line 10 width: 101.0625, height: 17.46875, bottom: 192.15625, baseline: 13.53125
+            frag 0 from TextNode start: 111, length: 13, rect: [108.640625,182.6875 101.0625x17.46875]
               "ultrices eget"
-          line 11 width: 88.109375, height: 17.625, bottom: 209.78125, baseline: 13.53125
-            frag 0 from TextNode start: 125, length: 12, rect: [108.640625,200 88.109375x17.46875]
+          line 11 width: 88.109375, height: 17.46875, bottom: 209.625, baseline: 13.53125
+            frag 0 from TextNode start: 125, length: 12, rect: [108.640625,200.15625 88.109375x17.46875]
               "eleifend at,"
-          line 12 width: 83.953125, height: 18.09375, bottom: 227.71875, baseline: 13.53125
-            frag 0 from TextNode start: 138, length: 9, rect: [108.640625,217 83.953125x17.46875]
+          line 12 width: 83.953125, height: 17.46875, bottom: 227.09375, baseline: 13.53125
+            frag 0 from TextNode start: 138, length: 9, rect: [108.640625,217.625 83.953125x17.46875]
               "consequat"
-          line 13 width: 61.609375, height: 17.5625, bottom: 244.65625, baseline: 13.53125
-            frag 0 from TextNode start: 148, length: 8, rect: [108.640625,235 61.609375x17.46875]
+          line 13 width: 61.609375, height: 17.46875, bottom: 244.5625, baseline: 13.53125
+            frag 0 from TextNode start: 148, length: 8, rect: [108.640625,235.09375 61.609375x17.46875]
               "ut orci."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.item-span-one-two> at (108.640625,252.65625) content-size 101.515625x315.40625 [BFC] children: inline
+        BlockContainer <div.grid-item.item-span-one-two> at (108.640625,252.5625) content-size 101.515625x314.4375 [BFC] children: inline
           line 0 width: 98.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 1, length: 11, rect: [108.640625,252.65625 98.65625x17.46875]
+            frag 0 from TextNode start: 1, length: 11, rect: [108.640625,252.5625 98.65625x17.46875]
               "Suspendisse"
-          line 1 width: 60.734375, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 13, length: 8, rect: [108.640625,269.65625 60.734375x17.46875]
+          line 1 width: 60.734375, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 13, length: 8, rect: [108.640625,270.03125 60.734375x17.46875]
               "potenti."
-          line 2 width: 101.515625, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 22, length: 12, rect: [108.640625,286.65625 101.515625x17.46875]
+          line 2 width: 101.515625, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 22, length: 12, rect: [108.640625,287.5 101.515625x17.46875]
               "Pellentesque"
-          line 3 width: 74.25, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 35, length: 9, rect: [108.640625,304.65625 74.25x17.46875]
+          line 3 width: 74.25, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 35, length: 9, rect: [108.640625,304.96875 74.25x17.46875]
               "at varius"
-          line 4 width: 80.546875, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 45, length: 10, rect: [108.640625,321.65625 80.546875x17.46875]
+          line 4 width: 80.546875, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+            frag 0 from TextNode start: 45, length: 10, rect: [108.640625,322.4375 80.546875x17.46875]
               "lacus, sed"
-          line 5 width: 84.84375, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-            frag 0 from TextNode start: 56, length: 12, rect: [108.640625,339.65625 84.84375x17.46875]
+          line 5 width: 84.84375, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+            frag 0 from TextNode start: 56, length: 12, rect: [108.640625,339.90625 84.84375x17.46875]
               "sollicitudin"
-          line 6 width: 27.65625, height: 18.28125, bottom: 123.09375, baseline: 13.53125
-            frag 0 from TextNode start: 69, length: 4, rect: [108.640625,356.65625 27.65625x17.46875]
+          line 6 width: 27.65625, height: 17.46875, bottom: 122.28125, baseline: 13.53125
+            frag 0 from TextNode start: 69, length: 4, rect: [108.640625,357.375 27.65625x17.46875]
               "leo."
-          line 7 width: 101.515625, height: 17.75, bottom: 140.03125, baseline: 13.53125
-            frag 0 from TextNode start: 74, length: 12, rect: [108.640625,374.65625 101.515625x17.46875]
+          line 7 width: 101.515625, height: 17.46875, bottom: 139.75, baseline: 13.53125
+            frag 0 from TextNode start: 74, length: 12, rect: [108.640625,374.84375 101.515625x17.46875]
               "Pellentesque"
-          line 8 width: 80.15625, height: 18.21875, bottom: 157.96875, baseline: 13.53125
-            frag 0 from TextNode start: 87, length: 9, rect: [108.640625,391.65625 80.15625x17.46875]
+          line 8 width: 80.15625, height: 17.46875, bottom: 157.21875, baseline: 13.53125
+            frag 0 from TextNode start: 87, length: 9, rect: [108.640625,392.3125 80.15625x17.46875]
               "malesuada"
-          line 9 width: 56.625, height: 17.6875, bottom: 174.90625, baseline: 13.53125
-            frag 0 from TextNode start: 97, length: 7, rect: [108.640625,409.65625 56.625x17.46875]
+          line 9 width: 56.625, height: 17.46875, bottom: 174.6875, baseline: 13.53125
+            frag 0 from TextNode start: 97, length: 7, rect: [108.640625,409.78125 56.625x17.46875]
               "mi eget"
-          line 10 width: 99.40625, height: 18.15625, bottom: 192.84375, baseline: 13.53125
-            frag 0 from TextNode start: 105, length: 12, rect: [108.640625,426.65625 99.40625x17.46875]
+          line 10 width: 99.40625, height: 17.46875, bottom: 192.15625, baseline: 13.53125
+            frag 0 from TextNode start: 105, length: 12, rect: [108.640625,427.25 99.40625x17.46875]
               "pellentesque"
-          line 11 width: 60.734375, height: 17.625, bottom: 209.78125, baseline: 13.53125
-            frag 0 from TextNode start: 118, length: 7, rect: [108.640625,444.65625 60.734375x17.46875]
+          line 11 width: 60.734375, height: 17.46875, bottom: 209.625, baseline: 13.53125
+            frag 0 from TextNode start: 118, length: 7, rect: [108.640625,444.71875 60.734375x17.46875]
               "tempor."
-          line 12 width: 48.71875, height: 18.09375, bottom: 227.71875, baseline: 13.53125
-            frag 0 from TextNode start: 126, length: 5, rect: [108.640625,461.65625 48.71875x17.46875]
+          line 12 width: 48.71875, height: 17.46875, bottom: 227.09375, baseline: 13.53125
+            frag 0 from TextNode start: 126, length: 5, rect: [108.640625,462.1875 48.71875x17.46875]
               "Donec"
-          line 13 width: 59.890625, height: 17.5625, bottom: 244.65625, baseline: 13.53125
+          line 13 width: 59.890625, height: 17.46875, bottom: 244.5625, baseline: 13.53125
             frag 0 from TextNode start: 132, length: 7, rect: [108.640625,479.65625 59.890625x17.46875]
               "egestas"
-          line 14 width: 92.015625, height: 18.03125, bottom: 262.59375, baseline: 13.53125
-            frag 0 from TextNode start: 140, length: 11, rect: [108.640625,496.65625 92.015625x17.46875]
+          line 14 width: 92.015625, height: 17.46875, bottom: 262.03125, baseline: 13.53125
+            frag 0 from TextNode start: 140, length: 11, rect: [108.640625,497.125 92.015625x17.46875]
               "mauris est,"
-          line 15 width: 88.640625, height: 17.5, bottom: 279.53125, baseline: 13.53125
-            frag 0 from TextNode start: 152, length: 11, rect: [108.640625,514.65625 88.640625x17.46875]
+          line 15 width: 88.640625, height: 17.46875, bottom: 279.5, baseline: 13.53125
+            frag 0 from TextNode start: 152, length: 11, rect: [108.640625,514.59375 88.640625x17.46875]
               "ut lobortis"
-          line 16 width: 84.9375, height: 17.96875, bottom: 297.46875, baseline: 13.53125
-            frag 0 from TextNode start: 164, length: 11, rect: [108.640625,531.65625 84.9375x17.46875]
+          line 16 width: 84.9375, height: 17.46875, bottom: 296.96875, baseline: 13.53125
+            frag 0 from TextNode start: 164, length: 11, rect: [108.640625,532.0625 84.9375x17.46875]
               "nisi luctus"
-          line 17 width: 20.546875, height: 18.4375, bottom: 315.40625, baseline: 13.53125
-            frag 0 from TextNode start: 176, length: 3, rect: [108.640625,548.65625 20.546875x17.46875]
+          line 17 width: 20.546875, height: 17.46875, bottom: 314.4375, baseline: 13.53125
+            frag 0 from TextNode start: 176, length: 3, rect: [108.640625,549.53125 20.546875x17.46875]
               "at."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.item-span-two> at (8,8) content-size 100.640625x560.0625 [BFC] children: inline
+        BlockContainer <div.grid-item.item-span-two> at (8,8) content-size 100.640625x559 [BFC] children: inline
           line 0 width: 50.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 1, length: 5, rect: [8,8 50.96875x17.46875]
               "Lorem"
-          line 1 width: 94.9375, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 7, length: 11, rect: [8,25 94.9375x17.46875]
+          line 1 width: 94.9375, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 7, length: 11, rect: [8,25.46875 94.9375x17.46875]
               "ipsum dolor"
-          line 2 width: 70.9375, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 19, length: 9, rect: [8,42 70.9375x17.46875]
+          line 2 width: 70.9375, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 19, length: 9, rect: [8,42.9375 70.9375x17.46875]
               "sit amet,"
-          line 3 width: 96.84375, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 29, length: 11, rect: [8,60 96.84375x17.46875]
+          line 3 width: 96.84375, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 29, length: 11, rect: [8,60.40625 96.84375x17.46875]
               "consectetur"
-          line 4 width: 75.71875, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 41, length: 10, rect: [8,77 75.71875x17.46875]
+          line 4 width: 75.71875, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+            frag 0 from TextNode start: 41, length: 10, rect: [8,77.875 75.71875x17.46875]
               "adipiscing"
-          line 5 width: 65.265625, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-            frag 0 from TextNode start: 52, length: 9, rect: [8,95 65.265625x17.46875]
+          line 5 width: 65.265625, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+            frag 0 from TextNode start: 52, length: 9, rect: [8,95.34375 65.265625x17.46875]
               "elit. Sed"
-          line 6 width: 37.6875, height: 18.28125, bottom: 123.09375, baseline: 13.53125
-            frag 0 from TextNode start: 62, length: 5, rect: [8,112 37.6875x17.46875]
+          line 6 width: 37.6875, height: 17.46875, bottom: 122.28125, baseline: 13.53125
+            frag 0 from TextNode start: 62, length: 5, rect: [8,112.8125 37.6875x17.46875]
               "vitae"
-          line 7 width: 100.640625, height: 17.75, bottom: 140.03125, baseline: 13.53125
-            frag 0 from TextNode start: 68, length: 11, rect: [8,130 100.640625x17.46875]
+          line 7 width: 100.640625, height: 17.46875, bottom: 139.75, baseline: 13.53125
+            frag 0 from TextNode start: 68, length: 11, rect: [8,130.28125 100.640625x17.46875]
               "condimentum"
-          line 8 width: 65.03125, height: 18.21875, bottom: 157.96875, baseline: 13.53125
-            frag 0 from TextNode start: 80, length: 8, rect: [8,147 65.03125x17.46875]
+          line 8 width: 65.03125, height: 17.46875, bottom: 157.21875, baseline: 13.53125
+            frag 0 from TextNode start: 80, length: 8, rect: [8,147.75 65.03125x17.46875]
               "erat, ac"
-          line 9 width: 65.15625, height: 17.6875, bottom: 174.90625, baseline: 13.53125
-            frag 0 from TextNode start: 89, length: 7, rect: [8,165 65.15625x17.46875]
+          line 9 width: 65.15625, height: 17.46875, bottom: 174.6875, baseline: 13.53125
+            frag 0 from TextNode start: 89, length: 7, rect: [8,165.21875 65.15625x17.46875]
               "posuere"
-          line 10 width: 41.171875, height: 18.15625, bottom: 192.84375, baseline: 13.53125
-            frag 0 from TextNode start: 97, length: 5, rect: [8,182 41.171875x17.46875]
+          line 10 width: 41.171875, height: 17.46875, bottom: 192.15625, baseline: 13.53125
+            frag 0 from TextNode start: 97, length: 5, rect: [8,182.6875 41.171875x17.46875]
               "arcu."
-          line 11 width: 60.265625, height: 17.625, bottom: 209.78125, baseline: 13.53125
-            frag 0 from TextNode start: 103, length: 6, rect: [8,200 60.265625x17.46875]
+          line 11 width: 60.265625, height: 17.46875, bottom: 209.625, baseline: 13.53125
+            frag 0 from TextNode start: 103, length: 6, rect: [8,200.15625 60.265625x17.46875]
               "Aenean"
-          line 12 width: 93.34375, height: 18.09375, bottom: 227.71875, baseline: 13.53125
-            frag 0 from TextNode start: 110, length: 12, rect: [8,217 93.34375x17.46875]
+          line 12 width: 93.34375, height: 17.46875, bottom: 227.09375, baseline: 13.53125
+            frag 0 from TextNode start: 110, length: 12, rect: [8,217.625 93.34375x17.46875]
               "tincidunt mi"
-          line 13 width: 73.90625, height: 17.5625, bottom: 244.65625, baseline: 13.53125
-            frag 0 from TextNode start: 123, length: 11, rect: [8,235 73.90625x17.46875]
+          line 13 width: 73.90625, height: 17.46875, bottom: 244.5625, baseline: 13.53125
+            frag 0 from TextNode start: 123, length: 11, rect: [8,235.09375 73.90625x17.46875]
               "ligula, vel"
-          line 14 width: 57.234375, height: 18.03125, bottom: 262.59375, baseline: 13.53125
-            frag 0 from TextNode start: 135, length: 6, rect: [8,252 57.234375x17.46875]
+          line 14 width: 57.234375, height: 17.46875, bottom: 262.03125, baseline: 13.53125
+            frag 0 from TextNode start: 135, length: 6, rect: [8,252.5625 57.234375x17.46875]
               "semper"
-          line 15 width: 41.640625, height: 17.5, bottom: 279.53125, baseline: 13.53125
-            frag 0 from TextNode start: 142, length: 5, rect: [8,270 41.640625x17.46875]
+          line 15 width: 41.640625, height: 17.46875, bottom: 279.5, baseline: 13.53125
+            frag 0 from TextNode start: 142, length: 5, rect: [8,270.03125 41.640625x17.46875]
               "dolor"
-          line 16 width: 83.09375, height: 17.96875, bottom: 297.46875, baseline: 13.53125
-            frag 0 from TextNode start: 148, length: 11, rect: [8,287 83.09375x17.46875]
+          line 16 width: 83.09375, height: 17.46875, bottom: 296.96875, baseline: 13.53125
+            frag 0 from TextNode start: 148, length: 11, rect: [8,287.5 83.09375x17.46875]
               "aliquet at."
-          line 17 width: 75.8125, height: 18.4375, bottom: 315.40625, baseline: 13.53125
-            frag 0 from TextNode start: 160, length: 9, rect: [8,304 75.8125x17.46875]
+          line 17 width: 75.8125, height: 17.46875, bottom: 314.4375, baseline: 13.53125
+            frag 0 from TextNode start: 160, length: 9, rect: [8,304.96875 75.8125x17.46875]
               "Phasellus"
-          line 18 width: 92.1875, height: 17.90625, bottom: 332.34375, baseline: 13.53125
-            frag 0 from TextNode start: 170, length: 11, rect: [8,322 92.1875x17.46875]
+          line 18 width: 92.1875, height: 17.46875, bottom: 331.90625, baseline: 13.53125
+            frag 0 from TextNode start: 170, length: 11, rect: [8,322.4375 92.1875x17.46875]
               "scelerisque"
-          line 19 width: 59.765625, height: 18.375, bottom: 350.28125, baseline: 13.53125
-            frag 0 from TextNode start: 182, length: 7, rect: [8,339 59.765625x17.46875]
+          line 19 width: 59.765625, height: 17.46875, bottom: 349.375, baseline: 13.53125
+            frag 0 from TextNode start: 182, length: 7, rect: [8,339.90625 59.765625x17.46875]
               "dapibus"
-          line 20 width: 67.890625, height: 17.84375, bottom: 367.21875, baseline: 13.53125
-            frag 0 from TextNode start: 190, length: 8, rect: [8,357 67.890625x17.46875]
+          line 20 width: 67.890625, height: 17.46875, bottom: 366.84375, baseline: 13.53125
+            frag 0 from TextNode start: 190, length: 8, rect: [8,357.375 67.890625x17.46875]
               "diam sed"
-          line 21 width: 70.4375, height: 18.3125, bottom: 385.15625, baseline: 13.53125
-            frag 0 from TextNode start: 199, length: 8, rect: [8,374 70.4375x17.46875]
+          line 21 width: 70.4375, height: 17.46875, bottom: 384.3125, baseline: 13.53125
+            frag 0 from TextNode start: 199, length: 8, rect: [8,374.84375 70.4375x17.46875]
               "rhoncus."
-          line 22 width: 78.8125, height: 17.78125, bottom: 402.09375, baseline: 13.53125
-            frag 0 from TextNode start: 208, length: 9, rect: [8,392 78.8125x17.46875]
+          line 22 width: 78.8125, height: 17.46875, bottom: 401.78125, baseline: 13.53125
+            frag 0 from TextNode start: 208, length: 9, rect: [8,392.3125 78.8125x17.46875]
               "Proin sed"
-          line 23 width: 68.296875, height: 18.25, bottom: 420.03125, baseline: 13.53125
-            frag 0 from TextNode start: 218, length: 9, rect: [8,409 68.296875x17.46875]
+          line 23 width: 68.296875, height: 17.46875, bottom: 419.25, baseline: 13.53125
+            frag 0 from TextNode start: 218, length: 9, rect: [8,409.78125 68.296875x17.46875]
               "orci leo."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-with-gaps.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-with-gaps.txt
@@ -1,107 +1,107 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x352.34375 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x352.34375 [GFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x351.90625 children: not-inline
+      Box <div.grid-container> at (8,8) content-size 784x351.90625 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.item-span-one-one> at (411.46875,8) content-size 382x139.765625 [BFC] children: inline
+        BlockContainer <div.grid-item.item-span-one-one> at (411.46875,8) content-size 382x139.75 [BFC] children: inline
           line 0 width: 319.171875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 1, length: 40, rect: [411.46875,8 319.171875x17.46875]
               "In a sollicitudin augue. Sed ante augue,"
-          line 1 width: 335.125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 42, length: 42, rect: [411.46875,25 335.125x17.46875]
+          line 1 width: 335.125, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 42, length: 42, rect: [411.46875,25.46875 335.125x17.46875]
               "rhoncus nec porttitor id, lacinia et nibh."
-          line 2 width: 378.625, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 85, length: 48, rect: [411.46875,42 378.625x17.46875]
+          line 2 width: 378.625, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 85, length: 48, rect: [411.46875,42.9375 378.625x17.46875]
               "Pellentesque diam libero, ultrices eget eleifend"
-          line 3 width: 182.8125, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 134, length: 22, rect: [411.46875,60 182.8125x17.46875]
+          line 3 width: 182.8125, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 134, length: 22, rect: [411.46875,60.40625 182.8125x17.46875]
               "at, consequat ut orci."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.item-span-one-two> at (411.46875,167.765625) content-size 382x192.578125 [BFC] children: inline
+        BlockContainer <div.grid-item.item-span-one-two> at (411.46875,167.75) content-size 382x192.15625 [BFC] children: inline
           line 0 width: 359.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 1, length: 43, rect: [411.46875,167.765625 359.15625x17.46875]
+            frag 0 from TextNode start: 1, length: 43, rect: [411.46875,167.75 359.15625x17.46875]
               "Suspendisse potenti. Pellentesque at varius"
-          line 1 width: 318.5625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 45, length: 41, rect: [411.46875,184.765625 318.5625x17.46875]
+          line 1 width: 318.5625, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 45, length: 41, rect: [411.46875,185.21875 318.5625x17.46875]
               "lacus, sed sollicitudin leo. Pellentesque"
-          line 2 width: 377.640625, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 87, length: 44, rect: [411.46875,201.765625 377.640625x17.46875]
+          line 2 width: 377.640625, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 87, length: 44, rect: [411.46875,202.6875 377.640625x17.46875]
               "malesuada mi eget pellentesque tempor. Donec"
-          line 3 width: 378.03125, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 132, length: 47, rect: [411.46875,219.765625 378.03125x17.46875]
+          line 3 width: 378.03125, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 132, length: 47, rect: [411.46875,220.15625 378.03125x17.46875]
               "egestas mauris est, ut lobortis nisi luctus at."
-          line 4 width: 345.953125, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 180, length: 41, rect: [411.46875,236.765625 345.953125x17.46875]
+          line 4 width: 345.953125, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+            frag 0 from TextNode start: 180, length: 41, rect: [411.46875,237.625 345.953125x17.46875]
               "Vivamus eleifend, lorem vulputate maximus"
-          line 5 width: 312.765625, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-            frag 0 from TextNode start: 222, length: 37, rect: [411.46875,254.765625 312.765625x17.46875]
+          line 5 width: 312.765625, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+            frag 0 from TextNode start: 222, length: 37, rect: [411.46875,255.09375 312.765625x17.46875]
               "porta, nunc metus porttitor nibh, nec"
-          line 6 width: 242.921875, height: 18.28125, bottom: 123.09375, baseline: 13.53125
-            frag 0 from TextNode start: 260, length: 31, rect: [411.46875,271.765625 242.921875x17.46875]
+          line 6 width: 242.921875, height: 17.46875, bottom: 122.28125, baseline: 13.53125
+            frag 0 from TextNode start: 260, length: 31, rect: [411.46875,272.5625 242.921875x17.46875]
               "bibendum nulla lectus ut felis."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.item-span-two> at (8,8) content-size 383.46875x352.34375 [BFC] children: inline
+        BlockContainer <div.grid-item.item-span-two> at (8,8) content-size 383.46875x351.90625 [BFC] children: inline
           line 0 width: 337.6875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 1, length: 39, rect: [8,8 337.6875x17.46875]
               "Lorem ipsum dolor sit amet, consectetur"
-          line 1 width: 376.34375, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 41, length: 47, rect: [8,25 376.34375x17.46875]
+          line 1 width: 376.34375, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 41, length: 47, rect: [8,25.46875 376.34375x17.46875]
               "adipiscing elit. Sed vitae condimentum erat, ac"
-          line 2 width: 365.84375, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 89, length: 45, rect: [8,42 365.84375x17.46875]
+          line 2 width: 365.84375, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 89, length: 45, rect: [8,42.9375 365.84375x17.46875]
               "posuere arcu. Aenean tincidunt mi ligula, vel"
-          line 3 width: 381.96875, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 135, length: 46, rect: [8,60 381.96875x17.46875]
+          line 3 width: 381.96875, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 135, length: 46, rect: [8,60.40625 381.96875x17.46875]
               "semper dolor aliquet at. Phasellus scelerisque"
-          line 4 width: 377.203125, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 182, length: 45, rect: [8,77 377.203125x17.46875]
+          line 4 width: 377.203125, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+            frag 0 from TextNode start: 182, length: 45, rect: [8,77.875 377.203125x17.46875]
               "dapibus diam sed rhoncus. Proin sed orci leo."
-          line 5 width: 375.390625, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-            frag 0 from TextNode start: 228, length: 45, rect: [8,95 375.390625x17.46875]
+          line 5 width: 375.390625, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+            frag 0 from TextNode start: 228, length: 45, rect: [8,95.34375 375.390625x17.46875]
               "Praesent pellentesque mi eu nunc gravida, vel"
-          line 6 width: 271.078125, height: 18.28125, bottom: 123.09375, baseline: 13.53125
-            frag 0 from TextNode start: 274, length: 32, rect: [8,112 271.078125x17.46875]
+          line 6 width: 271.078125, height: 17.46875, bottom: 122.28125, baseline: 13.53125
+            frag 0 from TextNode start: 274, length: 32, rect: [8,112.8125 271.078125x17.46875]
               "consectetur nulla malesuada. Sed"
-          line 7 width: 303.5625, height: 17.75, bottom: 140.03125, baseline: 13.53125
-            frag 0 from TextNode start: 307, length: 40, rect: [8,130 303.5625x17.46875]
+          line 7 width: 303.5625, height: 17.46875, bottom: 139.75, baseline: 13.53125
+            frag 0 from TextNode start: 307, length: 40, rect: [8,130.28125 303.5625x17.46875]
               "pellentesque, elit sit amet sollicitudin"
-          line 8 width: 346.625, height: 18.21875, bottom: 157.96875, baseline: 13.53125
-            frag 0 from TextNode start: 348, length: 46, rect: [8,147 346.625x17.46875]
+          line 8 width: 346.625, height: 17.46875, bottom: 157.21875, baseline: 13.53125
+            frag 0 from TextNode start: 348, length: 46, rect: [8,147.75 346.625x17.46875]
               "sollicitudin, lectus justo facilisis lacus, ac"
-          line 9 width: 350.234375, height: 17.6875, bottom: 174.90625, baseline: 13.53125
-            frag 0 from TextNode start: 395, length: 42, rect: [8,165 350.234375x17.46875]
+          line 9 width: 350.234375, height: 17.46875, bottom: 174.6875, baseline: 13.53125
+            frag 0 from TextNode start: 395, length: 42, rect: [8,165.21875 350.234375x17.46875]
               "vehicula metus neque ac mi. In in augue et"
-          line 10 width: 361.0625, height: 18.15625, bottom: 192.84375, baseline: 13.53125
-            frag 0 from TextNode start: 438, length: 40, rect: [8,182 361.0625x17.46875]
+          line 10 width: 361.0625, height: 17.46875, bottom: 192.15625, baseline: 13.53125
+            frag 0 from TextNode start: 438, length: 40, rect: [8,182.6875 361.0625x17.46875]
               "massa maximus venenatis auctor fermentum"
-          line 11 width: 371.734375, height: 17.625, bottom: 209.78125, baseline: 13.53125
-            frag 0 from TextNode start: 479, length: 46, rect: [8,200 371.734375x17.46875]
+          line 11 width: 371.734375, height: 17.46875, bottom: 209.625, baseline: 13.53125
+            frag 0 from TextNode start: 479, length: 46, rect: [8,200.15625 371.734375x17.46875]
               "dui. Aliquam dictum finibus urna, quis lacinia"
-          line 12 width: 369.59375, height: 18.09375, bottom: 227.71875, baseline: 13.53125
-            frag 0 from TextNode start: 526, length: 42, rect: [8,217 369.59375x17.46875]
+          line 12 width: 369.59375, height: 17.46875, bottom: 227.09375, baseline: 13.53125
+            frag 0 from TextNode start: 526, length: 42, rect: [8,217.625 369.59375x17.46875]
               "massa laoreet a. Suspendisse elementum non"
-          line 13 width: 323.78125, height: 17.5625, bottom: 244.65625, baseline: 13.53125
-            frag 0 from TextNode start: 569, length: 39, rect: [8,235 323.78125x17.46875]
+          line 13 width: 323.78125, height: 17.46875, bottom: 244.5625, baseline: 13.53125
+            frag 0 from TextNode start: 569, length: 39, rect: [8,235.09375 323.78125x17.46875]
               "lectus nec elementum. Quisque ultricies"
-          line 14 width: 337, height: 18.03125, bottom: 262.59375, baseline: 13.53125
-            frag 0 from TextNode start: 609, length: 40, rect: [8,252 337x17.46875]
+          line 14 width: 337, height: 17.46875, bottom: 262.03125, baseline: 13.53125
+            frag 0 from TextNode start: 609, length: 40, rect: [8,252.5625 337x17.46875]
               "suscipit porttitor. Sed non urna rutrum,"
-          line 15 width: 351.828125, height: 17.5, bottom: 279.53125, baseline: 13.53125
-            frag 0 from TextNode start: 650, length: 46, rect: [8,270 351.828125x17.46875]
+          line 15 width: 351.828125, height: 17.46875, bottom: 279.5, baseline: 13.53125
+            frag 0 from TextNode start: 650, length: 46, rect: [8,270.03125 351.828125x17.46875]
               "mattis nulla at, feugiat erat. Duis orci elit,"
-          line 16 width: 361.328125, height: 17.96875, bottom: 297.46875, baseline: 13.53125
-            frag 0 from TextNode start: 697, length: 45, rect: [8,287 361.328125x17.46875]
+          line 16 width: 361.328125, height: 17.46875, bottom: 296.96875, baseline: 13.53125
+            frag 0 from TextNode start: 697, length: 45, rect: [8,287.5 361.328125x17.46875]
               "vehicula sed blandit eget, auctor in arcu. Ut"
-          line 17 width: 345.75, height: 18.4375, bottom: 315.40625, baseline: 13.53125
-            frag 0 from TextNode start: 743, length: 41, rect: [8,304 345.75x17.46875]
+          line 17 width: 345.75, height: 17.46875, bottom: 314.4375, baseline: 13.53125
+            frag 0 from TextNode start: 743, length: 41, rect: [8,304.96875 345.75x17.46875]
               "cursus magna sit amet nulla cursus, vitae"
-          line 18 width: 180.234375, height: 17.90625, bottom: 332.34375, baseline: 13.53125
-            frag 0 from TextNode start: 785, length: 22, rect: [8,322 180.234375x17.46875]
+          line 18 width: 180.234375, height: 17.46875, bottom: 331.90625, baseline: 13.53125
+            frag 0 from TextNode start: 785, length: 22, rect: [8,322.4375 180.234375x17.46875]
               "gravida mauris dictum."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2.txt
@@ -1,104 +1,104 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x315.40625 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x315.40625 [GFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x314.4375 children: not-inline
+      Box <div.grid-container> at (8,8) content-size 784x314.4375 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.item-span-one-one> at (401.46875,8) content-size 392x131.296875 [BFC] children: inline
+        BlockContainer <div.grid-item.item-span-one-one> at (401.46875,8) content-size 392x131.015625 [BFC] children: inline
           line 0 width: 319.171875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 1, length: 40, rect: [401.46875,8 319.171875x17.46875]
               "In a sollicitudin augue. Sed ante augue,"
-          line 1 width: 335.125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 42, length: 42, rect: [401.46875,25 335.125x17.46875]
+          line 1 width: 335.125, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 42, length: 42, rect: [401.46875,25.46875 335.125x17.46875]
               "rhoncus nec porttitor id, lacinia et nibh."
-          line 2 width: 378.625, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 85, length: 48, rect: [401.46875,42 378.625x17.46875]
+          line 2 width: 378.625, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 85, length: 48, rect: [401.46875,42.9375 378.625x17.46875]
               "Pellentesque diam libero, ultrices eget eleifend"
-          line 3 width: 182.8125, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 134, length: 22, rect: [401.46875,60 182.8125x17.46875]
+          line 3 width: 182.8125, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 134, length: 22, rect: [401.46875,60.40625 182.8125x17.46875]
               "at, consequat ut orci."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.item-span-one-two> at (401.46875,139.296875) content-size 392x184.109375 [BFC] children: inline
+        BlockContainer <div.grid-item.item-span-one-two> at (401.46875,139.015625) content-size 392x183.421875 [BFC] children: inline
           line 0 width: 359.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 1, length: 43, rect: [401.46875,139.296875 359.15625x17.46875]
+            frag 0 from TextNode start: 1, length: 43, rect: [401.46875,139.015625 359.15625x17.46875]
               "Suspendisse potenti. Pellentesque at varius"
-          line 1 width: 318.5625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 45, length: 41, rect: [401.46875,156.296875 318.5625x17.46875]
+          line 1 width: 318.5625, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 45, length: 41, rect: [401.46875,156.484375 318.5625x17.46875]
               "lacus, sed sollicitudin leo. Pellentesque"
-          line 2 width: 377.640625, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 87, length: 44, rect: [401.46875,173.296875 377.640625x17.46875]
+          line 2 width: 377.640625, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 87, length: 44, rect: [401.46875,173.953125 377.640625x17.46875]
               "malesuada mi eget pellentesque tempor. Donec"
-          line 3 width: 378.03125, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 132, length: 47, rect: [401.46875,191.296875 378.03125x17.46875]
+          line 3 width: 378.03125, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 132, length: 47, rect: [401.46875,191.421875 378.03125x17.46875]
               "egestas mauris est, ut lobortis nisi luctus at."
-          line 4 width: 345.953125, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 180, length: 41, rect: [401.46875,208.296875 345.953125x17.46875]
+          line 4 width: 345.953125, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+            frag 0 from TextNode start: 180, length: 41, rect: [401.46875,208.890625 345.953125x17.46875]
               "Vivamus eleifend, lorem vulputate maximus"
-          line 5 width: 312.765625, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-            frag 0 from TextNode start: 222, length: 37, rect: [401.46875,226.296875 312.765625x17.46875]
+          line 5 width: 312.765625, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+            frag 0 from TextNode start: 222, length: 37, rect: [401.46875,226.359375 312.765625x17.46875]
               "porta, nunc metus porttitor nibh, nec"
-          line 6 width: 242.921875, height: 18.28125, bottom: 123.09375, baseline: 13.53125
-            frag 0 from TextNode start: 260, length: 31, rect: [401.46875,243.296875 242.921875x17.46875]
+          line 6 width: 242.921875, height: 17.46875, bottom: 122.28125, baseline: 13.53125
+            frag 0 from TextNode start: 260, length: 31, rect: [401.46875,243.828125 242.921875x17.46875]
               "bibendum nulla lectus ut felis."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.item-span-two> at (8,8) content-size 393.46875x315.40625 [BFC] children: inline
+        BlockContainer <div.grid-item.item-span-two> at (8,8) content-size 393.46875x314.4375 [BFC] children: inline
           line 0 width: 337.6875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 1, length: 39, rect: [8,8 337.6875x17.46875]
               "Lorem ipsum dolor sit amet, consectetur"
-          line 1 width: 376.34375, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 41, length: 47, rect: [8,25 376.34375x17.46875]
+          line 1 width: 376.34375, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+            frag 0 from TextNode start: 41, length: 47, rect: [8,25.46875 376.34375x17.46875]
               "adipiscing elit. Sed vitae condimentum erat, ac"
-          line 2 width: 365.84375, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 89, length: 45, rect: [8,42 365.84375x17.46875]
+          line 2 width: 365.84375, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+            frag 0 from TextNode start: 89, length: 45, rect: [8,42.9375 365.84375x17.46875]
               "posuere arcu. Aenean tincidunt mi ligula, vel"
-          line 3 width: 381.96875, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 135, length: 46, rect: [8,60 381.96875x17.46875]
+          line 3 width: 381.96875, height: 17.46875, bottom: 69.875, baseline: 13.53125
+            frag 0 from TextNode start: 135, length: 46, rect: [8,60.40625 381.96875x17.46875]
               "semper dolor aliquet at. Phasellus scelerisque"
-          line 4 width: 377.203125, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 182, length: 45, rect: [8,77 377.203125x17.46875]
+          line 4 width: 377.203125, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+            frag 0 from TextNode start: 182, length: 45, rect: [8,77.875 377.203125x17.46875]
               "dapibus diam sed rhoncus. Proin sed orci leo."
-          line 5 width: 375.390625, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-            frag 0 from TextNode start: 228, length: 45, rect: [8,95 375.390625x17.46875]
+          line 5 width: 375.390625, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+            frag 0 from TextNode start: 228, length: 45, rect: [8,95.34375 375.390625x17.46875]
               "Praesent pellentesque mi eu nunc gravida, vel"
-          line 6 width: 383.53125, height: 18.28125, bottom: 123.09375, baseline: 13.53125
-            frag 0 from TextNode start: 274, length: 46, rect: [8,112 383.53125x17.46875]
+          line 6 width: 383.53125, height: 17.46875, bottom: 122.28125, baseline: 13.53125
+            frag 0 from TextNode start: 274, length: 46, rect: [8,112.8125 383.53125x17.46875]
               "consectetur nulla malesuada. Sed pellentesque,"
-          line 7 width: 344.8125, height: 17.75, bottom: 140.03125, baseline: 13.53125
-            frag 0 from TextNode start: 321, length: 47, rect: [8,130 344.8125x17.46875]
+          line 7 width: 344.8125, height: 17.46875, bottom: 139.75, baseline: 13.53125
+            frag 0 from TextNode start: 321, length: 47, rect: [8,130.28125 344.8125x17.46875]
               "elit sit amet sollicitudin sollicitudin, lectus"
-          line 8 width: 374.703125, height: 18.21875, bottom: 157.96875, baseline: 13.53125
-            frag 0 from TextNode start: 369, length: 46, rect: [8,147 374.703125x17.46875]
+          line 8 width: 374.703125, height: 17.46875, bottom: 157.21875, baseline: 13.53125
+            frag 0 from TextNode start: 369, length: 46, rect: [8,147.75 374.703125x17.46875]
               "justo facilisis lacus, ac vehicula metus neque"
-          line 9 width: 384.125, height: 17.6875, bottom: 174.90625, baseline: 13.53125
-            frag 0 from TextNode start: 416, length: 45, rect: [8,165 384.125x17.46875]
+          line 9 width: 384.125, height: 17.46875, bottom: 174.6875, baseline: 13.53125
+            frag 0 from TextNode start: 416, length: 45, rect: [8,165.21875 384.125x17.46875]
               "ac mi. In in augue et massa maximus venenatis"
-          line 10 width: 373.25, height: 18.15625, bottom: 192.84375, baseline: 13.53125
-            frag 0 from TextNode start: 462, length: 44, rect: [8,182 373.25x17.46875]
+          line 10 width: 373.25, height: 17.46875, bottom: 192.15625, baseline: 13.53125
+            frag 0 from TextNode start: 462, length: 44, rect: [8,182.6875 373.25x17.46875]
               "auctor fermentum dui. Aliquam dictum finibus"
-          line 11 width: 288.203125, height: 17.625, bottom: 209.78125, baseline: 13.53125
-            frag 0 from TextNode start: 507, length: 35, rect: [8,200 288.203125x17.46875]
+          line 11 width: 288.203125, height: 17.46875, bottom: 209.625, baseline: 13.53125
+            frag 0 from TextNode start: 507, length: 35, rect: [8,200.15625 288.203125x17.46875]
               "urna, quis lacinia massa laoreet a."
-          line 12 width: 316.296875, height: 18.09375, bottom: 227.71875, baseline: 13.53125
-            frag 0 from TextNode start: 543, length: 36, rect: [8,217 316.296875x17.46875]
+          line 12 width: 316.296875, height: 17.46875, bottom: 227.09375, baseline: 13.53125
+            frag 0 from TextNode start: 543, length: 36, rect: [8,217.625 316.296875x17.46875]
               "Suspendisse elementum non lectus nec"
-          line 13 width: 388.78125, height: 17.5625, bottom: 244.65625, baseline: 13.53125
-            frag 0 from TextNode start: 580, length: 48, rect: [8,235 388.78125x17.46875]
+          line 13 width: 388.78125, height: 17.46875, bottom: 244.5625, baseline: 13.53125
+            frag 0 from TextNode start: 580, length: 48, rect: [8,235.09375 388.78125x17.46875]
               "elementum. Quisque ultricies suscipit porttitor."
-          line 14 width: 373.828125, height: 18.03125, bottom: 262.59375, baseline: 13.53125
-            frag 0 from TextNode start: 629, length: 45, rect: [8,252 373.828125x17.46875]
+          line 14 width: 373.828125, height: 17.46875, bottom: 262.03125, baseline: 13.53125
+            frag 0 from TextNode start: 629, length: 45, rect: [8,252.5625 373.828125x17.46875]
               "Sed non urna rutrum, mattis nulla at, feugiat"
-          line 15 width: 368.75, height: 17.5, bottom: 279.53125, baseline: 13.53125
-            frag 0 from TextNode start: 675, length: 48, rect: [8,270 368.75x17.46875]
+          line 15 width: 368.75, height: 17.46875, bottom: 279.5, baseline: 13.53125
+            frag 0 from TextNode start: 675, length: 48, rect: [8,270.03125 368.75x17.46875]
               "erat. Duis orci elit, vehicula sed blandit eget,"
-          line 16 width: 390.625, height: 17.96875, bottom: 297.46875, baseline: 13.53125
-            frag 0 from TextNode start: 724, length: 46, rect: [8,287 390.625x17.46875]
+          line 16 width: 390.625, height: 17.46875, bottom: 296.96875, baseline: 13.53125
+            frag 0 from TextNode start: 724, length: 46, rect: [8,287.5 390.625x17.46875]
               "auctor in arcu. Ut cursus magna sit amet nulla"
-          line 17 width: 294.90625, height: 18.4375, bottom: 315.40625, baseline: 13.53125
-            frag 0 from TextNode start: 771, length: 36, rect: [8,304 294.90625x17.46875]
+          line 17 width: 294.90625, height: 17.46875, bottom: 314.4375, baseline: 13.53125
+            frag 0 from TextNode start: 771, length: 36, rect: [8,304.96875 294.90625x17.46875]
               "cursus, vitae gravida mauris dictum."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/template-lines-and-areas.txt
+++ b/Tests/LibWeb/Layout/expected/grid/template-lines-and-areas.txt
@@ -2,13 +2,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
       Box <div.grid> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
-        BlockContainer <div.item-left> at (8,8) content-size 261.333333x17.46875 [BFC] children: inline
+        BlockContainer <div.item-left> at (8,8) content-size 261.328125x17.46875 [BFC] children: inline
           line 0 width: 21.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 3, rect: [8,8 21.609375x17.46875]
               "1fr"
           TextNode <#text>
-        BlockContainer <div.item-right> at (530.666666,8) content-size 261.333333x17.46875 [BFC] children: inline
+        BlockContainer <div.item-right> at (530.65625,8) content-size 261.328125x17.46875 [BFC] children: inline
           line 0 width: 21.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [530.666666,8 21.609375x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [530.65625,8 21.609375x17.46875]
               "1fr"
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/track-size-calc-with-percentage.txt
+++ b/Tests/LibWeb/Layout/expected/grid/track-size-calc-with-percentage.txt
@@ -1,13 +1,13 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x35.40625 children: not-inline
-      Box <div.ipc-page-grid> at (8,8) content-size 784x35.40625 flex-container(row) [FFC] children: not-inline
-        Box <div.ipc-sub-grid> at (8,8) content-size 401.28125x35.40625 flex-item [GFC] children: not-inline
-          BlockContainer <(anonymous)> at (8,8) content-size 401.281x35.40625 [BFC] children: inline
+    BlockContainer <body> at (8,8) content-size 784x34.9375 children: not-inline
+      Box <div.ipc-page-grid> at (8,8) content-size 784x34.9375 flex-container(row) [FFC] children: not-inline
+        Box <div.ipc-sub-grid> at (8,8) content-size 401.28125x34.9375 flex-item [GFC] children: not-inline
+          BlockContainer <(anonymous)> at (8,8) content-size 401.265625x34.9375 [BFC] children: inline
             line 0 width: 356.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
               frag 0 from TextNode start: 0, length: 40, rect: [8,8 356.96875x17.46875]
                 "The 10 Most Anticipated Summer Movies of"
-            line 1 width: 36.3125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-              frag 0 from TextNode start: 41, length: 4, rect: [8,25 36.3125x17.46875]
+            line 1 width: 36.3125, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+              frag 0 from TextNode start: 41, length: 4, rect: [8,25.46875 36.3125x17.46875]
                 "2023"
             TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/grid/unresolvable-percentage-track.txt
+++ b/Tests/LibWeb/Layout/expected/grid/unresolvable-percentage-track.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
       Box <div.ipc-page-grid> at (8,8) content-size 784x17.46875 flex-container(row) [FFC] children: not-inline
         Box <div.ipc-sub-grid> at (8,8) content-size 36.84375x17.46875 flex-item [GFC] children: not-inline
-          BlockContainer <div> at (8,8) content-size 36.844x17.46875 [BFC] children: inline
+          BlockContainer <div> at (8,8) content-size 36.84375x17.46875 [BFC] children: inline
             line 0 width: 36.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
               frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17.46875]
                 "hello"

--- a/Tests/LibWeb/Layout/expected/height-of-absolute-position-box-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/height-of-absolute-position-box-with-padding.txt
@@ -4,9 +4,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
     BlockContainer <body> at (8,8) content-size 784x0 children: inline
       TextNode <#text>
-      BlockContainer <h1> at (76.590551,103.754331) content-size 126x38 positioned [BFC] children: inline
-        line 0 width: 46.523437, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-          frag 0 from TextNode start: 0, length: 4, rect: [116.590551,103.754331 46.523437x21.835937]
+      BlockContainer <h1> at (76.578125,103.734375) content-size 126x38 positioned [BFC] children: inline
+        line 0 width: 46.515625, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+          frag 0 from TextNode start: 0, length: 4, rect: [116.3125,103.734375 46.515625x21.828125]
             "Test"
         TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/image-with-multiple-constraint-violations.txt
+++ b/Tests/LibWeb/Layout/expected/image-with-multiple-constraint-violations.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x80 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x62 children: inline
-      line 0 width: 82, height: 62, bottom: 62, baseline: 62
-        frag 0 from ImageBox start: 0, length: 0, rect: [11,11 80x60]
-      ImageBox <img> at (11,11) content-size 80x60 children: not-inline
+      line 0 width: 81.6875, height: 62, bottom: 62, baseline: 62
+        frag 0 from ImageBox start: 0, length: 0, rect: [11,11 79.6875x60]
+      ImageBox <img> at (11,11) content-size 79.6875x60 children: not-inline

--- a/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-min-content-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-min-content-containing-block-width.txt
@@ -2,5 +2,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 0x17.46875 children: inline
       line 0 width: 0, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-        frag 0 from ImageBox start: 0, length: 0, rect: [8,21 0x0]
-      ImageBox <img> at (8,21) content-size 0x0 children: not-inline
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,21.53125 0x0]
+      ImageBox <img> at (8,21.53125) content-size 0x0 children: not-inline

--- a/Tests/LibWeb/Layout/expected/inline-size.txt
+++ b/Tests/LibWeb/Layout/expected/inline-size.txt
@@ -1,20 +1,20 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x570.851562 [BFC] children: not-inline
-    BlockContainer <body> at (8,70) content-size 784x492.851562 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x570.84375 [BFC] children: not-inline
+    BlockContainer <body> at (8,70) content-size 784x492.84375 children: not-inline
       BlockContainer <p.min-inline-test> at (8,70) content-size 784x200 children: inline
-        line 0 width: 85.859375, height: 76.425781, bottom: 76.425781, baseline: 59.199218
-          frag 0 from TextNode start: 0, length: 2, rect: [8,70 85.859375x76.425781]
+        line 0 width: 85.859375, height: 76.421875, bottom: 76.421875, baseline: 59.1875
+          frag 0 from TextNode start: 0, length: 2, rect: [8,70 85.859375x76.421875]
             "KK"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,340) content-size 784x76.425781 children: inline
-        line 0 width: 0, height: 76.425781, bottom: 76.425781, baseline: 59.199218
+      BlockContainer <(anonymous)> at (8,340) content-size 784x76.421875 children: inline
+        line 0 width: 0, height: 76.421875, bottom: 76.421875, baseline: 59.1875
         TextNode <#text>
         BreakNode <br>
         TextNode <#text>
-      BlockContainer <p.max-inline-test> at (8,486.425781) content-size 100x76.425781 children: inline
-        line 0 width: 85.859375, height: 76.425781, bottom: 76.425781, baseline: 59.199218
-          frag 0 from TextNode start: 0, length: 2, rect: [8,486.425781 85.859375x76.425781]
+      BlockContainer <p.max-inline-test> at (8,486.421875) content-size 100x76.421875 children: inline
+        line 0 width: 85.859375, height: 76.421875, bottom: 76.421875, baseline: 59.1875
+          frag 0 from TextNode start: 0, length: 2, rect: [8,486.421875 85.859375x76.421875]
             "KK"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,632.851562) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,632.84375) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
+++ b/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
@@ -1,9 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x45.835937 [BFC] children: not-inline
-    BlockContainer <body> at (10,10) content-size 780x27.835937 children: inline
-      line 0 width: 202, height: 27.835937, bottom: 27.835937, baseline: 23.835937
-        frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 200x25.835937]
-      BlockContainer <input> at (11,11) content-size 200x25.835937 inline-block [BFC] children: not-inline
-        Box <div> at (13,12) content-size 196x23.835937 flex-container(row) [FFC] children: not-inline
-          BlockContainer <div> at (14,13) content-size 0x21.835937 flex-item [BFC] children: inline
+  BlockContainer <html> at (1,1) content-size 798x45.828125 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x27.828125 children: inline
+      line 0 width: 202, height: 27.828125, bottom: 27.828125, baseline: 23.828125
+        frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 200x25.828125]
+      BlockContainer <input> at (11,11) content-size 200x25.828125 inline-block [BFC] children: not-inline
+        Box <div> at (13,12) content-size 196x23.828125 flex-container(row) [FFC] children: not-inline
+          BlockContainer <div> at (14,13) content-size 0x21.828125 flex-item [BFC] children: inline
             TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/place-content-shorthand-property.txt
+++ b/Tests/LibWeb/Layout/expected/place-content-shorthand-property.txt
@@ -2,8 +2,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x37.46875 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x19.46875 children: not-inline
       Box <div.container> at (11,11) content-size 800x17.46875 flex-container(row) [FFC] children: not-inline
-        BlockContainer <(anonymous)> at (392.210937,11) content-size 37.578125x17.46875 flex-item [BFC] children: inline
+        BlockContainer <(anonymous)> at (392.203125,11) content-size 37.578125x17.46875 flex-item [BFC] children: inline
           line 0 width: 37.578125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 4, rect: [392.210937,11 37.578125x17.46875]
+            frag 0 from TextNode start: 0, length: 4, rect: [392.203125,11 37.578125x17.46875]
               "Text"
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties-2.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties-2.txt
@@ -1,26 +1,26 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x470.195312 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x454.195312 children: not-inline
-      BlockContainer <(anonymous)> at (8,8) content-size 784x21.835937 children: inline
-        line 0 width: 391.640625, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-          frag 0 from TextNode start: 0, length: 40, rect: [8,8 391.640625x21.835937]
+  BlockContainer <html> at (0,0) content-size 800x468.796875 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x452.796875 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x21.828125 children: inline
+        line 0 width: 391.578125, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+          frag 0 from TextNode start: 0, length: 40, rect: [8,8 391.578125x21.828125]
             "Variable set by inline style of element:"
         TextNode <#text>
         BreakNode <br>
         TextNode <#text>
-      BlockContainer <div.a> at (8,29.835937) content-size 784x100 children: inline
-        line 0 width: 200, height: 100, bottom: 100, baseline: 16.914062
-          frag 0 from BlockContainer start: 0, length: 0, rect: [8,29.835937 200x100]
-        BlockContainer <(anonymous)> at (8,29.835937) content-size 200x100 inline-block [BFC] children: inline
-          line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-            frag 0 from TextNode start: 0, length: 0, rect: [8,29.835937 0x21.835937]
+      BlockContainer <div.a> at (8,29.828125) content-size 784x100 children: inline
+        line 0 width: 200, height: 100, bottom: 100, baseline: 16.890625
+          frag 0 from BlockContainer start: 0, length: 0, rect: [8,29.828125 200x100]
+        BlockContainer <(anonymous)> at (8,29.828125) content-size 200x100 inline-block [BFC] children: inline
+          line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+            frag 0 from TextNode start: 0, length: 0, rect: [8,29.828125 0x21.828125]
               ""
           TextNode <#text>
-      BlockContainer <(anonymous)> at (8,129.835937) content-size 784x66.179687 children: inline
-        line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-        line 1 width: 0, height: 21.835937, bottom: 43.671875, baseline: 16.914062
-        line 2 width: 441.269531, height: 22.507812, bottom: 66.179687, baseline: 16.914062
-          frag 0 from TextNode start: 1, length: 42, rect: [8,172.835937 441.269531x21.835937]
+      BlockContainer <(anonymous)> at (8,129.828125) content-size 784x65.484375 children: inline
+        line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+        line 1 width: 0, height: 21.828125, bottom: 43.65625, baseline: 16.890625
+        line 2 width: 441.21875, height: 21.828125, bottom: 65.484375, baseline: 16.890625
+          frag 0 from TextNode start: 1, length: 42, rect: [8,173.484375 441.21875x21.828125]
             "Variable set by CSS rule matching element:"
         TextNode <#text>
         BreakNode <br>
@@ -28,19 +28,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         BreakNode <br>
         TextNode <#text>
-      BlockContainer <div.b> at (8,196.015625) content-size 784x100 children: inline
-        line 0 width: 200, height: 100, bottom: 100, baseline: 16.914062
-          frag 0 from BlockContainer start: 0, length: 0, rect: [8,196.015625 200x100]
-        BlockContainer <(anonymous)> at (8,196.015625) content-size 200x100 inline-block [BFC] children: inline
-          line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-            frag 0 from TextNode start: 0, length: 0, rect: [8,196.015625 0x21.835937]
+      BlockContainer <div.b> at (8,195.3125) content-size 784x100 children: inline
+        line 0 width: 200, height: 100, bottom: 100, baseline: 16.890625
+          frag 0 from BlockContainer start: 0, length: 0, rect: [8,195.3125 200x100]
+        BlockContainer <(anonymous)> at (8,195.3125) content-size 200x100 inline-block [BFC] children: inline
+          line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+            frag 0 from TextNode start: 0, length: 0, rect: [8,195.3125 0x21.828125]
               ""
           TextNode <#text>
-      BlockContainer <(anonymous)> at (8,296.015625) content-size 784x66.179687 children: inline
-        line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-        line 1 width: 0, height: 21.835937, bottom: 43.671875, baseline: 16.914062
-        line 2 width: 520.605468, height: 22.507812, bottom: 66.179687, baseline: 16.914062
-          frag 0 from TextNode start: 1, length: 49, rect: [8,339.015625 520.605468x21.835937]
+      BlockContainer <(anonymous)> at (8,295.3125) content-size 784x65.484375 children: inline
+        line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+        line 1 width: 0, height: 21.828125, bottom: 43.65625, baseline: 16.890625
+        line 2 width: 520.546875, height: 21.828125, bottom: 65.484375, baseline: 16.890625
+          frag 0 from TextNode start: 1, length: 49, rect: [8,338.96875 520.546875x21.828125]
             "Variable set by CSS rule matching pseudo element:"
         TextNode <#text>
         BreakNode <br>
@@ -48,13 +48,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         BreakNode <br>
         TextNode <#text>
-      BlockContainer <div.c> at (8,362.195312) content-size 784x100 children: inline
-        line 0 width: 200, height: 100, bottom: 100, baseline: 16.914062
-          frag 0 from BlockContainer start: 0, length: 0, rect: [8,362.195312 200x100]
-        BlockContainer <(anonymous)> at (8,362.195312) content-size 200x100 inline-block [BFC] children: inline
-          line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-            frag 0 from TextNode start: 0, length: 0, rect: [8,362.195312 0x21.835937]
+      BlockContainer <div.c> at (8,360.796875) content-size 784x100 children: inline
+        line 0 width: 200, height: 100, bottom: 100, baseline: 16.890625
+          frag 0 from BlockContainer start: 0, length: 0, rect: [8,360.796875 200x100]
+        BlockContainer <(anonymous)> at (8,360.796875) content-size 200x100 inline-block [BFC] children: inline
+          line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+            frag 0 from TextNode start: 0, length: 0, rect: [8,360.796875 0x21.828125]
               ""
           TextNode <#text>
-      BlockContainer <(anonymous)> at (8,462.195312) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,460.796875) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <div.hello> at (8,8) content-size 784x0 children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 500x100 positioned [BFC] children: inline
-          line 0 width: 0, height: 21.835937, bottom: 21.835937, baseline: 16.914062
-            frag 0 from TextNode start: 0, length: 0, rect: [8,8 0x21.835937]
+          line 0 width: 0, height: 21.828125, bottom: 21.828125, baseline: 16.890625
+            frag 0 from TextNode start: 0, length: 0, rect: [8,8 0x21.828125]
               ""
           TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/replaced-box-with-vertical-margins.txt
+++ b/Tests/LibWeb/Layout/expected/replaced-box-with-vertical-margins.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x216.46875 children: inline
-      line 0 width: 174.828125, height: 216.46875, bottom: 216.46875, baseline: 213
-        frag 0 from TextNode start: 0, length: 6, rect: [8,207 43.125x17.46875]
+    BlockContainer <body> at (8,8) content-size 784x216.9375 children: inline
+      line 0 width: 174.828125, height: 216.9375, bottom: 216.9375, baseline: 213
+        frag 0 from TextNode start: 0, length: 6, rect: [8,207.46875 43.125x17.46875]
           "Well, "
-        frag 1 from ImageBox start: 0, length: 0, rect: [51,33 64x138]
-        frag 2 from TextNode start: 0, length: 9, rect: [115,207 67.703125x17.46875]
+        frag 1 from ImageBox start: 0, length: 0, rect: [51.125,33 64x138]
+        frag 2 from TextNode start: 0, length: 9, rect: [115.125,207.46875 67.703125x17.46875]
           " friends."
       TextNode <#text>
-      ImageBox <img#image> at (51,33) content-size 64x138 children: not-inline
+      ImageBox <img#image> at (51.125,33) content-size 64x138 children: not-inline
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/resolve-cyclic-percentage-against-zero-when-available-size-is-min-content.txt
+++ b/Tests/LibWeb/Layout/expected/resolve-cyclic-percentage-against-zero-when-available-size-is-min-content.txt
@@ -3,8 +3,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x1233.46875 children: not-inline
       BlockContainer <div.w.min> at (11,11) content-size 2x17.46875 children: inline
         line 0 width: 4, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from ImageBox start: 0, length: 0, rect: [12,21 2x2]
-        ImageBox <img> at (12,21) content-size 2x2 children: not-inline
+          frag 0 from ImageBox start: 0, length: 0, rect: [12,21.53125 2x2]
+        ImageBox <img> at (12,21.53125) content-size 2x2 children: not-inline
       BlockContainer <(anonymous)> at (10,29.46875) content-size 780x0 children: inline
         TextNode <#text>
       BlockContainer <div.w.max> at (11,30.46875) content-size 402x404 children: inline

--- a/Tests/LibWeb/Layout/expected/svg-preserve-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/svg-preserve-aspect-ratio.txt
@@ -1,41 +1,41 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x257.46875 children: inline
-      line 0 width: 772, height: 130.46875, bottom: 130.46875, baseline: 127
+    BlockContainer <body> at (8,8) content-size 784x257.9375 children: inline
+      line 0 width: 772, height: 130.9375, bottom: 130.9375, baseline: 127
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,84 100x50]
-        frag 1 from TextNode start: 0, length: 1, rect: [110,121 8x17.46875]
+        frag 1 from TextNode start: 0, length: 1, rect: [110,121.46875 8x17.46875]
           " "
         frag 2 from SVGSVGBox start: 0, length: 0, rect: [119,84 100x50]
-        frag 3 from TextNode start: 0, length: 1, rect: [220,121 8x17.46875]
+        frag 3 from TextNode start: 0, length: 1, rect: [220,121.46875 8x17.46875]
           " "
         frag 4 from SVGSVGBox start: 0, length: 0, rect: [229,84 100x50]
-        frag 5 from TextNode start: 0, length: 1, rect: [330,121 8x17.46875]
+        frag 5 from TextNode start: 0, length: 1, rect: [330,121.46875 8x17.46875]
           " "
         frag 6 from SVGSVGBox start: 0, length: 0, rect: [339,84 100x50]
-        frag 7 from TextNode start: 0, length: 1, rect: [440,121 8x17.46875]
+        frag 7 from TextNode start: 0, length: 1, rect: [440,121.46875 8x17.46875]
           " "
         frag 8 from SVGSVGBox start: 0, length: 0, rect: [449,84 100x50]
-        frag 9 from TextNode start: 0, length: 1, rect: [550,121 8x17.46875]
+        frag 9 from TextNode start: 0, length: 1, rect: [550,121.46875 8x17.46875]
           " "
         frag 10 from SVGSVGBox start: 0, length: 0, rect: [559,84 100x50]
-        frag 11 from TextNode start: 0, length: 1, rect: [660,121 8x17.46875]
+        frag 11 from TextNode start: 0, length: 1, rect: [660,121.46875 8x17.46875]
           " "
         frag 12 from SVGSVGBox start: 0, length: 0, rect: [669,9 50x125]
-        frag 13 from TextNode start: 0, length: 1, rect: [720,121 8x17.46875]
+        frag 13 from TextNode start: 0, length: 1, rect: [720,121.46875 8x17.46875]
           " "
         frag 14 from SVGSVGBox start: 0, length: 0, rect: [729,9 50x125]
-      line 1 width: 402, height: 130.46875, bottom: 257.46875, baseline: 127
+      line 1 width: 402, height: 130.9375, bottom: 257.9375, baseline: 127
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,136 50x125]
-        frag 1 from TextNode start: 0, length: 1, rect: [60,248 8x17.46875]
+        frag 1 from TextNode start: 0, length: 1, rect: [60,248.46875 8x17.46875]
           " "
         frag 2 from SVGSVGBox start: 0, length: 0, rect: [69,136 50x125]
-        frag 3 from TextNode start: 0, length: 1, rect: [120,248 8x17.46875]
+        frag 3 from TextNode start: 0, length: 1, rect: [120,248.46875 8x17.46875]
           " "
         frag 4 from SVGSVGBox start: 0, length: 0, rect: [129,136 50x125]
-        frag 5 from TextNode start: 0, length: 1, rect: [180,248 8x17.46875]
+        frag 5 from TextNode start: 0, length: 1, rect: [180,248.46875 8x17.46875]
           " "
         frag 6 from SVGSVGBox start: 0, length: 0, rect: [189,136 50x125]
-        frag 7 from TextNode start: 0, length: 1, rect: [240,248 8x17.46875]
+        frag 7 from TextNode start: 0, length: 1, rect: [240,248.46875 8x17.46875]
           " "
         frag 8 from SVGSVGBox start: 0, length: 0, rect: [249,201 160x60]
       SVGSVGBox <svg> at (9,84) content-size 100x50 [SVG] children: inline
@@ -100,6 +100,6 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
       SVGSVGBox <svg> at (249,201) content-size 160x60 [SVG] children: inline
         TextNode <#text>
-        SVGGeometryBox <circle> at (299,200.999998) content-size 60x60.000003 children: not-inline
+        SVGGeometryBox <circle> at (299,201) content-size 60x60 children: not-inline
         TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
+++ b/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
@@ -1,20 +1,20 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x700 [BFC] children: not-inline
     BlockContainer <body> at (50,50) content-size 700x600 children: inline
-      line 0 width: 616, height: 203.46875, bottom: 203.46875, baseline: 200
+      line 0 width: 616, height: 203.9375, bottom: 203.9375, baseline: 200
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [50,150 200x100]
-        frag 1 from TextNode start: 0, length: 1, rect: [250,236 8x17.46875]
+        frag 1 from TextNode start: 0, length: 1, rect: [250,236.46875 8x17.46875]
           " "
         frag 2 from SVGSVGBox start: 0, length: 0, rect: [258,50 200x200]
-        frag 3 from TextNode start: 0, length: 1, rect: [458,236 8x17.46875]
+        frag 3 from TextNode start: 0, length: 1, rect: [458,236.46875 8x17.46875]
           " "
         frag 4 from SVGSVGBox start: 0, length: 0, rect: [466,50 200x200]
-      line 1 width: 616, height: 203.46875, bottom: 403.46875, baseline: 200
+      line 1 width: 616, height: 203.9375, bottom: 403.9375, baseline: 200
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [50,250 200x200]
-        frag 1 from TextNode start: 0, length: 1, rect: [250,436 8x17.46875]
+        frag 1 from TextNode start: 0, length: 1, rect: [250,436.46875 8x17.46875]
           " "
         frag 2 from SVGSVGBox start: 0, length: 0, rect: [258,250 200x200]
-        frag 3 from TextNode start: 0, length: 1, rect: [458,436 8x17.46875]
+        frag 3 from TextNode start: 0, length: 1, rect: [458,436.46875 8x17.46875]
           " "
         frag 4 from SVGSVGBox start: 0, length: 0, rect: [466,250 200x200]
       line 2 width: 200, height: 200, bottom: 600, baseline: 200
@@ -23,12 +23,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         SVGGraphicsBox <g> at (50,150) content-size 0x0 children: inline
           TextNode <#text>
-          SVGGeometryBox <path> at (45.690780,199.828884) content-size 118.784614x47.455844 children: not-inline
+          SVGGeometryBox <path> at (45.703125,199.828125) content-size 118.78125x47.453125 children: not-inline
           TextNode <#text>
         TextNode <#text>
         SVGGraphicsBox <g> at (50,150) content-size 0x0 children: inline
           TextNode <#text>
-          SVGGeometryBox <path> at (84.5,159.499996) content-size 81x81 children: not-inline
+          SVGGeometryBox <path> at (84.5,159.484375) content-size 81x81 children: not-inline
           TextNode <#text>
         TextNode <#text>
       TextNode <#text>
@@ -43,18 +43,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         SVGGeometryBox <rect> at (506,90) content-size 120x120 children: not-inline
         TextNode <#text>
-        SVGGeometryBox <rect> at (471.358985,90) content-size 189.282043x120 children: not-inline
+        SVGGeometryBox <rect> at (471.34375,90) content-size 189.28125x120 children: not-inline
         TextNode <#text>
       TextNode <#text>
       SVGSVGBox <svg> at (50,250) content-size 200x200 [SVG] children: inline
         TextNode <#text>
-        SVGGeometryBox <rect> at (120.588233,320.588241) content-size 58.823524x58.823532 children: not-inline
+        SVGGeometryBox <rect> at (120.578125,320.578125) content-size 58.8125x58.8125 children: not-inline
         TextNode <#text>
         TextNode <#text>
-        SVGGeometryBox <rect> at (52.443771,310.373641) content-size 68.144462x68.144454 children: not-inline
+        SVGGeometryBox <rect> at (52.4375,310.375) content-size 68.140625x68.140625 children: not-inline
         TextNode <#text>
         TextNode <#text>
-        SVGGeometryBox <rect> at (179.411773,321.481903) content-size 68.14447x68.14447 children: not-inline
+        SVGGeometryBox <rect> at (179.40625,321.484375) content-size 68.140625x68.140625 children: not-inline
         TextNode <#text>
       TextNode <#text>
       SVGSVGBox <svg> at (258,250) content-size 200x200 [SVG] children: inline
@@ -76,7 +76,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         SVGGeometryBox <rect> at (506,290) content-size 120x120 children: not-inline
         TextNode <#text>
-        SVGGeometryBox <rect> at (506,255.358985) content-size 120x189.282043 children: not-inline
+        SVGGeometryBox <rect> at (506,255.34375) content-size 120x189.28125 children: not-inline
         TextNode <#text>
       TextNode <#text>
       SVGSVGBox <svg> at (50,450) content-size 200x200 [SVG] children: inline

--- a/Tests/LibWeb/Layout/expected/svg/dont-stretch-fit-svg-with-indefinite-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/svg/dont-stretch-fit-svg-with-indefinite-containing-block-width.txt
@@ -2,5 +2,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 0x17.46875 children: inline
       line 0 width: 0, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,21 0x0]
-      SVGSVGBox <svg> at (8,21) content-size 0x0 [SVG] children: not-inline
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,21.53125 0x0]
+      SVGSVGBox <svg> at (8,21.53125) content-size 0x0 [SVG] children: not-inline

--- a/Tests/LibWeb/Layout/expected/svg/svg-as-image.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-as-image.txt
@@ -6,5 +6,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Viewport <#document> at (0,0) content-size 784x1568 children: inline
           SVGSVGBox <svg> at (0,0) content-size 784x1568 [SVG] children: inline
             TextNode <#text>
-            SVGGeometryBox <rect> at (-0.000007,-0.000015) content-size 784x1568 children: not-inline
+            SVGGeometryBox <rect> at (0,0) content-size 784x1568 children: not-inline
             TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/svg/svg-fill-with-bogus-url.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-fill-with-bogus-url.txt
@@ -4,4 +4,4 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       line 0 width: 784, height: 784, bottom: 784, baseline: 784
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x784]
       SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: not-inline
-        SVGGeometryBox <rect> at (7.999992,7.999992) content-size 784x784 children: not-inline
+        SVGGeometryBox <rect> at (8,8) content-size 784x784 children: not-inline

--- a/Tests/LibWeb/Layout/expected/svg/svg-negative-elliptical-arg-number.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-negative-elliptical-arg-number.txt
@@ -4,4 +4,4 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       line 0 width: 100, height: 100, bottom: 100, baseline: 48
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100]
       SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: not-inline
-        SVGGeometryBox <path> at (8,9.999999) content-size 100x48 children: not-inline
+        SVGGeometryBox <path> at (8,9.984375) content-size 100x48 children: not-inline

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-display-block.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-display-block.txt
@@ -2,4 +2,4 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x800 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x784 children: not-inline
       SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: not-inline
-        SVGGeometryBox <rect> at (7.999992,7.999992) content-size 784x784 children: not-inline
+        SVGGeometryBox <rect> at (8,8) content-size 784x784 children: not-inline

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
@@ -2,11 +2,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17.46875 children: inline
       line 0 width: 8, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-        frag 0 from ImageBox start: 0, length: 0, rect: [8,21 0x0]
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,21.53125 0x0]
         frag 1 from TextNode start: 0, length: 1, rect: [8,8 8x17.46875]
           " "
-        frag 2 from SVGSVGBox start: 0, length: 0, rect: [16,21 0x0]
-      ImageBox <img> at (8,21) content-size 0x0 children: not-inline
+        frag 2 from SVGSVGBox start: 0, length: 0, rect: [16,21.53125 0x0]
+      ImageBox <img> at (8,21.53125) content-size 0x0 children: not-inline
         (SVG-as-image isolated context)
         Viewport <#document> at (0,0) content-size 0x0 children: inline
           SVGSVGBox <svg> at (0,0) content-size 0x0 [SVG] children: inline
@@ -14,8 +14,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             SVGGeometryBox <rect> at (0,0) content-size 1x1 children: not-inline
             TextNode <#text>
       TextNode <#text>
-      SVGSVGBox <svg> at (16,21) content-size 0x0 [SVG] children: inline
+      SVGSVGBox <svg> at (16,21.53125) content-size 0x0 [SVG] children: inline
         TextNode <#text>
-        SVGGeometryBox <rect> at (16,21) content-size 1x1 children: not-inline
+        SVGGeometryBox <rect> at (16,21.53125) content-size 1x1 children: not-inline
         TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
+++ b/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
@@ -1,8 +1,8 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x163 children: inline
-      line 0 width: 300, height: 163, bottom: 163, baseline: 13.53125
-        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,21 300x150]
-      SVGSVGBox <svg> at (8,21) content-size 300x150 [SVG] children: not-inline
-        SVGTextBox <text> at (8,21) content-size 0x0 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x163.53125 children: inline
+      line 0 width: 300, height: 163.53125, bottom: 163.53125, baseline: 13.53125
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,21.53125 300x150]
+      SVGSVGBox <svg> at (8,21.53125) content-size 300x150 [SVG] children: not-inline
+        SVGTextBox <text> at (8,21.53125) content-size 0x0 children: not-inline
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
+++ b/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
@@ -1,43 +1,43 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x100.9375 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 200.328125x100.9375 [BFC] children: not-inline
-        Box <table> at (9,9) content-size 198.328125x98.9375 table-box [TFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x98.9375 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 197.328125x98.9375 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 195.328125x96.9375 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 198.328125x98.9375 table-row-group children: not-inline
-            Box <tr> at (9,9) content-size 198.328125x49.46875 table-row children: not-inline
+          Box <tbody> at (9,9) content-size 195.328125x96.9375 table-row-group children: not-inline
+            Box <tr> at (9,9) content-size 195.328125x48.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (25,25) content-size 32.078125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (24.5,24.5) content-size 32.078125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 32.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 3, rect: [25,25 32.078125x17.46875]
+                  frag 0 from TextNode start: 0, length: 3, rect: [24.5,24.5 32.078125x17.46875]
                     "Top"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (89.078125,74.46875) content-size 55.984375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (87.578125,72.96875) content-size 55.984375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 55.984375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 6, rect: [89.078125,74.46875 55.984375x17.46875]
+                  frag 0 from TextNode start: 0, length: 6, rect: [87.578125,72.96875 55.984375x17.46875]
                     "Bottom"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (177.0625,25) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (174.5625,24.5) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [177.0625,25 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [174.5625,24.5 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (9,58.46875) content-size 198.328125x49.46875 table-row children: not-inline
+            Box <tr> at (9,57.46875) content-size 195.328125x48.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (177.0625,74.46875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (174.5625,72.96875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [177.0625,74.46875 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [174.5625,72.96875 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/basic.txt
+++ b/Tests/LibWeb/Layout/expected/table/basic.txt
@@ -12,20 +12,20 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           BlockContainer <caption> at (8,10) content-size 82.734375x17.46875 [BFC] children: inline
             line 0 width: 82.734375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-              frag 0 from TextNode start: 1, length: 9, rect: [16,10 82.734375x17.46875]
+              frag 0 from TextNode start: 1, length: 9, rect: [16.21875,10 82.734375x17.46875]
                 "A Caption"
             TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <thead> at (8,10) content-size 95.171875x19.46875 table-header-group children: not-inline
+          Box <thead> at (8,10) content-size 95.171875x19.15625 table-header-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,29.46875) content-size 95.171875x19.46875 table-row children: not-inline
+            Box <tr> at (10,29.46875) content-size 95.171875x19.15625 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,30.46875) content-size 93.171875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,30.3125) content-size 93.171875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 73.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,30.46875 73.65625x17.46875]
+                  frag 0 from TextNode start: 0, length: 9, rect: [11,30.3125 73.65625x17.46875]
                     "Head Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -34,15 +34,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,29.46875) content-size 95.171875x19.46875 table-row-group children: not-inline
+          Box <tbody> at (8,29.15625) content-size 95.171875x19.15625 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,50.9375) content-size 95.171875x19.46875 table-row children: not-inline
+            Box <tr> at (10,50.625) content-size 95.171875x19.15625 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,51.9375) content-size 93.171875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,51.46875) content-size 93.171875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 70.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,51.9375 70.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 9, rect: [11,51.46875 70.234375x17.46875]
                     "Body Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -51,15 +51,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tfoot> at (8,48.9375) content-size 95.171875x19.46875 table-footer-group children: not-inline
+          Box <tfoot> at (8,48.3125) content-size 95.171875x19.15625 table-footer-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,72.40625) content-size 95.171875x19.46875 table-row children: not-inline
+            Box <tr> at (10,71.78125) content-size 95.171875x19.15625 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,73.40625) content-size 93.171875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,72.625) content-size 93.171875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 93.171875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 11, rect: [11,73.40625 93.171875x17.46875]
+                  frag 0 from TextNode start: 0, length: 11, rect: [11,72.625 93.171875x17.46875]
                     "Footer Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
@@ -1,154 +1,154 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x228.34375 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x223.875 [BFC] children: not-inline
     BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
       TextNode <#text>
-    BlockContainer <body> at (8,8) content-size 784x212.34375 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x207.875 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
-      BlockContainer <div.horizontal> at (8,8) content-size 784x212.34375 children: inline
-        line 0 width: 163.90625, height: 212.34375, bottom: 212.34375, baseline: 13.53125
-          frag 0 from BlockContainer start: 0, length: 0, rect: [9,22 161.90625x197.34375]
+      BlockContainer <div.horizontal> at (8,8) content-size 784x207.875 children: inline
+        line 0 width: 160.90625, height: 207.875, bottom: 207.875, baseline: 13.53125
+          frag 0 from BlockContainer start: 0, length: 0, rect: [9,22.53125 158.90625x192.34375]
         TextNode <#text>
-        BlockContainer <table> at (9,22) content-size 161.90625x197.34375 inline-block [BFC] children: not-inline
-          BlockContainer <(anonymous)> at (9,22) content-size 161.90625x0 children: inline
+        BlockContainer <table> at (9,22.53125) content-size 158.90625x192.34375 inline-block [BFC] children: not-inline
+          BlockContainer <(anonymous)> at (9,22.53125) content-size 158.90625x0 children: inline
             TextNode <#text>
-          TableWrapper <(anonymous)> at (9,22) content-size 161.90625x197.34375 inline-block [BFC] children: not-inline
-            Box <(anonymous)> at (9,22) content-size 161.90625x197.34375 inline-table table-box [TFC] children: not-inline
-              Box <tbody> at (9,22) content-size 161.90625x197.34375 table-row-group children: not-inline
+          TableWrapper <(anonymous)> at (9,22.53125) content-size 158.90625x192.34375 inline-block [BFC] children: not-inline
+            Box <(anonymous)> at (9,22.53125) content-size 158.90625x192.34375 inline-table table-box [TFC] children: not-inline
+              Box <tbody> at (9,22.53125) content-size 158.90625x180.3125 table-row-group children: not-inline
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                Box <tr> at (9,22) content-size 161.90625x39.46875 table-row children: not-inline
+                Box <tr> at (9,22.53125) content-size 158.90625x36.0625 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (30,33) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (29.5,31.828125) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                     line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [30,33 14.265625x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [29.5,31.828125 14.265625x17.46875]
                         "A"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (86.265625,33) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (84.765625,31.828125) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                     line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [88.265625,33 9.34375x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [86.359375,31.828125 9.34375x17.46875]
                         "B"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (140.8125,33) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (138.3125,31.828125) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                     line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [141.8125,33 6.34375x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [139.6875,31.828125 6.34375x17.46875]
                         "1"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                Box <tr> at (9,61.46875) content-size 161.90625x39.46875 table-row children: not-inline
+                Box <tr> at (9,58.59375) content-size 158.90625x36.0625 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (30,72.46875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (29.5,67.890625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                     line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [32,72.46875 10.3125x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [31.46875,67.890625 10.3125x17.46875]
                         "C"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (86.265625,72.46875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (84.765625,67.890625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                     line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [87.265625,72.46875 11.140625x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [85.46875,67.890625 11.140625x17.46875]
                         "D"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (140.8125,72.46875) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (138.3125,67.890625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                     line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [140.8125,72.46875 8.8125x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [138.453125,67.890625 8.8125x17.46875]
                         "2"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                Box <tr> at (9,100.9375) content-size 161.90625x39.46875 table-row children: not-inline
+                Box <tr> at (9,94.65625) content-size 158.90625x36.0625 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (30,111.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (29.5,103.953125) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                     line 0 width: 11.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [31,111.9375 11.859375x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [30.703125,103.953125 11.859375x17.46875]
                         "E"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (86.265625,111.9375) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (84.765625,103.953125) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                     line 0 width: 12.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [86.265625,111.9375 12.546875x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [84.765625,103.953125 12.546875x17.46875]
                         "F"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (140.8125,111.9375) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (138.3125,103.953125) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                     line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [140.8125,111.9375 9.09375x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [138.3125,103.953125 9.09375x17.46875]
                         "3"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                Box <tr> at (9,140.40625) content-size 161.90625x39.46875 table-row children: not-inline
+                Box <tr> at (9,130.71875) content-size 158.90625x36.0625 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (30,151.40625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (29.5,140.015625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                     line 0 width: 13.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [31,151.40625 13.234375x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [30.015625,140.015625 13.234375x17.46875]
                         "G"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (86.265625,151.40625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (84.765625,140.015625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                     line 0 width: 12.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [86.265625,151.40625 12.234375x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [84.921875,140.015625 12.234375x17.46875]
                         "H"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (140.8125,151.40625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (138.3125,140.015625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                     line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [141.8125,151.40625 7.75x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [138.984375,140.015625 7.75x17.46875]
                         "4"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                Box <tr> at (9,179.875) content-size 161.90625x39.46875 table-row children: not-inline
+                Box <tr> at (9,166.78125) content-size 158.90625x36.0625 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (30,190.875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (29.5,176.078125) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                     line 0 width: 4.59375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [35,190.875 4.59375x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [34.328125,176.078125 4.59375x17.46875]
                         "I"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (86.265625,190.875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (84.765625,176.078125) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                     line 0 width: 8.90625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [88.265625,190.875 8.90625x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [86.578125,176.078125 8.90625x17.46875]
                         "J"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (140.8125,190.875) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (138.3125,176.078125) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                     line 0 width: 8.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [140.8125,190.875 8.453125x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [138.625,176.078125 8.453125x17.46875]
                         "5"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-              BlockContainer <(anonymous)> at (9,22) content-size 0x0 children: inline
+              BlockContainer <(anonymous)> at (9,22.53125) content-size 0x0 children: inline
                 TextNode <#text>
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,220.34375) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,215.875) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
@@ -1,59 +1,59 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x86.9375 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 172.671875x86.9375 [BFC] children: not-inline
-        Box <table> at (8,8) content-size 172.671875x86.9375 table-box [TFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x84.9375 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 169.671875x84.9375 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 169.671875x84.9375 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 172.671875x86.9375 table-row-group children: not-inline
+          Box <tbody> at (8,8) content-size 169.671875x84.9375 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,8) content-size 172.671875x43.46875 table-row children: not-inline
+            Box <tr> at (8,8) content-size 169.671875x42.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (29,21) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (28.5,20.5) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [29,21 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [28.5,20.5 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td.td-thick-border> at (89.265625,21) content-size 9.859375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td.td-thick-border> at (87.765625,20.5) content-size 9.859375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [89.265625,21 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [87.765625,20.5 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (145.125,20) content-size 14.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (142.625,19.5) content-size 14.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [145.125,20 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [142.625,19.5 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,51.46875) content-size 172.671875x43.46875 table-row children: not-inline
+            Box <tr> at (8,50.46875) content-size 169.671875x42.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (29,64.46875) content-size 16.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (28.5,62.96875) content-size 16.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [29,64.46875 11.140625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [28.5,62.96875 11.140625x17.46875]
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,65.46875) content-size 11.859375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.765625,63.96875) content-size 11.859375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,65.46875 11.859375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,63.96875 11.859375x17.46875]
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td.td-thick-border> at (145.125,64.46875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td.td-thick-border> at (142.625,62.96875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [145.125,64.46875 12.546875x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [142.625,62.96875 12.546875x17.46875]
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
@@ -1,63 +1,63 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x177.875 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x173.875 [BFC] children: not-inline
     BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
       TextNode <#text>
-    BlockContainer <body> at (8,8) content-size 784x161.875 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x157.875 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
-      TableWrapper <(anonymous)> at (8,8) content-size 60.265625x161.875 [BFC] children: not-inline
-        Box <table> at (8,8) content-size 60.265625x161.875 table-box [TFC] children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 59.265625x157.875 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 59.265625x157.875 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
           BlockContainer <colgroup> (not painted) table-column-group children: not-inline
             BlockContainer <col> (not painted) children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 60.265625x161.875 table-row-group children: not-inline
+          Box <tbody> at (8,8) content-size 59.265625x152.9375 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,8) content-size 60.265625x41.468749 table-row children: not-inline
+            Box <tr> at (8,8) content-size 59.265625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,20.999999) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,20) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,20.999999 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,20 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,49.468749) content-size 60.265625x39.46875 table-row children: not-inline
+            Box <tr> at (8,47.46875) content-size 59.265625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,60.468749) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,57.234375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,60.468749 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,57.234375 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,88.9375) content-size 60.265625x39.46875 table-row children: not-inline
+            Box <tr> at (8,84.46875) content-size 59.265625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,99.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,94.234375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,99.9375 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,94.234375 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,128.40625) content-size 60.265625x41.468749 table-row children: not-inline
+            Box <tr> at (8,121.46875) content-size 59.265625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,139.40625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,131.46875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,139.40625 11.140625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,131.46875 11.140625x17.46875]
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -66,5 +66,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-      BlockContainer <(anonymous)> at (8,169.875) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,165.875) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
@@ -1,64 +1,64 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x130.40625 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 114.8125x130.40625 [BFC] children: not-inline
-        Box <table> at (8,8) content-size 114.8125x130.40625 table-box [TFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x127.40625 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 112.8125x127.40625 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 112.8125x127.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 114.8125x130.40625 table-row-group children: not-inline
+          Box <tbody> at (8,8) content-size 112.8125x125.390625 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr.td-thick-border> at (8,8) content-size 114.8125x43.46875 table-row children: not-inline
+            Box <tr.td-thick-border> at (8,8) content-size 112.8125x41.796875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,21) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,20.171875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,21 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,20.171875 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,21) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.765625,20.171875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,21 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,20.171875 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,51.46875) content-size 114.8125x43.46875 table-row children: not-inline
+            Box <tr> at (8,49.796875) content-size 112.8125x41.796875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (29,64.46875) content-size 16.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (28.5,61.96875) content-size 16.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [29,64.46875 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [28.5,61.96875 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,64.46875) content-size 14.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.765625,61.96875) content-size 14.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,64.46875 11.140625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,61.96875 11.140625x17.46875]
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr.td-thick-border> at (8,94.9375) content-size 114.8125x43.46875 table-row children: not-inline
+            Box <tr.td-thick-border> at (8,91.59375) content-size 112.8125x41.796875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,107.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,103.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,107.9375 11.859375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,103.765625 11.859375x17.46875]
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,107.9375) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.765625,103.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,107.9375 12.546875x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,103.765625 12.546875x17.46875]
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
@@ -1,65 +1,65 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x124.40625 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 113.40625x124.40625 [BFC] children: not-inline
-        Box <table> at (8,8) content-size 113.40625x124.40625 table-box [TFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x121.40625 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 111.40625x121.40625 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 111.40625x121.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <thead> at (8,8) content-size 113.40625x41.46875 table-header-group children: not-inline
+          Box <thead> at (8,8) content-size 111.40625x39.828125 table-header-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,8) content-size 113.40625x41.46875 table-row children: not-inline
-              BlockContainer <td> at (29,19) content-size 16.265625x17.46875 table-cell [BFC] children: inline
+            Box <tr> at (8,8) content-size 111.40625x39.828125 table-row children: not-inline
+              BlockContainer <td> at (28.5,18.1875) content-size 16.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.59375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [29,19 9.59375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [28.5,18.1875 9.59375x17.46875]
                     "0"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,19) content-size 13.140625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.765625,18.1875) content-size 13.140625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,19 6.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,18.1875 6.34375x17.46875]
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody.thick-border> at (8,49.46875) content-size 113.40625x82.9375 table-row-group children: not-inline
+          Box <tbody.thick-border> at (8,47.828125) content-size 111.40625x79.65625 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,49.46875) content-size 113.40625x41.46875 table-row children: not-inline
+            Box <tr> at (8,47.828125) content-size 111.40625x39.828125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,62.46875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,60.015625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,62.46875 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,60.015625 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,62.46875) content-size 11.140625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.765625,60.015625) content-size 11.140625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,62.46875 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,60.015625 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,90.9375) content-size 113.40625x41.46875 table-row children: not-inline
+            Box <tr> at (8,87.65625) content-size 111.40625x39.828125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,101.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,97.84375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,101.9375 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,97.84375 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,101.9375) content-size 11.140625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.765625,97.84375) content-size 11.140625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,101.9375 11.140625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,97.84375 11.140625x17.46875]
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
@@ -9,126 +9,126 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 241.90625x257.34375 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 161.90625x197.34375 table-row-group children: not-inline
+          Box <tbody> at (9,9) content-size 161.90625x185 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,19) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,19) content-size 161.90625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,30) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,28.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [50,28.765625 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,30) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,28.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.265625,30 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [127.859375,28.765625 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,30) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,28.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.8125,30 6.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [202.1875,28.765625 6.34375x17.46875]
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,68.46875) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,66) content-size 161.90625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,79.46875) content-size 88.8125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,75.765625) content-size 88.8125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [89,79.46875 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [89.25,75.765625 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,79.46875) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,75.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,79.46875 8.8125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.953125,75.765625 8.8125x17.46875]
                     "2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,117.9375) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,113) content-size 161.90625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,128.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,122.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [51,128.9375 11.859375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [51.203125,122.765625 11.859375x17.46875]
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,128.9375) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,122.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128.9375 12.546875x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,122.765625 12.546875x17.46875]
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,128.9375) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,122.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128.9375 9.09375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,122.765625 9.09375x17.46875]
                     "3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,167.40625) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,160) content-size 161.90625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,178.40625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,169.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 13.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [51,178.40625 13.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [50.515625,169.765625 13.234375x17.46875]
                     "G"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,178.40625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,169.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,178.40625 12.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.421875,169.765625 12.234375x17.46875]
                     "H"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,178.40625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,169.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.8125,178.40625 7.75x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.484375,169.765625 7.75x17.46875]
                     "4"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,216.875) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,207) content-size 161.90625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,227.875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,216.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 4.59375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [55,227.875 4.59375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [54.828125,216.765625 4.59375x17.46875]
                     "I"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,227.875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,216.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.90625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.265625,227.875 8.90625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [128.078125,216.765625 8.90625x17.46875]
                     "J"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,227.875) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,216.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,227.875 8.453125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.125,216.765625 8.453125x17.46875]
                     "5"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
@@ -9,126 +9,126 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 241.90625x257.34375 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 161.90625x197.34375 table-row-group children: not-inline
+          Box <tbody> at (9,9) content-size 161.90625x185 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,19) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,19) content-size 161.90625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,54.734375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,52.265625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [50,54.734375 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [50,52.265625 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,30) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,28.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.265625,30 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [127.859375,28.765625 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,30) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,28.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.8125,30 6.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [202.1875,28.765625 6.34375x17.46875]
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,68.46875) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,66) content-size 161.90625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,79.46875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,75.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [127.265625,79.46875 11.140625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.96875,75.765625 11.140625x17.46875]
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,79.46875) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,75.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,79.46875 8.8125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.953125,75.765625 8.8125x17.46875]
                     "2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,117.9375) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,113) content-size 161.90625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,128.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,122.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [51,128.9375 11.859375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [51.203125,122.765625 11.859375x17.46875]
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,128.9375) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,122.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128.9375 12.546875x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,122.765625 12.546875x17.46875]
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,128.9375) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,122.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128.9375 9.09375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,122.765625 9.09375x17.46875]
                     "3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,167.40625) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,160) content-size 161.90625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,178.40625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,169.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 13.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [51,178.40625 13.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [50.515625,169.765625 13.234375x17.46875]
                     "G"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,178.40625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,169.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,178.40625 12.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.421875,169.765625 12.234375x17.46875]
                     "H"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,178.40625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,169.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.8125,178.40625 7.75x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.484375,169.765625 7.75x17.46875]
                     "4"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,216.875) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,207) content-size 161.90625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,227.875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,216.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 4.59375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [55,227.875 4.59375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [54.828125,216.765625 4.59375x17.46875]
                     "I"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,227.875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,216.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.90625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.265625,227.875 8.90625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [128.078125,216.765625 8.90625x17.46875]
                     "J"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,227.875) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,216.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,227.875 8.453125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.125,216.765625 8.453125x17.46875]
                     "5"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
@@ -1,25 +1,25 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: inline
-      BlockContainer <div.left> at (8,8) content-size 117.599999x17.46875 floating [BFC] children: inline
+      BlockContainer <div.left> at (8,8) content-size 117.59375x17.46875 floating [BFC] children: inline
         line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
           frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17.46875]
             "A"
         TextNode <#text>
       TextNode <#text>
-      TableWrapper <(anonymous)> at (125.599999,8) content-size 478.24x23.46875 floating [BFC] children: not-inline
-        Box <table.middle> at (125.599999,8) content-size 478.24x23.46875 table-box [TFC] children: not-inline
+      TableWrapper <(anonymous)> at (125.59375,8) content-size 478.234375x23.46875 floating [BFC] children: not-inline
+        Box <table.middle> at (125.59375,8) content-size 478.234375x23.46875 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (125.599999,8) content-size 474.24x19.46875 table-row-group children: not-inline
+          Box <tbody> at (125.59375,8) content-size 474.234375x19.46875 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (127.599999,10) content-size 474.24x19.46875 table-row children: not-inline
+            Box <tr> at (127.59375,10) content-size 474.234375x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (128.599999,11) content-size 472.24x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (128.59375,11) content-size 472.234375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.599999,11 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [128.59375,11 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -29,8 +29,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
       TextNode <#text>
-      BlockContainer <div.right> at (8,32) content-size 188.159999x17.46875 floating [BFC] children: inline
+      BlockContainer <div.right> at (603.828125,8) content-size 188.15625x17.46875 floating [BFC] children: inline
         line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 1, length: 1, rect: [8,32 10.3125x17.46875]
+          frag 0 from TextNode start: 1, length: 1, rect: [603.828125,8 10.3125x17.46875]
             "C"
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/border-spacing.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing.txt
@@ -9,133 +9,133 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 241.90625x257.34375 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 161.90625x197.34375 table-row-group children: not-inline
+          Box <tbody> at (9,9) content-size 161.90625x185 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,19) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,19) content-size 161.90625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,30) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,28.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [50,28.765625 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,30) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,28.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.265625,30 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [127.859375,28.765625 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,30) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,28.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.8125,30 6.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [202.1875,28.765625 6.34375x17.46875]
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,68.46875) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,66) content-size 161.90625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,79.46875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,75.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [52,79.46875 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [51.96875,75.765625 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,79.46875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,75.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [127.265625,79.46875 11.140625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.96875,75.765625 11.140625x17.46875]
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,79.46875) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,75.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,79.46875 8.8125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.953125,75.765625 8.8125x17.46875]
                     "2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,117.9375) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,113) content-size 161.90625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,128.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,122.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [51,128.9375 11.859375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [51.203125,122.765625 11.859375x17.46875]
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,128.9375) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,122.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128.9375 12.546875x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,122.765625 12.546875x17.46875]
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,128.9375) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,122.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128.9375 9.09375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,122.765625 9.09375x17.46875]
                     "3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,167.40625) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,160) content-size 161.90625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,178.40625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,169.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 13.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [51,178.40625 13.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [50.515625,169.765625 13.234375x17.46875]
                     "G"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,178.40625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,169.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,178.40625 12.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.421875,169.765625 12.234375x17.46875]
                     "H"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,178.40625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,169.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.8125,178.40625 7.75x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.484375,169.765625 7.75x17.46875]
                     "4"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,216.875) content-size 161.90625x39.46875 table-row children: not-inline
+            Box <tr> at (29,207) content-size 161.90625x37 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,227.875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,216.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 4.59375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [55,227.875 4.59375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [54.828125,216.765625 4.59375x17.46875]
                     "I"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,227.875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,216.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.90625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.265625,227.875 8.90625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [128.078125,216.765625 8.90625x17.46875]
                     "J"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,227.875) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,216.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,227.875 8.453125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.125,216.765625 8.453125x17.46875]
                     "5"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/borders.txt
+++ b/Tests/LibWeb/Layout/expected/table/borders.txt
@@ -1,62 +1,62 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x265.625 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x261.625 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 174.296875x74.40625 [BFC] children: not-inline
         Box <table.table-border-black> at (9,9) content-size 172.296875x72.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 166.296875x64.40625 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 166.296875x21.46875 table-row children: not-inline
+          Box <tbody> at (9,9) content-size 166.296875x63.375 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 166.296875x21.125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,13) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (13,12.828125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 82.015625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 9, rect: [13,13 82.015625x17.46875]
+                  frag 0 from TextNode start: 0, length: 9, rect: [13,12.828125 82.015625x17.46875]
                     "Firstname"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (101.015625,13) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (101.015625,12.828125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 76.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 8, rect: [101.015625,13 76.28125x17.46875]
+                  frag 0 from TextNode start: 0, length: 8, rect: [101.015625,12.828125 76.28125x17.46875]
                     "Lastname"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,34.46875) content-size 166.296875x21.46875 table-row children: not-inline
+            Box <tr> at (11,34.125) content-size 166.296875x21.125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,36.46875) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (13,35.953125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 44.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 5, rect: [13,36.46875 44.65625x17.46875]
+                  frag 0 from TextNode start: 0, length: 5, rect: [13,35.953125 44.65625x17.46875]
                     "Peter"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (101.015625,36.46875) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (101.015625,35.953125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 7, rect: [101.015625,36.46875 53.671875x17.46875]
+                  frag 0 from TextNode start: 0, length: 7, rect: [101.015625,35.953125 53.671875x17.46875]
                     "Griffin"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,57.9375) content-size 166.296875x21.46875 table-row children: not-inline
+            Box <tr> at (11,57.25) content-size 166.296875x21.125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,59.9375) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (13,59.078125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 35.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 4, rect: [13,59.9375 35.125x17.46875]
+                  frag 0 from TextNode start: 0, length: 4, rect: [13,59.078125 35.125x17.46875]
                     "Lois"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (101.015625,59.9375) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (101.015625,59.078125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 7, rect: [101.015625,59.9375 53.671875x17.46875]
+                  frag 0 from TextNode start: 0, length: 7, rect: [101.015625,59.078125 53.671875x17.46875]
                     "Griffin"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -66,195 +66,195 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,82.40625) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      TableWrapper <(anonymous)> at (8,82.40625) content-size 164.296875x62.40625 [BFC] children: not-inline
-        Box <table.table-border-black> at (8,82.40625) content-size 164.296875x62.40625 table-box [TFC] children: not-inline
+      TableWrapper <(anonymous)> at (8,82.40625) content-size 163.296875x60.40625 [BFC] children: not-inline
+        Box <table.table-border-black> at (8,82.40625) content-size 163.296875x60.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,82.40625) content-size 164.296875x62.40625 table-row-group children: not-inline
-            Box <tr> at (8,82.40625) content-size 164.296875x20.46875 table-row children: not-inline
+          Box <tbody> at (8,82.40625) content-size 163.296875x59.4375 table-row-group children: not-inline
+            Box <tr> at (8,82.40625) content-size 163.296875x19.8125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (9,83.40625) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (9,83.328125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 82.015625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 9, rect: [9,83.40625 82.015625x17.46875]
+                  frag 0 from TextNode start: 0, length: 9, rect: [9,83.328125 82.015625x17.46875]
                     "Firstname"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (95.015625,83.40625) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (94.015625,83.328125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 76.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 8, rect: [95.015625,83.40625 76.28125x17.46875]
+                  frag 0 from TextNode start: 0, length: 8, rect: [94.015625,83.328125 76.28125x17.46875]
                     "Lastname"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,102.875) content-size 164.296875x21.46875 table-row children: not-inline
+            Box <tr> at (8,102.21875) content-size 163.296875x19.8125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (9,104.875) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (9,103.390625) content-size 82.015625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 44.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 5, rect: [9,104.875 44.65625x17.46875]
+                  frag 0 from TextNode start: 0, length: 5, rect: [9,103.390625 44.65625x17.46875]
                     "Peter"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (95.015625,104.875) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (94.015625,103.390625) content-size 76.28125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 7, rect: [95.015625,104.875 53.671875x17.46875]
+                  frag 0 from TextNode start: 0, length: 7, rect: [94.015625,103.390625 53.671875x17.46875]
                     "Griffin"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,124.34375) content-size 164.296875x20.46875 table-row children: not-inline
+            Box <tr> at (8,122.03125) content-size 163.296875x19.8125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (9,126.34375) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (9,123.453125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 35.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 4, rect: [9,126.34375 35.125x17.46875]
+                  frag 0 from TextNode start: 0, length: 4, rect: [9,123.453125 35.125x17.46875]
                     "Lois"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (95.015625,126.34375) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (94.015625,123.453125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 7, rect: [95.015625,126.34375 53.671875x17.46875]
+                  frag 0 from TextNode start: 0, length: 7, rect: [94.015625,123.453125 53.671875x17.46875]
                     "Griffin"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-      BlockContainer <(anonymous)> at (8,144.8125) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,142.8125) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      TableWrapper <(anonymous)> at (8,144.8125) content-size 160.296875x56.40625 [BFC] children: not-inline
-        Box <div.table.border-black> at (8,144.8125) content-size 160.296875x56.40625 table-box [TFC] children: not-inline
+      TableWrapper <(anonymous)> at (8,142.8125) content-size 159.296875x54.40625 [BFC] children: not-inline
+        Box <div.table.border-black> at (8,142.8125) content-size 159.296875x54.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <div.table-row.border-black> at (8,144.8125) content-size 160.296875x18.46875 table-row children: not-inline
+          Box <div.table-row.border-black> at (8,142.8125) content-size 159.296875x17.84375 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (8,144.8125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.border-black> at (8,142.8125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
               line 0 width: 82.015625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 9, rect: [8,144.8125 82.015625x17.46875]
+                frag 0 from TextNode start: 0, length: 9, rect: [8,142.8125 82.015625x17.46875]
                   "Firstname"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (92.015625,144.8125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.border-black> at (91.015625,142.8125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
               line 0 width: 76.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 8, rect: [92.015625,144.8125 76.28125x17.46875]
+                frag 0 from TextNode start: 0, length: 8, rect: [91.015625,142.8125 76.28125x17.46875]
                   "Lastname"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <div.table-row.border-black> at (8,163.28125) content-size 160.296875x19.46875 table-row children: not-inline
+          Box <div.table-row.border-black> at (8,160.65625) content-size 159.296875x17.84375 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (8,164.28125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.border-black> at (8,161.15625) content-size 82.015625x17.46875 table-cell [BFC] children: inline
               line 0 width: 44.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 5, rect: [8,164.28125 44.65625x17.46875]
+                frag 0 from TextNode start: 0, length: 5, rect: [8,161.15625 44.65625x17.46875]
                   "Peter"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (92.015625,164.28125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.border-black> at (91.015625,161.15625) content-size 76.28125x17.46875 table-cell [BFC] children: inline
               line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 7, rect: [92.015625,164.28125 53.671875x17.46875]
+                frag 0 from TextNode start: 0, length: 7, rect: [91.015625,161.15625 53.671875x17.46875]
                   "Griffin"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <div.table-row.border-black> at (8,182.75) content-size 160.296875x18.46875 table-row children: not-inline
+          Box <div.table-row.border-black> at (8,178.5) content-size 159.296875x17.84375 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (8,183.75) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.border-black> at (8,179) content-size 82.015625x17.46875 table-cell [BFC] children: inline
               line 0 width: 35.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 4, rect: [8,183.75 35.125x17.46875]
+                frag 0 from TextNode start: 0, length: 4, rect: [8,179 35.125x17.46875]
                   "Lois"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (92.015625,183.75) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.border-black> at (91.015625,179) content-size 76.28125x17.46875 table-cell [BFC] children: inline
               line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 7, rect: [92.015625,183.75 53.671875x17.46875]
+                frag 0 from TextNode start: 0, length: 7, rect: [91.015625,179 53.671875x17.46875]
                   "Griffin"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-      BlockContainer <(anonymous)> at (8,201.21875) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,197.21875) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
-      TableWrapper <(anonymous)> at (8,201.21875) content-size 168.296875x72.40625 [BFC] children: not-inline
-        Box <div.table.thick-border-black> at (8,201.21875) content-size 168.296875x72.40625 table-box [TFC] children: not-inline
+      TableWrapper <(anonymous)> at (8,197.21875) content-size 168.296875x72.40625 [BFC] children: not-inline
+        Box <div.table.thick-border-black> at (8,197.21875) content-size 168.296875x72.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <div.table-row.thick-border-black> at (8,201.21875) content-size 168.296875x22.46875 table-row children: not-inline
+          Box <div.table-row.thick-border-black> at (8,197.21875) content-size 168.296875x21.484375 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (8,201.21875) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.thick-border-black> at (8,197.21875) content-size 82.015625x17.46875 table-cell [BFC] children: inline
               line 0 width: 82.015625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 9, rect: [8,201.21875 82.015625x17.46875]
+                frag 0 from TextNode start: 0, length: 9, rect: [8,197.21875 82.015625x17.46875]
                   "Firstname"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (100.015625,201.21875) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.thick-border-black> at (100.015625,197.21875) content-size 76.28125x17.46875 table-cell [BFC] children: inline
               line 0 width: 76.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 8, rect: [100.015625,201.21875 76.28125x17.46875]
+                frag 0 from TextNode start: 0, length: 8, rect: [100.015625,197.21875 76.28125x17.46875]
                   "Lastname"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <div.table-row.thick-border-black> at (8,223.6875) content-size 168.296875x27.46875 table-row children: not-inline
+          Box <div.table-row.thick-border-black> at (8,218.703125) content-size 168.296875x27.140625 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (8,228.6875) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.thick-border-black> at (8,223.703125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
               line 0 width: 44.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 5, rect: [8,228.6875 44.65625x17.46875]
+                frag 0 from TextNode start: 0, length: 5, rect: [8,223.703125 44.65625x17.46875]
                   "Peter"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (100.015625,228.6875) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.thick-border-black> at (100.015625,223.703125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
               line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 7, rect: [100.015625,228.6875 53.671875x17.46875]
+                frag 0 from TextNode start: 0, length: 7, rect: [100.015625,223.703125 53.671875x17.46875]
                   "Griffin"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <div.table-row.thick-border-black> at (8,251.15625) content-size 168.296875x22.46875 table-row children: not-inline
+          Box <div.table-row.thick-border-black> at (8,245.84375) content-size 168.296875x21.484375 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (8,256.15625) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.thick-border-black> at (8,250.84375) content-size 82.015625x17.46875 table-cell [BFC] children: inline
               line 0 width: 35.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 4, rect: [8,256.15625 35.125x17.46875]
+                frag 0 from TextNode start: 0, length: 4, rect: [8,250.84375 35.125x17.46875]
                   "Lois"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (100.015625,256.15625) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.thick-border-black> at (100.015625,250.84375) content-size 76.28125x17.46875 table-cell [BFC] children: inline
               line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 7, rect: [100.015625,256.15625 53.671875x17.46875]
+                frag 0 from TextNode start: 0, length: 7, rect: [100.015625,250.84375 53.671875x17.46875]
                   "Griffin"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-      BlockContainer <(anonymous)> at (8,273.625) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,269.625) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
+++ b/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
@@ -9,20 +9,20 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           BlockContainer <caption> at (8,74.40625) content-size 82.734375x17.46875 [BFC] children: inline
             line 0 width: 82.734375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-              frag 0 from TextNode start: 1, length: 9, rect: [16,74.40625 82.734375x17.46875]
+              frag 0 from TextNode start: 1, length: 9, rect: [16.21875,74.40625 82.734375x17.46875]
                 "A Caption"
             TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <thead> at (8,8) content-size 95.171875x19.46875 table-header-group children: not-inline
+          Box <thead> at (8,8) content-size 95.171875x19.15625 table-header-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,10) content-size 95.171875x19.46875 table-row children: not-inline
+            Box <tr> at (10,10) content-size 95.171875x19.15625 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 93.171875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,10.84375) content-size 93.171875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 73.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,11 73.65625x17.46875]
+                  frag 0 from TextNode start: 0, length: 9, rect: [11,10.84375 73.65625x17.46875]
                     "Head Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -31,15 +31,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,27.46875) content-size 95.171875x19.46875 table-row-group children: not-inline
+          Box <tbody> at (8,27.15625) content-size 95.171875x19.15625 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,31.46875) content-size 95.171875x19.46875 table-row children: not-inline
+            Box <tr> at (10,31.15625) content-size 95.171875x19.15625 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32.46875) content-size 93.171875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,32) content-size 93.171875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 70.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,32.46875 70.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 9, rect: [11,32 70.234375x17.46875]
                     "Body Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -48,15 +48,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tfoot> at (8,46.9375) content-size 95.171875x19.46875 table-footer-group children: not-inline
+          Box <tfoot> at (8,46.3125) content-size 95.171875x19.15625 table-footer-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,52.9375) content-size 95.171875x19.46875 table-row children: not-inline
+            Box <tr> at (10,52.3125) content-size 95.171875x19.15625 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,53.9375) content-size 93.171875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,53.15625) content-size 93.171875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 93.171875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 11, rect: [11,53.9375 93.171875x17.46875]
+                  frag 0 from TextNode start: 0, length: 11, rect: [11,53.15625 93.171875x17.46875]
                     "Footer Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
@@ -8,29 +8,29 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <table#table> at (8,8) content-size 80x23.46875 table-box [TFC] children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tbody> at (8,8) content-size 72x19.46875 table-row-group children: not-inline
+            Box <tbody> at (8,8) content-size 71.984375x19.46875 table-row-group children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              Box <tr> at (10,10) content-size 72x19.46875 table-row children: not-inline
+              Box <tr> at (10,10) content-size 71.984375x19.46875 table-row children: not-inline
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                BlockContainer <td> at (11,11) content-size 17.828571x17.46875 table-cell [BFC] children: inline
+                BlockContainer <td> at (11,11) content-size 17.828125x17.46875 table-cell [BFC] children: inline
                   line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                     frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x17.46875]
                       "A"
                   TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                BlockContainer <td> at (32.828571,11) content-size 11.828571x17.46875 table-cell [BFC] children: inline
+                BlockContainer <td> at (32.828125,11) content-size 11.828125x17.46875 table-cell [BFC] children: inline
                   line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                    frag 0 from TextNode start: 0, length: 1, rect: [32.828571,11 9.34375x17.46875]
+                    frag 0 from TextNode start: 0, length: 1, rect: [32.828125,11 9.34375x17.46875]
                       "B"
                   TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                BlockContainer <td> at (48.657142,11) content-size 36.342857x17.46875 table-cell [BFC] children: inline
+                BlockContainer <td> at (48.65625,11) content-size 36.328125x17.46875 table-cell [BFC] children: inline
                   line 0 width: 29.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                    frag 0 from TextNode start: 0, length: 3, rect: [48.657142,11 29.453125x17.46875]
+                    frag 0 from TextNode start: 0, length: 3, rect: [48.65625,11 29.453125x17.46875]
                       "C D"
                   TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
@@ -5,55 +5,55 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (8,8) content-size 784x44.9375 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 776x38.9375 table-row-group children: not-inline
+          Box <tbody> at (8,8) content-size 775.96875x38.9375 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,10) content-size 776x19.46875 table-row children: not-inline
+            Box <tr> at (10,10) content-size 775.96875x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (11,11) content-size 300.639999x17.46875 table-cell [BFC] children: inline
+              BlockContainer <th> at (11,11) content-size 300.625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [154,11 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [154.171875,11 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (315.639999,11) content-size 168.719999x17.46875 table-cell [BFC] children: inline
+              BlockContainer <th> at (315.625,11) content-size 168.71875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [395.639999,11 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [395.3125,11 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (488.36,11) content-size 300.639999x17.46875 table-cell [BFC] children: inline
+              BlockContainer <th> at (488.34375,11) content-size 300.625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 29.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 3, rect: [624.36,11 29.453125x17.46875]
+                  frag 0 from TextNode start: 0, length: 3, rect: [623.921875,11 29.453125x17.46875]
                     "C D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,31.46875) content-size 776x19.46875 table-row children: not-inline
+            Box <tr> at (10,31.46875) content-size 775.96875x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32.46875) content-size 300.639999x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,32.46875) content-size 300.625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [155,32.46875 11.859375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [155.375,32.46875 11.859375x17.46875]
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (315.639999,32.46875) content-size 168.719999x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (315.625,32.46875) content-size 168.71875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [393.639999,32.46875 12.546875x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [393.703125,32.46875 12.546875x17.46875]
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (488.36,32.46875) content-size 300.639999x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (488.34375,32.46875) content-size 300.625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 13.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [632.36,32.46875 13.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [632.03125,32.46875 13.234375x17.46875]
                     "G"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
+++ b/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
@@ -1,62 +1,62 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x118.40625 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 92.359375x118.40625 [BFC] children: not-inline
-        Box <table> at (8,8) content-size 92.359375x118.40625 table-box [TFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x115.40625 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 89.359375x115.40625 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 89.359375x115.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 92.359375x118.40625 table-row-group children: not-inline
-            Box <tr> at (8,8) content-size 92.359375x39.46875 table-row children: not-inline
+          Box <tbody> at (8,8) content-size 89.359375x113.578125 table-row-group children: not-inline
+            Box <tr> at (8,8) content-size 89.359375x37.859375 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (19,19) content-size 8.453125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (18.5,18.203125) content-size 8.453125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [19,19 6.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [18.5,18.203125 6.34375x17.46875]
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (49.453125,19) content-size 8.8125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (47.953125,18.203125) content-size 8.8125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [49.453125,19 8.8125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [47.953125,18.203125 8.8125x17.46875]
                     "2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (80.265625,19) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (77.765625,18.203125) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [80.265625,19 9.09375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [77.765625,18.203125 9.09375x17.46875]
                     "3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,47.46875) content-size 92.359375x39.46875 table-row children: not-inline
+            Box <tr> at (8,45.859375) content-size 89.359375x37.859375 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (19,58.46875) content-size 8.453125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (18.5,56.0625) content-size 8.453125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [19,58.46875 7.75x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [18.5,56.0625 7.75x17.46875]
                     "4"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (49.453125,78.203125) content-size 39.90625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (47.953125,74.984375) content-size 38.90625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 24.046875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 3, rect: [49.453125,78.203125 24.046875x17.46875]
+                  frag 0 from TextNode start: 0, length: 3, rect: [47.953125,74.984375 24.046875x17.46875]
                     "6-9"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,86.9375) content-size 92.359375x39.46875 table-row children: not-inline
+            Box <tr> at (8,83.71875) content-size 89.359375x37.859375 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (19,97.9375) content-size 8.453125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (18.5,93.921875) content-size 8.453125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [19,97.9375 8.453125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [18.5,93.921875 8.453125x17.46875]
                     "5"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
@@ -9,23 +9,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 418x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 79.6x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,11) content-size 79.6875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [44,11 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [43.703125,11 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (94.6,11) content-size 157.343276x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (94.6875,11) content-size 157.3125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [168.6,11 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [168.671875,11 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (255.943276,11) content-size 169.056723x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (256,11) content-size 169x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [334.943276,11 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [335.34375,11 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -35,16 +35,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,30.46875) content-size 418x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32.46875) content-size 79.6x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,32.46875) content-size 79.6875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [45,32.46875 11.140625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [45.265625,32.46875 11.140625x17.46875]
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (94.6,32.46875) content-size 330.399999x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (94.6875,32.46875) content-size 330.3125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [253.6,32.46875 11.859375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [253.90625,32.46875 11.859375x17.46875]
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
@@ -11,14 +11,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
               BlockContainer <td> at (11,11) content-size 180x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [94,11 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [93.859375,11 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (195,11) content-size 20x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200,11 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.328125,11 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -30,7 +30,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
               BlockContainer <td> at (11,32.46875) content-size 204x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [108,32.46875 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [107.84375,32.46875 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
@@ -5,34 +5,34 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x44.9375 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
-      TableWrapper <(anonymous)> at (8,8) content-size 39.3125x44.9375 [BFC] children: not-inline
-        Box <table> at (9,9) content-size 37.3125x42.9375 table-box [TFC] children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 39.203125x44.9375 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 37.203125x42.9375 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 37.3125x42.9375 table-row-group children: not-inline
-            Box <tr> at (9,9) content-size 37.3125x21.46875 table-row children: not-inline
+          Box <tbody> at (9,9) content-size 37.203125x42.9375 table-row-group children: not-inline
+            Box <tr> at (9,9) content-size 37.203125x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 17.561202x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,11) content-size 17.46875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [13,11 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [12.59375,11 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (32.561202,11) content-size 11.751297x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (32.46875,11) content-size 11.734375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [33.561202,11 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [33.65625,11 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (9,30.46875) content-size 37.3125x21.46875 table-row children: not-inline
+            Box <tr> at (9,30.46875) content-size 37.203125x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32.46875) content-size 33.3125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,32.46875) content-size 33.203125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 33.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 3, rect: [11,32.46875 33.3125x17.46875]
                     "CDE"

--- a/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
@@ -1,31 +1,31 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x113.15625 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 784x113.15625 [BFC] children: not-inline
-        Box <table.ambox> at (9,9) content-size 784x111.15625 table-box [TFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x112.8125 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 784x112.8125 [BFC] children: not-inline
+        Box <table.ambox> at (9,9) content-size 784x110.8125 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 778x107.15625 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 778x107.15625 table-row children: not-inline
-              BlockContainer <td.mbox-image> at (12,39.578125) content-size 50x50 table-cell [BFC] children: not-inline
-                BlockContainer <div.mbox-image-div> at (12,39.578125) content-size 50x50 children: not-inline
-              BlockContainer <td.mbox-text> at (66,12) content-size 724x105.15625 table-cell [BFC] children: inline
+          Box <tbody> at (9,9) content-size 776.453125x106.8125 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 776.453125x106.8125 table-row children: not-inline
+              BlockContainer <td.mbox-image> at (12,39.40625) content-size 50x50 table-cell [BFC] children: not-inline
+                BlockContainer <div.mbox-image-div> at (12,39.40625) content-size 50x50 children: not-inline
+              BlockContainer <td.mbox-text> at (66,12) content-size 722.453125x104.8125 table-cell [BFC] children: inline
                 line 0 width: 689.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 1, length: 84, rect: [66,12 689.640625x17.46875]
                     "In a scene set in a lawyer's office, the lawyer sits alone and bounces a rubber ball"
-                line 1 width: 695.5625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-                  frag 0 from TextNode start: 86, length: 84, rect: [66,29 695.5625x17.46875]
+                line 1 width: 695.5625, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+                  frag 0 from TextNode start: 86, length: 84, rect: [66,29.46875 695.5625x17.46875]
                     "against the wall. They receive a call from their assistant who expresses frustration"
-                line 2 width: 703.125, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-                  frag 0 from TextNode start: 171, length: 85, rect: [66,46 703.125x17.46875]
+                line 2 width: 703.125, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+                  frag 0 from TextNode start: 171, length: 85, rect: [66,46.9375 703.125x17.46875]
                     "over a packed waiting room and the lawyer's lack of clients. The lawyer then looks at"
-                line 3 width: 695.90625, height: 17.875, bottom: 70.28125, baseline: 13.53125
-                  frag 0 from TextNode start: 257, length: 81, rect: [66,64 695.90625x17.46875]
+                line 3 width: 695.90625, height: 17.46875, bottom: 69.875, baseline: 13.53125
+                  frag 0 from TextNode start: 257, length: 81, rect: [66,64.40625 695.90625x17.46875]
                     "some papers from a large envelope, which turn out to be divorce papers from their"
-                line 4 width: 670.515625, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-                  frag 0 from TextNode start: 339, length: 84, rect: [66,81 670.515625x17.46875]
+                line 4 width: 670.515625, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+                  frag 0 from TextNode start: 339, length: 84, rect: [66,81.875 670.515625x17.46875]
                     "significant other. Finally, the lawyer instructs their assistant to send in the next"
-                line 5 width: 47.21875, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-                  frag 0 from TextNode start: 424, length: 7, rect: [66,99 47.21875x17.46875]
+                line 5 width: 47.21875, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+                  frag 0 from TextNode start: 424, length: 7, rect: [66,99.34375 47.21875x17.46875]
                     "client."
                 TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
@@ -1,15 +1,15 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x35.40625 children: not-inline
-      BlockContainer <div.wrapper> at (8,8) content-size 784x35.40625 children: not-inline
-        TableWrapper <(anonymous)> at (108,8) content-size 584x35.40625 [BFC] children: not-inline
-          Box <div.box> at (108,8) content-size 584x35.40625 table-box [TFC] children: not-inline
-            Box <(anonymous)> at (108,8) content-size 584x35.40625 table-row children: not-inline
-              BlockContainer <div.cell> at (108,8) content-size 584x35.40625 table-cell [BFC] children: inline
+    BlockContainer <body> at (8,8) content-size 784x34.9375 children: not-inline
+      BlockContainer <div.wrapper> at (8,8) content-size 784x34.9375 children: not-inline
+        TableWrapper <(anonymous)> at (108,8) content-size 584x34.9375 [BFC] children: not-inline
+          Box <div.box> at (108,8) content-size 584x34.9375 table-box [TFC] children: not-inline
+            Box <(anonymous)> at (108,8) content-size 575.171875x34.9375 table-row children: not-inline
+              BlockContainer <div.cell> at (108,8) content-size 575.171875x34.9375 table-cell [BFC] children: inline
                 line 0 width: 569.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 58, rect: [108,8 569.859375x17.46875]
                     "DaTa DisplaYiNg CSS WeBpaGE ScReEn OF aR AddITioN COmmOnLY"
-                line 1 width: 399.9375, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-                  frag 0 from TextNode start: 59, length: 40, rect: [108,25 399.9375x17.46875]
+                line 1 width: 399.9375, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+                  frag 0 from TextNode start: 59, length: 40, rect: [108,25.46875 399.9375x17.46875]
                     "To AdJuSt PRiCiNG sTYLiNG ceLL oF TAbLeS"
                 TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
@@ -1,38 +1,38 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x127.8125 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x127.34375 [BFC] children: not-inline
     BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
       TextNode <#text>
-    BlockContainer <body> at (8,8) content-size 784x111.8125 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 63.046875x111.8125 [BFC] children: not-inline
-        Box <table#full-table> at (10,43.40625) content-size 59.046875x72.40625 table-box [TFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x111.34375 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 63.046875x111.34375 [BFC] children: not-inline
+        Box <table#full-table> at (10,42.9375) content-size 59.046875x72.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          BlockContainer <caption> at (8,8) content-size 59.046875x35.40625 [BFC] children: inline
+          BlockContainer <caption> at (8,8) content-size 59.046875x34.9375 [BFC] children: inline
             line 0 width: 54.03125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-              frag 0 from TextNode start: 1, length: 6, rect: [11,8 54.03125x17.46875]
+              frag 0 from TextNode start: 1, length: 6, rect: [10.5,8 54.03125x17.46875]
                 "A long"
-            line 1 width: 59.046875, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-              frag 0 from TextNode start: 8, length: 7, rect: [8,25 59.046875x17.46875]
+            line 1 width: 59.046875, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+              frag 0 from TextNode start: 8, length: 7, rect: [8,25.46875 59.046875x17.46875]
                 "caption"
             TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <thead> at (10,10) content-size 53.046875x21.46875 table-header-group children: not-inline
+          Box <thead> at (10,10) content-size 53.03125x21.125 table-header-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (12,45.40625) content-size 53.046875x21.46875 table-row children: not-inline
+            Box <tr> at (12,44.9375) content-size 53.03125x21.125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (14,47.40625) content-size 21.256598x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (14,46.765625) content-size 21.25x17.46875 table-cell [BFC] children: inline
                 line 0 width: 20.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [14,47.40625 20.609375x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [14,46.765625 20.609375x17.46875]
                     "A1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (41.256598,47.40625) content-size 23.790276x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (41.25,46.765625) content-size 23.78125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 23.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [41.256598,47.40625 23.078125x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,46.765625 23.078125x17.46875]
                     "A2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -41,22 +41,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (10,31.46875) content-size 53.046875x21.46875 table-row-group children: not-inline
+          Box <tbody> at (10,31.125) content-size 53.03125x21.125 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (12,68.875) content-size 53.046875x21.46875 table-row children: not-inline
+            Box <tr> at (12,68.0625) content-size 53.03125x21.125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (14,70.875) content-size 21.256598x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (14,69.890625) content-size 21.25x17.46875 table-cell [BFC] children: inline
                 line 0 width: 15.6875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [14,70.875 15.6875x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [14,69.890625 15.6875x17.46875]
                     "B1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (41.256598,70.875) content-size 23.790276x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (41.25,69.890625) content-size 23.78125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 18.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [41.256598,70.875 18.15625x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,69.890625 18.15625x17.46875]
                     "B2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -65,22 +65,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tfoot> at (10,52.9375) content-size 53.046875x21.46875 table-footer-group children: not-inline
+          Box <tfoot> at (10,52.25) content-size 53.03125x21.125 table-footer-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (12,92.34375) content-size 53.046875x21.46875 table-row children: not-inline
+            Box <tr> at (12,91.1875) content-size 53.03125x21.125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (14,94.34375) content-size 21.256598x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (14,93.015625) content-size 21.25x17.46875 table-cell [BFC] children: inline
                 line 0 width: 18.890625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [14,94.34375 18.890625x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [14,93.015625 18.890625x17.46875]
                     "F1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (41.256598,94.34375) content-size 23.790276x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (41.25,93.015625) content-size 23.78125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 21.359375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [41.256598,94.34375 21.359375x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,93.015625 21.359375x17.46875]
                     "F2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -89,5 +89,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-      BlockContainer <(anonymous)> at (8,119.8125) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,119.34375) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
@@ -1,29 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x86.8125 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 81.4375x86.8125 [BFC] children: not-inline
-        Box <table> at (9,9) content-size 79.4375x84.8125 table-box [TFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x85.875 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 81.4375x85.875 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 79.4375x83.875 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 75.4375x78.8125 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 75.4375x21.468749 table-row children: not-inline
-              BlockContainer <td> at (13,12.999999) content-size 71.4375x17.46875 table-cell [BFC] children: inline
+          Box <tbody> at (9,9) content-size 75.4375x76.640625 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 75.4375x20.671875 table-row children: not-inline
+              BlockContainer <td> at (13,12.609375) content-size 71.4375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 7.9375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [13,12.999999 7.9375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [13,12.609375 7.9375x17.46875]
                     "*"
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,34.46875) content-size 75.4375x57.34375 table-row children: not-inline
-              BlockContainer <td> at (13,45.4375) content-size 71.4375x35.40625 table-cell [BFC] children: inline
+            Box <tr> at (11,33.671875) content-size 75.4375x55.96875 table-row children: not-inline
+              BlockContainer <td> at (13,44.1875) content-size 71.4375x34.9375 table-cell [BFC] children: inline
                 line 0 width: 71.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 9, rect: [13,45.4375 71.4375x17.46875]
+                  frag 0 from TextNode start: 0, length: 9, rect: [13,44.1875 71.4375x17.46875]
                     "*********"
-                line 1 width: 63.5625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-                  frag 0 from TextNode start: 10, length: 8, rect: [13,62.4375 63.5625x17.46875]
+                line 1 width: 63.5625, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+                  frag 0 from TextNode start: 10, length: 8, rect: [13,61.65625 63.5625x17.46875]
                     "***** **"
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-      BlockContainer <(anonymous)> at (8,94.8125) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,93.875) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
@@ -1,33 +1,33 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x23.46875 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 93.328125x23.46875 [BFC] children: not-inline
-        Box <table> at (9,9) content-size 91.328125x21.46875 table-box [TFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x22.46875 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 88.328125x22.46875 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 86.328125x20.46875 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 91.328125x21.46875 table-row-group children: not-inline
+          Box <tbody> at (9,9) content-size 86.328125x20.46875 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (9,9) content-size 91.328125x21.46875 table-row children: not-inline
+            Box <tr> at (9,9) content-size 86.328125x20.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (10.5,10.5) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [10.5,10.5 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (29.265625,11) content-size 50.796875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (27.765625,10.5) content-size 48.796875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [50.265625,11 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [47.484375,10.5 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (84.0625,11) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (79.5625,10.5) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [86.0625,11 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [81.53125,10.5 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,10) content-size 43.21875x9.734375 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,14.867187) content-size 0x0 table-cell [BFC] children: not-inline
+              BlockContainer <td> at (11,14.859375) content-size 0x0 table-cell [BFC] children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (16,12) content-size 37.21875x17.46875 table-cell [BFC] children: inline
@@ -27,7 +27,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,21.734375) content-size 43.21875x9.734375 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,26.601562) content-size 0x0 table-cell [BFC] children: not-inline
+              BlockContainer <td> at (11,26.59375) content-size 0x0 table-cell [BFC] children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
@@ -15,9 +15,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 67.828125x54.203125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (17,29.367187) content-size 11.5625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (17,29.359375) content-size 11.5625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.5625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [17,29.367187 11.5625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [17,29.359375 11.5625x17.46875]
                     "X"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -29,39 +29,39 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   Box <table> at (43.5625,18) content-size 30.265625x96.40625 table-box [TFC] children: not-inline
                     BlockContainer <(anonymous)> (not painted) children: inline
                       TextNode <#text>
-                    Box <tbody> at (43.5625,18) content-size 26.265625x88.40625 table-row-group children: not-inline
+                    Box <tbody> at (43.5625,18) content-size 26.265625x87 table-row-group children: not-inline
                       BlockContainer <(anonymous)> (not painted) children: inline
                         TextNode <#text>
-                      Box <tr> at (45.5625,20) content-size 26.265625x29.46875 table-row children: not-inline
+                      Box <tr> at (45.5625,20) content-size 26.265625x29 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (51.5625,26) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                        BlockContainer <td> at (51.5625,25.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                           line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,26 14.265625x17.46875]
+                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,25.765625 14.265625x17.46875]
                               "A"
                           TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
                         TextNode <#text>
-                      Box <tr> at (45.5625,51.46875) content-size 26.265625x29.46875 table-row children: not-inline
+                      Box <tr> at (45.5625,51) content-size 26.265625x29 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (51.5625,57.46875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                        BlockContainer <td> at (51.5625,56.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                           line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,57.46875 9.34375x17.46875]
+                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,56.765625 9.34375x17.46875]
                               "B"
                           TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
                         TextNode <#text>
-                      Box <tr> at (45.5625,82.9375) content-size 26.265625x29.46875 table-row children: not-inline
+                      Box <tr> at (45.5625,82) content-size 26.265625x29 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (51.5625,88.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                        BlockContainer <td> at (51.5625,87.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                           line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,88.9375 10.3125x17.46875]
+                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,87.765625 10.3125x17.46875]
                               "C"
                           TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
@@ -79,9 +79,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,67.203125) content-size 67.828125x54.203125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (17,85.570312) content-size 11.5625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (17,85.5625) content-size 11.5625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [17,85.570312 11.09375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [17,85.5625 11.09375x17.46875]
                     "Y"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-1.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x150 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 200x150 [BFC] children: not-inline
         Box <div.table> at (8,8) content-size 200x150 table-box [TFC] children: not-inline
-          Box <div.row.a> at (8,8) content-size 200x50 table-row children: not-inline
+          Box <div.row.a> at (8,8) content-size 200x49.21875 table-row children: not-inline
             BlockContainer <div.cell> at (8,8) content-size 200x0 table-cell [BFC] children: not-inline
-          Box <div.row.b> at (8,58) content-size 200x100 table-row children: not-inline
-            BlockContainer <div.cell> at (8,58) content-size 200x0 table-cell [BFC] children: not-inline
+          Box <div.row.b> at (8,57.21875) content-size 200x98.4375 table-row children: not-inline
+            BlockContainer <div.cell> at (8,57.21875) content-size 200x0 table-cell [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
+++ b/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
@@ -5,27 +5,27 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 91.328125x25.46875 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 83.328125x21.46875 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 83.328125x21.46875 table-row children: not-inline
+          Box <tbody> at (9,9) content-size 83.3125x21.46875 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 83.3125x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,13) content-size 18.032031x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (13,13) content-size 18.03125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (37.032031,13) content-size 36.864062x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (37.03125,13) content-size 36.859375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [37.032031,13 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [37.03125,13 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (79.896093,13) content-size 16.432031x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (79.890625,13) content-size 16.421875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [79.896093,13 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [79.890625,13 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
@@ -1,86 +1,86 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x159.875 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 103.421875x159.875 [BFC] children: not-inline
-        Box <table> at (9,9) content-size 101.421875x157.875 table-box [TFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x155.875 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 100.421875x155.875 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 98.421875x153.875 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 101.421875x157.875 table-row-group children: not-inline
-            Box <tr> at (9,9) content-size 101.421875x39.46875 table-row children: not-inline
+          Box <tbody> at (9,9) content-size 98.421875x153.875 table-row-group children: not-inline
+            Box <tr> at (9,9) content-size 98.421875x38.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (20,20) content-size 9.59375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (19.5,19.5) content-size 9.59375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.59375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,20 9.59375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [19.5,19.5 9.59375x17.46875]
                     "0"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (51.59375,39.734375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50.09375,38.734375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [51.59375,39.734375 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [50.09375,38.734375 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.859375,59.46875) content-size 11.5625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.359375,57.96875) content-size 11.5625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.5625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.859375,59.46875 11.5625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.359375,57.96875 11.5625x17.46875]
                     "X"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (9,48.46875) content-size 101.421875x39.46875 table-row children: not-inline
+            Box <tr> at (9,47.46875) content-size 98.421875x38.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (20,59.46875) content-size 9.59375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (19.5,57.96875) content-size 9.59375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,59.46875 6.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [19.5,57.96875 6.34375x17.46875]
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (9,87.9375) content-size 101.421875x39.46875 table-row children: not-inline
+            Box <tr> at (9,85.9375) content-size 98.421875x38.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (20,98.9375) content-size 9.59375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (19.5,96.4375) content-size 9.59375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,98.9375 8.8125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [19.5,96.4375 8.8125x17.46875]
                     "2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (51.59375,118.671875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50.09375,115.671875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [51.59375,118.671875 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [50.09375,115.671875 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (9,127.40625) content-size 101.421875x39.46875 table-row children: not-inline
+            Box <tr> at (9,124.40625) content-size 98.421875x38.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (20,138.40625) content-size 9.59375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (19.5,134.90625) content-size 9.59375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,138.40625 9.09375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [19.5,134.90625 9.09375x17.46875]
                     "3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.859375,138.40625) content-size 11.5625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.359375,134.90625) content-size 11.5625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.859375,138.40625 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.359375,134.90625 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-      BlockContainer <(anonymous)> at (8,167.875) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,163.875) content-size 784x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
@@ -1,33 +1,33 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x21.46875 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 784x21.46875 [BFC] children: not-inline
-        Box <table> at (8,8) content-size 784x21.46875 table-box [TFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x20.46875 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 784x20.46875 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 784x20.46875 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 784x21.46875 table-row-group children: not-inline
+          Box <tbody> at (8,8) content-size 783.96875x20.46875 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,8) content-size 784x21.46875 table-row children: not-inline
+            Box <tr> at (8,8) content-size 783.96875x20.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (10,10) content-size 216.099903x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (9.5,9.5) content-size 215.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 1, length: 1, rect: [10,10 14.265625x17.46875]
+                  frag 0 from TextNode start: 1, length: 1, rect: [9.5,9.5 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (230.099903,10) content-size 156.791546x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (227.59375,9.5) content-size 152.921875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 1, length: 1, rect: [230.099903,10 9.34375x17.46875]
+                  frag 0 from TextNode start: 1, length: 1, rect: [227.59375,9.5 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (390.891450,10) content-size 399.108549x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (383.515625,9.5) content-size 406.953125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 29.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 1, length: 3, rect: [390.891450,10 29.453125x17.46875]
+                  frag 0 from TextNode start: 1, length: 3, rect: [383.515625,9.5 29.453125x17.46875]
                     "C D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/text-align-justify-with-forced-break.txt
+++ b/Tests/LibWeb/Layout/expected/text-align-justify-with-forced-break.txt
@@ -5,68 +5,68 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         line 0 width: 98, height: 17.46875, bottom: 17.46875, baseline: 13.53125
           frag 0 from TextNode start: 1, length: 3, rect: [9,9 27.15625x17.46875]
             "foo"
-          frag 1 from TextNode start: 4, length: 1, rect: [36,9 9x17.46875]
+          frag 1 from TextNode start: 4, length: 1, rect: [36.15625,9 9x17.46875]
             " "
-          frag 2 from TextNode start: 5, length: 3, rect: [45,9 27.640625x17.46875]
+          frag 2 from TextNode start: 5, length: 3, rect: [45.15625,9 27.640625x17.46875]
             "bar"
-          frag 3 from TextNode start: 8, length: 1, rect: [73,9 9x17.46875]
+          frag 3 from TextNode start: 8, length: 1, rect: [72.796875,9 9x17.46875]
             " "
-          frag 4 from TextNode start: 9, length: 3, rect: [82,9 27.203125x17.46875]
+          frag 4 from TextNode start: 9, length: 3, rect: [81.796875,9 27.203125x17.46875]
             "baz"
-        line 1 width: 98, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-          frag 0 from TextNode start: 13, length: 3, rect: [9,26 27.15625x17.46875]
+        line 1 width: 98, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+          frag 0 from TextNode start: 13, length: 3, rect: [9,26.46875 27.15625x17.46875]
             "foo"
-          frag 1 from TextNode start: 16, length: 1, rect: [36,26 8x17.46875]
+          frag 1 from TextNode start: 16, length: 1, rect: [36.15625,26.46875 8x17.46875]
             " "
-          frag 2 from TextNode start: 17, length: 3, rect: [44,26 27.640625x17.46875]
+          frag 2 from TextNode start: 17, length: 3, rect: [44.15625,26.46875 27.640625x17.46875]
             "bar"
-          frag 3 from TextNode start: 20, length: 1, rect: [72,26 8x17.46875]
+          frag 3 from TextNode start: 20, length: 1, rect: [71.796875,26.46875 8x17.46875]
             " "
-          frag 4 from TextNode start: 21, length: 3, rect: [80,26 27.203125x17.46875]
+          frag 4 from TextNode start: 21, length: 3, rect: [79.796875,26.46875 27.203125x17.46875]
             "baz"
-        line 2 width: 98, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-          frag 0 from TextNode start: 1, length: 3, rect: [9,43 27.15625x17.46875]
+        line 2 width: 98, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+          frag 0 from TextNode start: 1, length: 3, rect: [9,43.9375 27.15625x17.46875]
             "foo"
-          frag 1 from TextNode start: 4, length: 1, rect: [36,43 9x17.46875]
+          frag 1 from TextNode start: 4, length: 1, rect: [36.15625,43.9375 9x17.46875]
             " "
-          frag 2 from TextNode start: 5, length: 3, rect: [45,43 27.640625x17.46875]
+          frag 2 from TextNode start: 5, length: 3, rect: [45.15625,43.9375 27.640625x17.46875]
             "bar"
-          frag 3 from TextNode start: 8, length: 1, rect: [73,43 9x17.46875]
+          frag 3 from TextNode start: 8, length: 1, rect: [72.796875,43.9375 9x17.46875]
             " "
-          frag 4 from TextNode start: 9, length: 3, rect: [82,43 27.203125x17.46875]
+          frag 4 from TextNode start: 9, length: 3, rect: [81.796875,43.9375 27.203125x17.46875]
             "baz"
-        line 3 width: 98, height: 17.875, bottom: 70.28125, baseline: 13.53125
-          frag 0 from TextNode start: 13, length: 3, rect: [9,61 27.15625x17.46875]
+        line 3 width: 98, height: 17.46875, bottom: 69.875, baseline: 13.53125
+          frag 0 from TextNode start: 13, length: 3, rect: [9,61.40625 27.15625x17.46875]
             "foo"
-          frag 1 from TextNode start: 16, length: 1, rect: [36,61 9x17.46875]
+          frag 1 from TextNode start: 16, length: 1, rect: [36.15625,61.40625 9x17.46875]
             " "
-          frag 2 from TextNode start: 17, length: 3, rect: [45,61 27.640625x17.46875]
+          frag 2 from TextNode start: 17, length: 3, rect: [45.15625,61.40625 27.640625x17.46875]
             "bar"
-          frag 3 from TextNode start: 20, length: 1, rect: [73,61 9x17.46875]
+          frag 3 from TextNode start: 20, length: 1, rect: [72.796875,61.40625 9x17.46875]
             " "
-          frag 4 from TextNode start: 21, length: 3, rect: [82,61 27.203125x17.46875]
+          frag 4 from TextNode start: 21, length: 3, rect: [81.796875,61.40625 27.203125x17.46875]
             "baz"
-        line 4 width: 98, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-          frag 0 from TextNode start: 25, length: 3, rect: [9,78 27.15625x17.46875]
+        line 4 width: 98, height: 17.46875, bottom: 87.34375, baseline: 13.53125
+          frag 0 from TextNode start: 25, length: 3, rect: [9,78.875 27.15625x17.46875]
             "foo"
-          frag 1 from TextNode start: 28, length: 1, rect: [36,78 8x17.46875]
+          frag 1 from TextNode start: 28, length: 1, rect: [36.15625,78.875 8x17.46875]
             " "
-          frag 2 from TextNode start: 29, length: 3, rect: [44,78 27.640625x17.46875]
+          frag 2 from TextNode start: 29, length: 3, rect: [44.15625,78.875 27.640625x17.46875]
             "bar"
-          frag 3 from TextNode start: 32, length: 1, rect: [72,78 8x17.46875]
+          frag 3 from TextNode start: 32, length: 1, rect: [71.796875,78.875 8x17.46875]
             " "
-          frag 4 from TextNode start: 33, length: 3, rect: [80,78 27.203125x17.46875]
+          frag 4 from TextNode start: 33, length: 3, rect: [79.796875,78.875 27.203125x17.46875]
             "baz"
-        line 5 width: 98, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-          frag 0 from TextNode start: 1, length: 3, rect: [9,96 27.15625x17.46875]
+        line 5 width: 98, height: 17.46875, bottom: 104.8125, baseline: 13.53125
+          frag 0 from TextNode start: 1, length: 3, rect: [9,96.34375 27.15625x17.46875]
             "foo"
-          frag 1 from TextNode start: 4, length: 1, rect: [36,96 8x17.46875]
+          frag 1 from TextNode start: 4, length: 1, rect: [36.15625,96.34375 8x17.46875]
             " "
-          frag 2 from TextNode start: 5, length: 3, rect: [44,96 27.640625x17.46875]
+          frag 2 from TextNode start: 5, length: 3, rect: [44.15625,96.34375 27.640625x17.46875]
             "bar"
-          frag 3 from TextNode start: 8, length: 1, rect: [72,96 8x17.46875]
+          frag 3 from TextNode start: 8, length: 1, rect: [71.796875,96.34375 8x17.46875]
             " "
-          frag 4 from TextNode start: 9, length: 3, rect: [80,96 27.203125x17.46875]
+          frag 4 from TextNode start: 9, length: 3, rect: [79.796875,96.34375 27.203125x17.46875]
             "baz"
         TextNode <#text>
         BreakNode <br>

--- a/Tests/LibWeb/Layout/expected/text-indent.txt
+++ b/Tests/LibWeb/Layout/expected/text-indent.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x161.21875 [BFC] children: not-inline
-    BlockContainer <body> at (10,10) content-size 780x143.21875 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x160.8125 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x142.8125 children: not-inline
       BlockContainer <div.px-indent> at (11,11) content-size 778x68.9375 children: not-inline
         BlockContainer <(anonymous)> at (11,11) content-size 778x17.46875 children: inline
           line 0 width: 142.390625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
@@ -12,17 +12,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 12, rect: [62,45.46875 90.921875x17.46875]
               "is inherited"
           TextNode <#text>
-      BlockContainer <div.pct-indent> at (11,81.9375) content-size 100x70.28125 children: inline
+      BlockContainer <div.pct-indent> at (11,81.9375) content-size 100x69.875 children: inline
         line 0 width: 80.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
           frag 0 from TextNode start: 0, length: 3, rect: [61,81.9375 30.34375x17.46875]
             "50%"
-        line 1 width: 88.15625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-          frag 0 from TextNode start: 4, length: 11, rect: [11,98.9375 88.15625x17.46875]
+        line 1 width: 88.15625, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+          frag 0 from TextNode start: 4, length: 11, rect: [11,99.40625 88.15625x17.46875]
             "indent snip"
-        line 2 width: 78.703125, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-          frag 0 from TextNode start: 16, length: 9, rect: [11,115.9375 78.703125x17.46875]
+        line 2 width: 78.703125, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+          frag 0 from TextNode start: 16, length: 9, rect: [11,116.875 78.703125x17.46875]
             "snap snib"
-        line 3 width: 37.765625, height: 17.875, bottom: 70.28125, baseline: 13.53125
-          frag 0 from TextNode start: 26, length: 4, rect: [11,133.9375 37.765625x17.46875]
+        line 3 width: 37.765625, height: 17.46875, bottom: 69.875, baseline: 13.53125
+          frag 0 from TextNode start: 26, length: 4, rect: [11,134.34375 37.765625x17.46875]
             "snab"
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/tolerate-css-percentage-overshoot.txt
+++ b/Tests/LibWeb/Layout/expected/tolerate-css-percentage-overshoot.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 500x0 children: not-inline
-      BlockContainer <div.larg.red> at (8,8) content-size 208.332999x100 floating [BFC] children: not-inline
-      BlockContainer <div.larg.green> at (216.332999,8) content-size 208.332999x100 floating [BFC] children: not-inline
-      BlockContainer <div.smol.blue> at (424.665999,8) content-size 83.332999x100 floating [BFC] children: not-inline
+      BlockContainer <div.larg.red> at (8,8) content-size 208.328125x100 floating [BFC] children: not-inline
+      BlockContainer <div.larg.green> at (216.328125,8) content-size 208.328125x100 floating [BFC] children: not-inline
+      BlockContainer <div.smol.blue> at (424.65625,8) content-size 83.328125x100 floating [BFC] children: not-inline

--- a/Tests/LibWeb/TestCSSPixels.cpp
+++ b/Tests/LibWeb/TestCSSPixels.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <LibWeb/PixelUnits.h>
+
+namespace Web {
+
+TEST_CASE(addition1)
+{
+    CSSPixels a(10);
+    CSSPixels b(20);
+    CSSPixels c = a + b;
+    EXPECT_EQ(c, CSSPixels(30));
+}
+
+TEST_CASE(subtraction1)
+{
+    CSSPixels a(30);
+    CSSPixels b(10);
+    CSSPixels c = a - b;
+    EXPECT_EQ(c, CSSPixels(20));
+}
+
+TEST_CASE(division1)
+{
+    CSSPixels a(10);
+    CSSPixels b(5);
+    CSSPixels c = a / b;
+    EXPECT_EQ(c, CSSPixels(2));
+}
+
+TEST_CASE(multiplication1)
+{
+    CSSPixels a(3);
+    CSSPixels b(4);
+    CSSPixels c = a * b;
+    EXPECT_EQ(c, CSSPixels(12));
+}
+
+TEST_CASE(addition2)
+{
+    CSSPixels a(3);
+    a += CSSPixels(2);
+    EXPECT_EQ(a, CSSPixels(5));
+}
+
+TEST_CASE(to_double)
+{
+    CSSPixels a(10);
+    EXPECT_EQ(a.to_double(), 10);
+}
+
+TEST_CASE(to_float)
+{
+    CSSPixels a(11);
+    EXPECT_EQ(a.to_float(), 11);
+}
+
+TEST_CASE(to_int)
+{
+    CSSPixels b(12);
+    EXPECT_EQ(b.to_int(), 12);
+}
+
+TEST_CASE(comparison1)
+{
+    EXPECT_EQ(CSSPixels(1) < CSSPixels(2), true);
+}
+
+TEST_CASE(comparison2)
+{
+    EXPECT_EQ(CSSPixels(123) == CSSPixels(123), true);
+}
+
+}

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -490,6 +490,7 @@ set(SOURCES
     PerformanceTimeline/EntryTypes.cpp
     PerformanceTimeline/PerformanceEntry.cpp
     PermissionsPolicy/AutoplayAllowlist.cpp
+    PixelUnits.cpp
     Platform/AudioCodecPlugin.cpp
     Platform/EventLoopPlugin.cpp
     Platform/EventLoopPluginSerenity.cpp

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1301,7 +1301,7 @@ void FlexFormattingContext::distribute_any_remaining_free_space()
         CSSPixels initial_offset = 0;
         auto number_of_items = flex_line.items.size();
 
-        if (auto_margins == 0) {
+        if (auto_margins == 0 && number_of_items > 0) {
             switch (flex_container().computed_values().justify_content()) {
             case CSS::JustifyContent::Start:
             case CSS::JustifyContent::FlexStart:

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -987,7 +987,7 @@ void FlexFormattingContext::resolve_flexible_lengths_for_line(FlexLine& line)
 
         // AD-HOC: We allow the remaining free space to be infinite, but we can't let infinity
         //         leak into the layout geometry, so we treat infinity as zero when used in arithmetic.
-        auto remaining_free_space_or_zero_if_infinite = isfinite(line.remaining_free_space.to_double()) ? line.remaining_free_space : 0;
+        auto remaining_free_space_or_zero_if_infinite = !line.remaining_free_space.might_be_saturated() ? line.remaining_free_space : 0;
 
         // c. If the remaining free space is non-zero, distribute it proportional to the flex factors:
         if (line.remaining_free_space != 0) {
@@ -1096,7 +1096,7 @@ void FlexFormattingContext::resolve_flexible_lengths_for_line(FlexLine& line)
 
     // AD-HOC: Due to the way we calculate the remaining free space, it can be infinite when sizing
     //         under a max-content constraint. In that case, we can simply set it to zero here.
-    if (!isfinite(line.remaining_free_space.to_double()))
+    if (line.remaining_free_space.might_be_saturated())
         line.remaining_free_space = 0;
 
     // 6. Set each item’s used main size to its target main size.

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -803,7 +803,7 @@ void GridFormattingContext::distribute_extra_space_across_spanned_tracks_base_si
     // 2. Distribute space up to limits:
     // FIXME: If a fixed-point type were used to represent CSS pixels, it would be possible to compare with 0
     //        instead of epsilon.
-    while (extra_space > NumericLimits<double>().epsilon()) {
+    while (extra_space > CSSPixels::epsilon()) {
         auto all_frozen = all_of(affected_tracks, [](auto const& track) { return track.base_size_frozen; });
         if (all_frozen)
             break;
@@ -893,7 +893,7 @@ void GridFormattingContext::distribute_extra_space_across_spanned_tracks_growth_
     // 2. Distribute space up to limits:
     // FIXME: If a fixed-point type were used to represent CSS pixels, it would be possible to compare with 0
     //        instead of epsilon.
-    while (extra_space > NumericLimits<double>().epsilon()) {
+    while (extra_space > CSSPixels::epsilon()) {
         auto all_frozen = all_of(affected_tracks, [](auto const& track) { return track.growth_limit_frozen; });
         if (all_frozen)
             break;

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -785,6 +785,9 @@ void GridFormattingContext::distribute_extra_space_across_spanned_tracks_base_si
             affected_tracks.append(track);
     }
 
+    if (affected_tracks.size() == 0)
+        return;
+
     for (auto& track : affected_tracks)
         track.item_incurred_increase = 0;
 
@@ -869,6 +872,9 @@ void GridFormattingContext::distribute_extra_space_across_spanned_tracks_growth_
 
     for (auto& track : affected_tracks)
         track.item_incurred_increase = 0;
+
+    if (affected_tracks.size() == 0)
+        return;
 
     // 1. Find the space to distribute:
     CSSPixels spanned_tracks_sizes_sum = 0;

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -10,6 +10,8 @@
 
 namespace Web::Layout {
 
+static int const infinity = -1;
+
 GridFormattingContext::GridTrack GridFormattingContext::GridTrack::create_from_definition(CSS::ExplicitGridTrack const& definition)
 {
     // NOTE: repeat() is expected to be expanded beforehand.
@@ -718,16 +720,16 @@ void GridFormattingContext::initialize_track_sizes(AvailableSpace const& availab
         if (track.max_track_sizing_function.is_fixed(available_size)) {
             track.growth_limit = track.max_track_sizing_function.css_size().to_px(grid_container(), available_size.to_px());
         } else if (track.max_track_sizing_function.is_flexible_length()) {
-            track.growth_limit = INFINITY;
+            track.growth_limit = infinity;
         } else if (track.max_track_sizing_function.is_intrinsic(available_size)) {
-            track.growth_limit = INFINITY;
+            track.growth_limit = infinity;
         } else {
             VERIFY_NOT_REACHED();
         }
 
         // In all cases, if the growth limit is less than the base size, increase the growth limit to match
         // the base size.
-        if (track.growth_limit < track.base_size)
+        if (track.growth_limit != infinity && track.growth_limit < track.base_size)
             track.growth_limit = track.base_size;
     }
 }
@@ -766,7 +768,7 @@ void GridFormattingContext::resolve_intrinsic_track_sizes(AvailableSpace const& 
     // 5. If any track still has an infinite growth limit (because, for example, it had no items placed in
     // it or it is a flexible track), set its growth limit to its base size.
     for (auto& track : tracks_and_gaps) {
-        if (!isfinite(track.growth_limit.to_double())) {
+        if (track.growth_limit == infinity) {
             track.growth_limit = track.base_size;
         }
     }
@@ -811,7 +813,7 @@ void GridFormattingContext::distribute_extra_space_across_spanned_tracks_base_si
             if (track.base_size_frozen)
                 continue;
 
-            if (increase_per_track >= track.growth_limit) {
+            if (track.growth_limit != infinity && increase_per_track >= track.growth_limit) {
                 track.base_size_frozen = true;
                 track.item_incurred_increase = track.growth_limit;
                 extra_space -= track.growth_limit;
@@ -871,7 +873,7 @@ void GridFormattingContext::distribute_extra_space_across_spanned_tracks_growth_
     // 1. Find the space to distribute:
     CSSPixels spanned_tracks_sizes_sum = 0;
     for (auto& track : spanned_tracks) {
-        if (isfinite(track.growth_limit.to_double())) {
+        if (track.growth_limit != infinity) {
             spanned_tracks_sizes_sum += track.growth_limit;
         } else {
             spanned_tracks_sizes_sum += track.base_size;
@@ -900,8 +902,8 @@ void GridFormattingContext::distribute_extra_space_across_spanned_tracks_growth_
 
             // For growth limits, the limit is infinity if it is marked as infinitely growable, and equal to the
             // growth limit otherwise.
-            auto limit = track.infinitely_growable ? INFINITY : track.growth_limit;
-            if (increase_per_track >= limit) {
+            auto limit = track.infinitely_growable ? infinity : track.growth_limit;
+            if (limit != infinity && increase_per_track >= limit) {
                 track.growth_limit_frozen = true;
                 track.item_incurred_increase = limit;
                 extra_space -= limit;
@@ -988,7 +990,7 @@ void GridFormattingContext::increase_sizes_to_accommodate_spanning_items_crossin
         // 4. If at this point any track’s growth limit is now less than its base size, increase its growth limit to
         //    match its base size.
         for (auto& track : tracks) {
-            if (track.growth_limit < track.base_size)
+            if (track.growth_limit != infinity && track.growth_limit < track.base_size)
                 track.growth_limit = track.base_size;
         }
 
@@ -997,7 +999,7 @@ void GridFormattingContext::increase_sizes_to_accommodate_spanning_items_crossin
             return track.max_track_sizing_function.is_intrinsic(available_size);
         });
         for (auto& track : spanned_tracks) {
-            if (!isfinite(track.growth_limit.to_double())) {
+            if (track.growth_limit == infinity) {
                 // If the affected size is an infinite growth limit, set it to the track’s base size plus the planned increase.
                 track.growth_limit = track.base_size + track.planned_increase;
                 // Mark any tracks whose growth limit changed from infinite to finite in this step as infinitely growable
@@ -1017,7 +1019,7 @@ void GridFormattingContext::increase_sizes_to_accommodate_spanning_items_crossin
             return track.max_track_sizing_function.is_max_content() || track.max_track_sizing_function.is_auto(available_size);
         });
         for (auto& track : spanned_tracks) {
-            if (!isfinite(track.growth_limit.to_double())) {
+            if (track.growth_limit == infinity) {
                 // If the affected size is an infinite growth limit, set it to the track’s base size plus the planned increase.
                 track.growth_limit = track.base_size + track.planned_increase;
             } else {
@@ -1058,7 +1060,7 @@ void GridFormattingContext::increase_sizes_to_accommodate_spanning_items_crossin
         // 4. If at this point any track’s growth limit is now less than its base size, increase its growth limit to
         //    match its base size.
         for (auto& track : tracks) {
-            if (track.growth_limit < track.base_size)
+            if (track.growth_limit != infinity && track.growth_limit < track.base_size)
                 track.growth_limit = track.base_size;
         }
     }
@@ -1093,7 +1095,7 @@ void GridFormattingContext::maximize_tracks(AvailableSpace const& available_spac
         for (auto& track : tracks) {
             if (track.base_size_frozen)
                 continue;
-            VERIFY(isfinite(track.growth_limit.to_double()));
+            VERIFY(track.growth_limit != infinity);
             track.base_size = min(track.growth_limit, track.base_size + free_space_to_distribute_per_track);
         }
         if (get_free_space_px() == free_space_px)

--- a/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -173,7 +173,7 @@ void SVGFormattingContext::run(Box const& box, LayoutMode layout_mode, Available
 
                 // The initial value for preserveAspectRatio is xMidYMid meet.
                 auto preserve_aspect_ratio = svg_svg_element.preserve_aspect_ratio().value_or(SVG::PreserveAspectRatio {});
-                auto viewbox_transform = scale_and_align_viewbox_content(preserve_aspect_ratio, view_box, { scale_width.to_double(), scale_height.to_double() }, svg_box_state);
+                auto viewbox_transform = scale_and_align_viewbox_content(preserve_aspect_ratio, view_box, { scale_width, scale_height }, svg_box_state);
                 path_transform = Gfx::AffineTransform {}.translate(viewbox_transform.offset.to_type<double>().to_type<float>()).scale(viewbox_transform.scale_factor, viewbox_transform.scale_factor).translate({ -view_box.min_x, -view_box.min_y }).multiply(path_transform);
                 viewbox_scale = viewbox_transform.scale_factor;
             }

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -94,8 +94,8 @@ CSSPixelPoint Page::device_to_css_point(DevicePixelPoint point) const
 DevicePixelPoint Page::css_to_device_point(CSSPixelPoint point) const
 {
     return {
-        (point.x() * client().device_pixels_per_css_pixel()).to_int(),
-        (point.y() * client().device_pixels_per_css_pixel()).to_int(),
+        point.x() * client().device_pixels_per_css_pixel(),
+        point.y() * client().device_pixels_per_css_pixel(),
     };
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -447,7 +447,7 @@ static void paint_text_decoration(PaintContext& context, Gfx::Painter& painter, 
         if (computed_thickness.is_auto())
             return max(glyph_height * 0.1, 1.);
 
-        return computed_thickness.to_px(text_node);
+        return computed_thickness.to_px(text_node).to_double();
     }();
     auto device_line_thickness = context.rounded_device_pixels(css_line_thickness);
 

--- a/Userland/Libraries/LibWeb/PixelUnits.cpp
+++ b/Userland/Libraries/LibWeb/PixelUnits.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Math.h>
+#include <LibWeb/PixelUnits.h>
+
+namespace Web {
+
+static i32 const fractional_bits = 6;
+static constexpr i32 fixed_point_denominator = 1 << fractional_bits;
+
+CSSPixels::CSSPixels(int value)
+{
+    m_value = value * fixed_point_denominator;
+}
+
+CSSPixels::CSSPixels(unsigned int value)
+{
+    m_value = value * fixed_point_denominator;
+}
+
+CSSPixels::CSSPixels(unsigned long value)
+{
+    m_value = value * fixed_point_denominator;
+}
+
+CSSPixels::CSSPixels(float value)
+{
+    if (!isnan(value))
+        m_value = AK::clamp_to_int(value * fixed_point_denominator);
+}
+
+CSSPixels::CSSPixels(double value)
+{
+    if (!isnan(value))
+        m_value = AK::clamp_to_int(value * fixed_point_denominator);
+}
+
+float CSSPixels::to_float() const
+{
+    return static_cast<float>(m_value) / fixed_point_denominator;
+}
+
+double CSSPixels::to_double() const
+{
+    return static_cast<double>(m_value) / fixed_point_denominator;
+}
+
+int CSSPixels::to_int() const
+{
+    return m_value / fixed_point_denominator;
+}
+
+bool CSSPixels::might_be_saturated() const
+{
+    return raw_value() == NumericLimits<i32>::max() || raw_value() == NumericLimits<i32>::min();
+}
+
+bool CSSPixels::operator==(CSSPixels const& other) const
+{
+    return raw_value() == other.raw_value();
+}
+
+CSSPixels& CSSPixels::operator++()
+{
+    m_value += fixed_point_denominator;
+    return *this;
+}
+CSSPixels& CSSPixels::operator--()
+{
+    m_value -= fixed_point_denominator;
+    return *this;
+}
+
+int CSSPixels::operator<=>(CSSPixels const& other) const
+{
+    return raw_value() > other.raw_value() ? 1 : raw_value() < other.raw_value() ? -1
+                                                                                 : 0;
+}
+
+CSSPixels CSSPixels::operator+() const
+{
+    CSSPixels result;
+    result.set_raw_value(+raw_value());
+    return result;
+}
+
+CSSPixels CSSPixels::operator-() const
+{
+    CSSPixels result;
+    result.set_raw_value(-raw_value());
+    return result;
+}
+
+static inline int saturated_addition(int a, int b)
+{
+    i32 overflow = (b > 0 && a > NumericLimits<i32>::max() - b);
+    i32 underflow = (b < 0 && a < NumericLimits<i32>::min() - b);
+    return overflow ? NumericLimits<i32>::max() : (underflow ? NumericLimits<i32>::min() : a + b);
+}
+
+CSSPixels CSSPixels::operator+(CSSPixels const& other) const
+{
+    CSSPixels result;
+    result.set_raw_value(saturated_addition(raw_value(), other.raw_value()));
+    return result;
+}
+
+CSSPixels CSSPixels::operator-(CSSPixels const& other) const
+{
+    CSSPixels result;
+    result.set_raw_value(raw_value() - other.raw_value());
+    return result;
+}
+
+CSSPixels CSSPixels::operator*(CSSPixels const& other) const
+{
+    CSSPixels result;
+    result.set_raw_value((raw_value() * other.raw_value()) >> fractional_bits);
+    return result;
+}
+
+CSSPixels CSSPixels::operator/(CSSPixels const& other) const
+{
+    CSSPixels result;
+    result.set_raw_value(static_cast<long long>(fixed_point_denominator) * raw_value() / other.raw_value());
+    return result;
+}
+
+CSSPixels& CSSPixels::operator+=(CSSPixels const& other)
+{
+    *this = *this + other;
+    return *this;
+}
+
+CSSPixels& CSSPixels::operator-=(CSSPixels const& other)
+{
+    *this = *this - other;
+    return *this;
+}
+
+CSSPixels& CSSPixels::operator*=(CSSPixels const& other)
+{
+    *this = *this * other;
+    return *this;
+}
+
+CSSPixels& CSSPixels::operator/=(CSSPixels const& other)
+{
+    *this = *this / other;
+    return *this;
+}
+
+CSSPixels CSSPixels::abs() const
+{
+    CSSPixels result;
+    result.set_raw_value(::abs(m_value));
+    return result;
+}
+
+float CSSPixels::epsilon()
+{
+    return 1.0f / fixed_point_denominator;
+}
+
+}

--- a/Userland/Libraries/LibWeb/PixelUnits.h
+++ b/Userland/Libraries/LibWeb/PixelUnits.h
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2012-2023, Apple Inc. All rights reserved.
  * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -50,154 +52,78 @@ constexpr DevicePixels operator%(DevicePixels left, T right) { return left.value
 /// See https://www.w3.org/TR/css-values-3/#reference-pixel
 class CSSPixels {
 public:
-    constexpr CSSPixels() = default;
+    CSSPixels() = default;
+    CSSPixels(int value);
+    CSSPixels(unsigned int value);
+    CSSPixels(unsigned long value);
+    CSSPixels(float value);
+    CSSPixels(double value);
 
-    constexpr CSSPixels(double value)
-        : m_value { value }
-    {
-    }
+    float to_float() const;
+    double to_double() const;
+    int to_int() const;
 
-    constexpr float to_float() const
-    {
-        return static_cast<float>(m_value);
-    }
+    inline int raw_value() const { return m_value; }
+    inline void set_raw_value(int value) { m_value = value; }
 
-    constexpr double to_double() const
-    {
-        return static_cast<double>(m_value);
-    }
+    bool might_be_saturated() const;
 
-    constexpr int to_int() const
-    {
-        return static_cast<int>(m_value);
-    }
+    bool operator==(CSSPixels const& other) const;
 
-    constexpr bool operator==(CSSPixels const& other) const
-    {
-        return this->m_value == other.m_value;
-    }
+    explicit operator double() const { return to_double(); }
 
-    constexpr explicit operator double() const
-    {
-        return to_double();
-    }
+    CSSPixels& operator++();
+    CSSPixels& operator--();
 
-    constexpr CSSPixels& operator++()
-    {
-        this->m_value += 1;
-        return *this;
-    }
-    constexpr CSSPixels operator++(int)
-    {
-        CSSPixels ret = this->m_value;
-        this->m_value += 1;
-        return ret;
-    }
-    constexpr CSSPixels& operator--()
-    {
-        this->m_value -= 1;
-        return *this;
-    }
-    constexpr CSSPixels operator--(int)
-    {
-        CSSPixels ret = this->m_value;
-        this->m_value -= 1;
-        return ret;
-    }
+    int operator<=>(CSSPixels const& other) const;
 
-    constexpr int operator<=>(CSSPixels const& other) const
-    {
-        return this->m_value > other.m_value ? 1 : this->m_value < other.m_value ? -1
-                                                                                 : 0;
-    }
+    CSSPixels operator+() const;
+    CSSPixels operator-() const;
 
-    constexpr CSSPixels operator+(CSSPixels const& other) const
-    {
-        return this->m_value + other.m_value;
-    }
+    CSSPixels operator+(CSSPixels const& other) const;
+    CSSPixels operator-(CSSPixels const& other) const;
+    CSSPixels operator*(CSSPixels const& other) const;
+    CSSPixels operator/(CSSPixels const& other) const;
 
-    constexpr CSSPixels operator-(CSSPixels const& other) const
-    {
-        return this->m_value - other.m_value;
-    }
+    CSSPixels& operator+=(CSSPixels const& other);
+    CSSPixels& operator-=(CSSPixels const& other);
+    CSSPixels& operator*=(CSSPixels const& other);
+    CSSPixels& operator/=(CSSPixels const& other);
 
-    constexpr CSSPixels operator+() const
-    {
-        return +this->m_value;
-    }
+    CSSPixels abs() const;
 
-    constexpr CSSPixels operator-() const
-    {
-        return -this->m_value;
-    }
-
-    constexpr CSSPixels operator*(CSSPixels const& other) const
-    {
-        return this->m_value * other.m_value;
-    }
-
-    constexpr CSSPixels operator/(CSSPixels const& other) const
-    {
-        return this->m_value / other.m_value;
-    }
-
-    constexpr CSSPixels& operator+=(CSSPixels const& other)
-    {
-        this->m_value += other.m_value;
-        return *this;
-    }
-
-    constexpr CSSPixels& operator-=(CSSPixels const& other)
-    {
-        this->m_value -= other.m_value;
-        return *this;
-    }
-
-    constexpr CSSPixels& operator*=(CSSPixels const& other)
-    {
-        this->m_value *= other.m_value;
-        return *this;
-    }
-
-    constexpr CSSPixels& operator/=(CSSPixels const& other)
-    {
-        this->m_value /= other.m_value;
-        return *this;
-    }
+    static float epsilon();
 
 private:
-    double m_value {};
+    i32 m_value { 0 };
 };
 
-template<Arithmetic T>
-constexpr bool operator==(CSSPixels left, T right) { return left.to_double() == right; }
+inline bool operator==(CSSPixels left, int right) { return left == CSSPixels(right); }
+inline bool operator==(CSSPixels left, float right) { return left.to_float() == right; }
+inline bool operator==(CSSPixels left, double right) { return left.to_double() == right; }
 
-template<Arithmetic T>
-constexpr bool operator!=(CSSPixels left, T right) { return left.to_double() != right; }
+inline bool operator>(CSSPixels left, int right) { return left > CSSPixels(right); }
+inline bool operator>(CSSPixels left, float right) { return left.to_float() > right; }
+inline bool operator>(CSSPixels left, double right) { return left.to_double() > right; }
 
-template<Arithmetic T>
-constexpr bool operator>(CSSPixels left, T right) { return left.to_double() > right; }
+inline bool operator<(CSSPixels left, int right) { return left < CSSPixels(right); }
+inline bool operator<(CSSPixels left, float right) { return left.to_float() < right; }
+inline bool operator<(CSSPixels left, double right) { return left.to_double() < right; }
 
-template<Arithmetic T>
-constexpr bool operator<(CSSPixels left, T right) { return left.to_double() < right; }
+inline CSSPixels operator*(CSSPixels left, int right) { return left * CSSPixels(right); }
+inline CSSPixels operator*(CSSPixels left, unsigned long right) { return left * CSSPixels(right); }
+inline float operator*(CSSPixels left, float right) { return left.to_float() * right; }
+inline double operator*(CSSPixels left, double right) { return left.to_double() * right; }
 
-template<Arithmetic T>
-constexpr bool operator>=(CSSPixels left, T right) { return left.to_double() >= right; }
+inline CSSPixels operator*(int left, CSSPixels right) { return right * CSSPixels(left); }
+inline CSSPixels operator*(unsigned long left, CSSPixels right) { return right * CSSPixels(left); }
+inline float operator*(float left, CSSPixels right) { return right.to_float() * left; }
+inline double operator*(double left, CSSPixels right) { return right.to_double() * left; }
 
-template<Arithmetic T>
-constexpr bool operator<=(CSSPixels left, T right) { return left.to_double() <= right; }
-
-template<Arithmetic T>
-constexpr CSSPixels operator*(CSSPixels left, T right) { return left.to_double() * right; }
-
-template<Arithmetic T>
-constexpr CSSPixels operator*(T left, CSSPixels right) { return right * left; }
-
-template<Arithmetic T>
-constexpr CSSPixels operator/(CSSPixels left, T right) { return left.to_double() / right; }
-
-template<Arithmetic T>
-constexpr CSSPixels operator%(CSSPixels left, T right) { return left.to_double() % right; }
+inline CSSPixels operator/(CSSPixels left, int right) { return left / CSSPixels(right); }
+inline CSSPixels operator/(CSSPixels left, unsigned long right) { return left / CSSPixels(right); }
+inline float operator/(CSSPixels left, float right) { return left.to_float() / right; }
+inline double operator/(CSSPixels left, double right) { return left.to_double() / right; }
 
 using CSSPixelLine = Gfx::Line<CSSPixels>;
 using CSSPixelPoint = Gfx::Point<CSSPixels>;
@@ -211,29 +137,27 @@ using DevicePixelSize = Gfx::Size<DevicePixels>;
 
 }
 
+inline Web::CSSPixels abs(Web::CSSPixels const& value)
+{
+    return value.abs();
+}
+
 constexpr Web::CSSPixels floor(Web::CSSPixels const& value)
 {
-    return ::floorf(value.to_float());
+    // FIXME: Actually floor value
+    return value;
 }
 
 constexpr Web::CSSPixels ceil(Web::CSSPixels const& value)
 {
-    return ::ceilf(value.to_float());
+    // FIXME: Actually ceil value
+    return value;
 }
 
 constexpr Web::CSSPixels round(Web::CSSPixels const& value)
 {
-    return ::roundf(value.to_float());
-}
-
-constexpr Web::CSSPixels fmod(Web::CSSPixels const& x, Web::CSSPixels const& y)
-{
-    return ::fmodf(x.to_float(), y.to_float());
-}
-
-constexpr Web::CSSPixels abs(Web::CSSPixels const& value)
-{
-    return AK::abs(value.to_float());
+    // FIXME: Actually round value
+    return value;
 }
 
 constexpr Web::DevicePixels abs(Web::DevicePixels const& value)


### PR DESCRIPTION
Using fixed-point saturated arithmetics for CSSPixels allows to avoid accumulating floating-point errors.

This implementation is not complete yet: currently saturated arithmetics implemented only for addition. But it is enough to not regress any of layout tests we have :)

See https://github.com/SerenityOS/serenity/issues/18566