### PR TITLE
Run with the JavaScript bytecode VM by default

### DIFF
--- a/Ladybird/main.cpp
+++ b/Ladybird/main.cpp
@@ -70,7 +70,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView webdriver_content_ipc_path;
     bool enable_callgrind_profiling = false;
     bool enable_sql_database = false;
-    bool use_javascript_bytecode = false;
+    bool use_ast_interpreter = false;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("The Ladybird web browser :^)");
@@ -78,7 +78,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(webdriver_content_ipc_path, "Path to WebDriver IPC for WebContent", "webdriver-content-path", 0, "path");
     args_parser.add_option(enable_callgrind_profiling, "Enable Callgrind profiling", "enable-callgrind-profiling", 'P');
     args_parser.add_option(enable_sql_database, "Enable SQL database", "enable-sql-database", 0);
-    args_parser.add_option(use_javascript_bytecode, "Enable JavaScript bytecode VM", "use-bytecode", 0);
+    args_parser.add_option(use_ast_interpreter, "Enable JavaScript AST interpreter (deprecated)", "ast", 0);
     args_parser.parse(arguments);
 
     auto get_formatted_url = [&](StringView const& raw_url) -> ErrorOr<URL> {
@@ -101,7 +101,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto cookie_jar = database ? TRY(Browser::CookieJar::create(*database)) : Browser::CookieJar::create();
 
     s_settings = adopt_own_if_nonnull(new Browser::Settings());
-    BrowserWindow window(cookie_jar, webdriver_content_ipc_path, enable_callgrind_profiling ? WebView::EnableCallgrindProfiling::Yes : WebView::EnableCallgrindProfiling::No, use_javascript_bytecode ? WebView::UseJavaScriptBytecode::Yes : WebView::UseJavaScriptBytecode::No);
+    BrowserWindow window(cookie_jar, webdriver_content_ipc_path, enable_callgrind_profiling ? WebView::EnableCallgrindProfiling::Yes : WebView::EnableCallgrindProfiling::No, use_ast_interpreter ? WebView::UseJavaScriptBytecode::No : WebView::UseJavaScriptBytecode::Yes);
     window.setWindowTitle("Ladybird");
     window.resize(800, 600);
     window.show();

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -667,10 +667,10 @@ if (BUILD_LAGOM)
         set_tests_properties(JS PROPERTIES ENVIRONMENT SERENITY_SOURCE_DIR=${SERENITY_PROJECT_ROOT})
 
         add_test(
-            NAME JS-Bytecode
-            COMMAND test-js -b --show-progress=false
+            NAME JS-AST
+            COMMAND test-js --ast --show-progress=false
         )
-        set_tests_properties(JS-Bytecode PROPERTIES ENVIRONMENT SERENITY_SOURCE_DIR=${SERENITY_PROJECT_ROOT})
+        set_tests_properties(JS-AST PROPERTIES ENVIRONMENT SERENITY_SOURCE_DIR=${SERENITY_PROJECT_ROOT})
 
         # Extra tests from Tests/LibJS
         lagom_test(../../Tests/LibJS/test-invalid-unicode-js.cpp LIBS LibJS)

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -57,9 +57,10 @@ static DeprecatedString search_engines_file_path()
     return builder.to_deprecated_string();
 }
 
-BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url)
+BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url, WebView::UseJavaScriptBytecode use_javascript_bytecode)
     : m_cookie_jar(cookie_jar)
     , m_window_actions(*this)
