### PR TITLE
LibPDF: Don't crash on encrypted files with streams with filter arrays

### DIFF
--- a/Userland/Libraries/LibPDF/Document.cpp
+++ b/Userland/Libraries/LibPDF/Document.cpp
@@ -297,6 +297,23 @@ PDFErrorOr<Optional<InfoDict>> Document::info_dict()
     return InfoDict(this, TRY(trailer()->get_dict(this, CommonNames::Info)));
 }
 
+PDFErrorOr<Vector<DeprecatedFlyString>> Document::read_filters(NonnullRefPtr<DictObject> dict)
+{
+    Vector<DeprecatedFlyString> filters;
+
+    // We may either get a single filter or an array of cascading filters
+    auto filter_object = TRY(dict->get_object(this, CommonNames::Filter));
+    if (filter_object->is<ArrayObject>()) {
+        auto filter_array = filter_object->cast<ArrayObject>();
+        for (size_t i = 0; i < filter_array->size(); ++i)
+            filters.append(TRY(filter_array->get_name_at(this, i))->name());
+    } else {
+        filters.append(filter_object->cast<NameObject>()->name());
+    }
+
+    return filters;
+}
+
 PDFErrorOr<void> Document::build_page_tree()
 {
     auto page_tree = TRY(m_catalog->get_dict(this, CommonNames::Pages));

--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -146,6 +146,8 @@ public:
 
     PDFErrorOr<Optional<InfoDict>> info_dict();
 
+    PDFErrorOr<Vector<DeprecatedFlyString>> read_filters(NonnullRefPtr<DictObject>);
+
 private:
     explicit Document(NonnullRefPtr<DocumentParser> const& parser);
 

--- a/Userland/Libraries/LibPDF/Encryption.cpp
+++ b/Userland/Libraries/LibPDF/Encryption.cpp
@@ -676,8 +676,10 @@ void StandardSecurityHandler::crypt(NonnullRefPtr<Object> object, Reference refe
         };
 
         if (stream->dict()->contains(CommonNames::Filter)) {
-            auto filter = stream->dict()->get_name(m_document, CommonNames::Filter).release_value_but_fixme_should_propagate_errors()->name();
-            if (filter == "Crypt")
+            // ISO 32000 (PDF 2.0), 7.4.10 Crypt filter
+            // "The Crypt filter shall be the first filter in the Filter array entry."
+            auto filters = m_document->read_filters(stream->dict()).release_value_but_fixme_should_propagate_errors();
+            if (!filters.is_empty() && filters[0] == "Crypt")
                 TODO();
         }
     } else if (object->is<StringObject>()) {

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -475,17 +475,7 @@ PDFErrorOr<NonnullRefPtr<StreamObject>> Parser::parse_stream(NonnullRefPtr<DictO
         m_document->security_handler()->decrypt(stream_object, m_current_reference_stack.last());
 
     if (dict->contains(CommonNames::Filter) && m_enable_filters) {
-        Vector<DeprecatedFlyString> filters;
-
-        // We may either get a single filter or an array of cascading filters
-        auto filter_object = TRY(dict->get_object(m_document, CommonNames::Filter));
-        if (filter_object->is<ArrayObject>()) {
-            auto filter_array = filter_object->cast<ArrayObject>();
-            for (size_t i = 0; i < filter_array->size(); ++i)
-                filters.append(TRY(filter_array->get_name_at(m_document, i))->name());
-        } else {
-            filters.append(filter_object->cast<NameObject>()->name());
-        }
+        Vector<DeprecatedFlyString> filters = TRY(m_document->read_filters(dict));
 
         // Every filter may get its own parameter dictionary
         Vector<RefPtr<DictObject>> decode_parms_vector;


### PR DESCRIPTION
Makes it possible to render more than 0 pages of CIPA_DC-003-2020_E.pdf