### PR TITLE
LibCore: Move the Promise::await() result instead of returning a ref

### DIFF
--- a/Tests/LibCore/TestLibCorePromise.cpp
+++ b/Tests/LibCore/TestLibCorePromise.cpp
@@ -18,7 +18,7 @@ TEST_CASE(promise_await_async_event)
         promise->resolve(42);
     });
 
-    auto& result = promise->await();
+    auto result = promise->await();
     EXPECT(!result.is_error());
     EXPECT_EQ(result.value(), 42);
 }
@@ -33,7 +33,7 @@ TEST_CASE(promise_await_async_event_rejection)
         promise->reject(AK::Error::from_string_literal("lol no"));
     });
 
-    auto& result = promise->await();
+    auto result = promise->await();
     EXPECT(result.is_error());
     EXPECT_EQ(result.error().string_literal(), "lol no"sv);
 }
@@ -53,7 +53,7 @@ TEST_CASE(promise_chain_handlers)
         promise->resolve(42);
     });
 
-    promise->await();
+    (void)promise->await();
     EXPECT(resolved);
     EXPECT(!rejected);
 }

--- a/Userland/Libraries/LibCore/Promise.h
+++ b/Userland/Libraries/LibCore/Promise.h
@@ -50,12 +50,12 @@ public:
         return m_result_or_rejection.has_value() && !m_result_or_rejection->is_error();
     }
 
-    ErrorOr<Result, ErrorType>& await()
+    ErrorOr<Result, ErrorType> await()
     {
         while (!m_result_or_rejection.has_value())
             Core::EventLoop::current().pump();
 
-        return *m_result_or_rejection;
+        return m_result_or_rejection.release_value();
     }
 
     // Converts a Promise<A> to a Promise<B> using a function func: A -> B


### PR DESCRIPTION
Returning a reference resulted in Mail's use of Promise causing a crash. Also, awaiting an already-awaited promise is an odd thing to do anyway, so let's just make it release the resolved/rejected value instead of returning a reference to it.

cc @vkoskiv.