### PR TITLE
LibWeb: Implement subtraction using saturated_addition in CSSPixels

### DIFF
--- a/Tests/LibWeb/TestCSSPixels.cpp
+++ b/Tests/LibWeb/TestCSSPixels.cpp
@@ -76,4 +76,15 @@ TEST_CASE(comparison2)
     EXPECT_EQ(CSSPixels(123) == CSSPixels(123), true);
 }
 
+TEST_CASE(saturated_addition)
+{
+    EXPECT_EQ(CSSPixels(INFINITY), CSSPixels(INFINITY) + 1);
+}
+
+TEST_CASE(saturated_subtraction)
+{
+    auto value = CSSPixels(INFINITY);
+    EXPECT_EQ(value - -1, CSSPixels(INFINITY));
+}
+
 }

--- a/Userland/Libraries/LibWeb/PixelUnits.cpp
+++ b/Userland/Libraries/LibWeb/PixelUnits.cpp
@@ -112,7 +112,7 @@ CSSPixels CSSPixels::operator+(CSSPixels const& other) const
 CSSPixels CSSPixels::operator-(CSSPixels const& other) const
 {
     CSSPixels result;
-    result.set_raw_value(raw_value() - other.raw_value());
+    result.set_raw_value(saturated_addition(raw_value(), -other.raw_value()));
     return result;
 }
 


### PR DESCRIPTION
Fixes overflow bug found by UBSAN.