### PR TITLE
AK+Userland+Kernel: Stop using AK::TypedTransfer in normal code

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -33,7 +33,7 @@ struct Array {
     {
         Array array;
         VERIFY(span.size() == Size);
-        TypedTransfer<T>::copy(array.data(), span.data(), Size);
+        Detail::TypedTransfer<T>::copy(array.data(), span.data(), Size);
         return array;
     }
 

--- a/AK/DisjointChunks.h
+++ b/AK/DisjointChunks.h
@@ -207,7 +207,7 @@ ChunkType shatter_chunk(ChunkType& source_chunk, size_t start, size_t sliced_len
     if constexpr (IsTriviallyConstructible<T>) {
         new_chunk.resize(wanted_slice.size());
 
-        TypedTransfer<T>::move(new_chunk.data(), wanted_slice.data(), wanted_slice.size());
+        Detail::TypedTransfer<T>::move(new_chunk.data(), wanted_slice.data(), wanted_slice.size());
     } else {
         new_chunk.ensure_capacity(wanted_slice.size());
         for (auto& entry : wanted_slice)
@@ -224,7 +224,7 @@ FixedArray<T> shatter_chunk(FixedArray<T>& source_chunk, size_t start, size_t sl
 
     FixedArray<T> new_chunk = FixedArray<T>::must_create_but_fixme_should_propagate_errors(wanted_slice.size());
     if constexpr (IsTriviallyConstructible<T>) {
-        TypedTransfer<T>::move(new_chunk.data(), wanted_slice.data(), wanted_slice.size());
+        Detail::TypedTransfer<T>::move(new_chunk.data(), wanted_slice.data(), wanted_slice.size());
     } else {
         auto copied_chunk = FixedArray<T>::create(wanted_slice).release_value_but_fixme_should_propagate_errors();
         new_chunk.swap(copied_chunk);

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -193,13 +193,13 @@ public:
     ALWAYS_INLINE constexpr size_t copy_to(Span<RemoveConst<T>> other) const
     {
         VERIFY(other.size() >= size());
-        return TypedTransfer<RemoveConst<T>>::copy(other.data(), data(), size());
+        return Detail::TypedTransfer<RemoveConst<T>>::copy(other.data(), data(), size());
     }
 
     ALWAYS_INLINE constexpr size_t copy_trimmed_to(Span<RemoveConst<T>> other) const
     {
         auto const count = min(size(), other.size());
-        return TypedTransfer<RemoveConst<T>>::copy(other.data(), data(), count);
+        return Detail::TypedTransfer<RemoveConst<T>>::copy(other.data(), data(), count);
     }
 
     ALWAYS_INLINE constexpr size_t fill(T const& value)
@@ -224,7 +224,7 @@ public:
         if (size() < other.size())
             return false;
 
-        return TypedTransfer<T>::compare(data(), other.data(), other.size());
+        return Detail::TypedTransfer<T>::compare(data(), other.data(), other.size());
     }
 
     [[nodiscard]] size_t constexpr matching_prefix_length(ReadonlySpan<T> other) const
@@ -286,7 +286,7 @@ public:
         if (size() != other.size())
             return false;
 
-        return TypedTransfer<T>::compare(data(), other.data(), size());
+        return Detail::TypedTransfer<T>::compare(data(), other.data(), size());
     }
 
     ALWAYS_INLINE constexpr operator ReadonlySpan<T>() const

--- a/AK/TypedTransfer.h
+++ b/AK/TypedTransfer.h
@@ -8,7 +8,7 @@
 
 #include <AK/Traits.h>
 
-namespace AK {
+namespace AK::Detail {
 
 template<typename T>
 class TypedTransfer {

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -73,8 +73,8 @@ public:
     {
         if constexpr (inline_capacity > 0) {
             if (!m_outline_buffer) {
-                TypedTransfer<T>::move(inline_buffer(), other.inline_buffer(), m_size);
-                TypedTransfer<T>::delete_(other.inline_buffer(), m_size);
+                Detail::TypedTransfer<T>::move(inline_buffer(), other.inline_buffer(), m_size);
+                Detail::TypedTransfer<T>::delete_(other.inline_buffer(), m_size);
             }
         }
         other.m_outline_buffer = nullptr;
@@ -85,7 +85,7 @@ public:
     Vector(Vector const& other)
     {
         ensure_capacity(other.size());
-        TypedTransfer<StorageType>::copy(data(), other.data(), other.size());
+        Detail::TypedTransfer<StorageType>::copy(data(), other.data(), other.size());
         m_size = other.size();
     }
 
@@ -93,7 +93,7 @@ public:
     requires(!IsLvalueReference<T>)
     {
         ensure_capacity(other.size());
-        TypedTransfer<StorageType>::copy(data(), other.data(), other.size());
+        Detail::TypedTransfer<StorageType>::copy(data(), other.data(), other.size());
         m_size = other.size();
     }
 
@@ -101,7 +101,7 @@ public:
     Vector(Vector<T, other_inline_capacity> const& other)
     {
         ensure_capacity(other.size());
-        TypedTransfer<StorageType>::copy(data(), other.data(), other.size());
+        Detail::TypedTransfer<StorageType>::copy(data(), other.data(), other.size());
         m_size = other.size();
     }
 
@@ -202,7 +202,7 @@ public:
     {
         if (m_size != other.size())
             return false;
-        return TypedTransfer<StorageType>::compare(data(), other.data(), size());
+        return Detail::TypedTransfer<StorageType>::compare(data(), other.data(), size());
     }
 
     template<typename V>
@@ -292,7 +292,7 @@ public:
         if (count == 0)
             return;
         VERIFY((size() + count) <= capacity());
-        TypedTransfer<StorageType>::copy(slot(m_size), values, count);
+        Detail::TypedTransfer<StorageType>::copy(slot(m_size), values, count);
         m_size += count;
     }
 
@@ -351,7 +351,7 @@ public:
         if (this != &other) {
             clear();
             ensure_capacity(other.size());
-            TypedTransfer<StorageType>::copy(data(), other.data(), other.size());
+            Detail::TypedTransfer<StorageType>::copy(data(), other.data(), other.size());
             m_size = other.size();
         }
         return *this;
@@ -362,7 +362,7 @@ public:
     {
         clear();
         ensure_capacity(other.size());
-        TypedTransfer<StorageType>::copy(data(), other.data(), other.size());
+        Detail::TypedTransfer<StorageType>::copy(data(), other.data(), other.size());
         m_size = other.size();
         return *this;
     }
@@ -389,7 +389,7 @@ public:
         VERIFY(index < m_size);
 
         if constexpr (Traits<StorageType>::is_trivial()) {
-            TypedTransfer<StorageType>::copy(slot(index), slot(index + 1), m_size - index - 1);
+            Detail::TypedTransfer<StorageType>::copy(slot(index), slot(index + 1), m_size - index - 1);
         } else {
             at(index).~StorageType();
             for (size_t i = index + 1; i < m_size; ++i) {
@@ -409,7 +409,7 @@ public:
         VERIFY(index + count <= m_size);
 
         if constexpr (Traits<StorageType>::is_trivial()) {
-            TypedTransfer<StorageType>::copy(slot(index), slot(index + count), m_size - index - count);
+            Detail::TypedTransfer<StorageType>::copy(slot(index), slot(index + count), m_size - index - count);
         } else {
             for (size_t i = index; i < index + count; i++)
                 at(i).~StorageType();
@@ -501,7 +501,7 @@ public:
         TRY(try_grow_capacity(size() + 1));
         ++m_size;
         if constexpr (Traits<StorageType>::is_trivial()) {
-            TypedTransfer<StorageType>::move(slot(index + 1), slot(index), m_size - index - 1);
+            Detail::TypedTransfer<StorageType>::move(slot(index + 1), slot(index), m_size - index - 1);
         } else {
             for (size_t i = size() - 1; i > index; --i) {
                 new (slot(i)) StorageType(move(at(i - 1)));
@@ -542,7 +542,7 @@ public:
         auto other_size = other.size();
         Vector tmp = move(other);
         TRY(try_grow_capacity(size() + other_size));
-        TypedTransfer<StorageType>::move(data() + m_size, tmp.data(), other_size);
+        Detail::TypedTransfer<StorageType>::move(data() + m_size, tmp.data(), other_size);
         m_size += other_size;
         return {};
     }
@@ -550,7 +550,7 @@ public:
     ErrorOr<void> try_extend(Vector const& other)
     {
         TRY(try_grow_capacity(size() + other.size()));
-        TypedTransfer<StorageType>::copy(data() + m_size, other.data(), other.size());
+        Detail::TypedTransfer<StorageType>::copy(data() + m_size, other.data(), other.size());
         m_size += other.m_size;
         return {};
     }
@@ -577,7 +577,7 @@ public:
         if (count == 0)
             return {};
         TRY(try_grow_capacity(size() + count));
-        TypedTransfer<StorageType>::copy(slot(m_size), values, count);
+        Detail::TypedTransfer<StorageType>::copy(slot(m_size), values, count);
         m_size += count;
         return {};
     }
@@ -618,7 +618,7 @@ public:
         }
 
         Vector tmp = move(other);
-        TypedTransfer<StorageType>::move(slot(0), tmp.data(), tmp.size());
+        Detail::TypedTransfer<StorageType>::move(slot(0), tmp.data(), tmp.size());
         m_size += other_size;
         return {};
     }
@@ -628,8 +628,8 @@ public:
         if (count == 0)
             return {};
         TRY(try_grow_capacity(size() + count));
-        TypedTransfer<StorageType>::move(slot(count), slot(0), m_size);
-        TypedTransfer<StorageType>::copy(slot(0), values, count);
+        Detail::TypedTransfer<StorageType>::move(slot(count), slot(0), m_size);
+        Detail::TypedTransfer<StorageType>::copy(slot(0), values, count);
         m_size += count;
         return {};
     }
@@ -651,7 +651,7 @@ public:
             return Error::from_errno(ENOMEM);
 
         if constexpr (Traits<StorageType>::is_trivial()) {
-            TypedTransfer<StorageType>::copy(new_buffer, data(), m_size);
+            Detail::TypedTransfer<StorageType>::copy(new_buffer, data(), m_size);
         } else {
             for (size_t i = 0; i < m_size; ++i) {
                 new (&new_buffer[i]) StorageType(move(at(i)));

--- a/Tests/AK/TestTypedTransfer.cpp
+++ b/Tests/AK/TestTypedTransfer.cpp
@@ -23,7 +23,7 @@ TEST_CASE(overlapping_source_and_destination_1)
     Array<NonPrimitiveIntWrapper, 6> const expected { 3, 4, 5, 6, 5, 6 };
 
     Array<NonPrimitiveIntWrapper, 6> actual { 1, 2, 3, 4, 5, 6 };
-    AK::TypedTransfer<NonPrimitiveIntWrapper>::copy(actual.data(), actual.data() + 2, 4);
+    AK::Detail::TypedTransfer<NonPrimitiveIntWrapper>::copy(actual.data(), actual.data() + 2, 4);
 
     for (size_t i = 0; i < 6; ++i)
         EXPECT_EQ(actual[i].m_value, expected[i].m_value);
@@ -34,7 +34,7 @@ TEST_CASE(overlapping_source_and_destination_2)
     Array<NonPrimitiveIntWrapper, 6> const expected { 1, 2, 1, 2, 3, 4 };
 
     Array<NonPrimitiveIntWrapper, 6> actual { 1, 2, 3, 4, 5, 6 };
-    AK::TypedTransfer<NonPrimitiveIntWrapper>::copy(actual.data() + 2, actual.data(), 4);
+    AK::Detail::TypedTransfer<NonPrimitiveIntWrapper>::copy(actual.data() + 2, actual.data(), 4);
 
     for (size_t i = 0; i < 6; ++i)
         EXPECT_EQ(actual[i].m_value, expected[i].m_value);

--- a/Userland/Applications/Piano/TrackManager.cpp
+++ b/Userland/Applications/Piano/TrackManager.cpp
@@ -11,7 +11,6 @@
 #include "Music.h"
 #include <AK/NoAllocationGuard.h>
 #include <AK/NonnullRefPtr.h>
-#include <AK/TypedTransfer.h>
 #include <LibDSP/Effects.h>
 #include <LibDSP/Synthesizers.h>
 

--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
@@ -8,7 +8,6 @@
 #include "BarsVisualizationWidget.h"
 #include <AK/IntegralMath.h>
 #include <AK/Math.h>
-#include <AK/TypedTransfer.h>
 #include <LibDSP/FFT.h>
 #include <LibDSP/Window.h>
 #include <LibGUI/Event.h>
@@ -31,7 +30,7 @@ void BarsVisualizationWidget::render(GUI::PaintEvent& event, FixedArray<float> c
     for (size_t i = 0; i < fft_size / 2; i++)
         m_fft_samples[i + fft_size / 2] = samples[i] * m_fft_window[i + fft_size / 2];
 
-    AK::TypedTransfer<float>::copy(m_previous_samples.data(), samples.data(), samples.size());
+    samples.span().copy_to(m_previous_samples.span());
 
     DSP::fft(m_fft_samples.span(), false);
 

--- a/Userland/Applications/SoundPlayer/VisualizationWidget.h
+++ b/Userland/Applications/SoundPlayer/VisualizationWidget.h
@@ -8,7 +8,6 @@
 
 #include <AK/FixedArray.h>
 #include <AK/Forward.h>
-#include <AK/TypedTransfer.h>
 #include <LibAudio/Sample.h>
 #include <LibGUI/Frame.h>
 #include <LibGUI/Painter.h>
@@ -62,7 +61,7 @@ public:
         if (buffer_position + m_render_buffer.size() >= m_sample_buffer.size())
             buffer_position = m_sample_buffer.size() - m_render_buffer.size();
 
-        AK::TypedTransfer<float>::copy(m_render_buffer.data(), m_sample_buffer.span().slice(buffer_position).data(), m_render_buffer.size());
+        memcpy(m_render_buffer.data(), m_sample_buffer.span().slice(buffer_position).data(), m_render_buffer.size() * sizeof(float));
 
         render(event, m_render_buffer);
     }

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/FixedArray.h>
 #include <AK/QuickSort.h>
-#include <AK/TypedTransfer.h>
 #include <AK/URL.h>
 #include <LibConfig/Client.h>
 #include <LibConfig/Listener.h>

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -16,7 +16,6 @@
 #include <AK/ScopeGuard.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Try.h>
-#include <AK/TypedTransfer.h>
 #include <AK/UFixedBigInt.h>
 #include <LibAudio/FlacLoader.h>
 #include <LibAudio/FlacTypes.h>

--- a/Userland/Libraries/LibAudio/Loader.cpp
+++ b/Userland/Libraries/LibAudio/Loader.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/TypedTransfer.h>
 #include <LibAudio/FlacLoader.h>
 #include <LibAudio/Loader.h>
 #include <LibAudio/MP3Loader.h>
@@ -80,7 +79,7 @@ LoaderSamples Loader::get_more_samples(size_t samples_to_read_from_input)
 
     if (m_buffer.size() > 0) {
         size_t to_transfer = min(m_buffer.size(), samples_to_read);
-        AK::TypedTransfer<Sample>::move(samples.data(), m_buffer.data(), to_transfer);
+        memmove(samples.data(), m_buffer.data(), to_transfer * sizeof(Sample));
         if (to_transfer < m_buffer.size())
             m_buffer.remove(0, to_transfer);
         else
@@ -99,7 +98,7 @@ LoaderSamples Loader::get_more_samples(size_t samples_to_read_from_input)
         for (auto& chunk : chunk_data) {
             if (sample_index < samples_to_read) {
                 auto count = min(samples_to_read - sample_index, chunk.size());
-                AK::TypedTransfer<Sample>::move(samples.span().offset(sample_index), chunk.data(), count);
+                memmove(samples.span().offset(sample_index), chunk.data(), count * sizeof(Sample));
                 // We didn't read all of the chunk; transfer the rest into the buffer.
                 if (count < chunk.size()) {
                     auto remaining_samples_count = chunk.size() - count;

--- a/Userland/Libraries/LibDSP/Track.cpp
+++ b/Userland/Libraries/LibDSP/Track.cpp
@@ -9,7 +9,6 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
 #include <AK/StdLibExtras.h>
-#include <AK/TypedTransfer.h>
 #include <AK/Types.h>
 #include <LibDSP/Music.h>
 #include <LibDSP/Processor.h>

--- a/Userland/Libraries/LibVideo/VP9/ContextStorage.h
+++ b/Userland/Libraries/LibVideo/VP9/ContextStorage.h
@@ -168,7 +168,7 @@ public:
         VERIFY(height() <= other.height());
         for (u32 row = 0; row < height(); row++) {
             auto other_index = other.index_at(row, 0);
-            AK::TypedTransfer<T>::copy(&m_storage[index_at(row, 0)], &other[other_index], width());
+            memcpy(&m_storage[index_at(row, 0)], &other[other_index], width() * sizeof(T));
         }
     }
 

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <AK/IntegralMath.h>
-#include <AK/TypedTransfer.h>
 #include <LibGfx/Size.h>
 #include <LibVideo/Color/CodingIndependentCodePoints.h>
 
@@ -1406,7 +1405,7 @@ inline DecoderErrorOr<void> Decoder::inverse_discrete_cosine_transform_array_per
 
     // 1.1. A temporary array named copyT is set equal to T.
     Array<Intermediate, block_size> data_copy;
-    AK::TypedTransfer<Intermediate>::copy(data_copy.data(), data.data(), block_size);
+    memcpy(data_copy.data(), data.data(), block_size * sizeof(Intermediate));
 
     // 1.2. T[ i ] is set equal to copyT[ brev( n, i ) ] for i = 0..((1<<n) - 1).
     for (auto i = 0u; i < block_size; i++)
@@ -1526,7 +1525,7 @@ inline void Decoder::inverse_asymmetric_discrete_sine_transform_input_array_perm
 
     // A temporary array named copyT is set equal to T.
     Array<Intermediate, block_size> data_copy;
-    AK::TypedTransfer<Intermediate>::copy(data_copy.data(), data.data(), block_size);
+    memcpy(data_copy.data(), data.data(), block_size * sizeof(Intermediate));
 
     // The values at even locations T[ 2 * i ] are set equal to copyT[ n0 - 1 - 2 * i ] for i = 0..(n1-1).
     // The values at odd locations T[ 2 * i + 1 ] are set equal to copyT[ 2 * i ] for i = 0..(n1-1).
@@ -1543,7 +1542,7 @@ inline void Decoder::inverse_asymmetric_discrete_sine_transform_output_array_per
 
     // A temporary array named copyT is set equal to T.
     Array<Intermediate, maximum_transform_size> data_copy;
-    AK::TypedTransfer<Intermediate>::copy(data_copy.data(), data.data(), block_size);
+    memcpy(data_copy.data(), data.data(), block_size * sizeof(Intermediate));
 
     // The permutation depends on n as follows:
     if (log2_of_block_size == 4) {
@@ -1959,7 +1958,7 @@ DecoderErrorOr<void> Decoder::update_reference_frames(FrameContext const& frame_
                     auto source_y = min(destination_y >= MV_BORDER ? destination_y - MV_BORDER : 0, height - 1);
                     auto const* source = &original_buffer[source_y * stride];
                     auto* destination = &frame_store_buffer[destination_y * frame_store_width + MV_BORDER];
-                    AK::TypedTransfer<RemoveReference<decltype(*destination)>>::copy(destination, source, width);
+                    memcpy(destination, source, width * sizeof(*destination));
                 }
 
                 for (auto destination_y = 0u; destination_y < frame_store_height; destination_y++) {

--- a/Userland/Libraries/LibVideo/VideoFrame.cpp
+++ b/Userland/Libraries/LibVideo/VideoFrame.cpp
@@ -109,8 +109,8 @@ ALWAYS_INLINE DecoderErrorOr<void> convert_to_bitmap_subsampled(Convert convert,
             }
         }
 
-        AK::TypedTransfer<RemoveReference<decltype(*u_row_a)>>::move(u_row_a, u_row_b, width);
-        AK::TypedTransfer<RemoveReference<decltype(*u_row_a)>>::move(v_row_a, v_row_b, width);
+        memmove(u_row_a, u_row_b, width * sizeof(*u_row_a));
+        memmove(v_row_a, v_row_b, width * sizeof(*v_row_a));
     }
 
     if constexpr (subsampling_vertical != 0) {


### PR DESCRIPTION
TypedTransfer is an implementation detail of AK containers such as
Array, Span, and Vector. It abstracts away the detail of whether a type
is trivial or not. All uses in Userland are on trivial types, so let's
remove them. Some of the code that was using this internal AK helper
looks quite C, and could use some Span treatment, but that's a Yak for
another day.

Previous callers who wanted a type safe memcpy should
use a proper container type for their data copying needs.

cc @kleinesfilmroellchen @Zaggy1024 and @alimpfard 

Note: Please check my memcpy's. I'll have a test of the affected apps later :tm: