### PR TITLE
LibPDF: Make JPEG decoding errors not assert

### DIFF
--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -271,7 +271,7 @@ PDFErrorOr<ByteBuffer> Filter::decode_jbig2(ReadonlyBytes)
 PDFErrorOr<ByteBuffer> Filter::decode_dct(ReadonlyBytes bytes)
 {
     if (Gfx::JPEGImageDecoderPlugin::sniff({ bytes.data(), bytes.size() })) {
-        auto decoder = Gfx::JPEGImageDecoderPlugin::create({ bytes.data(), bytes.size() }).release_value_but_fixme_should_propagate_errors();
+        auto decoder = TRY(Gfx::JPEGImageDecoderPlugin::create({ bytes.data(), bytes.size() }));
         auto frame = TRY(decoder->frame(0));
         return TRY(frame.image->serialize_to_byte_buffer());
     }


### PR DESCRIPTION
Instead, they're now turned into a diagnostic like other rendering problems, looking like so:

    Internal error while processing PDF file:
        Unsupported chroma subsampling factors

Makes us no longer crash rendering page 1141 of pdf_reference_1.7-pdf.