### PR TITLE
LibWeb: Avoid leaking infinite remaining_free_space in FFC calculation

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/inf-available-space-with-auto-margins.txt
+++ b/Tests/LibWeb/Layout/expected/flex/inf-available-space-with-auto-margins.txt
@@ -1,0 +1,8 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x17.46875 flex-container(column) [FFC] children: not-inline
+      BlockContainer <main> at (8,8) content-size 784x17.46875 flex-item [BFC] children: inline
+        line 0 width: 153.984375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 13, rect: [8,8 153.984375x17.46875]
+            "hmmMMMMmmmmmm"
+        TextNode <#text>

--- a/Tests/LibWeb/Layout/input/flex/inf-available-space-with-auto-margins.html
+++ b/Tests/LibWeb/Layout/input/flex/inf-available-space-with-auto-margins.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html><html><head><style>
+body {
+    display: flex;
+    flex-direction: column;
+}
+main {
+    margin-top: auto;
+    margin-bottom: auto;
+}
+</style></head><body><main>hmmMMMMmmmmmm

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -109,7 +109,7 @@ private:
     struct FlexLine {
         Vector<FlexItem&> items;
         CSSPixels cross_size { 0 };
-        CSSPixels remaining_free_space { 0 };
+        Optional<CSSPixels> remaining_free_space;
         double chosen_flex_fraction { 0 };
 
         double sum_of_flex_factor_of_unfrozen_items() const;


### PR DESCRIPTION
After switching to fixed-point arithmetic in CSSPixels, it no longer supports representing infinite values, which was previously the case for remaining_free_space in FFC. Using Optional that is not empty only when value is finite to store remaining_free_space ensures that infinity is avoided in layout calculations.

Fixes hanging on https://twinings.co.uk