### PR TITLE
AK: FixedPoint fixes 

### DIFF
--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -226,8 +226,14 @@ public:
     }
     constexpr This operator/(This const& other) const
     {
-        // FIXME: Better rounding?
-        return create_raw((m_value / other.m_value) << (precision));
+        // FIXME: Figure out a way to use more narrow types and avoid __int128
+        using DivRes = Conditional<sizeof(Underlying) < sizeof(i64), i64, __int128>;
+
+        DivRes value = raw();
+        value <<= precision;
+        value /= other.raw();
+
+        return create_raw(value);
     }
 
     template<Integral I>
@@ -278,9 +284,7 @@ public:
     }
     This& operator/=(This const& other)
     {
-        // FIXME: See above
-        m_value /= other.raw();
-        m_value <<= precision;
+        *this = *this / other;
         return *this;
     }
 

--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -99,17 +99,21 @@ public:
         return *this;
     }
 
-    // Note/FIXME: This uses round to nearest break-tie to even
-    //        Not break-tie away from 0 as the C99's round does
-    constexpr This round() const
+    constexpr This rint() const
     {
+        // Note: Round fair, break tie to even
         Underlying value = m_value >> precision;
+
+        // Note: For negative numbers the ordering are reversed,
+        //       and they were already decremented by the shift, so we need to
+        //       add 1 when we see a fract values behind the `.5`s place set,
+        //       because that means they are smaller than .5
         // fract(m_value) >= .5?
         if (m_value & (1u << (precision - 1))) {
             // fract(m_value) > .5?
             if (m_value & (radix_mask >> 2u)) {
                 // yes: round "up";
-                value += (m_value > 0 ? 1 : -1);
+                value += 1;
             } else {
                 //  no: round to even;
                 value += value & 1;
@@ -134,7 +138,7 @@ public:
                     : 0));
     }
 
