### PR TITLE
LibPDF: Add smoke-and-mirror implementation of SeparationColorSpace

### DIFF
--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -59,6 +59,9 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> ColorSpace::create(Document* document, Non
     if (color_space_name == CommonNames::ICCBased)
         return TRY(ICCBasedColorSpace::create(document, move(parameters)));
 
+    if (color_space_name == CommonNames::Separation)
+        return TRY(SeparationColorSpace::create(document, move(parameters)));
+
     dbgln("Unknown color space: {}", color_space_name);
     return Error::rendering_unsupported_error("unknown color space");
 }
@@ -366,6 +369,24 @@ Vector<float> ICCBasedColorSpace::default_decode() const
         }
         return decoding_ranges;
     }
+}
+
+PDFErrorOr<NonnullRefPtr<SeparationColorSpace>> SeparationColorSpace::create(Document*, Vector<Value>&&)
+{
+    auto color_space = adopt_ref(*new SeparationColorSpace());
+    // FIXME: Implement.
+    return color_space;
+}
+
+PDFErrorOr<Color> SeparationColorSpace::color(Vector<Value> const&) const
+{
+    return Error::rendering_unsupported_error("Separation color spaces not yet implemented");
+}
+
+Vector<float> SeparationColorSpace::default_decode() const
+{
+    warnln("PDF: TODO implement SeparationColorSpace::default_decode()");
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -144,4 +144,19 @@ private:
     NonnullRefPtr<Gfx::ICC::Profile> m_profile;
 };
 
+class SeparationColorSpace final : public ColorSpace {
+public:
+    static PDFErrorOr<NonnullRefPtr<SeparationColorSpace>> create(Document*, Vector<Value>&& parameters);
+
+    ~SeparationColorSpace() override = default;
+
+    PDFErrorOr<Color> color(Vector<Value> const& arguments) const override;
+    int number_of_components() const override { TODO(); }
+    Vector<float> default_decode() const override;
+    ColorSpaceFamily const& family() const override { return ColorSpaceFamily::Separation; }
+
+private:
+    SeparationColorSpace() = default;
+};
+
 }

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -134,6 +134,7 @@
     A(SA)                         \
     A(SM)                         \
     A(SMask)                      \
+    A(Separation)                 \
     A(StmF)                       \
     A(StrF)                       \
     A(Subject)                    \


### PR DESCRIPTION
None of the methods actually do anything, but we now create an
actual SeparationColorSpace object for /Separation color spaces.

This fixes a crash on page 810 of pdf_reference_1-7.pdf.
Previously, we'd log a "separation color space not supported" error,
which would lead to Renderer not updating its current color space.
It'd stay a DeviceCYMK color space, which would then later assert
when it got a 1-argument array as color (which now the
SeparationColorSpace gets instead, which logs an "unimplemented"
error for that instead of asserting).