### PR TITLE
LibPDF: Ensure all subpaths are closed before filling paths

### DIFF
--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -298,6 +298,7 @@ RENDERER_HANDLER(path_close_and_stroke)
 RENDERER_HANDLER(path_fill_nonzero)
 {
     begin_path_paint();
+    m_current_path.close_all_subpaths();
     m_anti_aliasing_painter.fill_path(m_current_path, state().paint_color, Gfx::Painter::WindingRule::Nonzero);
     end_path_paint();
     return {};
@@ -311,6 +312,7 @@ RENDERER_HANDLER(path_fill_nonzero_deprecated)
 RENDERER_HANDLER(path_fill_evenodd)
 {
     begin_path_paint();
+    m_current_path.close_all_subpaths();
     m_anti_aliasing_painter.fill_path(m_current_path, state().paint_color, Gfx::Painter::WindingRule::EvenOdd);
     end_path_paint();
     return {};


### PR DESCRIPTION
This fixes figure 3.4 in pdf_reference_1-7.pdf:
![pdf_reference_1-7.pdf_p130_after](https://github.com/SerenityOS/serenity/assets/11597044/aaa2a32b-e179-4943-a003-401d49febbb1)