-    constexpr Underlying lround() const { return round().raw() >> precision; }
+    constexpr Underlying lrint() const { return rint().raw() >> precision; }
     constexpr Underlying lfloor() const { return m_value >> precision; }
     constexpr Underlying lceil() const
     {

--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -396,7 +396,7 @@ ErrorOr<void> FormatBuilder::put_fixed_point(
         u64 scale = pow<u64>(10, precision);
 
         auto fraction = (scale * fraction_value) / fraction_one; // TODO: overflows
-        if (is_negative)
+        if (is_negative && fraction != 0)
             fraction = scale - fraction;
 
         size_t leading_zeroes = 0;

--- a/Tests/AK/TestFixedPoint.cpp
+++ b/Tests/AK/TestFixedPoint.cpp
@@ -41,42 +41,42 @@ TEST_CASE(rounding)
     EXPECT_EQ(Type(0.5).round(), Type(0));
     EXPECT_EQ(Type(0.5).floor(), Type(0));
     EXPECT_EQ(Type(0.5).ceil(), Type(1));
-    EXPECT_EQ(Type(0.75).trunk(), Type(0));
+    EXPECT_EQ(Type(0.75).trunc(), Type(0));
 
     EXPECT_EQ(Type(1.5).round(), Type(2));
     EXPECT_EQ(Type(1.5).floor(), Type(1));
     EXPECT_EQ(Type(1.5).ceil(), Type(2));
-    EXPECT_EQ(Type(1.25).trunk(), Type(1));
+    EXPECT_EQ(Type(1.25).trunc(), Type(1));
 
     EXPECT_EQ(Type(-0.5).round(), Type(0));
     EXPECT_EQ(Type(-0.5).floor(), Type(-1));
     EXPECT_EQ(Type(-0.5).ceil(), Type(0));
-    EXPECT_EQ(Type(-0.75).trunk(), Type(0));
+    EXPECT_EQ(Type(-0.75).trunc(), Type(0));
 
     EXPECT_EQ(Type(-1.5).round(), Type(-2));
     EXPECT_EQ(Type(-1.5).floor(), Type(-2));
     EXPECT_EQ(Type(-1.5).ceil(), Type(-1));
-    EXPECT_EQ(Type(-1.25).trunk(), Type(-1));
+    EXPECT_EQ(Type(-1.25).trunc(), Type(-1));
 
     EXPECT_EQ(Type(0.5).lround(), 0);
     EXPECT_EQ(Type(0.5).lfloor(), 0);
     EXPECT_EQ(Type(0.5).lceil(), 1);
-    EXPECT_EQ(Type(0.5).ltrunk(), 0);
+    EXPECT_EQ(Type(0.5).ltrunc(), 0);
 
     EXPECT_EQ(Type(1.5).lround(), 2);
     EXPECT_EQ(Type(1.5).lfloor(), 1);
     EXPECT_EQ(Type(1.5).lceil(), 2);
-    EXPECT_EQ(Type(1.5).ltrunk(), 1);
+    EXPECT_EQ(Type(1.5).ltrunc(), 1);
 
     EXPECT_EQ(Type(-0.5).lround(), 0);
     EXPECT_EQ(Type(-0.5).lfloor(), -1);
     EXPECT_EQ(Type(-0.5).lceil(), 0);
-    EXPECT_EQ(Type(-0.5).ltrunk(), 0);
+    EXPECT_EQ(Type(-0.5).ltrunc(), 0);
 
     EXPECT_EQ(Type(-1.5).lround(), -2);
     EXPECT_EQ(Type(-1.5).lfloor(), -2);
     EXPECT_EQ(Type(-1.5).lceil(), -1);
-    EXPECT_EQ(Type(-1.5).ltrunk(), -1);
+    EXPECT_EQ(Type(-1.5).ltrunc(), -1);
 
     // Check that sRGB TRC curve parameters match the s15fixed16 values stored in Gimp's built-in profile.
     // (This only requires that the FixedPoint<> constructor rounds before truncating to the fixed-point value,

--- a/Tests/AK/TestFixedPoint.cpp
+++ b/Tests/AK/TestFixedPoint.cpp
@@ -38,45 +38,50 @@ TEST_CASE(arithmetic)
 
 TEST_CASE(rounding)
 {
-    EXPECT_EQ(Type(0.5).round(), Type(0));
+    EXPECT_EQ(Type(0.5).rint(), Type(0));
     EXPECT_EQ(Type(0.5).floor(), Type(0));
     EXPECT_EQ(Type(0.5).ceil(), Type(1));
     EXPECT_EQ(Type(0.75).trunc(), Type(0));
 
-    EXPECT_EQ(Type(1.5).round(), Type(2));
+    EXPECT_EQ(Type(1.5).rint(), Type(2));
     EXPECT_EQ(Type(1.5).floor(), Type(1));
     EXPECT_EQ(Type(1.5).ceil(), Type(2));
     EXPECT_EQ(Type(1.25).trunc(), Type(1));
 
-    EXPECT_EQ(Type(-0.5).round(), Type(0));
+    EXPECT_EQ(Type(-0.5).rint(), Type(0));
     EXPECT_EQ(Type(-0.5).floor(), Type(-1));
     EXPECT_EQ(Type(-0.5).ceil(), Type(0));
     EXPECT_EQ(Type(-0.75).trunc(), Type(0));
 
-    EXPECT_EQ(Type(-1.5).round(), Type(-2));
+    EXPECT_EQ(Type(-1.5).rint(), Type(-2));
     EXPECT_EQ(Type(-1.5).floor(), Type(-2));
     EXPECT_EQ(Type(-1.5).ceil(), Type(-1));
     EXPECT_EQ(Type(-1.25).trunc(), Type(-1));
 
-    EXPECT_EQ(Type(0.5).lround(), 0);
+    EXPECT_EQ(Type(0.5).lrint(), 0);
     EXPECT_EQ(Type(0.5).lfloor(), 0);
     EXPECT_EQ(Type(0.5).lceil(), 1);
     EXPECT_EQ(Type(0.5).ltrunc(), 0);
 
-    EXPECT_EQ(Type(1.5).lround(), 2);
+    EXPECT_EQ(Type(1.5).lrint(), 2);
     EXPECT_EQ(Type(1.5).lfloor(), 1);
     EXPECT_EQ(Type(1.5).lceil(), 2);
     EXPECT_EQ(Type(1.5).ltrunc(), 1);
 
-    EXPECT_EQ(Type(-0.5).lround(), 0);
+    EXPECT_EQ(Type(-0.5).lrint(), 0);
     EXPECT_EQ(Type(-0.5).lfloor(), -1);
     EXPECT_EQ(Type(-0.5).lceil(), 0);
     EXPECT_EQ(Type(-0.5).ltrunc(), 0);
 
-    EXPECT_EQ(Type(-1.5).lround(), -2);
+    EXPECT_EQ(Type(-1.5).lrint(), -2);
     EXPECT_EQ(Type(-1.5).lfloor(), -2);
     EXPECT_EQ(Type(-1.5).lceil(), -1);
     EXPECT_EQ(Type(-1.5).ltrunc(), -1);
+
+    EXPECT_EQ(Type(-1.6).rint(), -2);
+    EXPECT_EQ(Type(-1.4).rint(), -1);
+    EXPECT_EQ(Type(1.6).rint(), 2);
+    EXPECT_EQ(Type(1.4).rint(), 1);
 
     // Check that sRGB TRC curve parameters match the s15fixed16 values stored in Gimp's built-in profile.
     // (This only requires that the FixedPoint<> constructor rounds before truncating to the fixed-point value,

--- a/Tests/AK/TestFixedPoint.cpp
+++ b/Tests/AK/TestFixedPoint.cpp
@@ -178,4 +178,8 @@ TEST_CASE(formatter)
     EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<16>(-0.1)), "-0.100007"sv);
     EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<16>(-0.02)), "-0.020005"sv);
     EXPECT_EQ(DeprecatedString::formatted("{}", FixedPoint<16>(-0.0000000005)), "0"sv);