+    , m_use_javascript_bytecode(use_javascript_bytecode)
 {
     auto app_icon = GUI::Icon::default_icon("app-browser"sv);
     m_bookmarks_bar = Browser::BookmarksBarWidget::construct(Browser::bookmarks_file_path(), true);
@@ -563,7 +564,7 @@ void BrowserWindow::set_window_title_for_tab(Tab const& tab)
 
 Tab& BrowserWindow::create_new_tab(URL url, Web::HTML::ActivateTab activate)
 {
-    auto& new_tab = m_tab_widget->add_tab<Browser::Tab>("New tab"_short_string, *this);
+    auto& new_tab = m_tab_widget->add_tab<Browser::Tab>("New tab"_short_string, *this, m_use_javascript_bytecode);
 
     m_tab_widget->set_bar_visible(!is_fullscreen() && m_tab_widget->children().size() > 1);
 

--- a/Userland/Applications/Browser/BrowserWindow.h
+++ b/Userland/Applications/Browser/BrowserWindow.h
@@ -50,7 +50,7 @@ public:
     void broadcast_window_size(Gfx::IntSize);
 
 private:
-    explicit BrowserWindow(CookieJar&, URL);
+    BrowserWindow(CookieJar&, URL, WebView::UseJavaScriptBytecode);
 
     void build_menus();
     ErrorOr<void> load_search_engines(GUI::Menu& settings_menu);
@@ -86,6 +86,8 @@ private:
     RefPtr<GUI::Action> m_disable_user_agent_spoofing;
     RefPtr<GUI::Action> m_disable_search_engine_action;
     RefPtr<GUI::Action> m_change_homepage_action;
+
+    WebView::UseJavaScriptBytecode m_use_javascript_bytecode {};
 };
 
 }

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -114,7 +114,7 @@ void Tab::update_status(Optional<String> text_override, i32 count_waiting)
     }
 }
 
-Tab::Tab(BrowserWindow& window)
+Tab::Tab(BrowserWindow& window, WebView::UseJavaScriptBytecode use_javascript_bytecode)
 {
     load_from_gml(tab_gml).release_value_but_fixme_should_propagate_errors();
 
@@ -123,7 +123,7 @@ Tab::Tab(BrowserWindow& window)
 
     auto& webview_container = *find_descendant_of_type_named<GUI::Widget>("webview_container");
 
-    m_web_content_view = webview_container.add<WebView::OutOfProcessWebView>();
+    m_web_content_view = webview_container.add<WebView::OutOfProcessWebView>(use_javascript_bytecode);
 
     auto preferred_color_scheme = Web::CSS::preferred_color_scheme_from_string(Config::read_string("Browser"sv, "Preferences"sv, "ColorScheme"sv, Browser::default_color_scheme));
     m_web_content_view->set_preferred_color_scheme(preferred_color_scheme);

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -15,6 +15,7 @@
 #include <LibGfx/ShareableBitmap.h>
 #include <LibHTTP/Job.h>
 #include <LibWeb/Forward.h>
+#include <LibWebView/ViewImplementation.h>
 
 namespace WebView {
 class OutOfProcessWebView;
@@ -98,7 +99,7 @@ public:
     WebView::OutOfProcessWebView& view() { return *m_web_content_view; }
 
 private:
-    explicit Tab(BrowserWindow&);
+    Tab(BrowserWindow&, WebView::UseJavaScriptBytecode);
 
     virtual void show_event(GUI::ShowEvent&) override;
     virtual void hide_event(GUI::HideEvent&) override;

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -96,10 +96,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd unix fattr cpath rpath wpath proc exec"));
 
     Vector<DeprecatedString> specified_urls;
+    bool use_ast_interpreter = false;
 
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(specified_urls, "URLs to open", "url", Core::ArgsParser::Required::No);
     args_parser.add_option(Browser::g_webdriver_content_ipc_path, "Path to WebDriver IPC for WebContent", "webdriver-content-path", 0, "path");
+    args_parser.add_option(use_ast_interpreter, "Enable JavaScript AST interpreter (deprecated)", "ast", 0);
 
     args_parser.parse(arguments);
 
@@ -173,7 +175,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         first_url = TRY(url_from_argument_string(specified_urls.first()));
 
     auto cookie_jar = TRY(Browser::CookieJar::create(*database));
-    auto window = Browser::BrowserWindow::construct(cookie_jar, first_url);
+    auto window = Browser::BrowserWindow::construct(cookie_jar, first_url, use_ast_interpreter ? WebView::UseJavaScriptBytecode::No : WebView::UseJavaScriptBytecode::Yes);
 
     auto content_filters_watcher = TRY(Core::FileWatcher::create());
     content_filters_watcher->on_change = [&](Core::FileWatcherEvent const&) {

--- a/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
@@ -93,7 +93,7 @@ int main(int argc, char** argv)
 #endif
     bool print_json = false;
     bool per_file = false;
-    bool use_bytecode = false;
+    bool use_ast_interpreter = false;
     StringView specified_test_root;
     DeprecatedString common_path;
     DeprecatedString test_glob;
@@ -119,7 +119,7 @@ int main(int argc, char** argv)
     args_parser.add_option(print_json, "Show results as JSON", "json", 'j');
     args_parser.add_option(per_file, "Show detailed per-file results as JSON (implies -j)", "per-file", 0);
     args_parser.add_option(g_collect_on_every_allocation, "Collect garbage after every allocation", "collect-often", 'g');
-    args_parser.add_option(use_bytecode, "Use the bytecode interpreter", "run-bytecode", 'b');
+    args_parser.add_option(use_ast_interpreter, "Enable JavaScript AST interpreter (deprecated)", "ast", 0);
     args_parser.add_option(JS::Bytecode::g_dump_bytecode, "Dump the bytecode", "dump-bytecode", 'd');
     args_parser.add_option(test_glob, "Only run tests matching the given glob", "filter", 'f', "glob");
     for (auto& entry : g_extra_args)
@@ -137,12 +137,12 @@ int main(int argc, char** argv)
         AK::set_debug_enabled(false);
     }
 
-    if (JS::Bytecode::g_dump_bytecode && !use_bytecode) {
-        warnln("--dump-bytecode can only be used when --run-bytecode is specified.");
+    if (JS::Bytecode::g_dump_bytecode && use_ast_interpreter) {
+        warnln("--dump-bytecode can not be used when --ast is specified.");
         return 1;
     }
 
-    JS::Bytecode::Interpreter::set_enabled(use_bytecode);
+    JS::Bytecode::Interpreter::set_enabled(!use_ast_interpreter);
 
     DeprecatedString test_root;
 

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -47,6 +47,8 @@ void OutOfProcessWebView::create_client(EnableCallgrindProfiling)
         });
     };
 
