### PR TITLE
LibWeb: Implement proper handling for vertical-align: middle

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1700,6 +1700,8 @@ CSSPixels FormattingContext::box_baseline(Box const& box) const
         case CSS::VerticalAlign::Bottom:
             // Bottom: Align the bottom of the aligned subtree with the bottom of the line box.
             return box_state.content_height() + box_state.margin_box_top();
+        case CSS::VerticalAlign::Middle:
+            return box_state.content_height() / 2 + ((box_state.margin_box_bottom() + box_state.margin_box_top()) * 2);
         case CSS::VerticalAlign::TextTop:
             // TextTop: Align the top of the box with the top of the parent's content area (see 10.6.1).
             return box.computed_values().font_size();


### PR DESCRIPTION
Leaving this as a separate commit, because I'm not sure if I did the math correctly, it's a bit tricky and I'm tired.

This fixes how the text gets vertically centered on [my weblog's listing page](https://sdomi.pl/weblog/); It supposedly doesn't break anything else, and I've tried to match the behavior to how Firefox renders things, but I don't feel like I have sufficiently tested this snippet.