+
+    EXPECT_EQ(DeprecatedString::formatted("{}", Type(-1)), "-1"sv);
+    EXPECT_EQ(DeprecatedString::formatted("{}", Type(-2)), "-2"sv);
+    EXPECT_EQ(DeprecatedString::formatted("{}", Type(-3)), "-3"sv);
 }

--- a/Tests/AK/TestFixedPoint.cpp
+++ b/Tests/AK/TestFixedPoint.cpp
@@ -26,6 +26,11 @@ TEST_CASE(arithmetic)
     EXPECT_EQ(
         Type((int)1) * Type(0.5),
         Type(0.5));
+    EXPECT_EQ(Type(0.125) * Type(3.75),
+        Type(0.125 * 3.75));
+    EXPECT_EQ(Type(0.125) * Type(-3.75),
+        Type(0.125 * -3.75));
+
     EXPECT_EQ(
         Type((int)1) / Type(0.5),
         Type(2));

--- a/Tests/LibEDID/TestEDID.cpp
+++ b/Tests/LibEDID/TestEDID.cpp
@@ -131,7 +131,7 @@ TEST_CASE(edid1)
             EXPECT(block_id == expected_timings.block_id);
             EXPECT(detailed_timing.horizontal_addressable_pixels() == expected_timings.width);
             EXPECT(detailed_timing.vertical_addressable_lines() == expected_timings.height);
-            EXPECT(detailed_timing.refresh_rate().lround() == expected_timings.refresh_rate);
+            EXPECT(detailed_timing.refresh_rate().lrint() == expected_timings.refresh_rate);
             detailed_timings_found++;
             return IterationDecision::Continue;
         }));
@@ -313,7 +313,7 @@ TEST_CASE(edid2)
             EXPECT(block_id == expected_timings.block_id);
             EXPECT(detailed_timing.horizontal_addressable_pixels() == expected_timings.width);
             EXPECT(detailed_timing.vertical_addressable_lines() == expected_timings.height);
-            EXPECT(detailed_timing.refresh_rate().lround() == expected_timings.refresh_rate);
+            EXPECT(detailed_timing.refresh_rate().lrint() == expected_timings.refresh_rate);
             detailed_timings_found++;
             return IterationDecision::Continue;
         }));
@@ -430,7 +430,7 @@ TEST_CASE(edid_extension_maps)
             EXPECT(block_id == expected_timings.block_id);
             EXPECT(detailed_timing.horizontal_addressable_pixels() == expected_timings.width);
             EXPECT(detailed_timing.vertical_addressable_lines() == expected_timings.height);
-            EXPECT(detailed_timing.refresh_rate().lround() == expected_timings.refresh_rate);
+            EXPECT(detailed_timing.refresh_rate().lrint() == expected_timings.refresh_rate);
             detailed_timings_found++;
             return IterationDecision::Continue;
         }));
@@ -479,7 +479,7 @@ TEST_CASE(edid_1_0)
             EXPECT(block_id == expected_timings.block_id);
             EXPECT(detailed_timing.horizontal_addressable_pixels() == expected_timings.width);
             EXPECT(detailed_timing.vertical_addressable_lines() == expected_timings.height);
-            EXPECT(detailed_timing.refresh_rate().lround() == expected_timings.refresh_rate);
+            EXPECT(detailed_timing.refresh_rate().lrint() == expected_timings.refresh_rate);
             detailed_timings_found++;
             return IterationDecision::Continue;
         }));

--- a/Userland/Libraries/LibEDID/DMT.cpp
+++ b/Userland/Libraries/LibEDID/DMT.cpp
@@ -116,7 +116,7 @@ FixedPoint<16, u32> DMT::MonitorTiming::vertical_frequency_hz() const
 
 u32 DMT::MonitorTiming::refresh_rate_hz() const
 {
-    return vertical_frequency_hz().ltrunk();
+    return vertical_frequency_hz().ltrunc();
 }
 
 #ifndef KERNEL


### PR DESCRIPTION
### AK: Fix FixedPoint multiplication rounding and overflow behaviour

We now preform the multiplication in a widened type which makes it
overflow-safe and use the correct bit for rounding direction detection.

### AK: Use wider type for FixedPoint division

This allows us to shift first and then divide, preserving more precision

### AK: Change standard casting method of FixedPoint to truncation

This matches what floats do.

Also fix typo `trunk`->`trunc`

### AK: Rename AK::FixedPoint::round to rint and fix a rounding error

`rint` is a more accurate name for the roudning mode as the fixme above
stated

### AK: Add FIXME about broken FixedPoint formatting test
