### PR TITLE
Meta+Utilities: Make pre-commit checks significantly less verbose

### DIFF
--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -34,8 +34,7 @@ for cmd in \
         Meta/lint-prettier.sh \
         Meta/lint-python.sh \
         Meta/lint-shell-scripts.sh; do
-    echo "Running ${cmd}"
-    if time "${cmd}" "$@"; then
+    if "${cmd}" "$@"; then
         echo -e "[${GREEN}OK${NC}]: ${cmd}"
     else
         echo -e "[${RED}FAIL${NC}]: ${cmd}"
@@ -44,8 +43,7 @@ for cmd in \
 done
 
 if [ -x ./Build/lagom/bin/IPCMagicLinter ]; then
-    echo "Running IPCMagicLinter"
-    if time { git ls-files '*.ipc' | xargs ./Build/lagom/bin/IPCMagicLinter; }; then
+    if { git ls-files '*.ipc' | xargs ./Build/lagom/bin/IPCMagicLinter; }; then
         echo -e "[${GREEN}OK${NC}]: IPCMagicLinter (in Meta/lint-ci.sh)"
     else
         echo -e "[${RED}FAIL${NC}]: IPCMagicLinter (in Meta/lint-ci.sh)"
@@ -55,8 +53,7 @@ else
     echo -e "[${GREEN}SKIP${NC}]: IPCMagicLinter (in Meta/lint-ci.sh)"
 fi
 
-echo "Running Meta/lint-clang-format.sh"
-if time Meta/lint-clang-format.sh --overwrite-inplace "$@" && git diff --exit-code; then
+if Meta/lint-clang-format.sh --overwrite-inplace "$@" && git diff --exit-code; then
     echo -e "[${GREEN}OK${NC}]: Meta/lint-clang-format.sh"
 else
     echo -e "[${RED}FAIL${NC}]: Meta/lint-clang-format.sh"
@@ -70,8 +67,7 @@ fi
 # when Ports/ files have changed and only invoke lint-ports.py when needed.
 #
 if [ "$ports" = true ]; then
-    echo "Running Meta/lint-ports.py"
-    if time Meta/lint-ports.py; then
+    if Meta/lint-ports.py; then
         echo -e "[${GREEN}OK${NC}]: Meta/lint-ports.py"
     else
         echo -e "[${RED}FAIL${NC}]: Meta/lint-ports.py"


### PR DESCRIPTION
When markdown-check is built, it outputs hundreds of lines of "ignoring this and that link because reasons". This is extremely not helpful when trying to figure out exactly which check failed on your commit. Also remove the timing numbers from lint-ci.sh These are just noise and also don't help to figure out which pre-commit check failed. Ideally the output on fail should be "[OK]: Check A" for all the passing checks and "[FAIL] Check N" with the required context for the failed check.

This should avoid this ridiculous output from one of my local branches where the pre-commit checks dumped literally 1000 lines of verbose output to my terminal when I had one line in one python file to fix. See if you can spot the actual error amid this forest of log lines. https://gist.github.com/ADKaster/0d527bddcbd7d0a34271856dfd97c2cd

cc @BenWiederhake 