### PR TITLE
LibWeb: Fix vertical position of top table caption

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
@@ -1,0 +1,27 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x60.9375 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 60.46875x60.9375 [BFC] children: not-inline
+        Box <table> at (8,35.46875) content-size 60.46875x23.46875 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          BlockContainer <caption> at (8,8) content-size 60.46875x17.46875 [BFC] children: inline
+            line 0 width: 60.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 1, length: 7, rect: [8,8 60.46875x17.46875]
+                "Caption"
+            TextNode <#text>
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (8,8) content-size 56.46875x19.46875 table-row-group children: not-inline
+            Box <tr> at (10,37.46875) content-size 56.46875x19.46875 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,38.46875) content-size 54.46875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 27.5, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 4, rect: [11,38.46875 27.5x17.46875]
+                    "Cell"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>

--- a/Tests/LibWeb/Layout/input/table/top-caption-with-padding.html
+++ b/Tests/LibWeb/Layout/input/table/top-caption-with-padding.html
@@ -1,0 +1,15 @@
+<style>
+  caption {
+    caption-side: top;
+    padding: 10px;
+  }
+</style>
+
+<table>
+  <caption>
+    Caption
+  </caption>
+  <tr>
+    <td>Cell</td>
+  </tr>
+</table>

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -91,7 +91,7 @@ CSSPixels TableFormattingContext::run_caption_layout(LayoutMode layout_mode, CSS
         caption_context->resolve_vertical_box_model_metrics(child_box);
         auto const& caption_state = m_state.get(child_box);
         if (phase == CSS::CaptionSide::Top) {
-            m_state.get_mutable(table_box()).set_content_y(caption_state.margin_box_height());
+            m_state.get_mutable(table_box()).set_content_y(caption_state.content_height() + caption_state.margin_box_bottom());
         } else {
             m_state.get_mutable(child_box).set_content_y(
                 m_state.get(table_box()).margin_box_height() + caption_state.margin_box_top());


### PR DESCRIPTION
Setting the top of the table coordinate should not consider the top padding and margin of the caption, just the bottom and content height.