### PR TITLE
LibXML: Actually append resolved references when parsing content

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -629,6 +629,7 @@ if (BUILD_LAGOM)
             LibTimeZone
             LibUnicode
             LibVideo
+            LibXML
         )
         if (ENABLE_LAGOM_LIBWEB)
             list(APPEND TEST_DIRECTORIES LibWeb)

--- a/Tests/LibXML/TestParser.cpp
+++ b/Tests/LibXML/TestParser.cpp
@@ -29,3 +29,15 @@ TEST_CASE(character_reference_integer_overflow)
         return Test::Crash::Failure::DidNotCrash;
     });
 }
+
+TEST_CASE(predefined_character_reference)
+{
+    XML::Parser parser("<a>Well hello &amp;, &lt;, &gt;, &apos;, and &quot;!</a>"sv);
+    auto document = MUST(parser.parse());
+
+    auto const& node = document.root().content.get<XML::Node::Element>();
+    EXPECT_EQ(node.name, "a");
+
+    auto const& content = node.children[0]->content.get<XML::Node::Text>();
+    EXPECT_EQ(content.builder.string_view(), "Well hello &, <, >, ', and \"!");
+}

--- a/Userland/Libraries/LibXML/Parser/Parser.cpp
+++ b/Userland/Libraries/LibXML/Parser/Parser.cpp
@@ -862,7 +862,7 @@ ErrorOr<void, ParseError> Parser::parse_content()
             if (auto char_reference = reference.get_pointer<DeprecatedString>())
                 append_text(*char_reference);
             else
-                TRY(resolve_reference(reference.get<EntityReference>(), ReferencePlacement::Content));
+                append_text(TRY(resolve_reference(reference.get<EntityReference>(), ReferencePlacement::Content)));
             goto try_char_data;
         }
         if (auto result = parse_cdata_section(); !result.is_error()) {


### PR DESCRIPTION
Previously, we were returning `Well hello , , , , and !` as a content of a root element of `<a>Well hello &amp;, &lt;, &gt;, &apos;, and &quot;!</a>`.