### PR TITLE
LibWeb: Minor rendering fixes

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -525,6 +525,15 @@ td, th {
 
 th {
     font-weight: bold;
+    /*
+    The text-align property for table headings is non-standard, but all
+    existing user-agents seem to render them centered by default.
+
+    See:
+    - https://trac.webkit.org/browser/trunk/Source/WebCore/css/html.css?rev=295625#L272
+    - https://searchfox.org/mozilla-central/rev/0b55b868c17835942d40ca3fedfca8057481207b/layout/style/res/html.css#473
+    */
+    text-align: center;
 }
 
 caption {

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -107,7 +107,8 @@ void HTMLLinkElement::attribute_changed(DeprecatedFlyString const& name, Depreca
         }
     }
 
-    if (m_relationship & Relationship::Stylesheet) {
+    // FIXME: Handle alternate stylesheets properly
+    if (m_relationship & Relationship::Stylesheet && !(m_relationship & Relationship::Alternate)) {
         if (name == HTML::AttributeNames::disabled && m_loaded_style_sheet)
             document().style_sheets().remove_sheet(*m_loaded_style_sheet);
 

--- a/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -119,7 +119,7 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
             break;
         // FIXME: This should use proper text layout logic!
         // This does not line up with the text in the <li> element which looks very sad :(
-        context.painter().draw_text(device_enclosing.to_type<int>(), layout_box().text(), layout_box().scaled_font(context), Gfx::TextAlignment::Center);
+        context.painter().draw_text(device_enclosing.to_type<int>(), layout_box().text(), layout_box().scaled_font(context), Gfx::TextAlignment::Center, color);
         break;
     case CSS::ListStyleType::None:
         return;


### PR DESCRIPTION
effect of an afternoon hacking session w/ @linusg :^)

my favourite fix is probably the stylesheet one, which makes this page render properly:
![image](https://github.com/SerenityOS/serenity/assets/22369758/6333c3af-8c73-4670-a4ea-c008290afdea)
