### PR TITLE
AK: Fix url host parsing check for 'ends in a number'

### DIFF
--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -190,11 +190,6 @@ bool URL::compute_validity() const
     return true;
 }
 
-bool URL::scheme_requires_port(StringView scheme)
-{
-    return (default_port_for_scheme(scheme) != 0);
-}
-
 u16 URL::default_port_for_scheme(StringView scheme)
 {
     if (scheme == "http")

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -120,7 +120,6 @@ public:
     static URL create_with_help_scheme(DeprecatedString const& path, DeprecatedString const& fragment = {}, DeprecatedString const& hostname = {});
     static URL create_with_data(DeprecatedString mime_type, DeprecatedString payload, bool is_base64 = false) { return URL(move(mime_type), move(payload), is_base64); }
 
-    static bool scheme_requires_port(StringView);
     static u16 default_port_for_scheme(StringView);
     static bool is_special_scheme(StringView);
 

--- a/Tests/AK/TestURL.cpp
+++ b/Tests/AK/TestURL.cpp
@@ -39,6 +39,16 @@ TEST_CASE(basic)
         EXPECT(url.fragment().is_null());
     }
     {
+        URL url("https://www.serenityos.org1/index.html"sv);
+        EXPECT_EQ(url.is_valid(), true);
+        EXPECT_EQ(url.scheme(), "https");
+        EXPECT_EQ(url.host(), "www.serenityos.org1");
+        EXPECT_EQ(url.port_or_default(), 443);
+        EXPECT_EQ(url.serialize_path(), "/index.html");
+        EXPECT(url.query().is_null());
+        EXPECT(url.fragment().is_null());
+    }
+    {
         URL url("https://localhost:1234/~anon/test/page.html"sv);
         EXPECT_EQ(url.is_valid(), true);
         EXPECT_EQ(url.scheme(), "https");


### PR DESCRIPTION
I misunderstood the spec step for checking whether the host 'ends with a
number'. We can't simply check for it if ends with a number, this check
is actually an algorithm which is required to avoid detecting hosts that
end with a number from an IPv4 host.

Implement this missing step, and add a test to cover this.

Also add some spec comments to URL::serialize as I'm currently debugging
why browser seems to be crashing in data URL serialization when browsing Jira instances