### PR TITLE
LibUnicode: Perform code point property lookups in constant time

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -979,13 +979,6 @@ struct CodePointComparator {
     }
 };
 
-struct CodePointRangeComparator {
-    constexpr int operator()(u32 code_point, CodePointRange const& range)
-    {
-        return (code_point > range.last) - (code_point < range.first);
-    }
-};
-
 struct BlockNameData {
     CodePointRange code_point_range {};
     @string_index_type@ display_name { 0 };

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -156,10 +156,6 @@ struct UnicodeData {
     Vector<Alias> script_aliases;
     PropList script_extensions;
 
-    PropList block_list {
-        { "No_Block"sv, {} },
-    };
-    Vector<Alias> block_aliases;
     Vector<BlockName> block_display_names;
 
     // FIXME: We are not yet doing anything with this data. It will be needed for String.prototype.normalize.
@@ -814,7 +810,6 @@ namespace Unicode {
     generate_enum("GeneralCategory"sv, {}, unicode_data.general_categories.keys(), unicode_data.general_category_aliases);
     generate_enum("Property"sv, {}, unicode_data.prop_list.keys(), unicode_data.prop_aliases);
     generate_enum("Script"sv, {}, unicode_data.script_list.keys(), unicode_data.script_aliases);
-    generate_enum("Block"sv, {}, unicode_data.block_list.keys(), unicode_data.block_aliases);
     generate_enum("GraphemeBreakProperty"sv, {}, unicode_data.grapheme_break_props.keys());
     generate_enum("WordBreakProperty"sv, {}, unicode_data.word_break_props.keys());
     generate_enum("SentenceBreakProperty"sv, {}, unicode_data.sentence_break_props.keys());
@@ -1149,7 +1144,6 @@ static constexpr Array<ReadonlySpan<CodePointRange>, @size@> @name@ { {)~~~");
     append_prop_list("s_properties"sv, "s_property_{}"sv, unicode_data.prop_list);
     append_prop_list("s_scripts"sv, "s_script_{}"sv, unicode_data.script_list);
     append_prop_list("s_script_extensions"sv, "s_script_extension_{}"sv, unicode_data.script_extensions);
-    append_prop_list("s_blocks"sv, "s_block_{}"sv, unicode_data.block_list);
     append_prop_list("s_grapheme_break_properties"sv, "s_grapheme_break_property_{}"sv, unicode_data.grapheme_break_props);
     append_prop_list("s_word_break_properties"sv, "s_word_break_property_{}"sv, unicode_data.word_break_props);
     append_prop_list("s_sentence_break_properties"sv, "s_sentence_break_property_{}"sv, unicode_data.sentence_break_props);
@@ -1342,9 +1336,6 @@ bool code_point_has_@enum_snake@(u32 code_point, @enum_title@ @enum_snake@)
     append_prop_search("Script"sv, "script"sv, "s_scripts"sv);
     append_prop_search("Script"sv, "script_extension"sv, "s_script_extensions"sv);
     TRY(append_from_string("Script"sv, "script"sv, unicode_data.script_list, unicode_data.script_aliases));
-
-    append_prop_search("Block"sv, "block"sv, "s_blocks"sv);
-    TRY(append_from_string("Block"sv, "block"sv, unicode_data.block_list, unicode_data.block_aliases));
 
     append_prop_search("GraphemeBreakProperty"sv, "grapheme_break_property"sv, "s_grapheme_break_properties"sv);
     append_prop_search("WordBreakProperty"sv, "word_break_property"sv, "s_word_break_properties"sv);
@@ -1564,7 +1555,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(parse_prop_list(*scripts_file, unicode_data.script_list));
     TRY(parse_prop_list(*script_extensions_file, unicode_data.script_extensions, true));
     TRY(parse_block_display_names(*blocks_file, unicode_data));
-    TRY(parse_prop_list(*blocks_file, unicode_data.block_list, false, true));
     TRY(parse_name_aliases(*name_alias_file, unicode_data));
     TRY(parse_prop_list(*grapheme_break_file, unicode_data.grapheme_break_props));
     TRY(parse_prop_list(*word_break_file, unicode_data.word_break_props));
@@ -1574,7 +1564,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(parse_unicode_data(*unicode_data_file, unicode_data));
     TRY(parse_value_alias_list(*prop_value_alias_file, "gc"sv, unicode_data.general_categories.keys(), unicode_data.general_category_aliases));
     TRY(parse_value_alias_list(*prop_value_alias_file, "sc"sv, unicode_data.script_list.keys(), unicode_data.script_aliases, false));
-    TRY(parse_value_alias_list(*prop_value_alias_file, "blk"sv, unicode_data.block_list.keys(), unicode_data.block_aliases, false, true));
     TRY(normalize_script_extensions(unicode_data.script_extensions, unicode_data.script_list, unicode_data.script_aliases));
 
     TRY(generate_unicode_data_header(*generated_header_file, unicode_data));

--- a/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
+++ b/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
@@ -594,6 +594,28 @@ TEST_CASE(general_category)
     }
 }
 
+BENCHMARK_CASE(general_category_performance)
+{
+    auto general_category_cased_letter = Unicode::general_category_from_string("Cased_Letter"sv).value();
+
+    for (size_t i = 0; i < 1'000'000; ++i) {
+        for (u32 code_point = 0; code_point <= 0x1f; ++code_point)
+            EXPECT(!Unicode::code_point_has_general_category(code_point, general_category_cased_letter));
+
+        for (u32 code_point = 0x41; code_point <= 0x5a; ++code_point)
+            EXPECT(Unicode::code_point_has_general_category(code_point, general_category_cased_letter));
+
+        for (u32 code_point = 0x61; code_point <= 0x7a; ++code_point)
+            EXPECT(Unicode::code_point_has_general_category(code_point, general_category_cased_letter));
+
+        for (u32 code_point = 0xe000; code_point <= 0xe100; ++code_point)
+            EXPECT(!Unicode::code_point_has_general_category(code_point, general_category_cased_letter));
+
+        for (u32 code_point = 0x101fe; code_point <= 0x1027f; ++code_point)
+            EXPECT(!Unicode::code_point_has_general_category(code_point, general_category_cased_letter));
+    }
+}
+
 TEST_CASE(property)
 {
     auto property = [](StringView name) {

--- a/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
+++ b/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
@@ -727,34 +727,6 @@ TEST_CASE(script)
 
 TEST_CASE(block)
 {
-    auto block = [](StringView name) {
-        auto block = Unicode::block_from_string(name);
-        VERIFY(block.has_value());
-        return *block;
-    };
-
-    auto no_block = block("No_Block"sv);
-    auto block_nb = block("NB"sv);
-    EXPECT_EQ(no_block, block_nb);
-
-    auto block_basic_latin = block("Basic_Latin"sv);
-    auto block_ascii = block("ASCII"sv);
-    EXPECT_EQ(block_basic_latin, block_ascii);
-
-    auto block_greek_coptic = block("Greek_And_Coptic"sv);
-    auto block_greek = block("Greek"sv);
-    EXPECT_EQ(block_greek_coptic, block_greek);
-
-    auto block_variation = block("Variation_Selectors_Supplement"sv);
-    auto block_vs_sup = block("VS_Sup"sv);
-    EXPECT_EQ(block_variation, block_vs_sup);
-
-    for (u32 code_point = 0x0000; code_point <= 0x007F; ++code_point)
-        EXPECT(Unicode::code_point_has_block(code_point, block_basic_latin));
-
-    for (u32 code_point = 0xE0100; code_point <= 0xE01EF; ++code_point)
-        EXPECT(Unicode::code_point_has_block(code_point, block_variation));
-
     for (u32 code_point = 0x0000; code_point <= 0x007F; ++code_point)
         EXPECT_EQ("Basic Latin"sv, Unicode::code_point_block_display_name(code_point).value());
 

--- a/Userland/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.cpp
@@ -143,9 +143,6 @@ Optional<Script> __attribute__((weak)) script_from_string(StringView) { return {
 bool __attribute__((weak)) code_point_has_script(u32, Script) { return {}; }
 bool __attribute__((weak)) code_point_has_script_extension(u32, Script) { return {}; }
 
-Optional<Block> __attribute__((weak)) block_from_string(StringView) { return {}; }
-bool __attribute__((weak)) code_point_has_block(u32, Block) { return {}; }
-
 bool __attribute__((weak)) code_point_has_grapheme_break_property(u32, GraphemeBreakProperty) { return {}; }
 bool __attribute__((weak)) code_point_has_word_break_property(u32, WordBreakProperty) { return {}; }
 bool __attribute__((weak)) code_point_has_sentence_break_property(u32, SentenceBreakProperty) { return {}; }

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -22,6 +22,13 @@ struct CodePointRange {
     u32 last { 0 };
 };
 
+struct CodePointRangeComparator {
+    constexpr int operator()(u32 code_point, CodePointRange const& range)
+    {
+        return (code_point > range.last) - (code_point < range.first);
+    }
+};
+
 struct BlockName {
     CodePointRange code_point_range {};
     StringView display_name;

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -57,9 +57,6 @@ Optional<Script> script_from_string(StringView);
 bool code_point_has_script(u32 code_point, Script script);
 bool code_point_has_script_extension(u32 code_point, Script script);
 
-Optional<Block> block_from_string(StringView);
-bool code_point_has_block(u32 code_point, Block block);
-
 bool code_point_has_grapheme_break_property(u32 code_point, GraphemeBreakProperty property);
 bool code_point_has_word_break_property(u32 code_point, WordBreakProperty property);
 bool code_point_has_sentence_break_property(u32 code_point, SentenceBreakProperty property);


### PR DESCRIPTION
We currently produce a single table for all categories of code point
properties (GeneralCategory, Script, etc.). Each row contains a field
indicating the range of code points to which that property applies. At
runtime, we then do a binary search through that table to decide if a
code point has a property.

This changes our approach to generate a 2-stage lookup table for each of
those categories. There is an in-depth explanation of these tables above
the new `create_code_point_tables` method. The end effect is that code
point property lookup is reduced from a binary search to constant-time
array lookups.

In total, this change:

* Increases the size of libunicode.so from 2.7 MB to 2.9 MB.

* Reduces the runtime of the new benchmark test case added here from
  3.576s to 1.020s (a 3.5x speedup).

* In a profile of resizing a TextEditor window with a 3MB file open,
  the runtime of checking if a code point has a word break property
  reduces from ~81% to ~56%.

Ref #19971