### PR TITLE
LibWeb: Fix division by zero in distribute_any_remaining_free_space

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/justify-content-space-between-single-item.txt
+++ b/Tests/LibWeb/Layout/expected/flex/justify-content-space-between-single-item.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
+      Box <div.container> at (8,8) content-size 784x17.46875 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (8,8) content-size 14.265625x17.46875 flex-item [BFC] children: inline
+          line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17.46875]
+              "A"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/flex/justify-content-space-between-single-item.html
+++ b/Tests/LibWeb/Layout/input/flex/justify-content-space-between-single-item.html
@@ -1,0 +1,6 @@
+<style>
+.container {
+    display: flex;
+    justify-content: space-between;
+}
+</style><div class="container"><div>A</div></div>

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1331,7 +1331,8 @@ void FlexFormattingContext::distribute_any_remaining_free_space()
                 } else {
                     initial_offset = 0;
                 }
-                space_between_items = flex_line.remaining_free_space / (number_of_items - 1);
+                if (number_of_items > 1)
+                    space_between_items = flex_line.remaining_free_space / (number_of_items - 1);
                 break;
             case CSS::JustifyContent::SpaceAround:
                 space_between_items = flex_line.remaining_free_space / number_of_items;


### PR DESCRIPTION
This change fixes division by zero in case flex container has "justify-content: space-between" and only single item.

Fixes UBSAN error on https://www.ekioh.com/flow-browser/