### PR TITLE
FuzzPDF: Initialize document so page count is accurate

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzPDF.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPDF.cpp
@@ -13,6 +13,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 
     if (auto maybe_document = PDF::Document::create(bytes); !maybe_document.is_error()) {
         auto document = maybe_document.release_value();
+        (void)document->initialize();
         auto pages = document->get_page_count();
         for (size_t i = 0; i < pages; ++i) {
             (void)document->get_page(i);


### PR DESCRIPTION
Without calling `initialize()`, the page count is 0, so the loop never ran and we never actually tested any of the code in `get_page()`.

Having to call `initialize()` at all is awkward, but seems necessary at the moment because of how providing a password works.