### PR TITLE
LibTLS: Move singleton for DefaultRootCACertificates out of line

### DIFF
--- a/Userland/Libraries/LibTLS/Certificate.h
+++ b/Userland/Libraries/LibTLS/Certificate.h
@@ -9,7 +9,6 @@
 #include <AK/ByteBuffer.h>
 #include <AK/Forward.h>
 #include <AK/Optional.h>
-#include <AK/Singleton.h>
 #include <AK/Types.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/DateTime.h>
@@ -295,11 +294,9 @@ public:
     static ErrorOr<Vector<Certificate>> parse_pem_root_certificate_authorities(ByteBuffer&);
     static ErrorOr<Vector<Certificate>> load_certificates();
 
-    static DefaultRootCACertificates& the() { return s_the; }
+    static DefaultRootCACertificates& the();
 
 private:
-    static Singleton<DefaultRootCACertificates> s_the;
-
     Vector<Certificate> m_ca_certificates;
 };
 

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -489,7 +489,6 @@ Vector<Certificate> TLSv12::parse_pem_certificate(ReadonlyBytes certificate_pem_
     return { move(certificate) };
 }
 
-Singleton<DefaultRootCACertificates> DefaultRootCACertificates::s_the;
 DefaultRootCACertificates::DefaultRootCACertificates()
 {
     auto load_result = load_certificates();
@@ -499,6 +498,12 @@ DefaultRootCACertificates::DefaultRootCACertificates()
     }
 
     m_ca_certificates = load_result.release_value();
+}
+
+DefaultRootCACertificates& DefaultRootCACertificates::the()
+{
+    static DefaultRootCACertificates s_the;
+    return s_the;
 }
 
 ErrorOr<Vector<Certificate>> DefaultRootCACertificates::load_certificates()


### PR DESCRIPTION
This follows the pattern of every other singleton in the system.

Also, remove use of AK::Singleton in place of a function-scope static. There are only three uses of that class outside of the Kernel, and all the remaining uses are suspect. We need it in the Kernel because we want to avoid global destructors to prevent nasty surprises about expected lifetimes of objects. In Userland, we have normal thread-safe statics available. 7d11edbe1 attempted to standardize the pattern, but it seems like more uses of awkward singleton creation have crept in or were missed back then.

Side note, this fixes a linker error for Lagos WebContent on macOS with `-g -O0`