+    client().async_set_use_javascript_bytecode(use_javascript_bytecode() == UseJavaScriptBytecode::Yes);
+
     m_client_state.client_handle = Web::Crypto::generate_random_uuid().release_value_but_fixme_should_propagate_errors();
     client().async_set_window_handle(m_client_state.client_handle);
 

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -14,6 +14,7 @@
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/SystemTheme.h>
+#include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Console.h>
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/ConsoleObject.h>
@@ -62,6 +63,11 @@ Web::Page& ConnectionFromClient::page()
 Web::Page const& ConnectionFromClient::page() const
 {
     return m_page_host->page();
+}
+
+void ConnectionFromClient::set_use_javascript_bytecode(bool use_bytecode)
+{
+    JS::Bytecode::Interpreter::set_enabled(use_bytecode);
 }
 
 Messages::WebContentServer::GetWindowHandleResponse ConnectionFromClient::get_window_handle()

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -48,6 +48,7 @@ private:
     Web::Page& page();
     Web::Page const& page() const;
 
+    virtual void set_use_javascript_bytecode(bool) override;
     virtual Messages::WebContentServer::GetWindowHandleResponse get_window_handle() override;
     virtual void set_window_handle(String const& handle) override;
     virtual void connect_to_webdriver(DeprecatedString const& webdriver_ipc_path) override;

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -9,6 +9,9 @@
 
 endpoint WebContentServer
 {
+    // NOTE: This is only used on SerenityOS when attaching to a WebContent process served by SystemServer.
+    set_use_javascript_bytecode(bool use_javascript_bytecode) =|
+
     get_window_handle() => (String handle)
     set_window_handle(String handle) =|
 

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -369,7 +369,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool dump_layout_tree = false;
     bool dump_text = false;
     bool is_layout_test_mode = false;
-    bool use_javascript_bytecode = false;
+    bool use_ast_interpreter = false;
     StringView test_root_path;
 
     Core::ArgsParser args_parser;
@@ -381,7 +381,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(resources_folder, "Path of the base resources folder (defaults to /res)", "resources", 'r', "resources-root-path");
     args_parser.add_option(web_driver_ipc_path, "Path to the WebDriver IPC socket", "webdriver-ipc-path", 0, "path");
     args_parser.add_option(is_layout_test_mode, "Enable layout test mode", "layout-test-mode", 0);
-    args_parser.add_option(use_javascript_bytecode, "Enable JavaScript bytecode VM", "use-bytecode", 0);
+    args_parser.add_option(use_ast_interpreter, "Enable JavaScript AST interpreter (deprecated)", "ast", 0);
     args_parser.add_positional_argument(url, "URL to open", "url", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
@@ -403,7 +403,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         is_layout_test_mode = true;
     }
 
-    auto view = TRY(HeadlessWebContentView::create(move(theme), window_size, web_driver_ipc_path, is_layout_test_mode ? WebView::IsLayoutTestMode::Yes : WebView::IsLayoutTestMode::No, use_javascript_bytecode ? WebView::UseJavaScriptBytecode::Yes : WebView::UseJavaScriptBytecode::No));
+    auto view = TRY(HeadlessWebContentView::create(move(theme), window_size, web_driver_ipc_path, is_layout_test_mode ? WebView::IsLayoutTestMode::Yes : WebView::IsLayoutTestMode::No, use_ast_interpreter ? WebView::UseJavaScriptBytecode::No : WebView::UseJavaScriptBytecode::Yes));
     RefPtr<Core::Timer> timer;
 
     if (!test_root_path.is_empty()) {

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -575,13 +575,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool use_test262_global = false;
     StringView evaluate_script;
     Vector<StringView> script_paths;
-    bool use_bytecode = false;
+    bool use_ast_interpreter = false;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("This is a JavaScript interpreter.");
     args_parser.add_option(s_dump_ast, "Dump the AST", "dump-ast", 'A');
     args_parser.add_option(JS::Bytecode::g_dump_bytecode, "Dump the bytecode", "dump-bytecode", 'd');
-    args_parser.add_option(use_bytecode, "Run the bytecode", "run-bytecode", 'b');
+    args_parser.add_option(use_ast_interpreter, "Enable JavaScript AST interpreter (deprecated)", "ast", 0);
     args_parser.add_option(s_as_module, "Treat as module", "as-module", 'm');
     args_parser.add_option(s_print_last_result, "Print last result", "print-last-result", 'l');
     args_parser.add_option(s_strip_ansi, "Disable ANSI colors", "disable-ansi-colors", 'i');
@@ -594,7 +594,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(script_paths, "Path to script files", "scripts", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    JS::Bytecode::Interpreter::set_enabled(use_bytecode);
+    JS::Bytecode::Interpreter::set_enabled(!use_ast_interpreter);
 
     bool syntax_highlight = !disable_syntax_highlight;
 


### PR DESCRIPTION
Summary of changes:

- The `ladybird`, `Browser`, `headless-browser`, `js` and `test-js` programs now use the LibJS bytecode VM by default.
- The AST interpreter is still available behind a new `--ast` flag.
- `test-js` now runs in bytecode mode when part of the `run-tests` battery.

While there are still a handful of test262 and test-js tests that are passing in AST but not BC, it's already the case that many websites work significantly better in bytecode mode.

We can deal with the remaining failures over time, but let's switch the default so we get more testing of the new VM. :^)